### PR TITLE
feat: pack component ownership — lock collections when pack installed (#385)

### DIFF
--- a/Sources/KeyPathAppKit/CLI/CLIFacade.swift
+++ b/Sources/KeyPathAppKit/CLI/CLIFacade.swift
@@ -239,6 +239,13 @@ public struct CLIFacade: Sendable {
         guard let index = try resolveCollectionIndex(nameOrId: nameOrId, in: collections) else {
             return nil
         }
+        if let owner = await InstalledPackTracker.shared.packManagingCollection(collections[index].id) {
+            throw PackManagedCollectionError(
+                collectionName: collections[index].name,
+                packName: owner.packName,
+                packID: owner.packID
+            )
+        }
         collections[index].isEnabled = true
         try await RuleCollectionStore.shared.saveCollections(collections)
         return collections[index].name
@@ -249,6 +256,13 @@ public struct CLIFacade: Sendable {
         var collections = await RuleCollectionStore.shared.loadCollections()
         guard let index = try resolveCollectionIndex(nameOrId: nameOrId, in: collections) else {
             return nil
+        }
+        if let owner = await InstalledPackTracker.shared.packManagingCollection(collections[index].id) {
+            throw PackManagedCollectionError(
+                collectionName: collections[index].name,
+                packName: owner.packName,
+                packID: owner.packID
+            )
         }
         collections[index].isEnabled = false
         try await RuleCollectionStore.shared.saveCollections(collections)
@@ -1711,6 +1725,16 @@ public struct CLIPackSettingError: Error, CustomStringConvertible {
             return "Pack '\(packName)' has no quick settings, but --setting \(settingKey) was provided"
         }
         return "Unknown setting '\(settingKey)' for pack '\(packName)'. Valid keys: \(validKeys.joined(separator: ", "))"
+    }
+}
+
+public struct PackManagedCollectionError: Error, CustomStringConvertible {
+    public let collectionName: String
+    public let packName: String
+    public let packID: String
+    public var description: String {
+        let slug = packName.lowercased().replacingOccurrences(of: " ", with: "-")
+        return "'\(collectionName)' is managed by pack '\(packName)'. Run 'keypath pack uninstall \(slug)' to release it."
     }
 }
 

--- a/Sources/KeyPathAppKit/Services/Packs/InstalledPackTracker.swift
+++ b/Sources/KeyPathAppKit/Services/Packs/InstalledPackTracker.swift
@@ -72,6 +72,18 @@ public actor InstalledPackTracker {
         return records[packID]
     }
 
+    /// Returns the installed pack that manages a given collection, or nil.
+    public func packManagingCollection(_ collectionID: UUID) async -> (packID: String, packName: String)? {
+        await ensureLoaded()
+        for (packID, _) in records {
+            guard let pack = PackRegistry.pack(id: packID) else { continue }
+            if pack.managedCollectionIDs.contains(collectionID) {
+                return (packID: packID, packName: pack.name)
+            }
+        }
+        return nil
+    }
+
     /// Mark a pack as installed (or update an existing record). Persists.
     public func upsert(_ record: InstalledPackRecord) async throws {
         await ensureLoaded()

--- a/Sources/KeyPathAppKit/Services/Packs/Pack.swift
+++ b/Sources/KeyPathAppKit/Services/Packs/Pack.swift
@@ -116,6 +116,22 @@ public struct Pack: Identifiable, Equatable, Sendable {
         Array(Set(bindings.map(\.input)))
     }
 
+    /// All rule collection UUIDs this pack manages when installed.
+    /// Most packs manage their single `associatedCollectionID`.
+    /// The Vallack system pack manages three collections atomically.
+    /// Visual-only packs manage none.
+    public var managedCollectionIDs: [UUID] {
+        if visualOnly { return [] }
+        if id == "com.keypath.pack.vallack-system" {
+            return [
+                RuleCollectionIdentifier.vallackNavigation,
+                RuleCollectionIdentifier.homeRowMods,
+                RuleCollectionIdentifier.homeRowLayerToggles,
+            ]
+        }
+        return [associatedCollectionID].compactMap { $0 }
+    }
+
     /// Preferred width for Pack Detail presentation (window or sheet).
     public var preferredDetailWidth: CGFloat {
         let widePacks: Set<String> = [

--- a/Sources/KeyPathAppKit/Services/Packs/PackInstaller.swift
+++ b/Sources/KeyPathAppKit/Services/Packs/PackInstaller.swift
@@ -110,7 +110,7 @@ public final class PackInstaller {
         // Collection-backed packs (e.g. Home Row Mods) don't generate custom
         // rules — they just toggle the built-in RuleCollection on.
         if let collectionID = pack.associatedCollectionID {
-            let ok = await manager.toggleCollection(id: collectionID, isEnabled: true, autoResolveConflicts: true)
+            let ok = await manager.toggleCollection(id: collectionID, isEnabled: true, autoResolveConflicts: true, bypassOwnershipCheck: true)
             if !ok {
                 throw InstallError.saveFailed("could not enable associated rule collection")
             }
@@ -206,7 +206,7 @@ public final class PackInstaller {
         if let pack = PackRegistry.pack(id: packID),
            let collectionID = pack.associatedCollectionID
         {
-            let ok = await manager.toggleCollection(id: collectionID, isEnabled: false)
+            let ok = await manager.toggleCollection(id: collectionID, isEnabled: false, bypassOwnershipCheck: true)
             guard ok else {
                 throw InstallError.saveFailed("could not disable associated rule collection")
             }

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+PublicAPI.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+PublicAPI.swift
@@ -21,8 +21,18 @@ extension RuleCollectionsManager {
     /// Toggle a rule collection on/off
     /// - Returns: `true` if the toggle was applied successfully, `false` if validation failed and state was rolled back
     @discardableResult
-    func toggleCollection(id: UUID, isEnabled: Bool, autoResolveConflicts: Bool = false) async -> Bool {
+    func toggleCollection(id: UUID, isEnabled: Bool, autoResolveConflicts: Bool = false, bypassOwnershipCheck: Bool = false) async -> Bool {
         AppLogger.shared.log("🔀 [RuleCollections] toggleCollection called: id=\(id), isEnabled=\(isEnabled)")
+
+        if !bypassOwnershipCheck {
+            if let owner = await InstalledPackTracker.shared.packManagingCollection(id) {
+                AppLogger.shared.log(
+                    "🔒 [RuleCollections] Toggle blocked: collection \(id) is managed by pack '\(owner.packName)'"
+                )
+                return false
+            }
+        }
+
         let snapshot = snapshotRuleState()
 
         let catalogMatch = RuleCollectionCatalog().defaultCollections().first { $0.id == id }

--- a/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView+CollectionRow.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView+CollectionRow.swift
@@ -29,6 +29,7 @@ struct ExpandableCollectionRow: View {
     var leaderKeyDisplay: String = "␣ Space"
     /// Optional activation hint from collection (overrides default formatting)
     var activationHint: String?
+    var managingPackName: String? = nil
     var defaultExpanded: Bool = false
     var displayStyle: RuleCollectionDisplayStyle = .list
     /// For singleKeyPicker style: the full collection with presets
@@ -249,6 +250,14 @@ private var fallbackKeyMappings: [KeyMapping] {
                                     .fontWeight(.regular)
                                     .foregroundColor(.secondary)
                             }
+                            if let packName = managingPackName {
+                                Text("Managed by \(packName)")
+                                    .font(.caption2)
+                                    .foregroundColor(.white.opacity(0.85))
+                                    .padding(.horizontal, 6)
+                                    .padding(.vertical, 2)
+                                    .background(Capsule().fill(Color.accentColor.opacity(0.7)))
+                            }
                         }
 
                         if let desc = description {
@@ -305,6 +314,7 @@ private var fallbackKeyMappings: [KeyMapping] {
             .labelsHidden()
             .toggleStyle(.switch)
             .tint(.blue)
+            .disabled(managingPackName != nil)
             .accessibilityIdentifier("rules-summary-toggle-\(collectionId)")
             .accessibilityLabel("Toggle \(name)")
         }

--- a/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView.swift
@@ -36,6 +36,8 @@ struct RulesTabView: View {
     @State private var pendingDisableDependents: [Pack] = []
     /// Tracks packs with unmet dependencies (for warning badges)
     @State private var unmetDependencyMap: [String: [UnmetDependency]] = [:]
+    /// Maps collection IDs to managing pack names (for installed packs only)
+    @State private var collectionOwnershipMap: [UUID: String] = [:]
     private let catalog = RuleCollectionCatalog()
 
     /// Total count of custom rules (everywhere + app-specific)
@@ -241,6 +243,7 @@ struct RulesTabView: View {
             layerActivator: collection.momentaryActivator,
             leaderKeyDisplay: currentLeaderKeyDisplay,
             activationHint: dynamicActivationHint(for: collection),
+            managingPackName: collectionOwnershipMap[collection.id],
             defaultExpanded: recommendationFocusCollectionId == collection.id,
             displayStyle: style,
             collection: needsCollection ? collection : nil,
@@ -335,6 +338,14 @@ struct RulesTabView: View {
     // MARK: - Dependency-Aware Toggle
 
     private func handleCollectionToggle(collection: RuleCollection, isOn: Bool) {
+        if let packName = collectionOwnershipMap[collection.id] {
+            settingsToastManager.showError(
+                "Managed by \(packName) — uninstall the pack to change this"
+            )
+            pendingToggles.removeValue(forKey: collection.id)
+            return
+        }
+
         let pack = packForCollection(collection)
 
         if isOn, let pack {
@@ -422,6 +433,16 @@ struct RulesTabView: View {
                 enabled: isOn
             )
         }
+    }
+
+    private func refreshCollectionOwnership() async {
+        var map: [UUID: String] = [:]
+        for collection in allCollections {
+            if let owner = await InstalledPackTracker.shared.packManagingCollection(collection.id) {
+                map[collection.id] = owner.packName
+            }
+        }
+        collectionOwnershipMap = map
     }
 
     private func refreshUnmetDependencies() {
@@ -660,15 +681,19 @@ struct RulesTabView: View {
             }
             // Load app-specific keymaps
             loadAppKeymaps()
-            // Check KindaVim pack install state
+            // Check KindaVim pack install state + collection ownership
             Task {
                 isKindaVimInstalled = await InstalledPackTracker.shared.isInstalled(
                     packID: PackRegistry.kindaVim.id
                 )
+                await refreshCollectionOwnership()
             }
         }
         .onReceive(NotificationCenter.default.publisher(for: .appKeymapsDidChange)) { _ in
             loadAppKeymaps()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .installedPacksChanged)) { _ in
+            Task { await refreshCollectionOwnership() }
         }
         .sheet(item: $homeRowModsEditState) { editState in
             HomeRowModsModalView(

--- a/Sources/KeyPathCLI/Commands/Collection/CollectionDisableCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Collection/CollectionDisableCommand.swift
@@ -29,6 +29,13 @@ struct CollectionDisable: AsyncParsableCommand {
             CLIOutput.write(["disabled": name], context: ctx) {
                 "Disabled '\(name)'"
             }
+        } catch let managed as PackManagedCollectionError {
+            let error = CLIError.conflict(
+                managed.description,
+                hint: "Run 'keypath pack uninstall \(managed.packName.lowercased().replacingOccurrences(of: " ", with: "-"))' to release this collection"
+            )
+            CLIOutput.writeError(error, context: ctx)
+            throw error.code.exitCode
         } catch let ambiguous as AmbiguousCollectionMatch {
             let error = CLIError.ambiguous(
                 ambiguous.description,

--- a/Sources/KeyPathCLI/Commands/Collection/CollectionEnableCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Collection/CollectionEnableCommand.swift
@@ -29,6 +29,13 @@ struct CollectionEnable: AsyncParsableCommand {
             CLIOutput.write(["enabled": name], context: ctx) {
                 "Enabled '\(name)'"
             }
+        } catch let managed as PackManagedCollectionError {
+            let error = CLIError.conflict(
+                managed.description,
+                hint: "Run 'keypath pack uninstall \(managed.packName.lowercased().replacingOccurrences(of: " ", with: "-"))' to release this collection"
+            )
+            CLIOutput.writeError(error, context: ctx)
+            throw error.code.exitCode
         } catch let ambiguous as AmbiguousCollectionMatch {
             let error = CLIError.ambiguous(
                 ambiguous.description,

--- a/Tests/KeyPathTests/PackOwnershipTests.swift
+++ b/Tests/KeyPathTests/PackOwnershipTests.swift
@@ -1,0 +1,151 @@
+@testable import KeyPathAppKit
+@preconcurrency import XCTest
+
+@MainActor
+final class PackOwnershipTests: XCTestCase {
+    private var originalInstalledPacks: [InstalledPackRecord] = []
+
+    override func setUp() async throws {
+        try await super.setUp()
+        originalInstalledPacks = await InstalledPackTracker.shared.allInstalled()
+    }
+
+    override func tearDown() async throws {
+        let current = await InstalledPackTracker.shared.allInstalled()
+        for record in current {
+            if !originalInstalledPacks.contains(where: { $0.packID == record.packID }) {
+                try await InstalledPackTracker.shared.remove(packID: record.packID)
+            }
+        }
+        for record in originalInstalledPacks {
+            if !(await InstalledPackTracker.shared.isInstalled(packID: record.packID)) {
+                try await InstalledPackTracker.shared.upsert(record)
+            }
+        }
+        try await super.tearDown()
+    }
+
+    // MARK: - managedCollectionIDs
+
+    func testManagedCollectionIDsSinglePack() {
+        let pack = PackRegistry.pack(id: "com.keypath.pack.home-row-mods")!
+        XCTAssertEqual(pack.managedCollectionIDs, [RuleCollectionIdentifier.homeRowMods])
+    }
+
+    func testManagedCollectionIDsVallack() {
+        let pack = PackRegistry.pack(id: "com.keypath.pack.vallack-system")!
+        let ids = Set(pack.managedCollectionIDs)
+        XCTAssertEqual(ids.count, 3)
+        XCTAssertTrue(ids.contains(RuleCollectionIdentifier.vallackNavigation))
+        XCTAssertTrue(ids.contains(RuleCollectionIdentifier.homeRowMods))
+        XCTAssertTrue(ids.contains(RuleCollectionIdentifier.homeRowLayerToggles))
+    }
+
+    func testManagedCollectionIDsVisualOnly() {
+        let pack = PackRegistry.pack(id: "com.keypath.pack.kindavim")!
+        XCTAssertTrue(pack.managedCollectionIDs.isEmpty)
+    }
+
+    // MARK: - packManagingCollection
+
+    func testPackManagingCollectionWhenInstalled() async throws {
+        let record = InstalledPackRecord(
+            packID: "com.keypath.pack.home-row-mods",
+            version: "1.0.0"
+        )
+        try await InstalledPackTracker.shared.upsert(record)
+
+        let owner = await InstalledPackTracker.shared.packManagingCollection(
+            RuleCollectionIdentifier.homeRowMods
+        )
+        XCTAssertNotNil(owner)
+        XCTAssertEqual(owner?.packName, "Home Row Mods")
+    }
+
+    func testPackManagingCollectionWhenNotInstalled() async throws {
+        if await InstalledPackTracker.shared.isInstalled(packID: "com.keypath.pack.chord-groups") {
+            try await InstalledPackTracker.shared.remove(packID: "com.keypath.pack.chord-groups")
+        }
+
+        let owner = await InstalledPackTracker.shared.packManagingCollection(
+            RuleCollectionIdentifier.chordGroups
+        )
+        XCTAssertNil(owner)
+    }
+
+    func testVallackOwnsAllThreeCollections() async throws {
+        let record = InstalledPackRecord(
+            packID: "com.keypath.pack.vallack-system",
+            version: "1.0.0"
+        )
+        try await InstalledPackTracker.shared.upsert(record)
+
+        let navOwner = await InstalledPackTracker.shared.packManagingCollection(
+            RuleCollectionIdentifier.vallackNavigation
+        )
+        let hrmOwner = await InstalledPackTracker.shared.packManagingCollection(
+            RuleCollectionIdentifier.homeRowMods
+        )
+        let togglesOwner = await InstalledPackTracker.shared.packManagingCollection(
+            RuleCollectionIdentifier.homeRowLayerToggles
+        )
+
+        XCTAssertEqual(navOwner?.packName, "Ben Vallack Approach")
+        XCTAssertEqual(hrmOwner?.packName, "Ben Vallack Approach")
+        XCTAssertEqual(togglesOwner?.packName, "Ben Vallack Approach")
+    }
+
+    func testOwnershipClearsOnUninstall() async throws {
+        let record = InstalledPackRecord(
+            packID: "com.keypath.pack.chord-groups",
+            version: "1.0.0"
+        )
+        try await InstalledPackTracker.shared.upsert(record)
+
+        let before = await InstalledPackTracker.shared.packManagingCollection(
+            RuleCollectionIdentifier.chordGroups
+        )
+        XCTAssertNotNil(before)
+
+        try await InstalledPackTracker.shared.remove(packID: "com.keypath.pack.chord-groups")
+
+        let after = await InstalledPackTracker.shared.packManagingCollection(
+            RuleCollectionIdentifier.chordGroups
+        )
+        XCTAssertNil(after)
+    }
+
+    // MARK: - CLI facade blocks managed collections
+
+    func testCLIFacadeBlocksEnableOnManagedCollection() async throws {
+        let record = InstalledPackRecord(
+            packID: "com.keypath.pack.chord-groups",
+            version: "1.0.0"
+        )
+        try await InstalledPackTracker.shared.upsert(record)
+
+        let facade = CLIFacade()
+        do {
+            _ = try await facade.enableCollection(nameOrId: "Chord Groups")
+            XCTFail("Should throw PackManagedCollectionError")
+        } catch is PackManagedCollectionError {
+            // expected
+        }
+    }
+
+    func testCLIFacadeBlocksDisableOnManagedCollection() async throws {
+        let record = InstalledPackRecord(
+            packID: "com.keypath.pack.chord-groups",
+            version: "1.0.0"
+        )
+        try await InstalledPackTracker.shared.upsert(record)
+
+        let facade = CLIFacade()
+        do {
+            _ = try await facade.disableCollection(nameOrId: "Chord Groups")
+            XCTFail("Should throw PackManagedCollectionError")
+        } catch is PackManagedCollectionError {
+            // expected
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements #385 — when a pack is installed, its managed collections are locked (toggle disabled, "Managed by [Pack]" badge shown). Users must uninstall the pack to release the collections. Internal settings (timing, modifiers) remain editable.

**Data layer:**
- `Pack.managedCollectionIDs` — Vallack returns 3 collections, most return 1, KindaVim 0
- `InstalledPackTracker.packManagingCollection()` — reverse lookup for ownership

**Enforcement:**
- `toggleCollection()` blocks when collection is pack-managed (PackInstaller bypasses via `bypassOwnershipCheck: true`)
- CLI `collection enable/disable` throws `PackManagedCollectionError` with uninstall hint

**UI:**
- "Managed by [Pack Name]" capsule badge + disabled toggle in Rules tab
- Toast error on toggle attempt

## Test plan

- [x] `swift build` — compiles clean
- [x] `swift test --filter PackOwnershipTests` — 9 tests pass
- [x] `swift test` — full suite 530 tests, 0 failures
- [ ] Manual: install Vallack pack, verify all 3 collections show badge + disabled toggle
- [ ] Manual: `keypath collection disable home-row-mods` with pack installed → error message