### PR TITLE
Mission Control pack (Tier-1 breadth)

### DIFF
--- a/Sources/KeyPathAppKit/Models/RuleCollectionModels.swift
+++ b/Sources/KeyPathAppKit/Models/RuleCollectionModels.swift
@@ -366,6 +366,7 @@ public enum RuleCollectionIdentifier {
     public static let kindaVim = UUID(uuidString: "F1A2B3C4-5D6E-7F8A-9B0C-1D2E3F4A5B6C")!
     public static let neovimTerminal = UUID(uuidString: "A2B3C4D5-6E7F-8A9B-0C1D-2E3F4A5B6C7D")!
     public static let autoShiftSymbols = UUID(uuidString: "D1E2F3A4-B5C6-7D8E-9F0A-1B2C3D4E5F6A")!
+    public static let missionControl = UUID(uuidString: "C3A5E2F1-8D4B-4C9A-A1E7-5F3D9B2C8A6E")!
 }
 
 public enum RuleCollectionLayer: Codable, Equatable, Sendable, Hashable {

--- a/Sources/KeyPathAppKit/Services/Packs/PackRegistry.swift
+++ b/Sources/KeyPathAppKit/Services/Packs/PackRegistry.swift
@@ -15,7 +15,8 @@ public enum PackRegistry {
         deleteEnhancement,
         backupCapsLock,
         vimNavigation,
-        windowSnapping
+        windowSnapping,
+        missionControl
     ]
 
     /// Look up a pack by id. Returns nil if unknown.
@@ -242,5 +243,28 @@ public enum PackRegistry {
         quickSettings: [],
         bindings: [],
         associatedCollectionID: RuleCollectionIdentifier.windowSnapping
+    )
+
+    // MARK: - Pack 8: Mission Control
+
+    /// Collection-backed pack over `missionControl`. Three-modifier chords
+    /// (lctl + lmet + lalt + {up,down,left,right,d,n}) fire the system's
+    /// Mission Control, Exposé, Desktop, and Notification Center actions —
+    /// without fighting the physical F3 or binding a new shortcut from
+    /// scratch. Renders via the generic collection-mappings fallback in
+    /// Pack Detail.
+    public static let missionControl = Pack(
+        id: "com.keypath.pack.mission-control",
+        version: "1.0.0",
+        name: "Mission Control",
+        tagline: "Shortcuts for Exposé, Desktop, Notification Center",
+        shortDescription:
+            "Triple-chord shortcuts (Ctrl + Cmd + Option + a direction) for Mission Control, App Exposé, Desktop switching, Show Desktop, and Notification Center. Avoids the F3 muscle memory, no reach.",
+        longDescription: "",
+        category: "Productivity",
+        iconSymbol: "rectangle.3.group",
+        quickSettings: [],
+        bindings: [],
+        associatedCollectionID: RuleCollectionIdentifier.missionControl
     )
 }

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionCatalog.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionCatalog.swift
@@ -323,7 +323,7 @@ struct RuleCollectionCatalog {
 
     private var missionControl: RuleCollection {
         RuleCollection(
-            id: UUID(uuidString: "C3A5E2F1-8D4B-4C9A-A1E7-5F3D9B2C8A6E")!,
+            id: RuleCollectionIdentifier.missionControl,
             name: "Mission Control",
             summary: "Quick access to Mission Control, App Exposé, and Desktop switching.",
             category: .navigation,

--- a/Tests/KeyPathTests/Config/PackRuntimeBehaviorTests.swift
+++ b/Tests/KeyPathTests/Config/PackRuntimeBehaviorTests.swift
@@ -93,6 +93,27 @@ final class PackRuntimeBehaviorTests: XCTestCase {
                        "Holding space + w should put us in the 'window' layer for window-snapping actions")
     }
 
+    /// Mission Control maps 3-modifier chords (lctl + lmet + lalt + direction
+    /// or letter) to plain key combos macOS already interprets — e.g. the
+    /// `lctl + lmet + lalt + up` chord emits `C-up`, which is macOS's own
+    /// Mission Control shortcut. No AX or push-msg indirection, so the
+    /// simulator observes the actual output.
+    func testMissionControlChordEmitsCtrlUp() throws {
+        let events = try simulate(
+            collectionIDs: [RuleCollectionIdentifier.missionControl],
+            // Press all 3 modifiers together with up inside the chord
+            // window, release in reverse. Timings stay under defchordsv2's
+            // chord window.
+            script: "↓lctl 🕐5 ↓lmet 🕐5 ↓lalt 🕐5 ↓up 🕐50 ↑up 🕐20 ↑lalt 🕐5 ↑lmet 🕐5 ↑lctl 🕐50"
+        )
+        let output = outputKeys(events)
+        // The chord resolves to `C-up` which emits lctl+up. If the chord
+        // hadn't fired, we'd still see lctl but not a clean `up` output
+        // (up would still be suppressed by defsrc's chord input claim).
+        XCTAssertTrue(output.contains("up"),
+                      "Mission Control chord should emit up (as part of C-up); got: \(output)")
+    }
+
     /// Vim Navigation's headline: hold Space → nav layer; inside the layer,
     /// h/j/k/l emit arrow keys. Without the Space-hold activation the letter
     /// should come through as-is. This checks both paths in one script.

--- a/Tests/KeyPathTests/PackRegistryTests.swift
+++ b/Tests/KeyPathTests/PackRegistryTests.swift
@@ -20,6 +20,7 @@ final class PackRegistryTests: XCTestCase {
         XCTAssertTrue(ids.contains("com.keypath.pack.backup-caps-lock"))
         XCTAssertTrue(ids.contains("com.keypath.pack.vim-navigation"))
         XCTAssertTrue(ids.contains("com.keypath.pack.window-snapping"))
+        XCTAssertTrue(ids.contains("com.keypath.pack.mission-control"))
     }
 
     func testCollectionBackedPacksPointAtRealCollections() {


### PR DESCRIPTION
## Summary

Second Tier-1 probe — wraps the existing `missionControl` collection so its three-modifier chord shortcuts (Mission Control, Exposé, Desktop switching, Show Desktop, Notification Center) are discoverable from Gallery.

No new UI: uses the generic collection-mappings fallback from Vim Navigation. No new infrastructure — the Mission Control chord-input form bug was already fixed in #309.

Small cleanup: added `RuleCollectionIdentifier.missionControl` so the pack references the collection by name rather than an inline UUID literal.

## Coverage

Runtime behavior test simulates the `lctl + lmet + lalt + up` chord and asserts the output includes `up` (part of the expanded `C-up` emission). Catches regressions in defchordsv2 emission and concurrent-tap-hold wiring.

## Test plan
- [ ] `swift test --filter PackRuntimeBehaviorTests` passes (6 tests)
- [ ] Gallery shows Mission Control card in Productivity
- [ ] Pressing Ctrl+Cmd+Option+Up opens Mission Control (macOS default shortcut, which kanata now routes there)

🤖 Generated with [Claude Code](https://claude.com/claude-code)