### PR TITLE
Hide batch badges from rules list

### DIFF
--- a/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView+CollectionRow.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView+CollectionRow.swift
@@ -250,14 +250,6 @@ private var fallbackKeyMappings: [KeyMapping] {
                                     .fontWeight(.regular)
                                     .foregroundColor(.secondary)
                             }
-                            if let packName = managingPackName {
-                                Text("Managed by \(packName)")
-                                    .font(.caption2)
-                                    .foregroundColor(.white.opacity(0.85))
-                                    .padding(.horizontal, 6)
-                                    .padding(.vertical, 2)
-                                    .background(Capsule().fill(Color.accentColor.opacity(0.7)))
-                            }
                         }
 
                         if let desc = description {


### PR DESCRIPTION
## Summary
- Removed the "Managed by [pack name]" capsule badge from rules list rows
- Pack ownership is still communicated via the detail page header and the disabled toggle
- The `managingPackName` property is preserved for functional use (toggle disable + error toast)

## Test plan
- [ ] Open Rules tab with a pack-managed collection (e.g. Home Row Mods managed by Ben Vallack Approach)
- [ ] Verify no "Managed by" badge appears in the list row
- [ ] Tap the row to open the detail page — verify pack name still shown in header
- [ ] Try toggling a pack-managed collection — verify the error toast still appears