### PR TITLE
revert(wizard): move orderedPages sweep to PR

### DIFF
--- a/Sources/KeyPath/InstallationWizard/Core/WizardNavigationEngine.swift
+++ b/Sources/KeyPath/InstallationWizard/Core/WizardNavigationEngine.swift
@@ -172,7 +172,7 @@ class WizardNavigationEngine: WizardNavigating {
 
         return WizardNavigationState(
             currentPage: currentPage,
-            availablePages: WizardPage.orderedPages,
+            availablePages: WizardPage.allCases,
             canNavigateNext: shouldAutoNavigate,
             canNavigatePrevious: true, // Users can always go back manually
             shouldAutoNavigate: shouldAutoNavigate

--- a/Sources/KeyPath/InstallationWizard/UI/Components/WizardSystemStatusOverview.swift
+++ b/Sources/KeyPath/InstallationWizard/UI/Components/WizardSystemStatusOverview.swift
@@ -126,7 +126,7 @@ struct WizardSystemStatusOverview: View {
                 title: "Input Monitoring Permission",
                 status: inputMonitoringStatus,
                 isNavigable: true,
-                targetPage: .permissions,
+                targetPage: .inputMonitoring,
                 relatedIssues: inputMonitoringIssues
             ))
 
@@ -145,7 +145,7 @@ struct WizardSystemStatusOverview: View {
                 title: "Accessibility Permission",
                 status: accessibilityStatus,
                 isNavigable: true,
-                targetPage: .permissions,
+                targetPage: .accessibility,
                 relatedIssues: accessibilityIssues
             ))
 
@@ -162,7 +162,7 @@ struct WizardSystemStatusOverview: View {
                 title: "Karabiner Driver Setup",
                 status: karabinerStatus,
                 isNavigable: true,
-                targetPage: .components,
+                targetPage: .karabinerComponents,
                 relatedIssues: karabinerIssues
             ))
 
@@ -186,7 +186,7 @@ struct WizardSystemStatusOverview: View {
                     title: "Kanata Engine Setup",
                     status: kanataComponentsStatus,
                     isNavigable: true,
-                    targetPage: .components,
+                    targetPage: .kanataComponents,
                     relatedIssues: kanataComponentsIssues
                 ))
         }
@@ -418,8 +418,10 @@ struct WizardSystemStatusOverview: View {
         }
 
         // Navigate to the first blocking permission page
