### PR TITLE
CLI quality batch: MainActor, output routing, timeout, error envelope, smoke tests, facade split

### DIFF
--- a/Sources/KeyPathAppKit/CLI/CLIFacade+Collections.swift
+++ b/Sources/KeyPathAppKit/CLI/CLIFacade+Collections.swift
@@ -1,0 +1,122 @@
+import Foundation
+import KeyPathCore
+
+// MARK: - Rule Collections
+
+extension CLIFacade {
+    public func loadRuleCollections() async -> [CLIRuleCollection] {
+        let collections = await RuleCollectionStore.shared.loadCollections()
+        return collections.map { CLIRuleCollection(from: $0) }
+    }
+
+    public func enableCollection(nameOrId: String) async throws -> String? {
+        var collections = await RuleCollectionStore.shared.loadCollections()
+        guard let index = try resolveCollectionIndex(nameOrId: nameOrId, in: collections) else {
+            return nil
+        }
+        if let owner = await InstalledPackTracker.shared.packManagingCollection(collections[index].id) {
+            throw PackManagedCollectionError(
+                collectionName: collections[index].name,
+                packName: owner.packName,
+                packID: owner.packID
+            )
+        }
+        collections[index].isEnabled = true
+        try await RuleCollectionStore.shared.saveCollections(collections)
+        return collections[index].name
+    }
+
+    public func disableCollection(nameOrId: String) async throws -> String? {
+        var collections = await RuleCollectionStore.shared.loadCollections()
+        guard let index = try resolveCollectionIndex(nameOrId: nameOrId, in: collections) else {
+            return nil
+        }
+        if let owner = await InstalledPackTracker.shared.packManagingCollection(collections[index].id) {
+            throw PackManagedCollectionError(
+                collectionName: collections[index].name,
+                packName: owner.packName,
+                packID: owner.packID
+            )
+        }
+        collections[index].isEnabled = false
+        try await RuleCollectionStore.shared.saveCollections(collections)
+        return collections[index].name
+    }
+
+    public func showCollection(nameOrId: String) async throws -> CLIRuleCollection? {
+        let collections = await RuleCollectionStore.shared.loadCollections()
+        guard let index = try resolveCollectionIndex(nameOrId: nameOrId, in: collections) else {
+            return nil
+        }
+        return CLIRuleCollection(from: collections[index])
+    }
+
+    public func createCollection(name: String, category: String?, summary: String?) async throws -> CLIRuleCollection {
+        var collections = await RuleCollectionStore.shared.loadCollections()
+        let cat: RuleCollectionCategory = if let category {
+            RuleCollectionCategory(rawValue: category) ?? .custom
+        } else {
+            .custom
+        }
+        let collection = RuleCollection(
+            name: name,
+            summary: summary ?? "",
+            category: cat,
+            mappings: []
+        )
+        collections.append(collection)
+        try await RuleCollectionStore.shared.saveCollections(collections)
+        return CLIRuleCollection(from: collection)
+    }
+
+    public func renameCollection(nameOrId: String, newName: String) async throws -> String? {
+        var collections = await RuleCollectionStore.shared.loadCollections()
+        guard let index = try resolveCollectionIndex(nameOrId: nameOrId, in: collections) else {
+            return nil
+        }
+        let oldName = collections[index].name
+        collections[index].name = newName
+        try await RuleCollectionStore.shared.saveCollections(collections)
+        return oldName
+    }
+
+    public func deleteCollection(nameOrId: String) async throws -> Bool {
+        var collections = await RuleCollectionStore.shared.loadCollections()
+        guard let index = try resolveCollectionIndex(nameOrId: nameOrId, in: collections) else {
+            return false
+        }
+        collections.remove(at: index)
+        try await RuleCollectionStore.shared.saveCollections(collections)
+        return true
+    }
+
+    public func duplicateCollection(nameOrId: String, newName: String?) async throws -> CLIRuleCollection? {
+        var collections = await RuleCollectionStore.shared.loadCollections()
+        guard let index = try resolveCollectionIndex(nameOrId: nameOrId, in: collections) else {
+            return nil
+        }
+        var duplicate = collections[index]
+        duplicate = RuleCollection(
+            name: newName ?? "\(duplicate.name) (Copy)",
+            summary: duplicate.summary,
+            category: duplicate.category,
+            mappings: duplicate.mappings,
+            isEnabled: false
+        )
+        collections.insert(duplicate, at: index + 1)
+        try await RuleCollectionStore.shared.saveCollections(collections)
+        return CLIRuleCollection(from: duplicate)
+    }
+
+    public func reorderCollection(nameOrId: String, position: Int) async throws -> Bool {
+        var collections = await RuleCollectionStore.shared.loadCollections()
+        guard let index = try resolveCollectionIndex(nameOrId: nameOrId, in: collections) else {
+            return false
+        }
+        let collection = collections.remove(at: index)
+        let targetIndex = min(max(0, position), collections.count)
+        collections.insert(collection, at: targetIndex)
+        try await RuleCollectionStore.shared.saveCollections(collections)
+        return true
+    }
+}

--- a/Sources/KeyPathAppKit/CLI/CLIFacade+Packs.swift
+++ b/Sources/KeyPathAppKit/CLI/CLIFacade+Packs.swift
@@ -1,0 +1,278 @@
+import Foundation
+import KeyPathCore
+
+// MARK: - Pack Management
+
+extension CLIFacade {
+    public func listPacks() async -> [CLIPack] {
+        let allPacks = PackRegistry.starterKit
+        let installed = await InstalledPackTracker.shared.allInstalled()
+        let installedMap = Dictionary(uniqueKeysWithValues: installed.map { ($0.packID, $0) })
+
+        return allPacks.map { pack in
+            let record = installedMap[pack.id]
+            return CLIPack(
+                id: pack.id,
+                name: pack.name,
+                version: pack.version,
+                category: pack.category,
+                tagline: pack.tagline,
+                isInstalled: record != nil,
+                installedAt: record?.installedAt
+            )
+        }
+    }
+
+    public func showPack(nameOrId: String) async throws -> CLIPackDetail? {
+        guard let pack = try resolvePack(nameOrId: nameOrId) else { return nil }
+        let record = await InstalledPackTracker.shared.record(for: pack.id)
+        return CLIPackDetail(from: pack, record: record)
+    }
+
+    @MainActor
+    public func installPack(
+        nameOrId: String,
+        settingValues: [String: Int] = [:],
+        dryRun: Bool = false
+    ) async throws -> CLIPackInstallResult {
+        guard let pack = try resolvePack(nameOrId: nameOrId) else {
+            throw CLIPackNotFound(query: nameOrId)
+        }
+
+        let isAlready = await InstalledPackTracker.shared.isInstalled(packID: pack.id)
+        if isAlready {
+            return CLIPackInstallResult(
+                packID: pack.id,
+                packName: pack.name,
+                action: "already-installed",
+                warnings: [],
+                quickSettingValues: [:]
+            )
+        }
+
+        for key in settingValues.keys {
+            guard pack.quickSettings.contains(where: { $0.id == key }) else {
+                throw CLIPackSettingError(
+                    packName: pack.name,
+                    settingKey: key,
+                    validKeys: pack.quickSettings.map(\.id)
+                )
+            }
+        }
+
+        if dryRun {
+            var warnings: [String] = []
+            let installedIDs = Set(await InstalledPackTracker.shared.allInstalled().map(\.packID))
+            let suggestions = PackDependencyChecker.suggestions(for: pack.id, installedPackIDs: installedIDs)
+            for dep in suggestions {
+                let depName = PackRegistry.pack(id: dep.packID)?.name ?? dep.packID
+                warnings.append("Enhanced by '\(depName)' — install it for best results")
+            }
+            return CLIPackInstallResult(
+                packID: pack.id,
+                packName: pack.name,
+                action: "would-install",
+                warnings: warnings,
+                quickSettingValues: settingValues
+            )
+        }
+
+        let manager = await makePackManager()
+        let record = try await PackInstaller.shared.install(
+            pack,
+            quickSettingValues: settingValues,
+            manager: manager
+        )
+
+        var warnings: [String] = []
+        let installedIDs = Set(await InstalledPackTracker.shared.allInstalled().map(\.packID))
+        let suggestions = PackDependencyChecker.suggestions(for: pack.id, installedPackIDs: installedIDs)
+        for dep in suggestions {
+            let depName = PackRegistry.pack(id: dep.packID)?.name ?? dep.packID
+            warnings.append("Enhanced by '\(depName)' — install it for best results")
+        }
+
+        return CLIPackInstallResult(
+            packID: pack.id,
+            packName: pack.name,
+            action: "installed",
+            warnings: warnings,
+            quickSettingValues: record.quickSettingValues
+        )
+    }
+
+    @MainActor
+    public func uninstallPack(
+        nameOrId: String,
+        dryRun: Bool = false
+    ) async throws -> CLIPackInstallResult {
+        guard let pack = try resolvePack(nameOrId: nameOrId) else {
+            throw CLIPackNotFound(query: nameOrId)
+        }
+
+        let isInstalled = await InstalledPackTracker.shared.isInstalled(packID: pack.id)
+        guard isInstalled else {
+            return CLIPackInstallResult(
+                packID: pack.id,
+                packName: pack.name,
+                action: "not-installed",
+                warnings: [],
+                quickSettingValues: [:]
+            )
+        }
+
+        if dryRun {
+            return CLIPackInstallResult(
+                packID: pack.id,
+                packName: pack.name,
+                action: "would-uninstall",
+                warnings: [],
+                quickSettingValues: [:]
+            )
+        }
+
+        let manager = await makePackManager()
+        try await PackInstaller.shared.uninstall(packID: pack.id, manager: manager)
+
+        return CLIPackInstallResult(
+            packID: pack.id,
+            packName: pack.name,
+            action: "uninstalled",
+            warnings: [],
+            quickSettingValues: [:]
+        )
+    }
+
+    @MainActor
+    public func configurePack(
+        nameOrId: String,
+        settingValues: [String: Int],
+        dryRun: Bool = false
+    ) async throws -> CLIPackInstallResult {
+        guard let pack = try resolvePack(nameOrId: nameOrId) else {
+            throw CLIPackNotFound(query: nameOrId)
+        }
+
+        let isInstalled = await InstalledPackTracker.shared.isInstalled(packID: pack.id)
+        guard isInstalled else {
+            return CLIPackInstallResult(
+                packID: pack.id,
+                packName: pack.name,
+                action: "not-installed",
+                warnings: ["Pack must be installed before configuring settings."],
+                quickSettingValues: [:]
+            )
+        }
+
+        guard !pack.quickSettings.isEmpty else {
+            throw CLIPackSettingError(
+                packName: pack.name,
+                settingKey: settingValues.keys.first ?? "",
+                validKeys: []
+            )
+        }
+
+        for key in settingValues.keys {
+            guard pack.quickSettings.contains(where: { $0.id == key }) else {
+                throw CLIPackSettingError(
+                    packName: pack.name,
+                    settingKey: key,
+                    validKeys: pack.quickSettings.map(\.id)
+                )
+            }
+        }
+
+        if dryRun {
+            let current = await PackInstaller.shared.quickSettings(for: pack.id)
+            var merged = current
+            for (k, v) in settingValues { merged[k] = v }
+            return CLIPackInstallResult(
+                packID: pack.id,
+                packName: pack.name,
+                action: "would-configure",
+                warnings: [],
+                quickSettingValues: merged
+            )
+        }
+
+        let manager = await makePackManager()
+        try await PackInstaller.shared.updateQuickSettings(
+            packID: pack.id,
+            newValues: settingValues,
+            manager: manager
+        )
+
+        let updatedSettings = await PackInstaller.shared.quickSettings(for: pack.id)
+
+        return CLIPackInstallResult(
+            packID: pack.id,
+            packName: pack.name,
+            action: "configured",
+            warnings: [],
+            quickSettingValues: updatedSettings
+        )
+    }
+
+    func resolvePack(nameOrId: String) throws -> Pack? {
+        let allPacks = PackRegistry.starterKit
+
+        if let pack = allPacks.first(where: { $0.id == nameOrId }) {
+            return pack
+        }
+
+        let prefix = "com.keypath.pack."
+        let slugMatches = allPacks.filter { pack in
+            guard pack.id.hasPrefix(prefix) else { return false }
+            let slug = String(pack.id.dropFirst(prefix.count))
+            return slug.caseInsensitiveCompare(nameOrId) == .orderedSame
+        }
+        if slugMatches.count == 1 { return slugMatches[0] }
+        if slugMatches.count > 1 {
+            throw AmbiguousPackMatch(
+                query: nameOrId,
+                matches: slugMatches.map { .init(name: $0.name, id: $0.id) },
+                hint: "Multiple packs match this slug. Use the full ID to disambiguate."
+            )
+        }
+
+        let exactMatches = allPacks.filter {
+            $0.name.caseInsensitiveCompare(nameOrId) == .orderedSame
+        }
+        if exactMatches.count == 1 { return exactMatches[0] }
+        if exactMatches.count > 1 {
+            throw AmbiguousPackMatch(
+                query: nameOrId,
+                matches: exactMatches.map { .init(name: $0.name, id: $0.id) },
+                hint: "Multiple packs share this name. Use the ID to disambiguate."
+            )
+        }
+
+        let substringMatches = allPacks.filter {
+            $0.name.localizedCaseInsensitiveContains(nameOrId)
+        }
+        if substringMatches.count == 1 { return substringMatches[0] }
+        if substringMatches.count > 1 {
+            throw AmbiguousPackMatch(
+                query: nameOrId,
+                matches: substringMatches.map { .init(name: $0.name, id: $0.id) }
+            )
+        }
+
+        return nil
+    }
+
+    @MainActor
+    func makePackManager() async -> RuleCollectionsManager {
+        let configService = ConfigurationService()
+        let manager = RuleCollectionsManager(
+            ruleCollectionStore: .shared,
+            customRulesStore: .shared,
+            configurationService: configService
+        )
+        let collections = await RuleCollectionStore.shared.loadCollections()
+        let customRules = await CustomRulesStore.shared.loadRules()
+        manager.ruleCollections = RuleCollectionDeduplicator.dedupe(collections)
+        manager.customRules = customRules
+        return manager
+    }
+}

