### PR TITLE
refactor: remove Combine artifacts in favor of @Observable

### DIFF
--- a/Sources/KeyPathAppKit/InstallationWizard/UI/WizardToastManager.swift
+++ b/Sources/KeyPathAppKit/InstallationWizard/UI/WizardToastManager.swift
@@ -7,7 +7,7 @@ import SwiftUI
 /// Provides temporary feedback for user actions like auto-fix operations
 @Observable
 @MainActor
-class WizardToastManager: ToastPresenting, ObservableObject {
+class WizardToastManager: ToastPresenting {
     var currentToast: WizardToast?
 
     private var toastTask: Task<Void, Never>?

--- a/Sources/KeyPathAppKit/MenuBar/MenuBarController.swift
+++ b/Sources/KeyPathAppKit/MenuBar/MenuBarController.swift
@@ -1,5 +1,4 @@
 import AppKit
-import Combine
 import Foundation
 import KeyPathCore
 import KeyPathWizardCore
@@ -24,7 +23,7 @@ final class MenuBarController: NSObject, NSMenuDelegate {
 
     // MARK: - State Observation
 
-    private var cancellables = Set<AnyCancellable>()
+    private var keymapObservationTask: Task<Void, Never>?
     private weak var appStateController: MainAppStateController?
     private weak var ruleCollectionsManager: RuleCollectionsManager?
 
@@ -89,12 +88,13 @@ final class MenuBarController: NSObject, NSMenuDelegate {
         }
 
         // Observe app keymap changes to keep cache fresh
-        NotificationCenter.default.publisher(for: .appKeymapsDidChange)
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] _ in
-                self?.refreshAppKeymapCache()
+        keymapObservationTask?.cancel()
+        keymapObservationTask = Task { @MainActor [weak self] in
+            for await _ in NotificationCenter.default.notifications(named: .appKeymapsDidChange) {
+                guard let self, !Task.isCancelled else { break }
+                self.refreshAppKeymapCache()
             }
-            .store(in: &cancellables)
+        }
 
         // Initial icon update
         updateStatusIcon()

--- a/Sources/KeyPathAppKit/Services/MainAppStateController.swift
+++ b/Sources/KeyPathAppKit/Services/MainAppStateController.swift
@@ -1,4 +1,3 @@
-import Combine
 import Foundation
 import KeyPathCore
 import KeyPathDaemonLifecycle
@@ -65,7 +64,7 @@ class MainAppStateController {
 
     // MARK: - Service Health Monitoring (Fix for stale overlay state)
 
-    @ObservationIgnored private var cancellables = Set<AnyCancellable>()
+    @ObservationIgnored private var errorDetectionTask: Task<Void, Never>?
     @ObservationIgnored private var lastKnownRuntimeHealthy: Bool?
     @ObservationIgnored private var serviceHealthTask: Task<Void, Never>?
     @ObservationIgnored private var periodicRefreshTask: Task<Void, Never>?
@@ -110,7 +109,7 @@ class MainAppStateController {
 
     // NOTE: No deinit needed - this is a singleton that lives for the app's lifetime.
     // Cleanup would be impossible anyway since deinit is nonisolated and can't access
-    // MainActor-isolated properties like cancellables.
+    // MainActor-isolated properties like task handles.
 
     /// Configure with RuntimeCoordinator (called after init)
     func configure(with kanataManager: RuntimeCoordinator) {
@@ -143,10 +142,10 @@ class MainAppStateController {
     /// Subscribe to KanataErrorMonitor crash detection to trigger immediate revalidation.
     /// This ensures crashes are detected even if service state hasn't transitioned yet.
     private func subscribeToErrorDetection() {
-        NotificationCenter.default.publisher(for: .kanataErrorDetected)
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] notification in
-                guard let self else { return }
+        errorDetectionTask?.cancel()
+        errorDetectionTask = Task { @MainActor [weak self] in
+            for await notification in NotificationCenter.default.notifications(named: .kanataErrorDetected) {
+                guard let self, !Task.isCancelled else { break }
 
                 // Log crash for later analysis
                 if let error = notification.object as? KanataError {
@@ -157,13 +156,11 @@ class MainAppStateController {
                         AppLogger.shared.error(
                             "🚨 [MainAppStateController] Critical error detected - triggering immediate revalidation"
                         )
-                        Task { @MainActor in
-                            await self.revalidate()
-                        }
+                        await self.revalidate()
                     }
                 }
             }
-            .store(in: &cancellables)
+        }
 
         AppLogger.shared.log("🔔 [MainAppStateController] Subscribed to crash/error detection")
     }

--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayHealthIndicatorObserver.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayHealthIndicatorObserver.swift
@@ -1,8 +1,6 @@
-import Combine
 import Foundation
 import KeyPathCore
 import KeyPathWizardCore
-import Observation
 
 @MainActor
 final class OverlayHealthIndicatorObserver {
@@ -12,7 +10,6 @@ final class OverlayHealthIndicatorObserver {
     private let onStateChange: StateHandler
     private let onDismiss: () -> Void
     private let sleep: Sleep
-    private var cancellable: AnyCancellable?
     private var dismissTask: Task<Void, Never>?
     private var checkingDebounceTask: Task<Void, Never>?
     private var currentState: HealthIndicatorState = .dismissed
@@ -31,28 +28,6 @@ final class OverlayHealthIndicatorObserver {
         self.onStateChange = onStateChange
         self.onDismiss = onDismiss
         self.sleep = sleep
-    }
-
-    /// Start observing using Combine publishers (used by tests with CurrentValueSubject)
-    func start(
-        validationStatePublisher: AnyPublisher<MainAppStateController.ValidationState?, Never>,
-        issuesPublisher: AnyPublisher<[WizardIssue], Never>
-    ) {
-        AppLogger.shared.log("🔔 [HealthObserver] start(publishers:) called - isObserving=\(isObserving)")
-        guard !isObserving else {
-            AppLogger.shared.log("🔔 [HealthObserver] start() - already observing, skipping")
-            return
-        }
-        isObserving = true
-
-        cancellable = Publishers.CombineLatest(
-            validationStatePublisher,
-            issuesPublisher
-        )
-        .receive(on: DispatchQueue.main)
-        .sink { [weak self] state, issues in
-            self?.handle(state: state, issues: issues)
-        }
     }
 
     /// Start observing an @Observable MainAppStateController via polling


### PR DESCRIPTION
## Summary
- **WizardToastManager**: removed redundant `ObservableObject` conformance (class is already `@Observable`)
- **MainAppStateController**: replaced Combine `NotificationCenter.default.publisher` + `AnyCancellable` with async `NotificationCenter.notifications` sequence
- **OverlayHealthIndicatorObserver**: removed unused Combine-based `start(validationStatePublisher:issuesPublisher:)` method and `AnyCancellable` property — only the `@Observable` polling path (`startObserving(controller:)`) was in use
- **MenuBarController**: replaced Combine publisher subscription with async notification sequence for app keymap change observation

Combine is intentionally retained in two places where it is genuinely needed:
- `OverlayMapperSection`: SwiftUI `.onReceive()` requires Combine publishers
- `VHIDDeviceManager` + `WizardKarabinerComponentsPage`: `PassthroughSubject` for cross-component step progress reporting during driver installation

## Test plan
- [x] `swift build` passes
- [ ] Verify overlay health indicator still transitions correctly on validation state changes
- [ ] Verify menu bar icon updates when system health changes
- [ ] Verify error crash detection still triggers revalidation
- [ ] Verify Karabiner driver install step progress still shows in wizard

🤖 Generated with [Claude Code](https://claude.com/claude-code)