### PR TITLE
fix: replace silent try? with do/catch error handling

### DIFF
--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayInspectorPanel+LauncherCustomize.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayInspectorPanel+LauncherCustomize.swift
@@ -151,14 +151,18 @@ extension OverlayInspectorPanel {
         updatedConfig.hasSeenWelcome = true
 
         Task {
-            let collections = await services.ruleCollectionStore.loadCollections()
-            if var launcherCollection = collections.first(where: { $0.id == RuleCollectionIdentifier.launcher }) {
-                launcherCollection.configuration = .launcherGrid(updatedConfig)
-                var allCollections = collections
-                if let index = allCollections.firstIndex(where: { $0.id == RuleCollectionIdentifier.launcher }) {
-                    allCollections[index] = launcherCollection
-                    try? await services.ruleCollectionStore.saveCollections(allCollections)
+            do {
+                let collections = await services.ruleCollectionStore.loadCollections()
+                if var launcherCollection = collections.first(where: { $0.id == RuleCollectionIdentifier.launcher }) {
+                    launcherCollection.configuration = .launcherGrid(updatedConfig)
+                    var allCollections = collections
+                    if let index = allCollections.firstIndex(where: { $0.id == RuleCollectionIdentifier.launcher }) {
+                        allCollections[index] = launcherCollection
+                        try await services.ruleCollectionStore.saveCollections(allCollections)
+                    }
                 }
+            } catch {
+                AppLogger.shared.log("⚠️ [Launcher] Failed to save welcome config: \(error.localizedDescription)")
             }
         }
     }
@@ -210,21 +214,24 @@ extension OverlayInspectorPanel {
     /// Save launcher config to store
     private func saveLauncherConfig() {
         Task {
-            var collections = await services.ruleCollectionStore.loadCollections()
-            if let index = collections.firstIndex(where: { $0.id == RuleCollectionIdentifier.launcher }) {
-                var collection = collections[index]
-                if var config = collection.configuration.launcherGridConfig {
-                    config.activationMode = launcherActivationMode
-                    config.hyperTriggerMode = launcherHyperTriggerMode
-                    collection.configuration = .launcherGrid(config)
-                    collections[index] = collection
-                    try? await services.ruleCollectionStore.saveCollections(collections)
-                    // Notify that rules changed so config regenerates
-                    Foundation.NotificationCenter.default.post(
-                        name: Foundation.Notification.Name.ruleCollectionsChanged,
-                        object: nil
-                    )
+            do {
+                var collections = await services.ruleCollectionStore.loadCollections()
+                if let index = collections.firstIndex(where: { $0.id == RuleCollectionIdentifier.launcher }) {
+                    var collection = collections[index]
+                    if var config = collection.configuration.launcherGridConfig {
+                        config.activationMode = launcherActivationMode
+                        config.hyperTriggerMode = launcherHyperTriggerMode
+                        collection.configuration = .launcherGrid(config)
+                        collections[index] = collection
+                        try await services.ruleCollectionStore.saveCollections(collections)
+                        Foundation.NotificationCenter.default.post(
+                            name: Foundation.Notification.Name.ruleCollectionsChanged,
+                            object: nil
+                        )
+                    }
                 }
+            } catch {
+                AppLogger.shared.log("⚠️ [Launcher] Failed to save launcher config: \(error.localizedDescription)")
             }
         }
     }
@@ -232,45 +239,47 @@ extension OverlayInspectorPanel {
     /// Add suggested sites from browser history to launcher
     private func addSuggestedSitesToLauncher(_ sites: [BrowserHistoryScanner.VisitedSite]) {
         Task {
-            var collections = await services.ruleCollectionStore.loadCollections()
-            if let index = collections.firstIndex(where: { $0.id == RuleCollectionIdentifier.launcher }) {
-                var collection = collections[index]
-                if var config = collection.configuration.launcherGridConfig {
-                    // Get existing keys
-                    var existingKeys = Set(config.mappings.map { LauncherGridConfig.normalizeKey($0.key) })
-                    let existingDomains = Set(config.mappings.compactMap { mapping in
-                        if case let .openURL(domain) = mapping.action {
-                            return normalizeDomain(domain)
-                        }
-                        return nil
-                    })
+            do {
+                var collections = await services.ruleCollectionStore.loadCollections()
+                if let index = collections.firstIndex(where: { $0.id == RuleCollectionIdentifier.launcher }) {
+                    var collection = collections[index]
+                    if var config = collection.configuration.launcherGridConfig {
+                        var existingKeys = Set(config.mappings.map { LauncherGridConfig.normalizeKey($0.key) })
+                        let existingDomains = Set(config.mappings.compactMap { mapping in
+                            if case let .openURL(domain) = mapping.action {
+                                return normalizeDomain(domain)
+                            }
+                            return nil
+                        })
 
-                    // Add new mappings for each suggested site
-                    for site in sites {
-                        if existingDomains.contains(normalizeDomain(site.domain)) {
-                            continue
-                        }
-                        guard let key = LauncherGridConfig.suggestionKeyOrder.first(where: { !existingKeys.contains($0) }) else {
-                            continue
+                        for site in sites {
+                            if existingDomains.contains(normalizeDomain(site.domain)) {
+                                continue
+                            }
+                            guard let key = LauncherGridConfig.suggestionKeyOrder.first(where: { !existingKeys.contains($0) }) else {
+                                continue
+                            }
+
+                            existingKeys.insert(key)
+
+                            let mapping = LauncherMapping(
+                                key: key,
+                                action: .openURL(site.domain)
+                            )
+                            config.mappings.append(mapping)
                         }
 
-                        existingKeys.insert(key)
-
-                        let mapping = LauncherMapping(
-                            key: key,
-                            action: .openURL(site.domain)
+                        collection.configuration = .launcherGrid(config)
+                        collections[index] = collection
+                        try await services.ruleCollectionStore.saveCollections(collections)
+                        Foundation.NotificationCenter.default.post(
+                            name: Foundation.Notification.Name.ruleCollectionsChanged,
+                            object: nil
                         )
-                        config.mappings.append(mapping)
                     }
-
-                    collection.configuration = .launcherGrid(config)
-                    collections[index] = collection
-                    try? await services.ruleCollectionStore.saveCollections(collections)
-                    Foundation.NotificationCenter.default.post(
-                        name: Foundation.Notification.Name.ruleCollectionsChanged,
-                        object: nil
-                    )
                 }
+            } catch {
+                AppLogger.shared.log("⚠️ [Launcher] Failed to save suggested sites: \(error.localizedDescription)")
             }
         }
     }

--- a/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView.swift
@@ -927,16 +927,22 @@ struct RulesTabView: View {
                 onToggle: { newValue in
                     isKindaVimInstalled = newValue
                     Task {
-                        if newValue {
-                            let record = InstalledPackRecord(
-                                packID: pack.id,
-                                version: pack.version,
-                                installedAt: Date(),
-                                quickSettingValues: [:]
-                            )
-                            try? await InstalledPackTracker.shared.upsert(record)
-                        } else {
-                            try? await InstalledPackTracker.shared.remove(packID: pack.id)
+                        do {
+                            if newValue {
+                                let record = InstalledPackRecord(
+                                    packID: pack.id,
+                                    version: pack.version,
+                                    installedAt: Date(),
+                                    quickSettingValues: [:]
+                                )
+                                try await InstalledPackTracker.shared.upsert(record)
+                            } else {
+                                try await InstalledPackTracker.shared.remove(packID: pack.id)
+                            }
+                        } catch {
+                            AppLogger.shared.log("⚠️ [Rules] KindaVim toggle failed: \(error.localizedDescription)")
+                            isKindaVimInstalled = !newValue
+                            settingsToastManager.showError("Failed to \(newValue ? "enable" : "disable") KindaVim")
                         }
                     }
                 },
@@ -975,6 +981,7 @@ struct RulesTabView: View {
                 _ = await kanataManager.underlyingManager.restartKanata(reason: "App rule deleted from Settings")
             } catch {
                 AppLogger.shared.log("⚠️ [RulesTabView] Failed to delete app rule: \(error)")
+                settingsToastManager.showError("Failed to delete rule: \(error.localizedDescription)")
             }
         }
     }


### PR DESCRIPTION
## Summary
- Replaced 3 silent `try?` in launcher config saves (`OverlayInspectorPanel+LauncherCustomize.swift`) with `do/catch` blocks that log errors
- Replaced 2 silent `try?` in KindaVim toggle (`RulesSummaryView.swift`) with `do/catch` that reverts toggle state and shows toast on failure
- Added toast error feedback to `deleteAppRule` catch block (was log-only)

These `try?` calls silently discarded save failures, making them invisible to users and AI agents.

## Test plan
- [ ] Toggle KindaVim on/off — verify it works normally
- [ ] Change launcher activation mode — verify config persists across app restart
- [ ] Add browser history suggestions to launcher — verify they appear
- [ ] Verify no regressions in rules tab delete functionality