### PR TITLE
fix(ci): install numpy + Pillow for publish regression checks

### DIFF
--- a/.github/workflows/publish-help-docs.yml
+++ b/.github/workflows/publish-help-docs.yml
@@ -38,6 +38,13 @@ jobs:
       - name: Install zsh
         run: sudo apt-get install -y zsh
 
+      - name: Install Python dependencies
+        # `Scripts/test-help-publish-regressions.sh` uses numpy + Pillow
+        # for pixel-level analysis of header banners (side-whitespace
+        # detection). The runner image doesn't bundle them, so install
+        # via pip rather than apt — keeps the install scoped and fast.
+        run: pip3 install --quiet numpy pillow
+
       - name: Verify App Help Registry Parity
         run: |
           chmod +x Scripts/check-help-parity.sh


### PR DESCRIPTION
## Summary

Fourth blocker uncovered as the previous ones cleared. The publish workflow's regression check uses inline Python with `numpy` + `PIL.Image` for pixel-level analysis of header banners (detects excess side whitespace). The runner image doesn't ship with them.

```
Traceback (most recent call last):
  File "<stdin>", line 3, in <module>
ModuleNotFoundError: No module named 'numpy'
```

## Fix

Single `pip install --quiet numpy pillow` step in the workflow, right after the `apt install zsh` step. Scoped install, ~5–10s on cold cache.

## Sequence so far

| PR | Fix |
|---|---|
| #331 | Stale CSS check (object-fit: cover removed in March; check still required it) |
| #332 | `rg` → `grep` (runner doesn't have ripgrep) |
| #333 | Path filter didn't cover `test-help-publish-regressions.sh` + add `workflow_dispatch` |
| #334 (this) | Install `numpy` + `Pillow` for header pixel analysis |

Each blocker only surfaced after fixing the previous one, because Bash exits on the first failure. Honest take: I should have run the entire script in a Docker `ubuntu-latest` image locally before opening #331 instead of relying on my own dev machine. Lesson noted.

## Test plan

- [ ] After merge: publish workflow completes successfully
- [ ] gh-pages gets a new commit from `github-actions[bot]`
- [ ] https://malpern.github.io/KeyPath/guides/kindavim/ shows the new content + watercolor header
- [ ] Future docs changes auto-publish without manual intervention

🤖 Generated with [Claude Code](https://claude.com/claude-code)