### PR TITLE
feat: completions install + pack configure commands

### DIFF
--- a/Sources/KeyPathAppKit/CLI/CLIFacade.swift
+++ b/Sources/KeyPathAppKit/CLI/CLIFacade.swift
@@ -1403,6 +1403,77 @@ extension CLIFacade {
         )
     }
 
+    /// Update quick settings on an installed pack.
+    @MainActor
+    public func configurePack(
+        nameOrId: String,
+        settingValues: [String: Int],
+        dryRun: Bool = false
+    ) async throws -> CLIPackInstallResult {
+        guard let pack = try resolvePack(nameOrId: nameOrId) else {
+            throw CLIPackNotFound(query: nameOrId)
+        }
+
+        let isInstalled = await InstalledPackTracker.shared.isInstalled(packID: pack.id)
+        guard isInstalled else {
+            return CLIPackInstallResult(
+                packID: pack.id,
+                packName: pack.name,
+                action: "not-installed",
+                warnings: ["Pack must be installed before configuring settings."],
+                quickSettingValues: [:]
+            )
+        }
+
+        guard !pack.quickSettings.isEmpty else {
+            throw CLIPackSettingError(
+                packName: pack.name,
+                settingKey: settingValues.keys.first ?? "",
+                validKeys: []
+            )
+        }
+
+        for key in settingValues.keys {
+            guard pack.quickSettings.contains(where: { $0.id == key }) else {
+                throw CLIPackSettingError(
+                    packName: pack.name,
+                    settingKey: key,
+                    validKeys: pack.quickSettings.map(\.id)
+                )
+            }
+        }
+
+        if dryRun {
+            let current = await PackInstaller.shared.quickSettings(for: pack.id)
+            var merged = current
+            for (k, v) in settingValues { merged[k] = v }
+            return CLIPackInstallResult(
+                packID: pack.id,
+                packName: pack.name,
+                action: "would-configure",
+                warnings: [],
+                quickSettingValues: merged
+            )
+        }
+
+        let manager = await makePackManager()
+        try await PackInstaller.shared.updateQuickSettings(
+            packID: pack.id,
+            newValues: settingValues,
+            manager: manager
+        )
+
+        let updatedSettings = await PackInstaller.shared.quickSettings(for: pack.id)
+
+        return CLIPackInstallResult(
+            packID: pack.id,
+            packName: pack.name,
+            action: "configured",
+            warnings: [],
+            quickSettingValues: updatedSettings
+        )
+    }
+
     // MARK: - Pack Name Resolution
 
     /// Resolve a pack by ID, slug, name, or substring. Returns nil if not found.

--- a/Sources/KeyPathAppKit/Services/Packs/PackInstaller.swift
+++ b/Sources/KeyPathAppKit/Services/Packs/PackInstaller.swift
@@ -331,6 +331,66 @@ public final class PackInstaller {
         return rec?.quickSettingValues ?? [:]
     }
 
+    /// Update quick settings on an already-installed pack. Re-applies the
+    /// settings to the underlying config/rules and persists the new values.
+    ///
+    /// For **rule-based packs**: removes old CustomRules and re-renders with new settings.
+    /// For **collection-backed packs**: updates the collection's timing config directly.
+    func updateQuickSettings(
+        packID: String,
+        newValues: [String: Int],
+        manager: RuleCollectionsManager
+    ) async throws {
+        guard let pack = PackRegistry.pack(id: packID) else {
+            throw InstallError.saveFailed("pack not found in registry: \(packID)")
+        }
+        guard var record = await InstalledPackTracker.shared.record(for: packID) else {
+            throw InstallError.saveFailed("pack is not installed: \(packID)")
+        }
+
+        // Merge new values into existing settings
+        var mergedSettings = record.quickSettingValues
+        for (key, value) in newValues {
+            mergedSettings[key] = value
+        }
+
+        // Clamp to valid ranges
+        let resolved = resolveQuickSettings(pack: pack, overrides: mergedSettings)
+
+        if let collectionID = pack.associatedCollectionID {
+            // Collection-backed pack: update timing config
+            if let holdTimeout = resolved["holdTimeout"],
+               let index = manager.ruleCollections.firstIndex(where: { $0.id == collectionID })
+            {
+                if case .homeRowMods(var config) = manager.ruleCollections[index].configuration {
+                    config.timing.tapWindow = holdTimeout
+                    config.timing.holdDelay = holdTimeout
+                    manager.ruleCollections[index].configuration = .homeRowMods(config)
+                    await manager.regenerateConfigFromCollections()
+                }
+            }
+        } else if !pack.bindings.isEmpty {
+            // Rule-based pack: re-render bindings with new settings
+            let oldRules = await manager.snapshotCurrentRules().filter { $0.packSource == packID }
+            for rule in oldRules {
+                await manager.removeCustomRule(id: rule.id)
+            }
+            let newRules = renderBindings(for: pack, quickSettings: resolved)
+            for (index, rule) in newRules.enumerated() {
+                let isLast = (index == newRules.count - 1)
+                _ = await manager.saveCustomRule(rule, skipReload: !isLast)
+            }
+        }
+
+        // Persist updated record
+        record.quickSettingValues = resolved
+        try await InstalledPackTracker.shared.upsert(record)
+
+        AppLogger.shared.log(
+            "✅ [PackInstaller] Updated quick settings for '\(pack.name)': \(resolved)"
+        )
+    }
+
     // MARK: - Rendering
 
     /// Convert a pack's binding templates into concrete CustomRules tagged

