### PR TITLE
fix: wire up layer mapping cache prebuild and fix cache key mismatch

### DIFF
--- a/Sources/KeyPathAppKit/Services/LayerMapping/LayerKeyMapper.swift
+++ b/Sources/KeyPathAppKit/Services/LayerMapping/LayerKeyMapper.swift
@@ -255,22 +255,28 @@ actor LayerKeyMapper {
         configHash = ""
     }
 
-    /// Pre-build mappings for all layers at once
-    /// This should be called at startup to ensure instant layer switching
+    /// Pre-build mappings for all layers at once, populating both neovim-scope cache partitions.
+    /// Call after layer names and rule collections are available to ensure instant layer switching.
     /// - Parameters:
-    ///   - layerNames: List of all layer names (from TCP RequestLayerNames)
+    ///   - layerNames: List of all layer names (e.g. from rule collections or TCP RequestLayerNames)
     ///   - configPath: Path to the kanata config file
     ///   - layout: The physical keyboard layout to use for mapping
-    ///   - collections: All rule collections (for tracking collection ownership)
-    func prebuildAllLayers(_ layerNames: [String], configPath: String, layout: PhysicalLayout, collections: [RuleCollection] = []) async {
-        // Normalize layer names to lowercase
+    ///   - allEnabledCollections: All enabled rule collections
+    func prebuildAllLayers(
+        _ layerNames: [String],
+        configPath: String,
+        layout: PhysicalLayout,
+        allEnabledCollections: [RuleCollection] = []
+    ) async {
         let normalizedLayers = layerNames.map { $0.lowercased() }
         AppLogger.shared.info("🗺️ [LayerKeyMapper] Pre-building mappings for \(normalizedLayers.count) layers: \(normalizedLayers.joined(separator: ", "))")
 
         if !FeatureFlags.simulatorAndVirtualKeysEnabled {
             let mapping = buildFallbackMapping(layout: layout)
             for layer in normalizedLayers {
-                cache[layer] = mapping
+                cache["\(layer)|default"] = mapping
+                cache["\(layer)|neovim-scope-approved"] = mapping
+                cache["\(layer)|neovim-scope-fallback"] = mapping
             }
             AppLogger.shared.info("🗺️ [LayerKeyMapper] Simulator disabled; cached fallback mapping for \(normalizedLayers.count) layers")
             return
@@ -284,15 +290,19 @@ actor LayerKeyMapper {
             }
         }
 
-        // Build mappings for all layers in parallel
-        await withTaskGroup(of: (String, [UInt16: LayerKeyInfo]?).self) { group in
+        let collectionsWithoutNeovim = allEnabledCollections.filter { $0.id != RuleCollectionIdentifier.neovimTerminal }
+        let hasNeovimCollection = allEnabledCollections.contains { $0.id == RuleCollectionIdentifier.neovimTerminal }
+
+        // Build both neovim scope variants for each layer in parallel.
+        // Each task returns (layer, suffix, mapping) so we store with the correct composite key.
+        await withTaskGroup(of: (String, String, [UInt16: LayerKeyInfo]?).self) { group in
             for layer in normalizedLayers {
+                // Fallback variant (no neovim collection)
                 group.addTask {
                     do {
-                        // Build key→collection map for this layer
-                        let keyToCollection = self.buildKeyCollectionMap(for: layer, collections: collections)
-                        let activatorKeys = self.buildActivatorKeySet(for: layer, collections: collections)
-                        let keyToVimLabel = self.buildKeyVimLabelMap(for: layer, collections: collections)
+                        let keyToCollection = self.buildKeyCollectionMap(for: layer, collections: collectionsWithoutNeovim)
+                        let activatorKeys = self.buildActivatorKeySet(for: layer, collections: collectionsWithoutNeovim)
+                        let keyToVimLabel = self.buildKeyVimLabelMap(for: layer, collections: collectionsWithoutNeovim)
                         let mapping = try await self.buildMappingWithSimulator(
                             for: layer,
                             configPath: configPath,
@@ -301,22 +311,45 @@ actor LayerKeyMapper {
                             activatorKeys: activatorKeys,
                             keyToVimLabel: keyToVimLabel
                         )
-                        return (layer, mapping)
+                        return (layer, "neovim-scope-fallback", mapping)
                     } catch {
-                        AppLogger.shared.error("🗺️ [LayerKeyMapper] Failed to build mapping for '\(layer)': \(error)")
-                        return (layer, nil)
+                        AppLogger.shared.error("🗺️ [LayerKeyMapper] Failed to build fallback mapping for '\(layer)': \(error)")
+                        return (layer, "neovim-scope-fallback", nil)
+                    }
+                }
+
+                // Approved variant (with neovim collection) — only if the collection exists
+                if hasNeovimCollection {
+                    group.addTask {
+                        do {
+                            let keyToCollection = self.buildKeyCollectionMap(for: layer, collections: allEnabledCollections)
+                            let activatorKeys = self.buildActivatorKeySet(for: layer, collections: allEnabledCollections)
+                            let keyToVimLabel = self.buildKeyVimLabelMap(for: layer, collections: allEnabledCollections)
+                            let mapping = try await self.buildMappingWithSimulator(
+                                for: layer,
+                                configPath: configPath,
+                                layout: layout,
+                                keyToCollection: keyToCollection,
+                                activatorKeys: activatorKeys,
+                                keyToVimLabel: keyToVimLabel
+                            )
+                            return (layer, "neovim-scope-approved", mapping)
+                        } catch {
+                            AppLogger.shared.error("🗺️ [LayerKeyMapper] Failed to build approved mapping for '\(layer)': \(error)")
+                            return (layer, "neovim-scope-approved", nil)
+                        }
                     }
                 }
             }
 
-            for await (layer, mapping) in group {
+            for await (layer, suffix, mapping) in group {
                 if let mapping {
-                    cache[layer] = mapping
-                    AppLogger.shared.debug("🗺️ [LayerKeyMapper] Cached mapping for '\(layer)' (\(mapping.count) keys)")
+                    cache["\(layer)|\(suffix)"] = mapping
+                    AppLogger.shared.debug("🗺️ [LayerKeyMapper] Cached mapping for '\(layer)|\(suffix)' (\(mapping.count) keys)")
                 }
             }
         }
 
-        AppLogger.shared.info("🗺️ [LayerKeyMapper] Pre-build complete: \(cache.count) layers cached")
+        AppLogger.shared.info("🗺️ [LayerKeyMapper] Pre-build complete: \(cache.count) cache entries")
     }
 }

--- a/Sources/KeyPathAppKit/UI/KeyboardVisualization/KeyboardVisualizationViewModel+Capture.swift
+++ b/Sources/KeyPathAppKit/UI/KeyboardVisualization/KeyboardVisualizationViewModel+Capture.swift
@@ -30,6 +30,7 @@ extension KeyboardVisualizationViewModel {
         rebuildLayerMapping() // Build initial layer mapping
         loadFeatureCollectionStates() // Load optional feature collection states
         preloadAllIcons() // Pre-cache launcher and layer icons
+        prebuildLayerMappingsInBackground() // Warm cache for all layers
 
         AppLogger.shared.info("✅ [KeyboardViz] TCP-based key capture started")
     }

--- a/Sources/KeyPathAppKit/UI/KeyboardVisualization/KeyboardVisualizationViewModel+LayoutMapping.swift
+++ b/Sources/KeyPathAppKit/UI/KeyboardVisualization/KeyboardVisualizationViewModel+LayoutMapping.swift
@@ -587,6 +587,34 @@ extension KeyboardVisualizationViewModel {
         return String(output[range]).trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
+    /// Fire-and-forget prebuild of all layer mappings so first layer switches hit cache.
+    func prebuildLayerMappingsInBackground() {
+        Task {
+            let allCollections = await RuleCollectionStore.shared.loadCollections()
+            let enabledCollections = allCollections.filter(\.isEnabled)
+
+            var layerNames = Set<String>(["base"])
+            for collection in enabledCollections {
+                layerNames.insert(collection.targetLayer.kanataName.lowercased())
+                if let activator = collection.momentaryActivator {
+                    layerNames.insert(activator.targetLayer.kanataName.lowercased())
+                }
+            }
+
+            let configPath = WizardSystemPaths.userConfigPath
+            AppLogger.shared.info("🗺️ [KeyboardViz] Starting background prebuild for \(layerNames.count) layers")
+
+            await layerKeyMapper.prebuildAllLayers(
+                Array(layerNames),
+                configPath: configPath,
+                layout: layout,
+                allEnabledCollections: enabledCollections
+            )
+
+            AppLogger.shared.info("🗺️ [KeyboardViz] Background prebuild complete")
+        }
+    }
+
     /// Invalidate cached mappings (call when config changes)
     func invalidateLayerMappings() {
         AppLogger.shared.info("🔔 [KeyboardViz] invalidateLayerMappings called - will rebuild layer mapping for '\(currentLayerName)'")
@@ -596,6 +624,7 @@ extension KeyboardVisualizationViewModel {
             AppLogger.shared.info("🔔 [KeyboardViz] Cache invalidated, now calling rebuildLayerMapping()")
 
             rebuildLayerMapping()
+            prebuildLayerMappingsInBackground()
         }
     }
 }

--- a/Tests/KeyPathTests/Services/LayerKeyMapperPrebuildTests.swift
+++ b/Tests/KeyPathTests/Services/LayerKeyMapperPrebuildTests.swift
@@ -1,0 +1,140 @@
+@testable import KeyPathAppKit
+@testable import KeyPathCore
+@preconcurrency import XCTest
+
+final class LayerKeyMapperPrebuildTests: XCTestCase {
+    private var previousSimulatorFlag: Bool?
+
+    override func setUp() {
+        super.setUp()
+        previousSimulatorFlag = FeatureFlags.simulatorAndVirtualKeysEnabled
+        FeatureFlags.setSimulatorAndVirtualKeysEnabled(false)
+    }
+
+    override func tearDown() {
+        if let previousSimulatorFlag {
+            FeatureFlags.setSimulatorAndVirtualKeysEnabled(previousSimulatorFlag)
+        }
+        super.tearDown()
+    }
+
+    // MARK: - Cache Key Format
+
+    func testPrebuildStoresCompositeKeysMatchingGetMapping() async throws {
+        let mapper = LayerKeyMapper()
+        let configPath = try createTempConfig("(defcfg)(defsrc)(deflayer base)")
+
+        await mapper.prebuildAllLayers(
+            ["nav", "launcher"],
+            configPath: configPath,
+            layout: .macBookUS
+        )
+
+        let cacheKeys = await mapper.cache.keys.sorted()
+
+        XCTAssertTrue(cacheKeys.contains("nav|default"), "Should store nav|default")
+        XCTAssertTrue(cacheKeys.contains("nav|neovim-scope-approved"), "Should store nav|neovim-scope-approved")
+        XCTAssertTrue(cacheKeys.contains("nav|neovim-scope-fallback"), "Should store nav|neovim-scope-fallback")
+        XCTAssertTrue(cacheKeys.contains("launcher|default"), "Should store launcher|default")
+        XCTAssertTrue(cacheKeys.contains("launcher|neovim-scope-approved"), "Should store launcher|neovim-scope-approved")
+        XCTAssertTrue(cacheKeys.contains("launcher|neovim-scope-fallback"), "Should store launcher|neovim-scope-fallback")
+
+        for key in cacheKeys {
+            XCTAssertTrue(key.contains("|"), "Cache key '\(key)' must use composite format (layer|suffix)")
+        }
+    }
+
+    func testPrebuildCacheHitsOnGetMapping() async throws {
+        let mapper = LayerKeyMapper()
+        let configPath = try createTempConfig("(defcfg)(defsrc)(deflayer base)")
+
+        await mapper.prebuildAllLayers(
+            ["nav"],
+            configPath: configPath,
+            layout: .macBookUS
+        )
+
+        let prebuiltCount = await mapper.cache.count
+
+        let mapping = try await mapper.getMapping(
+            for: "nav",
+            configPath: configPath,
+            layout: .macBookUS,
+            cacheKeySuffix: "neovim-scope-fallback"
+        )
+
+        let postGetCount = await mapper.cache.count
+        XCTAssertEqual(prebuiltCount, postGetCount, "getMapping should hit cache, not add a new entry")
+        XCTAssertFalse(mapping.isEmpty, "Mapping should contain fallback keys")
+    }
+
+    func testPrebuildNormalizesLayerNamesToLowercase() async throws {
+        let mapper = LayerKeyMapper()
+        let configPath = try createTempConfig("(defcfg)(defsrc)(deflayer base)")
+
+        await mapper.prebuildAllLayers(
+            ["Nav", "LAUNCHER"],
+            configPath: configPath,
+            layout: .macBookUS
+        )
+
+        let cacheKeys = await mapper.cache.keys.sorted()
+        XCTAssertTrue(cacheKeys.contains("nav|neovim-scope-fallback"))
+        XCTAssertTrue(cacheKeys.contains("launcher|neovim-scope-fallback"))
+        XCTAssertFalse(cacheKeys.contains { $0.hasPrefix("Nav|") || $0.hasPrefix("LAUNCHER|") },
+                       "Keys should be lowercased")
+    }
+
+    // MARK: - Neovim Scope Variants
+
+    func testPrebuildSkipsApprovedVariantWhenNoNeovimCollection() async throws {
+        let mapper = LayerKeyMapper()
+        let configPath = try createTempConfig("(defcfg)(defsrc)(deflayer base)")
+
+        await mapper.prebuildAllLayers(
+            ["nav"],
+            configPath: configPath,
+            layout: .macBookUS,
+            allEnabledCollections: []
+        )
+
+        let cacheKeys = await mapper.cache.keys.sorted()
+        XCTAssertTrue(cacheKeys.contains("nav|neovim-scope-fallback"),
+                      "Fallback variant should always be built")
+        XCTAssertTrue(cacheKeys.contains("nav|default"),
+                      "Default variant should always be built")
+        // Without neovim collection, approved variant is still built in fallback mode
+        // (simulator disabled uses same fallback mapping for all variants)
+    }
+
+    // MARK: - Cache Invalidation
+
+    func testInvalidateCacheClearsPrebuiltEntries() async throws {
+        let mapper = LayerKeyMapper()
+        let configPath = try createTempConfig("(defcfg)(defsrc)(deflayer base)")
+
+        await mapper.prebuildAllLayers(
+            ["nav"],
+            configPath: configPath,
+            layout: .macBookUS
+        )
+
+        let countBefore = await mapper.cache.count
+        XCTAssertGreaterThan(countBefore, 0)
+
+        await mapper.invalidateCache()
+
+        let countAfter = await mapper.cache.count
+        XCTAssertEqual(countAfter, 0, "invalidateCache should clear all prebuilt entries")
+    }
+
+    // MARK: - Helpers
+
+    private func createTempConfig(_ content: String) throws -> String {
+        let tempDir = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+        let configPath = tempDir.appendingPathComponent("test-prebuild-\(UUID().uuidString).kbd").path
+        try content.write(toFile: configPath, atomically: true, encoding: .utf8)
+        addTeardownBlock { try? FileManager.default.removeItem(atPath: configPath) }
+        return configPath
+    }
+}


### PR DESCRIPTION
## Summary

Closes #409.

- **Fixed cache key mismatch in `prebuildAllLayers`** — was storing with bare keys (`cache["nav"]`) while `getMapping()` looks up composite keys (`cache["nav|neovim-scope-fallback"]`). Now stores with correct `layer|suffix` format for all neovim-scope variants.
- **Wired up `prebuildAllLayers` call** — was dead code, never invoked. Now triggers at overlay startup (`startCapturing`) and after rule collection changes (`invalidateLayerMappings`), so the cache is warm before the user switches layers.
- **Builds both neovim scope variants per layer** — `neovim-scope-fallback` (without neovim collection) and `neovim-scope-approved` (with neovim collection, when it exists), matching exactly what `getMapping()` callers request.

## Test plan

- [x] `swift build` passes
- [x] All 530 tests pass
- [x] Verified prebuild fires in test logs (fallback path since simulator disabled in tests)
- [ ] Manual: open overlay, switch to nav/launcher/vim layers — labels should appear instantly on first activation (no stale-label flash)