### PR TITLE
feat(kindavim): strategy-aware HUD cheat sheet + Pack Detail badges

### DIFF
--- a/Sources/KeyPathAppKit/Services/KindaVim/KindaVimPackController.swift
+++ b/Sources/KeyPathAppKit/Services/KindaVim/KindaVimPackController.swift
@@ -1,7 +1,9 @@
-// Bridges the KindaVim pack's install/uninstall state to
-// `KindaVimStateAdapter`. Started once at app launch; observes
-// `installedPacksChanged` and refcount-starts/stops the adapter as the
-// user toggles the pack from Gallery (or Pack Detail).
+// Bridges the KindaVim pack's install/uninstall state to the live
+// helpers it depends on (`KindaVimStateAdapter` for mode signals,
+// `KindaVimStrategyMonitor` for per-app strategy tracking). Started
+// once at app launch; observes `installedPacksChanged` and refcount-
+// starts/stops both monitors as the user toggles the pack from
+// Gallery (or Pack Detail).
 
 import Foundation
 import KeyPathCore
@@ -32,21 +34,24 @@ final class KindaVimPackController {
         observer = nil
         if isMonitoring {
             KindaVimStateAdapter.shared.stopMonitoring()
+            KindaVimStrategyMonitor.shared.stopMonitoring()
             isMonitoring = false
         }
     }
 
-    /// Tracks whether we currently hold a refcount on the adapter so we
-    /// can balance start/stop calls without double-decrementing.
+    /// Tracks whether we currently hold refcounts on the adapter / strategy
+    /// monitor so we balance start/stop calls without double-decrementing.
     private var isMonitoring = false
 
     private func refresh() async {
         let installed = await InstalledPackTracker.shared.isInstalled(packID: PackRegistry.kindaVim.id)
         if installed, !isMonitoring {
             KindaVimStateAdapter.shared.startMonitoring()
+            KindaVimStrategyMonitor.shared.startMonitoring()
             isMonitoring = true
         } else if !installed, isMonitoring {
             KindaVimStateAdapter.shared.stopMonitoring()
+            KindaVimStrategyMonitor.shared.stopMonitoring()
             isMonitoring = false
         }
     }

