### PR TITLE
feat: auto-inject drawer key on QMK imports, fix layer key rendering

### DIFF
--- a/Sources/KeyPathAppKit/Models/PhysicalLayout.swift
+++ b/Sources/KeyPathAppKit/Models/PhysicalLayout.swift
@@ -96,6 +96,8 @@ struct PhysicalLayout: Identifiable {
         let layouts: [PhysicalLayout] = store.layouts.compactMap { storedLayout -> PhysicalLayout? in
             let layoutId = "custom-\(storedLayout.id)"
 
+            let parsed: PhysicalLayout?
+
             // Strategy 1: Use cached keymap tokens (best quality)
             if let keymapTokens = storedLayout.defaultKeymap,
                let result = QMKLayoutParser.parseWithKeymap(
@@ -105,35 +107,34 @@ struct PhysicalLayout: Identifiable {
                    nameOverride: storedLayout.name
                )
             {
-                return result.layout
+                parsed = result.layout
             }
-
             // Strategy 2: Position-based parsing (works for any QMK keyboard)
-            if let result = QMKLayoutParser.parseByPositionWithQuality(
+            else if let result = QMKLayoutParser.parseByPositionWithQuality(
                 data: storedLayout.layoutJSON,
                 idOverride: layoutId,
                 nameOverride: storedLayout.name
             ) {
-                return result.layout
+                parsed = result.layout
             }
-
             // Strategy 3: Matrix-based parsing for bundled keyboards with known matrices
-            let keyMapping: (Int, Int) -> (keyCode: UInt16, label: String)? = if let variant = storedLayout.layoutVariant?.lowercased(), variant.contains("iso") {
-                ISOPositionTable.keyMapping(row:col:)
-            } else {
-                ANSIPositionTable.keyMapping(row:col:)
+            else {
+                let keyMapping: (Int, Int) -> (keyCode: UInt16, label: String)? = if let variant = storedLayout.layoutVariant?.lowercased(), variant.contains("iso") {
+                    ISOPositionTable.keyMapping(row:col:)
+                } else {
+                    ANSIPositionTable.keyMapping(row:col:)
+                }
+
+                parsed = QMKLayoutParser.parse(
+                    data: storedLayout.layoutJSON,
+                    keyMapping: keyMapping,
+                    idOverride: layoutId,
+                    nameOverride: storedLayout.name
+                )
             }
 
-            guard let layout = QMKLayoutParser.parse(
-                data: storedLayout.layoutJSON,
-                keyMapping: keyMapping,
-                idOverride: layoutId,
-                nameOverride: storedLayout.name
-            ) else {
-                return nil
-            }
-
-            return layout
+            // Inject drawer key if the layout has layer keys but no drawer button
+            return parsed?.withDrawerKeyInjected()
         }
 
         // Update cache
@@ -176,5 +177,66 @@ struct PhysicalLayout: Identifiable {
     /// Whether this layout has a Touch ID key that acts as the drawer toggle
     var hasDrawerButtons: Bool {
         keys.contains { $0.keyCode == PhysicalKey.unmappedKeyCode && $0.label == "🔒" }
+    }
+
+    // MARK: - Drawer Key Injection
+
+    /// Whether a label indicates a pure layer-switch key (MO, TG, OSL, DF abbreviations).
+    /// These are candidates for drawer key injection. Layer-taps (LT) resolve to their
+    /// base key with a real keyCode, so they're naturally excluded.
+    static func isLayerKeyLabel(_ label: String) -> Bool {
+        guard label.count >= 2, label.count <= 3 else { return false }
+        let first = label.first!
+        guard "LTD".contains(first) else { return false }
+        return label.dropFirst().allSatisfy(\.isNumber)
+    }
+
+    /// For QMK-imported layouts without a drawer key, find the best layer key
+    /// candidate and convert it to the drawer toggle (🔒).
+    ///
+    /// Picks the rightmost pure layer-switch key (highest x), breaking ties with
+    /// bottom-most (highest y). Layer-taps (LT) that resolve to a base key are
+    /// excluded since they're typing keys.
+    func withDrawerKeyInjected() -> PhysicalLayout {
+        // Already has a drawer button — no injection needed
+        guard !hasDrawerButtons else { return self }
+
+        // Only apply to custom/QMK layouts (not built-in)
+        guard id.hasPrefix("custom-") else { return self }
+
+        // Find candidate layer keys
+        let candidates = keys.enumerated().filter { _, key in
+            key.keyCode == PhysicalKey.unmappedKeyCode
+                && Self.isLayerKeyLabel(key.label)
+        }
+
+        guard let best = candidates.max(by: { a, b in
+            if a.element.visualX != b.element.visualX {
+                return a.element.visualX < b.element.visualX // rightmost wins
+            }
+            return a.element.visualY < b.element.visualY // bottom-most breaks ties
+        }) else {
+            return self // No candidates found
+        }
+
+        // Build new keys array with the chosen key's label replaced
+        var newKeys = keys
+        newKeys[best.offset] = PhysicalKey(
+            id: best.element.id,
+            keyCode: best.element.keyCode,
+            label: "🔒",
+            x: best.element.x,
+            y: best.element.y,
+            width: best.element.width,
+            height: best.element.height,
+            rotation: best.element.rotation,
+            rotationPivotX: best.element.rotationPivotX,
+            rotationPivotY: best.element.rotationPivotY,
+            shiftLabel: best.element.shiftLabel,
+            subLabel: best.element.subLabel,
+            tertiaryLabel: best.element.tertiaryLabel
+        )
+
+        return PhysicalLayout(id: id, name: name, keys: newKeys, totalWidth: totalWidth, totalHeight: totalHeight)
     }
 }

--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView+ContentAndStyling.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView+ContentAndStyling.swift
@@ -235,8 +235,10 @@ extension OverlayKeycapView {
     /// Standard key content routing (used for .standard legend style)
     @ViewBuilder
     var standardKeyContent: some View {
-        // TouchID/Power key: ALWAYS show drawer icon regardless of mode
-        if key.keyCode == PhysicalKey.unmappedKeyCode {
+        // TouchID/Drawer key: ALWAYS show drawer icon regardless of mode
+        // Only for keys with .touchId role (keyCode 0xFFFF + label "🔒"),
+        // NOT all unmapped keys (layer switches like L0, T1 should show their labels)
+        if key.layoutRole == .touchId {
             touchIdContent
         }
         // Launcher mode: ALL keys use launcher styling (icons for mapped, labels for unmapped)

--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView+LayoutContent.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView+LayoutContent.swift
@@ -268,6 +268,11 @@ extension OverlayKeycapView {
             return true
         }
 
+        // Layer switch abbreviations (L0-L9, T0-T9, D0-D9 from QMK imports)
+        if PhysicalLayout.isLayerKeyLabel(key.label) {
+            return true
+        }
+
         // Also treat mapped output labels (e.g., Hyper/Meh) as special so they render in keycaps
         return specialLabels.contains(effectiveLabel)
     }
@@ -383,6 +388,9 @@ extension OverlayKeycapView {
                     .font(.system(size: 14 * scale, weight: .medium))
                     .foregroundStyle(foregroundColor)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if PhysicalLayout.isLayerKeyLabel(key.label) {
+                // Layer switch key (L0, T1, D2, etc.) — show layers icon
+                layerKeyContent(label: key.label)
             } else {
                 // For special keys, prefer key.label if effectiveLabel is empty
                 // Numpad keys just show their number/symbol centered
@@ -708,6 +716,22 @@ extension OverlayKeycapView {
                 .foregroundStyle(foregroundColor)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
+    }
+
+    // MARK: - Layout: Layer Key
+
+    /// Layer switch key content: SF Symbol icon with layer label below
+    @ViewBuilder
+    func layerKeyContent(label: String) -> some View {
+        VStack(spacing: 1 * scale) {
+            Image(systemName: "square.3.layers.3d")
+                .font(.system(size: 10 * scale, weight: .regular))
+                .foregroundStyle(foregroundColor.opacity(0.7))
+            Text(label)
+                .font(.system(size: 7 * scale, weight: .regular))
+                .foregroundStyle(foregroundColor.opacity(0.6))
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
     // MARK: - Layout: ESC Key

--- a/Tests/KeyPathTests/Models/PhysicalLayoutDrawerInjectionTests.swift
+++ b/Tests/KeyPathTests/Models/PhysicalLayoutDrawerInjectionTests.swift
@@ -1,0 +1,171 @@
+import Foundation
+import Testing
+
+@testable import KeyPathAppKit
+
+@Suite("PhysicalLayout Drawer Key Injection")
+struct PhysicalLayoutDrawerInjectionTests {
+    // MARK: - Helper
+
+    private func makeKey(
+        keyCode: UInt16 = PhysicalKey.unmappedKeyCode,
+        label: String,
+        x: Double,
+        y: Double,
+        width: Double = 1.0
+    ) -> PhysicalKey {
+        PhysicalKey(keyCode: keyCode, label: label, x: x, y: y, width: width)
+    }
+
+    private func makeLayout(id: String = "custom-test", keys: [PhysicalKey]) -> PhysicalLayout {
+        let maxX = keys.map { $0.x + $0.width }.max() ?? 0
+        let maxY = keys.map { $0.y + $0.height }.max() ?? 0
+        return PhysicalLayout(id: id, name: "Test", keys: keys, totalWidth: maxX, totalHeight: maxY)
+    }
+
+    // MARK: - isLayerKeyLabel
+
+    @Test func isLayerKeyLabel_recognizesValidLabels() {
+        #expect(PhysicalLayout.isLayerKeyLabel("L0"))
+        #expect(PhysicalLayout.isLayerKeyLabel("L1"))
+        #expect(PhysicalLayout.isLayerKeyLabel("L9"))
+        #expect(PhysicalLayout.isLayerKeyLabel("T0"))
+        #expect(PhysicalLayout.isLayerKeyLabel("T2"))
+        #expect(PhysicalLayout.isLayerKeyLabel("D0"))
+        #expect(PhysicalLayout.isLayerKeyLabel("D3"))
+        #expect(PhysicalLayout.isLayerKeyLabel("L12")) // two-digit layer number
+    }
+
+    @Test func isLayerKeyLabel_rejectsNonLayerLabels() {
+        #expect(!PhysicalLayout.isLayerKeyLabel("🔒"))
+        #expect(!PhysicalLayout.isLayerKeyLabel("RGB"))
+        #expect(!PhysicalLayout.isLayerKeyLabel("BL"))
+        #expect(!PhysicalLayout.isLayerKeyLabel("⟲"))
+        #expect(!PhysicalLayout.isLayerKeyLabel("a"))
+        #expect(!PhysicalLayout.isLayerKeyLabel("Fn"))
+        #expect(!PhysicalLayout.isLayerKeyLabel("Lower"))
+        #expect(!PhysicalLayout.isLayerKeyLabel(""))
+        #expect(!PhysicalLayout.isLayerKeyLabel("L")) // no number
+    }
+
+    // MARK: - Drawer Key Injection
+
+    @Test func picksRightmostLayerKey() {
+        let layout = makeLayout(keys: [
+            makeKey(label: "L0", x: 0, y: 5),
+            makeKey(label: "L1", x: 12, y: 5),
+            makeKey(keyCode: 49, label: "", x: 3, y: 5, width: 6), // spacebar
+        ])
+
+        let result = layout.withDrawerKeyInjected()
+
+        #expect(result.hasDrawerButtons)
+        // L1 at x=12 should become the drawer key
+        let drawerKey = result.keys.first { $0.label == "🔒" }
+        #expect(drawerKey != nil)
+        #expect(drawerKey?.x == 12)
+        // L0 should remain unchanged
+        let layerKey = result.keys.first { $0.label == "L0" }
+        #expect(layerKey != nil)
+    }
+
+    @Test func tieBreaksWithBottomMost() {
+        let layout = makeLayout(keys: [
+            makeKey(label: "L0", x: 12, y: 2),
+            makeKey(label: "L1", x: 12, y: 5),
+        ])
+
+        let result = layout.withDrawerKeyInjected()
+
+        let drawerKey = result.keys.first { $0.label == "🔒" }
+        #expect(drawerKey != nil)
+        #expect(drawerKey?.y == 5) // bottom-most wins
+        // Other layer key preserved
+        let remaining = result.keys.first { $0.label == "L0" }
+        #expect(remaining != nil)
+    }
+
+    @Test func skipsNonLayerLabels() {
+        let layout = makeLayout(keys: [
+            makeKey(label: "RGB", x: 12, y: 5),
+            makeKey(label: "BL", x: 11, y: 5),
+            makeKey(label: "⟲", x: 10, y: 5),
+        ])
+
+        let result = layout.withDrawerKeyInjected()
+
+        #expect(!result.hasDrawerButtons)
+        // All keys unchanged
+        #expect(result.keys.contains { $0.label == "RGB" })
+        #expect(result.keys.contains { $0.label == "BL" })
+    }
+
+    @Test func preservesExistingDrawerKey() {
+        let layout = makeLayout(keys: [
+            makeKey(label: "🔒", x: 14, y: 0),
+            makeKey(label: "L1", x: 12, y: 5),
+        ])
+
+        let result = layout.withDrawerKeyInjected()
+
+        // Should not change anything — already has drawer
+        let drawerKeys = result.keys.filter { $0.label == "🔒" }
+        #expect(drawerKeys.count == 1)
+        #expect(drawerKeys.first?.x == 14) // original position
+        // L1 still present
+        #expect(result.keys.contains { $0.label == "L1" })
+    }
+
+    @Test func noCandidatesReturnsUnchanged() {
+        let layout = makeLayout(keys: [
+            makeKey(keyCode: 49, label: "", x: 3, y: 5, width: 6),
+            makeKey(keyCode: 55, label: "⌘", x: 0, y: 5),
+        ])
+
+        let result = layout.withDrawerKeyInjected()
+
+        #expect(!result.hasDrawerButtons)
+        #expect(result.keys.count == layout.keys.count)
+    }
+
+    @Test func onlyAppliesToCustomLayouts() {
+        let layout = makeLayout(id: "ansi-80", keys: [
+            makeKey(label: "L0", x: 12, y: 5),
+        ])
+
+        let result = layout.withDrawerKeyInjected()
+
+        // Non-custom layout should be unchanged
+        #expect(!result.hasDrawerButtons)
+        #expect(result.keys.first?.label == "L0")
+    }
+
+    @Test func singleLayerKeyBecomesDrawer() {
+        let layout = makeLayout(keys: [
+            makeKey(keyCode: 55, label: "⌘", x: 0, y: 5),
+            makeKey(label: "L0", x: 12, y: 5),
+            makeKey(keyCode: 62, label: "⌃", x: 13, y: 5),
+        ])
+
+        let result = layout.withDrawerKeyInjected()
+
+        #expect(result.hasDrawerButtons)
+        let drawerKey = result.keys.first { $0.label == "🔒" }
+        #expect(drawerKey?.x == 12)
+        // No L0 remaining
+        #expect(!result.keys.contains { $0.label == "L0" })
+    }
+
+    @Test func preservesKeyProperties() {
+        let original = makeKey(label: "T2", x: 12.5, y: 5.5, width: 1.25)
+        let layout = makeLayout(keys: [original])
+
+        let result = layout.withDrawerKeyInjected()
+
+        let drawerKey = result.keys.first { $0.label == "🔒" }
+        #expect(drawerKey?.x == 12.5)
+        #expect(drawerKey?.y == 5.5)
+        #expect(drawerKey?.width == 1.25)
+        #expect(drawerKey?.keyCode == PhysicalKey.unmappedKeyCode)
+    }
+}


### PR DESCRIPTION
## Summary

- **Drawer key injection**: QMK-imported layouts now automatically get a drawer toggle by converting the rightmost pure layer-switch key (MO/TG/OSL/DF) into the 🔒 drawer key. Layer-taps (LT) are excluded since they're typing keys.
- **Fix rendering bug**: ALL unmapped keys were showing the drawer icon (`sidebar.right`) because `standardKeyContent` checked `keyCode == unmappedKeyCode` instead of `layoutRole == .touchId`. Layer keys like L0, T1 now render correctly.
- **Layer key icon**: Non-drawer layer keys now show `square.3.layers.3d` SF Symbol with their label (e.g., "L0") instead of the drawer icon or plain text.

## Test plan

- [ ] Import a QMK keyboard with layer keys (e.g., Mode 80 v2) → rightmost layer key should show drawer icon
- [ ] Click the injected drawer key → drawer should open/close
- [ ] Verify other layer keys show the layers icon (`square.3.layers.3d`) not the drawer icon
- [ ] Select a built-in layout (MacBook, ANSI 80%) → drawer key behavior unchanged
- [ ] Select a QMK keyboard with no layer keys → header button should still work as fallback
- [ ] Verify physical layer key still functions normally when pressed on the keyboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)