### PR TITLE
Numpad Layer pack + generator fix for nested-layer activators

### DIFF
--- a/Sources/KeyPathAppKit/Infrastructure/Config/KanataConfiguration+BlockBuilders.swift
+++ b/Sources/KeyPathAppKit/Infrastructure/Config/KanataConfiguration+BlockBuilders.swift
@@ -549,9 +549,16 @@ extension KanataConfiguration {
             let name = OverlayKeyboardView.keyCodeToKanataName(key.keyCode).lowercased()
             // Skip unknown keycodes
             guard !name.hasPrefix("unknown-") else { return nil }
+            // Early skip via the raw kanata name (covers defaults like "leftmeta").
             guard !skip.contains(name) else { return nil }
             let converted = KanataKeyConverter.convertToKanataKey(name)
             let kanata = normalizeInternationalKey(converted)
+            // Second skip pass against the *converted* kanata name so callers
+            // that pass activator keys in kanata form (e.g. ";" rather than
+            // "semicolon") correctly exclude them. Without this, nested-layer
+            // activators from source layers like nav get silently replaced by
+            // an "XX blocker" entry, breaking their runtime activation.
+            guard !skip.contains(kanata) else { return nil }
             guard !mappedKeys.contains(kanata) else { return nil }
             return kanata
         }

--- a/Sources/KeyPathAppKit/Services/Packs/PackRegistry.swift
+++ b/Sources/KeyPathAppKit/Services/Packs/PackRegistry.swift
@@ -17,7 +17,8 @@ public enum PackRegistry {
         vimNavigation,
         windowSnapping,
         missionControl,
-        autoShiftSymbols
+        autoShiftSymbols,
+        numpadLayer
     ]
 
     /// Look up a pack by id. Returns nil if unknown.
@@ -301,5 +302,28 @@ public enum PackRegistry {
             PackBindingTemplate(input: "/", output: "/", holdOutput: "S-/", title: "/ · tap / ? · hold")
         ],
         associatedCollectionID: RuleCollectionIdentifier.autoShiftSymbols
+    )
+
+    // MARK: - Pack 10: Numpad Layer
+
+    /// Collection-backed pack over `numpadLayer`. Activated via the two-step
+    /// Leader → ; sequence, the right hand becomes a numpad (u/i/o → 7/8/9,
+    /// j/k/l → 4/5/6, m/,/. → 1/2/3, n → 0). Left hand gets operators
+    /// (f → +, d → −, s → ×, a → ÷, g → ⏎). Great for spreadsheets,
+    /// calculators, and CSS pixel-counting without reaching for the number
+    /// row or the physical numpad.
+    public static let numpadLayer = Pack(
+        id: "com.keypath.pack.numpad-layer",
+        version: "1.0.0",
+        name: "Numpad",
+        tagline: "Turn your right hand into a numpad",
+        shortDescription:
+            "Hold Space, press `;`, then use u/i/o + j/k/l + m/,/. as a numpad. Left-hand keys become operators (+ − × ÷ ⏎). Release Space to go back to normal typing.",
+        longDescription: "",
+        category: "Layers",
+        iconSymbol: "number.square",
+        quickSettings: [],
+        bindings: [],
+        associatedCollectionID: RuleCollectionIdentifier.numpadLayer
     )
 }

--- a/Tests/KeyPathTests/Config/PackRuntimeBehaviorTests.swift
+++ b/Tests/KeyPathTests/Config/PackRuntimeBehaviorTests.swift
@@ -136,6 +136,15 @@ final class PackRuntimeBehaviorTests: XCTestCase {
                        "Short tap should NOT engage shift; got: \(output)")
     }
 
+    // Numpad Layer: no runtime behavior test yet. The collection's
+    // `;` activator (sourceLayer: .navigation → targetLayer: .custom("num"))
+    // is emitted as `XX` inside deflayer nav rather than as
+    // `@layer_num_;`, so the second activation hop never fires.
+    // That's a pre-existing generator bug that affects any nested
+    // layer whose activator key is not already mapped in the source
+    // layer — filed as a follow-up, not caused by this pack.
+    // `--check` still accepts the config (covered by testEveryCatalogCollectionValidates).
+
     /// Vim Navigation's headline: hold Space → nav layer; inside the layer,
     /// h/j/k/l emit arrow keys. Without the Space-hold activation the letter
     /// should come through as-is. This checks both paths in one script.

--- a/Tests/KeyPathTests/Config/PackRuntimeBehaviorTests.swift
+++ b/Tests/KeyPathTests/Config/PackRuntimeBehaviorTests.swift
@@ -136,14 +136,21 @@ final class PackRuntimeBehaviorTests: XCTestCase {
                        "Short tap should NOT engage shift; got: \(output)")
     }
 
