### PR TITLE
refactor(managers): split KanataManager into focused extensions (no behavior change)

### DIFF
--- a/Sources/KeyPath/Managers/KanataManager+Arguments.swift
+++ b/Sources/KeyPath/Managers/KanataManager+Arguments.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+@MainActor
+extension KanataManager {
+    // MARK: - Kanata Arguments Builder
+
+    /// Builds Kanata command line arguments including TCP port when enabled
+    func buildKanataArguments(configPath: String, checkOnly: Bool = false) -> [String] {
+        var arguments = ["--cfg", configPath]
+
+        // Add TCP communication arguments if enabled
+        let commConfig = PreferencesService.communicationSnapshot()
+        if commConfig.shouldUseTCP {
+            arguments.append(contentsOf: commConfig.communicationLaunchArguments)
+            AppLogger.shared.log("📡 [KanataArgs] TCP server enabled on port \(commConfig.tcpPort)")
+        } else {
+            AppLogger.shared.log("📡 [KanataArgs] TCP server disabled")
+        }
+
+        if checkOnly {
+            arguments.append("--check")
+        } else {
+            // Note: --watch removed - we use TCP reload commands for config changes
+            arguments.append("--debug")
+            arguments.append("--log-layer-changes")
+        }
+
+        AppLogger.shared.log("🔧 [KanataArgs] Built arguments: \(arguments.joined(separator: " "))")
+        return arguments
+    }
+}
+

--- a/Sources/KeyPath/Managers/KanataManager+Claude.swift
+++ b/Sources/KeyPath/Managers/KanataManager+Claude.swift
@@ -1,0 +1,84 @@
+import Foundation
+
+@MainActor
+extension KanataManager {
+    // MARK: - Claude API Integration
+
+    /// Call Claude API to repair configuration
+    private func callClaudeAPI(prompt: String) async throws -> String {
+        // Check for API key in environment or keychain
+        guard let apiKey = getClaudeAPIKey() else {
+            throw NSError(domain: "ClaudeAPI", code: 1, userInfo: [NSLocalizedDescriptionKey: "Claude API key not found. Set ANTHROPIC_API_KEY environment variable or store in Keychain."])
+        }
+
+        let url = URL(string: "https://api.anthropic.com/v1/messages")!
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.addValue(apiKey, forHTTPHeaderField: "x-api-key")
+        request.addValue("2023-06-01", forHTTPHeaderField: "anthropic-version")
+
+        let requestBody: [String: Any] = [
+            "model": "claude-3-5-sonnet-20241022",
+            "max_tokens": 4096,
+            "messages": [
+                [
+                    "role": "user",
+                    "content": prompt
+                ]
+            ]
+        ]
+
+        request.httpBody = try JSONSerialization.data(withJSONObject: requestBody)
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw NSError(domain: "ClaudeAPI", code: 2, userInfo: [NSLocalizedDescriptionKey: "Invalid response"])
+        }
+
+        guard 200 ... 299 ~= httpResponse.statusCode else {
+            let errorMessage = String(data: data, encoding: .utf8) ?? "Unknown error"
+            throw NSError(domain: "ClaudeAPI", code: httpResponse.statusCode, userInfo: [NSLocalizedDescriptionKey: "API request failed (\(httpResponse.statusCode)): \(errorMessage)"])
+        }
+
+        guard let jsonResponse = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let content = jsonResponse["content"] as? [[String: Any]],
+              let firstContent = content.first,
+              let text = firstContent["text"] as? String
+        else {
+            throw NSError(domain: "ClaudeAPI", code: 3, userInfo: [NSLocalizedDescriptionKey: "Failed to parse Claude API response"])
+        }
+
+        return text.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    /// Get Claude API key from environment variable or keychain
+    func getClaudeAPIKey() -> String? {
+        // First try environment variable
+        if let envKey = ProcessInfo.processInfo.environment["ANTHROPIC_API_KEY"], !envKey.isEmpty {
+            return envKey
+        }
+
+        // Try keychain (using the same pattern as other keychain access in the app)
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: "KeyPath",
+            kSecAttrAccount as String: "claude-api-key",
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+
+        var dataTypeRef: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &dataTypeRef)
+
+        guard status == errSecSuccess,
+              let data = dataTypeRef as? Data,
+              let key = String(data: data, encoding: .utf8)
+        else {
+            return nil
+        }
+
+        return key
+    }
+}

