### PR TITLE
fix: device picker polish — headers, cache, empty names

### DIFF
--- a/Sources/KeyPathAppKit/Models/ConnectedDevice.swift
+++ b/Sources/KeyPathAppKit/Models/ConnectedDevice.swift
@@ -27,8 +27,10 @@ struct ConnectedDevice: Codable, Identifiable, Hashable, Sendable {
     }
 
     /// Cleaned-up product name for display in the UI.
+    /// Falls back to the device hash when the product key is empty.
     var displayName: String {
-        DeviceDisplayNameFormatter.format(productKey)
+        let formatted = DeviceDisplayNameFormatter.format(productKey)
+        return formatted.isEmpty ? "Device \(hash.suffix(8))" : formatted
     }
 
     /// Formatted vendor:product hex string, e.g. "05ac:0342"

--- a/Sources/KeyPathAppKit/Services/Devices/DeviceEnumerationService.swift
+++ b/Sources/KeyPathAppKit/Services/Devices/DeviceEnumerationService.swift
@@ -49,6 +49,18 @@ enum DeviceEnumerationService {
         return devices
     }
 
+    // MARK: - Dev Fake Devices
+
+    // DEV FALLBACK: macOS multi-device is blocked upstream (psych3r/driverkit#15).
+    // These fake devices let the keyboard picker UI be tested with a single physical keyboard.
+    // TODO: Remove once upstream lands. Tracked by #254.
+    private static let devFakeDevices: [ConnectedDevice] = [
+        ConnectedDevice(hash: "0xDEADBEEF", vendorID: 0x29EA, productID: 0x0041,
+                        productKey: "Kinesis Advantage360 Pro", isVirtualHID: false),
+        ConnectedDevice(hash: "0xCAFEBABE", vendorID: 0x1209, productID: 0x4173,
+                        productKey: "ZSA Moonlander Mark I", isVirtualHID: false),
+    ]
+
     // MARK: - Enumeration
 
     #if os(macOS)
@@ -61,7 +73,9 @@ enum DeviceEnumerationService {
             let fm = Foundation.FileManager()
             guard let kanataPath = candidates.first(where: { fm.isExecutableFile(atPath: $0) }) else {
                 AppLogger.shared.warn("⚠️ [DeviceEnumeration] No kanata binary found at known paths")
-                return []
+                let fallback = devFakeDevices
+                DeviceSelectionCache.shared.updateConnectedDevices(fallback)
+                return fallback
             }
 
             do {
@@ -84,8 +98,19 @@ enum DeviceEnumerationService {
                     return []
                 }
 
-                let devices = parseAllDevices(fromKanataList: output)
+                var devices = parseAllDevices(fromKanataList: output)
                 AppLogger.shared.log("🔌 [DeviceEnumeration] Found \(devices.count) device(s): \(devices.map(\.displayName).joined(separator: ", "))")
+
+                // Supplement with fake devices when fewer than 2 physical keyboards detected
+                let physicalCount = devices.filter { !$0.isVirtualHID }.count
+                if physicalCount < 2 {
+                    let fakes = devFakeDevices.filter { fake in
+                        !devices.contains(where: { $0.hash == fake.hash })
+                    }
+                    devices.append(contentsOf: fakes)
+                    AppLogger.shared.log("🔌 [DeviceEnumeration] Added \(fakes.count) fake device(s) for UI development")
+                }
+
                 // Cache for synchronous config generator reads
                 DeviceSelectionCache.shared.updateConnectedDevices(devices)
                 return devices

--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayMapperSection+AppMappingIndicators.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayMapperSection+AppMappingIndicators.swift
@@ -156,6 +156,17 @@ extension OverlayMapperSection {
         .focusable(false)
     }
 
+    var appSectionHeader: some View {
+        HStack {
+            Text("Active App")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Spacer()
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 6)
+    }
+
     var onlyInHeader: some View {
         HStack {
             Text("Only in...")

--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayMapperSection.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayMapperSection.swift
@@ -653,9 +653,13 @@ struct OverlayMapperSection: View {
         DeviceSelectionCache.shared.getConnectedDevices().filter { !$0.isVirtualHID }
     }
 
-    /// Pre-load running apps when view appears for instant popover display
+    /// Pre-load running apps and connected devices when view appears for instant popover display
     private func preloadRunningApps() {
         cachedRunningApps = fetchRunningAppsSynchronously()
+        // Prime device cache so keyboard section appears in popover
+        if DeviceSelectionCache.shared.getConnectedDevices().isEmpty {
+            _ = DeviceEnumerationService.enumerateConnectedDevices()
+        }
     }
 
     /// Refresh the cached running apps list - synchronous since NSWorkspace is fast
@@ -687,11 +691,11 @@ struct OverlayMapperSection: View {
                     PopoverListDivider()
                 }
 
+                // App section
+                PopoverListDivider()
+                appSectionHeader
                 everywhereOption
-                PopoverListDivider()
-                onlyInHeader
                 runningAppsList
-                PopoverListDivider()
                 chooseAppOption
 
                 // Keyboard section — only shown when multiple physical devices are connected


### PR DESCRIPTION
## Summary

- **"Active App" section header** — "Everywhere" now sits under a clear "Active App" header instead of floating between Trigger and the app list
- **Device cache priming** — popover triggers `enumerateConnectedDevices()` on first load so the Keyboard section actually appears
- **Dev fake devices** — seeds Kinesis + Moonlander fake devices when <2 physical keyboards detected (upstream multi-device blocked by psych3r/driverkit#15, tracked #254)
- **Empty device name fix** — devices with empty product keys (common with some USB devices) now show "Device XXXXXXXX" instead of "?"

Follow-up to #259.

## Test plan

- [x] `swift build` — compiles cleanly
- [ ] Open mapper popover → verify "Active App" header above "Everywhere"
- [ ] Verify Keyboard section appears with real + fake devices
- [ ] Verify empty-name device shows hash fallback instead of "?"

🤖 Generated with [Claude Code](https://claude.com/claude-code)