-        if hasInputMonitoringIssues || hasAccessibilityIssues {
-            return (.permissions, "Permissions required")
+        if hasInputMonitoringIssues {
+            return (.inputMonitoring, "Input Monitoring permission required")
+        } else if hasAccessibilityIssues {
+            return (.accessibility, "Accessibility permission required")
         } else {
             // Default to service page if no specific permission issue
             return (.service, "Check service status")

--- a/Sources/KeyPath/InstallationWizard/UI/InstallationWizardView.swift
+++ b/Sources/KeyPath/InstallationWizard/UI/InstallationWizardView.swift
@@ -929,7 +929,7 @@ struct InstallationWizardView: View {
 
     /// Navigate to the previous page using keyboard left arrow
     private func navigateToPreviousPage() {
-        let allPages = WizardPage.orderedPages
+        let allPages = WizardPage.allCases
         guard let currentIndex = allPages.firstIndex(of: navigationCoordinator.currentPage),
               currentIndex > 0
         else { return }
@@ -942,7 +942,7 @@ struct InstallationWizardView: View {
 
     /// Navigate to the next page using keyboard right arrow
     private func navigateToNextPage() {
-        let allPages = WizardPage.orderedPages
+        let allPages = WizardPage.allCases
         guard let currentIndex = allPages.firstIndex(of: navigationCoordinator.currentPage),
               currentIndex < allPages.count - 1
         else { return }

--- a/Sources/KeyPath/InstallationWizard/UI/Pages/WizardAccessibilityPage.swift
+++ b/Sources/KeyPath/InstallationWizard/UI/Pages/WizardAccessibilityPage.swift
@@ -279,7 +279,7 @@ struct WizardAccessibilityPage: View {
     // MARK: - Helper Methods
 
     private func navigateToNextPage() {
-        let allPages = WizardPage.orderedPages
+        let allPages = WizardPage.allCases
         guard let currentIndex = allPages.firstIndex(of: navigationCoordinator.currentPage),
               currentIndex < allPages.count - 1
         else { return }

--- a/Sources/KeyPath/InstallationWizard/UI/Pages/WizardConflictsPage.swift
+++ b/Sources/KeyPath/InstallationWizard/UI/Pages/WizardConflictsPage.swift
@@ -227,7 +227,7 @@ struct WizardConflictsPage: View {
     // MARK: - Helper Methods
 
     private func navigateToNextPage() {
-        let allPages = WizardPage.orderedPages
+        let allPages = WizardPage.allCases
         guard let currentIndex = allPages.firstIndex(of: navigationCoordinator.currentPage),
               currentIndex < allPages.count - 1
         else { return }

--- a/Sources/KeyPath/InstallationWizard/UI/Pages/WizardFullDiskAccessPage.swift
+++ b/Sources/KeyPath/InstallationWizard/UI/Pages/WizardFullDiskAccessPage.swift
@@ -197,7 +197,7 @@ struct WizardFullDiskAccessPage: View {
     // MARK: - Helper Methods
 
     private func navigateToNextPage() {
-        let allPages = WizardPage.orderedPages
+        let allPages = WizardPage.allCases
         guard let currentIndex = allPages.firstIndex(of: navigationCoordinator.currentPage),
               currentIndex < allPages.count - 1
         else { return }

--- a/Sources/KeyPath/InstallationWizard/UI/Pages/WizardKanataComponentsPage.swift
+++ b/Sources/KeyPath/InstallationWizard/UI/Pages/WizardKanataComponentsPage.swift
@@ -246,7 +246,7 @@ struct WizardKanataComponentsPage: View {
     // MARK: - Helper Methods
 
     private func navigateToNextPage() {
-        let allPages = WizardPage.orderedPages
+        let allPages = WizardPage.allCases
         guard let currentIndex = allPages.firstIndex(of: navigationCoordinator.currentPage),
               currentIndex < allPages.count - 1
         else { return }

--- a/Sources/KeyPath/InstallationWizard/UI/Pages/WizardKarabinerComponentsPage.swift
+++ b/Sources/KeyPath/InstallationWizard/UI/Pages/WizardKarabinerComponentsPage.swift
@@ -270,7 +270,7 @@ struct WizardKarabinerComponentsPage: View {
     }
 
     private func navigateToNextPage() {
-        let allPages = WizardPage.orderedPages
+        let allPages = WizardPage.allCases
         guard let currentIndex = allPages.firstIndex(of: navigationCoordinator.currentPage),
               currentIndex < allPages.count - 1
         else { return }

--- a/Tests/KeyPathTests/ContentViewDebounceTests.swift
+++ b/Tests/KeyPathTests/ContentViewDebounceTests.swift
@@ -1,0 +1,164 @@
+import SwiftUI
+import XCTest
+
+@testable import KeyPath
+
+/// Phase 1 Unit Tests: ContentView Debouncing
+/// Tests the save operation debouncing added in Phase 1.3 to prevent rapid successive saves
+@MainActor
+class ContentViewDebounceTests: XCTestCase {
+    lazy var testManager: KanataManager = KanataManager()
+
+    // MARK: - Debounce Logic Tests (Non-UI)
+
+    func testConfigurationSaveDebouncing() async throws {
+        // Test actual debounce behavior by making rapid saves and verifying only the final result persists
+        _ = KanataManager()
+
+        // Create test directory
+        let testConfigDir = "/tmp/keypath-debounce-test-\(UUID().uuidString)"
+        try FileManager.default.createDirectory(
+            atPath: testConfigDir, withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(atPath: testConfigDir) }
+
+        // Test that rapid configuration changes result in final state being saved
+        let finalInput = "caps"
+        let finalOutput = "ctrl"
+
+        let mapping = KeyMapping(input: finalInput, output: finalOutput)
+        let config = KanataConfiguration.generateFromMappings([mapping])
+        XCTAssertTrue(config.contains(finalInput), "Configuration should contain final input mapping")
+        XCTAssertTrue(config.contains(finalOutput), "Configuration should contain final output mapping")
+
+        AppLogger.shared.log("✅ [Test] Configuration debouncing behavior verified")
+    }
+
+    func testErrorHandlingPreservesUIState() async {
+        // Test that errors during save operations properly reset the UI state
+        let manager = KanataManager()
+
+        // This test verifies that the error handling structure exists
+        // In a full implementation, we would:
+        // 1. Trigger a save operation that causes an error
+        // 2. Verify that isSaving is reset to false
+        // 3. Verify that the button becomes enabled again
+        // 4. Verify that error messages are displayed
+
+        XCTAssertNotNil(manager)
+        AppLogger.shared.log("✅ [Test] Error handling structure verified")
+    }
+
+    // MARK: - Configuration Save Integration Tests
+
+    func testConfigurationSaveFlow() async throws {
+        // Test the complete save flow without UI dependencies
+        _ = KanataManager()
+
+        // Create a test directory for configuration
+        let testConfigDir = "/tmp/keypath-test-\(UUID().uuidString)"
+        try FileManager.default.createDirectory(
+            atPath: testConfigDir, withIntermediateDirectories: true
+        )
+
+        defer {
+            try? FileManager.default.removeItem(atPath: testConfigDir)
+        }
+
+        // Test saving a simple configuration
+        // This would normally call manager.saveConfiguration(input:output:)
+        // For now, we test the configuration generation
+        let mapping = KeyMapping(input: "caps", output: "esc")
+        let config = KanataConfiguration.generateFromMappings([mapping])
+
+        XCTAssertTrue(config.contains("caps"))
+        XCTAssertTrue(config.contains("esc"))
+
+        AppLogger.shared.log("✅ [Test] Configuration save flow structure verified")
+    }
+
+    func testMultipleConcurrentSaves() async throws {
+        // Test that multiple concurrent save attempts are handled gracefully
+        _ = KanataManager()
+
+        // Create multiple concurrent save tasks
+        let saveTasks = (1 ... 3).map { taskId in
+            Task {
+                AppLogger.shared.log("🧪 [Test] Starting concurrent save task \(taskId)")
+
+                // In a real test, this would call the debounced save function
+                // For now, we test the configuration generation under concurrent access
+                let mapping = KeyMapping(input: "key\(taskId)", output: "output\(taskId)")
+                let config = KanataConfiguration.generateFromMappings([mapping])
+
+                XCTAssertTrue(config.contains("key\(taskId)"))
+                AppLogger.shared.log("🧪 [Test] Completed concurrent save task \(taskId)")
+            }
+        }
+
+        // Wait for all tasks to complete
+        for task in saveTasks {
+            await task.value
+        }
+
+        AppLogger.shared.log("✅ [Test] Concurrent saves handled successfully")
+    }
+
+    // MARK: - Helper Methods
+
+    private func createTestRecordingSection() -> RecordingSection? {
+        // Create a test RecordingSection with minimal bindings
+        // This tests that the structure can be instantiated
+
+        // Note: SwiftUI view testing requires more complex setup
+        // For Phase 1, we focus on the underlying logic
+
+        nil // Placeholder for now
+    }
+}
+
+// MARK: - Logging and Monitoring Tests
+
+@MainActor
+class Phase1LoggingTests: XCTestCase {
+    func testLoggingCapturesActualOperations() async {
+        // Test that logging captures important operational information
+        _ = await KanataManager()
+
+        // Test that we can generate a config and logging reflects the operation
+        let mapping = KeyMapping(input: "f1", output: "f13")
+        let config = KanataConfiguration.generateFromMappings([mapping])
+
+        // Verify the actual config generation worked (tests business logic)
+        XCTAssertTrue(config.contains("(defsrc f1)"), "Config should contain source key definition")
+        XCTAssertTrue(config.contains("f13"), "Config should contain target key mapping")
+
+        // The logging system should be capturing these operations in real usage
+        AppLogger.shared.log("✅ [Test] Logging captures actual business operations")
+    }
+
+    func testPhase1LoggingPatterns() {
+        // Test that our Phase 1 logging patterns are consistent
+        let testMessages = [
+            "🚀 [Start] Starting Kanata with synchronization lock...",
+            "💾 [Save] ========== SAVE OPERATION START ==========",
+            "🔧 [Conflicts] ========== USER CONFIRMED TERMINATION ==========",
+            "🧪 [Test] Testing logging pattern consistency"
+        ]
+
+        for message in testMessages {
+            // Verify messages can be logged without issues
+            AppLogger.shared.log(message)
+
+            // Verify pattern consistency
+            XCTAssertTrue(message.contains("["), "Log message should contain category marker")
+            XCTAssertTrue(
+                message.hasPrefix("🚀") || message.hasPrefix("💾") || message.hasPrefix("🔧")
+                    || message.hasPrefix("🧪") || message.contains("=========="),
+                "Log message should follow Phase 1 patterns"
+            )
+        }
+
+        AppLogger.shared.log("✅ [Test] Phase 1 logging patterns verified")
+    }
+}

--- a/Tests/KeyPathTests/ProcessLifecycleIntegrationTests.swift
+++ b/Tests/KeyPathTests/ProcessLifecycleIntegrationTests.swift
@@ -1,0 +1,194 @@
+import XCTest
+
+@testable import KeyPath
+
+/// Integration tests for ProcessLifecycleManager - tests the actual system
+/// Updated to work with the simplified ProcessLifecycleManager that uses PID files
+final class ProcessLifecycleIntegrationTests: XCTestCase {
+    var processManager: ProcessLifecycleManager!
+
+    override func setUp() {
+        super.setUp()
+        processManager = ProcessLifecycleManager()
+    }
+
+    override func tearDown() {
+        processManager = nil
+        super.tearDown()
+    }
+
+    // MARK: - Basic Operations Tests
+
+    func testProcessLifecycleManagerBasicOperations() async {
+        // Test the basic operations available in the current ProcessLifecycleManager
+
+        // Test intent setting
+        processManager.setIntent(.shouldBeRunning(source: "test_basic_operations"))
+
+        // Test process registration
+        await processManager.registerStartedProcess(pid: pid_t(1234), command: "test command")
+
+        // Test process unregistration
+        await processManager.unregisterProcess()
+
+        // Test crash recovery
+        await processManager.recoverFromCrash()
+
+        XCTAssertTrue(true, "Basic ProcessLifecycleManager operations should complete without errors")
+    }
+
+    // MARK: - Conflict Detection Tests
+
+    func testConflictDetection() async throws {
+        // Test that conflict detection works with the current ProcessLifecycleManager
+
+        // Set intent to run
+        processManager.setIntent(.shouldBeRunning(source: "test_conflict_detection"))
+
+        // Register a process as started by KeyPath
+        await processManager.registerStartedProcess(pid: pid_t(1234), command: "kanata command")
+
+        // Detect conflicts
+        let conflicts = await processManager.detectConflicts()
+
+        // Should have basic conflict resolution structure
+        XCTAssertNotNil(conflicts.externalProcesses, "Should return external processes array")
+        XCTAssertNotNil(conflicts.canAutoResolve, "Should indicate if conflicts can be auto-resolved")
+    }
+
+    func testProcessTermination() async throws {
+        // Test that ProcessLifecycleManager can handle process termination
+
+        processManager.setIntent(.shouldBeRunning(source: "test_termination"))
+
+        // Test terminating external processes
+        do {
+            try await processManager.terminateExternalProcesses()
+            XCTAssertTrue(true, "Process termination should complete without errors")
+        } catch {
+            // It's okay if this fails in test environment - just testing that the method exists
+            XCTAssertTrue(true, "Process termination method exists and can be called")
+        }
+    }
+
+    func testOrphanedProcessCleanup() async {
+        // Test that ProcessLifecycleManager can clean up orphaned processes
+
+        await processManager.cleanupOrphanedProcesses()
+        XCTAssertTrue(true, "Orphaned process cleanup should complete without errors")
+    }
+
+    // MARK: - Performance Tests
+
+    func testProcessDetectionPerformance() async {
+        // Test that process detection is efficient on the real implementation
+
+        let startTime = CFAbsoluteTimeGetCurrent()
+
+        // Test realistic process operations
+        for testIndex in 0 ..< 100 {
+            processManager.setIntent(.shouldBeRunning(source: "perf_test_\(testIndex)"))
+            await processManager.registerStartedProcess(pid: pid_t(10000 + testIndex), command: "test command")
+            await processManager.unregisterProcess()
+        }
+
+        let endTime = CFAbsoluteTimeGetCurrent()
+        let duration = endTime - startTime
+
+        // Should complete quickly (less than 0.1 seconds for 100 operations)
+        XCTAssertLessThan(duration, 0.1, "Process operations should be efficient")
+    }
+
+    // MARK: - Error Handling Tests
+
+    func testProcessErrorTypes() async {
+        // Test that error types exist and work correctly (migrated to KeyPathError)
+
+        let error = KeyPathError.process(.noManager)
+
+        // Test that we can pattern match on the new error type
+        if case .process(let processError) = error {
+            switch processError {
+            case .noManager:
+                XCTAssertTrue(true, "NoManager error exists")
+            case .startFailed:
+                XCTAssertTrue(true, "StartFailed error exists")
+            case .stopFailed:
+                XCTAssertTrue(true, "StopFailed error exists")
+            case .terminateFailed:
+                XCTAssertTrue(true, "TerminateFailed error exists")
+            default:
+                break
+            }
+        }
+    }
+
+    // MARK: - Thread Safety Tests
+
+    func testConcurrentProcessManagement() async throws {
+        // Test concurrent access to ProcessLifecycleManager (real implementation)
+        let manager = processManager!
+
+        let concurrentTasks = (1 ... 10).map { taskId in
+            Task {
+                // Test concurrent operations on real ProcessLifecycleManager
+                manager.setIntent(.shouldBeRunning(source: "concurrent_\(taskId)"))
+
+                // Test basic operations on ProcessLifecycleManager
+                await manager.registerStartedProcess(pid: pid_t(20000 + taskId), command: "test command")
+
+                await manager.unregisterProcess()
+            }
+        }
+
+        // Wait for all concurrent tasks
+        for task in concurrentTasks {
+            await task.value
+        }
+
+        // Should complete without crashes or data corruption
+        XCTAssertTrue(true, "Concurrent operations completed successfully")
+    }
+
+    // MARK: - Real-World Integration Tests
+
+    func testProcessLifecycleManagerInitialization() async {
+        // Test that ProcessLifecycleManager can be initialized without issues
+
+        let manager = ProcessLifecycleManager()
+
+        // Should be able to set intent
+        manager.setIntent(.shouldBeRunning(source: "initialization_test"))
+
+        // Should be able to recover from crash
+        await manager.recoverFromCrash()
+
+        XCTAssertTrue(true, "ProcessLifecycleManager initializes and operates correctly")
+    }
+
+    func testConflictResolutionStructure() async {
+        // Test conflict resolution returns the expected structure
+
+        let conflicts = await processManager.detectConflicts()
+
+        // Should have expected properties
+        _ = conflicts.externalProcesses
+        _ = conflicts.canAutoResolve
+
+        XCTAssertTrue(true, "ConflictResolution has expected structure")
+    }
+
+    func testIntentReconciliation() async throws {
+        // Test that intent reconciliation works
+
+        processManager.setIntent(.shouldBeRunning(source: "test_intent"))
+
+        do {
+            try await processManager.reconcileWithIntent()
+            XCTAssertTrue(true, "Intent reconciliation should complete")
+        } catch {
+            // It's okay if this fails in test environment - just testing that the method exists
+            XCTAssertTrue(true, "Intent reconciliation method exists and can be called")
+        }
+    }
+}

--- a/Tests/KeyPathTests/WizardTriggeringTests.swift
+++ b/Tests/KeyPathTests/WizardTriggeringTests.swift
@@ -1,0 +1,231 @@
+import XCTest
+
+@testable import KeyPath
+
+/// Tests for wizard triggering scenarios - verifies wizard behavior in the actual system
+/// These tests ensure the wizard is triggered correctly and NOT triggered inappropriately
+@MainActor
+final class WizardTriggeringTests: XCTestCase {
+    // MARK: - Wizard State Validation
+
+    func testWizardStateConsistency() async {
+        // Test wizard state is consistent across different KanataManager instances
+
+        let kanataManager1 = KanataManager()
+        // Consolidated: simpleManager is now just kanataManager
+
+        let kanataManager2 = KanataManager()
+        // Consolidated: simpleManager is now just kanataManager
+
+        // Both should start with consistent state
+        XCTAssertEqual(
+            kanataManager1.currentState, .starting, "Manager 1 should start in starting state"
+        )
+        XCTAssertEqual(
+            kanataManager2.currentState, .starting, "Manager 2 should start in starting state"
+        )
+
+        XCTAssertFalse(kanataManager1.showWizard, "Manager 1 should not show wizard initially")
+        XCTAssertFalse(kanataManager2.showWizard, "Manager 2 should not show wizard initially")
+    }
+
+    func testWizardCallbacksExist() async {
+        // Test that all expected wizard callback methods exist
+
+        let kanataManager = KanataManager()
+        // Consolidated: simpleManager is now just kanataManager
+
+        // Should have wizard callback methods
+        await kanataManager.onWizardClosed()
+        await kanataManager.retryAfterFix("Test feedback")
+
+        XCTAssertTrue(true, "All wizard callback methods exist and are callable")
+    }
+
+    // MARK: - State Transition Validation
+
+    func testStateTransitionIntegrity() async {
+        // Test that state transitions maintain integrity in the real system
+
+        let kanataManager = KanataManager()
+        // Consolidated: simpleManager is now just kanataManager
+
+        // Initial state
+        let initialState = kanataManager.currentState
+        XCTAssertEqual(initialState, .starting, "Should start in starting state")
+
+        // Attempt auto-launch (will likely fail in test environment, but should transition properly)
+        await kanataManager.startAutoLaunch()
+
+        // Should be in a valid end state
+        let finalState = kanataManager.currentState
+        let validEndStates: [SimpleKanataState] = [.running, .needsHelp]
+        XCTAssertTrue(
+            validEndStates.contains(finalState),
+            "Should transition to either running or needsHelp, got: \(finalState)"
+        )
+    }
+
+    func testManualStateChanges() async {
+        // Test manual start/stop operations
+
+        let kanataManager = KanataManager()
+        // Consolidated: simpleManager is now just kanataManager
+
+        // Test manual operations don't throw
+        await kanataManager.manualStart()
+        await kanataManager.manualStop()
+
+        // Should complete without errors
+        XCTAssertTrue(true, "Manual state changes completed")
+    }
+
+    // MARK: - Error Handling Validation
+
+    func testErrorStateProperties() async {
+        // Test that error states have proper properties
+
+        let kanataManager = KanataManager()
+        // Consolidated: simpleManager is now just kanataManager
+
+        // Try to trigger an error state (auto-launch will likely fail in test environment)
+        await kanataManager.startAutoLaunch()
+
+        // Check error handling properties exist and are accessible
+        let errorReason = kanataManager.errorReason
+        let showWizard = kanataManager.showWizard
+        let currentState = kanataManager.currentState
+
+        // If in needsHelp state, should have consistent error properties
+        if currentState == .needsHelp {
+            XCTAssertTrue(showWizard, "Should show wizard when in needsHelp state")
+            // Error reason may or may not be present depending on the specific failure
+        }
+
+        // These properties should always be accessible
+        XCTAssertTrue(
+            errorReason == nil || !errorReason!.isEmpty, "Error reason should be nil or non-empty"
+        )
+        XCTAssertTrue(showWizard == true || showWizard == false, "ShowWizard should be boolean")
+    }
+
+    // MARK: - Integration with Real Components
+
+    func testIntegrationWithKanataManager() async {
+        // Test integration with actual KanataManager
+
+        let kanataManager = KanataManager()
+        // Consolidated: simpleManager is now just kanataManager
+
+        // Test that KanataManager properly integrates with KanataManager
+        await kanataManager.forceRefreshStatus()
+
+        // Should complete integration without throwing
+        XCTAssertTrue(true, "Integration with KanataManager successful")
+    }
+
+    func testRetryMechanismIntegration() async {
+        // Test the retry mechanism with real system
+
+        let kanataManager = KanataManager()
+        // Consolidated: simpleManager is now just kanataManager
+
+        // Test retry scenarios
+        await kanataManager.retryAfterFix("Fixed permissions")
+        await kanataManager.onWizardClosed()
+
+        // Should handle retry scenarios gracefully
+        XCTAssertTrue(true, "Retry mechanisms work with real system")
+    }
+
+    // MARK: - Timer Consolidation Validation
+
+    func testStatusRefreshConsolidation() async {
+        // Test that multiple status refreshes don't cause conflicts
+        // This validates the timer consolidation solution
+
+        let kanataManager = KanataManager()
+        // Consolidated: simpleManager is now just kanataManager
+
+        // Multiple rapid refreshes (this previously caused timer conflicts)
+        for _ in 0 ..< 10 {
+            await kanataManager.forceRefreshStatus()
+        }
+
+        // Should handle multiple refreshes without issues
+        XCTAssertTrue(true, "Multiple status refreshes handled gracefully")
+    }
+
+    func testConcurrentUIOperations() async {
+        // Test concurrent UI operations don't interfere
+
+        let kanataManager = KanataManager()
+        // Consolidated: simpleManager is now just kanataManager
+
+        // Simulate concurrent operations from multiple UI components
+        let concurrentTasks = (1 ... 5).map { _ in
+            Task {
+                await kanataManager.forceRefreshStatus()
+            }
+        }
+
+        // Wait for all concurrent tasks
+        for task in concurrentTasks {
+            await task.value
+        }
+
+        // Should handle concurrent operations without conflicts
+        XCTAssertTrue(true, "Concurrent UI operations handled successfully")
+    }
+
+    // MARK: - Real System Validation
+
+    func testRealSystemPermissionChecks() async {
+        // Test permission-related wizard behavior on real system
+
+        let kanataManager = KanataManager()
+        // Consolidated: simpleManager is now just kanataManager
+
+        // Test permission checking integration
+        await kanataManager.startAutoLaunch()
+
+        // If the system lacks permissions, should be in needsHelp state
+        let finalState = kanataManager.currentState
+        if finalState == .needsHelp {
+            XCTAssertTrue(kanataManager.showWizard, "Should show wizard for permission issues")
+
+            if let errorReason = kanataManager.errorReason {
+                // Error should be informative
+                XCTAssertFalse(errorReason.isEmpty, "Error reason should be informative")
+            }
+        }
+
+        XCTAssertTrue(true, "Permission checking integration validated")
+    }
+
+    func testSystemHealthMonitoring() async {
+        // Test system health monitoring behavior
+
+        let kanataManager = KanataManager()
+        // Consolidated: simpleManager is now just kanataManager
+
+        // Test health monitoring properties are accessible
+        let lastHealthCheck = kanataManager.lastHealthCheck
+        let autoStartAttempts = kanataManager.autoStartAttempts
+        let retryCount = kanataManager.retryCount
+        let isRetryingAfterFix = kanataManager.isRetryingAfterFix
+
+        // These should be accessible and have reasonable values
+        XCTAssertTrue(autoStartAttempts >= 0, "Auto start attempts should be non-negative")
+        XCTAssertTrue(retryCount >= 0, "Retry count should be non-negative")
+        XCTAssertTrue(
+            isRetryingAfterFix == true || isRetryingAfterFix == false,
+            "IsRetryingAfterFix should be boolean"
+        )
+
+        // lastHealthCheck can be nil initially
+        if let healthCheck = lastHealthCheck {
+            XCTAssertTrue(healthCheck <= Date(), "Health check time should not be in the future")
+        }
+    }
+}


### PR DESCRIPTION
Revert direct commit 5e6f0d6 to restore tests. A follow-up PR will re-introduce the orderedPages sweep without deleting tests.