--- a/Sources/KeyPathAppKit/Services/KindaVim/KindaVimStrategyMonitor.swift
+++ b/Sources/KeyPathAppKit/Services/KindaVim/KindaVimStrategyMonitor.swift
@@ -1,0 +1,111 @@
+// Live, observable wrapper around `KindaVimStrategyResolver`. Watches
+// kindaVim's prefs plist and the frontmost macOS app, republishes a
+// `currentStrategy` every time either input changes.
+//
+// Used by:
+// - The Pack Detail status block (strategy badge)
+// - The vim-hint UI to filter the static `VimBindings` table down to
+//   commands the active strategy actually supports
+
+import AppKit
+import KeyPathCore
+import Observation
+
+@MainActor
+@Observable
+final class KindaVimStrategyMonitor {
+    static let shared = KindaVimStrategyMonitor()
+
+    private(set) var currentStrategy: KindaVimStrategy = .accessibility
+    private(set) var currentBundleID: String?
+
+    @ObservationIgnored
+    private var lists: KindaVimStrategyResolver.PreferenceLists = .empty
+
+    @ObservationIgnored
+    private let resolver: KindaVimStrategyResolver
+
+    @ObservationIgnored
+    private var monitoringCount = 0
+
+    @ObservationIgnored
+    private var plistWatcher: ConfigFileWatcher?
+
+    @ObservationIgnored
+    private var frontmostObserver: NSObjectProtocol?
+
+    init(resolver: KindaVimStrategyResolver = KindaVimStrategyResolver()) {
+        self.resolver = resolver
+    }
+
+    /// Refcounted start. Idempotent across multiple callers.
+    func startMonitoring() {
+        monitoringCount += 1
+        guard monitoringCount == 1 else { return }
+
+        AppLogger.shared.log("👀 [KindaVimStrategy] Starting monitor")
+
+        lists = resolver.loadPreferenceLists()
+        currentBundleID = NSWorkspace.shared.frontmostApplication?.bundleIdentifier
+        recomputeStrategy()
+
+        let watcher = ConfigFileWatcher()
+        watcher.startWatching(path: KindaVimStrategyResolver.defaultPreferencesURL.path) { [weak self] in
+            await self?.handlePreferencesChanged()
+        }
+        plistWatcher = watcher
+
+        frontmostObserver = NSWorkspace.shared.notificationCenter.addObserver(
+            forName: NSWorkspace.didActivateApplicationNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            guard let app = notification.userInfo?[NSWorkspace.applicationUserInfoKey]
+                as? NSRunningApplication else { return }
+            Task { @MainActor in
+                self?.handleFrontmostAppChanged(bundleID: app.bundleIdentifier)
+            }
+        }
+    }
+
+    func stopMonitoring() {
+        guard monitoringCount > 0 else { return }
+        monitoringCount -= 1
+        guard monitoringCount == 0 else { return }
+
+        AppLogger.shared.log("🛑 [KindaVimStrategy] Stopping monitor")
+
+        plistWatcher?.stopWatching()
+        plistWatcher = nil
+
+        if let token = frontmostObserver {
+            NSWorkspace.shared.notificationCenter.removeObserver(token)
+        }
+        frontmostObserver = nil
+    }
+
+    // MARK: - Reactions
+
+    private func handlePreferencesChanged() async {
+        let newLists = resolver.loadPreferenceLists()
+        guard newLists != lists else { return }
+        lists = newLists
+        AppLogger.shared.log("👀 [KindaVimStrategy] Prefs plist changed; recomputing")
+        recomputeStrategy()
+    }
+
+    private func handleFrontmostAppChanged(bundleID: String?) {
+        guard bundleID != currentBundleID else { return }
+        currentBundleID = bundleID
+        recomputeStrategy()
+    }
+
+    private func recomputeStrategy() {
+        let resolved = resolver.strategy(for: currentBundleID, lists: lists)
+        guard resolved != currentStrategy else { return }
+        currentStrategy = resolved
+        AppLogger.shared.log(
+            "👀 [KindaVimStrategy] strategy → \(resolved.rawValue) (bundle=\(currentBundleID ?? "nil"))"
+        )
+    }
+}

--- a/Sources/KeyPathAppKit/Services/KindaVim/KindaVimStrategyResolver.swift
+++ b/Sources/KeyPathAppKit/Services/KindaVim/KindaVimStrategyResolver.swift
@@ -1,0 +1,80 @@
+// Resolves the kindaVim "strategy" (Accessibility / Keyboard / Hybrid /
+// Ignored) for a given app bundle ID, by reading the user's kindaVim
+// preferences plist.
+//
+// The plist lists three opt-in/out groups:
+// - `appsToIgnore`: kindaVim does nothing in these apps
+// - `appsForWhichToEnforceKeyboardStrategy`: forced into the degraded
+//   Keyboard fallback (e.g. Slack, where AX support is shaky)
+// - `appsForWhichToUseHybridMode`: explicit Hybrid bucket
+//
+// Anything not in any of these lists falls through to the default,
+// which kindaVim's docs describe as the Accessibility strategy.
+
+import Foundation
+
+struct KindaVimStrategyResolver: Sendable {
+    /// Lists pulled from the kindaVim prefs plist.
+    struct PreferenceLists: Equatable, Sendable {
+        let ignored: Set<String>
+        let keyboardEnforced: Set<String>
+        let hybrid: Set<String>
+
+        static let empty = PreferenceLists(ignored: [], keyboardEnforced: [], hybrid: [])
+    }
+
+    static let defaultPreferencesURL: URL = URL(fileURLWithPath: NSHomeDirectory())
+        .appendingPathComponent("Library")
+        .appendingPathComponent("Preferences")
+        .appendingPathComponent("mo.com.sleeplessmind.kindaVim.plist")
+
+    private let preferencesURL: URL
+
+    init(preferencesURL: URL = KindaVimStrategyResolver.defaultPreferencesURL) {
+        self.preferencesURL = preferencesURL
+    }
+
+    /// Read the three app lists out of the kindaVim plist. Returns
+    /// `.empty` if the file is missing or unreadable — callers can treat
+    /// that as "no overrides, default everywhere."
+    func loadPreferenceLists() -> PreferenceLists {
+        guard let data = try? Data(contentsOf: preferencesURL) else {
+            return .empty
+        }
+        return Self.parsePreferenceLists(from: data)
+    }
+
+    /// Resolve a bundle ID against the given lists.
+    func strategy(
+        for bundleID: String?,
+        lists: PreferenceLists
+    ) -> KindaVimStrategy {
+        guard let bundleID, !bundleID.isEmpty else { return .accessibility }
+        if lists.ignored.contains(bundleID) { return .ignored }
+        if lists.hybrid.contains(bundleID) { return .hybrid }
+        if lists.keyboardEnforced.contains(bundleID) { return .keyboard }
+        return .accessibility
+    }
+
+    // MARK: - Parsing
+
+    static func parsePreferenceLists(from data: Data) -> PreferenceLists {
+        guard let plist = try? PropertyListSerialization.propertyList(
+            from: data,
+            options: [],
+            format: nil
+        ) as? [String: Any] else {
+            return .empty
+        }
+        return PreferenceLists(
+            ignored: stringSet(in: plist, forKey: "appsToIgnore"),
+            keyboardEnforced: stringSet(in: plist, forKey: "appsForWhichToEnforceKeyboardStrategy"),
+            hybrid: stringSet(in: plist, forKey: "appsForWhichToUseHybridMode")
+        )
+    }
+
+    private static func stringSet(in plist: [String: Any], forKey key: String) -> Set<String> {
+        guard let array = plist[key] as? [Any] else { return [] }
+        return Set(array.compactMap { $0 as? String })
+    }
+}