--- a/Sources/KeyPathAppKit/CLI/CLIFacade+Rules.swift
+++ b/Sources/KeyPathAppKit/CLI/CLIFacade+Rules.swift
@@ -1,0 +1,211 @@
+import Foundation
+import KeyPathCore
+
+// MARK: - Custom Rules
+
+extension CLIFacade {
+    public func loadCustomRules() async -> [CLICustomRule] {
+        let rules = await CustomRulesStore.shared.loadRules()
+        return rules.map { CLICustomRule(input: $0.input, output: $0.action.outputString, behavior: $0.behavior.map(Self.describeBehavior)) }
+    }
+
+    static func describeBehavior(_ behavior: MappingBehavior) -> String {
+        switch behavior {
+        case let .dualRole(d):
+            "tap-hold: tap=\(d.tapActionString), hold=\(d.holdActionString), timeout=\(d.tapTimeout)ms"
+        case .tapOrTapDance(.tap):
+            "tap"
+        case let .tapOrTapDance(.tapDance(td)):
+            "tap-dance: \(td.steps.map(\.actionString).joined(separator: ", "))"
+        case let .macro(m):
+            "macro: \(m.text ?? m.outputs.joined(separator: " "))"
+        case let .chord(c):
+            "chord: \(c.keys.joined(separator: "+")) → \(c.outputString)"
+        }
+    }
+
+    @discardableResult
+    public func addSimpleRemap(input: String, output: String) async throws -> Bool {
+        var rules = await CustomRulesStore.shared.loadRules()
+        let hadExisting = rules.contains { $0.input == input }
+        rules.removeAll { $0.input == input }
+        let rule = CustomRule(input: input, action: .keystroke(key: output))
+        rules.append(rule)
+        try await CustomRulesStore.shared.saveRules(rules)
+        return hadExisting
+    }
+
+    @discardableResult
+    public func addTapHoldRemap(input: String, tap: String, hold: String, timeout: Int = 200) async throws -> Bool {
+        var rules = await CustomRulesStore.shared.loadRules()
+        let hadExisting = rules.contains { $0.input == input }
+        rules.removeAll { $0.input == input }
+        let rule = CustomRule(
+            input: input,
+            action: .keystroke(key: tap),
+            behavior: .dualRole(DualRoleBehavior(
+                tapAction: .keystroke(key: tap),
+                holdAction: .keystroke(key: hold),
+                tapTimeout: timeout
+            ))
+        )
+        rules.append(rule)
+        try await CustomRulesStore.shared.saveRules(rules)
+        return hadExisting
+    }
+
+    public func addRule(
+        input: String,
+        action: KeyAction,
+        behavior: MappingBehavior? = nil,
+        shiftedOutput: String? = nil,
+        title: String? = nil,
+        notes: String? = nil,
+        targetLayer: String? = nil,
+        deviceOverrides: [DeviceKeyOverride]? = nil,
+        onConflict: CLIConflictStrategy = .fail
+    ) async throws -> RuleAddResult {
+        var rules = await CustomRulesStore.shared.loadRules()
+        let existingIndex = rules.firstIndex(where: { $0.input == input })
+
+        if let existingIndex {
+            switch onConflict {
+            case .fail:
+                throw CLIConflictError(input: input)
+            case .skip:
+                return .skipped
+            case .replace:
+                rules.removeAll { $0.input == input }
+            case .merge:
+                let existing = rules[existingIndex]
+                let merged = try Self.mergeRules(existing: existing, newAction: action, newBehavior: behavior)
+                rules[existingIndex] = merged
+                try await CustomRulesStore.shared.saveRules(rules)
+                return .merged(CLIRuleDetail(from: merged))
+            }
+        }
+
+        let layer: RuleCollectionLayer = if let targetLayer {
+            Self.parseLayer(targetLayer)
+        } else {
+            .base
+        }
+
+        let rule = CustomRule(
+            title: title ?? "",
+            input: input,
+            action: action,
+            shiftedOutput: shiftedOutput,
+            notes: notes,
+            behavior: behavior,
+            targetLayer: layer,
+            deviceOverrides: deviceOverrides
+        )
+        rules.append(rule)
+        try await CustomRulesStore.shared.saveRules(rules)
+
+        let detail = CLIRuleDetail(from: rule)
+        return existingIndex != nil ? .replaced(detail) : .created(detail)
+    }
+
+    public func listRules(enabledOnly: Bool = false) async -> [CLIRuleDetail] {
+        let rules = await CustomRulesStore.shared.loadRules()
+        let filtered = enabledOnly ? rules.filter(\.isEnabled) : rules
+        return filtered.map { CLIRuleDetail(from: $0) }
+    }
+
+    public func showRule(input: String) async -> CLIRuleDetail? {
+        let rules = await CustomRulesStore.shared.loadRules()
+        guard let rule = rules.first(where: { $0.input == input }) else { return nil }
+        return CLIRuleDetail(from: rule)
+    }
+
+    public func removeRemap(input: String) async throws -> Bool {
+        var rules = await CustomRulesStore.shared.loadRules()
+        let before = rules.count
+        rules.removeAll { $0.input == input }
+        if rules.count == before { return false }
+        try await CustomRulesStore.shared.saveRules(rules)
+        return true
+    }
+
+    public func enableRule(input: String) async throws -> String? {
+        var rules = await CustomRulesStore.shared.loadRules()
+        guard let index = rules.firstIndex(where: { $0.input.caseInsensitiveCompare(input) == .orderedSame }) else {
+            return nil
+        }
+        rules[index].isEnabled = true
+        try await CustomRulesStore.shared.saveRules(rules)
+        return rules[index].displayTitle
+    }
+
+    public func disableRule(input: String) async throws -> String? {
+        var rules = await CustomRulesStore.shared.loadRules()
+        guard let index = rules.firstIndex(where: { $0.input.caseInsensitiveCompare(input) == .orderedSame }) else {
+            return nil
+        }
+        rules[index].isEnabled = false
+        try await CustomRulesStore.shared.saveRules(rules)
+        return rules[index].displayTitle
+    }
+
+    static func parseLayer(_ name: String) -> RuleCollectionLayer {
+        switch name.lowercased() {
+        case "base": .base
+        case "nav", "navigation": .navigation
+        default: .custom(name)
+        }
+    }
+
+    static func mergeRules(existing: CustomRule, newAction: KeyAction, newBehavior: MappingBehavior?) throws -> CustomRule {
+        let existingIsSimple = existing.behavior == nil
+        let newIsSimple = newBehavior == nil
+
+        if existingIsSimple && newIsSimple {
+            throw CLIMergeError(
+                input: existing.input,
+                reason: "both rules are simple remaps with different outputs — ambiguous"
+            )
+        }
+
+        var merged = existing
+
+        if existingIsSimple, case let .dualRole(newDual) = newBehavior {
+            merged.behavior = .dualRole(DualRoleBehavior(
+                tapAction: existing.action,
+                holdAction: newDual.holdAction,
+                tapTimeout: newDual.tapTimeout,
+                holdTimeout: newDual.holdTimeout,
+                activateHoldOnOtherKey: newDual.activateHoldOnOtherKey
+            ))
+            merged.action = existing.action
+            return merged
+        }
+
+        if case .dualRole(var existingDual) = existing.behavior, newIsSimple {
+            existingDual.tapAction = newAction
+            merged.behavior = .dualRole(existingDual)
+            merged.action = newAction
+            return merged
+        }
+
+        if case let .dualRole(existingDual) = existing.behavior,
+           case let .dualRole(newDual) = newBehavior
+        {
+            merged.behavior = .dualRole(DualRoleBehavior(
+                tapAction: newDual.tapAction,
+                holdAction: newDual.holdAction,
+                tapTimeout: newDual.tapTimeout,
+                holdTimeout: existingDual.holdTimeout,
+                activateHoldOnOtherKey: newDual.activateHoldOnOtherKey
+            ))
+            merged.action = newDual.tapAction
+            return merged
+        }
+
+        throw CLIMergeError(
+            input: existing.input,
+            reason: "incompatible behavior types cannot be merged"
+        )
+    }
+}

