### PR TITLE
feat: Command-K palette with grouped sections

### DIFF
--- a/Sources/KeyPathAppKit/Core/AppMenuCommands.swift
+++ b/Sources/KeyPathAppKit/Core/AppMenuCommands.swift
@@ -101,10 +101,10 @@ struct AppMenuCommands: Commands {
 
             Button(
                 action: {
-                    LiveKeyboardOverlayController.shared.toggle()
+                    CommandPaletteWindowController.shared.toggle()
                 },
                 label: {
-                    Label("Live Keyboard Overlay", systemImage: "keyboard.badge.eye")
+                    Label("Command Palette", systemImage: "command")
                 }
             )
             .keyboardShortcut("k", modifiers: .command)

--- a/Sources/KeyPathAppKit/UI/CommandPalette/CommandPaletteItem.swift
+++ b/Sources/KeyPathAppKit/UI/CommandPalette/CommandPaletteItem.swift
@@ -6,6 +6,7 @@ struct CommandPaletteItem: Identifiable {
     let subtitle: String?
     let icon: String
     let shortcut: String?
+    let group: String
     let action: () -> Void
 
     func matches(_ query: String) -> Bool {
@@ -13,5 +14,11 @@ struct CommandPaletteItem: Identifiable {
         let lower = query.lowercased()
         return title.lowercased().contains(lower)
             || (subtitle?.lowercased().contains(lower) ?? false)
+            || group.lowercased().contains(lower)
     }
+}
+
+struct CommandPaletteGroup: Identifiable {
+    let id: String
+    let items: [CommandPaletteItem]
 }

--- a/Sources/KeyPathAppKit/UI/CommandPalette/CommandPaletteItem.swift
+++ b/Sources/KeyPathAppKit/UI/CommandPalette/CommandPaletteItem.swift
@@ -1,0 +1,17 @@
+import AppKit
+
+struct CommandPaletteItem: Identifiable {
+    let id: String
+    let title: String
+    let subtitle: String?
+    let icon: String
+    let shortcut: String?
+    let action: () -> Void
+
+    func matches(_ query: String) -> Bool {
+        if query.isEmpty { return true }
+        let lower = query.lowercased()
+        return title.lowercased().contains(lower)
+            || (subtitle?.lowercased().contains(lower) ?? false)
+    }
+}

--- a/Sources/KeyPathAppKit/UI/CommandPalette/CommandPaletteView.swift
+++ b/Sources/KeyPathAppKit/UI/CommandPalette/CommandPaletteView.swift
@@ -1,0 +1,227 @@
+import SwiftUI
+
+struct CommandPaletteView: View {
+    let items: [CommandPaletteItem]
+    let onDismiss: () -> Void
+
+    @State private var searchText = ""
+    @State private var selectedIndex = 0
+    @FocusState private var isSearchFocused: Bool
+
+    private var filtered: [CommandPaletteItem] {
+        items.filter { $0.matches(searchText) }
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            searchField
+            Divider()
+            if filtered.isEmpty {
+                emptyState
+            } else {
+                resultsList
+            }
+            Divider()
+            hintBar
+        }
+        .frame(width: 440, height: 340)
+        .background(VisualEffectBlur(material: .hudWindow, blendingMode: .behindWindow))
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .shadow(color: .black.opacity(0.3), radius: 20, y: 8)
+        .onAppear {
+            selectedIndex = 0
+            searchText = ""
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+                isSearchFocused = true
+            }
+        }
+        .onChange(of: searchText) { _, _ in
+            selectedIndex = 0
+        }
+        .onKeyPress(.upArrow) {
+            if selectedIndex > 0 { selectedIndex -= 1 }
+            return .handled
+        }
+        .onKeyPress(.downArrow) {
+            if selectedIndex < filtered.count - 1 { selectedIndex += 1 }
+            return .handled
+        }
+        .onKeyPress(.escape) {
+            onDismiss()
+            return .handled
+        }
+        .onKeyPress(.return) {
+            if selectedIndex < filtered.count {
+                let item = filtered[selectedIndex]
+                onDismiss()
+                item.action()
+            }
+            return .handled
+        }
+        .focusable()
+    }
+
+    // MARK: - Search Field
+
+    private var searchField: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "command")
+                .font(.system(size: 14, weight: .medium))
+                .foregroundStyle(.secondary)
+
+            TextField("Type a command\u{2026}", text: $searchText)
+                .textFieldStyle(.plain)
+                .font(.system(size: 15))
+                .focused($isSearchFocused)
+                .onSubmit {
+                    if selectedIndex < filtered.count {
+                        let item = filtered[selectedIndex]
+                        onDismiss()
+                        item.action()
+                    }
+                }
+
+            if !searchText.isEmpty {
+                Button {
+                    searchText = ""
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundStyle(.tertiary)
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 10)
+    }
+
+    // MARK: - Results
+
+    private var resultsList: some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack(spacing: 0) {
+                    ForEach(Array(filtered.enumerated()), id: \.element.id) { index, item in
+                        CommandPaletteRow(
+                            item: item,
+                            isSelected: index == selectedIndex
+                        ) {
+                            onDismiss()
+                            item.action()
+                        }
+                        .id(item.id)
+                        .onHover { hovering in
+                            if hovering { selectedIndex = index }
+                        }
+                    }
+                }
+                .padding(.vertical, 4)
+            }
+            .onChange(of: selectedIndex) { _, newIndex in
+                if newIndex < filtered.count {
+                    withAnimation(.easeOut(duration: 0.1)) {
+                        proxy.scrollTo(filtered[newIndex].id, anchor: .center)
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Empty State
+
+    private var emptyState: some View {
+        VStack(spacing: 6) {
+            Text("No matching commands")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    // MARK: - Hint Bar
+
+    private var hintBar: some View {
+        HStack(spacing: 12) {
+            Label("navigate", systemImage: "arrow.up.arrow.down")
+            Label("select", systemImage: "return")
+            Label("dismiss", systemImage: "escape")
+        }
+        .font(.caption2)
+        .foregroundStyle(.tertiary)
+        .padding(.horizontal, 14)
+        .padding(.vertical, 6)
+    }
+}
+
+// MARK: - Row
+
+private struct CommandPaletteRow: View {
+    let item: CommandPaletteItem
+    let isSelected: Bool
+    let onSelect: () -> Void
+
+    var body: some View {
+        Button(action: onSelect) {
+            HStack(spacing: 10) {
+                Image(systemName: item.icon)
+                    .font(.system(size: 14))
+                    .foregroundStyle(isSelected ? .white : .secondary)
+                    .frame(width: 22, alignment: .center)
+
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(item.title)
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundStyle(isSelected ? .white : .primary)
+                    if let subtitle = item.subtitle {
+                        Text(subtitle)
+                            .font(.system(size: 11))
+                            .foregroundStyle(isSelected ? .white.opacity(0.7) : .secondary)
+                    }
+                }
+
+                Spacer(minLength: 4)
+
+                if let shortcut = item.shortcut {
+                    Text(shortcut)
+                        .font(.system(size: 11, design: .rounded))
+                        .foregroundColor(isSelected ? .white.opacity(0.6) : .secondary.opacity(0.5))
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(
+                            RoundedRectangle(cornerRadius: 4)
+                                .fill(isSelected ? Color.white.opacity(0.15) : Color.secondary.opacity(0.12))
+                        )
+                }
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 7)
+            .background(
+                RoundedRectangle(cornerRadius: 6)
+                    .fill(isSelected ? Color.accentColor : Color.clear)
+            )
+            .padding(.horizontal, 4)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+// MARK: - Visual Effect Blur
+
+private struct VisualEffectBlur: NSViewRepresentable {
+    let material: NSVisualEffectView.Material
+    let blendingMode: NSVisualEffectView.BlendingMode
+
+    func makeNSView(context _: Context) -> NSVisualEffectView {
+        let view = NSVisualEffectView()
+        view.material = material
+        view.blendingMode = blendingMode
+        view.state = .active
+        return view
+    }
+
+    func updateNSView(_ nsView: NSVisualEffectView, context _: Context) {
+        nsView.material = material
+        nsView.blendingMode = blendingMode
+    }
+}

--- a/Sources/KeyPathAppKit/UI/CommandPalette/CommandPaletteView.swift
+++ b/Sources/KeyPathAppKit/UI/CommandPalette/CommandPaletteView.swift
@@ -12,6 +12,17 @@ struct CommandPaletteView: View {
         items.filter { $0.matches(searchText) }
     }
 
+    private var groupedFiltered: [CommandPaletteGroup] {
+        let ordered = filtered
+        var seen: [String] = []
+        var groups: [String: [CommandPaletteItem]] = [:]
+        for item in ordered {
+            if groups[item.group] == nil { seen.append(item.group) }
+            groups[item.group, default: []].append(item)
+        }
+        return seen.map { CommandPaletteGroup(id: $0, items: groups[$0]!) }
+    }
+
     var body: some View {
         VStack(spacing: 0) {
             searchField
@@ -24,7 +35,7 @@ struct CommandPaletteView: View {
             Divider()
             hintBar
         }
-        .frame(width: 440, height: 340)
+        .frame(width: 440, height: 360)
         .background(VisualEffectBlur(material: .hudWindow, blendingMode: .behindWindow))
         .clipShape(RoundedRectangle(cornerRadius: 12))
         .shadow(color: .black.opacity(0.3), radius: 20, y: 8)
@@ -86,7 +97,7 @@ struct CommandPaletteView: View {
                     searchText = ""
                 } label: {
                     Image(systemName: "xmark.circle.fill")
-                        .foregroundStyle(.tertiary)
+                        .foregroundStyle(.secondary)
                 }
                 .buttonStyle(.plain)
             }
@@ -100,27 +111,47 @@ struct CommandPaletteView: View {
     private var resultsList: some View {
         ScrollViewReader { proxy in
             ScrollView {
-                LazyVStack(spacing: 0) {
-                    ForEach(Array(filtered.enumerated()), id: \.element.id) { index, item in
-                        CommandPaletteRow(
-                            item: item,
-                            isSelected: index == selectedIndex
-                        ) {
-                            onDismiss()
-                            item.action()
+                LazyVStack(alignment: .leading, spacing: 0) {
+                    let flatItems = filtered
+                    var runningIndex = 0
+
+                    ForEach(groupedFiltered) { group in
+                        let groupStart = runningIndex
+
+                        Section {
+                            ForEach(Array(group.items.enumerated()), id: \.element.id) { offset, item in
+                                let globalIndex = groupStart + offset
+                                CommandPaletteRow(
+                                    item: item,
+                                    isSelected: globalIndex == selectedIndex
+                                ) {
+                                    onDismiss()
+                                    item.action()
+                                }
+                                .id(item.id)
+                                .onHover { hovering in
+                                    if hovering { selectedIndex = globalIndex }
+                                }
+                            }
+                        } header: {
+                            Text(group.id)
+                                .font(.system(size: 11, weight: .semibold))
+                                .foregroundStyle(.secondary)
+                                .padding(.horizontal, 16)
+                                .padding(.top, groupStart == 0 ? 6 : 12)
+                                .padding(.bottom, 4)
                         }
-                        .id(item.id)
-                        .onHover { hovering in
-                            if hovering { selectedIndex = index }
-                        }
+
+                        let _ = (runningIndex = groupStart + group.items.count)
                     }
                 }
-                .padding(.vertical, 4)
+                .padding(.bottom, 4)
             }
             .onChange(of: selectedIndex) { _, newIndex in
-                if newIndex < filtered.count {
+                let flatItems = filtered
+                if newIndex < flatItems.count {
                     withAnimation(.easeOut(duration: 0.1)) {
-                        proxy.scrollTo(filtered[newIndex].id, anchor: .center)
+                        proxy.scrollTo(flatItems[newIndex].id, anchor: .center)
                     }
                 }
             }
@@ -147,7 +178,7 @@ struct CommandPaletteView: View {
             Label("dismiss", systemImage: "escape")
         }
         .font(.caption2)
-        .foregroundStyle(.tertiary)
+        .foregroundStyle(.secondary.opacity(0.5))
         .padding(.horizontal, 14)
         .padding(.vertical, 6)
     }

--- a/Sources/KeyPathAppKit/UI/CommandPalette/CommandPaletteWindowController.swift
+++ b/Sources/KeyPathAppKit/UI/CommandPalette/CommandPaletteWindowController.swift
@@ -1,0 +1,209 @@
+import AppKit
+import SwiftUI
+
+@MainActor
+final class CommandPaletteWindowController {
+    static let shared = CommandPaletteWindowController()
+
+    private var panel: NSPanel?
+
+    private init() {}
+
+    var isVisible: Bool {
+        panel?.isVisible ?? false
+    }
+
+    func toggle() {
+        if isVisible {
+            dismiss()
+        } else {
+            show()
+        }
+    }
+
+    func show() {
+        dismiss()
+
+        let items = buildItems()
+        let view = CommandPaletteView(items: items) { [weak self] in
+            self?.dismiss()
+        }
+
+        let hosting = NSHostingController(rootView: view)
+        let panel = NSPanel(
+            contentRect: .zero,
+            styleMask: [.nonactivatingPanel, .fullSizeContentView],
+            backing: .buffered,
+            defer: true
+        )
+        panel.contentViewController = hosting
+        panel.isFloatingPanel = true
+        panel.level = .floating
+        panel.hasShadow = true
+        panel.backgroundColor = .clear
+        panel.isOpaque = false
+        panel.titlebarAppearsTransparent = true
+        panel.titleVisibility = .hidden
+        panel.isMovableByWindowBackground = false
+        panel.isReleasedWhenClosed = false
+        panel.hidesOnDeactivate = true
+        panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+        panel.animationBehavior = .utilityWindow
+
+        panel.setContentSize(NSSize(width: 440, height: 340))
+        positionPanel(panel)
+
+        self.panel = panel
+        panel.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+    }
+
+    func dismiss() {
+        panel?.orderOut(nil)
+        panel = nil
+    }
+
+    // MARK: - Positioning
+
+    private func positionPanel(_ panel: NSPanel) {
+        guard let screen = NSScreen.main else { return }
+        let screenFrame = screen.visibleFrame
+        let panelSize = panel.frame.size
+        let x = screenFrame.midX - panelSize.width / 2
+        let y = screenFrame.midY + screenFrame.height * 0.15
+        panel.setFrameOrigin(NSPoint(x: x, y: y))
+    }
+
+    // MARK: - Command Items
+
+    private func buildItems() -> [CommandPaletteItem] {
+        [
+            CommandPaletteItem(
+                id: "toggle-app",
+                title: "Hide / Show KeyPath",
+                subtitle: "Toggle the main KeyPath window",
+                icon: "eye",
+                shortcut: nil
+            ) {
+                DispatchQueue.main.async {
+                    if NSApp.isHidden {
+                        NSApp.unhide(nil)
+                        NSApp.activate(ignoringOtherApps: true)
+                    } else {
+                        NSApp.hide(nil)
+                    }
+                }
+            },
+
+            CommandPaletteItem(
+                id: "mappings",
+                title: "Mappings",
+                subtitle: "Open the key mapper overlay",
+                icon: "keyboard",
+                shortcut: "\u{21e7}\u{2318}M"
+            ) {
+                DispatchQueue.main.async {
+                    NotificationCenter.default.post(name: .openOverlayWithMapper, object: nil)
+                }
+            },
+
+            CommandPaletteItem(
+                id: "rules",
+                title: "Rules",
+                subtitle: "Manage rule collections",
+                icon: "list.bullet",
+                shortcut: "\u{2318}R"
+            ) {
+                DispatchQueue.main.async {
+                    openPreferencesTab(.openSettingsRules)
+                }
+            },
+
+            CommandPaletteItem(
+                id: "packs",
+                title: "Packs",
+                subtitle: "Browse and install keyboard packs",
+                icon: "shippingbox",
+                shortcut: nil
+            ) {
+                DispatchQueue.main.async {
+                    openPreferencesTab(.openSettingsRules)
+                }
+            },
+
+            CommandPaletteItem(
+                id: "overlay",
+                title: "Live Keyboard Overlay",
+                subtitle: "Show the floating keyboard visualization",
+                icon: "keyboard.badge.eye",
+                shortcut: "\u{2325}\u{2318}K"
+            ) {
+                DispatchQueue.main.async {
+                    LiveKeyboardOverlayController.shared.toggle()
+                }
+            },
+
+            CommandPaletteItem(
+                id: "status",
+                title: "System Status",
+                subtitle: "Check service health and permissions",
+                icon: "gauge.with.dots.needle.67percent",
+                shortcut: "\u{2318}S"
+            ) {
+                DispatchQueue.main.async {
+                    openPreferencesTab(.openSettingsSystemStatus)
+                }
+            },
+
+            CommandPaletteItem(
+                id: "edit-config",
+                title: "Edit Config",
+                subtitle: "Open keypath.kbd in your editor",
+                icon: "chevron.left.forwardslash.chevron.right",
+                shortcut: "\u{2318}O"
+            ) {
+                DispatchQueue.main.async {
+                    if let vm = (NSApp.delegate as? AppDelegate)?.viewModel {
+                        openConfigInEditor(viewModel: vm)
+                    }
+                }
+            },
+
+            CommandPaletteItem(
+                id: "logs",
+                title: "Logs",
+                subtitle: "View debug and runtime logs",
+                icon: "doc.text.magnifyingglass",
+                shortcut: "\u{2318}L"
+            ) {
+                DispatchQueue.main.async {
+                    openPreferencesTab(.openSettingsLogs)
+                }
+            },
+
+            CommandPaletteItem(
+                id: "wizard",
+                title: "Installation Wizard",
+                subtitle: "Run the setup wizard",
+                icon: "wand.and.stars",
+                shortcut: "\u{21e7}\u{2318}N"
+            ) {
+                DispatchQueue.main.async {
+                    NotificationCenter.default.post(name: NSNotification.Name("ShowWizard"), object: nil)
+                }
+            },
+
+            CommandPaletteItem(
+                id: "help",
+                title: "Help",
+                subtitle: "Open the KeyPath help browser",
+                icon: "questionmark.circle",
+                shortcut: "\u{2318}?"
+            ) {
+                DispatchQueue.main.async {
+                    HelpWindowController.shared.showBrowser()
+                }
+            },
+        ]
+    }
+}

--- a/Sources/KeyPathAppKit/UI/CommandPalette/CommandPaletteWindowController.swift
+++ b/Sources/KeyPathAppKit/UI/CommandPalette/CommandPaletteWindowController.swift
@@ -50,7 +50,7 @@ final class CommandPaletteWindowController {
         panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
         panel.animationBehavior = .utilityWindow
 
-        panel.setContentSize(NSSize(width: 440, height: 340))
+        panel.setContentSize(NSSize(width: 440, height: 360))
         positionPanel(panel)
 
         self.panel = panel
@@ -78,12 +78,14 @@ final class CommandPaletteWindowController {
 
     private func buildItems() -> [CommandPaletteItem] {
         [
+            // Navigation
             CommandPaletteItem(
                 id: "toggle-app",
                 title: "Hide / Show KeyPath",
                 subtitle: "Toggle the main KeyPath window",
                 icon: "eye",
-                shortcut: nil
+                shortcut: nil,
+                group: "Navigation"
             ) {
                 DispatchQueue.main.async {
                     if NSApp.isHidden {
@@ -94,73 +96,63 @@ final class CommandPaletteWindowController {
                     }
                 }
             },
-
+            CommandPaletteItem(
+                id: "overlay",
+                title: "Live Keyboard Overlay",
+                subtitle: "Show the floating keyboard visualization",
+                icon: "keyboard.badge.eye",
+                shortcut: "\u{2325}\u{2318}K",
+                group: "Navigation"
+            ) {
+                DispatchQueue.main.async {
+                    LiveKeyboardOverlayController.shared.toggle()
+                }
+            },
             CommandPaletteItem(
                 id: "mappings",
                 title: "Mappings",
                 subtitle: "Open the key mapper overlay",
                 icon: "keyboard",
-                shortcut: "\u{21e7}\u{2318}M"
+                shortcut: "\u{21e7}\u{2318}M",
+                group: "Navigation"
             ) {
                 DispatchQueue.main.async {
                     NotificationCenter.default.post(name: .openOverlayWithMapper, object: nil)
                 }
             },
 
+            // Rules
             CommandPaletteItem(
                 id: "rules",
                 title: "Rules",
                 subtitle: "Manage rule collections",
                 icon: "list.bullet",
-                shortcut: "\u{2318}R"
+                shortcut: "\u{2318}R",
+                group: "Rules"
             ) {
                 DispatchQueue.main.async {
                     openPreferencesTab(.openSettingsRules)
                 }
             },
-
             CommandPaletteItem(
                 id: "packs",
                 title: "Packs",
                 subtitle: "Browse and install keyboard packs",
                 icon: "shippingbox",
-                shortcut: nil
+                shortcut: nil,
+                group: "Rules"
             ) {
                 DispatchQueue.main.async {
                     openPreferencesTab(.openSettingsRules)
                 }
             },
-
-            CommandPaletteItem(
-                id: "overlay",
-                title: "Live Keyboard Overlay",
-                subtitle: "Show the floating keyboard visualization",
-                icon: "keyboard.badge.eye",
-                shortcut: "\u{2325}\u{2318}K"
-            ) {
-                DispatchQueue.main.async {
-                    LiveKeyboardOverlayController.shared.toggle()
-                }
-            },
-
-            CommandPaletteItem(
-                id: "status",
-                title: "System Status",
-                subtitle: "Check service health and permissions",
-                icon: "gauge.with.dots.needle.67percent",
-                shortcut: "\u{2318}S"
-            ) {
-                DispatchQueue.main.async {
-                    openPreferencesTab(.openSettingsSystemStatus)
-                }
-            },
-
             CommandPaletteItem(
                 id: "edit-config",
                 title: "Edit Config",
                 subtitle: "Open keypath.kbd in your editor",
                 icon: "chevron.left.forwardslash.chevron.right",
-                shortcut: "\u{2318}O"
+                shortcut: "\u{2318}O",
+                group: "Rules"
             ) {
                 DispatchQueue.main.async {
                     if let vm = (NSApp.delegate as? AppDelegate)?.viewModel {
@@ -169,36 +161,50 @@ final class CommandPaletteWindowController {
                 }
             },
 
+            // Settings
+            CommandPaletteItem(
+                id: "status",
+                title: "System Status",
+                subtitle: "Check service health and permissions",
+                icon: "gauge.with.dots.needle.67percent",
+                shortcut: "\u{2318}S",
+                group: "Settings"
+            ) {
+                DispatchQueue.main.async {
+                    openPreferencesTab(.openSettingsSystemStatus)
+                }
+            },
             CommandPaletteItem(
                 id: "logs",
                 title: "Logs",
                 subtitle: "View debug and runtime logs",
                 icon: "doc.text.magnifyingglass",
-                shortcut: "\u{2318}L"
+                shortcut: "\u{2318}L",
+                group: "Settings"
             ) {
                 DispatchQueue.main.async {
                     openPreferencesTab(.openSettingsLogs)
                 }
             },
-
             CommandPaletteItem(
                 id: "wizard",
                 title: "Installation Wizard",
                 subtitle: "Run the setup wizard",
                 icon: "wand.and.stars",
-                shortcut: "\u{21e7}\u{2318}N"
+                shortcut: "\u{21e7}\u{2318}N",
+                group: "Settings"
             ) {
                 DispatchQueue.main.async {
                     NotificationCenter.default.post(name: NSNotification.Name("ShowWizard"), object: nil)
                 }
             },
-
             CommandPaletteItem(
                 id: "help",
                 title: "Help",
                 subtitle: "Open the KeyPath help browser",
                 icon: "questionmark.circle",
-                shortcut: "\u{2318}?"
+                shortcut: "\u{2318}?",
+                group: "Settings"
             ) {
                 DispatchQueue.main.async {
                     HelpWindowController.shared.showBrowser()


### PR DESCRIPTION
## Summary

- Adds a custom Command-K palette (`⌘K`) as a floating NSPanel with search, arrow-key navigation, Enter to select, Esc to dismiss
- 10 commands organized into 3 grouped sections: Navigation, Rules, Settings
- Each item has an SF Symbol icon and keyboard shortcut hint badge
- `⌘K` now opens the palette; overlay toggle stays on `⌥⌘K`

Closes #434

## Test plan

- [ ] Press `⌘K` — palette appears centered near top of screen
- [ ] Type to filter items by title, subtitle, or group name
- [ ] Arrow keys move selection highlight, Enter executes, Esc dismisses
- [ ] Section headers (Navigation, Rules, Settings) display correctly
- [ ] Each command navigates to the right destination
- [ ] `⌥⌘K` still toggles the overlay
- [ ] 530 tests pass, build clean