### PR TITLE
perf: deduplicate redundant launchctl calls in SystemValidator

### DIFF
--- a/Sources/KeyPathAppKit/Services/System/SystemValidator.swift
+++ b/Sources/KeyPathAppKit/Services/System/SystemValidator.swift
@@ -546,19 +546,11 @@ public class SystemValidator {
             "🔍 [SystemValidator] checkHealth() - Karabiner daemon check complete: \(karabinerDaemonRunning) (took \(String(format: "%.3f", karabinerDuration))s)"
         )
 
-        // ⚠️ FIX: Use ServiceHealthChecker instead of vhidDeviceManager.detectConnectionHealth()
-        // VHIDDeviceManager.detectConnectionHealth() uses pgrep with retries and can HANG in TaskGroups!
-        // Per ADR-022 and VHIDDeviceManager docs, use launchctl-based health check instead.
+        // Reuse karabinerDaemonRunning for vhidHealthy — both check the same service ID
+        // ("com.keypath.karabiner-vhiddaemon"), so there's no need for a second launchctl call.
+        let vhidHealthy = karabinerDaemonRunning
         AppLogger.shared.log(
-            "🔍 [SystemValidator] checkHealth() - About to check VHID daemon health (via ServiceHealthChecker)..."
-        )
-        let vhidStart = Date()
-        let vhidHealthy = await ServiceHealthChecker.shared.isServiceHealthy(
-            serviceID: "com.keypath.karabiner-vhiddaemon"
-        )
-        let vhidDuration = Date().timeIntervalSince(vhidStart)
-        AppLogger.shared.log(
-            "🔍 [SystemValidator] checkHealth() - VHID daemon check complete: \(vhidHealthy) (took \(String(format: "%.3f", vhidDuration))s)"
+            "🔍 [SystemValidator] checkHealth() - VHID daemon health reused from karabinerDaemonRunning: \(vhidHealthy)"
         )
 
         let totalDuration = Date().timeIntervalSince(startTime)

--- a/Sources/KeyPathInstallationWizard/Core/ServiceHealthChecker.swift
+++ b/Sources/KeyPathInstallationWizard/Core/ServiceHealthChecker.swift
@@ -4,6 +4,7 @@ import KeyPathCore
 import KeyPathWizardCore
 import Network
 import os.lock
+import os.lock
 
 /// Handles health checking and status reporting for LaunchDaemon services.
 ///
@@ -19,12 +20,32 @@ import os.lock
 /// ## Service Configuration Checks
 /// - `isKanataPlistInstalled`: Check if Kanata plist exists
 /// - `isVHIDDaemonConfiguredCorrectly`: Verify VHID plist configuration
-// SAFETY: @unchecked Sendable — singleton with no mutable instance state.
-// All methods are stateless queries delegating to SubprocessRunner or file checks.
+// SAFETY: @unchecked Sendable — singleton with mutable state protected by OSAllocatedUnfairLock.
+// The healthCache provides short-lived deduplication (~2s TTL) so that parallel validation tasks
+// (e.g. checkHealth + checkComponents in SystemValidator) don't spawn redundant launchctl calls.
 public final class ServiceHealthChecker: @unchecked Sendable {
     @MainActor public static let shared = ServiceHealthChecker()
     private nonisolated static let launchctlNotFoundExitCode: Int32 = 113
     private nonisolated static let kanataRestartGraceWindow: TimeInterval = 12.0
+
+    // MARK: - Short-lived health cache
+
+    private struct HealthCacheEntry {
+        let result: Bool
+        let timestamp: Date
+        func isValid(ttl: TimeInterval) -> Bool {
+            Date().timeIntervalSince(timestamp) < ttl
+        }
+    }
+
+    private nonisolated static let healthCacheTTL: TimeInterval = 2.0
+
+    private let healthCache = OSAllocatedUnfairLock(initialState: [String: HealthCacheEntry]())
+
+    /// Clear cached health results. Useful in tests or after service state changes.
+    public nonisolated func invalidateHealthCache() {
+        healthCache.withLock { $0.removeAll() }
+    }
 
     // MARK: - Dependencies
 
@@ -207,6 +228,27 @@ public final class ServiceHealthChecker: @unchecked Sendable {
     /// - Parameter serviceID: The service identifier to check
     /// - Returns: `true` if the service is healthy
     public nonisolated func isServiceHealthy(serviceID: String) async -> Bool {
+        // Check short-lived cache first — avoids redundant launchctl calls within the same
+        // validation cycle when multiple parallel tasks query the same service.
+        if let cached = healthCache.withLock({ $0[serviceID] }),
+           cached.isValid(ttl: Self.healthCacheTTL)
+        {
+            AppLogger.shared.log(
+                "🔍 [ServiceHealthChecker] isServiceHealthy() CACHE HIT for: \(serviceID) → \(cached.result)"
+            )
+            return cached.result
+        }
+
+        let result = await _isServiceHealthyUncached(serviceID: serviceID)
+
+        healthCache.withLock {
+            $0[serviceID] = HealthCacheEntry(result: result, timestamp: Date())
+        }
+
+        return result
+    }
+
+    private nonisolated func _isServiceHealthyUncached(serviceID: String) async -> Bool {
         AppLogger.shared.log(
             "🔍 [ServiceHealthChecker] isServiceHealthy() ENTRY - HEALTH CHECK (system/print) for: \(serviceID)"
         )


### PR DESCRIPTION
## Summary

- `checkHealth()` called `isServiceHealthy("com.keypath.karabiner-vhiddaemon")` twice (for `karabinerDaemonRunning` and `vhidHealthy`) — same service ID, now reuses the first result
- Added 2-second TTL cache to `ServiceHealthChecker.isServiceHealthy()` so parallel TaskGroup tasks share results instead of each spawning launchctl subprocesses
- Net effect: 3-4 launchctl calls per validation cycle reduced to 1

Closes #271

## Test plan

- [x] Build succeeds
- [ ] Verify CACHE HIT log entries appear during validation cycles
- [ ] Verify no regression in Settings Status tab or overlay health

🤖 Generated with [Claude Code](https://claude.com/claude-code)