### PR TITLE
feat: CLI pack management commands

### DIFF
--- a/Sources/KeyPathAppKit/CLI/CLIFacade.swift
+++ b/Sources/KeyPathAppKit/CLI/CLIFacade.swift
@@ -1256,6 +1256,371 @@ struct RealSimulatorProvider: CLISimulatorProvider {
     }
 }
 
+// MARK: - Pack Management
+
+extension CLIFacade {
+    /// List all available packs with their install status.
+    public func listPacks() async -> [CLIPack] {
+        let allPacks = PackRegistry.starterKit
+        let installed = await InstalledPackTracker.shared.allInstalled()
+        let installedMap = Dictionary(uniqueKeysWithValues: installed.map { ($0.packID, $0) })
+
+        return allPacks.map { pack in
+            let record = installedMap[pack.id]
+            return CLIPack(
+                id: pack.id,
+                name: pack.name,
+                version: pack.version,
+                category: pack.category,
+                tagline: pack.tagline,
+                isInstalled: record != nil,
+                installedAt: record?.installedAt
+            )
+        }
+    }
+
+    /// Show detailed information about a pack.
+    public func showPack(nameOrId: String) async throws -> CLIPackDetail? {
+        guard let pack = try resolvePack(nameOrId: nameOrId) else { return nil }
+        let record = await InstalledPackTracker.shared.record(for: pack.id)
+        return CLIPackDetail(from: pack, record: record)
+    }
+
+    /// Install a pack with optional quick setting overrides.
+    @MainActor
+    public func installPack(
+        nameOrId: String,
+        settingValues: [String: Int] = [:],
+        dryRun: Bool = false
+    ) async throws -> CLIPackInstallResult {
+        guard let pack = try resolvePack(nameOrId: nameOrId) else {
+            throw CLIPackNotFound(query: nameOrId)
+        }
+
+        let isAlready = await InstalledPackTracker.shared.isInstalled(packID: pack.id)
+        if isAlready {
+            return CLIPackInstallResult(
+                packID: pack.id,
+                packName: pack.name,
+                action: "already-installed",
+                warnings: [],
+                quickSettingValues: [:]
+            )
+        }
+
+        // Validate quick setting keys
+        for key in settingValues.keys {
+            guard pack.quickSettings.contains(where: { $0.id == key }) else {
+                throw CLIPackSettingError(
+                    packName: pack.name,
+                    settingKey: key,
+                    validKeys: pack.quickSettings.map(\.id)
+                )
+            }
+        }
+
+        if dryRun {
+            var warnings: [String] = []
+            let installedIDs = Set(await InstalledPackTracker.shared.allInstalled().map(\.packID))
+            let suggestions = PackDependencyChecker.suggestions(for: pack.id, installedPackIDs: installedIDs)
+            for dep in suggestions {
+                let depName = PackRegistry.pack(id: dep.packID)?.name ?? dep.packID
+                warnings.append("Enhanced by '\(depName)' — install it for best results")
+            }
+            return CLIPackInstallResult(
+                packID: pack.id,
+                packName: pack.name,
+                action: "would-install",
+                warnings: warnings,
+                quickSettingValues: settingValues
+            )
+        }
+
+        let manager = await makePackManager()
+        let record = try await PackInstaller.shared.install(
+            pack,
+            quickSettingValues: settingValues,
+            manager: manager
+        )
+
+        var warnings: [String] = []
+        let installedIDs = Set(await InstalledPackTracker.shared.allInstalled().map(\.packID))
+        let suggestions = PackDependencyChecker.suggestions(for: pack.id, installedPackIDs: installedIDs)
+        for dep in suggestions {
+            let depName = PackRegistry.pack(id: dep.packID)?.name ?? dep.packID
+            warnings.append("Enhanced by '\(depName)' — install it for best results")
+        }
+
+        return CLIPackInstallResult(
+            packID: pack.id,
+            packName: pack.name,
+            action: "installed",
+            warnings: warnings,
+            quickSettingValues: record.quickSettingValues
+        )
+    }
+
+    /// Uninstall a pack.
+    @MainActor
+    public func uninstallPack(
+        nameOrId: String,
+        dryRun: Bool = false
+    ) async throws -> CLIPackInstallResult {
+        guard let pack = try resolvePack(nameOrId: nameOrId) else {
+            throw CLIPackNotFound(query: nameOrId)
+        }
+
+        let isInstalled = await InstalledPackTracker.shared.isInstalled(packID: pack.id)
+        guard isInstalled else {
+            return CLIPackInstallResult(
+                packID: pack.id,
+                packName: pack.name,
+                action: "not-installed",
+                warnings: [],
+                quickSettingValues: [:]
+            )
+        }
+
+        if dryRun {
+            return CLIPackInstallResult(
+                packID: pack.id,
+                packName: pack.name,
+                action: "would-uninstall",
+                warnings: [],
+                quickSettingValues: [:]
+            )
+        }
+
+        let manager = await makePackManager()
+        try await PackInstaller.shared.uninstall(packID: pack.id, manager: manager)
+
+        return CLIPackInstallResult(
+            packID: pack.id,
+            packName: pack.name,
+            action: "uninstalled",
+            warnings: [],
+            quickSettingValues: [:]
+        )
+    }
+
+    // MARK: - Pack Name Resolution
+
+    /// Resolve a pack by ID, slug, name, or substring. Returns nil if not found.
+    /// Throws `AmbiguousPackMatch` on multiple matches.
+    func resolvePack(nameOrId: String) throws -> Pack? {
+        let allPacks = PackRegistry.starterKit
+
+        // 1. Exact ID match
+        if let pack = allPacks.first(where: { $0.id == nameOrId }) {
+            return pack
+        }
+
+        // 2. Slug match (strip com.keypath.pack. prefix)
+        let prefix = "com.keypath.pack."
+        let slugMatches = allPacks.filter { pack in
+            guard pack.id.hasPrefix(prefix) else { return false }
+            let slug = String(pack.id.dropFirst(prefix.count))
+            return slug.caseInsensitiveCompare(nameOrId) == .orderedSame
+        }
+        if slugMatches.count == 1 { return slugMatches[0] }
+        if slugMatches.count > 1 {
+            throw AmbiguousPackMatch(
+                query: nameOrId,
+                matches: slugMatches.map { .init(name: $0.name, id: $0.id) },
+                hint: "Multiple packs match this slug. Use the full ID to disambiguate."
+            )
+        }
+
+        // 3. Exact name match (case-insensitive)
+        let exactMatches = allPacks.filter {
+            $0.name.caseInsensitiveCompare(nameOrId) == .orderedSame
+        }
+        if exactMatches.count == 1 { return exactMatches[0] }
+        if exactMatches.count > 1 {
+            throw AmbiguousPackMatch(
+                query: nameOrId,
+                matches: exactMatches.map { .init(name: $0.name, id: $0.id) },
+                hint: "Multiple packs share this name. Use the ID to disambiguate."
+            )
+        }
+
+        // 4. Substring fallback
+        let substringMatches = allPacks.filter {
+            $0.name.localizedCaseInsensitiveContains(nameOrId)
+        }
+        if substringMatches.count == 1 { return substringMatches[0] }
+        if substringMatches.count > 1 {
+            throw AmbiguousPackMatch(
+                query: nameOrId,
+                matches: substringMatches.map { .init(name: $0.name, id: $0.id) }
+            )
+        }
+
+        return nil
+    }
+
+    // MARK: - Pack Manager Helper
+
+    /// Create a lightweight RuleCollectionsManager for install/uninstall.
+    /// Loads current state from stores without running full bootstrap (which
+    /// would regenerate config unnecessarily).
+    @MainActor
+    private func makePackManager() async -> RuleCollectionsManager {
+        let configService = ConfigurationService()
+        let manager = RuleCollectionsManager(
+            ruleCollectionStore: .shared,
+            customRulesStore: .shared,
+            configurationService: configService
+        )
+        let collections = await RuleCollectionStore.shared.loadCollections()
+        let customRules = await CustomRulesStore.shared.loadRules()
+        manager.ruleCollections = RuleCollectionDeduplicator.dedupe(collections)
+        manager.customRules = customRules
+        return manager
+    }
+}
+
+// MARK: - Pack CLI Types
+
+public struct CLIPack: Codable, Sendable {
+    public let id: String
+    public let name: String
+    public let version: String
+    public let category: String
+    public let tagline: String
+    public let isInstalled: Bool
+    public let installedAt: Date?
+}
+
+public struct CLIPackDetail: Codable, Sendable {
+    public let id: String
+    public let name: String
+    public let version: String
+    public let category: String
+    public let tagline: String
+    public let shortDescription: String
+    public let longDescription: String
+    public let author: String
+    public let isInstalled: Bool
+    public let installedAt: Date?
+    public let visualOnly: Bool
+    public let bindings: [CLIPackBinding]
+    public let quickSettings: [CLIPackQuickSetting]
+    public let dependencies: [CLIPackDep]
+    public let quickSettingValues: [String: Int]
+
+    public init(from pack: Pack, record: InstalledPackRecord?) {
+        id = pack.id
+        name = pack.name
+        version = pack.version
+        category = pack.category
+        tagline = pack.tagline
+        shortDescription = pack.shortDescription
+        longDescription = pack.longDescription
+        author = pack.author
+        isInstalled = record != nil
+        installedAt = record?.installedAt
+        visualOnly = pack.visualOnly
+        bindings = pack.bindings.map { CLIPackBinding(input: $0.input, output: $0.output, holdOutput: $0.holdOutput) }
+        quickSettings = pack.quickSettings.map { CLIPackQuickSetting(from: $0) }
+        dependencies = pack.dependencies.map { CLIPackDep(from: $0) }
+        quickSettingValues = record?.quickSettingValues ?? [:]
+    }
+}
+
+public struct CLIPackBinding: Codable, Sendable {
+    public let input: String
+    public let output: String
+    public let holdOutput: String?
+}
+
+public struct CLIPackQuickSetting: Codable, Sendable {
+    public let id: String
+    public let label: String
+    public let defaultValue: Int
+    public let min: Int
+    public let max: Int
+    public let step: Int
+    public let unitSuffix: String
+
+    public init(from setting: PackQuickSetting) {
+        id = setting.id
+        label = setting.label
+        switch setting.kind {
+        case let .slider(defaultValue, min, max, step, unitSuffix):
+            self.defaultValue = defaultValue
+            self.min = min
+            self.max = max
+            self.step = step
+            self.unitSuffix = unitSuffix
+        }
+    }
+}
+
+public struct CLIPackDep: Codable, Sendable {
+    public let packID: String
+    public let kind: String
+    public let description: String?
+
+    public init(from dep: PackDependency) {
+        packID = dep.packID
+        kind = dep.kind.rawValue
+        description = dep.description
+    }
+}
+
+public struct CLIPackInstallResult: Codable, Sendable {
+    public let packID: String
+    public let packName: String
+    public let action: String
+    public let warnings: [String]
+    public let quickSettingValues: [String: Int]
+}
+
+/// Thrown when a pack name/ID query matches multiple packs.
+public struct AmbiguousPackMatch: Error, CustomStringConvertible {
+    public struct Match: Sendable {
+        public let name: String
+        public let id: String
+    }
+
+    public let query: String
+    public let matches: [Match]
+    public let hint: String
+
+    public init(query: String, matches: [Match], hint: String = "Use the full name or ID to disambiguate.") {
+        self.query = query
+        self.matches = matches
+        self.hint = hint
+    }
+
+    public var description: String {
+        var lines = ["Found \(matches.count) packs matching \"\(query)\":"]
+        for match in matches {
+            lines.append("  - \(match.name) (id: \(match.id))")
+        }
+        lines.append(hint)
+        return lines.joined(separator: "\n")
+    }
+}
+
+public struct CLIPackNotFound: Error, CustomStringConvertible {
+    public let query: String
+    public var description: String { "No pack found matching \"\(query)\"" }
+}
+
+public struct CLIPackSettingError: Error, CustomStringConvertible {
+    public let packName: String
+    public let settingKey: String
+    public let validKeys: [String]
+    public var description: String {
+        if validKeys.isEmpty {
+            return "Pack '\(packName)' has no quick settings, but --setting \(settingKey) was provided"
+        }
+        return "Unknown setting '\(settingKey)' for pack '\(packName)'. Valid keys: \(validKeys.joined(separator: ", "))"
+    }
+}
+
 // MARK: - Stderr Helper
 
 /// Write a diagnostic message to stderr. Use for errors and warnings so stdout stays clean for scripts.

