### PR TITLE
ci: give coverage lane realistic timeout headroom

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   build-and-test:
     runs-on: macos-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     env:
       COVERAGE_BASELINE_PERCENT: "0.27"
       COVERAGE_TOLERANCE_PERCENT: "0.01"
@@ -106,7 +106,9 @@ jobs:
         ./Scripts/verify-kanata-plist.sh Sources/KeyPathApp/com.keypath.kanata.plist
 
     - name: Generate Coverage (single pass)
-      timeout-minutes: 5
+      # Coverage instrumentation triggers a separate rebuild of the package.
+      # On current GitHub macOS runners that rebuild takes a bit over 5 minutes.
+      timeout-minutes: 8
       run: |
         echo "Generating coverage with combined filter..."
         swift test --enable-code-coverage --filter 'KeyPathErrorTests|PermissionOracleTests'


### PR DESCRIPTION
## Summary
CI workflow tweak: raise the coverage-lane timeout so coverage runs don't fail spuriously on slow lanes.

Diff is entirely in `.github/workflows/ci.yml` (+4 / -2).

## History
This PR originally carried three feature changes — keyboard-detection UX fixes, overlay label bug fixes, orphan-dialog simplification. That work was already merged to master via PR #305 (mWave keyboard support), so after rebasing onto master those commits were detected as "previously applied" and dropped. The CI timeout fix is the only remaining unique commit.

## Test plan
- [ ] CI passes on this branch
- [ ] No coverage lane timeout regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)