### PR TITLE
refactor: decompose oversized view bodies (#433)

### DIFF
--- a/Sources/KeyPathAppKit/UI/SimpleModsView.swift
+++ b/Sources/KeyPathAppKit/UI/SimpleModsView.swift
@@ -26,145 +26,15 @@ struct SimpleModsView: View {
     var body: some View {
         NavigationStack {
             VStack(spacing: 0) {
-                // Tab selector
-                HStack(spacing: 0) {
-                    TabButton(
-                        title: "Installed",
-                        badge: service.installedMappings.count,
-                        isSelected: selectedTab == .installed
-                    ) {
-                        selectedTab = .installed
-                    }
-
-                    TabButton(
-                        title: "Available",
-                        badge: service.availablePresets.count,
-                        isSelected: selectedTab == .available
-                    ) {
-                        selectedTab = .available
-                    }
-                }
-                .padding(.horizontal)
-                .padding(.top, 8)
-
-                // Search bar
-                HStack {
-                    Image(systemName: "magnifyingglass")
-                        .foregroundColor(.secondary)
-                    TextField("Search mappings...", text: $searchText)
-                        .textFieldStyle(.plain)
-                }
-                .padding()
-                .background(Color(NSColor.controlBackgroundColor))
-
-                // Category filter (only for Available tab)
-                if selectedTab == .available {
-                    ScrollView(.horizontal, showsIndicators: false) {
-                        HStack(spacing: 12) {
-                            CategoryButton(
-                                title: "All",
-                                isSelected: selectedCategory == nil
-                            ) {
-                                selectedCategory = nil
-                            }
-
-                            ForEach(Array(service.getPresetsByCategory().keys.sorted()), id: \.self) { category in
-                                CategoryButton(
-                                    title: category,
-                                    isSelected: selectedCategory == category
-                                ) {
-                                    selectedCategory = category
-                                }
-                            }
-                        }
-                        .padding(.horizontal)
-                    }
-                    .padding(.vertical, 8)
-                }
-
+                tabSelector
+                searchBar
+                categoryFilter
                 Divider()
-
-                // Content
-                if service.isApplying {
-                    HStack {
-                        ProgressView()
-                            .scaleEffect(0.8)
-                        Text("Applying changes...")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                    }
-                    .padding()
-                }
-
-                ScrollView {
-                    LazyVStack(alignment: .leading, spacing: 12) {
-                        if selectedTab == .installed {
-                            if filteredInstalledMappings.isEmpty {
-                                VStack(spacing: 12) {
-                                    EmptyStateView(
-                                        icon: "keyboard",
-                                        title: "No mappings installed",
-                                        message: "Add mappings from the Available tab to get started."
-                                    )
-
-                                    Button(
-                                        action: { selectedTab = .available },
-                                        label: {
-                                            HStack(spacing: 6) {
-                                                Image(systemName: "arrow.right.circle")
-                                                Text("Browse available presets")
-                                            }
-                                        }
-                                    )
-                                    .buttonStyle(.bordered)
-                                    .accessibilityIdentifier("simple-mods-browse-presets-button")
-                                    .accessibilityLabel("Browse available presets")
-                                    .controlSize(.small)
-                                }
-                            } else {
-                                ForEach(filteredInstalledMappings) { mapping in
-                                    InstalledMappingRow(
-                                        mapping: mapping,
-                                        service: service
-                                    )
-                                }
-                            }
-                        } else {
-                            if filteredAvailablePresets.isEmpty {
-                                EmptyStateView(
-                                    icon: "checkmark.circle",
-                                    title: "All presets installed",
-                                    message: "All available mappings are already in your config."
-                                )
-                            } else {
-                                ForEach(filteredAvailablePresets) { preset in
-                                    AvailablePresetRow(
-                                        preset: preset,
-                                        service: service
-                                    )
-                                }
-                            }
-                        }
-                    }
-                    .padding()
-                }
+                applyingIndicator
+                mappingsList
             }
             .safeAreaInset(edge: .bottom, spacing: 0) {
-                // Toast notification area (similar to ContentView)
-                Group {
-                    if showErrorMessage || showSuccessMessage {
-                        StatusMessageView(message: statusMessage, isVisible: true)
-                            .padding(.horizontal)
-                            .padding(.bottom, 12)
-                            .transition(.opacity)
-                    } else {
-                        Color.clear
-                            .frame(height: 0)
-                    }
-                }
-                .frame(height: (showErrorMessage || showSuccessMessage) ? 80 : 0)
-                .animation(.easeInOut(duration: 0.25), value: showErrorMessage)
-                .animation(.easeInOut(duration: 0.25), value: showSuccessMessage)
+                toastOverlay
             }
             .navigationTitle("Simple Key Mappings")
             .toolbar {
@@ -176,79 +46,11 @@ struct SimpleModsView: View {
                     .accessibilityLabel("Done")
                 }
             }
-            .onAppear {
-                // Set dependencies
-                let viewModel = findViewModel()
-                service.setDependencies(
-                    kanataManager: viewModel.underlyingManager
-                )
-
-                // Load mappings
-                do {
-                    try service.load()
-                    previousMappingCount = service.installedMappings.count
-                } catch {
-                    uiError = "Failed to load mappings: \(error.localizedDescription)"
-                }
-            }
-            // Show toast notifications for errors and success
-            .onChange(of: service.lastError) { _, newValue in
-                if let error = newValue {
-                    // Check if this is a rollback scenario
-                    if let rollbackReason = service.lastRollbackReason {
-                        let details = service.lastRollbackDetails ?? ""
-                        let fullMessage = "❌ Configuration Error\n\(rollbackReason)\n\nDetails:\n\(details)"
-                        showToast(fullMessage, isError: true)
-                    } else {
-                        showToast("❌ \(error)", isError: true)
-                    }
-                    uiError = error
-                } else {
-                    // Success - clear errors
-                    uiError = nil
-                    showErrorMessage = false
-                }
-            }
-            .onChange(of: service.installedMappings.count) { oldCount, newCount in
-                // Track previous count
-                previousMappingCount = oldCount
-
-                // Only show success toast if NOT a rollback (no error state)
-                if service.lastError == nil, service.lastRollbackReason == nil {
-                    // Switch to installed tab when a mapping is added
-                    if newCount > oldCount, selectedTab == .available {
-                        selectedTab = .installed
-                        // Fetch last reload duration from TCP status for richer success message
-                        Task {
-                            let client = KanataTCPClient(port: 37001)
-                            let status = try? await client.getStatus()
-
-                            // FIX #1: Explicitly close connection to prevent file descriptor leak
-                            await client.cancelInflightAndCloseConnection()
-
-                            if let dur = status?.last_reload?.duration_ms {
-                                showToast("✅ Mapping added (reload \(dur) ms)", isError: false)
-                            } else {
-                                showToast("✅ Mapping added successfully", isError: false)
-                            }
-                        }
-                    } else if newCount < oldCount {
-                        // Only show success if user-initiated (not rollback)
-                        showToast("✅ Mapping removed successfully", isError: false)
-                    }
-                }
-            }
-            .onChange(of: service.lastRollbackReason) { _, rollbackReason in
-                if let reason = rollbackReason {
-                    // This is a rollback - show error toast with details
-                    let details = service.lastRollbackDetails ?? "No additional details available"
-                    let fullMessage =
-                        "❌ Configuration Error\n\(reason)\n\nChanges have been rolled back.\n\n\(details)"
-                    showToast(fullMessage, isError: true)
-                }
-            }
+            .onAppear(perform: loadMappings)
+            .onChange(of: service.lastError, handleErrorChange)
+            .onChange(of: service.installedMappings.count, handleMappingCountChange)
+            .onChange(of: service.lastRollbackReason, handleRollbackChange)
             .onChange(of: service.isApplying) { _, isApplying in
-                // When applying starts, clear any existing messages
                 if isApplying {
                     showErrorMessage = false
                     showSuccessMessage = false
@@ -256,6 +58,228 @@ struct SimpleModsView: View {
             }
         }
         .frame(width: 600, height: 500)
+    }
+
+    // MARK: - Body Sections
+
+    private var tabSelector: some View {
+        HStack(spacing: 0) {
+            TabButton(
+                title: "Installed",
+                badge: service.installedMappings.count,
+                isSelected: selectedTab == .installed
+            ) {
+                selectedTab = .installed
+            }
+
+            TabButton(
+                title: "Available",
+                badge: service.availablePresets.count,
+                isSelected: selectedTab == .available
+            ) {
+                selectedTab = .available
+            }
+        }
+        .padding(.horizontal)
+        .padding(.top, 8)
+    }
+
+    private var searchBar: some View {
+        HStack {
+            Image(systemName: "magnifyingglass")
+                .foregroundColor(.secondary)
+            TextField("Search mappings...", text: $searchText)
+                .textFieldStyle(.plain)
+        }
+        .padding()
+        .background(Color(NSColor.controlBackgroundColor))
+    }
+
+    @ViewBuilder
+    private var categoryFilter: some View {
+        if selectedTab == .available {
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 12) {
+                    CategoryButton(
+                        title: "All",
+                        isSelected: selectedCategory == nil
+                    ) {
+                        selectedCategory = nil
+                    }
+
+                    ForEach(Array(service.getPresetsByCategory().keys.sorted()), id: \.self) { category in
+                        CategoryButton(
+                            title: category,
+                            isSelected: selectedCategory == category
+                        ) {
+                            selectedCategory = category
+                        }
+                    }
+                }
+                .padding(.horizontal)
+            }
+            .padding(.vertical, 8)
+        }
+    }
+
+    @ViewBuilder
+    private var applyingIndicator: some View {
+        if service.isApplying {
+            HStack {
+                ProgressView()
+                    .scaleEffect(0.8)
+                Text("Applying changes...")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+            .padding()
+        }
+    }
+
+    private var mappingsList: some View {
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: 12) {
+                if selectedTab == .installed {
+                    installedContent
+                } else {
+                    availableContent
+                }
+            }
+            .padding()
+        }
+    }
+
+    @ViewBuilder
+    private var installedContent: some View {
+        if filteredInstalledMappings.isEmpty {
+            VStack(spacing: 12) {
+                EmptyStateView(
+                    icon: "keyboard",
+                    title: "No mappings installed",
+                    message: "Add mappings from the Available tab to get started."
+                )
+
+                Button(
+                    action: { selectedTab = .available },
+                    label: {
+                        HStack(spacing: 6) {
+                            Image(systemName: "arrow.right.circle")
+                            Text("Browse available presets")
+                        }
+                    }
+                )
+                .buttonStyle(.bordered)
+                .accessibilityIdentifier("simple-mods-browse-presets-button")
+                .accessibilityLabel("Browse available presets")
+                .controlSize(.small)
+            }
+        } else {
+            ForEach(filteredInstalledMappings) { mapping in
+                InstalledMappingRow(
+                    mapping: mapping,
+                    service: service
+                )
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var availableContent: some View {
+        if filteredAvailablePresets.isEmpty {
+            EmptyStateView(
+                icon: "checkmark.circle",
+                title: "All presets installed",
+                message: "All available mappings are already in your config."
+            )
+        } else {
+            ForEach(filteredAvailablePresets) { preset in
+                AvailablePresetRow(
+                    preset: preset,
+                    service: service
+                )
+            }
+        }
+    }
+
+    private var toastOverlay: some View {
+        Group {
+            if showErrorMessage || showSuccessMessage {
+                StatusMessageView(message: statusMessage, isVisible: true)
+                    .padding(.horizontal)
+                    .padding(.bottom, 12)
+                    .transition(.opacity)
+            } else {
+                Color.clear
+                    .frame(height: 0)
+            }
+        }
+        .frame(height: (showErrorMessage || showSuccessMessage) ? 80 : 0)
+        .animation(.easeInOut(duration: 0.25), value: showErrorMessage)
+        .animation(.easeInOut(duration: 0.25), value: showSuccessMessage)
+    }
+
+    // MARK: - Event Handlers
+
+    private func loadMappings() {
+        let viewModel = findViewModel()
+        service.setDependencies(
+            kanataManager: viewModel.underlyingManager
+        )
+
+        do {
+            try service.load()
+            previousMappingCount = service.installedMappings.count
+        } catch {
+            uiError = "Failed to load mappings: \(error.localizedDescription)"
+        }
+    }
+
+    private func handleErrorChange(_: String?, _ newValue: String?) {
+        if let error = newValue {
+            if let rollbackReason = service.lastRollbackReason {
+                let details = service.lastRollbackDetails ?? ""
+                let fullMessage = "❌ Configuration Error\n\(rollbackReason)\n\nDetails:\n\(details)"
+                showToast(fullMessage, isError: true)
+            } else {
+                showToast("❌ \(error)", isError: true)
+            }
+            uiError = error
+        } else {
+            uiError = nil
+            showErrorMessage = false
+        }
+    }
+
+    private func handleMappingCountChange(_ oldCount: Int, _ newCount: Int) {
+        previousMappingCount = oldCount
+
+        if service.lastError == nil, service.lastRollbackReason == nil {
+            if newCount > oldCount, selectedTab == .available {
+                selectedTab = .installed
+                Task {
+                    let client = KanataTCPClient(port: 37001)
+                    let status = try? await client.getStatus()
+                    await client.cancelInflightAndCloseConnection()
+
+                    if let dur = status?.last_reload?.duration_ms {
+                        showToast("✅ Mapping added (reload \(dur) ms)", isError: false)
+                    } else {
+                        showToast("✅ Mapping added successfully", isError: false)
+                    }
+                }
+            } else if newCount < oldCount {
+                showToast("✅ Mapping removed successfully", isError: false)
+            }
+        }
+    }
+
+    private func handleRollbackChange(_: String?, _ rollbackReason: String?) {
+        if let reason = rollbackReason {
+            let details = service.lastRollbackDetails ?? "No additional details available"
+            let fullMessage =
+                "❌ Configuration Error\n\(reason)\n\nChanges have been rolled back.\n\n\(details)"
+            showToast(fullMessage, isError: true)
+        }
     }
 
     private var filteredInstalledMappings: [SimpleMapping] {

--- a/Sources/KeyPathInstallationWizard/UI/InstallationWizardView.swift
+++ b/Sources/KeyPathInstallationWizard/UI/InstallationWizardView.swift
@@ -80,98 +80,16 @@ public struct InstallationWizardView: View {
 
     public var body: some View {
         ZStack {
-            if let banner = statusBannerMessage {
-                VStack(spacing: 0) {
-                    HStack(spacing: 8) {
-                        Image(systemName: "info.circle")
-                        Text(banner)
-                            .font(.callout)
-                            .multilineTextAlignment(.leading)
-                        Spacer()
-                    }
-                    .padding(10)
-                    .background(.thinMaterial)
-                    .overlay(
-                        Rectangle()
-                            .frame(height: 1)
-                            .foregroundColor(Color.gray.opacity(0.15)),
-                        alignment: .bottom
-                    )
-                    Spacer()
-                }
-                .transition(.move(edge: .top).combined(with: .opacity))
-                .zIndex(2)
-            }
-
-            // Dark mode-aware background for cross-fade effect
+            statusBanner
             WizardDesign.Colors.wizardBackground
                 .ignoresSafeArea()
-
-            VStack(spacing: 0) {
-                // Always show page content - no preflight view
-                pageContent()
-                    .id(stateMachine.currentPage) // Force view recreation on page change
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    .background(GeometryReader { geo in
-                        Color.clear.preference(key: WizardContentHeightKey.self, value: geo.size.height)
-                    })
-                    .onPreferenceChange(WizardContentHeightKey.self) { _ in
-                        NotificationCenter.default.post(name: .wizardContentSizeChanged, object: nil)
-                    }
-                    .onPreferenceChange(WizardInlineProgressVisiblePreferenceKey.self) { newValue in
-                        hasInlineProgressIndicator = newValue
-                    }
-                    .overlay {
-                        // Don't show overlay during validation - summary page has its own validating indicator
-                        // Also suppress overlay when the page already shows an inline progress bar,
-                        // to avoid two simultaneous indeterminate bars.
-                        if isOperationRunning, !isValidating, !hasInlineProgressIndicator {
-                            operationProgressOverlay()
-                                .allowsHitTesting(false) // Don't block X button interaction
-                        }
-                    }
-            }
-            .frame(width: WizardDesign.Layout.pageWidth)
-            .frame(minHeight: 480, maxHeight: .infinity) // Consistent min height prevents size jumps between pages
-            .fixedSize(horizontal: true, vertical: false) // Allow vertical growth; keep width fixed
-            .animation(.easeInOut(duration: 0.25), value: isValidating)
-            // Prevent vertical position animation during page transitions
-            .animation(nil, value: stateMachine.currentPage)
-            // Remove animation on frame changes to prevent window movement
-            .background(WizardDesign.Colors.wizardBackground) // Simple solid background, no visual effect
+            pageContainer
         }
         .withToasts(toastManager)
         .environment(stateMachine)
-        .focused($hasKeyboardFocus) // Enable focus for reliable ESC key handling
-        // Aggressively disable focus rings during validation
-        .onChange(of: isValidating) { _, newValue in
-            if newValue {
-                // Clear focus when validation starts (deferred to next run loop for AppKit interop)
-                Task { @MainActor in
-                    NSApp.keyWindow?.makeFirstResponder(nil)
-                    if let window = NSApp.keyWindow, let contentView = window.contentView {
-                        disableFocusRings(in: contentView)
-                    }
-                }
-            } else {
-                // Validation finished; set navigation sequence based on current filter
-                stateMachine.customSequence = showAllSummaryItems ? nil : navSequence
-            }
-        }
-        // Global navigation + close button overlay for all detail pages
-        .overlay(alignment: .top) {
-            if stateMachine.currentPage != .summary {
-                HStack {
-                    WizardNavigationControl()
-                    Spacer()
-                    CloseButton()
-                }
-                .environment(stateMachine)
-                .padding(.top, 12)
-                .padding(.horizontal, 12)
-                .animation(nil, value: stateMachine.currentPage)
-            }
-        }
+        .focused($hasKeyboardFocus)
+        .onChange(of: isValidating, handleValidationChange)
+        .overlay(alignment: .top) { navigationOverlay }
         .onAppear {
             hasKeyboardFocus = true
             Task { await setupWizard() }
@@ -182,12 +100,8 @@ public struct InstallationWizardView: View {
             }
         }
         .onChange(of: isOperationRunning) { _, newValue in
-            // When overlays disappear, reclaim focus for ESC key
-            if !newValue {
-                hasKeyboardFocus = true
-            }
+            if !newValue { hasKeyboardFocus = true }
         }
-        // Keep navigation sequence in sync with summary filter state
         .onChange(of: showAllSummaryItems) { _, showAll in
             stateMachine.customSequence = showAll ? nil : navSequence
         }
@@ -195,14 +109,11 @@ public struct InstallationWizardView: View {
             handlePageChange(from: oldPage, to: newPage)
         }
         .onChange(of: navSequence) { _, newSeq in
-            if !showAllSummaryItems {
-                stateMachine.customSequence = newSeq
-            }
+            if !showAllSummaryItems { stateMachine.customSequence = newSeq }
         }
         .onChange(of: showingCloseConfirmation) { _, newValue in
             if !newValue { hasKeyboardFocus = true }
         }
-        // Add keyboard navigation support for left/right arrow keys and ESC (macOS 14.0+)
         .modifier(
             KeyboardNavigationModifier(
                 onLeftArrow: navigateToPreviousPage,
@@ -210,54 +121,145 @@ public struct InstallationWizardView: View {
                 onEscape: forciblyCloseWizard
             )
         )
-        // Ensure ESC always closes the wizard, even if key focus isn't on our view
-        .onExitCommand {
-            forciblyCloseWizard()
-        }
-        .task {
-            // Monitor state changes
-            await monitorSystemState()
-        }
+        .onExitCommand { forciblyCloseWizard() }
+        .task { await monitorSystemState() }
         .onReceive(NotificationCenter.default.publisher(for: .wizardSmAppServiceApprovalRequired)) { _ in
             showingBackgroundApprovalPrompt = true
         }
         .alert("Close Setup Wizard?", isPresented: $showingCloseConfirmation) {
-            Button("Cancel", role: .cancel) {
-                showingCloseConfirmation = false
-            }
-            Button("Close Anyway", role: .destructive) {
-                forceInstantClose()
-                performBackgroundCleanup()
-            }
-            .keyboardShortcut(.defaultAction) // Return key for destructive action
+            closeConfirmationButtons
         } message: {
-            let criticalCount = stateMachine.wizardIssues.filter { $0.severity == .critical }.count
-            Text(
-                "There \(criticalCount == 1 ? "is" : "are") \(criticalCount) critical \(criticalCount == 1 ? "issue" : "issues") "
-                    + "that may prevent KeyPath from working properly. Are you sure you want to close the setup wizard?"
-            )
+            closeConfirmationMessage
         }
         .alert("Enable KeyPath in Login Items", isPresented: $showingBackgroundApprovalPrompt) {
-            Button("OK") {
-                showingBackgroundApprovalPrompt = false
-                openLoginItemsSettings()
-            }
-            .keyboardShortcut(.defaultAction)
-            Button("Later", role: .cancel) {
-                showingBackgroundApprovalPrompt = false
-                stopLoginItemsApprovalPolling()
-            }
+            loginItemsApprovalButtons
         } message: {
-            Text(
-                "Login Items will open. Find KeyPath under Background Items and flip the switch to enable it."
-            )
+            Text("Login Items will open. Find KeyPath under Background Items and flip the switch to enable it.")
         }
         .onChange(of: showingBackgroundApprovalPrompt) { _, isShowing in
-            if isShowing {
-                // Start polling immediately when dialog appears, so approval is detected
-                // even if user enables KeyPath before clicking OK
-                startLoginItemsApprovalPolling()
+            if isShowing { startLoginItemsApprovalPolling() }
+        }
+    }
+
+    // MARK: - Body Sections
+
+    @ViewBuilder
+    private var statusBanner: some View {
+        if let banner = statusBannerMessage {
+            VStack(spacing: 0) {
+                HStack(spacing: 8) {
+                    Image(systemName: "info.circle")
+                    Text(banner)
+                        .font(.callout)
+                        .multilineTextAlignment(.leading)
+                    Spacer()
+                }
+                .padding(10)
+                .background(.thinMaterial)
+                .overlay(
+                    Rectangle()
+                        .frame(height: 1)
+                        .foregroundColor(Color.gray.opacity(0.15)),
+                    alignment: .bottom
+                )
+                Spacer()
             }
+            .transition(.move(edge: .top).combined(with: .opacity))
+            .zIndex(2)
+        }
+    }
+
+    private var pageContainer: some View {
+        VStack(spacing: 0) {
+            pageContent()
+                .id(stateMachine.currentPage)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .background(GeometryReader { geo in
+                    Color.clear.preference(key: WizardContentHeightKey.self, value: geo.size.height)
+                })
+                .onPreferenceChange(WizardContentHeightKey.self) { _ in
+                    NotificationCenter.default.post(name: .wizardContentSizeChanged, object: nil)
+                }
+                .onPreferenceChange(WizardInlineProgressVisiblePreferenceKey.self) { newValue in
+                    hasInlineProgressIndicator = newValue
+                }
+                .overlay {
+                    if isOperationRunning, !isValidating, !hasInlineProgressIndicator {
+                        operationProgressOverlay()
+                            .allowsHitTesting(false)
+                    }
+                }
+        }
+        .frame(width: WizardDesign.Layout.pageWidth)
+        .frame(minHeight: 480, maxHeight: .infinity)
+        .fixedSize(horizontal: true, vertical: false)
+        .animation(.easeInOut(duration: 0.25), value: isValidating)
+        .animation(nil, value: stateMachine.currentPage)
+        .background(WizardDesign.Colors.wizardBackground)
+    }
+
+    @ViewBuilder
+    private var navigationOverlay: some View {
+        if stateMachine.currentPage != .summary {
+            HStack {
+                WizardNavigationControl()
+                Spacer()
+                CloseButton()
+            }
+            .environment(stateMachine)
+            .padding(.top, 12)
+            .padding(.horizontal, 12)
+            .animation(nil, value: stateMachine.currentPage)
+        }
+    }
+
+    // MARK: - Alert Content
+
+    @ViewBuilder
+    private var closeConfirmationButtons: some View {
+        Button("Cancel", role: .cancel) {
+            showingCloseConfirmation = false
+        }
+        Button("Close Anyway", role: .destructive) {
+            forceInstantClose()
+            performBackgroundCleanup()
+        }
+        .keyboardShortcut(.defaultAction)
+    }
+
+    private var closeConfirmationMessage: some View {
+        let criticalCount = stateMachine.wizardIssues.filter { $0.severity == .critical }.count
+        return Text(
+            "There \(criticalCount == 1 ? "is" : "are") \(criticalCount) critical \(criticalCount == 1 ? "issue" : "issues") "
+                + "that may prevent KeyPath from working properly. Are you sure you want to close the setup wizard?"
+        )
+    }
+
+    @ViewBuilder
+    private var loginItemsApprovalButtons: some View {
+        Button("OK") {
+            showingBackgroundApprovalPrompt = false
+            openLoginItemsSettings()
+        }
+        .keyboardShortcut(.defaultAction)
+        Button("Later", role: .cancel) {
+            showingBackgroundApprovalPrompt = false
+            stopLoginItemsApprovalPolling()
+        }
+    }
+
+    // MARK: - Event Handlers
+
+    private func handleValidationChange(_: Bool, _ newValue: Bool) {
+        if newValue {
+            Task { @MainActor in
+                NSApp.keyWindow?.makeFirstResponder(nil)
+                if let window = NSApp.keyWindow, let contentView = window.contentView {
+                    disableFocusRings(in: contentView)
+                }
+            }
+        } else {
+            stateMachine.customSequence = showAllSummaryItems ? nil : navSequence
         }
     }
 }


### PR DESCRIPTION
## Summary
Decompose the two worst-offender SwiftUI view bodies identified in the Swift best practices audit.

- **SimpleModsView.body**: 231 lines → **36 lines** (84% reduction). Extracted `tabSelector`, `searchBar`, `categoryFilter`, `applyingIndicator`, `mappingsList`, `installedContent`, `availableContent`, `toastOverlay`, and 4 `onChange` handlers into named computed properties and methods.
- **InstallationWizardView.body**: 180 lines → **62 lines** (66% reduction). Extracted `statusBanner`, `pageContainer`, `navigationOverlay`, `closeConfirmationButtons`, `closeConfirmationMessage`, `loginItemsApprovalButtons`, and `handleValidationChange` into named sections.

No behavior change — pure decomposition for readability and compilation performance.

Closes #433

## Test plan
- [x] `swift build` passes
- [x] `swift test` — 530 tests pass
- [ ] Smoke test Simple Mods dialog (install/remove mappings, tab switching, search, conflict dialog)
- [ ] Smoke test Installation Wizard (page navigation, close confirmation, status banner)