### PR TITLE
feat: add live HRM decision trace stream to insights panel

### DIFF
--- a/Sources/KeyPathAppKit/Models/KanataHrmObservability.swift
+++ b/Sources/KeyPathAppKit/Models/KanataHrmObservability.swift
@@ -306,3 +306,34 @@ public struct KanataHrmTraceEvent: Codable, Sendable, Equatable {
         )
     }
 }
+
+// MARK: - Identifiable & Display Helpers
+
+extension KanataHrmTraceEvent: Identifiable {
+    public var id: String {
+        "\(key)-\(decision.rawValue)-\(timestamp?.timeIntervalSince1970 ?? 0)"
+    }
+
+    /// One-line explanation like "opposite-hand" or "release-before-timeout"
+    var shortExplanation: String {
+        reason.displayName
+    }
+
+    private static let timeFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "HH:mm:ss"
+        return f
+    }()
+
+    /// Formatted timestamp like "12:04:31"
+    var formattedTimestamp: String {
+        guard let timestamp else { return "" }
+        return Self.timeFormatter.string(from: timestamp)
+    }
+
+    /// Latency display like "12ms" or em-dash
+    var latencyDisplay: String {
+        if let ms = decideLatencyMs { return "\(ms)ms" }
+        return "\u{2014}"
+    }
+}

--- a/Sources/KeyPathAppKit/UI/Rules/HomeRowTimingSection.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/HomeRowTimingSection.swift
@@ -525,6 +525,10 @@ struct HomeRowTimingSection: View {
                     .foregroundStyle(.secondary)
             }
 
+            if !hrmObservability.recentTraceEvents.isEmpty {
+                liveTraceSection
+            }
+
             if !hrmObservability.recommendations.isEmpty {
                 VStack(alignment: .leading, spacing: 6) {
                     Text("Recommendation Preview")
@@ -588,6 +592,49 @@ struct HomeRowTimingSection: View {
                 }
             }
         }
+    }
+
+    // MARK: - Live Decision Stream
+
+    private var liveTraceSection: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Live Decision Stream")
+                .font(.caption.weight(.semibold))
+
+            VStack(alignment: .leading, spacing: 3) {
+                ForEach(hrmObservability.recentTraceEvents.suffix(10).reversed()) { event in
+                    HStack(spacing: 6) {
+                        Text(event.key)
+                            .font(.caption.monospaced())
+                            .padding(.horizontal, 5)
+                            .padding(.vertical, 1)
+                            .background(Color.secondary.opacity(0.12))
+                            .clipShape(RoundedRectangle(cornerRadius: 3))
+
+                        Text(event.decision == .tap ? "tap" : "hold")
+                            .font(.caption2.weight(.medium))
+                            .foregroundStyle(event.decision == .tap ? .blue : .orange)
+                            .frame(width: 28, alignment: .leading)
+
+                        Text(event.shortExplanation)
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+
+                        Spacer()
+
+                        Text(event.latencyDisplay)
+                            .font(.caption2.monospacedDigit())
+                            .foregroundStyle(.secondary)
+                            .frame(width: 36, alignment: .trailing)
+
+                        Text(event.formattedTimestamp)
+                            .font(.caption2.monospacedDigit())
+                            .foregroundStyle(.tertiary)
+                    }
+                }
+            }
+        }
+        .accessibilityIdentifier("home-row-mods-hrm-live-trace")
     }
 
     private func hrmMetricChip(title: String, value: String) -> some View {


### PR DESCRIPTION
## Summary

- Add scrolling real-time log of tap-hold decisions to the HRM Insights section
- Each row shows: key badge, tap/hold (blue/orange), decision reason, latency, timestamp
- Auto-appears when trace events are ingested; shows most recent 10 in reverse chronological order
- Adds `Identifiable` + display helpers (`shortExplanation`, `formattedTimestamp`, `latencyDisplay`) to `KanataHrmTraceEvent`

This is Phase 4a Step 1 from the HRM roadmap — the minimum viable consumer that answers "why did that key do the wrong thing?"

Closes #265

## Test plan

- [x] Build succeeds
- [ ] Enable HRM in Rules > Home Row Mods, open the insights section
- [ ] Type on home row keys — live trace stream should populate with decisions
- [ ] Verify tap (blue) and hold (orange) labels, reason text, latency, timestamps

🤖 Generated with [Claude Code](https://claude.com/claude-code)