### PR TITLE
refactor(config): adopt ConfigurationManager for backup/repair flows

### DIFF
--- a/Sources/KeyPath/Managers/KanataManager.swift
+++ b/Sources/KeyPath/Managers/KanataManager.swift
@@ -2124,7 +2124,7 @@ class KanataManager {
     private func parseKanataConfig(_ configContent: String) -> [KeyMapping] {
         // Delegate to ConfigurationService for parsing
         do {
-            let config = try configurationService.parseConfigurationFromString(configContent)
+        let config = try configurationService.parseConfigurationFromString(configContent)
             return config.keyMappings
         } catch {
             AppLogger.shared.log("⚠️ [Parse] Failed to parse config: \(error)")
@@ -2452,7 +2452,7 @@ class KanataManager {
         async throws -> String
     {
         // Delegate to ConfigurationService for rule-based repair
-        return try await configurationService.repairConfiguration(config: config, errors: errors, mappings: mappings)
+        return try await configurationManager.repair(config: config, errors: errors, mappings: mappings)
     }
 
     /// Saves a validated config to disk
@@ -2553,7 +2553,7 @@ class KanataManager {
         -> String
     {
         // Delegate to ConfigurationService for backup and safe config application
-        let backupPath = try await configurationService.backupFailedConfigAndApplySafe(
+        let backupPath = try await configurationManager.backupFailedAndApplySafe(
             failedConfig: failedConfig,
             mappings: mappings
         )


### PR DESCRIPTION
## Purpose
Continue safe adoption of the ConfigurationManager wrapper by moving backup/repair call sites off ConfigurationService.

## Changes
- KanataManager: use `ConfigurationManager.backupFailedAndApplySafe` and `ConfigurationManager.repair`.
- Leaves parse and low-level validation as-is for now to keep the diff small.

## Testing
- `./run-core-tests.sh` passes locally.

## Notes
- No behavior change intended; thin indirection only.