--- a/Sources/KeyPathCLI/Commands/CompletionsCommand.swift
+++ b/Sources/KeyPathCLI/Commands/CompletionsCommand.swift
@@ -4,11 +4,12 @@ import Foundation
 struct Completions: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "completions",
-        abstract: "Generate shell completions",
+        abstract: "Generate or install shell completions",
         subcommands: [
             Zsh.self,
             Bash.self,
             Fish.self,
+            Install.self,
         ]
     )
 
@@ -42,6 +43,73 @@ struct Completions: ParsableCommand {
         mutating func run() throws {
             let script = KeyPathCLI.completionScript(for: .fish)
             print(script)
+        }
+    }
+
+    struct Install: ParsableCommand {
+        static let configuration = CommandConfiguration(
+            abstract: "Install completions for your shell"
+        )
+
+        @Option(help: "Shell to install for (zsh, bash, fish). Defaults to current shell from $SHELL.")
+        var shell: String?
+
+        mutating func run() throws {
+            let shellName = try resolveShell()
+            let script: String
+            let path: String
+
+            switch shellName {
+            case "zsh":
+                script = KeyPathCLI.completionScript(for: .zsh)
+                path = NSString("~/.zsh/completions/_keypath").expandingTildeInPath
+            case "bash":
+                script = KeyPathCLI.completionScript(for: .bash)
+                path = NSString("~/.bash_completion.d/keypath").expandingTildeInPath
+            case "fish":
+                script = KeyPathCLI.completionScript(for: .fish)
+                path = NSString("~/.config/fish/completions/keypath.fish").expandingTildeInPath
+            default:
+                throw ValidationError("Unsupported shell: '\(shellName)'. Use zsh, bash, or fish.")
+            }
+
+            let dir = (path as NSString).deletingLastPathComponent
+            try FileManager.default.createDirectory(
+                atPath: dir,
+                withIntermediateDirectories: true
+            )
+            try script.write(toFile: path, atomically: true, encoding: .utf8)
+
+            print("Installed \(shellName) completions to \(path)")
+
+            if shellName == "zsh" {
+                let completionsDir = NSString("~/.zsh/completions").expandingTildeInPath
+                print("")
+                print("If completions don't work, ensure this is in your ~/.zshrc:")
+                print("  fpath=(~/.zsh/completions $fpath)")
+                print("  autoload -Uz compinit && compinit")
+                let _ = completionsDir
+            }
+        }
+
+        private func resolveShell() throws -> String {
+            if let explicit = shell {
+                let normalized = explicit.lowercased()
+                guard ["zsh", "bash", "fish"].contains(normalized) else {
+                    throw ValidationError("Unsupported shell: '\(explicit)'. Use zsh, bash, or fish.")
+                }
+                return normalized
+            }
+
+            guard let shellEnv = ProcessInfo.processInfo.environment["SHELL"] else {
+                throw ValidationError("Cannot detect shell from $SHELL. Use --shell to specify.")
+            }
+
+            let basename = (shellEnv as NSString).lastPathComponent
+            guard ["zsh", "bash", "fish"].contains(basename) else {
+                throw ValidationError("Unsupported shell '\(basename)' from $SHELL. Use --shell zsh, bash, or fish.")
+            }
+            return basename
         }
     }
 }

