### PR TITLE
refactor: extract SystemFacade + ConfigFacade from CLIFacade

### DIFF
--- a/Sources/KeyPathAppKit/CLI/CLIFacade.swift
+++ b/Sources/KeyPathAppKit/CLI/CLIFacade.swift
@@ -1,18 +1,17 @@
 import Foundation
 import KeyPathCore
 import KeyPathDaemonLifecycle
-import KeyPathInstallationWizard
-import KeyPathWizardCore
 
 /// Public facade exposing KeyPathAppKit internals for the CLI binary.
 /// This is the stable API boundary between the CLI and the app library.
 ///
-/// Method groups live in extension files and standalone facades:
-/// - RulesFacade.swift — Custom rules CRUD (standalone)
-/// - SimulatorFacade.swift — Key simulation and validation (standalone)
-/// - CollectionsFacade.swift — Collections, export/import, layers (standalone)
-/// - CLIFacade+Service.swift — Service lifecycle, config, TCP, status, installer
-/// - CLIFacade+Packs.swift — Pack management
+/// Standalone facades:
+/// - RulesFacade.swift — Custom rules CRUD
+/// - SimulatorFacade.swift — Key simulation and validation
+/// - CollectionsFacade.swift — Collections, export/import, layers
+/// - SystemFacade.swift — Service lifecycle, status, installer
+/// - ConfigFacade.swift — Config, apply, TCP
+/// - CLIFacade+Packs.swift — Pack management (extension on CLIFacade)
 public struct CLIFacade: Sendable {
     public init() {}
 }
@@ -34,104 +33,6 @@ public enum CLIVersion {
         }
         return "1.0.0"
     }()
-}
-
-// MARK: - Service & Config Types
-
-public struct CLIApplyResult: Codable, Sendable {
-    public let collectionsCount: Int
-    public let enabledCount: Int
-    public let customRulesCount: Int
-    public let reloadSuccess: Bool
-    public let changeset: CLIApplyChangeset?
-}
-
-public struct CLIApplyChangeset: Codable, Sendable {
-    public let enabledCollections: [String]
-    public let disabledCollections: [String]
-    public let customRules: [String]
-}
-
-public struct CLIHrmStats: Codable, Sendable {
-    public let totalDecisions: Int
-    public let tapCount: Int
-    public let holdCount: Int
-}
-
-public struct CLIStatusResult: Codable, Sendable {
-    public let isOperational: Bool
-    public let helperInstalled: Bool
-    public let helperWorking: Bool
-    public let helperVersion: String?
-    public let keyPathAccessibility: Bool
-    public let keyPathInputMonitoring: Bool
-    public let kanataAccessibility: Bool
-    public let kanataInputMonitoring: Bool
-    public let kanataBinaryInstalled: Bool
-    public let karabinerDriverInstalled: Bool
-    public let vhidDeviceHealthy: Bool
-    public let kanataRunning: Bool
-    public let karabinerDaemonRunning: Bool
-    public let vhidHealthy: Bool
-    public let activeRuntimePathTitle: String?
-    public let activeRuntimePathDetail: String?
-    public let hasConflicts: Bool
-    public let timestamp: Date
-}
-
-public struct CLIValidationResult: Codable, Sendable {
-    public let isValid: Bool
-    public let errors: [String]
-    public let configPath: String?
-    public let configBytes: Int?
-    public let collectionsCount: Int?
-    public let customRulesCount: Int?
-
-    public init(isValid: Bool, errors: [String], configPath: String? = nil, configBytes: Int? = nil, collectionsCount: Int? = nil, customRulesCount: Int? = nil) {
-        self.isValid = isValid
-        self.errors = errors
-        self.configPath = configPath
-        self.configBytes = configBytes
-        self.collectionsCount = collectionsCount
-        self.customRulesCount = customRulesCount
-    }
-}
-
-public struct CLIInstallerReport: Codable, Sendable {
-    public let success: Bool
-    public let failureReason: String?
-    public let steps: [CLIInstallerStep]
-    public let fastRepair: Bool
-
-    init(from report: InstallerReport) {
-        success = report.success
-        failureReason = report.failureReason
-        steps = report.executedRecipes.map {
-            CLIInstallerStep(name: $0.recipeID, success: $0.success, error: $0.error)
-        }
-        fastRepair = false
-    }
-
-    init(success: Bool, failureReason: String?, steps: [CLIInstallerStep], fastRepair: Bool) {
-        self.success = success
-        self.failureReason = failureReason
-        self.steps = steps
-        self.fastRepair = fastRepair
-    }
-}
-
-public struct CLIInstallerStep: Codable, Sendable {
-    public let name: String
-    public let success: Bool
-    public let error: String?
-}
-
-public struct CLIInspectResult: Codable, Sendable {
-    public let macOSVersion: String
-    public let driverCompatible: Bool
-    public let planStatus: String
-    public let blockedBy: String?
-    public let plannedRecipes: [String]
 }
 
 // MARK: - Pack CLI Types

