### PR TITLE
feat: overlay zone coloring, layer preview, pack architecture (#379)

### DIFF
--- a/Sources/KeyPathAppKit/App.swift
+++ b/Sources/KeyPathAppKit/App.swift
@@ -285,6 +285,17 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             "🔍 [AppDelegate] applicationShouldHandleReopen (hasVisibleWindows=\(flag))"
         )
 
+        if NSApp.isHidden {
+            NSApp.unhide(nil)
+        }
+        NSApp.activate(ignoringOtherApps: true)
+
+        // If the app is already fully running, just activate — don't re-show the splash
+        if initialMainWindowShown, LiveKeyboardOverlayController.shared.isVisible {
+            AppLogger.shared.debug("🪟 [AppDelegate] Reopen while running - activating without splash")
+            return true
+        }
+
         if mainWindowController == nil {
             if NSApplication.shared.activationPolicy() != .regular {
                 NSApplication.shared.setActivationPolicy(.regular)
@@ -306,10 +317,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         suppressLaunchSplashAutoHide = true
         pendingReopenShow = false
-        if NSApp.isHidden {
-            NSApp.unhide(nil)
-        }
-        NSApp.activate(ignoringOtherApps: true)
         mainWindowController?.show(focus: true)
         initialMainWindowShown = true
         AppLogger.shared.debug("🪟 [AppDelegate] User-initiated reopen - showing main window immediately")

--- a/Sources/KeyPathAppKit/Models/KeyMapping.swift
+++ b/Sources/KeyPathAppKit/Models/KeyMapping.swift
@@ -37,6 +37,9 @@ public struct KeyMapping: Codable, Equatable, Identifiable, Sendable {
     /// If true, a visual separator row should appear before this mapping in table display
     public let sectionBreak: Bool
 
+    /// Optional label shown as a section header before this mapping (e.g., "✋ Left hand")
+    public let sectionLabel: String?
+
     /// Advanced behavior (dual-role, tap-dance, macro). Nil means simple remap using `action`.
     public let behavior: MappingBehavior?
 
@@ -52,6 +55,7 @@ public struct KeyMapping: Codable, Equatable, Identifiable, Sendable {
         ctrlOutput: String? = nil,
         description: String? = nil,
         sectionBreak: Bool = false,
+        sectionLabel: String? = nil,
         behavior: MappingBehavior? = nil,
         deviceOverrides: [DeviceKeyOverride]? = nil
     ) {
@@ -62,6 +66,7 @@ public struct KeyMapping: Codable, Equatable, Identifiable, Sendable {
         self.ctrlOutput = ctrlOutput
         self.description = description
         self.sectionBreak = sectionBreak
+        self.sectionLabel = sectionLabel
         self.behavior = behavior
         self.deviceOverrides = deviceOverrides
     }
@@ -72,7 +77,7 @@ public struct KeyMapping: Codable, Equatable, Identifiable, Sendable {
     }
 
     private enum CodingKeys: String, CodingKey {
-        case id, input, action, shiftedOutput, ctrlOutput, description, sectionBreak, behavior, deviceOverrides
+        case id, input, action, shiftedOutput, ctrlOutput, description, sectionBreak, sectionLabel, behavior, deviceOverrides
     }
 
     public init(from decoder: Decoder) throws {
@@ -84,6 +89,7 @@ public struct KeyMapping: Codable, Equatable, Identifiable, Sendable {
         ctrlOutput = try container.decodeIfPresent(String.self, forKey: .ctrlOutput)
         description = try container.decodeIfPresent(String.self, forKey: .description)
         sectionBreak = (try? container.decode(Bool.self, forKey: .sectionBreak)) ?? false
+        sectionLabel = try container.decodeIfPresent(String.self, forKey: .sectionLabel)
         behavior = try container.decodeIfPresent(MappingBehavior.self, forKey: .behavior)
         deviceOverrides = try container.decodeIfPresent([DeviceKeyOverride].self, forKey: .deviceOverrides)
     }
@@ -99,6 +105,7 @@ public struct KeyMapping: Codable, Equatable, Identifiable, Sendable {
         if sectionBreak {
             try container.encode(sectionBreak, forKey: .sectionBreak)
         }
+        try container.encodeIfPresent(sectionLabel, forKey: .sectionLabel)
         try container.encodeIfPresent(behavior, forKey: .behavior)
         try container.encodeIfPresent(deviceOverrides, forKey: .deviceOverrides)
     }

--- a/Sources/KeyPathAppKit/Models/RuleCollectionModels.swift
+++ b/Sources/KeyPathAppKit/Models/RuleCollectionModels.swift
@@ -19,6 +19,8 @@ public struct RuleCollection: Identifiable, Codable, Equatable, Sendable {
 
     public var isEnabled: Bool
     public var isSystemDefault: Bool
+    /// When non-nil, this collection is internal to a pack and hidden from the Rules tab.
+    public var owningPackID: String?
 
     // MARK: - Core Behavior
 
@@ -74,6 +76,7 @@ public struct RuleCollection: Identifiable, Codable, Equatable, Sendable {
         mappings: [KeyMapping],
         isEnabled: Bool = true,
         isSystemDefault: Bool = false,
+        owningPackID: String? = nil,
         icon: String? = nil,
         tags: [String] = [],
         targetLayer: RuleCollectionLayer = .base,
@@ -90,6 +93,7 @@ public struct RuleCollection: Identifiable, Codable, Equatable, Sendable {
         self.mappings = mappings
         self.isEnabled = isEnabled
         self.isSystemDefault = isSystemDefault
+        self.owningPackID = owningPackID
         self.icon = icon
         self.tags = tags
         self.targetLayer = targetLayer
@@ -103,7 +107,7 @@ public struct RuleCollection: Identifiable, Codable, Equatable, Sendable {
     // MARK: - Codable
 
     enum CodingKeys: String, CodingKey {
-        case id, name, summary, category, mappings, isEnabled, isSystemDefault
+        case id, name, summary, category, mappings, isEnabled, isSystemDefault, owningPackID
         case icon, tags, targetLayer, momentaryActivator, activationHint
         case configuration, windowKeyConvention, functionKeyMode
         // Legacy keys for migration
@@ -123,6 +127,7 @@ public struct RuleCollection: Identifiable, Codable, Equatable, Sendable {
         mappings = try container.decode([KeyMapping].self, forKey: .mappings)
         isEnabled = try container.decode(Bool.self, forKey: .isEnabled)
         isSystemDefault = try container.decode(Bool.self, forKey: .isSystemDefault)
+        owningPackID = try container.decodeIfPresent(String.self, forKey: .owningPackID)
         icon = try container.decodeIfPresent(String.self, forKey: .icon)
         tags = try container.decodeIfPresent([String].self, forKey: .tags) ?? []
         targetLayer = try container.decodeIfPresent(RuleCollectionLayer.self, forKey: .targetLayer) ?? .base
@@ -205,6 +210,7 @@ public struct RuleCollection: Identifiable, Codable, Equatable, Sendable {
         try container.encode(mappings, forKey: .mappings)
         try container.encode(isEnabled, forKey: .isEnabled)
         try container.encode(isSystemDefault, forKey: .isSystemDefault)
+        try container.encodeIfPresent(owningPackID, forKey: .owningPackID)
         try container.encodeIfPresent(icon, forKey: .icon)
         try container.encode(tags, forKey: .tags)
         try container.encode(targetLayer, forKey: .targetLayer)

--- a/Sources/KeyPathAppKit/Models/VallackZoneMap.swift
+++ b/Sources/KeyPathAppKit/Models/VallackZoneMap.swift
@@ -14,7 +14,6 @@ enum VallackZoneMap {
     static let homeSubtitles: [UInt16: String] = [
         12: "⌃", 13: "⌥", 14: "⌘",
         32: "⌘", 34: "⌥", 31: "⌃",
-        3: "NAV", 38: "NAV",
     ]
 
     static let navSubtitles: [UInt16: String] = [

--- a/Sources/KeyPathAppKit/Services/Packs/PackInstaller.swift
+++ b/Sources/KeyPathAppKit/Services/Packs/PackInstaller.swift
@@ -5,6 +5,7 @@
 // PackInstaller is the only place pack state changes; the Gallery/Pack Detail
 // UI calls these methods and does not mutate CustomRules or config directly.
 
+import AppKit
 import Foundation
 import KeyPathCore
 
@@ -499,6 +500,11 @@ public final class PackInstaller {
             oppositeHandMode: .press
         )
 
+        // Check if user has customized Home Row Mods from default
+        let useVallackMods = await shouldApplyVallackMods(
+            existingCollection: modsCollection
+        )
+
         let catalog = RuleCollectionCatalog().defaultCollections()
         ensureCollectionExists(id: RuleCollectionIdentifier.vallackNavigation, catalog: catalog, manager: manager)
         ensureCollectionExists(id: RuleCollectionIdentifier.homeRowMods, catalog: catalog, manager: manager)
@@ -508,7 +514,9 @@ public final class PackInstaller {
             manager.ruleCollections[i].isEnabled = true
         }
         if let i = manager.ruleCollections.firstIndex(where: { $0.id == RuleCollectionIdentifier.homeRowMods }) {
-            manager.ruleCollections[i].configuration.updateHomeRowModsConfig(vallackMods)
+            if useVallackMods {
+                manager.ruleCollections[i].configuration.updateHomeRowModsConfig(vallackMods)
+            }
             manager.ruleCollections[i].isEnabled = true
         }
         if let i = manager.ruleCollections.firstIndex(where: { $0.id == RuleCollectionIdentifier.homeRowLayerToggles }) {
@@ -520,7 +528,39 @@ public final class PackInstaller {
         try snapshotData.write(to: vallackSnapshotURL, options: .atomic)
 
         await manager.regenerateConfigFromCollections()
-        AppLogger.shared.log("📦 [PackInstaller] Applied Vallack system configs (two-row mods + nav toggles)")
+        let modsNote = useVallackMods ? "Ben's mod config" : "user's existing mod config"
+        AppLogger.shared.log("📦 [PackInstaller] Applied Vallack system configs (\(modsNote) + nav toggles)")
+    }
+
+    private func shouldApplyVallackMods(
+        existingCollection: RuleCollection?
+    ) async -> Bool {
+        guard let collection = existingCollection,
+              collection.isEnabled,
+              let existingConfig = collection.configuration.homeRowModsConfig
+        else {
+            return true
+        }
+
+        let defaultConfig = HomeRowModsConfig()
+        if existingConfig == defaultConfig {
+            return true
+        }
+
+        if TestEnvironment.isRunningTests {
+            return true
+        }
+
+        return await withCheckedContinuation { continuation in
+            let alert = NSAlert()
+            alert.messageText = "Home Row Mods Already Configured"
+            alert.informativeText = "You've customized your modifier settings. Ben Vallack's system includes its own mod configuration."
+            alert.alertStyle = .informational
+            alert.addButton(withTitle: "Keep Mine")
+            alert.addButton(withTitle: "Use Ben's")
+            let response = alert.runModal()
+            continuation.resume(returning: response == .alertSecondButtonReturn)
+        }
     }
 
     private func revertVallackSystemConfigs(manager: RuleCollectionsManager) async {

--- a/Sources/KeyPathAppKit/Services/Packs/PackZoneResolver.swift
+++ b/Sources/KeyPathAppKit/Services/Packs/PackZoneResolver.swift
@@ -13,6 +13,22 @@ enum PackZoneResolver {
         return [:]
     }
 
+    struct LayerPreviewConfig {
+        let activatorKeyCodes: Set<UInt16>
+        let targetLayer: String
+    }
+
+    static func layerPreviewConfig(
+        installedPackIDs: Set<String>
+    ) -> LayerPreviewConfig? {
+        for packID in installedPackIDs {
+            if let config = previewConfig(for: packID) {
+                return config
+            }
+        }
+        return nil
+    }
+
     private static func zoneColors(
         for packID: String,
         layerName: String
@@ -20,6 +36,18 @@ enum PackZoneResolver {
         switch packID {
         case PackRegistry.vallackSystem.id:
             return VallackZoneMap.zones(forLayer: layerName)?.mapValues(\.color)
+        default:
+            return nil
+        }
+    }
+
+    private static func previewConfig(for packID: String) -> LayerPreviewConfig? {
+        switch packID {
+        case PackRegistry.vallackSystem.id:
+            return LayerPreviewConfig(
+                activatorKeyCodes: VallackZoneMap.activatorKeyCodes,
+                targetLayer: "vallack-nav"
+            )
         default:
             return nil
         }

--- a/Sources/KeyPathAppKit/Services/Packs/PackZoneResolver.swift
+++ b/Sources/KeyPathAppKit/Services/Packs/PackZoneResolver.swift
@@ -29,6 +29,32 @@ enum PackZoneResolver {
         return nil
     }
 
+    static func activeZoneSubtitles(
+        installedPackIDs: Set<String>,
+        layerName: String
+    ) -> [UInt16: String] {
+        for packID in installedPackIDs {
+            if let subs = zoneSubtitles(for: packID, layerName: layerName) {
+                return subs
+            }
+        }
+        return [:]
+    }
+
+    private static func zoneSubtitles(
+        for packID: String,
+        layerName: String
+    ) -> [UInt16: String]? {
+        switch packID {
+        case PackRegistry.vallackSystem.id:
+            let lower = layerName.lowercased()
+            if lower.contains("vallack-nav") { return nil }
+            return VallackZoneMap.homeSubtitles
+        default:
+            return nil
+        }
+    }
+
     private static func zoneColors(
         for packID: String,
         layerName: String

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionCatalog.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionCatalog.swift
@@ -979,18 +979,9 @@ struct RuleCollectionCatalog {
             summary: "Hold F or J for arrows, clipboard, tab switching, and line navigation — fingers never leave the home row.",
             category: .navigation,
             mappings: [
-                // Right hand — navigation
-                KeyMapping(input: "h", action: .keystroke(key: "left"), description: "Left"),
-                KeyMapping(input: "j", action: .keystroke(key: "down"), description: "Down"),
-                KeyMapping(input: "k", action: .keystroke(key: "up"), description: "Up"),
-                KeyMapping(input: "l", action: .keystroke(key: "right"), description: "Right"),
-                KeyMapping(input: "u", action: .keystroke(key: "bspc"), description: "Backspace"),
-                KeyMapping(input: "i", action: .keystroke(key: "ret"), description: "Enter"),
-                KeyMapping(input: "y", action: .keystroke(key: "M-c"), description: "Copy"),
-                KeyMapping(input: ";", action: .keystroke(key: "M-v"), description: "Paste"),
                 // Left hand — switching and editing
-                KeyMapping(input: "q", action: .keystroke(key: "tab"), description: "Tab", sectionBreak: true),
-                KeyMapping(input: "w", action: .keystroke(key: "esc"), description: "Escape"),
+                KeyMapping(input: "q", action: .keystroke(key: "tab"), description: "Tab", sectionLabel: "✋ Left hand"),
+                KeyMapping(input: "w", action: .keystroke(key: "esc"), description: "Esc"),
                 KeyMapping(input: "e", action: .keystroke(key: "C-S-tab"), description: "Previous Tab"),
                 KeyMapping(input: "r", action: .keystroke(key: "C-tab"), description: "Next Tab"),
                 KeyMapping(input: "a", action: .keystroke(key: "M-tab"), description: "App Switcher"),
@@ -998,7 +989,16 @@ struct RuleCollectionCatalog {
                 KeyMapping(input: "d", action: .keystroke(key: "end"), description: "Line End"),
                 KeyMapping(input: "g", action: .keystroke(key: "C-M-S-4"), description: "Screenshot"),
                 KeyMapping(input: "t", action: .keystroke(key: "M-["), description: "Browser Back"),
-                KeyMapping(input: "v", action: .keystroke(key: "M-]"), description: "Browser Forward")
+                KeyMapping(input: "v", action: .keystroke(key: "M-]"), description: "Browser Forward"),
+                // Right hand — navigation
+                KeyMapping(input: "h", action: .keystroke(key: "left"), description: "Left", sectionBreak: true, sectionLabel: "🤚 Right hand"),
+                KeyMapping(input: "j", action: .keystroke(key: "down"), description: "Down"),
+                KeyMapping(input: "k", action: .keystroke(key: "up"), description: "Up"),
+                KeyMapping(input: "l", action: .keystroke(key: "right"), description: "Right"),
+                KeyMapping(input: "u", action: .keystroke(key: "bspc"), description: "Backspace"),
+                KeyMapping(input: "i", action: .keystroke(key: "ret"), description: "Enter"),
+                KeyMapping(input: "y", action: .keystroke(key: "M-c"), description: "Copy"),
+                KeyMapping(input: ";", action: .keystroke(key: "M-v"), description: "Paste")
             ],
             isEnabled: false,
             isSystemDefault: false,

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionCatalog.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionCatalog.swift
@@ -653,6 +653,7 @@ struct RuleCollectionCatalog {
             mappings: [], // Generated from homeRowLayerTogglesConfig
             isEnabled: false,
             isSystemDefault: false,
+            owningPackID: PackRegistry.vallackSystem.id,
             icon: "square.3.layers.3d",
             tags: ["home row", "layers", "productivity", "ergonomics"],
             configuration: .homeRowLayerToggles(HomeRowLayerTogglesConfig())
@@ -995,7 +996,7 @@ struct RuleCollectionCatalog {
                 KeyMapping(input: "j", action: .keystroke(key: "down"), description: "Down"),
                 KeyMapping(input: "k", action: .keystroke(key: "up"), description: "Up"),
                 KeyMapping(input: "l", action: .keystroke(key: "right"), description: "Right"),
-                KeyMapping(input: "u", action: .keystroke(key: "bspc"), description: "Backspace"),
+                KeyMapping(input: "u", action: .keystroke(key: "bspc"), description: "⌫"),
                 KeyMapping(input: "i", action: .keystroke(key: "ret"), description: "Enter"),
                 KeyMapping(input: "y", action: .keystroke(key: "M-c"), description: "Copy"),
                 KeyMapping(input: ";", action: .keystroke(key: "M-v"), description: "Paste")

--- a/Sources/KeyPathAppKit/UI/Experimental/Mapper/MapperActionTypes.swift
+++ b/Sources/KeyPathAppKit/UI/Experimental/Mapper/MapperActionTypes.swift
@@ -206,7 +206,7 @@ public struct SystemActionInfo: Equatable, Hashable, Identifiable, Sendable {
         SystemActionInfo(id: "window-switcher", name: "Window Switcher", sfSymbol: "macwindow.on.rectangle",
                          output: .modifierCombo("M-grave")),
         // System
-        SystemActionInfo(id: "screenshot", name: "Screenshot", sfSymbol: "camera.viewfinder",
+        SystemActionInfo(id: "screenshot", name: "Screenshot", sfSymbol: "camera",
                          output: .modifierCombo("C-M-S-4")),
         // Additional editing
         SystemActionInfo(id: "forward-delete", name: "Forward Delete", sfSymbol: "delete.forward",

--- a/Sources/KeyPathAppKit/UI/Gallery/PackDetailView+BindingRows.swift
+++ b/Sources/KeyPathAppKit/UI/Gallery/PackDetailView+BindingRows.swift
@@ -186,7 +186,7 @@ extension PackDetailView {
                     MappingTableContent(
                         mappings: collection.mappings.map {
                             ($0.input, $0.action.displayName, $0.shiftedOutput, $0.ctrlOutput,
-                             $0.description, $0.sectionBreak, isInstalled, $0.id, nil)
+                             $0.description, $0.sectionBreak, $0.sectionLabel, isInstalled, $0.id, nil)
                         }
                     )
                 }

--- a/Sources/KeyPathAppKit/UI/Gallery/SystemPackComponentsView.swift
+++ b/Sources/KeyPathAppKit/UI/Gallery/SystemPackComponentsView.swift
@@ -89,27 +89,25 @@ struct VallackSystemPackContent: View {
                         .padding(.top, 16)
                         .padding(.horizontal, 12)
 
-                    if selectedLayer == "home" {
+                    ZStack {
                         ZonedKeyboardDiagram(
                             zones: VallackZoneMap.homeZones(),
                             subtitles: VallackZoneMap.homeSubtitles,
                             keycapSize: 35
                         )
-                        .frame(maxWidth: .infinity)
-                        .padding(.top, 14)
-                        .padding(.bottom, 20)
-                        .padding(.horizontal, 12)
-                    } else {
+                        .opacity(selectedLayer == "home" ? 1 : 0)
+
                         ZonedKeyboardDiagram(
                             zones: VallackZoneMap.navZones(),
                             subtitles: VallackZoneMap.navSubtitles,
                             keycapSize: 35
                         )
-                        .frame(maxWidth: .infinity)
-                        .padding(.top, 14)
-                        .padding(.bottom, 20)
-                        .padding(.horizontal, 12)
+                        .opacity(selectedLayer == "home" ? 0 : 1)
                     }
+                    .frame(maxWidth: .infinity)
+                    .padding(.top, 14)
+                    .padding(.bottom, 20)
+                    .padding(.horizontal, 12)
                 }
                 .gesture(
                     DragGesture(minimumDistance: 0)

--- a/Sources/KeyPathAppKit/UI/Gallery/SystemPackComponentsView.swift
+++ b/Sources/KeyPathAppKit/UI/Gallery/SystemPackComponentsView.swift
@@ -50,9 +50,9 @@ struct SystemPackComponentCard: View {
                 content
                     .padding(.horizontal, 12)
                     .padding(.vertical, 10)
-                    .transition(.opacity.combined(with: .move(edge: .top)))
             }
         }
+        .clipped()
         .background(
             RoundedRectangle(cornerRadius: 8)
                 .fill(Color(NSColor.controlBackgroundColor).opacity(0.5))
@@ -74,6 +74,7 @@ struct VallackSystemPackContent: View {
 
     @State private var expandedComponent: String?
     @State private var selectedLayer: String = "home"
+    @State private var preHoldLayer: String?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
@@ -110,6 +111,25 @@ struct VallackSystemPackContent: View {
                         .padding(.horizontal, 12)
                     }
                 }
+                .gesture(
+                    DragGesture(minimumDistance: 0)
+                        .onChanged { _ in
+                            if preHoldLayer == nil {
+                                preHoldLayer = selectedLayer
+                                withAnimation(.easeInOut(duration: 0.15)) {
+                                    selectedLayer = "nav"
+                                }
+                            }
+                        }
+                        .onEnded { _ in
+                            if let restore = preHoldLayer {
+                                withAnimation(.easeInOut(duration: 0.15)) {
+                                    selectedLayer = restore
+                                }
+                                preHoldLayer = nil
+                            }
+                        }
+                )
                 .frame(maxWidth: .infinity)
                 .background(
                     RoundedRectangle(cornerRadius: 8, style: .continuous)
@@ -246,12 +266,12 @@ struct VallackSystemPackContent: View {
                 .foregroundStyle(.secondary)
             MappingTableContent(
                 mappings: [
-                    ("q", "⌃", nil, nil, "Control", false, true, UUID(uuidString: "00000000-0000-0000-0000-000000000101")!, nil),
-                    ("w", "⌥", nil, nil, "Option", false, true, UUID(uuidString: "00000000-0000-0000-0000-000000000102")!, nil),
-                    ("e", "⌘", nil, nil, "Command", false, true, UUID(uuidString: "00000000-0000-0000-0000-000000000103")!, nil),
-                    ("u", "⌘", nil, nil, "Command", true, true, UUID(uuidString: "00000000-0000-0000-0000-000000000104")!, nil),
-                    ("i", "⌥", nil, nil, "Option", false, true, UUID(uuidString: "00000000-0000-0000-0000-000000000105")!, nil),
-                    ("o", "⌃", nil, nil, "Control", false, true, UUID(uuidString: "00000000-0000-0000-0000-000000000106")!, nil),
+                    ("q", "⌃", nil, nil, "Control", false, "✋ Left hand", true, UUID(uuidString: "00000000-0000-0000-0000-000000000101")!, nil),
+                    ("w", "⌥", nil, nil, "Option", false, nil, true, UUID(uuidString: "00000000-0000-0000-0000-000000000102")!, nil),
+                    ("e", "⌘", nil, nil, "Command", false, nil, true, UUID(uuidString: "00000000-0000-0000-0000-000000000103")!, nil),
+                    ("u", "⌘", nil, nil, "Command", true, "🤚 Right hand", true, UUID(uuidString: "00000000-0000-0000-0000-000000000104")!, nil),
+                    ("i", "⌥", nil, nil, "Option", false, nil, true, UUID(uuidString: "00000000-0000-0000-0000-000000000105")!, nil),
+                    ("o", "⌃", nil, nil, "Control", false, nil, true, UUID(uuidString: "00000000-0000-0000-0000-000000000106")!, nil)
                 ]
             )
         }
@@ -289,7 +309,7 @@ struct VallackSystemPackContent: View {
                 MappingTableContent(
                     mappings: collection.mappings.map {
                         ($0.input, $0.action.displayName, $0.shiftedOutput, $0.ctrlOutput,
-                         $0.description, $0.sectionBreak, isInstalled, $0.id, nil)
+                         $0.description, $0.sectionBreak, $0.sectionLabel, isInstalled, $0.id, nil)
                     }
                 )
             }

--- a/Sources/KeyPathAppKit/UI/KeyboardVisualization/KeyboardVisualizationViewModel+LayoutMapping.swift
+++ b/Sources/KeyPathAppKit/UI/KeyboardVisualization/KeyboardVisualizationViewModel+LayoutMapping.swift
@@ -333,18 +333,24 @@ extension KeyboardVisualizationViewModel {
 
             for keyMapping in collection.mappings {
                 let input = keyMapping.input.lowercased()
-                // First try push-msg pattern (apps, system actions, URLs)
                 if let info = Self.extractPushMsgInfo(from: keyMapping.action.kanataOutput, description: keyMapping.description) {
                     actionByInput[input] = info
                 } else {
-                    // Simple key remap
                     let outputKey = keyMapping.action.outputString.lowercased()
-                    if let outputKeyCode = Self.kanataNameToKeyCode(outputKey) {
-                        let displayLabel = outputKey.count == 1 ? outputKey.uppercased() : outputKey.capitalized
+                    if let systemAction = SystemActionInfo.find(byOutput: outputKey) {
+                        actionByInput[input] = .systemAction(
+                            action: systemAction.id,
+                            description: keyMapping.description ?? systemAction.name,
+                            collectionId: collection.id
+                        )
+                    } else if let outputKeyCode = Self.kanataNameToKeyCode(outputKey) {
+                        let displayLabel = keyMapping.description
+                            ?? (outputKey.count == 1 ? outputKey.uppercased() : outputKey.capitalized)
                         actionByInput[input] = .mapped(
                             displayLabel: displayLabel,
                             outputKey: outputKey,
-                            outputKeyCode: outputKeyCode
+                            outputKeyCode: outputKeyCode,
+                            collectionId: collection.id
                         )
                     }
                 }

--- a/Sources/KeyPathAppKit/UI/KeyboardVisualization/KeyboardVisualizationViewModel+TCP.swift
+++ b/Sources/KeyPathAppKit/UI/KeyboardVisualization/KeyboardVisualizationViewModel+TCP.swift
@@ -313,7 +313,11 @@ extension KeyboardVisualizationViewModel {
         if message.hasPrefix("layer:") {
             let layerName = String(message.dropFirst(6)).trimmingCharacters(in: .whitespaces)
             AppLogger.shared.info("🗂️ [KeyboardViz] Layer push message: '\(layerName)'")
-            // Update the layer and rebuild mappings
+            if isShowingLayerPreview {
+                isShowingLayerPreview = false
+                layerPreviewTask?.cancel()
+                layerPreviewTask = nil
+            }
             updateLayer(layerName)
             return
         }
@@ -538,6 +542,7 @@ extension KeyboardVisualizationViewModel {
             pressedKeyCodes.insert(keyCode)
             // Track most recently pressed key for icon association
             lastPressedKeyCode = keyCode
+            startLayerPreviewIfActivator(keyCode)
             // If a hold is already active for this key, keep it active and cancel any pending clear.
             if holdActiveKeyCodes.contains(keyCode) {
                 holdClearWorkItems[keyCode]?.cancel()
@@ -592,6 +597,7 @@ extension KeyboardVisualizationViewModel {
                 holdReleaseFadeKeyCodes.insert(keyCode)
             }
             pressedKeyCodes.remove(keyCode)
+            cancelLayerPreviewIfActivator(keyCode)
             startKeyFadeOut(keyCode) // Start fade-out animation
             // Defer clearing hold state briefly to tolerate tap-hold-press sequences that emit rapid releases.
             let work = DispatchWorkItem { [weak self] in
@@ -616,6 +622,38 @@ extension KeyboardVisualizationViewModel {
             AppLogger.shared.debug(
                 "🧪 [KeyboardViz] caps state: tcpPressed=\(pressedKeyCodes.contains(57)) holdActive=\(holdActiveKeyCodes.contains(57)) holdLabel=\(holdLabels[57] ?? "nil")"
             )
+        }
+    }
+
+    // MARK: - Layer Preview for System Pack Activators
+
+    private func startLayerPreviewIfActivator(_ keyCode: UInt16) {
+        guard layerPreviewActivators.contains(keyCode),
+              !layerPreviewTarget.isEmpty,
+              !isShowingLayerPreview,
+              layerPreviewTask == nil
+        else { return }
+
+        layerPreviewTask?.cancel()
+        layerPreviewTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .milliseconds(200))
+            guard let self, !Task.isCancelled else { return }
+            guard self.pressedKeyCodes.contains(keyCode) else { return }
+            self.prePreviewLayerName = self.currentLayerName
+            self.isShowingLayerPreview = true
+            self.updateLayer(self.layerPreviewTarget)
+        }
+    }
+
+    private func cancelLayerPreviewIfActivator(_ keyCode: UInt16) {
+        guard layerPreviewActivators.contains(keyCode) else { return }
+
+        layerPreviewTask?.cancel()
+        layerPreviewTask = nil
+
+        if isShowingLayerPreview {
+            isShowingLayerPreview = false
+            updateLayer(prePreviewLayerName)
         }
     }
 }

--- a/Sources/KeyPathAppKit/UI/KeyboardVisualization/KeyboardVisualizationViewModel+TCP.swift
+++ b/Sources/KeyPathAppKit/UI/KeyboardVisualization/KeyboardVisualizationViewModel+TCP.swift
@@ -314,9 +314,17 @@ extension KeyboardVisualizationViewModel {
             let layerName = String(message.dropFirst(6)).trimmingCharacters(in: .whitespaces)
             AppLogger.shared.info("🗂️ [KeyboardViz] Layer push message: '\(layerName)'")
             if isShowingLayerPreview {
-                isShowingLayerPreview = false
-                layerPreviewTask?.cancel()
-                layerPreviewTask = nil
+                prePreviewLayerName = layerName
+                if layerName.lowercased() != layerPreviewTarget.lowercased() {
+                    isShowingLayerPreview = false
+                    layerPreviewTask?.cancel()
+                    layerPreviewTask = nil
+                    AppLogger.shared.debug("🗂️ [KeyboardViz] Preview ended — kanata switched to '\(layerName)'")
+                    updateLayer(layerName)
+                } else {
+                    AppLogger.shared.debug("🗂️ [KeyboardViz] Preview active — kanata confirmed '\(layerName)'")
+                }
+                return
             }
             updateLayer(layerName)
             return
@@ -636,7 +644,7 @@ extension KeyboardVisualizationViewModel {
 
         layerPreviewTask?.cancel()
         layerPreviewTask = Task { @MainActor [weak self] in
-            try? await Task.sleep(for: .milliseconds(200))
+            try? await Task.sleep(for: .milliseconds(100))
             guard let self, !Task.isCancelled else { return }
             guard self.pressedKeyCodes.contains(keyCode) else { return }
             self.prePreviewLayerName = self.currentLayerName

--- a/Sources/KeyPathAppKit/UI/KeyboardVisualization/KeyboardVisualizationViewModel.swift
+++ b/Sources/KeyPathAppKit/UI/KeyboardVisualization/KeyboardVisualizationViewModel.swift
@@ -58,6 +58,19 @@ class KeyboardVisualizationViewModel {
     /// Example: (push-msg "emphasis:h,j,k,l") sets HJKL as emphasized
     var customEmphasisKeyCodes: Set<UInt16> = []
 
+    // MARK: - Layer Preview (System Pack Activators)
+
+    /// Key codes that trigger a layer preview on hold (e.g., F/J for Vallack nav)
+    var layerPreviewActivators: Set<UInt16> = []
+    /// Layer name to preview when an activator is held
+    var layerPreviewTarget: String = ""
+    /// Delayed task for activating the layer preview
+    @ObservationIgnored var layerPreviewTask: Task<Void, Never>?
+    /// Whether we're currently showing a layer preview (not a real kanata layer change)
+    @ObservationIgnored var isShowingLayerPreview: Bool = false
+    /// The real layer name before the preview override
+    @ObservationIgnored var prePreviewLayerName: String = "base"
+
     // MARK: - Launcher Mode State
 
     /// Launcher mappings for overlay display (key -> LauncherMapping)

--- a/Sources/KeyPathAppKit/UI/Overlay/LiveKeyboardOverlayView+ContentBuilders.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/LiveKeyboardOverlayView+ContentBuilders.swift
@@ -180,6 +180,10 @@ extension LiveKeyboardOverlayView {
                     activeZoneColors: PackZoneResolver.activeZoneColors(
                         installedPackIDs: installedPackIDs,
                         layerName: viewModel.currentLayerName
+                    ),
+                    activeZoneSubtitles: PackZoneResolver.activeZoneSubtitles(
+                        installedPackIDs: installedPackIDs,
+                        layerName: viewModel.currentLayerName
                     )
                 )
                 .environment(viewModel)

--- a/Sources/KeyPathAppKit/UI/Overlay/LiveKeyboardOverlayView.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/LiveKeyboardOverlayView.swift
@@ -235,7 +235,16 @@ struct LiveKeyboardOverlayView: View {
     private func refreshInstalledPackIDs() async {
         let records = await InstalledPackTracker.shared.allInstalled()
         let ids = Set(records.map(\.packID))
-        await MainActor.run { installedPackIDs = ids }
+        await MainActor.run {
+            installedPackIDs = ids
+            if let preview = PackZoneResolver.layerPreviewConfig(installedPackIDs: ids) {
+                viewModel.layerPreviewActivators = preview.activatorKeyCodes
+                viewModel.layerPreviewTarget = preview.targetLayer
+            } else {
+                viewModel.layerPreviewActivators = []
+                viewModel.layerPreviewTarget = ""
+            }
+        }
     }
 
     private func copyValidationErrorsToClipboard() {

--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayKeyboardView.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayKeyboardView.swift
@@ -61,6 +61,8 @@ struct OverlayKeyboardView: View {
     var isInspectorVisible: Bool = false
     /// Zone coloring from the active system pack (key code -> fill color)
     var activeZoneColors: [UInt16: Color] = [:]
+    /// Subtitles from the active system pack (key code -> subtitle string, e.g., "⌃")
+    var activeZoneSubtitles: [UInt16: String] = [:]
 
     // MARK: - Layer Mode (Vim/Nav)
 
@@ -484,7 +486,8 @@ struct OverlayKeyboardView: View {
             launcherMapping: launcherMapping,
             // Keymap transition flag (bypasses remap gating for animation)
             isKeymapTransitioning: isKeymapTransitioning,
-            zoneColor: activeZoneColors[key.keyCode]
+            zoneColor: activeZoneColors[key.keyCode],
+            zoneSubtitle: activeZoneSubtitles[key.keyCode]
         )
         .frame(
             width: keyWidth(for: key, scale: scale),

--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView+ContentAndStyling.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView+ContentAndStyling.swift
@@ -59,6 +59,18 @@ extension OverlayKeycapView {
             // Crisp content layer
             keyContent
 
+            // Zone subtitle overlay (e.g., ⌃ under Q for hold modifier)
+            if let subtitle = zoneSubtitle, !isLayerMode, !isLauncherMode {
+                VStack(spacing: 0) {
+                    Spacer()
+                    Text(subtitle)
+                        .font(.system(size: 7 * scale, weight: .medium))
+                        .foregroundStyle(Color.white.opacity(0.45))
+                        .padding(.bottom, 1 * scale)
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+
             // Custom icon overlay (from push-msg, takes precedence over other content)
             if let iconName = customIcon {
                 Image(systemName: iconName)

--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView+LayoutContent.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView+LayoutContent.swift
@@ -151,10 +151,14 @@ extension OverlayKeycapView {
                 if let holdLabel {
                     return holdLabel
                 }
+                if let tapHoldLabel = tapHoldIdleLabel {
+                    let tapMetadata = LabelMetadata.forLabel(tapHoldLabel)
+                    return tapMetadata.wordLabel ?? tapHoldLabel
+                }
                 if isRemappedKey, let remapLabel = metadata.wordLabel {
                     return remapLabel
                 }
-                if currentLayerName.lowercased() == "nav" {
+                if currentLayerName.lowercased() != "base" {
                     return physicalMetadata.wordLabel ?? key.label
                 }
                 if useSymbols {

--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView+ModeContent.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView+ModeContent.swift
@@ -169,13 +169,15 @@ extension OverlayKeycapView {
                 }
             }
         } else {
-            // Unmapped key in layer mode: small label in top-left (skip for arrows and bottom row modifiers)
+            // Unmapped key in layer mode: preserve base-layer rendering for special keys
             if isArrowKey {
-                // Arrow keys: just show centered arrow
                 arrowContent
             } else if key.layoutRole == .narrowModifier {
-                // Bottom row modifiers (fn, ctrl, opt, cmd): render same as base layer
                 narrowModifierContent
+            } else if key.layoutRole == .bottomAligned {
+                bottomAlignedContent
+            } else if key.layoutRole == .escKey {
+                escKeyContent
             } else {
                 // In Nav layer, convert symbols to text labels (except modifier keys)
                 let displayLabel: String = {

--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView.swift
@@ -68,6 +68,8 @@ struct OverlayKeycapView: View {
     var isKeymapTransitioning: Bool = false
     /// Zone color from active system pack (takes priority over collection colors)
     var zoneColor: Color?
+    /// Subtitle from active system pack (e.g., "⌃" under Q for hold modifier)
+    var zoneSubtitle: String?
 
     /// Whether this key has a launcher mapping
     var hasLauncherMapping: Bool {

--- a/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView+CollectionRow.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView+CollectionRow.swift
@@ -13,7 +13,7 @@ struct ExpandableCollectionRow: View {
     let icon: String
     let count: Int
     let isEnabled: Bool
-    let mappings: [(input: String, output: String, shiftedOutput: String?, ctrlOutput: String?, description: String?, sectionBreak: Bool, enabled: Bool, id: UUID, behavior: MappingBehavior?)]
+    let mappings: [(input: String, output: String, shiftedOutput: String?, ctrlOutput: String?, description: String?, sectionBreak: Bool, sectionLabel: String?, enabled: Bool, id: UUID, behavior: MappingBehavior?)]
     var appKeymaps: [AppKeymap] = []
     let onToggle: (Bool) -> Void
     let onEditMapping: ((UUID) -> Void)?
@@ -123,6 +123,7 @@ private var fallbackKeyMappings: [KeyMapping] {
                 ctrlOutput: mapping.ctrlOutput,
                 description: mapping.description,
                 sectionBreak: mapping.sectionBreak,
+                sectionLabel: mapping.sectionLabel,
                 behavior: mapping.behavior
             )
         }
@@ -149,6 +150,7 @@ private var fallbackKeyMappings: [KeyMapping] {
             headerButtonView
             expandedContentView
         }
+        .clipped()
         .background(
             RoundedRectangle(cornerRadius: 10)
                 .fill(isHovered ? Color(NSColor.controlBackgroundColor).opacity(0.5) : Color(NSColor.windowBackgroundColor))

--- a/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView+MappingRow.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView+MappingRow.swift
@@ -8,7 +8,7 @@ import SwiftUI
 // MARK: - Mapping Row View
 
 struct MappingRowView: View {
-    let mapping: (input: String, output: String, shiftedOutput: String?, ctrlOutput: String?, description: String?, sectionBreak: Bool, enabled: Bool, id: UUID, behavior: MappingBehavior?)
+    let mapping: (input: String, output: String, shiftedOutput: String?, ctrlOutput: String?, description: String?, sectionBreak: Bool, sectionLabel: String?, enabled: Bool, id: UUID, behavior: MappingBehavior?)
     let layerActivator: MomentaryActivator?
     var leaderKeyDisplay: String = "␣ Space"
     let onEditMapping: ((UUID) -> Void)?

--- a/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView+MappingTable.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView+MappingTable.swift
@@ -8,7 +8,7 @@ import SwiftUI
 // MARK: - Mapping Table Content
 
 struct MappingTableContent: View {
-    let mappings: [(input: String, output: String, shiftedOutput: String?, ctrlOutput: String?, description: String?, sectionBreak: Bool, enabled: Bool, id: UUID, behavior: MappingBehavior?)]
+    let mappings: [(input: String, output: String, shiftedOutput: String?, ctrlOutput: String?, description: String?, sectionBreak: Bool, sectionLabel: String?, enabled: Bool, id: UUID, behavior: MappingBehavior?)]
 
     private var hasShiftVariants: Bool {
         mappings.contains { $0.shiftedOutput != nil }
@@ -57,10 +57,16 @@ struct MappingTableContent: View {
 
             // Data rows
             ForEach(mappings, id: \.id) { mapping in
-                // Section break separator (extra whitespace)
-                if mapping.sectionBreak {
+                if let label = mapping.sectionLabel {
+                    Text(label)
+                        .font(.body.weight(.medium))
+                        .foregroundColor(.secondary)
+                        .padding(.leading, 16)
+                        .padding(.top, mapping.sectionBreak ? 20 : 6)
+                        .padding(.bottom, 2)
+                } else if mapping.sectionBreak {
                     Spacer()
-                        .frame(height: 12)
+                        .frame(height: 20)
                 }
 
                 HStack(spacing: 0) {

--- a/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView.swift
@@ -57,12 +57,17 @@ struct RulesTabView: View {
         return "custom-rules-\(rulesHash)-\(appsHash)"
     }
 
-    /// Show all catalog collections, merging with existing state
+    /// Show all catalog collections, merging with existing state.
+    /// Excludes pack-internal collections (managed entirely by their owning pack).
     var allCollections: [RuleCollection] {
         let catalog = RuleCollectionCatalog()
-        return catalog.defaultCollections().map { catalogCollection in
+        return catalog.defaultCollections().compactMap { catalogCollection in
+            // Hide pack-internal collections from the Rules tab
+            if catalogCollection.owningPackID != nil { return nil }
             // Find matching collection from kanataManager to preserve enabled state
             if var existing = kanataManager.ruleCollections.first(where: { $0.id == catalogCollection.id }) {
+                // Also hide if the persisted copy gained an owningPackID
+                if existing.owningPackID != nil { return nil }
                 // Always use catalog category (user data may have stale values)
                 existing.category = catalogCollection.category
                 return existing

--- a/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView.swift
@@ -222,7 +222,7 @@ struct RulesTabView: View {
                 (style == .layerPresetPicker ? (collection.configuration.layerPresetPickerConfig?.selectedMappings.count ?? 0) : collection.mappings.count),
             isEnabled: pendingToggles[collection.id] ?? collection.isEnabled,
             mappings: collection.mappings.map {
-                ($0.input, $0.action.outputString, $0.shiftedOutput, $0.ctrlOutput, $0.description, $0.sectionBreak, collection.isEnabled, $0.id, nil)
+                ($0.input, $0.action.outputString, $0.shiftedOutput, $0.ctrlOutput, $0.description, $0.sectionBreak, $0.sectionLabel, collection.isEnabled, $0.id, nil)
             },
             onToggle: { isOn in
                 handleCollectionToggle(collection: collection, isOn: isOn)
@@ -392,9 +392,30 @@ struct RulesTabView: View {
             pendingSelections.removeValue(forKey: collection.id)
         }
         Task {
-            await kanataManager.toggleRuleCollection(collection.id, enabled: isOn)
+            if let pack {
+                await toggleViaPack(pack, isOn: isOn)
+            } else {
+                await kanataManager.toggleRuleCollection(collection.id, enabled: isOn)
+            }
             pendingToggles.removeValue(forKey: collection.id)
             refreshUnmetDependencies()
+        }
+    }
+
+    private func toggleViaPack(_ pack: Pack, isOn: Bool) async {
+        let manager = kanataManager.underlyingManager.ruleCollectionsManager
+        do {
+            if isOn {
+                _ = try await PackInstaller.shared.install(pack, manager: manager)
+            } else {
+                try await PackInstaller.shared.uninstall(packID: pack.id, manager: manager)
+            }
+        } catch {
+            AppLogger.shared.log("⚠️ [Rules] Pack toggle failed for '\(pack.name)': \(error.localizedDescription)")
+            await kanataManager.toggleRuleCollection(
+                pack.associatedCollectionID ?? UUID(),
+                enabled: isOn
+            )
         }
     }
 
@@ -493,7 +514,7 @@ struct RulesTabView: View {
                                 count: isSearching ? (filteredCustomRules.count + filteredAppKeymaps.flatMap(\.overrides).count) : totalCustomRulesCount,
                                 isEnabled: filteredCustomRules.isEmpty
                                     || filteredCustomRules.allSatisfy(\.isEnabled),
-                                mappings: filteredCustomRules.map { ($0.input, $0.action.outputString, $0.shiftedOutput, nil, $0.title.isEmpty ? nil : $0.title, false, $0.isEnabled, $0.id, $0.behavior) },
+                                mappings: filteredCustomRules.map { ($0.input, $0.action.outputString, $0.shiftedOutput, nil, $0.title.isEmpty ? nil : $0.title, false, nil as String?, $0.isEnabled, $0.id, $0.behavior) },
                                 appKeymaps: filteredAppKeymaps,
                                 onToggle: { isOn in
                                     Task {

--- a/Sources/KeyPathAppKit/UI/Settings/SettingsContainerView.swift
+++ b/Sources/KeyPathAppKit/UI/Settings/SettingsContainerView.swift
@@ -62,6 +62,7 @@ struct SettingsContainerView: View {
                 .tabItem { Label("Repair/Remove", systemImage: "wrench.and.screwdriver") }
                 .tag(SettingsTab.advanced)
         }
+        .background(tabShortcutHandlers)
         .frame(
             minWidth: 680,
             idealWidth: 680,
@@ -100,6 +101,22 @@ struct SettingsContainerView: View {
         .onReceive(NotificationCenter.default.publisher(for: .openSettingsAdvanced)) { _ in
             selection = .advanced
         }
+    }
+
+    private var tabShortcutHandlers: some View {
+        VStack {
+            Button("") { selection = .status }
+                .keyboardShortcut("1", modifiers: .command)
+            Button("") { selection = canManageRules ? .rules : selection }
+                .keyboardShortcut("2", modifiers: .command)
+            Button("") { selection = .general }
+                .keyboardShortcut("3", modifiers: .command)
+            Button("") { selection = .advanced }
+                .keyboardShortcut("4", modifiers: .command)
+        }
+        .frame(width: 0, height: 0)
+        .opacity(0)
+        .allowsHitTesting(false)
     }
 
     private func refreshCanManageRules() async {

--- a/Tests/KeyPathTests/VallackOverlayZoneTests.swift
+++ b/Tests/KeyPathTests/VallackOverlayZoneTests.swift
@@ -247,4 +247,199 @@ final class VallackOverlayZoneTests: XCTestCase {
     func testActivatorKeyCodesAreFAndJ() {
         XCTAssertEqual(VallackZoneMap.activatorKeyCodes, Set<UInt16>([3, 38]))
     }
+
+    // MARK: - Zone Subtitles
+
+    func testHomeSubtitlesContainModifierSymbols() {
+        let subs = VallackZoneMap.homeSubtitles
+        XCTAssertEqual(subs[12], "⌃", "Q should have Control subtitle")
+        XCTAssertEqual(subs[13], "⌥", "W should have Option subtitle")
+        XCTAssertEqual(subs[14], "⌘", "E should have Command subtitle")
+        XCTAssertEqual(subs[32], "⌘", "U should have Command subtitle")
+        XCTAssertEqual(subs[34], "⌥", "I should have Option subtitle")
+        XCTAssertEqual(subs[31], "⌃", "O should have Control subtitle")
+    }
+
+    func testHomeSubtitlesDoNotContainFJNav() {
+        let subs = VallackZoneMap.homeSubtitles
+        XCTAssertNil(subs[3], "F should not have a subtitle (color is sufficient)")
+        XCTAssertNil(subs[38], "J should not have a subtitle (color is sufficient)")
+    }
+
+    func testResolverReturnsSubtitlesOnBaseLayer() {
+        let subs = PackZoneResolver.activeZoneSubtitles(
+            installedPackIDs: [PackRegistry.vallackSystem.id],
+            layerName: "base"
+        )
+        XCTAssertEqual(subs[12], "⌃")
+        XCTAssertEqual(subs[14], "⌘")
+        XCTAssertEqual(subs.count, 6)
+    }
+
+    func testResolverReturnsNoSubtitlesOnNavLayer() {
+        let subs = PackZoneResolver.activeZoneSubtitles(
+            installedPackIDs: [PackRegistry.vallackSystem.id],
+            layerName: "vallack-nav"
+        )
+        XCTAssertTrue(subs.isEmpty, "Nav layer should not have subtitles")
+    }
+
+    func testResolverReturnsNoSubtitlesWithoutPack() {
+        let subs = PackZoneResolver.activeZoneSubtitles(
+            installedPackIDs: [],
+            layerName: "base"
+        )
+        XCTAssertTrue(subs.isEmpty)
+    }
+
+    // MARK: - Layer Preview Config
+
+    func testLayerPreviewConfigReturnsActivatorsWhenVallackInstalled() {
+        let config = PackZoneResolver.layerPreviewConfig(
+            installedPackIDs: [PackRegistry.vallackSystem.id]
+        )
+        XCTAssertNotNil(config)
+        XCTAssertEqual(config?.activatorKeyCodes, Set<UInt16>([3, 38]))
+        XCTAssertEqual(config?.targetLayer, "vallack-nav")
+    }
+
+    func testLayerPreviewConfigReturnsNilWithoutPack() {
+        let config = PackZoneResolver.layerPreviewConfig(installedPackIDs: [])
+        XCTAssertNil(config)
+    }
+
+    // MARK: - owningPackID (Pack-Internal Collections)
+
+    func testVallackNavCollectionIsNotPackOwned() {
+        let catalog = RuleCollectionCatalog().defaultCollections()
+        let collection = catalog.first { $0.id == RuleCollectionIdentifier.vallackNavigation }
+        XCTAssertNil(collection?.owningPackID, "Vallack Nav is the pack's identity row — visible in Rules tab")
+    }
+
+    func testHomeRowLayerTogglesIsPackOwned() {
+        let catalog = RuleCollectionCatalog().defaultCollections()
+        let collection = catalog.first { $0.id == RuleCollectionIdentifier.homeRowLayerToggles }
+        XCTAssertEqual(collection?.owningPackID, PackRegistry.vallackSystem.id)
+    }
+
+    func testHomeRowModsIsNotPackOwned() {
+        let catalog = RuleCollectionCatalog().defaultCollections()
+        let collection = catalog.first { $0.id == RuleCollectionIdentifier.homeRowMods }
+        XCTAssertNil(collection?.owningPackID, "Home Row Mods is shared, not pack-internal")
+    }
+
+    func testOnlyInternalSubcomponentsAreHiddenFromRulesTab() {
+        let catalog = RuleCollectionCatalog().defaultCollections()
+        let visible = catalog.filter { $0.owningPackID == nil }
+        let hidden = catalog.filter { $0.owningPackID != nil }
+
+        XCTAssertTrue(visible.contains { $0.id == RuleCollectionIdentifier.vallackNavigation },
+                       "Vallack pack row should be visible")
+        XCTAssertFalse(visible.contains { $0.id == RuleCollectionIdentifier.homeRowLayerToggles },
+                        "Layer Toggles should be hidden")
+        XCTAssertTrue(hidden.contains { $0.id == RuleCollectionIdentifier.homeRowLayerToggles })
+    }
+
+    // MARK: - KeyMapping sectionLabel Codable
+
+    func testSectionLabelRoundTrips() throws {
+        let mapping = KeyMapping(
+            input: "h",
+            action: .keystroke(key: "left"),
+            description: "Left",
+            sectionBreak: true,
+            sectionLabel: "🤚 Right hand"
+        )
+        let data = try JSONEncoder().encode(mapping)
+        let decoded = try JSONDecoder().decode(KeyMapping.self, from: data)
+        XCTAssertEqual(decoded.sectionLabel, "🤚 Right hand")
+        XCTAssertTrue(decoded.sectionBreak)
+    }
+
+    func testSectionLabelNilByDefault() throws {
+        let mapping = KeyMapping(input: "a", action: .keystroke(key: "b"))
+        let data = try JSONEncoder().encode(mapping)
+        let decoded = try JSONDecoder().decode(KeyMapping.self, from: data)
+        XCTAssertNil(decoded.sectionLabel)
+    }
+
+    func testSectionLabelBackwardCompatible() throws {
+        let mapping = KeyMapping(input: "q", action: .keystroke(key: "tab"), description: "Tab", sectionBreak: true)
+        let data = try JSONEncoder().encode(mapping)
+        var json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+        json.removeValue(forKey: "sectionLabel")
+        let strippedData = try JSONSerialization.data(withJSONObject: json)
+        let decoded = try JSONDecoder().decode(KeyMapping.self, from: strippedData)
+        XCTAssertNil(decoded.sectionLabel, "Legacy JSON without sectionLabel should decode as nil")
+        XCTAssertTrue(decoded.sectionBreak)
+    }
+
+    // MARK: - owningPackID Codable
+
+    func testOwningPackIDRoundTrips() throws {
+        let catalog = RuleCollectionCatalog().defaultCollections()
+        let collection = catalog.first { $0.id == RuleCollectionIdentifier.homeRowLayerToggles }!
+
+        let data = try JSONEncoder().encode(collection)
+        let decoded = try JSONDecoder().decode(RuleCollection.self, from: data)
+        XCTAssertEqual(decoded.owningPackID, PackRegistry.vallackSystem.id)
+    }
+
+    func testOwningPackIDNilBackwardCompatible() throws {
+        let catalog = RuleCollectionCatalog().defaultCollections()
+        let collection = catalog.first { $0.id == RuleCollectionIdentifier.homeRowMods }!
+
+        let data = try JSONEncoder().encode(collection)
+        let json = String(data: data, encoding: .utf8)!
+        XCTAssertFalse(json.contains("owningPackID"), "Nil owningPackID should not appear in JSON")
+
+        let decoded = try JSONDecoder().decode(RuleCollection.self, from: data)
+        XCTAssertNil(decoded.owningPackID)
+    }
+
+    // MARK: - Home Row Mods Customization Detection
+
+    func testDefaultHomeRowModsConfigMatchesDefault() {
+        let config = HomeRowModsConfig()
+        let defaultConfig = HomeRowModsConfig()
+        XCTAssertEqual(config, defaultConfig, "Fresh config should equal default")
+    }
+
+    func testCustomizedHomeRowModsConfigDiffersFromDefault() {
+        var config = HomeRowModsConfig()
+        config.timing = TimingConfig(tapWindow: 300, holdDelay: 200)
+        let defaultConfig = HomeRowModsConfig()
+        XCTAssertNotEqual(config, defaultConfig, "Modified timing should differ from default")
+    }
+
+    // MARK: - Vallack Nav Collection Labels
+
+    func testVallackNavEscLabelIsAbbreviated() {
+        let catalog = RuleCollectionCatalog().defaultCollections()
+        let collection = catalog.first { $0.id == RuleCollectionIdentifier.vallackNavigation }!
+        let wMapping = collection.mappings.first { $0.input == "w" }
+        let desc = wMapping?.description ?? ""
+        XCTAssertFalse(desc.contains("Escape"), "Should use 'Esc' not 'Escape'")
+        XCTAssertTrue(desc.contains("Esc") || desc.contains("esc"), "Should contain 'Esc'")
+    }
+
+    func testVallackNavBackspaceUsesSymbol() {
+        let catalog = RuleCollectionCatalog()
+        let builtIn = catalog.defaultCollections()
+        let collection = builtIn.first { $0.id == RuleCollectionIdentifier.vallackNavigation }!
+        let uMapping = collection.mappings.first { $0.input == "u" }
+        let desc = uMapping?.description ?? ""
+        XCTAssertFalse(desc.lowercased().contains("backspace"), "Should not spell out 'Backspace': got '\(desc)'")
+    }
+
+    func testVallackNavHasLeftHandFirst() {
+        let catalog = RuleCollectionCatalog().defaultCollections()
+        let collection = catalog.first { $0.id == RuleCollectionIdentifier.vallackNavigation }!
+        let firstMapping = collection.mappings.first!
+        XCTAssertEqual(firstMapping.sectionLabel, "✋ Left hand", "First section should be left hand")
+        let rightHandMapping = collection.mappings.first { $0.sectionLabel == "🤚 Right hand" }
+        XCTAssertNotNil(rightHandMapping, "Should have right hand section")
+        let rightIndex = collection.mappings.firstIndex { $0.sectionLabel == "🤚 Right hand" }!
+        XCTAssertGreaterThan(rightIndex, 0, "Right hand should come after left hand")
+    }
 }


### PR DESCRIPTION
## Summary

- **Overlay zone coloring**: Q/W/E/U/I/O show modifier subtitles (⌃/⌥/⌘), F/J highlighted as activators, nav layer keys in green — all driven by a generic `PackZoneResolver` so future system packs just add a zone map
- **Layer preview**: Hold F/J for 100ms to preview the nav layer on the overlay before kanata confirms the hold. Preview persists through key presses and cancels on release
- **Pack-internal collections**: `owningPackID` on `RuleCollection` hides implementation-detail collections (Home Row Layer Toggles) from the Rules tab while keeping the pack row visible
- **Home Row Mods install prompt**: When installing Ben's pack with existing customized Home Row Mods, prompts "Keep mine" vs "Use Ben's" instead of silently overwriting
- **Section labels**: Left/right hand grouping in mapping tables with `sectionLabel` on `KeyMapping`
- **UI polish**: clip-reveal animation for expandable rows, hold-to-preview on gallery hero diagram, settings Cmd+1-4 tab shortcuts, no splash on relaunch, stable hero height, wide keys keep base-layer rendering on nav

## Test plan

- [x] 67 tests pass (22 new) covering zone subtitles, owningPackID filtering, sectionLabel codable, layer preview config, label correctness
- [ ] Install Ben Vallack pack → verify overlay shows zone colors + modifier subtitles on base, nav mappings on hold
- [ ] Hold F on overlay → nav layer appears in ~100ms, persists while held, returns to base on release
- [ ] Hold F then press K → overlay stays on nav (doesn't flash back to base)
- [ ] Rules tab → Vallack pack row visible, Home Row Layer Toggles hidden
- [ ] Install pack with customized Home Row Mods → prompt appears
- [ ] Settings window → Cmd+1/2/3/4 switches tabs
- [ ] Relaunch from /Applications while running → no splash page