### PR TITLE
feat: Ben Vallack Approach system pack

### DIFF
--- a/Sources/KeyPathAppKit/Models/HomeRowLayerTogglesConfig.swift
+++ b/Sources/KeyPathAppKit/Models/HomeRowLayerTogglesConfig.swift
@@ -96,6 +96,11 @@ public struct HomeRowLayerTogglesConfig: Codable, Equatable, Sendable {
         "j": "nav", "k": "sym", "l": "num", ";": "fun"
     ]
 
+    /// Vallack system: index fingers hold for nav layer (mirrored)
+    public static let vallackLayerAssignments: [String: String] = [
+        "f": "vallack-nav", "j": "vallack-nav"
+    ]
+
     /// Left hand keys
     public static let leftHandKeys = ["a", "s", "d", "f"]
 

--- a/Sources/KeyPathAppKit/Models/HomeRowModsConfig.swift
+++ b/Sources/KeyPathAppKit/Models/HomeRowModsConfig.swift
@@ -115,6 +115,16 @@ public struct HomeRowModsConfig: Codable, Equatable, Sendable {
         "j": "rsft", "k": "rctl", "l": "ralt", ";": "rmet"
     ]
 
+    /// Vallack two-row split: OS modifiers on the top row, freeing the home row for layer toggles.
+    /// Pinkies get 300ms tap window (slower fingers), others 200ms.
+    public static let vallackTwoRowSplit: [String: String] = [
+        "q": "lctl", "w": "lalt", "e": "lmet",
+        "u": "rmet", "i": "ralt", "o": "rctl"
+    ]
+
+    /// Top row keys used by the Vallack two-row split
+    public static let vallackTopRowKeys = ["q", "w", "e", "u", "i", "o"]
+
     /// Default layer assignments (community standard mirror setup)
     public static let defaultLayerAssignments: [String: String] = [
         "a": "fun", "s": "num", "d": "sym", "f": "nav",

--- a/Sources/KeyPathAppKit/Models/RuleCollectionModels.swift
+++ b/Sources/KeyPathAppKit/Models/RuleCollectionModels.swift
@@ -370,6 +370,7 @@ public enum RuleCollectionIdentifier {
     public static let autoShiftSymbols = UUID(uuidString: "D1E2F3A4-B5C6-7D8E-9F0A-1B2C3D4E5F6A")!
     public static let missionControl = UUID(uuidString: "C3A5E2F1-8D4B-4C9A-A1E7-5F3D9B2C8A6E")!
     public static let keyRepeatControl = UUID(uuidString: "E4F6A8B0-2C3D-5E7F-9A1B-4D6E8F0A2C4E")!
+    public static let vallackNavigation = UUID(uuidString: "F2A4B6C8-1D3E-5F7A-9B0C-2D4E6F8A0B2C")!
 }
 
 public enum RuleCollectionLayer: Codable, Equatable, Sendable, Hashable {

--- a/Sources/KeyPathAppKit/Services/Configuration/PreferencesService.swift
+++ b/Sources/KeyPathAppKit/Services/Configuration/PreferencesService.swift
@@ -398,7 +398,7 @@ final class PreferencesService: @unchecked Sendable {
         #endif
         static let keyLabelStyle = KeyLabelStyle.symbols
         static let accessibilityTestMode = false
-        static let contextHUDDisplayMode = ContextHUDDisplayMode.both
+        static let contextHUDDisplayMode = ContextHUDDisplayMode.overlayOnly
         static let contextHUDTriggerMode = ContextHUDTriggerMode.holdToShow
         static let contextHUDTimeout: TimeInterval = 3.0
         static let contextHUDHoldDelayPreset = ContextHUDHoldDelayPreset.long

--- a/Sources/KeyPathAppKit/Services/Packs/PackInstaller.swift
+++ b/Sources/KeyPathAppKit/Services/Packs/PackInstaller.swift
@@ -89,6 +89,8 @@ public final class PackInstaller {
         }
 
         // System packs batch all collection changes into a single config regen.
+        // TODO: When a second system pack is added, replace ID matching with
+        // a Pack.systemConfig property that the installer dispatches on generically.
         if pack.id == PackRegistry.vallackSystem.id {
             try await applyVallackSystemConfigs(manager: manager)
             let record = InstalledPackRecord(
@@ -479,8 +481,6 @@ public final class PackInstaller {
             homeRowLayerTogglesConfig: togglesCollection?.configuration.homeRowLayerTogglesConfig,
             homeRowLayerTogglesEnabled: togglesCollection?.isEnabled ?? false
         )
-        let data = try JSONEncoder().encode(snapshot)
-        try data.write(to: vallackSnapshotURL, options: .atomic)
 
         let vallackMods = HomeRowModsConfig(
             enabledKeys: Set(HomeRowModsConfig.vallackTopRowKeys),
@@ -516,6 +516,9 @@ public final class PackInstaller {
             manager.ruleCollections[i].isEnabled = true
         }
 
+        let snapshotData = try JSONEncoder().encode(snapshot)
+        try snapshotData.write(to: vallackSnapshotURL, options: .atomic)
+
         await manager.regenerateConfigFromCollections()
         AppLogger.shared.log("📦 [PackInstaller] Applied Vallack system configs (two-row mods + nav toggles)")
     }
@@ -546,7 +549,6 @@ public final class PackInstaller {
             manager.ruleCollections[i].isEnabled = snapshot.homeRowLayerTogglesEnabled
         }
 
-        await manager.regenerateConfigFromCollections()
         try? FileManager.default.removeItem(at: vallackSnapshotURL)
         AppLogger.shared.log("📦 [PackInstaller] Reverted Vallack system configs from snapshot")
     }

--- a/Sources/KeyPathAppKit/Services/Packs/PackInstaller.swift
+++ b/Sources/KeyPathAppKit/Services/Packs/PackInstaller.swift
@@ -88,6 +88,22 @@ public final class PackInstaller {
             return record
         }
 
+        // System packs batch all collection changes into a single config regen.
+        if pack.id == PackRegistry.vallackSystem.id {
+            try await applyVallackSystemConfigs(manager: manager)
+            let record = InstalledPackRecord(
+                packID: pack.id,
+                version: pack.version,
+                installedAt: Date(),
+                quickSettingValues: resolvedSettings
+            )
+            try await InstalledPackTracker.shared.upsert(record)
+            AppLogger.shared.log(
+                "✅ [PackInstaller] Installed system pack '\(pack.name)'"
+            )
+            return record
+        }
+
         // Collection-backed packs (e.g. Home Row Mods) don't generate custom
         // rules — they just toggle the built-in RuleCollection on.
         if let collectionID = pack.associatedCollectionID {
@@ -95,6 +111,7 @@ public final class PackInstaller {
             if !ok {
                 throw InstallError.saveFailed("could not enable associated rule collection")
             }
+
             let record = InstalledPackRecord(
                 packID: pack.id,
                 version: pack.version,
@@ -164,6 +181,22 @@ public final class PackInstaller {
             return
         }
 
+        // System packs batch all collection changes into a single config regen.
+        if packID == PackRegistry.vallackSystem.id {
+            await revertVallackSystemConfigs(manager: manager)
+            if let collectionID = PackRegistry.vallackSystem.associatedCollectionID,
+               let i = manager.ruleCollections.firstIndex(where: { $0.id == collectionID })
+            {
+                manager.ruleCollections[i].isEnabled = false
+            }
+            await manager.regenerateConfigFromCollections()
+            try await InstalledPackTracker.shared.remove(packID: packID)
+            AppLogger.shared.log(
+                "✅ [PackInstaller] Uninstalled system pack '\(packID)'"
+            )
+            return
+        }
+
         // Collection-backed packs uninstall by disabling the associated
         // built-in collection; they don't have their own CustomRules to
         // remove.
@@ -172,9 +205,6 @@ public final class PackInstaller {
         {
             let ok = await manager.toggleCollection(id: collectionID, isEnabled: false)
             guard ok else {
-                // Leave the tracker record alone — the collection is still
-                // enabled, so the pack is still effectively installed. Surface
-                // the failure so the UI rolls its toggle back to "on".
                 throw InstallError.saveFailed("could not disable associated rule collection")
             }
             try await InstalledPackTracker.shared.remove(packID: packID)
@@ -419,6 +449,112 @@ public final class PackInstaller {
         switch kind {
         case let .slider(_, minValue, maxValue, _, _):
             return min(max(value, minValue), maxValue)
+        }
+    }
+
+    // MARK: - Vallack System Config
+
+    private struct VallackConfigSnapshot: Codable {
+        var homeRowModsConfig: HomeRowModsConfig?
+        var homeRowModsEnabled: Bool
+        var homeRowLayerTogglesConfig: HomeRowLayerTogglesConfig?
+        var homeRowLayerTogglesEnabled: Bool
+    }
+
+    private var vallackSnapshotURL: URL {
+        let home = FileManager.default.homeDirectoryForCurrentUser
+        return home
+            .appendingPathComponent(".config", isDirectory: true)
+            .appendingPathComponent("keypath", isDirectory: true)
+            .appendingPathComponent("vallack-system-snapshot.json")
+    }
+
+    private func applyVallackSystemConfigs(manager: RuleCollectionsManager) async throws {
+        let modsCollection = manager.ruleCollections.first { $0.id == RuleCollectionIdentifier.homeRowMods }
+        let togglesCollection = manager.ruleCollections.first { $0.id == RuleCollectionIdentifier.homeRowLayerToggles }
+
+        let snapshot = VallackConfigSnapshot(
+            homeRowModsConfig: modsCollection?.configuration.homeRowModsConfig,
+            homeRowModsEnabled: modsCollection?.isEnabled ?? false,
+            homeRowLayerTogglesConfig: togglesCollection?.configuration.homeRowLayerTogglesConfig,
+            homeRowLayerTogglesEnabled: togglesCollection?.isEnabled ?? false
+        )
+        let data = try JSONEncoder().encode(snapshot)
+        try data.write(to: vallackSnapshotURL, options: .atomic)
+
+        let vallackMods = HomeRowModsConfig(
+            enabledKeys: Set(HomeRowModsConfig.vallackTopRowKeys),
+            modifierAssignments: HomeRowModsConfig.vallackTwoRowSplit,
+            holdMode: .modifiers,
+            hasUserSelectedHoldMode: true,
+            timing: TimingConfig(tapWindow: 200, holdDelay: 150, tapOffsets: ["q": 100, "o": 100]),
+            keySelection: .custom,
+            oppositeHandMode: .press
+        )
+        let vallackToggles = HomeRowLayerTogglesConfig(
+            enabledKeys: Set(["f", "j"]),
+            layerAssignments: HomeRowLayerTogglesConfig.vallackLayerAssignments,
+            keySelection: .custom,
+            toggleMode: .whileHeld,
+            oppositeHandMode: .press
+        )
+
+        let catalog = RuleCollectionCatalog().defaultCollections()
+        ensureCollectionExists(id: RuleCollectionIdentifier.vallackNavigation, catalog: catalog, manager: manager)
+        ensureCollectionExists(id: RuleCollectionIdentifier.homeRowMods, catalog: catalog, manager: manager)
+        ensureCollectionExists(id: RuleCollectionIdentifier.homeRowLayerToggles, catalog: catalog, manager: manager)
+
+        if let i = manager.ruleCollections.firstIndex(where: { $0.id == RuleCollectionIdentifier.vallackNavigation }) {
+            manager.ruleCollections[i].isEnabled = true
+        }
+        if let i = manager.ruleCollections.firstIndex(where: { $0.id == RuleCollectionIdentifier.homeRowMods }) {
+            manager.ruleCollections[i].configuration.updateHomeRowModsConfig(vallackMods)
+            manager.ruleCollections[i].isEnabled = true
+        }
+        if let i = manager.ruleCollections.firstIndex(where: { $0.id == RuleCollectionIdentifier.homeRowLayerToggles }) {
+            manager.ruleCollections[i].configuration.updateHomeRowLayerTogglesConfig(vallackToggles)
+            manager.ruleCollections[i].isEnabled = true
+        }
+
+        await manager.regenerateConfigFromCollections()
+        AppLogger.shared.log("📦 [PackInstaller] Applied Vallack system configs (two-row mods + nav toggles)")
+    }
+
+    private func revertVallackSystemConfigs(manager: RuleCollectionsManager) async {
+        guard let data = try? Data(contentsOf: vallackSnapshotURL),
+              let snapshot = try? JSONDecoder().decode(VallackConfigSnapshot.self, from: data)
+        else {
+            AppLogger.shared.log("⚠️ [PackInstaller] No Vallack config snapshot found — skipping revert")
+            return
+        }
+
+        if let config = snapshot.homeRowModsConfig,
+           let i = manager.ruleCollections.firstIndex(where: { $0.id == RuleCollectionIdentifier.homeRowMods })
+        {
+            manager.ruleCollections[i].configuration.updateHomeRowModsConfig(config)
+            manager.ruleCollections[i].isEnabled = snapshot.homeRowModsEnabled
+        } else if let i = manager.ruleCollections.firstIndex(where: { $0.id == RuleCollectionIdentifier.homeRowMods }) {
+            manager.ruleCollections[i].isEnabled = snapshot.homeRowModsEnabled
+        }
+
+        if let config = snapshot.homeRowLayerTogglesConfig,
+           let i = manager.ruleCollections.firstIndex(where: { $0.id == RuleCollectionIdentifier.homeRowLayerToggles })
+        {
+            manager.ruleCollections[i].configuration.updateHomeRowLayerTogglesConfig(config)
+            manager.ruleCollections[i].isEnabled = snapshot.homeRowLayerTogglesEnabled
+        } else if let i = manager.ruleCollections.firstIndex(where: { $0.id == RuleCollectionIdentifier.homeRowLayerToggles }) {
+            manager.ruleCollections[i].isEnabled = snapshot.homeRowLayerTogglesEnabled
+        }
+
+        await manager.regenerateConfigFromCollections()
+        try? FileManager.default.removeItem(at: vallackSnapshotURL)
+        AppLogger.shared.log("📦 [PackInstaller] Reverted Vallack system configs from snapshot")
+    }
+
+    private func ensureCollectionExists(id: UUID, catalog: [RuleCollection], manager: RuleCollectionsManager) {
+        guard !manager.ruleCollections.contains(where: { $0.id == id }) else { return }
+        if let catalogCollection = catalog.first(where: { $0.id == id }) {
+            manager.ruleCollections.append(catalogCollection)
         }
     }
 

--- a/Sources/KeyPathAppKit/Services/Packs/PackRegistry.swift
+++ b/Sources/KeyPathAppKit/Services/Packs/PackRegistry.swift
@@ -25,6 +25,7 @@ public enum PackRegistry {
         leaderKey,
         keyRepeatControl,
         chordGroups,
+        vallackSystem,
         kindaVim
     ]
 
@@ -545,6 +546,23 @@ public enum PackRegistry {
         quickSettings: [],
         bindings: [],
         associatedCollectionID: RuleCollectionIdentifier.keyRepeatControl
+    )
+
+    // MARK: - Pack: Vallack System
+
+    public static let vallackSystem = Pack(
+        id: "com.keypath.pack.vallack-system",
+        version: "1.0.0",
+        name: "Ben Vallack Approach",
+        tagline: "Your fingers stay put, the keyboard changes",
+        shortDescription:
+            "Navigate, copy, paste, and switch tabs without your fingers leaving the home row. Inspired by [Ben Vallack](https://www.youtube.com/@BenVallacksKeyboards) — hold an index finger to transform your keyboard into a navigation surface, with modifiers on the top row so nothing competes for space.",
+        longDescription: "",
+        category: "Navigation",
+        iconSymbol: "rectangle.stack.badge.play",
+        quickSettings: [],
+        bindings: [],
+        associatedCollectionID: RuleCollectionIdentifier.vallackNavigation
     )
 
     // MARK: - Pack 16: KindaVim (visual-only companion)

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionCatalog.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionCatalog.swift
@@ -62,6 +62,7 @@ struct RuleCollectionCatalog {
             escapeRemap,
             deleteRemap,
             homeRowMods,
+            homeRowLayerToggles,
             chordGroups,
             sequences,
             numpadLayer,
@@ -69,6 +70,7 @@ struct RuleCollectionCatalog {
             funLayer,
             autoShiftSymbols,
             keyRepeatControl,
+            vallackNavigation,
             launcher
         ]
     }
@@ -965,6 +967,46 @@ struct RuleCollectionCatalog {
             icon: "hare",
             tags: ["fast", "navigation", "arrows", "repeat", "speed"],
             configuration: .keyRepeatControl(config)
+        )
+    }
+
+    // MARK: - Vallack Navigation
+
+    private var vallackNavigation: RuleCollection {
+        RuleCollection(
+            id: RuleCollectionIdentifier.vallackNavigation,
+            name: "Ben Vallack Approach",
+            summary: "Hold F or J for arrows, clipboard, tab switching, and line navigation — fingers never leave the home row.",
+            category: .navigation,
+            mappings: [
+                // Right hand — navigation
+                KeyMapping(input: "h", action: .keystroke(key: "left"), description: "Left"),
+                KeyMapping(input: "j", action: .keystroke(key: "down"), description: "Down"),
+                KeyMapping(input: "k", action: .keystroke(key: "up"), description: "Up"),
+                KeyMapping(input: "l", action: .keystroke(key: "right"), description: "Right"),
+                KeyMapping(input: "u", action: .keystroke(key: "bspc"), description: "Backspace"),
+                KeyMapping(input: "i", action: .keystroke(key: "ret"), description: "Enter"),
+                KeyMapping(input: "y", action: .keystroke(key: "M-c"), description: "Copy"),
+                KeyMapping(input: ";", action: .keystroke(key: "M-v"), description: "Paste"),
+                // Left hand — switching and editing
+                KeyMapping(input: "q", action: .keystroke(key: "tab"), description: "Tab", sectionBreak: true),
+                KeyMapping(input: "w", action: .keystroke(key: "esc"), description: "Escape"),
+                KeyMapping(input: "e", action: .keystroke(key: "C-S-tab"), description: "Previous Tab"),
+                KeyMapping(input: "r", action: .keystroke(key: "C-tab"), description: "Next Tab"),
+                KeyMapping(input: "a", action: .keystroke(key: "M-tab"), description: "App Switcher"),
+                KeyMapping(input: "s", action: .keystroke(key: "home"), description: "Line Start"),
+                KeyMapping(input: "d", action: .keystroke(key: "end"), description: "Line End"),
+                KeyMapping(input: "g", action: .keystroke(key: "C-M-S-4"), description: "Screenshot"),
+                KeyMapping(input: "t", action: .keystroke(key: "M-["), description: "Browser Back"),
+                KeyMapping(input: "v", action: .keystroke(key: "M-]"), description: "Browser Forward")
+            ],
+            isEnabled: false,
+            isSystemDefault: false,
+            icon: "rectangle.stack.badge.play",
+            tags: ["vallack", "navigation", "arrows", "home row", "system"],
+            targetLayer: .custom("vallack-nav"),
+            activationHint: "Hold F or J to enter navigation layer",
+            configuration: .table
         )
     }
 

--- a/Sources/KeyPathAppKit/UI/Components/OutputActionTypes.swift
+++ b/Sources/KeyPathAppKit/UI/Components/OutputActionTypes.swift
@@ -6,12 +6,23 @@ struct OutputActionGroup: Identifiable {
     var id: String { title }
 }
 
+private let clipboardIDs: Set<String> = ["cut", "copy", "paste", "undo", "redo", "select-all", "save", "find"]
+private let cursorIDs: Set<String> = ["word-left", "word-right", "line-start", "line-end"]
+private let deletionIDs: Set<String> = ["delete-word", "kill-line", "forward-delete"]
+private let selectionIDs: Set<String> = ["select-word-left", "select-word-right", "select-to-line-start", "select-to-line-end"]
+private let tabWindowIDs: Set<String> = ["prev-tab", "next-tab", "app-switcher", "window-switcher", "close-tab"]
+private let systemExtraIDs: Set<String> = ["screenshot"]
+
 enum OutputActionGrouping {
     static var detailed: [OutputActionGroup] {
         let all = SystemActionInfo.allActions
         return [
-            OutputActionGroup(title: "Editing", actions: all.filter(\.isEditingShortcut)),
-            OutputActionGroup(title: "System", actions: all.filter(\.isSystemAction)),
+            OutputActionGroup(title: "Clipboard", actions: all.filter { clipboardIDs.contains($0.id) }),
+            OutputActionGroup(title: "Cursor Movement", actions: all.filter { cursorIDs.contains($0.id) }),
+            OutputActionGroup(title: "Selection", actions: all.filter { selectionIDs.contains($0.id) }),
+            OutputActionGroup(title: "Deletion", actions: all.filter { deletionIDs.contains($0.id) }),
+            OutputActionGroup(title: "Tab / Window", actions: all.filter { tabWindowIDs.contains($0.id) }),
+            OutputActionGroup(title: "System", actions: all.filter { $0.isSystemAction || systemExtraIDs.contains($0.id) }),
             OutputActionGroup(title: "Playback", actions: all.filter {
                 ["play-pause", "next-track", "prev-track"].contains($0.id)
             }),

--- a/Sources/KeyPathAppKit/UI/Components/OutputActionTypes.swift
+++ b/Sources/KeyPathAppKit/UI/Components/OutputActionTypes.swift
@@ -12,6 +12,16 @@ private let deletionIDs: Set<String> = ["delete-word", "kill-line", "forward-del
 private let selectionIDs: Set<String> = ["select-word-left", "select-word-right", "select-to-line-start", "select-to-line-end"]
 private let tabWindowIDs: Set<String> = ["prev-tab", "next-tab", "app-switcher", "window-switcher", "close-tab"]
 private let systemExtraIDs: Set<String> = ["screenshot"]
+private let mediaIDs: Set<String> = [
+    "play-pause", "next-track", "prev-track",
+    "mute", "volume-up", "volume-down",
+    "brightness-up", "brightness-down",
+]
+private let editingIDs: Set<String> = clipboardIDs
+    .union(cursorIDs)
+    .union(selectionIDs)
+    .union(deletionIDs)
+    .union(tabWindowIDs)
 
 enum OutputActionGrouping {
     static var detailed: [OutputActionGroup] {
@@ -23,24 +33,18 @@ enum OutputActionGrouping {
             OutputActionGroup(title: "Deletion", actions: all.filter { deletionIDs.contains($0.id) }),
             OutputActionGroup(title: "Tab / Window", actions: all.filter { tabWindowIDs.contains($0.id) }),
             OutputActionGroup(title: "System", actions: all.filter { $0.isSystemAction || systemExtraIDs.contains($0.id) }),
-            OutputActionGroup(title: "Playback", actions: all.filter {
-                ["play-pause", "next-track", "prev-track"].contains($0.id)
-            }),
-            OutputActionGroup(title: "Volume", actions: all.filter {
-                ["mute", "volume-up", "volume-down"].contains($0.id)
-            }),
-            OutputActionGroup(title: "Display", actions: all.filter {
-                ["brightness-up", "brightness-down"].contains($0.id)
-            }),
+            OutputActionGroup(title: "Playback", actions: all.filter { mediaIDs.contains($0.id) && ["play-pause", "next-track", "prev-track"].contains($0.id) }),
+            OutputActionGroup(title: "Volume", actions: all.filter { ["mute", "volume-up", "volume-down"].contains($0.id) }),
+            OutputActionGroup(title: "Display", actions: all.filter { ["brightness-up", "brightness-down"].contains($0.id) }),
         ]
     }
 
     static var compact: [OutputActionGroup] {
         let all = SystemActionInfo.allActions
         return [
-            OutputActionGroup(title: "System", actions: all.filter(\.isSystemAction)),
-            OutputActionGroup(title: "Media", actions: all.filter(\.isMediaKey)),
-            OutputActionGroup(title: "Editing", actions: all.filter(\.isEditingShortcut)),
+            OutputActionGroup(title: "System", actions: all.filter { $0.isSystemAction || systemExtraIDs.contains($0.id) }),
+            OutputActionGroup(title: "Media", actions: all.filter { mediaIDs.contains($0.id) }),
+            OutputActionGroup(title: "Editing", actions: all.filter { editingIDs.contains($0.id) }),
         ]
     }
 }

--- a/Sources/KeyPathAppKit/UI/Experimental/Mapper/MapperActionTypes.swift
+++ b/Sources/KeyPathAppKit/UI/Experimental/Mapper/MapperActionTypes.swift
@@ -173,6 +173,46 @@ public struct SystemActionInfo: Equatable, Hashable, Identifiable, Sendable {
         SystemActionInfo(id: "select-all", name: "Select All", sfSymbol: "selection.pin.in.out", output: .modifierCombo("C-a")),
         SystemActionInfo(id: "save", name: "Save", sfSymbol: "square.and.arrow.down", output: .modifierCombo("C-s")),
         SystemActionInfo(id: "find", name: "Find", sfSymbol: "magnifyingglass", output: .modifierCombo("C-f")),
+        // Cursor movement
+        SystemActionInfo(id: "word-left", name: "Word Left", sfSymbol: "arrow.left.to.line",
+                         output: .modifierCombo("A-left")),
+        SystemActionInfo(id: "word-right", name: "Word Right", sfSymbol: "arrow.right.to.line",
+                         output: .modifierCombo("A-right")),
+        SystemActionInfo(id: "line-start", name: "Line Start", sfSymbol: "arrow.backward.to.line",
+                         output: .hidKeycode("home", simulatorName: nil)),
+        SystemActionInfo(id: "line-end", name: "Line End", sfSymbol: "arrow.forward.to.line",
+                         output: .hidKeycode("end", simulatorName: nil)),
+        // Deletion
+        SystemActionInfo(id: "delete-word", name: "Delete Word", sfSymbol: "delete.backward",
+                         output: .modifierCombo("A-bspc")),
+        SystemActionInfo(id: "kill-line", name: "Kill Line", sfSymbol: "strikethrough",
+                         output: .modifierCombo("C-k")),
+        // Selection
+        SystemActionInfo(id: "select-word-left", name: "Select Word Left", sfSymbol: "text.badge.checkmark",
+                         output: .modifierCombo("S-A-left")),
+        SystemActionInfo(id: "select-word-right", name: "Select Word Right", sfSymbol: "text.badge.checkmark",
+                         output: .modifierCombo("S-A-right")),
+        SystemActionInfo(id: "select-to-line-start", name: "Select to Line Start", sfSymbol: "text.badge.checkmark",
+                         output: .modifierCombo("S-M-left")),
+        SystemActionInfo(id: "select-to-line-end", name: "Select to Line End", sfSymbol: "text.badge.checkmark",
+                         output: .modifierCombo("S-M-right")),
+        // Tab/Window management
+        SystemActionInfo(id: "prev-tab", name: "Previous Tab", sfSymbol: "arrow.left.square",
+                         output: .modifierCombo("C-S-tab")),
+        SystemActionInfo(id: "next-tab", name: "Next Tab", sfSymbol: "arrow.right.square",
+                         output: .modifierCombo("C-tab")),
+        SystemActionInfo(id: "app-switcher", name: "App Switcher", sfSymbol: "rectangle.stack",
+                         output: .modifierCombo("M-tab")),
+        SystemActionInfo(id: "window-switcher", name: "Window Switcher", sfSymbol: "macwindow.on.rectangle",
+                         output: .modifierCombo("M-grave")),
+        // System
+        SystemActionInfo(id: "screenshot", name: "Screenshot", sfSymbol: "camera.viewfinder",
+                         output: .modifierCombo("C-M-S-4")),
+        // Additional editing
+        SystemActionInfo(id: "forward-delete", name: "Forward Delete", sfSymbol: "delete.forward",
+                         output: .hidKeycode("del", simulatorName: nil)),
+        SystemActionInfo(id: "close-tab", name: "Close Tab", sfSymbol: "xmark.square",
+                         output: .modifierCombo("M-w")),
     ]
 
     /// Look up a SystemActionInfo by its kanata output (id, display name, keycode,

--- a/Sources/KeyPathAppKit/UI/Gallery/PackDetailView+BindingRows.swift
+++ b/Sources/KeyPathAppKit/UI/Gallery/PackDetailView+BindingRows.swift
@@ -161,6 +161,15 @@ extension PackDetailView {
                     }
                 )
             }
+        } else if pack.id == PackRegistry.vallackSystem.id {
+            embeddedEditor {
+                VallackSystemPackContent(
+                    navCollection: liveAssociatedCollection,
+                    modsCollection: liveCollection(for: RuleCollectionIdentifier.homeRowMods),
+                    togglesCollection: liveCollection(for: RuleCollectionIdentifier.homeRowLayerToggles),
+                    isInstalled: isInstalled
+                )
+            }
         } else if pack.bindings.isEmpty, let collection = liveAssociatedCollection,
                   !collection.mappings.isEmpty {
             // Collection-backed pack with no explicit bindings and a plain

--- a/Sources/KeyPathAppKit/UI/Gallery/PackDetailView+Toast.swift
+++ b/Sources/KeyPathAppKit/UI/Gallery/PackDetailView+Toast.swift
@@ -36,7 +36,10 @@ extension PackDetailView {
     }
 
     var installedToastMessage: String {
-        pack.bindings.count == 1
+        if pack.associatedCollectionID != nil, pack.bindings.isEmpty {
+            return "\(pack.name) turned on."
+        }
+        return pack.bindings.count == 1
             ? "\(pack.name) turned on."
             : "\(pack.name) turned on · \(pack.bindings.count) bindings added."
     }

--- a/Sources/KeyPathAppKit/UI/Gallery/PackDetailView.swift
+++ b/Sources/KeyPathAppKit/UI/Gallery/PackDetailView.swift
@@ -317,6 +317,15 @@ struct PackDetailView: View {
             .first { $0.id == collectionID }
     }
 
+    func liveCollection(for id: UUID) -> RuleCollection? {
+        let live = kanataManager.underlyingManager
+            .ruleCollectionsManager.ruleCollections
+            .first { $0.id == id }
+        if let live { return live }
+        return RuleCollectionCatalog().defaultCollections()
+            .first { $0.id == id }
+    }
+
     /// Collection with a `.singleKeyPicker` configuration — drives the
     /// SingleKeyPickerContent dispatch in Pack Detail.
     var associatedSingleKeyCollection: RuleCollection? {

--- a/Sources/KeyPathAppKit/UI/Gallery/SystemPackComponentsView.swift
+++ b/Sources/KeyPathAppKit/UI/Gallery/SystemPackComponentsView.swift
@@ -1,0 +1,343 @@
+import SwiftUI
+
+#if os(macOS)
+    import AppKit
+#endif
+
+// MARK: - Vallack Zone Definitions
+
+enum VallackZones {
+    static let modifierKeyCodes: Set<UInt16> = [12, 13, 14, 32, 34, 31]
+    static let activatorKeyCodes: Set<UInt16> = [3, 38]
+
+    static let navMappingKeyCodes: Set<UInt16> = [
+        4, 38, 40, 37, 32, 34, 16, 41,
+        12, 13, 14, 15, 0, 1, 2, 5, 17, 9
+    ]
+
+    static let homeSubtitles: [UInt16: String] = [
+        12: "⌃", 13: "⌥", 14: "⌘",
+        32: "⌘", 34: "⌥", 31: "⌃",
+        3: "NAV", 38: "NAV"
+    ]
+
+    static let navSubtitles: [UInt16: String] = [
+        4: "←", 38: "↓", 40: "↑", 37: "→",
+        32: "⌫", 34: "↵", 16: "⌘C", 41: "⌘V",
+        12: "⇥", 13: "esc", 14: "◀Tab", 15: "Tab▶",
+        0: "⌘⇥", 1: "Home", 2: "End", 5: "camera",
+        17: "◀", 9: "▶"
+    ]
+
+    static func homeZones() -> [UInt16: KeyboardZone] {
+        var zones: [UInt16: KeyboardZone] = [:]
+        for code in modifierKeyCodes { zones[code] = .modifier }
+        for code in activatorKeyCodes { zones[code] = .activator }
+        return zones
+    }
+
+    static func navZones() -> [UInt16: KeyboardZone] {
+        var zones: [UInt16: KeyboardZone] = [:]
+        for code in navMappingKeyCodes { zones[code] = .navMapping }
+        return zones
+    }
+}
+
+// MARK: - Component Card
+
+struct SystemPackComponentCard: View {
+    let icon: String
+    let title: String
+    let summary: String
+    let isExpanded: Bool
+    let onToggle: () -> Void
+    let content: AnyView
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Button(action: onToggle) {
+                HStack(spacing: 10) {
+                    Image(systemName: icon)
+                        .font(.system(size: 14, weight: .medium))
+                        .foregroundStyle(.secondary)
+                        .frame(width: 20)
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(title)
+                            .font(.system(size: 13, weight: .semibold))
+                            .foregroundStyle(.primary)
+                        Text(summary)
+                            .font(.system(size: 11))
+                            .foregroundStyle(.secondary)
+                            .lineLimit(isExpanded ? nil : 1)
+                    }
+                    Spacer(minLength: 0)
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundStyle(.tertiary)
+                        .rotationEffect(.degrees(isExpanded ? 90 : 0))
+                        .animation(.easeInOut(duration: 0.2), value: isExpanded)
+                }
+                .padding(.vertical, 10)
+                .padding(.horizontal, 12)
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+
+            if isExpanded {
+                Divider()
+                    .padding(.horizontal, 12)
+                content
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 10)
+                    .transition(.opacity.combined(with: .move(edge: .top)))
+            }
+        }
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(Color(NSColor.controlBackgroundColor).opacity(0.5))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8)
+                        .strokeBorder(Color.white.opacity(0.1), lineWidth: 1)
+                )
+        )
+    }
+}
+
+// MARK: - Main Content
+
+struct VallackSystemPackContent: View {
+    let navCollection: RuleCollection?
+    let modsCollection: RuleCollection?
+    let togglesCollection: RuleCollection?
+    let isInstalled: Bool
+
+    @State private var expandedComponent: String?
+    @State private var selectedLayer: String = "home"
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            VStack(spacing: 0) {
+                HStack(spacing: 0) {
+                    layerTab(id: "home", icon: "keyboard", label: "Home")
+                    layerTab(id: "nav", icon: "arrow.up.and.down.and.arrow.left.and.right", label: "Navigation")
+                }
+
+                VStack(spacing: 0) {
+                    layerHint
+                        .padding(.top, 16)
+                        .padding(.horizontal, 12)
+
+                    if selectedLayer == "home" {
+                        ZonedKeyboardDiagram(
+                            zones: VallackZones.homeZones(),
+                            subtitles: VallackZones.homeSubtitles,
+                            keycapSize: 35
+                        )
+                        .frame(maxWidth: .infinity)
+                        .padding(.top, 14)
+                        .padding(.bottom, 20)
+                        .padding(.horizontal, 12)
+                    } else {
+                        ZonedKeyboardDiagram(
+                            zones: VallackZones.navZones(),
+                            subtitles: VallackZones.navSubtitles,
+                            keycapSize: 35
+                        )
+                        .frame(maxWidth: .infinity)
+                        .padding(.top, 14)
+                        .padding(.bottom, 20)
+                        .padding(.horizontal, 12)
+                    }
+                }
+                .frame(maxWidth: .infinity)
+                .background(
+                    RoundedRectangle(cornerRadius: 8, style: .continuous)
+                        .fill(Color.black.opacity(0.25))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                                .strokeBorder(Color.white.opacity(0.08), lineWidth: 1)
+                        )
+                )
+                .clipShape(
+                    UnevenRoundedRectangle(
+                        topLeadingRadius: selectedLayer == "home" ? 0 : 8,
+                        bottomLeadingRadius: 8,
+                        bottomTrailingRadius: 8,
+                        topTrailingRadius: selectedLayer == "nav" ? 0 : 8
+                    )
+                )
+            }
+
+            // How it works
+            VStack(alignment: .leading, spacing: 6) {
+                Text("How it works")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(.tertiary)
+                    .padding(.leading, 4)
+
+                SystemPackComponentCard(
+                    icon: "hand.tap",
+                    title: "Layer Activation",
+                    summary: "Hold either index finger to enter nav",
+                    isExpanded: expandedComponent == "toggles",
+                    onToggle: { toggleExpanded("toggles") },
+                    content: AnyView(activatorCardContent)
+                )
+
+                SystemPackComponentCard(
+                    icon: "keyboard",
+                    title: "Top Row Modifiers",
+                    summary: "Tap for letters, hold for ⌃ ⌥ ⌘",
+                    isExpanded: expandedComponent == "mods",
+                    onToggle: { toggleExpanded("mods") },
+                    content: AnyView(modsCardContent)
+                )
+
+                SystemPackComponentCard(
+                    icon: "arrow.up.and.down.and.arrow.left.and.right",
+                    title: "Navigation Mappings",
+                    summary: "\(navCollection?.mappings.count ?? 0) keys — arrows, clipboard, tabs",
+                    isExpanded: expandedComponent == "nav",
+                    onToggle: { toggleExpanded("nav") },
+                    content: AnyView(navCardContent)
+                )
+            }
+        }
+    }
+
+    // MARK: - Layer Hint
+
+    @ViewBuilder
+    private var layerHint: some View {
+        if selectedLayer == "nav" {
+            HStack(spacing: 6) {
+                Text("Hold")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+                ZonedKeycap(label: "F", zone: .activator, size: 20)
+                Text("or")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+                ZonedKeycap(label: "J", zone: .activator, size: 20)
+                Text("to enter  ·  release to exit")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+            }
+        } else {
+            HStack(spacing: 6) {
+                Text("Normal typing with dual-role keys")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    // MARK: - Layer Tab
+
+    private func layerTab(id: String, icon: String, label: String) -> some View {
+        let isSelected = selectedLayer == id
+        return Button {
+            withAnimation(.easeInOut(duration: 0.15)) { selectedLayer = id }
+        } label: {
+            HStack(spacing: 5) {
+                Image(systemName: icon)
+                    .font(.system(size: 11, weight: .medium))
+                Text(label)
+                    .font(.system(size: 12, weight: .semibold))
+            }
+            .foregroundStyle(isSelected ? .primary : .secondary)
+            .padding(.horizontal, 14)
+            .padding(.vertical, 8)
+            .background(
+                UnevenRoundedRectangle(
+                    topLeadingRadius: 8,
+                    bottomLeadingRadius: 0,
+                    bottomTrailingRadius: 0,
+                    topTrailingRadius: 8
+                )
+                .fill(isSelected
+                    ? Color.black.opacity(0.25)
+                    : Color.clear)
+                .overlay(
+                    UnevenRoundedRectangle(
+                        topLeadingRadius: 8,
+                        bottomLeadingRadius: 0,
+                        bottomTrailingRadius: 0,
+                        topTrailingRadius: 8
+                    )
+                    .strokeBorder(isSelected
+                        ? Color.white.opacity(0.08)
+                        : Color.clear, lineWidth: 1)
+                )
+            )
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    // MARK: - Card Content
+
+    @ViewBuilder
+    private var modsCardContent: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Modifiers move to the top row so the home row is free for layer toggles. Tap for the letter, hold for the modifier.")
+                .font(.system(size: 11))
+                .foregroundStyle(.secondary)
+            MappingTableContent(
+                mappings: [
+                    ("q", "⌃", nil, nil, "Control", false, true, UUID(uuidString: "00000000-0000-0000-0000-000000000101")!, nil),
+                    ("w", "⌥", nil, nil, "Option", false, true, UUID(uuidString: "00000000-0000-0000-0000-000000000102")!, nil),
+                    ("e", "⌘", nil, nil, "Command", false, true, UUID(uuidString: "00000000-0000-0000-0000-000000000103")!, nil),
+                    ("u", "⌘", nil, nil, "Command", true, true, UUID(uuidString: "00000000-0000-0000-0000-000000000104")!, nil),
+                    ("i", "⌥", nil, nil, "Option", false, true, UUID(uuidString: "00000000-0000-0000-0000-000000000105")!, nil),
+                    ("o", "⌃", nil, nil, "Control", false, true, UUID(uuidString: "00000000-0000-0000-0000-000000000106")!, nil),
+                ]
+            )
+        }
+    }
+
+    @ViewBuilder
+    private var activatorCardContent: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Hold either index finger to activate the navigation layer. Release to return to normal typing. Both activate the same layer — use whichever hand is free.")
+                .font(.system(size: 11))
+                .foregroundStyle(.secondary)
+            HStack(spacing: 8) {
+                Text("Hold")
+                    .font(.system(size: 12))
+                    .foregroundStyle(.secondary)
+                StandardKeyBadge(key: "F", color: .orange)
+                Text("or")
+                    .font(.system(size: 12))
+                    .foregroundStyle(.secondary)
+                StandardKeyBadge(key: "J", color: .orange)
+                Text("→ navigation layer")
+                    .font(.system(size: 12))
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var navCardContent: some View {
+        if let collection = navCollection {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Right hand navigates (HJKL arrows, backspace, enter). Left hand switches and edits (tabs, clipboard, escape).")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+                MappingTableContent(
+                    mappings: collection.mappings.map {
+                        ($0.input, $0.action.displayName, $0.shiftedOutput, $0.ctrlOutput,
+                         $0.description, $0.sectionBreak, isInstalled, $0.id, nil)
+                    }
+                )
+            }
+        }
+    }
+
+    private func toggleExpanded(_ id: String) {
+        withAnimation(.easeInOut(duration: 0.2)) {
+            expandedComponent = expandedComponent == id ? nil : id
+        }
+    }
+}

--- a/Sources/KeyPathAppKit/UI/Gallery/ZonedKeyboardDiagram.swift
+++ b/Sources/KeyPathAppKit/UI/Gallery/ZonedKeyboardDiagram.swift
@@ -1,0 +1,185 @@
+import SwiftUI
+
+#if os(macOS)
+    import AppKit
+#endif
+
+enum KeyboardZone: Equatable {
+    case modifier
+    case activator
+    case navMapping
+    case dimmed
+}
+
+struct ZonedKeycap: View {
+    let label: String
+    let zone: KeyboardZone
+    let subtitle: String?
+    let size: CGFloat
+
+    init(label: String, zone: KeyboardZone, subtitle: String? = nil, size: CGFloat = 22) {
+        self.label = label
+        self.zone = zone
+        self.subtitle = subtitle
+        self.size = size
+    }
+
+    private var fillColor: Color {
+        switch zone {
+        case .modifier: Color.blue.opacity(0.45)
+        case .activator: Color.orange.opacity(0.5)
+        case .navMapping: Color.green.opacity(0.45)
+        case .dimmed: Color(NSColor.controlBackgroundColor).opacity(0.3)
+        }
+    }
+
+    private var borderColor: Color {
+        switch zone {
+        case .modifier: Color.blue.opacity(0.7)
+        case .activator: Color.orange.opacity(0.8)
+        case .navMapping: Color.green.opacity(0.7)
+        case .dimmed: Color.secondary.opacity(0.1)
+        }
+    }
+
+    private var textColor: Color {
+        switch zone {
+        case .dimmed: .secondary.opacity(0.25)
+        default: .primary
+        }
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Text(label)
+                .font(.system(size: size * 0.5, weight: zone == .dimmed ? .regular : .semibold, design: .monospaced))
+                .foregroundColor(textColor)
+            if let subtitle {
+                if NSImage(systemSymbolName: subtitle, accessibilityDescription: nil) != nil {
+                    Image(systemName: subtitle)
+                        .font(.system(size: size * 0.28, weight: .medium))
+                        .foregroundColor(textColor.opacity(0.7))
+                } else {
+                    Text(subtitle)
+                        .font(.system(size: size * 0.3, weight: .medium))
+                        .foregroundColor(textColor.opacity(0.7))
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.6)
+                }
+            }
+        }
+        .frame(width: size, height: subtitle != nil ? size * 1.2 : size)
+        .background(
+            RoundedRectangle(cornerRadius: size * 0.18)
+                .fill(fillColor)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: size * 0.18)
+                .stroke(borderColor, lineWidth: 1)
+        )
+    }
+}
+
+struct ZonedKeyboardDiagram: View {
+    let zones: [UInt16: KeyboardZone]
+    let subtitles: [UInt16: String]
+    let keycapSize: CGFloat
+    let highlightOnly: Bool
+
+    @AppStorage(LayoutPreferences.layoutIdKey) private var selectedLayoutId: String = LayoutPreferences.defaultLayoutId
+    @AppStorage(KeymapPreferences.keymapIdKey) private var selectedKeymapId: String = LogicalKeymap.defaultId
+
+    init(
+        zones: [UInt16: KeyboardZone],
+        subtitles: [UInt16: String] = [:],
+        keycapSize: CGFloat = 26,
+        highlightOnly: Bool = false
+    ) {
+        self.zones = zones
+        self.subtitles = subtitles
+        self.keycapSize = keycapSize
+        self.highlightOnly = highlightOnly
+    }
+
+    private struct DisplayKey: Identifiable {
+        let keyCode: UInt16
+        let label: String
+        let x: Double
+        let y: Double
+        var id: UInt16 { keyCode }
+    }
+
+    private var activeKeymap: LogicalKeymap {
+        .resolve(id: selectedKeymapId)
+    }
+
+    private var activeLayout: PhysicalLayout {
+        PhysicalLayout.find(id: selectedLayoutId) ?? .macBookUS
+    }
+
+    private static let alphaKeys: Set<String> = [
+        "q", "w", "e", "r", "t", "y", "u", "i", "o", "p",
+        "a", "s", "d", "f", "g", "h", "j", "k", "l", "semicolon",
+        "z", "x", "c", "v", "b", "n", "m", "comma", "dot", "slash"
+    ]
+
+    private var keyboardRows: [[DisplayKey]] {
+        let keys = activeLayout.keys.compactMap { key -> DisplayKey? in
+            guard key.keyCode != PhysicalKey.unmappedKeyCode else { return nil }
+            let canonical = OverlayKeyboardView.keyCodeToKanataName(key.keyCode).lowercased()
+            guard Self.alphaKeys.contains(canonical) else { return nil }
+            if highlightOnly, zones[key.keyCode] == nil { return nil }
+            let fallback: [String: String] = [
+                "semicolon": ";", "comma": ",", "dot": ".", "slash": "/"
+            ]
+            let label = activeKeymap.label(for: key.keyCode, includeExtraKeys: false)
+                ?? fallback[canonical] ?? canonical
+            return DisplayKey(keyCode: key.keyCode, label: label, x: key.visualX, y: key.visualY)
+        }
+
+        let sorted = keys.sorted {
+            if abs($0.y - $1.y) > 0.01 { return $0.y < $1.y }
+            return $0.x < $1.x
+        }
+
+        var rows: [[DisplayKey]] = []
+        var rowAnchors: [Double] = []
+        for key in sorted {
+            if let lastIndex = rowAnchors.indices.last, abs(key.y - rowAnchors[lastIndex]) <= 0.6 {
+                rows[lastIndex].append(key)
+            } else {
+                rows.append([key])
+                rowAnchors.append(key.y)
+            }
+        }
+        return rows.map { $0.sorted { $0.x < $1.x } }.filter { !$0.isEmpty }
+    }
+
+    var body: some View {
+        let rows = keyboardRows
+        let globalMinX = rows.flatMap { $0 }.map(\.x).min() ?? 0
+        let keyPitch = keycapSize + 3
+
+        VStack(alignment: .leading, spacing: 3) {
+            ForEach(Array(rows.enumerated()), id: \.offset) { _, row in
+                let rowMinX = row.first?.x ?? globalMinX
+                let indent = CGFloat(max(0, rowMinX - globalMinX)) * keyPitch
+
+                HStack(spacing: 3) {
+                    if indent > 0 {
+                        Spacer().frame(width: indent)
+                    }
+                    ForEach(row) { key in
+                        let zone = zones[key.keyCode] ?? .dimmed
+                        ZonedKeycap(
+                            label: key.label.count == 1 ? key.label.uppercased() : key.label,
+                            zone: zone,
+                            subtitle: subtitles[key.keyCode],
+                            size: keycapSize
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Sources/KeyPathAppKit/UI/Rules/MacSearchField.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/MacSearchField.swift
@@ -15,10 +15,14 @@ import SwiftUI
             searchField.placeholderString = nil
             searchField.sendsSearchStringImmediately = true
             searchField.sendsWholeSearchString = false
+            searchField.focusRingType = .none
             searchField.delegate = context.coordinator
             searchField.stringValue = text
             searchField.setAccessibilityIdentifier("rules-search-field")
             searchField.setAccessibilityLabel("Search rules")
+            DispatchQueue.main.async {
+                searchField.window?.makeFirstResponder(searchField)
+            }
             return searchField
         }
 

--- a/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView+MappingTable.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView+MappingTable.swift
@@ -38,10 +38,10 @@ struct MappingTableContent: View {
                     .padding(.trailing, 24)
                 if hasDescriptions {
                     headerCell("Description")
-                        .frame(minWidth: 150, maxWidth: .infinity, alignment: .leading)
+                        .frame(minWidth: 150, maxWidth: .infinity, alignment: .center)
                 }
                 headerCell("Action")
-                    .frame(width: 90)
+                    .frame(width: 110)
                 if hasShiftVariants {
                     headerCell("+ Shift ⇧", color: .orange)
                         .frame(width: 100)
@@ -73,7 +73,7 @@ struct MappingTableContent: View {
                             .frame(minWidth: 150, maxWidth: .infinity)
                     }
                     actionCell(formatOutput(mapping.output))
-                        .frame(width: 90)
+                        .frame(width: 110)
                     if hasShiftVariants {
                         modifierCell(mapping.shiftedOutput.map { formatOutput($0) }, color: .orange)
                             .frame(width: 100)
@@ -111,13 +111,12 @@ struct MappingTableContent: View {
         Text(text ?? "")
             .font(.body)
             .foregroundColor(.primary.opacity(0.8))
-            .frame(maxWidth: .infinity, alignment: .leading)
+            .frame(maxWidth: .infinity, alignment: .center)
     }
 
     private func actionCell(_ text: String) -> some View {
-        Text(text)
-            .font(.body.monospaced())
-            .foregroundColor(.secondary)
+        StandardKeyBadge(key: text, color: .secondary, uppercase: false)
+            .font(.system(size: 15, weight: .semibold, design: .monospaced))
             .fixedSize(horizontal: true, vertical: false)
             .frame(maxWidth: .infinity)
     }
@@ -290,7 +289,7 @@ struct MappingTableContent: View {
                 .replacingOccurrences(of: "del", with: "⌦")
                 .replacingOccurrences(of: "pgup", with: "Pg↑")
                 .replacingOccurrences(of: "pgdn", with: "Pg↓")
-                .replacingOccurrences(of: "esc", with: "⎋")
+                .replacingOccurrences(of: "esc", with: "esc")
         }.joined(separator: " ")
     }
 }

--- a/Tests/KeyPathTests/PackRegistryTests.swift
+++ b/Tests/KeyPathTests/PackRegistryTests.swift
@@ -28,6 +28,7 @@ final class PackRegistryTests: XCTestCase {
         XCTAssertTrue(ids.contains("com.keypath.pack.quick-launcher"))
         XCTAssertTrue(ids.contains("com.keypath.pack.leader-key"))
         XCTAssertTrue(ids.contains("com.keypath.pack.kindavim"))
+        XCTAssertTrue(ids.contains("com.keypath.pack.vallack-system"))
     }
 
     func testKindaVimPackIsVisualOnlyAndUnbacked() {

--- a/Tests/KeyPathTests/UI/OutputActionGroupingTests.swift
+++ b/Tests/KeyPathTests/UI/OutputActionGroupingTests.swift
@@ -6,11 +6,14 @@ struct OutputActionGroupingTests {
 
     // MARK: - Detailed grouping (overlay mapper)
 
-    @Test("detailed produces 5 groups in expected order")
+    @Test("detailed produces 9 groups in expected order")
     func detailedGroupCount() {
         let groups = OutputActionGrouping.detailed
-        #expect(groups.count == 5)
-        #expect(groups.map(\.title) == ["Editing", "System", "Playback", "Volume", "Display"])
+        #expect(groups.count == 9)
+        #expect(groups.map(\.title) == [
+            "Clipboard", "Cursor Movement", "Selection", "Deletion",
+            "Tab / Window", "System", "Playback", "Volume", "Display"
+        ])
     }
 
     @Test("detailed covers every action exactly once")
@@ -30,11 +33,16 @@ struct OutputActionGroupingTests {
         }
     }
 
-    @Test("detailed Editing group contains only editing shortcuts")
-    func detailedEditingGroup() {
-        let editing = OutputActionGrouping.detailed.first { $0.title == "Editing" }!
-        for action in editing.actions {
-            #expect(action.isEditingShortcut, "\(action.id) should be an editing shortcut")
+    @Test("detailed editing subgroups are disjoint")
+    func detailedEditingGroupsDisjoint() {
+        let editingGroupNames = ["Clipboard", "Cursor Movement", "Selection", "Deletion", "Tab / Window"]
+        let editingGroups = OutputActionGrouping.detailed.filter { editingGroupNames.contains($0.title) }
+        var seen = Set<String>()
+        for group in editingGroups {
+            for action in group.actions {
+                #expect(!seen.contains(action.id), "\(action.id) appears in multiple editing subgroups")
+                seen.insert(action.id)
+            }
         }
     }
 
@@ -42,7 +50,7 @@ struct OutputActionGroupingTests {
     func detailedSystemGroup() {
         let system = OutputActionGrouping.detailed.first { $0.title == "System" }!
         for action in system.actions {
-            #expect(action.isSystemAction, "\(action.id) should be a system action")
+            #expect(action.isSystemAction || action.isEditingShortcut, "\(action.id) should be a system or editing action")
         }
     }
 
@@ -93,28 +101,33 @@ struct OutputActionGroupingTests {
         }
     }
 
-    @Test("compact System group matches isSystemAction filter")
+    @Test("compact System group matches detailed System group")
     func compactSystemGroup() {
-        let system = OutputActionGrouping.compact.first { $0.title == "System" }!
-        for action in system.actions {
-            #expect(action.isSystemAction, "\(action.id) should be a system action")
-        }
+        let compactIDs = Set(OutputActionGrouping.compact.first { $0.title == "System" }!.actions.map(\.id))
+        let detailedIDs = Set(OutputActionGrouping.detailed.first { $0.title == "System" }!.actions.map(\.id))
+        #expect(compactIDs == detailedIDs)
     }
 
-    @Test("compact Media group matches isMediaKey filter")
+    @Test("compact Media group matches detailed Playback+Volume+Display")
     func compactMediaGroup() {
-        let media = OutputActionGrouping.compact.first { $0.title == "Media" }!
-        for action in media.actions {
-            #expect(action.isMediaKey, "\(action.id) should be a media key")
-        }
+        let compactIDs = Set(OutputActionGrouping.compact.first { $0.title == "Media" }!.actions.map(\.id))
+        let detailed = OutputActionGrouping.detailed
+        let detailedMediaIDs = Set(
+            detailed.filter { ["Playback", "Volume", "Display"].contains($0.title) }
+                .flatMap { $0.actions.map(\.id) }
+        )
+        #expect(compactIDs == detailedMediaIDs)
     }
 
-    @Test("compact Editing group matches isEditingShortcut filter")
+    @Test("compact Editing group matches detailed editing subgroups")
     func compactEditingGroup() {
-        let editing = OutputActionGrouping.compact.first { $0.title == "Editing" }!
-        for action in editing.actions {
-            #expect(action.isEditingShortcut, "\(action.id) should be an editing shortcut")
-        }
+        let compactIDs = Set(OutputActionGrouping.compact.first { $0.title == "Editing" }!.actions.map(\.id))
+        let detailed = OutputActionGrouping.detailed
+        let detailedEditingIDs = Set(
+            detailed.filter { ["Clipboard", "Cursor Movement", "Selection", "Deletion", "Tab / Window"].contains($0.title) }
+                .flatMap { $0.actions.map(\.id) }
+        )
+        #expect(compactIDs == detailedEditingIDs)
     }
 
     // MARK: - Cross-grouping consistency
@@ -126,17 +139,13 @@ struct OutputActionGroupingTests {
         #expect(detailedIDs == compactIDs)
     }
 
-    @Test("detailed media subgroups union equals compact Media group")
-    func detailedMediaSubgroupsMatchCompact() {
+    @Test("detailed and compact group the same actions into matching categories")
+    func detailedAndCompactGroupsAlign() {
         let detailed = OutputActionGrouping.detailed
-        let detailedMediaIDs = Set(
-            detailed.filter { ["Playback", "Volume", "Display"].contains($0.title) }
-                .flatMap { $0.actions.map(\.id) }
-        )
-        let compactMediaIDs = Set(
-            OutputActionGrouping.compact.first { $0.title == "Media" }!.actions.map(\.id)
-        )
-        #expect(detailedMediaIDs == compactMediaIDs, "Playback+Volume+Display should equal Media")
+        let compact = OutputActionGrouping.compact
+        let detailedTotal = detailed.flatMap { $0.actions.map(\.id) }.count
+        let compactTotal = compact.flatMap { $0.actions.map(\.id) }.count
+        #expect(detailedTotal == compactTotal, "Both groupings should cover the same number of actions")
     }
 
     // MARK: - OutputActionGroup identity

--- a/Tests/KeyPathTests/UI/SystemActionInfoTests.swift
+++ b/Tests/KeyPathTests/UI/SystemActionInfoTests.swift
@@ -210,8 +210,8 @@ final class SystemActionInfoTests: XCTestCase {
     // MARK: - All Actions Coverage
 
     func testAllActions_containsExpectedCount() {
-        // 7 push-msg + 8 media keys + 8 editing shortcuts = 23 total
-        XCTAssertEqual(SystemActionInfo.allActions.count, 23)
+        // 7 push-msg + 11 media/HID keys + 22 editing shortcuts = 40 total
+        XCTAssertEqual(SystemActionInfo.allActions.count, 40)
     }
 
     func testAllActions_pushMsgActions() {
@@ -230,7 +230,7 @@ final class SystemActionInfoTests: XCTestCase {
 
     func testAllActions_mediaKeys() {
         let mediaKeys = SystemActionInfo.allActions.filter(\.isMediaKey)
-        XCTAssertEqual(mediaKeys.count, 8)
+        XCTAssertEqual(mediaKeys.count, 11)
 
         let ids = Set(mediaKeys.map(\.id))
         XCTAssertTrue(ids.contains("play-pause"))
@@ -245,7 +245,7 @@ final class SystemActionInfoTests: XCTestCase {
 
     func testAllActions_editingShortcuts() {
         let editing = SystemActionInfo.allActions.filter(\.isEditingShortcut)
-        XCTAssertEqual(editing.count, 8)
+        XCTAssertEqual(editing.count, 22)
 
         let ids = Set(editing.map(\.id))
         XCTAssertTrue(ids.contains("cut"))

--- a/Tests/KeyPathTests/VallackSystemPackTests.swift
+++ b/Tests/KeyPathTests/VallackSystemPackTests.swift
@@ -1,0 +1,321 @@
+@testable import KeyPathAppKit
+import KeyPathCore
+import XCTest
+
+final class VallackSystemPackTests: XCTestCase {
+
+    // MARK: - Nav Layer Collection
+
+    func testVallackNavigationCollectionExistsInCatalog() {
+        let catalog = RuleCollectionCatalog().defaultCollections()
+        let collection = catalog.first { $0.id == RuleCollectionIdentifier.vallackNavigation }
+        XCTAssertNotNil(collection, "Vallack Navigation collection must exist in catalog")
+    }
+
+    func testVallackNavigationHas18Mappings() {
+        let catalog = RuleCollectionCatalog().defaultCollections()
+        let collection = catalog.first { $0.id == RuleCollectionIdentifier.vallackNavigation }!
+        XCTAssertEqual(collection.mappings.count, 18, "Should have 18 key mappings (10 right hand + 8 left hand)")
+    }
+
+    func testVallackNavigationTargetsCustomLayer() {
+        let catalog = RuleCollectionCatalog().defaultCollections()
+        let collection = catalog.first { $0.id == RuleCollectionIdentifier.vallackNavigation }!
+        XCTAssertEqual(collection.targetLayer, .custom("vallack-nav"))
+    }
+
+    func testVallackNavigationHasNoMomentaryActivator() {
+        let catalog = RuleCollectionCatalog().defaultCollections()
+        let collection = catalog.first { $0.id == RuleCollectionIdentifier.vallackNavigation }!
+        XCTAssertNil(
+            collection.momentaryActivator,
+            "Activation is handled by homeRowLayerToggles (F/J), not a momentaryActivator"
+        )
+    }
+
+    func testVallackNavigationIsDisabledByDefault() {
+        let catalog = RuleCollectionCatalog().defaultCollections()
+        let collection = catalog.first { $0.id == RuleCollectionIdentifier.vallackNavigation }!
+        XCTAssertFalse(collection.isEnabled)
+        XCTAssertFalse(collection.isSystemDefault)
+    }
+
+    func testVallackNavigationContainsExpectedArrowMappings() {
+        let catalog = RuleCollectionCatalog().defaultCollections()
+        let collection = catalog.first { $0.id == RuleCollectionIdentifier.vallackNavigation }!
+        let mappingsByInput = Dictionary(uniqueKeysWithValues: collection.mappings.map { ($0.input, $0) })
+
+        XCTAssertEqual(mappingsByInput["h"]?.action, .keystroke(key: "left"))
+        XCTAssertEqual(mappingsByInput["j"]?.action, .keystroke(key: "down"))
+        XCTAssertEqual(mappingsByInput["k"]?.action, .keystroke(key: "up"))
+        XCTAssertEqual(mappingsByInput["l"]?.action, .keystroke(key: "right"))
+    }
+
+    func testVallackNavigationContainsClipboardAndEditing() {
+        let catalog = RuleCollectionCatalog().defaultCollections()
+        let collection = catalog.first { $0.id == RuleCollectionIdentifier.vallackNavigation }!
+        let mappingsByInput = Dictionary(uniqueKeysWithValues: collection.mappings.map { ($0.input, $0) })
+
+        XCTAssertEqual(mappingsByInput["y"]?.action, .keystroke(key: "M-c"), "y should be Copy")
+        XCTAssertEqual(mappingsByInput[";"]?.action, .keystroke(key: "M-v"), "; should be Paste")
+        XCTAssertEqual(mappingsByInput["u"]?.action, .keystroke(key: "bspc"), "u should be Backspace")
+        XCTAssertEqual(mappingsByInput["i"]?.action, .keystroke(key: "ret"), "i should be Enter")
+    }
+
+    func testVallackNavigationInputKeysAreUnique() {
+        let catalog = RuleCollectionCatalog().defaultCollections()
+        let collection = catalog.first { $0.id == RuleCollectionIdentifier.vallackNavigation }!
+        let inputs = collection.mappings.map(\.input)
+        XCTAssertEqual(Set(inputs).count, inputs.count, "No duplicate input keys")
+    }
+
+    // MARK: - Config Presets
+
+    func testVallackTwoRowSplitHas6Keys() {
+        let preset = HomeRowModsConfig.vallackTwoRowSplit
+        XCTAssertEqual(preset.count, 6, "Two-row split maps Q/W/E on left, U/I/O on right")
+    }
+
+    func testVallackTwoRowSplitUsesTopRowKeys() {
+        let preset = HomeRowModsConfig.vallackTwoRowSplit
+        let expectedKeys: Set<String> = ["q", "w", "e", "u", "i", "o"]
+        XCTAssertEqual(Set(preset.keys), expectedKeys)
+    }
+
+    func testVallackTwoRowSplitMapsToValidModifiers() {
+        let validModifiers: Set<String> = ["lctl", "lalt", "lmet", "lsft", "rctl", "ralt", "rmet", "rsft"]
+        for (key, modifier) in HomeRowModsConfig.vallackTwoRowSplit {
+            XCTAssertTrue(
+                validModifiers.contains(modifier),
+                "Key '\(key)' maps to '\(modifier)' which is not a valid kanata modifier"
+            )
+        }
+    }
+
+    func testVallackTwoRowSplitIsMirrored() {
+        let preset = HomeRowModsConfig.vallackTwoRowSplit
+        XCTAssertEqual(preset["q"], "lctl")
+        XCTAssertEqual(preset["o"], "rctl")
+        XCTAssertEqual(preset["w"], "lalt")
+        XCTAssertEqual(preset["i"], "ralt")
+        XCTAssertEqual(preset["e"], "lmet")
+        XCTAssertEqual(preset["u"], "rmet")
+    }
+
+    func testVallackTopRowKeysMatchPresetKeys() {
+        let presetKeys = Set(HomeRowModsConfig.vallackTwoRowSplit.keys)
+        let topRowKeys = Set(HomeRowModsConfig.vallackTopRowKeys)
+        XCTAssertEqual(presetKeys, topRowKeys)
+    }
+
+    func testVallackLayerAssignmentsTargetNavLayer() {
+        let assignments = HomeRowLayerTogglesConfig.vallackLayerAssignments
+        XCTAssertEqual(assignments.count, 2)
+        XCTAssertEqual(assignments["f"], "vallack-nav")
+        XCTAssertEqual(assignments["j"], "vallack-nav")
+    }
+
+    // MARK: - Pack Registration
+
+    func testVallackSystemPackExistsInStarterKit() {
+        let ids = Set(PackRegistry.starterKit.map(\.id))
+        XCTAssertTrue(ids.contains("com.keypath.pack.vallack-system"))
+    }
+
+    func testVallackSystemPackPointsAtNavCollection() {
+        let pack = PackRegistry.pack(id: "com.keypath.pack.vallack-system")
+        XCTAssertNotNil(pack)
+        XCTAssertEqual(pack?.associatedCollectionID, RuleCollectionIdentifier.vallackNavigation)
+    }
+
+    func testVallackSystemPackHasNoDirectBindings() {
+        let pack = PackRegistry.vallackSystem
+        XCTAssertTrue(pack.bindings.isEmpty, "System packs configure via presets, not direct bindings")
+    }
+
+    func testVallackSystemPackIsNotVisualOnly() {
+        XCTAssertFalse(PackRegistry.vallackSystem.visualOnly)
+    }
+
+    // MARK: - PackInstaller Snapshot/Restore
+
+    @MainActor
+    func testVallackInstallAppliesConfigPresets() async throws {
+        TestEnvironment.forceTestMode = true
+        defer { TestEnvironment.forceTestMode = false }
+
+        let (manager, tempDir) = try makeTestManager()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let record = try await PackInstaller.shared.install(
+            PackRegistry.vallackSystem,
+            manager: manager
+        )
+        XCTAssertEqual(record.packID, PackRegistry.vallackSystem.id)
+
+        let collections = manager.ruleCollections
+
+        // Nav layer should be enabled
+        let navCollection = collections.first { $0.id == RuleCollectionIdentifier.vallackNavigation }
+        XCTAssertTrue(navCollection?.isEnabled ?? false, "Vallack nav collection should be enabled")
+
+        // Home Row Mods should be enabled with Vallack top-row config
+        let modsCollection = collections.first { $0.id == RuleCollectionIdentifier.homeRowMods }
+        XCTAssertTrue(modsCollection?.isEnabled ?? false, "Home Row Mods should be enabled")
+        if let config = modsCollection?.configuration.homeRowModsConfig {
+            XCTAssertEqual(config.enabledKeys, Set(HomeRowModsConfig.vallackTopRowKeys))
+            XCTAssertEqual(config.modifierAssignments, HomeRowModsConfig.vallackTwoRowSplit)
+        } else {
+            XCTFail("Home Row Mods should have homeRowModsConfig after Vallack install")
+        }
+
+        // Home Row Layer Toggles should be enabled with Vallack assignments
+        let togglesCollection = collections.first { $0.id == RuleCollectionIdentifier.homeRowLayerToggles }
+        XCTAssertTrue(togglesCollection?.isEnabled ?? false, "Layer Toggles should be enabled")
+        if let config = togglesCollection?.configuration.homeRowLayerTogglesConfig {
+            XCTAssertEqual(config.enabledKeys, Set(["f", "j"]))
+            XCTAssertEqual(config.layerAssignments, HomeRowLayerTogglesConfig.vallackLayerAssignments)
+        } else {
+            XCTFail("Layer Toggles should have homeRowLayerTogglesConfig after Vallack install")
+        }
+    }
+
+    @MainActor
+    func testVallackInstallCreatesSnapshotFile() async throws {
+        TestEnvironment.forceTestMode = true
+        defer { TestEnvironment.forceTestMode = false }
+
+        let (manager, tempDir) = try makeTestManager()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        _ = try await PackInstaller.shared.install(
+            PackRegistry.vallackSystem,
+            manager: manager
+        )
+
+        let snapshotURL = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".config/keypath/vallack-system-snapshot.json")
+        XCTAssertTrue(
+            FileManager.default.fileExists(atPath: snapshotURL.path),
+            "Snapshot file should exist after install"
+        )
+        // Clean up snapshot
+        defer { try? FileManager.default.removeItem(at: snapshotURL) }
+
+        let data = try Data(contentsOf: snapshotURL)
+        XCTAssertFalse(data.isEmpty, "Snapshot file should not be empty")
+    }
+
+    @MainActor
+    func testVallackUninstallRevertsConfigs() async throws {
+        TestEnvironment.forceTestMode = true
+        defer { TestEnvironment.forceTestMode = false }
+
+        let (manager, tempDir) = try makeTestManager()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let snapshotURL = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".config/keypath/vallack-system-snapshot.json")
+        defer { try? FileManager.default.removeItem(at: snapshotURL) }
+
+        // Capture pre-install state
+        let preModsEnabled = manager.ruleCollections
+            .first { $0.id == RuleCollectionIdentifier.homeRowMods }?.isEnabled ?? false
+        let preTogglesEnabled = manager.ruleCollections
+            .first { $0.id == RuleCollectionIdentifier.homeRowLayerToggles }?.isEnabled ?? false
+
+        // Install then uninstall
+        _ = try await PackInstaller.shared.install(PackRegistry.vallackSystem, manager: manager)
+        try await PackInstaller.shared.uninstall(packID: PackRegistry.vallackSystem.id, manager: manager)
+
+        let collections = manager.ruleCollections
+
+        // Nav layer should be disabled
+        let navCollection = collections.first { $0.id == RuleCollectionIdentifier.vallackNavigation }
+        XCTAssertFalse(navCollection?.isEnabled ?? true, "Vallack nav should be disabled after uninstall")
+
+        // Home Row Mods should revert to pre-install enabled state
+        let modsCollection = collections.first { $0.id == RuleCollectionIdentifier.homeRowMods }
+        XCTAssertEqual(
+            modsCollection?.isEnabled ?? !preModsEnabled,
+            preModsEnabled,
+            "Home Row Mods enabled state should revert"
+        )
+
+        // Home Row Layer Toggles should revert to pre-install enabled state
+        let togglesCollection = collections.first { $0.id == RuleCollectionIdentifier.homeRowLayerToggles }
+        XCTAssertEqual(
+            togglesCollection?.isEnabled ?? !preTogglesEnabled,
+            preTogglesEnabled,
+            "Layer Toggles enabled state should revert"
+        )
+
+        // Snapshot file should be cleaned up
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: snapshotURL.path),
+            "Snapshot file should be removed after uninstall"
+        )
+    }
+
+    @MainActor
+    func testVallackUninstallWithoutSnapshotDoesNotCrash() async throws {
+        TestEnvironment.forceTestMode = true
+        defer { TestEnvironment.forceTestMode = false }
+
+        let (manager, tempDir) = try makeTestManager()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        // Manually enable the nav collection without going through the installer
+        // (simulates a corrupted state where snapshot file is missing)
+        _ = await manager.toggleCollection(
+            id: RuleCollectionIdentifier.vallackNavigation,
+            isEnabled: true,
+            autoResolveConflicts: true
+        )
+
+        // Register as installed in the tracker
+        try await InstalledPackTracker.shared.upsert(InstalledPackRecord(
+            packID: PackRegistry.vallackSystem.id,
+            version: PackRegistry.vallackSystem.version
+        ))
+        defer {
+            Task { try? await InstalledPackTracker.shared.remove(packID: PackRegistry.vallackSystem.id) }
+        }
+
+        // Ensure no snapshot file exists
+        let snapshotURL = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".config/keypath/vallack-system-snapshot.json")
+        try? FileManager.default.removeItem(at: snapshotURL)
+
+        // Uninstall should not crash — just skip the revert
+        try await PackInstaller.shared.uninstall(
+            packID: PackRegistry.vallackSystem.id,
+            manager: manager
+        )
+
+        let navCollection = manager.ruleCollections
+            .first { $0.id == RuleCollectionIdentifier.vallackNavigation }
+        XCTAssertFalse(navCollection?.isEnabled ?? true, "Nav collection should still be disabled")
+    }
+
+    // MARK: - Helpers
+
+    @MainActor
+    private func makeTestManager() throws -> (RuleCollectionsManager, URL) {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("vallack-test-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+
+        let manager = RuleCollectionsManager(
+            ruleCollectionStore: RuleCollectionStore(
+                fileURL: tempDir.appendingPathComponent("RuleCollections.json")
+            ),
+            customRulesStore: CustomRulesStore(
+                fileURL: tempDir.appendingPathComponent("CustomRules.json")
+            ),
+            configurationService: ConfigurationService(configDirectory: tempDir.path),
+            eventListener: KanataEventListener()
+        )
+        return (manager, tempDir)
+    }
+}

--- a/docs/plans/vallack-system-pack.md
+++ b/docs/plans/vallack-system-pack.md
@@ -1,0 +1,158 @@
+# Vallack System Pack — Implementation Plan
+
+## Context
+
+We researched Ben Vallack's keyboard system (#340) and want to build a "Vallack System" pack that users can toggle on/off as a unit. The system bundles two interdependent pieces: a **two-row modifier split** (OS mods on top row, layer toggles on home row) and a **nav layer** (arrows, clipboard, tab switching, Home/End).
+
+This is the first "system pack" — a pack that coordinates multiple mechanisms (RuleCollection + HomeRowModsConfig + HomeRowLayerTogglesConfig) behind a single toggle. It uses the existing `Pack` model's `associatedCollectionID` and install/uninstall flow, extended to apply config presets atomically.
+
+Related issues: #340 (research), #374 (system pack spec), #375 (conflict detection), #376 (system packs vision).
+
+## Scope
+
+- All-or-nothing toggle (no per-component toggles)
+- Two components: two-row mod split + nav layer
+- Action catalog expansion (prerequisite)
+
+## Progress
+
+- [x] Step 1: Expand action catalog (23 → 40 actions)
+- [x] Step 2: Add Vallack nav layer RuleCollection
+- [x] Step 3: Add two-row mod split presets
+- [x] Step 4: Register pack in PackRegistry
+- [x] Step 5: Extend PackInstaller for system-level config changes
+
+## Step 1: Expand SystemActionInfo.allActions ✅
+
+**File:** `Sources/KeyPathAppKit/UI/Experimental/Mapper/MapperActionTypes.swift`
+
+Added 17 new actions:
+- Cursor movement: Word Left/Right (`A-left`/`A-right`), Line Start/End (`home`/`end`)
+- Deletion: Delete Word (`A-bspc`), Kill Line (`C-k`)
+- Selection: Select Word Left/Right, Select to Line Start/End
+- Tab/Window: Previous/Next Tab, App Switcher, Window Switcher, Close Tab
+- System: Screenshot (`C-M-S-4`), Forward Delete (`del`)
+
+**File:** `Sources/KeyPathAppKit/UI/Components/OutputActionTypes.swift`
+
+Reorganized output picker from 5 groups to 9: Clipboard, Cursor Movement, Selection, Deletion, Tab/Window, System, Playback, Volume, Display.
+
+**Tests:** Updated count assertions in `SystemActionInfoTests.swift` (23 → 40 total, 8 → 11 media/HID, 8 → 22 editing).
+
+## Step 2: Add Vallack Nav Layer as a RuleCollection
+
+**File:** `Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionCatalog.swift`
+
+Add a new builder method that returns a `RuleCollection` with:
+- Stable UUID in `RuleCollectionIdentifier` (file: `RuleCollectionModels.swift`)
+- `name`: "Vallack Navigation"
+- `category`: `.navigation`
+- `targetLayer`: New layer activated by momentary activator
+- `momentaryActivator`: Mirrored — hold left index (F) or right index (J)
+- `configuration`: `.list`
+- Disabled by default (the Pack toggle controls it)
+
+Key mappings (adapted from Vallack's Kanata `cmd` layer to QWERTY positions):
+
+```
+Right hand (navigation)          Left hand (switching/editing)
+─────────────────────           ─────────────────────────────
+H → Left                        Q → Tab
+J → Down                        W → Esc
+K → Up                          E → Prev Tab (C-S-tab)
+L → Right                       R → Next Tab (C-tab)
+U → Backspace                   A → Cmd+Tab (app switcher)
+I → Enter                       S → Home (line start)
+Y → Copy (M-c)                  D → End (line end)
+; → Paste (M-v)                 G → Screenshot (C-M-S-4)
+                                T → Cmd+[ (browser back)
+                                V → Cmd+] (browser forward)
+```
+
+Design note: Vallack's layout is for Graphite, so we adapt the concept (right hand = arrows + editing, left hand = switching + clipboard) to QWERTY physical positions. The principle is the same: hold an index finger, everything you need is under the other hand.
+
+## Step 3: Add HomeRowModsConfig Preset for Two-Row Split
+
+**File:** `Sources/KeyPathAppKit/Models/HomeRowModsConfig.swift`
+
+Add static preset `vallackTwoRowSplit` alongside `cagsMacDefault` and `gacsWindows`:
+
+Top row keys (Q-row) get OS modifiers:
+- Left: Q→Ctrl, W→Alt, E→Cmd (pinkies get 300ms, others 200ms)
+- Right: O→Ctrl, I→Alt, U→Cmd
+
+This frees the home row for layer toggles.
+
+**File:** `Sources/KeyPathAppKit/Models/HomeRowLayerTogglesConfig.swift`
+
+Add preset with nav layer toggles on home-row index fingers:
+- F-hold → nav layer (left hand activator)
+- J-hold → nav layer (right hand activator, mirrored)
+
+Uses `layer-while-held` mode so the layer deactivates on release.
+
+## Step 4: Register the Vallack System Pack
+
+**File:** `Sources/KeyPathAppKit/Services/Packs/PackRegistry.swift`
+
+```swift
+public static let vallackSystem = Pack(
+    id: "com.keypath.pack.vallack-system",
+    version: "1.0",
+    name: "Vallack System",
+    tagline: "Your fingers stay put, the keyboard changes",
+    shortDescription: "...",
+    longDescription: "...",
+    category: "System",
+    iconSymbol: "rectangle.stack.badge.play",
+    bindings: [],
+    associatedCollectionID: RuleCollectionIdentifier.vallackNavigation
+)
+```
+
+Add to `starterKit` array.
+
+The Pack uses `associatedCollectionID` to toggle the nav layer RuleCollection. The two-row mod config is applied as part of the install flow (Step 5).
+
+## Step 5: Extend PackInstaller for System-Level Config Changes
+
+**File:** `Sources/KeyPathAppKit/Services/Packs/PackInstaller.swift`
+
+When installing `vallackSystem`:
+1. Toggle the associated nav layer RuleCollection (existing flow via `associatedCollectionID`)
+2. Snapshot current HomeRowModsConfig and HomeRowLayerTogglesConfig
+3. Apply `vallackTwoRowSplit` HomeRowModsConfig preset
+4. Apply the nav layer toggle HomeRowLayerTogglesConfig preset
+
+When uninstalling:
+1. Toggle off the nav layer RuleCollection
+2. Revert HomeRowModsConfig to snapshot
+3. Revert HomeRowLayerTogglesConfig to snapshot
+
+This follows the same snapshot/rollback pattern already used by the collection toggle mechanism in `RuleCollectionsManager+PublicAPI.swift`.
+
+## Files to Modify
+
+| File | Change | Status |
+|------|--------|--------|
+| `MapperActionTypes.swift` | Add 17 new actions | ✅ Done |
+| `OutputActionTypes.swift` | Reorganize into 9 groups | ✅ Done |
+| `SystemActionInfoTests.swift` | Update count assertions | ✅ Done |
+| `RuleCollectionCatalog.swift` | Add `vallackNavigation` collection | ✅ Done |
+| `RuleCollectionModels.swift` | Add UUID to `RuleCollectionIdentifier` | ✅ Done |
+| `HomeRowModsConfig.swift` | Add `vallackTwoRowSplit` preset | ✅ Done |
+| `HomeRowLayerTogglesConfig.swift` | Add Vallack layer toggle preset | ✅ Done |
+| `PackRegistry.swift` | Add `vallackSystem` pack | ✅ Done |
+| `PackInstaller.swift` | Handle system-level config on install/uninstall | ✅ Done |
+| `OutputActionGroupingTests.swift` | Fix tests for 9-group structure | ✅ Done |
+
+## Verification
+
+1. `swift build` — no compiler errors
+2. `swift test` — all pass
+3. Open overlay mapper → output picker shows 9 groups with new actions
+4. Gallery shows Vallack System pack with philosophy description
+5. Toggle on → nav layer activates, home row mods switch to two-row split
+6. Hold F or J → arrows, clipboard, tab switching all work on the nav layer
+7. Toggle off → everything reverts to previous state
+8. Undo snapshot works for the multi-config change


### PR DESCRIPTION
## Summary

- Adds the **Ben Vallack Approach** pack — a system pack that coordinates three mechanisms behind a single toggle: top-row modifiers, home-row layer activation, and an 18-key navigation layer
- Introduces **system pack gallery UI** with tabbed hero keyboard diagram, color-coded zones, and expandable "How it works" cards
- Fixes output action grouping to use explicit ID sets (no more media/editing misclassification)
- Batches multi-collection config changes into a single kanata reload

## What's included

**Pack infrastructure:**
- Vallack nav layer collection (18 mappings: arrows, clipboard, tabs, editing)
- `HomeRowModsConfig.vallackTwoRowSplit` preset (Q/W/E/U/I/O → Ctrl/Alt/Cmd)
- `HomeRowLayerTogglesConfig.vallackLayerAssignments` (F/J → vallack-nav layer)
- `PackInstaller` snapshot/restore for atomic install/uninstall of multi-collection packs
- Single config regen per toggle (was 3 separate reloads)

**Gallery UI:**
- `ZonedKeyboardDiagram` + `ZonedKeycap` — reusable color-zoned keyboard renderer
- Tabbed hero showing Home and Navigation layer states
- `SystemPackComponentCard` — expandable cards for multi-mechanism pack detail
- `MappingTableContent` action column upgraded to `StandardKeyBadge`

**Fixes:**
- `homeRowLayerToggles` added to catalog `builtInList` (was missing — install silently failed)
- Output action grouping uses ID sets instead of type-sniffing
- Toast no longer shows "0 bindings added" for collection-backed packs
- Default Shortcut List mode → Overlay Only
- Rules search field auto-focuses without focus ring

## Test plan

- [x] `swift build` passes
- [x] `swift test` passes (all 22 new Vallack tests + full suite)
- [ ] Toggle pack ON → nav layer + top-row mods + layer toggles all activate
- [ ] Hold F or J → overlay switches to nav layer, arrows/clipboard work
- [ ] Toggle pack OFF → all configs revert to previous state
- [ ] Re-toggle ON/OFF → clean round-trip
- [ ] Gallery hero shows correct zones on Home and Navigation tabs
- [ ] Other packs' mapping tables render correctly with new action badge styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)