### PR TITLE
ci: build kanata fork in CI, fix config validation test

### DIFF
--- a/.github/workflows/cache-warm.yml
+++ b/.github/workflows/cache-warm.yml
@@ -15,9 +15,18 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          submodules: true
 
-      - name: Add Homebrew to PATH
-        run: echo "/opt/homebrew/bin" >> $GITHUB_PATH
+      - name: Add Homebrew and Cargo to PATH
+        run: |
+          echo "/opt/homebrew/bin" >> $GITHUB_PATH
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
-      - name: Build (warms .build cache for PR jobs)
+      - name: Build Swift (warms .build cache for PR jobs)
         run: swift build
+
+      - name: Build kanata fork (warms cargo cache)
+        run: |
+          cd External/kanata
+          cargo build --release --target aarch64-apple-darwin 2>&1 | tail -3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,11 +36,12 @@ jobs:
         echo "/opt/homebrew/bin" >> $GITHUB_PATH
         echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
-    - name: Build kanata fork
+    - name: Build and install kanata fork
       run: |
         cd External/kanata
         cargo build --release --target aarch64-apple-darwin 2>&1 | tail -3
-        ./target/aarch64-apple-darwin/release/kanata --version
+        cp ./target/aarch64-apple-darwin/release/kanata /opt/homebrew/bin/kanata
+        kanata --version
 
     - name: Lint WizardAutoFixer for forbidden subprocess usage
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,12 +28,19 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
+      with:
+        submodules: true
 
-    - name: Add Homebrew to PATH
-      run: echo "/opt/homebrew/bin" >> $GITHUB_PATH
+    - name: Add Homebrew and Cargo to PATH
+      run: |
+        echo "/opt/homebrew/bin" >> $GITHUB_PATH
+        echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
-    - name: Verify Kanata available
-      run: kanata --version
+    - name: Build kanata fork
+      run: |
+        cd External/kanata
+        cargo build --release --target aarch64-apple-darwin 2>&1 | tail -3
+        ./target/aarch64-apple-darwin/release/kanata --version
 
     - name: Lint WizardAutoFixer for forbidden subprocess usage
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,9 @@ jobs:
         cargo build --release --target aarch64-apple-darwin 2>&1 | tail -3
         cp ./target/aarch64-apple-darwin/release/kanata /opt/homebrew/bin/kanata
         kanata --version
+        cargo build --release --target aarch64-apple-darwin -p kanata-sim 2>&1 | tail -3
+        cp ./target/aarch64-apple-darwin/release/kanata_simulated_input /opt/homebrew/bin/kanata-simulator
+        kanata-simulator --version
 
     - name: Lint WizardAutoFixer for forbidden subprocess usage
       run: |
@@ -52,6 +55,7 @@ jobs:
     - name: Build and Run All Tests
       env:
         KP_SIGN_DRY_RUN: "1"
+        KEYPATH_BUNDLED_SIMULATOR_OVERRIDE: /opt/homebrew/bin/kanata-simulator
       run: |
         echo "Building and running full test suite..."
         export CI_ENVIRONMENT=true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: true
+        persist-credentials: false
 
     - name: Add Homebrew and Cargo to PATH
       run: |
@@ -158,6 +159,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
+        persist-credentials: false
 
     - name: Add Homebrew to PATH
       run: echo "/opt/homebrew/bin" >> $GITHUB_PATH

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,11 @@ jobs:
       COVERAGE_TOLERANCE_PERCENT: "0.01"
 
     steps:
+    - name: Clean stale git credentials
+      run: |
+        git config --global --unset-all http.https://github.com/.extraheader 2>/dev/null || true
+        git config --global --unset-all url.https://github.com/.insteadof 2>/dev/null || true
+
     - name: Checkout code
       uses: actions/checkout@v4
       with:
@@ -159,6 +164,11 @@ jobs:
     timeout-minutes: 5
 
     steps:
+    - name: Clean stale git credentials
+      run: |
+        git config --global --unset-all http.https://github.com/.extraheader 2>/dev/null || true
+        git config --global --unset-all url.https://github.com/.insteadof 2>/dev/null || true
+
     - name: Checkout code
       uses: actions/checkout@v4
       with:

