### PR TITLE
feat(kindavim): local-only opt-in telemetry infrastructure

### DIFF
--- a/Sources/KeyPathAppKit/Services/KindaVim/KindaVimStrategyMonitor.swift
+++ b/Sources/KeyPathAppKit/Services/KindaVim/KindaVimStrategyMonitor.swift
@@ -107,5 +107,8 @@ final class KindaVimStrategyMonitor {
         AppLogger.shared.log(
             "👀 [KindaVimStrategy] strategy → \(resolved.rawValue) (bundle=\(currentBundleID ?? "nil"))"
         )
+        // Telemetry: sample on every app-switch transition. Off by
+        // default; the store gates writes on the user's opt-in flag.
+        KindaVimTelemetryStore.shared.recordStrategySample(resolved.rawValue)
     }
 }

--- a/Sources/KeyPathAppKit/Services/KindaVim/KindaVimTelemetryStore.swift
+++ b/Sources/KeyPathAppKit/Services/KindaVim/KindaVimTelemetryStore.swift
@@ -1,0 +1,185 @@
+// Local-only, opt-in usage counters for the KindaVim Mode Display pack.
+//
+// Privacy invariants — these are *the* design constraints, not soft
+// preferences:
+// 1. **Off by default.** No data is recorded until the user explicitly
+//    opts in via the toggle in Pack Detail.
+// 2. **Local-only.** Data is written to a single JSON file at
+//    `~/Library/Application Support/KeyPath/kindavim-telemetry.json`.
+//    KeyPath never reads this file off-device, never uploads it, never
+//    transmits it. The data never leaves the user's Mac.
+// 3. **User-deletable.** A "Clear all data" button in Pack Detail wipes
+//    the file at any time, no questions asked.
+// 4. **Aggregate counters only.** We record *frequencies* (how many
+//    times the user pressed `h`), not *sequences* (the order of
+//    keystrokes). No timestamps on individual keys, no full keystroke
+//    log, nothing that could reconstruct a session.
+//
+// Future PRs that surface this data to the user (#6) will build on top
+// of this contract. If those PRs ever need finer-grained data, they
+// must extend the snapshot type explicitly and update the privacy
+// guarantees here.
+
+import Foundation
+import KeyPathCore
+
+/// Aggregate usage counters. Pure values — safe to send across actor
+/// boundaries, safe to serialise.
+struct KindaVimTelemetrySnapshot: Codable, Equatable, Sendable {
+    /// Counter for every vim command the user has pressed (key →
+    /// total press count). Keys are stored in lowercased physical-key
+    /// form ("h", "j", "0", "slash", etc.) — same vocabulary as
+    /// `OverlayKeyboardView.keyCodeToKanataName`.
+    var commandFrequency: [String: Int] = [:]
+
+    /// Cumulative seconds spent in each mode. Insert is included so
+    /// "what fraction of time am I actually using vim modes?" is a
+    /// derivable insight.
+    var modeDwellSeconds: [String: TimeInterval] = [:]
+
+    /// Strategy distribution. Counts how many times the user's
+    /// frontmost-app strategy resolved to each value, sampled on every
+    /// app-switch. Useful for "you're using the Keyboard fallback most
+    /// of the time" insight.
+    var strategySamples: [String: Int] = [:]
+
+    /// Operator-pending sequences started; how many completed (flipped
+    /// to normal/visual after picking a motion) vs cancelled (flipped
+    /// to insert or back to the same mode without a motion). Useful as
+    /// a learning-progress signal.
+    var operatorPendingCompleted: Int = 0
+    var operatorPendingCancelled: Int = 0
+
+    /// First time we wrote any data to the file. Used in PR #6's
+    /// "since you started using vim" framing — never a timestamp on an
+    /// individual event.
+    var firstRecordedAt: Date?
+
+    /// Last write timestamp. Lets PR #6 surface "last active" without
+    /// retaining individual events.
+    var lastUpdatedAt: Date?
+}
+
+@MainActor
+final class KindaVimTelemetryStore {
+    static let shared = KindaVimTelemetryStore()
+
+    /// `@AppStorage`-equivalent key — read directly so we don't depend
+    /// on a SwiftUI view to gate writes. Settings UI flips this same
+    /// `UserDefaults` key.
+    static let optInKey = "kindaVim.telemetryEnabled"
+
+    static var defaultFileURL: URL {
+        let support = FileManager.default
+            .homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Application Support", isDirectory: true)
+            .appendingPathComponent("KeyPath", isDirectory: true)
+        return support.appendingPathComponent("kindavim-telemetry.json")
+    }
+
+    private let fileURL: URL
+    private let userDefaults: UserDefaults
+    private var cached: KindaVimTelemetrySnapshot?
+
+    init(
+        fileURL: URL = KindaVimTelemetryStore.defaultFileURL,
+        userDefaults: UserDefaults = .standard
+    ) {
+        self.fileURL = fileURL
+        self.userDefaults = userDefaults
+    }
+
+    // MARK: - Opt-in gate
+
+    /// Whether the user has explicitly opted in. Default off.
+    var isEnabled: Bool {
+        userDefaults.bool(forKey: Self.optInKey)
+    }
+
+    // MARK: - Recording
+
+    func recordCommand(_ key: String) {
+        guard isEnabled, !key.isEmpty else { return }
+        mutate { snapshot in
+            snapshot.commandFrequency[key.lowercased(), default: 0] += 1
+        }
+    }
+
+    func recordModeDwell(_ mode: String, duration: TimeInterval) {
+        guard isEnabled, duration > 0 else { return }
+        mutate { snapshot in
+            snapshot.modeDwellSeconds[mode, default: 0] += duration
+        }
+    }
+
+    func recordStrategySample(_ strategy: String) {
+        guard isEnabled, !strategy.isEmpty else { return }
+        mutate { snapshot in
+            snapshot.strategySamples[strategy, default: 0] += 1
+        }
+    }
+
+    func recordOperatorPendingExit(completed: Bool) {
+        guard isEnabled else { return }
+        mutate { snapshot in
+            if completed {
+                snapshot.operatorPendingCompleted += 1
+            } else {
+                snapshot.operatorPendingCancelled += 1
+            }
+        }
+    }
+
+    // MARK: - Snapshot + clear
+
+    /// Read the current snapshot. Returns an empty snapshot if the
+    /// file is absent or unreadable — never throws to the caller.
+    func loadSnapshot() -> KindaVimTelemetrySnapshot {
+        if let cached { return cached }
+        let snapshot = readFromDisk() ?? KindaVimTelemetrySnapshot()
+        cached = snapshot
+        return snapshot
+    }
+
+    /// Wipe the file and the in-memory cache. Intentional: the user
+    /// asked us to forget their data, so we forget it.
+    func clearAll() {
+        cached = nil
+        try? FileManager.default.removeItem(at: fileURL)
+        AppLogger.shared.log("🧹 [KindaVimTelemetry] Cleared all usage data")
+    }
+
+    // MARK: - Internals
+
+    private func mutate(_ body: (inout KindaVimTelemetrySnapshot) -> Void) {
+        var snapshot = loadSnapshot()
+        let now = Date()
+        if snapshot.firstRecordedAt == nil {
+            snapshot.firstRecordedAt = now
+        }
+        snapshot.lastUpdatedAt = now
+        body(&snapshot)
+        cached = snapshot
+        writeToDisk(snapshot)
+    }
+
+    private func readFromDisk() -> KindaVimTelemetrySnapshot? {
+        guard let data = try? Data(contentsOf: fileURL) else { return nil }
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try? decoder.decode(KindaVimTelemetrySnapshot.self, from: data)
+    }
+
+    private func writeToDisk(_ snapshot: KindaVimTelemetrySnapshot) {
+        let dir = fileURL.deletingLastPathComponent()
+        try? FileManager.default.createDirectory(
+            at: dir,
+            withIntermediateDirectories: true
+        )
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+        guard let data = try? encoder.encode(snapshot) else { return }
+        try? data.write(to: fileURL, options: .atomic)
+    }
+}

