### PR TITLE
feat(kindavim): overlay vim hint layer — hjkl loud arrows + tier-styled chips

### DIFF
--- a/Sources/KeyPathAppKit/UI/Overlay/LiveKeyboardOverlayView.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/LiveKeyboardOverlayView.swift
@@ -37,6 +37,10 @@ struct LiveKeyboardOverlayView: View {
 
     @State private var escKeyLeftInset: CGFloat = 0
     @State private var keyboardWidth: CGFloat = 0
+    /// Cached "is the KindaVim Mode Display pack installed?" flag.
+    /// Refreshed on `.installedPacksChanged` so the keyboard render path
+    /// doesn't have to await the tracker actor.
+    @State private var kindaVimPackInstalled = false
     @State private var inspectorSectionRaw: String = InspectorSection.mapper.rawValue
     @AppStorage("inspectorSettingsSection") private var settingsSectionRaw: String = InspectorSection.keyboard.rawValue
     var inspectorSection: InspectorSection {
@@ -219,6 +223,15 @@ struct LiveKeyboardOverlayView: View {
         NotificationCenter.default.post(name: .openSettingsSystemStatus, object: nil)
     }
 
+    /// Refresh the cached "kindaVim pack installed" flag from the
+    /// tracker. Called on appear and on `.installedPacksChanged`. The
+    /// flag drives the overlay vim-hint layer's render gate.
+    private func refreshKindaVimPackInstalled() async {
+        let installed = await InstalledPackTracker.shared
+            .isInstalled(packID: PackRegistry.kindaVim.id)
+        await MainActor.run { kindaVimPackInstalled = installed }
+    }
+
     private func copyValidationErrorsToClipboard() {
         let text = validationFailureErrors.joined(separator: "\n")
         NSPasteboard.general.clearContents()
@@ -310,6 +323,7 @@ struct LiveKeyboardOverlayView: View {
                     viewModel.setLayout(activeLayout)
                 }
                 loadCustomRulesState()
+                Task { await refreshKindaVimPackInstalled() }
             },
             onDisappearAction: {
                 inputSourceDetector.stopMonitoring()
@@ -391,6 +405,9 @@ struct LiveKeyboardOverlayView: View {
                 }
             }
         ))
