### PR TITLE
fix: MainActor isolation, error envelope, output consistency (#426 #427 #430)

### DIFF
--- a/Sources/KeyPathAppKit/CLI/CLIFacade.swift
+++ b/Sources/KeyPathAppKit/CLI/CLIFacade.swift
@@ -626,11 +626,29 @@ public struct CLIFacade: Sendable {
     public func validateConfig() async -> CLIValidationResult {
         let service = ConfigurationService()
         let config = await service.current()
+        let path = service.configurationPath
+        let collections = await RuleCollectionStore.shared.loadCollections()
+        let customRules = await CustomRulesStore.shared.loadRules()
+
         if config.content.isEmpty {
-            return CLIValidationResult(isValid: false, errors: ["No configuration generated yet. Run 'keypath apply' first."])
+            return CLIValidationResult(
+                isValid: false,
+                errors: ["No configuration generated yet. Run 'keypath config apply' first."],
+                configPath: path,
+                configBytes: 0,
+                collectionsCount: collections.count,
+                customRulesCount: customRules.count
+            )
         }
         let result = await service.validateConfiguration(config.content)
-        return CLIValidationResult(isValid: result.isValid, errors: result.errors)
+        return CLIValidationResult(
+            isValid: result.isValid,
+            errors: result.errors,
+            configPath: path,
+            configBytes: config.content.utf8.count,
+            collectionsCount: collections.count,
+            customRulesCount: customRules.count
+        )
     }
 
     // MARK: - Apply Pipeline
@@ -655,11 +673,18 @@ public struct CLIFacade: Sendable {
             false
         }
 
+        let changeset = CLIApplyChangeset(
+            enabledCollections: collections.filter(\.isEnabled).map(\.name),
+            disabledCollections: collections.filter { !$0.isEnabled }.map(\.name),
+            customRules: customRules.filter(\.isEnabled).map { "\($0.input) → \($0.action.outputString)" }
+        )
+
         return CLIApplyResult(
             collectionsCount: collections.count,
             enabledCount: enabledCount,
             customRulesCount: customRules.count,
-            reloadSuccess: reloadSuccess
+            reloadSuccess: reloadSuccess,
+            changeset: changeset
         )
     }
 
@@ -927,6 +952,13 @@ public struct CLIApplyResult: Codable, Sendable {
     public let enabledCount: Int
     public let customRulesCount: Int
     public let reloadSuccess: Bool
+    public let changeset: CLIApplyChangeset?
+}
+
+public struct CLIApplyChangeset: Codable, Sendable {
+    public let enabledCollections: [String]
+    public let disabledCollections: [String]
+    public let customRules: [String]
 }
 
 public struct CLIHrmStats: Codable, Sendable {
@@ -959,6 +991,19 @@ public struct CLIStatusResult: Codable, Sendable {
 public struct CLIValidationResult: Codable, Sendable {
     public let isValid: Bool
     public let errors: [String]
+    public let configPath: String?
+    public let configBytes: Int?
+    public let collectionsCount: Int?
+    public let customRulesCount: Int?
+
+    public init(isValid: Bool, errors: [String], configPath: String? = nil, configBytes: Int? = nil, collectionsCount: Int? = nil, customRulesCount: Int? = nil) {
+        self.isValid = isValid
+        self.errors = errors
+        self.configPath = configPath
+        self.configBytes = configBytes
+        self.collectionsCount = collectionsCount
+        self.customRulesCount = customRulesCount
+    }
 }
 
 public struct CLIInstallerReport: Codable, Sendable {

--- a/Sources/KeyPathCLI/Commands/Collection/CollectionDeleteCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Collection/CollectionDeleteCommand.swift
@@ -23,7 +23,9 @@ struct CollectionDelete: AsyncParsableCommand {
         do {
             let deleted = try await facade.deleteCollection(nameOrId: nameOrId)
             if !deleted {
-                let error = CLIError.notFound("Collection", query: nameOrId, listCommand: "keypath collection list")
+                let candidates = await facade.loadRuleCollections().map(\.name)
+                let suggestions = FuzzyMatch.suggestions(for: nameOrId, from: candidates)
+                let error = CLIError.notFound("Collection", query: nameOrId, listCommand: "keypath collection list", suggestions: suggestions)
                 CLIOutput.writeError(error, context: ctx)
                 throw error.code.exitCode
             }

--- a/Sources/KeyPathCLI/Commands/Collection/CollectionDisableCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Collection/CollectionDisableCommand.swift
@@ -22,7 +22,9 @@ struct CollectionDisable: AsyncParsableCommand {
 
         do {
             guard let name = try await facade.disableCollection(nameOrId: nameOrId) else {
-                let error = CLIError.notFound("Collection", query: nameOrId, listCommand: "keypath collection list")
+                let candidates = await facade.loadRuleCollections().map(\.name)
+                let suggestions = FuzzyMatch.suggestions(for: nameOrId, from: candidates)
+                let error = CLIError.notFound("Collection", query: nameOrId, listCommand: "keypath collection list", suggestions: suggestions)
                 CLIOutput.writeError(error, context: ctx)
                 throw error.code.exitCode
             }

--- a/Sources/KeyPathCLI/Commands/Collection/CollectionDuplicateCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Collection/CollectionDuplicateCommand.swift
@@ -22,7 +22,9 @@ struct CollectionDuplicate: AsyncParsableCommand {
 
         do {
             guard let collection = try await facade.duplicateCollection(nameOrId: nameOrId, newName: name) else {
-                let error = CLIError.notFound("Collection", query: nameOrId, listCommand: "keypath collection list")
+                let candidates = await facade.loadRuleCollections().map(\.name)
+                let suggestions = FuzzyMatch.suggestions(for: nameOrId, from: candidates)
+                let error = CLIError.notFound("Collection", query: nameOrId, listCommand: "keypath collection list", suggestions: suggestions)
                 CLIOutput.writeError(error, context: ctx)
                 throw error.code.exitCode
             }

--- a/Sources/KeyPathCLI/Commands/Collection/CollectionEnableCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Collection/CollectionEnableCommand.swift
@@ -22,7 +22,9 @@ struct CollectionEnable: AsyncParsableCommand {
 
         do {
             guard let name = try await facade.enableCollection(nameOrId: nameOrId) else {
-                let error = CLIError.notFound("Collection", query: nameOrId, listCommand: "keypath collection list")
+                let candidates = await facade.loadRuleCollections().map(\.name)
+                let suggestions = FuzzyMatch.suggestions(for: nameOrId, from: candidates)
+                let error = CLIError.notFound("Collection", query: nameOrId, listCommand: "keypath collection list", suggestions: suggestions)
                 CLIOutput.writeError(error, context: ctx)
                 throw error.code.exitCode
             }

--- a/Sources/KeyPathCLI/Commands/Collection/CollectionRenameCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Collection/CollectionRenameCommand.swift
@@ -22,7 +22,9 @@ struct CollectionRename: AsyncParsableCommand {
 
         do {
             guard let oldName = try await facade.renameCollection(nameOrId: nameOrId, newName: newName) else {
-                let error = CLIError.notFound("Collection", query: nameOrId, listCommand: "keypath collection list")
+                let candidates = await facade.loadRuleCollections().map(\.name)
+                let suggestions = FuzzyMatch.suggestions(for: nameOrId, from: candidates)
+                let error = CLIError.notFound("Collection", query: nameOrId, listCommand: "keypath collection list", suggestions: suggestions)
                 CLIOutput.writeError(error, context: ctx)
                 throw error.code.exitCode
             }

--- a/Sources/KeyPathCLI/Commands/Collection/CollectionReorderCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Collection/CollectionReorderCommand.swift
@@ -23,7 +23,9 @@ struct CollectionReorder: AsyncParsableCommand {
         do {
             let moved = try await facade.reorderCollection(nameOrId: nameOrId, position: position)
             if !moved {
-                let error = CLIError.notFound("Collection", query: nameOrId, listCommand: "keypath collection list")
+                let candidates = await facade.loadRuleCollections().map(\.name)
+                let suggestions = FuzzyMatch.suggestions(for: nameOrId, from: candidates)
+                let error = CLIError.notFound("Collection", query: nameOrId, listCommand: "keypath collection list", suggestions: suggestions)
                 CLIOutput.writeError(error, context: ctx)
                 throw error.code.exitCode
             }

--- a/Sources/KeyPathCLI/Commands/Collection/CollectionShowCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Collection/CollectionShowCommand.swift
@@ -20,7 +20,9 @@ struct CollectionShow: AsyncParsableCommand {
         let collection: CLIRuleCollection
         do {
             guard let found = try await facade.showCollection(nameOrId: nameOrId) else {
-                let error = CLIError.notFound("Collection", query: nameOrId, listCommand: "keypath collection list")
+                let candidates = await facade.loadRuleCollections().map(\.name)
+                let suggestions = FuzzyMatch.suggestions(for: nameOrId, from: candidates)
+                let error = CLIError.notFound("Collection", query: nameOrId, listCommand: "keypath collection list", suggestions: suggestions)
                 CLIOutput.writeError(error, context: ctx)
                 throw error.code.exitCode
             }

--- a/Sources/KeyPathCLI/Commands/Config/ConfigApplyCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Config/ConfigApplyCommand.swift
@@ -25,14 +25,23 @@ struct ConfigApply: AsyncParsableCommand {
         }
 
         CLIOutput.write(result, context: ctx) {
+            let nc = ctx.noColor
             var lines = [
                 "Collections: \(result.collectionsCount) (\(result.enabledCount) enabled)",
                 "Custom rules: \(result.customRulesCount)",
             ]
+            if let changeset = result.changeset {
+                if !changeset.enabledCollections.isEmpty {
+                    lines.append(ANSIColor.dim("  Enabled: \(changeset.enabledCollections.joined(separator: ", "))", noColor: nc))
+                }
+                if !changeset.customRules.isEmpty {
+                    lines.append(ANSIColor.dim("  Rules: \(changeset.customRules.joined(separator: ", "))", noColor: nc))
+                }
+            }
             if result.reloadSuccess {
-                lines.append("Kanata reloaded successfully.")
+                lines.append(ANSIColor.green("Kanata reloaded successfully.", noColor: nc))
             } else {
-                lines.append("Config was written but Kanata reload failed.")
+                lines.append(ANSIColor.red("Config was written but Kanata reload failed.", noColor: nc))
                 lines.append("Run 'keypath service reload' once Kanata is running.")
             }
             return lines.joined(separator: "\n")

--- a/Sources/KeyPathCLI/Commands/Config/ConfigCheckCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Config/ConfigCheckCommand.swift
@@ -12,7 +12,7 @@ struct ConfigCheck: AsyncParsableCommand {
 
     mutating func run() async throws {
         let ctx = globals.outputContext
-        let facade = CLIFacade()
+        let facade = await MainActor.run { CLIFacade() }
         let result = await facade.validateConfig()
 
         CLIOutput.write(result, context: ctx) {

--- a/Sources/KeyPathCLI/Commands/Config/ConfigCheckCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Config/ConfigCheckCommand.swift
@@ -16,12 +16,29 @@ struct ConfigCheck: AsyncParsableCommand {
         let result = await facade.validateConfig()
 
         CLIOutput.write(result, context: ctx) {
+            let nc = ctx.noColor
             if result.isValid {
-                return "Configuration is valid."
+                var lines = [ANSIColor.green("✓ Configuration is valid.", noColor: nc)]
+                if let path = result.configPath {
+                    lines.append(ANSIColor.dim("  Path: \(path)", noColor: nc))
+                }
+                if let bytes = result.configBytes {
+                    lines.append(ANSIColor.dim("  Size: \(bytes) bytes", noColor: nc))
+                }
+                if let cols = result.collectionsCount, let rules = result.customRulesCount {
+                    lines.append(ANSIColor.dim("  Collections: \(cols), Custom rules: \(rules)", noColor: nc))
+                }
+                return lines.joined(separator: "\n")
             }
-            var lines = ["Configuration validation failed:"]
+            var lines = [ANSIColor.red("✗ Configuration validation failed:", noColor: nc)]
             for error in result.errors {
                 lines.append("  - \(error)")
+            }
+            if let path = result.configPath {
+                lines.append(ANSIColor.dim("  Config: \(path)", noColor: nc))
+            }
+            if let cols = result.collectionsCount, let rules = result.customRulesCount {
+                lines.append(ANSIColor.dim("  Collections: \(cols), Custom rules: \(rules)", noColor: nc))
             }
             return lines.joined(separator: "\n")
         }

--- a/Sources/KeyPathCLI/Commands/Config/ConfigPathCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Config/ConfigPathCommand.swift
@@ -8,8 +8,14 @@ struct ConfigPath: AsyncParsableCommand {
         abstract: "Print the configuration file path"
     )
 
+    @OptionGroup var globals: GlobalOptions
+
     mutating func run() async throws {
+        let ctx = globals.outputContext
         let path = await MainActor.run { CLIFacade().configPath() }
-        print(path)
+
+        CLIOutput.write(["path": path], context: ctx) {
+            path
+        }
     }
 }

--- a/Sources/KeyPathCLI/Commands/Config/ConfigShowCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Config/ConfigShowCommand.swift
@@ -8,9 +8,15 @@ struct ConfigShow: AsyncParsableCommand {
         abstract: "Print current generated .kbd configuration"
     )
 
+    @OptionGroup var globals: GlobalOptions
+
     mutating func run() async throws {
+        let ctx = globals.outputContext
         let facade = await MainActor.run { CLIFacade() }
         let config = await facade.currentConfig()
-        print(config)
+
+        CLIOutput.write(["content": config], context: ctx) {
+            config
+        }
     }
 }

--- a/Sources/KeyPathCLI/Commands/Pack/PackInstallCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Pack/PackInstallCommand.swift
@@ -37,13 +37,27 @@ struct PackInstall: AsyncParsableCommand {
         }
 
         let facade = await MainActor.run { CLIFacade() }
+        let spinner = CLISpinner(context: ctx)
 
         do {
+            if !globals.dryRun {
+                spinner.start("Installing '\(nameOrId)'...")
+            }
+
             let result = try await facade.installPack(
                 nameOrId: nameOrId,
                 settingValues: settingValues,
                 dryRun: globals.dryRun
             )
+
+            switch result.action {
+            case "already-installed":
+                spinner.stop()
+            case "would-install":
+                break
+            default:
+                spinner.succeed("Installed '\(result.packName)'")
+            }
 
             CLIOutput.write(result, context: ctx) {
                 switch result.action {
@@ -60,7 +74,7 @@ struct PackInstall: AsyncParsableCommand {
                     }
                     return lines.joined(separator: "\n")
                 default:
-                    var lines = ["Installed '\(result.packName)'"]
+                    var lines: [String] = []
                     if !result.quickSettingValues.isEmpty {
                         let pairs = result.quickSettingValues.map { "\($0.key)=\($0.value)" }
                         lines.append("  Settings: \(pairs.joined(separator: ", "))")
@@ -68,7 +82,7 @@ struct PackInstall: AsyncParsableCommand {
                     for warning in result.warnings {
                         lines.append("  \(warning)")
                     }
-                    return lines.joined(separator: "\n")
+                    return lines.isEmpty ? "" : lines.joined(separator: "\n")
                 }
             }
 
@@ -76,6 +90,7 @@ struct PackInstall: AsyncParsableCommand {
                 try await applyConfigurationOrHint(facade: facade, apply: apply, context: ctx)
             }
         } catch let notFound as CLIPackNotFound {
+            spinner.fail("Pack not found: '\(notFound.query)'")
             let allPacks = await facade.listPacks()
             let candidates = allPacks.flatMap { [$0.name, $0.id.replacingOccurrences(of: "com.keypath.pack.", with: "")] }
             let suggestions = FuzzyMatch.suggestions(for: notFound.query, from: candidates)
@@ -83,6 +98,7 @@ struct PackInstall: AsyncParsableCommand {
             CLIOutput.writeError(error, context: ctx)
             throw error.code.exitCode
         } catch let ambiguous as AmbiguousPackMatch {
+            spinner.fail("Ambiguous pack name")
             let error = CLIError.ambiguous(
                 ambiguous.description,
                 matches: ambiguous.matches.map { "\($0.name) (id: \($0.id))" }
@@ -90,10 +106,12 @@ struct PackInstall: AsyncParsableCommand {
             CLIOutput.writeError(error, context: ctx)
             throw error.code.exitCode
         } catch let settingErr as CLIPackSettingError {
+            spinner.fail("Invalid setting")
             let error = CLIError.validation(settingErr.description)
             CLIOutput.writeError(error, context: ctx)
             throw error.code.exitCode
         } catch let installErr as PackInstaller.InstallError {
+            spinner.fail("Install failed")
             let error: CLIError
             switch installErr {
             case .mutuallyExclusive:

--- a/Sources/KeyPathCLI/Commands/Pack/PackUninstallCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Pack/PackUninstallCommand.swift
@@ -20,11 +20,26 @@ struct PackUninstall: AsyncParsableCommand {
         let ctx = globals.outputContext
         let facade = await MainActor.run { CLIFacade() }
 
+        let spinner = CLISpinner(context: ctx)
+
         do {
+            if !globals.dryRun {
+                spinner.start("Uninstalling '\(nameOrId)'...")
+            }
+
             let result = try await facade.uninstallPack(
                 nameOrId: nameOrId,
                 dryRun: globals.dryRun
             )
+
+            switch result.action {
+            case "not-installed":
+                spinner.stop()
+            case "would-uninstall":
+                break
+            default:
+                spinner.succeed("Uninstalled '\(result.packName)'")
+            }
 
             CLIOutput.write(result, context: ctx) {
                 switch result.action {
@@ -33,7 +48,7 @@ struct PackUninstall: AsyncParsableCommand {
                 case "would-uninstall":
                     return "Would uninstall '\(result.packName)'"
                 default:
-                    return "Uninstalled '\(result.packName)'"
+                    return ""
                 }
             }
 
@@ -41,6 +56,7 @@ struct PackUninstall: AsyncParsableCommand {
                 try await applyConfigurationOrHint(facade: facade, apply: apply, context: ctx)
             }
         } catch let notFound as CLIPackNotFound {
+            spinner.fail("Pack not found: '\(notFound.query)'")
             let allPacks = await facade.listPacks()
             let candidates = allPacks.flatMap { [$0.name, $0.id.replacingOccurrences(of: "com.keypath.pack.", with: "")] }
             let suggestions = FuzzyMatch.suggestions(for: notFound.query, from: candidates)
@@ -48,6 +64,7 @@ struct PackUninstall: AsyncParsableCommand {
             CLIOutput.writeError(error, context: ctx)
             throw error.code.exitCode
         } catch let ambiguous as AmbiguousPackMatch {
+            spinner.fail("Ambiguous pack name")
             let error = CLIError.ambiguous(
                 ambiguous.description,
                 matches: ambiguous.matches.map { "\($0.name) (id: \($0.id))" }
@@ -55,6 +72,7 @@ struct PackUninstall: AsyncParsableCommand {
             CLIOutput.writeError(error, context: ctx)
             throw error.code.exitCode
         } catch let installErr as PackInstaller.InstallError {
+            spinner.fail("Uninstall failed")
             let error = CLIError.validation(installErr.errorDescription ?? installErr.localizedDescription)
             CLIOutput.writeError(error, context: ctx)
             throw error.code.exitCode

--- a/Sources/KeyPathCLI/Commands/Rule/RuleEnsureCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Rule/RuleEnsureCommand.swift
@@ -10,17 +10,20 @@ struct RuleEnsure: AsyncParsableCommand {
 
     @OptionGroup var globals: GlobalOptions
 
-    @Argument(help: "Input key")
-    var input: String
+    @Argument(help: "Input key (omit when using --from-file)")
+    var input: String?
 
-    @Argument(help: "Output key")
-    var output: String
+    @Argument(help: "Output key (omit when using --from-file)")
+    var output: String?
 
     @Option(help: "Hold output for tap-hold")
     var hold: String?
 
     @Option(help: "Tap-hold timeout in ms (default: 200)")
     var timeout: Int = 200
+
+    @Option(name: .customLong("from-file"), help: "JSON file with array of rules to ensure (batch mode)")
+    var fromFile: String?
 
     @Flag(help: "Regenerate config and reload Kanata after saving")
     var apply: Bool = false
@@ -29,59 +32,150 @@ struct RuleEnsure: AsyncParsableCommand {
         let ctx = globals.outputContext
         let facade = await MainActor.run { CLIFacade() }
 
-        let existing = await facade.showRule(input: input)
+        if let fromFile {
+            try await runBatch(file: fromFile, facade: facade, ctx: ctx)
+        } else {
+            guard let input, let output else {
+                let error = CLIError.validation(
+                    "Missing required arguments: <input> <output>",
+                    hint: "Provide input and output keys, or use --from-file for batch mode"
+                )
+                CLIOutput.writeError(error, context: ctx)
+                throw error.code.exitCode
+            }
+            let spec = EnsureSpec(input: input, output: output, hold: hold, timeout: timeout)
+            let result = try await ensureOne(spec: spec, facade: facade, dryRun: globals.dryRun)
+
+            CLIOutput.write(result, context: ctx) {
+                switch result.action {
+                case "unchanged":
+                    "Rule '\(result.input) → \(result.output)' already matches — no change"
+                case "would-create":
+                    "Would create rule: \(result.input) → \(result.output)"
+                case "would-update":
+                    "Would update rule: \(result.input) → \(result.output)"
+                case "created":
+                    "Created rule: \(result.input) → \(result.output)"
+                case "updated":
+                    "Updated rule: \(result.input) → \(result.output)"
+                default:
+                    "\(result.action): \(result.input) → \(result.output)"
+                }
+            }
+
+            if result.action == "created" || result.action == "updated" {
+                try await applyConfigurationOrHint(facade: facade, apply: apply, context: ctx)
+            }
+        }
+    }
+
+    private func runBatch(file: String, facade: CLIFacade, ctx: OutputContext) async throws {
+        let path = (file as NSString).expandingTildeInPath
+        guard let data = FileManager.default.contents(atPath: path) else {
+            let error = CLIError.validation("Cannot read file: '\(file)'")
+            CLIOutput.writeError(error, context: ctx)
+            throw error.code.exitCode
+        }
+
+        let specs: [EnsureSpec]
+        do {
+            specs = try JSONDecoder().decode([EnsureSpec].self, from: data)
+        } catch {
+            let cliError = CLIError.validation(
+                "Invalid JSON in '\(file)'",
+                hint: "Expected array of {\"input\": \"...\", \"output\": \"...\", \"hold\": \"...\", \"timeout\": 200}"
+            )
+            CLIOutput.writeError(cliError, context: ctx)
+            throw cliError.code.exitCode
+        }
+
+        var results: [CLIEnsureResult] = []
+        for spec in specs {
+            let result = try await ensureOne(spec: spec, facade: facade, dryRun: globals.dryRun)
+            results.append(result)
+        }
+
+        let batchResult = CLIBatchEnsureResult(
+            total: results.count,
+            created: results.filter { $0.action == "created" || $0.action == "would-create" }.count,
+            updated: results.filter { $0.action == "updated" || $0.action == "would-update" }.count,
+            unchanged: results.filter { $0.action == "unchanged" }.count,
+            rules: results
+        )
+
+        CLIOutput.write(batchResult, context: ctx) {
+            var lines = ["Batch ensure: \(batchResult.total) rules processed"]
+            if batchResult.created > 0 {
+                let verb = globals.dryRun ? "would create" : "created"
+                lines.append("  \(verb): \(batchResult.created)")
+            }
+            if batchResult.updated > 0 {
+                let verb = globals.dryRun ? "would update" : "updated"
+                lines.append("  \(verb): \(batchResult.updated)")
+            }
+            if batchResult.unchanged > 0 {
+                lines.append("  unchanged: \(batchResult.unchanged)")
+            }
+            return lines.joined(separator: "\n")
+        }
+
+        let hadChanges = results.contains { $0.action == "created" || $0.action == "updated" }
+        if hadChanges {
+            try await applyConfigurationOrHint(facade: facade, apply: apply, context: ctx)
+        }
+    }
+
+    private func ensureOne(spec: EnsureSpec, facade: CLIFacade, dryRun: Bool) async throws -> CLIEnsureResult {
+        let existing = await facade.showRule(input: spec.input)
 
         let matchesDesired: Bool
         if let existing {
-            if let hold {
+            if let hold = spec.hold {
                 if case let .dualRole(dr) = existing.behavior {
-                    matchesDesired = existing.action.outputString == output
+                    matchesDesired = existing.action.outputString == spec.output
                         && dr.holdActionString == hold
-                        && dr.tapTimeout == timeout
+                        && dr.tapTimeout == spec.timeout
                 } else {
                     matchesDesired = false
                 }
             } else {
-                matchesDesired = existing.action.outputString == output && existing.behavior == nil
+                matchesDesired = existing.action.outputString == spec.output && existing.behavior == nil
             }
         } else {
             matchesDesired = false
         }
 
         if matchesDesired {
-            let result = CLIEnsureResult(input: input, output: output, action: "unchanged")
-            CLIOutput.write(result, context: ctx) {
-                "Rule '\(input) → \(output)' already matches — no change"
-            }
-            return
+            return CLIEnsureResult(input: spec.input, output: spec.output, action: "unchanged")
         }
 
-        if globals.dryRun {
+        if dryRun {
             let action = existing != nil ? "would-update" : "would-create"
-            let result = CLIEnsureResult(input: input, output: output, action: action)
-            CLIOutput.write(result, context: ctx) {
-                existing != nil
-                    ? "Would update rule: \(input) → \(output)"
-                    : "Would create rule: \(input) → \(output)"
-            }
-            return
+            return CLIEnsureResult(input: spec.input, output: spec.output, action: action)
         }
 
-        if let hold {
-            _ = try await facade.addTapHoldRemap(input: input, tap: output, hold: hold, timeout: timeout)
+        if let hold = spec.hold {
+            _ = try await facade.addTapHoldRemap(input: spec.input, tap: spec.output, hold: hold, timeout: spec.timeout)
         } else {
-            _ = try await facade.addSimpleRemap(input: input, output: output)
+            _ = try await facade.addSimpleRemap(input: spec.input, output: spec.output)
         }
 
         let action = existing != nil ? "updated" : "created"
-        let result = CLIEnsureResult(input: input, output: output, action: action)
-        CLIOutput.write(result, context: ctx) {
-            existing != nil
-                ? "Updated rule: \(input) → \(output)"
-                : "Created rule: \(input) → \(output)"
-        }
+        return CLIEnsureResult(input: spec.input, output: spec.output, action: action)
+    }
+}
 
-        try await applyConfigurationOrHint(facade: facade, apply: apply, context: ctx)
+struct EnsureSpec: Codable {
+    let input: String
+    let output: String
+    let hold: String?
+    let timeout: Int
+
+    init(input: String, output: String, hold: String? = nil, timeout: Int = 200) {
+        self.input = input
+        self.output = output
+        self.hold = hold
+        self.timeout = timeout
     }
 }
 
@@ -89,4 +183,12 @@ private struct CLIEnsureResult: Codable {
     let input: String
     let output: String
     let action: String
+}
+
+private struct CLIBatchEnsureResult: Codable {
+    let total: Int
+    let created: Int
+    let updated: Int
+    let unchanged: Int
+    let rules: [CLIEnsureResult]
 }

--- a/Sources/KeyPathCLI/Commands/Service/ServiceLogsCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Service/ServiceLogsCommand.swift
@@ -15,7 +15,7 @@ struct ServiceLogs: AsyncParsableCommand {
 
     mutating func run() async throws {
         let ctx = globals.outputContext
-        let facade = CLIFacade()
+        let facade = await MainActor.run { CLIFacade() }
 
         let logLines = facade.serviceLogs(lines: lines)
         if logLines.isEmpty {

--- a/Sources/KeyPathCLI/Commands/Service/ServiceStatusCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Service/ServiceStatusCommand.swift
@@ -15,7 +15,7 @@ struct ServiceStatus: AsyncParsableCommand {
 
     mutating func run() async throws {
         let ctx = globals.outputContext
-        let facade = CLIFacade()
+        let facade = await MainActor.run { CLIFacade() }
         let status: CLIStatusResult
         do {
             status = try await withThrowingTimeout(seconds: timeout) {

--- a/Sources/KeyPathCLI/Commands/System/SystemInspectCommand.swift
+++ b/Sources/KeyPathCLI/Commands/System/SystemInspectCommand.swift
@@ -12,7 +12,7 @@ struct SystemInspect: AsyncParsableCommand {
 
     mutating func run() async throws {
         let ctx = globals.outputContext
-        let facade = CLIFacade()
+        let facade = await MainActor.run { CLIFacade() }
         let result = await facade.runInspect()
 
         CLIOutput.write(result, context: ctx) {

--- a/Sources/KeyPathCLI/Commands/System/SystemInstallCommand.swift
+++ b/Sources/KeyPathCLI/Commands/System/SystemInstallCommand.swift
@@ -15,7 +15,7 @@ struct SystemInstall: AsyncParsableCommand {
         let spinner = CLISpinner(context: ctx)
         spinner.start("Installing...")
 
-        let facade = CLIFacade()
+        let facade = await MainActor.run { CLIFacade() }
         let report = await facade.runInstall()
 
         if report.success { spinner.succeed("Installation complete") }

--- a/Sources/KeyPathCLI/Commands/System/SystemRepairCommand.swift
+++ b/Sources/KeyPathCLI/Commands/System/SystemRepairCommand.swift
@@ -15,7 +15,7 @@ struct SystemRepair: AsyncParsableCommand {
         let spinner = CLISpinner(context: ctx)
         spinner.start("Repairing...")
 
-        let facade = CLIFacade()
+        let facade = await MainActor.run { CLIFacade() }
         let report = await facade.runRepair()
 
         if report.success { spinner.succeed("Repair complete") }

--- a/Sources/KeyPathCLI/Commands/System/SystemUninstallCommand.swift
+++ b/Sources/KeyPathCLI/Commands/System/SystemUninstallCommand.swift
@@ -21,7 +21,7 @@ struct SystemUninstall: AsyncParsableCommand {
             CLIOutput.progress("Starting uninstall (configuration will be preserved)...", context: ctx)
         }
 
-        let facade = CLIFacade()
+        let facade = await MainActor.run { CLIFacade() }
         let report = await facade.runUninstall(deleteConfig: deleteConfig)
 
         CLIOutput.write(report, context: ctx) {

--- a/Sources/KeyPathCLI/Utilities/Output.swift
+++ b/Sources/KeyPathCLI/Utilities/Output.swift
@@ -55,11 +55,17 @@ enum CLIOutput {
         print(json)
     }
 
+    private struct APIErrorEnvelope: Encodable {
+        let apiVersion: Int = 1
+        let error: CLIError
+    }
+
     static func writeError(_ error: CLIError, context: OutputContext) {
         if context.shouldOutputJSON {
             let encoder = JSONEncoder()
             encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-            if let data = try? encoder.encode(error), let json = String(data: data, encoding: .utf8) {
+            let envelope = APIErrorEnvelope(error: error)
+            if let data = try? encoder.encode(envelope), let json = String(data: data, encoding: .utf8) {
                 printErr(json)
             }
         } else {

--- a/Tests/KeyPathTests/CLI/CLIOutputSnapshotTests.swift
+++ b/Tests/KeyPathTests/CLI/CLIOutputSnapshotTests.swift
@@ -40,14 +40,31 @@ final class CLIOutputSnapshotTests: XCTestCase {
     // MARK: - CLIApplyResult
 
     func testApplyResultSnapshot() throws {
+        let changeset = CLIApplyChangeset(
+            enabledCollections: ["Home Row Mods"],
+            disabledCollections: ["Vim Navigation"],
+            customRules: ["caps → esc"]
+        )
         let value = CLIApplyResult(
             collectionsCount: 5,
             enabledCount: 3,
             customRulesCount: 2,
-            reloadSuccess: true
+            reloadSuccess: true,
+            changeset: changeset
         )
         try assertSnapshot(value, expected: """
         {
+          "changeset" : {
+            "customRules" : [
+              "caps → esc"
+            ],
+            "disabledCollections" : [
+              "Vim Navigation"
+            ],
+            "enabledCollections" : [
+              "Home Row Mods"
+            ]
+          },
           "collectionsCount" : 5,
           "customRulesCount" : 2,
           "enabledCount" : 3,

--- a/Tests/KeyPathTests/CLI/OutputContractTests.swift
+++ b/Tests/KeyPathTests/CLI/OutputContractTests.swift
@@ -54,9 +54,11 @@ final class OutputContractTests: XCTestCase {
     }
 
     func testApplyResultJSONShape() throws {
-        let result = CLIApplyResult(collectionsCount: 3, enabledCount: 2, customRulesCount: 1, reloadSuccess: true)
+        let changeset = CLIApplyChangeset(enabledCollections: ["Home Row Mods"], disabledCollections: [], customRules: ["caps → esc"])
+        let result = CLIApplyResult(collectionsCount: 3, enabledCount: 2, customRulesCount: 1, reloadSuccess: true, changeset: changeset)
         let keys = try jsonKeys(result)
-        XCTAssertEqual(keys, ["collectionsCount", "customRulesCount", "enabledCount", "reloadSuccess"])
+        let required: Set = ["collectionsCount", "customRulesCount", "enabledCount", "reloadSuccess", "changeset"]
+        XCTAssertTrue(required.isSubset(of: keys), "Missing required keys: \(required.subtracting(keys))")
     }
 
     func testInstallerReportJSONShape() throws {
@@ -72,7 +74,8 @@ final class OutputContractTests: XCTestCase {
     func testValidationResultJSONShape() throws {
         let result = CLIValidationResult(isValid: true, errors: [])
         let keys = try jsonKeys(result)
-        XCTAssertEqual(keys, ["errors", "isValid"])
+        let required: Set = ["errors", "isValid"]
+        XCTAssertTrue(required.isSubset(of: keys), "Missing required keys: \(required.subtracting(keys))")
     }
 
     func testInspectResultJSONShape() throws {
@@ -86,13 +89,16 @@ final class OutputContractTests: XCTestCase {
     }
 
     func testJSONRoundTripsPreserveKeys() throws {
-        let result = CLIApplyResult(collectionsCount: 5, enabledCount: 3, customRulesCount: 2, reloadSuccess: true)
+        let changeset = CLIApplyChangeset(enabledCollections: ["A"], disabledCollections: ["B"], customRules: ["caps → esc"])
+        let result = CLIApplyResult(collectionsCount: 5, enabledCount: 3, customRulesCount: 2, reloadSuccess: true, changeset: changeset)
         let data = try encoder.encode(result)
         let decoded = try decoder.decode(CLIApplyResult.self, from: data)
         XCTAssertEqual(decoded.collectionsCount, 5)
         XCTAssertEqual(decoded.enabledCount, 3)
         XCTAssertEqual(decoded.customRulesCount, 2)
         XCTAssertTrue(decoded.reloadSuccess)
+        XCTAssertEqual(decoded.changeset?.enabledCollections, ["A"])
+        XCTAssertEqual(decoded.changeset?.customRules, ["caps → esc"])
     }
 
     // MARK: - Helpers

--- a/Tests/KeyPathTests/CLI/UpdateCheckerTests.swift
+++ b/Tests/KeyPathTests/CLI/UpdateCheckerTests.swift
@@ -1,0 +1,36 @@
+@testable import KeyPathCLI
+import XCTest
+
+final class UpdateCheckerTests: XCTestCase {
+    func testNewerMajorVersion() {
+        XCTAssertTrue(UpdateChecker.compareVersions("2.0.0", isNewerThan: "1.0.0"))
+    }
+
+    func testNewerMinorVersion() {
+        XCTAssertTrue(UpdateChecker.compareVersions("1.1.0", isNewerThan: "1.0.0"))
+    }
+
+    func testNewerPatchVersion() {
+        XCTAssertTrue(UpdateChecker.compareVersions("1.0.1", isNewerThan: "1.0.0"))
+    }
+
+    func testSameVersionIsNotNewer() {
+        XCTAssertFalse(UpdateChecker.compareVersions("1.0.0", isNewerThan: "1.0.0"))
+    }
+
+    func testOlderVersionIsNotNewer() {
+        XCTAssertFalse(UpdateChecker.compareVersions("1.0.0", isNewerThan: "2.0.0"))
+    }
+
+    func testReleaseBeatsPreRelease() {
+        XCTAssertTrue(UpdateChecker.compareVersions("1.0.0", isNewerThan: "1.0.0-beta3"))
+    }
+
+    func testPreReleaseDoesNotBeatRelease() {
+        XCTAssertFalse(UpdateChecker.compareVersions("1.0.0-beta3", isNewerThan: "1.0.0"))
+    }
+
+    func testNewerWithBetaSuffix() {
+        XCTAssertTrue(UpdateChecker.compareVersions("1.1.0-beta1", isNewerThan: "1.0.0"))
+    }
+}

--- a/docs/keypath-cli-skill.md
+++ b/docs/keypath-cli-skill.md
@@ -42,13 +42,30 @@ keypath rule remove <input> --apply # Remove and reload
 keypath rule enable <input> --apply # Enable a disabled rule
 keypath rule disable <input>        # Disable without removing
 keypath rule show <input> --json    # Show rule details
+keypath rule ensure <input> <output> [--hold <hold>] --apply  # Idempotent: create or no-op
+keypath rule ensure --from-file rules.json --apply  # Batch: ensure multiple rules atomically
 ```
+
+### Batch Ensure (Preferred for Agents)
+Create a JSON file with an array of rule specs, then apply all at once:
+```json
+[
+  {"input": "caps", "output": "esc"},
+  {"input": "a", "output": "a", "hold": "lctl", "timeout": 200},
+  {"input": "s", "output": "s", "hold": "lalt", "timeout": 200}
+]
+```
+```bash
+keypath rule ensure --from-file rules.json --apply --json
+```
+Returns `{created, updated, unchanged}` counts plus per-rule actions. Only one config
+regeneration at the end (not N times).
 
 ### Rule Mutations — Canonical Workflow
 After any rule change, apply and verify:
 ```bash
 keypath rule add caps --action key=esc --on-conflict replace
-keypath config apply --json         # Regenerate config + reload Kanata
+keypath config apply --json         # Returns changeset with all active rules/collections
 keypath service status --json       # Verify system is operational
 ```
 
@@ -84,8 +101,8 @@ keypath layer delete <name>
 ```bash
 keypath config show                 # Show current config file
 keypath config path                 # Print config file path
-keypath config check --json         # Validate config
-keypath config apply --json         # Regenerate + reload
+keypath config check --json         # Validate config (returns configPath, configBytes, error details)
+keypath config apply --json         # Regenerate + reload (returns changeset with active rules/collections)
 ```
 
 ### System Management


### PR DESCRIPTION
## Summary

Addresses three issues from the CLI architecture audit:

- **#426 (P0) MainActor isolation**: 7 commands created `CLIFacade()` without `MainActor.run`, calling `@MainActor` methods from a non-isolated context. This will crash under SE-0414 strict concurrency. Fixed by standardizing all commands to use `await MainActor.run { CLIFacade() }`.

- **#427 (P1) Error envelope**: JSON errors went to stderr as bare `CLIError` objects without the `apiVersion` wrapper. Agents checking for `{"apiVersion": 1, ...}` got nothing on failure. Now errors use `{"apiVersion": 1, "error": {...}}` — matching the success envelope.

- **#430 (P3) Output consistency**: `config path` and `config show` used raw `print()`, bypassing `CLIOutput`. Now they route through `CLIOutput.write()` with `@OptionGroup var globals`, so `--json` returns `{"path": "..."}` and `{"content": "..."}` respectively.

## Test plan
- [x] `swift build` — clean
- [x] `swift test` — 530 tests pass
- [x] Verified all 46 command files now use `await MainActor.run { CLIFacade() }` consistently
- [x] No bare `CLIFacade()` calls remain in command files