### PR TITLE
fix: revert optimistic toggle state when pack install/uninstall fails

### DIFF
--- a/Sources/KeyPathAppKit/UI/Gallery/PackDetailView+PackActions.swift
+++ b/Sources/KeyPathAppKit/UI/Gallery/PackDetailView+PackActions.swift
@@ -6,7 +6,6 @@ import SwiftUI
 extension PackDetailView {
     func handleToggle(to newValue: Bool) {
         guard newValue != isInstalled else { return }
-        // Optimistic: update UI immediately so the switch feels instant
         isInstalled = newValue
         toggleTask?.cancel()
         toggleTask = Task { newValue ? await install() : await uninstall() }
@@ -35,6 +34,7 @@ extension PackDetailView {
                 }
             }
         } catch let error as PackInstaller.InstallError {
+            await refreshInstallState()
             if case let .mutuallyExclusive(conflicts) = error {
                 packConflict = PackConflictState(
                     packToInstall: pack,
@@ -44,6 +44,7 @@ extension PackDetailView {
                 showTemporaryError(error.localizedDescription)
             }
         } catch {
+            await refreshInstallState()
             showTemporaryError(error.localizedDescription)
         }
         isWorking = false
@@ -66,6 +67,7 @@ extension PackDetailView {
                 }
             }
         } catch {
+            await refreshInstallState()
             withAnimation { errorMessage = error.localizedDescription }
         }
         isWorking = false


### PR DESCRIPTION
## Summary
- When `install()` or `uninstall()` throws, call `refreshInstallState()` to re-sync the toggle from `InstalledPackTracker` instead of leaving it stuck at the optimistic value
- Fixes the scenario where a failed uninstall leaves the toggle at OFF while the pack is still installed, and subsequent toggle attempts silently no-op

Closes #384

## Test plan
- [x] `swift build` passes
- [x] All 530 tests pass
- [ ] Manual: install a pack, simulate uninstall failure (e.g., disconnect kanata mid-uninstall), verify toggle reverts to ON