### PR TITLE
docs: rewrite CLAUDE.md lean, extract deep-dive docs, add PR workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,12 +1,8 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+KeyPath is a macOS keyboard remapping app (SwiftUI + Kanata backend, LaunchDaemon architecture).
 
-## Project Overview
-
-KeyPath is a macOS application that provides keyboard remapping using Kanata as the backend engine. It features a SwiftUI frontend and a LaunchDaemon architecture for reliable system-level key remapping.
-
-## High-Level Architecture
+## Architecture
 
 ```
 KeyPath.app (SwiftUI) → InstallerEngine → LaunchDaemon/PrivilegedHelper
@@ -16,370 +12,88 @@ KeyPath.app (SwiftUI) → InstallerEngine → LaunchDaemon/PrivilegedHelper
    TCP/Runtime Control
 ```
 
-### Core Components
-- **KeyPath.app**: SwiftUI application with Liquid Glass UI (macOS 15+)
-- **InstallerEngine**: Unified façade for installation, repair, and system inspection
-- **LaunchDaemon**: System service (`com.keypath.kanata`) that runs Kanata
-- **Configuration**: User config at `~/.config/keypath/keypath.kbd`
-
-### Key Manager Classes
 | Class | Responsibility |
 |-------|---------------|
-| `SystemInspector` | **Pure function** - SystemContext → (WizardSystemState, [WizardIssue]) |
-| `WizardRouter` | **Pure function** - state + issues → WizardPage (sole routing logic) |
-| `InstallerEngine` | **The Façade** - all install/repair/uninstall + system inspection |
-| `RuntimeCoordinator` | Runtime Coordinator - service orchestration (NOT ObservableObject) |
-| `ServiceLifecycleCoordinator` | **Start/stop/restart Kanata** - the ONLY entry point for service lifecycle |
-| `KanataDaemonService` | **LaunchDaemon lifecycle** - register/unregister via SMAppService, status polling |
-| `ServiceHealthChecker` | **Health checks** - the ONLY way to check if kanata is running (launchctl + TCP) |
-| `ConfigReloadCoordinator` | **Config reload** - TCP-based reload after rule changes, safety checks |
-| `KanataViewModel` | UI Layer (MVVM) - @Published properties for SwiftUI |
-| `ConfigurationService` | Config file management |
-| `PermissionOracle` | **🔮 CRITICAL** - Single source of truth for permissions |
+| `InstallerEngine` | **The Facade** — all install/repair/uninstall + system inspection |
+| `RuntimeCoordinator` | Service orchestration (NOT ObservableObject) |
+| `ServiceLifecycleCoordinator` | **Start/stop/restart Kanata** — the ONLY entry point |
+| `ServiceHealthChecker` | **Health checks** — the ONLY way to check if kanata is running |
+| `ConfigReloadCoordinator` | TCP-based reload after rule changes |
+| `KanataViewModel` | UI Layer (MVVM) — @Observable properties for SwiftUI |
+| `PermissionOracle` | **CRITICAL** — Single source of truth for permissions |
 
-## 🔮 PermissionOracle (CRITICAL - DO NOT BREAK)
+User config: `~/.config/keypath/keypath.kbd`. Logs: `~/Library/Logs/KeyPath/keypath-debug.log`.
 
-**THE FUNDAMENTAL RULE: Apple APIs ALWAYS take precedence over TCC database**
+## Critical Rules
 
-1. **APPLE APIs** (IOHIDCheckAccess) → **AUTHORITATIVE**
-   - `.granted` / `.denied` → TRUST THIS RESULT
-   - `.unknown` → Proceed to TCC fallback
-2. **TCC DATABASE** → Fallback for `.unknown` cases only
+**PermissionOracle**: Apple APIs (IOHIDCheckAccess) ALWAYS take precedence over TCC database. See [ADR-001](docs/adr/adr-001-oracle-pattern.md), [ADR-006](docs/adr/adr-006-apple-api-priority.md).
 
-See [ADR-001](docs/adr/adr-001-oracle-pattern.md) and [ADR-006](docs/adr/adr-006-apple-api-priority.md).
+**Validation order**: Conflicts → Components → Permissions → Service Status ([ADR-026](docs/adr/adr-026-validation-ordering.md)).
 
-## 🎯 Validation Architecture
+**Keyboard visualization**: Geometry follows `PhysicalLayout`, labels follow `LogicalKeymap`. No UI toggle.
 
-**Validation is pull-based via `InstallerEngine.inspectSystem()`**:
-```swift
-let engine = InstallerEngine()
-let context = await engine.inspectSystem() // Pure value struct
-if context.permissions.inputMonitoring != .granted { ... }
-```
+## Anti-Patterns
 
-**Validation Order** (see [ADR-026](docs/adr/adr-026-validation-ordering.md)):
-1. Conflicts → 2. Components → 3. Permissions → 4. Service Status
-
-## 🚫 Critical Anti-Patterns
-
-### Permission Detection
-- ❌ Never bypass `PermissionOracle.shared`
-- ❌ Never check permissions from root process
-
-### Service Management
+- ❌ Never bypass `PermissionOracle.shared` or check permissions from root
 - ❌ Don't use KanataManager for installation → Use `InstallerEngine`
 - ❌ Don't manually call launchctl → Use `InstallerEngine`
