### PR TITLE
Auto Shift Symbols pack (Tier-1 breadth)

### DIFF
--- a/Sources/KeyPathAppKit/Services/Packs/PackRegistry.swift
+++ b/Sources/KeyPathAppKit/Services/Packs/PackRegistry.swift
@@ -16,7 +16,8 @@ public enum PackRegistry {
         backupCapsLock,
         vimNavigation,
         windowSnapping,
-        missionControl
+        missionControl,
+        autoShiftSymbols
     ]
 
     /// Look up a pack by id. Returns nil if unknown.
@@ -266,5 +267,39 @@ public enum PackRegistry {
         quickSettings: [],
         bindings: [],
         associatedCollectionID: RuleCollectionIdentifier.missionControl
+    )
+
+    // MARK: - Pack 9: Auto Shift Symbols
+
+    /// Collection-backed pack over `autoShiftSymbols`. Tap a symbol key
+    /// normally; hold it slightly longer (~180ms) to get the shifted
+    /// variant — no Shift reach needed. Tap hyphen for `-`; hold for `_`.
+    /// Tap apostrophe for `'`; hold for `"`. Etc.
+    ///
+    /// Bindings here are illustrative: the kanata config is generated
+    /// from the collection's `AutoShiftSymbolsConfig` at install, not
+    /// from these templates. They exist so Pack Detail's fallback block
+    /// can show users what they'll get without needing a dedicated editor.
+    public static let autoShiftSymbols = Pack(
+        id: "com.keypath.pack.auto-shift-symbols",
+        version: "1.0.0",
+        name: "Auto Shift Symbols",
+        tagline: "Hold a symbol key for its shifted version",
+        shortDescription:
+            "Tap `-` for `-`, hold for `_`. Tap `'` for `'`, hold for `\"`. Tap `/` for `/`, hold for `?`. Works for all the usual shifted-symbol pairs — no more awkward Shift stretches.",
+        longDescription: "",
+        category: "Productivity",
+        iconSymbol: "arrow.up.square",
+        quickSettings: [],
+        bindings: [
+            PackBindingTemplate(input: "-", output: "-", holdOutput: "S--", title: "- · tap / _ · hold"),
+            PackBindingTemplate(input: "=", output: "=", holdOutput: "S-=", title: "= · tap / + · hold"),
+            PackBindingTemplate(input: "'", output: "'", holdOutput: "S-'", title: "' · tap / \" · hold"),
+            PackBindingTemplate(input: ";", output: ";", holdOutput: "S-;", title: "; · tap / : · hold"),
+            PackBindingTemplate(input: ",", output: ",", holdOutput: "S-,", title: ", · tap / < · hold"),
+            PackBindingTemplate(input: ".", output: ".", holdOutput: "S-.", title: ". · tap / > · hold"),
+            PackBindingTemplate(input: "/", output: "/", holdOutput: "S-/", title: "/ · tap / ? · hold")
+        ],
+        associatedCollectionID: RuleCollectionIdentifier.autoShiftSymbols
     )
 }

--- a/Tests/KeyPathTests/Config/PackRuntimeBehaviorTests.swift
+++ b/Tests/KeyPathTests/Config/PackRuntimeBehaviorTests.swift
@@ -114,6 +114,28 @@ final class PackRuntimeBehaviorTests: XCTestCase {
                       "Mission Control chord should emit up (as part of C-up); got: \(output)")
     }
 
+    /// Auto Shift Symbols makes symbol keys dual-role: quick tap emits the
+    /// symbol normally; holding past ~180ms emits the shifted variant. We
+    /// check the tap path — hold emits `S-'` which the simulator renders as
+    /// lsft + apostrophe, but timing is picky across platforms so we just
+    /// pin down the easy case (short tap must still give the raw symbol).
+    func testAutoShiftSymbolsShortTapEmitsRawSymbol() throws {
+        let events = try simulate(
+            collectionIDs: [RuleCollectionIdentifier.autoShiftSymbols],
+            // 30ms well under the ~180ms auto-shift threshold.
+            script: "↓' 🕐30 ↑' 🕐50"
+        )
+        let output = outputKeys(events)
+        // Simulator reports apostrophe as kanata's internal `apos` name.
+        // Either that or the raw `'` is acceptable; both mean the tap path
+        // is working.
+        let emittedApostrophe = output.contains("'") || output.contains("apos")
+        XCTAssertTrue(emittedApostrophe,
+                      "Short tap on apostrophe should still emit apostrophe; got: \(output)")
+        XCTAssertFalse(output.contains("lsft"),
+                       "Short tap should NOT engage shift; got: \(output)")
+    }
+
     /// Vim Navigation's headline: hold Space → nav layer; inside the layer,
     /// h/j/k/l emit arrow keys. Without the Space-hold activation the letter
     /// should come through as-is. This checks both paths in one script.

--- a/Tests/KeyPathTests/PackRegistryTests.swift
+++ b/Tests/KeyPathTests/PackRegistryTests.swift
@@ -21,6 +21,7 @@ final class PackRegistryTests: XCTestCase {
         XCTAssertTrue(ids.contains("com.keypath.pack.vim-navigation"))
         XCTAssertTrue(ids.contains("com.keypath.pack.window-snapping"))
         XCTAssertTrue(ids.contains("com.keypath.pack.mission-control"))
+        XCTAssertTrue(ids.contains("com.keypath.pack.auto-shift-symbols"))
     }
 
     func testCollectionBackedPacksPointAtRealCollections() {


### PR DESCRIPTION
## Summary

Third Tier-1 probe — wraps the existing `autoShiftSymbols` collection. Tap a symbol key normally; hold past ~180ms to get the shifted variant (e.g. `-` → `_`, `'` → `\"`, `/` → `?`).

No new UI. Uses the pack-bindings display path (vs the generic collection-mappings fallback) because the collection synthesizes kanata mappings from its `AutoShiftSymbolsConfig` at install time, leaving `mappings: []` on the collection itself. The pack's `bindings` are illustrative; install still goes through `associatedCollectionID`.

## Coverage

Runtime behavior test asserts short-tap on apostrophe emits an apostrophe (whether as literal `'` or kanata's `apos` token) and crucially does NOT engage `lsft`. Catches regressions in the dual-role tap/hold generation.

## Test plan
- [ ] `swift test --filter PackRuntimeBehaviorTests` passes (7 tests)
- [ ] Gallery shows an Auto Shift Symbols card in Productivity
- [ ] Holding `-` for a second produces `_`, same for `'` → `\"`, `/` → `?`

🤖 Generated with [Claude Code](https://claude.com/claude-code)