### PR TITLE
Add accessibilityValue to sliders, steppers, and pickers

### DIFF
--- a/Sources/KeyPathAppKit/UI/Gallery/PackDetailView.swift
+++ b/Sources/KeyPathAppKit/UI/Gallery/PackDetailView.swift
@@ -568,6 +568,8 @@ struct PackDetailView: View {
                     in: Double(lo) ... Double(hi),
                     step: Double(step)
                 )
+                .accessibilityLabel(setting.label)
+                .accessibilityValue("\(quickSettingValues[setting.id] ?? 0)\(suffix)")
                 Text("\(quickSettingValues[setting.id] ?? 0)\(suffix)")
                     .font(.system(size: 11, design: .monospaced))
                     .foregroundStyle(.secondary)

--- a/Sources/KeyPathAppKit/UI/Overlay/TypingSoundsSection.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/TypingSoundsSection.swift
@@ -187,6 +187,8 @@ private struct SoundProfileDescriptionBar: View {
 
                     Slider(value: $volume, in: 0 ... 1)
                         .controlSize(.small)
+                        .accessibilityLabel("Typing sound volume")
+                        .accessibilityValue("\(Int(volume * 100))%")
 
                     Image(systemName: "speaker.wave.3.fill")
                         .font(.caption2)

--- a/Sources/KeyPathAppKit/UI/Rules/ChordGroupsModalView.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/ChordGroupsModalView.swift
@@ -233,6 +233,8 @@ struct ChordGroupsModalView: View {
                         in: 100 ... 800,
                         step: 50
                     )
+                    .accessibilityLabel("Chord timeout")
+                    .accessibilityValue("\(group.timeout) ms, \(ChordSpeed.nearest(to: group.timeout).rawValue)")
 
                     // Speed preset buttons
                     HStack(spacing: 8) {

--- a/Sources/KeyPathAppKit/UI/Rules/HomeRowLayerTogglesModalView.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/HomeRowLayerTogglesModalView.swift
@@ -205,6 +205,8 @@ struct HomeRowLayerTogglesModalView: View {
                                 get: { Double(localConfig.timing.quickTapTermMs) },
                                 set: { localConfig.timing.quickTapTermMs = Int($0) }
                             ), in: 0 ... 80, step: 5)
+                            .accessibilityLabel("Quick tap term")
+                            .accessibilityValue("\(localConfig.timing.quickTapTermMs) ms")
                             Text(String(localized: "\(localConfig.timing.quickTapTermMs) ms"))
                                 .font(.caption)
                                 .foregroundColor(.secondary)

--- a/Sources/KeyPathAppKit/UI/Rules/HomeRowTimingSection.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/HomeRowTimingSection.swift
@@ -187,6 +187,7 @@ struct HomeRowTimingSection: View {
                         )
                         .accessibilityIdentifier("home-row-mods-feel-slider")
                         .accessibilityLabel("Typing feel")
+                        .accessibilityValue("\(TypingFeelMapping.helperText(forSliderPosition: effectiveSliderPosition)), tap \(config.timing.tapWindow)ms, hold \(config.timing.holdDelay)ms")
 
                         Text("More Modifiers")
                             .font(.caption2)
@@ -260,6 +261,7 @@ struct HomeRowTimingSection: View {
                     ), in: 50 ... 300, step: 10)
                         .accessibilityIdentifier("home-row-mods-prior-idle-slider")
                         .accessibilityLabel("Fast typing protection threshold")
+                        .accessibilityValue("\(config.timing.requirePriorIdleMs) ms")
 
                     Text("Forgiving")
                         .font(.caption2)
@@ -302,6 +304,7 @@ struct HomeRowTimingSection: View {
                     ), in: 0 ... 80, step: 5)
                         .accessibilityIdentifier("home-row-mods-quick-tap-term-slider")
                         .accessibilityLabel("Quick tap extra time")
+                        .accessibilityValue("\(config.timing.quickTapTermMs) ms")
 
                     Text("Forgiving")
                         .font(.caption2)
@@ -390,6 +393,7 @@ struct HomeRowTimingSection: View {
             )
             .accessibilityIdentifier("home-row-mods-finger-\(finger.rawValue)-slider")
             .accessibilityLabel("\(finger.displayName) finger sensitivity")
