### PR TITLE
Hoist mapper popovers above the inspector sidebar

### DIFF
--- a/Sources/KeyPathAppKit/UI/Overlay/LiveKeyboardOverlayView.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/LiveKeyboardOverlayView.swift
@@ -407,6 +407,7 @@ struct LiveKeyboardOverlayView: View {
         .onReceive(NotificationCenter.default.publisher(for: .installedPacksChanged)) { _ in
             Task { await refreshKindaVimPackInstalled() }
         }
+        .windowAnchoredPopoverHost()
         .background(
             glassBackground(
                 cornerRadius: cornerRadius,

--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayMapperSection+HoldVariantPicker.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayMapperSection+HoldVariantPicker.swift
@@ -31,7 +31,9 @@ extension OverlayMapperSection {
         }
         .buttonStyle(.plain)
         .accessibilityIdentifier("hold-variant-button")
-        // Popover rendered at OverlayMapperSection.body level to avoid clipping
+        .windowAnchoredPopover(isPresented: $isHoldVariantPopoverOpen) {
+            holdVariantPopover
+        }
     }
 
     /// Popover content for hold variant selection

--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayMapperSection+OutputTypeDropdown.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayMapperSection+OutputTypeDropdown.swift
@@ -13,7 +13,9 @@ extension OverlayMapperSection {
         )
         .accessibilityIdentifier("overlay-mapper-output-type")
         .accessibilityLabel("Select output action type")
-        // Popover rendered at OverlayMapperSection.body level to avoid clipping
+        .windowAnchoredPopover(isPresented: $isSystemActionPickerOpen) {
+            systemActionPopover
+        }
     }
 
     /// Info about current output type for display

--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayMapperSection.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayMapperSection.swift
@@ -33,7 +33,6 @@ struct OverlayMapperSection: View {
     @State var newLayerName = ""
     @State var isHoldVariantPopoverOpen = false
     @State var showMultiTapSlideOver = false
-    @State private var popoverDismissMonitor: Any?
     /// Currently selected layer for "Go to Layer" output
     @State var selectedLayerOutput: String?
     /// Selected tap count (1 = single, 2 = double, 3 = triple)
@@ -58,72 +57,6 @@ struct OverlayMapperSection: View {
 
     var body: some View {
         bodyView
-            .overlay {
-                if isSystemActionPickerOpen || isAppConditionPickerOpen || isHoldVariantPopoverOpen {
-                    GeometryReader { _ in
-                        ZStack(alignment: .top) {
-                            Color.black.opacity(0.001)
-                                .onTapGesture { dismissAllPopovers() }
-
-                            if isSystemActionPickerOpen {
-                                systemActionPopover
-                                    .shadow(color: .black.opacity(0.3), radius: 12, y: 4)
-                            }
-
-                            if isAppConditionPickerOpen {
-                                appConditionPopover
-                                    .shadow(color: .black.opacity(0.3), radius: 12, y: 4)
-                            }
-
-                            if isHoldVariantPopoverOpen {
-                                holdVariantPopover
-                                    .shadow(color: .black.opacity(0.3), radius: 12, y: 4)
-                            }
-                        }
-                        .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    }
-                    .transition(.opacity)
-                    .zIndex(999)
-                }
-            }
-        .onChange(of: anyPopoverOpen) { _, isOpen in
-            if isOpen {
-                installPopoverDismissMonitor()
-            } else {
-                removePopoverDismissMonitor()
-            }
-        }
-        .onDisappear {
-            removePopoverDismissMonitor()
-        }
-    }
-
-    private var anyPopoverOpen: Bool {
-        isSystemActionPickerOpen || isAppConditionPickerOpen || isHoldVariantPopoverOpen
-    }
-
-    private func installPopoverDismissMonitor() {
-        removePopoverDismissMonitor()
-        popoverDismissMonitor = NSEvent.addLocalMonitorForEvents(matching: [.keyDown]) { event in
-            if event.keyCode == 53 {
-                dismissAllPopovers()
-                return nil
-            }
-            return event
-        }
-    }
-
-    private func removePopoverDismissMonitor() {
-        if let monitor = popoverDismissMonitor {
-            NSEvent.removeMonitor(monitor)
-            popoverDismissMonitor = nil
-        }
-    }
-
-    private func dismissAllPopovers() {
-        isSystemActionPickerOpen = false
-        isAppConditionPickerOpen = false
-        isHoldVariantPopoverOpen = false
     }
 
     private var bodyView: some View {
@@ -713,7 +646,9 @@ struct OverlayMapperSection: View {
             action: { isAppConditionPickerOpen = true }
         )
         .accessibilityIdentifier("overlay-mapper-app-condition")
-        // Popover rendered at OverlayMapperSection.body level to avoid clipping
+        .windowAnchoredPopover(isPresented: $isAppConditionPickerOpen) {
+            appConditionPopover
+        }
         .confirmationDialog("How many taps?", isPresented: $showTapCountPicker) {
             Button("Single Tap") { selectedTapCount = 1 }
             Button("Double Tap") { selectedTapCount = 2 }

--- a/Sources/KeyPathAppKit/UI/Overlay/Popover/WindowAnchoredPopover.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/Popover/WindowAnchoredPopover.swift
@@ -1,0 +1,270 @@
+import AppKit
+import SwiftUI
+
+// MARK: - Public API
+
+/// Edge of the trigger that an anchored popover should attach to.
+public enum WindowAnchoredPopoverEdge {
+    case leading
+    case trailing
+    case top
+    case bottom
+}
+
+public extension View {
+    /// Attaches a popover whose content is rendered at the nearest
+    /// `windowAnchoredPopoverHost()` ancestor instead of as a local overlay.
+    ///
+    /// Use this when the trigger lives inside a clipped container (e.g. a
+    /// narrow sidebar) and the popover content needs to float over the rest
+    /// of the window without being cropped by the trigger's parent.
+    func windowAnchoredPopover<PopoverContent: View>(
+        isPresented: Binding<Bool>,
+        edge: WindowAnchoredPopoverEdge = .leading,
+        gap: CGFloat = 8,
+        @ViewBuilder content: @escaping () -> PopoverContent
+    ) -> some View {
+        modifier(
+            WindowAnchoredPopoverModifier(
+                isPresented: isPresented,
+                edge: edge,
+                gap: gap,
+                contentBuilder: content
+            )
+        )
+    }
+
+    /// Hosts window-anchored popovers. Apply once on an ancestor that
+    /// covers the area the popover should be able to float over (typically
+    /// the root view of the window). Any descendant calling
+    /// `.windowAnchoredPopover(...)` will render into this host.
+    func windowAnchoredPopoverHost() -> some View {
+        modifier(WindowAnchoredPopoverHostModifier())
+    }
+}
+
+// MARK: - Internal Entry
+
+struct WindowAnchoredPopoverEntry: Identifiable, Equatable {
+    let id: UUID
+    let anchor: Anchor<CGRect>
+    let edge: WindowAnchoredPopoverEdge
+    let gap: CGFloat
+    let content: AnyView
+    let dismiss: () -> Void
+
+    static func == (lhs: WindowAnchoredPopoverEntry, rhs: WindowAnchoredPopoverEntry) -> Bool {
+        lhs.id == rhs.id && lhs.edge == rhs.edge && lhs.gap == rhs.gap
+    }
+}
+
+struct WindowAnchoredPopoverPreferenceKey: PreferenceKey {
+    static let defaultValue: [WindowAnchoredPopoverEntry] = []
+
+    static func reduce(value: inout [WindowAnchoredPopoverEntry], nextValue: () -> [WindowAnchoredPopoverEntry]) {
+        value.append(contentsOf: nextValue())
+    }
+}
+
+// MARK: - Trigger Modifier
+
+private struct WindowAnchoredPopoverModifier<PopoverContent: View>: ViewModifier {
+    @Binding var isPresented: Bool
+    let edge: WindowAnchoredPopoverEdge
+    let gap: CGFloat
+    let contentBuilder: () -> PopoverContent
+
+    @State private var id = UUID()
+
+    func body(content: Content) -> some View {
+        content.anchorPreference(
+            key: WindowAnchoredPopoverPreferenceKey.self,
+            value: .bounds
+        ) { anchor in
+            guard isPresented else { return [] }
+            return [
+                WindowAnchoredPopoverEntry(
+                    id: id,
+                    anchor: anchor,
+                    edge: edge,
+                    gap: gap,
+                    content: AnyView(contentBuilder()),
+                    dismiss: { isPresented = false }
+                )
+            ]
+        }
+    }
+}
+
+// MARK: - Host Modifier
+
+private struct WindowAnchoredPopoverHostModifier: ViewModifier {
+    @State private var escMonitor: Any?
+
+    func body(content: Content) -> some View {
+        content.overlayPreferenceValue(WindowAnchoredPopoverPreferenceKey.self) { entries in
+            hostOverlay(entries: entries)
+        }
+    }
+
+    @ViewBuilder
+    private func hostOverlay(entries: [WindowAnchoredPopoverEntry]) -> some View {
+        GeometryReader { proxy in
+            ZStack(alignment: .topLeading) {
+                if !entries.isEmpty {
+                    Color.black.opacity(0.001)
+                        .contentShape(Rectangle())
+                        .onTapGesture {
+                            for entry in entries { entry.dismiss() }
+                        }
+                        .transition(.identity)
+                }
+
+                ForEach(entries) { entry in
+                    WindowAnchoredPopoverContent(
+                        entry: entry,
+                        triggerFrame: proxy[entry.anchor],
+                        hostSize: proxy.size
+                    )
+                    .transition(.opacity)
+                }
+            }
+            .animation(.easeOut(duration: 0.12), value: entries)
+        }
+        .allowsHitTesting(!entries.isEmpty)
+        .onChange(of: entries) { _, newEntries in
+            if newEntries.isEmpty {
+                removeEscMonitor()
+            } else {
+                installEscMonitor(dismissAll: { for entry in newEntries { entry.dismiss() } })
+            }
+        }
+        .onDisappear { removeEscMonitor() }
+    }
+
+    private func installEscMonitor(dismissAll: @escaping () -> Void) {
+        removeEscMonitor()
+        escMonitor = NSEvent.addLocalMonitorForEvents(matching: [.keyDown]) { event in
+            guard event.keyCode == 53 else { return event }
+            dismissAll()
+            return nil
+        }
+    }
+
+    private func removeEscMonitor() {
+        if let monitor = escMonitor {
+            NSEvent.removeMonitor(monitor)
+            escMonitor = nil
+        }
+    }
+}
+
+// MARK: - Positioning
+
+private struct WindowAnchoredPopoverContent: View {
+    let entry: WindowAnchoredPopoverEntry
+    let triggerFrame: CGRect
+    let hostSize: CGSize
+
+    @State private var measuredSize: CGSize = .zero
+
+    var body: some View {
+        let isMeasured = measuredSize.width > 0 && measuredSize.height > 0
+        let size = isMeasured ? measuredSize : fallbackSize
+        let edge = resolveEdge(size: size)
+        let center = position(for: edge, size: size)
+
+        entry.content
+            .background(
+                GeometryReader { proxy in
+                    Color.clear.preference(
+                        key: WindowAnchoredPopoverSizeKey.self,
+                        value: proxy.size
+                    )
+                }
+            )
+            .onPreferenceChange(WindowAnchoredPopoverSizeKey.self) { newSize in
+                if newSize != measuredSize, newSize.width > 0, newSize.height > 0 {
+                    measuredSize = newSize
+                }
+            }
+            .shadow(color: .black.opacity(0.3), radius: 12, y: 4)
+            .opacity(isMeasured ? 1 : 0)
+            .position(center)
+    }
+
+    private var fallbackSize: CGSize {
+        CGSize(width: 280, height: 220)
+    }
+
+    private func resolveEdge(size: CGSize) -> WindowAnchoredPopoverEdge {
+        switch entry.edge {
+        case .leading:
+            if triggerFrame.minX - entry.gap - size.width < 0 {
+                return .trailing
+            }
+        case .trailing:
+            if triggerFrame.maxX + entry.gap + size.width > hostSize.width {
+                return .leading
+            }
+        case .top:
+            if triggerFrame.minY - entry.gap - size.height < 0 {
+                return .bottom
+            }
+        case .bottom:
+            if triggerFrame.maxY + entry.gap + size.height > hostSize.height {
+                return .top
+            }
+        }
+        return entry.edge
+    }
+
+    private func position(for edge: WindowAnchoredPopoverEdge, size: CGSize) -> CGPoint {
+        switch edge {
+        case .leading:
+            return CGPoint(
+                x: triggerFrame.minX - entry.gap - size.width / 2,
+                y: clampVertical(centerY: triggerFrame.midY, size: size)
+            )
+        case .trailing:
+            return CGPoint(
+                x: triggerFrame.maxX + entry.gap + size.width / 2,
+                y: clampVertical(centerY: triggerFrame.midY, size: size)
+            )
+        case .top:
+            return CGPoint(
+                x: clampHorizontal(centerX: triggerFrame.midX, size: size),
+                y: triggerFrame.minY - entry.gap - size.height / 2
+            )
+        case .bottom:
+            return CGPoint(
+                x: clampHorizontal(centerX: triggerFrame.midX, size: size),
+                y: triggerFrame.maxY + entry.gap + size.height / 2
+            )
+        }
+    }
+
+    private func clampVertical(centerY: CGFloat, size: CGSize) -> CGFloat {
+        let inset: CGFloat = 8
+        let half = size.height / 2
+        let minCenter = half + inset
+        let maxCenter = max(minCenter, hostSize.height - half - inset)
+        return min(maxCenter, max(minCenter, centerY))
+    }
+
+    private func clampHorizontal(centerX: CGFloat, size: CGSize) -> CGFloat {
+        let inset: CGFloat = 8
+        let half = size.width / 2
+        let minCenter = half + inset
+        let maxCenter = max(minCenter, hostSize.width - half - inset)
+        return min(maxCenter, max(minCenter, centerX))
+    }
+}
+
+private struct WindowAnchoredPopoverSizeKey: PreferenceKey {
+    static let defaultValue: CGSize = .zero
+    static func reduce(value: inout CGSize, nextValue: () -> CGSize) {
+        let next = nextValue()
+        if next.width > 0, next.height > 0 { value = next }
+    }
+}

--- a/Sources/KeyPathAppKit/UI/Overlay/Popover/WindowAnchoredPopover.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/Popover/WindowAnchoredPopover.swift
@@ -57,7 +57,7 @@ public extension View {
 
 // MARK: - Internal Entry
 
-struct WindowAnchoredPopoverEntry: Identifiable, Equatable {
+struct WindowAnchoredPopoverEntry: Identifiable, Equatable, @unchecked Sendable {
     let id: UUID
     let anchor: Anchor<CGRect>
     let edge: WindowAnchoredPopoverEdge

--- a/Sources/KeyPathAppKit/UI/Overlay/Popover/WindowAnchoredPopover.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/Popover/WindowAnchoredPopover.swift
@@ -18,6 +18,18 @@ public extension View {
     /// Use this when the trigger lives inside a clipped container (e.g. a
     /// narrow sidebar) and the popover content needs to float over the rest
     /// of the window without being cropped by the trigger's parent.
+    ///
+    /// - Parameters:
+    ///   - isPresented: Controls visibility. Setting to `false` (e.g. via the
+    ///     host's tap-outside or ESC handling) dismisses the popover.
+    ///   - edge: The edge of the trigger the popover attaches to. Defaults to
+    ///     `.leading` (popover floats left of the trigger), which is the right
+    ///     choice for triggers in a right-side sidebar. The host auto-flips
+    ///     to the opposite edge if the popover would clip the host bounds.
+    ///   - gap: Space between the trigger edge and the popover edge.
+    ///   - content: The popover content. Built once when `isPresented`
+    ///     becomes `true` and cached until dismissal, so heavier content
+    ///     doesn't pay a rebuild cost on every layout pass.
     func windowAnchoredPopover<PopoverContent: View>(
         isPresented: Binding<Bool>,
         edge: WindowAnchoredPopoverEdge = .leading,
@@ -53,8 +65,14 @@ struct WindowAnchoredPopoverEntry: Identifiable, Equatable {
     let content: AnyView
     let dismiss: () -> Void
 
+    /// Identity-only equality. `anchor` is `Anchor<CGRect>` (not Equatable),
+    /// `content` is `AnyView` (untyped), and `dismiss` is a closure — none of
+    /// these can participate. Comparing only `id` also matches our semantic
+    /// intent: the host only needs to know when the *set of open popovers*
+    /// changes (so it can rebind the ESC monitor). Layout-driven anchor
+    /// movement should not retrigger that work.
     static func == (lhs: WindowAnchoredPopoverEntry, rhs: WindowAnchoredPopoverEntry) -> Bool {
-        lhs.id == rhs.id && lhs.edge == rhs.edge && lhs.gap == rhs.gap
+        lhs.id == rhs.id
     }
 }
 
@@ -74,25 +92,42 @@ private struct WindowAnchoredPopoverModifier<PopoverContent: View>: ViewModifier
     let gap: CGFloat
     let contentBuilder: () -> PopoverContent
 
+    /// Stable per trigger-site identity. SwiftUI preserves `@State` across
+    /// recompositions of the same view, so this UUID is generated once and
+    /// reused for every emitted entry from this modifier.
     @State private var id = UUID()
 
+    /// Cached popover content. Built once when `isPresented` flips to `true`
+    /// and held until dismissal, so the popover view tree is not
+    /// re-instantiated on every layout pass (which the surrounding
+    /// `anchorPreference` transform would otherwise trigger).
+    @State private var cachedContent: AnyView?
+
     func body(content: Content) -> some View {
-        content.anchorPreference(
-            key: WindowAnchoredPopoverPreferenceKey.self,
-            value: .bounds
-        ) { anchor in
-            guard isPresented else { return [] }
-            return [
-                WindowAnchoredPopoverEntry(
-                    id: id,
-                    anchor: anchor,
-                    edge: edge,
-                    gap: gap,
-                    content: AnyView(contentBuilder()),
-                    dismiss: { isPresented = false }
-                )
-            ]
-        }
+        content
+            .anchorPreference(
+                key: WindowAnchoredPopoverPreferenceKey.self,
+                value: .bounds
+            ) { anchor in
+                guard isPresented, let cachedContent else { return [] }
+                return [
+                    WindowAnchoredPopoverEntry(
+                        id: id,
+                        anchor: anchor,
+                        edge: edge,
+                        gap: gap,
+                        content: cachedContent,
+                        dismiss: { isPresented = false }
+                    )
+                ]
+            }
+            .onChange(of: isPresented) { _, isOpen in
+                if isOpen {
+                    cachedContent = AnyView(contentBuilder())
+                } else {
+                    cachedContent = nil
+                }
+            }
     }
 }
 
@@ -112,11 +147,15 @@ private struct WindowAnchoredPopoverHostModifier: ViewModifier {
         GeometryReader { proxy in
             ZStack(alignment: .topLeading) {
                 if !entries.isEmpty {
+                    // 0.001 opacity makes this layer invisible while still
+                    // hit-testable, so taps outside the popover dismiss it
+                    // without darkening the underlying UI.
                     Color.black.opacity(0.001)
                         .contentShape(Rectangle())
                         .onTapGesture {
                             for entry in entries { entry.dismiss() }
                         }
+                        .accessibilityIdentifier("window-anchored-popover-dismiss-backdrop")
                         .transition(.identity)
                 }
 
@@ -171,7 +210,11 @@ private struct WindowAnchoredPopoverContent: View {
     var body: some View {
         let isMeasured = measuredSize.width > 0 && measuredSize.height > 0
         let size = isMeasured ? measuredSize : fallbackSize
-        let edge = resolveEdge(size: size)
+        // Skip the flip on the unmeasured first frame so a stale
+        // `fallbackSize` can't move the popover to the wrong side
+        // (which would then need to animate back once measured).
+        // The view is opacity-0 in that frame anyway.
+        let edge = isMeasured ? resolveEdge(size: size) : entry.edge
         let center = position(for: edge, size: size)
 
         entry.content

--- a/Sources/KeyPathAppKit/UI/Overlay/Popover/WindowAnchoredPopover.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/Popover/WindowAnchoredPopover.swift
@@ -62,6 +62,11 @@ struct WindowAnchoredPopoverEntry: Identifiable, Equatable {
     let anchor: Anchor<CGRect>
     let edge: WindowAnchoredPopoverEdge
     let gap: CGFloat
+    /// Type-erased so any caller can attach arbitrary popover content
+    /// without bubbling a generic parameter all the way to the host.
+    /// The trade-off is that SwiftUI can't diff inside the popover
+    /// subtree across `entries` updates — acceptable for picker-style
+    /// content; revisit if the host renders large dynamic trees.
     let content: AnyView
     let dismiss: () -> Void
 
@@ -144,9 +149,20 @@ private struct WindowAnchoredPopoverHostModifier: ViewModifier {
 
     @ViewBuilder
     private func hostOverlay(entries: [WindowAnchoredPopoverEntry]) -> some View {
-        GeometryReader { proxy in
-            ZStack(alignment: .topLeading) {
-                if !entries.isEmpty {
+        // When no popover is open the host contributes nothing to the view
+        // tree at all (no GeometryReader, no overlay layer). This keeps
+        // `.windowAnchoredPopoverHost()` invisible to snapshot tests and
+        // hit-testing when idle.
+        if entries.isEmpty {
+            Color.clear
+                .frame(width: 0, height: 0)
+                .hidden()
+                .allowsHitTesting(false)
+                .onChange(of: entries) { _, _ in removeEscMonitor() }
+                .onDisappear { removeEscMonitor() }
+        } else {
+            GeometryReader { proxy in
+                ZStack(alignment: .topLeading) {
                     // 0.001 opacity makes this layer invisible while still
                     // hit-testable, so taps outside the popover dismiss it
                     // without darkening the underlying UI.
@@ -156,34 +172,39 @@ private struct WindowAnchoredPopoverHostModifier: ViewModifier {
                             for entry in entries { entry.dismiss() }
                         }
                         .accessibilityIdentifier("window-anchored-popover-dismiss-backdrop")
+                        .accessibilityLabel("Dismiss popover")
+                        .accessibilityAddTraits(.isButton)
                         .transition(.identity)
-                }
 
-                ForEach(entries) { entry in
-                    WindowAnchoredPopoverContent(
-                        entry: entry,
-                        triggerFrame: proxy[entry.anchor],
-                        hostSize: proxy.size
-                    )
-                    .transition(.opacity)
+                    ForEach(entries) { entry in
+                        WindowAnchoredPopoverContent(
+                            entry: entry,
+                            triggerFrame: proxy[entry.anchor],
+                            hostSize: proxy.size
+                        )
+                        .transition(.opacity)
+                    }
+                }
+                .animation(.easeOut(duration: 0.12), value: entries)
+            }
+            .onChange(of: entries) { _, newEntries in
+                if newEntries.isEmpty {
+                    removeEscMonitor()
+                } else {
+                    installEscMonitor(dismissAll: { for entry in newEntries { entry.dismiss() } })
                 }
             }
-            .animation(.easeOut(duration: 0.12), value: entries)
-        }
-        .allowsHitTesting(!entries.isEmpty)
-        .onChange(of: entries) { _, newEntries in
-            if newEntries.isEmpty {
-                removeEscMonitor()
-            } else {
-                installEscMonitor(dismissAll: { for entry in newEntries { entry.dismiss() } })
+            .onAppear {
+                installEscMonitor(dismissAll: { for entry in entries { entry.dismiss() } })
             }
+            .onDisappear { removeEscMonitor() }
         }
-        .onDisappear { removeEscMonitor() }
     }
 
     private func installEscMonitor(dismissAll: @escaping () -> Void) {
         removeEscMonitor()
         escMonitor = NSEvent.addLocalMonitorForEvents(matching: [.keyDown]) { event in
+            // 53 = kVK_Escape (no Carbon import needed for this single constant)
             guard event.keyCode == 53 else { return event }
             dismissAll()
             return nil

--- a/docs/screenshot-manifest.yaml
+++ b/docs/screenshot-manifest.yaml
@@ -21,7 +21,7 @@
 # Last updated: 2026-02-19
 
 # =============================================================================
-# SCREENSHOTS (25 total — from embedded <!-- screenshot: --> tags)
+# SCREENSHOTS (23 total — from embedded <!-- screenshot: --> tags)
 # =============================================================================
 
 screenshots:
@@ -29,13 +29,6 @@ screenshots:
   # ---------------------------------------------------------------------------
   # installation.md (6 screenshots)
   # ---------------------------------------------------------------------------
-
-  - id: install-overlay-base
-    file: installation.md
-    method: snapshot
-    view: LiveKeyboardOverlayView
-    state: "service:running,layer:base"
-    description: "The KeyPath overlay showing the active base layer layout"
 
   - id: install-auth-prompt
     file: installation.md
@@ -130,17 +123,6 @@ screenshots:
     description: "Rule editor with hold behavior options (Basic, Trigger early, Quick tap)"
 
   # ---------------------------------------------------------------------------
-  # use-cases.md (1 screenshot)
-  # ---------------------------------------------------------------------------
-
-  - id: use-cases-launchers-tab
-    file: use-cases.md
-    method: snapshot
-    view: OverlayLaunchersSection
-    state: "shortcuts:3-items"
-    description: "Compact launchers tab with 3 items (Safari, Terminal, github.com)"
-
-  # ---------------------------------------------------------------------------
   # home-row-mods.md (3 screenshots)
   # ---------------------------------------------------------------------------
 
@@ -163,18 +145,7 @@ screenshots:
     method: snapshot
     view: HomeRowTimingSection
     state: "prior-idle:visible"
-    description: "Prior-idle protection so fast typing never triggers hold accidentally"
-
-  # ---------------------------------------------------------------------------
-  # chords.md (1 screenshot)
-  # ---------------------------------------------------------------------------
-
-  - id: chords-collection-view
-    file: chords.md
-    method: snapshot
-    view: ChordGroupsCollectionView
-    state: "groups:2,chords:5,activeGroup:navigation"
-    description: "Chord groups collection with 2 groups and 5 chords, navigation group active"
+    description: "Fast typing protection toggle showing prior-idle detection"
 
   # ---------------------------------------------------------------------------
   # auto-shift.md (1 screenshot)
@@ -185,7 +156,18 @@ screenshots:
     method: snapshot
     view: AutoShiftCollectionView
     state: "timeout:180,protectFastTyping:on,allKeys:enabled"
-    description: "Auto-shift configuration with 180ms timeout, fast-typing protection on, all keys enabled"
+    description: "Auto-shift configuration showing timeout, fast typing protection, and key selection"
+
+  # ---------------------------------------------------------------------------
+  # chords.md (1 screenshot)
+  # ---------------------------------------------------------------------------
+
+  - id: chords-collection-view
+    file: chords.md
+    method: snapshot
+    view: ChordGroupsCollectionView
+    state: "groups:2,chords:5,activeGroup:navigation"
+    description: "Chord groups view showing navigation group with 5 chords"
 
   # ---------------------------------------------------------------------------
   # window-management.md (1 screenshot)
@@ -197,17 +179,6 @@ screenshots:
     view: OverlayInspectorPanel
     state: "tab:customRules,rules:app-specific,apps:safari+terminal"
     description: "Custom Rules tab with global and app-specific rule cards for Safari and Terminal"
-
-  # ---------------------------------------------------------------------------
-  # concepts.md (1 screenshot)
-  # ---------------------------------------------------------------------------
-
-  - id: concepts-new-rule-dialog
-    file: concepts.md
-    method: snapshot
-    view: CustomRulesInlineEditor
-    state: "start:caps_lock,finish:escape,hold:disabled"
-    description: "Simple remap dialog: Caps Lock to Escape, no hold behavior"
 
   # ---------------------------------------------------------------------------
   # alternative-layouts.md (2 screenshots)
@@ -369,8 +340,8 @@ illustrations:
 # SUMMARY
 # =============================================================================
 #
-# Screenshots: 25 total
-#   - snapshot:  21 (SwiftUI snapshot tests)
+# Screenshots: 23 total
+#   - snapshot:  19 (SwiftUI snapshot tests)
 #   - peekaboo:   3 (System Settings UI automation)
 #   - manual:     1 (macOS auth dialog)
 #

--- a/docs/screenshot-manifest.yaml
+++ b/docs/screenshot-manifest.yaml
@@ -21,7 +21,7 @@
 # Last updated: 2026-02-19
 
 # =============================================================================
-# SCREENSHOTS (23 total — from embedded <!-- screenshot: --> tags)
+# SCREENSHOTS (25 total — from embedded <!-- screenshot: --> tags)
 # =============================================================================
 
 screenshots:
@@ -29,6 +29,13 @@ screenshots:
   # ---------------------------------------------------------------------------
   # installation.md (6 screenshots)
   # ---------------------------------------------------------------------------
+
+  - id: install-overlay-base
+    file: installation.md
+    method: snapshot
+    view: LiveKeyboardOverlayView
+    state: "service:running,layer:base"
+    description: "The KeyPath overlay showing the active base layer layout"
 
   - id: install-auth-prompt
     file: installation.md
@@ -123,6 +130,17 @@ screenshots:
     description: "Rule editor with hold behavior options (Basic, Trigger early, Quick tap)"
 
   # ---------------------------------------------------------------------------
+  # use-cases.md (1 screenshot)
+  # ---------------------------------------------------------------------------
+
+  - id: use-cases-launchers-tab
+    file: use-cases.md
+    method: snapshot
+    view: OverlayLaunchersSection
+    state: "shortcuts:3-items"
+    description: "Compact launchers tab with 3 items (Safari, Terminal, github.com)"
+
+  # ---------------------------------------------------------------------------
   # home-row-mods.md (3 screenshots)
   # ---------------------------------------------------------------------------
 
@@ -145,18 +163,7 @@ screenshots:
     method: snapshot
     view: HomeRowTimingSection
     state: "prior-idle:visible"
-    description: "Fast typing protection toggle showing prior-idle detection"
-
-  # ---------------------------------------------------------------------------
-  # auto-shift.md (1 screenshot)
-  # ---------------------------------------------------------------------------
-
-  - id: auto-shift-config
-    file: auto-shift.md
-    method: snapshot
-    view: AutoShiftCollectionView
-    state: "timeout:180,protectFastTyping:on,allKeys:enabled"
-    description: "Auto-shift configuration showing timeout, fast typing protection, and key selection"
+    description: "Prior-idle protection so fast typing never triggers hold accidentally"
 
   # ---------------------------------------------------------------------------
   # chords.md (1 screenshot)
@@ -167,7 +174,18 @@ screenshots:
     method: snapshot
     view: ChordGroupsCollectionView
     state: "groups:2,chords:5,activeGroup:navigation"
-    description: "Chord groups view showing navigation group with 5 chords"
+    description: "Chord groups collection with 2 groups and 5 chords, navigation group active"
+
+  # ---------------------------------------------------------------------------
+  # auto-shift.md (1 screenshot)
+  # ---------------------------------------------------------------------------
+
+  - id: auto-shift-config
+    file: auto-shift.md
+    method: snapshot
+    view: AutoShiftCollectionView
+    state: "timeout:180,protectFastTyping:on,allKeys:enabled"
+    description: "Auto-shift configuration with 180ms timeout, fast-typing protection on, all keys enabled"
 
   # ---------------------------------------------------------------------------
   # window-management.md (1 screenshot)
@@ -179,6 +197,17 @@ screenshots:
     view: OverlayInspectorPanel
     state: "tab:customRules,rules:app-specific,apps:safari+terminal"
     description: "Custom Rules tab with global and app-specific rule cards for Safari and Terminal"
+
+  # ---------------------------------------------------------------------------
+  # concepts.md (1 screenshot)
+  # ---------------------------------------------------------------------------
+
+  - id: concepts-new-rule-dialog
+    file: concepts.md
+    method: snapshot
+    view: CustomRulesInlineEditor
+    state: "start:caps_lock,finish:escape,hold:disabled"
+    description: "Simple remap dialog: Caps Lock to Escape, no hold behavior"
 
   # ---------------------------------------------------------------------------
   # alternative-layouts.md (2 screenshots)
@@ -340,8 +369,8 @@ illustrations:
 # SUMMARY
 # =============================================================================
 #
-# Screenshots: 23 total
-#   - snapshot:  19 (SwiftUI snapshot tests)
+# Screenshots: 25 total
+#   - snapshot:  21 (SwiftUI snapshot tests)
 #   - peekaboo:   3 (System Settings UI automation)
 #   - manual:     1 (macOS auth dialog)
 #


### PR DESCRIPTION
## Summary

Rebased version of #343 (clean cherry-pick onto current master).

- Introduces `WindowAnchoredPopover` — a preference-key-based system that renders popovers at the window level, preventing sidebar clipping
- Mapper output type picker, app condition picker, and hold variant picker all use the new system
- Popovers auto-flip edge when they'd overflow the window bounds

## Changes

- `WindowAnchoredPopover.swift` — new popover infrastructure (trigger modifier + host modifier)
- `OverlayMapperSection.swift` — migrated from `.overlay` to `.windowAnchoredPopover`
- `WindowAnchoredPopoverEntry` marked `@unchecked Sendable` for PreferenceKey compatibility
- Snapshot baselines regenerated

## Test plan

- [x] Build passes
- [x] 413 tests pass
- [x] Popover renders above sidebar, not clipped
- [x] ESC dismisses popover
- [x] Click-outside dismisses popover

Closes #341

🤖 Generated with [Claude Code](https://claude.com/claude-code)