### PR TITLE
refactor: extract RulesFacade and SimulatorFacade from CLIFacade

### DIFF
--- a/Sources/KeyPathAppKit/CLI/CLIFacade.swift
+++ b/Sources/KeyPathAppKit/CLI/CLIFacade.swift
@@ -7,13 +7,22 @@ import KeyPathWizardCore
 /// Public facade exposing KeyPathAppKit internals for the CLI binary.
 /// This is the stable API boundary between the CLI and the app library.
 ///
-/// Method groups live in extension files:
-/// - CLIFacade+Rules.swift — Custom rules CRUD
+/// Method groups live in extension files and standalone facades:
+/// - RulesFacade.swift — Custom rules CRUD (standalone)
+/// - SimulatorFacade.swift — Key simulation and validation (standalone)
 /// - CLIFacade+Collections.swift — Rule collections CRUD
 /// - CLIFacade+Service.swift — Service lifecycle, config, TCP, status, installer
 /// - CLIFacade+Packs.swift — Pack management
 public struct CLIFacade: Sendable {
     public init() {}
+
+    static func parseLayer(_ name: String) -> RuleCollectionLayer {
+        switch name.lowercased() {
+        case "base": .base
+        case "nav", "navigation": .navigation
+        default: .custom(name)
+        }
+    }
 
     // MARK: - Export / Import
 
@@ -141,24 +150,6 @@ public struct CLIFacade: Sendable {
         return try service.convert(data: wrappedData, profileIndex: 0)
     }
 
-    // MARK: - Simulate
-
-    public func simulate(
-        keys: [CLISimulatorKeyTap],
-        configPath: String?,
-        simulatorProvider: CLISimulatorProvider? = nil
-    ) async throws -> CLISimulationResult {
-        let config: String
-        if let configPath {
-            config = configPath
-        } else {
-            config = await MainActor.run { ConfigurationService().configurationPath }
-        }
-
-        let provider = simulatorProvider ?? RealSimulatorProvider()
-        return try await provider.simulate(taps: keys, configPath: config)
-    }
-
     // MARK: - Layer CRUD
 
     public func listDefinedLayers() async -> [String] {
@@ -217,13 +208,6 @@ public struct CLIFacade: Sendable {
             try await RuleCollectionStore.shared.saveCollections(collections)
         }
         return updated
-    }
-
-    // MARK: - Key Validation
-
-    public func validateKey(_ key: String) -> String? {
-        guard CustomRuleValidator.isValidKey(key) else { return nil }
-        return CustomRuleValidator.normalizeKey(key)
     }
 
     // MARK: - Helpers
@@ -312,12 +296,6 @@ public enum CLIVersion {
 }
 
 // MARK: - Public CLI Types
-
-public struct CLICustomRule: Codable, Sendable {
-    public let input: String
-    public let output: String
-    public let behavior: String?
-}
 
 public struct CLIRuleCollection: Codable, Sendable {
     public let id: String
@@ -431,160 +409,6 @@ public struct CLIInspectResult: Codable, Sendable {
     public let plannedRecipes: [String]
 }
 
-// MARK: - Rule Detail Types
-
-public struct CLIRuleDetail: Codable, Sendable {
-    public let input: String
-    public let action: KeyAction
-    public let behavior: MappingBehavior?
-    public let shiftedOutput: String?
-    public let title: String?
-    public let notes: String?
-    public let targetLayer: String
-    public let deviceOverrides: [CLIDeviceOverride]?
-    public let isEnabled: Bool
-    public let createdAt: Date
-
-    public init(from rule: CustomRule) {
-        input = rule.input
-        action = rule.action
-        behavior = rule.behavior
-        shiftedOutput = rule.shiftedOutput
-        title = rule.title.isEmpty ? nil : rule.title
-        notes = rule.notes
-        targetLayer = rule.targetLayer.kanataName
-        deviceOverrides = rule.deviceOverrides?.map { CLIDeviceOverride(from: $0) }
-        isEnabled = rule.isEnabled
-        createdAt = rule.createdAt
-    }
-
-    public static func dryRunPreview(
-        input: String,
-        action: KeyAction?,
-        behavior: MappingBehavior?,
-        shiftedOutput: String?,
-        title: String?,
-        notes: String?,
-        targetLayer: String?
-    ) -> CLIRuleDetail {
-        CLIRuleDetail(
-            input: input,
-            action: action ?? .empty,
-            behavior: behavior,
-            shiftedOutput: shiftedOutput,
-            title: title,
-            notes: notes,
-            targetLayer: targetLayer ?? "base",
-            deviceOverrides: nil,
-            isEnabled: true,
-            createdAt: Date()
-        )
-    }
-
-    public init(
-        input: String,
-        action: KeyAction,
-        behavior: MappingBehavior?,
-        shiftedOutput: String?,
-        title: String?,
-        notes: String?,
-        targetLayer: String,
-        deviceOverrides: [CLIDeviceOverride]?,
-        isEnabled: Bool,
-        createdAt: Date
-    ) {
-        self.input = input
-        self.action = action
-        self.behavior = behavior
-        self.shiftedOutput = shiftedOutput
-        self.title = title
-        self.notes = notes
-        self.targetLayer = targetLayer
-        self.deviceOverrides = deviceOverrides
-        self.isEnabled = isEnabled
-        self.createdAt = createdAt
-    }
-}
-
-public struct CLIDeviceOverride: Codable, Sendable {
-    public let deviceHash: String
-    public let action: KeyAction
-    public let behavior: MappingBehavior?
-
-    public init(from override: DeviceKeyOverride) {
-        deviceHash = override.deviceHash
-        action = override.output
-        behavior = override.behavior
-    }
-}
-
-public enum RuleAddResult: Codable, Sendable {
-    case created(CLIRuleDetail)
-    case replaced(CLIRuleDetail)
-    case merged(CLIRuleDetail)
-    case skipped
-
-    private enum CodingKeys: String, CodingKey {
-        case status
-        case rule
-    }
-
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        let status = try container.decode(String.self, forKey: .status)
-        switch status {
-        case "created":
-            let rule = try container.decode(CLIRuleDetail.self, forKey: .rule)
-            self = .created(rule)
-        case "replaced":
-            let rule = try container.decode(CLIRuleDetail.self, forKey: .rule)
-            self = .replaced(rule)
-        case "merged":
-            let rule = try container.decode(CLIRuleDetail.self, forKey: .rule)
-            self = .merged(rule)
-        case "skipped":
-            self = .skipped
-        default:
-            throw DecodingError.dataCorruptedError(forKey: .status, in: container, debugDescription: "Unknown status: \(status)")
-        }
-    }
-
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
-        switch self {
-        case let .created(rule):
-            try container.encode("created", forKey: .status)
-            try container.encode(rule, forKey: .rule)
-        case let .replaced(rule):
-            try container.encode("replaced", forKey: .status)
-            try container.encode(rule, forKey: .rule)
-        case let .merged(rule):
-            try container.encode("merged", forKey: .status)
-            try container.encode(rule, forKey: .rule)
-        case .skipped:
-            try container.encode("skipped", forKey: .status)
-        }
-    }
-}
-
-public enum CLIConflictStrategy: String, Sendable {
-    case fail
-    case replace
-    case skip
-    case merge
-}
-
-public struct CLIMergeError: Error, CustomStringConvertible {
-    public let input: String
-    public let reason: String
-    public var description: String { "Cannot merge rules for '\(input)': \(reason)" }
-}
-
-public struct CLIConflictError: Error, CustomStringConvertible {
-    public let input: String
-    public var description: String { "Rule already exists for '\(input)'" }
-}
-
 // MARK: - Karabiner Import Types
 
 public struct CLIKarabinerImportResult: Codable, Sendable {
@@ -657,69 +481,6 @@ public struct CLIExportedMapping: Codable, Sendable {
 
     public func toKeyMapping() -> KeyMapping {
         KeyMapping(input: input, action: action, shiftedOutput: shiftedOutput, behavior: behavior)
-    }
-}
-
-// MARK: - Simulator Types
-
-public struct CLISimulatorKeyTap: Sendable {
-    public let key: String
-    public let delayMs: UInt64
-    public let isHold: Bool
-
-    public init(key: String, delayMs: UInt64 = 200, isHold: Bool = false) {
-        self.key = key
-        self.delayMs = delayMs
-        self.isHold = isHold
-    }
-}
-
-public struct CLISimulationResult: Codable, Sendable {
-    public let events: [CLISimEvent]
-    public let finalLayer: String
-    public let durationMs: UInt64
-}
-
-public struct CLISimEvent: Codable, Sendable {
-    public let type: String
-    public let timeMs: UInt64
-    public let action: String?
-    public let key: String?
-
-    public init(type: String, timeMs: UInt64, action: String? = nil, key: String? = nil) {
-        self.type = type
-        self.timeMs = timeMs
-        self.action = action
-        self.key = key
-    }
-}
-
-public protocol CLISimulatorProvider: Sendable {
-    func simulate(taps: [CLISimulatorKeyTap], configPath: String) async throws -> CLISimulationResult
-}
-
-struct RealSimulatorProvider: CLISimulatorProvider {
-    func simulate(taps: [CLISimulatorKeyTap], configPath: String) async throws -> CLISimulationResult {
-        let service = SimulatorService()
-        let internalTaps = taps.map {
-            SimulatorKeyTap(kanataKey: $0.key, displayLabel: $0.key, delayAfterMs: $0.delayMs, isHold: $0.isHold)
-        }
-        let result = try await service.simulate(taps: internalTaps, configPath: configPath)
-        let events = result.events.map { event -> CLISimEvent in
-            switch event {
-            case let .input(t, action, key):
-                CLISimEvent(type: "input", timeMs: t, action: action.rawValue, key: key)
-            case let .output(t, action, key):
-                CLISimEvent(type: "output", timeMs: t, action: action.rawValue, key: key)
-            case let .layer(t, from, to):
-                CLISimEvent(type: "layer", timeMs: t, key: "\(from) -> \(to)")
-            case let .unicode(t, char):
-                CLISimEvent(type: "unicode", timeMs: t, key: char)
-            case let .mouse(t, action, data):
-                CLISimEvent(type: "mouse", timeMs: t, action: action.rawValue, key: data)
-            }
-        }
-        return CLISimulationResult(events: events, finalLayer: result.finalLayer ?? "base", durationMs: result.durationMs)
     }
 }
 

--- a/Sources/KeyPathAppKit/CLI/RulesFacade.swift
+++ b/Sources/KeyPathAppKit/CLI/RulesFacade.swift
@@ -1,9 +1,9 @@
 import Foundation
 import KeyPathCore
 
-// MARK: - Custom Rules
+public struct RulesFacade: Sendable {
+    public init() {}
 
-extension CLIFacade {
     public func loadCustomRules() async -> [CLICustomRule] {
         let rules = await CustomRulesStore.shared.loadRules()
         return rules.map { CLICustomRule(input: $0.input, output: $0.action.outputString, behavior: $0.behavior.map(Self.describeBehavior)) }
@@ -208,4 +208,161 @@ extension CLIFacade {
             reason: "incompatible behavior types cannot be merged"
         )
     }
+}
+
+// MARK: - Rule Types
+
+public struct CLICustomRule: Codable, Sendable {
+    public let input: String
+    public let output: String
+    public let behavior: String?
+}
+
+public struct CLIRuleDetail: Codable, Sendable {
+    public let input: String
+    public let action: KeyAction
+    public let behavior: MappingBehavior?
+    public let shiftedOutput: String?
+    public let title: String?
+    public let notes: String?
+    public let targetLayer: String
+    public let deviceOverrides: [CLIDeviceOverride]?
+    public let isEnabled: Bool
+    public let createdAt: Date
+
+    public init(from rule: CustomRule) {
+        input = rule.input
+        action = rule.action
+        behavior = rule.behavior
+        shiftedOutput = rule.shiftedOutput
+        title = rule.title.isEmpty ? nil : rule.title
+        notes = rule.notes
+        targetLayer = rule.targetLayer.kanataName
+        deviceOverrides = rule.deviceOverrides?.map { CLIDeviceOverride(from: $0) }
+        isEnabled = rule.isEnabled
+        createdAt = rule.createdAt
+    }
+
+    public static func dryRunPreview(
+        input: String,
+        action: KeyAction?,
+        behavior: MappingBehavior?,
+        shiftedOutput: String?,
+        title: String?,
+        notes: String?,
+        targetLayer: String?
+    ) -> CLIRuleDetail {
+        CLIRuleDetail(
+            input: input,
+            action: action ?? .empty,
+            behavior: behavior,
+            shiftedOutput: shiftedOutput,
+            title: title,
+            notes: notes,
+            targetLayer: targetLayer ?? "base",
+            deviceOverrides: nil,
+            isEnabled: true,
+            createdAt: Date()
+        )
+    }
+
+    public init(
+        input: String,
+        action: KeyAction,
+        behavior: MappingBehavior?,
+        shiftedOutput: String?,
+        title: String?,
+        notes: String?,
+        targetLayer: String,
+        deviceOverrides: [CLIDeviceOverride]?,
+        isEnabled: Bool,
+        createdAt: Date
+    ) {
+        self.input = input
+        self.action = action
+        self.behavior = behavior
+        self.shiftedOutput = shiftedOutput
+        self.title = title
+        self.notes = notes
+        self.targetLayer = targetLayer
+        self.deviceOverrides = deviceOverrides
+        self.isEnabled = isEnabled
+        self.createdAt = createdAt
+    }
+}
+
+public struct CLIDeviceOverride: Codable, Sendable {
+    public let deviceHash: String
+    public let action: KeyAction
+    public let behavior: MappingBehavior?
+
+    public init(from override: DeviceKeyOverride) {
+        deviceHash = override.deviceHash
+        action = override.output
+        behavior = override.behavior
+    }
+}
+
+public enum RuleAddResult: Codable, Sendable {
+    case created(CLIRuleDetail)
+    case replaced(CLIRuleDetail)
+    case merged(CLIRuleDetail)
+    case skipped
+
+    private enum CodingKeys: String, CodingKey {
+        case status
+        case rule
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let status = try container.decode(String.self, forKey: .status)
+        switch status {
+        case "created":
+            self = .created(try container.decode(CLIRuleDetail.self, forKey: .rule))
+        case "replaced":
+            self = .replaced(try container.decode(CLIRuleDetail.self, forKey: .rule))
+        case "merged":
+            self = .merged(try container.decode(CLIRuleDetail.self, forKey: .rule))
+        case "skipped":
+            self = .skipped
+        default:
+            throw DecodingError.dataCorruptedError(forKey: .status, in: container, debugDescription: "Unknown status: \(status)")
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case let .created(rule):
+            try container.encode("created", forKey: .status)
+            try container.encode(rule, forKey: .rule)
+        case let .replaced(rule):
+            try container.encode("replaced", forKey: .status)
+            try container.encode(rule, forKey: .rule)
+        case let .merged(rule):
+            try container.encode("merged", forKey: .status)
+            try container.encode(rule, forKey: .rule)
+        case .skipped:
+            try container.encode("skipped", forKey: .status)
+        }
+    }
+}
+
+public enum CLIConflictStrategy: String, Sendable {
+    case fail
+    case replace
+    case skip
+    case merge
+}
+
+public struct CLIMergeError: Error, CustomStringConvertible {
+    public let input: String
+    public let reason: String
+    public var description: String { "Cannot merge rules for '\(input)': \(reason)" }
+}
+
+public struct CLIConflictError: Error, CustomStringConvertible {
+    public let input: String
+    public var description: String { "Rule already exists for '\(input)'" }
 }

--- a/Sources/KeyPathAppKit/CLI/SimulatorFacade.swift
+++ b/Sources/KeyPathAppKit/CLI/SimulatorFacade.swift
@@ -1,0 +1,90 @@
+import Foundation
+import KeyPathCore
+
+public struct SimulatorFacade: Sendable {
+    public init() {}
+
+    public func simulate(
+        keys: [CLISimulatorKeyTap],
+        configPath: String?,
+        simulatorProvider: CLISimulatorProvider? = nil
+    ) async throws -> CLISimulationResult {
+        let config: String
+        if let configPath {
+            config = configPath
+        } else {
+            config = await MainActor.run { ConfigurationService().configurationPath }
+        }
+
+        let provider = simulatorProvider ?? RealSimulatorProvider()
+        return try await provider.simulate(taps: keys, configPath: config)
+    }
+
+    public func validateKey(_ key: String) -> String? {
+        guard CustomRuleValidator.isValidKey(key) else { return nil }
+        return CustomRuleValidator.normalizeKey(key)
+    }
+}
+
+// MARK: - Simulator Types
+
+public struct CLISimulatorKeyTap: Sendable {
+    public let key: String
+    public let delayMs: UInt64
+    public let isHold: Bool
+
+    public init(key: String, delayMs: UInt64 = 200, isHold: Bool = false) {
+        self.key = key
+        self.delayMs = delayMs
+        self.isHold = isHold
+    }
+}
+
+public struct CLISimulationResult: Codable, Sendable {
+    public let events: [CLISimEvent]
+    public let finalLayer: String
+    public let durationMs: UInt64
+}
+
+public struct CLISimEvent: Codable, Sendable {
+    public let type: String
+    public let timeMs: UInt64
+    public let action: String?
+    public let key: String?
+
+    public init(type: String, timeMs: UInt64, action: String? = nil, key: String? = nil) {
+        self.type = type
+        self.timeMs = timeMs
+        self.action = action
+        self.key = key
+    }
+}
+
+public protocol CLISimulatorProvider: Sendable {
+    func simulate(taps: [CLISimulatorKeyTap], configPath: String) async throws -> CLISimulationResult
+}
+
+struct RealSimulatorProvider: CLISimulatorProvider {
+    func simulate(taps: [CLISimulatorKeyTap], configPath: String) async throws -> CLISimulationResult {
+        let service = SimulatorService()
+        let internalTaps = taps.map {
+            SimulatorKeyTap(kanataKey: $0.key, displayLabel: $0.key, delayAfterMs: $0.delayMs, isHold: $0.isHold)
+        }
+        let result = try await service.simulate(taps: internalTaps, configPath: configPath)
+        let events = result.events.map { event -> CLISimEvent in
+            switch event {
+            case let .input(t, action, key):
+                CLISimEvent(type: "input", timeMs: t, action: action.rawValue, key: key)
+            case let .output(t, action, key):
+                CLISimEvent(type: "output", timeMs: t, action: action.rawValue, key: key)
+            case let .layer(t, from, to):
+                CLISimEvent(type: "layer", timeMs: t, key: "\(from) -> \(to)")
+            case let .unicode(t, char):
+                CLISimEvent(type: "unicode", timeMs: t, key: char)
+            case let .mouse(t, action, data):
+                CLISimEvent(type: "mouse", timeMs: t, action: action.rawValue, key: data)
+            }
+        }
+        return CLISimulationResult(events: events, finalLayer: result.finalLayer ?? "base", durationMs: result.durationMs)
+    }
+}

--- a/Sources/KeyPathCLI/Commands/Collection/CollectionDisableCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Collection/CollectionDisableCommand.swift
@@ -47,6 +47,6 @@ struct CollectionDisable: AsyncParsableCommand {
             throw error.code.exitCode
         }
 
-        try await applyConfigurationOrHint(facade: facade, apply: apply, context: ctx)
+        try await applyConfigurationOrHint(apply: apply, context: ctx)
     }
 }