-- ❌ Don't mark Kanata healthy from restart-window timing alone
-- ❌ Don't return installer action success before runtime readiness (`running + TCP responding`) is verified
-- ✅ Treat `SMAppService.status == .enabled` as registration state, not runtime liveness
+- ❌ Don't roll your own `pgrep`/`launchctl` → Use `ServiceHealthChecker`
+- ❌ Don't start/stop/restart kanata except via `ServiceLifecycleCoordinator`
+- ❌ Don't send TCP reload directly → Use `ConfigReloadCoordinator.triggerConfigReload()`
+- ❌ Don't skip TCP reload after config changes — causes stale config
+- ❌ Don't call `SMAppService.status` in a hot path — synchronous IPC, blocks 10-30s
+- ❌ Never call real `pgrep` in tests → deadlock. Use `KeyPathTestCase` base class
+- ✅ Keep tests fast (<5s total) — use backdated timestamps, not real sleeps
 
-### Health Checks & Service Lifecycle
-- ❌ Don't roll your own `pgrep`/`launchctl` to check if kanata is running → Use `ServiceHealthChecker`
-- ❌ Don't call `KanataDaemonService.isDaemonRunning()` directly from UI/coordinator code → Use `ServiceHealthChecker.checkKanataServiceHealth()`
-- ❌ Don't start/stop/restart kanata from anywhere except `ServiceLifecycleCoordinator`
-- ❌ Don't send TCP reload commands directly → Use `ConfigReloadCoordinator.triggerConfigReload()`
-- ❌ Don't skip TCP reload after config file changes — this causes kanata to run stale config
+## Bug Investigation
 
-### Test Seams
-- ❌ Never call real `pgrep` in tests → Tests will deadlock
-- ✅ Use `KeyPathTestCase` base class (sets up `VHIDDeviceManager.testPIDProvider`)
-- ✅ Keep tests fast (<5s total) - use backdated timestamps, not real sleeps
+1. Check logs first (`~/Library/Logs/KeyPath/keypath-debug.log`)
+2. Trace the full code path including actor hops and async boundaries
+3. Fix both the proximate cause and the deeper cause
+4. Document in `docs/bugs/`
 
-### Watchdog / Timeout Handlers
-- ❌ Never use a specific service identifier (e.g., `.component(.kanataService)`) in generic timeout catch blocks — it creates false alerts for the wrong service
-- ❌ Never call `SMAppService.status` repeatedly in a hot path — it does synchronous IPC and can block for 10-30+ seconds under load
-- ✅ Cache `isHelperInstalled()` and `getHelperVersion()` results within a single validation cycle
-- ✅ Use `.validationTimeout` for generic watchdog failures
+## PR Workflow & Git Safety
 
-### Apple Framework IPC
-- ❌ Don't assume `SMAppService.status` is fast — it's synchronous IPC to the ServiceManagement daemon
-- ❌ Don't call `nonisolated async` actor methods repeatedly if they do synchronous blocking IPC — each call involves actor hop + thread scheduling + IPC round-trip
-- ✅ Call once, cache locally, pass the result down
+Follow the invariants in [`docs/agent-pr-invariants.md`](docs/agent-pr-invariants.md). Step-by-step reference: [`docs/agent-pr-workflow.md`](docs/agent-pr-workflow.md).
 
-## 🐛 Bug Investigation Protocol
+**Key rule:** After merging a PR, always pull master and deploy from master before reporting done.
 
-When investigating runtime bugs (false alerts, service failures, unexpected state):
+Git guardrail hooks in `.claude/settings.json` block: commits on master, force-push to master, `reset --hard`, `clean -f`.
 
