### PR TITLE
feat: agent-friendly CLI — skill, schemas, ensure, quiet, apiVersion

### DIFF
--- a/Sources/KeyPathCLI/Commands/Help/HelpSchemasCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Help/HelpSchemasCommand.swift
@@ -49,6 +49,10 @@ struct HelpSchemas: AsyncParsableCommand {
                     return lines.joined(separator: "\n")
                 }
             case "rule":
+                if ctx.shouldOutputJSON {
+                    CLIOutput.writeJSON(CLISchemas.ruleAdd)
+                    return
+                }
                 let schema = RuleSchema.description
                 CLIOutput.write(schema, context: ctx) {
                     var lines = ["Rule Add Schema:"]
@@ -76,6 +80,10 @@ struct HelpSchemas: AsyncParsableCommand {
                     return lines.joined(separator: "\n")
                 }
             case "collection":
+                if ctx.shouldOutputJSON {
+                    CLIOutput.writeJSON(CLISchemas.collectionToggle)
+                    return
+                }
                 let schema = CollectionSchema.description
                 CLIOutput.write(schema, context: ctx) {
                     var lines = ["Collection Schema:"]
@@ -139,4 +147,73 @@ private struct CollectionSchema: Codable {
     )
     let commands: [String]
     let categories: [String]
+}
+
+// MARK: - JSON Schema Types (for agent consumption)
+
+struct JSONSchemaProperty: Codable {
+    let type: String
+    let description: String
+    let `enum`: [String]?
+    let `default`: String?
+
+    init(type: String, description: String, enum: [String]? = nil, default: String? = nil) {
+        self.type = type
+        self.description = description
+        self.enum = `enum`
+        self.default = `default`
+    }
+}
+
+struct JSONSchema: Codable {
+    let name: String
+    let description: String
+    let properties: [String: JSONSchemaProperty]
+    let required: [String]
+}
+
+enum CLISchemas {
+    static let ruleAdd = JSONSchema(
+        name: "rule.add",
+        description: "Add or update a custom key remapping",
+        properties: [
+            "input": JSONSchemaProperty(type: "string", description: "Input key (kanata name, e.g., caps, a, lalt, spc)"),
+            "output": JSONSchemaProperty(type: "string", description: "Output key for simple remap"),
+            "action": JSONSchemaProperty(type: "object", description: "Full KeyAction JSON (alternative to output)"),
+            "behavior": JSONSchemaProperty(type: "object", description: "Full MappingBehavior JSON"),
+            "tap": JSONSchemaProperty(type: "string", description: "Tap output for tap-hold shorthand"),
+            "hold": JSONSchemaProperty(type: "string", description: "Hold output for tap-hold shorthand"),
+            "timeout": JSONSchemaProperty(type: "integer", description: "Tap-hold timeout in ms", default: "200"),
+            "shifted": JSONSchemaProperty(type: "string", description: "Alternate output when shift held"),
+            "layer": JSONSchemaProperty(type: "string", description: "Target layer", default: "base"),
+            "title": JSONSchemaProperty(type: "string", description: "Human-readable title"),
+            "notes": JSONSchemaProperty(type: "string", description: "Description/notes"),
+            "on-conflict": JSONSchemaProperty(type: "string", description: "Conflict resolution strategy", enum: ["fail", "replace", "skip", "merge"], default: "fail"),
+            "dry-run": JSONSchemaProperty(type: "boolean", description: "Preview without saving", default: "false"),
+            "apply": JSONSchemaProperty(type: "boolean", description: "Regenerate config after saving", default: "false"),
+        ],
+        required: ["input"]
+    )
+
+    static let packInstall = JSONSchema(
+        name: "pack.install",
+        description: "Install a keyboard pack",
+        properties: [
+            "name-or-id": JSONSchemaProperty(type: "string", description: "Pack name, slug, or full ID"),
+            "setting": JSONSchemaProperty(type: "string", description: "Quick setting as key=value (repeatable)"),
+            "apply": JSONSchemaProperty(type: "boolean", description: "Reload Kanata after installing", default: "false"),
+            "dry-run": JSONSchemaProperty(type: "boolean", description: "Preview without installing", default: "false"),
+        ],
+        required: ["name-or-id"]
+    )
+
+    static let collectionToggle = JSONSchema(
+        name: "collection.enable",
+        description: "Enable or disable a rule collection",
+        properties: [
+            "name-or-id": JSONSchemaProperty(type: "string", description: "Collection name or UUID"),
+            "apply": JSONSchemaProperty(type: "boolean", description: "Reload Kanata after toggling", default: "false"),
+        ],
+        required: ["name-or-id"]
+    )
 }

--- a/Sources/KeyPathCLI/Commands/Rule/RuleCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Rule/RuleCommand.swift
@@ -11,6 +11,7 @@ struct Rule: AsyncParsableCommand {
             RuleShow.self,
             RuleEnable.self,
             RuleDisable.self,
+            RuleEnsure.self,
         ]
     )
 }

