### PR TITLE
feat(kindavim): keystream sequence observer — operator-aware op-pending + count badge

### DIFF
--- a/Sources/KeyPathAppKit/Services/KindaVim/KindaVimPackController.swift
+++ b/Sources/KeyPathAppKit/Services/KindaVim/KindaVimPackController.swift
@@ -1,8 +1,9 @@
 // Bridges the KindaVim pack's install/uninstall state to the live
 // helpers it depends on (`KindaVimStateAdapter` for mode signals,
-// `KindaVimStrategyMonitor` for per-app strategy tracking). Started
-// once at app launch; observes `installedPacksChanged` and refcount-
-// starts/stops both monitors as the user toggles the pack from
+// `KindaVimStrategyMonitor` for per-app strategy tracking,
+// `VimSequenceObserver` for keystream sub-state). Started once at
+// app launch; observes `installedPacksChanged` and refcount-
+// starts/stops all helpers as the user toggles the pack from
 // Gallery (or Pack Detail).
 
 import Foundation
@@ -35,12 +36,13 @@ final class KindaVimPackController {
         if isMonitoring {
             KindaVimStateAdapter.shared.stopMonitoring()
             KindaVimStrategyMonitor.shared.stopMonitoring()
+            VimSequenceObserver.shared.stopMonitoring()
             isMonitoring = false
         }
     }
 
-    /// Tracks whether we currently hold refcounts on the adapter / strategy
-    /// monitor so we balance start/stop calls without double-decrementing.
+    /// Tracks whether we currently hold refcounts on the helpers so we
+    /// balance start/stop calls without double-decrementing.
     private var isMonitoring = false
 
     private func refresh() async {
@@ -48,10 +50,12 @@ final class KindaVimPackController {
         if installed, !isMonitoring {
             KindaVimStateAdapter.shared.startMonitoring()
             KindaVimStrategyMonitor.shared.startMonitoring()
+            VimSequenceObserver.shared.startMonitoring()
             isMonitoring = true
         } else if !installed, isMonitoring {
             KindaVimStateAdapter.shared.stopMonitoring()
             KindaVimStrategyMonitor.shared.stopMonitoring()
+            VimSequenceObserver.shared.stopMonitoring()
             isMonitoring = false
         }
     }

--- a/Sources/KeyPathAppKit/Services/KindaVim/VimSequenceObserver.swift
+++ b/Sources/KeyPathAppKit/Services/KindaVim/VimSequenceObserver.swift
@@ -65,10 +65,13 @@ final class VimSequenceObserver {
             }
         }
 
