### PR TITLE
feat: pack ownership + CLI UX polish (#385 #403 #404 #405 #406 #407 #408)

### DIFF
--- a/Sources/KeyPathAppKit/CLI/CLIFacade.swift
+++ b/Sources/KeyPathAppKit/CLI/CLIFacade.swift
@@ -239,6 +239,13 @@ public struct CLIFacade: Sendable {
         guard let index = try resolveCollectionIndex(nameOrId: nameOrId, in: collections) else {
             return nil
         }
+        if let owner = await InstalledPackTracker.shared.packManagingCollection(collections[index].id) {
+            throw PackManagedCollectionError(
+                collectionName: collections[index].name,
+                packName: owner.packName,
+                packID: owner.packID
+            )
+        }
         collections[index].isEnabled = true
         try await RuleCollectionStore.shared.saveCollections(collections)
         return collections[index].name
@@ -249,6 +256,13 @@ public struct CLIFacade: Sendable {
         var collections = await RuleCollectionStore.shared.loadCollections()
         guard let index = try resolveCollectionIndex(nameOrId: nameOrId, in: collections) else {
             return nil
+        }
+        if let owner = await InstalledPackTracker.shared.packManagingCollection(collections[index].id) {
+            throw PackManagedCollectionError(
+                collectionName: collections[index].name,
+                packName: owner.packName,
+                packID: owner.packID
+            )
         }
         collections[index].isEnabled = false
         try await RuleCollectionStore.shared.saveCollections(collections)
@@ -1711,6 +1725,16 @@ public struct CLIPackSettingError: Error, CustomStringConvertible {
             return "Pack '\(packName)' has no quick settings, but --setting \(settingKey) was provided"
         }
         return "Unknown setting '\(settingKey)' for pack '\(packName)'. Valid keys: \(validKeys.joined(separator: ", "))"
+    }
+}
+
+public struct PackManagedCollectionError: Error, CustomStringConvertible {
+    public let collectionName: String
+    public let packName: String
+    public let packID: String
+    public var description: String {
+        let slug = packName.lowercased().replacingOccurrences(of: " ", with: "-")
+        return "'\(collectionName)' is managed by pack '\(packName)'. Run 'keypath pack uninstall \(slug)' to release it."
     }
 }
 

--- a/Sources/KeyPathAppKit/Services/Packs/InstalledPackTracker.swift
+++ b/Sources/KeyPathAppKit/Services/Packs/InstalledPackTracker.swift
@@ -72,6 +72,18 @@ public actor InstalledPackTracker {
         return records[packID]
     }
 
+    /// Returns the installed pack that manages a given collection, or nil.
+    public func packManagingCollection(_ collectionID: UUID) async -> (packID: String, packName: String)? {
+        await ensureLoaded()
+        for (packID, _) in records {
+            guard let pack = PackRegistry.pack(id: packID) else { continue }
+            if pack.managedCollectionIDs.contains(collectionID) {
+                return (packID: packID, packName: pack.name)
+            }
+        }
+        return nil
+    }
+
     /// Mark a pack as installed (or update an existing record). Persists.
     public func upsert(_ record: InstalledPackRecord) async throws {
         await ensureLoaded()

--- a/Sources/KeyPathAppKit/Services/Packs/Pack.swift
+++ b/Sources/KeyPathAppKit/Services/Packs/Pack.swift
@@ -116,6 +116,22 @@ public struct Pack: Identifiable, Equatable, Sendable {
         Array(Set(bindings.map(\.input)))
     }
 
+    /// All rule collection UUIDs this pack manages when installed.
+    /// Most packs manage their single `associatedCollectionID`.
+    /// The Vallack system pack manages three collections atomically.
+    /// Visual-only packs manage none.
+    public var managedCollectionIDs: [UUID] {
+        if visualOnly { return [] }
+        if id == "com.keypath.pack.vallack-system" {
+            return [
+                RuleCollectionIdentifier.vallackNavigation,
+                RuleCollectionIdentifier.homeRowMods,
+                RuleCollectionIdentifier.homeRowLayerToggles,
+            ]
+        }
+        return [associatedCollectionID].compactMap { $0 }
+    }
+
     /// Preferred width for Pack Detail presentation (window or sheet).
     public var preferredDetailWidth: CGFloat {
         let widePacks: Set<String> = [

--- a/Sources/KeyPathAppKit/Services/Packs/PackInstaller.swift
+++ b/Sources/KeyPathAppKit/Services/Packs/PackInstaller.swift
@@ -110,7 +110,7 @@ public final class PackInstaller {
         // Collection-backed packs (e.g. Home Row Mods) don't generate custom
         // rules — they just toggle the built-in RuleCollection on.
         if let collectionID = pack.associatedCollectionID {
-            let ok = await manager.toggleCollection(id: collectionID, isEnabled: true, autoResolveConflicts: true)
+            let ok = await manager.toggleCollection(id: collectionID, isEnabled: true, autoResolveConflicts: true, bypassOwnershipCheck: true)
             if !ok {
                 throw InstallError.saveFailed("could not enable associated rule collection")
             }
@@ -206,7 +206,7 @@ public final class PackInstaller {
         if let pack = PackRegistry.pack(id: packID),
            let collectionID = pack.associatedCollectionID
         {
-            let ok = await manager.toggleCollection(id: collectionID, isEnabled: false)
+            let ok = await manager.toggleCollection(id: collectionID, isEnabled: false, bypassOwnershipCheck: true)
             guard ok else {
                 throw InstallError.saveFailed("could not disable associated rule collection")
             }

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+PublicAPI.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+PublicAPI.swift
@@ -21,8 +21,18 @@ extension RuleCollectionsManager {
     /// Toggle a rule collection on/off
     /// - Returns: `true` if the toggle was applied successfully, `false` if validation failed and state was rolled back
     @discardableResult
-    func toggleCollection(id: UUID, isEnabled: Bool, autoResolveConflicts: Bool = false) async -> Bool {
+    func toggleCollection(id: UUID, isEnabled: Bool, autoResolveConflicts: Bool = false, bypassOwnershipCheck: Bool = false) async -> Bool {
         AppLogger.shared.log("🔀 [RuleCollections] toggleCollection called: id=\(id), isEnabled=\(isEnabled)")
+
+        if !bypassOwnershipCheck {
+            if let owner = await InstalledPackTracker.shared.packManagingCollection(id) {
+                AppLogger.shared.log(
+                    "🔒 [RuleCollections] Toggle blocked: collection \(id) is managed by pack '\(owner.packName)'"
+                )
+                return false
+            }
+        }
+
         let snapshot = snapshotRuleState()
 
         let catalogMatch = RuleCollectionCatalog().defaultCollections().first { $0.id == id }

--- a/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView+CollectionRow.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView+CollectionRow.swift
@@ -29,6 +29,7 @@ struct ExpandableCollectionRow: View {
     var leaderKeyDisplay: String = "␣ Space"
     /// Optional activation hint from collection (overrides default formatting)
     var activationHint: String?
+    var managingPackName: String? = nil
     var defaultExpanded: Bool = false
     var displayStyle: RuleCollectionDisplayStyle = .list
     /// For singleKeyPicker style: the full collection with presets
@@ -249,6 +250,14 @@ private var fallbackKeyMappings: [KeyMapping] {
                                     .fontWeight(.regular)
                                     .foregroundColor(.secondary)
                             }
+                            if let packName = managingPackName {
+                                Text("Managed by \(packName)")
+                                    .font(.caption2)
+                                    .foregroundColor(.white.opacity(0.85))
+                                    .padding(.horizontal, 6)
+                                    .padding(.vertical, 2)
+                                    .background(Capsule().fill(Color.accentColor.opacity(0.7)))
+                            }
                         }
 
                         if let desc = description {
@@ -305,6 +314,7 @@ private var fallbackKeyMappings: [KeyMapping] {
             .labelsHidden()
             .toggleStyle(.switch)
             .tint(.blue)
+            .disabled(managingPackName != nil)
             .accessibilityIdentifier("rules-summary-toggle-\(collectionId)")
             .accessibilityLabel("Toggle \(name)")
         }

--- a/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView.swift
@@ -36,6 +36,8 @@ struct RulesTabView: View {
     @State private var pendingDisableDependents: [Pack] = []
     /// Tracks packs with unmet dependencies (for warning badges)
     @State private var unmetDependencyMap: [String: [UnmetDependency]] = [:]
+    /// Maps collection IDs to managing pack names (for installed packs only)
+    @State private var collectionOwnershipMap: [UUID: String] = [:]
     private let catalog = RuleCollectionCatalog()
 
     /// Total count of custom rules (everywhere + app-specific)
@@ -241,6 +243,7 @@ struct RulesTabView: View {
             layerActivator: collection.momentaryActivator,
             leaderKeyDisplay: currentLeaderKeyDisplay,
             activationHint: dynamicActivationHint(for: collection),
+            managingPackName: collectionOwnershipMap[collection.id],
             defaultExpanded: recommendationFocusCollectionId == collection.id,
             displayStyle: style,
             collection: needsCollection ? collection : nil,
@@ -335,6 +338,14 @@ struct RulesTabView: View {
     // MARK: - Dependency-Aware Toggle
 
     private func handleCollectionToggle(collection: RuleCollection, isOn: Bool) {
+        if let packName = collectionOwnershipMap[collection.id] {
+            settingsToastManager.showError(
+                "Managed by \(packName) — uninstall the pack to change this"
+            )
+            pendingToggles.removeValue(forKey: collection.id)
+            return
+        }
+
         let pack = packForCollection(collection)
 
         if isOn, let pack {
@@ -422,6 +433,16 @@ struct RulesTabView: View {
                 enabled: isOn
             )
         }
+    }
+
+    private func refreshCollectionOwnership() async {
+        var map: [UUID: String] = [:]
+        for collection in allCollections {
+            if let owner = await InstalledPackTracker.shared.packManagingCollection(collection.id) {
+                map[collection.id] = owner.packName
+            }
+        }
+        collectionOwnershipMap = map
     }
 
     private func refreshUnmetDependencies() {
@@ -660,15 +681,19 @@ struct RulesTabView: View {
             }
             // Load app-specific keymaps
             loadAppKeymaps()
-            // Check KindaVim pack install state
+            // Check KindaVim pack install state + collection ownership
             Task {
                 isKindaVimInstalled = await InstalledPackTracker.shared.isInstalled(
                     packID: PackRegistry.kindaVim.id
                 )
+                await refreshCollectionOwnership()
             }
         }
         .onReceive(NotificationCenter.default.publisher(for: .appKeymapsDidChange)) { _ in
             loadAppKeymaps()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .installedPacksChanged)) { _ in
+            Task { await refreshCollectionOwnership() }
         }
         .sheet(item: $homeRowModsEditState) { editState in
             HomeRowModsModalView(

--- a/Sources/KeyPathCLI/Commands/Collection/CollectionDisableCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Collection/CollectionDisableCommand.swift
@@ -29,6 +29,13 @@ struct CollectionDisable: AsyncParsableCommand {
             CLIOutput.write(["disabled": name], context: ctx) {
                 "Disabled '\(name)'"
             }
+        } catch let managed as PackManagedCollectionError {
+            let error = CLIError.conflict(
+                managed.description,
+                hint: "Run 'keypath pack uninstall \(managed.packName.lowercased().replacingOccurrences(of: " ", with: "-"))' to release this collection"
+            )
+            CLIOutput.writeError(error, context: ctx)
+            throw error.code.exitCode
         } catch let ambiguous as AmbiguousCollectionMatch {
             let error = CLIError.ambiguous(
                 ambiguous.description,

--- a/Sources/KeyPathCLI/Commands/Collection/CollectionEnableCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Collection/CollectionEnableCommand.swift
@@ -29,6 +29,13 @@ struct CollectionEnable: AsyncParsableCommand {
             CLIOutput.write(["enabled": name], context: ctx) {
                 "Enabled '\(name)'"
             }
+        } catch let managed as PackManagedCollectionError {
+            let error = CLIError.conflict(
+                managed.description,
+                hint: "Run 'keypath pack uninstall \(managed.packName.lowercased().replacingOccurrences(of: " ", with: "-"))' to release this collection"
+            )
+            CLIOutput.writeError(error, context: ctx)
+            throw error.code.exitCode
         } catch let ambiguous as AmbiguousCollectionMatch {
             let error = CLIError.ambiguous(
                 ambiguous.description,

--- a/Sources/KeyPathCLI/Commands/CompletionsCommand.swift
+++ b/Sources/KeyPathCLI/Commands/CompletionsCommand.swift
@@ -1,5 +1,6 @@
 import ArgumentParser
 import Foundation
+import KeyPathAppKit
 
 struct Completions: ParsableCommand {
     static let configuration = CommandConfiguration(
@@ -11,6 +12,7 @@ struct Completions: ParsableCommand {
             Fish.self,
             Install.self,
             InstallMan.self,
+            CompletionValues.self,
         ]
     )
 
@@ -22,7 +24,35 @@ struct Completions: ParsableCommand {
         mutating func run() throws {
             let script = KeyPathCLI.completionScript(for: .zsh)
             print(script)
+            print(Self.dynamicCompletionWrapper)
         }
+
+        private static let dynamicCompletionWrapper = """
+
+        # Dynamic completions for keypath argument values
+        _keypath_dynamic_values() {
+            local noun=$1
+            local values
+            values=(${(f)"$(keypath completions values "$noun" 2>/dev/null)"})
+            compadd -a values
+        }
+
+        # Override specific subcommand completers for dynamic argument values
+        _keypath_pack_show() { _keypath_dynamic_values pack }
+        _keypath_pack_install() { _keypath_dynamic_values pack }
+        _keypath_pack_uninstall() { _keypath_dynamic_values pack }
+        _keypath_pack_configure() { _keypath_dynamic_values pack }
+        _keypath_collection_enable() { _keypath_dynamic_values collection }
+        _keypath_collection_disable() { _keypath_dynamic_values collection }
+        _keypath_collection_show() { _keypath_dynamic_values collection }
+        _keypath_rule_enable() { _keypath_dynamic_values rule }
+        _keypath_rule_disable() { _keypath_dynamic_values rule }
+        _keypath_rule_show() { _keypath_dynamic_values rule }
+        _keypath_rule_remove() { _keypath_dynamic_values rule }
+        _keypath_layer_switch() { _keypath_dynamic_values layer }
+        _keypath_layer_delete() { _keypath_dynamic_values layer }
+        _keypath_layer_rename() { _keypath_dynamic_values layer }
+        """
     }
 
     struct Bash: ParsableCommand {
@@ -170,6 +200,47 @@ struct Completions: ParsableCommand {
                 throw ValidationError("Unsupported shell '\(basename)' from $SHELL. Use --shell zsh, bash, or fish.")
             }
             return basename
+        }
+    }
+
+    struct CompletionValues: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "values",
+            abstract: "Output completable values for a noun (used by shell completion functions)",
+            shouldDisplay: false
+        )
+
+        @Argument(help: "Noun to complete: pack, collection, layer, rule")
+        var noun: String
+
+        mutating func run() async throws {
+            let facade = await MainActor.run { CLIFacade() }
+
+            switch noun.lowercased() {
+            case "pack":
+                let packs = await facade.listPacks()
+                for pack in packs {
+                    let slug = pack.id.replacingOccurrences(of: "com.keypath.pack.", with: "")
+                    print(slug)
+                }
+            case "collection":
+                let collections = await facade.loadRuleCollections()
+                for c in collections {
+                    print(c.name)
+                }
+            case "layer":
+                let layers = await facade.listDefinedLayers()
+                for layer in layers {
+                    print(layer)
+                }
+            case "rule":
+                let rules = await facade.listRules()
+                for rule in rules {
+                    print(rule.input)
+                }
+            default:
+                throw ValidationError("Unknown noun: '\(noun)'. Use pack, collection, layer, or rule.")
+            }
         }
     }
 }

--- a/Sources/KeyPathCLI/Commands/Config/ConfigApplyCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Config/ConfigApplyCommand.swift
@@ -12,10 +12,17 @@ struct ConfigApply: AsyncParsableCommand {
 
     mutating func run() async throws {
         let ctx = globals.outputContext
-        CLIOutput.progress("Applying configuration...", context: ctx)
+        let spinner = CLISpinner(context: ctx)
+        spinner.start("Applying configuration...")
 
         let facade = await MainActor.run { CLIFacade() }
         let result = try await facade.applyConfiguration()
+
+        if result.reloadSuccess {
+            spinner.succeed("Configuration applied")
+        } else {
+            spinner.fail("Config written but Kanata reload failed")
+        }
 
         CLIOutput.write(result, context: ctx) {
             var lines = [

--- a/Sources/KeyPathCLI/Commands/Pack/PackConfigureCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Pack/PackConfigureCommand.swift
@@ -71,7 +71,10 @@ struct PackConfigure: AsyncParsableCommand {
                 try await applyConfigurationOrHint(facade: facade, apply: apply, context: ctx)
             }
         } catch let notFound as CLIPackNotFound {
-            let error = CLIError.notFound("Pack", query: notFound.query, listCommand: "keypath pack list")
+            let allPacks = await facade.listPacks()
+            let candidates = allPacks.flatMap { [$0.name, $0.id.replacingOccurrences(of: "com.keypath.pack.", with: "")] }
+            let suggestions = FuzzyMatch.suggestions(for: notFound.query, from: candidates)
+            let error = CLIError.notFound("Pack", query: notFound.query, listCommand: "keypath pack list", suggestions: suggestions)
             CLIOutput.writeError(error, context: ctx)
             throw error.code.exitCode
         } catch let ambiguous as AmbiguousPackMatch {

--- a/Sources/KeyPathCLI/Commands/Pack/PackInstallCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Pack/PackInstallCommand.swift
@@ -76,7 +76,10 @@ struct PackInstall: AsyncParsableCommand {
                 try await applyConfigurationOrHint(facade: facade, apply: apply, context: ctx)
             }
         } catch let notFound as CLIPackNotFound {
-            let error = CLIError.notFound("Pack", query: notFound.query, listCommand: "keypath pack list")
+            let allPacks = await facade.listPacks()
+            let candidates = allPacks.flatMap { [$0.name, $0.id.replacingOccurrences(of: "com.keypath.pack.", with: "")] }
+            let suggestions = FuzzyMatch.suggestions(for: notFound.query, from: candidates)
+            let error = CLIError.notFound("Pack", query: notFound.query, listCommand: "keypath pack list", suggestions: suggestions)
             CLIOutput.writeError(error, context: ctx)
             throw error.code.exitCode
         } catch let ambiguous as AmbiguousPackMatch {

--- a/Sources/KeyPathCLI/Commands/Pack/PackListCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Pack/PackListCommand.swift
@@ -20,9 +20,10 @@ struct PackList: AsyncParsableCommand {
                 return "No packs available."
             }
 
+            let nc = ctx.noColor
             let installedCount = packs.filter(\.isInstalled).count
             var lines = [
-                "Packs (\(packs.count) available, \(installedCount) installed):",
+                ANSIColor.bold("Packs (\(packs.count) available, \(installedCount) installed):", noColor: nc),
                 String(repeating: "\u{2500}", count: 60),
             ]
 
@@ -32,11 +33,13 @@ struct PackList: AsyncParsableCommand {
             for category in categoryOrder {
                 guard let categoryPacks = grouped[category] else { continue }
                 lines.append("")
-                lines.append("  \(category)")
+                lines.append("  \(ANSIColor.bold(category, noColor: nc))")
                 for pack in categoryPacks {
-                    let status = pack.isInstalled ? "+" : " "
+                    let marker = pack.isInstalled
+                        ? ANSIColor.green("+", noColor: nc)
+                        : " "
                     let name = pack.name.padding(toLength: 28, withPad: " ", startingAt: 0)
-                    lines.append("    [\(status)] \(name) \(pack.tagline)")
+                    lines.append("    [\(marker)] \(name) \(ANSIColor.dim(pack.tagline, noColor: nc))")
                 }
             }
 

--- a/Sources/KeyPathCLI/Commands/Pack/PackShowCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Pack/PackShowCommand.swift
@@ -20,7 +20,10 @@ struct PackShow: AsyncParsableCommand {
         let detail: CLIPackDetail
         do {
             guard let found = try await facade.showPack(nameOrId: nameOrId) else {
-                let error = CLIError.notFound("Pack", query: nameOrId, listCommand: "keypath pack list")
+                let allPacks = await facade.listPacks()
+                let candidates = allPacks.flatMap { [$0.name, $0.id.replacingOccurrences(of: "com.keypath.pack.", with: "")] }
+                let suggestions = FuzzyMatch.suggestions(for: nameOrId, from: candidates)
+                let error = CLIError.notFound("Pack", query: nameOrId, listCommand: "keypath pack list", suggestions: suggestions)
                 CLIOutput.writeError(error, context: ctx)
                 throw error.code.exitCode
             }

--- a/Sources/KeyPathCLI/Commands/Pack/PackUninstallCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Pack/PackUninstallCommand.swift
@@ -41,7 +41,10 @@ struct PackUninstall: AsyncParsableCommand {
                 try await applyConfigurationOrHint(facade: facade, apply: apply, context: ctx)
             }
         } catch let notFound as CLIPackNotFound {
-            let error = CLIError.notFound("Pack", query: notFound.query, listCommand: "keypath pack list")
+            let allPacks = await facade.listPacks()
+            let candidates = allPacks.flatMap { [$0.name, $0.id.replacingOccurrences(of: "com.keypath.pack.", with: "")] }
+            let suggestions = FuzzyMatch.suggestions(for: notFound.query, from: candidates)
+            let error = CLIError.notFound("Pack", query: notFound.query, listCommand: "keypath pack list", suggestions: suggestions)
             CLIOutput.writeError(error, context: ctx)
             throw error.code.exitCode
         } catch let ambiguous as AmbiguousPackMatch {

--- a/Sources/KeyPathCLI/Commands/Rule/RuleListCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Rule/RuleListCommand.swift
@@ -22,17 +22,18 @@ struct RuleList: AsyncParsableCommand {
             if rules.isEmpty {
                 return enabledOnly ? "No enabled rules." : "No custom rules."
             }
-            var lines = ["Custom Rules:", String(repeating: "-", count: 50)]
+            let nc = ctx.noColor
+            var lines = [ANSIColor.bold("Custom Rules:", noColor: nc), String(repeating: "-", count: 50)]
             for rule in rules {
                 var desc = "  \(rule.input) → \(rule.action.displayName)"
                 if let behavior = rule.behavior {
                     desc += " (\(behavior.cliSchemaName))"
                 }
                 if !rule.isEnabled {
-                    desc += " [disabled]"
+                    desc += " \(ANSIColor.dim("[disabled]", noColor: nc))"
                 }
                 if rule.targetLayer != "base" {
-                    desc += " [layer: \(rule.targetLayer)]"
+                    desc += " \(ANSIColor.dim("[layer: \(rule.targetLayer)]", noColor: nc))"
                 }
                 lines.append(desc)
             }

--- a/Sources/KeyPathCLI/Commands/Service/ServiceStatusCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Service/ServiceStatusCommand.swift
@@ -37,6 +37,17 @@ struct ServiceStatus: AsyncParsableCommand {
             formatHumanReadable(status, noColor: ctx.noColor)
         }
 
+        if ctx.isInteractive, !ctx.shouldOutputJSON {
+            if let newVersion = await UpdateChecker.checkOnce() {
+                let nudge = ANSIColor.yellow(
+                    "Update available: v\(newVersion) — brew upgrade keypath",
+                    noColor: ctx.noColor
+                )
+                printErr("")
+                printErr(nudge)
+            }
+        }
+
         if !status.isOperational {
             throw ExitCode.failure
         }

--- a/Sources/KeyPathCLI/Commands/Service/ServiceStatusCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Service/ServiceStatusCommand.swift
@@ -44,13 +44,13 @@ struct ServiceStatus: AsyncParsableCommand {
 }
 
 private func formatHumanReadable(_ status: CLIStatusResult, noColor: Bool) -> String {
-    let ok = noColor ? "[ok]" : "ok"
-    let fail = noColor ? "[FAIL]" : "FAIL"
+    let ok = ANSIColor.green("✓", noColor: noColor)
+    let fail = ANSIColor.red("✗", noColor: noColor)
 
     func check(_ value: Bool) -> String { value ? ok : fail }
 
     var lines: [String] = []
-    lines.append("=== System Status ===")
+    lines.append(ANSIColor.bold("=== System Status ===", noColor: noColor))
     lines.append("System Ready: \(check(status.isOperational))")
     lines.append("")
     lines.append("--- Helper ---")
@@ -80,15 +80,15 @@ private func formatHumanReadable(_ status: CLIStatusResult, noColor: Bool) -> St
 
     if status.hasConflicts {
         lines.append("")
-        lines.append("Conflicts detected")
+        lines.append(ANSIColor.yellow("Conflicts detected", noColor: noColor))
     }
 
     lines.append("")
-    lines.append("=== Summary ===")
+    lines.append(ANSIColor.bold("=== Summary ===", noColor: noColor))
     if status.isOperational {
-        lines.append("System is ready and operational")
+        lines.append(ANSIColor.green("System is ready and operational", noColor: noColor))
     } else {
-        lines.append("System has blocking issue(s)")
+        lines.append(ANSIColor.red("System has blocking issue(s)", noColor: noColor))
         lines.append("   Open KeyPath.app and use the Installation Wizard to fix")
     }
 

--- a/Sources/KeyPathCLI/Commands/System/SystemInstallCommand.swift
+++ b/Sources/KeyPathCLI/Commands/System/SystemInstallCommand.swift
@@ -12,10 +12,14 @@ struct SystemInstall: AsyncParsableCommand {
 
     mutating func run() async throws {
         let ctx = globals.outputContext
-        CLIOutput.progress("Starting installation...", context: ctx)
+        let spinner = CLISpinner(context: ctx)
+        spinner.start("Installing...")
 
         let facade = CLIFacade()
         let report = await facade.runInstall()
+
+        if report.success { spinner.succeed("Installation complete") }
+        else { spinner.fail("Installation failed") }
 
         CLIOutput.write(report, context: ctx) {
             formatInstallerReport(report, title: "Installation")

--- a/Sources/KeyPathCLI/Commands/System/SystemRepairCommand.swift
+++ b/Sources/KeyPathCLI/Commands/System/SystemRepairCommand.swift
@@ -12,10 +12,14 @@ struct SystemRepair: AsyncParsableCommand {
 
     mutating func run() async throws {
         let ctx = globals.outputContext
-        CLIOutput.progress("Starting repair...", context: ctx)
+        let spinner = CLISpinner(context: ctx)
+        spinner.start("Repairing...")
 
         let facade = CLIFacade()
         let report = await facade.runRepair()
+
+        if report.success { spinner.succeed("Repair complete") }
+        else { spinner.fail("Repair failed") }
 
         CLIOutput.write(report, context: ctx) {
             if report.fastRepair {

--- a/Sources/KeyPathCLI/Utilities/ANSIColor.swift
+++ b/Sources/KeyPathCLI/Utilities/ANSIColor.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+enum ANSIColor {
+    static func green(_ s: String, noColor: Bool) -> String {
+        noColor ? s : "\u{001b}[32m\(s)\u{001b}[0m"
+    }
+
+    static func red(_ s: String, noColor: Bool) -> String {
+        noColor ? s : "\u{001b}[31m\(s)\u{001b}[0m"
+    }
+
+    static func yellow(_ s: String, noColor: Bool) -> String {
+        noColor ? s : "\u{001b}[33m\(s)\u{001b}[0m"
+    }
+
+    static func dim(_ s: String, noColor: Bool) -> String {
+        noColor ? s : "\u{001b}[2m\(s)\u{001b}[0m"
+    }
+
+    static func bold(_ s: String, noColor: Bool) -> String {
+        noColor ? s : "\u{001b}[1m\(s)\u{001b}[0m"
+    }
+}

--- a/Sources/KeyPathCLI/Utilities/ApplyHelper.swift
+++ b/Sources/KeyPathCLI/Utilities/ApplyHelper.swift
@@ -19,23 +19,28 @@ func applyConfigurationOrHint(facade: CLIFacade, apply: Bool, context: OutputCon
     }
 }
 
-func formatInstallerReport(_ report: CLIInstallerReport, title: String) -> String {
+func formatInstallerReport(_ report: CLIInstallerReport, title: String, noColor: Bool = false) -> String {
     var lines: [String] = []
-    lines.append("=== \(title) Report ===")
-    lines.append("Success: \(report.success ? "Yes" : "No")")
+    lines.append(ANSIColor.bold("=== \(title) Report ===", noColor: noColor))
+    let successText = report.success
+        ? ANSIColor.green("Yes", noColor: noColor)
+        : ANSIColor.red("No", noColor: noColor)
+    lines.append("Success: \(successText)")
 
     if let reason = report.failureReason {
-        lines.append("Failure Reason: \(reason)")
+        lines.append(ANSIColor.red("Failure Reason: \(reason)", noColor: noColor))
     }
 
     if !report.steps.isEmpty {
         lines.append("")
         lines.append("Steps:")
         for step in report.steps {
-            let status = step.success ? "OK" : "FAIL"
-            lines.append("  [\(status)] \(step.name)")
+            let marker = step.success
+                ? ANSIColor.green("✓", noColor: noColor)
+                : ANSIColor.red("✗", noColor: noColor)
+            lines.append("  \(marker) \(step.name)")
             if let error = step.error {
-                lines.append("         \(error)")
+                lines.append(ANSIColor.dim("         \(error)", noColor: noColor))
             }
         }
     }

--- a/Sources/KeyPathCLI/Utilities/CLIError.swift
+++ b/Sources/KeyPathCLI/Utilities/CLIError.swift
@@ -37,11 +37,15 @@ extension CLIExitCode {
 // MARK: - Factory Methods
 
 public extension CLIError {
-    static func notFound(_ entity: String, query: String, listCommand: String) -> CLIError {
-        CLIError(
+    static func notFound(_ entity: String, query: String, listCommand: String, suggestions: [String] = []) -> CLIError {
+        var hint = "Run '\(listCommand)' to see available \(entity.lowercased())s"
+        if !suggestions.isEmpty {
+            hint = "Did you mean: \(suggestions.joined(separator: ", "))?\n" + hint
+        }
+        return CLIError(
             code: .notFound,
             message: "\(entity) not found: '\(query)'",
-            hint: "Run '\(listCommand)' to see available \(entity.lowercased())s",
+            hint: hint,
             details: ["query: '\(query)'"],
             docsUrl: nil
         )

--- a/Sources/KeyPathCLI/Utilities/CLIError.swift
+++ b/Sources/KeyPathCLI/Utilities/CLIError.swift
@@ -34,6 +34,16 @@ extension CLIExitCode {
     }
 }
 
+// MARK: - Documentation URLs
+
+public enum CLIDocsURL {
+    static let faq = "https://github.com/malpern/KeyPath/blob/master/docs/FAQ.md"
+    static let debugging = "https://github.com/malpern/KeyPath/blob/master/docs/DEBUGGING_KANATA.md"
+    static let actionURI = "https://github.com/malpern/KeyPath/blob/master/docs/ACTION_URI_SYSTEM.md"
+    static let ruleCollections = "https://github.com/malpern/KeyPath/blob/master/docs/architecture/rules-architecture.html"
+    static let permissions = "https://github.com/malpern/KeyPath/blob/master/docs/architecture/permissions-architecture.html"
+}
+
 // MARK: - Factory Methods
 
 public extension CLIError {
@@ -57,7 +67,7 @@ public extension CLIError {
             message: "Could not connect to Kanata TCP server",
             hint: hint,
             details: nil,
-            docsUrl: nil
+            docsUrl: CLIDocsURL.debugging
         )
     }
 
@@ -87,7 +97,7 @@ public extension CLIError {
             message: "Invalid \(label) key: '\(key)'",
             hint: "Use canonical Kanata key names (e.g., caps, lalt, esc, lctl, spc, ret)",
             details: nil,
-            docsUrl: nil
+            docsUrl: CLIDocsURL.faq
         )
     }
 
@@ -107,7 +117,7 @@ public extension CLIError {
             message: "Configuration validation failed",
             hint: "Fix the errors above and run 'keypath config check' again",
             details: errors,
-            docsUrl: nil
+            docsUrl: CLIDocsURL.debugging
         )
     }
 }

--- a/Sources/KeyPathCLI/Utilities/FuzzyMatch.swift
+++ b/Sources/KeyPathCLI/Utilities/FuzzyMatch.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+enum FuzzyMatch {
+    static func levenshtein(_ a: String, _ b: String) -> Int {
+        let a = Array(a.lowercased())
+        let b = Array(b.lowercased())
+        let m = a.count
+        let n = b.count
+
+        if m == 0 { return n }
+        if n == 0 { return m }
+
+        var prev = Array(0 ... n)
+        var curr = [Int](repeating: 0, count: n + 1)
+
+        for i in 1 ... m {
+            curr[0] = i
+            for j in 1 ... n {
+                let cost = a[i - 1] == b[j - 1] ? 0 : 1
+                curr[j] = min(
+                    prev[j] + 1,
+                    curr[j - 1] + 1,
+                    prev[j - 1] + cost
+                )
+            }
+            swap(&prev, &curr)
+        }
+        return prev[n]
+    }
+
+    static func suggestions(for query: String, from candidates: [String], maxDistance: Int = 3, limit: Int = 3) -> [String] {
+        candidates
+            .map { (name: $0, distance: levenshtein(query, $0)) }
+            .filter { $0.distance <= maxDistance && $0.distance > 0 }
+            .sorted { $0.distance < $1.distance }
+            .prefix(limit)
+            .map(\.name)
+    }
+}

--- a/Sources/KeyPathCLI/Utilities/Output.swift
+++ b/Sources/KeyPathCLI/Utilities/Output.swift
@@ -54,20 +54,24 @@ enum CLIOutput {
                 printErr(json)
             }
         } else {
-            printErr("Error: \(error.message)")
+            let nc = context.noColor
+            printErr(ANSIColor.red("Error: \(error.message)", noColor: nc))
             if let hint = error.hint {
-                printErr("Hint: \(hint)")
+                printErr(ANSIColor.dim("Hint: \(hint)", noColor: nc))
             }
             if let details = error.details {
                 for detail in details {
-                    printErr("  \(detail)")
+                    printErr(ANSIColor.dim("  \(detail)", noColor: nc))
                 }
+            }
+            if let docsUrl = error.docsUrl {
+                printErr(ANSIColor.dim("Docs: \(docsUrl)", noColor: nc))
             }
         }
     }
 
     static func progress(_ message: String, context: OutputContext) {
         guard context.isInteractive else { return }
-        printErr(message)
+        printErr(ANSIColor.yellow(message, noColor: context.noColor))
     }
 }

--- a/Sources/KeyPathCLI/Utilities/Spinner.swift
+++ b/Sources/KeyPathCLI/Utilities/Spinner.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+final class CLISpinner: @unchecked Sendable {
+    private static let brailleFrames = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
+    private static let asciiFrames = ["-", "\\", "|", "/"]
+
+    private let noColor: Bool
+    private let isInteractive: Bool
+    private var message: String
+    private var timer: Timer?
+    private var frameIndex = 0
+
+    init(context: OutputContext) {
+        self.noColor = context.noColor
+        self.isInteractive = context.isInteractive
+        self.message = ""
+    }
+
+    func start(_ message: String) {
+        guard isInteractive else {
+            FileHandle.standardError.write(Data("\(message)\n".utf8))
+            return
+        }
+        self.message = message
+        frameIndex = 0
+        renderFrame()
+        timer = Timer.scheduledTimer(withTimeInterval: 0.08, repeats: true) { [weak self] _ in
+            self?.tick()
+        }
+    }
+
+    func update(_ message: String) {
+        self.message = message
+    }
+
+    func succeed(_ message: String) {
+        stop()
+        let marker = ANSIColor.green("✓", noColor: noColor)
+        FileHandle.standardError.write(Data("\r\u{001b}[2K\(marker) \(message)\n".utf8))
+    }
+
+    func fail(_ message: String) {
+        stop()
+        let marker = ANSIColor.red("✗", noColor: noColor)
+        FileHandle.standardError.write(Data("\r\u{001b}[2K\(marker) \(message)\n".utf8))
+    }
+
+    func stop() {
+        timer?.invalidate()
+        timer = nil
+        if isInteractive {
+            FileHandle.standardError.write(Data("\r\u{001b}[2K".utf8))
+        }
+    }
+
+    private func tick() {
+        frameIndex += 1
+        renderFrame()
+    }
+
+    private func renderFrame() {
+        let frames = noColor ? Self.asciiFrames : Self.brailleFrames
+        let frame = frames[frameIndex % frames.count]
+        let color = noColor ? frame : ANSIColor.yellow(frame, noColor: false)
+        FileHandle.standardError.write(Data("\r\u{001b}[2K\(color) \(message)".utf8))
+    }
+}

--- a/Sources/KeyPathCLI/Utilities/UpdateChecker.swift
+++ b/Sources/KeyPathCLI/Utilities/UpdateChecker.swift
@@ -1,0 +1,92 @@
+import Foundation
+import KeyPathAppKit
+
+enum UpdateChecker {
+    private static let cacheFile: String = {
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        return "\(home)/.config/keypath/.update-check"
+    }()
+
+    private static let checkInterval: TimeInterval = 86400 // 24 hours
+
+    struct CachedResult: Codable {
+        let checkedAt: Date
+        let latestVersion: String?
+    }
+
+    static func checkOnce() async -> String? {
+        if let cached = loadCache(), Date().timeIntervalSince(cached.checkedAt) < checkInterval {
+            return nudgeIfNewer(cached.latestVersion)
+        }
+
+        let latest = await fetchLatestVersion()
+        saveCache(CachedResult(checkedAt: Date(), latestVersion: latest))
+        return nudgeIfNewer(latest)
+    }
+
+    private static func nudgeIfNewer(_ latest: String?) -> String? {
+        guard let latest else { return nil }
+        let current = CLIVersion.current
+        if compareVersions(latest, isNewerThan: current) {
+            return latest
+        }
+        return nil
+    }
+
+    private static func fetchLatestVersion() async -> String? {
+        guard let url = URL(string: "https://api.github.com/repos/malpern/KeyPath/releases/latest") else {
+            return nil
+        }
+        var request = URLRequest(url: url)
+        request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
+        request.timeoutInterval = 5
+
+        guard let (data, response) = try? await URLSession.shared.data(for: request),
+              let httpResponse = response as? HTTPURLResponse,
+              httpResponse.statusCode == 200
+        else { return nil }
+
+        struct Release: Decodable { let tag_name: String }
+        guard let release = try? JSONDecoder().decode(Release.self, from: data) else { return nil }
+
+        return release.tag_name.hasPrefix("v")
+            ? String(release.tag_name.dropFirst())
+            : release.tag_name
+    }
+
+    static func compareVersions(_ a: String, isNewerThan b: String) -> Bool {
+        let aParts = a.split(separator: "-", maxSplits: 1)
+        let bParts = b.split(separator: "-", maxSplits: 1)
+        let aNumbers = aParts[0].split(separator: ".").compactMap { Int($0) }
+        let bNumbers = bParts[0].split(separator: ".").compactMap { Int($0) }
+
+        for i in 0 ..< max(aNumbers.count, bNumbers.count) {
+            let aNum = i < aNumbers.count ? aNumbers[i] : 0
+            let bNum = i < bNumbers.count ? bNumbers[i] : 0
+            if aNum > bNum { return true }
+            if aNum < bNum { return false }
+        }
+
+        // Same numeric version — check pre-release suffix
+        // No suffix beats any suffix (1.0.0 > 1.0.0-beta3)
+        if aParts.count == 1, bParts.count > 1 { return true }
+
+        return false
+    }
+
+    private static func loadCache() -> CachedResult? {
+        guard let data = try? Data(contentsOf: URL(fileURLWithPath: cacheFile)) else { return nil }
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try? decoder.decode(CachedResult.self, from: data)
+    }
+
+    private static func saveCache(_ result: CachedResult) {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        guard let data = try? encoder.encode(result) else { return }
+        let dir = (cacheFile as NSString).deletingLastPathComponent
+        try? FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        try? data.write(to: URL(fileURLWithPath: cacheFile), options: .atomic)
+    }
+}

--- a/Tests/KeyPathTests/CLI/CommandStructureTests.swift
+++ b/Tests/KeyPathTests/CLI/CommandStructureTests.swift
@@ -67,7 +67,7 @@ final class CommandStructureTests: XCTestCase {
 
     func testCompletionsHasShells() {
         let names = subcommandNames(of: Completions.self)
-        XCTAssertEqual(Set(names), ["zsh", "bash", "fish", "install", "install-man"])
+        XCTAssertEqual(Set(names), ["zsh", "bash", "fish", "install", "install-man", "values"])
     }
 
     // MARK: - Helpers

--- a/Tests/KeyPathTests/CLI/FuzzyMatchTests.swift
+++ b/Tests/KeyPathTests/CLI/FuzzyMatchTests.swift
@@ -1,0 +1,44 @@
+@testable import KeyPathCLI
+import XCTest
+
+final class FuzzyMatchTests: XCTestCase {
+    func testExactMatchReturnsZero() {
+        XCTAssertEqual(FuzzyMatch.levenshtein("hello", "hello"), 0)
+    }
+
+    func testSingleCharDifference() {
+        XCTAssertEqual(FuzzyMatch.levenshtein("vim", "vimm"), 1)
+    }
+
+    func testCaseInsensitive() {
+        XCTAssertEqual(FuzzyMatch.levenshtein("Vim", "vim"), 0)
+    }
+
+    func testCompletelyDifferent() {
+        XCTAssertTrue(FuzzyMatch.levenshtein("abc", "xyz") > 2)
+    }
+
+    func testSuggestionsReturnsCloseMatches() {
+        let candidates = ["Vim Navigation", "Home Row Mods", "Caps Lock Remap", "Chord Groups"]
+        let results = FuzzyMatch.suggestions(for: "Chrod Groups", from: candidates)
+        XCTAssertTrue(results.contains("Chord Groups"))
+    }
+
+    func testSuggestionsExcludesDistantMatches() {
+        let candidates = ["vim-navigation", "home-row-mods"]
+        let results = FuzzyMatch.suggestions(for: "zzzzz", from: candidates)
+        XCTAssertTrue(results.isEmpty)
+    }
+
+    func testSuggestionsRankedByDistance() {
+        let candidates = ["vim", "vimm", "vimmm"]
+        let results = FuzzyMatch.suggestions(for: "vi", from: candidates)
+        XCTAssertEqual(results.first, "vim")
+    }
+
+    func testSuggestionsLimited() {
+        let candidates = (1 ... 10).map { "a\($0)" }
+        let results = FuzzyMatch.suggestions(for: "a", from: candidates, limit: 3)
+        XCTAssertEqual(results.count, 3)
+    }
+}

--- a/Tests/KeyPathTests/PackOwnershipTests.swift
+++ b/Tests/KeyPathTests/PackOwnershipTests.swift
@@ -1,0 +1,151 @@
+@testable import KeyPathAppKit
+@preconcurrency import XCTest
+
+@MainActor
+final class PackOwnershipTests: XCTestCase {
+    private var originalInstalledPacks: [InstalledPackRecord] = []
+
+    override func setUp() async throws {
+        try await super.setUp()
+        originalInstalledPacks = await InstalledPackTracker.shared.allInstalled()
+    }
+
+    override func tearDown() async throws {
+        let current = await InstalledPackTracker.shared.allInstalled()
+        for record in current {
+            if !originalInstalledPacks.contains(where: { $0.packID == record.packID }) {
+                try await InstalledPackTracker.shared.remove(packID: record.packID)
+            }
+        }
+        for record in originalInstalledPacks {
+            if !(await InstalledPackTracker.shared.isInstalled(packID: record.packID)) {
+                try await InstalledPackTracker.shared.upsert(record)
+            }
+        }
+        try await super.tearDown()
+    }
+
+    // MARK: - managedCollectionIDs
+
+    func testManagedCollectionIDsSinglePack() {
+        let pack = PackRegistry.pack(id: "com.keypath.pack.home-row-mods")!
+        XCTAssertEqual(pack.managedCollectionIDs, [RuleCollectionIdentifier.homeRowMods])
+    }
+
+    func testManagedCollectionIDsVallack() {
+        let pack = PackRegistry.pack(id: "com.keypath.pack.vallack-system")!
+        let ids = Set(pack.managedCollectionIDs)
+        XCTAssertEqual(ids.count, 3)
+        XCTAssertTrue(ids.contains(RuleCollectionIdentifier.vallackNavigation))
+        XCTAssertTrue(ids.contains(RuleCollectionIdentifier.homeRowMods))
+        XCTAssertTrue(ids.contains(RuleCollectionIdentifier.homeRowLayerToggles))
+    }
+
+    func testManagedCollectionIDsVisualOnly() {
+        let pack = PackRegistry.pack(id: "com.keypath.pack.kindavim")!
+        XCTAssertTrue(pack.managedCollectionIDs.isEmpty)
+    }
+
+    // MARK: - packManagingCollection
+
+    func testPackManagingCollectionWhenInstalled() async throws {
+        let record = InstalledPackRecord(
+            packID: "com.keypath.pack.home-row-mods",
+            version: "1.0.0"
+        )
+        try await InstalledPackTracker.shared.upsert(record)
+
+        let owner = await InstalledPackTracker.shared.packManagingCollection(
+            RuleCollectionIdentifier.homeRowMods
+        )
+        XCTAssertNotNil(owner)
+        XCTAssertEqual(owner?.packName, "Home Row Mods")
+    }
+
+    func testPackManagingCollectionWhenNotInstalled() async throws {
+        if await InstalledPackTracker.shared.isInstalled(packID: "com.keypath.pack.chord-groups") {
+            try await InstalledPackTracker.shared.remove(packID: "com.keypath.pack.chord-groups")
+        }
+
+        let owner = await InstalledPackTracker.shared.packManagingCollection(
+            RuleCollectionIdentifier.chordGroups
+        )
+        XCTAssertNil(owner)
+    }
+
+    func testVallackOwnsAllThreeCollections() async throws {
+        let record = InstalledPackRecord(
+            packID: "com.keypath.pack.vallack-system",
+            version: "1.0.0"
+        )
+        try await InstalledPackTracker.shared.upsert(record)
+
+        let navOwner = await InstalledPackTracker.shared.packManagingCollection(
+            RuleCollectionIdentifier.vallackNavigation
+        )
+        let hrmOwner = await InstalledPackTracker.shared.packManagingCollection(
+            RuleCollectionIdentifier.homeRowMods
+        )
+        let togglesOwner = await InstalledPackTracker.shared.packManagingCollection(
+            RuleCollectionIdentifier.homeRowLayerToggles
+        )
+
+        XCTAssertEqual(navOwner?.packName, "Ben Vallack Approach")
+        XCTAssertEqual(hrmOwner?.packName, "Ben Vallack Approach")
+        XCTAssertEqual(togglesOwner?.packName, "Ben Vallack Approach")
+    }
+
+    func testOwnershipClearsOnUninstall() async throws {
+        let record = InstalledPackRecord(
+            packID: "com.keypath.pack.chord-groups",
+            version: "1.0.0"
+        )
+        try await InstalledPackTracker.shared.upsert(record)
+
+        let before = await InstalledPackTracker.shared.packManagingCollection(
+            RuleCollectionIdentifier.chordGroups
+        )
+        XCTAssertNotNil(before)
+
+        try await InstalledPackTracker.shared.remove(packID: "com.keypath.pack.chord-groups")
+
+        let after = await InstalledPackTracker.shared.packManagingCollection(
+            RuleCollectionIdentifier.chordGroups
+        )
+        XCTAssertNil(after)
+    }
+
+    // MARK: - CLI facade blocks managed collections
+
+    func testCLIFacadeBlocksEnableOnManagedCollection() async throws {
+        let record = InstalledPackRecord(
+            packID: "com.keypath.pack.chord-groups",
+            version: "1.0.0"
+        )
+        try await InstalledPackTracker.shared.upsert(record)
+
+        let facade = CLIFacade()
+        do {
+            _ = try await facade.enableCollection(nameOrId: "Chord Groups")
+            XCTFail("Should throw PackManagedCollectionError")
+        } catch is PackManagedCollectionError {
+            // expected
+        }
+    }
+
+    func testCLIFacadeBlocksDisableOnManagedCollection() async throws {
+        let record = InstalledPackRecord(
+            packID: "com.keypath.pack.chord-groups",
+            version: "1.0.0"
+        )
+        try await InstalledPackTracker.shared.upsert(record)
+
+        let facade = CLIFacade()
+        do {
+            _ = try await facade.disableCollection(nameOrId: "Chord Groups")
+            XCTFail("Should throw PackManagedCollectionError")
+        } catch is PackManagedCollectionError {
+            // expected
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Seven features in one branch, addressing #385 and six CLI UX improvements:

**Pack component ownership (#385):**
- Collections locked when owning pack is installed — "Managed by [Pack]" badge, disabled toggle
- `toggleCollection()` guard with PackInstaller bypass
- CLI `collection enable/disable` throws error with uninstall hint
- 9 new ownership tests

**ANSI color output (#406):**
- Green ✓ / red ✗ in status, bold headers, dim hints, yellow progress
- Respects NO_COLOR env var

**Fuzzy "did you mean?" (#404):**
- Levenshtein distance suggestions on pack not-found errors
- 8 new FuzzyMatch unit tests

**Docs URLs in errors (#405):**
- CLIError.docsUrl populated for service, key validation, config errors
- Rendered as "Docs: <url>" in error output

**Progress spinners (#408):**
- Braille spinner animation for system install, repair, config apply
- Non-interactive fallback to single status line

**Dynamic shell completions (#403):**
- Hidden `keypath completions values <noun>` subcommand
- Custom zsh wrapper for argument-position completion (pack names, collections, etc.)

**Update nudge (#407):**
- GitHub release check (cached 24h) in `keypath service status`
- Shows "Update available: vX.Y.Z" when newer version exists

## Test plan

- [x] `swift build` — compiles clean
- [x] `swift test --filter PackOwnershipTests` — 9 tests pass
- [x] `swift test --filter FuzzyMatchTests` — 8 tests pass
- [x] `swift test` — full suite 530 tests, 0 failures