--- a/Sources/KeyPathCLI/Commands/Rule/RuleEnsureCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Rule/RuleEnsureCommand.swift
@@ -1,0 +1,92 @@
+import ArgumentParser
+import Foundation
+import KeyPathAppKit
+
+struct RuleEnsure: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "ensure",
+        abstract: "Ensure a rule exists with the given mapping (idempotent)"
+    )
+
+    @OptionGroup var globals: GlobalOptions
+
+    @Argument(help: "Input key")
+    var input: String
+
+    @Argument(help: "Output key")
+    var output: String
+
+    @Option(help: "Hold output for tap-hold")
+    var hold: String?
+
+    @Option(help: "Tap-hold timeout in ms (default: 200)")
+    var timeout: Int = 200
+
+    @Flag(help: "Regenerate config and reload Kanata after saving")
+    var apply: Bool = false
+
+    mutating func run() async throws {
+        let ctx = globals.outputContext
+        let facade = await MainActor.run { CLIFacade() }
+
+        let existing = await facade.showRule(input: input)
+
+        let matchesDesired: Bool
+        if let existing {
+            if let hold {
+                if case let .dualRole(dr) = existing.behavior {
+                    matchesDesired = existing.action.outputString == output
+                        && dr.holdActionString == hold
+                        && dr.tapTimeout == timeout
+                } else {
+                    matchesDesired = false
+                }
+            } else {
+                matchesDesired = existing.action.outputString == output && existing.behavior == nil
+            }
+        } else {
+            matchesDesired = false
+        }
+
+        if matchesDesired {
+            let result = CLIEnsureResult(input: input, output: output, action: "unchanged")
+            CLIOutput.write(result, context: ctx) {
+                "Rule '\(input) → \(output)' already matches — no change"
+            }
+            return
+        }
+
+        if globals.dryRun {
+            let action = existing != nil ? "would-update" : "would-create"
+            let result = CLIEnsureResult(input: input, output: output, action: action)
+            CLIOutput.write(result, context: ctx) {
+                existing != nil
+                    ? "Would update rule: \(input) → \(output)"
+                    : "Would create rule: \(input) → \(output)"
+            }
+            return
+        }
+
+        if let hold {
+            _ = try await facade.addTapHoldRemap(input: input, tap: output, hold: hold, timeout: timeout)
+        } else {
+            _ = try await facade.addSimpleRemap(input: input, output: output)
+        }
+
+        let action = existing != nil ? "updated" : "created"
+        let result = CLIEnsureResult(input: input, output: output, action: action)
+        CLIOutput.write(result, context: ctx) {
+            existing != nil
+                ? "Updated rule: \(input) → \(output)"
+                : "Created rule: \(input) → \(output)"
+        }
+
+        try await applyConfigurationOrHint(facade: facade, apply: apply, context: ctx)
+    }
+}
+
+private struct CLIEnsureResult: Codable {
+    let input: String
+    let output: String
+    let action: String
+}