--- a/Sources/KeyPathCLI/Commands/Pack/PackCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Pack/PackCommand.swift
@@ -9,6 +9,7 @@ struct Pack: AsyncParsableCommand {
             PackShow.self,
             PackInstall.self,
             PackUninstall.self,
+            PackConfigure.self,
         ]
     )
 }

--- a/Sources/KeyPathCLI/Commands/Pack/PackConfigureCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Pack/PackConfigureCommand.swift
@@ -1,0 +1,90 @@
+import ArgumentParser
+import Foundation
+import KeyPathAppKit
+
+struct PackConfigure: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "configure",
+        abstract: "Update quick settings on an installed pack"
+    )
+
+    @OptionGroup var globals: GlobalOptions
+
+    @Argument(help: "Pack name, slug, or ID (e.g., 'home-row-mods')")
+    var nameOrId: String
+
+    @Option(name: .customLong("setting"), help: "Quick setting value (key=value, repeatable)")
+    var settings: [String] = []
+
+    @Flag(help: "Regenerate config and reload Kanata after configuring")
+    var apply: Bool = false
+
+    mutating func run() async throws {
+        let ctx = globals.outputContext
+
+        guard !settings.isEmpty else {
+            let error = CLIError.validation(
+                "No settings provided",
+                hint: "Use --setting key=value (e.g., --setting holdTimeout=250)"
+            )
+            CLIOutput.writeError(error, context: ctx)
+            throw error.code.exitCode
+        }
+
+        var settingValues: [String: Int] = [:]
+        for setting in settings {
+            let parts = setting.split(separator: "=", maxSplits: 1)
+            guard parts.count == 2, let value = Int(parts[1]) else {
+                let error = CLIError.validation(
+                    "Invalid setting format: '\(setting)'",
+                    hint: "Use key=value format, e.g., --setting holdTimeout=250"
+                )
+                CLIOutput.writeError(error, context: ctx)
+                throw error.code.exitCode
+            }
+            settingValues[String(parts[0])] = value
+        }
+
+        let facade = await MainActor.run { CLIFacade() }
+
+        do {
+            let result = try await facade.configurePack(
+                nameOrId: nameOrId,
+                settingValues: settingValues,
+                dryRun: globals.dryRun
+            )
+
+            CLIOutput.write(result, context: ctx) {
+                switch result.action {
+                case "not-installed":
+                    return "Pack '\(result.packName)' is not installed. Install it first with 'keypath pack install \(nameOrId)'."
+                case "would-configure":
+                    let pairs = result.quickSettingValues.map { "\($0.key)=\($0.value)" }
+                    return "Would configure '\(result.packName)': \(pairs.joined(separator: ", "))"
+                default:
+                    let pairs = result.quickSettingValues.map { "\($0.key)=\($0.value)" }
+                    return "Configured '\(result.packName)': \(pairs.joined(separator: ", "))"
+                }
+            }
+
+            if result.action == "configured" {
+                try await applyConfigurationOrHint(facade: facade, apply: apply, context: ctx)
+            }
+        } catch let notFound as CLIPackNotFound {
+            let error = CLIError.notFound("Pack", query: notFound.query, listCommand: "keypath pack list")
+            CLIOutput.writeError(error, context: ctx)
+            throw error.code.exitCode
+        } catch let ambiguous as AmbiguousPackMatch {
+            let error = CLIError.ambiguous(
+                ambiguous.description,
+                matches: ambiguous.matches.map { "\($0.name) (id: \($0.id))" }
+            )
+            CLIOutput.writeError(error, context: ctx)
+            throw error.code.exitCode
+        } catch let settingErr as CLIPackSettingError {
+            let error = CLIError.validation(settingErr.description)
+            CLIOutput.writeError(error, context: ctx)
+            throw error.code.exitCode
+        }
+    }
+}

--- a/Tests/KeyPathTests/CLI/CLIPackCRUDTests.swift
+++ b/Tests/KeyPathTests/CLI/CLIPackCRUDTests.swift
@@ -205,4 +205,60 @@ final class CLIPackCRUDTests: XCTestCase {
         XCTAssertEqual(result.action, "installed")
         XCTAssertEqual(result.quickSettingValues["holdTimeout"], 200)
     }
