### PR TITLE
Config Apply Pipeline: integrate atomic write via ConfigurationManager + diagnostics timings

### DIFF
--- a/Sources/KeyPath/Models/ConfigApplyTypes.swift
+++ b/Sources/KeyPath/Models/ConfigApplyTypes.swift
@@ -45,19 +45,28 @@ public struct ConfigDiagnostics: Equatable, Sendable {
     public let mappingCountAfter: Int?
     public let validationOutput: String?
     public let timestamp: Date
+    public let preValidationMs: Double?
+    public let postValidationMs: Double?
+    public let readinessWaitMs: Double?
 
     public init(configPathBefore: String? = nil,
                 configPathAfter: String? = nil,
                 mappingCountBefore: Int? = nil,
                 mappingCountAfter: Int? = nil,
                 validationOutput: String? = nil,
-                timestamp: Date = Date()) {
+                timestamp: Date = Date(),
+                preValidationMs: Double? = nil,
+                postValidationMs: Double? = nil,
+                readinessWaitMs: Double? = nil) {
         self.configPathBefore = configPathBefore
         self.configPathAfter = configPathAfter
         self.mappingCountBefore = mappingCountBefore
         self.mappingCountAfter = mappingCountAfter
         self.validationOutput = validationOutput
         self.timestamp = timestamp
+        self.preValidationMs = preValidationMs
+        self.postValidationMs = postValidationMs
+        self.readinessWaitMs = readinessWaitMs
     }
 }
 


### PR DESCRIPTION
This PR wires the actor to use the existing ConfigurationManager and expands diagnostics:

- Pipeline now calls `ConfigurationManager.writeConfigAtomically(_:)` (no duplication).
- Keeps inline atomic replace only as a fallback when manager is unavailable.
- Extends `ConfigDiagnostics` with timing fields: `preValidationMs`, `postValidationMs`, `readinessWaitMs`.
- Uses manager for pre-validation when available; otherwise skips (unchanged behavior path).

Still gated by `FeatureFlags.useConfigApplyPipeline` (default OFF).