--- a/Sources/KeyPathAppKit/CLI/CLIFacade+Service.swift
+++ b/Sources/KeyPathAppKit/CLI/CLIFacade+Service.swift
@@ -1,0 +1,217 @@
+import Foundation
+import KeyPathCore
+import KeyPathDaemonLifecycle
+import KeyPathInstallationWizard
+import KeyPathWizardCore
+
+// MARK: - Service Lifecycle, Config, TCP, Status, Installer
+
+extension CLIFacade {
+    public func startService() async -> Bool {
+        do {
+            try await SubprocessRunner.shared.launchctl("kickstart", ["system/com.keypath.kanata"])
+            return true
+        } catch {
+            return false
+        }
+    }
+
+    public func stopService() async -> Bool {
+        do {
+            try await SubprocessRunner.shared.launchctl("kill", ["SIGTERM", "system/com.keypath.kanata"])
+            return true
+        } catch {
+            return false
+        }
+    }
+
+    public func restartService() async -> Bool {
+        _ = await stopService()
+        try? await Task.sleep(nanoseconds: 500_000_000)
+        return await startService()
+    }
+
+    public func serviceLogs(lines: Int = 50) -> [String] {
+        let logPath = NSString("~/Library/Logs/KeyPath/keypath-debug.log").expandingTildeInPath
+        guard let content = try? String(contentsOfFile: logPath, encoding: .utf8) else {
+            return []
+        }
+        let allLines = content.components(separatedBy: .newlines)
+        return Array(allLines.suffix(lines))
+    }
+
+    @MainActor
+    public func currentConfig() async -> String {
+        let service = ConfigurationService()
+        let config = await service.current()
+        return config.content
+    }
+
+    @MainActor
+    public func configPath() -> String {
+        ConfigurationService().configurationPath
+    }
+
+    @MainActor
+    public func validateConfig() async -> CLIValidationResult {
+        let service = ConfigurationService()
+        let config = await service.current()
+        if config.content.isEmpty {
+            return CLIValidationResult(isValid: false, errors: ["No configuration generated yet. Run 'keypath apply' first."])
+        }
+        let result = await service.validateConfiguration(config.content)
+        return CLIValidationResult(isValid: result.isValid, errors: result.errors)
+    }
+
+    public func applyConfiguration() async throws -> CLIApplyResult {
+        let collections = await RuleCollectionStore.shared.loadCollections()
+        let customRules = await CustomRulesStore.shared.loadRules()
+        let enabledCount = collections.filter(\.isEnabled).count
+
+        let service = await MainActor.run { ConfigurationService() }
+        try await service.saveConfiguration(
+            ruleCollections: collections,
+            customRules: customRules
+        )
+
+        let port = await MainActor.run { PreferencesService.shared.tcpServerPort }
+        let client = KanataTCPClient(port: port)
+        let result = await client.reloadConfig()
+        let reloadSuccess = if case .success = result {
+            true
+        } else {
+            false
+        }
+
+        return CLIApplyResult(
+            collectionsCount: collections.count,
+            enabledCount: enabledCount,
+            customRulesCount: customRules.count,
+            reloadSuccess: reloadSuccess
+        )
+    }
+
+    func tcpClient() async -> KanataTCPClient {
+        let port = await MainActor.run { PreferencesService.shared.tcpServerPort }
+        return KanataTCPClient(port: port)
+    }
+
+    public func tcpCheckHealth() async -> Bool {
+        let client = await tcpClient()
+        return await client.checkServerStatus()
+    }
+
+    public func tcpGetLayers() async throws -> [String] {
+        let client = await tcpClient()
+        return try await client.requestLayerNames()
+    }
+
+    public func tcpReload() async -> Bool {
+        let client = await tcpClient()
+        let result = await client.reloadConfig()
+        if case .success = result { return true }
+        return false
+    }
+
+    public func tcpGetHrmStats() async throws -> CLIHrmStats {
+        let client = await tcpClient()
+        let stats = try await client.requestHrmStats()
+        return CLIHrmStats(
+            totalDecisions: stats.decisionsTotal,
+            tapCount: stats.tapCount,
+            holdCount: stats.holdCount
+        )
+    }
+
+    public func tcpResetHrmStats() async throws {
+        let client = await tcpClient()
+        try await client.resetHrmStats()
+    }
+
+    public func tcpChangeLayer(_ layerName: String) async -> Bool {
+        let client = await tcpClient()
+        let result = await client.changeLayer(layerName)
+        if case .success = result { return true }
+        return false
+    }
+
+    @MainActor
+    public func runStatus() async -> CLIStatusResult {
+        let engine = InstallerEngine()
+        let context = await engine.inspectSystem()
+
+        return CLIStatusResult(
+            isOperational: context.permissions.isSystemReady
+                && context.helper.isReady
+                && context.components.hasAllRequired
+                && context.services.isHealthy
+                && !context.conflicts.hasConflicts,
+            helperInstalled: context.helper.isInstalled,
+            helperWorking: context.helper.isWorking,
+            helperVersion: context.helper.version,
+            keyPathAccessibility: context.permissions.keyPath.accessibility.isReady,
+            keyPathInputMonitoring: context.permissions.keyPath.inputMonitoring.isReady,
+            kanataAccessibility: context.permissions.kanata.accessibility.isReady,
+            kanataInputMonitoring: context.permissions.kanata.inputMonitoring.isReady,
+            kanataBinaryInstalled: context.components.kanataBinaryInstalled,
+            karabinerDriverInstalled: context.components.karabinerDriverInstalled,
+            vhidDeviceHealthy: context.components.vhidDeviceHealthy,
+            kanataRunning: context.services.kanataRunning,
+            karabinerDaemonRunning: context.services.karabinerDaemonRunning,
+            vhidHealthy: context.services.vhidHealthy,
+            activeRuntimePathTitle: context.services.activeRuntimePathTitle,
+            activeRuntimePathDetail: context.services.activeRuntimePathDetail,
+            hasConflicts: context.conflicts.hasConflicts,
+            timestamp: context.timestamp
+        )
+    }
+
+    @MainActor
+    public func runInstall() async -> CLIInstallerReport {
+        let engine = InstallerEngine()
+        let broker = PrivilegeBroker()
+        let report = await engine.run(intent: .install, using: broker)
+        return CLIInstallerReport(from: report)
+    }
+
+    @MainActor
+    public func runRepair() async -> CLIInstallerReport {
+        let engine = InstallerEngine()
+        let broker = PrivilegeBroker()
+        let report = await engine.run(intent: .repair, using: broker)
+        return CLIInstallerReport(from: report)
+    }
+
+    @MainActor
+    public func runUninstall(deleteConfig: Bool) async -> CLIInstallerReport {
+        let engine = InstallerEngine()
+        let broker = PrivilegeBroker()
+        let report = await engine.uninstall(deleteConfig: deleteConfig, using: broker)
+        return CLIInstallerReport(from: report)
+    }
+
+    @MainActor
+    public func runInspect() async -> CLIInspectResult {
+        let engine = InstallerEngine()
+        let context = await engine.inspectSystem()
+        let plan = await engine.makePlan(for: .inspectOnly, context: context)
+
+        let planStatus: String
+        var blockedBy: String?
+        switch plan.status {
+        case .ready:
+            planStatus = "ready"
+        case let .blocked(requirement):
+            planStatus = "blocked"
+            blockedBy = requirement.name
+        }
+
+        return CLIInspectResult(
+            macOSVersion: context.system.macOSVersion,
+            driverCompatible: context.system.driverCompatible,
+            planStatus: planStatus,
+            blockedBy: blockedBy,
+            plannedRecipes: plan.recipes.map { "\($0.id) (\($0.type))" }
+        )
+    }
+}

--- a/Sources/KeyPathAppKit/CLI/CLIFacade.swift
+++ b/Sources/KeyPathAppKit/CLI/CLIFacade.swift
@@ -6,355 +6,17 @@ import KeyPathWizardCore
 
 /// Public facade exposing KeyPathAppKit internals for the CLI binary.
 /// This is the stable API boundary between the CLI and the app library.