--- a/Sources/KeyPathAppKit/UI/ContextHUD/ContextHUDKindaVimLearningView.swift
+++ b/Sources/KeyPathAppKit/UI/ContextHUD/ContextHUDKindaVimLearningView.swift
@@ -107,13 +107,15 @@ struct ContextHUDKindaVimLearningView: View {
 
     @ViewBuilder
     private var quickReferenceSection: some View {
-        // Insert mode and Ignored strategy fall back to the small escape-
-        // hatch hint list; everything else reads the static VimBindings
-        // table filtered for the current strategy and advanced toggle.
-        if mode == .insert {
-            insertModeHints
-        } else if strategyMonitor.currentStrategy == .ignored {
+        // Strategy.ignored wins over mode: switching from an insert-mode
+        // app into an ignore-listed app and opening the HUD before the
+        // mode signal updates would otherwise show insert-mode guidance
+        // even though kindaVim isn't running there. Show the off-here
+        // hint first, then fall back to mode-driven branches.
+        if strategyMonitor.currentStrategy == .ignored {
             ignoredStrategyHint
+        } else if mode == .insert {
+            insertModeHints
         } else {
             vimBindingsSections
         }

--- a/Sources/KeyPathAppKit/UI/ContextHUD/ContextHUDKindaVimLearningView.swift
+++ b/Sources/KeyPathAppKit/UI/ContextHUD/ContextHUDKindaVimLearningView.swift
@@ -7,6 +7,9 @@ struct ContextHUDKindaVimLearningView: View {
     let state: KindaVimStateAdapter.StateSnapshot?
     let modeSetting: KindaVimLeaderHUDMode
 
+    @State private var strategyMonitor = KindaVimStrategyMonitor.shared
+    @AppStorage("kindaVim.showAdvancedHints") private var showAdvancedHints: Bool = false
+
     private struct CommandItem: Identifiable {
         let id = UUID()
         let keys: String
@@ -102,31 +105,104 @@ struct ContextHUDKindaVimLearningView: View {
         )
     }
 
+    @ViewBuilder
     private var quickReferenceSection: some View {
-        VStack(alignment: .leading, spacing: 7) {
-            Text("Motions + Window Nav")
-                .font(.footnote.monospaced().weight(.semibold))
-                .foregroundStyle(.white.opacity(0.75))
-                .tracking(1.2)
+        // Insert mode and Ignored strategy fall back to the small escape-
+        // hatch hint list; everything else reads the static VimBindings
+        // table filtered for the current strategy and advanced toggle.
+        if mode == .insert {
+            insertModeHints
+        } else if strategyMonitor.currentStrategy == .ignored {
+            ignoredStrategyHint
+        } else {
+            vimBindingsSections
+        }
+    }
 
-            ForEach(commands(for: mode)) { command in
-                HStack(spacing: 10) {
-                    Text(command.keys)
-                        .font(.system(.footnote, design: .monospaced).weight(.bold))
-                        .foregroundStyle(.white)
-                        .padding(.horizontal, 7)
-                        .padding(.vertical, 3)
-                        .background(
-                            RoundedRectangle(cornerRadius: 5)
-                                .fill(.white.opacity(0.12))
-                        )
-                    Text(command.meaning)
-                        .font(.footnote)
-                        .lineSpacing(1.5)
-                        .foregroundStyle(.white.opacity(0.85))
-                }
+    private var insertModeHints: some View {
+        VStack(alignment: .leading, spacing: 7) {
+            sectionHeader("Insert mode")
+            ForEach(insertModeCommands) { command in
+                commandRow(keys: command.keys, meaning: command.meaning, loud: false)
             }
         }
+    }
+
+    private var ignoredStrategyHint: some View {
+        VStack(alignment: .leading, spacing: 7) {
+            sectionHeader("KindaVim is off here")
+            Text("This app is in KindaVim's ignore list. Mode signals don't apply.")
+                .font(.footnote)
+                .lineSpacing(1.5)
+                .foregroundStyle(.white.opacity(0.7))
+        }
+    }
+
+    private var vimBindingsSections: some View {
+        let bindingGroups = VimBindings.grouped(
+            strategy: strategyMonitor.currentStrategy,
+            mode: mode,
+            showAdvanced: showAdvancedHints
+        )
+        return VStack(alignment: .leading, spacing: 11) {
+            ForEach(Array(bindingGroups.enumerated()), id: \.offset) { _, group in
+                bindingGroupSection(group)
+            }
+            if mode == .operatorPending {
+                Text("Press the same operator twice (dd · yy · cc) to act on the whole line.")
+                    .font(.footnote)
+                    .foregroundStyle(.white.opacity(0.75))
+                    .lineSpacing(1.5)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func bindingGroupSection(_ group: VimHintGroup) -> some View {
+        let isMovement = group.group == .movement
+        VStack(alignment: .leading, spacing: 6) {
+            sectionHeader(group.displayName)
+            ForEach(group.entries) { entry in
+                commandRow(
+                    keys: entry.displayLabel,
+                    meaning: entry.actionLabel,
+                    loud: isMovement && entry.tier == .core
+                )
+            }
+        }
+    }
+
+    private func sectionHeader(_ text: String) -> some View {
+        Text(text)
+            .font(.footnote.monospaced().weight(.semibold))
+            .foregroundStyle(.white.opacity(0.75))
+            .tracking(1.2)
+    }
+
+    private func commandRow(keys: String, meaning: String, loud: Bool) -> some View {
+        HStack(spacing: 10) {
+            Text(keys)
+                .font(.system(loud ? .body : .footnote, design: .monospaced).weight(.bold))
+                .foregroundStyle(.white)
+                .padding(.horizontal, loud ? 9 : 7)
+                .padding(.vertical, loud ? 4 : 3)
+                .background(
+                    RoundedRectangle(cornerRadius: 5)
+                        .fill(loud ? Color.accentColor.opacity(0.5) : .white.opacity(0.12))
+                )
+            Text(meaning)
+                .font(loud ? .footnote.weight(.semibold) : .footnote)
+                .lineSpacing(1.5)
+                .foregroundStyle(.white.opacity(loud ? 1.0 : 0.85))
+        }
+    }
+
+    private var insertModeCommands: [CommandItem] {
+        [
+            .init(keys: "Esc", meaning: "enter Normal mode"),
+            .init(keys: "Ctrl-[", meaning: "alternate Esc"),
+            .init(keys: "Leader hold", meaning: "open KeyPath motion keylist"),
+        ]
     }
 
     private var leaderShortcutsSection: some View {
@@ -211,41 +287,7 @@ struct ContextHUDKindaVimLearningView: View {
         }
     }
 
-    private func commands(for mode: KindaVimStateAdapter.Mode) -> [CommandItem] {
-        switch mode {
-        case .insert:
-            [
-                .init(keys: "Esc", meaning: "enter Normal mode"),
-                .init(keys: "Ctrl-[", meaning: "alternate Esc"),
-                .init(keys: "Leader hold", meaning: "open KeyPath motion keylist"),
-            ]
-        case .normal:
-            [
-                .init(keys: "h j k l", meaning: "left/down/up/right"),
-                .init(keys: "w b e", meaning: "word motions"),
-                .init(keys: "0  $", meaning: "line start/end"),
-                .init(keys: "gg  G", meaning: "document top/bottom"),
-                .init(keys: "Ctrl-w h/j/k/l", meaning: "move between windows"),
-                .init(keys: "v / V", meaning: "enter Visual mode"),
-            ]
-        case .visual:
-            [
-                .init(keys: "h j k l", meaning: "expand selection"),
-                .init(keys: "w b e", meaning: "word-wise selection"),
-                .init(keys: "0  $", meaning: "line bounds"),
-                .init(keys: "gg  G", meaning: "document bounds"),
-                .init(keys: "Ctrl-w h/j/k/l", meaning: "window focus navigation"),
-                .init(keys: "Esc", meaning: "return to Normal mode"),
-            ]
-        case .operatorPending:
-            [
-                .init(keys: "h j k l", meaning: "motion targets"),
-                .init(keys: "w b e", meaning: "word motion targets"),
-                .init(keys: "0  $", meaning: "line ends"),
-                .init(keys: "(same op)", meaning: "× 2 = whole line"),
-            ]
-        case .unknown:
-            commands(for: .normal)
-        }
-    }
+    // The hardcoded `commands(for:)` switch was replaced with
+    // `VimBindings.grouped(strategy:mode:showAdvanced:)` so the cheat
+    // sheet narrows to what the active strategy actually supports.
 }

--- a/Sources/KeyPathAppKit/UI/Gallery/KindaVimStatusBlock.swift
+++ b/Sources/KeyPathAppKit/UI/Gallery/KindaVimStatusBlock.swift
@@ -7,6 +7,8 @@ import SwiftUI
 @MainActor
 struct KindaVimStatusBlock: View {
     @State private var adapter = KindaVimStateAdapter.shared
+    @State private var strategyMonitor = KindaVimStrategyMonitor.shared
+    @AppStorage("kindaVim.showAdvancedHints") private var showAdvancedHints: Bool = false
     @State private var appInstalled: Bool = FileManager.default
         .fileExists(atPath: "/Applications/kindaVim.app")
 
@@ -24,6 +26,25 @@ struct KindaVimStatusBlock: View {
                 value: modeDisplay,
                 tint: modeTint
             )
+            row(
+                label: "Strategy (frontmost app)",
+                value: strategyMonitor.currentStrategy.displayName,
+                tint: strategyTint
+            )
+            Divider()
+            Toggle(isOn: $showAdvancedHints) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Show all keys (advanced)")
+                        .font(.system(size: 12, weight: .medium))
+                    Text("Adds page motions, search, and bracket-match hints.")
+                        .font(.system(size: 11))
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .toggleStyle(.switch)
+            .controlSize(.small)
+            .accessibilityIdentifier("kindavim-status-show-advanced")
+
             Divider()
             Text(
                 "This pack adds no remappings. KindaVim itself handles every keypress; KeyPath just shows you the current mode in the overlay."
@@ -75,6 +96,15 @@ struct KindaVimStatusBlock: View {
         case .visual: return .orange
         case .operatorPending: return .purple
         case .unknown: return .secondary
+        }
+    }
+
+    private var strategyTint: Color {
+        switch strategyMonitor.currentStrategy {
+        case .accessibility: return .green
+        case .hybrid: return .blue
+        case .keyboard: return .orange
+        case .ignored: return .secondary
         }
     }
 }

--- a/Tests/KeyPathTests/KindaVimStrategyResolverTests.swift
+++ b/Tests/KeyPathTests/KindaVimStrategyResolverTests.swift
@@ -1,0 +1,100 @@
+@testable import KeyPathAppKit
+import XCTest
+
+/// Pure-data assertions on the kindaVim plist parser + bundle-ID
+/// resolver. No file I/O — everything goes through `parsePreferenceLists`
+/// with synthetic plist data.
+final class KindaVimStrategyResolverTests: XCTestCase {
+    private let resolver = KindaVimStrategyResolver()
+
+    // MARK: - Parsing
+
+    func testParseExtractsAllThreeLists() throws {
+        let plist: [String: Any] = [
+            "appsToIgnore": ["net.kovidgoyal.kitty", "com.mitchellh.ghostty"],
+            "appsForWhichToEnforceKeyboardStrategy": ["com.tinyspeck.slackmacgap"],
+            "appsForWhichToUseHybridMode": ["com.example.hybrid"],
+            "unrelatedKey": 42,
+        ]
+        let data = try PropertyListSerialization.data(
+            fromPropertyList: plist,
+            format: .binary,
+            options: 0
+        )
+
+        let lists = KindaVimStrategyResolver.parsePreferenceLists(from: data)
+
+        XCTAssertEqual(lists.ignored, ["net.kovidgoyal.kitty", "com.mitchellh.ghostty"])
+        XCTAssertEqual(lists.keyboardEnforced, ["com.tinyspeck.slackmacgap"])
+        XCTAssertEqual(lists.hybrid, ["com.example.hybrid"])
+    }
+
+    func testParseEmptyPlistGivesEmptyLists() throws {
+        let data = try PropertyListSerialization.data(
+            fromPropertyList: [String: Any](),
+            format: .binary,
+            options: 0
+        )
+        let lists = KindaVimStrategyResolver.parsePreferenceLists(from: data)
+        XCTAssertEqual(lists, .empty)
+    }
+
+    func testParseGarbageReturnsEmpty() {
+        let data = Data([0x00, 0x01, 0x02])
+        let lists = KindaVimStrategyResolver.parsePreferenceLists(from: data)
+        XCTAssertEqual(lists, .empty)
+    }
+
+    // MARK: - Resolution priority
+
+    func testIgnoredBeatsKeyboardBeatsHybrid() {
+        // Same bundle-ID in all three lists should resolve to the strictest
+        // one (.ignored). This is defensive — kindaVim shouldn't normally
+        // produce overlapping lists, but a hand-edited plist could.
+        let lists = KindaVimStrategyResolver.PreferenceLists(
+            ignored: ["com.example.app"],
+            keyboardEnforced: ["com.example.app"],
+            hybrid: ["com.example.app"]
+        )
+        XCTAssertEqual(resolver.strategy(for: "com.example.app", lists: lists), .ignored)
+    }
+
+    func testHybridBeatsKeyboardWhenIgnoredIsAbsent() {
+        let lists = KindaVimStrategyResolver.PreferenceLists(
+            ignored: [],
+            keyboardEnforced: ["com.example.app"],
+            hybrid: ["com.example.app"]
+        )
+        XCTAssertEqual(resolver.strategy(for: "com.example.app", lists: lists), .hybrid)
+    }
+
+    func testKeyboardForExplicitlyEnforcedBundle() {
+        let lists = KindaVimStrategyResolver.PreferenceLists(
+            ignored: [],
+            keyboardEnforced: ["com.tinyspeck.slackmacgap"],
+            hybrid: []
+        )
+        XCTAssertEqual(
+            resolver.strategy(for: "com.tinyspeck.slackmacgap", lists: lists),
+            .keyboard
+        )
+    }
+
+    func testAccessibilityIsTheDefault() {
+        let lists = KindaVimStrategyResolver.PreferenceLists(
+            ignored: ["net.kovidgoyal.kitty"],
+            keyboardEnforced: [],
+            hybrid: []
+        )
+        XCTAssertEqual(
+            resolver.strategy(for: "com.apple.Safari", lists: lists),
+            .accessibility
+        )
+    }
+
+    func testNilOrEmptyBundleIDFallsBackToAccessibility() {
+        let lists = KindaVimStrategyResolver.PreferenceLists.empty
+        XCTAssertEqual(resolver.strategy(for: nil, lists: lists), .accessibility)
+        XCTAssertEqual(resolver.strategy(for: "", lists: lists), .accessibility)
+    }
+}


### PR DESCRIPTION
## Summary

Phase 2 of the KindaVim hint feature, on top of #324. The leader-hold ContextHUD now narrows its KindaVim cheat sheet to the commands kindaVim actually wires up for the frontmost app, instead of showing the union and letting users discover by trial-and-error which keys their app doesn't support.

### How it works

kindaVim ships two backends — Accessibility (full set, default) and Keyboard (degraded fallback for apps that don't expose AX, e.g. Slack today on this machine). The plist's `appsForWhichToEnforceKeyboardStrategy`, `appsForWhichToUseHybridMode`, and `appsToIgnore` lists determine which strategy applies per-app.

- `KindaVimStrategyResolver` reads those lists out of `~/Library/Preferences/mo.com.sleeplessmind.kindaVim.plist`.
- `KindaVimStrategyMonitor` (Observable) watches the plist + `NSWorkspace` frontmost-app changes and republishes `currentStrategy`.
- `KindaVimPackController` refcount-starts/stops the strategy monitor alongside the existing mode adapter, so neither fires when the pack is off.

### Surfaces

- **`ContextHUDKindaVimLearningView`** now reads `VimBindings.grouped(strategy:mode:showAdvanced:)` instead of its hardcoded text list. Result: Slack users see the Keyboard subset (no `gg`/`G`, no Visual mode, no text-objects), Safari users see the full Accessibility set. \`hjkl\` rows render with taller, accent-coloured chips for visual emphasis. \`.ignored\` strategy shows a "KindaVim is off here" hint instead of the cheat sheet.
- **`KindaVimStatusBlock`** in Pack Detail surfaces a live strategy badge ("Accessibility", "Keyboard fallback", "Hybrid", "Ignored for this app") and a "Show all keys (advanced)" toggle backed by \`@AppStorage\`. Toggle controls whether page motions, search, and bracket-match show in both the HUD and (eventually) the overlay.

### Tests

- \`KindaVimStrategyResolverTests\` (8 cases) — plist parsing (well-formed, empty dict, garbage data), bundle-ID-vs-lists priority resolution (ignored > hybrid > keyboard > default), nil/empty bundle-ID fallback.
- \`VimBindingsTests\` (already in #324) — \`hjkl\` always core, strategy filtering, mode filtering, op-pending shrinking to motions+operators, advanced toggle, group ordering. Phase 2 doesn't touch the table itself, so those still cover the data layer.

Full suite: 421 tests, 0 failures locally.

### Deferred to v3 PR

- **Live keyboard overlay's per-keycap hint layer.** Touches the core \`OverlayKeycapView\` rendering pipeline (~200 lines handling layer mode, launcher mode, hold states, fade animations). Deserves a focused review.
- **Keystream-driven sequence observer.** Operator-pending behaviour already works via the JSON mode signal alone — keystream observation would only refine which-operator-was-pressed and count-prefix detection. Not critical for v1.

## Test plan

- [x] \`swift test\` (421 tests pass locally)
- [ ] Install kindaVim.app + the pack
- [ ] Hold leader on the nav layer with Safari frontmost: HUD should show the Accessibility set including \`gg\`/\`G\`, all groups visible
- [ ] Switch to Slack and hold leader again: HUD should drop \`gg\`/\`G\`, Visual section, and the search/page sections
- [ ] Switch to Kitty (in \`appsToIgnore\`): HUD should show "KindaVim is off here"
- [ ] Open Pack Detail: strategy badge updates as you change frontmost app
- [ ] Toggle "Show all keys (advanced)": HUD gains/loses page-motion + bracket + search rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)