### PR TITLE
refactor: replace force unwraps with guard-let and optional binding

### DIFF
--- a/Sources/KeyPathAppKit/Models/KeyAction.swift
+++ b/Sources/KeyPathAppKit/Models/KeyAction.swift
@@ -66,7 +66,7 @@ public extension KeyAction {
         case .meh:
             return "(multi lctl lalt lsft)"
         case let .launchApp(name, bundleId):
-            let identifier = bundleId?.isEmpty == false ? bundleId! : name
+            let identifier = (bundleId?.isEmpty == false) ? (bundleId ?? name) : name
             return "(push-msg \"launch:\(identifier)\")"
         case let .openURL(urlString):
             let encoded = URLMappingFormatter.encodeForPushMessage(urlString)

--- a/Sources/KeyPathAppKit/Services/Configuration/ConfigFileWatcher.swift
+++ b/Sources/KeyPathAppKit/Services/Configuration/ConfigFileWatcher.swift
@@ -139,7 +139,7 @@ class ConfigFileWatcher: @unchecked Sendable {
             queue: queue
         )
 
-        let source = fileMonitorSource!
+        guard let source = fileMonitorSource else { return }
         source.setEventHandler { [weak self] in
             let flags = DispatchSource.FileSystemEvent(rawValue: source.data)
             AppLogger.shared.log("📁 [FileWatcher] File system event received - flags: \(flags)")

--- a/Sources/KeyPathAppKit/Services/KeyboardCapture/KeyboardCapture.swift
+++ b/Sources/KeyPathAppKit/Services/KeyboardCapture/KeyboardCapture.swift
@@ -556,17 +556,16 @@ public class KeyboardCapture {
 
         guard isKeyDown else { return } // Only capture key down events
 
-        let keyName = mediaKeyCodeToString(Int(mediaKeyCode))
-        guard keyName != nil else { return } // Unknown media key
+        guard let keyName = mediaKeyCodeToString(Int(mediaKeyCode)) else { return }
 
         let now = Date()
-        AppLogger.shared.log("🎹 [KeyboardCapture] mediaKey: \(keyName!) code=\(mediaKeyCode)")
+        AppLogger.shared.log("🎹 [KeyboardCapture] mediaKey: \(keyName) code=\(mediaKeyCode)")
         anyEventSeen = true
         noKeyBreadcrumbTimer?.invalidate()
         noKeyBreadcrumbTimer = nil
 
         let keyPress = KeyPress(
-            baseKey: keyName!,
+            baseKey: keyName,
             modifiers: [],
             timestamp: now,
             keyCode: Int64(mediaKeyCode) + 1000 // Offset to avoid collision with regular keyCodes
@@ -577,7 +576,7 @@ public class KeyboardCapture {
             if last.baseKey == keyPress.baseKey,
                now.timeIntervalSince(lastAt) <= dedupWindow
             {
-                AppLogger.shared.log("🎹 [KeyboardCapture] Deduped duplicate mediaKey: \(keyName!)")
+                AppLogger.shared.log("🎹 [KeyboardCapture] Deduped duplicate mediaKey: \(keyName)")
                 return
             }
         }
@@ -585,7 +584,7 @@ public class KeyboardCapture {
         lastCaptureAt = now
 
         if sequenceCallback == nil, let legacyCallback = captureCallback {
-            legacyCallback(keyName!)
+            legacyCallback(keyName)
             if !isContinuous {
                 stopCapture()
             } else {

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+PublicAPI.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+PublicAPI.swift
@@ -675,8 +675,7 @@ extension RuleCollectionsManager {
     private func applyLeaderKeyToMomentaryActivators(_ newKey: String) {
         // Update all collections that have a momentary activator
         for index in ruleCollections.indices {
-            if ruleCollections[index].momentaryActivator != nil {
-                let oldActivator = ruleCollections[index].momentaryActivator!
+            if let oldActivator = ruleCollections[index].momentaryActivator {
                 ruleCollections[index].momentaryActivator = MomentaryActivator(
                     input: newKey,
                     targetLayer: oldActivator.targetLayer

--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView+SpecialKeys.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView+SpecialKeys.swift
@@ -153,8 +153,8 @@ extension OverlayKeycapView {
         let hasSystemRemapping = sfSymbolResult != nil
         let isRemappedToRegularKey = remappedLabel != nil && !hasSystemRemapping && remappedLabel != key.label
 
-        if isRemappedToRegularKey {
-            Text(remappedLabel!.uppercased())
+        if isRemappedToRegularKey, let label = remappedLabel {
+            Text(label.uppercased())
                 .font(.system(size: 10 * scale, weight: .medium))
                 .foregroundStyle(foregroundColor)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/Sources/KeyPathAppKit/UI/Overlay/QMKKeyboardSearchView.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/QMKKeyboardSearchView.swift
@@ -238,7 +238,7 @@ struct QMKKeyboardSearchView: View {
                 isLoading = false
                 if query != searchText {
                     selectedIndex = nil
-                } else if selectedIndex != nil, selectedIndex! >= results.count {
+                } else if let idx = selectedIndex, idx >= results.count {
                     selectedIndex = results.isEmpty ? nil : 0
                 }
             }

--- a/Sources/KeyPathInstallationWizard/UI/Pages/WizardHelperPage.swift
+++ b/Sources/KeyPathInstallationWizard/UI/Pages/WizardHelperPage.swift
@@ -207,7 +207,7 @@ public struct WizardHelperPage: View {
                 .multilineTextAlignment(.center)
 
             // Description
-            Text(helperVersion != nil ? "Version \(helperVersion!) — system operations available" : "System operations available without password prompts.")
+            Text(helperVersion.map { "Version \($0) — system operations available" } ?? "System operations available without password prompts.")
                 .font(.body)
                 .foregroundColor(.secondary)
                 .multilineTextAlignment(.center)

--- a/Sources/KeyPathLayoutTracerKit/LayoutAnalysisRunner.swift
+++ b/Sources/KeyPathLayoutTracerKit/LayoutAnalysisRunner.swift
@@ -32,7 +32,7 @@ enum LayoutAnalysisRunner {
             throw NSError(
                 domain: "KeyPathLayoutTracer.Analysis",
                 code: Int(process.terminationStatus),
-                userInfo: [NSLocalizedDescriptionKey: errorText?.isEmpty == false ? errorText! : "Keyboard analysis failed."]
+                userInfo: [NSLocalizedDescriptionKey: (errorText?.isEmpty == false) ? (errorText ?? "Keyboard analysis failed.") : "Keyboard analysis failed."]
             )
         }
 


### PR DESCRIPTION
## Summary
- Convert 8 force unwrap patterns across 8 files to idiomatic Swift optional binding
- No behavior change — pure style improvement for safety and readability

**Files changed:**
- `KeyboardCapture.swift` — `guard keyName != nil; keyName!` → `guard let keyName`
- `QMKKeyboardSearchView.swift` — `selectedIndex!` → `if let idx = selectedIndex`
- `RuleCollectionsManager+PublicAPI.swift` — `momentaryActivator!` → `if let oldActivator`
- `KeyAction.swift` — ternary + `bundleId!` → ternary + `bundleId ?? name`
- `LayoutAnalysisRunner.swift` — ternary + `errorText!` → ternary + `errorText ??`
- `WizardHelperPage.swift` — ternary + `helperVersion!` → `.map { }`
- `ConfigFileWatcher.swift` — `fileMonitorSource!` → `guard let source`
- `OverlayKeycapView+SpecialKeys.swift` — `remappedLabel!` → `if let label`

## Test plan
- [x] `swift build` passes
- [x] `swift test` — 530 tests pass
- [ ] Smoke test overlay, wizard, keyboard capture