### PR TITLE
refactor: consolidate duplicate LayerKeyMapper into shared singleton

### DIFF
--- a/Sources/KeyPathAppKit/Services/LayerMapping/LayerKeyMapper.swift
+++ b/Sources/KeyPathAppKit/Services/LayerMapping/LayerKeyMapper.swift
@@ -173,6 +173,8 @@ struct LayerKeyInfo: Equatable, Sendable {
 /// Service that builds key mappings for each layer using the kanata-simulator.
 /// Maps physical key codes to what they output in each layer.
 actor LayerKeyMapper {
+    static let shared = LayerKeyMapper()
+
     let simulatorService: SimulatorService
     var cache: [String: [UInt16: LayerKeyInfo]] = [:]
     var configHash: String = ""

--- a/Sources/KeyPathAppKit/UI/ContextHUD/ContextHUDController.swift
+++ b/Sources/KeyPathAppKit/UI/ContextHUD/ContextHUDController.swift
@@ -12,7 +12,7 @@ final class ContextHUDController {
     private var window: ContextHUDWindow?
     private var hostingView: NSHostingView<ContextHUDView>?
     private let viewModel = ContextHUDViewModel()
-    private let layerKeyMapper = LayerKeyMapper()
+    private let layerKeyMapper = LayerKeyMapper.shared
     private let kindaVimStateAdapter = KindaVimStateAdapter.shared
     private var hasStartedKindaVimStateMonitoring = false
 

--- a/Sources/KeyPathAppKit/UI/KeyboardVisualization/KeyboardVisualizationViewModel.swift
+++ b/Sources/KeyPathAppKit/UI/KeyboardVisualization/KeyboardVisualizationViewModel.swift
@@ -164,7 +164,7 @@ class KeyboardVisualizationViewModel {
     // MARK: - Layer Mapping
 
     /// Service for building layer key mappings
-    @ObservationIgnored let layerKeyMapper = LayerKeyMapper()
+    @ObservationIgnored let layerKeyMapper = LayerKeyMapper.shared
     /// Task for building layer mapping
     @ObservationIgnored var layerMapTask: Task<Void, Never>?
 


### PR DESCRIPTION
## Summary

Closes #419.

- Added `LayerKeyMapper.shared` static singleton
- Updated `KeyboardVisualizationViewModel` and `ContextHUDController` to use the shared instance instead of creating their own
- Halves simulator work on cold start since both consumers now share one cache

3 files changed, 4 insertions, 2 deletions.

## Test plan

- [x] `swift build` passes
- [x] All 530 tests pass (tests create fresh instances with custom `SimulatorService`, unaffected)
- [ ] Manual: open overlay + trigger HUD — both should show correct labels with shared cache