### PR TITLE
fix: use KeyPathAppKitResources.bundle instead of Bundle.module

### DIFF
--- a/Sources/KeyPathAppKit/WizardProtocolConformances.swift
+++ b/Sources/KeyPathAppKit/WizardProtocolConformances.swift
@@ -156,7 +156,7 @@ public func configureWizardDependencies(runtimeCoordinator: RuntimeCoordinator) 
         let result = try await AdminCommandExecutorHolder.shared.execute(batch: batch)
         return (exitCode: result.exitCode, output: result.output)
     }
-    WizardDependencies.resourceBundle = Bundle.module
+    WizardDependencies.resourceBundle = KeyPathAppKitResources.bundle
 
     // ExternalKanataService static methods
     WizardDependencies.getExternalKanataInfo = {


### PR DESCRIPTION
## Summary
- Replace `Bundle.module` with `KeyPathAppKitResources.bundle` in `WizardProtocolConformances.swift`
- `Bundle.module` can crash at runtime when the generated resource accessor is unavailable; `KeyPathAppKitResources.bundle` is the stable, explicit accessor

## Test plan
- [ ] Build succeeds
- [ ] Wizard pages that use bundled resources (images, strings) load without crash