### PR TITLE
feat: redirect QMK search to built-in layouts

### DIFF
--- a/Sources/KeyPathAppKit/Models/KeyboardMetadata.swift
+++ b/Sources/KeyPathAppKit/Models/KeyboardMetadata.swift
@@ -10,6 +10,7 @@ struct KeyboardMetadata: Identifiable, Hashable, Sendable {
     let tags: [String] // Inferred tags (split, RGB, ortho, OLED, etc.)
     let infoJsonURL: URL? // QMK API URL to info.json (nil for custom/local layouts)
     let isBundled: Bool // Whether this keyboard has full layout data in popular-keyboards.json
+    let builtInLayoutId: String? // If set, this QMK keyboard has a built-in PhysicalLayout equivalent
 
     /// Initialize with all fields
     init(
@@ -20,7 +21,8 @@ struct KeyboardMetadata: Identifiable, Hashable, Sendable {
         maintainer: String? = nil,
         tags: [String] = [],
         infoJsonURL: URL? = nil,
-        isBundled: Bool = false
+        isBundled: Bool = false,
+        builtInLayoutId: String? = nil
     ) {
         self.id = id
         self.name = name
@@ -30,6 +32,7 @@ struct KeyboardMetadata: Identifiable, Hashable, Sendable {
         self.tags = tags
         self.infoJsonURL = infoJsonURL
         self.isBundled = isBundled
+        self.builtInLayoutId = builtInLayoutId
     }
 
     /// Initialize from QMKKeyboardInfo and directory path
@@ -46,5 +49,6 @@ struct KeyboardMetadata: Identifiable, Hashable, Sendable {
         tags = info.features?.tags ?? []
         self.infoJsonURL = infoJsonURL
         isBundled = false
+        builtInLayoutId = nil
     }
 }

--- a/Sources/KeyPathAppKit/Services/Import/QMKKeyboardDatabase.swift
+++ b/Sources/KeyPathAppKit/Services/Import/QMKKeyboardDatabase.swift
@@ -45,6 +45,24 @@ actor QMKKeyboardDatabase {
     /// Set of bundled keyboard IDs for quick lookup
     private var bundledIds: Set<String> = []
 
+    /// QMK paths that map to built-in PhysicalLayout IDs.
+    /// When a search result matches one of these, selecting it activates the
+    /// built-in layout directly instead of importing from QMK.
+    private static let qmkToBuiltInLayout: [String: String] = [
+        // Ergonomic / split keyboards
+        "crkbd": "corne",
+        "crkbd/rev1": "corne",
+        "crkbd/r2g": "corne",
+        "crkbd/rev4_0/standard": "corne",
+        "crkbd/rev4_1/standard": "corne",
+        "sofle": "sofle",
+        "sofle/rev1": "sofle",
+        "ferris/sweep": "ferris-sweep",
+        // HHKB
+        "hhkb": "hhkb",
+        "hhkb/ansi": "hhkb",
+    ]
+
     /// Disk cache directory for fetched keyboard layouts
     private let cacheDirectory: URL = {
         let caches = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
@@ -258,7 +276,8 @@ actor QMKKeyboardDatabase {
                     maintainer: bundled.info.maintainer,
                     tags: bundled.info.features?.tags ?? [],
                     infoJsonURL: apiURL,
-                    isBundled: true
+                    isBundled: true,
+                    builtInLayoutId: Self.qmkToBuiltInLayout[bundled.path]
                 )
             }
             bundledKeyboards = keyboards
@@ -326,7 +345,8 @@ actor QMKKeyboardDatabase {
                 name: name,
                 manufacturer: meta?.manufacturer ?? Self.formatPath([entry.vendor]),
                 infoJsonURL: URL(string: "\(qmkAPIBase)/\(entry.path)/info.json"),
-                isBundled: false
+                isBundled: false,
+                builtInLayoutId: Self.qmkToBuiltInLayout[entry.path]
             )
             return (kb, score)
         }

--- a/Sources/KeyPathAppKit/UI/Overlay/KeyboardSelectionGridView.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/KeyboardSelectionGridView.swift
@@ -277,6 +277,14 @@ struct KeyboardSelectionGridView: View {
     }
 
     private func importKeyboard(_ keyboard: KeyboardMetadata) {
+        // If this QMK keyboard has a built-in equivalent, select it directly
+        if let builtInId = keyboard.builtInLayoutId {
+            selectedLayoutId = builtInId
+            searchText = ""
+            showImportToast("Selected built-in \(keyboard.name) layout", type: .success)
+            return
+        }
+
         Task {
             do {
                 // Fetch keyboard data (uses disk cache, handles QMK API unwrapping)
@@ -781,6 +789,15 @@ private struct SearchKeyboardRow: View {
 
                 // Tags
                 HStack(spacing: 4) {
+                    if keyboard.builtInLayoutId != nil {
+                        Text("Built-in")
+                            .font(.caption2)
+                            .padding(.horizontal, 6)
+                            .padding(.vertical, 2)
+                            .background(Color.green.opacity(0.15))
+                            .foregroundColor(.green)
+                            .clipShape(RoundedRectangle(cornerRadius: 4))
+                    }
                     ForEach(keyboard.tags.prefix(3), id: \.self) { tag in
                         SearchTagBadge(tag: tag, keyboardId: keyboard.id)
                     }

--- a/Sources/KeyPathAppKit/UI/Overlay/QMKKeyboardSearchView.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/QMKKeyboardSearchView.swift
@@ -238,6 +238,14 @@ struct QMKKeyboardSearchView: View {
     }
 
     private func importKeyboard(_ keyboard: KeyboardMetadata) {
+        // If this QMK keyboard has a built-in equivalent, select it directly
+        if let builtInId = keyboard.builtInLayoutId {
+            selectedLayoutId = builtInId
+            onImportComplete?()
+            dismiss()
+            return
+        }
+
         Task {
             do {
                 // Fetch keyboard data (uses disk cache, handles QMK API unwrapping)
@@ -368,6 +376,15 @@ private struct PopoverKeyboardRow: View {
 
                 // Tags
                 HStack(spacing: 4) {
+                    if keyboard.builtInLayoutId != nil {
+                        Text("Built-in")
+                            .font(.caption2)
+                            .padding(.horizontal, 6)
+                            .padding(.vertical, 2)
+                            .background(Color.green.opacity(0.15))
+                            .foregroundColor(.green)
+                            .clipShape(RoundedRectangle(cornerRadius: 4))
+                    }
                     ForEach(keyboard.tags.prefix(3), id: \.self) { tag in
                         TagBadge(tag: tag, keyboardId: keyboard.id)
                     }


### PR DESCRIPTION
## Summary
- When a QMK keyboard has a hand-tuned built-in equivalent (Corne, Sofle, Ferris Sweep, HHKB), selecting it from search now activates the built-in layout directly instead of importing a lower-quality QMK parse
- Adds a mapping table from QMK paths (including revision variants like `crkbd/rev1`) to built-in layout IDs
- Search results show a green "Built-in" badge for keyboards with local equivalents
- Both the grid search and popover search views handle the redirect

## Test plan
- [ ] Search "corne" — result shows "Built-in" badge, selecting it activates `corne` layout (no import)
- [ ] Search "sofle" — same behavior, activates `sofle` layout
- [ ] Search "ferris sweep" — activates `ferris-sweep` layout  
- [ ] Search a non-built-in keyboard (e.g., "planck") — imports normally from QMK as before
- [ ] Verify built-in layouts still work from the grid picker (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)