### PR TITLE
refactor: Remove all AnyView usage for better SwiftUI diffing

### DIFF
--- a/Sources/KeyPathAppKit/InstallationWizard/UI/WizardDesignSystem.swift
+++ b/Sources/KeyPathAppKit/InstallationWizard/UI/WizardDesignSystem.swift
@@ -463,7 +463,6 @@ enum WizardDesign {
             let subtitle: String
             let status: HeroStatus
             let actionLinks: [ActionLink]?
-            let contentCard: (() -> AnyView)?
 
             enum HeroStatus {
                 case success(Color = WizardDesign.Colors.success)
@@ -500,15 +499,13 @@ enum WizardDesign {
                 title: String,
                 subtitle: String,
                 status: HeroStatus,
-                actionLinks: [ActionLink]? = nil,
-                contentCard: (() -> AnyView)? = nil
+                actionLinks: [ActionLink]? = nil
             ) {
                 self.icon = icon
                 self.title = title
                 self.subtitle = subtitle
                 self.status = status
                 self.actionLinks = actionLinks
-                self.contentCard = contentCard
             }
 
             var body: some View {
@@ -559,11 +556,6 @@ enum WizardDesign {
                             .padding(.top, WizardDesign.Spacing.elementGap)
                         }
 
-                        // Optional content card
-                        if let contentCard {
-                            contentCard()
-                                .padding(.top, WizardDesign.Spacing.sectionGap)
-                        }
                     }
                     .padding(.vertical, WizardDesign.Spacing.pageVertical)
 

--- a/Sources/KeyPathAppKit/InstallationWizard/UI/WizardWindowController.swift
+++ b/Sources/KeyPathAppKit/InstallationWizard/UI/WizardWindowController.swift
@@ -15,7 +15,7 @@ final class WizardWindowController {
     static let shared = WizardWindowController()
 
     private var window: NSWindow?
-    private var hostingView: NSHostingView<AnyView>?
+    private var hostingView: NSView?
     private var windowDelegate: WizardWindowDelegate?
     private var onDismiss: (() -> Void)?
     private var sizeObserver: NSObjectProtocol?
@@ -43,21 +43,18 @@ final class WizardWindowController {
         let wizardView = InstallationWizardView(initialPage: initialPage)
 
         // Create hosting view - let SwiftUI determine ideal height
-        let hosting: NSHostingView<AnyView> = if let viewModel = kanataViewModel {
-            NSHostingView(rootView:
-                AnyView(
-                    wizardView
-                        .environment(viewModel)
-                        .frame(width: 700)
-                        .fixedSize(horizontal: false, vertical: true)
-                ))
+        let styledView = wizardView
+            .frame(width: 700)
+            .fixedSize(horizontal: false, vertical: true)
+
+        let hosting: NSView
+        if let viewModel = kanataViewModel {
+            hosting = NSHostingView(rootView:
+                styledView
+                    .environment(viewModel)
+            )
         } else {
-            NSHostingView(rootView:
-                AnyView(
-                    wizardView
-                        .frame(width: 700)
-                        .fixedSize(horizontal: false, vertical: true)
-                ))
+            hosting = NSHostingView(rootView: styledView)
         }
 
         let window = NSWindow(

--- a/Sources/KeyPathAppKit/UI/Overlay/LiveKeyboardOverlayController.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/LiveKeyboardOverlayController.swift
@@ -26,7 +26,7 @@ final class LiveKeyboardOverlayController: NSObject, NSWindowDelegate {
     var resizeStartFrame: NSRect = .zero
     var inspectorDebugLastLog: CFTimeInterval = 0
     private var healthObserver: OverlayHealthIndicatorObserver?
-    private weak var hostingView: NSHostingView<AnyView>?
+    private weak var hostingView: NSHostingView<LiveKeyboardOverlayView>?
     private let frameStore = OverlayWindowFrameStore()
     var hintWindowController: HideHintWindowController?
     var hintBubbleObserver: Task<Void, Never>?
@@ -1249,8 +1249,8 @@ final class LiveKeyboardOverlayController: NSObject, NSWindowDelegate {
         observeKeyboardAspectRatio()
     }
 
-    private func buildRootView() -> AnyView {
-        let contentView = LiveKeyboardOverlayView(
+    private func buildRootView() -> LiveKeyboardOverlayView {
+        LiveKeyboardOverlayView(
             viewModel: viewModel,
             uiState: uiState,
             inspectorWidth: inspectorPanelWidth,
@@ -1273,8 +1273,6 @@ final class LiveKeyboardOverlayController: NSObject, NSWindowDelegate {
                 self?.handleHealthIndicatorTap()
             }
         )
-
-        return AnyView(contentView)
     }
 
     private func refreshOverlayContent() {

--- a/Sources/KeyPathAppKit/UI/Overlay/LiveKeyboardOverlayView.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/LiveKeyboardOverlayView.swift
@@ -926,9 +926,8 @@ extension LiveKeyboardOverlayView {
         onHealthTap: @escaping () -> Void,
         onKeySelected: @escaping (UInt16?) -> Void,
         onRuleHover: @escaping (String?) -> Void
-    ) -> AnyView {
-        AnyView(
-            OverlayInspectorPanel(
+    ) -> some View {
+        OverlayInspectorPanel(
                 selectedSection: inspectorSection,
                 onSelectSection: { selectInspectorSection($0) },
                 fadeAmount: fadeAmount,
@@ -968,7 +967,6 @@ extension LiveKeyboardOverlayView {
                 onRuleHover: onRuleHover
             )
             .frame(width: inspectorTotalWidth, alignment: .trailing)
-        )
     }
 
     private func moveKeyboardWindow(deltaX: CGFloat, deltaY: CGFloat) {

--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayMapperSection+ShiftOutput.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayMapperSection+ShiftOutput.swift
@@ -42,8 +42,8 @@ extension OverlayMapperSection {
                     subtitle: shiftVariantSummary,
                     mode: .shifted,
                     accessibilityIdentifier: "overlay-mapper-shift-mode-shifted",
-                    trailingAction: viewModel.hasShiftedOutputConfigured
-                        ? AnyView(
+                    trailingAction: {
+                        if viewModel.hasShiftedOutputConfigured {
                             Button("Remove") {
                                 removeShiftVariant()
                             }
@@ -51,8 +51,8 @@ extension OverlayMapperSection {
                             .font(.caption2)
                             .foregroundStyle(.secondary)
                             .accessibilityIdentifier("overlay-mapper-shift-remove")
-                        )
-                        : nil
+                        }
+                    }
                 )
 
                 if selectedTapOutputMode == .shifted {
@@ -136,12 +136,12 @@ extension OverlayMapperSection {
             .accessibilityHidden(true)
     }
 
-    private func tapOutputModeRow(
+    private func tapOutputModeRow<TrailingAction: View>(
         title: String,
         subtitle: String,
         mode: TapOutputMode,
         accessibilityIdentifier: String,
-        trailingAction: AnyView? = nil
+        @ViewBuilder trailingAction: () -> TrailingAction = { EmptyView() }
     ) -> some View {
         let isSelected = selectedTapOutputMode == mode
         return Button {
@@ -161,9 +161,7 @@ extension OverlayMapperSection {
 
                 Spacer(minLength: 8)
 
-                if let trailingAction {
-                    trailingAction
-                }
+                trailingAction()
 
                 Image(systemName: isSelected ? "record.circle.fill" : "chevron.right")
                     .font(.caption.weight(.semibold))

--- a/Sources/KeyPathAppKit/UI/Rules/HomeRowKeyboardView.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/HomeRowKeyboardView.swift
@@ -4,14 +4,14 @@ import SwiftUI
 #endif
 
 /// Visual keyboard representation for home row mods
-struct HomeRowKeyboardView: View {
+struct HomeRowKeyboardView<PopoverContent: View>: View {
     let enabledKeys: Set<String>
     let modifierAssignments: [String: String]
     let holdMode: HomeRowHoldMode
     let selectedKey: String?
     let keyDisplayLabels: [String: String]
     let helperText: String
-    let keyPopoverContent: ((String) -> AnyView)?
+    let keyPopoverContent: ((String) -> PopoverContent)?
     let onPopoverDismiss: (() -> Void)?
     let onKeySelected: (String) -> Void
     let keyChipSize: CGFloat
@@ -56,7 +56,7 @@ struct HomeRowKeyboardView: View {
         keyDisplayLabels: [String: String] = [:],
         helperText: String = "Tap for letter, hold for modifier",
         keyChipSize: CGFloat = 78,
-        keyPopoverContent: ((String) -> AnyView)? = nil,
+        keyPopoverContent: ((String) -> PopoverContent)? = nil,
         onPopoverDismiss: (() -> Void)? = nil,
         onKeySelected: @escaping (String) -> Void
     ) {
@@ -190,6 +190,31 @@ struct HomeRowKeyboardView: View {
                 }
             }
         )
+    }
+}
+
+extension HomeRowKeyboardView where PopoverContent == EmptyView {
+    init(
+        enabledKeys: Set<String>,
+        modifierAssignments: [String: String],
+        holdMode: HomeRowHoldMode = .modifiers,
+        selectedKey: String?,
+        keyDisplayLabels: [String: String] = [:],
+        helperText: String = "Tap for letter, hold for modifier",
+        keyChipSize: CGFloat = 78,
+        onPopoverDismiss: (() -> Void)? = nil,
+        onKeySelected: @escaping (String) -> Void
+    ) {
+        self.enabledKeys = enabledKeys
+        self.modifierAssignments = modifierAssignments
+        self.holdMode = holdMode
+        self.selectedKey = selectedKey
+        self.keyDisplayLabels = keyDisplayLabels
+        self.helperText = helperText
+        self.keyChipSize = keyChipSize
+        self.keyPopoverContent = nil
+        self.onPopoverDismiss = onPopoverDismiss
+        self.onKeySelected = onKeySelected
     }
 }
 

--- a/Sources/KeyPathAppKit/UI/Rules/HomeRowModsCollectionView.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/HomeRowModsCollectionView.swift
@@ -135,17 +135,15 @@ struct HomeRowModsCollectionView: View {
             helperText: config.holdMode == .modifiers ? "Tap for letter, hold for modifier" : "Tap for letter, hold for layer",
             keyChipSize: size,
             keyPopoverContent: { key in
-                AnyView(
-                    Group {
-                        if !config.enabledKeys.contains(key) {
-                            enableKeyPopoverContent(for: key)
-                        } else if config.holdMode == .layers {
-                            layerPopoverContent(for: key)
-                        } else {
-                            modifierPopoverContent(for: key)
-                        }
+                Group {
+                    if !config.enabledKeys.contains(key) {
+                        enableKeyPopoverContent(for: key)
+                    } else if config.holdMode == .layers {
+                        layerPopoverContent(for: key)
+                    } else {
+                        modifierPopoverContent(for: key)
                     }
-                )
+                }
             },
             onPopoverDismiss: {
                 selectedKey = nil


### PR DESCRIPTION
## Summary
- Removes all 7 instances of `AnyView` across the codebase, replacing them with concrete types, `@ViewBuilder`, and generics
- Improves SwiftUI view diffing performance, especially in the hot `buildRootView()` path of `LiveKeyboardOverlayController`
- No behavioral changes -- pure type-level refactor

## Changes by file
| File | Approach |
|------|----------|
| `LiveKeyboardOverlayController` | `NSHostingView<AnyView>` → `NSHostingView<LiveKeyboardOverlayView>` |
| `LiveKeyboardOverlayView` | `-> AnyView` → `-> some View` |
| `WizardWindowController` | `NSHostingView<AnyView>` → `NSView` (only used for layout methods) |
| `HomeRowKeyboardView` | Generic `<PopoverContent: View>` parameter |
| `HomeRowModsCollectionView` | Remove `AnyView()` wrapper, pass `Group` directly |
| `OverlayMapperSection+ShiftOutput` | `AnyView?` → `@ViewBuilder` closure |
| `WizardDesignSystem.HeroSection` | Remove unused `contentCard: AnyView` slot |

## Test plan
- [x] `swift build` passes
- [ ] Verify overlay opens and inspector panel works
- [ ] Verify wizard window opens correctly
- [ ] Verify home row mods keyboard popovers work

🤖 Generated with [Claude Code](https://claude.com/claude-code)