--- a/Sources/KeyPathCLI/Utilities/CLIError.swift
+++ b/Sources/KeyPathCLI/Utilities/CLIError.swift
@@ -61,7 +61,7 @@ public extension CLIError {
         )
     }
 
-    static func serviceUnreachable(hint: String = "Is Kanata running? Check with 'keypath service status'") -> CLIError {
+    static func serviceUnreachable(hint: String = "Run 'keypath service status --json' to check if Kanata is running") -> CLIError {
         CLIError(
             code: .serviceUnreachable,
             message: "Could not connect to Kanata TCP server",
@@ -95,7 +95,7 @@ public extension CLIError {
         CLIError(
             code: .validation,
             message: "Invalid \(label) key: '\(key)'",
-            hint: "Use canonical Kanata key names (e.g., caps, lalt, esc, lctl, spc, ret)",
+            hint: "Run 'keypath help-topics schemas rule' for valid key names (e.g., caps, lalt, esc, lctl, spc, ret)",
             details: nil,
             docsUrl: CLIDocsURL.faq
         )
@@ -115,7 +115,7 @@ public extension CLIError {
         CLIError(
             code: .kanataInvalid,
             message: "Configuration validation failed",
-            hint: "Fix the errors above and run 'keypath config check' again",
+            hint: "Fix the errors above, then run 'keypath config check --json'",
             details: errors,
             docsUrl: CLIDocsURL.debugging
         )

--- a/Sources/KeyPathCLI/Utilities/GlobalOptions.swift
+++ b/Sources/KeyPathCLI/Utilities/GlobalOptions.swift
@@ -10,11 +10,14 @@ struct GlobalOptions: ParsableArguments {
     @Flag(name: .customLong("dry-run"), help: "Preview changes without applying")
     var dryRun: Bool = false
 
+    @Flag(name: .customLong("quiet"), help: "Suppress stderr decoration (spinners, progress, hints)")
+    var quiet: Bool = false
+
     @Option(name: .customLong("on-conflict"), help: "Conflict resolution: fail|replace|skip|merge")
     var onConflict: ConflictStrategy = .fail
 
     var outputContext: OutputContext {
-        OutputContext.detect(forceJSON: json, forceHuman: noJson)
+        OutputContext.detect(forceJSON: json, forceHuman: noJson, quiet: quiet)
     }
 }
 

--- a/Sources/KeyPathCLI/Utilities/Output.swift
+++ b/Sources/KeyPathCLI/Utilities/Output.swift
@@ -6,22 +6,25 @@ public struct OutputContext: Sendable {
     public let forceJSON: Bool
     public let forceHuman: Bool
     public let noColor: Bool
+    public let quiet: Bool
 
     public var shouldOutputJSON: Bool { forceJSON || (!forceHuman && !isInteractive) }
 
-    public init(isInteractive: Bool, forceJSON: Bool, forceHuman: Bool, noColor: Bool) {
+    public init(isInteractive: Bool, forceJSON: Bool, forceHuman: Bool, noColor: Bool, quiet: Bool = false) {
         self.isInteractive = isInteractive
         self.forceJSON = forceJSON
         self.forceHuman = forceHuman
         self.noColor = noColor
+        self.quiet = quiet
     }
 
-    public static func detect(forceJSON: Bool = false, forceHuman: Bool = false) -> OutputContext {
+    public static func detect(forceJSON: Bool = false, forceHuman: Bool = false, quiet: Bool = false) -> OutputContext {
         OutputContext(
             isInteractive: isatty(STDOUT_FILENO) != 0,
             forceJSON: forceJSON,
             forceHuman: forceHuman,
-            noColor: ProcessInfo.processInfo.environment["NO_COLOR"] != nil
+            noColor: ProcessInfo.processInfo.environment["NO_COLOR"] != nil,
+            quiet: quiet
         )
     }
 }
@@ -36,11 +39,17 @@ enum CLIOutput {
         }
     }
 
+    private struct APIEnvelope<T: Encodable>: Encodable {
+        let apiVersion: Int = 1
+        let data: T
+    }
+
     static func writeJSON<T: Encodable>(_ value: T) {
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
         encoder.dateEncodingStrategy = .iso8601
-        guard let data = try? encoder.encode(value), let json = String(data: data, encoding: .utf8) else {
+        let envelope = APIEnvelope(data: value)
+        guard let data = try? encoder.encode(envelope), let json = String(data: data, encoding: .utf8) else {
             return
         }
         print(json)
@@ -71,7 +80,7 @@ enum CLIOutput {
     }
 
     static func progress(_ message: String, context: OutputContext) {
-        guard context.isInteractive else { return }
+        guard context.isInteractive, !context.quiet else { return }
         printErr(ANSIColor.yellow(message, noColor: context.noColor))
     }
 }

--- a/Sources/KeyPathCLI/Utilities/Spinner.swift
+++ b/Sources/KeyPathCLI/Utilities/Spinner.swift
@@ -12,7 +12,7 @@ final class CLISpinner: @unchecked Sendable {
 
     init(context: OutputContext) {
         self.noColor = context.noColor
-        self.isInteractive = context.isInteractive
+        self.isInteractive = context.isInteractive && !context.quiet
         self.message = ""
     }
 

--- a/Tests/KeyPathTests/CLI/CommandStructureTests.swift
+++ b/Tests/KeyPathTests/CLI/CommandStructureTests.swift
@@ -27,7 +27,7 @@ final class CommandStructureTests: XCTestCase {
 
     func testRuleHasExpectedVerbs() {
         let names = subcommandNames(of: Rule.self)
-        XCTAssertEqual(Set(names), ["list", "add", "remove", "show", "enable", "disable"])
+        XCTAssertEqual(Set(names), ["list", "add", "remove", "show", "enable", "disable", "ensure"])
     }
 
     func testCollectionHasExpectedVerbs() {

--- a/docs/keypath-cli-skill.md
+++ b/docs/keypath-cli-skill.md
@@ -1,0 +1,150 @@
+---
+name: keypath-cli
+description: >
+  Configure KeyPath keyboard remapping via the keypath CLI. Use when the user
+  wants to remap keys, add shortcuts, configure tap-hold or home row mods,
+  install/uninstall packs, manage layers, import from Karabiner, or control
+  the KeyPath service. Triggers on: remap key, keyboard shortcut, tap-hold,
+  home row mods, caps lock remap, key mapping, layer, pack install, Kanata,
+  keypath CLI, keyboard configuration.
+metadata:
+  author: KeyPath Team
+  version: "1.0"
+---
+
+Use the `keypath` CLI to manage keyboard remapping. Always prefer the CLI over
+editing config files directly.
+
+## Output Mode
+
+- Always pass `--json` when you need to parse the result
+- When piped (non-TTY), output is JSON automatically
+- Use `--quiet` to suppress stderr decoration (spinners, progress)
+- Use `--dry-run` to preview any mutation before committing
+
+## Command Reference
+
+### Status & Health
+```bash
+keypath service status --json       # Full system health check
+keypath service start               # Start Kanata service
+keypath service stop                # Stop Kanata service
+keypath service restart             # Restart Kanata service
+keypath service reload              # Reload config without restart
+```
+
+### Rules (Custom Key Remaps)
+```bash
+keypath rule list --json            # List all custom rules
+keypath rule add <input> --action key=<output>  # Simple remap
+keypath rule add <input> --action key=<tap> --behavior tap-hold --hold <hold> --timeout 200  # Tap-hold
+keypath rule remove <input> --apply # Remove and reload
+keypath rule enable <input> --apply # Enable a disabled rule
+keypath rule disable <input>        # Disable without removing
+keypath rule show <input> --json    # Show rule details
+```
+
+### Rule Mutations — Canonical Workflow
+After any rule change, apply and verify:
+```bash
+keypath rule add caps --action key=esc --on-conflict replace
+keypath config apply --json         # Regenerate config + reload Kanata
+keypath service status --json       # Verify system is operational
+```
+
+### Collections (Built-in Rule Sets)
+```bash
+keypath collection list --json      # List all collections with enabled status
+keypath collection enable <name>    # Enable a collection
+keypath collection disable <name>   # Disable a collection
+keypath collection show <name> --json
+```
+
+### Packs (Gallery Packs)
+```bash
+keypath pack list --json            # All packs with install status
+keypath pack show <slug> --json     # Pack details, bindings, dependencies
+keypath pack install <slug> --apply # Install and reload
+keypath pack install <slug> --setting holdTimeout=200 --apply  # With quick settings
+keypath pack uninstall <slug> --apply
+keypath pack configure <slug> --setting holdTimeout=250 --apply  # Update settings
+```
+
+Pack names use slugs: `vim-navigation`, `home-row-mods`, `caps-lock-to-escape`, etc.
+
+### Layers
+```bash
+keypath layer list --json           # List defined layers
+keypath layer create <name>         # Create a new layer
+keypath layer switch <name>         # Switch active layer
+keypath layer delete <name>
+```
+
+### Config Management
+```bash
+keypath config show                 # Show current config file
+keypath config path                 # Print config file path
+keypath config check --json         # Validate config
+keypath config apply --json         # Regenerate + reload
+```
+
+### System Management
+```bash
+keypath system inspect --json       # Check system state and plan
+keypath system install              # Install services and components
+keypath system repair               # Fix broken services
+keypath system uninstall            # Remove all services
+```
+
+### Import/Export
+```bash
+keypath export all --json           # Export all collections
+keypath export collection <name> --json
+keypath import collection < file.json
+keypath import karabiner < karabiner.json  # Migrate from Karabiner-Elements
+```
+
+### Discovery
+```bash
+keypath help-topics schemas         # List all action types and behaviors
+keypath help-topics examples        # Common usage examples per noun
+keypath completions values pack     # List completable pack slugs
+keypath completions values collection  # List collection names
+keypath completions values rule     # List rule input keys
+keypath completions values layer    # List layer names
+```
+
+## Conflict Resolution
+
+Use `--on-conflict` for declarative handling:
+- `fail` (default) — error if rule exists
+- `replace` — overwrite existing rule
+- `skip` — no-op if rule exists
+- `merge` — merge compatible behaviors
+
+For idempotent operations, use `--on-conflict replace`.
+
+## Error Handling
+
+Exit codes:
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 2 | Usage error (bad arguments) |
+| 3 | Validation error |
+| 4 | Conflict |
+| 5 | Not found |
+| 6 | Service unreachable |
+| 7 | Permission blocked |
+| 8 | Kanata config invalid |
+
+When an error includes a `hint` field, it contains a runnable command to fix the issue.
+
+## Important Rules
+
+- After any mutation, run `keypath config apply --json` then verify with `keypath service status --json`
+- Use `--dry-run` before destructive operations
+- Use `--on-conflict replace` for idempotent updates
+- Never use `keypath service logs --follow` — it blocks indefinitely
+- Pack-managed collections cannot be toggled independently — uninstall the pack first
+- The `simulate` command requires Kanata binary — skip if not installed


### PR DESCRIPTION
## Summary

Six improvements making the KeyPath CLI agent-native (#412 #413 #414 #415 #416 #417):

- **Claude Code skill** (`docs/keypath-cli-skill.md`) — triggers on remap/shortcut/pack keywords, encodes canonical workflows
- **JSON Schema from `help-topics schemas --json`** — typed schema with properties, required, enums for rule/collection/pack commands
- **`keypath rule ensure`** — idempotent apply (no-op if matches, create/update otherwise). Eliminates check-then-act for agents
- **Executable error hints** — all hints are runnable commands, not prose
- **`--quiet` flag** — suppresses stderr decoration (spinners, progress) for clean agent output
- **`apiVersion: 1` envelope** — all JSON wrapped in `{"apiVersion": 1, "data": ...}` for contract stability

## Test plan

- [x] `swift build` — compiles clean
- [x] `swift test --filter CommandStructureTests` — includes new "ensure" verb + "values" subcommand
- [x] `swift test` — full suite 530 tests, 0 failures