### PR TITLE
fix: use throwing FileHandle methods to prevent logger crash

### DIFF
--- a/Sources/KeyPathCore/Logger.swift
+++ b/Sources/KeyPathCore/Logger.swift
@@ -263,9 +263,9 @@ public final class AppLogger {
             // Append to existing file
             do {
                 let fileHandle = try FileHandle(forWritingTo: URL(fileURLWithPath: logPath))
-                fileHandle.seekToEndOfFile()
-                fileHandle.write(data)
-                fileHandle.closeFile()
+                try fileHandle.seekToEnd()
+                try fileHandle.write(contentsOf: data)
+                try fileHandle.close()
             } catch {
                 // Fallback: try to create new file
                 try? data.write(to: URL(fileURLWithPath: logPath))
@@ -289,9 +289,9 @@ public final class AppLogger {
             // Append to existing file
             do {
                 let fileHandle = try FileHandle(forWritingTo: URL(fileURLWithPath: logPath))
-                fileHandle.seekToEndOfFile()
-                fileHandle.write(data)
-                fileHandle.closeFile()
+                try fileHandle.seekToEnd()
+                try fileHandle.write(contentsOf: data)
+                try fileHandle.close()
             } catch {
                 // Fallback: try to create new file
                 try? data.write(to: URL(fileURLWithPath: logPath))


### PR DESCRIPTION
## Summary
- Replaced legacy `FileHandle` methods (`seekToEndOfFile()`, `write(_:)`, `closeFile()`) with modern throwing variants (`seekToEnd()`, `write(contentsOf:)`, `close()`) in both `writeLogMessageDirectly` and `flushBufferUnsafe`
- The legacy methods throw ObjC exceptions that Swift `do/catch` cannot intercept, causing SIGABRT on the `com.keypath.logger` dispatch queue when the file handle becomes invalid (e.g. during log rotation or disk-full conditions)
- The modern variants throw Swift errors, caught by the existing fallback path

## Test plan
- [x] All 530 tests pass
- [x] Build succeeds