### PR TITLE
refactor(config): start adopting ConfigurationManager in KanataManager (safe subset)

### DIFF
--- a/Sources/KeyPath/Managers/KanataManager+Configuration.swift
+++ b/Sources/KeyPath/Managers/KanataManager+Configuration.swift
@@ -10,7 +10,7 @@ extension KanataManager {
 
     func createInitialConfigIfNeeded() async {
         do {
-            try await configurationService.createInitialConfigIfNeeded()
+            try await configurationManager.createInitialConfigIfNeeded()
         } catch {
             AppLogger.shared.log("❌ [Config] Failed to create initial config via ConfigurationService: \(error)")
         }
@@ -41,7 +41,7 @@ extension KanataManager {
         let commConfig = PreferencesService.communicationSnapshot()
         if commConfig.shouldUseTCP, isRunning {
             AppLogger.shared.log("📡 [Validation] Attempting TCP validation")
-            if let tcpResult = await configurationService.validateConfigViaTCP() {
+            if let tcpResult = await configurationManager.validateTCP() {
                 return tcpResult
             } else {
                 AppLogger.shared.log(
@@ -51,7 +51,7 @@ extension KanataManager {
 
         // Fallback to traditional file-based validation
         AppLogger.shared.log("📄 [Validation] Using file-based validation")
-        return configurationService.validateConfigViaFile()
+        return configurationManager.validateFile()
     }
 
     // MARK: - Hot Reload via TCP

--- a/Sources/KeyPath/Managers/KanataManager.swift
+++ b/Sources/KeyPath/Managers/KanataManager.swift
@@ -213,6 +213,7 @@ class KanataManager {
     // MARK: - Service Dependencies (Milestone 4)
 
     let configurationService: ConfigurationService
+    let configurationManager: ConfigurationManager
     private let healthMonitor: ServiceHealthMonitorProtocol
     private nonisolated let diagnosticsService: DiagnosticsServiceProtocol
     private let karabinerConflictService: KarabinerConflictManaging
@@ -266,6 +267,7 @@ class KanataManager {
 
         // Initialize service dependencies
         configurationService = ConfigurationService(configDirectory: "\(NSHomeDirectory())/.config/keypath")
+        configurationManager = ConfigurationManager(service: configurationService)
 
         // Initialize process lifecycle manager and façade service
         processLifecycleManager = ProcessLifecycleManager(kanataManager: nil)
@@ -1362,9 +1364,9 @@ class KanataManager {
             // Backup current config before making changes
             await backupCurrentConfig()
 
-            // Delegate to ConfigurationService for saving
-            try await configurationService.saveConfiguration(keyMappings: keyMappings)
-            AppLogger.shared.log("💾 [Config] Config saved with \(keyMappings.count) mappings via ConfigurationService")
+            // Delegate to ConfigurationManager for saving (thin wrapper over ConfigurationService)
+            try await configurationManager.save(keyMappings: keyMappings)
+            AppLogger.shared.log("💾 [Config] Config saved with \(keyMappings.count) mappings via ConfigurationManager")
 
             // Play tink sound asynchronously to avoid blocking save pipeline
             Task { @MainActor in SoundManager.shared.playTinkSound() }


### PR DESCRIPTION
## Purpose
Begin minimal, safe migration from `ConfigurationService` call sites to the thin `ConfigurationManager` wrapper, per Phase 2 plan. This keeps diffs small while preparing for `KanataCoordinator` wiring.

## Changes
- Add `configurationManager` property in `KanataManager`, constructed from the existing `configurationService` to preserve behavior and observers.
- Switch selected calls to wrapper:
  - `createInitialConfigIfNeeded()`
  - `validateConfigFile()` (TCP + file validation paths)
  - `saveConfiguration(input:output:)` when persisting mappings

## Why
Reduces direct coupling to the large `ConfigurationService` while retaining its implementation. The wrapper offers a stable seam for coordinator orchestration and future refactors.

## Testing
- `./run-core-tests.sh` — all enabled tests pass locally.
- `swift build` (debug) — OK.

## Notes
- No behavior changes; purely indirection.
- Follow-up PRs can migrate a few more call sites incrementally.