+///
+/// Method groups live in extension files:
+/// - CLIFacade+Rules.swift — Custom rules CRUD
+/// - CLIFacade+Collections.swift — Rule collections CRUD
+/// - CLIFacade+Service.swift — Service lifecycle, config, TCP, status, installer
+/// - CLIFacade+Packs.swift — Pack management
 public struct CLIFacade: Sendable {
     public init() {}
 
-    // MARK: - Custom Rules
-
-    public func loadCustomRules() async -> [CLICustomRule] {
-        let rules = await CustomRulesStore.shared.loadRules()
-        return rules.map { CLICustomRule(input: $0.input, output: $0.action.outputString, behavior: $0.behavior.map(Self.describeBehavior)) }
-    }
-
-    private static func describeBehavior(_ behavior: MappingBehavior) -> String {
-        switch behavior {
-        case let .dualRole(d):
-            "tap-hold: tap=\(d.tapActionString), hold=\(d.holdActionString), timeout=\(d.tapTimeout)ms"
-        case .tapOrTapDance(.tap):
-            "tap"
-        case let .tapOrTapDance(.tapDance(td)):
-            "tap-dance: \(td.steps.map(\.actionString).joined(separator: ", "))"
-        case let .macro(m):
-            "macro: \(m.text ?? m.outputs.joined(separator: " "))"
-        case let .chord(c):
-            "chord: \(c.keys.joined(separator: "+")) → \(c.outputString)"
-        }
-    }
-
-    /// Add a simple key remap. Returns `true` if an existing mapping for the input key was replaced.
-    @discardableResult
-    public func addSimpleRemap(input: String, output: String) async throws -> Bool {
-        var rules = await CustomRulesStore.shared.loadRules()
-        let hadExisting = rules.contains { $0.input == input }
-        rules.removeAll { $0.input == input }
-        let rule = CustomRule(input: input, action: .keystroke(key: output))
-        rules.append(rule)
-        try await CustomRulesStore.shared.saveRules(rules)
-        return hadExisting
-    }
-
-    /// Add a tap-hold remap. Returns `true` if an existing mapping for the input key was replaced.
-    @discardableResult
-    public func addTapHoldRemap(input: String, tap: String, hold: String, timeout: Int = 200) async throws -> Bool {
-        var rules = await CustomRulesStore.shared.loadRules()
-        let hadExisting = rules.contains { $0.input == input }
-        rules.removeAll { $0.input == input }
-        let rule = CustomRule(
-            input: input,
-            action: .keystroke(key: tap),
-            behavior: .dualRole(DualRoleBehavior(
-                tapAction: .keystroke(key: tap),
-                holdAction: .keystroke(key: hold),
-                tapTimeout: timeout
-            ))
-        )
-        rules.append(rule)
-        try await CustomRulesStore.shared.saveRules(rules)
-        return hadExisting
-    }
-
-    /// Add a rule with full KeyAction and optional MappingBehavior. Supports all 13 action variants.
-    public func addRule(
-        input: String,
-        action: KeyAction,
-        behavior: MappingBehavior? = nil,
-        shiftedOutput: String? = nil,
-        title: String? = nil,
-        notes: String? = nil,
-        targetLayer: String? = nil,
-        deviceOverrides: [DeviceKeyOverride]? = nil,
-        onConflict: CLIConflictStrategy = .fail
-    ) async throws -> RuleAddResult {
-        var rules = await CustomRulesStore.shared.loadRules()
-        let existingIndex = rules.firstIndex(where: { $0.input == input })
-
-        if let existingIndex {
-            switch onConflict {
-            case .fail:
-                throw CLIConflictError(input: input)
-            case .skip:
-                return .skipped
-            case .replace:
-                rules.removeAll { $0.input == input }
-            case .merge:
-                let existing = rules[existingIndex]
-                let merged = try Self.mergeRules(existing: existing, newAction: action, newBehavior: behavior)
-                rules[existingIndex] = merged
-                try await CustomRulesStore.shared.saveRules(rules)
-                return .merged(CLIRuleDetail(from: merged))
-            }
-        }
-
-        let layer: RuleCollectionLayer = if let targetLayer {
-            Self.parseLayer(targetLayer)
-        } else {
-            .base
-        }
-
-        let rule = CustomRule(
-            title: title ?? "",
-            input: input,
-            action: action,
-            shiftedOutput: shiftedOutput,
-            notes: notes,
-            behavior: behavior,
-            targetLayer: layer,
-            deviceOverrides: deviceOverrides
-        )
-        rules.append(rule)
-        try await CustomRulesStore.shared.saveRules(rules)
-
-        let detail = CLIRuleDetail(from: rule)
-        return existingIndex != nil ? .replaced(detail) : .created(detail)
-    }
-
-    /// List all custom rules with full detail.
-    public func listRules(enabledOnly: Bool = false) async -> [CLIRuleDetail] {
-        let rules = await CustomRulesStore.shared.loadRules()
-        let filtered = enabledOnly ? rules.filter(\.isEnabled) : rules
-        return filtered.map { CLIRuleDetail(from: $0) }
-    }
-
-    /// Show a single rule by input key. Returns nil if not found.
-    public func showRule(input: String) async -> CLIRuleDetail? {
-        let rules = await CustomRulesStore.shared.loadRules()
-        guard let rule = rules.first(where: { $0.input == input }) else { return nil }
-        return CLIRuleDetail(from: rule)
-    }
-
-    public func removeRemap(input: String) async throws -> Bool {
-        var rules = await CustomRulesStore.shared.loadRules()
-        let before = rules.count
-        rules.removeAll { $0.input == input }
-        if rules.count == before { return false }
-        try await CustomRulesStore.shared.saveRules(rules)
-        return true
-    }
-
-    /// Enable a rule by input key. Returns the rule's display title, or nil if not found.
-    public func enableRule(input: String) async throws -> String? {
-        var rules = await CustomRulesStore.shared.loadRules()
-        guard let index = rules.firstIndex(where: { $0.input.caseInsensitiveCompare(input) == .orderedSame }) else {
-            return nil
-        }
-        rules[index].isEnabled = true
-        try await CustomRulesStore.shared.saveRules(rules)
-        return rules[index].displayTitle
-    }
-
-    /// Disable a rule by input key. Returns the rule's display title, or nil if not found.
-    public func disableRule(input: String) async throws -> String? {
-        var rules = await CustomRulesStore.shared.loadRules()
-        guard let index = rules.firstIndex(where: { $0.input.caseInsensitiveCompare(input) == .orderedSame }) else {
-            return nil
-        }
-        rules[index].isEnabled = false
-        try await CustomRulesStore.shared.saveRules(rules)
-        return rules[index].displayTitle
-    }
-
-    private static func parseLayer(_ name: String) -> RuleCollectionLayer {
-        switch name.lowercased() {
-        case "base": .base
-        case "nav", "navigation": .navigation
-        default: .custom(name)
-        }
-    }
-
-    static func mergeRules(existing: CustomRule, newAction: KeyAction, newBehavior: MappingBehavior?) throws -> CustomRule {
-        let existingIsSimple = existing.behavior == nil
-        let newIsSimple = newBehavior == nil
-
-        if existingIsSimple && newIsSimple {
-            throw CLIMergeError(
-                input: existing.input,
-                reason: "both rules are simple remaps with different outputs — ambiguous"
-            )
-        }
-
-        var merged = existing
-
-        if existingIsSimple, case let .dualRole(newDual) = newBehavior {
-            // Existing simple remap becomes tap, new hold action stays
-            merged.behavior = .dualRole(DualRoleBehavior(
-                tapAction: existing.action,
-                holdAction: newDual.holdAction,
-                tapTimeout: newDual.tapTimeout,
-                holdTimeout: newDual.holdTimeout,
-                activateHoldOnOtherKey: newDual.activateHoldOnOtherKey
-            ))
-            merged.action = existing.action
-            return merged
-        }
-
-        if case .dualRole(var existingDual) = existing.behavior, newIsSimple {
-            // Existing tap-hold keeps hold, new simple remap updates tap
-            existingDual.tapAction = newAction
-            merged.behavior = .dualRole(existingDual)
-            merged.action = newAction
-            return merged
-        }
-
-        if case let .dualRole(existingDual) = existing.behavior,
-           case let .dualRole(newDual) = newBehavior
-        {
-            // Both tap-hold: new values override
-            merged.behavior = .dualRole(DualRoleBehavior(
-                tapAction: newDual.tapAction,
-                holdAction: newDual.holdAction,
-                tapTimeout: newDual.tapTimeout,
-                holdTimeout: existingDual.holdTimeout,
-                activateHoldOnOtherKey: newDual.activateHoldOnOtherKey
-            ))
-            merged.action = newDual.tapAction
-            return merged
-        }
-
-        throw CLIMergeError(
-            input: existing.input,
-            reason: "incompatible behavior types cannot be merged"
-        )
-    }
-
-    // MARK: - Rule Collections
-
-    public func loadRuleCollections() async -> [CLIRuleCollection] {
-        let collections = await RuleCollectionStore.shared.loadCollections()
-        return collections.map { CLIRuleCollection(from: $0) }
-    }
-
-    /// Enable a collection by name or ID. Returns the name, or nil if not found. Throws on ambiguous match.
-    public func enableCollection(nameOrId: String) async throws -> String? {
-        var collections = await RuleCollectionStore.shared.loadCollections()
-        guard let index = try resolveCollectionIndex(nameOrId: nameOrId, in: collections) else {
-            return nil
-        }
-        if let owner = await InstalledPackTracker.shared.packManagingCollection(collections[index].id) {
-            throw PackManagedCollectionError(
-                collectionName: collections[index].name,
-                packName: owner.packName,
-                packID: owner.packID
-            )
-        }
-        collections[index].isEnabled = true
-        try await RuleCollectionStore.shared.saveCollections(collections)
-        return collections[index].name
-    }
-
-    /// Disable a collection by name or ID. Returns the name, or nil if not found. Throws on ambiguous match.
-    public func disableCollection(nameOrId: String) async throws -> String? {
-        var collections = await RuleCollectionStore.shared.loadCollections()
-        guard let index = try resolveCollectionIndex(nameOrId: nameOrId, in: collections) else {
-            return nil
-        }
-        if let owner = await InstalledPackTracker.shared.packManagingCollection(collections[index].id) {
-            throw PackManagedCollectionError(
-                collectionName: collections[index].name,
-                packName: owner.packName,
-                packID: owner.packID
-            )
-        }
-        collections[index].isEnabled = false
-        try await RuleCollectionStore.shared.saveCollections(collections)
-        return collections[index].name
-    }
-
-    /// Show a collection by name or ID. Returns nil if not found. Throws on ambiguous match.
-    public func showCollection(nameOrId: String) async throws -> CLIRuleCollection? {
-        let collections = await RuleCollectionStore.shared.loadCollections()
-        guard let index = try resolveCollectionIndex(nameOrId: nameOrId, in: collections) else {
-            return nil
-        }
-        return CLIRuleCollection(from: collections[index])
-    }
-
-    /// Create a new empty collection.
-    public func createCollection(name: String, category: String?, summary: String?) async throws -> CLIRuleCollection {
-        var collections = await RuleCollectionStore.shared.loadCollections()
-        let cat: RuleCollectionCategory = if let category {
-            RuleCollectionCategory(rawValue: category) ?? .custom
-        } else {
-            .custom
-        }
-        let collection = RuleCollection(
-            name: name,
-            summary: summary ?? "",
-            category: cat,
-            mappings: []
-        )
-        collections.append(collection)
-        try await RuleCollectionStore.shared.saveCollections(collections)
-        return CLIRuleCollection(from: collection)
-    }
-
-    /// Rename a collection. Returns the old name, or nil if not found.
-    public func renameCollection(nameOrId: String, newName: String) async throws -> String? {
-        var collections = await RuleCollectionStore.shared.loadCollections()
-        guard let index = try resolveCollectionIndex(nameOrId: nameOrId, in: collections) else {
-            return nil
-        }
-        let oldName = collections[index].name
-        collections[index].name = newName
-        try await RuleCollectionStore.shared.saveCollections(collections)
-        return oldName
-    }
-
-    /// Delete a collection. Returns true if deleted, false if not found.
-    public func deleteCollection(nameOrId: String) async throws -> Bool {
-        var collections = await RuleCollectionStore.shared.loadCollections()
-        guard let index = try resolveCollectionIndex(nameOrId: nameOrId, in: collections) else {
-            return false
-        }
-        collections.remove(at: index)
-        try await RuleCollectionStore.shared.saveCollections(collections)
-        return true
-    }
-
-    /// Duplicate a collection with an optional new name.
-    public func duplicateCollection(nameOrId: String, newName: String?) async throws -> CLIRuleCollection? {
-        var collections = await RuleCollectionStore.shared.loadCollections()
-        guard let index = try resolveCollectionIndex(nameOrId: nameOrId, in: collections) else {
-            return nil
-        }
-        var duplicate = collections[index]
-        duplicate = RuleCollection(
-            name: newName ?? "\(duplicate.name) (Copy)",
-            summary: duplicate.summary,
-            category: duplicate.category,
-            mappings: duplicate.mappings,
-            isEnabled: false
-        )
-        collections.insert(duplicate, at: index + 1)
-        try await RuleCollectionStore.shared.saveCollections(collections)
-        return CLIRuleCollection(from: duplicate)
-    }
-
-    /// Reorder a collection to a new position (0-indexed).
-    public func reorderCollection(nameOrId: String, position: Int) async throws -> Bool {
-        var collections = await RuleCollectionStore.shared.loadCollections()
-        guard let index = try resolveCollectionIndex(nameOrId: nameOrId, in: collections) else {
-            return false
-        }
-        let collection = collections.remove(at: index)
-        let targetIndex = min(max(0, position), collections.count)
-        collections.insert(collection, at: targetIndex)
-        try await RuleCollectionStore.shared.saveCollections(collections)
-        return true
-    }
-
     // MARK: - Export / Import
 
-    /// Export a single collection as portable JSON.
     public func exportCollection(nameOrId: String) async throws -> CLIExportedCollection? {
         let collections = await RuleCollectionStore.shared.loadCollections()
         guard let index = try resolveCollectionIndex(nameOrId: nameOrId, in: collections) else {
@@ -363,13 +25,11 @@ public struct CLIFacade: Sendable {
         return CLIExportedCollection(from: collections[index])
     }
 
-    /// Export all collections as portable JSON.
     public func exportAllCollections() async -> [CLIExportedCollection] {
         let collections = await RuleCollectionStore.shared.loadCollections()
         return collections.map { CLIExportedCollection(from: $0) }
     }
 
-    /// Import a collection from portable JSON. Returns the imported collection info.
     public func importCollection(_ exported: CLIExportedCollection, onConflict: CLIConflictStrategy = .fail) async throws -> CLIRuleCollection {
         var collections = await RuleCollectionStore.shared.loadCollections()
         let existingIndex = collections.firstIndex(where: { $0.name == exported.name })
@@ -397,8 +57,6 @@ public struct CLIFacade: Sendable {
 
     // MARK: - Karabiner Import
 
-    /// Parse a Karabiner-Elements configuration and return importable collections.
-    /// Handles both full karabiner.json and standalone complex_modifications rule files.
     public func importFromKarabiner(data: Data, collectionName: String?, profileIndex: Int?) throws -> CLIKarabinerImportResult {
         let service = KarabinerConverterService()
 
@@ -450,7 +108,6 @@ public struct CLIFacade: Sendable {
         )
     }
 
-    /// List profiles available in a Karabiner configuration file.
     public func listKarabinerProfiles(data: Data) throws -> [CLIKarabinerProfile] {
         let service = KarabinerConverterService()
         let profiles = try service.getProfiles(from: data)
@@ -486,8 +143,6 @@ public struct CLIFacade: Sendable {
 
     // MARK: - Simulate
 
-    /// Simulate a key sequence and return structured events.
-    /// Uses the real SimulatorService by default, or an injected provider for tests.
     public func simulate(
         keys: [CLISimulatorKeyTap],
         configPath: String?,
@@ -506,7 +161,6 @@ public struct CLIFacade: Sendable {
 
     // MARK: - Layer CRUD
 
-    /// Get all layers defined by rule collections (unique targetLayer values).
     public func listDefinedLayers() async -> [String] {
         let collections = await RuleCollectionStore.shared.loadCollections()
         var layers = Set<String>()
@@ -517,7 +171,6 @@ public struct CLIFacade: Sendable {
         return layers.sorted()
     }
 
-    /// Create a layer by creating an empty collection targeting it.
     public func createLayer(name: String) async throws -> CLIRuleCollection {
         var collections = await RuleCollectionStore.shared.loadCollections()
         let layer: RuleCollectionLayer = switch name.lowercased() {
@@ -537,7 +190,6 @@ public struct CLIFacade: Sendable {
         return CLIRuleCollection(from: collection)
     }
 
-    /// Delete all collections targeting a layer. Returns count of deleted collections.
     public func deleteLayer(name: String) async throws -> Int {
         var collections = await RuleCollectionStore.shared.loadCollections()
         let targetName = Self.parseLayer(name).kanataName
@@ -550,7 +202,6 @@ public struct CLIFacade: Sendable {
         return removed
     }
 
-    /// Rename a layer by updating all collections that target it.
     public func renameLayer(oldName: String, newName: String) async throws -> Int {
         var collections = await RuleCollectionStore.shared.loadCollections()
         let oldLayerName = Self.parseLayer(oldName).kanataName
@@ -568,240 +219,8 @@ public struct CLIFacade: Sendable {
         return updated
     }
 
-    // MARK: - Service Lifecycle
-
-    /// Start the Kanata service via launchctl kickstart.
-    public func startService() async -> Bool {
-        do {
-            try await SubprocessRunner.shared.launchctl("kickstart", ["system/com.keypath.kanata"])
-            return true
-        } catch {
-            return false
-        }
-    }
-
-    /// Stop the Kanata service via launchctl kill.
-    public func stopService() async -> Bool {
-        do {
-            try await SubprocessRunner.shared.launchctl("kill", ["SIGTERM", "system/com.keypath.kanata"])
-            return true
-        } catch {
-            return false
-        }
-    }
-
-    /// Restart the Kanata service (stop + start).
-    public func restartService() async -> Bool {
-        _ = await stopService()
-        try? await Task.sleep(nanoseconds: 500_000_000)
-        return await startService()
-    }
-
-    /// Read the last N lines from the debug log.
-    public func serviceLogs(lines: Int = 50) -> [String] {
-        let logPath = NSString("~/Library/Logs/KeyPath/keypath-debug.log").expandingTildeInPath
-        guard let content = try? String(contentsOfFile: logPath, encoding: .utf8) else {
-            return []
-        }
-        let allLines = content.components(separatedBy: .newlines)
-        return Array(allLines.suffix(lines))
-    }
-
-    // MARK: - Configuration
-
-    @MainActor
-    public func currentConfig() async -> String {
-        let service = ConfigurationService()
-        let config = await service.current()
-        return config.content
-    }
-
-    @MainActor
-    public func configPath() -> String {
-        ConfigurationService().configurationPath
-    }
-
-    /// Validate configuration content using kanata --check.
-    @MainActor
-    public func validateConfig() async -> CLIValidationResult {
-        let service = ConfigurationService()
-        let config = await service.current()
-        if config.content.isEmpty {
-            return CLIValidationResult(isValid: false, errors: ["No configuration generated yet. Run 'keypath apply' first."])
-        }
-        let result = await service.validateConfiguration(config.content)
-        return CLIValidationResult(isValid: result.isValid, errors: result.errors)
-    }
-
-    // MARK: - Apply Pipeline
-
-    public func applyConfiguration() async throws -> CLIApplyResult {
-        let collections = await RuleCollectionStore.shared.loadCollections()
-        let customRules = await CustomRulesStore.shared.loadRules()
-        let enabledCount = collections.filter(\.isEnabled).count
-
-        let service = await MainActor.run { ConfigurationService() }
-        try await service.saveConfiguration(
-            ruleCollections: collections,
-            customRules: customRules
-        )
-
-        let port = await MainActor.run { PreferencesService.shared.tcpServerPort }
-        let client = KanataTCPClient(port: port)
-        let result = await client.reloadConfig()
-        let reloadSuccess = if case .success = result {
-            true
-        } else {
-            false
-        }
-
-        return CLIApplyResult(
-            collectionsCount: collections.count,
-            enabledCount: enabledCount,
-            customRulesCount: customRules.count,
-            reloadSuccess: reloadSuccess
-        )
-    }
-
-    // MARK: - TCP
-
-    private func tcpClient() async -> KanataTCPClient {
-        let port = await MainActor.run { PreferencesService.shared.tcpServerPort }
-        return KanataTCPClient(port: port)
-    }
-
-    public func tcpCheckHealth() async -> Bool {
-        let client = await tcpClient()
-        return await client.checkServerStatus()
-    }
-
-    public func tcpGetLayers() async throws -> [String] {
-        let client = await tcpClient()
-        return try await client.requestLayerNames()
-    }
-
-    public func tcpReload() async -> Bool {
-        let client = await tcpClient()
-        let result = await client.reloadConfig()
-        if case .success = result { return true }
-        return false
-    }
-
-    public func tcpGetHrmStats() async throws -> CLIHrmStats {
-        let client = await tcpClient()
-        let stats = try await client.requestHrmStats()
-        return CLIHrmStats(
-            totalDecisions: stats.decisionsTotal,
-            tapCount: stats.tapCount,
-            holdCount: stats.holdCount
-        )
-    }
-
-    public func tcpResetHrmStats() async throws {
-        let client = await tcpClient()
-        try await client.resetHrmStats()
-    }
-
-    public func tcpChangeLayer(_ layerName: String) async -> Bool {
-        let client = await tcpClient()
-        let result = await client.changeLayer(layerName)
-        if case .success = result { return true }
-        return false
-    }
-
-    // MARK: - Status
-
-    /// ⚠️ inspectSystem() calls SMAppService.status which does synchronous IPC —
-    /// can take 10-30s under launchd load. Callers should be aware of potential latency.
-    @MainActor
-    public func runStatus() async -> CLIStatusResult {
-        let engine = InstallerEngine()
-        let context = await engine.inspectSystem()
-
-        return CLIStatusResult(
-            isOperational: context.permissions.isSystemReady
-                && context.helper.isReady
-                && context.components.hasAllRequired
-                && context.services.isHealthy
-                && !context.conflicts.hasConflicts,
-            helperInstalled: context.helper.isInstalled,
-            helperWorking: context.helper.isWorking,
-            helperVersion: context.helper.version,
-            keyPathAccessibility: context.permissions.keyPath.accessibility.isReady,
-            keyPathInputMonitoring: context.permissions.keyPath.inputMonitoring.isReady,
-            kanataAccessibility: context.permissions.kanata.accessibility.isReady,
-            kanataInputMonitoring: context.permissions.kanata.inputMonitoring.isReady,
-            kanataBinaryInstalled: context.components.kanataBinaryInstalled,
-            karabinerDriverInstalled: context.components.karabinerDriverInstalled,
-            vhidDeviceHealthy: context.components.vhidDeviceHealthy,
-            kanataRunning: context.services.kanataRunning,
-            karabinerDaemonRunning: context.services.karabinerDaemonRunning,
-            vhidHealthy: context.services.vhidHealthy,
-            activeRuntimePathTitle: context.services.activeRuntimePathTitle,
-            activeRuntimePathDetail: context.services.activeRuntimePathDetail,
-            hasConflicts: context.conflicts.hasConflicts,
-            timestamp: context.timestamp
-        )
-    }
-
-    // MARK: - Installer Operations
-
-    /// Run install via InstallerEngine. Requires privileged helper.
-    @MainActor
-    public func runInstall() async -> CLIInstallerReport {
-        let engine = InstallerEngine()
-        let broker = PrivilegeBroker()
-        let report = await engine.run(intent: .install, using: broker)
-        return CLIInstallerReport(from: report)
-    }
-
-    /// Run repair via InstallerEngine.
-    @MainActor
-    public func runRepair() async -> CLIInstallerReport {
-        let engine = InstallerEngine()
-        let broker = PrivilegeBroker()
-        let report = await engine.run(intent: .repair, using: broker)
-        return CLIInstallerReport(from: report)
-    }
-
-    /// Run uninstall via InstallerEngine.
-    @MainActor
-    public func runUninstall(deleteConfig: Bool) async -> CLIInstallerReport {
-        let engine = InstallerEngine()
-        let broker = PrivilegeBroker()
-        let report = await engine.uninstall(deleteConfig: deleteConfig, using: broker)
-        return CLIInstallerReport(from: report)
-    }
-
-    /// Inspect system and generate an install plan without executing it.
-    @MainActor
-    public func runInspect() async -> CLIInspectResult {
-        let engine = InstallerEngine()
-        let context = await engine.inspectSystem()
-        let plan = await engine.makePlan(for: .inspectOnly, context: context)
-
-        let planStatus: String
-        var blockedBy: String?
-        switch plan.status {
-        case .ready:
-            planStatus = "ready"
-        case let .blocked(requirement):
-            planStatus = "blocked"
-            blockedBy = requirement.name
-        }
-
-        return CLIInspectResult(
-            macOSVersion: context.system.macOSVersion,
-            driverCompatible: context.system.driverCompatible,
-            planStatus: planStatus,
-            blockedBy: blockedBy,
-            plannedRecipes: plan.recipes.map { "\($0.id) (\($0.type))" }
-        )
-    }
-
     // MARK: - Key Validation
 
-    /// Validate a key name against the Kanata key set. Returns the canonical form, or nil if invalid.
     public func validateKey(_ key: String) -> String? {
         guard CustomRuleValidator.isValidKey(key) else { return nil }
         return CustomRuleValidator.normalizeKey(key)
@@ -809,14 +228,11 @@ public struct CLIFacade: Sendable {
 
     // MARK: - Helpers
 
-    /// Resolve a collection by name or UUID. Returns nil if not found. Throws `AmbiguousCollectionMatch` on multiple matches.
     func resolveCollectionIndex(nameOrId: String, in collections: [RuleCollection]) throws -> Int? {
-        // Exact UUID match
         if let index = collections.firstIndex(where: { $0.id.uuidString == nameOrId }) {
             return index
         }
 
-        // Exact name match (case-insensitive)
         let exactMatches = collections.enumerated().filter {
             $0.element.name.caseInsensitiveCompare(nameOrId) == .orderedSame
         }
@@ -831,7 +247,6 @@ public struct CLIFacade: Sendable {
             )
         }
 
-        // Substring match as fallback
         let substringMatches = collections.enumerated().filter {
             $0.element.name.localizedCaseInsensitiveContains(nameOrId)
         }
@@ -849,7 +264,8 @@ public struct CLIFacade: Sendable {
     }
 }
 
-/// Thrown when a collection name/ID query matches multiple collections.
+// MARK: - Ambiguous Match Errors
+
 public struct AmbiguousCollectionMatch: Error, CustomStringConvertible {
     public struct Match: Sendable {
         public let name: String
@@ -878,14 +294,11 @@ public struct AmbiguousCollectionMatch: Error, CustomStringConvertible {
 
 // MARK: - Version
 
-/// Shared version constant for the CLI binary.
-/// Reads from the KeyPath.app bundle, checking /Applications and ~/Applications,
-/// falling back to a hardcoded value.
 public enum CLIVersion {
     public static let current: String = {
         let candidates = [
             "/Applications/KeyPath.app",
-            NSString("~/Applications/KeyPath.app").expandingTildeInPath
+            NSString("~/Applications/KeyPath.app").expandingTildeInPath,
         ]
         for path in candidates {
             if let bundle = Bundle(path: path),
@@ -998,7 +411,7 @@ public struct CLIInspectResult: Codable, Sendable {
     public let plannedRecipes: [String]
 }
 
-// MARK: - Phase 1A Rule Detail Types
+// MARK: - Rule Detail Types
 
 public struct CLIRuleDetail: Codable, Sendable {
     public let input: String
@@ -1261,12 +674,10 @@ public struct CLISimEvent: Codable, Sendable {
     }
 }
 
-/// Protocol for simulator injection — allows mock implementations in tests.
 public protocol CLISimulatorProvider: Sendable {
     func simulate(taps: [CLISimulatorKeyTap], configPath: String) async throws -> CLISimulationResult
 }
 
-/// Default provider that delegates to the real SimulatorService actor.
 struct RealSimulatorProvider: CLISimulatorProvider {
     func simulate(taps: [CLISimulatorKeyTap], configPath: String) async throws -> CLISimulationResult {
         let service = SimulatorService()
@@ -1289,301 +700,6 @@ struct RealSimulatorProvider: CLISimulatorProvider {
             }
         }
         return CLISimulationResult(events: events, finalLayer: result.finalLayer ?? "base", durationMs: result.durationMs)
-    }
-}
-
-// MARK: - Pack Management
-
-extension CLIFacade {
-    /// List all available packs with their install status.
-    public func listPacks() async -> [CLIPack] {
-        let allPacks = PackRegistry.starterKit
-        let installed = await InstalledPackTracker.shared.allInstalled()
-        let installedMap = Dictionary(uniqueKeysWithValues: installed.map { ($0.packID, $0) })
-
-        return allPacks.map { pack in
-            let record = installedMap[pack.id]
-            return CLIPack(
-                id: pack.id,
-                name: pack.name,
-                version: pack.version,
-                category: pack.category,
-                tagline: pack.tagline,
-                isInstalled: record != nil,
-                installedAt: record?.installedAt
-            )
-        }
-    }
-
-    /// Show detailed information about a pack.
-    public func showPack(nameOrId: String) async throws -> CLIPackDetail? {
-        guard let pack = try resolvePack(nameOrId: nameOrId) else { return nil }
-        let record = await InstalledPackTracker.shared.record(for: pack.id)
-        return CLIPackDetail(from: pack, record: record)
-    }
-
-    /// Install a pack with optional quick setting overrides.
-    @MainActor
-    public func installPack(
-        nameOrId: String,
-        settingValues: [String: Int] = [:],
-        dryRun: Bool = false
-    ) async throws -> CLIPackInstallResult {
-        guard let pack = try resolvePack(nameOrId: nameOrId) else {
-            throw CLIPackNotFound(query: nameOrId)
-        }
-
-        let isAlready = await InstalledPackTracker.shared.isInstalled(packID: pack.id)
-        if isAlready {
-            return CLIPackInstallResult(
-                packID: pack.id,
-                packName: pack.name,
-                action: "already-installed",
-                warnings: [],
-                quickSettingValues: [:]
-            )
-        }
-
-        // Validate quick setting keys
-        for key in settingValues.keys {
-            guard pack.quickSettings.contains(where: { $0.id == key }) else {
-                throw CLIPackSettingError(
-                    packName: pack.name,
-                    settingKey: key,
-                    validKeys: pack.quickSettings.map(\.id)
-                )
-            }
-        }
-
-        if dryRun {
-            var warnings: [String] = []
-            let installedIDs = Set(await InstalledPackTracker.shared.allInstalled().map(\.packID))
-            let suggestions = PackDependencyChecker.suggestions(for: pack.id, installedPackIDs: installedIDs)
-            for dep in suggestions {
-                let depName = PackRegistry.pack(id: dep.packID)?.name ?? dep.packID
-                warnings.append("Enhanced by '\(depName)' — install it for best results")
-            }
-            return CLIPackInstallResult(
-                packID: pack.id,
-                packName: pack.name,
-                action: "would-install",
-                warnings: warnings,
-                quickSettingValues: settingValues
-            )
-        }
-
-        let manager = await makePackManager()
-        let record = try await PackInstaller.shared.install(
-            pack,
-            quickSettingValues: settingValues,
-            manager: manager
-        )
-
-        var warnings: [String] = []
-        let installedIDs = Set(await InstalledPackTracker.shared.allInstalled().map(\.packID))
-        let suggestions = PackDependencyChecker.suggestions(for: pack.id, installedPackIDs: installedIDs)
-        for dep in suggestions {
-            let depName = PackRegistry.pack(id: dep.packID)?.name ?? dep.packID
-            warnings.append("Enhanced by '\(depName)' — install it for best results")
-        }
-
-        return CLIPackInstallResult(
-            packID: pack.id,
-            packName: pack.name,
-            action: "installed",
-            warnings: warnings,
-            quickSettingValues: record.quickSettingValues
-        )
-    }
-
-    /// Uninstall a pack.
-    @MainActor
-    public func uninstallPack(
-        nameOrId: String,
-        dryRun: Bool = false
-    ) async throws -> CLIPackInstallResult {
-        guard let pack = try resolvePack(nameOrId: nameOrId) else {
-            throw CLIPackNotFound(query: nameOrId)
-        }
-
-        let isInstalled = await InstalledPackTracker.shared.isInstalled(packID: pack.id)
-        guard isInstalled else {
-            return CLIPackInstallResult(
-                packID: pack.id,
-                packName: pack.name,
-                action: "not-installed",
-                warnings: [],
-                quickSettingValues: [:]
-            )
-        }
-
-        if dryRun {
-            return CLIPackInstallResult(
-                packID: pack.id,
-                packName: pack.name,
-                action: "would-uninstall",
-                warnings: [],
-                quickSettingValues: [:]
-            )
-        }
-
-        let manager = await makePackManager()
-        try await PackInstaller.shared.uninstall(packID: pack.id, manager: manager)
-
-        return CLIPackInstallResult(
-            packID: pack.id,
-            packName: pack.name,
-            action: "uninstalled",
-            warnings: [],
-            quickSettingValues: [:]
-        )
-    }
-
-    /// Update quick settings on an installed pack.
-    @MainActor
-    public func configurePack(
-        nameOrId: String,
-        settingValues: [String: Int],
-        dryRun: Bool = false
-    ) async throws -> CLIPackInstallResult {
-        guard let pack = try resolvePack(nameOrId: nameOrId) else {
-            throw CLIPackNotFound(query: nameOrId)
-        }
-
-        let isInstalled = await InstalledPackTracker.shared.isInstalled(packID: pack.id)
-        guard isInstalled else {
-            return CLIPackInstallResult(
-                packID: pack.id,
-                packName: pack.name,
-                action: "not-installed",
-                warnings: ["Pack must be installed before configuring settings."],
-                quickSettingValues: [:]
-            )
-        }
-
-        guard !pack.quickSettings.isEmpty else {
-            throw CLIPackSettingError(
-                packName: pack.name,
-                settingKey: settingValues.keys.first ?? "",
-                validKeys: []
-            )
-        }
-
-        for key in settingValues.keys {
-            guard pack.quickSettings.contains(where: { $0.id == key }) else {
-                throw CLIPackSettingError(
-                    packName: pack.name,
-                    settingKey: key,
-                    validKeys: pack.quickSettings.map(\.id)
-                )
-            }
-        }
-
-        if dryRun {
-            let current = await PackInstaller.shared.quickSettings(for: pack.id)
-            var merged = current
-            for (k, v) in settingValues { merged[k] = v }
-            return CLIPackInstallResult(
-                packID: pack.id,
-                packName: pack.name,
-                action: "would-configure",
-                warnings: [],
-                quickSettingValues: merged
-            )
-        }
-
-        let manager = await makePackManager()
-        try await PackInstaller.shared.updateQuickSettings(
-            packID: pack.id,
-            newValues: settingValues,
-            manager: manager
-        )
-
-        let updatedSettings = await PackInstaller.shared.quickSettings(for: pack.id)
-
-        return CLIPackInstallResult(
-            packID: pack.id,
-            packName: pack.name,
-            action: "configured",
-            warnings: [],
-            quickSettingValues: updatedSettings
-        )
-    }
-
-    // MARK: - Pack Name Resolution
-
-    /// Resolve a pack by ID, slug, name, or substring. Returns nil if not found.
-    /// Throws `AmbiguousPackMatch` on multiple matches.
-    func resolvePack(nameOrId: String) throws -> Pack? {
-        let allPacks = PackRegistry.starterKit
-
-        // 1. Exact ID match
-        if let pack = allPacks.first(where: { $0.id == nameOrId }) {
-            return pack
-        }
-
-        // 2. Slug match (strip com.keypath.pack. prefix)
-        let prefix = "com.keypath.pack."
-        let slugMatches = allPacks.filter { pack in
-            guard pack.id.hasPrefix(prefix) else { return false }
-            let slug = String(pack.id.dropFirst(prefix.count))
-            return slug.caseInsensitiveCompare(nameOrId) == .orderedSame
-        }
-        if slugMatches.count == 1 { return slugMatches[0] }
-        if slugMatches.count > 1 {
-            throw AmbiguousPackMatch(
-                query: nameOrId,
-                matches: slugMatches.map { .init(name: $0.name, id: $0.id) },
-                hint: "Multiple packs match this slug. Use the full ID to disambiguate."
-            )
-        }
-
-        // 3. Exact name match (case-insensitive)
-        let exactMatches = allPacks.filter {
-            $0.name.caseInsensitiveCompare(nameOrId) == .orderedSame
-        }
-        if exactMatches.count == 1 { return exactMatches[0] }
-        if exactMatches.count > 1 {
-            throw AmbiguousPackMatch(
-                query: nameOrId,
-                matches: exactMatches.map { .init(name: $0.name, id: $0.id) },
-                hint: "Multiple packs share this name. Use the ID to disambiguate."
-            )
-        }
-
-        // 4. Substring fallback
-        let substringMatches = allPacks.filter {
-            $0.name.localizedCaseInsensitiveContains(nameOrId)
-        }
-        if substringMatches.count == 1 { return substringMatches[0] }
-        if substringMatches.count > 1 {
-            throw AmbiguousPackMatch(
-                query: nameOrId,
-                matches: substringMatches.map { .init(name: $0.name, id: $0.id) }
-            )
-        }
-
-        return nil
-    }
-
-    // MARK: - Pack Manager Helper
-
-    /// Create a lightweight RuleCollectionsManager for install/uninstall.
-    /// Loads current state from stores without running full bootstrap (which
-    /// would regenerate config unnecessarily).
-    @MainActor
-    private func makePackManager() async -> RuleCollectionsManager {
-        let configService = ConfigurationService()
-        let manager = RuleCollectionsManager(
-            ruleCollectionStore: .shared,
-            customRulesStore: .shared,
-            configurationService: configService
-        )
-        let collections = await RuleCollectionStore.shared.loadCollections()
-        let customRules = await CustomRulesStore.shared.loadRules()
-        manager.ruleCollections = RuleCollectionDeduplicator.dedupe(collections)
-        manager.customRules = customRules
-        return manager
     }
 }
 
@@ -1684,7 +800,6 @@ public struct CLIPackInstallResult: Codable, Sendable {
     public let quickSettingValues: [String: Int]
 }
 
-/// Thrown when a pack name/ID query matches multiple packs.
 public struct AmbiguousPackMatch: Error, CustomStringConvertible {
     public struct Match: Sendable {
         public let name: String
@@ -1740,7 +855,6 @@ public struct PackManagedCollectionError: Error, CustomStringConvertible {
 
 // MARK: - Stderr Helper
 
-/// Write a diagnostic message to stderr. Use for errors and warnings so stdout stays clean for scripts.
 public func printErr(_ message: String) {
     FileHandle.standardError.write(Data((message + "\n").utf8))
 }

--- a/Sources/KeyPathCLI/Commands/CompletionsCommand.swift
+++ b/Sources/KeyPathCLI/Commands/CompletionsCommand.swift
@@ -23,8 +23,8 @@ struct Completions: ParsableCommand {
 
         mutating func run() throws {
             let script = KeyPathCLI.completionScript(for: .zsh)
-            print(script)
-            print(Self.dynamicCompletionWrapper)
+            CLIOutput.writeRaw(script)
+            CLIOutput.writeRaw(Self.dynamicCompletionWrapper)
         }
 
         private static let dynamicCompletionWrapper = """
@@ -62,7 +62,7 @@ struct Completions: ParsableCommand {
 
         mutating func run() throws {
             let script = KeyPathCLI.completionScript(for: .bash)
-            print(script)
+            CLIOutput.writeRaw(script)
         }
     }
 
@@ -73,7 +73,7 @@ struct Completions: ParsableCommand {
 
         mutating func run() throws {
             let script = KeyPathCLI.completionScript(for: .fish)
-            print(script)
+            CLIOutput.writeRaw(script)
         }
     }
 
@@ -104,14 +104,14 @@ struct Completions: ParsableCommand {
             }
 
             guard let source = sourceDir else {
-                print("Man pages not found. They ship with KeyPath.app.")
-                print("")
-                print("If you installed from source, generate them with:")
-                print("  swift package plugin --allow-writing-to-directory docs/man generate-manual --multi-page --output-directory docs/man")
-                print("")
-                print("Then copy to your man path:")
-                print("  mkdir -p \(manDir)")
-                print("  cp docs/man/*.1 \(manDir)/")
+                printErr("Man pages not found. They ship with KeyPath.app.")
+                printErr("")
+                printErr("If you installed from source, generate them with:")
+                printErr("  swift package plugin --allow-writing-to-directory docs/man generate-manual --multi-page --output-directory docs/man")
+                printErr("")
+                printErr("Then copy to your man path:")
+                printErr("  mkdir -p \(manDir)")
+                printErr("  cp docs/man/*.1 \(manDir)/")
                 return
             }
 
@@ -133,8 +133,8 @@ struct Completions: ParsableCommand {
                 try fm.copyItem(atPath: src, toPath: dst)
             }
 
-            print("Installed \(pages.count) man page(s) to \(manDir)")
-            print("Try: man keypath")
+            printErr("Installed \(pages.count) man page(s) to \(manDir)")
+            printErr("Try: man keypath")
         }
     }
 
@@ -172,13 +172,13 @@ struct Completions: ParsableCommand {
             )
             try script.write(toFile: path, atomically: true, encoding: .utf8)
 
-            print("Installed \(shellName) completions to \(path)")
+            printErr("Installed \(shellName) completions to \(path)")
 
             if shellName == "zsh" {
-                print("")
-                print("If completions don't work, ensure this is in your ~/.zshrc:")
-                print("  fpath=(~/.zsh/completions $fpath)")
-                print("  autoload -Uz compinit && compinit")
+                printErr("")
+                printErr("If completions don't work, ensure this is in your ~/.zshrc:")
+                printErr("  fpath=(~/.zsh/completions $fpath)")
+                printErr("  autoload -Uz compinit && compinit")
             }
         }
 
@@ -221,22 +221,22 @@ struct Completions: ParsableCommand {
                 let packs = await facade.listPacks()
                 for pack in packs {
                     let slug = pack.id.replacingOccurrences(of: "com.keypath.pack.", with: "")
-                    print(slug)
+                    CLIOutput.writeRaw(slug)
                 }
             case "collection":
                 let collections = await facade.loadRuleCollections()
                 for c in collections {
-                    print(c.name)
+                    CLIOutput.writeRaw(c.name)
                 }
             case "layer":
                 let layers = await facade.listDefinedLayers()
                 for layer in layers {
-                    print(layer)
+                    CLIOutput.writeRaw(layer)
                 }
             case "rule":
                 let rules = await facade.listRules()
                 for rule in rules {
-                    print(rule.input)
+                    CLIOutput.writeRaw(rule.input)
                 }
             default:
                 throw ValidationError("Unknown noun: '\(noun)'. Use pack, collection, layer, or rule.")

--- a/Sources/KeyPathCLI/Commands/Config/ConfigCheckCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Config/ConfigCheckCommand.swift
@@ -12,7 +12,7 @@ struct ConfigCheck: AsyncParsableCommand {
 
     mutating func run() async throws {
         let ctx = globals.outputContext
-        let facade = CLIFacade()
+        let facade = await MainActor.run { CLIFacade() }
         let result = await facade.validateConfig()
 
         CLIOutput.write(result, context: ctx) {

--- a/Sources/KeyPathCLI/Commands/Config/ConfigPathCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Config/ConfigPathCommand.swift
@@ -8,8 +8,14 @@ struct ConfigPath: AsyncParsableCommand {
         abstract: "Print the configuration file path"
     )
 
+    @OptionGroup var globals: GlobalOptions
+
     mutating func run() async throws {
+        let ctx = globals.outputContext
         let path = await MainActor.run { CLIFacade().configPath() }
-        print(path)
+
+        CLIOutput.write(["path": path], context: ctx) {
+            path
+        }
     }
 }

--- a/Sources/KeyPathCLI/Commands/Config/ConfigShowCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Config/ConfigShowCommand.swift
@@ -8,9 +8,15 @@ struct ConfigShow: AsyncParsableCommand {
         abstract: "Print current generated .kbd configuration"
     )
 
+    @OptionGroup var globals: GlobalOptions
+
     mutating func run() async throws {
+        let ctx = globals.outputContext
         let facade = await MainActor.run { CLIFacade() }
         let config = await facade.currentConfig()
-        print(config)
+
+        CLIOutput.write(["config": config], context: ctx) {
+            config
+        }
     }
 }

--- a/Sources/KeyPathCLI/Commands/Export/ExportAllCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Export/ExportAllCommand.swift
@@ -32,7 +32,7 @@ struct ExportAll: AsyncParsableCommand {
                 "Exported \(exported.count) collection\(exported.count == 1 ? "" : "s") to \(url.path)"
             }
         } else {
-            print(json)
+            CLIOutput.writeRaw(json)
         }
     }
 }

--- a/Sources/KeyPathCLI/Commands/Export/ExportCollectionCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Export/ExportCollectionCommand.swift
@@ -40,7 +40,7 @@ struct ExportCollection: AsyncParsableCommand {
                     "Exported '\(exported.name)' to \(url.path)"
                 }
             } else {
-                print(json)
+                CLIOutput.writeRaw(json)
             }
         } catch let error as AmbiguousCollectionMatch {
             let cliError = CLIError.ambiguous(error.description, matches: error.matches.map { "\($0.name) (\($0.id))" })

--- a/Sources/KeyPathCLI/Commands/Porcelain/RemapShortcut.swift
+++ b/Sources/KeyPathCLI/Commands/Porcelain/RemapShortcut.swift
@@ -23,8 +23,8 @@ struct RemapShortcut: AsyncParsableCommand {
     @Option(help: "Key to emit on hold (for tap-hold)")
     var hold: String?
 
-    @Option(help: "Tap-hold timeout in milliseconds (default: 200)")
-    var timeout: Int = 200
+    @Option(name: .customLong("tap-timeout"), help: "Tap-hold timeout in milliseconds (default: 200)")
+    var tapTimeout: Int = 200
 
     @Flag(help: "Regenerate config and reload Kanata after saving")
     var apply: Bool = false
@@ -42,7 +42,7 @@ struct RemapShortcut: AsyncParsableCommand {
         cmd.output = output
         cmd.tap = tap
         cmd.hold = hold
-        cmd.timeout = timeout
+        cmd.tapTimeout = tapTimeout
         cmd.apply = apply
         try await cmd.run()
     }

--- a/Sources/KeyPathCLI/Commands/Porcelain/StatusShortcut.swift
+++ b/Sources/KeyPathCLI/Commands/Porcelain/StatusShortcut.swift
@@ -11,13 +11,9 @@ struct StatusShortcut: AsyncParsableCommand {
 
     @OptionGroup var globals: GlobalOptions
 
-    @Option(help: "Timeout in seconds (default: 30)")
-    var timeout: Int = 30
-
     mutating func run() async throws {
         var cmd = ServiceStatus()
         cmd.globals = globals
-        cmd.timeout = timeout
         try await cmd.run()
     }
 }

--- a/Sources/KeyPathCLI/Commands/Rule/RuleAddCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Rule/RuleAddCommand.swift
@@ -28,8 +28,8 @@ struct RuleAdd: AsyncParsableCommand {
     @Option(help: "Key to emit on hold (for tap-hold)")
     var hold: String?
 
-    @Option(help: "Tap-hold timeout in milliseconds (default: 200)")
-    var timeout: Int = 200
+    @Option(name: .customLong("tap-timeout"), help: "Tap-hold timeout in milliseconds (default: 200)")
+    var tapTimeout: Int = 200
 
     @Option(help: "Alternate output when shift is held")
     var shifted: String?
@@ -86,7 +86,7 @@ struct RuleAdd: AsyncParsableCommand {
             resolvedBehavior = .dualRole(DualRoleBehavior(
                 tapAction: .keystroke(key: tap),
                 holdAction: .keystroke(key: hold),
-                tapTimeout: timeout
+                tapTimeout: tapTimeout
             ))
         } else if let output {
             guard facade.validateKey(output) != nil else {

--- a/Sources/KeyPathCLI/Commands/Rule/RuleEnsureCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Rule/RuleEnsureCommand.swift
@@ -19,8 +19,8 @@ struct RuleEnsure: AsyncParsableCommand {
     @Option(help: "Hold output for tap-hold")
     var hold: String?
 
-    @Option(help: "Tap-hold timeout in ms (default: 200)")
-    var timeout: Int = 200
+    @Option(name: .customLong("tap-timeout"), help: "Tap-hold timeout in ms (default: 200)")
+    var tapTimeout: Int = 200
 
     @Flag(help: "Regenerate config and reload Kanata after saving")
     var apply: Bool = false
@@ -37,7 +37,7 @@ struct RuleEnsure: AsyncParsableCommand {
                 if case let .dualRole(dr) = existing.behavior {
                     matchesDesired = existing.action.outputString == output
                         && dr.holdActionString == hold
-                        && dr.tapTimeout == timeout
+                        && dr.tapTimeout == tapTimeout
                 } else {
                     matchesDesired = false
                 }
@@ -68,7 +68,7 @@ struct RuleEnsure: AsyncParsableCommand {
         }
 
         if let hold {
-            _ = try await facade.addTapHoldRemap(input: input, tap: output, hold: hold, timeout: timeout)
+            _ = try await facade.addTapHoldRemap(input: input, tap: output, hold: hold, timeout: tapTimeout)
         } else {
             _ = try await facade.addSimpleRemap(input: input, output: output)
         }

--- a/Sources/KeyPathCLI/Commands/Service/ServiceLogsCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Service/ServiceLogsCommand.swift
@@ -15,7 +15,7 @@ struct ServiceLogs: AsyncParsableCommand {
 
     mutating func run() async throws {
         let ctx = globals.outputContext
-        let facade = CLIFacade()
+        let facade = await MainActor.run { CLIFacade() }
 
         let logLines = facade.serviceLogs(lines: lines)
         if logLines.isEmpty {

--- a/Sources/KeyPathCLI/Commands/Service/ServiceStatusCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Service/ServiceStatusCommand.swift
@@ -15,7 +15,7 @@ struct ServiceStatus: AsyncParsableCommand {
 
     mutating func run() async throws {
         let ctx = globals.outputContext
-        let facade = CLIFacade()
+        let facade = await MainActor.run { CLIFacade() }
         let status: CLIStatusResult
         do {
             status = try await withThrowingTimeout(seconds: timeout) {

--- a/Sources/KeyPathCLI/Commands/Service/ServiceStatusCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Service/ServiceStatusCommand.swift
@@ -10,11 +10,9 @@ struct ServiceStatus: AsyncParsableCommand {
 
     @OptionGroup var globals: GlobalOptions
 
-    @Option(help: "Timeout in seconds (default: 30)")
-    var timeout: Int = 30
-
     mutating func run() async throws {
         let ctx = globals.outputContext
+        let timeout = globals.timeout
         let facade = await MainActor.run { CLIFacade() }
         let status: CLIStatusResult
         do {

--- a/Sources/KeyPathCLI/Commands/System/SystemInspectCommand.swift
+++ b/Sources/KeyPathCLI/Commands/System/SystemInspectCommand.swift
@@ -12,7 +12,7 @@ struct SystemInspect: AsyncParsableCommand {
 
     mutating func run() async throws {
         let ctx = globals.outputContext
-        let facade = CLIFacade()
+        let facade = await MainActor.run { CLIFacade() }
         let result = await facade.runInspect()
 
         CLIOutput.write(result, context: ctx) {

--- a/Sources/KeyPathCLI/Commands/System/SystemInspectCommand.swift
+++ b/Sources/KeyPathCLI/Commands/System/SystemInspectCommand.swift
@@ -13,7 +13,16 @@ struct SystemInspect: AsyncParsableCommand {
     mutating func run() async throws {
         let ctx = globals.outputContext
         let facade = await MainActor.run { CLIFacade() }
-        let result = await facade.runInspect()
+        let result: CLIInspectResult
+        do {
+            result = try await withThrowingTimeout(seconds: globals.timeout) {
+                await facade.runInspect()
+            }
+        } catch is TimeoutError {
+            let error = CLIError.serviceUnreachable(hint: "System inspection timed out. Try --timeout \(globals.timeout * 2)")
+            CLIOutput.writeError(error, context: ctx)
+            throw error.code.exitCode
+        }
 
         CLIOutput.write(result, context: ctx) {
             var lines = [

--- a/Sources/KeyPathCLI/Commands/System/SystemInstallCommand.swift
+++ b/Sources/KeyPathCLI/Commands/System/SystemInstallCommand.swift
@@ -15,7 +15,7 @@ struct SystemInstall: AsyncParsableCommand {
         let spinner = CLISpinner(context: ctx)
         spinner.start("Installing...")
 
-        let facade = CLIFacade()
+        let facade = await MainActor.run { CLIFacade() }
         let report = await facade.runInstall()
 
         if report.success { spinner.succeed("Installation complete") }

--- a/Sources/KeyPathCLI/Commands/System/SystemInstallCommand.swift
+++ b/Sources/KeyPathCLI/Commands/System/SystemInstallCommand.swift
@@ -16,7 +16,15 @@ struct SystemInstall: AsyncParsableCommand {
         spinner.start("Installing...")
 
         let facade = await MainActor.run { CLIFacade() }
-        let report = await facade.runInstall()
+        let report: CLIInstallerReport
+        do {
+            report = try await withThrowingTimeout(seconds: globals.timeout) {
+                await facade.runInstall()
+            }
+        } catch is TimeoutError {
+            spinner.fail("Installation timed out after \(globals.timeout)s")
+            throw ExitCode.failure
+        }
 
         if report.success { spinner.succeed("Installation complete") }
         else { spinner.fail("Installation failed") }

--- a/Sources/KeyPathCLI/Commands/System/SystemRepairCommand.swift
+++ b/Sources/KeyPathCLI/Commands/System/SystemRepairCommand.swift
@@ -15,7 +15,7 @@ struct SystemRepair: AsyncParsableCommand {
         let spinner = CLISpinner(context: ctx)
         spinner.start("Repairing...")
 
-        let facade = CLIFacade()
+        let facade = await MainActor.run { CLIFacade() }
         let report = await facade.runRepair()
 
         if report.success { spinner.succeed("Repair complete") }

--- a/Sources/KeyPathCLI/Commands/System/SystemRepairCommand.swift
+++ b/Sources/KeyPathCLI/Commands/System/SystemRepairCommand.swift
@@ -16,7 +16,15 @@ struct SystemRepair: AsyncParsableCommand {
         spinner.start("Repairing...")
 
         let facade = await MainActor.run { CLIFacade() }
-        let report = await facade.runRepair()
+        let report: CLIInstallerReport
+        do {
+            report = try await withThrowingTimeout(seconds: globals.timeout) {
+                await facade.runRepair()
+            }
+        } catch is TimeoutError {
+            spinner.fail("Repair timed out after \(globals.timeout)s")
+            throw ExitCode.failure
+        }
 
         if report.success { spinner.succeed("Repair complete") }
         else { spinner.fail("Repair failed") }

--- a/Sources/KeyPathCLI/Commands/System/SystemUninstallCommand.swift
+++ b/Sources/KeyPathCLI/Commands/System/SystemUninstallCommand.swift
@@ -21,7 +21,7 @@ struct SystemUninstall: AsyncParsableCommand {
             CLIOutput.progress("Starting uninstall (configuration will be preserved)...", context: ctx)
         }
 
-        let facade = CLIFacade()
+        let facade = await MainActor.run { CLIFacade() }
         let report = await facade.runUninstall(deleteConfig: deleteConfig)
 
         CLIOutput.write(report, context: ctx) {

--- a/Sources/KeyPathCLI/Commands/System/SystemUninstallCommand.swift
+++ b/Sources/KeyPathCLI/Commands/System/SystemUninstallCommand.swift
@@ -22,13 +22,15 @@ struct SystemUninstall: AsyncParsableCommand {
         }
 
         let facade = await MainActor.run { CLIFacade() }
+        let shouldDeleteConfig = deleteConfig
+        let timeoutSeconds = globals.timeout
         let report: CLIInstallerReport
         do {
-            report = try await withThrowingTimeout(seconds: globals.timeout) {
-                await facade.runUninstall(deleteConfig: deleteConfig)
+            report = try await withThrowingTimeout(seconds: timeoutSeconds) {
+                await facade.runUninstall(deleteConfig: shouldDeleteConfig)
             }
         } catch is TimeoutError {
-            CLIOutput.progress("Uninstall timed out after \(globals.timeout)s", context: ctx)
+            CLIOutput.progress("Uninstall timed out after \(timeoutSeconds)s", context: ctx)
             throw ExitCode.failure
         }
 

--- a/Sources/KeyPathCLI/Commands/System/SystemUninstallCommand.swift
+++ b/Sources/KeyPathCLI/Commands/System/SystemUninstallCommand.swift
@@ -22,7 +22,15 @@ struct SystemUninstall: AsyncParsableCommand {
         }
 
         let facade = await MainActor.run { CLIFacade() }
-        let report = await facade.runUninstall(deleteConfig: deleteConfig)
+        let report: CLIInstallerReport
+        do {
+            report = try await withThrowingTimeout(seconds: globals.timeout) {
+                await facade.runUninstall(deleteConfig: deleteConfig)
+            }
+        } catch is TimeoutError {
+            CLIOutput.progress("Uninstall timed out after \(globals.timeout)s", context: ctx)
+            throw ExitCode.failure
+        }
 
         CLIOutput.write(report, context: ctx) {
             formatInstallerReport(report, title: "Uninstall")

--- a/Sources/KeyPathCLI/Utilities/GlobalOptions.swift
+++ b/Sources/KeyPathCLI/Utilities/GlobalOptions.swift
@@ -13,6 +13,9 @@ struct GlobalOptions: ParsableArguments {
     @Flag(name: .customLong("quiet"), help: "Suppress stderr decoration (spinners, progress, hints)")
     var quiet: Bool = false
 
+    @Option(name: .customLong("timeout"), help: "Timeout in seconds for IPC and network operations (default: 30)")
+    var timeout: Int = 30
+
     @Option(name: .customLong("on-conflict"), help: "Conflict resolution: fail|replace|skip|merge")
     var onConflict: ConflictStrategy = .fail
 

--- a/Sources/KeyPathCLI/Utilities/Output.swift
+++ b/Sources/KeyPathCLI/Utilities/Output.swift
@@ -79,6 +79,10 @@ enum CLIOutput {
         }
     }
 
+    static func writeRaw(_ text: String) {
+        Swift.print(text)
+    }
+
     static func progress(_ message: String, context: OutputContext) {
         guard context.isInteractive, !context.quiet else { return }
         printErr(ANSIColor.yellow(message, noColor: context.noColor))

--- a/Sources/KeyPathCLI/Utilities/Output.swift
+++ b/Sources/KeyPathCLI/Utilities/Output.swift
@@ -55,11 +55,17 @@ enum CLIOutput {
         print(json)
     }
 
+    private struct APIErrorEnvelope: Encodable {
+        let apiVersion: Int = 1
+        let error: CLIError
+    }
+
     static func writeError(_ error: CLIError, context: OutputContext) {
         if context.shouldOutputJSON {
             let encoder = JSONEncoder()
             encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-            if let data = try? encoder.encode(error), let json = String(data: data, encoding: .utf8) {
+            let envelope = APIErrorEnvelope(error: error)
+            if let data = try? encoder.encode(envelope), let json = String(data: data, encoding: .utf8) {
                 printErr(json)
             }
         } else {

--- a/Tests/KeyPathTests/CLI/CLICommandValidationTests.swift
+++ b/Tests/KeyPathTests/CLI/CLICommandValidationTests.swift
@@ -54,11 +54,11 @@ final class CLICommandValidationTests: XCTestCase {
     }
 
     func testRuleAddAcceptsTapHold() throws {
-        let cmd = try RuleAdd.parse(["a", "--tap", "a", "--hold", "lctl", "--timeout", "250"])
+        let cmd = try RuleAdd.parse(["a", "--tap", "a", "--hold", "lctl", "--tap-timeout", "250"])
         XCTAssertEqual(cmd.input, "a")
         XCTAssertEqual(cmd.tap, "a")
         XCTAssertEqual(cmd.hold, "lctl")
-        XCTAssertEqual(cmd.timeout, 250)
+        XCTAssertEqual(cmd.tapTimeout, 250)
     }
 
     func testRuleAddAcceptsBehaviorOnly() throws {

--- a/Tests/KeyPathTests/CLI/CLISmokeTests.swift
+++ b/Tests/KeyPathTests/CLI/CLISmokeTests.swift
@@ -1,0 +1,152 @@
+import ArgumentParser
+@testable import KeyPathCLI
+import XCTest
+
+final class CLISmokeTests: XCTestCase {
+    // MARK: - Global options
+
+    func testGlobalOptionsDefaults() throws {
+        let cmd = try KeyPathCLI.parseAsRoot(["rule", "list"]) as! RuleList
+        XCTAssertFalse(cmd.globals.json)
+        XCTAssertFalse(cmd.globals.noJson)
+        XCTAssertFalse(cmd.globals.quiet)
+        XCTAssertFalse(cmd.globals.dryRun)
+        XCTAssertEqual(cmd.globals.timeout, 30)
+        XCTAssertEqual(cmd.globals.onConflict, .fail)
+    }
+
+    func testGlobalOptionsJSON() throws {
+        let cmd = try KeyPathCLI.parseAsRoot(["rule", "list", "--json"]) as! RuleList
+        XCTAssertTrue(cmd.globals.json)
+    }
+
+    func testGlobalOptionsQuiet() throws {
+        let cmd = try KeyPathCLI.parseAsRoot(["collection", "list", "--quiet"]) as! CollectionList
+        XCTAssertTrue(cmd.globals.quiet)
+    }
+
+    func testGlobalOptionsTimeout() throws {
+        let cmd = try KeyPathCLI.parseAsRoot(["service", "status", "--timeout", "60"]) as! ServiceStatus
+        XCTAssertEqual(cmd.globals.timeout, 60)
+    }
+
+    func testGlobalOptionsDryRun() throws {
+        let cmd = try KeyPathCLI.parseAsRoot(["rule", "add", "caps", "esc", "--dry-run"]) as! RuleAdd
+        XCTAssertTrue(cmd.globals.dryRun)
+    }
+
+    // MARK: - Rule commands
+
+    func testRuleAddParses() throws {
+        let cmd = try KeyPathCLI.parseAsRoot(["rule", "add", "caps", "esc"]) as! RuleAdd
+        XCTAssertEqual(cmd.input, "caps")
+        XCTAssertEqual(cmd.output, "esc")
+    }
+
+    func testRuleAddWithBehavior() throws {
+        let cmd = try KeyPathCLI.parseAsRoot(["rule", "add", "caps", "esc", "--behavior", "tap-hold"]) as! RuleAdd
+        XCTAssertEqual(cmd.behavior, "tap-hold")
+    }
+
+    func testRuleRemoveParses() throws {
+        let cmd = try KeyPathCLI.parseAsRoot(["rule", "remove", "caps"]) as! RuleRemove
+        XCTAssertEqual(cmd.input, "caps")
+    }
+
+    func testRuleShowParses() throws {
+        let cmd = try KeyPathCLI.parseAsRoot(["rule", "show", "caps"]) as! RuleShow
+        XCTAssertEqual(cmd.input, "caps")
+    }
+
+    func testRuleEnableParses() throws {
+        let cmd = try KeyPathCLI.parseAsRoot(["rule", "enable", "caps"]) as! RuleEnable
+        XCTAssertEqual(cmd.input, "caps")
+    }
+
+    func testRuleEnsureParses() throws {
+        let cmd = try KeyPathCLI.parseAsRoot(["rule", "ensure", "caps", "esc"]) as! RuleEnsure
+        XCTAssertEqual(cmd.input, "caps")
+        XCTAssertEqual(cmd.output, "esc")
+    }
+
+    // MARK: - Collection commands
+
+    func testCollectionCreateParses() throws {
+        let cmd = try KeyPathCLI.parseAsRoot(["collection", "create", "My Collection"]) as! CollectionCreate
+        XCTAssertEqual(cmd.name, "My Collection")
+    }
+
+    func testCollectionDeleteParses() throws {
+        let cmd = try KeyPathCLI.parseAsRoot(["collection", "delete", "test"]) as! CollectionDelete
+        XCTAssertEqual(cmd.nameOrId, "test")
+    }
+
+    // MARK: - Pack commands
+
+    func testPackInstallParses() throws {
+        let cmd = try KeyPathCLI.parseAsRoot(["pack", "install", "caps-escape"]) as! PackInstall
+        XCTAssertEqual(cmd.nameOrId, "caps-escape")
+    }
+
+    func testPackUninstallParses() throws {
+        let cmd = try KeyPathCLI.parseAsRoot(["pack", "uninstall", "caps-escape"]) as! PackUninstall
+        XCTAssertEqual(cmd.nameOrId, "caps-escape")
+    }
+
+    // MARK: - Config commands
+
+    func testConfigCheckParses() throws {
+        _ = try KeyPathCLI.parseAsRoot(["config", "check"]) as! ConfigCheck
+    }
+
+    func testConfigShowParses() throws {
+        _ = try KeyPathCLI.parseAsRoot(["config", "show"]) as! ConfigShow
+    }
+
+    // MARK: - Service commands
+
+    func testServiceLogsWithLines() throws {
+        let cmd = try KeyPathCLI.parseAsRoot(["service", "logs", "--lines", "100"]) as! ServiceLogs
+        XCTAssertEqual(cmd.lines, 100)
+    }
+
+    // MARK: - System commands
+
+    func testSystemUninstallDeleteConfig() throws {
+        let cmd = try KeyPathCLI.parseAsRoot(["system", "uninstall", "--delete-config"]) as! SystemUninstall
+        XCTAssertTrue(cmd.deleteConfig)
+    }
+
+    // MARK: - Conflict strategy
+
+    func testOnConflictReplace() throws {
+        let cmd = try KeyPathCLI.parseAsRoot(["rule", "add", "a", "b", "--on-conflict", "replace"]) as! RuleAdd
+        XCTAssertEqual(cmd.globals.onConflict, .replace)
+    }
+
+    // MARK: - Invalid input
+
+    func testUnknownSubcommandThrows() {
+        XCTAssertThrowsError(try KeyPathCLI.parseAsRoot(["nonexistent"]))
+    }
+
+    func testMissingRequiredArgThrows() {
+        XCTAssertThrowsError(try KeyPathCLI.parseAsRoot(["rule", "add"]))
+    }
+
+    func testInvalidOnConflictThrows() {
+        XCTAssertThrowsError(try KeyPathCLI.parseAsRoot(["--on-conflict", "nope", "rule", "list"]))
+    }
+
+    // MARK: - Porcelain shortcuts
+
+    func testStatusShortcutParses() throws {
+        _ = try KeyPathCLI.parseAsRoot(["status"]) as! StatusShortcut
+    }
+
+    func testRemapShortcutParses() throws {
+        let cmd = try KeyPathCLI.parseAsRoot(["remap", "caps", "esc"]) as! RemapShortcut
+        XCTAssertEqual(cmd.input, "caps")
+        XCTAssertEqual(cmd.output, "esc")
+    }
+}


### PR DESCRIPTION
## Summary
- **#426** — Wrap `CLIFacade()` in `MainActor.run` in 7 commands that were creating it off-MainActor
- **#430** — Route all CLI output through `CLIOutput` — replace raw `print()` with `CLIOutput.writeRaw()` for machine output and `printErr()` for user messages; add `--json` support to `config show` and `config path`
- **#431** — Add global `--timeout` flag (default 30s) to `GlobalOptions`, wired into status/inspect/install/repair/uninstall; rename `--timeout` to `--tap-timeout` on `rule add`/`ensure`/`remap` to avoid collision
- **#427** — Wrap JSON error output in `apiVersion: 1` envelope matching the data envelope format
- **#429** — Add 25 CLI smoke tests via `parseAsRoot` covering all major command groups, global options, porcelain shortcuts, and invalid input rejection
- **#428** — Split `CLIFacade.swift` (1,746 → 860 lines) into 4 domain extensions: Rules, Collections, Service, Packs

Closes #426, #427, #428, #429, #430, #431

Also closes #404, #405, #406, #407, #408 (already implemented)

## Test plan
- [x] `swift build` passes
- [x] All 530 tests pass (including 25 new smoke tests)
- [ ] Manual: `keypath status --timeout 5` respects timeout
- [ ] Manual: `keypath config show --json` returns apiVersion envelope