### PR TITLE
Localize System keymap fallback, simplify startup mode (#295, #287)

### DIFF
--- a/Sources/KeyPathAppKit/Core/CompositionRoot.swift
+++ b/Sources/KeyPathAppKit/Core/CompositionRoot.swift
@@ -41,10 +41,11 @@ enum CompositionRoot {
         // Verify running process signature matches installed bundle (catches failed restarts)
         SignatureHealthCheck.verifySignatureConsistency()
 
-        // Set startup mode to prevent blocking operations during app launch (in-memory flag)
-        FeatureFlags.shared.activateStartupMode(timeoutSeconds: 5.0)
+        // Set startup mode to prevent blocking operations during app launch (in-memory flag).
+        // Cleared explicitly by MainAppStateController once services are ready.
+        FeatureFlags.shared.activateStartupMode()
         AppLogger.shared.log(
-            "🔍 [App] Startup mode set (auto-clear in 5s) - IOHIDCheckAccess calls will be skipped"
+            "🔍 [App] Startup mode set - cleared when services are ready"
         )
 
         // Phase 4: MVVM - Initialize services and RuntimeCoordinator via composition root

--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayInspectorPanel+Keymaps.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayInspectorPanel+Keymaps.swift
@@ -30,7 +30,7 @@ private struct SystemKeymapCard: View {
     }
 
     private var subtitle: String {
-        inputSourceName.isEmpty ? "Current Input Source" : inputSourceName
+        inputSourceName.isEmpty ? String(localized: "Current Input Source") : inputSourceName
     }
 
     var body: some View {

--- a/Sources/KeyPathCore/FeatureFlags.swift
+++ b/Sources/KeyPathCore/FeatureFlags.swift
@@ -27,16 +27,10 @@ public final class FeatureFlags {
         return stateQueue.sync { _startupModeActive }
     }
 
-    /// Activate startup mode, optionally auto-deactivating after a timeout.
-    public func activateStartupMode(timeoutSeconds: Double = 5.0) {
+    /// Activate startup mode. Deactivated explicitly by MainAppStateController
+    /// once services are ready — no auto-timeout.
+    public func activateStartupMode() {
         stateQueue.sync { _startupModeActive = true }
-        if timeoutSeconds > 0 {
-            Task { @MainActor [weak self] in
-                try? await Task.sleep(for: .seconds(timeoutSeconds))
-                guard let self, startupModeActive else { return }
-                deactivateStartupMode()
-            }
-        }
     }
 
     /// Deactivate startup mode.


### PR DESCRIPTION
## Summary
- **#295**: Localize "Current Input Source" fallback string in System keymap card using `String(localized:)`
- **#287**: Remove fragile 5-second `Task.sleep` auto-timeout from startup mode. `MainAppStateController` already deactivates it explicitly when services are ready — the timer was redundant and could fire at unexpected times

## Test plan
- [x] `swift build` — clean
- [x] `swift test` — all tests pass (zero failures)
- [ ] Manual: verify System keymap card shows input source name (or localized fallback)
- [ ] Manual: verify app startup completes and startup mode is cleared

Closes #295
Closes #287

🤖 Generated with [Claude Code](https://claude.com/claude-code)