### PR TITLE
ci: PR-time publish dry-run + fail-loud on missing screenshot PNGs

### DIFF
--- a/.github/workflows/publish-dry-run.yml
+++ b/.github/workflows/publish-dry-run.yml
@@ -1,0 +1,104 @@
+# Pre-merge dry-run for the gh-pages publish pipeline.
+#
+# Triggered on every PR that touches a docs file or a script in
+# the publish pipeline. Runs the same scripts the post-merge
+# `publish-help-docs.yml` workflow runs, but stops short of
+# committing or pushing to `gh-pages`. Lets us catch:
+#   - orphan screenshot directives whose PNGs are missing
+#   - manifest / tag count mismatches
+#   - CSS regression assertions that would fail
+#   - missing runner dependencies (handled in advance by
+#     `Scripts/check-publish-deps.sh` but verified end-to-end here)
+#
+# Goal: stop the "merge then fix forward" cycle that bit us four
+# times unblocking the publish pipeline. By the time something
+# lands on `master` the publish should be guaranteed to pass.
+
+name: Publish Dry-Run (PR)
+
+on:
+  pull_request:
+    branches: [master]
+    paths:
+      - 'Sources/KeyPathAppKit/Resources/*.md'
+      - 'Sources/KeyPathAppKit/Resources/*.png'
+      - 'Sources/KeyPathAppKit/Resources/*.css'
+      - 'Scripts/publish-help-to-web.sh'
+      - 'Scripts/test-help-publish-regressions.sh'
+      - 'Scripts/check-help-parity.sh'
+      - 'Scripts/validate-screenshot-manifest.sh'
+      - 'Scripts/check-publish-deps.sh'
+      - 'docs/screenshot-manifest.yaml'
+      - '.github/workflows/publish-help-docs.yml'
+      - '.github/workflows/publish-dry-run.yml'
+
+# One run per PR — supersede on rapid pushes so we don't queue up
+# stale checks.
+concurrency:
+  group: publish-dry-run-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  dry-run:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check out PR head
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Fetch gh-pages branch
+        run: git fetch origin gh-pages
+
+      - name: Add gh-pages worktree
+        run: git worktree add .worktrees/gh-pages gh-pages
+
+      - name: Install zsh
+        run: sudo apt-get install -y zsh
+
+      - name: Install Python dependencies
+        # Mirror what the real publish workflow installs — keeps the
+        # dry-run a faithful preview.
+        run: pip3 install --quiet numpy pillow
+
+      - name: Static dependency precheck
+        # Catches missing runner tools / Python imports BEFORE we
+        # spend cycles on the full pipeline. <1s. `--strict` exits
+        # non-zero on any finding.
+        run: |
+          chmod +x Scripts/check-publish-deps.sh
+          Scripts/check-publish-deps.sh --strict
+
+      - name: Verify App Help Registry Parity
+        run: |
+          chmod +x Scripts/check-help-parity.sh
+          Scripts/check-help-parity.sh
+
+      - name: Run publish script (no commit, no push)
+        run: |
+          chmod +x Scripts/publish-help-to-web.sh
+          zsh Scripts/publish-help-to-web.sh
+
+      - name: Run Publish Regression Checks
+        run: |
+          chmod +x Scripts/test-help-publish-regressions.sh
+          Scripts/test-help-publish-regressions.sh
+
+      - name: Verify Published Help Set Matches App Set
+        run: |
+          app_ids=$(find Sources/KeyPathAppKit/Resources -maxdepth 1 -type f -name '*.md' | sed 's#^.*/##; s#\.md$##' | sort)
+          web_ids=$(find .worktrees/gh-pages/getting-started .worktrees/gh-pages/guides .worktrees/gh-pages/migration -maxdepth 1 -type f -name '*.md' | sed 's#^.*/##; s#\.md$##' | sort | grep -v -E '^(first-mapping|activity-insights)$')
+          diff -u <(echo "$app_ids") <(echo "$web_ids")
+
+      - name: Summarise diff that would be pushed
+        # Show what *would* land on `gh-pages` if this PR merged.
+        # No commit, no push. The next-step instructions printed by
+        # the publish script make the actual flow obvious.
+        run: |
+          cd .worktrees/gh-pages
+          echo "Files that would change on gh-pages:"
+          git status --short || true
+          echo ""
+          echo "Diff summary:"
+          git diff --stat || true

--- a/Scripts/publish-help-to-web.sh
+++ b/Scripts/publish-help-to-web.sh
@@ -26,6 +26,14 @@ SRC="$REPO_ROOT/Sources/KeyPathAppKit/Resources"
 GHPAGES="$REPO_ROOT/.worktrees/gh-pages"
 IMG_DEST="$GHPAGES/images/help"
 