--- a/Sources/KeyPathAppKit/Services/KindaVim/VimSequenceObserver.swift
+++ b/Sources/KeyPathAppKit/Services/KindaVim/VimSequenceObserver.swift
@@ -41,6 +41,9 @@ final class VimSequenceObserver {
     @ObservationIgnored
     private var lastObservedMode: KindaVimStateAdapter.Mode = .unknown
 
+    @ObservationIgnored
+    private var modeEnteredAt: Date?
+
     /// Production callers use the no-arg init which reads from the
     /// shared `KindaVimStateAdapter`. Tests inject a `modeProvider`
     /// closure so they can drive mode transitions deterministically
@@ -111,9 +114,38 @@ final class VimSequenceObserver {
     func syncWithMode() {
         let currentMode = modeProvider()
         guard currentMode != lastObservedMode else { return }
+
+        let previousMode = lastObservedMode
+        recordModeExitTelemetry(from: previousMode, to: currentMode)
+
         currentOperator = nil
         countBuffer = ""
         lastObservedMode = currentMode
+        modeEnteredAt = Date()
+    }
+
+    private func recordModeExitTelemetry(
+        from previous: KindaVimStateAdapter.Mode,
+        to next: KindaVimStateAdapter.Mode
+    ) {
+        // Mode dwell: how long did we stay in `previous`?
+        if let enteredAt = modeEnteredAt {
+            let duration = Date().timeIntervalSince(enteredAt)
+            KindaVimTelemetryStore.shared.recordModeDwell(
+                previous.rawValue,
+                duration: duration
+            )
+        }
+
+        // Operator-pending exit classification: did the user complete a
+        // sequence (flip back to normal/visual after picking a motion)
+        // or cancel it (flip to insert / back to the same mode)?
+        if previous == .operatorPending {
+            let completed = (next == .normal || next == .visual)
+            KindaVimTelemetryStore.shared.recordOperatorPendingExit(
+                completed: completed
+            )
+        }
     }
 
     private func observeAdapterMode() {
@@ -149,7 +181,12 @@ final class VimSequenceObserver {
             // No bookkeeping — user is typing or kindaVim isn't reporting.
             currentOperator = nil
             countBuffer = ""
+            return  // skip telemetry recording
         }
+
+        // Telemetry: record the keypress. Off by default; the store gates
+        // writes on the user's opt-in flag and is otherwise a no-op.
+        KindaVimTelemetryStore.shared.recordCommand(character)
     }
 
     private func applyNormalOrVisual(character: String) {

--- a/Sources/KeyPathAppKit/UI/Gallery/KindaVimStatusBlock.swift
+++ b/Sources/KeyPathAppKit/UI/Gallery/KindaVimStatusBlock.swift
@@ -9,8 +9,10 @@ struct KindaVimStatusBlock: View {
     @State private var adapter = KindaVimStateAdapter.shared
     @State private var strategyMonitor = KindaVimStrategyMonitor.shared
     @AppStorage("kindaVim.showAdvancedHints") private var showAdvancedHints: Bool = false
+    @AppStorage("kindaVim.telemetryEnabled") private var telemetryEnabled: Bool = false
     @State private var appInstalled: Bool = FileManager.default
         .fileExists(atPath: "/Applications/kindaVim.app")
+    @State private var showClearTelemetryConfirmation: Bool = false
 
     private static let websiteURL = URL(string: "https://kindavim.app")!
 
@@ -46,6 +48,9 @@ struct KindaVimStatusBlock: View {
             .accessibilityIdentifier("kindavim-status-show-advanced")
 
             Divider()
+            telemetrySection
+
+            Divider()
             Text(
                 "This pack adds no remappings. KindaVim itself handles every keypress; KeyPath just shows you the current mode in the overlay."
             )
@@ -64,6 +69,53 @@ struct KindaVimStatusBlock: View {
         .onAppear {
             appInstalled = FileManager.default
                 .fileExists(atPath: "/Applications/kindaVim.app")
+        }
+        .alert("Clear KindaVim usage data?", isPresented: $showClearTelemetryConfirmation) {
+            Button("Clear", role: .destructive) {
+                KindaVimTelemetryStore.shared.clearAll()
+            }
+            .accessibilityIdentifier("kindavim-status-clear-telemetry-confirm")
+            Button("Cancel", role: .cancel) {}
+                .accessibilityIdentifier("kindavim-status-clear-telemetry-cancel")
+        } message: {
+            Text(
+                "This permanently deletes all locally-recorded command counts, " +
+                "mode dwell time, and other usage statistics. KeyPath has no " +
+                "copies of this data — it stays on your Mac and is never sent " +
+                "anywhere."
+            )
+        }
+    }
+
+    @ViewBuilder
+    private var telemetrySection: some View {
+        Toggle(isOn: $telemetryEnabled) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Record local KindaVim usage stats")
+                    .font(.system(size: 12, weight: .medium))
+                Text(
+                    "Used by KeyPath to show you which vim commands you use " +
+                    "most. This data stays on your Mac and is never sent " +
+                    "anywhere."
+                )
+                .font(.system(size: 11))
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .toggleStyle(.switch)
+        .controlSize(.small)
+        .accessibilityIdentifier("kindavim-status-telemetry-toggle")
+
+        if telemetryEnabled {
+            Button(role: .destructive) {
+                showClearTelemetryConfirmation = true
+            } label: {
+                Text("Clear all KindaVim usage data")
+                    .font(.system(size: 11))
+            }
+            .buttonStyle(.borderless)
+            .accessibilityIdentifier("kindavim-status-clear-telemetry")
         }
     }
 

--- a/Tests/KeyPathTests/KindaVimTelemetryStoreTests.swift
+++ b/Tests/KeyPathTests/KindaVimTelemetryStoreTests.swift
@@ -1,0 +1,165 @@
+@testable import KeyPathAppKit
+import XCTest
+
+/// Tests for the local-only telemetry store. Uses a temp file URL and
+/// an isolated UserDefaults suite per test so we never touch real
+/// Application Support or the production opt-in flag.
+@MainActor
+final class KindaVimTelemetryStoreTests: XCTestCase {
+    private var tempFileURL: URL!
+    private var defaults: UserDefaults!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        tempFileURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("kindavim-telemetry-\(UUID().uuidString).json")
+
+        // Per-test UserDefaults suite so the opt-in flag doesn't leak
+        // between tests (and never touches the user's real prefs).
+        let suiteName = "KindaVimTelemetryStoreTests-\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+    }
+
+    override func tearDown() async throws {
+        try? FileManager.default.removeItem(at: tempFileURL)
+        defaults.removePersistentDomain(forName: defaults.dictionaryRepresentation().keys.first ?? "")
+        try await super.tearDown()
+    }
+
+    private func makeStore() -> KindaVimTelemetryStore {
+        KindaVimTelemetryStore(fileURL: tempFileURL, userDefaults: defaults)
+    }
+
+    // MARK: - Opt-in gate
+
+    func testRecordingIsNoOpWhenOptOut() {
+        let store = makeStore()
+        XCTAssertFalse(store.isEnabled, "Should default to off")
+
+        store.recordCommand("h")
+        store.recordModeDwell("normal", duration: 5)
+        store.recordStrategySample("accessibility")
+        store.recordOperatorPendingExit(completed: true)
+
+        let snapshot = store.loadSnapshot()
+        XCTAssertTrue(snapshot.commandFrequency.isEmpty)
+        XCTAssertTrue(snapshot.modeDwellSeconds.isEmpty)
+        XCTAssertTrue(snapshot.strategySamples.isEmpty)
+        XCTAssertEqual(snapshot.operatorPendingCompleted, 0)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: tempFileURL.path),
+                       "Should not have written anything to disk while opted out")
+    }
+
+    // MARK: - Recording (opted in)
+
+    func testCommandFrequencyAccumulates() {
+        defaults.set(true, forKey: KindaVimTelemetryStore.optInKey)
+        let store = makeStore()
+
+        store.recordCommand("h")
+        store.recordCommand("h")
+        store.recordCommand("J")  // case-insensitive
+        store.recordCommand("k")
+
+        let snapshot = store.loadSnapshot()
+        XCTAssertEqual(snapshot.commandFrequency["h"], 2)
+        XCTAssertEqual(snapshot.commandFrequency["j"], 1, "should lowercase")
+        XCTAssertEqual(snapshot.commandFrequency["k"], 1)
+    }
+
+    func testModeDwellAccumulates() {
+        defaults.set(true, forKey: KindaVimTelemetryStore.optInKey)
+        let store = makeStore()
+
+        store.recordModeDwell("normal", duration: 5)
+        store.recordModeDwell("normal", duration: 3)
+        store.recordModeDwell("insert", duration: 100)
+
+        let snapshot = store.loadSnapshot()
+        XCTAssertEqual(snapshot.modeDwellSeconds["normal"], 8)
+        XCTAssertEqual(snapshot.modeDwellSeconds["insert"], 100)
+    }
+
+    func testZeroOrNegativeDurationIsIgnored() {
+        defaults.set(true, forKey: KindaVimTelemetryStore.optInKey)
+        let store = makeStore()
+
+        store.recordModeDwell("normal", duration: 0)
+        store.recordModeDwell("normal", duration: -3)
+
+        let snapshot = store.loadSnapshot()
+        XCTAssertNil(snapshot.modeDwellSeconds["normal"])
+    }
+
+    func testStrategySampleCounts() {
+        defaults.set(true, forKey: KindaVimTelemetryStore.optInKey)
+        let store = makeStore()
+
+        store.recordStrategySample("accessibility")
+        store.recordStrategySample("accessibility")
+        store.recordStrategySample("keyboard")
+
+        let snapshot = store.loadSnapshot()
+        XCTAssertEqual(snapshot.strategySamples["accessibility"], 2)
+        XCTAssertEqual(snapshot.strategySamples["keyboard"], 1)
+    }
+
+    func testOperatorPendingExitClassification() {
+        defaults.set(true, forKey: KindaVimTelemetryStore.optInKey)
+        let store = makeStore()
+
+        store.recordOperatorPendingExit(completed: true)
+        store.recordOperatorPendingExit(completed: true)
+        store.recordOperatorPendingExit(completed: false)
+
+        let snapshot = store.loadSnapshot()
+        XCTAssertEqual(snapshot.operatorPendingCompleted, 2)
+        XCTAssertEqual(snapshot.operatorPendingCancelled, 1)
+    }
+
+    // MARK: - Persistence + roundtrip
+
+    func testRoundtripThroughDisk() {
+        defaults.set(true, forKey: KindaVimTelemetryStore.optInKey)
+
+        do {
+            let storeA = makeStore()
+            storeA.recordCommand("h")
+            storeA.recordModeDwell("normal", duration: 12)
+        }
+
+        // New store instance reading the same file should see the data.
+        let storeB = makeStore()
+        let snapshot = storeB.loadSnapshot()
+        XCTAssertEqual(snapshot.commandFrequency["h"], 1)
+        XCTAssertEqual(snapshot.modeDwellSeconds["normal"], 12)
+        XCTAssertNotNil(snapshot.firstRecordedAt)
+        XCTAssertNotNil(snapshot.lastUpdatedAt)
+    }
+
+    // MARK: - Clear
+
+    func testClearAllWipesFileAndCache() {
+        defaults.set(true, forKey: KindaVimTelemetryStore.optInKey)
+        let store = makeStore()
+        store.recordCommand("h")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: tempFileURL.path))
+
+        store.clearAll()
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: tempFileURL.path),
+                       "clearAll should remove the file")
+        let snapshot = store.loadSnapshot()
+        XCTAssertTrue(snapshot.commandFrequency.isEmpty,
+                      "After clear, snapshot should be empty (and cache cleared)")
+    }
+
+    // MARK: - Missing file is harmless
+
+    func testLoadSnapshotWithNoFileReturnsEmpty() {
+        let store = makeStore()
+        XCTAssertFalse(FileManager.default.fileExists(atPath: tempFileURL.path))
+        let snapshot = store.loadSnapshot()
+        XCTAssertEqual(snapshot, KindaVimTelemetrySnapshot())
+    }
+}

