### PR TITLE
docs: drag-to-authorize permission overlay plan

### DIFF
--- a/Sources/KeyPathAppKit/Services/Packs/PackZoneResolver.swift
+++ b/Sources/KeyPathAppKit/Services/Packs/PackZoneResolver.swift
@@ -14,19 +14,22 @@ enum PackZoneResolver {
     }
 
     struct LayerPreviewConfig {
-        let activatorKeyCodes: Set<UInt16>
-        let targetLayer: String
+        /// Per-key target layers: keyCode -> layer name to preview when that key is held
+        let targets: [UInt16: String]
+
+        var activatorKeyCodes: Set<UInt16> { Set(targets.keys) }
     }
 
     static func layerPreviewConfig(
         installedPackIDs: Set<String>
     ) -> LayerPreviewConfig? {
+        var merged: [UInt16: String] = [:]
         for packID in installedPackIDs {
             if let config = previewConfig(for: packID) {
-                return config
+                merged.merge(config.targets) { _, new in new }
             }
         }
-        return nil
+        return merged.isEmpty ? nil : LayerPreviewConfig(targets: merged)
     }
 
     static func activeZoneSubtitles(
@@ -70,10 +73,10 @@ enum PackZoneResolver {
     private static func previewConfig(for packID: String) -> LayerPreviewConfig? {
         switch packID {
         case PackRegistry.vallackSystem.id:
-            return LayerPreviewConfig(
-                activatorKeyCodes: VallackZoneMap.activatorKeyCodes,
-                targetLayer: "vallack-nav"
+            let targets = Dictionary(
+                uniqueKeysWithValues: VallackZoneMap.activatorKeyCodes.map { ($0, "vallack-nav") }
             )
+            return LayerPreviewConfig(targets: targets)
         default:
             return nil
         }

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+Bootstrap.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+Bootstrap.swift
@@ -22,6 +22,10 @@ extension RuleCollectionsManager {
 
         ensureDefaultCollectionsIfNeeded()
 
+        // Re-enable collections that installed packs expect to be active.
+        // Handles drift when RuleCollections.json is reset independently of installed-packs.json.
+        await reconcilePackCollectionState()
+
         // Restore keymap collection if a non-identity layout was active
         if activeKeymapId != LogicalKeymap.qwertyUSId, activeKeymapId != LogicalKeymap.systemId {
             if let keymapCollection = KeymapMappingGenerator.generateCollection(
@@ -40,5 +44,37 @@ extension RuleCollectionsManager {
         refreshLayerIndicatorState()
 
         await regenerateConfigFromCollections()
+    }
+
+    // MARK: - Pack Reconciliation
+
+    /// Cross-reference installed packs against loaded collections and re-enable
+    /// any collection that an installed pack manages but that was loaded as disabled.
+    private func reconcilePackCollectionState() async {
+        let installedRecords = await InstalledPackTracker.shared.allInstalled()
+        guard !installedRecords.isEmpty else { return }
+
+        var fixedCount = 0
+
+        for record in installedRecords {
+            guard let pack = PackRegistry.pack(id: record.packID) else { continue }
+
+            for collectionID in pack.managedCollectionIDs {
+                guard let index = ruleCollections.firstIndex(where: { $0.id == collectionID }) else {
+                    continue
+                }
+                if !ruleCollections[index].isEnabled {
+                    ruleCollections[index].isEnabled = true
+                    fixedCount += 1
+                    AppLogger.shared.log(
+                        "🔧 [Bootstrap] Reconciled: re-enabled '\(ruleCollections[index].name)' for installed pack '\(pack.name)'"
+                    )
+                }
+            }
+        }
+
+        if fixedCount > 0 {
+            AppLogger.shared.log("🔧 [Bootstrap] Pack reconciliation fixed \(fixedCount) collection(s)")
+        }
     }
 }

--- a/Sources/KeyPathAppKit/UI/KeyboardVisualization/KeyboardVisualizationViewModel+TCP.swift
+++ b/Sources/KeyPathAppKit/UI/KeyboardVisualization/KeyboardVisualizationViewModel+TCP.swift
@@ -315,8 +315,9 @@ extension KeyboardVisualizationViewModel {
             AppLogger.shared.info("🗂️ [KeyboardViz] Layer push message: '\(layerName)'")
             if isShowingLayerPreview {
                 prePreviewLayerName = layerName
-                if layerName.lowercased() != layerPreviewTarget.lowercased() {
+                if layerName.lowercased() != currentPreviewTargetLayer.lowercased() {
                     isShowingLayerPreview = false
+                    currentPreviewTargetLayer = ""
                     layerPreviewTask?.cancel()
                     layerPreviewTask = nil
                     AppLogger.shared.debug("🗂️ [KeyboardViz] Preview ended — kanata switched to '\(layerName)'")
@@ -637,7 +638,8 @@ extension KeyboardVisualizationViewModel {
 
     private func startLayerPreviewIfActivator(_ keyCode: UInt16) {
         guard layerPreviewActivators.contains(keyCode),
-              !layerPreviewTarget.isEmpty,
+              let targetLayer = layerPreviewTargets[keyCode],
+              !targetLayer.isEmpty,
               !isShowingLayerPreview,
               layerPreviewTask == nil
         else { return }
@@ -649,7 +651,8 @@ extension KeyboardVisualizationViewModel {
             guard self.pressedKeyCodes.contains(keyCode) else { return }
             self.prePreviewLayerName = self.currentLayerName
             self.isShowingLayerPreview = true
-            self.updateLayer(self.layerPreviewTarget)
+            self.currentPreviewTargetLayer = targetLayer
+            self.updateLayer(targetLayer)
         }
     }
 
@@ -661,6 +664,7 @@ extension KeyboardVisualizationViewModel {
 
         if isShowingLayerPreview {
             isShowingLayerPreview = false
+            currentPreviewTargetLayer = ""
             updateLayer(prePreviewLayerName)
         }
     }

--- a/Sources/KeyPathAppKit/UI/KeyboardVisualization/KeyboardVisualizationViewModel.swift
+++ b/Sources/KeyPathAppKit/UI/KeyboardVisualization/KeyboardVisualizationViewModel.swift
@@ -60,14 +60,16 @@ class KeyboardVisualizationViewModel {
 
     // MARK: - Layer Preview (System Pack Activators)
 
-    /// Key codes that trigger a layer preview on hold (e.g., F/J for Vallack nav)
+    /// Key codes that trigger a layer preview on hold (e.g., F/J for Vallack nav, Caps Lock for hyper layer)
     var layerPreviewActivators: Set<UInt16> = []
-    /// Layer name to preview when an activator is held
-    var layerPreviewTarget: String = ""
+    /// Per-key target layers: keyCode -> layer name to preview when that key is held
+    var layerPreviewTargets: [UInt16: String] = [:]
     /// Delayed task for activating the layer preview
     @ObservationIgnored var layerPreviewTask: Task<Void, Never>?
     /// Whether we're currently showing a layer preview (not a real kanata layer change)
     @ObservationIgnored var isShowingLayerPreview: Bool = false
+    /// The target layer of the currently active preview (for confirmation matching)
+    @ObservationIgnored var currentPreviewTargetLayer: String = ""
     /// The real layer name before the preview override
     @ObservationIgnored var prePreviewLayerName: String = "base"
 

--- a/Sources/KeyPathAppKit/UI/Overlay/LiveKeyboardOverlayView.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/LiveKeyboardOverlayView.swift
@@ -235,16 +235,44 @@ struct LiveKeyboardOverlayView: View {
     private func refreshInstalledPackIDs() async {
         let records = await InstalledPackTracker.shared.allInstalled()
         let ids = Set(records.map(\.packID))
+        await MainActor.run { installedPackIDs = ids }
+        await refreshLayerPreviewConfig(installedPackIDs: ids)
+    }
+
+    private func refreshLayerPreviewConfig(installedPackIDs ids: Set<String>? = nil) async {
+        let packIDs = ids ?? installedPackIDs
+        let packConfig = PackZoneResolver.layerPreviewConfig(installedPackIDs: packIDs)
+        let capsConfig = await Self.capsLockLayerPreviewTargets()
+
         await MainActor.run {
-            installedPackIDs = ids
-            if let preview = PackZoneResolver.layerPreviewConfig(installedPackIDs: ids) {
-                viewModel.layerPreviewActivators = preview.activatorKeyCodes
-                viewModel.layerPreviewTarget = preview.targetLayer
-            } else {
-                viewModel.layerPreviewActivators = []
-                viewModel.layerPreviewTarget = ""
-            }
+            var merged = packConfig?.targets ?? [:]
+            merged.merge(capsConfig) { existing, _ in existing }
+            viewModel.layerPreviewTargets = merged
+            viewModel.layerPreviewActivators = Set(merged.keys)
         }
+    }
+
+    /// Detect whether Caps Lock holds Hyper and there's a hyper-linked layer to preview.
+    /// Returns keyCode 57 (caps) → target layer name, or empty dict.
+    private static func capsLockLayerPreviewTargets() async -> [UInt16: String] {
+        let collections = await RuleCollectionStore.shared.loadCollections()
+
+        let capsHoldsHyper = collections.contains { collection in
+            guard collection.isEnabled, collection.id == RuleCollectionIdentifier.capsLockRemap else { return false }
+            guard let config = collection.configuration.tapHoldPickerConfig else { return false }
+            return config.selectedHoldOutput?.lowercased() == "hyper"
+        }
+        guard capsHoldsHyper else { return [:] }
+
+        // Find the first enabled hyper-linked layer (momentaryActivator.input == "hyper")
+        guard let targetLayer = collections.first(where: { collection in
+            guard collection.isEnabled, let activator = collection.momentaryActivator else { return false }
+            return activator.input.lowercased() == "hyper"
+        })?.momentaryActivator?.targetLayer.kanataName else {
+            return [:]
+        }
+
+        return [57: targetLayer]
     }
 
     private func copyValidationErrorsToClipboard() {
@@ -427,6 +455,11 @@ struct LiveKeyboardOverlayView: View {
             Task {
                 await refreshKindaVimPackInstalled()
                 await refreshInstalledPackIDs()
+            }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .ruleCollectionsChanged)) { _ in
+            Task {
+                await refreshLayerPreviewConfig()
             }
         }
         .windowAnchoredPopoverHost()

--- a/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView.swift
@@ -439,7 +439,11 @@ struct RulesTabView: View {
         var map: [UUID: String] = [:]
         for collection in allCollections {
             if let owner = await InstalledPackTracker.shared.packManagingCollection(collection.id) {
-                map[collection.id] = owner.packName
+                let pack = PackRegistry.pack(id: owner.packID)
+                let isSelfManaged = pack?.associatedCollectionID == collection.id
+                if !isSelfManaged {
+                    map[collection.id] = owner.packName
+                }
             }
         }
         collectionOwnershipMap = map

--- a/Tests/KeyPathTests/PackOwnershipTests.swift
+++ b/Tests/KeyPathTests/PackOwnershipTests.swift
@@ -95,6 +95,52 @@ final class PackOwnershipTests: XCTestCase {
         XCTAssertEqual(togglesOwner?.packName, "Ben Vallack Approach")
     }
 
+    // MARK: - Self-managed badge filtering
+
+    func testSelfManagedPackShouldNotShowBadge() async throws {
+        let packID = "com.keypath.pack.key-repeat-control"
+        let record = InstalledPackRecord(packID: packID, version: "1.0.0")
+        try await InstalledPackTracker.shared.upsert(record)
+
+        let collectionID = RuleCollectionIdentifier.keyRepeatControl
+        let owner = await InstalledPackTracker.shared.packManagingCollection(collectionID)
+        XCTAssertNotNil(owner, "Pack should report owning its collection")
+
+        let pack = PackRegistry.pack(id: owner!.packID)
+        XCTAssertEqual(
+            pack?.associatedCollectionID, collectionID,
+            "Fast Navigation's associatedCollectionID should match its own collection — badge must be hidden"
+        )
+    }
+
+    func testVallackExternallyManagedCollectionShouldShowBadge() async throws {
+        let record = InstalledPackRecord(
+            packID: "com.keypath.pack.vallack-system",
+            version: "1.0.0"
+        )
+        try await InstalledPackTracker.shared.upsert(record)
+
+        let owner = await InstalledPackTracker.shared.packManagingCollection(
+            RuleCollectionIdentifier.homeRowMods
+        )
+        XCTAssertNotNil(owner)
+
+        let pack = PackRegistry.pack(id: owner!.packID)!
+        XCTAssertNotEqual(
+            pack.associatedCollectionID, RuleCollectionIdentifier.homeRowMods,
+            "Vallack's associatedCollectionID is vallackNavigation, not homeRowMods — badge should show"
+        )
+    }
+
+    func testAllPacksWithAssociatedCollectionAreSelfManaged() {
+        for pack in PackRegistry.starterKit where pack.associatedCollectionID != nil {
+            XCTAssertTrue(
+                pack.managedCollectionIDs.contains(pack.associatedCollectionID!),
+                "\(pack.name) manages collections \(pack.managedCollectionIDs) but its associatedCollectionID \(pack.associatedCollectionID!) is missing"
+            )
+        }
+    }
+
     func testOwnershipClearsOnUninstall() async throws {
         let record = InstalledPackRecord(
             packID: "com.keypath.pack.chord-groups",

--- a/Tests/KeyPathTests/RuleCollections/RuleCollectionsManagerTests.swift
+++ b/Tests/KeyPathTests/RuleCollections/RuleCollectionsManagerTests.swift
@@ -754,4 +754,71 @@ final class RuleCollectionsManagerTests: XCTestCase {
         XCTAssertEqual(manager.ruleCollections.count, 1)
         XCTAssertTrue(manager.ruleCollections.contains { $0.name == "Vim" })
     }
+
+    // MARK: - Pack Reconciliation Tests
+
+    @MainActor
+    func testBootstrapReconcilesPacks_ReEnablesDisabledCollections() async throws {
+        TestEnvironment.forceTestMode = true
+        defer { TestEnvironment.forceTestMode = false }
+
+        let (manager, tempDir) = try await createTestManager()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        // Simulate: caps-lock-to-escape pack is installed (it manages capsLockRemap collection)
+        let record = InstalledPackRecord(
+            packID: "com.keypath.pack.caps-lock-to-escape",
+            version: "1.0.0"
+        )
+        try await InstalledPackTracker.shared.upsert(record)
+        defer { Task { try? await InstalledPackTracker.shared.remove(packID: record.packID) } }
+
+        // Save all collections with everything disabled (simulates post-reset state)
+        var allDisabled = RuleCollectionCatalog().defaultCollections()
+        for i in allDisabled.indices {
+            allDisabled[i].isEnabled = false
+        }
+        try await manager.ruleCollectionStore.saveCollections(allDisabled)
+
+        // Bootstrap should reconcile: re-enable capsLockRemap because the pack is installed
+        await manager.bootstrap()
+
+        let capsCollection = manager.ruleCollections.first {
+            $0.id == RuleCollectionIdentifier.capsLockRemap
+        }
+        XCTAssertNotNil(capsCollection)
+        XCTAssertTrue(
+            capsCollection?.isEnabled == true,
+            "Caps Lock Remap should be re-enabled by reconciliation because its pack is installed"
+        )
+    }
+
+    @MainActor
+    func testBootstrapReconciliation_DoesNotEnableUninstalledPacks() async throws {
+        TestEnvironment.forceTestMode = true
+        defer { TestEnvironment.forceTestMode = false }
+
+        let (manager, tempDir) = try await createTestManager()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        // Ensure no packs are installed for this collection
+        try? await InstalledPackTracker.shared.remove(packID: "com.keypath.pack.vim-navigation")
+
+        // Save all collections disabled
+        var allDisabled = RuleCollectionCatalog().defaultCollections()
+        for i in allDisabled.indices {
+            allDisabled[i].isEnabled = false
+        }
+        try await manager.ruleCollectionStore.saveCollections(allDisabled)
+
+        await manager.bootstrap()
+
+        let vimCollection = manager.ruleCollections.first {
+            $0.id == RuleCollectionIdentifier.vimNavigation
+        }
+        XCTAssertFalse(
+            vimCollection?.isEnabled == true,
+            "Vim Navigation should remain disabled when its pack is not installed"
+        )
+    }
 }

--- a/Tests/KeyPathTests/VallackOverlayZoneTests.swift
+++ b/Tests/KeyPathTests/VallackOverlayZoneTests.swift
@@ -300,7 +300,8 @@ final class VallackOverlayZoneTests: XCTestCase {
         )
         XCTAssertNotNil(config)
         XCTAssertEqual(config?.activatorKeyCodes, Set<UInt16>([3, 38]))
-        XCTAssertEqual(config?.targetLayer, "vallack-nav")
+        XCTAssertEqual(config?.targets[3], "vallack-nav")
+        XCTAssertEqual(config?.targets[38], "vallack-nav")
     }
 
     func testLayerPreviewConfigReturnsNilWithoutPack() {

--- a/docs/plans/drag-to-authorize-permissions.md
+++ b/docs/plans/drag-to-authorize-permissions.md
@@ -1,0 +1,148 @@
+# Drag-to-Authorize Permission Overlay
+
+**Status:** Planning — no implementation started  
+**Created:** 2026-05-17  
+**Branch:** TBD (will create feature branch when implementation begins)
+
+## Goal
+
+Replace the current Finder-reveal permission flow with a floating overlay panel that lets users drag `kanata-launcher` directly into System Settings' privacy lists. Inspired by [Permiso](https://github.com/zats/permiso) and OpenAI Codex Desktop's approach.
+
+## Problem
+
+The current flow (`WizardPermissionFinderHelper.revealKanataLauncher()`) is fragile and confusing:
+
+1. Opens System Settings to the correct privacy pane
+2. Reveals `kanata-launcher` in Finder with siblings hidden via `chflags hidden`
+3. Positions Settings and Finder side-by-side
+4. User must locate the file in Finder, then drag it into Settings
+
+Issues:
+- Users don't understand they need to drag from Finder to Settings
+- `chflags hidden` leaves files hidden if the app crashes before cleanup
+- `positionSettingsAndFinderSideBySide()` can't actually resize Settings (it only repositions windows the app owns — Settings is a separate process)
+- The Finder window often opens in column view, burying the file
+
+## Proposed Solution
+
+A floating `NSPanel` positioned directly below the Settings window, containing a clearly-labeled draggable icon of `kanata-launcher` with an animated arrow pointing up toward the privacy list.
+
+### Key Design Decisions
+
+1. **NSPanel, not NSWindow** — non-activating so dragging doesn't steal focus from Settings
+2. **Track Settings window position** — poll `CGWindowListCopyWindowInfo` to keep the panel anchored below Settings even if the user moves it
+3. **NSDraggingSource with `.fileURL`** — standard file drag pasteboard type that Settings accepts
+4. **Permission polling** — use `PermissionOracle.forceRefresh()` to detect when the drop succeeds
+
+### Proposed File Structure
+
+```
+Sources/KeyPathInstallationWizard/UI/Helpers/DragToAuthorize/
+  DragToAuthorizeController.swift      — State machine, lifecycle, permission polling
+  DragToAuthorizePanel.swift           — NSPanel (non-activating, borderless, floating)
+  DragToAuthorizeOverlayView.swift     — SwiftUI content with glass material + animations
+  DragToAuthorizeStateModel.swift      — @Observable model driving animation transitions
+  DragToAuthorizeDragSource.swift      — NSView providing NSDraggingSource with .fileURL
+  SettingsWindowTracker.swift          — CGWindowList polling with lerp interpolation
+```
+
+### State Machine
+
+```
+idle → presenting → visible → dragging → success → dismissing → idle
+                            ↘ retrying ↗
+```
+
+### How It Would Work
+
+1. User clicks "Add in Settings" on the wizard permission page
+2. `DragToAuthorizeController.shared.present(for: .accessibility)` is called
+3. Controller opens System Settings via deep-link URL
+4. After brief delay, creates floating `DragToAuthorizePanel`
+5. `SettingsWindowTracker` polls `CGWindowListCopyWindowInfo` to find and track Settings window
+6. Panel anchors below Settings, horizontally centered, with lerp-smoothed tracking
+7. User drags `kanata-launcher` icon from overlay into the Settings privacy list
+8. Controller polls `PermissionOracle.forceRefresh()` to detect grant
+9. On success: checkmark animation → auto-dismiss
+
+### Animation Specs
+
+| Animation | Spec |
+|-----------|------|
+| Present (from source rect) | Spring response: 0.5, damping: 0.75. Scale 0.3→1.0, opacity 0→1 |
+| Present (no source) | Fade + slide up 20pt over 0.35s ease-out |
+| Arrow pulse | scaleEffect 1.0↔1.15, easeInOut 1.2s, repeating |
+| Drag lift | Scale 1.0→1.03, shadow 4→12, spring response: 0.2 |
+| Success | Checkmark with .bounce symbolEffect, green circle bg |
+| Retry shake | Offset x: [-8, 8, -4, 4, 0] over 0.3s |
+| Dismiss | Opacity 1→0, offset y: 0→+20, easeIn 0.25s |
+| Window tracking | Lerp factor 0.3 per 150ms tick |
+
+### Integration Points
+
+- **WizardAccessibilityPage** — replace `revealKanataLauncher()` + `openAccessibilitySettings()` with controller call
+- **WizardInputMonitoringPage** — same pattern
+- **onDisappear** — dismiss overlay when navigating away
+- **AdvancedSettingsTabView** — `#if DEBUG` test buttons for manual validation
+
+### Deep-Link URLs (already defined in `KeyPathConstants.swift`)
+
+- Accessibility: `x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility`
+- Input Monitoring: `x-apple.systempreferences:com.apple.preference.security?Privacy_ListenEvent`
+- Full Disk Access: `x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles`
+
+## Risk: Bare Binary Drag Acceptance
+
+**Status: UNVALIDATED — requires manual test before implementation**
+
+System Settings privacy lists accept `.fileURL` drops. Permiso proves this works for `.app` bundles. The open question is whether it works for bare Mach-O executables like `kanata-launcher`.
+
+**Evidence supporting it will work:**
+- TCC database registers kanata-launcher by full path (not bundle ID)
+- kanata-launcher is properly code-signed with team ID X2RKZ5TG99
+- The pasteboard type (`.fileURL`) is format-agnostic — it's just a URL
+
+**How to validate (do this FIRST before building anything):**
+1. Create a minimal test app with an `NSDraggingSource` that puts `kanata-launcher`'s path on the pasteboard as `.fileURL`
+2. Open System Settings → Privacy & Security → Accessibility
+3. Try to drag from the test app into the privacy list
+4. If it works → proceed with full implementation
+5. If it doesn't → fall back to dragging `KeyPath.app` bundle instead
+
+**Fallback if bare binary doesn't work:**
+- Drag `KeyPath.app` instead (definitely works per Permiso)
+- KeyPath.app in the Accessibility list may still cover kanata-launcher if it's a child process (needs verification)
+
+## Current Implementation (to be replaced)
+
+`WizardPermissionFinderHelper` at:
+```
+Sources/KeyPathInstallationWizard/UI/Helpers/WizardPermissionFinderHelper.swift
+```
+
+Called from:
+- `WizardAccessibilityPage.swift:449` — `WizardPermissionFinderHelper.revealKanataLauncher()`
+- `WizardInputMonitoringPage.swift:465` — `WizardPermissionFinderHelper.revealKanataLauncher()`
+
+## Implementation Order
+
+1. **Validate bare binary drag** — build minimal test, confirm it works
+2. **SettingsWindowTracker** — CGWindowList polling, tested standalone
+3. **DragToAuthorizeDragSource** — NSView + NSDraggingSource, confirm pasteboard works
+4. **DragToAuthorizePanel** — NSPanel shell, positioning logic
+5. **DragToAuthorizeOverlayView** — SwiftUI content, animations
+6. **DragToAuthorizeStateModel** — @Observable state machine
+7. **DragToAuthorizeController** — orchestrator, Oracle polling, lifecycle
+8. **Integration** — wire into wizard pages, remove old Finder helper calls
+9. **Edge cases** — Settings closed mid-drag, space switching, multiple displays
+10. **Cleanup** — remove `WizardPermissionFinderHelper` if no longer needed
+
+## Research: Why Not Use Permiso Directly
+
+Evaluated [zats/permiso](https://github.com/zats/permiso) and decided to implement natively:
+- No license file (legally unusable)
+- macOS 26 minimum (KeyPath targets macOS 15+)
+- Only supports Accessibility + Screen Recording (missing Input Monitoring)
+- Single-day proof of concept (8 commits, April 17 2026)
+- No permission detection (we already have PermissionOracle)
+- We need tighter integration with our wizard flow and state machine


### PR DESCRIPTION
## Summary

- Adds a design plan for replacing the current Finder-reveal permission flow with a floating NSPanel overlay that lets users drag `kanata-launcher` directly into System Settings' privacy lists
- Documents the proposed state machine, file structure, animation specs, integration points, and a risk-first validation approach (test bare binary drag acceptance before building anything)
- Inspired by [Permiso](https://github.com/zats/permiso) but implemented natively due to licensing, OS target, and integration concerns

## Context

The current `WizardPermissionFinderHelper` flow is fragile: it relies on `chflags hidden`, can't resize System Settings windows, and confuses users who don't understand the drag-from-Finder interaction. This plan proposes a purpose-built floating panel anchored below Settings with a clearly-labeled draggable icon and animated guidance.

No implementation yet -- this is the design document to align on approach before writing code.

## Test plan

- [ ] Review plan for completeness and feasibility
- [ ] Validate bare binary drag acceptance (Step 1 in Implementation Order) before approving implementation work