--- a/Sources/KeyPathCLI/Commands/Pack/PackCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Pack/PackCommand.swift
@@ -1,0 +1,14 @@
+import ArgumentParser
+
+struct Pack: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "pack",
+        abstract: "Manage keyboard packs",
+        subcommands: [
+            PackList.self,
+            PackShow.self,
+            PackInstall.self,
+            PackUninstall.self,
+        ]
+    )
+}

--- a/Sources/KeyPathCLI/Commands/Pack/PackInstallCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Pack/PackInstallCommand.swift
@@ -1,0 +1,113 @@
+import ArgumentParser
+import Foundation
+import KeyPathAppKit
+
+struct PackInstall: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "install",
+        abstract: "Install a pack"
+    )
+
+    @OptionGroup var globals: GlobalOptions
+
+    @Argument(help: "Pack name, slug, or ID (e.g., 'vim-navigation', 'Home Row Mods')")
+    var nameOrId: String
+
+    @Option(name: .customLong("setting"), help: "Quick setting value (key=value, repeatable)")
+    var settings: [String] = []
+
+    @Flag(help: "Regenerate config and reload Kanata after installing")
+    var apply: Bool = false
+
+    mutating func run() async throws {
+        let ctx = globals.outputContext
+
+        var settingValues: [String: Int] = [:]
+        for setting in settings {
+            let parts = setting.split(separator: "=", maxSplits: 1)
+            guard parts.count == 2, let value = Int(parts[1]) else {
+                let error = CLIError.validation(
+                    "Invalid setting format: '\(setting)'",
+                    hint: "Use key=value format, e.g., --setting holdTimeout=200"
+                )
+                CLIOutput.writeError(error, context: ctx)
+                throw error.code.exitCode
+            }
+            settingValues[String(parts[0])] = value
+        }
+
+        let facade = await MainActor.run { CLIFacade() }
+
+        do {
+            let result = try await facade.installPack(
+                nameOrId: nameOrId,
+                settingValues: settingValues,
+                dryRun: globals.dryRun
+            )
+
+            CLIOutput.write(result, context: ctx) {
+                switch result.action {
+                case "already-installed":
+                    return "Pack '\(result.packName)' is already installed."
+                case "would-install":
+                    var lines = ["Would install '\(result.packName)'"]
+                    if !result.quickSettingValues.isEmpty {
+                        let pairs = result.quickSettingValues.map { "\($0.key)=\($0.value)" }
+                        lines.append("  Settings: \(pairs.joined(separator: ", "))")
+                    }
+                    for warning in result.warnings {
+                        lines.append("  \(warning)")
+                    }
+                    return lines.joined(separator: "\n")
+                default:
+                    var lines = ["Installed '\(result.packName)'"]
+                    if !result.quickSettingValues.isEmpty {
+                        let pairs = result.quickSettingValues.map { "\($0.key)=\($0.value)" }
+                        lines.append("  Settings: \(pairs.joined(separator: ", "))")
+                    }
+                    for warning in result.warnings {
+                        lines.append("  \(warning)")
+                    }
+                    return lines.joined(separator: "\n")
+                }
+            }
+
+            if result.action == "installed" {
+                try await applyConfigurationOrHint(facade: facade, apply: apply, context: ctx)
+            }
+        } catch let notFound as CLIPackNotFound {
+            let error = CLIError.notFound("Pack", query: notFound.query, listCommand: "keypath pack list")
+            CLIOutput.writeError(error, context: ctx)
+            throw error.code.exitCode
+        } catch let ambiguous as AmbiguousPackMatch {
+            let error = CLIError.ambiguous(
+                ambiguous.description,
+                matches: ambiguous.matches.map { "\($0.name) (id: \($0.id))" }
+            )
+            CLIOutput.writeError(error, context: ctx)
+            throw error.code.exitCode
+        } catch let settingErr as CLIPackSettingError {
+            let error = CLIError.validation(settingErr.description)
+            CLIOutput.writeError(error, context: ctx)
+            throw error.code.exitCode
+        } catch let installErr as PackInstaller.InstallError {
+            let error: CLIError
+            switch installErr {
+            case .mutuallyExclusive:
+                error = CLIError.conflict(
+                    installErr.errorDescription ?? installErr.localizedDescription,
+                    hint: "Uninstall the conflicting pack first"
+                )
+            case let .dependencyMissing(name, _):
+                error = CLIError.validation(
+                    installErr.errorDescription ?? installErr.localizedDescription,
+                    hint: "Install \(name) first"
+                )
+            default:
+                error = CLIError.validation(installErr.errorDescription ?? installErr.localizedDescription)
+            }
+            CLIOutput.writeError(error, context: ctx)
+            throw error.code.exitCode
+        }
+    }
+}

