### PR TITLE
feat(packs): redesign KindaVim pack as visual-only companion

### DIFF
--- a/Sources/KeyPathAppKit/App.swift
+++ b/Sources/KeyPathAppKit/App.swift
@@ -451,6 +451,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // the user has listed in Settings → Experimental (default: Figma).
         OverlayAppSuppressor.shared.start()
 
+        // Mirror KindaVim pack state into the KindaVim mode monitor —
+        // start watching kindaVim's environment.json when the pack is on,
+        // stop when it's off.
+        KindaVimPackController.shared.start()
+
         // Sequential startup: regenerate config, auto-launch, validate, auto-wizard
         Task { @MainActor in
             do {

--- a/Sources/KeyPathAppKit/Services/KindaVim/KindaVimModeMonitor.swift
+++ b/Sources/KeyPathAppKit/Services/KindaVim/KindaVimModeMonitor.swift
@@ -1,0 +1,220 @@
+// Watches kindaVim's published mode state from
+// `~/Library/Application Support/kindaVim/environment.json` and exposes
+// the current mode as an Observable property the overlay can react to.
+//
+// kindaVim writes the file on every mode change (see
+// https://docs.kindavim.app/integrations/json-file). The file path is
+// stable across kindaVim versions and survives app restarts, which makes
+// it more robust than the older NSDistributedNotification API some
+// users have reported issues with on newer macOS releases.
+
+import Foundation
+import KeyPathCore
+
+@MainActor
+@Observable
+final class KindaVimModeMonitor {
+    static let shared = KindaVimModeMonitor()
+
+    enum Mode: String, Sendable, Equatable {
+        case insert
+        case normal
+        case visual
+        case operatorPending = "operator-pending"
+
+        public var displayLabel: String {
+            switch self {
+            case .insert: "Insert"
+            case .normal: "Normal"
+            case .visual: "Visual"
+            case .operatorPending: "Op"
+            }
+        }
+    }
+
+    /// Current mode, or nil if kindaVim isn't running / file not present yet.
+    private(set) var mode: Mode?
+
+    /// True if the environment file exists at all (kindaVim was ever launched).
+    private(set) var environmentFileExists: Bool = false
+
+    @ObservationIgnored
+    private var fileSource: DispatchSourceFileSystemObject?
+
+    @ObservationIgnored
+    private var fileDescriptor: Int32 = -1
+
+    @ObservationIgnored
+    private var directorySource: DispatchSourceFileSystemObject?
+
+    @ObservationIgnored
+    private var directoryDescriptor: Int32 = -1
+
+    @ObservationIgnored
+    private var notificationObservers: [NSObjectProtocol] = []
+
+    static let environmentFileURL: URL = {
+        let appSupport = FileManager.default
+            .homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Application Support", isDirectory: true)
+        return appSupport
+            .appendingPathComponent("kindaVim", isDirectory: true)
+            .appendingPathComponent("environment.json")
+    }()
+
+    /// Start observing the kindaVim environment file. Idempotent.
+    func start() {
+        guard fileSource == nil, directorySource == nil else { return }
+        AppLogger.shared.log("👀 [KindaVimMonitor] Starting")
+        readCurrentState()
+        if FileManager.default.fileExists(atPath: Self.environmentFileURL.path) {
+            attachFileWatcher()
+        } else {
+            attachDirectoryWatcher()
+        }
+        attachDistributedNotificationFallback()
+    }
+
+    /// Stop observing. Idempotent.
+    func stop() {
+        AppLogger.shared.log("🛑 [KindaVimMonitor] Stopping")
+        detachFileWatcher()
+        detachDirectoryWatcher()
+        for token in notificationObservers {
+            DistributedNotificationCenter.default().removeObserver(token)
+        }
+        notificationObservers.removeAll()
+        mode = nil
+        environmentFileExists = false
+    }
+
+    // MARK: - File watching
+
+    private func attachFileWatcher() {
+        let url = Self.environmentFileURL
+        let fd = open(url.path, O_EVTONLY)
+        guard fd >= 0 else {
+            AppLogger.shared.warn("⚠️ [KindaVimMonitor] open() failed for \(url.path)")
+            return
+        }
+        fileDescriptor = fd
+        let source = DispatchSource.makeFileSystemObjectSource(
+            fileDescriptor: fd,
+            eventMask: [.write, .extend, .delete, .rename],
+            queue: .main
+        )
+        source.setEventHandler { [weak self] in
+            guard let self else { return }
+            let events = source.data
+            // Re-read on any write / extend.
+            if events.contains(.write) || events.contains(.extend) {
+                self.readCurrentState()
+            }
+            // File replaced or moved (atomic write) — re-attach.
+            if events.contains(.delete) || events.contains(.rename) {
+                self.detachFileWatcher()
+                self.attachDirectoryWatcher()
+                self.readCurrentState()
+            }
+        }
+        source.setCancelHandler {
+            close(fd)
+        }
+        source.resume()
+        fileSource = source
+    }
+
+    private func detachFileWatcher() {
+        fileSource?.cancel()
+        fileSource = nil
+        fileDescriptor = -1
+    }
+
+    /// Watches the parent directory so we notice when kindaVim creates the
+    /// environment.json for the first time after KeyPath launches before kV.
+    private func attachDirectoryWatcher() {
+        let dir = Self.environmentFileURL.deletingLastPathComponent()
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let fd = open(dir.path, O_EVTONLY)
+        guard fd >= 0 else { return }
+        directoryDescriptor = fd
+        let source = DispatchSource.makeFileSystemObjectSource(
+            fileDescriptor: fd,
+            eventMask: [.write],
+            queue: .main
+        )
+        source.setEventHandler { [weak self] in
+            guard let self else { return }
+            if FileManager.default.fileExists(atPath: Self.environmentFileURL.path) {
+                self.detachDirectoryWatcher()
+                self.attachFileWatcher()
+                self.readCurrentState()
+            }
+        }
+        source.setCancelHandler {
+            close(fd)
+        }
+        source.resume()
+        directorySource = source
+    }
+
+    private func detachDirectoryWatcher() {
+        directorySource?.cancel()
+        directorySource = nil
+        directoryDescriptor = -1
+    }
+
+    private func readCurrentState() {
+        let url = Self.environmentFileURL
+        guard let data = try? Data(contentsOf: url) else {
+            environmentFileExists = false
+            mode = nil
+            return
+        }
+        environmentFileExists = true
+        struct Payload: Decodable { let mode: String }
+        guard let payload = try? JSONDecoder().decode(Payload.self, from: data),
+              let parsed = Mode(rawValue: payload.mode)
+        else {
+            mode = nil
+            return
+        }
+        if mode != parsed {
+            mode = parsed
+            AppLogger.shared.log("👀 [KindaVimMonitor] mode → \(parsed.rawValue)")
+        }
+    }
+
+    // MARK: - Distributed notification fallback
+
+    /// Subscribe to kindaVim's `kindaVimDidEnter*Mode` distributed
+    /// notifications as a belt-and-suspenders signal. The JSON file is
+    /// the primary path; this catches the rare case where file events
+    /// aren't delivered (some users have reported flakiness on newer
+    /// macOS releases).
+    private func attachDistributedNotificationFallback() {
+        let center = DistributedNotificationCenter.default()
+        let pairs: [(name: String, mode: Mode)] = [
+            ("kindaVimDidEnterInsertMode", .insert),
+            ("kindaVimDidEnterNormalMode", .normal),
+            ("kindaVimDidEnterVisualMode", .visual),
+            ("kindaVimDidEnterOperatorPendingMode", .operatorPending)
+        ]
+        for (name, target) in pairs {
+            let token = center.addObserver(
+                forName: Notification.Name(name),
+                object: nil,
+                queue: .main
+            ) { [weak self] _ in
+                MainActor.assumeIsolated {
+                    guard let self else { return }
+                    if self.mode != target {
+                        self.mode = target
+                        AppLogger.shared.log("👀 [KindaVimMonitor] (notif) mode → \(target.rawValue)")
+                    }
+                }
+            }
+            notificationObservers.append(token)
+        }
+    }
+}

--- a/Sources/KeyPathAppKit/Services/KindaVim/KindaVimPackController.swift
+++ b/Sources/KeyPathAppKit/Services/KindaVim/KindaVimPackController.swift
@@ -1,0 +1,44 @@
+// Bridges the KindaVim pack's install/uninstall state to the
+// `KindaVimModeMonitor`. Started once at app launch; observes
+// `installedPacksChanged` and starts/stops the monitor as the user
+// toggles the pack from Gallery (or Pack Detail).
+
+import Foundation
+import KeyPathCore
+
+@MainActor
+final class KindaVimPackController {
+    static let shared = KindaVimPackController()
+
+    private var observer: NSObjectProtocol?
+
+    func start() {
+        guard observer == nil else { return }
+        observer = NotificationCenter.default.addObserver(
+            forName: .installedPacksChanged,
+            object: nil,
+            queue: .main
+        ) { _ in
+            Task { @MainActor in
+                await KindaVimPackController.shared.refresh()
+            }
+        }
+        // Apply initial state.
+        Task { await refresh() }
+    }
+
+    func stop() {
+        observer.map(NotificationCenter.default.removeObserver)
+        observer = nil
+        KindaVimModeMonitor.shared.stop()
+    }
+
+    private func refresh() async {
+        let installed = await InstalledPackTracker.shared.isInstalled(packID: PackRegistry.kindaVim.id)
+        if installed {
+            KindaVimModeMonitor.shared.start()
+        } else {
+            KindaVimModeMonitor.shared.stop()
+        }
+    }
+}

--- a/Sources/KeyPathAppKit/Services/Packs/InstalledPackTracker.swift
+++ b/Sources/KeyPathAppKit/Services/Packs/InstalledPackTracker.swift
@@ -77,6 +77,7 @@ public actor InstalledPackTracker {
         await ensureLoaded()
         records[record.packID] = record
         try persist()
+        await postChangeNotification()
     }
 
     /// Remove an installed-pack record. Persists.
@@ -84,6 +85,16 @@ public actor InstalledPackTracker {
         await ensureLoaded()
         records.removeValue(forKey: packID)
         try persist()
+        await postChangeNotification()
+    }
+
+    /// Post a foreground notification so observers (e.g. KindaVim mode
+    /// monitor) can react to install/uninstall in real time. Hops to the
+    /// main actor to keep the post on the main runloop.
+    private func postChangeNotification() async {
+        await MainActor.run {
+            NotificationCenter.default.post(name: .installedPacksChanged, object: nil)
+        }
     }
 
     // MARK: - Persistence

--- a/Sources/KeyPathAppKit/Services/Packs/Pack.swift
+++ b/Sources/KeyPathAppKit/Services/Packs/Pack.swift
@@ -59,6 +59,13 @@ public struct Pack: Identifiable, Equatable, Sendable {
     /// a rule collection (Home Row Mods, future layers, etc).
     public let associatedCollectionID: UUID?
 
+    /// True for "visual-only" packs — install/uninstall just toggles the
+    /// installed-pack tracker record, with no kanata config side effects.
+    /// Used for packs whose value is metadata + companion-app integration
+    /// rather than remapping (e.g. KindaVim, where the kindaVim.app itself
+    /// handles all key behavior and our pack only drives mode visualization).
+    public let visualOnly: Bool
+
     public init(
         id: String,
         version: String,
@@ -72,7 +79,8 @@ public struct Pack: Identifiable, Equatable, Sendable {
         iconSecondarySymbol: String? = nil,
         quickSettings: [PackQuickSetting] = [],
         bindings: [PackBindingTemplate],
-        associatedCollectionID: UUID? = nil
+        associatedCollectionID: UUID? = nil,
+        visualOnly: Bool = false
     ) {
         self.id = id
         self.version = version
@@ -87,6 +95,7 @@ public struct Pack: Identifiable, Equatable, Sendable {
         self.quickSettings = quickSettings
         self.bindings = bindings
         self.associatedCollectionID = associatedCollectionID
+        self.visualOnly = visualOnly
     }
 
     /// The physical keys this pack affects. Drives Pack Detail's keyboard

--- a/Sources/KeyPathAppKit/Services/Packs/PackInstaller.swift
+++ b/Sources/KeyPathAppKit/Services/Packs/PackInstaller.swift
@@ -65,7 +65,7 @@ public final class PackInstaller {
             "📦 [PackInstaller] Installing pack '\(pack.name)' (id=\(pack.id), v\(pack.version))"
         )
 
-        try await enforcePreInstallGates(for: pack)
+        try await enforcePreInstallGates(for: pack, manager: manager)
 
         // Resolve effective quick-setting values (user-provided ∪ defaults).
         let resolvedSettings = resolveQuickSettings(pack: pack, overrides: quickSettingValues)
@@ -353,17 +353,27 @@ public final class PackInstaller {
     /// Pack-specific install gates. Right now only the KindaVim Mode
     /// Display pack has any: it conflicts with Vim Navigation (both want
     /// to own the h/j/k/l story) and requires kindaVim.app to be present.
-    private func enforcePreInstallGates(for pack: Pack) async throws {
+    private func enforcePreInstallGates(
+        for pack: Pack,
+        manager: RuleCollectionsManager
+    ) async throws {
         if pack.id == PackRegistry.kindaVim.id {
             // Mutex: refuse if any conflicting pack is installed.
-            let conflictIDs = ["com.keypath.pack.vim-navigation"]
             var conflictNames: [String] = []
-            for id in conflictIDs {
-                if await InstalledPackTracker.shared.isInstalled(packID: id),
-                   let conflict = PackRegistry.pack(id: id)
-                {
-                    conflictNames.append(conflict.name)
-                }
+            if await InstalledPackTracker.shared.isInstalled(packID: "com.keypath.pack.vim-navigation"),
+               let conflict = PackRegistry.pack(id: "com.keypath.pack.vim-navigation")
+            {
+                conflictNames.append(conflict.name)
+            }
+            // Also block on the legacy KindaVim rule collection (retired
+            // in this release but preserved on disk for upgraders until the
+            // migration runs). If it's still enabled, kindaVim.app would be
+            // fighting our old h/j/k/l remaps — refuse and surface it as
+            // a conflict the user can resolve from Rules.
+            if manager.ruleCollections.contains(where: {
+                $0.id == RuleCollectionIdentifier.kindaVim && $0.isEnabled
+            }) {
+                conflictNames.append("Legacy KindaVim rules")
             }
             if !conflictNames.isEmpty {
                 throw InstallError.mutuallyExclusive(conflicts: conflictNames)

--- a/Sources/KeyPathAppKit/Services/Packs/PackInstaller.swift
+++ b/Sources/KeyPathAppKit/Services/Packs/PackInstaller.swift
@@ -19,13 +19,26 @@ public final class PackInstaller {
     public enum InstallError: LocalizedError {
         case noRuleCollectionsManager
         case saveFailed(String)
+        /// One or more other packs the user has installed are mutually
+        /// exclusive with this one. Carries the conflicting pack names so
+        /// the UI can name them in the alert.
+        case mutuallyExclusive(conflicts: [String])
+        /// A required external app/dependency isn't installed. Carries
+        /// the dependency display name and a website URL the UI can
+        /// surface as a "Get it →" CTA.
+        case dependencyMissing(name: String, websiteURL: URL)
 
         public var errorDescription: String? {
             switch self {
             case .noRuleCollectionsManager:
-                "RuleCollectionsManager is not available. The app may not be fully initialised."
+                return "RuleCollectionsManager is not available. The app may not be fully initialised."
             case let .saveFailed(reason):
-                "Could not save pack rules: \(reason)"
+                return "Could not save pack rules: \(reason)"
+            case let .mutuallyExclusive(conflicts):
+                let names = conflicts.joined(separator: ", ")
+                return "Conflicts with \(names). Turn that pack off first to enable this one."
+            case let .dependencyMissing(name, _):
+                return "\(name) isn't installed."
             }
         }
     }
@@ -52,8 +65,28 @@ public final class PackInstaller {
             "📦 [PackInstaller] Installing pack '\(pack.name)' (id=\(pack.id), v\(pack.version))"
         )
 
+        try await enforcePreInstallGates(for: pack)
+
         // Resolve effective quick-setting values (user-provided ∪ defaults).
         let resolvedSettings = resolveQuickSettings(pack: pack, overrides: quickSettingValues)
+
+        // Visual-only packs (e.g. KindaVim Mode Display) don't touch the
+        // kanata config at all — install just persists the tracker record
+        // so other parts of the app (overlay, mode monitor) can react to
+        // "this pack is active". No collection toggle, no reload.
+        if pack.visualOnly {
+            let record = InstalledPackRecord(
+                packID: pack.id,
+                version: pack.version,
+                installedAt: Date(),
+                quickSettingValues: resolvedSettings
+            )
+            try await InstalledPackTracker.shared.upsert(record)
+            AppLogger.shared.log(
+                "✅ [PackInstaller] Installed visual-only pack '\(pack.name)' (no kanata side effects)"
+            )
+            return record
+        }
 
         // Collection-backed packs (e.g. Home Row Mods) don't generate custom
         // rules — they just toggle the built-in RuleCollection on.
@@ -120,6 +153,16 @@ public final class PackInstaller {
         manager: RuleCollectionsManager
     ) async throws {
         AppLogger.shared.log("📦 [PackInstaller] Uninstalling pack '\(packID)'")
+
+        // Visual-only packs just clear the tracker record; no kanata
+        // changes to revert.
+        if let pack = PackRegistry.pack(id: packID), pack.visualOnly {
+            try await InstalledPackTracker.shared.remove(packID: packID)
+            AppLogger.shared.log(
+                "✅ [PackInstaller] Uninstalled visual-only pack '\(packID)'"
+            )
+            return
+        }
 
         // Collection-backed packs uninstall by disabling the associated
         // built-in collection; they don't have their own CustomRules to
@@ -302,6 +345,43 @@ public final class PackInstaller {
                 deviceOverrides: nil,
                 packSource: pack.id
             )
+        }
+    }
+
+    // MARK: - Pre-install gates
+
+    /// Pack-specific install gates. Right now only the KindaVim Mode
+    /// Display pack has any: it conflicts with Vim Navigation (both want
+    /// to own the h/j/k/l story) and requires kindaVim.app to be present.
+    private func enforcePreInstallGates(for pack: Pack) async throws {
+        if pack.id == PackRegistry.kindaVim.id {
+            // Mutex: refuse if any conflicting pack is installed.
+            let conflictIDs = ["com.keypath.pack.vim-navigation"]
+            var conflictNames: [String] = []
+            for id in conflictIDs {
+                if await InstalledPackTracker.shared.isInstalled(packID: id),
+                   let conflict = PackRegistry.pack(id: id)
+                {
+                    conflictNames.append(conflict.name)
+                }
+            }
+            if !conflictNames.isEmpty {
+                throw InstallError.mutuallyExclusive(conflicts: conflictNames)
+            }
+
+            // Dependency: kindaVim.app must be installed.
+            if !FileManager.default.fileExists(atPath: "/Applications/kindaVim.app") {
+                throw InstallError.dependencyMissing(
+                    name: "KindaVim",
+                    websiteURL: URL(string: "https://kindavim.app")!
+                )
+            }
+        }
+
+        if pack.id == "com.keypath.pack.vim-navigation",
+           await InstalledPackTracker.shared.isInstalled(packID: PackRegistry.kindaVim.id)
+        {
+            throw InstallError.mutuallyExclusive(conflicts: [PackRegistry.kindaVim.name])
         }
     }
 

--- a/Sources/KeyPathAppKit/Services/Packs/PackRegistry.swift
+++ b/Sources/KeyPathAppKit/Services/Packs/PackRegistry.swift
@@ -22,7 +22,8 @@ public enum PackRegistry {
         symbolLayer,
         funLayer,
         launcher,
-        leaderKey
+        leaderKey,
+        kindaVim
     ]
 
     /// Look up a pack by id. Returns nil if unknown.
@@ -442,5 +443,38 @@ public enum PackRegistry {
         quickSettings: [],
         bindings: [],
         associatedCollectionID: RuleCollectionIdentifier.leaderKey
+    )
+
+    // MARK: - Pack 15: KindaVim (visual-only companion)
+
+    /// Visual-only companion pack for the third-party
+    /// [KindaVim](https://kindavim.app) app. KindaVim handles all the Vim
+    /// modal behavior itself — our pack adds *no kanata bindings*. What
+    /// installing it does:
+    ///
+    /// 1. Subscribes to KindaVim's mode signal (the JSON file at
+    ///    `~/Library/Application Support/kindaVim/environment.json`,
+    ///    fallback to `kindaVimDidEnter*Mode` distributed notifications).
+    /// 2. Lets the live keyboard overlay and Context HUD react to mode
+    ///    changes — show vim keys when KindaVim is in Normal mode,
+    ///    return to base typing when in Insert.
+    ///
+    /// Mutually exclusive with Vim Navigation (and Neovim Terminal once
+    /// that ships) — they target the same workflow with different
+    /// implementations.
+    public static let kindaVim = Pack(
+        id: "com.keypath.pack.kindavim",
+        version: "1.0.0",
+        name: "KindaVim Mode Display",
+        tagline: "Show KindaVim mode in the overlay (no remapping)",
+        shortDescription:
+            "If you use KindaVim for full Vim modes, this pack tells the KeyPath overlay and hint panel about your current mode. When KindaVim is in Normal mode, the overlay surfaces the Vim keys you can press; in Insert mode, it gets out of the way. Adds no kanata remappings of its own — KindaVim itself handles every keypress. Requires KindaVim.app to be installed.",
+        longDescription: "",
+        category: "Navigation",
+        iconSymbol: "keyboard.macwindow",
+        quickSettings: [],
+        bindings: [],
+        associatedCollectionID: nil,
+        visualOnly: true
     )
 }

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionCatalog.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionCatalog.swift
@@ -51,7 +51,12 @@ struct RuleCollectionCatalog {
             macOSFunctionKeys,
             leaderKeyConfig,
             navigationArrows,
-            kindaVimNavigation,
+            // KindaVim used to ship as a rule collection (raw kanata
+            // remappings for h/j/k/l etc). The KindaVim pack now handles
+            // discovery as a visual-only companion to the kindaVim.app —
+            // no kanata bindings of our own. The collection definition
+            // stays below as `kindaVimNavigation` for reference but is no
+            // longer surfaced.
             neovimTerminal,
             missionControl,
             windowSnapping,

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+Migrations.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+Migrations.swift
@@ -14,6 +14,7 @@ extension RuleCollectionsManager {
         static let vimDescriptionsToVimTerms = "RuleCollections.Migration.VimDescriptionsToVimTerms"
         static let capsLockRemapForLauncher = "RuleCollections.Migration.CapsLockRemapForLauncher"
         static let capsLockRemapForLauncherV2 = "RuleCollections.Migration.CapsLockRemapForLauncherV2"
+        static let retireKindaVimCollection = "RuleCollections.Migration.RetireKindaVimCollection"
     }
 
     /// Run one-time migrations for collection state changes
@@ -73,6 +74,27 @@ extension RuleCollectionsManager {
         if !UserDefaults.standard.bool(forKey: MigrationKey.capsLockRemapForLauncherV2) {
             migrateCapsLockRemapForLauncher()
             UserDefaults.standard.set(true, forKey: MigrationKey.capsLockRemapForLauncherV2)
+        }
+
+        // Migration: KindaVim used to ship as a rule collection (h/j/k/l
+        // remappings). It's now a visual-only pack — kindaVim.app handles
+        // every keypress. Disable any leftover legacy collection so an
+        // upgrader's old remaps don't fight with the real kindaVim.app.
+        if !UserDefaults.standard.bool(forKey: MigrationKey.retireKindaVimCollection) {
+            disableLegacyKindaVimCollection()
+            UserDefaults.standard.set(true, forKey: MigrationKey.retireKindaVimCollection)
+        }
+    }
+
+    private func disableLegacyKindaVimCollection() {
+        guard let index = ruleCollections.firstIndex(where: {
+            $0.id == RuleCollectionIdentifier.kindaVim
+        }) else { return }
+        if ruleCollections[index].isEnabled {
+            ruleCollections[index].isEnabled = false
+            AppLogger.shared.log(
+                "♻️ [RuleCollections] Migration: Disabled retired KindaVim rule collection"
+            )
         }
     }
 

--- a/Sources/KeyPathAppKit/UI/Gallery/GalleryView.swift
+++ b/Sources/KeyPathAppKit/UI/Gallery/GalleryView.swift
@@ -40,23 +40,28 @@ struct GalleryView: View {
             PackDetailView(pack: pack)
                 .environment(kanataManager)
         }
-        .alert(item: $installAlert) { alert in
-            if let url = alert.websiteURL {
-                return Alert(
-                    title: Text(alert.title),
-                    message: Text(alert.message),
-                    primaryButton: .default(Text("Get KindaVim →")) {
+        .alert(
+            installAlert?.title ?? "",
+            isPresented: Binding(
+                get: { installAlert != nil },
+                set: { if !$0 { installAlert = nil } }
+            ),
+            presenting: installAlert,
+            actions: { alert in
+                if let url = alert.websiteURL {
+                    Button("Get KindaVim →") {
                         NSWorkspace.shared.open(url)
-                    },
-                    secondaryButton: .cancel()
-                )
-            }
-            return Alert(
-                title: Text(alert.title),
-                message: Text(alert.message),
-                dismissButton: .default(Text("OK"))
-            )
-        }
+                    }
+                    .accessibilityIdentifier("gallery-install-alert-get-kindavim")
+                    Button("Cancel", role: .cancel) {}
+                        .accessibilityIdentifier("gallery-install-alert-cancel")
+                } else {
+                    Button("OK", role: .cancel) {}
+                        .accessibilityIdentifier("gallery-install-alert-ok")
+                }
+            },
+            message: { alert in Text(alert.message) }
+        )
     }
 
     // MARK: - Sections

--- a/Sources/KeyPathAppKit/UI/Gallery/GalleryView.swift
+++ b/Sources/KeyPathAppKit/UI/Gallery/GalleryView.swift
@@ -17,6 +17,14 @@ struct GalleryView: View {
     @State private var installedIDs: Set<String> = []
     @State private var packForDetail: Pack?
     @State private var busyPackIDs: Set<String> = []
+    @State private var installAlert: InstallAlert?
+
+    private struct InstallAlert: Identifiable {
+        let id = UUID()
+        let title: String
+        let message: String
+        let websiteURL: URL?
+    }
 
     var body: some View {
         VStack(spacing: 0) {
@@ -31,6 +39,23 @@ struct GalleryView: View {
         .sheet(item: $packForDetail, onDismiss: { Task { await refreshInstalledIDs() } }) { pack in
             PackDetailView(pack: pack)
                 .environment(kanataManager)
+        }
+        .alert(item: $installAlert) { alert in
+            if let url = alert.websiteURL {
+                return Alert(
+                    title: Text(alert.title),
+                    message: Text(alert.message),
+                    primaryButton: .default(Text("Get KindaVim →")) {
+                        NSWorkspace.shared.open(url)
+                    },
+                    secondaryButton: .cancel()
+                )
+            }
+            return Alert(
+                title: Text(alert.title),
+                message: Text(alert.message),
+                dismissButton: .default(Text("OK"))
+            )
         }
     }
 
@@ -165,7 +190,36 @@ struct GalleryView: View {
             AppLogger.shared.log(
                 "⚠️ [Gallery] Toggle failed for pack '\(pack.id)': \(error.localizedDescription)"
             )
+            await presentAlert(for: error, pack: pack)
             await refreshInstalledIDs()
         }
+    }
+
+    private func presentAlert(for error: Error, pack: Pack) async {
+        let alert: InstallAlert
+        if let installError = error as? PackInstaller.InstallError {
+            switch installError {
+            case let .dependencyMissing(name, url):
+                alert = InstallAlert(
+                    title: "\(name) isn't installed",
+                    message:
+                        "“\(pack.name)” needs the \(name) app to be installed first. " +
+                        "It's a separate macOS app that handles Vim modes; KeyPath just shows you which keys are active.",
+                    websiteURL: url
+                )
+            case let .mutuallyExclusive(conflicts):
+                let names = conflicts.joined(separator: ", ")
+                alert = InstallAlert(
+                    title: "Conflicts with \(names)",
+                    message: "Turn off \(names) first, then enable “\(pack.name)”.",
+                    websiteURL: nil
+                )
+            case .noRuleCollectionsManager, .saveFailed:
+                return
+            }
+        } else {
+            return
+        }
+        await MainActor.run { installAlert = alert }
     }
 }

--- a/Sources/KeyPathAppKit/UI/Gallery/KindaVimStatusBlock.swift
+++ b/Sources/KeyPathAppKit/UI/Gallery/KindaVimStatusBlock.swift
@@ -37,6 +37,7 @@ struct KindaVimStatusBlock: View {
                     NSWorkspace.shared.open(Self.websiteURL)
                 }
                 .buttonStyle(.borderedProminent)
+                .accessibilityIdentifier("kindavim-status-get-kindavim")
             }
         }
         .onAppear {

--- a/Sources/KeyPathAppKit/UI/Gallery/KindaVimStatusBlock.swift
+++ b/Sources/KeyPathAppKit/UI/Gallery/KindaVimStatusBlock.swift
@@ -1,0 +1,70 @@
+// Custom Pack Detail block for the KindaVim Mode Display pack. Shows
+// whether the kindaVim.app companion is installed, the current mode if
+// available, and a link to the project's homepage when it isn't.
+
+import SwiftUI
+
+@MainActor
+struct KindaVimStatusBlock: View {
+    @State private var monitor = KindaVimModeMonitor.shared
+    @State private var appInstalled: Bool = FileManager.default
+        .fileExists(atPath: "/Applications/kindaVim.app")
+
+    private static let websiteURL = URL(string: "https://kindavim.app")!
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            row(
+                label: "KindaVim app",
+                value: appInstalled ? "Installed" : "Not installed",
+                tint: appInstalled ? .green : .orange
+            )
+            row(
+                label: "Current mode",
+                value: monitor.mode?.displayLabel ?? "—",
+                tint: modeTint
+            )
+            Divider()
+            Text(
+                "This pack adds no remappings. KindaVim itself handles every keypress; KeyPath just shows you the current mode in the overlay."
+            )
+            .font(.system(size: 12))
+            .foregroundStyle(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
+
+            if !appInstalled {
+                Button("Get KindaVim →") {
+                    NSWorkspace.shared.open(Self.websiteURL)
+                }
+                .buttonStyle(.borderedProminent)
+            }
+        }
+        .onAppear {
+            appInstalled = FileManager.default
+                .fileExists(atPath: "/Applications/kindaVim.app")
+        }
+    }
+
+    @ViewBuilder
+    private func row(label: String, value: String, tint: Color) -> some View {
+        HStack {
+            Text(label)
+                .font(.system(size: 12))
+                .foregroundStyle(.secondary)
+            Spacer()
+            Text(value)
+                .font(.system(size: 12, weight: .medium))
+                .foregroundStyle(tint)
+        }
+    }
+
+    private var modeTint: Color {
+        guard let mode = monitor.mode else { return .secondary }
+        switch mode {
+        case .normal: return .green
+        case .insert: return .blue
+        case .visual: return .orange
+        case .operatorPending: return .purple
+        }
+    }
+}

--- a/Sources/KeyPathAppKit/UI/Gallery/PackDetailView.swift
+++ b/Sources/KeyPathAppKit/UI/Gallery/PackDetailView.swift
@@ -539,6 +539,8 @@ struct PackDetailView: View {
                     )
                 }
             }
+        } else if pack.id == PackRegistry.kindaVim.id {
+            embeddedEditor { KindaVimStatusBlock() }
         } else {
             VStack(alignment: .leading, spacing: 8) {
                 Divider()

--- a/Sources/KeyPathAppKit/UI/Overlay/KindaVimModeBadge.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/KindaVimModeBadge.swift
@@ -1,0 +1,40 @@
+// Small pill that surfaces the current KindaVim mode in the overlay
+// header. Only renders when KindaVim Mode Display pack is installed and
+// kindaVim is producing a mode signal — otherwise it draws nothing.
+
+import SwiftUI
+
+@MainActor
+struct KindaVimModeBadge: View {
+    @State private var monitor = KindaVimModeMonitor.shared
+    let isPackInstalled: Bool
+
+    var body: some View {
+        if isPackInstalled, let mode = monitor.mode {
+            HStack(spacing: 4) {
+                Text("VIM")
+                    .font(.system(size: 9, weight: .heavy))
+                    .foregroundStyle(.secondary)
+                Text(mode.displayLabel.uppercased())
+                    .font(.system(size: 9, weight: .heavy))
+                    .foregroundStyle(tint(for: mode))
+            }
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(
+                RoundedRectangle(cornerRadius: 4, style: .continuous)
+                    .fill(tint(for: mode).opacity(0.15))
+            )
+            .accessibilityLabel("KindaVim mode: \(mode.displayLabel)")
+        }
+    }
+
+    private func tint(for mode: KindaVimModeMonitor.Mode) -> Color {
+        switch mode {
+        case .normal: .green
+        case .insert: .blue
+        case .visual: .orange
+        case .operatorPending: .purple
+        }
+    }
+}

--- a/Sources/KeyPathAppKit/UI/Overlay/LiveKeyboardOverlayView+Header.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/LiveKeyboardOverlayView+Header.swift
@@ -142,6 +142,10 @@ struct OverlayDragHeader: View {
     /// When the health indicator dismissed — used to suppress "No TCP" briefly at startup
     @State private var healthDismissedAt: Date?
 
+    /// Tracks whether the KindaVim Mode Display pack is installed, so the
+    /// header can render its mode badge without polling on every redraw.
+    @State private var kindaVimPackInstalled: Bool = false
+
     init(
         isDark: Bool,
         fadeAmount: CGFloat,
@@ -234,6 +238,10 @@ struct OverlayDragHeader: View {
             // Controls aligned to the right side of the header
             // Order: Status indicators (left) → Drawer → Close (far right)
             HStack(spacing: 6) {
+                // 0. KindaVim mode badge (renders nothing unless the pack is
+                // installed and kindaVim is publishing a mode).
+                KindaVimModeBadge(isPackInstalled: kindaVimPackInstalled)
+
                 // 1. Status slot (leftmost of the right-aligned group):
                 // - Shows health indicator when not dismissed (including the "Ready" pill)
                 // - Otherwise shows Japanese input + layer pill
@@ -291,9 +299,13 @@ struct OverlayDragHeader: View {
         )
         .onAppear {
             refreshAvailableLayers()
+            Task { await refreshKindaVimPackInstalled() }
         }
         .onReceive(NotificationCenter.default.publisher(for: .ruleCollectionsChanged)) { _ in
             refreshAvailableLayers()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .installedPacksChanged)) { _ in
+            Task { await refreshKindaVimPackInstalled() }
         }
         .onChange(of: isInspectorOpen) { _, _ in
             // Dismiss tooltips when drawer opens/closes so they don't get stuck
@@ -308,6 +320,12 @@ struct OverlayDragHeader: View {
     }
 
     /// Refresh available layers from rule collections
+    private func refreshKindaVimPackInstalled() async {
+        let installed = await InstalledPackTracker.shared
+            .isInstalled(packID: PackRegistry.kindaVim.id)
+        await MainActor.run { kindaVimPackInstalled = installed }
+    }
+
     private func refreshAvailableLayers() {
         Task {
             let collections = await services.ruleCollectionStore.loadCollections()

--- a/Sources/KeyPathAppKit/Utilities/Notifications.swift
+++ b/Sources/KeyPathAppKit/Utilities/Notifications.swift
@@ -52,6 +52,11 @@ extension Notification.Name {
     /// re-evaluate whether to hide/show the overlay for the current app.
     static let overlaySuppressedBundleIDsChanged = Notification.Name("KeyPath.Overlay.SuppressedBundleIDsChanged")
 
+    /// `InstalledPackTracker` upserted or removed a pack record. Observers
+    /// such as the KindaVim mode monitor controller use this to start/stop
+    /// based on whether their pack is installed.
+    static let installedPacksChanged = Notification.Name("KeyPath.Packs.InstalledPacksChanged")
+
     /// Mapper drawer
     /// Posted when a key is clicked and should be selected in the mapper drawer
     /// userInfo: keyCode (UInt16), inputKey (String), outputKey (String), optional shiftedOutputKey (String), layer (String)

--- a/Tests/KeyPathTests/PackRegistryTests.swift
+++ b/Tests/KeyPathTests/PackRegistryTests.swift
@@ -27,6 +27,19 @@ final class PackRegistryTests: XCTestCase {
         XCTAssertTrue(ids.contains("com.keypath.pack.fun-layer"))
         XCTAssertTrue(ids.contains("com.keypath.pack.quick-launcher"))
         XCTAssertTrue(ids.contains("com.keypath.pack.leader-key"))
+        XCTAssertTrue(ids.contains("com.keypath.pack.kindavim"))
+    }
+
+    func testKindaVimPackIsVisualOnlyAndUnbacked() {
+        guard let pack = PackRegistry.pack(id: "com.keypath.pack.kindavim") else {
+            return XCTFail("KindaVim pack missing from registry")
+        }
+        XCTAssertTrue(pack.visualOnly, "KindaVim pack must be visual-only")
+        XCTAssertNil(
+            pack.associatedCollectionID,
+            "KindaVim pack should not point at a rule collection"
+        )
+        XCTAssertTrue(pack.bindings.isEmpty, "KindaVim pack must define no bindings")
     }
 
     func testCollectionBackedPacksPointAtRealCollections() {

--- a/Tests/KeyPathTests/RuleCollections/RuleCollectionsManagerTests.swift
+++ b/Tests/KeyPathTests/RuleCollections/RuleCollectionsManagerTests.swift
@@ -518,73 +518,11 @@ final class RuleCollectionsManagerTests: XCTestCase {
         XCTAssertNil(updated.first(where: { $0.id == second.id })?.momentaryActivator)
     }
 
-    @MainActor
-    func testToggleCollectionConflictKeepNew_EnablesKindaVimAndDisablesVimShortcuts() async throws {
-        let (manager, _) = try await createTestManager()
-        defer { TestEnvironment.forceTestMode = false }
+    // KindaVim ⇄ Vim Navigation conflict-resolution tests were removed when
+    // the KindaVim rule collection was retired from the catalog; KindaVim now
+    // ships as a visual-only pack and the mutex is enforced by PackInstaller.
 
-        manager.onConflictResolution = { _ in .keepNew }
-
-        let catalogCollections = RuleCollectionCatalog().defaultCollections()
-        await manager.replaceCollections(catalogCollections)
-
-        XCTAssertTrue(
-            manager.ruleCollections.contains { $0.id == RuleCollectionIdentifier.vimNavigation && $0.isEnabled },
-            "Vim shortcuts should start enabled from catalog defaults"
-        )
-        XCTAssertTrue(
-            manager.ruleCollections.contains { $0.id == RuleCollectionIdentifier.kindaVim && !$0.isEnabled },
-            "KindaVim should start disabled from catalog defaults"
-        )
-
-        await manager.toggleCollection(id: RuleCollectionIdentifier.kindaVim, isEnabled: true)
-
-        XCTAssertTrue(
-            manager.ruleCollections.contains { $0.id == RuleCollectionIdentifier.kindaVim && $0.isEnabled },
-            "KindaVim should be enabled after choosing keepNew"
-        )
-        XCTAssertTrue(
-            manager.ruleCollections.contains { $0.id == RuleCollectionIdentifier.vimNavigation && !$0.isEnabled },
-            "Vim shortcuts should be disabled after choosing keepNew"
-        )
-    }
-
-    @MainActor
-    func testToggleCollectionConflictKeepNew_EnablesVimShortcutsAndDisablesKindaVim() async throws {
-        let (manager, _) = try await createTestManager()
-        defer { TestEnvironment.forceTestMode = false }
-
-        manager.onConflictResolution = { _ in .keepNew }
-
-        let catalogCollections = RuleCollectionCatalog().defaultCollections()
-        await manager.replaceCollections(catalogCollections)
-
-        // First switch to KindaVim.
-        await manager.toggleCollection(id: RuleCollectionIdentifier.kindaVim, isEnabled: true)
-
-        XCTAssertTrue(
-            manager.ruleCollections.contains { $0.id == RuleCollectionIdentifier.kindaVim && $0.isEnabled },
-            "KindaVim should be enabled after switching from Vim shortcuts"
-        )
-        XCTAssertTrue(
-            manager.ruleCollections.contains { $0.id == RuleCollectionIdentifier.vimNavigation && !$0.isEnabled },
-            "Vim shortcuts should be disabled after switching to KindaVim"
-        )
-
-        // Then switch back to Vim shortcuts.
-        await manager.toggleCollection(id: RuleCollectionIdentifier.vimNavigation, isEnabled: true)
-
-        XCTAssertTrue(
-            manager.ruleCollections.contains { $0.id == RuleCollectionIdentifier.vimNavigation && $0.isEnabled },
-            "Vim shortcuts should be enabled after choosing keepNew"
-        )
-        XCTAssertTrue(
-            manager.ruleCollections.contains { $0.id == RuleCollectionIdentifier.kindaVim && !$0.isEnabled },
-            "KindaVim should be disabled after choosing keepNew for Vim shortcuts"
-        )
-    }
-
-    @MainActor
+@MainActor
     func testNeovimReferenceCoexistsWithVimNavigationWithoutConflictDialog() async throws {
         let (manager, _) = try await createTestManager()
         defer { TestEnvironment.forceTestMode = false }


### PR DESCRIPTION
## Summary
- The KindaVim pack no longer ships its own h/j/k/l rule collection. It's now a **visual-only** companion to the kindaVim.app: kindaVim handles every keypress, KeyPath surfaces the current mode in the overlay.
- New `Pack.visualOnly` flag short-circuits these packs past the kanata side effects in `PackInstaller`.
- `KindaVimModeMonitor` watches `~/Library/Application Support/kindaVim/environment.json` (with a `kindaVimDidEnter*Mode` distributed-notification fallback) and exposes the mode to SwiftUI.
- Install gates: refuses if Vim Navigation is installed (mutex) or if `/Applications/kindaVim.app` is missing (Gallery card surfaces a "Get KindaVim →" alert).
- Overlay header now renders a small **VIM: NORMAL / INSERT** mode badge when the pack is installed and a mode is being published.
- Pack Detail shows a custom status block (app detected? current mode? website CTA when not installed) instead of the default empty bindings list.
- The `kindaVimNavigation` rule collection is removed from the catalog — the pack is the only surface area now.

## Follow-up (not in this PR)
- **Mode-aware key surfacing on the overlay.** When KindaVim is in `.normal`, render vim-relevant key labels (h/j/k/l, w/b, i/a, etc.) on the live keyboard; in `.insert`, hide them. Needs a new static "VimBindings" reference table and a hook into the keycap label pipeline.

## Test plan
- [ ] `swift test` (420 tests pass locally — added `testKindaVimPackIsVisualOnlyAndUnbacked` and updated `testExpectedPacksShip`)
- [ ] Install kindaVim.app and the pack: badge appears, switches between NORMAL / INSERT as you toggle modes
- [ ] Without kindaVim.app: enabling the pack from Gallery surfaces the "Get KindaVim →" alert
- [ ] With Vim Navigation installed: enabling KindaVim from Gallery surfaces the mutex alert (and vice versa)
- [ ] Pack Detail status block reflects detection + current mode
- [ ] Uninstalling the pack stops the file watcher (no badge in overlay)

🤖 Generated with [Claude Code](https://claude.com/claude-code)