### PR TITLE
Window Snapping pack (Tier-3 probe)

### DIFF
--- a/Sources/KeyPathAppKit/Services/Packs/PackRegistry.swift
+++ b/Sources/KeyPathAppKit/Services/Packs/PackRegistry.swift
@@ -14,7 +14,8 @@ public enum PackRegistry {
         escapeRemap,
         deleteEnhancement,
         backupCapsLock,
-        vimNavigation
+        vimNavigation,
+        windowSnapping
     ]
 
     /// Look up a pack by id. Returns nil if unknown.
@@ -213,5 +214,33 @@ public enum PackRegistry {
         quickSettings: [],
         bindings: [],
         associatedCollectionID: RuleCollectionIdentifier.vimNavigation
+    )
+
+    // MARK: - Pack 7: Window Snapping
+
+    /// Collection-backed pack over `windowSnapping`. Entered as a nested
+    /// layer — Leader → w takes you to the window layer, then action keys
+    /// (l/r for halves, u/i/j/k for corners, [/] for displays, ,/. for
+    /// Spaces) fire Accessibility-driven window moves.
+    ///
+    /// **Runtime dependency:** window moves require Accessibility API
+    /// access. If the user has not granted it, pressing the action keys
+    /// will parse but do nothing — kanata emits a `push-msg` that KeyPath
+    /// intercepts; no AX access means no window ever moves. Surfacing a
+    /// permission-check UI at install time is tracked as follow-up work
+    /// (see docs/gallery/pack-migration-plan.md Tier-3 notes).
+    public static let windowSnapping = Pack(
+        id: "com.keypath.pack.window-snapping",
+        version: "1.0.0",
+        name: "Window Snapping",
+        tagline: "Snap, move, and tile windows with Leader → w",
+        shortDescription:
+            "Hold Space, press W, then: L/R for left/right halves, M to maximize, U/I/J/K for corners, [ ] for displays, , . for Spaces, Z to undo. Requires Accessibility access (macOS will prompt on first use).",
+        longDescription: "",
+        category: "Productivity",
+        iconSymbol: "rectangle.split.2x2",
+        quickSettings: [],
+        bindings: [],
+        associatedCollectionID: RuleCollectionIdentifier.windowSnapping
     )
 }

--- a/Tests/KeyPathTests/Config/PackRuntimeBehaviorTests.swift
+++ b/Tests/KeyPathTests/Config/PackRuntimeBehaviorTests.swift
@@ -74,6 +74,25 @@ final class PackRuntimeBehaviorTests: XCTestCase {
                       "Short tap on 'a' should emit 'a'; got: \(output)")
     }
 
+    /// Window Snapping is activated via Leader → w (nested layer). The
+    /// simulator cannot observe `push-msg` outputs (they go through TCP,
+    /// which isn't running in the sim), so instead we assert on the
+    /// `finalLayer` — holding space+w should land us in the "window" layer
+    /// where action keys fire Accessibility-driven window moves.
+    func testWindowSnappingNestedLayerActivation() throws {
+        let result = try simulateFull(
+            collectionIDs: [
+                RuleCollectionIdentifier.windowSnapping,
+                // The window layer is nested inside nav; nav is activated by
+                // vimNavigation's Space-hold activator.
+                RuleCollectionIdentifier.vimNavigation
+            ],
+            script: "↓spc 🕐300 ↓w 🕐200"
+        )
+        XCTAssertEqual(result.finalLayer, "window",
+                       "Holding space + w should put us in the 'window' layer for window-snapping actions")
+    }
+
     /// Vim Navigation's headline: hold Space → nav layer; inside the layer,
     /// h/j/k/l emit arrow keys. Without the Space-hold activation the letter
     /// should come through as-is. This checks both paths in one script.
@@ -99,11 +118,16 @@ final class PackRuntimeBehaviorTests: XCTestCase {
 
     private struct SimResult: Decodable {
         let events: [SimEvent]
+        let finalLayer: String?
     }
 
     /// Generate a kanata config with the given collections enabled, drive
     /// the simulator with `script`, return the parsed events.
     private func simulate(collectionIDs: [UUID], script: String) throws -> [SimEvent] {
+        try simulateFull(collectionIDs: collectionIDs, script: script).events
+    }
+
+    private func simulateFull(collectionIDs: [UUID], script: String) throws -> SimResult {
         guard let simulator = simulatorURL else {
             throw XCTSkip("kanata_simulated_input binary not available")
         }
@@ -142,17 +166,17 @@ final class PackRuntimeBehaviorTests: XCTestCase {
         guard process.terminationStatus == 0 else {
             let err = String(data: stderr.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
             XCTFail("simulator exited \(process.terminationStatus): \(err)")
-            return []
+            return SimResult(events: [], finalLayer: nil)
         }
 
         // Some log lines (info/warn) can precede the JSON block. Find the
         // first '{' and decode from there.
         guard let start = data.firstIndex(of: UInt8(ascii: "{")) else {
             XCTFail("simulator output contained no JSON: \(String(data: data, encoding: .utf8) ?? "")")
-            return []
+            return SimResult(events: [], finalLayer: nil)
         }
         let json = data[start...]
-        return try JSONDecoder().decode(SimResult.self, from: Data(json)).events
+        return try JSONDecoder().decode(SimResult.self, from: Data(json))
     }
 
     /// Pull the distinct key identifiers from output events (press-only),

--- a/Tests/KeyPathTests/PackRegistryTests.swift
+++ b/Tests/KeyPathTests/PackRegistryTests.swift
@@ -19,6 +19,7 @@ final class PackRegistryTests: XCTestCase {
         XCTAssertTrue(ids.contains("com.keypath.pack.delete-enhancement"))
         XCTAssertTrue(ids.contains("com.keypath.pack.backup-caps-lock"))
         XCTAssertTrue(ids.contains("com.keypath.pack.vim-navigation"))
+        XCTAssertTrue(ids.contains("com.keypath.pack.window-snapping"))
     }
 
     func testCollectionBackedPacksPointAtRealCollections() {


### PR DESCRIPTION
## Summary

First Tier-3 probe from `docs/gallery/pack-migration-plan.md` — tests whether packs with OS-level runtime deps (Accessibility API, private CGS APIs) fit the existing pack shape. Short answer: yes, with one documented follow-up.

### What's in
- Window Snapping pack in `PackRegistry` pointing at the existing `windowSnapping` collection. Activation: Space → nav → w → window layer, then l/r/m/c/u/i/j/k/[/]/,/./z for window moves.
- Runtime behavior test uses the simulator's `finalLayer` field — `push-msg` actions go through TCP which the sim doesn't run, so asserting on output events isn't possible. Instead we verify the nested-layer activation path (`space+w → "window"`).
- `testExpectedPacksShip` updated.

### Deferred
Install-time Accessibility permission check. Pack installs fine today; action keys silently no-op until macOS grants AX access (same status quo as the Rules-tab toggle). Tracked in migration plan Tier-3 notes.

### Context
Originally opened as PR #311 stacked on #310; when #310 merged the base branch was deleted and GitHub auto-closed the stack. Reopening here with just the Window Snapping commit cherry-picked onto fresh master.

## Test plan
- [ ] `swift test --filter PackRuntimeBehaviorTests` — 6 tests incl. new nested-layer check
- [ ] Gallery shows "Window Snapping" card in Productivity
- [ ] Space + w + l snaps focused window left (with AX permission)

🤖 Generated with [Claude Code](https://claude.com/claude-code)