### PR TITLE
feat: expand Command-K palette with collections, packs, overlay tabs, recency

### DIFF
--- a/Sources/KeyPathAppKit/UI/CommandPalette/CommandPaletteView.swift
+++ b/Sources/KeyPathAppKit/UI/CommandPalette/CommandPaletteView.swift
@@ -108,41 +108,49 @@ struct CommandPaletteView: View {
 
     // MARK: - Results
 
+    private var indexedGroups: [(group: String, items: [(globalIndex: Int, item: CommandPaletteItem)])] {
+        var result: [(group: String, items: [(globalIndex: Int, item: CommandPaletteItem)])] = []
+        var globalIndex = 0
+        for group in groupedFiltered {
+            var indexedItems: [(globalIndex: Int, item: CommandPaletteItem)] = []
+            for item in group.items {
+                indexedItems.append((globalIndex: globalIndex, item: item))
+                globalIndex += 1
+            }
+            result.append((group: group.id, items: indexedItems))
+        }
+        return result
+    }
+
     private var resultsList: some View {
         ScrollViewReader { proxy in
             ScrollView {
                 LazyVStack(alignment: .leading, spacing: 0) {
-                    let flatItems = filtered
-                    var runningIndex = 0
+                    let groups = indexedGroups
 
-                    ForEach(groupedFiltered) { group in
-                        let groupStart = runningIndex
-
+                    ForEach(Array(groups.enumerated()), id: \.element.group) { groupIdx, group in
                         Section {
-                            ForEach(Array(group.items.enumerated()), id: \.element.id) { offset, item in
-                                let globalIndex = groupStart + offset
+                            ForEach(group.items, id: \.item.id) { entry in
                                 CommandPaletteRow(
-                                    item: item,
-                                    isSelected: globalIndex == selectedIndex
+                                    item: entry.item,
+                                    isSelected: entry.globalIndex == selectedIndex
                                 ) {
                                     onDismiss()
-                                    item.action()
+                                    entry.item.action()
                                 }
-                                .id(item.id)
+                                .id(entry.item.id)
                                 .onHover { hovering in
-                                    if hovering { selectedIndex = globalIndex }
+                                    if hovering { selectedIndex = entry.globalIndex }
                                 }
                             }
                         } header: {
-                            Text(group.id)
+                            Text(group.group)
                                 .font(.system(size: 11, weight: .semibold))
                                 .foregroundStyle(.secondary)
                                 .padding(.horizontal, 16)
-                                .padding(.top, groupStart == 0 ? 6 : 12)
+                                .padding(.top, groupIdx == 0 ? 6 : 12)
                                 .padding(.bottom, 4)
                         }
-
-                        let _ = (runningIndex = groupStart + group.items.count)
                     }
                 }
                 .padding(.bottom, 4)

--- a/Sources/KeyPathAppKit/UI/CommandPalette/CommandPaletteWindowController.swift
+++ b/Sources/KeyPathAppKit/UI/CommandPalette/CommandPaletteWindowController.swift
@@ -6,8 +6,45 @@ final class CommandPaletteWindowController {
     static let shared = CommandPaletteWindowController()
 
     private var panel: NSPanel?
+    private let recencyKey = "CommandPalette.Recency"
 
     private init() {}
+
+    // MARK: - Recency Tracking
+
+    func recordUsage(_ itemID: String) {
+        var recency = UserDefaults.standard.dictionary(forKey: recencyKey) as? [String: Double] ?? [:]
+        recency[itemID] = Date().timeIntervalSinceReferenceDate
+        UserDefaults.standard.set(recency, forKey: recencyKey)
+    }
+
+    private func recencyScore(_ itemID: String) -> Double {
+        let recency = UserDefaults.standard.dictionary(forKey: recencyKey) as? [String: Double] ?? [:]
+        return recency[itemID] ?? 0
+    }
+
+    private func sortByRecency(_ items: [CommandPaletteItem]) -> [CommandPaletteItem] {
+        let pinned = items.filter { $0.id == "toggle-app" }
+        let recentIDs = (UserDefaults.standard.dictionary(forKey: recencyKey) as? [String: Double] ?? [:])
+            .sorted { $0.value > $1.value }
+            .prefix(5)
+            .map(\.key)
+        let recentSet = Set(recentIDs)
+
+        let recentItems = recentIDs.compactMap { id in
+            items.first(where: { $0.id == id && $0.id != "toggle-app" })
+        }.map { item in
+            CommandPaletteItem(
+                id: item.id, title: item.title, subtitle: item.subtitle,
+                icon: item.icon, shortcut: item.shortcut, group: "Recent",
+                action: item.action
+            )
+        }
+
+        let rest = items.filter { $0.id != "toggle-app" && !recentSet.contains($0.id) }
+
+        return pinned + recentItems + rest
+    }
 
     var isVisible: Bool {
         panel?.isVisible ?? false
@@ -32,7 +69,7 @@ final class CommandPaletteWindowController {
         let hosting = NSHostingController(rootView: view)
         let panel = NSPanel(
             contentRect: .zero,
-            styleMask: [.nonactivatingPanel, .fullSizeContentView],
+            styleMask: [.titled, .fullSizeContentView],
             backing: .buffered,
             defer: true
         )
@@ -50,7 +87,7 @@ final class CommandPaletteWindowController {
         panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
         panel.animationBehavior = .utilityWindow
 
-        panel.setContentSize(NSSize(width: 440, height: 360))
+        panel.setContentSize(NSSize(width: 440, height: 420))
         positionPanel(panel)
 
         self.panel = panel
@@ -63,22 +100,71 @@ final class CommandPaletteWindowController {
         panel = nil
     }
 
+    func allItemIDs() -> Set<String> {
+        var items: [CommandPaletteItem] = []
+        items.append(contentsOf: navigationItems())
+        items.append(contentsOf: collectionItems())
+        items.append(contentsOf: packItems())
+        items.append(contentsOf: overlayTabItems())
+        items.append(contentsOf: settingsItems())
+        return Set(items.map(\.id))
+    }
+
     // MARK: - Positioning
 
     private func positionPanel(_ panel: NSPanel) {
         guard let screen = NSScreen.main else { return }
         let screenFrame = screen.visibleFrame
         let panelSize = panel.frame.size
-        let x = screenFrame.midX - panelSize.width / 2
-        let y = screenFrame.midY + screenFrame.height * 0.15
-        panel.setFrameOrigin(NSPoint(x: x, y: y))
+
+        if let overlayFrame = LiveKeyboardOverlayController.shared.window?.frame,
+           LiveKeyboardOverlayController.shared.window?.isVisible == true
+        {
+            let x = overlayFrame.midX - panelSize.width / 2
+            let y = overlayFrame.maxY - panelSize.height - 24
+            let clamped = NSPoint(
+                x: min(max(x, screenFrame.minX), screenFrame.maxX - panelSize.width),
+                y: max(y, screenFrame.minY)
+            )
+            panel.setFrameOrigin(clamped)
+        } else {
+            let x = screenFrame.midX - panelSize.width / 2
+            let y = screenFrame.midY + screenFrame.height * 0.15
+            panel.setFrameOrigin(NSPoint(x: x, y: y))
+        }
     }
 
     // MARK: - Command Items
 
     private func buildItems() -> [CommandPaletteItem] {
+        var items: [CommandPaletteItem] = []
+
+        items.append(contentsOf: navigationItems())
+        items.append(contentsOf: collectionItems())
+        items.append(contentsOf: packItems())
+        items.append(contentsOf: overlayTabItems())
+        items.append(contentsOf: settingsItems())
+
+        return sortByRecency(items.map { item in
+            let originalAction = item.action
+            return CommandPaletteItem(
+                id: item.id,
+                title: item.title,
+                subtitle: item.subtitle,
+                icon: item.icon,
+                shortcut: item.shortcut,
+                group: item.group
+            ) { [weak self] in
+                self?.recordUsage(item.id)
+                originalAction()
+            }
+        })
+    }
+
+    // MARK: - Navigation
+
+    private func navigationItems() -> [CommandPaletteItem] {
         [
-            // Navigation
             CommandPaletteItem(
                 id: "toggle-app",
                 title: "Hide / Show KeyPath",
@@ -120,39 +206,13 @@ final class CommandPaletteWindowController {
                     NotificationCenter.default.post(name: .openOverlayWithMapper, object: nil)
                 }
             },
-
-            // Rules
-            CommandPaletteItem(
-                id: "rules",
-                title: "Rules",
-                subtitle: "Manage rule collections",
-                icon: "list.bullet",
-                shortcut: "\u{2318}R",
-                group: "Rules"
-            ) {
-                DispatchQueue.main.async {
-                    openPreferencesTab(.openSettingsRules)
-                }
-            },
-            CommandPaletteItem(
-                id: "packs",
-                title: "Packs",
-                subtitle: "Browse and install keyboard packs",
-                icon: "shippingbox",
-                shortcut: nil,
-                group: "Rules"
-            ) {
-                DispatchQueue.main.async {
-                    openPreferencesTab(.openSettingsRules)
-                }
-            },
             CommandPaletteItem(
                 id: "edit-config",
                 title: "Edit Config",
                 subtitle: "Open keypath.kbd in your editor",
                 icon: "chevron.left.forwardslash.chevron.right",
                 shortcut: "\u{2318}O",
-                group: "Rules"
+                group: "Navigation"
             ) {
                 DispatchQueue.main.async {
                     if let vm = (NSApp.delegate as? AppDelegate)?.viewModel {
@@ -160,10 +220,109 @@ final class CommandPaletteWindowController {
                     }
                 }
             },
-
-            // Settings
             CommandPaletteItem(
-                id: "status",
+                id: "help",
+                title: "Help",
+                subtitle: "Open the KeyPath help browser",
+                icon: "questionmark.circle",
+                shortcut: "\u{2318}?",
+                group: "Navigation"
+            ) {
+                DispatchQueue.main.async {
+                    HelpWindowController.shared.showBrowser()
+                }
+            },
+        ]
+    }
+
+    // MARK: - Rule Collections
+
+    private func collectionItems() -> [CommandPaletteItem] {
+        let catalog = RuleCollectionCatalog()
+        return catalog.defaultCollections().map { collection in
+            CommandPaletteItem(
+                id: "collection-\(collection.id.uuidString)",
+                title: collection.name,
+                subtitle: collection.summary,
+                icon: collection.icon ?? "list.bullet",
+                shortcut: nil,
+                group: "Collections"
+            ) {
+                DispatchQueue.main.async {
+                    openPreferencesTab(.openSettingsRules)
+                }
+            }
+        }
+    }
+
+    // MARK: - Packs
+
+    private func packItems() -> [CommandPaletteItem] {
+        PackRegistry.starterKit.map { pack in
+            CommandPaletteItem(
+                id: "pack-\(pack.id)",
+                title: pack.name,
+                subtitle: pack.tagline,
+                icon: pack.iconSymbol,
+                shortcut: nil,
+                group: "Packs"
+            ) {
+                DispatchQueue.main.async {
+                    if let vm = (NSApp.delegate as? AppDelegate)?.viewModel {
+                        PackDetailWindowController.shared.showWindow(pack: pack, kanataManager: vm)
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Overlay Inspector Tabs
+
+    private func overlayTabItems() -> [CommandPaletteItem] {
+        let tabs: [(section: InspectorSection, title: String, subtitle: String, icon: String)] = [
+            (.mapper, "Mapper", "Key mapper and conflict detection", "arrow.left.arrow.right"),
+            (.customRules, "Custom Rules", "Global and app-specific rules", "text.badge.star"),
+            (.keyboard, "Keymap", "Logical key labels", "character.textbox"),
+            (.layout, "Layout", "Physical keyboard layout", "rectangle.split.3x3"),
+            (.keycaps, "Keycaps", "Keycap appearance and colors", "paintpalette"),
+            (.sounds, "Sounds", "Typing sounds", "speaker.wave.2"),
+            (.launchers, "Launchers", "App and website launchers", "arrow.up.forward.app"),
+            (.devices, "Devices", "Keyboard device selection", "desktopcomputer"),
+        ]
+
+        return tabs.map { tab in
+            CommandPaletteItem(
+                id: "inspector-\(tab.section.rawValue)",
+                title: tab.title,
+                subtitle: tab.subtitle,
+                icon: tab.icon,
+                shortcut: nil,
+                group: "Overlay"
+            ) {
+                DispatchQueue.main.async {
+                    let controller = LiveKeyboardOverlayController.shared
+                    if controller.window == nil || controller.window?.isVisible != true {
+                        controller.showResetCentered()
+                    }
+                    controller.openInspector(animated: true)
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                        NotificationCenter.default.post(
+                            name: .commandPaletteSelectInspectorSection,
+                            object: nil,
+                            userInfo: ["section": tab.section.rawValue]
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Settings Tabs
+
+    private func settingsItems() -> [CommandPaletteItem] {
+        [
+            CommandPaletteItem(
+                id: "settings-status",
                 title: "System Status",
                 subtitle: "Check service health and permissions",
                 icon: "gauge.with.dots.needle.67percent",
@@ -175,7 +334,43 @@ final class CommandPaletteWindowController {
                 }
             },
             CommandPaletteItem(
-                id: "logs",
+                id: "settings-rules",
+                title: "Rules Tab",
+                subtitle: "Manage rule collections",
+                icon: "list.bullet",
+                shortcut: "\u{2318}R",
+                group: "Settings"
+            ) {
+                DispatchQueue.main.async {
+                    openPreferencesTab(.openSettingsRules)
+                }
+            },
+            CommandPaletteItem(
+                id: "settings-general",
+                title: "General",
+                subtitle: "App preferences and startup options",
+                icon: "gearshape",
+                shortcut: nil,
+                group: "Settings"
+            ) {
+                DispatchQueue.main.async {
+                    openPreferencesTab(.openSettingsGeneral)
+                }
+            },
+            CommandPaletteItem(
+                id: "settings-advanced",
+                title: "Repair / Remove",
+                subtitle: "Reinstall components or uninstall",
+                icon: "wrench.and.screwdriver",
+                shortcut: nil,
+                group: "Settings"
+            ) {
+                DispatchQueue.main.async {
+                    openPreferencesTab(.openSettingsAdvanced)
+                }
+            },
+            CommandPaletteItem(
+                id: "settings-logs",
                 title: "Logs",
                 subtitle: "View debug and runtime logs",
                 icon: "doc.text.magnifyingglass",
@@ -187,7 +382,7 @@ final class CommandPaletteWindowController {
                 }
             },
             CommandPaletteItem(
-                id: "wizard",
+                id: "settings-wizard",
                 title: "Installation Wizard",
                 subtitle: "Run the setup wizard",
                 icon: "wand.and.stars",
@@ -196,18 +391,6 @@ final class CommandPaletteWindowController {
             ) {
                 DispatchQueue.main.async {
                     NotificationCenter.default.post(name: NSNotification.Name("ShowWizard"), object: nil)
-                }
-            },
-            CommandPaletteItem(
-                id: "help",
-                title: "Help",
-                subtitle: "Open the KeyPath help browser",
-                icon: "questionmark.circle",
-                shortcut: "\u{2318}?",
-                group: "Settings"
-            ) {
-                DispatchQueue.main.async {
-                    HelpWindowController.shared.showBrowser()
                 }
             },
         ]

--- a/Sources/KeyPathAppKit/UI/Overlay/LiveKeyboardOverlayView.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/LiveKeyboardOverlayView.swift
@@ -449,6 +449,13 @@ struct LiveKeyboardOverlayView: View {
                         }
                     }
                 }
+            },
+            onSelectInspectorSection: { notification in
+                if let rawValue = notification.userInfo?["section"] as? String,
+                   let section = InspectorSection(rawValue: rawValue)
+                {
+                    selectInspectorSection(section)
+                }
             }
         ))
         .onReceive(NotificationCenter.default.publisher(for: .installedPacksChanged)) { _ in

--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayInspectorTypes.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayInspectorTypes.swift
@@ -11,7 +11,7 @@ enum DrawerPanel {
     }
 }
 
-enum InspectorSection: String {
+enum InspectorSection: String, CaseIterable {
     case mapper
     case customRules // Only shown when custom rules exist
     case keyboard

--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayNotificationsModifier.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayNotificationsModifier.swift
@@ -14,6 +14,7 @@ struct OverlayNotificationsModifier: ViewModifier {
     let onSwitchToAppRulesTab: () -> Void
     let onSwitchToMapperTab: (Notification) -> Void
     let onMapperKeySelected: (Notification) -> Void
+    let onSelectInspectorSection: (Notification) -> Void
 
     func body(content: Content) -> some View {
         content
@@ -52,6 +53,9 @@ struct OverlayNotificationsModifier: ViewModifier {
             // Switch to Mapper tab when a key is clicked while in Rules tab
             .onReceive(NotificationCenter.default.publisher(for: .mapperDrawerKeySelected)) { notification in
                 onMapperKeySelected(notification)
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .commandPaletteSelectInspectorSection)) { notification in
+                onSelectInspectorSection(notification)
             }
     }
 }

--- a/Sources/KeyPathAppKit/Utilities/Notifications.swift
+++ b/Sources/KeyPathAppKit/Utilities/Notifications.swift
@@ -81,4 +81,8 @@ extension Notification.Name {
     static let hidKeyboardConnected = Notification.Name("KeyPath.HID.KeyboardConnected")
     /// HID keyboard disconnected (posted by HIDDeviceMonitor). object = HIDKeyboardEvent
     static let hidKeyboardDisconnected = Notification.Name("KeyPath.HID.KeyboardDisconnected")
+
+    /// Command palette requests a specific overlay inspector section.
+    /// userInfo["section"] = InspectorSection.rawValue (String)
+    static let commandPaletteSelectInspectorSection = Notification.Name("KeyPath.CommandPalette.SelectInspectorSection")
 }

--- a/Tests/KeyPathTests/UI/CommandPaletteCoverageTests.swift
+++ b/Tests/KeyPathTests/UI/CommandPaletteCoverageTests.swift
@@ -1,0 +1,41 @@
+@testable import KeyPathAppKit
+import Testing
+
+@Suite("Command Palette Coverage")
+struct CommandPaletteCoverageTests {
+    @Test("Every InspectorSection has a palette entry")
+    @MainActor
+    func allInspectorSectionsCovered() {
+        let controller = CommandPaletteWindowController.shared
+        let items = controller.allItemIDs()
+
+        for section in InspectorSection.allCases {
+            let expectedID = "inspector-\(section.rawValue)"
+            #expect(
+                items.contains(expectedID),
+                "Missing command palette entry for InspectorSection.\(section.rawValue)"
+            )
+        }
+    }
+
+    @Test("Every SettingsTab has a palette entry")
+    @MainActor
+    func allSettingsTabsCovered() {
+        let controller = CommandPaletteWindowController.shared
+        let items = controller.allItemIDs()
+
+        let expectedMappings: [SettingsTab: String] = [
+            .status: "settings-status",
+            .rules: "settings-rules",
+            .general: "settings-general",
+            .advanced: "settings-advanced",
+        ]
+
+        for (tab, expectedID) in expectedMappings {
+            #expect(
+                items.contains(expectedID),
+                "Missing command palette entry for SettingsTab.\(tab)"
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds all rule collections and packs to the command palette (dynamically sourced, so new ones auto-appear)
- Adds overlay inspector tabs (Mapper, Custom Rules, Keymap, Layout, Keycaps, Sounds, Launchers, Devices)
- Adds all settings tabs (Status, Rules, General, Repair/Remove, Logs, Wizard)
- Recency tracking: your 5 most recent selections appear in a "Recent" group at the top
- "Hide / Show KeyPath" always pinned as the first item
- Coverage tests that fail if a new `InspectorSection` or `SettingsTab` is added without a palette entry
- Positions palette relative to the overlay window when visible
- Fixes grouped section rendering with correct global index tracking

## Test plan

- [ ] `⌘K` opens palette with all groups: Navigation, Recent (after first use), Collections, Packs, Overlay, Settings
- [ ] Type to filter across all items
- [ ] Select a collection → opens Rules settings tab
- [ ] Select a pack → opens Pack Detail window
- [ ] Select an overlay tab → opens overlay with that inspector section
- [ ] Select a settings tab → opens that settings tab
- [ ] Recently used items appear in "Recent" group on next open
- [ ] "Hide / Show KeyPath" always first regardless of recency
- [ ] `swift test --filter CommandPaletteCoverage` passes
- [ ] 532 tests pass