-        // Mirror the mode signal as a dependency: `KindaVimStateAdapter`
-        // is `@Observable`, but we also need a side-effect on every flip
-        // (hard-reset). Polling on each keystroke is simpler than wiring
-        // up a Combine subscription, so we just check before each event.
+        // Subscribe to adapter mode flips so we hard-reset *immediately*
+        // when kindaVim flips back to normal/insert at the end of a
+        // sequence (e.g. `d3w` completes → motion done → mode flips
+        // without the user pressing another tracked key). Without this,
+        // `currentOperator` and `countBuffer` would stay stale until the
+        // next keystroke. Re-arms itself inside `onChange`.
+        observeAdapterMode()
     }
 
     func stopMonitoring() {
@@ -100,14 +103,41 @@ final class VimSequenceObserver {
         ingestCore(character: chars)
     }
 
+    /// Re-read the current mode and apply the hard-reset if it changed.
+    /// Production callers don't usually need to invoke this directly — the
+    /// adapter observation in `startMonitoring` covers the empty-keystream
+    /// case, and `ingestCore` calls it before every keystroke. Public so
+    /// tests can drive transitions deterministically.
+    func syncWithMode() {
+        let currentMode = modeProvider()
+        guard currentMode != lastObservedMode else { return }
+        currentOperator = nil
+        countBuffer = ""
+        lastObservedMode = currentMode
+    }
+
+    private func observeAdapterMode() {
+        withObservationTracking {
+            // Touch `state.mode` so the tracker registers it as a
+            // dependency. We don't read the actual value through this
+            // path — `syncWithMode()` does that consistently via
+            // `modeProvider`, which tests can swap out.
+            _ = KindaVimStateAdapter.shared.state.mode
+        } onChange: { [weak self] in
+            Task { @MainActor in
+                guard let self, self.monitoringCount > 0 else { return }
+                self.syncWithMode()
+                // Re-arm: `withObservationTracking` only fires once per
+                // setup. Schedule a fresh subscription for the next flip.
+                self.observeAdapterMode()
+            }
+        }
+    }
+
     private func ingestCore(character: String) {
         // Hard-reset on every adapter mode transition — see file header.
-        let currentMode = modeProvider()
-        if currentMode != lastObservedMode {
-            currentOperator = nil
-            countBuffer = ""
-            lastObservedMode = currentMode
-        }
+        syncWithMode()
+        let currentMode = lastObservedMode
 
         // Only track sub-state while in a vim-y mode.
         switch currentMode {

--- a/Sources/KeyPathAppKit/Services/KindaVim/VimSequenceObserver.swift
+++ b/Sources/KeyPathAppKit/Services/KindaVim/VimSequenceObserver.swift
@@ -1,0 +1,169 @@
+// Lightweight observer over the user's keystream while kindaVim is in
+// a vim-y mode. Maintains a tiny state machine — `currentOperator`
+// (the operator key that put us into op-pending), `countBuffer` (digit
+// prefix the user is building) — that the HUD and the overlay use to
+// sharpen their feedback.
+//
+// Architecture invariant: `KindaVimStateAdapter.state.mode` is the
+// authoritative signal for which mode we're in. This observer's
+// derived state is informational sub-state. Every mode transition
+// **hard-resets** the observer, so any desync (kindaVim cancels a
+// sequence via Esc, an unsupported motion, or a timeout) is bounded
+// to the next mode change.
+
+import AppKit
+import KeyPathCore
+import Observation
+
+@MainActor
+@Observable
+final class VimSequenceObserver {
+    static let shared = VimSequenceObserver()
+
+    /// The operator key the user pressed to enter operator-pending mode
+    /// (`d`, `c`, `y`). Nil unless adapter mode is `.operatorPending`.
+    private(set) var currentOperator: String?
+
+    /// Numeric prefix being typed before a motion (`5j`, `3dw`). Empty
+    /// when no count is in flight or when adapter mode isn't a vim mode.
+    /// Stored as the raw digit string so the UI can render `5×` directly.
+    private(set) var countBuffer: String = ""
+
+    @ObservationIgnored
+    private let modeProvider: @MainActor () -> KindaVimStateAdapter.Mode
+
+    @ObservationIgnored
+    private var monitoringCount = 0
+
+    @ObservationIgnored
+    private var globalMonitor: Any?
+
+    @ObservationIgnored
+    private var lastObservedMode: KindaVimStateAdapter.Mode = .unknown
+
+    /// Production callers use the no-arg init which reads from the
+    /// shared `KindaVimStateAdapter`. Tests inject a `modeProvider`
+    /// closure so they can drive mode transitions deterministically
+    /// without touching the file watcher.
+    init(modeProvider: @MainActor @escaping () -> KindaVimStateAdapter.Mode = {
+        KindaVimStateAdapter.shared.state.mode
+    }) {
+        self.modeProvider = modeProvider
+    }
+
+    /// Refcounted start. Idempotent across multiple callers.
+    func startMonitoring() {
+        monitoringCount += 1
+        guard monitoringCount == 1 else { return }
+        AppLogger.shared.log("👀 [VimSeq] Starting observer")
+
+        lastObservedMode = modeProvider()
+
+        globalMonitor = NSEvent.addGlobalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            Task { @MainActor in
+                self?.handleKeyDown(event)
+            }
+        }
+
+        // Mirror the mode signal as a dependency: `KindaVimStateAdapter`
+        // is `@Observable`, but we also need a side-effect on every flip
+        // (hard-reset). Polling on each keystroke is simpler than wiring
+        // up a Combine subscription, so we just check before each event.
+    }
+
+    func stopMonitoring() {
+        guard monitoringCount > 0 else { return }
+        monitoringCount -= 1
+        guard monitoringCount == 0 else { return }
+        AppLogger.shared.log("🛑 [VimSeq] Stopping observer")
+
+        if let monitor = globalMonitor {
+            NSEvent.removeMonitor(monitor)
+        }
+        globalMonitor = nil
+
+        currentOperator = nil
+        countBuffer = ""
+        lastObservedMode = .unknown
+    }
+
+    // MARK: - Event handling
+
+    /// Test seam — synthetic event injection so unit tests don't need to
+    /// drive real `NSEvent`. Production path goes through `handleKeyDown`.
+    func ingest(character: String) {
+        ingestCore(character: character)
+    }
+
+    private func handleKeyDown(_ event: NSEvent) {
+        guard let chars = event.charactersIgnoringModifiers, !chars.isEmpty else { return }
+        ingestCore(character: chars)
+    }
+
+    private func ingestCore(character: String) {
+        // Hard-reset on every adapter mode transition — see file header.
+        let currentMode = modeProvider()
+        if currentMode != lastObservedMode {
+            currentOperator = nil
+            countBuffer = ""
+            lastObservedMode = currentMode
+        }
+
+        // Only track sub-state while in a vim-y mode.
+        switch currentMode {
+        case .normal, .visual:
+            applyNormalOrVisual(character: character)
+        case .operatorPending:
+            applyOperatorPending(character: character)
+        case .insert, .unknown:
+            // No bookkeeping — user is typing or kindaVim isn't reporting.
+            currentOperator = nil
+            countBuffer = ""
+        }
+    }
+
+    private func applyNormalOrVisual(character: String) {
+        // Digit accumulating into a count prefix (`5`, `12`, `100`).
+        if Self.isDigit(character) {
+            // Avoid leading zero: `0` alone is "line start", not a count.
+            if countBuffer.isEmpty, character == "0" { return }
+            countBuffer.append(character)
+            return
+        }
+
+        // An operator key starts an op-pending sequence (the actual mode
+        // flip will follow from kindaVim's environment.json signal).
+        if Self.isOperator(character) {
+            currentOperator = character
+            return
+        }
+
+        // Anything else (motion, edit, escape, ...) consumes the count
+        // prefix and clears it.
+        countBuffer = ""
+        currentOperator = nil
+    }
+
+    private func applyOperatorPending(character: String) {
+        // Inside op-pending the user picks a motion or text-object; once
+        // they do, kindaVim flips back to normal/visual and our hard-reset
+        // path clears state. We don't try to model individual motions;
+        // currentOperator is the only useful sub-state here.
+        if Self.isDigit(character) {
+            // Some operators allow counts before the motion: `d3w`.
+            countBuffer.append(character)
+        }
+    }
+
+    // MARK: - Helpers
+
+    private static func isDigit(_ s: String) -> Bool {
+        s.count == 1 && s.allSatisfy(\.isNumber)
+    }
+
+    private static let operatorChars: Set<String> = ["d", "c", "y"]
+
+    private static func isOperator(_ s: String) -> Bool {
+        operatorChars.contains(s.lowercased())
+    }
+}

--- a/Sources/KeyPathAppKit/UI/ContextHUD/ContextHUDKindaVimLearningView.swift
+++ b/Sources/KeyPathAppKit/UI/ContextHUD/ContextHUDKindaVimLearningView.swift
@@ -8,6 +8,7 @@ struct ContextHUDKindaVimLearningView: View {
     let modeSetting: KindaVimLeaderHUDMode
 
     @State private var strategyMonitor = KindaVimStrategyMonitor.shared
+    @State private var sequenceObserver = VimSequenceObserver.shared
     @AppStorage("kindaVim.showAdvancedHints") private var showAdvancedHints: Bool = false
 
     private struct CommandItem: Identifiable {
@@ -151,11 +152,27 @@ struct ContextHUDKindaVimLearningView: View {
                 bindingGroupSection(group)
             }
             if mode == .operatorPending {
-                Text("Press the same operator twice (dd · yy · cc) to act on the whole line.")
-                    .font(.footnote)
-                    .foregroundStyle(.white.opacity(0.75))
-                    .lineSpacing(1.5)
+                operatorPendingCallout
             }
+        }
+    }
+
+    @ViewBuilder
+    private var operatorPendingCallout: some View {
+        // Observer-aware: if we know which operator triggered op-pending,
+        // name it specifically. Otherwise fall back to the generic hint.
+        if let op = sequenceObserver.currentOperator?.lowercased(),
+           ["d", "c", "y"].contains(op)
+        {
+            Text("Press \(op) again for the whole line.")
+                .font(.footnote.weight(.semibold))
+                .foregroundStyle(Color.accentColor)
+                .lineSpacing(1.5)
+        } else {
+            Text("Press the same operator twice (dd · yy · cc) to act on the whole line.")
+                .font(.footnote)
+                .foregroundStyle(.white.opacity(0.75))
+                .lineSpacing(1.5)
         }
     }
 

--- a/Sources/KeyPathAppKit/UI/Overlay/KindaVimModeBadge.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/KindaVimModeBadge.swift
@@ -7,6 +7,7 @@ import SwiftUI
 @MainActor
 struct KindaVimModeBadge: View {
     @State private var adapter = KindaVimStateAdapter.shared
+    @State private var sequenceObserver = VimSequenceObserver.shared
     let isPackInstalled: Bool
 
     var body: some View {
@@ -19,6 +20,17 @@ struct KindaVimModeBadge: View {
                 Text(mode.displayName.uppercased())
                     .font(.system(size: 9, weight: .heavy))
                     .foregroundStyle(tint(for: mode))
+                if !sequenceObserver.countBuffer.isEmpty {
+                    Text("\(sequenceObserver.countBuffer)×")
+                        .font(.system(size: 9, weight: .heavy, design: .monospaced))
+                        .foregroundStyle(.white)
+                        .padding(.horizontal, 4)
+                        .padding(.vertical, 1)
+                        .background(
+                            RoundedRectangle(cornerRadius: 3, style: .continuous)
+                                .fill(Color.accentColor.opacity(0.85))
+                        )
+                }
             }
             .padding(.horizontal, 6)
             .padding(.vertical, 2)
@@ -26,8 +38,15 @@ struct KindaVimModeBadge: View {
                 RoundedRectangle(cornerRadius: 4, style: .continuous)
                     .fill(tint(for: mode).opacity(0.15))
             )
-            .accessibilityLabel("KindaVim mode: \(mode.displayName)")
+            .accessibilityLabel(accessibilityDescription(for: mode))
         }
+    }
+
+    private func accessibilityDescription(for mode: KindaVimStateAdapter.Mode) -> String {
+        if sequenceObserver.countBuffer.isEmpty {
+            return "KindaVim mode: \(mode.displayName)"
+        }
+        return "KindaVim mode: \(mode.displayName), count \(sequenceObserver.countBuffer)"
     }
 
     /// Don't surface a badge for `.unknown` — kindaVim hasn't published a

--- a/Tests/KeyPathTests/VimSequenceObserverTests.swift
+++ b/Tests/KeyPathTests/VimSequenceObserverTests.swift
@@ -82,6 +82,34 @@ final class VimSequenceObserverTests: XCTestCase {
         XCTAssertEqual(observer.countBuffer, "")
     }
 
+    func testSyncWithModeClearsStateWithoutAnyKeystroke() {
+        // The actual op-pending sequence completes inside kindaVim
+        // (e.g. `d3w` → motion done → adapter flips back to normal)
+        // without any new key event arriving at our observer. Stale
+        // state would cause the badge/HUD to show outdated count or
+        // operator until the next keystroke. `syncWithMode()` is the
+        // hard-reset path we wire up via withObservationTracking in
+        // production — tests drive it explicitly.
+        let observer = makeObserver()
+        mode = .normal
+        observer.ingest(character: "5")
+        observer.ingest(character: "d")
+        XCTAssertEqual(observer.countBuffer, "5")
+        XCTAssertEqual(observer.currentOperator, "d")
+
+        // Sequence completes: kindaVim flips back to normal. No new key.
+        mode = .normal  // (still normal — but pretend we transitioned through op-pending)
+        observer.syncWithMode()
+        // Mode didn't actually change, so state should remain.
+        XCTAssertEqual(observer.currentOperator, "d")
+
+        // Now actually flip to a different mode without typing.
+        mode = .insert
+        observer.syncWithMode()
+        XCTAssertNil(observer.currentOperator)
+        XCTAssertEqual(observer.countBuffer, "")
+    }
+
     func testInsertModeIgnoresTrackedKeys() {
         let observer = makeObserver()
         mode = .insert

--- a/Tests/KeyPathTests/VimSequenceObserverTests.swift
+++ b/Tests/KeyPathTests/VimSequenceObserverTests.swift
@@ -1,0 +1,129 @@
+@testable import KeyPathAppKit
+import XCTest
+
+/// State-machine tests for `VimSequenceObserver`. We don't drive real
+/// `NSEvent` here — production reads the keystream from a global
+/// monitor, but the observer exposes `ingest(character:)` as a test
+/// seam and accepts a `modeProvider` closure so we can flip vim modes
+/// deterministically without touching the kindaVim file watcher.
+@MainActor
+final class VimSequenceObserverTests: XCTestCase {
+    private var mode: KindaVimStateAdapter.Mode = .unknown
+
+    private func makeObserver() -> VimSequenceObserver {
+        VimSequenceObserver(modeProvider: { [weak self] in
+            self?.mode ?? .unknown
+        })
+    }
+
+    // MARK: - Operator capture
+
+    func testTypingDInNormalSetsCurrentOperator() {
+        let observer = makeObserver()
+        mode = .normal
+        observer.ingest(character: "d")
+        XCTAssertEqual(observer.currentOperator, "d")
+    }
+
+    func testNonOperatorClearsAnyPendingOperator() {
+        let observer = makeObserver()
+        mode = .normal
+        observer.ingest(character: "d")
+        // User immediately presses `j` — that's a motion, not an operator.
+        // (In practice kindaVim would flip to op-pending after `d` and the
+        // hard-reset path would clear state anyway. This covers the
+        // single-mode happy path.)
+        observer.ingest(character: "j")
+        XCTAssertNil(observer.currentOperator)
+    }
+
+    // MARK: - Count buffer
+
+    func testDigitsAccumulateInCountBuffer() {
+        let observer = makeObserver()
+        mode = .normal
+        observer.ingest(character: "5")
+        XCTAssertEqual(observer.countBuffer, "5")
+        observer.ingest(character: "0")  // not a leading zero — ok mid-buffer
+        XCTAssertEqual(observer.countBuffer, "50")
+    }
+
+    func testLeadingZeroIsIgnoredAsCount() {
+        // `0` alone in vim is "go to line start", not a count prefix.
+        let observer = makeObserver()
+        mode = .normal
+        observer.ingest(character: "0")
+        XCTAssertEqual(observer.countBuffer, "")
+    }
+
+    func testMotionAfterCountClearsBuffer() {
+        let observer = makeObserver()
+        mode = .normal
+        observer.ingest(character: "5")
+        XCTAssertEqual(observer.countBuffer, "5")
+        observer.ingest(character: "j")  // motion consumes the count
+        XCTAssertEqual(observer.countBuffer, "")
+    }
+
+    // MARK: - Hard reset on mode transition
+
+    func testModeTransitionClearsAllState() {
+        let observer = makeObserver()
+        mode = .normal
+        observer.ingest(character: "5")
+        observer.ingest(character: "d")
+        XCTAssertEqual(observer.countBuffer, "5")
+        XCTAssertEqual(observer.currentOperator, "d")
+
+        // kindaVim flips to insert (e.g. user pressed Esc, then `i`).
+        mode = .insert
+        observer.ingest(character: "x")  // insert mode keystroke
+        XCTAssertNil(observer.currentOperator)
+        XCTAssertEqual(observer.countBuffer, "")
+    }
+
+    func testInsertModeIgnoresTrackedKeys() {
+        let observer = makeObserver()
+        mode = .insert
+        observer.ingest(character: "d")
+        observer.ingest(character: "5")
+        XCTAssertNil(observer.currentOperator, "operators are not tracked in insert mode")
+        XCTAssertEqual(observer.countBuffer, "", "counts are not tracked in insert mode")
+    }
+
+    func testUnknownModeIgnoresTrackedKeys() {
+        // kindaVim hasn't published a mode yet (`.unknown`) — observer
+        // should be inert, not eagerly populate state.
+        let observer = makeObserver()
+        mode = .unknown
+        observer.ingest(character: "d")
+        XCTAssertNil(observer.currentOperator)
+    }
+
+    // MARK: - Operator-pending sub-state
+
+    func testCountInOpPendingAccumulates() {
+        // After `d`, kindaVim flips to operator-pending. The user can
+        // type `3w` for "delete 3 words". The count prefix in op-pending
+        // should accumulate into the buffer for display.
+        let observer = makeObserver()
+        mode = .normal
+        observer.ingest(character: "d")
+        XCTAssertEqual(observer.currentOperator, "d")
+
+        mode = .operatorPending
+        observer.ingest(character: "3")
+        XCTAssertEqual(observer.countBuffer, "3")
+    }
+
+    // MARK: - Visual mode tracks like normal
+
+    func testVisualModeTracksOperatorsAndCounts() {
+        let observer = makeObserver()
+        mode = .visual
+        observer.ingest(character: "5")
+        observer.ingest(character: "y")
+        XCTAssertEqual(observer.countBuffer, "5")
+        XCTAssertEqual(observer.currentOperator, "y")
+    }
+}


### PR DESCRIPTION
## Summary

The HUD's op-pending callout was generic ("dd / yy / cc") because we only knew kindaVim was in op-pending, not which operator triggered it. The count-prefix grammar (\`5j\`, \`3dw\`) had no UI surface at all. This PR adds a lightweight keystream observer that fills both gaps.

## How it works

\`VimSequenceObserver\` watches the user's keystream while kindaVim is in a vim-y mode and maintains two pieces of derived sub-state:

- \`currentOperator\` — the operator key (\`d\`, \`c\`, \`y\`) that put us into op-pending
- \`countBuffer\` — the digit prefix being typed before a motion (\`5j\`, \`3dw\`)

### Architecture invariant

\`KindaVimStateAdapter.state.mode\` remains authoritative for which mode we're in. The observer's state is **informational** — it annotates mode, never overrides it. Every adapter mode transition **hard-resets** the observer. If kindaVim cancels a sequence (Esc / unsupported motion / timeout) and we miss it, the next mode flip self-heals.

### Implementation notes

- \`NSEvent.addGlobalMonitorForEvents(.keyDown)\` for keystream — same pattern \`GlobalHotkeyService\` uses. Requires the existing Input Monitoring permission, no new prompts.
- Test seam: \`init(modeProvider:)\` + \`ingest(character:)\` lets unit tests drive mode transitions and synthetic keystrokes without touching \`NSEvent\` or the kindaVim file watcher.
- Lifecycle wired through \`KindaVimPackController\` alongside the adapter and strategy monitor — refcount-starts on pack install, stops on uninstall.

## UX wins

- **HUD op-pending callout is now operator-specific**: "Press d again for the whole line." Accent-coloured, semibold. Falls back to the generic dd/yy/cc hint when the observer hasn't captured the operator (e.g. user pressed it before the pack started monitoring).
- **Mode badge gains a \`5×\` chip** while a count prefix is in flight. Cleared on motion or mode flip.

## Tests (10 new cases)

- Operator capture in normal/visual modes
- Leading-zero suppression (\`0\` alone is line-start, not a count)
- Count buffer accumulation (\`5\` → \`50\`)
- Motion-clears-count
- **Hard reset on mode transition** — switching from normal → insert clears \`currentOperator\` and \`countBuffer\`
- Insert / unknown modes are inert (no tracking)
- Op-pending allows additional count digits (\`d3w\`)
- Visual mode tracks like normal

Broader KindaVim suite: 38/38 pass.

## Test plan
- [ ] Install kindaVim.app + the pack
- [ ] In Safari, press \`d\` → operator-pending fires → HUD says "Press d again for the whole line."
- [ ] Press \`5j\` → mode badge shows \`5×\` between digits and motion
- [ ] Press Esc to cancel before completing → state clears (verify via badge disappears)
- [ ] Switch to insert mode → all observer state clears
- [ ] Disable the pack → observer stops monitoring (no NSEvent monitor leak)

🤖 Generated with [Claude Code](https://claude.com/claude-code)