### PR TITLE
fix(docs): replace ripgrep with grep in publish regression check

### DIFF
--- a/Scripts/test-help-publish-regressions.sh
+++ b/Scripts/test-help-publish-regressions.sh
@@ -114,8 +114,11 @@ assert_not_contains "$(cat "$APP_HELP_CSS")" "object-fit:[[:space:]]*cover" \
   "app header images must not use object-fit: cover (would crop watercolor banners)"
 
 echo "Checking screenshot insertion parity..."
-src_count="$(rg -n '^<!-- screenshot:' "$REPO_ROOT"/Sources/KeyPathAppKit/Resources/*.md | wc -l | tr -d ' ')"
-web_count="$(rg -n -F "![Screenshot]({{ '/images/help/" \
+# Use plain grep (always available on macOS + ubuntu-latest runners)
+# rather than ripgrep, which the runner image doesn't include and
+# `apt install ripgrep` adds ~10s of unnecessary cold-cache time.
+src_count="$(grep -h '^<!-- screenshot:' "$REPO_ROOT"/Sources/KeyPathAppKit/Resources/*.md | wc -l | tr -d ' ')"
+web_count="$(grep -hF "![Screenshot]({{ '/images/help/" \
   "$GHPAGES"/getting-started/*.md \
   "$GHPAGES"/guides/*.md \
   "$GHPAGES"/migration/*.md | wc -l | tr -d ' ')"


### PR DESCRIPTION
## Summary

Follow-up to #331. The publish workflow on `ubuntu-latest` doesn't ship with ripgrep, which made `Scripts/test-help-publish-regressions.sh` fail at line 117 with `rg: command not found` (exit 127). Local dev machines (and my own verification of #331) all had ripgrep installed, so this didn't surface until the workflow actually ran on the runner.

Notably, `Scripts/check-help-parity.sh` already had the `command -v rg` fallback pattern. The regression-check script just hadn't been ported.

## Fix

Replace the two `rg` invocations with `grep -h` / `grep -hF`. Same output for these specific patterns (we only need the lines that match, not numbered locations), ships on every runner image, no install step.

## Verified locally

Ran the publish + regression scripts against a fresh gh-pages worktree with ripgrep stripped from PATH (simulating the runner): all eight stages pass.

```
Checking header image CSS regression guards...
Checking screenshot sizing CSS guards...
Checking screenshot insertion parity...
Checking Google Fonts non-blocking load guards...
Checking docs container compatibility guards...
Checking divider asset geometry regression guards...
Checking header image side-whitespace regression guards...
Checking generated screenshot source resolution guards...
Publish regression checks passed.
```

After merge, the next master push that touches a docs path will fire the publish workflow. With this + #331, all the previous blockers are clear.

## Test plan
- [x] Local run with PATH stripped of ripgrep → all eight regression stages pass
- [ ] After merge: publish workflow completes, gh-pages gets updated, kindavim help page goes live with new content + watercolor header

🤖 Generated with [Claude Code](https://claude.com/claude-code)