### PR TITLE
fix: prevent tests from opening Calculator and Accessibility preferences

### DIFF
--- a/Sources/KeyPathAppKit/Services/ActionDispatcher.swift
+++ b/Sources/KeyPathAppKit/Services/ActionDispatcher.swift
@@ -167,22 +167,22 @@ public final class ActionDispatcher {
 
         // Try each URL (fire-and-forget since openApplication is async)
         for appURL in urlsToTry {
-            let config = NSWorkspace.OpenConfiguration()
-            let capturedAppIdentifier = appIdentifier
-            let capturedPath = appURL.path
-            workspace.openApplication(at: appURL, configuration: config) { [weak self] app, error in
-                Task { @MainActor in
-                    if let error {
-                        AppLogger.shared.log("⚠️ [ActionDispatcher] Failed to launch from \(capturedPath): \(error)")
-                        self?.onError?("Failed to launch \(capturedAppIdentifier): \(error.localizedDescription)")
-                    } else if app != nil {
-                        AppLogger.shared.log("✅ [ActionDispatcher] Launched \(capturedAppIdentifier) from \(capturedPath)")
+            if !TestEnvironment.isRunningTests {
+                let config = NSWorkspace.OpenConfiguration()
+                let capturedAppIdentifier = appIdentifier
+                let capturedPath = appURL.path
+                workspace.openApplication(at: appURL, configuration: config) { [weak self] app, error in
+                    Task { @MainActor in
+                        if let error {
+                            AppLogger.shared.log("⚠️ [ActionDispatcher] Failed to launch from \(capturedPath): \(error)")
+                            self?.onError?("Failed to launch \(capturedAppIdentifier): \(error.localizedDescription)")
+                        } else if app != nil {
+                            AppLogger.shared.log("✅ [ActionDispatcher] Launched \(capturedAppIdentifier) from \(capturedPath)")
+                        }
                     }
                 }
+                LiveKeyboardOverlayController.shared.noteLauncherActionDispatched()
             }
-            // Return success optimistically - the app will launch async
-            // First URL in list is most likely to succeed (bundle ID match)
-            LiveKeyboardOverlayController.shared.noteLauncherActionDispatched()
             return .success
         }
 

--- a/Sources/KeyPathAppKit/Services/KeyboardCapture/KeyboardCapture.swift
+++ b/Sources/KeyPathAppKit/Services/KeyboardCapture/KeyboardCapture.swift
@@ -790,6 +790,7 @@ public class KeyboardCapture {
 
     /// Public method to explicitly request permissions (for use in wizard)
     func requestPermissionsExplicitly() {
+        guard !TestEnvironment.isRunningTests else { return }
         if let url = URL(
             string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility"
         ) {


### PR DESCRIPTION
## Summary
- Add `TestEnvironment.isRunningTests` guard to `ActionDispatcher.handleLaunch` so it no longer opens Calculator.app during tests
- Add same guard to `KeyboardCapture.requestPermissionsExplicitly()` so it no longer opens System Settings Accessibility pane during tests
- Both `handleOpen` and `handleFolder` already had these guards — `handleLaunch` was the only dispatch handler missing one

## Test plan
- [x] All 532 tests pass
- [x] Build succeeds
- [x] Verified `ActionDispatcherRoutingTests` still validates launch dispatch routing without opening Calculator