-1. **Check actual logs first** — `~/Library/Logs/KeyPath/keypath-debug.log` has timestamped evidence. Don't theorize before reading logs.
-2. **Trace the full code path** — Follow the issue from UI trigger back through the call chain to the data source. Map every actor hop and async boundary.
-3. **Identify ALL layers** — Most bugs have a proximate cause (wrong identifier) and a deeper cause (redundant IPC). Fix both.
-4. **Verify the theory against timestamps** — Align log timestamps with code paths to confirm which calls are slow vs. fast.
-5. **Document in `docs/bugs/`** — Write up the root cause chain, evidence, and fixes for future reference.
-
-Past investigations: [`docs/bugs/`](docs/bugs/)
-
-## ⌨️ Keyboard Visualization Principle
-- **Geometry follows selected `PhysicalLayout`** (user-selected layout ID).
-- **Labels follow selected `LogicalKeymap`** (user-selected keymap).
-- Do **not** expose a UI toggle for this; treat it as a single consistent rule.
-
-## 📐 Architecture Documentation
-
-Interactive guides at [malpern.github.io/KeyPath/architecture](https://malpern.github.io/KeyPath/architecture/) (also in `docs/architecture/`):
-
-| Guide | Covers |
-|-------|--------|
-| [Installation Wizard](docs/architecture/wizard-architecture.html) | SystemInspector, WizardRouter, InstallerEngine loop |
-| [Live Keyboard Overlay](docs/architecture/overlay-architecture.html) | CGEvent tap, 7 extension files, visibility model |
-| [Runtime & Service Lifecycle](docs/architecture/runtime-architecture.html) | Orchestration, health checks, crash recovery |
-| [PermissionOracle](docs/architecture/permissions-architecture.html) | Apple API priority, TCC fallback, validation |
-| [Rule Collections & Config](docs/architecture/rules-architecture.html) | RuleCollection pattern, config generation, TCP reload |
-| [Privileged Helper & XPC](docs/architecture/xpc-architecture.html) | SMAppService, code signing, helper protocol |
-| [Keyboard Layouts](docs/architecture/layouts-architecture.html) | PhysicalLayout, LogicalKeymap, HID device detection |
-| [KindaVim](docs/architecture/kindavim-architecture.html) | Vim layers, hint overlay, telemetry |
-
-## 📜 Architecture Decision Records
-
-Full records in [`docs/adr/`](docs/adr/README.md). Key decisions:
-
-| ADR | Summary |
-|-----|---------|
-| [001](docs/adr/adr-001-oracle-pattern.md), [006](docs/adr/adr-006-apple-api-priority.md) | PermissionOracle - Apple API authoritative |
-| [015](docs/adr/adr-015-installer-engine.md) | InstallerEngine is the façade for all install/repair |
-| [023](docs/adr/adr-023-no-config-parsing.md) | Never parse Kanata configs - use TCP and simulator |
-| [026](docs/adr/adr-026-validation-ordering.md) | Validate components before service status |
-| [031](docs/adr/adr-031-kanata-service-lifecycle-invariants-and-postcondition-enforcement.md) | Installer success requires verified runtime readiness; stale recovery bypasses throttle |
-| [022](docs/adr/adr-022-no-concurrent-pgrep.md) | No concurrent pgrep in TaskGroups |
-| [018](docs/adr/adr-018-helper-protocol-duplication.md) | HelperProtocol.swift must be identical in both locations |
-
-## 📦 Feature Documentation
-
-| Feature | Documentation |
-|---------|--------------|
-| RuleCollection Pattern | [`docs/architecture/rule-collection-pattern.md`](docs/architecture/rule-collection-pattern.md) |
-| Action URI System | [`docs/ACTION_URI_SYSTEM.md`](docs/ACTION_URI_SYSTEM.md) |
-| Window Management | [`docs/features/window-management.md`](docs/features/window-management.md) |
-
-## 📖 Help Content Philosophy
-
-Help articles live in `Sources/KeyPathAppKit/Resources/*.md` and render in the in-app Help Browser (`HelpBrowserView.swift`). All help content follows this layered structure:
-
-### Content hierarchy (this order matters)
-
-1. **User goals and problems first** — Every article opens with the problem the user has, not the feature name. "Stop reaching for the Dock" not "Action URI System". "Every shortcut forces your fingers off the home row" not "Home row mods turn keys into dual-role keys."
-2. **KeyPath UI and how to accomplish the goal** — Show the user how to do it in the app. Use ASCII mockups labeled as screenshots, reference actual tab names, buttons, and pickers. Step-by-step instructions tied to what they see on screen.
-3. **Mechanical keyboard context (secondary)** — Introduce insider concepts (layers, tap-hold, Kanata variants, Chordal Hold, etc.) only after the user understands what they're trying to accomplish and how to do it in KeyPath. Position these in "Advanced" or "Technical Details" sections near the end.
-4. **Rich external resources** — Every article ends with curated links to community references, tool docs, learning resources, and hardware. Use `↗` suffix for external links.
-
-### Content rules
-
-- **Titles are user goals**, not feature names: "Shortcuts Without Reaching" not "Home Row Mods", "One Key, Multiple Actions" not "Tap-Hold & Tap-Dance", "Launching Apps" not "Action URIs"
-- **Cross-links use goal-oriented names** throughout all articles
-- **ASCII UI mockups** labeled as "Screenshot — [description]:" show actual KeyPath UI (inspector tabs, pickers, drawers, rule editors) — not just keyboard diagrams
-- **Watercolor header images** (`header-*.png`) at top of each article, rendered with `mix-blend-mode: multiply` on parchment background
-- **Watercolor divider images** (`decor-divider.png`) between sections, blending into background (no white boxes)
-- **Internal links** use `help:resource-name` scheme (e.g., `[Shortcuts Without Reaching](help:home-row-mods)`)
-- **Technical reference docs** (like Action URI Reference) are separate from user-facing guides
-
-### Anti-patterns to avoid
-
-- ❌ **Don't lead with jargon** — "Hyper key", "tap-hold-release-keys", "deflayer", "CAGS layout" should never be the first thing a user reads in a section
-- ❌ **Don't write feature-centric content** — "KeyPath supports 4 tap-hold variants" is engineer-speak. Write "Here's how to make one key do two things" instead
-- ❌ **Don't skip the UI** — If there's a button, tab, slider, or picker involved, show it (ASCII mockup or step-by-step). Don't just say "configure it in settings"
-- ❌ **Don't make the user learn Kanata to use KeyPath** — Kanata config syntax belongs in the "From Kanata" switching guide and technical references, not in user-facing how-to articles
-- ❌ **Don't mix UI guides with technical references** — App launching UI guide and Action URI deep-link reference are separate articles, not one article trying to serve both audiences
-- ❌ **Don't use stale tab/button names** — The UI has specific names: "Custom Rules" tab, "Key Mapper" tab, "Launchers" tab, "Add Shortcut" button, gear icon for settings shelf. Use the real names.
-- ❌ **Don't rely solely on watercolor illustrations** — They set the aesthetic tone but don't teach. Use ASCII mockups of the actual KeyPath UI to show what the user will see
-
-## 🤖 External Tools: Peekaboo for UI Automation
-
-For AI-driven UI automation (screenshots, clicks, typing, scrolling), use **Peekaboo** alongside KeyPath. KeyPath handles keyboard remapping; Peekaboo handles GUI automation. Unix philosophy - compose small tools.
-
-**Installation:**
-```bash
-brew install steipete/tap/peekaboo
-```
-
-**Available Commands:**
-| Command | Purpose |
-|---------|---------|
-| `peekaboo see` | Screenshot + AI analysis ("What buttons are visible?") |
-| `peekaboo click` | Click by element ID, label, or coordinates |
-| `peekaboo type` | Enter text with pacing options |
-| `peekaboo scroll` | Scroll in any direction |
-| `peekaboo hotkey` | Trigger keyboard shortcuts |
-| `peekaboo app` | Launch, quit, switch apps |
-| `peekaboo window` | Move/resize/focus windows |
-| `peekaboo menu` | Interact with app menus |
-
-**Composing with KeyPath:**
-```bash
-# Take screenshot, analyze, then trigger KeyPath action
-peekaboo see "Find the search field"
-open "keypath://layer/vim"  # Switch to vim layer
-peekaboo type "search query"
-```
-
-**Why not build our own?** Peekaboo uses the same AX/CGS APIs we have, but with 25+ polished tools. steipete maintains it actively. See `docs/LLM_VISION_UI_AUTOMATION.md` for architecture details.
-
-## Build Commands
+## Build & Deploy
 
 ```bash
-./Scripts/quick-deploy.sh      # Incremental local dev (fast, deploys to /Applications)
-./build.sh                     # Canonical build (sign + notarize; SKIP_NOTARIZE=1 for faster local)
-./Scripts/build-and-sign.sh    # Release (signed + notarized, legacy entry)
-```
-
-### Quick Deploy Shortcuts
-When the user says **"dd"**, immediately:
-1. Run `SKIP_NOTARIZE=1 ./build.sh` to build, sign, and deploy to `/Applications`
-2. Respond with **"Eye eye Captain!"**
-
-When the user says **"df"**, immediately:
-1. Run `./Scripts/quick-deploy.sh` for a fast debug deploy to `/Applications`
-2. Respond with **"Eye eye Cap, fast deploying!"**
-
-## Release Process
-
-To publish a new release, run:
-
-```bash
-./Scripts/release.sh 1.0.0-beta4    # Specify the new version
-./Scripts/release.sh --dry-run 1.0.0-beta4  # Preview without doing anything
-```
-
-**The script automates:**
-1. Version bump in Info.plist (CFBundleVersion + CFBundleShortVersionString)
-2. Full build, code sign, **notarize**, and Sparkle EdDSA signing
-3. Styled DMG creation (branded background, drag-to-Applications)
-4. Git tag creation
-5. GitHub Release with zip + DMG attached
-6. Appcast.xml update (Sparkle auto-update feed)
-7. gh-pages download link update (marketing site always points to latest DMG)
-8. Homebrew cask update (`malpern/tap/keypath` — version + SHA256)
-
-**⚠️ Releases MUST be notarized.** Never use `SKIP_NOTARIZE=1` or `--skip-notarize` for release builds. Unnotarized apps trigger macOS Gatekeeper warnings that erode user trust. `SKIP_NOTARIZE` is only for local dev iteration (`dd`/`df` shortcuts).
-
-**After the script finishes, you must:**
-1. Write release notes on the GitHub Release page
-2. `git push` to push the appcast commit on master
-
-**Sparkle auto-update:** Existing users get notified within 24 hours. The appcast is served from `raw.githubusercontent.com/malpern/KeyPath/master/appcast.xml`. All releases currently omit `sparkle:channel` so all users see them (no stable/beta split yet).
-
-**Marketing site:** The download button on keypath-app.com links to the DMG. The release script updates this automatically via a gh-pages worktree commit. Never hardcode a version-specific download URL in index.md manually.
-
-**Homebrew cask:** Users can install via `brew install --cask malpern/tap/keypath`. The cask lives in `github.com/malpern/homebrew-tap/Casks/keypath.rb`. The release script updates the version and SHA256 automatically.
-
-## Linear Workspace Management
-
-KeyPath development uses Linear for issue tracking with two workspaces:
-- **Personal**: malpern@gmail.com (linear-personal MCP server)
-- **Smirkhealth**: micah@smirkhealth.com (linear-smirkhealth MCP server)
-
-### Switching Workspaces
-Use the `/linear-switch` skill to change workspaces:
-
-```bash
-/linear-switch personal      # Switch to Personal workspace
-/linear-switch smirkhealth   # Switch to Smirkhealth workspace
-/linear-switch status        # Check current workspace
-```
-
-**Note**: After switching, you must restart Claude Code by typing `/exit` and starting a new session for the change to take effect.
-
-### Manual Terminal Commands
-Alternatively, use these terminal commands directly:
-```bash
-linear-personal      # Activate Personal workspace
-linear-smirkhealth   # Activate Smirkhealth workspace
-linear-which         # Show current workspace
-```
-
-Full documentation: `~/.claude/LINEAR_SWITCHING.md`
-
-### Poltergeist (Auto-Deploy)
-```bash
-poltergeist start    # Watch + auto-deploy on save (~2s)
-poltergeist stop     # Stop watching
-```
-
-**IMPORTANT: Stop Poltergeist before running parallel agents!**
-
-Poltergeist watches for file changes and triggers builds. When multiple agents write files simultaneously, this causes SwiftPM lock contention (only one build at a time allowed).
-
-**Parallel Agent Workflow:**
-```bash
-# 1. Stop auto-build to prevent lock contention
-poltergeist stop
-
-# 2. Launch parallel agents (they edit code without building)
-# ... agents work simultaneously ...
-
-# 3. Manual verification after all agents complete
-swift build && swift test
-
-# 4. Commit & push
-git add -A && git commit && git push
-
-# 5. Resume auto-deploy for normal dev work
-poltergeist start
-```
-
-## Test Commands
-
-```bash
-swift test                                        # All tests (~413 tests, <5s)
-swift test --filter LabelMetadataTests            # Single test class
-swift test --filter "testCapitalizedEscReturnsWordLabel"  # Single test method
-KEYPATH_USE_SUDO=1 swift test                     # With sudo (requires NOPASSWD sudoers rules)
-```
-
-**Test targets:** All unit tests live in `Tests/KeyPathTests/` (target: `KeyPathTests`). Files in `Tests/KeyPathAppKitTests/` are **not compiled** — they exist but are not part of any test target. Snapshot tests are in `Tests/KeyPathSnapshotTests/`.
-
-## Code Quality
-
-```bash
+./build.sh                        # Canonical build (SKIP_NOTARIZE=1 for local dev)
+./Scripts/quick-deploy.sh         # Fast debug deploy
+swift test                        # All tests (~532 tests, <5s)
 swiftformat Sources/ Tests/ --swiftversion 5.9
 swiftlint --fix --quiet
 ```
 
-## 🗺️ Overlay → Mapper → Gallery Data Flow
+**"dd"** → Run `SKIP_NOTARIZE=1 ./build.sh`, respond **"Eye eye Captain!"**
+**"df"** → Run `./Scripts/quick-deploy.sh`, respond **"Eye eye Cap, fast deploying!"**
 
-The overlay, mapper drawer, and gallery are connected through notifications and shared state. Bugs here are common because the same data takes different paths for display vs. saving.
+Test targets: `Tests/KeyPathTests/` (target: `KeyPathTests`). Files in `Tests/KeyPathAppKitTests/` are NOT compiled. Snapshot tests in `Tests/KeyPathSnapshotTests/`.
 
-### Key Rendering Pipeline (Overlay)
+## Poltergeist (Auto-Deploy)
 
-```
-PhysicalLayout.keys → LayerKeyMapper (simulator) → layerKeyMap[keyCode] → OverlayKeycapView
-                                                                              ↓
-                                                                   layoutRole determines renderer:
-                                                                   .centered → centeredContent (effectiveLabel)
-                                                                   .bottomAligned → bottomAlignedContent (wordLabel from LabelMetadata)
-                                                                   .escKey → escKeyContent
-                                                                   .functionKey → functionKeyWithMappingContent
-```
+`poltergeist start` / `poltergeist stop`. **Stop before running parallel agents** — file change watchers cause SwiftPM lock contention.
 
-**Label priority in `effectiveLabel`:** holdLabel (if pressed) → tapHoldIdleLabel (if idle on base) → layerKeyInfo.displayLabel → baseLabel (from keymap)
+## Linear
 
-**`tapHoldIdleLabels`**: For tap-hold keys, the simulator returns the *hold* output (it simulates a 50ms press which triggers hold for `tap-hold-press`). The `tapHoldIdleLabels` system overrides this with the *tap* output when the key is idle on the base layer. These labels come from `TapHoldPickerConfig.selectedTapOutput` on enabled collections.
+Personal workspace (`malpern@gmail.com`) via `/linear-switch personal`. Smirkhealth (`micah@smirkhealth.com`) via `/linear-switch smirkhealth`. Restart Claude Code after switching.
 
-### Mapper Drawer Communication
+## Deep-Dive References
 
-The mapper receives key selections via `.mapperDrawerKeySelected` notification (not direct binding):
-```
-OverlayKeycapView click → LiveKeyboardOverlayController.handleKeyClick()
-  → posts .mapperDrawerKeySelected with { keyCode, inputKey, outputKey, displayLabel, ... }
-  → OverlayMapperSection receives notification → calls viewModel.setInputFromKeyClick()
-```
+Load these on demand — don't need them every session:
 
-**Critical distinction:** `outputKey` is the kanata key name (e.g., "lctl") used for saving rules. `displayLabel` is the human-readable label (e.g., "✦" for Hyper). The mapper uses `outputKey` for the data/save path and `displayLabel` for visual override. Mixing these up causes config validation errors ("Unknown key/action: ✦").
-
-### Conflict Resolution
-
-When saving a rule that conflicts with an existing rule collection:
-- **Mapper:** uses `autoResolveConflicts: true` — the new mapping silently wins
-- **Pack installer:** uses `autoResolveConflicts: true` — the pack silently wins
-- **Rules tab (ActiveRulesView, RulesSummaryView):** shows a conflict resolution dialog via `onConflictResolution` callback on `RuntimeCoordinator`
-
-### Layer Map Refresh Chain
-
-```
-Rule change → regenerateConfigFromCollections() → posts .ruleCollectionsChanged
-  → KeyboardVisualizationViewModel.setupRuleCollectionsObserver() receives it
-  → invalidateLayerMappings() → rebuildLayerMappingForLayer()
-  → simulator re-runs → layerKeyMap updated → SwiftUI re-renders overlay
-```
-
-### LabelMetadata (Display Labels for Wide Keys)
-
-`LabelMetadata.forLabel()` converts symbols/key names to word labels for bottom-aligned keys (shift, return, capslock, etc.). It is case-insensitive for multi-character labels — "Esc", "esc", "ESC" all match. Single-character symbols (⇧, ⎋, ⇪) match directly.
+| Topic | Doc |
+|-------|-----|
+| Release process | [`docs/release-process.md`](docs/release-process.md) |
+| Help content writing | [`docs/help-content-philosophy.md`](docs/help-content-philosophy.md) |
+| Pack dependency system | [`docs/architecture/pack-dependency-system.md`](docs/architecture/pack-dependency-system.md) |
+| Overlay/mapper/gallery data flow | [`docs/architecture/overlay-data-flow.md`](docs/architecture/overlay-data-flow.md) |
+| Peekaboo UI automation | [`docs/LLM_VISION_UI_AUTOMATION.md`](docs/LLM_VISION_UI_AUTOMATION.md) |
+| All architecture guides | [`docs/architecture/`](docs/architecture/) |
+| All ADRs | [`docs/adr/README.md`](docs/adr/README.md) |
+| Feature docs | [`docs/features/`](docs/features/) |

--- a/docs/agent-pr-invariants.md
+++ b/docs/agent-pr-invariants.md
@@ -1,0 +1,56 @@
+# Agent PR Invariants
+
+What must be true at each phase boundary. The agent's job is to make these true and verify they are — the specific commands are implementation details.
+
+## After Setup
+
+- [ ] Working in an isolated worktree (not the user's checkout)
+- [ ] Build succeeds from the worktree
+
+## After Development
+
+- [ ] `swift build` passes
+- [ ] `swift test` passes (all tests, zero failures)
+- [ ] Changes are committed with descriptive messages
+
+## After PR Creation
+
+- [ ] Single squashed commit on the branch
+- [ ] Branch pushed to origin
+- [ ] PR exists on GitHub with summary and test plan
+- [ ] Every open issue addressed by this work has `Fixes #NNN` in the PR body
+
+## After Babysitting
+
+- [ ] All CI checks green
+- [ ] Zero unaddressed review comments
+- [ ] No merge conflicts with master
+- [ ] User has approved the merge
+
+## After Merge — The Completion Gate
+
+All of these must be true before the agent reports "done." If any fails, fix it before proceeding.
+
+```
+PR state == MERGED
+local master SHA == origin/master SHA
+running app built from master (not worktree)
+linked issues state == CLOSED
+no worktrees left for this branch
+```
+
+The agent must verify each assertion, not assume prior steps succeeded. A single verification block at the end catches everything — skipped steps, failed pushes, stale deploys.
+
+## Why Invariants Over Checklists
+
+Agents lose context in long conversations. A 23-step checklist works when followed perfectly but fails silently when step 20 is skipped. Invariants are self-healing: the verification gate at the end catches any gap regardless of how the agent got there.
+
+The procedural workflow (`agent-pr-workflow.md`) is still useful as a reference for the *typical* path through these phases. But the invariants are what matter — they define "done" unambiguously.
+
+## Non-Negotiable Rules
+
+- **Never merge without user permission.**
+- **The running app must match merged master.** This is the #1 cause of "lost work."
+- **Never force-push to master.**
+- **Always link and verify issues.**
+- **Clean up worktrees.** No orphaned branches or directories.

--- a/docs/agent-pr-workflow.md
+++ b/docs/agent-pr-workflow.md
@@ -1,0 +1,65 @@
+# Agent PR Workflow
+
+End-to-end process for shepherding code from initial request through to a clean master. Every agent working on code changes must follow this workflow. The goal is zero lost work and a clean repo state at every stage.
+
+## Phase 1: Setup
+
+1. **Enter a worktree** — isolates your work from the user's working copy and other parallel agents. Verify you're in the worktree before editing files.
+2. **Initialize submodules** if needed — worktrees don't automatically check out submodules. Run `git submodule update --init --recursive` before building.
+
+## Phase 2: Development
+
+3. **Do the work** — edit code, iterate with the user.
+4. **Build** — `swift build` must pass before any commit.
+5. **Test** — `swift test` must pass (all 532+ tests). Never commit code that breaks tests.
+6. **Commit** — commit frequently as you work. Use descriptive messages. Include `Co-Authored-By` tag.
+
+## Phase 3: PR Creation
+
+7. **Squash commits** — `git reset --soft master && git commit` with a comprehensive message covering all changes.
+8. **Push the branch** — `git push -u origin <branch-name>`.
+9. **Link issues** — check if any open GitHub issues are addressed by this work (`gh issue list --state open`). Include `Fixes #NNN` in the PR body for each one so GitHub auto-closes them on merge.
+10. **Create the PR** — `gh pr create` with a summary, `Fixes` references, and test plan. Return the URL to the user.
+
+## Phase 4: Babysit the PR
+
+11. **Wait for CI** — poll `gh pr checks <number>` until all checks complete. Don't guess — wait for actual results.
+12. **Address review comments** — read `gh api repos/owner/repo/pulls/<number>/comments`, fix each issue, amend the commit, force-push.
+13. **Resolve conflicts** — if master has moved ahead, `git fetch origin master && git merge origin/master`, resolve conflicts, commit the merge, push.
+14. **Re-check CI** — after any push, wait for all checks to go green again.
+15. **Repeat 11-14** until all checks pass and no unaddressed review comments remain.
+
+## Phase 5: Merge
+
+16. **Ask the user for permission to merge** — never merge without explicit approval.
+17. **Merge** — `gh pr merge <number> --squash --delete-branch`. If git complains about the local branch being in use (worktree), that's fine — the merge happens on GitHub. The error about local branch deletion is cosmetic.
+18. **Verify the merge** — `gh pr view <number> --json state` should show `"state": "MERGED"`.
+19. **Verify issues closed** — for each `Fixes #NNN` reference, confirm the issue is now closed: `gh issue view <number> --json state`.
+
+## Phase 6: Cleanup
+
+20. **Exit the worktree** — `ExitWorktree` with `action: "remove"` and `discard_changes: true` (safe because all work is merged). This deletes the worktree directory and branch.
+21. **Pull master** — `git pull` from the main repo directory. Verify it fast-forwards to include your merged PR. If it doesn't fast-forward, something went wrong — investigate before proceeding.
+22. **Deploy from master** — run `SKIP_NOTARIZE=1 ./build.sh` (or `dd`) so the running app matches the merged code. This is critical — without this step, the user is running stale code and thinks the work is lost.
+23. **Confirm to the user** — state explicitly: PR merged, issues closed, master pulled, deployed, worktree cleaned up.
+
+## What Can Go Wrong
+
+| Symptom | Cause | Prevention |
+|---------|-------|------------|
+| Work "disappears" after merge | Merged to GitHub but never pulled to local master, or deployed from worktree not master | Always do Phase 6 steps 21-22 |
+| Issues stay open after merge | PR body didn't include `Fixes #NNN` keywords | Step 9: link issues before creating the PR |
+| PR shows conflicts after merge | Another PR merged first, moving master ahead | Resolve conflicts before merging (step 13) |
+| CI passes but app is broken | Tests don't cover the feature; only tested in worktree | Deploy from master (step 22) and have user verify |
+| Worktree left behind | Agent exited without cleanup | Always exit worktree on completion |
+| Stale build running | Deployed from worktree during dev, never redeployed from master | Step 22 is mandatory, not optional |
+| Amending a commit after merge | Force-push after squash-merge creates a diverged branch | Never push after merge — go straight to cleanup |
+
+## Non-Negotiable Rules
+
+- **Never merge without user permission.** Even if CI is green and reviews are addressed.
+- **Never skip the deploy-from-master step.** This is the #1 cause of "lost work" — the code is in GitHub but the local app is running old code.
+- **Never leave a worktree behind.** Clean up on completion or abandonment.
+- **Never force-push to master.** Only force-push to feature branches during PR iteration.
+- **Always verify CI after every push.** Don't assume a previous green carries forward.
+- **Always link issues.** If the work addresses an open issue, the PR must include `Fixes #NNN` so it auto-closes on merge.

--- a/docs/architecture/overlay-data-flow.md
+++ b/docs/architecture/overlay-data-flow.md
@@ -1,0 +1,50 @@
+# Overlay → Mapper → Gallery Data Flow
+
+The overlay, mapper drawer, and gallery are connected through notifications and shared state. Bugs here are common because the same data takes different paths for display vs. saving.
+
+## Key Rendering Pipeline (Overlay)
+
+```
+PhysicalLayout.keys → LayerKeyMapper (simulator) → layerKeyMap[keyCode] → OverlayKeycapView
+                                                                              ↓
+                                                                   layoutRole determines renderer:
+                                                                   .centered → centeredContent (effectiveLabel)
+                                                                   .bottomAligned → bottomAlignedContent (wordLabel from LabelMetadata)
+                                                                   .escKey → escKeyContent
+                                                                   .functionKey → functionKeyWithMappingContent
+```
+
+**Label priority in `effectiveLabel`:** holdLabel (if pressed) → tapHoldIdleLabel (if idle on base) → layerKeyInfo.displayLabel → baseLabel (from keymap)
+
+**`tapHoldIdleLabels`**: For tap-hold keys, the simulator returns the *hold* output (it simulates a 50ms press which triggers hold for `tap-hold-press`). The `tapHoldIdleLabels` system overrides this with the *tap* output when the key is idle on the base layer. These labels come from `TapHoldPickerConfig.selectedTapOutput` on enabled collections.
+
+## Mapper Drawer Communication
+
+The mapper receives key selections via `.mapperDrawerKeySelected` notification (not direct binding):
+```
+OverlayKeycapView click → LiveKeyboardOverlayController.handleKeyClick()
+  → posts .mapperDrawerKeySelected with { keyCode, inputKey, outputKey, displayLabel, ... }
+  → OverlayMapperSection receives notification → calls viewModel.setInputFromKeyClick()
+```
+
+**Critical distinction:** `outputKey` is the kanata key name (e.g., "lctl") used for saving rules. `displayLabel` is the human-readable label (e.g., "✦" for Hyper). The mapper uses `outputKey` for the data/save path and `displayLabel` for visual override. Mixing these up causes config validation errors ("Unknown key/action: ✦").
+
+## Conflict Resolution
+
+When saving a rule that conflicts with an existing rule collection:
+- **Mapper:** uses `autoResolveConflicts: true` — the new mapping silently wins
+- **Pack installer:** uses `autoResolveConflicts: true` — the pack silently wins
+- **Rules tab (ActiveRulesView, RulesSummaryView):** shows a conflict resolution dialog via `onConflictResolution` callback on `RuntimeCoordinator`
+
+## Layer Map Refresh Chain
+
+```
+Rule change → regenerateConfigFromCollections() → posts .ruleCollectionsChanged
+  → KeyboardVisualizationViewModel.setupRuleCollectionsObserver() receives it
+  → invalidateLayerMappings() → rebuildLayerMappingForLayer()
+  → simulator re-runs → layerKeyMap updated → SwiftUI re-renders overlay
+```
+
+## LabelMetadata (Display Labels for Wide Keys)
+
+`LabelMetadata.forLabel()` converts symbols/key names to word labels for bottom-aligned keys (shift, return, capslock, etc.). It is case-insensitive for multi-character labels — "Esc", "esc", "ESC" all match. Single-character symbols (⇧, ⎋, ⇪) match directly.

--- a/docs/help-content-philosophy.md
+++ b/docs/help-content-philosophy.md
@@ -1,0 +1,30 @@
+# Help Content Philosophy
+
+Help articles live in `Sources/KeyPathAppKit/Resources/*.md` and render in the in-app Help Browser (`HelpBrowserView.swift`). All help content follows this layered structure.
+
+## Content hierarchy (this order matters)
+
+1. **User goals and problems first** — Every article opens with the problem the user has, not the feature name. "Stop reaching for the Dock" not "Action URI System". "Every shortcut forces your fingers off the home row" not "Home row mods turn keys into dual-role keys."
+2. **KeyPath UI and how to accomplish the goal** — Show the user how to do it in the app. Use ASCII mockups labeled as screenshots, reference actual tab names, buttons, and pickers. Step-by-step instructions tied to what they see on screen.
+3. **Mechanical keyboard context (secondary)** — Introduce insider concepts (layers, tap-hold, Kanata variants, Chordal Hold, etc.) only after the user understands what they're trying to accomplish and how to do it in KeyPath. Position these in "Advanced" or "Technical Details" sections near the end.
+4. **Rich external resources** — Every article ends with curated links to community references, tool docs, learning resources, and hardware. Use `↗` suffix for external links.
+
+## Content rules
+
+- **Titles are user goals**, not feature names: "Shortcuts Without Reaching" not "Home Row Mods", "One Key, Multiple Actions" not "Tap-Hold & Tap-Dance", "Launching Apps" not "Action URIs"
+- **Cross-links use goal-oriented names** throughout all articles
+- **ASCII UI mockups** labeled as "Screenshot — [description]:" show actual KeyPath UI (inspector tabs, pickers, drawers, rule editors) — not just keyboard diagrams
+- **Watercolor header images** (`header-*.png`) at top of each article, rendered with `mix-blend-mode: multiply` on parchment background
+- **Watercolor divider images** (`decor-divider.png`) between sections, blending into background (no white boxes)
+- **Internal links** use `help:resource-name` scheme (e.g., `[Shortcuts Without Reaching](help:home-row-mods)`)
+- **Technical reference docs** (like Action URI Reference) are separate from user-facing guides
+
+## Anti-patterns to avoid
+
+- ❌ **Don't lead with jargon** — "Hyper key", "tap-hold-release-keys", "deflayer", "CAGS layout" should never be the first thing a user reads in a section
+- ❌ **Don't write feature-centric content** — "KeyPath supports 4 tap-hold variants" is engineer-speak. Write "Here's how to make one key do two things" instead
+- ❌ **Don't skip the UI** — If there's a button, tab, slider, or picker involved, show it (ASCII mockup or step-by-step). Don't just say "configure it in settings"
+- ❌ **Don't make the user learn Kanata to use KeyPath** — Kanata config syntax belongs in the "From Kanata" switching guide and technical references, not in user-facing how-to articles
+- ❌ **Don't mix UI guides with technical references** — App launching UI guide and Action URI deep-link reference are separate articles, not one article trying to serve both audiences
+- ❌ **Don't use stale tab/button names** — The UI has specific names: "Custom Rules" tab, "Key Mapper" tab, "Launchers" tab, "Add Shortcut" button, gear icon for settings shelf. Use the real names.
+- ❌ **Don't rely solely on watercolor illustrations** — They set the aesthetic tone but don't teach. Use ASCII mockups of the actual KeyPath UI to show what the user will see

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -1,0 +1,30 @@
+# Release Process
+
+To publish a new release, run:
+
+```bash
+./Scripts/release.sh 1.0.0-beta4    # Specify the new version
+./Scripts/release.sh --dry-run 1.0.0-beta4  # Preview without doing anything
+```
+
+**The script automates:**
+1. Version bump in Info.plist (CFBundleVersion + CFBundleShortVersionString)
+2. Full build, code sign, **notarize**, and Sparkle EdDSA signing
+3. Styled DMG creation (branded background, drag-to-Applications)
+4. Git tag creation
+5. GitHub Release with zip + DMG attached
+6. Appcast.xml update (Sparkle auto-update feed)
+7. gh-pages download link update (marketing site always points to latest DMG)
+8. Homebrew cask update (`malpern/tap/keypath` — version + SHA256)
+
+**⚠️ Releases MUST be notarized.** Never use `SKIP_NOTARIZE=1` or `--skip-notarize` for release builds. Unnotarized apps trigger macOS Gatekeeper warnings that erode user trust. `SKIP_NOTARIZE` is only for local dev iteration (`dd`/`df` shortcuts).
+
+**After the script finishes, you must:**
+1. Write release notes on the GitHub Release page
+2. `git push` to push the appcast commit on master
+
+**Sparkle auto-update:** Existing users get notified within 24 hours. The appcast is served from `raw.githubusercontent.com/malpern/KeyPath/master/appcast.xml`. All releases currently omit `sparkle:channel` so all users see them (no stable/beta split yet).
+
+**Marketing site:** The download button on keypath-app.com links to the DMG. The release script updates this automatically via a gh-pages worktree commit. Never hardcode a version-specific download URL in index.md manually.
+
+**Homebrew cask:** Users can install via `brew install --cask malpern/tap/keypath`. The cask lives in `github.com/malpern/homebrew-tap/Casks/keypath.rb`. The release script updates the version and SHA256 automatically.


### PR DESCRIPTION
## Summary

- CLAUDE.md rewritten from 394 → 99 lines: core rules inline, deep-dive content extracted to linked docs
- New PR workflow docs (invariants + step-by-step) referenced from CLAUDE.md
- Extracted: help content philosophy, release process, overlay data flow

## Test plan

- [ ] `swift build` passes
- [ ] CLAUDE.md links resolve to existing docs
- [ ] No code changes — docs only