### PR TITLE
fix(ci): cover all publish-pipeline scripts in path filter + add workflow_dispatch

### DIFF
--- a/.github/workflows/publish-help-docs.yml
+++ b/.github/workflows/publish-help-docs.yml
@@ -8,7 +8,14 @@ on:
       - 'Sources/KeyPathAppKit/Resources/*.png'
       - 'Sources/KeyPathAppKit/Resources/*.css'
       - 'Scripts/publish-help-to-web.sh'
+      - 'Scripts/test-help-publish-regressions.sh'
+      - 'Scripts/check-help-parity.sh'
       - '.github/workflows/publish-help-docs.yml'
+  # Allow re-running on demand from the Actions tab. Useful when a
+  # fix to one of the publish/regression scripts didn't trigger via
+  # the path filter, or to force a re-publish after manual gh-pages
+  # edits.
+  workflow_dispatch:
 
 jobs:
   publish:


### PR DESCRIPTION
## Summary

Follow-up to #332. The publish workflow's path filter only listed `Scripts/publish-help-to-web.sh` and the workflow file itself — not `Scripts/test-help-publish-regressions.sh` or `Scripts/check-help-parity.sh`. So when #332 fixed the rg→grep issue in the regression script, the workflow didn't fire on merge and the publish stayed broken.

## Two improvements

1. **Path filter coverage** — add the two missing pipeline scripts (`test-help-publish-regressions.sh`, `check-help-parity.sh`). Any change to anything that runs as part of publish now triggers a fresh publish run.

2. **`workflow_dispatch`** — let us re-run the workflow manually from the Actions tab (or `gh workflow run`) without touching a docs file. Useful for retrying after a transient runner failure or forcing a re-publish after manual gh-pages edits.

## What happens after merge

This PR itself touches the workflow file, which is in its own path filter, so merging fires the publish run. With #331 + #332 + this together, the publish completes successfully and brings six weeks of accumulated content drift live — including the kindavim help-doc rewrite from #329 with its watercolor header.

## Test plan
- [ ] After merge: publish workflow fires automatically, completes successfully
- [ ] gh-pages branch gets a new commit from `github-actions[bot]`
- [ ] https://malpern.github.io/KeyPath/guides/kindavim/ shows the new content + header
- [ ] In the future: `gh workflow run "Publish Help Docs to Website"` manually triggers a re-publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)