### PR TITLE
fix: deduplicate kanata config aliases and surface config parse errors

### DIFF
--- a/Sources/KeyPathAppKit/Infrastructure/Config/KanataConfiguration+BlockBuilders.swift
+++ b/Sources/KeyPathAppKit/Infrastructure/Config/KanataConfiguration+BlockBuilders.swift
@@ -510,6 +510,31 @@ extension KanataConfiguration {
         }
     }
 
+    /// Deduplicate alias definitions by name. When multiple collections generate
+    /// aliases with the same name (e.g., Home Row Mods and Home Row Layer Toggles
+    /// both emit `beh_base_;`), the last definition wins. Kanata rejects configs
+    /// with duplicate alias names, so this is required for correctness.
+    static func deduplicateAliases(_ aliases: [AliasDefinition]) -> [AliasDefinition] {
+        var seen: [String: Int] = [:]
+        var result: [AliasDefinition] = []
+
+        for alias in aliases {
+            if let existingIndex = seen[alias.aliasName] {
+                AppLogger.shared.log("⚠️ [ConfigDedup] Duplicate alias '\(alias.aliasName)': replacing '\(result[existingIndex].definition.prefix(60))…' with '\(alias.definition.prefix(60))…'")
+                result[existingIndex] = alias
+            } else {
+                seen[alias.aliasName] = result.count
+                result.append(alias)
+            }
+        }
+
+        if result.count < aliases.count {
+            AppLogger.shared.log("📋 [ConfigDedup] Deduplicated \(aliases.count - result.count) alias(es) (\(aliases.count) → \(result.count))")
+        }
+
+        return result
+    }
+
     static func deduplicateBlocks(_ blocks: [CollectionBlock]) -> [CollectionBlock] {
         // Merge entries with the same source key instead of just keeping the first one.
         // This ensures layer-specific mappings (like launcher in launcher layer) aren't lost

--- a/Sources/KeyPathAppKit/Infrastructure/Config/KanataConfiguration+BlockBuilders.swift
+++ b/Sources/KeyPathAppKit/Infrastructure/Config/KanataConfiguration+BlockBuilders.swift
@@ -510,17 +510,20 @@ extension KanataConfiguration {
         }
     }
 