+# Accumulated orphan-screenshot reports. The transformation step
+# adds an entry here every time a `<!-- screenshot: id="X" -->`
+# directive references a PNG that doesn't exist in `$SRC`. We
+# collect all of them across the run so the final report names
+# every missing PNG at once instead of dripping them out one publish
+# at a time.
+MISSING_SCREENSHOT_PNGS=()
+
 # Screenshot IDs in markdown are stable IDs; PNG filenames occasionally differ.
 typeset -A SCREENSHOT_ALIASES
 SCREENSHOT_ALIASES=(
@@ -240,7 +248,13 @@ transform_file() {
             if [[ -f "$SRC/$file" ]]; then
                 converted_content+=$'\n'"![Screenshot]({{ '/images/help/${file}' | relative_url }})"$'\n'
             else
-                echo "  WARNING: screenshot id '${sid}' has no matching PNG (expected: ${file})"
+                # Record the orphan and keep going so we can report
+                # *every* missing PNG in one batch at the end of the
+                # run rather than dripping them out across multiple
+                # publish attempts. The reference is still skipped
+                # in the output (otherwise the rendered site would
+                # show a broken image link).
+                MISSING_SCREENSHOT_PNGS+=("${resource}.md → screenshot id='${sid}' (expected: ${file})")
             fi
         else
             converted_content+="${line}"$'\n'
@@ -471,6 +485,30 @@ done
 
 copy_images
 copy_theme_css
+
+# Surface any screenshot directives whose PNGs are missing. We
+# deliberately collect all offenders during transformation rather
+# than failing at the first one — that way one publish attempt
+# names every gap at once. Loud, structured failure beats the old
+# silent-drop behaviour, which trickled missing references into
+# the count-parity check downstream as cryptic "src=N web=N-1"
+# errors.
+if [[ ${#MISSING_SCREENSHOT_PNGS[@]} -gt 0 ]]; then
+    echo ""
+    echo "ERROR: ${#MISSING_SCREENSHOT_PNGS[@]} screenshot directive(s) reference missing PNG(s)."
+    echo "Each entry below is an in-app markdown directive whose corresponding"
+    echo "PNG was not found in $SRC."
+    for entry in "${MISSING_SCREENSHOT_PNGS[@]}"; do
+        echo "  - $entry"
+    done
+    echo ""
+    echo "To fix:"
+    echo "  - Run \`Scripts/regenerate-screenshots.sh\` to produce the missing PNGs, OR"
+    echo "  - Comment out the corresponding \`<!-- screenshot: -->\` directive in source"
+    echo "    until the PNG can be generated (and update docs/screenshot-manifest.yaml"
+    echo "    to keep tag/manifest counts in sync)."
+    exit 1
+fi
 
 echo ""
 echo "--- Generating navigation ---"


### PR DESCRIPTION
## Summary

Two related improvements that close the "merge then fix forward" cycle we hit four times unblocking the gh-pages publish pipeline this afternoon.

## #1 — Pre-merge publish dry-run

New workflow `.github/workflows/publish-dry-run.yml`. Triggers on every PR that touches a docs file or a publish-pipeline script. Runs the same scripts the post-merge publish runs:

| Step | What it catches |
|---|---|
| `Scripts/check-publish-deps.sh --strict` | missing CLI tools (rg/ag/yq/…) or Python imports — <1s precheck |
| `Scripts/check-help-parity.sh` | new help articles missing from registry, dangling PNG refs |
| `Scripts/publish-help-to-web.sh` | full transformation against a `gh-pages` worktree |
| `Scripts/test-help-publish-regressions.sh` | CSS / screenshot-count / Liquid / divider geometry guards |
| App-vs-web ID diff | missing or extra published pages |

…then a final "summarise diff that would land" step so reviewers can see the gh-pages delta inline.

It does **not** push — the post-merge `publish-help-docs.yml` is still the only thing that actually writes to `gh-pages`. By the time a PR lands on master, publish is guaranteed to succeed.

Concurrency-grouped per PR so rapid pushes supersede earlier dry-runs.

## #2 — `publish-help-to-web.sh` fails loudly on missing screenshot PNGs

Lines 240–244 used to silently drop the markdown reference for any `<!-- screenshot: id="X" ... -->` directive whose PNG was missing from `Resources/`. That trickled into the count-parity check downstream as the cryptic `src=N web=N-1` failure (PR #331's bug).

Replace the silent drop with a global accumulator that collects every offender across the run. After all files process, if non-empty, print a structured error naming each missing directive's source markdown + screenshot ID + expected PNG path, and `exit 1`.

Collects *all* offenders rather than failing at the first — one publish attempt now names every gap at once instead of dripping them out across multiple runs.

```
ERROR: 1 screenshot directive(s) reference missing PNG(s).
Each entry below is an in-app markdown directive whose corresponding
PNG was not found in $SRC.
  - kindavim.md → screenshot id='phony-orphan-for-test' (expected: phony-orphan-for-test.png)

To fix:
  - Run `Scripts/regenerate-screenshots.sh` to produce the missing PNGs, OR
  - Comment out the corresponding `<!-- screenshot: -->` directive in source
    until the PNG can be generated (and update docs/screenshot-manifest.yaml
    to keep tag/manifest counts in sync).
```

## Test plan

- [x] Locally: clean source state → publish succeeds (exit 0).
- [x] Locally: inject one phony orphan → exit 1 with structured error.
- [ ] After merge: this very PR should fire the dry-run on itself before merging (the workflow file is in its own path filter), and pass.
- [ ] Future PR: edit a `Resources/*.md` and intentionally introduce an issue (broken Jekyll link, missing PNG, ripgrep dependency) → dry-run catches it before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)