+            .accessibilityValue("\(displayValue) ms")
 
             if isCustom {
                 Text("Mixed")

--- a/Sources/KeyPathAppKit/UI/Rules/KeyRepeatControlView.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/KeyRepeatControlView.swift
@@ -378,7 +378,11 @@ struct KeyRepeatControlView: View {
     // MARK: - Clean Slider
 
     private func cleanSlider(label: String, value: Binding<Int>, range: ClosedRange<Int>, snap: Int, id: String = "") -> some View {
-        HStack(spacing: 8) {
+        let unit = label == "Delay" ? "ms" : "keys/sec"
+        let displayValue = label == "Speed"
+            ? KeyRepeatControlConfig.keysPerSecond(fromIntervalMs: value.wrappedValue)
+            : "\(value.wrappedValue) \(unit)"
+        return HStack(spacing: 8) {
             Text(label)
                 .font(.system(size: 10))
                 .foregroundStyle(.tertiary)
@@ -389,6 +393,7 @@ struct KeyRepeatControlView: View {
             ), in: Double(range.lowerBound)...Double(range.upperBound))
             .controlSize(.small)
             .accessibilityIdentifier(id.isEmpty ? "key-repeat-slider-\(label.lowercased())" : "key-repeat-slider-\(id)")
+            .accessibilityValue(displayValue)
         }
     }
 

--- a/Sources/KeyPathAppKit/UI/Rules/MappingBehaviorEditor.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/MappingBehaviorEditor.swift
@@ -50,6 +50,7 @@ struct MappingBehaviorEditor: View {
             .pickerStyle(.segmented)
             .accessibilityIdentifier("mapping-behavior-mode-picker")
             .accessibilityLabel("Mapping mode")
+            .accessibilityValue(mode.rawValue)
             .onChange(of: mode) { _, newMode in
                 if newMode == .simple {
                     // Clear behavior when switching to simple
@@ -104,6 +105,7 @@ struct MappingBehaviorEditor: View {
             .pickerStyle(.segmented)
             .accessibilityIdentifier("mapping-behavior-type-picker")
             .accessibilityLabel("Behavior type")
+            .accessibilityValue(behaviorType.rawValue)
             .onChange(of: behaviorType) { _, _ in
                 syncBehaviorFromState()
             }
@@ -160,6 +162,7 @@ struct MappingBehaviorEditor: View {
                             step: 10
                         )
                         .accessibilityIdentifier("mapping-behavior-tap-timeout-stepper")
+                        .accessibilityValue("\(tapTimeout) ms")
                         .onChange(of: tapTimeout) { _, _ in syncBehaviorFromState() }
                     }
 
@@ -178,6 +181,7 @@ struct MappingBehaviorEditor: View {
                                 )
                                 .controlSize(.small)
                                 .accessibilityIdentifier("mapping-behavior-hold-timeout-stepper")
+                                .accessibilityValue("\(holdTimeout) ms")
                                 .onChange(of: holdTimeout) { _, _ in syncBehaviorFromState() }
                             }
                         }
@@ -239,6 +243,7 @@ struct MappingBehaviorEditor: View {
                         step: 10
                     )
                     .accessibilityIdentifier("mapping-behavior-tap-dance-window-stepper")
+                    .accessibilityValue("\(tapDanceWindow) ms")
                     .onChange(of: tapDanceWindow) { _, _ in syncBehaviorFromState() }
                 }
                 .padding(.vertical, 4)

--- a/Sources/KeyPathAppKit/UI/Rules/SequencesModalView.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/SequencesModalView.swift
@@ -384,7 +384,8 @@ struct SequencesModalView: View {
                         set: { localConfig.globalTimeout = Int($0) }
                     ), in: 300 ... 1000, step: 50)
                         .accessibilityIdentifier("sequences-modal-timeout-slider")
-                        .accessibilityLabel("Global timeout: \(localConfig.globalTimeout) milliseconds")
+                        .accessibilityLabel("Global timeout")
+                        .accessibilityValue("\(localConfig.globalTimeout) ms")
 
                     Text("\(localConfig.globalTimeout)ms")
                         .font(.system(.body, design: .monospaced))


### PR DESCRIPTION
## Summary
- Adds `.accessibilityValue()` to 20 stateful controls across 8 files so agents can read current settings values, not just labels
- Covers all sliders, steppers, and segmented pickers in settings and rules views

## What agents see now

**Before:** An agent queries the key repeat delay slider and sees: label "Delay". No way to know the current value is 150ms.

**After:** Same slider reports: label "Delay", value "150 ms". An agent can verify settings are correct or describe the current configuration.

| Control | Example value |
|---------|--------------|
| Key repeat delay slider | "150 ms" |
| Key repeat speed slider | "50 keys/sec" |
| Typing feel slider | "Balanced, tap 200ms, hold 200ms" |
| Prior idle threshold | "130 ms" |
| Finger sensitivity | "40 ms" |
| Chord timeout | "200 ms, Normal" |
| Tap timeout stepper | "200 ms" |
| Typing sound volume | "75%" |
| Mode picker | "Simple" / "Advanced" |
| Behavior type picker | "Tap / Hold" / "Tap Dance" |
| Pack quick setting | "150ms" |

## Test plan
- [ ] Build succeeds (verified locally)
- [ ] No visual regressions — only `.accessibilityValue()` modifiers added
- [ ] Slider values update as the slider is dragged
- [ ] Stepper values update on increment/decrement
- [ ] Picker values reflect the selected segment