### PR TITLE
fix: show header drawer button on QMK keyboards

### DIFF
--- a/Sources/KeyPathAppKit/Models/PhysicalLayout.swift
+++ b/Sources/KeyPathAppKit/Models/PhysicalLayout.swift
@@ -173,8 +173,8 @@ struct PhysicalLayout: Identifiable {
         all.first { $0.id == id }
     }
 
-    /// Whether this layout has action keys (Touch ID, Layer, etc.) that open the drawer
+    /// Whether this layout has a Touch ID key that acts as the drawer toggle
     var hasDrawerButtons: Bool {
-        keys.contains { $0.keyCode == PhysicalKey.unmappedKeyCode }
+        keys.contains { $0.keyCode == PhysicalKey.unmappedKeyCode && $0.label == "🔒" }
     }
 }


### PR DESCRIPTION
## Summary

- QMK keyboards with layer switches/transparent keys had `hasDrawerButtons` returning `true` (any `unmappedKeyCode` key), which hid the header fallback drawer button
- Only MacBook layouts have an actual Touch ID key (`🔒`) that acts as a drawer toggle — QMK layer keys don't open the drawer
- Now `hasDrawerButtons` checks for the Touch ID label specifically, matching the `.touchId` layout role condition

## Test plan

- [ ] Select a QMK keyboard (e.g., Mode M80H) — header should show drawer button (sidebar.right icon)
- [ ] Click the header drawer button — inspector drawer should open
- [ ] Switch to MacBook layout — drawer button should appear on the Touch ID keycap, not in header
- [ ] Verify drawer opens/closes on both layout types

🤖 Generated with [Claude Code](https://claude.com/claude-code)