--- a/Sources/KeyPathCLI/Commands/Collection/CollectionEnableCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Collection/CollectionEnableCommand.swift
@@ -47,6 +47,6 @@ struct CollectionEnable: AsyncParsableCommand {
             throw error.code.exitCode
         }
 
-        try await applyConfigurationOrHint(facade: facade, apply: apply, context: ctx)
+        try await applyConfigurationOrHint(apply: apply, context: ctx)
     }
 }

--- a/Sources/KeyPathCLI/Commands/CompletionsCommand.swift
+++ b/Sources/KeyPathCLI/Commands/CompletionsCommand.swift
@@ -234,7 +234,8 @@ struct Completions: ParsableCommand {
                     CLIOutput.writeRaw(layer)
                 }
             case "rule":
-                let rules = await facade.listRules()
+                let rulesFacade = RulesFacade()
+                let rules = await rulesFacade.listRules()
                 for rule in rules {
                     CLIOutput.writeRaw(rule.input)
                 }

--- a/Sources/KeyPathCLI/Commands/Pack/PackConfigureCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Pack/PackConfigureCommand.swift
@@ -68,7 +68,7 @@ struct PackConfigure: AsyncParsableCommand {
             }
 
             if result.action == "configured" {
-                try await applyConfigurationOrHint(facade: facade, apply: apply, context: ctx)
+                try await applyConfigurationOrHint(apply: apply, context: ctx)
             }
         } catch let notFound as CLIPackNotFound {
             let allPacks = await facade.listPacks()

--- a/Sources/KeyPathCLI/Commands/Pack/PackInstallCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Pack/PackInstallCommand.swift
@@ -87,7 +87,7 @@ struct PackInstall: AsyncParsableCommand {
             }
 
             if result.action == "installed" {
-                try await applyConfigurationOrHint(facade: facade, apply: apply, context: ctx)
+                try await applyConfigurationOrHint(apply: apply, context: ctx)
             }
         } catch let notFound as CLIPackNotFound {
             spinner.fail("Pack not found: '\(notFound.query)'")

--- a/Sources/KeyPathCLI/Commands/Pack/PackUninstallCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Pack/PackUninstallCommand.swift
@@ -53,7 +53,7 @@ struct PackUninstall: AsyncParsableCommand {
             }
 
             if result.action == "uninstalled" {
-                try await applyConfigurationOrHint(facade: facade, apply: apply, context: ctx)
+                try await applyConfigurationOrHint(apply: apply, context: ctx)
             }
         } catch let notFound as CLIPackNotFound {
             spinner.fail("Pack not found: '\(notFound.query)'")

--- a/Sources/KeyPathCLI/Commands/Rule/RuleAddCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Rule/RuleAddCommand.swift
@@ -61,9 +61,10 @@ struct RuleAdd: AsyncParsableCommand {
 
     mutating func run() async throws {
         let ctx = globals.outputContext
-        let facade = await MainActor.run { CLIFacade() }
+        let validator = SimulatorFacade()
+        let rules = RulesFacade()
 
-        guard facade.validateKey(input) != nil else {
+        guard validator.validateKey(input) != nil else {
             let error = CLIError.invalidKey(input, label: "input")
             CLIOutput.writeError(error, context: ctx)
             throw error.code.exitCode
@@ -76,7 +77,7 @@ struct RuleAdd: AsyncParsableCommand {
             resolvedAction = try decodeAction(actionJSON, context: ctx)
         } else if let tap, let hold {
             for (key, label) in [(tap, "tap"), (hold, "hold")] {
-                guard facade.validateKey(key) != nil else {
+                guard validator.validateKey(key) != nil else {
                     let error = CLIError.invalidKey(key, label: label)
                     CLIOutput.writeError(error, context: ctx)
                     throw error.code.exitCode
@@ -89,7 +90,7 @@ struct RuleAdd: AsyncParsableCommand {
                 tapTimeout: tapTimeout
             ))
         } else if let output {
-            guard facade.validateKey(output) != nil else {
+            guard validator.validateKey(output) != nil else {
                 let error = CLIError.invalidKey(output, label: "output")
                 CLIOutput.writeError(error, context: ctx)
                 throw error.code.exitCode
@@ -130,7 +131,7 @@ struct RuleAdd: AsyncParsableCommand {
         let finalAction = resolvedAction.isEmpty ? .keystroke(key: input) : resolvedAction
 
         do {
-            let result = try await facade.addRule(
+            let result = try await rules.addRule(
                 input: input,
                 action: finalAction,
                 behavior: resolvedBehavior,
@@ -169,7 +170,7 @@ struct RuleAdd: AsyncParsableCommand {
             throw CLIExitCode.conflict.exitCode
         }
 
-        try await applyConfigurationOrHint(facade: facade, apply: apply, context: ctx)
+        try await applyConfigurationOrHint(apply: apply, context: ctx)
     }
 
     private func decodeAction(_ json: String, context: OutputContext) throws -> KeyAction {

--- a/Sources/KeyPathCLI/Commands/Rule/RuleDisableCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Rule/RuleDisableCommand.swift
@@ -18,7 +18,7 @@ struct RuleDisable: AsyncParsableCommand {
 
     mutating func run() async throws {
         let ctx = globals.outputContext
-        let facade = await MainActor.run { CLIFacade() }
+        let facade = RulesFacade()
 
         guard let title = try await facade.disableRule(input: input) else {
             let error = CLIError.notFound("Rule", query: input, listCommand: "keypath rule list")
@@ -30,6 +30,6 @@ struct RuleDisable: AsyncParsableCommand {
             "Disabled '\(title)' (\(input))"
         }
 
-        try await applyConfigurationOrHint(facade: facade, apply: apply, context: ctx)
+        try await applyConfigurationOrHint(apply: apply, context: ctx)
     }
 }

--- a/Sources/KeyPathCLI/Commands/Rule/RuleEnableCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Rule/RuleEnableCommand.swift
@@ -18,7 +18,7 @@ struct RuleEnable: AsyncParsableCommand {
 
     mutating func run() async throws {
         let ctx = globals.outputContext
-        let facade = await MainActor.run { CLIFacade() }
+        let facade = RulesFacade()
 
         guard let title = try await facade.enableRule(input: input) else {
             let error = CLIError.notFound("Rule", query: input, listCommand: "keypath rule list")
@@ -30,6 +30,6 @@ struct RuleEnable: AsyncParsableCommand {
             "Enabled '\(title)' (\(input))"
         }
 
-        try await applyConfigurationOrHint(facade: facade, apply: apply, context: ctx)
+        try await applyConfigurationOrHint(apply: apply, context: ctx)
     }
 }

--- a/Sources/KeyPathCLI/Commands/Rule/RuleEnsureCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Rule/RuleEnsureCommand.swift
@@ -30,7 +30,7 @@ struct RuleEnsure: AsyncParsableCommand {
 
     mutating func run() async throws {
         let ctx = globals.outputContext
-        let facade = await MainActor.run { CLIFacade() }
+        let facade = RulesFacade()
 
         if let fromFile {
             try await runBatch(file: fromFile, facade: facade, ctx: ctx)
@@ -64,12 +64,12 @@ struct RuleEnsure: AsyncParsableCommand {
             }
 
             if result.action == "created" || result.action == "updated" {
-                try await applyConfigurationOrHint(facade: facade, apply: apply, context: ctx)
+                try await applyConfigurationOrHint(apply: apply, context: ctx)
             }
         }
     }
 
-    private func runBatch(file: String, facade: CLIFacade, ctx: OutputContext) async throws {
+    private func runBatch(file: String, facade: RulesFacade, ctx: OutputContext) async throws {
         let path = (file as NSString).expandingTildeInPath
         guard let data = FileManager.default.contents(atPath: path) else {
             let error = CLIError.validation("Cannot read file: '\(file)'")
@@ -121,11 +121,11 @@ struct RuleEnsure: AsyncParsableCommand {
 
         let hadChanges = results.contains { $0.action == "created" || $0.action == "updated" }
         if hadChanges {
-            try await applyConfigurationOrHint(facade: facade, apply: apply, context: ctx)
+            try await applyConfigurationOrHint(apply: apply, context: ctx)
         }
     }
 
-    private func ensureOne(spec: EnsureSpec, facade: CLIFacade, dryRun: Bool) async throws -> CLIEnsureResult {
+    private func ensureOne(spec: EnsureSpec, facade: RulesFacade, dryRun: Bool) async throws -> CLIEnsureResult {
         let existing = await facade.showRule(input: spec.input)
 
         let matchesDesired: Bool

--- a/Sources/KeyPathCLI/Commands/Rule/RuleListCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Rule/RuleListCommand.swift
@@ -15,7 +15,7 @@ struct RuleList: AsyncParsableCommand {
 
     mutating func run() async throws {
         let ctx = globals.outputContext
-        let facade = await MainActor.run { CLIFacade() }
+        let facade = RulesFacade()
         let rules = await facade.listRules(enabledOnly: enabledOnly)
 
         CLIOutput.write(rules, context: ctx) {

--- a/Sources/KeyPathCLI/Commands/Rule/RuleRemoveCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Rule/RuleRemoveCommand.swift
@@ -18,7 +18,7 @@ struct RuleRemove: AsyncParsableCommand {
 
     mutating func run() async throws {
         let ctx = globals.outputContext
-        let facade = await MainActor.run { CLIFacade() }
+        let facade = RulesFacade()
 
         if globals.dryRun {
             let rule = await facade.showRule(input: input)
@@ -45,6 +45,6 @@ struct RuleRemove: AsyncParsableCommand {
             "Removed mapping for '\(input)'"
         }
 
-        try await applyConfigurationOrHint(facade: facade, apply: apply, context: ctx)
+        try await applyConfigurationOrHint(apply: apply, context: ctx)
     }
 }

--- a/Sources/KeyPathCLI/Commands/Rule/RuleShowCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Rule/RuleShowCommand.swift
@@ -15,7 +15,7 @@ struct RuleShow: AsyncParsableCommand {
 
     mutating func run() async throws {
         let ctx = globals.outputContext
-        let facade = await MainActor.run { CLIFacade() }
+        let facade = RulesFacade()
 
         guard let rule = await facade.showRule(input: input) else {
             let error = CLIError.notFound("Rule", query: input, listCommand: "keypath rule list")

--- a/Sources/KeyPathCLI/Commands/SimulateCommand.swift
+++ b/Sources/KeyPathCLI/Commands/SimulateCommand.swift
@@ -22,7 +22,7 @@ struct Simulate: AsyncParsableCommand {
 
     mutating func run() async throws {
         let ctx = globals.outputContext
-        let facade = await MainActor.run { CLIFacade() }
+        let facade = SimulatorFacade()
 
         let taps = keys.map { key -> CLISimulatorKeyTap in
             let parts = key.split(separator: ":", maxSplits: 1)

--- a/Sources/KeyPathCLI/Utilities/ApplyHelper.swift
+++ b/Sources/KeyPathCLI/Utilities/ApplyHelper.swift
@@ -2,8 +2,9 @@ import ArgumentParser
 import Foundation
 import KeyPathAppKit
 
-func applyConfigurationOrHint(facade: CLIFacade, apply: Bool, context: OutputContext) async throws {
+func applyConfigurationOrHint(apply: Bool, context: OutputContext) async throws {
     if apply {
+        let facade = await MainActor.run { CLIFacade() }
         let result = try await facade.applyConfiguration()
         if result.reloadSuccess {
             CLIOutput.write(["applied": true], context: context) {

--- a/Tests/KeyPathTests/CLI/CLIFacadeTests.swift
+++ b/Tests/KeyPathTests/CLI/CLIFacadeTests.swift
@@ -90,19 +90,6 @@ final class CLIFacadeTests: XCTestCase {
         XCTAssertNil(index)
     }
 
-    // MARK: - validateKey
-
-    func testValidateKeyReturnsCanonicalForm() {
-        XCTAssertEqual(facade.validateKey("caps"), "caps")
-        XCTAssertEqual(facade.validateKey("Escape"), "esc")
-        XCTAssertEqual(facade.validateKey("LALT"), "lalt")
-    }
-
-    func testValidateKeyReturnsNilForInvalid() {
-        XCTAssertNil(facade.validateKey("blahblah"))
-        XCTAssertNil(facade.validateKey("notakey123"))
-    }
-
     // MARK: - Helpers
 
     private func makeCollections(_ names: [String]) -> [RuleCollection] {

--- a/Tests/KeyPathTests/CLI/CLIRuleAddIntegrationTests.swift
+++ b/Tests/KeyPathTests/CLI/CLIRuleAddIntegrationTests.swift
@@ -3,7 +3,7 @@
 
 @MainActor
 final class CLIRuleAddIntegrationTests: XCTestCase {
-    private let facade = CLIFacade()
+    private let facade = RulesFacade()
 
     override func setUp() async throws {
         try await super.setUp()

--- a/Tests/KeyPathTests/CLI/CLIRuleCRUDTests.swift
+++ b/Tests/KeyPathTests/CLI/CLIRuleCRUDTests.swift
@@ -3,7 +3,7 @@
 
 @MainActor
 final class CLIRuleCRUDTests: XCTestCase {
-    private let facade = CLIFacade()
+    private let facade = RulesFacade()
 
     override func setUp() async throws {
         try await super.setUp()

--- a/Tests/KeyPathTests/CLI/CLISimulateTests.swift
+++ b/Tests/KeyPathTests/CLI/CLISimulateTests.swift
@@ -21,7 +21,7 @@ final class MockSimulatorProvider: CLISimulatorProvider, @unchecked Sendable {
 
 @MainActor
 final class CLISimulateTests: XCTestCase {
-    private let facade = CLIFacade()
+    private let facade = SimulatorFacade()
 
     // MARK: - Basic Simulation
 
@@ -194,7 +194,7 @@ final class CLISimulateTests: XCTestCase {
 /// Skipped automatically if the binary isn't found (e.g., CI without a built app).
 @MainActor
 final class CLISimulateIntegrationTests: XCTestCase {
-    private let facade = CLIFacade()
+    private let facade = SimulatorFacade()
 
     private func requireSimulatorPath() throws -> String {
         let which = Process()

--- a/Tests/KeyPathTests/CLI/ConflictMergeTests.swift
+++ b/Tests/KeyPathTests/CLI/ConflictMergeTests.swift
@@ -7,7 +7,7 @@ final class ConflictMergeTests: XCTestCase {
     func testMergeTwoSimpleRemapsThrows() {
         let existing = makeRule(input: "caps", action: .keystroke(key: "esc"))
         XCTAssertThrowsError(
-            try CLIFacade.mergeRules(existing: existing, newAction: .keystroke(key: "lctl"), newBehavior: nil)
+            try RulesFacade.mergeRules(existing: existing, newAction: .keystroke(key: "lctl"), newBehavior: nil)
         ) { error in
             guard let mergeErr = error as? CLIMergeError else {
                 XCTFail("Expected CLIMergeError, got \(error)")
@@ -27,7 +27,7 @@ final class ConflictMergeTests: XCTestCase {
             tapTimeout: 300
         ))
 
-        let merged = try CLIFacade.mergeRules(
+        let merged = try RulesFacade.mergeRules(
             existing: existing,
             newAction: .keystroke(key: "x"),
             newBehavior: newBehavior
@@ -54,7 +54,7 @@ final class ConflictMergeTests: XCTestCase {
             ))
         )
 
-        let merged = try CLIFacade.mergeRules(
+        let merged = try RulesFacade.mergeRules(
             existing: existing,
             newAction: .keystroke(key: "esc"),
             newBehavior: nil
@@ -87,7 +87,7 @@ final class ConflictMergeTests: XCTestCase {
             tapTimeout: 300
         )
 
-        let merged = try CLIFacade.mergeRules(
+        let merged = try RulesFacade.mergeRules(
             existing: existing,
             newAction: .keystroke(key: "esc"),
             newBehavior: .dualRole(newDual)
@@ -116,7 +116,7 @@ final class ConflictMergeTests: XCTestCase {
         ))
 
         XCTAssertThrowsError(
-            try CLIFacade.mergeRules(existing: existing, newAction: .keystroke(key: "a"), newBehavior: newBehavior)
+            try RulesFacade.mergeRules(existing: existing, newAction: .keystroke(key: "a"), newBehavior: newBehavior)
         ) { error in
             guard let mergeErr = error as? CLIMergeError else {
                 XCTFail("Expected CLIMergeError, got \(error)")
@@ -137,7 +137,7 @@ final class ConflictMergeTests: XCTestCase {
             holdAction: .keystroke(key: "lctl")
         ))
 
-        let merged = try CLIFacade.mergeRules(
+        let merged = try RulesFacade.mergeRules(
             existing: existing,
             newAction: .keystroke(key: "x"),
             newBehavior: newBehavior

--- a/Tests/KeyPathTests/CLI/SimulatorFacadeTests.swift
+++ b/Tests/KeyPathTests/CLI/SimulatorFacadeTests.swift
@@ -1,0 +1,17 @@
+@testable import KeyPathAppKit
+import XCTest
+
+final class SimulatorFacadeTests: XCTestCase {
+    private let facade = SimulatorFacade()
+
+    func testValidateKeyReturnsCanonicalForm() {
+        XCTAssertEqual(facade.validateKey("caps"), "caps")
+        XCTAssertEqual(facade.validateKey("Escape"), "esc")
+        XCTAssertEqual(facade.validateKey("LALT"), "lalt")
+    }
+
+    func testValidateKeyReturnsNilForInvalid() {
+        XCTAssertNil(facade.validateKey("blahblah"))
+        XCTAssertNil(facade.validateKey("notakey123"))
+    }
+}


### PR DESCRIPTION
## Summary
- Extract rules CRUD operations into `RulesFacade` (add, remove, enable, disable, list, show, ensure)
- Extract simulator logic into `SimulatorFacade` (simulate key taps, validate keys)
- CLIFacade retains collections, packs, service, and system operations
- All CLI commands updated to use the appropriate facade directly
- Includes `SimulatorFacadeTests` for the new simulator facade

## Test plan
- [x] All 530 tests pass
- [x] Build succeeds
- [ ] Verify CLI rule commands work end-to-end (`keypath rule add`, `keypath rule list`, etc.)
- [ ] Verify `keypath simulate` command works