+
+    // MARK: - configurePack
+
+    func testConfigurePackUpdatesSettings() async throws {
+        try await ensureUninstalled("com.keypath.pack.home-row-mods")
+        _ = try await facade.installPack(nameOrId: "home-row-mods", settingValues: ["holdTimeout": 200])
+
+        let result = try await facade.configurePack(
+            nameOrId: "home-row-mods",
+            settingValues: ["holdTimeout": 250]
+        )
+        XCTAssertEqual(result.action, "configured")
+        XCTAssertEqual(result.quickSettingValues["holdTimeout"], 250)
+    }
+
+    func testConfigurePackDryRun() async throws {
+        try await ensureUninstalled("com.keypath.pack.home-row-mods")
+        _ = try await facade.installPack(nameOrId: "home-row-mods", settingValues: ["holdTimeout": 200])
+
+        let result = try await facade.configurePack(
+            nameOrId: "home-row-mods",
+            settingValues: ["holdTimeout": 300],
+            dryRun: true
+        )
+        XCTAssertEqual(result.action, "would-configure")
+        XCTAssertEqual(result.quickSettingValues["holdTimeout"], 300)
+
+        // Verify actual value unchanged
+        let current = await InstalledPackTracker.shared.record(for: "com.keypath.pack.home-row-mods")
+        XCTAssertEqual(current?.quickSettingValues["holdTimeout"], 200)
+    }
+
+    func testConfigurePackNotInstalledReturnsNotInstalled() async throws {
+        try await ensureUninstalled("com.keypath.pack.home-row-mods")
+
+        let result = try await facade.configurePack(
+            nameOrId: "home-row-mods",
+            settingValues: ["holdTimeout": 250]
+        )
+        XCTAssertEqual(result.action, "not-installed")
+    }
+
+    func testConfigurePackInvalidSettingThrows() async throws {
+        try await ensureUninstalled("com.keypath.pack.home-row-mods")
+        _ = try await facade.installPack(nameOrId: "home-row-mods", settingValues: ["holdTimeout": 200])
+
+        do {
+            _ = try await facade.configurePack(
+                nameOrId: "home-row-mods",
+                settingValues: ["bogus": 123]
+            )
+            XCTFail("Should throw CLIPackSettingError")
+        } catch is CLIPackSettingError {
+            // expected
+        }
+    }
 }

--- a/Tests/KeyPathTests/CLI/CommandStructureTests.swift
+++ b/Tests/KeyPathTests/CLI/CommandStructureTests.swift
@@ -42,7 +42,7 @@ final class CommandStructureTests: XCTestCase {
 
     func testPackHasExpectedVerbs() {
         let names = subcommandNames(of: Pack.self)
-        XCTAssertEqual(Set(names), ["list", "show", "install", "uninstall"])
+        XCTAssertEqual(Set(names), ["list", "show", "install", "uninstall", "configure"])
     }
 
     func testServiceHasExpectedVerbs() {
@@ -67,7 +67,7 @@ final class CommandStructureTests: XCTestCase {
 
     func testCompletionsHasShells() {
         let names = subcommandNames(of: Completions.self)
-        XCTAssertEqual(Set(names), ["zsh", "bash", "fish"])
+        XCTAssertEqual(Set(names), ["zsh", "bash", "fish", "install"])
     }
 
     // MARK: - Helpers


### PR DESCRIPTION
## Summary

- Adds `keypath completions install [--shell zsh|bash|fish]` — auto-detects shell from `$SHELL`, writes completions to user-local directory, prints fpath hint for zsh
- Adds `keypath pack configure <pack> --setting key=value` — updates quick settings on an installed pack without uninstall/reinstall cycle
- Adds `PackInstaller.updateQuickSettings()` — generic handler for collection-backed packs (updates timing config) and rule-based packs (re-renders bindings)

## Test plan

- [x] `swift build` — compiles clean
- [x] `swift test --filter CommandStructureTests` — 12 tests pass (new "install" in completions, "configure" in pack)
- [x] `swift test --filter CLIPackCRUDTests` — 23 tests pass (4 new configure tests)
- [x] `swift test` — full suite 530 tests, 0 failures