### PR TITLE
refactor: DeviceKeyOverride.output String → KeyAction (#346 Phase 3a)

### DIFF
--- a/Sources/KeyPathAppKit/Infrastructure/Config/KanataConfiguration+DeviceSwitch.swift
+++ b/Sources/KeyPathAppKit/Infrastructure/Config/KanataConfiguration+DeviceSwitch.swift
@@ -29,19 +29,14 @@ extension KanataConfiguration {
             guard let index = hashToIndex[override.deviceHash] else { continue }
             let output: String
             if let behavior = override.behavior {
-                // Render behavior using the behavior renderer.
-                // KanataBehaviorRenderer currently uses only output+behavior from the mapping,
-                // but we pass the real input key for correctness and future-proofing.
                 let syntheticMapping = KeyMapping(
                     input: inputKey,
-                    action: .keystroke(key: override.output),
+                    action: override.output,
                     behavior: behavior
                 )
-                // TODO: Thread real hyperLinkedLayerInfos through when per-device
-                // behavior overrides involving hyper layers are supported in the UI.
                 output = KanataBehaviorRenderer.render(syntheticMapping, hyperLinkedLayerInfos: [])
             } else {
-                output = KanataKeyConverter.convertToKanataSequence(override.output)
+                output = override.output.kanataOutput
             }
             cases.append("((device \(index))) \(output) break")
         }

--- a/Sources/KeyPathAppKit/Models/KeyMapping.swift
+++ b/Sources/KeyPathAppKit/Models/KeyMapping.swift
@@ -7,11 +7,11 @@ public struct DeviceKeyOverride: Codable, Equatable, Sendable {
     /// Device hash from kanata --list (e.g., "0x1234ABCD")
     public let deviceHash: String
     /// Output action for this device (replaces the default output)
-    public let output: String
+    public let output: KeyAction
     /// Optional advanced behavior override for this device
     public let behavior: MappingBehavior?
 
-    public init(deviceHash: String, output: String, behavior: MappingBehavior? = nil) {
+    public init(deviceHash: String, output: KeyAction, behavior: MappingBehavior? = nil) {
         self.deviceHash = deviceHash
         self.output = output
         self.behavior = behavior

--- a/Sources/KeyPathAppKit/UI/Experimental/MapperViewModel+ConflictResolution.swift
+++ b/Sources/KeyPathAppKit/UI/Experimental/MapperViewModel+ConflictResolution.swift
@@ -682,14 +682,14 @@ extension MapperViewModel {
         // Apply device condition: scoped output goes into deviceOverrides,
         // default output becomes identity (pass-through for other devices)
         if let deviceCondition = selectedDeviceCondition {
+            let overrideAction = customRule.action
             customRule.deviceOverrides = [
                 DeviceKeyOverride(
                     deviceHash: deviceCondition.deviceHash,
-                    output: outputKanata,
+                    output: overrideAction,
                     behavior: customRule.behavior
                 )
             ]
-            // Default output becomes identity (pass-through for unmatched devices)
             customRule.action = .keystroke(key: inputKanata)
             customRule.behavior = nil
         }

--- a/Sources/KeyPathAppKit/UI/Experimental/MapperViewModel+LayerManagement.swift
+++ b/Sources/KeyPathAppKit/UI/Experimental/MapperViewModel+LayerManagement.swift
@@ -163,8 +163,9 @@ extension MapperViewModel {
         customRule.targetLayer = targetLayer
 
         if let deviceCondition = selectedDeviceCondition {
+            let overrideAction = customRule.action
             customRule.deviceOverrides = [
-                DeviceKeyOverride(deviceHash: deviceCondition.deviceHash, output: app.kanataOutput, behavior: nil)
+                DeviceKeyOverride(deviceHash: deviceCondition.deviceHash, output: overrideAction, behavior: nil)
             ]
             customRule.action = .keystroke(key: inputKanata)
         }
@@ -232,8 +233,9 @@ extension MapperViewModel {
         customRule.targetLayer = targetLayer
 
         if let deviceCondition = selectedDeviceCondition {
+            let overrideAction = customRule.action
             customRule.deviceOverrides = [
-                DeviceKeyOverride(deviceHash: deviceCondition.deviceHash, output: action.kanataOutput, behavior: nil)
+                DeviceKeyOverride(deviceHash: deviceCondition.deviceHash, output: overrideAction, behavior: nil)
             ]
             customRule.action = .keystroke(key: inputKanata)
         }
@@ -333,8 +335,9 @@ extension MapperViewModel {
         customRule.targetLayer = targetLayer
 
         if let deviceCondition = selectedDeviceCondition {
+            let overrideAction = customRule.action
             customRule.deviceOverrides = [
-                DeviceKeyOverride(deviceHash: deviceCondition.deviceHash, output: outputKanata, behavior: nil)
+                DeviceKeyOverride(deviceHash: deviceCondition.deviceHash, output: overrideAction, behavior: nil)
             ]
             customRule.action = .keystroke(key: inputKanata)
         }
@@ -406,8 +409,9 @@ extension MapperViewModel {
         customRule.targetLayer = targetLayer
 
         if let deviceCondition = selectedDeviceCondition {
+            let overrideAction = customRule.action
             customRule.deviceOverrides = [
-                DeviceKeyOverride(deviceHash: deviceCondition.deviceHash, output: action.kanataOutput, behavior: nil)
+                DeviceKeyOverride(deviceHash: deviceCondition.deviceHash, output: overrideAction, behavior: nil)
             ]
             customRule.action = .keystroke(key: inputKanata)
         }
@@ -469,8 +473,9 @@ extension MapperViewModel {
         customRule.targetLayer = targetLayer
 
         if let deviceCondition = selectedDeviceCondition {
+            let overrideAction = customRule.action
             customRule.deviceOverrides = [
-                DeviceKeyOverride(deviceHash: deviceCondition.deviceHash, output: action.kanataOutput, behavior: nil)
+                DeviceKeyOverride(deviceHash: deviceCondition.deviceHash, output: overrideAction, behavior: nil)
             ]
             customRule.action = .keystroke(key: inputKanata)
         }

--- a/Sources/KeyPathAppKit/UI/Previews/PreviewFixtures.swift
+++ b/Sources/KeyPathAppKit/UI/Previews/PreviewFixtures.swift
@@ -18,21 +18,21 @@
                 input: "caps",
                 action: .keystroke(key: "caps"),
                 isEnabled: true,
-                deviceOverrides: [DeviceKeyOverride(deviceHash: "0xDEADBEEF", output: "lctl")]
+                deviceOverrides: [DeviceKeyOverride(deviceHash: "0xDEADBEEF", output: .keystroke(key: "lctl"))]
             ),
             CustomRule(
                 title: "Kinesis: Tab → Hyper",
                 input: "tab",
                 action: .keystroke(key: "tab"),
                 isEnabled: true,
-                deviceOverrides: [DeviceKeyOverride(deviceHash: "0xDEADBEEF", output: "lmet")]
+                deviceOverrides: [DeviceKeyOverride(deviceHash: "0xDEADBEEF", output: .keystroke(key: "lmet"))]
             ),
             CustomRule(
                 title: "Moonlander: A → Ctrl",
                 input: "a",
                 action: .keystroke(key: "a"),
                 isEnabled: true,
-                deviceOverrides: [DeviceKeyOverride(deviceHash: "0xCAFEBABE", output: "lctl")]
+                deviceOverrides: [DeviceKeyOverride(deviceHash: "0xCAFEBABE", output: .keystroke(key: "lctl"))]
             ),
         ]
 

--- a/Tests/KeyPathTests/Infrastructure/DeviceSwitchConfigTests.swift
+++ b/Tests/KeyPathTests/Infrastructure/DeviceSwitchConfigTests.swift
@@ -26,7 +26,7 @@ final class DeviceSwitchConfigTests: XCTestCase {
 
     func testKeyWithDeviceOverrides_EmitsSwitchExpression() {
         let overrides = [
-            DeviceKeyOverride(deviceHash: "0xAAAA0000", output: "x"),
+            DeviceKeyOverride(deviceHash: "0xAAAA0000", output: .keystroke(key: "x")),
         ]
 
         let result = KanataConfiguration.renderDeviceSwitchExpression(
@@ -43,7 +43,7 @@ final class DeviceSwitchConfigTests: XCTestCase {
 
     func testDeviceOverrideWithUnknownHash_SkipsCase() {
         let overrides = [
-            DeviceKeyOverride(deviceHash: "0xDEADBEEF", output: "z"),
+            DeviceKeyOverride(deviceHash: "0xDEADBEEF", output: .keystroke(key: "z")),
         ]
 
         let result = KanataConfiguration.renderDeviceSwitchExpression(
@@ -60,8 +60,8 @@ final class DeviceSwitchConfigTests: XCTestCase {
 
     func testMultipleDeviceOverrides_PreservesInputOrder() {
         let overrides = [
-            DeviceKeyOverride(deviceHash: "0xBBBB1111", output: "y"),
-            DeviceKeyOverride(deviceHash: "0xAAAA0000", output: "x"),
+            DeviceKeyOverride(deviceHash: "0xBBBB1111", output: .keystroke(key: "y")),
+            DeviceKeyOverride(deviceHash: "0xAAAA0000", output: .keystroke(key: "x")),
         ]
 
         let result = KanataConfiguration.renderDeviceSwitchExpression(
@@ -118,7 +118,7 @@ final class DeviceSwitchConfigTests: XCTestCase {
             holdAction: .keystroke(key: "lctl")
         ))
         let overrides = [
-            DeviceKeyOverride(deviceHash: "0xAAAA0000", output: "a", behavior: behavior),
+            DeviceKeyOverride(deviceHash: "0xAAAA0000", output: .keystroke(key: "a"), behavior: behavior),
         ]
 
         let result = KanataConfiguration.renderDeviceSwitchExpression(
@@ -140,7 +140,7 @@ final class DeviceSwitchConfigTests: XCTestCase {
             outputs: ["M-c", "v"]
         ))
         let overrides = [
-            DeviceKeyOverride(deviceHash: "0xBBBB1111", output: "a", behavior: behavior),
+            DeviceKeyOverride(deviceHash: "0xBBBB1111", output: .keystroke(key: "a"), behavior: behavior),
         ]
 
         let result = KanataConfiguration.renderDeviceSwitchExpression(
@@ -160,10 +160,10 @@ final class DeviceSwitchConfigTests: XCTestCase {
         let overrides = [
             DeviceKeyOverride(
                 deviceHash: "0xAAAA0000",
-                output: "esc",
+                output: .keystroke(key: "esc"),
                 behavior: .dualRole(DualRoleBehavior(tapAction: .keystroke(key: "esc"), holdAction: .keystroke(key: "lctl")))
             ),
-            DeviceKeyOverride(deviceHash: "0xBBBB1111", output: "caps"),
+            DeviceKeyOverride(deviceHash: "0xBBBB1111", output: .keystroke(key: "caps")),
         ]
 
         let result = KanataConfiguration.renderDeviceSwitchExpression(
@@ -180,8 +180,8 @@ final class DeviceSwitchConfigTests: XCTestCase {
 
     func testAllOverridesUnresolvable_EmitsOnlyDefault() {
         let overrides = [
-            DeviceKeyOverride(deviceHash: "0xDEAD0001", output: "x"),
-            DeviceKeyOverride(deviceHash: "0xDEAD0002", output: "y"),
+            DeviceKeyOverride(deviceHash: "0xDEAD0001", output: .keystroke(key: "x")),
+            DeviceKeyOverride(deviceHash: "0xDEAD0002", output: .keystroke(key: "y")),
         ]
 
         let result = KanataConfiguration.renderDeviceSwitchExpression(
@@ -206,8 +206,8 @@ final class DeviceSwitchConfigTests: XCTestCase {
             input: "a",
             action: .keystroke(key: "b"),
             deviceOverrides: [
-                DeviceKeyOverride(deviceHash: "0xAAAA0000", output: "x"),
-                DeviceKeyOverride(deviceHash: "0xBBBB1111", output: "y"),
+                DeviceKeyOverride(deviceHash: "0xAAAA0000", output: .keystroke(key: "x")),
+                DeviceKeyOverride(deviceHash: "0xBBBB1111", output: .keystroke(key: "y")),
             ]
         )
 
@@ -239,7 +239,7 @@ final class DeviceSwitchConfigTests: XCTestCase {
             input: "h",
             action: .keystroke(key: "left"),
             deviceOverrides: [
-                DeviceKeyOverride(deviceHash: "0xAAAA0000", output: "home"),
+                DeviceKeyOverride(deviceHash: "0xAAAA0000", output: .keystroke(key: "home")),
             ]
         )
 
@@ -307,7 +307,7 @@ final class DeviceSwitchConfigTests: XCTestCase {
             input: "a",
             action: .keystroke(key: "b"),
             deviceOverrides: [
-                DeviceKeyOverride(deviceHash: "0xAAAA0000", output: "x"),
+                DeviceKeyOverride(deviceHash: "0xAAAA0000", output: .keystroke(key: "x")),
             ]
         )
 
@@ -336,7 +336,7 @@ final class DeviceSwitchConfigTests: XCTestCase {
             input: "a",
             action: .keystroke(key: "b"),
             deviceOverrides: [
-                DeviceKeyOverride(deviceHash: "0xAAAA0000", output: "x"),
+                DeviceKeyOverride(deviceHash: "0xAAAA0000", output: .keystroke(key: "x")),
             ]
         )
 

--- a/Tests/KeyPathTests/Models/CustomRuleDeviceOverrideTests.swift
+++ b/Tests/KeyPathTests/Models/CustomRuleDeviceOverrideTests.swift
@@ -6,7 +6,7 @@ final class CustomRuleDeviceOverrideTests: XCTestCase {
 
     func testAsKeyMappingIncludesDeviceOverrides() {
         let overrides = [
-            DeviceKeyOverride(deviceHash: "0xABCD1234", output: "b", behavior: nil)
+            DeviceKeyOverride(deviceHash: "0xABCD1234", output: .keystroke(key: "b"), behavior: nil)
         ]
         let rule = CustomRule(input: "a", action: .keystroke(key: "a"), deviceOverrides: overrides)
 
@@ -16,7 +16,7 @@ final class CustomRuleDeviceOverrideTests: XCTestCase {
         XCTAssertEqual(mapping.action, .keystroke(key: "a"))
         XCTAssertEqual(mapping.deviceOverrides?.count, 1)
         XCTAssertEqual(mapping.deviceOverrides?.first?.deviceHash, "0xABCD1234")
-        XCTAssertEqual(mapping.deviceOverrides?.first?.output, "b")
+        XCTAssertEqual(mapping.deviceOverrides?.first?.output, .keystroke(key: "b"))
     }
 
     func testAsKeyMappingWithoutDeviceOverridesReturnsNil() {
@@ -35,7 +35,7 @@ final class CustomRuleDeviceOverrideTests: XCTestCase {
             holdTimeout: 200
         )
         let overrides = [
-            DeviceKeyOverride(deviceHash: "0xDEAD", output: "b", behavior: .dualRole(dualRole))
+            DeviceKeyOverride(deviceHash: "0xDEAD", output: .keystroke(key: "b"), behavior: .dualRole(dualRole))
         ]
         let rule = CustomRule(input: "a", action: .keystroke(key: "a"), deviceOverrides: overrides)
 
@@ -54,8 +54,8 @@ final class CustomRuleDeviceOverrideTests: XCTestCase {
     func testCodableRoundTripPreservesDeviceOverrides() throws {
         let fixedDate = Date(timeIntervalSinceReferenceDate: 1000)
         let overrides = [
-            DeviceKeyOverride(deviceHash: "0xABCD1234", output: "b", behavior: nil),
-            DeviceKeyOverride(deviceHash: "0xDEADBEEF", output: "c", behavior: nil)
+            DeviceKeyOverride(deviceHash: "0xABCD1234", output: .keystroke(key: "b"), behavior: nil),
+            DeviceKeyOverride(deviceHash: "0xDEADBEEF", output: .keystroke(key: "c"), behavior: nil)
         ]
         let original = CustomRule(
             id: UUID(),
@@ -73,9 +73,9 @@ final class CustomRuleDeviceOverrideTests: XCTestCase {
         XCTAssertEqual(decoded, original)
         XCTAssertEqual(decoded.deviceOverrides?.count, 2)
         XCTAssertEqual(decoded.deviceOverrides?[0].deviceHash, "0xABCD1234")
-        XCTAssertEqual(decoded.deviceOverrides?[0].output, "b")
+        XCTAssertEqual(decoded.deviceOverrides?[0].output, .keystroke(key: "b"))
         XCTAssertEqual(decoded.deviceOverrides?[1].deviceHash, "0xDEADBEEF")
-        XCTAssertEqual(decoded.deviceOverrides?[1].output, "c")
+        XCTAssertEqual(decoded.deviceOverrides?[1].output, .keystroke(key: "c"))
     }
 
     func testDecodeLegacyJSONWithoutDeviceOverridesDefaultsToNil() throws {
@@ -106,7 +106,7 @@ final class CustomRuleDeviceOverrideTests: XCTestCase {
             holdTimeout: 200
         )
         let overrides = [
-            DeviceKeyOverride(deviceHash: "0xCAFE", output: "b", behavior: .dualRole(dualRole))
+            DeviceKeyOverride(deviceHash: "0xCAFE", output: .keystroke(key: "b"), behavior: .dualRole(dualRole))
         ]
         let original = CustomRule(
             id: UUID(),
@@ -180,14 +180,17 @@ final class CustomRuleDeviceOverrideTests: XCTestCase {
 
     func testDeviceOverrideProducesDeviceSwitchConfig() {
         let overrides = [
-            DeviceKeyOverride(deviceHash: "0xABCD1234", output: "b", behavior: nil)
+            DeviceKeyOverride(deviceHash: "0xABCD1234", output: .keystroke(key: "b"), behavior: nil)
         ]
         let rule = CustomRule(input: "a", action: .keystroke(key: "a"), deviceOverrides: overrides)
         let mapping = rule.asKeyMapping()
 
         // The mapping should have the identity action as default and the override
         XCTAssertEqual(mapping.action, .keystroke(key: "a"))
-        XCTAssertEqual(mapping.deviceOverrides?.first?.output, "b")
+        XCTAssertEqual(mapping.deviceOverrides?.first?.output, .keystroke(key: "b"))
+
+        // The override output should produce valid kanata
+        XCTAssertEqual(mapping.deviceOverrides?.first?.output.kanataOutput, "b")
 
         // Verify config generation produces switch expression
         let device = ConnectedDevice(
@@ -223,7 +226,7 @@ final class CustomRuleDeviceOverrideTests: XCTestCase {
         // User mapped 'a' → 'b' only on the Kinesis
         // Default (Apple) stays identity: a → a
         let overrides = [
-            DeviceKeyOverride(deviceHash: "0xBBBB1111", output: "b", behavior: nil)
+            DeviceKeyOverride(deviceHash: "0xBBBB1111", output: .keystroke(key: "b"), behavior: nil)
         ]
         let rule = CustomRule(input: "a", action: .keystroke(key: "a"), deviceOverrides: overrides)
         let mapping = rule.asKeyMapping()


### PR DESCRIPTION
## Summary

Phase 3a of the action model unification (#346). Changes `DeviceKeyOverride.output` from `String` to `KeyAction`.

- Callers already had typed `KeyAction` values and were converting to strings via `.kanataOutput` to construct overrides — now they pass the `KeyAction` directly
- Device-switch renderer uses `override.output.kanataOutput` instead of `KanataKeyConverter.convertToKanataSequence(override.output)`, and passes the typed action directly when building synthetic mappings for behavior rendering
- All construction sites in MapperViewModel now capture `customRule.action` before overwriting it with identity, eliminating the string round-trip

**7 files changed, all 505 tests pass with identical config output.**

## Test plan

- [x] All 505 existing tests pass (golden tests verify identical kanata config output)
- [x] `CustomRuleDeviceOverrideTests` — model, Codable round-trip, config generation
- [x] `DeviceSwitchConfigTests` — switch expression rendering, behavior overrides, full config snapshots
- [ ] Manual: verify device-scoped mappings work in the mapper UI (if device hardware available)

🤖 Generated with [Claude Code](https://claude.com/claude-code)