--- a/Sources/KeyPathAppKit/CLI/ConfigFacade.swift
+++ b/Sources/KeyPathAppKit/CLI/ConfigFacade.swift
@@ -1,0 +1,154 @@
+import Foundation
+import KeyPathCore
+
+public struct ConfigFacade: Sendable {
+    public init() {}
+
+    // MARK: - Configuration
+
+    @MainActor
+    public func currentConfig() async -> String {
+        let service = ConfigurationService()
+        let config = await service.current()
+        return config.content
+    }
+
+    @MainActor
+    public func configPath() -> String {
+        ConfigurationService().configurationPath
+    }
+
+    @MainActor
+    public func validateConfig() async -> CLIValidationResult {
+        let service = ConfigurationService()
+        let config = await service.current()
+        if config.content.isEmpty {
+            return CLIValidationResult(isValid: false, errors: ["No configuration generated yet. Run 'keypath apply' first."])
+        }
+        let result = await service.validateConfiguration(config.content)
+        return CLIValidationResult(isValid: result.isValid, errors: result.errors)
+    }
+
+    // MARK: - Apply
+
+    public func applyConfiguration() async throws -> CLIApplyResult {
+        let collections = await RuleCollectionStore.shared.loadCollections()
+        let customRules = await CustomRulesStore.shared.loadRules()
+        let enabledCount = collections.filter(\.isEnabled).count
+
+        let service = await MainActor.run { ConfigurationService() }
+        try await service.saveConfiguration(
+            ruleCollections: collections,
+            customRules: customRules
+        )
+
+        let port = await MainActor.run { PreferencesService.shared.tcpServerPort }
+        let client = KanataTCPClient(port: port)
+        let result = await client.reloadConfig()
+        let reloadSuccess = if case .success = result {
+            true
+        } else {
+            false
+        }
+
+        let changeset = CLIApplyChangeset(
+            enabledCollections: collections.filter(\.isEnabled).map(\.name),
+            disabledCollections: collections.filter { !$0.isEnabled }.map(\.name),
+            customRules: customRules.filter(\.isEnabled).map { "\($0.input) → \($0.action.outputString)" }
+        )
+
+        return CLIApplyResult(
+            collectionsCount: collections.count,
+            enabledCount: enabledCount,
+            customRulesCount: customRules.count,
+            reloadSuccess: reloadSuccess,
+            changeset: changeset
+        )
+    }
+
+    // MARK: - TCP
+
+    func tcpClient() async -> KanataTCPClient {
+        let port = await MainActor.run { PreferencesService.shared.tcpServerPort }
+        return KanataTCPClient(port: port)
+    }
+
+    public func tcpCheckHealth() async -> Bool {
+        let client = await tcpClient()
+        return await client.checkServerStatus()
+    }
+
+    public func tcpGetLayers() async throws -> [String] {
+        let client = await tcpClient()
+        return try await client.requestLayerNames()
+    }
+
+    public func tcpReload() async -> Bool {
+        let client = await tcpClient()
+        let result = await client.reloadConfig()
+        if case .success = result { return true }
+        return false
+    }
+
+    public func tcpGetHrmStats() async throws -> CLIHrmStats {
+        let client = await tcpClient()
+        let stats = try await client.requestHrmStats()
+        return CLIHrmStats(
+            totalDecisions: stats.decisionsTotal,
+            tapCount: stats.tapCount,
+            holdCount: stats.holdCount
+        )
+    }
+
+    public func tcpResetHrmStats() async throws {
+        let client = await tcpClient()
+        try await client.resetHrmStats()
+    }
+
+    public func tcpChangeLayer(_ layerName: String) async -> Bool {
+        let client = await tcpClient()
+        let result = await client.changeLayer(layerName)
+        if case .success = result { return true }
+        return false
+    }
+}
+
+// MARK: - Config Types
+
+public struct CLIApplyResult: Codable, Sendable {
+    public let collectionsCount: Int
+    public let enabledCount: Int
+    public let customRulesCount: Int
+    public let reloadSuccess: Bool
+    public let changeset: CLIApplyChangeset?
+}
+
+public struct CLIApplyChangeset: Codable, Sendable {
+    public let enabledCollections: [String]
+    public let disabledCollections: [String]
+    public let customRules: [String]
+}
+
+public struct CLIValidationResult: Codable, Sendable {
+    public let isValid: Bool
+    public let errors: [String]
+    public let configPath: String?
+    public let configBytes: Int?
+    public let collectionsCount: Int?
+    public let customRulesCount: Int?
+
+    public init(isValid: Bool, errors: [String], configPath: String? = nil, configBytes: Int? = nil, collectionsCount: Int? = nil, customRulesCount: Int? = nil) {
+        self.isValid = isValid
+        self.errors = errors
+        self.configPath = configPath
+        self.configBytes = configBytes
+        self.collectionsCount = collectionsCount
+        self.customRulesCount = customRulesCount
+    }
+}
+
+public struct CLIHrmStats: Codable, Sendable {
+    public let totalDecisions: Int
+    public let tapCount: Int
+    public let holdCount: Int
+}

