### PR TITLE
fix: detect and explain within-collection chord group key conflicts

### DIFF
--- a/Sources/KeyPathAppKit/Models/RuleCollectionDeduplicator.swift
+++ b/Sources/KeyPathAppKit/Models/RuleCollectionDeduplicator.swift
@@ -20,8 +20,12 @@ enum RuleCollectionDeduplicator {
 
         for collection in collections where collection.isEnabled {
             let mappings = KanataConfiguration.effectiveMappings(for: collection)
+            var seenKeysInCollection = Set<String>()
             for mapping in mappings {
                 let normalizedInput = KanataKeyConverter.convertToKanataKey(mapping.input)
+                // Skip duplicate keys within the same collection (e.g., chord groups
+                // sharing keys). Within-collection conflicts are detected separately.
+                guard seenKeysInCollection.insert(normalizedInput).inserted else { continue }
                 let inputKey = InputKey(input: normalizedInput, layer: collection.targetLayer)
 
                 let holdDesc = mapping.behavior.flatMap { behavior -> String? in
@@ -51,6 +55,30 @@ enum RuleCollectionDeduplicator {
                 conflictingCollections: collectionNames,
                 holdDescriptions: holdDescriptions
             ))
+        }
+
+        // Within-collection chord group conflicts: two chord groups sharing keys
+        // produces duplicate aliases that kanata rejects.
+        for collection in collections where collection.isEnabled {
+            if case let .chordGroups(config) = collection.configuration {
+                let chordConflicts = config.detectCrossGroupConflicts()
+                for conflict in chordConflicts {
+                    let groupNames = conflict.groups.map(\.name)
+                    let chordDescriptions = conflict.groups.map { group -> String in
+                        let chordOutputs = group.chords
+                            .filter { $0.keys.contains(conflict.key) }
+                            .map { "(\($0.keys.joined(separator: "+")) → \($0.action.displayName))" }
+                            .joined(separator: ", ")
+                        return "\(group.name): \(chordOutputs)"
+                    }
+                    conflicts.append(KeyPathError.MappingConflictInfo(
+                        inputKey: conflict.key,
+                        layer: collection.targetLayer.displayName,
+                        conflictingCollections: groupNames,
+                        holdDescriptions: chordDescriptions
+                    ))
+                }
+            }
         }
 
         return conflicts.sorted { $0.inputKey < $1.inputKey }

--- a/Sources/KeyPathCore/KeyPathError.swift
+++ b/Sources/KeyPathCore/KeyPathError.swift
@@ -76,14 +76,14 @@ public enum KeyPathError: Error, LocalizedError {
         /// User-friendly explanation of the conflict and resolution options
         public var userExplanation: String {
             let collections = conflictingCollections.joined(separator: " and ")
-            var explanation = "\(collections) both configure the \"\(inputKey)\" key with different hold behaviors."
+            var explanation = "\(collections) both configure the \"\(inputKey)\" key with different behaviors."
 
             if !holdDescriptions.isEmpty {
                 explanation += " " + holdDescriptions.joined(separator: "; ") + "."
             }
 
-            explanation += " A key can only have one hold action."
-            explanation += " Either disable one of these collections, or change their key assignments so they don't overlap."
+            explanation += " A key can only have one action assigned."
+            explanation += " Either change the key assignments so they don't overlap, or disable one."
 
             return explanation
         }

--- a/Tests/KeyPathTests/Infrastructure/AliasDeduplicationTests.swift
+++ b/Tests/KeyPathTests/Infrastructure/AliasDeduplicationTests.swift
@@ -127,7 +127,7 @@ final class AliasDeduplicationTests: XCTestCase {
         XCTAssertTrue(explanation.contains("\";\"\u{20}key"), "Should mention the conflicting key")
         XCTAssertTrue(explanation.contains("hold → rsft"), "Should describe what first collection does")
         XCTAssertTrue(explanation.contains("hold → (layer-while-held fun)"), "Should describe what second collection does")
-        XCTAssertTrue(explanation.contains("disable one"), "Should suggest disabling one collection")
+        XCTAssertTrue(explanation.contains("disable one"), "Should suggest disabling one")
         XCTAssertTrue(explanation.contains("key assignments"), "Should suggest changing key assignments")
     }
 
@@ -142,7 +142,7 @@ final class AliasDeduplicationTests: XCTestCase {
 
         XCTAssertTrue(explanation.contains("Custom Rules"))
         XCTAssertTrue(explanation.contains("Home Row Mods"))
-        XCTAssertTrue(explanation.contains("only have one hold action"))
+        XCTAssertTrue(explanation.contains("only have one action assigned"))
     }
 
     // MARK: - Integration: config gen safety net still works

--- a/Tests/KeyPathTests/Infrastructure/ChordGroupsIntegrationTests.swift
+++ b/Tests/KeyPathTests/Infrastructure/ChordGroupsIntegrationTests.swift
@@ -409,10 +409,9 @@ final class ChordGroupsIntegrationTests: XCTestCase {
         XCTAssertFalse(output.contains("(defchords  )")) // No empty defchords
     }
 
-    // MARK: - Cross-Group Conflict Resolution
+    // MARK: - Cross-Group Conflict Detection
 
-    func testCrossGroupConflictGeneration() {
-        // Verify first group wins behavior in generated config
+    func testCrossGroupConflictIsDetected() {
         let chord1 = ChordDefinition(id: UUID(), keys: ["s", "d"], action: .keystroke(key: "esc"))
         let chord2 = ChordDefinition(id: UUID(), keys: ["s", "d"], action: .keystroke(key: "bspc"))
 
@@ -430,19 +429,44 @@ final class ChordGroupsIntegrationTests: XCTestCase {
             configuration: .chordGroups(config)
         )
 
-        let output = KanataConfiguration.generateFromCollections([collection])
+        // Conflict detection should catch shared keys between chord groups
+        let conflicts = RuleCollectionDeduplicator.detectConflicts(in: [collection])
 
-        // First group (Navigation) should win for 's' and 'd' keys
-        // Check that Navigation group's chord mappings appear
-        XCTAssertTrue(output.contains("(chord Navigation s)") || output.contains("chord Navigation s"))
-        XCTAssertTrue(output.contains("(chord Navigation d)") || output.contains("chord Navigation d"))
+        XCTAssertFalse(conflicts.isEmpty, "Should detect conflicts when chord groups share keys")
+        XCTAssertEqual(conflicts.count, 2, "Should detect 2 conflicting keys (s and d)")
 
-        // Both groups should still be defined (just deduplicated in deflayer)
-        XCTAssertTrue(output.contains("(defchords Navigation 250"))
-        XCTAssertTrue(output.contains("(defchords Editing 300"))
+        let sConflict = conflicts.first { $0.inputKey == "s" }
+        XCTAssertNotNil(sConflict)
+        XCTAssertTrue(sConflict?.conflictingCollections.contains("Navigation") ?? false)
+        XCTAssertTrue(sConflict?.conflictingCollections.contains("Editing") ?? false)
 
-        // Both chords should exist in their respective defchords blocks
-        XCTAssertTrue(output.contains("(s d) esc"))
-        XCTAssertTrue(output.contains("(s d) bspc"))
+        // User explanation should mention both groups and suggest resolution
+        if let explanation = sConflict?.userExplanation {
+            XCTAssertTrue(explanation.contains("Navigation"), "Should mention Navigation group")
+            XCTAssertTrue(explanation.contains("Editing"), "Should mention Editing group")
+            XCTAssertTrue(explanation.contains("\"s\""), "Should mention the conflicting key")
+        }
+    }
+
+    func testNoConflictWhenChordGroupsUseDistinctKeys() {
+        let chord1 = ChordDefinition(id: UUID(), keys: ["s", "d"], action: .keystroke(key: "esc"))
+        let chord2 = ChordDefinition(id: UUID(), keys: ["j", "k"], action: .keystroke(key: "bspc"))
+
+        let group1 = ChordGroup(id: UUID(), name: "Navigation", timeout: 250, chords: [chord1])
+        let group2 = ChordGroup(id: UUID(), name: "Editing", timeout: 300, chords: [chord2])
+
+        let config = ChordGroupsConfig(groups: [group1, group2])
+        let collection = RuleCollection(
+            id: RuleCollectionIdentifier.chordGroups,
+            name: "Chord Groups",
+            summary: "Test",
+            category: .productivity,
+            mappings: [],
+            isEnabled: true,
+            configuration: .chordGroups(config)
+        )
+
+        let conflicts = RuleCollectionDeduplicator.detectConflicts(in: [collection])
+        XCTAssertTrue(conflicts.isEmpty, "No conflicts when chord groups use distinct keys")
     }
 }


### PR DESCRIPTION
## Summary

- **Root cause**: When two chord groups within the same collection share keys (e.g., Navigation and Editing both use `s`+`d`), the config generator produced duplicate `act_base_s` / `act_base_d` aliases that kanata rejected
- **Detect, don't resolve**: Extended `detectConflicts()` to check for within-collection chord group key conflicts using the existing `ChordGroupsConfig.detectCrossGroupConflicts()` method
- **User-facing explanation**: Conflict info includes group names (Navigation, Editing), what each group does with the shared keys, and resolution guidance
- **Fixes pre-existing test failure**: `testCrossGroupConflictGeneration` was failing on master — replaced with `testCrossGroupConflictIsDetected` that verifies conflicts are detected and explained, not silently resolved

Closes #459

## Test plan

- [x] All 532 tests pass (0 failures — the pre-existing failure is now fixed)
- [x] `testCrossGroupConflictIsDetected` — verifies conflict detection for shared chord group keys
- [x] `testNoConflictWhenChordGroupsUseDistinctKeys` — verifies no false positives
- [x] Existing AliasDeduplicationTests still pass with updated wording
- [x] Build succeeds clean