### PR TITLE
feat: split Vallack HUD shortcut list by hand (#383)

### DIFF
--- a/Sources/KeyPathAppKit/UI/ContextHUD/ContextHUDViewModel.swift
+++ b/Sources/KeyPathAppKit/UI/ContextHUD/ContextHUDViewModel.swift
@@ -183,7 +183,54 @@ final class ContextHUDViewModel {
         // visual-only pack); the .kindaVimLearning style is its own view and
         // doesn't read `groups[]`. Nothing to do for KindaVim in this pass.
 
-// Split Neovim Terminal entries into semantic sub-groups
+// Split Vallack Navigation entries into hand sub-groups using sectionBreak/sectionLabel
+        if let vallackGroup = groupMap[RuleCollectionIdentifier.vallackNavigation],
+           let vallackCollection = collectionLookup[RuleCollectionIdentifier.vallackNavigation]
+        {
+            groupMap.removeValue(forKey: RuleCollectionIdentifier.vallackNavigation)
+
+            // Walk the collection's mapping order to determine which section each input belongs to
+            var sectionForInput: [String: Int] = [:]
+            var sectionLabels: [Int: String] = [0: vallackCollection.name]
+            var currentSection = 0
+            for m in vallackCollection.mappings {
+                if m.sectionBreak { currentSection += 1 }
+                if let label = m.sectionLabel { sectionLabels[currentSection] = label }
+                sectionForInput[m.input.lowercased()] = currentSection
+            }
+
+            // Classify HUD entries into sections, override action with description
+            var sectionEntries: [Int: [HUDKeyEntry]] = [:]
+            var mappingsByInput: [String: KeyMapping] = [:]
+            for m in vallackCollection.mappings { mappingsByInput[m.input.lowercased()] = m }
+
+            for entry in vallackGroup.entries {
+                let kanataName = OverlayKeyboardView.keyCodeToKanataName(entry.keyCode).lowercased()
+                let inputKey = mappingsByInput[kanataName] != nil
+                    ? kanataName
+                    : Self.punctuationShortNames[kanataName] ?? kanataName
+                let mapping = mappingsByInput[inputKey]
+                let section = sectionForInput[inputKey] ?? 0
+
+                let action = mapping?.description ?? entry.action
+                let updated = HUDKeyEntry(
+                    keycap: entry.keycap, action: action, sfSymbol: entry.sfSymbol,
+                    appIdentifier: entry.appIdentifier, urlIdentifier: entry.urlIdentifier,
+                    holdAction: entry.holdAction, color: entry.color, keyCode: entry.keyCode
+                )
+                sectionEntries[section, default: []].append(updated)
+            }
+
+            for (index, entries) in sectionEntries.sorted(by: { $0.key < $1.key }) {
+                let label = sectionLabels[index] ?? vallackCollection.name
+                vimSubGroups.append(HUDKeyGroup(
+                    name: label, color: vallackGroup.color,
+                    entries: entries, sortOrder: index
+                ))
+            }
+        }
+
+        // Split Neovim Terminal entries into semantic sub-groups
         if let neovimGroup = groupMap[RuleCollectionIdentifier.neovimTerminal] {
             groupMap.removeValue(forKey: RuleCollectionIdentifier.neovimTerminal)
             var subGroupEntries: [String: (order: Int, entries: [HUDKeyEntry])] = [:]
@@ -228,6 +275,21 @@ final class ContextHUDViewModel {
     }
 
     // MARK: - Private Helpers
+
+    /// Kanata full names → short symbol names used in KeyMapping.input
+    private static let punctuationShortNames: [String: String] = [
+        "semicolon": ";",
+        "apostrophe": "'",
+        "comma": ",",
+        "dot": ".",
+        "slash": "/",
+        "backslash": "\\",
+        "leftbrace": "[",
+        "rightbrace": "]",
+        "equal": "=",
+        "minus": "-",
+        "grave": "`",
+    ]
 
     /// Punctuation key names → display symbols
     private static let keycapSymbols: [String: String] = [

--- a/Sources/KeyPathAppKit/UI/KeyboardVisualization/KeyboardVisualizationViewModel+LayoutMapping.swift
+++ b/Sources/KeyPathAppKit/UI/KeyboardVisualization/KeyboardVisualizationViewModel+LayoutMapping.swift
@@ -349,7 +349,7 @@ extension KeyboardVisualizationViewModel {
                     } else if let systemAction = SystemActionInfo.find(byOutput: outputKey) {
                         actionByInput[input] = .systemAction(
                             action: systemAction.id,
-                            description: keyMapping.description ?? systemAction.name,
+                            description: systemAction.name,
                             collectionId: collection.id
                         )
                     } else if let outputKeyCode = Self.kanataNameToKeyCode(outputKey) {

--- a/Sources/KeyPathAppKit/UI/KeyboardVisualization/KeyboardVisualizationViewModel+LayoutMapping.swift
+++ b/Sources/KeyPathAppKit/UI/KeyboardVisualization/KeyboardVisualizationViewModel+LayoutMapping.swift
@@ -349,7 +349,7 @@ extension KeyboardVisualizationViewModel {
                     } else if let systemAction = SystemActionInfo.find(byOutput: outputKey) {
                         actionByInput[input] = .systemAction(
                             action: systemAction.id,
-                            description: systemAction.name,
+                            description: keyMapping.description ?? systemAction.name,
                             collectionId: collection.id
                         )
                     } else if let outputKeyCode = Self.kanataNameToKeyCode(outputKey) {

--- a/Tests/KeyPathTests/UI/ContextHUDTests.swift
+++ b/Tests/KeyPathTests/UI/ContextHUDTests.swift
@@ -381,6 +381,100 @@ final class ContextHUDViewModelTests: XCTestCase {
         XCTAssertTrue(names.contains("Other"))
     }
 
+    // MARK: - Vallack Sub-Group Tests
+
+    func testVallackEntriesSplitByHand() {
+        let vm = ContextHUDViewModel()
+        // Left hand: q(12), w(13) — Right hand: h(4), j(38), ;(41)
+        let keyMap: [UInt16: LayerKeyInfo] = [
+            12: .mapped(displayLabel: "Tab", outputKey: "tab", outputKeyCode: nil,
+                        collectionId: RuleCollectionIdentifier.vallackNavigation),
+            13: .mapped(displayLabel: "Esc", outputKey: "esc", outputKeyCode: nil,
+                        collectionId: RuleCollectionIdentifier.vallackNavigation),
+            4: .mapped(displayLabel: "←", outputKey: "left", outputKeyCode: nil,
+                       collectionId: RuleCollectionIdentifier.vallackNavigation),
+            38: .mapped(displayLabel: "↓", outputKey: "down", outputKeyCode: nil,
+                        collectionId: RuleCollectionIdentifier.vallackNavigation),
+            41: .mapped(displayLabel: "⌘V", outputKey: "M-v", outputKeyCode: nil,
+                        collectionId: RuleCollectionIdentifier.vallackNavigation),
+        ]
+
+        let collection = RuleCollection(
+            id: RuleCollectionIdentifier.vallackNavigation,
+            name: "Ben Vallack Approach",
+            summary: "", category: .navigation,
+            mappings: [
+                KeyMapping(input: "q", action: .keystroke(key: "tab"), description: "tab", sectionLabel: "✋ Left hand"),
+                KeyMapping(input: "w", action: .keystroke(key: "esc"), description: "esc"),
+                KeyMapping(input: "h", action: .keystroke(key: "left"), description: "←", sectionBreak: true, sectionLabel: "🤚 Right hand"),
+                KeyMapping(input: "j", action: .keystroke(key: "down"), description: "↓"),
+                KeyMapping(input: ";", action: .keystroke(key: "M-v"), description: "⌘V"),
+            ],
+            targetLayer: .custom("vallack-nav")
+        )
+
+        vm.update(layerName: "vallack-nav", keyMap: keyMap, collections: [collection], style: .defaultList)
+
+        XCTAssertEqual(vm.groups.count, 2, "Should split into Left hand and Right hand")
+        XCTAssertEqual(vm.groups[0].name, "✋ Left hand")
+        XCTAssertEqual(vm.groups[1].name, "🤚 Right hand")
+        XCTAssertEqual(vm.groups[0].entries.count, 2)
+        XCTAssertEqual(vm.groups[1].entries.count, 3)
+    }
+
+    func testVallackUsesDescriptionLabels() {
+        let vm = ContextHUDViewModel()
+        let keyMap: [UInt16: LayerKeyInfo] = [
+            12: .mapped(displayLabel: "Tab", outputKey: "tab", outputKeyCode: nil,
+                        collectionId: RuleCollectionIdentifier.vallackNavigation),
+            4: .mapped(displayLabel: "←", outputKey: "left", outputKeyCode: nil,
+                       collectionId: RuleCollectionIdentifier.vallackNavigation),
+        ]
+
+        let collection = RuleCollection(
+            id: RuleCollectionIdentifier.vallackNavigation,
+            name: "Ben Vallack Approach",
+            summary: "", category: .navigation,
+            mappings: [
+                KeyMapping(input: "q", action: .keystroke(key: "tab"), description: "tab", sectionLabel: "✋ Left hand"),
+                KeyMapping(input: "h", action: .keystroke(key: "left"), description: "←", sectionBreak: true, sectionLabel: "🤚 Right hand"),
+            ],
+            targetLayer: .custom("vallack-nav")
+        )
+
+        vm.update(layerName: "vallack-nav", keyMap: keyMap, collections: [collection], style: .defaultList)
+
+        let leftEntry = vm.groups[0].entries.first
+        XCTAssertEqual(leftEntry?.action, "tab", "Should use KeyMapping.description, not displayLabel")
+        let rightEntry = vm.groups[1].entries.first
+        XCTAssertEqual(rightEntry?.action, "←")
+    }
+
+    func testVallackSemicolonMatchesPunctuationInput() {
+        let vm = ContextHUDViewModel()
+        // keyCode 41 → kanata "semicolon", but collection uses ";" as input
+        let keyMap: [UInt16: LayerKeyInfo] = [
+            41: .mapped(displayLabel: "⌘V", outputKey: "M-v", outputKeyCode: nil,
+                        collectionId: RuleCollectionIdentifier.vallackNavigation),
+        ]
+
+        let collection = RuleCollection(
+            id: RuleCollectionIdentifier.vallackNavigation,
+            name: "Ben Vallack Approach",
+            summary: "", category: .navigation,
+            mappings: [
+                KeyMapping(input: ";", action: .keystroke(key: "M-v"), description: "⌘V", sectionLabel: "🤚 Right hand"),
+            ],
+            targetLayer: .custom("vallack-nav")
+        )
+
+        vm.update(layerName: "vallack-nav", keyMap: keyMap, collections: [collection], style: .defaultList)
+
+        XCTAssertEqual(vm.groups.count, 1)
+        XCTAssertEqual(vm.groups.first?.entries.first?.action, "⌘V",
+                       "Semicolon key should match ';' input via punctuation alias")
+    }
+
     // MARK: - Hold Label Tests
 
     func testUpdateWithHoldLabels() {


### PR DESCRIPTION
## Summary
- Splits Vallack nav entries in the Context HUD shortcut list into two sub-groups ("✋ Left hand" / "🤚 Right hand") using the existing `sectionBreak`/`sectionLabel` metadata on `KeyMapping`
- Shows `KeyMapping.description` (e.g., "←", "tab", "⌘V") instead of the raw `displayLabel` format
- Handles punctuation key name aliases (e.g., kanata `semicolon` → collection input `;`) via a static lookup table
- Follows the same sub-group splitting pattern already used for Vim and Neovim collections

Closes #383

## Test plan
- [x] 3 new unit tests: hand splitting, description-only labels, semicolon punctuation alias
- [x] All 530 existing tests pass
- [ ] Visual verification: activate Vallack pack, hold F/J, confirm HUD shows two labeled groups with clean descriptions