-    // Numpad Layer: no runtime behavior test yet. The collection's
-    // `;` activator (sourceLayer: .navigation → targetLayer: .custom("num"))
-    // is emitted as `XX` inside deflayer nav rather than as
-    // `@layer_num_;`, so the second activation hop never fires.
-    // That's a pre-existing generator bug that affects any nested
-    // layer whose activator key is not already mapped in the source
-    // layer — filed as a follow-up, not caused by this pack.
-    // `--check` still accepts the config (covered by testEveryCatalogCollectionValidates).
+    /// Numpad Layer is two-step-activated (Leader → `;`). Nested-layer
+    /// activators render as one-shot-press, so `;` is tapped (not held)
+    /// while Space is held for nav. Inside the num layer, j should emit kp4.
+    func testNumpadLayerJBecomesKp4() throws {
+        let events = try simulate(
+            collectionIDs: [
+                RuleCollectionIdentifier.numpadLayer,
+                RuleCollectionIdentifier.vimNavigation
+            ],
+            script: "↓spc 🕐300 ↓; 🕐30 ↑; 🕐30 ↓j 🕐30 ↑j 🕐30 ↑spc 🕐20"
+        )
+        let output = outputKeys(events)
+        XCTAssertTrue(output.contains("kp4"),
+                      "j inside numpad layer should emit kp4; got: \(output)")
+    }
 
     /// Vim Navigation's headline: hold Space → nav layer; inside the layer,
     /// h/j/k/l emit arrow keys. Without the Space-hold activation the letter

--- a/Tests/KeyPathTests/PackRegistryTests.swift
+++ b/Tests/KeyPathTests/PackRegistryTests.swift
@@ -22,6 +22,7 @@ final class PackRegistryTests: XCTestCase {
         XCTAssertTrue(ids.contains("com.keypath.pack.window-snapping"))
         XCTAssertTrue(ids.contains("com.keypath.pack.mission-control"))
         XCTAssertTrue(ids.contains("com.keypath.pack.auto-shift-symbols"))
+        XCTAssertTrue(ids.contains("com.keypath.pack.numpad-layer"))
     }
 
     func testCollectionBackedPacksPointAtRealCollections() {

--- a/docs/gallery/pack-migration-plan.md
+++ b/docs/gallery/pack-migration-plan.md
@@ -106,7 +106,7 @@ For each pack ported:
 
 ## Known generator gaps surfaced by packs
 
-- **Nested-layer activators from unmapped source keys** — When a collection declares `momentaryActivator(sourceLayer: .navigation, input: X)` and X isn't already mapped within the nav layer by some other collection, the generator writes `XX` (no-op) into the nav layer's slot for X rather than the expected `@layer_<target>_<X>` alias. Visible on Numpad (`;` activator from nav) but the alias itself is correctly defined — it just isn't referenced in the source layer's deflayer. Window Snapping didn't hit this because `w` is mapped within nav through some other path. Covered by `--check` (config parses) but breaks runtime activation.
+- ~~**Nested-layer activators from unmapped source keys**~~ — **Fixed** in the Numpad pack PR. Root cause was `navigationUnmappedKeys` skipping activator keys by their pre-conversion name but callers passed post-conversion kanata names, so keys like `;` fell through, got rendered as `XX` blockers, and overwrote the activator entry in dedupe. Fix adds a second skip pass against the converted name.
 
 ## Risks / known sharp edges
 

--- a/docs/gallery/pack-migration-plan.md
+++ b/docs/gallery/pack-migration-plan.md
@@ -104,6 +104,10 @@ For each pack ported:
 - [ ] Add to `PackRegistryTests.testExpectedPacksShip`.
 - [ ] Capture a screenshot for the pack card's hero icon decision (SF Symbols first; no custom art).
 
+## Known generator gaps surfaced by packs
+
+- **Nested-layer activators from unmapped source keys** — When a collection declares `momentaryActivator(sourceLayer: .navigation, input: X)` and X isn't already mapped within the nav layer by some other collection, the generator writes `XX` (no-op) into the nav layer's slot for X rather than the expected `@layer_<target>_<X>` alias. Visible on Numpad (`;` activator from nav) but the alias itself is correctly defined — it just isn't referenced in the source layer's deflayer. Window Snapping didn't hit this because `w` is mapped within nav through some other path. Covered by `--check` (config parses) but breaks runtime activation.
+
 ## Risks / known sharp edges
 
 - **Collection conflicts.** Enabling two collections that both bind the same physical key today produces undefined behavior. The validation harness will catch outright parse errors, but semantic conflicts (same key, two different tap outputs) will silently pick one. Consider a `packConflicts(pack:)` helper before enabling Window Snapping alongside HRM (both may want letter keys).


### PR DESCRIPTION
## Summary

- **Numpad pack** — wraps the existing `numpadLayer` collection. Two-step activation: hold Space for nav, tap `;` to enter the num layer. Right hand u/i/o + j/k/l + m/,/. becomes a 3x3 numpad; left hand a/s/d/f/g becomes ÷/×/−/+/⏎.
- **Generator fix** — `navigationUnmappedKeys` was skipping activator keys by their pre-conversion name but callers passed post-conversion kanata names, so keys like `;` fell through, got rendered as XX blockers, and overwrote the correct `@layer_num_;` activator entry in dedupe. Two-line fix: add a second skip pass against the converted name.
- **Runtime behavior test** — scripted `space held + ; tapped + j` → kp4. Caught the generator bug above before merge.

### Context
Originally opened as #315, rebase got ugly after #314's auto-shift-symbols merge. Re-opened fresh.

## Test plan
- [ ] `swift test --filter PackRuntimeBehaviorTests` passes (8 tests incl. Numpad)
- [ ] Gallery shows Numpad card in Layers category
- [ ] Space + ; + j moves the cursor/emits kp4 (depending on app)

🤖 Generated with [Claude Code](https://claude.com/claude-code)