### PR TITLE
fix: ActivityLogger data race and notification queue safety

### DIFF
--- a/Sources/KeyPathInsights/ActivityLogging/Services/ActivityLogger.swift
+++ b/Sources/KeyPathInsights/ActivityLogging/Services/ActivityLogger.swift
@@ -31,8 +31,7 @@ public final class ActivityLogger {
     // MARK: - Initialization
 
     private init() {
-        // Load initial state
-        Task {
+        Task { @MainActor in
             eventCount = await storage.totalEventCount()
         }
     }
@@ -164,7 +163,7 @@ public final class ActivityLogger {
         let activateToken = center.addObserver(
             forName: NSWorkspace.didActivateApplicationNotification,
             object: nil,
-            queue: nil
+            queue: .main
         ) { [weak self] notification in
             guard let app = notification.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication else {
                 return
@@ -181,7 +180,7 @@ public final class ActivityLogger {
         let launchToken = center.addObserver(
             forName: NSWorkspace.didLaunchApplicationNotification,
             object: nil,
-            queue: nil
+            queue: .main
         ) { [weak self] notification in
             guard let app = notification.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication else {
                 return

--- a/Sources/KeyPathWizardCore/WizardDependencies.swift
+++ b/Sources/KeyPathWizardCore/WizardDependencies.swift
@@ -106,7 +106,9 @@ public enum WizardDependencies {
     // MARK: - Test Support
 
     /// Reset all dependencies to nil/false for test teardown.
-    /// Call from KeyPathTestCase.tearDown() to prevent state leaking between tests.
+    /// Call from KeyPathTestCase.tearDown() within `MainActor.assumeIsolated` or `MainActor.run`.
+    /// The nonisolated(unsafe) properties are safe to clear here because XCTest runs tests
+    /// serially and wizard views are not active during teardown.
     public static func reset() {
         runtimeCoordinator = nil
         helperManager = nil


### PR DESCRIPTION
## Summary
- Add `@MainActor` to `Task` in `ActivityLogger.init()` — prevents data race when setting `@Published eventCount` from a non-isolated context
- Change notification observer queues from `nil` to `.main` — callbacks now arrive on the main thread directly instead of arbitrary threads
- Document `WizardDependencies.reset()` safety invariants for test teardown

Found during a Swift concurrency best practices audit. The ActivityLogger init issue is a real data race (HIGH severity); the notification queue change is a safety/efficiency improvement (MEDIUM).

**Not changed (with reasoning):**
- `HIDDeviceMonitor` `nonisolated(unsafe)` fields — correctly documented, protected by NSLock, inherent to IOKit interop
- `WizardDependencies` `nonisolated(unsafe)` statics — intentional cross-module DI pattern, callers are correctly MainActor-isolated

## Test plan
- [x] `swift test` — 530 tests pass
- [ ] Verify activity logging still records app switches after enable
- [ ] Verify wizard setup/teardown works in tests