### PR TITLE
Leader Key pack — change which key activates nav layer

### DIFF
--- a/Sources/KeyPathAppKit/Services/Packs/PackRegistry.swift
+++ b/Sources/KeyPathAppKit/Services/Packs/PackRegistry.swift
@@ -21,7 +21,8 @@ public enum PackRegistry {
         numpadLayer,
         symbolLayer,
         funLayer,
-        launcher
+        launcher,
+        leaderKey
     ]
 
     /// Look up a pack by id. Returns nil if unknown.
@@ -413,5 +414,33 @@ public enum PackRegistry {
         quickSettings: [],
         bindings: [],
         associatedCollectionID: RuleCollectionIdentifier.launcher
+    )
+
+    // MARK: - Pack 14: Leader Key
+
+    /// Collection-backed pack over `leaderKey`. Picks which physical key
+    /// activates the navigation layer (the "Leader") for every other
+    /// nav-based pack you have on — Vim Navigation, Window Snapping,
+    /// Mission Control, Numpad, Symbol, Function, Delete Enhancement.
+    /// Default is Space; alternatives are Caps Lock, Tab, or Backtick.
+    ///
+    /// This pack doesn't add new mappings of its own — it changes a global
+    /// preference that the config generator reads when it emits the nav
+    /// activator. Touching it from Pack Detail routes through
+    /// `updateCollectionOutput` which special-cases the Leader Key
+    /// collection and writes through to `LeaderKeyPreference`.
+    public static let leaderKey = Pack(
+        id: "com.keypath.pack.leader-key",
+        version: "1.0.0",
+        name: "Leader Key",
+        tagline: "Pick which key activates the navigation layer",
+        shortDescription:
+            "Default is Space — but if your thumb's already busy, swap to Caps Lock (the most common alternative), Tab, or Backtick. The change applies everywhere: Vim Nav, Mission Control, Numpad, Symbol, Function, Window Snapping, and Delete Enhancement all use whatever you pick.",
+        longDescription: "",
+        category: "Productivity",
+        iconSymbol: "hand.point.up.left",
+        quickSettings: [],
+        bindings: [],
+        associatedCollectionID: RuleCollectionIdentifier.leaderKey
     )
 }

--- a/Tests/KeyPathTests/PackRegistryTests.swift
+++ b/Tests/KeyPathTests/PackRegistryTests.swift
@@ -26,6 +26,7 @@ final class PackRegistryTests: XCTestCase {
         XCTAssertTrue(ids.contains("com.keypath.pack.symbol-layer"))
         XCTAssertTrue(ids.contains("com.keypath.pack.fun-layer"))
         XCTAssertTrue(ids.contains("com.keypath.pack.quick-launcher"))
+        XCTAssertTrue(ids.contains("com.keypath.pack.leader-key"))
     }
 
     func testCollectionBackedPacksPointAtRealCollections() {


### PR DESCRIPTION
## Summary

Wraps the existing `leaderKey` collection as the 14th Gallery pack. Default leader is Space; alternatives are Caps Lock (most common), Tab, or Backtick. The change applies globally — every nav-based pack (Vim Nav, Numpad, Symbol, Fun, Mission Control, Window Snapping, Delete Enhancement) reads the same preference.

## How it works

Pack Detail routes through the existing `singleKeyPicker` dispatch already used by Escape Remap, Delete Enhancement, and Backup Caps Lock — same UI, same dispatch, same `applySingleKeyEdit` apply method. On the manager side, `updateCollectionOutput` already special-cases the Leader Key id and writes through to `LeaderKeyPreference`, so no new wiring needed.

## Was Tier-3, became Tier-2

Originally categorized as Tier-3 in the migration plan because of "different shape" reasoning (pack modifies a global preference rather than adding bindings). Looking again, it fits the existing single-key picker dispatch path cleanly. It's effectively Tier-2.

## Catalog migration status after this

| Status | Pack |
|--------|------|
| Shipped (14) | Caps Lock Remap, Home Row Mods, Escape Remap, Delete Enhancement, Backup Caps Lock, Vim Navigation, Window Snapping, Mission Control, Auto Shift Symbols, Numpad, Symbol, Function, Quick Launcher, **Leader Key** |
| Remaining (4 — true Tier-3) | Chord Groups, Sequences (ship-empty author frameworks); KindaVim, Neovim Terminal (need app-scope primitive) |
| Excluded | macOS Function Keys (always-on system default) |

## Test plan
- [ ] `swift test` passes (420 tests)
- [ ] Gallery shows Leader Key in Productivity
- [ ] Pack Detail shows the Space / Caps / Tab / Grave picker
- [ ] Changing the Leader from Space to Caps reloads kanata; pressing+holding Caps now activates nav layer for Vim Nav et al.

🤖 Generated with [Claude Code](https://claude.com/claude-code)