--- a/Sources/KeyPathCLI/Commands/Pack/PackListCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Pack/PackListCommand.swift
@@ -1,0 +1,57 @@
+import ArgumentParser
+import Foundation
+import KeyPathAppKit
+
+struct PackList: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "list",
+        abstract: "List available packs and their install status"
+    )
+
+    @OptionGroup var globals: GlobalOptions
+
+    mutating func run() async throws {
+        let ctx = globals.outputContext
+        let facade = await MainActor.run { CLIFacade() }
+        let packs = await facade.listPacks()
+
+        CLIOutput.write(packs, context: ctx) {
+            if packs.isEmpty {
+                return "No packs available."
+            }
+
+            let installedCount = packs.filter(\.isInstalled).count
+            var lines = [
+                "Packs (\(packs.count) available, \(installedCount) installed):",
+                String(repeating: "\u{2500}", count: 60),
+            ]
+
+            let grouped = Dictionary(grouping: packs, by: \.category)
+            let categoryOrder = orderedCategories(from: packs)
+
+            for category in categoryOrder {
+                guard let categoryPacks = grouped[category] else { continue }
+                lines.append("")
+                lines.append("  \(category)")
+                for pack in categoryPacks {
+                    let status = pack.isInstalled ? "+" : " "
+                    let name = pack.name.padding(toLength: 28, withPad: " ", startingAt: 0)
+                    lines.append("    [\(status)] \(name) \(pack.tagline)")
+                }
+            }
+
+            return lines.joined(separator: "\n")
+        }
+    }
+
+    private func orderedCategories(from packs: [CLIPack]) -> [String] {
+        var seen = Set<String>()
+        var order: [String] = []
+        for pack in packs {
+            if seen.insert(pack.category).inserted {
+                order.append(pack.category)
+            }
+        }
+        return order
+    }
+}

