### PR TITLE
fix(docs): unblock auto-publish pipeline (CSS check + orphan screenshot)

### DIFF
--- a/Scripts/test-help-publish-regressions.sh
+++ b/Scripts/test-help-publish-regressions.sh
@@ -102,9 +102,16 @@ assert_contains "$(cat "$APP_HELP_CSS")" "\\.help-img\\[alt\\^=\"Screenshot\"\\]
 assert_contains "$(cat "$APP_HELP_CSS")" "max-width:[[:space:]]*100%;" \
   "app help images must keep max-width: 100%"
 assert_contains "$(cat "$APP_HELP_CSS")" "\\.help-header-img" \
-  "app help CSS must include dedicated header image crop rules"
-assert_contains "$(cat "$APP_HELP_CSS")" "object-fit:[[:space:]]*cover;" \
-  "app header images must use object-fit: cover"
+  "app help CSS must include dedicated header image rules"
+# The app intentionally renders header watercolor banners at their
+# natural aspect ratio (`height: auto`) — see the comment on
+# `.help-header-img` and commit 5ccac8fc which removed the previous
+# `object-fit: cover` cropping. The website's `.article-header-img`
+# (checked above) still uses object-fit: cover by design — that's
+# intentional asymmetry between the two surfaces. Guard against
+# accidental re-introduction of cropping in the app CSS.
+assert_not_contains "$(cat "$APP_HELP_CSS")" "object-fit:[[:space:]]*cover" \
+  "app header images must not use object-fit: cover (would crop watercolor banners)"
 
 echo "Checking screenshot insertion parity..."
 src_count="$(rg -n '^<!-- screenshot:' "$REPO_ROOT"/Sources/KeyPathAppKit/Resources/*.md | wc -l | tr -d ' ')"

--- a/Sources/KeyPathAppKit/Resources/home-row-mods.md
+++ b/Sources/KeyPathAppKit/Resources/home-row-mods.md
@@ -141,7 +141,16 @@ This uses Kanata's native `tap-hold-opposite-hand` with a global hand definition
 
 When you're typing quickly, the last thing you want is for "fd" to become Ctrl+D. Fast typing protection solves this: keys pressed shortly after your last keystroke produce the letter immediately — no hold detection, no waiting state.
 
-<!-- screenshot: id="hrm-fast-typing" method="snapshot" view="HomeRowTimingSection" state="prior-idle:visible" -->
+<!--
+TODO: regenerate-screenshots.sh hasn't produced hrm-fast-typing.png yet,
+so the directive below is commented out. The publish-to-web script
+silently drops references whose PNG is missing, which knocks the
+screenshot-count parity check out of alignment and fails the publish
+workflow. Re-enable this directive once the PNG is committed under
+`Sources/KeyPathAppKit/Resources/hrm-fast-typing.png`.
+
+screenshot: id="hrm-fast-typing" method="snapshot" view="HomeRowTimingSection" state="prior-idle:visible"
+-->
 Screenshot — Fast typing protection in rule settings:
 ```
   ┌─────────────────────────────────────────────────────┐

--- a/docs/screenshot-manifest.yaml
+++ b/docs/screenshot-manifest.yaml
@@ -158,12 +158,11 @@ screenshots:
     state: "per-finger:visible"
     description: "Per-finger sensitivity sliders (pinky +40ms, ring +25ms, etc.)"
 
-  - id: hrm-fast-typing
-    file: home-row-mods.md
-    method: snapshot
-    view: HomeRowTimingSection
-    state: "prior-idle:visible"
-    description: "Fast typing protection toggle and threshold slider (require-prior-idle)"
+  # TODO: hrm-fast-typing entry removed temporarily so the validator
+  # stays balanced with the commented-out directive in
+  # home-row-mods.md. Re-add an entry pointing at HomeRowTimingSection
+  # with the prior-idle state once regenerate-screenshots.sh produces
+  # the PNG (see TODO comment in the source markdown).
 
   # ---------------------------------------------------------------------------
   # window-management.md (1 screenshot)


### PR DESCRIPTION
## Summary

The **Publish Help Docs** workflow has been failing on every master push since **2026-03-10** — six weeks. Two unrelated bugs together prevent it from ever succeeding; both are pre-existing and predate today's work. This PR fixes both.

Notably: this is why the kindavim help-doc rewrite from #329 hasn't appeared on the live site at https://malpern.github.io/KeyPath/guides/kindavim/. The auto-publish pipeline already exists; it just hasn't been able to run.

I went looking for "missing" auto-sync infrastructure first (started on a parallel implementation in #330) before realizing the existing pipeline was just blocked.

## Bug 1: stale CSS regression assertion

\`Scripts/test-help-publish-regressions.sh\` line 106 required \`object-fit: cover\` in the app's \`help-theme.css\`. But commit \`5ccac8fc\` (Mar 10) deliberately removed that property when the header design switched from cropped fixed-height banners to natural-aspect-ratio banners — the in-line comment is explicit:

> Header watercolor banners fill the article width at their natural aspect ratio so nothing is cropped.

The website CSS still uses \`object-fit: cover\` by design — that's intentional asymmetry between the two surfaces. The regression check just missed the migration.

**Fix:** replace the stale positive assertion with a guard against accidental re-introduction (\`assert_not_contains object-fit: cover\`). The check now matches the design intent.

## Bug 2: orphan screenshot directive without a PNG

\`Resources/home-row-mods.md\` had a screenshot directive:

\`\`\`
<!-- screenshot: id="hrm-fast-typing" method="snapshot" view="HomeRowTimingSection" state="prior-idle:visible" -->
\`\`\`

…but \`Resources/hrm-fast-typing.png\` doesn't exist anywhere in the repo. \`regenerate-screenshots.sh\` was never run for this one. The publish script (\`Scripts/publish-help-to-web.sh\` line 240–244) silently drops the markdown reference for any directive whose PNG is missing, which then trips the count parity check downstream (\`source=23\` vs \`web=22\`).

**Fix:** comment out the directive in source with a TODO explaining how to re-enable. The user-facing ASCII screenshot mockup that follows the directive stays in place — readers in the in-app help still get an explanation of fast typing protection. They just don't get a rendered PNG above it until someone commits one.

## Verified locally

After both fixes, against a fresh \`gh-pages\` worktree:

- \`Scripts/publish-help-to-web.sh\` runs cleanly.
- \`Scripts/test-help-publish-regressions.sh\` passes all eight check stages:
  \`\`\`
  Checking header image CSS regression guards...
  Checking screenshot sizing CSS guards...
  Checking screenshot insertion parity...
  Checking Google Fonts non-blocking load guards...
  Checking docs container compatibility guards...
  Checking divider asset geometry regression guards...
  Checking header image side-whitespace regression guards...
  Checking generated screenshot source resolution guards...
  Publish regression checks passed.
  \`\`\`

## What happens after merge

The very next master push that touches \`Resources/*.md\` (or this fix itself, since the workflow is path-filtered on \`Scripts/test-help-publish-regressions.sh\`) will fire the existing \`publish-help-docs.yml\` workflow successfully and bring **six weeks of accumulated content drift live in one go** — including the kindavim help-doc rewrite from #329 with its watercolor header.

## Test plan
- [x] Local publish + regression run against fresh \`gh-pages\` worktree → all 8 stages pass
- [ ] After merge: the Publish Help Docs workflow fires, completes, and pushes to gh-pages
- [ ] Live site at https://malpern.github.io/KeyPath/guides/kindavim/ updates with new content + header

🤖 Generated with [Claude Code](https://claude.com/claude-code)