+        .onReceive(NotificationCenter.default.publisher(for: .installedPacksChanged)) { _ in
+            Task { await refreshKindaVimPackInstalled() }
+        }
         .background(
             glassBackground(
                 cornerRadius: cornerRadius,
@@ -718,6 +735,7 @@ struct LiveKeyboardOverlayView: View {
                     onKeyClick: onKeyClick,
                     selectedKeyCode: viewModel.selectedKeyCode,
                     hoveredRuleKeyCode: viewModel.hoveredRuleKeyCode,
+                    vimHintsActive: kindaVimPackInstalled,
                     isLauncherMode: viewModel.isLauncherModeActive || (uiState.isInspectorOpen && inspectorSection == .launchers),
                     launcherMappings: viewModel.launcherMappings,
                     isInspectorVisible: inspectorVisible

--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayKeyboardView.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayKeyboardView.swift
@@ -45,6 +45,12 @@ struct OverlayKeyboardView: View {
     /// Key code being hovered in rules/launcher tabs (for secondary highlight)
     var hoveredRuleKeyCode: UInt16?
 
+    /// Whether the KindaVim hint layer should render on top of the keycap
+    /// grid. Driven by the parent (LiveKeyboardOverlayView) from the pack
+    /// install state; the layer itself decides per-key visibility from
+    /// the live mode + strategy signals.
+    var vimHintsActive: Bool = false
+
     // MARK: - Launcher Mode
 
     /// Whether launcher mode is active (shows app icons on mapped keys)
@@ -230,6 +236,27 @@ struct OverlayKeyboardView: View {
                 // Layer 1: Keycap backgrounds (stable positions)
                 ForEach(keys, id: \.id) { key in
                     keyView(key: key, scale: scale)
+                }
+
+                // Layer 3: KindaVim hints (renders only while pack is
+                // installed, frontmost app isn't ignored, and adapter
+                // mode is normal / op-pending / visual). Sits on top of
+                // the keycaps but below the floating-label animation.
+                if vimHintsActive {
+                    VimHintLayer(
+                        layout: layout,
+                        scale: scale,
+                        keyFrame: { key in
+                            CGRect(
+                                x: keyPositionX(for: key, scale: scale)
+                                    - keyWidth(for: key, scale: scale) / 2,
+                                y: keyPositionY(for: key, scale: scale)
+                                    - keyHeight(for: key, scale: scale) / 2,
+                                width: keyWidth(for: key, scale: scale),
+                                height: keyHeight(for: key, scale: scale)
+                            )
+                        }
+                    )
                 }
 
                 // Layer 2: Floating labels (animate between keycap positions)

--- a/Sources/KeyPathAppKit/UI/Overlay/VimHintLayer.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/VimHintLayer.swift
@@ -1,0 +1,164 @@
+// Renders a hint label on top of every keycap that has a corresponding
+// command in `VimBindings`, while kindaVim is in a vim-y mode (normal /
+// operator-pending / visual). Designed to live as a sibling layer inside
+// `OverlayKeyboardView`'s `ZStack`, sharing its position math via the
+// `keyFrame` builder passed from the parent.
+//
+// hjkl get the loudest treatment: large, accent-coloured arrow glyphs
+// centered on the keycap. Other core/secondary hints render as a smaller
+// chip pinned to the keycap's top-right corner. Advanced hints are gated
+// behind the user's "Show all keys" toggle.
+
+import KeyPathCore
+import SwiftUI
+
+@MainActor
+struct VimHintLayer: View {
+    let layout: PhysicalLayout
+    let scale: CGFloat
+    let keyFrame: (PhysicalKey) -> CGRect
+
+    @State private var adapter = KindaVimStateAdapter.shared
+    @State private var strategyMonitor = KindaVimStrategyMonitor.shared
+    @AppStorage("kindaVim.showAdvancedHints") private var showAdvancedHints: Bool = false
+
+    var body: some View {
+        if shouldRender {
+            ZStack(alignment: .topLeading) {
+                ForEach(layout.keys, id: \.id) { key in
+                    if let hint = hint(for: key) {
+                        VimHintLabel(
+                            hint: hint,
+                            isLoud: isHjkl(key),
+                            isDimmed: isDimmedInOperatorPending(hint: hint),
+                            scale: scale
+                        )
+                        .frame(
+                            width: keyFrame(key).width,
+                            height: keyFrame(key).height
+                        )
+                        .position(
+                            x: keyFrame(key).midX,
+                            y: keyFrame(key).midY
+                        )
+                    }
+                }
+            }
+            .allowsHitTesting(false)
+            .accessibilityHidden(true)
+        }
+    }
+
+    // MARK: - Visibility
+
+    /// Render only while kindaVim is publishing a vim-y mode and the
+    /// frontmost app isn't in kindaVim's ignore list. Insert mode and
+    /// `.unknown` mode hide the layer entirely.
+    private var shouldRender: Bool {
+        guard strategyMonitor.currentStrategy != .ignored else { return false }
+        switch adapter.state.mode {
+        case .normal, .operatorPending, .visual: return true
+        case .insert, .unknown: return false
+        }
+    }
+
+    // MARK: - Per-key hint resolution
+
+    /// Public-friendly lookup helper (also used by tests) that resolves
+    /// a physical key to the `VimHint` that should render on it given
+    /// the current strategy + mode + advanced flag.
+    nonisolated static func resolveHint(
+        for keyCode: UInt16,
+        strategy: KindaVimStrategy,
+        mode: KindaVimStateAdapter.Mode,
+        showAdvanced: Bool
+    ) -> VimHint? {
+        let kanataName = OverlayKeyboardView.keyCodeToKanataName(keyCode).lowercased()
+        let candidates = VimBindings.hints(
+            strategy: strategy,
+            mode: mode,
+            showAdvanced: showAdvanced
+        )
+        return candidates.first { $0.key.lowercased() == kanataName }
+    }
+
+    private func hint(for key: PhysicalKey) -> VimHint? {
+        Self.resolveHint(
+            for: key.keyCode,
+            strategy: strategyMonitor.currentStrategy,
+            mode: adapter.state.mode,
+            showAdvanced: showAdvancedHints
+        )
+    }
+
+    private func isHjkl(_ key: PhysicalKey) -> Bool {
+        let name = OverlayKeyboardView.keyCodeToKanataName(key.keyCode).lowercased()
+        return ["h", "j", "k", "l"].contains(name)
+    }
+
+    /// Op-pending mode: keep motion targets bright, dim everything else
+    /// (operators show through but at reduced strength as a "next step is
+    /// a motion" cue).
+    private func isDimmedInOperatorPending(hint: VimHint) -> Bool {
+        guard adapter.state.mode == .operatorPending else { return false }
+        let motionGroups: Set<VimHint.Group> = [
+            .movement, .wordMotion, .lineMotion, .findChar, .doc,
+        ]
+        return !motionGroups.contains(hint.group)
+    }
+}
+
+// MARK: - Per-key label
+
+private struct VimHintLabel: View {
+    let hint: VimHint
+    let isLoud: Bool
+    let isDimmed: Bool
+    let scale: CGFloat
+
+    var body: some View {
+        if isLoud {
+            // hjkl: large arrow glyph centered, normal label ghosts under it.
+            Text(hint.displayLabel)
+                .font(.system(size: max(14, 26 * scale), weight: .heavy))
+                .foregroundStyle(Color.accentColor.opacity(opacity))
+                .shadow(color: .black.opacity(0.4), radius: 1, x: 0, y: 0.5)
+        } else {
+            // Other hints: small chip pinned top-right.
+            VStack(alignment: .trailing) {
+                HStack {
+                    Spacer()
+                    Text(hint.displayLabel)
+                        .font(.system(size: max(7, 9 * scale), weight: .heavy, design: .monospaced))
+                        .foregroundStyle(.white.opacity(opacity))
+                        .padding(.horizontal, 3)
+                        .padding(.vertical, 1)
+                        .background(
+                            RoundedRectangle(cornerRadius: 3, style: .continuous)
+                                .fill(chipFill)
+                        )
+                        .padding(2)
+                }
+                Spacer()
+            }
+        }
+    }
+
+    private var opacity: Double {
+        if isDimmed { return 0.18 }
+        switch hint.tier {
+        case .core: return 1.0
+        case .secondary: return 0.7
+        case .advanced: return 0.5
+        }
+    }
+
+    private var chipFill: Color {
+        if isDimmed { return Color.black.opacity(0.25) }
+        switch hint.tier {
+        case .core: return Color.accentColor.opacity(0.55)
+        case .secondary: return Color.accentColor.opacity(0.35)
+        case .advanced: return Color.black.opacity(0.4)
+        }
+    }
+}

--- a/Sources/KeyPathAppKit/UI/Overlay/VimHintLayer.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/VimHintLayer.swift
@@ -79,7 +79,29 @@ struct VimHintLayer: View {
             mode: mode,
             showAdvanced: showAdvanced
         )
-        return candidates.first { $0.key.lowercased() == kanataName }
+        return candidates.first { hint in
+            physicalKanataName(for: hint.key) == kanataName
+        }
+    }
+
+    /// Translate a `VimHint.key` (which uses vim notation: `/`, `$`,
+    /// `ctrl-d`, etc.) into the underlying physical kanata key name
+    /// returned by `keyCodeToKanataName`. Returns an empty string for
+    /// chord-only hints (e.g. `ctrl-d`) so they don't render on the
+    /// `d` keycap and conflict with the `d` operator hint — chords
+    /// belong in the HUD list, not the per-key overlay.
+    nonisolated static func physicalKanataName(for vimKey: String) -> String {
+        let lower = vimKey.lowercased()
+        if lower.hasPrefix("ctrl-") {
+            // Chord — suppress on the overlay; HUD list still surfaces it.
+            return ""
+        }
+        switch lower {
+        case "/", "?": return "slash"
+        case "$": return "4"
+        case "%": return "5"
+        default: return lower
+        }
     }
 
     private func hint(for key: PhysicalKey) -> VimHint? {

--- a/Tests/KeyPathTests/VimHintLayerResolveTests.swift
+++ b/Tests/KeyPathTests/VimHintLayerResolveTests.swift
@@ -86,6 +86,50 @@ final class VimHintLayerResolveTests: XCTestCase {
         XCTAssertNil(result, "Escape isn't a vim normal-mode binding")
     }
 
+    // MARK: - Symbol-key normalization
+
+    func testSlashKeyResolvesSearchHint() {
+        // keyCode 44 → kanata "slash". VimBindings stores `/` and `?`.
+        // Without normalization, the lookup would miss; with it, `/` resolves.
+        let slashKeyCode: UInt16 = 44
+        let hint = VimHintLayer.resolveHint(
+            for: slashKeyCode, strategy: .accessibility, mode: .normal, showAdvanced: true
+        )
+        XCTAssertEqual(hint?.displayLabel, "/")
+    }
+
+    func testFourKeyResolvesDollarSign() {
+        // keyCode 21 → kanata "4". VimBindings stores `$` (line end).
+        let fourKeyCode: UInt16 = 21
+        let hint = VimHintLayer.resolveHint(
+            for: fourKeyCode, strategy: .accessibility, mode: .normal, showAdvanced: false
+        )
+        XCTAssertEqual(hint?.displayLabel, "$")
+    }
+
+    func testCtrlPrefixedHintsAreNotResolvedFromKeyCode() {
+        // ctrl-d is a chord; we don't want it rendering on the `d` keycap
+        // and conflicting with the `d` operator hint.
+        let dKeyCode: UInt16 = 2
+        let hint = VimHintLayer.resolveHint(
+            for: dKeyCode, strategy: .accessibility, mode: .normal, showAdvanced: true
+        )
+        // The `d` operator should win; ctrl-d should be filtered out.
+        XCTAssertEqual(hint?.displayLabel, "d", "operator d should win over ctrl-d on keycode 2")
+    }
+
+    func testPhysicalKanataNameNormalization() {
+        // Sanity-check the helper directly so the contract is documented
+        // alongside the resolver tests.
+        XCTAssertEqual(VimHintLayer.physicalKanataName(for: "/"), "slash")
+        XCTAssertEqual(VimHintLayer.physicalKanataName(for: "?"), "slash")
+        XCTAssertEqual(VimHintLayer.physicalKanataName(for: "$"), "4")
+        XCTAssertEqual(VimHintLayer.physicalKanataName(for: "%"), "5")
+        XCTAssertEqual(VimHintLayer.physicalKanataName(for: "ctrl-d"), "")
+        XCTAssertEqual(VimHintLayer.physicalKanataName(for: "h"), "h")
+        XCTAssertEqual(VimHintLayer.physicalKanataName(for: "G"), "g")
+    }
+
     // MARK: - Op-pending narrows the set
 
     func testOperatorPendingResolvesMotionsAndOperators() {

--- a/Tests/KeyPathTests/VimHintLayerResolveTests.swift
+++ b/Tests/KeyPathTests/VimHintLayerResolveTests.swift
@@ -1,0 +1,106 @@
+@testable import KeyPathAppKit
+import XCTest
+
+/// Pure-data assertions on `VimHintLayer.resolveHint` — the per-key
+/// lookup that maps a physical macOS keyCode to a `VimHint` given the
+/// current strategy / mode / advanced flag. No view rendering.
+final class VimHintLayerResolveTests: XCTestCase {
+    // macOS virtual keycodes.
+    private let hKeyCode: UInt16 = 4
+    private let jKeyCode: UInt16 = 38
+    private let kKeyCode: UInt16 = 40
+    private let lKeyCode: UInt16 = 37
+    private let gKeyCode: UInt16 = 5
+    private let zeroKeyCode: UInt16 = 29
+    private let escKeyCode: UInt16 = 53
+
+    // MARK: - hjkl resolve to arrow hints in every supported strategy
+
+    func testHjklAlwaysResolveInNormalMode() {
+        for strategy in [KindaVimStrategy.accessibility, .keyboard, .hybrid] {
+            let h = VimHintLayer.resolveHint(
+                for: hKeyCode, strategy: strategy, mode: .normal, showAdvanced: false
+            )
+            let j = VimHintLayer.resolveHint(
+                for: jKeyCode, strategy: strategy, mode: .normal, showAdvanced: false
+            )
+            let k = VimHintLayer.resolveHint(
+                for: kKeyCode, strategy: strategy, mode: .normal, showAdvanced: false
+            )
+            let l = VimHintLayer.resolveHint(
+                for: lKeyCode, strategy: strategy, mode: .normal, showAdvanced: false
+            )
+            XCTAssertEqual(h?.displayLabel, "←", "h missing for \(strategy)")
+            XCTAssertEqual(j?.displayLabel, "↓", "j missing for \(strategy)")
+            XCTAssertEqual(k?.displayLabel, "↑", "k missing for \(strategy)")
+            XCTAssertEqual(l?.displayLabel, "→", "l missing for \(strategy)")
+        }
+    }
+
+    // MARK: - Strategy filters carry through
+
+    func testGgIsAccessibilityOnly() {
+        let ax = VimHintLayer.resolveHint(
+            for: gKeyCode, strategy: .accessibility, mode: .normal, showAdvanced: false
+        )
+        let kb = VimHintLayer.resolveHint(
+            for: gKeyCode, strategy: .keyboard, mode: .normal, showAdvanced: false
+        )
+        XCTAssertEqual(ax?.displayLabel, "gg")
+        XCTAssertNil(kb, "Keyboard strategy should drop gg")
+    }
+
+    // MARK: - Mode filters
+
+    func testInsertModeYieldsNoHints() {
+        let result = VimHintLayer.resolveHint(
+            for: hKeyCode, strategy: .accessibility, mode: .insert, showAdvanced: false
+        )
+        XCTAssertNil(result, "Insert mode should suppress all hints")
+    }
+
+    func testIgnoredStrategyYieldsNoHints() {
+        let result = VimHintLayer.resolveHint(
+            for: hKeyCode, strategy: .ignored, mode: .normal, showAdvanced: false
+        )
+        XCTAssertNil(result, "Ignored strategy should suppress hints even for hjkl")
+    }
+
+    // MARK: - Advanced toggle gates non-core hints
+
+    func testZeroIsCoreEvenWithAdvancedOff() {
+        // 0 is a core line-motion key; should resolve regardless of toggle.
+        let result = VimHintLayer.resolveHint(
+            for: zeroKeyCode, strategy: .accessibility, mode: .normal, showAdvanced: false
+        )
+        XCTAssertEqual(result?.displayLabel, "0")
+        XCTAssertEqual(result?.tier, .core)
+    }
+
+    // MARK: - Keys without a vim binding return nil
+
+    func testEscapeHasNoHint() {
+        let result = VimHintLayer.resolveHint(
+            for: escKeyCode, strategy: .accessibility, mode: .normal, showAdvanced: true
+        )
+        XCTAssertNil(result, "Escape isn't a vim normal-mode binding")
+    }
+
+    // MARK: - Op-pending narrows the set
+
+    func testOperatorPendingResolvesMotionsAndOperators() {
+        // h is a motion → resolves
+        let h = VimHintLayer.resolveHint(
+            for: hKeyCode, strategy: .accessibility, mode: .operatorPending, showAdvanced: false
+        )
+        XCTAssertNotNil(h)
+
+        // 'a' (enter Insert via append) is in `.enterInsert` group, which is
+        // dropped in op-pending → nil
+        let aKeyCode: UInt16 = 0
+        let a = VimHintLayer.resolveHint(
+            for: aKeyCode, strategy: .accessibility, mode: .operatorPending, showAdvanced: false
+        )
+        XCTAssertNil(a, "enterInsert group is dropped in operator-pending")
+    }
+}


### PR DESCRIPTION
## Summary

The visual showpiece of the KindaVim hint feature. Renders hint labels on top of every keycap in the live keyboard overlay while kindaVim is in a vim-y mode. Originally promised in the spec discussion, deferred from #325 to its own PR for focused review.

### Design

- **\`hjkl\` are the loudest signal in the overlay.** Large accent-coloured arrow glyphs (◀ ▼ ▲ ▶) centered on each keycap, scaled with keyboard size.
- **Other hints render as small chips** pinned to the top-right corner of the keycap, opacity per tier:
  - core: 1.0
  - secondary: 0.7
  - advanced: 0.5 (only shown when "Show all keys" is on)
- **Operator-pending mode dims non-motion hints** to ~18% — visual cue that the next press should be a motion.
- **Hidden when** kindaVim isn't installed, the frontmost app is in kindaVim's ignore list, or mode is \`.insert\` / \`.unknown\`.

### Implementation

- New \`VimHintLayer.swift\` is rendered as Layer 3 inside \`OverlayKeyboardView\`'s existing \`ZStack\`, alongside the keycap layer and the floating-labels layer. Position math is shared via a \`keyFrame\` closure passed in from the parent — no duplication, and no changes to per-keycap rendering, so launcher / layer / hold / fade behaviours are entirely unaffected.
- \`OverlayKeyboardView\` gains one new boolean parameter, \`vimHintsActive\`. The layer itself reads \`KindaVimStateAdapter\`, \`KindaVimStrategyMonitor\`, and the \`kindaVim.showAdvancedHints\` \`@AppStorage\` flag for everything else.
- \`LiveKeyboardOverlayView\` caches the pack-install state and refreshes via \`.installedPacksChanged\` — identical pattern to the ContextHUDController gate landed in #324.
- \`VimHintLayer.resolveHint\` is the \`nonisolated\` testable lookup helper.

### Tests

\`VimHintLayerResolveTests\` (7 cases):
- \`hjkl\` resolves in every supported strategy
- \`gg\` is Accessibility-only (drops on Keyboard fallback)
- Insert mode + Ignored strategy yield no hints
- Core keys (\`0\`) resolve regardless of advanced toggle
- Escape has no hint (filter rejects unmapped keys cleanly)
- Op-pending keeps motions, drops \`enterInsert\` group

Full suite: 420 + 17 (XCTest) tests, 0 failures.

### Test plan
- [ ] Install kindaVim.app + the pack
- [ ] Confirm hjkl render large arrow glyphs in normal mode
- [ ] Switch to insert mode: hint layer disappears
- [ ] Press an operator (e.g. \`d\`); op-pending kicks in: motion keys stay bright, others dim
- [ ] Switch to a Keyboard-strategy app (Slack): \`gg\`/\`G\`/page motions / \`%\`/\`/\` should not render
- [ ] Switch to Kitty (in \`appsToIgnore\`): hint layer disappears
- [ ] Toggle "Show all keys (advanced)" in Pack Detail: page-motion + bracket + search hints appear/disappear
- [ ] Confirm clicks pass through (\`.allowsHitTesting(false)\` works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)