--- a/Sources/KeyPathCLI/Commands/Pack/PackShowCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Pack/PackShowCommand.swift
@@ -1,0 +1,103 @@
+import ArgumentParser
+import Foundation
+import KeyPathAppKit
+
+struct PackShow: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "show",
+        abstract: "Show details of a pack"
+    )
+
+    @OptionGroup var globals: GlobalOptions
+
+    @Argument(help: "Pack name, slug, or ID (e.g., 'vim-navigation', 'Home Row Mods')")
+    var nameOrId: String
+
+    mutating func run() async throws {
+        let ctx = globals.outputContext
+        let facade = await MainActor.run { CLIFacade() }
+
+        let detail: CLIPackDetail
+        do {
+            guard let found = try await facade.showPack(nameOrId: nameOrId) else {
+                let error = CLIError.notFound("Pack", query: nameOrId, listCommand: "keypath pack list")
+                CLIOutput.writeError(error, context: ctx)
+                throw error.code.exitCode
+            }
+            detail = found
+        } catch let ambiguous as AmbiguousPackMatch {
+            let error = CLIError.ambiguous(
+                ambiguous.description,
+                matches: ambiguous.matches.map { "\($0.name) (id: \($0.id))" }
+            )
+            CLIOutput.writeError(error, context: ctx)
+            throw error.code.exitCode
+        }
+
+        CLIOutput.write(detail, context: ctx) {
+            var lines = [
+                "Name: \(detail.name)",
+                "ID: \(detail.id)",
+                "Version: \(detail.version)",
+                "Category: \(detail.category)",
+                "Author: \(detail.author)",
+            ]
+
+            if detail.isInstalled {
+                if let date = detail.installedAt {
+                    let formatter = ISO8601DateFormatter()
+                    formatter.formatOptions = [.withFullDate]
+                    lines.append("Status: Installed (since \(formatter.string(from: date)))")
+                } else {
+                    lines.append("Status: Installed")
+                }
+            } else {
+                lines.append("Status: Not installed")
+            }
+
+            if detail.visualOnly {
+                lines.append("Type: Visual only (no kanata config changes)")
+            }
+
+            lines.append("")
+            lines.append(detail.shortDescription)
+            if !detail.longDescription.isEmpty {
+                lines.append("")
+                lines.append(detail.longDescription)
+            }
+
+            if !detail.bindings.isEmpty {
+                lines.append("")
+                lines.append("Bindings:")
+                for binding in detail.bindings {
+                    if let hold = binding.holdOutput {
+                        lines.append("  \(binding.input) \u{2192} tap: \(binding.output), hold: \(hold)")
+                    } else {
+                        lines.append("  \(binding.input) \u{2192} \(binding.output)")
+                    }
+                }
+            }
+
+            if !detail.quickSettings.isEmpty {
+                lines.append("")
+                lines.append("Quick Settings:")
+                for setting in detail.quickSettings {
+                    let current = detail.quickSettingValues[setting.id] ?? setting.defaultValue
+                    lines.append("  \(setting.label): \(current)\(setting.unitSuffix) (range: \(setting.min)-\(setting.max)\(setting.unitSuffix), default: \(setting.defaultValue)\(setting.unitSuffix))")
+                }
+            }
+
+            if !detail.dependencies.isEmpty {
+                lines.append("")
+                lines.append("Dependencies:")
+                for dep in detail.dependencies {
+                    let kindLabel = dep.kind == "requires" ? "Requires" : "Enhanced by"
+                    let desc = dep.description ?? dep.packID
+                    lines.append("  [\(kindLabel)] \(desc)")
+                }
+            }
+
+            return lines.joined(separator: "\n")
+        }
+    }
+}

