### PR TITLE
fix: generate deflayer for layers referenced in aliases

### DIFF
--- a/Sources/KeyPathAppKit/Infrastructure/Config/KanataConfiguration+BlockBuilders.swift
+++ b/Sources/KeyPathAppKit/Infrastructure/Config/KanataConfiguration+BlockBuilders.swift
@@ -403,6 +403,21 @@ extension KanataConfiguration {
             blocks.append(CollectionBlock(metadata: metadata, entries: [entry]))
         }
 
+        // Scan alias definitions for layer references (layer-while-held, layer-switch)
+        // that aren't already in additionalLayers. This catches cases where a collection
+        // (e.g., Home Row Layer Toggles) generates hold actions referencing layers whose
+        // source collection isn't enabled — without a matching deflayer, kanata rejects the config.
+        let layerRefPattern = #/\((?:layer-while-held|layer-switch)\s+([\w-]+)\)/#
+        for alias in aliasDefinitions {
+            for match in alias.definition.matches(of: layerRefPattern) {
+                let layerName = String(match.1)
+                let layer = RuleCollectionLayer(kanataName: layerName)
+                guard layer != .base, !seenLayers.contains(layer) else { continue }
+                seenLayers.insert(layer)
+                additionalLayers.append(layer)
+            }
+        }
+
         return (activatorBlocks + blocks, aliasDefinitions, additionalLayers, chordMappings)
     }
 

--- a/Tests/KeyPathTests/Infrastructure/KanataConfigurationGeneratorSnapshotTests.swift
+++ b/Tests/KeyPathTests/Infrastructure/KanataConfigurationGeneratorSnapshotTests.swift
@@ -300,6 +300,29 @@ final class KanataConfigurationGeneratorSnapshotTests: XCTestCase {
         XCTAssertFalse(config.contains("require-prior-idle"), "Should not contain require-prior-idle when 0")
     }
 
+    // MARK: - Layer Reference Completeness
+
+    func testHomeRowLayerToggles_GeneratesDeflayerForReferencedLayers() throws {
+        let collection = try makeCollection(
+            id: XCTUnwrap(UUID(uuidString: "33333333-3333-3333-3333-333333333333")),
+            name: "Home Row Layer Toggles",
+            summary: "Hold for layers",
+            category: .productivity,
+            mappings: [],
+            targetLayer: .base,
+            momentaryActivator: nil,
+            configuration: .homeRowLayerToggles(HomeRowLayerTogglesConfig(
+                enabledKeys: [";", "a"],
+                layerAssignments: [";": "fun", "a": "fun"]
+            ))
+        )
+
+        let config = KanataConfiguration.generateFromCollections([collection])
+
+        assertContains(config, "layer-while-held fun")
+        assertContains(config, "(deflayer fun")
+    }
+
     private func assertContains(
         _ config: String,
         _ snippet: String,


### PR DESCRIPTION
## Summary

- Home Row Layer Toggles generates `layer-while-held fun` aliases on the base layer, but `deflayer fun` was only emitted when the Function Keys collection (which has `targetLayer: .custom("fun")`) was separately enabled
- With that collection disabled, kanata rejected the config on startup due to the undeclared layer — silently preventing the service from running
- After building alias definitions, scan them for `layer-while-held` and `layer-switch` references and add any missing layers to `additionalLayers` so they always get a deflayer

## Root cause

`buildCollectionBlocks` only added layers to `additionalLayers` when a collection's `targetLayer != .base`. But Home Row Layer Toggles has `targetLayer = .base` and references other layers (fun, num, sym, nav) inside alias definitions via `layer-while-held`. Those layer references were invisible to the layer discovery logic.

## Test plan

- [x] New regression test: `testHomeRowLayerToggles_GeneratesDeflayerForReferencedLayers`
- [x] Full test suite passes (530 tests)
- [ ] Deploy and verify kanata starts with Home Row Layer Toggles enabled but Function Keys collection disabled