### PR TITLE
fix: drawer key tap blocked by parent's highPriorityGesture

### DIFF
--- a/Sources/KeyPathAppKit/UI/Overlay/LiveKeyboardOverlayView.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/LiveKeyboardOverlayView.swift
@@ -618,7 +618,11 @@ struct LiveKeyboardOverlayView: View {
                 if allowKeyboardDrag {
                     keyboardView
                         .contentShape(Rectangle())
-                        .highPriorityGesture(
+                        // Use simultaneousGesture (not highPriority) so the Touch ID keycap's
+                        // TapGesture can fire alongside this drag gesture. Non-TouchID keycaps
+                        // already have .allowsHitTesting(false) when the drawer is closed,
+                        // so there's no risk of accidental key clicks during drag.
+                        .simultaneousGesture(
                             DragGesture(minimumDistance: 3, coordinateSpace: .global)
                                 .onChanged { _ in
                                     if !isKeyboardDragging, let window = findOverlayWindow() {

--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView+ContentAndStyling.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView+ContentAndStyling.swift
@@ -108,15 +108,25 @@ extension OverlayKeycapView {
         // Click behavior based on drawer state:
         // - Drawer CLOSED: only Touch ID key captures clicks (opens drawer), all other keys pass through for window drag
         // - Drawer OPEN: all keys capture clicks for mapping
-        // The `including:` parameter completely disables the gesture when .none, allowing window drag to work
+        // Touch ID uses highPriorityGesture(TapGesture) so it wins over the parent keyboard's
+        // highPriorityGesture(DragGesture) which would otherwise swallow tap events.
+        // Other keys use simultaneousGesture(DragGesture) so they coexist with keyboard drag.
+        .highPriorityGesture(
+            TapGesture()
+                .onEnded {
+                    guard key.layoutRole == .touchId, let onKeyClick else { return }
+                    onKeyClick(key, layerKeyInfo)
+                },
+            including: key.layoutRole == .touchId ? .all : .none
+        )
         .simultaneousGesture(
             DragGesture(minimumDistance: 0)
                 .onEnded { _ in
-                    guard let onKeyClick else { return }
+                    guard key.layoutRole != .touchId, let onKeyClick else { return }
                     onKeyClick(key, layerKeyInfo)
                 },
-            // Only capture gestures when drawer is open OR this is the Touch ID key
-            including: (isInspectorVisible || key.layoutRole == .touchId) ? .all : .none
+            // Only capture gestures when drawer is open (Touch ID handled by highPriorityGesture above)
+            including: isInspectorVisible ? .all : .none
         )
         .onAppear {
             loadAppIconIfNeeded()


### PR DESCRIPTION
## Summary

- The Touch ID / drawer key (🔒) on built-in layouts (ansi-80, ansi-75, corne, etc.) was unresponsive when the drawer was closed
- Root cause: the keyboard wrapper's `.highPriorityGesture(DragGesture)` was swallowing the keycap's `.simultaneousGesture` because high-priority gestures block all descendant gestures while tracking
- Fix: use `TapGesture` with `.highPriorityGesture` for the Touch ID keycap, and downgrade the keyboard wrapper from `.highPriorityGesture` to `.simultaneousGesture`

## Test plan

- [ ] Select a built-in layout with a drawer key (e.g. ANSI 80%, Corne)
- [ ] With drawer closed, click the 🔒 keycap → drawer should open
- [ ] Click again → drawer should close
- [ ] Drag from the 🔒 keycap → window should drag (no drawer toggle)
- [ ] Drag from any other key area → window should drag normally
- [ ] With drawer open, click any key → mapper should select it
- [ ] Verify Cmd+Opt+D hotkey still toggles the drawer

🤖 Generated with [Claude Code](https://claude.com/claude-code)