--- a/Sources/KeyPathCLI/Commands/Pack/PackUninstallCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Pack/PackUninstallCommand.swift
@@ -1,0 +1,60 @@
+import ArgumentParser
+import Foundation
+import KeyPathAppKit
+
+struct PackUninstall: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "uninstall",
+        abstract: "Uninstall a pack"
+    )
+
+    @OptionGroup var globals: GlobalOptions
+
+    @Argument(help: "Pack name, slug, or ID (e.g., 'vim-navigation', 'Home Row Mods')")
+    var nameOrId: String
+
+    @Flag(help: "Regenerate config and reload Kanata after uninstalling")
+    var apply: Bool = false
+
+    mutating func run() async throws {
+        let ctx = globals.outputContext
+        let facade = await MainActor.run { CLIFacade() }
+
+        do {
+            let result = try await facade.uninstallPack(
+                nameOrId: nameOrId,
+                dryRun: globals.dryRun
+            )
+
+            CLIOutput.write(result, context: ctx) {
+                switch result.action {
+                case "not-installed":
+                    return "Pack '\(result.packName)' is not installed."
+                case "would-uninstall":
+                    return "Would uninstall '\(result.packName)'"
+                default:
+                    return "Uninstalled '\(result.packName)'"
+                }
+            }
+
+            if result.action == "uninstalled" {
+                try await applyConfigurationOrHint(facade: facade, apply: apply, context: ctx)
+            }
+        } catch let notFound as CLIPackNotFound {
+            let error = CLIError.notFound("Pack", query: notFound.query, listCommand: "keypath pack list")
+            CLIOutput.writeError(error, context: ctx)
+            throw error.code.exitCode
+        } catch let ambiguous as AmbiguousPackMatch {
+            let error = CLIError.ambiguous(
+                ambiguous.description,
+                matches: ambiguous.matches.map { "\($0.name) (id: \($0.id))" }
+            )
+            CLIOutput.writeError(error, context: ctx)
+            throw error.code.exitCode
+        } catch let installErr as PackInstaller.InstallError {
+            let error = CLIError.validation(installErr.errorDescription ?? installErr.localizedDescription)
+            CLIOutput.writeError(error, context: ctx)
+            throw error.code.exitCode
+        }
+    }
+}

