### PR TITLE
fix: instant layer switch by setting currentLayerName eagerly

### DIFF
--- a/Sources/KeyPathAppKit/UI/KeyboardVisualization/KeyboardVisualizationViewModel+LayoutMapping.swift
+++ b/Sources/KeyPathAppKit/UI/KeyboardVisualization/KeyboardVisualizationViewModel+LayoutMapping.swift
@@ -21,10 +21,13 @@ extension KeyboardVisualizationViewModel {
     /// Update the current layer and rebuild key mapping
     func updateLayer(_ layerName: String) {
         let wasLauncherMode = isLauncherModeActive
-
-        // IMPORTANT: Don't update currentLayerName yet - wait until mapping is ready
-        // This prevents UI flash where old mapping shows with new layer name
         let targetLayerName = layerName
+
+        // Set layer name immediately so computed properties (isLauncherModeActive,
+        // layer indicators) update without waiting for the async mapping rebuild.
+        // The key map refreshes in the background — a brief stale-label window is
+        // far less noticeable than a 500ms+ frozen overlay.
+        currentLayerName = targetLayerName
 
         // Clear tap-hold sources on layer change to prevent stale suppressions
         // (e.g., user switches layers while holding a tap-hold key)
@@ -57,7 +60,7 @@ extension KeyboardVisualizationViewModel {
         noteInteraction()
         noteTcpEventReceived()
 
-        // Build mapping first, then update layer name atomically when ready
+        // Rebuild the detailed key map in the background
         rebuildLayerMappingForLayer(targetLayerName)
     }
 
@@ -218,8 +221,8 @@ extension KeyboardVisualizationViewModel {
                 // Enrich mapping with custom shift labels from custom rules
                 mapping = enrichWithCustomShiftLabels(mapping: mapping, customRules: customRules)
 
-                // Update layer name and mapping atomically to prevent UI flash
-                // This ensures the UI never shows mismatched layer name + old mapping
+                // Update mapping (layer name was already set eagerly in updateLayer;
+                // re-assign here for the rebuildLayerMapping() path from setLayout)
                 await MainActor.run {
                     self.currentLayerName = targetLayerName
                     self.layerKeyMap = mapping


### PR DESCRIPTION
## Summary
- Moves `currentLayerName` assignment from end of async rebuild pipeline to synchronous `updateLayer()`, so `isLauncherModeActive` and layer indicators flip immediately on TCP layer message
- Eliminates 500ms-2s perceived delay when switching to launcher/nav/vim layers — the overlay now transitions instantly while key labels fill in the background

Closes #397

## Test plan
- [x] Build passes
- [x] 530 tests pass
- [ ] Hold Caps Lock (Hyper) → launcher overlay appears instantly (no two-phase transition)
- [ ] Nav/vim layer switches feel instant
- [ ] Returning to base layer clears state correctly