### PR TITLE
fix: show close button and All Rules link in overlay pack detail

### DIFF
--- a/Sources/KeyPathAppKit/UI/Experimental/MapperView+Inspector.swift
+++ b/Sources/KeyPathAppKit/UI/Experimental/MapperView+Inspector.swift
@@ -62,9 +62,6 @@ struct MapperInspectorPanel: View {
 
     // MARK: - Pack Suggestions
 
-    /// Pack selected by the user to open in Pack Detail (sheet presentation).
-    @State private var packForDetail: Pack?
-
     /// Packs from the Starter Kit whose bindings target the currently
     /// selected input key. Empty ⇒ the section doesn't render.
     private var packSuggestions: [Pack] {
@@ -85,10 +82,6 @@ struct MapperInspectorPanel: View {
                 packSuggestionRow(pack)
             }
         }
-        .sheet(item: $packForDetail) { pack in
-            PackDetailView(pack: pack)
-                .environment(kanataManagerForGallery())
-        }
     }
 
     private func isPackEnabled(_ pack: Pack) -> Bool {
@@ -98,7 +91,9 @@ struct MapperInspectorPanel: View {
 
     private func packSuggestionRow(_ pack: Pack) -> some View {
         let enabled = isPackEnabled(pack)
-        return Button(action: { packForDetail = pack }) {
+        return Button(action: {
+            PackDetailWindowController.shared.showWindow(pack: pack, kanataManager: kanataManager, fromOverlay: true)
+        }) {
             HStack(spacing: 6) {
                 if enabled {
                     PackActiveLED()
@@ -142,10 +137,6 @@ struct MapperInspectorPanel: View {
                     .symbolRenderingMode(.hierarchical)
             }
         }
-    }
-
-    private func kanataManagerForGallery() -> KanataViewModel {
-        kanataManager
     }
 
     /// Display-friendly label for the current input (⇪, D, ⌘, etc.).

--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayMapperSection.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayMapperSection.swift
@@ -727,8 +727,6 @@ struct OverlayMapperSection: View {
 
     // MARK: - Pack Suggestions for Selected Key
 
-    @State private var packForDetail: Pack?
-
     private var packsForSelectedKey: [Pack] {
         guard let keyCode = viewModel.inputKeyCode else { return [] }
         let kanataKey = OverlayKeyboardView.keyCodeToKanataName(keyCode)
@@ -764,7 +762,9 @@ struct OverlayMapperSection: View {
                 ForEach(packs) { pack in
                     let enabled = isPackEnabled(pack)
                     Button {
-                        packForDetail = pack
+                        if let vm = kanataViewModel {
+                            PackDetailWindowController.shared.showWindow(pack: pack, kanataManager: vm, fromOverlay: true)
+                        }
                     } label: {
                         HStack(spacing: 8) {
                             if enabled {
@@ -798,12 +798,6 @@ struct OverlayMapperSection: View {
             .padding(.horizontal, 8)
             .padding(.top, 3)
             .padding(.bottom, 4)
-            .sheet(item: $packForDetail) { pack in
-                if let vm = kanataViewModel {
-                    PackDetailView(pack: pack)
-                        .environment(vm)
-                }
-            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Two overlay code paths (OverlayMapperSection, MapperInspectorPanel) were opening PackDetailView as a `.sheet` without `showBackToRules: true`, hiding the close button and "All Rules" breadcrumb
- Switched both to use `PackDetailWindowController.shared.showWindow(fromOverlay: true)`, matching the other overlay → pack detail paths (inspector panel, launchers section)

## Test plan
- [x] Build passes
- [x] 530 tests pass
- [ ] Click a pack suggestion in the overlay mapper drawer → pack detail opens with close button (far right) and "All Rules" link (left)
- [ ] Click a pack suggestion in the mapper inspector panel → same
- [ ] Clicking "All Rules" closes pack detail and opens Settings on rules tab
- [ ] Clicking ✕ does the same