### PR TITLE
Enrich overlay keycap accessibility for agent interaction

### DIFF
--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayKeyboardView.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayKeyboardView.swift
@@ -232,6 +232,10 @@ struct OverlayKeyboardView: View {
         return mappedLabel != normalizedLabel
     }
 
+    var keyboardAccessibilityLabel: String {
+        "Keyboard overlay, \(layout.name), layer \(currentLayerName)"
+    }
+
     var body: some View {
         GeometryReader { geometry in
             let scale = calculateScale(for: geometry.size)
@@ -312,6 +316,8 @@ struct OverlayKeyboardView: View {
             .animation(nil, value: isLauncherMode)
         }
         .aspectRatio(layout.totalWidth / layout.totalHeight, contentMode: .fit)
+        .accessibilityIdentifier("overlay-keyboard")
+        .accessibilityLabel(keyboardAccessibilityLabel)
         // Also disable at container level for any inherited animations
         .animation(nil, value: isLauncherMode)
         .onChange(of: effectivePressedKeyCodes) { _, _ in

--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView+ContentAndStyling.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView+ContentAndStyling.swift
@@ -172,6 +172,8 @@ extension OverlayKeycapView {
         .accessibilityElement(children: .ignore)
         .accessibilityIdentifier(keycapAccessibilityId)
         .accessibilityLabel(keycapAccessibilityLabel)
+        .accessibilityValue(keycapAccessibilityValue)
+        .accessibilityAddTraits(isInspectorVisible ? .isButton : [])
     }
 
     /// Accessibility identifier for this keycap
@@ -199,10 +201,57 @@ extension OverlayKeycapView {
             return "\(keyName), \(colorDescription) \(shape)"
         }
 
-        if let info = layerKeyInfo, !info.displayLabel.isEmpty, info.displayLabel != keyName {
+        guard let info = layerKeyInfo else { return keyName }
+
+        // Layer switch keys
+        if info.isLayerSwitch {
+            return "\(keyName), layer switch to \(info.displayLabel)"
+        }
+
+        // App launch keys (non-launcher mode)
+        if let appId = info.appLaunchIdentifier {
+            return "\(keyName), launches \(info.displayLabel.isEmpty ? appId : info.displayLabel)"
+        }
+
+        // System action keys
+        if let actionId = info.systemActionIdentifier {
+            return "\(keyName), \(info.displayLabel.isEmpty ? actionId : info.displayLabel)"
+        }
+
+        // URL keys
+        if let url = info.urlIdentifier {
+            return "\(keyName), opens \(info.displayLabel.isEmpty ? url : info.displayLabel)"
+        }
+
+        // Tap-hold keys: describe both actions when idle on base layer
+        if let idleLabel = tapHoldIdleLabel, !isLauncherMode,
+           currentLayerName.lowercased() == "base",
+           !info.displayLabel.isEmpty, info.displayLabel != idleLabel
+        {
+            return "\(keyName), tap \(idleLabel), hold \(info.displayLabel)"
+        }
+
+        // Standard mapping
+        if !info.displayLabel.isEmpty, info.displayLabel != keyName {
             return "\(keyName), mapped to \(info.displayLabel)"
         }
         return keyName
+    }
+
+    /// Accessibility value describing the key's current state
+    var keycapAccessibilityValue: String {
+        if isPressed, isHoldActive {
+            return "held"
+        } else if isPressed {
+            return "pressed"
+        } else if isOneShot {
+            return "one-shot active"
+        } else if isEmphasized {
+            return "highlighted"
+        } else if isSelected {
+            return "selected"
+        }
+        return ""
     }
 
     /// Human-readable color description for dots legend accessibility


### PR DESCRIPTION
## Summary
- Enriches the accessibility tree for every keycap in the keyboard overlay so AI agents (Peekaboo) can understand what each key does and what state it's in
- Adds `accessibilityValue` for real-time key state (pressed, held, selected)
- Adds `accessibilityAddTraits(.isButton)` when keys are clickable
- Adds container-level label to the keyboard view itself

## What agents see now

**Before:** An agent querying the overlay sees ~80 elements with labels like "A" or "A, mapped to Escape" — but no information about app launches, layer switches, tap-hold behavior, system actions, URLs, or key state.

**After:** The same keys expose rich descriptions:
| Key type | Example label |
|----------|--------------|
| Layer switch | "F, layer switch to nav" |
| App launch | "K, launches Safari" |
| System action | "M, Mission Control" |
| URL mapping | "G, opens github.com" |
| Tap-hold (idle) | "A, tap a, hold left control" |
| Standard remap | "CapsLock, mapped to Escape" |
| Launcher mode | "S, launches app Safari" |

Plus real-time state via `accessibilityValue`: "pressed", "held", "one-shot active", "highlighted", "selected", or "" (idle).

## Test plan
- [ ] Build succeeds (verified locally)
- [ ] No visual regressions — only accessibility modifiers added
- [ ] `peekaboo see` on the overlay shows descriptive key labels
- [ ] Key state changes (press/hold/release) reflected in accessibility value