### PR TITLE
Add guardrail test for WizardAutoFixer façade

### DIFF
--- a/Tests/KeyPathTests/InstallationWizard/WizardAutoFixerFacadeTests.swift
+++ b/Tests/KeyPathTests/InstallationWizard/WizardAutoFixerFacadeTests.swift
@@ -1,0 +1,32 @@
+import XCTest
+@testable import KeyPathAppKit
+import KeyPathWizardCore
+import KeyPathCore
+
+@MainActor
+final class WizardAutoFixerFacadeTests: XCTestCase {
+    func testPerformAutoFixDelegatesToInstallerEngine() async {
+        let mockEngine = MockInstallerEngine()
+        let fixer = WizardAutoFixer(
+            kanataManager: RuntimeCoordinator(),
+            installerEngine: mockEngine
+        )
+
+        let success = await fixer.performAutoFix(.installBundledKanata)
+
+        XCTAssertTrue(success)
+        XCTAssertEqual(mockEngine.actions, [.installBundledKanata])
+    }
+}
+
+// MARK: - Test Doubles
+
+@MainActor
+private final class MockInstallerEngine: WizardInstallerEngineProtocol {
+    private(set) var actions: [AutoFixAction] = []
+
+    func runSingleAction(_ action: AutoFixAction, using _: PrivilegeBroker) async -> InstallerReport {
+        actions.append(action)
+        return InstallerReport(success: true, failureReason: nil, executedRecipes: [], logs: [])
+    }
+}


### PR DESCRIPTION
Fixes #47.

- Route WizardAutoFixer auto-fix dispatch through InstallerEngine via a single runSingleAction hook.
- Add MockInstallerEngine-based test to assert delegation to façade.

Test: swift test --filter WizardAutoFixerFacadeTests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Routes WizardAutoFixer auto-fix actions through InstallerEngine and adds a test verifying the delegation.
> 
> - **Core (WizardAutoFixer.swift)**:
>   - Introduces `WizardInstallerEngineProtocol` and injects it into `WizardAutoFixer` (defaulting to `InstallerEngine`).
>   - `performAutoFix` now delegates all `AutoFixAction` handling to `installerEngine.runSingleAction(...)` via a façade.
>   - Keeps `AutoFixCapable` conformance via an extension.
> - **Tests**:
>   - Adds `WizardAutoFixerFacadeTests` using `MockInstallerEngine` to assert delegation and success path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f5667b8f332646fe8c915e4fa5513b199851d886. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->