--- a/Sources/KeyPathCLI/KeyPathTool.swift
+++ b/Sources/KeyPathCLI/KeyPathTool.swift
@@ -14,6 +14,7 @@ public struct KeyPathCLI: AsyncParsableCommand {
             Rule.self,
             Collection.self,
             Layer.self,
+            Pack.self,
             Service.self,
             Config.self,
             System.self,

--- a/Tests/KeyPathTests/CLI/CLIPackCRUDTests.swift
+++ b/Tests/KeyPathTests/CLI/CLIPackCRUDTests.swift
@@ -1,0 +1,208 @@
+@testable import KeyPathAppKit
+@preconcurrency import XCTest
+
+@MainActor
+final class CLIPackCRUDTests: XCTestCase {
+    private let facade = CLIFacade()
+    private var originalInstalledPacks: [InstalledPackRecord] = []
+
+    // Use a pack that's unlikely to be installed in the user's environment
+    private let testPackSlug = "chord-groups"
+    private let testPackID = "com.keypath.pack.chord-groups"
+    private let testPackName = "Chord Groups"
+
+    override func setUp() async throws {
+        try await super.setUp()
+        originalInstalledPacks = await InstalledPackTracker.shared.allInstalled()
+    }
+
+    override func tearDown() async throws {
+        let current = await InstalledPackTracker.shared.allInstalled()
+        for record in current {
+            if !originalInstalledPacks.contains(where: { $0.packID == record.packID }) {
+                try await InstalledPackTracker.shared.remove(packID: record.packID)
+            }
+        }
+        for record in originalInstalledPacks {
+            if !(await InstalledPackTracker.shared.isInstalled(packID: record.packID)) {
+                try await InstalledPackTracker.shared.upsert(record)
+            }
+        }
+        try await super.tearDown()
+    }
+
+    private func ensureUninstalled(_ packID: String) async throws {
+        if await InstalledPackTracker.shared.isInstalled(packID: packID) {
+            try await InstalledPackTracker.shared.remove(packID: packID)
+        }
+    }
+
+    // MARK: - listPacks
+
+    func testListPacksReturnsAllStarterKitPacks() async {
+        let packs = await facade.listPacks()
+        XCTAssertEqual(packs.count, PackRegistry.starterKit.count)
+    }
+
+    func testListPacksShowsInstalledStatus() async throws {
+        let record = InstalledPackRecord(packID: testPackID, version: "1.0.0")
+        try await InstalledPackTracker.shared.upsert(record)
+
+        let packs = await facade.listPacks()
+        let found = packs.first(where: { $0.id == testPackID })
+        XCTAssertNotNil(found)
+        XCTAssertTrue(found?.isInstalled == true)
+    }
+
+    // MARK: - showPack
+
+    func testShowPackByExactName() async throws {
+        let detail = try await facade.showPack(nameOrId: "Vim Navigation")
+        XCTAssertNotNil(detail)
+        XCTAssertEqual(detail?.id, "com.keypath.pack.vim-navigation")
+    }
+
+    func testShowPackBySlug() async throws {
+        let detail = try await facade.showPack(nameOrId: "vim-navigation")
+        XCTAssertNotNil(detail)
+        XCTAssertEqual(detail?.id, "com.keypath.pack.vim-navigation")
+    }
+
+    func testShowPackByFullID() async throws {
+        let detail = try await facade.showPack(nameOrId: "com.keypath.pack.vim-navigation")
+        XCTAssertNotNil(detail)
+        XCTAssertEqual(detail?.name, "Vim Navigation")
+    }
+
+    func testShowPackNotFoundReturnsNil() async throws {
+        let detail = try await facade.showPack(nameOrId: "nonexistent-pack-zzz")
+        XCTAssertNil(detail)
+    }
+
+    func testShowPackBySubstringUnique() async throws {
+        let detail = try await facade.showPack(nameOrId: "Chord")
+        XCTAssertNotNil(detail)
+        XCTAssertEqual(detail?.id, "com.keypath.pack.chord-groups")
+    }
+
+    func testShowPackIncludesQuickSettings() async throws {
+        let detail = try await facade.showPack(nameOrId: "home-row-mods")
+        XCTAssertNotNil(detail)
+        XCTAssertFalse(detail!.quickSettings.isEmpty)
+        XCTAssertEqual(detail!.quickSettings.first?.id, "holdTimeout")
+    }
+
+    func testShowPackIncludesDependencies() async throws {
+        let detail = try await facade.showPack(nameOrId: "delete-enhancement")
+        XCTAssertNotNil(detail)
+        XCTAssertFalse(detail!.dependencies.isEmpty)
+    }
+
+    // MARK: - Name Resolution Edge Cases
+
+    func testResolvePackAmbiguousThrows() async throws {
+        // "Navigation" matches both "Vim Navigation" and "Fast Navigation"
+        do {
+            _ = try await facade.showPack(nameOrId: "Navigation")
+            XCTFail("Should throw AmbiguousPackMatch")
+        } catch is AmbiguousPackMatch {
+            // expected
+        }
+    }
+
+    func testResolvePackCaseInsensitive() async throws {
+        let detail = try await facade.showPack(nameOrId: "VIM NAVIGATION")
+        XCTAssertNotNil(detail)
+        XCTAssertEqual(detail?.id, "com.keypath.pack.vim-navigation")
+    }
+
+    // MARK: - installPack / uninstallPack
+
+    func testInstallAndUninstallRoundTrip() async throws {
+        try await ensureUninstalled(testPackID)
+
+        let installResult = try await facade.installPack(nameOrId: testPackSlug)
+        XCTAssertEqual(installResult.action, "installed")
+        XCTAssertEqual(installResult.packName, testPackName)
+
+        let isInstalled = await InstalledPackTracker.shared.isInstalled(packID: testPackID)
+        XCTAssertTrue(isInstalled)
+
+        let uninstallResult = try await facade.uninstallPack(nameOrId: testPackSlug)
+        XCTAssertEqual(uninstallResult.action, "uninstalled")
+
+        let stillInstalled = await InstalledPackTracker.shared.isInstalled(packID: testPackID)
+        XCTAssertFalse(stillInstalled)
+    }
+
+    func testInstallAlreadyInstalledReturnsAlreadyInstalled() async throws {
+        let record = InstalledPackRecord(packID: testPackID, version: "1.0.0")
+        try await InstalledPackTracker.shared.upsert(record)
+
+        let result = try await facade.installPack(nameOrId: testPackSlug)
+        XCTAssertEqual(result.action, "already-installed")
+    }
+
+    func testUninstallNotInstalledReturnsNotInstalled() async throws {
+        try await ensureUninstalled(testPackID)
+
+        let result = try await facade.uninstallPack(nameOrId: testPackSlug)
+        XCTAssertEqual(result.action, "not-installed")
+    }
+
+    func testInstallDryRun() async throws {
+        try await ensureUninstalled(testPackID)
+
+        let result = try await facade.installPack(nameOrId: testPackSlug, dryRun: true)
+        XCTAssertEqual(result.action, "would-install")
+
+        let isInstalled = await InstalledPackTracker.shared.isInstalled(packID: testPackID)
+        XCTAssertFalse(isInstalled)
+    }
+
+    func testUninstallDryRun() async throws {
+        let record = InstalledPackRecord(packID: testPackID, version: "1.0.0")
+        try await InstalledPackTracker.shared.upsert(record)
+
+        let result = try await facade.uninstallPack(nameOrId: testPackSlug, dryRun: true)
+        XCTAssertEqual(result.action, "would-uninstall")
+
+        let stillInstalled = await InstalledPackTracker.shared.isInstalled(packID: testPackID)
+        XCTAssertTrue(stillInstalled)
+    }
+
+    func testInstallNotFoundThrows() async throws {
+        do {
+            _ = try await facade.installPack(nameOrId: "nonexistent-zzz")
+            XCTFail("Should throw CLIPackNotFound")
+        } catch is CLIPackNotFound {
+            // expected
+        }
+    }
+
+    func testInstallWithInvalidSettingKeyThrows() async throws {
+        // Use a pack that's not installed and has no quick settings
+        try await ensureUninstalled(testPackID)
+
+        do {
+            _ = try await facade.installPack(
+                nameOrId: testPackSlug,
+                settingValues: ["bogusKey": 999]
+            )
+            XCTFail("Should throw CLIPackSettingError")
+        } catch is CLIPackSettingError {
+            // expected
+        }
+    }
+
+    func testInstallWithValidQuickSettings() async throws {
+        try await ensureUninstalled("com.keypath.pack.home-row-mods")
+
+        let result = try await facade.installPack(
+            nameOrId: "home-row-mods",
+            settingValues: ["holdTimeout": 200]
+        )
+        XCTAssertEqual(result.action, "installed")
+        XCTAssertEqual(result.quickSettingValues["holdTimeout"], 200)
+    }
+}

--- a/Tests/KeyPathTests/CLI/CommandStructureTests.swift
+++ b/Tests/KeyPathTests/CLI/CommandStructureTests.swift
@@ -9,7 +9,7 @@ final class CommandStructureTests: XCTestCase {
 
     func testRootHasExpectedSubcommands() {
         let names = subcommandNames(of: KeyPathCLI.self)
-        for expected in ["rule", "collection", "layer", "service", "config", "system", "export", "import", "help-topics", "completions"] {
+        for expected in ["rule", "collection", "layer", "pack", "service", "config", "system", "export", "import", "help-topics", "completions"] {
             XCTAssertTrue(names.contains(expected), "Missing subcommand: \(expected). Found: \(names)")
         }
     }
@@ -38,6 +38,11 @@ final class CommandStructureTests: XCTestCase {
     func testLayerHasExpectedVerbs() {
         let names = subcommandNames(of: Layer.self)
         XCTAssertEqual(Set(names), ["list", "create", "delete", "rename", "switch"])
+    }
+
+    func testPackHasExpectedVerbs() {
+        let names = subcommandNames(of: Pack.self)
+        XCTAssertEqual(Set(names), ["list", "show", "install", "uninstall"])
     }
 
     func testServiceHasExpectedVerbs() {


### PR DESCRIPTION
## Summary

- Adds `keypath pack list/show/install/uninstall` commands to the CLI (#378)
- Name resolution supports full ID, slug, exact name, and substring matching (mirrors collection pattern)
- Install supports `--setting key=value` for quick settings (e.g., `--setting holdTimeout=200`)
- All commands support `--json`, `--dry-run`, `--apply`
- CLIFacade gains 5 pack methods + lightweight RuleCollectionsManager helper for install/uninstall

## New files

| File | Purpose |
|------|---------|
| `Commands/Pack/PackCommand.swift` | Group definition with 4 subcommands |
| `Commands/Pack/PackListCommand.swift` | List packs grouped by category with install status |
| `Commands/Pack/PackShowCommand.swift` | Pack details, bindings, quick settings, dependencies |
| `Commands/Pack/PackInstallCommand.swift` | Install with optional quick settings, error mapping |
| `Commands/Pack/PackUninstallCommand.swift` | Uninstall with dependency warnings |
| `CLIPackCRUDTests.swift` | 19 facade-level tests |

## Test plan

- [x] `swift build` — compiles clean
- [x] `swift test --filter CommandStructureTests` — 12 tests pass (includes new pack verb test)
- [x] `swift test --filter CLIPackCRUDTests` — 19 tests pass
- [x] `swift test` — full suite 530 tests, 0 failures