-    /// Deduplicate alias definitions by name. When multiple collections generate
-    /// aliases with the same name (e.g., Home Row Mods and Home Row Layer Toggles
-    /// both emit `beh_base_;`), the last definition wins. Kanata rejects configs
-    /// with duplicate alias names, so this is required for correctness.
+    /// Safety net: detect duplicate alias names and keep only the last definition
+    /// so kanata doesn't reject the config outright.
+    ///
+    /// The primary defense is `RuleCollectionDeduplicator.detectConflicts()` which
+    /// blocks config writes when collections overlap. This function catches edge
+    /// cases that slip past (e.g., aliases generated from non-mapping paths).
+    /// It logs warnings so the root cause is visible in diagnostics.
     static func deduplicateAliases(_ aliases: [AliasDefinition]) -> [AliasDefinition] {
         var seen: [String: Int] = [:]
         var result: [AliasDefinition] = []
 
         for alias in aliases {
             if let existingIndex = seen[alias.aliasName] {
-                AppLogger.shared.log("⚠️ [ConfigDedup] Duplicate alias '\(alias.aliasName)': replacing '\(result[existingIndex].definition.prefix(60))…' with '\(alias.definition.prefix(60))…'")
+                AppLogger.shared.error("🚨 [ConfigGen] Duplicate alias '\(alias.aliasName)' — this should have been caught by conflict detection. Keeping last definition as safety fallback. First: '\(result[existingIndex].definition.prefix(80))' → Replaced by: '\(alias.definition.prefix(80))'")
                 result[existingIndex] = alias
             } else {
                 seen[alias.aliasName] = result.count
@@ -529,7 +532,7 @@ extension KanataConfiguration {
         }
 
         if result.count < aliases.count {
-            AppLogger.shared.log("📋 [ConfigDedup] Deduplicated \(aliases.count - result.count) alias(es) (\(aliases.count) → \(result.count))")
+            AppLogger.shared.error("🚨 [ConfigGen] Had to deduplicate \(aliases.count - result.count) alias(es) — investigate why conflict detection missed this")
         }
 
         return result

--- a/Sources/KeyPathAppKit/Infrastructure/Config/KanataConfigurationGenerator.swift
+++ b/Sources/KeyPathAppKit/Infrastructure/Config/KanataConfigurationGenerator.swift
@@ -87,8 +87,8 @@ public struct KanataConfiguration: Sendable {
             navHoldDelayMs: navHoldDelayMs,
             globalRequirePriorIdleMs: requirePriorIdleMs
         )
-        let mergedAliasDefinitions = aliasDefinitions
-        AppLogger.shared.log("📚 [KanataConfig] Total alias definitions: \(mergedAliasDefinitions.count), first 5: \(mergedAliasDefinitions.prefix(5).map(\.aliasName).joined(separator: ", "))")
+        let mergedAliasDefinitions = deduplicateAliases(aliasDefinitions)
+        AppLogger.shared.log("📚 [KanataConfig] Total alias definitions: \(mergedAliasDefinitions.count) (before dedup: \(aliasDefinitions.count)), first 5: \(mergedAliasDefinitions.prefix(5).map(\.aliasName).joined(separator: ", "))")
         let blocks = deduplicateBlocks(rawBlocks)
         let enabledNames = enabledCollections.map(\.name).joined(separator: ", ")
 

--- a/Sources/KeyPathAppKit/Models/RuleCollectionDeduplicator.swift
+++ b/Sources/KeyPathAppKit/Models/RuleCollectionDeduplicator.swift
@@ -7,26 +7,49 @@ enum RuleCollectionDeduplicator {
     /// Detects mapping conflicts BEFORE deduplication.
     /// Returns conflicts where multiple collections map the same key in the same layer.
     /// Call this before `dedupe()` to catch conflicts that would otherwise be silently resolved.
+    ///
+    /// Uses `effectiveMappings(for:)` to include config-generated mappings (Home Row Mods,
+    /// Layer Toggles, etc.) — not just the raw `.mappings` array.
     static func detectConflicts(in collections: [RuleCollection]) -> [KeyPathError.MappingConflictInfo] {
-        // Track which collections claim each (input, layer) pair
-        var claimedKeys: [InputKey: [String]] = [:]
+        struct ClaimInfo {
+            let collectionName: String
+            let holdDescription: String?
+        }
+
+        var claimedKeys: [InputKey: [ClaimInfo]] = [:]
 
         for collection in collections where collection.isEnabled {
-            for mapping in collection.mappings {
+            let mappings = KanataConfiguration.effectiveMappings(for: collection)
+            for mapping in mappings {
                 let normalizedInput = KanataKeyConverter.convertToKanataKey(mapping.input)
                 let inputKey = InputKey(input: normalizedInput, layer: collection.targetLayer)
 
-                claimedKeys[inputKey, default: []].append(collection.name)
+                let holdDesc = mapping.behavior.flatMap { behavior -> String? in
+                    if case let .dualRole(dr) = behavior {
+                        return dr.holdActionString
+                    }
+                    return nil
+                }
+
+                claimedKeys[inputKey, default: []].append(
+                    ClaimInfo(collectionName: collection.name, holdDescription: holdDesc)
+                )
             }
         }
 
-        // Find keys claimed by more than one collection
         var conflicts: [KeyPathError.MappingConflictInfo] = []
-        for (inputKey, collectionNames) in claimedKeys where collectionNames.count > 1 {
+        for (inputKey, claims) in claimedKeys where claims.count > 1 {
+            let collectionNames = claims.map(\.collectionName)
+            let holdDescriptions = claims.compactMap { claim -> String? in
+                guard let hold = claim.holdDescription else { return nil }
+                return "\(claim.collectionName): hold → \(hold)"
+            }
+
             conflicts.append(KeyPathError.MappingConflictInfo(
                 inputKey: inputKey.input,
                 layer: inputKey.layer.displayName,
-                conflictingCollections: collectionNames
+                conflictingCollections: collectionNames,
+                holdDescriptions: holdDescriptions
             ))
         }
 

--- a/Sources/KeyPathAppKit/Services/Monitoring/KanataErrorMonitor.swift
+++ b/Sources/KeyPathAppKit/Services/Monitoring/KanataErrorMonitor.swift
@@ -160,6 +160,17 @@ final class KanataErrorMonitor {
             toastThreshold: 1
         ),
 
+        // Configuration parse errors - CRITICAL
+        // Kanata refuses to start when the config has syntax errors or duplicates.
+        // This causes a crash loop and must be surfaced immediately.
+        ErrorPattern(
+            pattern: "Error in configuration|failed to parse file|Duplicate alias",
+            severity: .critical,
+            userMessage: "Configuration error is preventing keyboard remapping. Open Settings to see details or reset to default config.",
+            patternName: "config_parse_error",
+            toastThreshold: 1
+        ),
+
         // VirtualHID driver issues - CRITICAL
         ErrorPattern(
             pattern: "VirtualHID.*failed|driver.*not found|kext.*error",

--- a/Sources/KeyPathAppKit/Services/System/SystemValidator.swift
+++ b/Sources/KeyPathAppKit/Services/System/SystemValidator.swift
@@ -536,13 +536,18 @@ public class SystemValidator {
             "🔍 [SystemValidator] checkHealth() EXIT - Health: kanata=\(kanataRunning), daemon=\(karabinerDaemonRunning) (launchctl), vhid=\(vhidHealthy), permRejected=\(stderrDiagnosis.permissionRejected) (total: \(String(format: "%.3f", totalDuration))s)"
         )
 
+        if let configError = stderrDiagnosis.configParseError {
+            AppLogger.shared.error("🔍 [SystemValidator] checkHealth() - Config parse error detected: \(configError)")
+        }
+
         return HealthStatus(
             kanataRunning: kanataRunning,
             karabinerDaemonRunning: karabinerDaemonRunning,
             vhidHealthy: vhidHealthy,
             kanataInputCaptureReady: stderrDiagnosis.inputCapture.isReady,
             kanataInputCaptureIssue: stderrDiagnosis.inputCapture.issue,
-            kanataPermissionRejected: stderrDiagnosis.permissionRejected
+            kanataPermissionRejected: stderrDiagnosis.permissionRejected,
+            configParseError: stderrDiagnosis.configParseError
         )
     }
 

--- a/Sources/KeyPathCore/KeyPathError.swift
+++ b/Sources/KeyPathCore/KeyPathError.swift
@@ -52,16 +52,40 @@ public enum KeyPathError: Error, LocalizedError {
         public let inputKey: String
         public let layer: String
         public let conflictingCollections: [String]
+        /// Per-collection descriptions of what each does with the key on hold.
+        /// e.g., ["Home Row Mods: hold → rsft", "Home Row Layer Toggles: hold → (layer-while-held fun)"]
+        public let holdDescriptions: [String]
 
-        public init(inputKey: String, layer: String, conflictingCollections: [String]) {
+        public init(
+            inputKey: String,
+            layer: String,
+            conflictingCollections: [String],
+            holdDescriptions: [String] = []
+        ) {
             self.inputKey = inputKey
             self.layer = layer
             self.conflictingCollections = conflictingCollections
+            self.holdDescriptions = holdDescriptions
         }
 
         public var description: String {
             let collections = conflictingCollections.joined(separator: "\" and \"")
             return "Key '\(inputKey)' is mapped in both \"\(collections)\" (layer: \(layer))"
+        }
+
+        /// User-friendly explanation of the conflict and resolution options
+        public var userExplanation: String {
+            let collections = conflictingCollections.joined(separator: " and ")
+            var explanation = "\(collections) both configure the \"\(inputKey)\" key with different hold behaviors."
+
+            if !holdDescriptions.isEmpty {
+                explanation += " " + holdDescriptions.joined(separator: "; ") + "."
+            }
+
+            explanation += " A key can only have one hold action."
+            explanation += " Either disable one of these collections, or change their key assignments so they don't overlap."
+
+            return explanation
         }
     }
 
@@ -286,7 +310,7 @@ public enum KeyPathError: Error, LocalizedError {
         case let .repairFailed(reason):
             "Failed to repair configuration: \(reason)"
         case let .mappingConflicts(conflicts):
-            "Mapping conflicts detected: \(conflicts.map(\.description).joined(separator: "; "))"
+            conflicts.map(\.userExplanation).joined(separator: "\n\n")
         }
     }
 

--- a/Sources/KeyPathInstallationWizard/Core/ServiceHealthChecker.swift
+++ b/Sources/KeyPathInstallationWizard/Core/ServiceHealthChecker.swift
@@ -94,6 +94,19 @@ public final class ServiceHealthChecker: @unchecked Sendable {
         public let permissionRejected: Bool
         /// Input capture status (keyboard open failure)
         public let inputCapture: KanataInputCaptureStatus
+        /// Non-nil when stderr shows a kanata config parse error (e.g., duplicate alias, syntax error).
+        /// Contains the user-facing error message extracted from kanata's output.
+        public let configParseError: String?
+
+        public init(
+            permissionRejected: Bool,
+            inputCapture: KanataInputCaptureStatus,
+            configParseError: String? = nil
+        ) {
+            self.permissionRejected = permissionRejected
+            self.inputCapture = inputCapture
+            self.configParseError = configParseError
+        }
 
         public static let clear = KanataDaemonDiagnosis(
             permissionRejected: false,
@@ -663,10 +676,51 @@ public final class ServiceHealthChecker: @unchecked Sendable {
             }
         }
 
+        // Check for configuration parse errors (e.g., duplicate aliases, syntax errors).
+        // These cause kanata to exit immediately and crash-loop via launchd.
+        let configParseError = Self.extractConfigParseError(from: logChunk)
+
         return KanataDaemonDiagnosis(
             permissionRejected: permissionRejected,
-            inputCapture: inputCaptureIssue
+            inputCapture: inputCaptureIssue,
+            configParseError: configParseError
         )
+    }
+
+    /// Extract a user-facing config parse error from kanata stderr output.
+    /// Looks for "help:" lines (most specific), falls back to "Error in configuration" / "failed to parse".
+    static func extractConfigParseError(from logChunk: String) -> String? {
+        let hasParseFailure = logChunk.contains("failed to parse file")
+            || logChunk.contains("Error in configuration")
+            || logChunk.contains("Host bridge config validation failed")
+        guard hasParseFailure else { return nil }
+
+        // Extract the "help:" line — kanata puts the most actionable info there
+        // e.g., "help: Duplicate alias: beh_base_;"
+        let lines = logChunk.components(separatedBy: .newlines)
+        for line in lines.reversed() {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if trimmed.hasPrefix("help:") {
+                let detail = String(trimmed.dropFirst(5)).trimmingCharacters(in: .whitespaces)
+                if !detail.isEmpty {
+                    return detail
+                }
+            }
+        }
+
+        // Fallback: use the [ERROR] line
+        for line in lines.reversed() {
+            if line.contains("[ERROR]") {
+                if let range = line.range(of: "[ERROR]") {
+                    let msg = String(line[range.upperBound...])
+                        .trimmingCharacters(in: .whitespaces)
+                        .trimmingCharacters(in: CharacterSet(charactersIn: "\u{1B}[0m"))
+                    if !msg.isEmpty { return msg }
+                }
+            }
+        }
+
+        return "Configuration has errors that prevent Kanata from starting"
     }
 
     // MARK: - Configuration Checks

--- a/Sources/KeyPathInstallationWizard/Core/ServiceHealthChecker.swift
+++ b/Sources/KeyPathInstallationWizard/Core/ServiceHealthChecker.swift
@@ -712,9 +712,13 @@ public final class ServiceHealthChecker: @unchecked Sendable {
         for line in lines.reversed() {
             if line.contains("[ERROR]") {
                 if let range = line.range(of: "[ERROR]") {
-                    let msg = String(line[range.upperBound...])
+                    let raw = String(line[range.upperBound...])
                         .trimmingCharacters(in: .whitespaces)
-                        .trimmingCharacters(in: CharacterSet(charactersIn: "\u{1B}[0m"))
+                    let msg = raw.replacingOccurrences(
+                        of: "\u{1B}\\[[0-9;]*[A-Za-z]",
+                        with: "",
+                        options: .regularExpression
+                    ).trimmingCharacters(in: .whitespaces)
                     if !msg.isEmpty { return msg }
                 }
             }

--- a/Sources/KeyPathWizardCore/SystemSnapshot.swift
+++ b/Sources/KeyPathWizardCore/SystemSnapshot.swift
@@ -123,7 +123,9 @@ public struct SystemSnapshot: Sendable {
 
         // Health issues
         if !health.isHealthy {
-            if !health.kanataRunning, health.kanataPermissionRejected {
+            if !health.kanataRunning, let configError = health.configParseError {
+                issues.append(.configParseError(detail: configError))
+            } else if !health.kanataRunning, health.kanataPermissionRejected {
                 issues.append(
                     .permissionMissing(
                         app: "Kanata",
@@ -260,6 +262,10 @@ public struct HealthStatus: Sendable {
     /// at runtime despite the TCC database reporting permissions as granted
     /// (stale grant after a rebuild/move/upgrade).
     public let kanataPermissionRejected: Bool
+    /// Non-nil when kanata's stderr contains a configuration parse error
+    /// (e.g., duplicate alias, syntax error). This causes kanata to exit
+    /// immediately and crash-loop. The string is a user-facing error message.
+    public let configParseError: String?
 
     public init(
         kanataRunning: Bool,
@@ -269,7 +275,8 @@ public struct HealthStatus: Sendable {
         kanataInputCaptureIssue: String? = nil,
         activeRuntimePathTitle: String? = nil,
         activeRuntimePathDetail: String? = nil,
-        kanataPermissionRejected: Bool = false
+        kanataPermissionRejected: Bool = false,
+        configParseError: String? = nil
     ) {
         self.kanataRunning = kanataRunning
         self.karabinerDaemonRunning = karabinerDaemonRunning
@@ -279,6 +286,7 @@ public struct HealthStatus: Sendable {
         self.activeRuntimePathTitle = activeRuntimePathTitle
         self.activeRuntimePathDetail = activeRuntimePathDetail
         self.kanataPermissionRejected = kanataPermissionRejected
+        self.configParseError = configParseError
     }
 
     /// Overall health (includes Kanata runtime)
@@ -333,6 +341,9 @@ public enum Issue: Equatable {
     case componentVersionMismatch(name: String, autoFix: Bool)
     case serviceNotRunning(name: String, autoFix: Bool)
     case conflict(SystemConflict)
+    /// Kanata refuses to start because the generated config has errors.
+    /// `detail` is the user-facing error message (e.g., "Duplicate alias: beh_base_;").
+    case configParseError(detail: String)
 
     public var title: String {
         switch self {
@@ -359,6 +370,8 @@ public enum Issue: Equatable {
             case let .exclusiveDeviceAccess(device):
                 "Device \(device) in use"
             }
+        case .configParseError:
+            "Configuration error prevents remapping"
         }
     }
 
@@ -373,6 +386,8 @@ public enum Issue: Equatable {
             autoFix
         case .conflict:
             true // Can terminate conflicting processes
+        case .configParseError:
+            true // Can reset to default config
         }
     }
 
@@ -390,6 +405,8 @@ public enum Issue: Equatable {
             "Start service"
         case .conflict:
             "Terminate conflicting process"
+        case let .configParseError(detail):
+            "Config error: \(detail). Reset to default config to restore remapping."
         }
     }
 }

--- a/Sources/KeyPathWizardCore/SystemSnapshot.swift
+++ b/Sources/KeyPathWizardCore/SystemSnapshot.swift
@@ -387,7 +387,7 @@ public enum Issue: Equatable {
         case .conflict:
             true // Can terminate conflicting processes
         case .configParseError:
-            true // Can reset to default config
+            false // Requires user decision — reset is destructive
         }
     }
 
@@ -405,8 +405,8 @@ public enum Issue: Equatable {
             "Start service"
         case .conflict:
             "Terminate conflicting process"
-        case let .configParseError(detail):
-            "Config error: \(detail). Reset to default config to restore remapping."
+        case .configParseError:
+            "Reset to default config"
         }
     }
 }

--- a/Tests/KeyPathTests/Core/KeyPathErrorTests.swift
+++ b/Tests/KeyPathTests/Core/KeyPathErrorTests.swift
@@ -276,8 +276,10 @@ struct KeyPathErrorTests {
         ]
 
         let mappingConflict = KeyPathError.configuration(.mappingConflicts(conflicts: conflicts))
-        #expect(mappingConflict.errorDescription?.contains("Key 'a'") == true)
+        #expect(mappingConflict.errorDescription?.contains("\"a\" key") == true)
         #expect(mappingConflict.errorDescription?.contains("One") == true)
+        #expect(mappingConflict.errorDescription?.contains("Two") == true)
+        #expect(mappingConflict.errorDescription?.contains("disable one") == true)
 
         let parseWithoutLine = KeyPathError.configuration(.parseError(line: nil, message: "boom"))
         #expect(parseWithoutLine.errorDescription == "Parse error: boom")

--- a/Tests/KeyPathTests/Infrastructure/AliasDeduplicationTests.swift
+++ b/Tests/KeyPathTests/Infrastructure/AliasDeduplicationTests.swift
@@ -1,0 +1,182 @@
+@testable import KeyPathAppKit
+@testable import KeyPathInstallationWizard
+@testable import KeyPathWizardCore
+import XCTest
+
+final class AliasDeduplicationTests: XCTestCase {
+    // MARK: - deduplicateAliases
+
+    func testNoDuplicatesPassesThrough() {
+        let aliases = [
+            KanataConfiguration.AliasDefinition(aliasName: "beh_base_a", definition: "(tap-hold 200 200 a lsft)"),
+            KanataConfiguration.AliasDefinition(aliasName: "beh_base_s", definition: "(tap-hold 200 200 s lctl)"),
+        ]
+
+        let result = KanataConfiguration.deduplicateAliases(aliases)
+
+        XCTAssertEqual(result.count, 2)
+        XCTAssertEqual(result[0].aliasName, "beh_base_a")
+        XCTAssertEqual(result[1].aliasName, "beh_base_s")
+    }
+
+    func testDuplicateAliasLastWins() {
+        let aliases = [
+            KanataConfiguration.AliasDefinition(aliasName: "beh_base_;", definition: "(tap-hold 200 200 ; rsft)", comment: "home row mod"),
+            KanataConfiguration.AliasDefinition(aliasName: "beh_base_a", definition: "(tap-hold 200 200 a lsft)"),
+            KanataConfiguration.AliasDefinition(aliasName: "beh_base_;", definition: "(tap-hold 150 ; (layer-while-held fun))", comment: "layer toggle"),
+        ]
+
+        let result = KanataConfiguration.deduplicateAliases(aliases)
+
+        XCTAssertEqual(result.count, 2, "Should have 2 unique aliases, not 3")
+        XCTAssertEqual(result[0].aliasName, "beh_base_;")
+        XCTAssertTrue(result[0].definition.contains("layer-while-held fun"), "Last definition should win")
+        XCTAssertEqual(result[0].comment, "layer toggle")
+        XCTAssertEqual(result[1].aliasName, "beh_base_a")
+    }
+
+    func testMultipleDuplicatesAllDeduped() {
+        let aliases = [
+            KanataConfiguration.AliasDefinition(aliasName: "beh_base_;", definition: "def1"),
+            KanataConfiguration.AliasDefinition(aliasName: "beh_base_a", definition: "def2"),
+            KanataConfiguration.AliasDefinition(aliasName: "beh_base_s", definition: "def3"),
+            KanataConfiguration.AliasDefinition(aliasName: "beh_base_;", definition: "def4"),
+            KanataConfiguration.AliasDefinition(aliasName: "beh_base_a", definition: "def5"),
+            KanataConfiguration.AliasDefinition(aliasName: "beh_base_s", definition: "def6"),
+        ]
+
+        let result = KanataConfiguration.deduplicateAliases(aliases)
+
+        XCTAssertEqual(result.count, 3)
+        XCTAssertEqual(result[0].definition, "def4")
+        XCTAssertEqual(result[1].definition, "def5")
+        XCTAssertEqual(result[2].definition, "def6")
+    }
+
+    func testEmptyInputReturnsEmpty() {
+        let result = KanataConfiguration.deduplicateAliases([])
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    func testPreservesInsertionOrder() {
+        let aliases = [
+            KanataConfiguration.AliasDefinition(aliasName: "z_alias", definition: "z"),
+            KanataConfiguration.AliasDefinition(aliasName: "a_alias", definition: "a"),
+            KanataConfiguration.AliasDefinition(aliasName: "m_alias", definition: "m"),
+        ]
+
+        let result = KanataConfiguration.deduplicateAliases(aliases)
+
+        XCTAssertEqual(result.map(\.aliasName), ["z_alias", "a_alias", "m_alias"])
+    }
+
+    // MARK: - Integration: HRM + Layer Toggles don't produce duplicate aliases
+
+    func testHRMAndLayerTogglesProduceNoDuplicateAliases() throws {
+        let hrmCollection = makeCollection(
+            name: "Home Row Mods",
+            configuration: .homeRowMods(HomeRowModsConfig(
+                enabledKeys: [";", "a"],
+                modifierAssignments: [";": "rsft", "a": "lsft"],
+                holdMode: .modifiers
+            ))
+        )
+
+        let layerTogglesCollection = makeCollection(
+            name: "Home Row Layer Toggles",
+            configuration: .homeRowLayerToggles(HomeRowLayerTogglesConfig(
+                enabledKeys: [";", "a"],
+                layerAssignments: [";": "fun", "a": "fun"]
+            ))
+        )
+
+        let config = KanataConfiguration.generateFromCollections([
+            hrmCollection, layerTogglesCollection,
+        ])
+
+        // Config should be parseable (no duplicate aliases)
+        let aliasMatches = config.components(separatedBy: "\n").filter { $0.contains("beh_base_;") }
+        let definitionLines = aliasMatches.filter { $0.trimmingCharacters(in: .whitespaces).hasPrefix("beh_base_;") }
+        XCTAssertEqual(definitionLines.count, 1, "Should have exactly one beh_base_; definition, not \(definitionLines.count): \(definitionLines)")
+    }
+
+    // MARK: - extractConfigParseError
+
+    func testExtractsDuplicateAliasError() {
+        let log = """
+        [kanata-launcher] Launching Kanata for user=test
+        04:28:32 [ERROR]  × Error in configuration
+             ╭─[keypath.kbd:159:1]
+         159 │   beh_base_; (tap-hold-opposite-hand 150 ; (layer-while-held fun))
+             ·   ─────┬────
+             ·        ╰── Error here
+         160 │   beh_base_a (tap-hold-opposite-hand 150 a (layer-while-held fun))
+             ╰────
+          help: Duplicate alias: beh_base_;
+        04:28:32 [ERROR] failed to parse file
+        """
+
+        let error = ServiceHealthChecker.extractConfigParseError(from: log)
+
+        XCTAssertNotNil(error)
+        XCTAssertEqual(error, "Duplicate alias: beh_base_;")
+    }
+
+    func testExtractsGenericConfigError() {
+        let log = """
+        [kanata-launcher] Host bridge config validation failed: Error in configuration
+        [kanata-launcher] Host bridge runtime creation failed: failed to parse file
+        04:28:32 [ERROR]  × Error in configuration
+        04:28:32 [ERROR] failed to parse file
+        """
+
+        let error = ServiceHealthChecker.extractConfigParseError(from: log)
+
+        XCTAssertNotNil(error)
+    }
+
+    func testNoConfigErrorWhenLogIsClean() {
+        let log = """
+        [kanata-launcher] Launching Kanata for user=test
+        [kanata-launcher] Runtime started successfully
+        """
+
+        let error = ServiceHealthChecker.extractConfigParseError(from: log)
+
+        XCTAssertNil(error)
+    }
+
+    // MARK: - Issue.configParseError
+
+    func testConfigParseErrorIssueProperties() {
+        let issue = Issue.configParseError(detail: "Duplicate alias: beh_base_;")
+
+        XCTAssertEqual(issue.title, "Configuration error prevents remapping")
+        XCTAssertTrue(issue.canAutoFix)
+        XCTAssertTrue(issue.action.contains("Duplicate alias: beh_base_;"))
+        XCTAssertTrue(issue.action.contains("Reset to default config"))
+    }
+
+    // MARK: - Helpers
+
+    private func makeCollection(
+        name: String,
+        configuration: RuleCollectionConfiguration
+    ) -> RuleCollection {
+        RuleCollection(
+            id: UUID(),
+            name: name,
+            summary: "",
+            category: .custom,
+            mappings: [],
+            isEnabled: true,
+            isSystemDefault: false,
+            icon: nil,
+            tags: [],
+            targetLayer: .base,
+            momentaryActivator: nil,
+            activationHint: nil,
+            configuration: configuration
+        )
+    }
+}

--- a/Tests/KeyPathTests/Infrastructure/AliasDeduplicationTests.swift
+++ b/Tests/KeyPathTests/Infrastructure/AliasDeduplicationTests.swift
@@ -1,10 +1,11 @@
 @testable import KeyPathAppKit
 @testable import KeyPathInstallationWizard
 @testable import KeyPathWizardCore
+import KeyPathCore
 import XCTest
 
 final class AliasDeduplicationTests: XCTestCase {
-    // MARK: - deduplicateAliases
+    // MARK: - deduplicateAliases (safety net)
 
     func testNoDuplicatesPassesThrough() {
         let aliases = [
@@ -19,7 +20,7 @@ final class AliasDeduplicationTests: XCTestCase {
         XCTAssertEqual(result[1].aliasName, "beh_base_s")
     }
 
-    func testDuplicateAliasLastWins() {
+    func testDuplicateAliasSafetyNetKeepsLastDefinition() {
         let aliases = [
             KanataConfiguration.AliasDefinition(aliasName: "beh_base_;", definition: "(tap-hold 200 200 ; rsft)", comment: "home row mod"),
             KanataConfiguration.AliasDefinition(aliasName: "beh_base_a", definition: "(tap-hold 200 200 a lsft)"),
@@ -28,29 +29,9 @@ final class AliasDeduplicationTests: XCTestCase {
 
         let result = KanataConfiguration.deduplicateAliases(aliases)
 
-        XCTAssertEqual(result.count, 2, "Should have 2 unique aliases, not 3")
+        XCTAssertEqual(result.count, 2, "Safety net should keep 2 unique aliases")
         XCTAssertEqual(result[0].aliasName, "beh_base_;")
-        XCTAssertTrue(result[0].definition.contains("layer-while-held fun"), "Last definition should win")
-        XCTAssertEqual(result[0].comment, "layer toggle")
-        XCTAssertEqual(result[1].aliasName, "beh_base_a")
-    }
-
-    func testMultipleDuplicatesAllDeduped() {
-        let aliases = [
-            KanataConfiguration.AliasDefinition(aliasName: "beh_base_;", definition: "def1"),
-            KanataConfiguration.AliasDefinition(aliasName: "beh_base_a", definition: "def2"),
-            KanataConfiguration.AliasDefinition(aliasName: "beh_base_s", definition: "def3"),
-            KanataConfiguration.AliasDefinition(aliasName: "beh_base_;", definition: "def4"),
-            KanataConfiguration.AliasDefinition(aliasName: "beh_base_a", definition: "def5"),
-            KanataConfiguration.AliasDefinition(aliasName: "beh_base_s", definition: "def6"),
-        ]
-
-        let result = KanataConfiguration.deduplicateAliases(aliases)
-
-        XCTAssertEqual(result.count, 3)
-        XCTAssertEqual(result[0].definition, "def4")
-        XCTAssertEqual(result[1].definition, "def5")
-        XCTAssertEqual(result[2].definition, "def6")
+        XCTAssertTrue(result[0].definition.contains("layer-while-held fun"), "Last definition should win in safety net")
     }
 
     func testEmptyInputReturnsEmpty() {
@@ -70,9 +51,9 @@ final class AliasDeduplicationTests: XCTestCase {
         XCTAssertEqual(result.map(\.aliasName), ["z_alias", "a_alias", "m_alias"])
     }
 
-    // MARK: - Integration: HRM + Layer Toggles don't produce duplicate aliases
+    // MARK: - Conflict detection (effectiveMappings)
 
-    func testHRMAndLayerTogglesProduceNoDuplicateAliases() throws {
+    func testDetectsConflictBetweenHRMAndLayerToggles() {
         let hrmCollection = makeCollection(
             name: "Home Row Mods",
             configuration: .homeRowMods(HomeRowModsConfig(
@@ -90,17 +71,112 @@ final class AliasDeduplicationTests: XCTestCase {
             ))
         )
 
+        let conflicts = RuleCollectionDeduplicator.detectConflicts(in: [
+            hrmCollection, layerTogglesCollection,
+        ])
+
+        XCTAssertFalse(conflicts.isEmpty, "Should detect conflicts when HRM and Layer Toggles share keys")
+        XCTAssertEqual(conflicts.count, 2, "Should detect 2 conflicting keys (; and a)")
+
+        let semicolonConflict = conflicts.first { $0.inputKey == ";" }
+        XCTAssertNotNil(semicolonConflict)
+        XCTAssertEqual(semicolonConflict?.conflictingCollections.count, 2)
+        XCTAssertTrue(semicolonConflict?.conflictingCollections.contains("Home Row Mods") ?? false)
+        XCTAssertTrue(semicolonConflict?.conflictingCollections.contains("Home Row Layer Toggles") ?? false)
+    }
+
+    func testNoConflictWhenCollectionsUseDistinctKeys() {
+        let hrmCollection = makeCollection(
+            name: "Home Row Mods",
+            configuration: .homeRowMods(HomeRowModsConfig(
+                enabledKeys: ["a", "s"],
+                modifierAssignments: ["a": "lsft", "s": "lctl"],
+                holdMode: .modifiers
+            ))
+        )
+
+        let layerTogglesCollection = makeCollection(
+            name: "Home Row Layer Toggles",
+            configuration: .homeRowLayerToggles(HomeRowLayerTogglesConfig(
+                enabledKeys: ["j", "k"],
+                layerAssignments: ["j": "nav", "k": "sym"]
+            ))
+        )
+
+        let conflicts = RuleCollectionDeduplicator.detectConflicts(in: [
+            hrmCollection, layerTogglesCollection,
+        ])
+
+        XCTAssertTrue(conflicts.isEmpty, "No conflicts when collections use distinct keys")
+    }
+
+    // MARK: - User-friendly conflict explanation
+
+    func testConflictExplanationIncludesCollectionNames() {
+        let conflict = KeyPathError.MappingConflictInfo(
+            inputKey: ";",
+            layer: "Base",
+            conflictingCollections: ["Home Row Mods", "Home Row Layer Toggles"],
+            holdDescriptions: ["Home Row Mods: hold → rsft", "Home Row Layer Toggles: hold → (layer-while-held fun)"]
+        )
+
+        let explanation = conflict.userExplanation
+
+        XCTAssertTrue(explanation.contains("Home Row Mods"), "Should mention first collection")
+        XCTAssertTrue(explanation.contains("Home Row Layer Toggles"), "Should mention second collection")
+        XCTAssertTrue(explanation.contains("\";\"\u{20}key"), "Should mention the conflicting key")
+        XCTAssertTrue(explanation.contains("hold → rsft"), "Should describe what first collection does")
+        XCTAssertTrue(explanation.contains("hold → (layer-while-held fun)"), "Should describe what second collection does")
+        XCTAssertTrue(explanation.contains("disable one"), "Should suggest disabling one collection")
+        XCTAssertTrue(explanation.contains("key assignments"), "Should suggest changing key assignments")
+    }
+
+    func testConflictExplanationWithoutHoldDescriptions() {
+        let conflict = KeyPathError.MappingConflictInfo(
+            inputKey: "a",
+            layer: "Base",
+            conflictingCollections: ["Custom Rules", "Home Row Mods"]
+        )
+
+        let explanation = conflict.userExplanation
+
+        XCTAssertTrue(explanation.contains("Custom Rules"))
+        XCTAssertTrue(explanation.contains("Home Row Mods"))
+        XCTAssertTrue(explanation.contains("only have one hold action"))
+    }
+
+    // MARK: - Integration: config gen safety net still works
+
+    func testConfigGenSafetyNetProducesValidConfig() throws {
+        let hrmCollection = makeCollection(
+            name: "Home Row Mods",
+            configuration: .homeRowMods(HomeRowModsConfig(
+                enabledKeys: [";", "a"],
+                modifierAssignments: [";": "rsft", "a": "lsft"],
+                holdMode: .modifiers
+            ))
+        )
+
+        let layerTogglesCollection = makeCollection(
+            name: "Home Row Layer Toggles",
+            configuration: .homeRowLayerToggles(HomeRowLayerTogglesConfig(
+                enabledKeys: [";", "a"],
+                layerAssignments: [";": "fun", "a": "fun"]
+            ))
+        )
+
+        // generateFromCollections doesn't run detectConflicts (that's in saveConfiguration),
+        // but the safety net deduplicateAliases prevents duplicate alias names
         let config = KanataConfiguration.generateFromCollections([
             hrmCollection, layerTogglesCollection,
         ])
 
-        // Config should be parseable (no duplicate aliases)
-        let aliasMatches = config.components(separatedBy: "\n").filter { $0.contains("beh_base_;") }
-        let definitionLines = aliasMatches.filter { $0.trimmingCharacters(in: .whitespaces).hasPrefix("beh_base_;") }
-        XCTAssertEqual(definitionLines.count, 1, "Should have exactly one beh_base_; definition, not \(definitionLines.count): \(definitionLines)")
+        let aliasLines = config.components(separatedBy: "\n")
+            .filter { $0.trimmingCharacters(in: .whitespaces).hasPrefix("beh_base_;") }
+        XCTAssertEqual(aliasLines.count, 1, "Safety net should ensure exactly one beh_base_; definition")
     }
 
-    // MARK: - extractConfigParseError
+    // MARK: - extractConfigParseError (stderr detection)
 
     func testExtractsDuplicateAliasError() {
         let log = """

--- a/Tests/KeyPathTests/Infrastructure/AliasDeduplicationTests.swift
+++ b/Tests/KeyPathTests/Infrastructure/AliasDeduplicationTests.swift
@@ -209,6 +209,10 @@ final class AliasDeduplicationTests: XCTestCase {
         let error = ServiceHealthChecker.extractConfigParseError(from: log)
 
         XCTAssertNotNil(error)
+        XCTAssertTrue(
+            error?.contains("failed to parse file") == true || error?.contains("Error in configuration") == true,
+            "Should extract a meaningful error, got: \(error ?? "nil")"
+        )
     }
 
     func testNoConfigErrorWhenLogIsClean() {
@@ -228,9 +232,8 @@ final class AliasDeduplicationTests: XCTestCase {
         let issue = Issue.configParseError(detail: "Duplicate alias: beh_base_;")
 
         XCTAssertEqual(issue.title, "Configuration error prevents remapping")
-        XCTAssertTrue(issue.canAutoFix)
-        XCTAssertTrue(issue.action.contains("Duplicate alias: beh_base_;"))
-        XCTAssertTrue(issue.action.contains("Reset to default config"))
+        XCTAssertFalse(issue.canAutoFix, "Destructive reset should not be auto-fixable")
+        XCTAssertEqual(issue.action, "Reset to default config")
     }
 
     // MARK: - Helpers


### PR DESCRIPTION
## Summary

- **Root cause**: When Home Row Mods and Home Row Layer Toggles are both enabled for the same keys, the config generator emitted duplicate alias names (e.g., `beh_base_;`), causing kanata to reject the config and crash-loop (155 restarts observed)
- **Conflict detection**: `detectConflicts()` now uses `effectiveMappings()` to catch config-generated mappings (HRM, Layer Toggles) that the raw `.mappings` array missed — conflicts are caught **before** config generation
- **User-facing explanations**: `MappingConflictInfo.userExplanation` generates clear English describing which collections conflict, which keys overlap, what each collection does with the key, and what the user's options are (disable one or change key assignments)
- **Safety net**: Alias dedup remains as an error-logged fallback — if conflicts slip past detection, it prevents kanata crash but logs 🚨 errors for investigation
- **Config error detection**: Extended `diagnoseDaemonStderr()` to parse kanata stderr for config parse errors and surface them through the health check pipeline as `Issue.configParseError` with actionable messages
- **Toast alerts**: Added config parse error pattern to `KanataErrorMonitor` for immediate user notification

## Test plan

- [x] 13 new unit tests covering conflict detection (HRM+LayerToggles overlap, distinct keys no-conflict), user explanations, alias dedup safety net, config error extraction from stderr, and Issue properties
- [x] Full test suite passes (532+ tests, 1 pre-existing failure in `testCrossGroupConflictGeneration` unrelated to this change)
- [x] Build succeeds clean
- [ ] Manual: Enable both Home Row Mods and Home Row Layer Toggles for overlapping keys → verify conflict error shown before config is written
- [ ] Manual: Intentionally break config → verify toast and specific error message appear instead of generic "not running"