--- a/Sources/KeyPath/Managers/KanataManager+Diagnostics.swift
+++ b/Sources/KeyPath/Managers/KanataManager+Diagnostics.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+@MainActor
+extension KanataManager {
+    // MARK: - Diagnostics
+
+    func addDiagnostic(_ diagnostic: KanataDiagnostic) {
+        diagnostics.append(diagnostic)
+        AppLogger.shared.log(
+            "\(diagnostic.severity.emoji) [Diagnostic] \(diagnostic.title): \(diagnostic.description)")
+
+        // Keep only last 50 diagnostics to prevent memory bloat
+        if diagnostics.count > 50 {
+            diagnostics.removeFirst(diagnostics.count - 50)
+        }
+    }
+}
+

--- a/Sources/KeyPath/Managers/KanataManager+FileWatcher.swift
+++ b/Sources/KeyPath/Managers/KanataManager+FileWatcher.swift
@@ -1,0 +1,84 @@
+import Foundation
+import SwiftUI
+
+@MainActor
+extension KanataManager {
+    // MARK: - Configuration File Watching
+
+    /// Start watching the configuration file for external changes
+    func startConfigFileWatching() {
+        guard let fileWatcher = self.configFileWatcher else {
+            AppLogger.shared.log("⚠️ [FileWatcher] ConfigFileWatcher not initialized")
+            return
+        }
+
+        let configPath = configPath
+        AppLogger.shared.log("📁 [FileWatcher] Starting to watch config file: \(configPath)")
+
+        fileWatcher.startWatching(path: configPath) { [weak self] in
+            await self?.handleExternalConfigChange()
+        }
+    }
+
+    /// Stop watching the configuration file
+    func stopConfigFileWatching() {
+        self.configFileWatcher?.stopWatching()
+        AppLogger.shared.log("📁 [FileWatcher] Stopped watching config file")
+    }
+
+    /// Handle external configuration file changes
+    func handleExternalConfigChange() async {
+        AppLogger.shared.log("📝 [FileWatcher] External config file change detected")
+
+        // Play the initial sound to indicate detection
+        Task { @MainActor in SoundManager.shared.playTinkSound() }
+
+        // Show initial status message
+        await MainActor.run {
+            saveStatus = .saving
+        }
+
+        // Read the updated configuration
+        let configPath = configPath
+        guard FileManager.default.fileExists(atPath: configPath) else {
+            AppLogger.shared.log("❌ [FileWatcher] Config file no longer exists: \(configPath)")
+            Task { @MainActor in SoundManager.shared.playErrorSound() }
+            await MainActor.run {
+                saveStatus = .failed("Config file was deleted")
+            }
+            return
+        }
+
+        do {
+            let currentConfig = try String(contentsOfFile: configPath, encoding: .utf8)
+            AppLogger.shared.log("📝 [FileWatcher] Read updated config: \(currentConfig.count) chars")
+
+            // Parse + validate via existing flow
+            let validation = await validateConfigFile()
+            if !validation.isValid {
+                AppLogger.shared.log("❌ [FileWatcher] Updated config is invalid: \(validation.errors.joined(separator: ", "))")
+                Task { @MainActor in SoundManager.shared.playErrorSound() }
+                await MainActor.run {
+                    saveStatus = .failed(validation.errors.first ?? "Invalid configuration")
+                }
+                return
+            }
+
+            // Trigger reload (best-effort)
+            let reloadResult = await triggerTCPReload()
+            if reloadResult.isSuccess {
+                AppLogger.shared.log("✅ [FileWatcher] Reloaded config after external change")
+                Task { @MainActor in SoundManager.shared.playTinkSound() }
+                await MainActor.run { saveStatus = .success }
+            } else {
+                AppLogger.shared.log("⚠️ [FileWatcher] Failed to hot-reload after external change: \(reloadResult.errorMessage ?? "Unknown error")")
+                Task { @MainActor in SoundManager.shared.playErrorSound() }
+                await MainActor.run { saveStatus = .failed("Hot reload failed") }
+            }
+        } catch {
+            AppLogger.shared.log("❌ [FileWatcher] Failed to read updated config: \(error)")
+            Task { @MainActor in SoundManager.shared.playErrorSound() }
+            await MainActor.run { saveStatus = .failed("Failed to read updated config") }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Split `KanataManager.swift` into small, focused extensions to reduce file size and improve readability, without changing behavior.

## Changes
- Added:
  - `KanataManager+FileWatcher.swift` — start/stop file watching + external change handling
  - `KanataManager+Diagnostics.swift` — diagnostic helper
  - `KanataManager+Arguments.swift` — Kanata argument builder
  - `KanataManager+Claude.swift` — Claude API helpers
- Left minimal stubs/renamed originals in main file to avoid redeclaration and to ease diffs.
- Adjusted access levels (`configFileWatcher`, `getClaudeAPIKey`) for cross-file extensions.

## Why
Moves cohesive chunks out of the 2.7k‑line file toward the <700 LOC goal, enabling incremental refactors with low risk.

## Tests
- `./run-core-tests.sh` — all enabled tests pass locally (warnings unchanged).