--- a/Sources/KeyPathAppKit/CLI/SystemFacade.swift
+++ b/Sources/KeyPathAppKit/CLI/SystemFacade.swift
@@ -4,9 +4,11 @@ import KeyPathDaemonLifecycle
 import KeyPathInstallationWizard
 import KeyPathWizardCore
 
-// MARK: - Service Lifecycle, Config, TCP, Status, Installer
+public struct SystemFacade: Sendable {
+    public init() {}
 
-extension CLIFacade {
+    // MARK: - Service Lifecycle
+
     public func startService() async -> Bool {
         do {
             try await SubprocessRunner.shared.launchctl("kickstart", ["system/com.keypath.kanata"])
@@ -40,107 +42,7 @@ extension CLIFacade {
         return Array(allLines.suffix(lines))
     }
 
-    @MainActor
-    public func currentConfig() async -> String {
-        let service = ConfigurationService()
-        let config = await service.current()
-        return config.content
-    }
-
-    @MainActor
-    public func configPath() -> String {
-        ConfigurationService().configurationPath
-    }
-
-    @MainActor
-    public func validateConfig() async -> CLIValidationResult {
-        let service = ConfigurationService()
-        let config = await service.current()
-        if config.content.isEmpty {
-            return CLIValidationResult(isValid: false, errors: ["No configuration generated yet. Run 'keypath apply' first."])
-        }
-        let result = await service.validateConfiguration(config.content)
-        return CLIValidationResult(isValid: result.isValid, errors: result.errors)
-    }
-
-    public func applyConfiguration() async throws -> CLIApplyResult {
-        let collections = await RuleCollectionStore.shared.loadCollections()
-        let customRules = await CustomRulesStore.shared.loadRules()
-        let enabledCount = collections.filter(\.isEnabled).count
-
-        let service = await MainActor.run { ConfigurationService() }
-        try await service.saveConfiguration(
-            ruleCollections: collections,
-            customRules: customRules
-        )
-
-        let port = await MainActor.run { PreferencesService.shared.tcpServerPort }
-        let client = KanataTCPClient(port: port)
-        let result = await client.reloadConfig()
-        let reloadSuccess = if case .success = result {
-            true
-        } else {
-            false
-        }
-
-        let changeset = CLIApplyChangeset(
-            enabledCollections: collections.filter(\.isEnabled).map(\.name),
-            disabledCollections: collections.filter { !$0.isEnabled }.map(\.name),
-            customRules: customRules.filter(\.isEnabled).map { "\($0.input) → \($0.action.outputString)" }
-        )
-
-        return CLIApplyResult(
-            collectionsCount: collections.count,
-            enabledCount: enabledCount,
-            customRulesCount: customRules.count,
-            reloadSuccess: reloadSuccess,
-            changeset: changeset
-        )
-    }
-
-    func tcpClient() async -> KanataTCPClient {
-        let port = await MainActor.run { PreferencesService.shared.tcpServerPort }
-        return KanataTCPClient(port: port)
-    }
-
-    public func tcpCheckHealth() async -> Bool {
-        let client = await tcpClient()
-        return await client.checkServerStatus()
-    }
-
-    public func tcpGetLayers() async throws -> [String] {
-        let client = await tcpClient()
-        return try await client.requestLayerNames()
-    }
-
-    public func tcpReload() async -> Bool {
-        let client = await tcpClient()
-        let result = await client.reloadConfig()
-        if case .success = result { return true }
-        return false
-    }
-
-    public func tcpGetHrmStats() async throws -> CLIHrmStats {
-        let client = await tcpClient()
-        let stats = try await client.requestHrmStats()
-        return CLIHrmStats(
-            totalDecisions: stats.decisionsTotal,
-            tapCount: stats.tapCount,
-            holdCount: stats.holdCount
-        )
-    }
-
-    public func tcpResetHrmStats() async throws {
-        let client = await tcpClient()
-        try await client.resetHrmStats()
-    }
-
-    public func tcpChangeLayer(_ layerName: String) async -> Bool {
-        let client = await tcpClient()
-        let result = await client.changeLayer(layerName)
-        if case .success = result { return true }
-        return false
-    }
+    // MARK: - Status
 
     @MainActor
     public func runStatus() async -> CLIStatusResult {
@@ -172,6 +74,8 @@ extension CLIFacade {
             timestamp: context.timestamp
         )
     }
+
+    // MARK: - Installer
 
     @MainActor
     public func runInstall() async -> CLIInstallerReport {
@@ -221,4 +125,64 @@ extension CLIFacade {
             plannedRecipes: plan.recipes.map { "\($0.id) (\($0.type))" }
         )
     }
+}
+
+// MARK: - System Types
+
+public struct CLIStatusResult: Codable, Sendable {
+    public let isOperational: Bool
+    public let helperInstalled: Bool
+    public let helperWorking: Bool
+    public let helperVersion: String?
+    public let keyPathAccessibility: Bool
+    public let keyPathInputMonitoring: Bool
+    public let kanataAccessibility: Bool
+    public let kanataInputMonitoring: Bool
+    public let kanataBinaryInstalled: Bool
+    public let karabinerDriverInstalled: Bool
+    public let vhidDeviceHealthy: Bool
+    public let kanataRunning: Bool
+    public let karabinerDaemonRunning: Bool
+    public let vhidHealthy: Bool
+    public let activeRuntimePathTitle: String?
+    public let activeRuntimePathDetail: String?
+    public let hasConflicts: Bool
+    public let timestamp: Date
+}
+
+public struct CLIInstallerReport: Codable, Sendable {
+    public let success: Bool
+    public let failureReason: String?
+    public let steps: [CLIInstallerStep]
+    public let fastRepair: Bool
+
+    init(from report: InstallerReport) {
+        success = report.success
+        failureReason = report.failureReason
+        steps = report.executedRecipes.map {
+            CLIInstallerStep(name: $0.recipeID, success: $0.success, error: $0.error)
+        }
+        fastRepair = false
+    }
+
+    init(success: Bool, failureReason: String?, steps: [CLIInstallerStep], fastRepair: Bool) {
+        self.success = success
+        self.failureReason = failureReason
+        self.steps = steps
+        self.fastRepair = fastRepair
+    }
+}
+
+public struct CLIInstallerStep: Codable, Sendable {
+    public let name: String
+    public let success: Bool
+    public let error: String?
+}
+
+public struct CLIInspectResult: Codable, Sendable {
+    public let macOSVersion: String
+    public let driverCompatible: Bool
+    public let planStatus: String
+    public let blockedBy: String?
+    public let plannedRecipes: [String]
 }

--- a/Sources/KeyPathCLI/Commands/Config/ConfigApplyCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Config/ConfigApplyCommand.swift
@@ -15,7 +15,7 @@ struct ConfigApply: AsyncParsableCommand {
         let spinner = CLISpinner(context: ctx)
         spinner.start("Applying configuration...")
 
-        let facade = await MainActor.run { CLIFacade() }
+        let facade = ConfigFacade()
         let result = try await facade.applyConfiguration()
 
         if result.reloadSuccess {

--- a/Sources/KeyPathCLI/Commands/Config/ConfigCheckCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Config/ConfigCheckCommand.swift
@@ -12,7 +12,7 @@ struct ConfigCheck: AsyncParsableCommand {
 
     mutating func run() async throws {
         let ctx = globals.outputContext
-        let facade = await MainActor.run { CLIFacade() }
+        let facade = ConfigFacade()
         let result = await facade.validateConfig()
 
         CLIOutput.write(result, context: ctx) {

--- a/Sources/KeyPathCLI/Commands/Config/ConfigPathCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Config/ConfigPathCommand.swift
@@ -12,7 +12,7 @@ struct ConfigPath: AsyncParsableCommand {
 
     mutating func run() async throws {
         let ctx = globals.outputContext
-        let path = await MainActor.run { CLIFacade().configPath() }
+        let path = await MainActor.run { ConfigFacade().configPath() }
 
         CLIOutput.write(["path": path], context: ctx) {
             path

--- a/Sources/KeyPathCLI/Commands/Config/ConfigShowCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Config/ConfigShowCommand.swift
@@ -12,7 +12,7 @@ struct ConfigShow: AsyncParsableCommand {
 
     mutating func run() async throws {
         let ctx = globals.outputContext
-        let facade = await MainActor.run { CLIFacade() }
+        let facade = ConfigFacade()
         let config = await facade.currentConfig()
 
         CLIOutput.write(["config": config], context: ctx) {

--- a/Sources/KeyPathCLI/Commands/Layer/LayerListCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Layer/LayerListCommand.swift
@@ -12,7 +12,7 @@ struct LayerList: AsyncParsableCommand {
 
     mutating func run() async throws {
         let ctx = globals.outputContext
-        let facade = await MainActor.run { CLIFacade() }
+        let facade = ConfigFacade()
 
         let layers: [String]
         do {

--- a/Sources/KeyPathCLI/Commands/Layer/LayerSwitchCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Layer/LayerSwitchCommand.swift
@@ -15,7 +15,7 @@ struct LayerSwitch: AsyncParsableCommand {
 
     mutating func run() async throws {
         let ctx = globals.outputContext
-        let facade = await MainActor.run { CLIFacade() }
+        let facade = ConfigFacade()
         let success = await facade.tcpChangeLayer(name)
         if success {
             CLIOutput.write(["layer": name], context: ctx) {

--- a/Sources/KeyPathCLI/Commands/Service/ServiceLogsCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Service/ServiceLogsCommand.swift
@@ -15,7 +15,7 @@ struct ServiceLogs: AsyncParsableCommand {
 
     mutating func run() async throws {
         let ctx = globals.outputContext
-        let facade = await MainActor.run { CLIFacade() }
+        let facade = SystemFacade()
 
         let logLines = facade.serviceLogs(lines: lines)
         if logLines.isEmpty {

--- a/Sources/KeyPathCLI/Commands/Service/ServiceReloadCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Service/ServiceReloadCommand.swift
@@ -14,7 +14,7 @@ struct ServiceReload: AsyncParsableCommand {
         let ctx = globals.outputContext
         CLIOutput.progress("Reloading Kanata configuration...", context: ctx)
 
-        let facade = await MainActor.run { CLIFacade() }
+        let facade = ConfigFacade()
         let success = await facade.tcpReload()
 
         if success {

--- a/Sources/KeyPathCLI/Commands/Service/ServiceRestartCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Service/ServiceRestartCommand.swift
@@ -12,7 +12,7 @@ struct ServiceRestart: AsyncParsableCommand {
 
     mutating func run() async throws {
         let ctx = globals.outputContext
-        let facade = await MainActor.run { CLIFacade() }
+        let facade = SystemFacade()
 
         CLIOutput.progress("Restarting Kanata service...", context: ctx)
         let success = await facade.restartService()

--- a/Sources/KeyPathCLI/Commands/Service/ServiceStartCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Service/ServiceStartCommand.swift
@@ -12,7 +12,7 @@ struct ServiceStart: AsyncParsableCommand {
 
     mutating func run() async throws {
         let ctx = globals.outputContext
-        let facade = await MainActor.run { CLIFacade() }
+        let facade = SystemFacade()
 
         let success = await facade.startService()
         if success {

--- a/Sources/KeyPathCLI/Commands/Service/ServiceStatusCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Service/ServiceStatusCommand.swift
@@ -13,7 +13,7 @@ struct ServiceStatus: AsyncParsableCommand {
     mutating func run() async throws {
         let ctx = globals.outputContext
         let timeout = globals.timeout
-        let facade = await MainActor.run { CLIFacade() }
+        let facade = SystemFacade()
         let status: CLIStatusResult
         do {
             status = try await withThrowingTimeout(seconds: timeout) {

--- a/Sources/KeyPathCLI/Commands/Service/ServiceStopCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Service/ServiceStopCommand.swift
@@ -12,7 +12,7 @@ struct ServiceStop: AsyncParsableCommand {
 
     mutating func run() async throws {
         let ctx = globals.outputContext
-        let facade = await MainActor.run { CLIFacade() }
+        let facade = SystemFacade()
 
         let success = await facade.stopService()
         if success {

--- a/Sources/KeyPathCLI/Commands/System/SystemInspectCommand.swift
+++ b/Sources/KeyPathCLI/Commands/System/SystemInspectCommand.swift
@@ -12,7 +12,7 @@ struct SystemInspect: AsyncParsableCommand {
 
     mutating func run() async throws {
         let ctx = globals.outputContext
-        let facade = await MainActor.run { CLIFacade() }
+        let facade = SystemFacade()
         let result: CLIInspectResult
         do {
             result = try await withThrowingTimeout(seconds: globals.timeout) {

--- a/Sources/KeyPathCLI/Commands/System/SystemInstallCommand.swift
+++ b/Sources/KeyPathCLI/Commands/System/SystemInstallCommand.swift
@@ -15,7 +15,7 @@ struct SystemInstall: AsyncParsableCommand {
         let spinner = CLISpinner(context: ctx)
         spinner.start("Installing...")
 
-        let facade = await MainActor.run { CLIFacade() }
+        let facade = SystemFacade()
         let report: CLIInstallerReport
         do {
             report = try await withThrowingTimeout(seconds: globals.timeout) {

--- a/Sources/KeyPathCLI/Commands/System/SystemRepairCommand.swift
+++ b/Sources/KeyPathCLI/Commands/System/SystemRepairCommand.swift
@@ -15,7 +15,7 @@ struct SystemRepair: AsyncParsableCommand {
         let spinner = CLISpinner(context: ctx)
         spinner.start("Repairing...")
 
-        let facade = await MainActor.run { CLIFacade() }
+        let facade = SystemFacade()
         let report: CLIInstallerReport
         do {
             report = try await withThrowingTimeout(seconds: globals.timeout) {

--- a/Sources/KeyPathCLI/Commands/System/SystemUninstallCommand.swift
+++ b/Sources/KeyPathCLI/Commands/System/SystemUninstallCommand.swift
@@ -21,7 +21,7 @@ struct SystemUninstall: AsyncParsableCommand {
             CLIOutput.progress("Starting uninstall (configuration will be preserved)...", context: ctx)
         }
 
-        let facade = await MainActor.run { CLIFacade() }
+        let facade = SystemFacade()
         let shouldDeleteConfig = deleteConfig
         let timeoutSeconds = globals.timeout
         let report: CLIInstallerReport

--- a/Sources/KeyPathCLI/Utilities/ApplyHelper.swift
+++ b/Sources/KeyPathCLI/Utilities/ApplyHelper.swift
@@ -4,7 +4,7 @@ import KeyPathAppKit
 
 func applyConfigurationOrHint(apply: Bool, context: OutputContext) async throws {
     if apply {
-        let facade = await MainActor.run { CLIFacade() }
+        let facade = ConfigFacade()
         let result = try await facade.applyConfiguration()
         if result.reloadSuccess {
             CLIOutput.write(["applied": true], context: context) {

--- a/Tests/KeyPathTests/CLI/CLIServiceTests.swift
+++ b/Tests/KeyPathTests/CLI/CLIServiceTests.swift
@@ -3,7 +3,7 @@
 
 @MainActor
 final class CLIServiceTests: XCTestCase {
-    private let facade = CLIFacade()
+    private let facade = SystemFacade()
 
     // MARK: - serviceLogs
 


### PR DESCRIPTION
## Summary
- Extract `SystemFacade` with service lifecycle (start/stop/restart/logs), status, and installer operations (install/repair/uninstall/inspect)
- Extract `ConfigFacade` with configuration (show/path/validate), apply pipeline, and all TCP operations (health/layers/reload/HRM stats/layer switch)
- Delete `CLIFacade+Service.swift` extension file
- CLIFacade now only contains pack types and `CLIVersion` — the last extension file is `CLIFacade+Packs.swift` (step 4)
- `ApplyHelper` updated to use `ConfigFacade` directly
- All service, system, config, and layer TCP commands updated

Closes #442

## Test plan
- [x] All 530 tests pass
- [x] Build succeeds
- [x] Service tests updated to use SystemFacade