--- a/Tests/KeyPathTests/KindaVimTelemetryStoreTests.swift
+++ b/Tests/KeyPathTests/KindaVimTelemetryStoreTests.swift
@@ -9,21 +9,23 @@ final class KindaVimTelemetryStoreTests: XCTestCase {
     private var tempFileURL: URL!
     private var defaults: UserDefaults!
 
-    override func setUp() async throws {
-        try await super.setUp()
+    private var suiteName: String!
+
+    override func setUp() {
+        super.setUp()
         tempFileURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("kindavim-telemetry-\(UUID().uuidString).json")
 
         // Per-test UserDefaults suite so the opt-in flag doesn't leak
         // between tests (and never touches the user's real prefs).
-        let suiteName = "KindaVimTelemetryStoreTests-\(UUID().uuidString)"
+        suiteName = "KindaVimTelemetryStoreTests-\(UUID().uuidString)"
         defaults = UserDefaults(suiteName: suiteName)
     }
 
-    override func tearDown() async throws {
+    override func tearDown() {
         try? FileManager.default.removeItem(at: tempFileURL)
-        defaults.removePersistentDomain(forName: defaults.dictionaryRepresentation().keys.first ?? "")
-        try await super.tearDown()
+        defaults?.removePersistentDomain(forName: suiteName)
+        super.tearDown()
     }
 
     private func makeStore() -> KindaVimTelemetryStore {

--- a/Tests/KeyPathTests/KindaVimTelemetryStoreTests.swift
+++ b/Tests/KeyPathTests/KindaVimTelemetryStoreTests.swift
@@ -4,7 +4,12 @@ import XCTest
 /// Tests for the local-only telemetry store. Uses a temp file URL and
 /// an isolated UserDefaults suite per test so we never touch real
 /// Application Support or the production opt-in flag.
-@MainActor
+///
+/// Note: not class-level `@MainActor`. XCTestCase's `setUp`/`tearDown`
+/// are nonisolated, and CI's strict concurrency rejects mutations of
+/// MainActor-isolated stored properties from those overrides. Test
+/// methods call into the MainActor-isolated `KindaVimTelemetryStore`
+/// via short `MainActor.assumeIsolated` blocks.
 final class KindaVimTelemetryStoreTests: XCTestCase {
     private var tempFileURL: URL!
     private var defaults: UserDefaults!
@@ -28,13 +33,14 @@ final class KindaVimTelemetryStoreTests: XCTestCase {
         super.tearDown()
     }
 
+    @MainActor
     private func makeStore() -> KindaVimTelemetryStore {
         KindaVimTelemetryStore(fileURL: tempFileURL, userDefaults: defaults)
     }
 
     // MARK: - Opt-in gate
 
-    func testRecordingIsNoOpWhenOptOut() {
+    @MainActor func testRecordingIsNoOpWhenOptOut() {
         let store = makeStore()
         XCTAssertFalse(store.isEnabled, "Should default to off")
 
@@ -54,7 +60,7 @@ final class KindaVimTelemetryStoreTests: XCTestCase {
 
     // MARK: - Recording (opted in)
 
-    func testCommandFrequencyAccumulates() {
+    @MainActor func testCommandFrequencyAccumulates() {
         defaults.set(true, forKey: KindaVimTelemetryStore.optInKey)
         let store = makeStore()
 
@@ -69,7 +75,7 @@ final class KindaVimTelemetryStoreTests: XCTestCase {
         XCTAssertEqual(snapshot.commandFrequency["k"], 1)
     }
 
-    func testModeDwellAccumulates() {
+    @MainActor func testModeDwellAccumulates() {
         defaults.set(true, forKey: KindaVimTelemetryStore.optInKey)
         let store = makeStore()
 
@@ -82,7 +88,7 @@ final class KindaVimTelemetryStoreTests: XCTestCase {
         XCTAssertEqual(snapshot.modeDwellSeconds["insert"], 100)
     }
 
-    func testZeroOrNegativeDurationIsIgnored() {
+    @MainActor func testZeroOrNegativeDurationIsIgnored() {
         defaults.set(true, forKey: KindaVimTelemetryStore.optInKey)
         let store = makeStore()
 
@@ -93,7 +99,7 @@ final class KindaVimTelemetryStoreTests: XCTestCase {
         XCTAssertNil(snapshot.modeDwellSeconds["normal"])
     }
 
-    func testStrategySampleCounts() {
+    @MainActor func testStrategySampleCounts() {
         defaults.set(true, forKey: KindaVimTelemetryStore.optInKey)
         let store = makeStore()
 
@@ -106,7 +112,7 @@ final class KindaVimTelemetryStoreTests: XCTestCase {
         XCTAssertEqual(snapshot.strategySamples["keyboard"], 1)
     }
 
-    func testOperatorPendingExitClassification() {
+    @MainActor func testOperatorPendingExitClassification() {
         defaults.set(true, forKey: KindaVimTelemetryStore.optInKey)
         let store = makeStore()
 
@@ -121,7 +127,7 @@ final class KindaVimTelemetryStoreTests: XCTestCase {
 
     // MARK: - Persistence + roundtrip
 
-    func testRoundtripThroughDisk() {
+    @MainActor func testRoundtripThroughDisk() {
         defaults.set(true, forKey: KindaVimTelemetryStore.optInKey)
 
         do {
@@ -141,7 +147,7 @@ final class KindaVimTelemetryStoreTests: XCTestCase {
 
     // MARK: - Clear
 
-    func testClearAllWipesFileAndCache() {
+    @MainActor func testClearAllWipesFileAndCache() {
         defaults.set(true, forKey: KindaVimTelemetryStore.optInKey)
         let store = makeStore()
         store.recordCommand("h")
@@ -158,7 +164,7 @@ final class KindaVimTelemetryStoreTests: XCTestCase {
 
     // MARK: - Missing file is harmless
 
-    func testLoadSnapshotWithNoFileReturnsEmpty() {
+    @MainActor func testLoadSnapshotWithNoFileReturnsEmpty() {
         let store = makeStore()
         XCTAssertFalse(FileManager.default.fileExists(atPath: tempFileURL.path))
         let snapshot = store.loadSnapshot()


### PR DESCRIPTION
## Summary

Plumbing for the upcoming "Your vim usage" insights panel (PR #6). **Infrastructure only** — this PR records data when the user opts in, but doesn't yet surface any of it back to them. The visualization story comes next.

## Privacy contract

These are *the* design constraints, not soft preferences. They live in the store's file header and any future PR that touches this code is bound by them:

1. **Off by default.** No data is recorded until the user explicitly flips the toggle in Pack Detail.
2. **Local-only.** Single JSON file at \`~/Library/Application Support/KeyPath/kindavim-telemetry.json\`. KeyPath never reads, uploads, or transmits this file.
3. **User-deletable.** "Clear all KindaVim usage data" button in Pack Detail wipes the file at any time, with a confirmation alert.
4. **Aggregate counters only.** Frequencies (how many times the user pressed \`h\`), not sequences. No per-keystroke timestamps, no full keystroke log — nothing that could reconstruct a session.

Persistence: the opt-in toggle uses \`@AppStorage("kindaVim.telemetryEnabled")\`; both the toggle state and the JSON data file survive app upgrades. The data file is wiped if the user accepts macOS's "remove data?" prompt during uninstall — which is the correct behavior.

## What gets recorded (when opted in)

- **Command frequency** — key → press count, lowercased
- **Mode dwell** — cumulative seconds per mode
- **Strategy distribution** — sample on every frontmost-app switch
- **Operator-pending exit** — completed vs cancelled classification
- **First-recorded-at + last-updated-at** — no per-event timestamps

## Hooks

- \`VimSequenceObserver.ingestCore\` records the keypress (after the mode filter, so insert-mode typing isn't logged)
- \`VimSequenceObserver.syncWithMode\` records mode dwell on every transition + classifies op-pending exits (completed = flipped to normal/visual, cancelled = flipped to insert / back to same mode)
- \`KindaVimStrategyMonitor.recomputeStrategy\` records the resolved strategy after each app-switch

## UI

\`KindaVimStatusBlock\` gains:

- **Toggle:** "Record local KindaVim usage stats. Used by KeyPath to show you which vim commands you use most. This data stays on your Mac and is never sent anywhere."
- **"Clear all KindaVim usage data"** button (only visible when opted in, destructive role) with a confirmation alert that re-states the privacy guarantees.

## Tests (9 cases)

- Opt-out is a silent no-op (no file written, no in-memory state)
- All four recording types accumulate correctly
- Zero/negative durations ignored
- Disk roundtrip — second store instance reads what first wrote
- \`clearAll\` wipes file + cache
- Missing file returns empty snapshot

Each test uses a temp file URL and an isolated UserDefaults suite — never touches real Application Support or real prefs.

Full suite: 420 + 47 KindaVim XCTest cases, 0 failures.

## Test plan
- [ ] Install kindaVim.app + the pack
- [ ] Open Pack Detail; confirm telemetry toggle is **off** by default
- [ ] Verify no \`kindavim-telemetry.json\` exists in Application Support
- [ ] Flip toggle on; do some vim editing
- [ ] Confirm the JSON file appears with command counts
- [ ] Click "Clear all KindaVim usage data" → confirmation alert → file is deleted
- [ ] Disable + re-enable pack: counters should persist (the file isn't tied to install state)

🤖 Generated with [Claude Code](https://claude.com/claude-code)