--- a/Scripts/run-tests-safe.sh
+++ b/Scripts/run-tests-safe.sh
@@ -108,10 +108,6 @@ FAIL_COUNT=$(grep -cE "Test Case '.*' failed|Test .* failed after" "$LOG" 2>/dev
 FAIL_COUNT=${FAIL_COUNT:-0}
 PASS_COUNT=$(grep -cE "Test Case '.*' passed|Test .* passed after" "$LOG" 2>/dev/null || true)
 PASS_COUNT=${PASS_COUNT:-0}
-# XCTest distinguishes "expected" vs "unexpected" failures. Only unexpected failures
-# should block CI (expected failures are tests marked with XCTExpectFailure or similar).
-UNEXPECTED_COUNT=$(grep -oE "[0-9]+ unexpected" "$LOG" 2>/dev/null | awk '{s+=$1} END {print s+0}')
-UNEXPECTED_COUNT=${UNEXPECTED_COUNT:-0}
 IS_SIGNAL_CRASH=false
 if [ "$EXIT_CODE" -gt 128 ] 2>/dev/null; then
   IS_SIGNAL_CRASH=true
@@ -134,24 +130,17 @@ if [ "$IS_SIGNAL_CRASH" = true ]; then
   echo "⚠️  Test runner crashed with signal $SIGNAL_NUM (exit $EXIT_CODE)"
   echo "   Passed: $PASS_COUNT | Failed: $FAIL_COUNT"
 
-  if [ "$UNEXPECTED_COUNT" -le 1 ] && [ "$PASS_COUNT" -gt 0 ]; then
-    # At most 1 unexpected failure (the interrupted test) + many passes = runner crash, not test failure
+  if [ "$FAIL_COUNT" -le 1 ] && [ "$PASS_COUNT" -gt 0 ]; then
     echo "✅ Tests passed (ignoring runner crash — $PASS_COUNT passed, $FAIL_COUNT interrupted by crash)"
     exit 0
   fi
 fi
 
-# Check for real (unexpected) test failures
-if [ "$UNEXPECTED_COUNT" -gt 0 ]; then
-  echo "❌ $UNEXPECTED_COUNT unexpected test failure(s) ($PASS_COUNT passed, $FAIL_COUNT total failed)"
+# Check for real test failures
+if [ "$FAIL_COUNT" -gt 0 ]; then
+  echo "❌ $FAIL_COUNT test(s) failed ($PASS_COUNT passed)"
   grep -E "Test Case '.*' failed|Test .* failed after" "$LOG" || true
   exit 1
-fi
-
-# Expected failures only — not a CI blocker
-if [ "$FAIL_COUNT" -gt 0 ] && [ "$UNEXPECTED_COUNT" -eq 0 ]; then
-  echo "✅ Tests passed ($PASS_COUNT passed, $FAIL_COUNT expected failure(s))"
-  exit 0
 fi
 
 # Non-zero exit but no failures found — check for any passing output

--- a/Tests/KeyPathTests/CLI/CLISimulateTests.swift
+++ b/Tests/KeyPathTests/CLI/CLISimulateTests.swift
@@ -197,13 +197,27 @@ final class CLISimulateIntegrationTests: XCTestCase {
     private let facade = CLIFacade()
 
     private func requireSimulatorPath() throws -> String {
+        let which = Process()
+        which.executableURL = URL(fileURLWithPath: "/usr/bin/which")
+        which.arguments = ["kanata-simulator"]
+        let pipe = Pipe()
+        which.standardOutput = pipe
+        try? which.run()
+        which.waitUntilExit()
+        if which.terminationStatus == 0 {
+            let path = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
+                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            if !path.isEmpty { return path }
+        }
+
         let candidates = [
+            "/opt/homebrew/bin/kanata-simulator",
             "/Applications/KeyPath.app/Contents/Library/KeyPath/kanata-simulator",
             URL(fileURLWithPath: #filePath)
-                .deletingLastPathComponent() // CLI/
-                .deletingLastPathComponent() // KeyPathTests/
-                .deletingLastPathComponent() // Tests/
-                .deletingLastPathComponent() // project root
+                .deletingLastPathComponent()
+                .deletingLastPathComponent()
+                .deletingLastPathComponent()
+                .deletingLastPathComponent()
                 .appendingPathComponent("build/kanata-simulator").path,
         ]
         if let path = candidates.first(where: { FileManager.default.fileExists(atPath: $0) }) {

--- a/Tests/KeyPathTests/Services/ConfigurationServiceTests.swift
+++ b/Tests/KeyPathTests/Services/ConfigurationServiceTests.swift
@@ -1301,19 +1301,14 @@ class ConfigurationServiceTests: XCTestCase {
             .deletingLastPathComponent() // Tests/
             .deletingLastPathComponent() // project root
 
-        // Candidate locations in priority order
+        // Candidate locations in priority order (fork build first — it has the latest syntax support)
         let candidates = [
-            // Local dev build (Kanata Engine.app bundle)
-            projectRoot.appendingPathComponent("dist/KeyPath.app/Contents/Library/KeyPath/Kanata Engine.app/Contents/MacOS/kanata").path,
-            // Local dev build (backward-compat symlink)
-            projectRoot.appendingPathComponent("dist/KeyPath.app/Contents/Library/KeyPath/kanata").path,
-            // Installed app (Kanata Engine.app bundle)
-            "/Applications/KeyPath.app/Contents/Library/KeyPath/Kanata Engine.app/Contents/MacOS/kanata",
-            // Installed app (backward-compat symlink)
-            "/Applications/KeyPath.app/Contents/Library/KeyPath/kanata",
-            // External kanata build (for CI or fresh clones)
             projectRoot.appendingPathComponent("External/kanata/target/aarch64-apple-darwin/release/kanata").path,
-            projectRoot.appendingPathComponent("External/kanata/target/release/kanata").path
+            projectRoot.appendingPathComponent("External/kanata/target/release/kanata").path,
+            projectRoot.appendingPathComponent("dist/KeyPath.app/Contents/Library/KeyPath/Kanata Engine.app/Contents/MacOS/kanata").path,
+            projectRoot.appendingPathComponent("dist/KeyPath.app/Contents/Library/KeyPath/kanata").path,
+            "/Applications/KeyPath.app/Contents/Library/KeyPath/Kanata Engine.app/Contents/MacOS/kanata",
+            "/Applications/KeyPath.app/Contents/Library/KeyPath/kanata",
         ]
 
         for candidate in candidates {

--- a/Tests/KeyPathTests/Services/ConfigurationServiceTests.swift
+++ b/Tests/KeyPathTests/Services/ConfigurationServiceTests.swift
@@ -1312,7 +1312,9 @@ class ConfigurationServiceTests: XCTestCase {
         ]
 
         for candidate in candidates {
-            if FileManager.default.isExecutableFile(atPath: candidate) {
+            let exists = FileManager.default.isExecutableFile(atPath: candidate)
+            print("[findKanataBinary] \(exists ? "✅" : "❌") \(candidate)")
+            if exists {
                 return candidate
             }
         }

--- a/Tests/KeyPathTests/Services/ConfigurationServiceTests.swift
+++ b/Tests/KeyPathTests/Services/ConfigurationServiceTests.swift
@@ -1292,37 +1292,36 @@ class ConfigurationServiceTests: XCTestCase {
 
     /// Find the kanata binary, checking multiple locations
     private func findKanataBinary() throws -> String {
-        // Get project root from this test file's location
-        // #file = .../Tests/KeyPathTests/Services/ConfigurationServiceTests.swift
-        let testFile = URL(fileURLWithPath: #file)
-        let projectRoot = testFile
-            .deletingLastPathComponent() // Services/
-            .deletingLastPathComponent() // KeyPathTests/
-            .deletingLastPathComponent() // Tests/
-            .deletingLastPathComponent() // project root
+        // Use Process to find kanata in PATH (includes /opt/homebrew/bin where CI installs the fork)
+        let which = Process()
+        which.executableURL = URL(fileURLWithPath: "/usr/bin/which")
+        which.arguments = ["kanata"]
+        let pipe = Pipe()
+        which.standardOutput = pipe
+        try? which.run()
+        which.waitUntilExit()
+        if which.terminationStatus == 0 {
+            let path = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
+                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            if !path.isEmpty {
+                return path
+            }
+        }
 
-        // Candidate locations in priority order (fork build first — it has the latest syntax support)
+        // Fallback to well-known locations
         let candidates = [
-            projectRoot.appendingPathComponent("External/kanata/target/aarch64-apple-darwin/release/kanata").path,
-            projectRoot.appendingPathComponent("External/kanata/target/release/kanata").path,
-            projectRoot.appendingPathComponent("dist/KeyPath.app/Contents/Library/KeyPath/Kanata Engine.app/Contents/MacOS/kanata").path,
-            projectRoot.appendingPathComponent("dist/KeyPath.app/Contents/Library/KeyPath/kanata").path,
+            "/opt/homebrew/bin/kanata",
             "/Applications/KeyPath.app/Contents/Library/KeyPath/Kanata Engine.app/Contents/MacOS/kanata",
             "/Applications/KeyPath.app/Contents/Library/KeyPath/kanata",
         ]
 
         for candidate in candidates {
-            let exists = FileManager.default.isExecutableFile(atPath: candidate)
-            print("[findKanataBinary] \(exists ? "✅" : "❌") \(candidate)")
-            if exists {
+            if FileManager.default.isExecutableFile(atPath: candidate) {
                 return candidate
             }
         }
 
-        throw XCTSkip("""
-        Kanata binary not found - skipping real validation test.
-        Searched: \(candidates.joined(separator: ", "))
-        """)
+        throw XCTSkip("Kanata binary not found in PATH or known locations")
     }
 
     private func validateCatalogConfig(withBinary kanataBinary: String) async throws {


### PR DESCRIPTION
## Summary
- Build the kanata fork (`External/kanata` submodule) in CI so `testDefaultCatalogGeneratesValidKanataConfig` validates against the correct kanata version
- Root cause: test was finding old kanata v1.10.0 in `/Applications/KeyPath.app` instead of our fork (v1.12.0-prerelease-2)
- Also warms cargo cache on push to master via `cache-warm.yml`
- Installed fork binary on Mini, removed old Homebrew v1.11.0

## Test plan
- [ ] CI `build-and-test` passes — the previously-expected-failing `testDefaultCatalogGeneratesValidKanataConfig` should now pass
- [ ] `kanata --version` in CI shows v1.12.0-prerelease-2

🤖 Generated with [Claude Code](https://claude.com/claude-code)