### PR TITLE
feat: keystroke history overlay tab with smart timeline

### DIFF
--- a/Sources/KeyPathAppKit/Models/KeystrokeTimelineEvent.swift
+++ b/Sources/KeyPathAppKit/Models/KeystrokeTimelineEvent.swift
@@ -1,0 +1,65 @@
+import Foundation
+
+struct KeystrokeTimelineEvent: Identifiable {
+    let id: UUID
+    let timestamp: Date
+    let kind: EventKind
+
+    enum EventKind {
+        case keyInput(KeyInputPayload)
+        case tapActivated(TapHoldPayload)
+        case holdActivated(TapHoldPayload)
+        case hrmDecision(HrmDecisionPayload)
+        case layerChanged(LayerChangePayload)
+        case oneShotActivated(OneShotPayload)
+        case chordResolved(ChordPayload)
+        case tapDanceResolved(TapDancePayload)
+    }
+}
+
+struct KeyInputPayload {
+    let key: String
+    let action: KanataKeyAction
+    let layer: String?
+    let kanataTimestamp: UInt64?
+}
+
+struct TapHoldPayload {
+    let key: String
+    let outputAction: String
+    let reason: String?
+    let kanataTimestamp: UInt64
+}
+
+struct HrmDecisionPayload {
+    let key: String
+    let decision: KanataHrmDecision
+    let reason: KanataHrmDecisionReason
+    let decideLatencyMs: Int?
+    let nextKey: String?
+    let nextKeyHand: KanataHrmKeyHand?
+    let configuredThresholdMs: Int?
+    let isNearThreshold: Bool
+
+    static let nearThresholdMarginMs = 30
+}
+
+struct LayerChangePayload {
+    let layerName: String
+}
+
+struct OneShotPayload {
+    let key: String
+    let modifiers: String
+}
+
+struct ChordPayload {
+    let keys: String
+    let action: String
+}
+
+struct TapDancePayload {
+    let key: String
+    let tapCount: UInt8
+    let action: String
+}

--- a/Sources/KeyPathAppKit/Services/Monitoring/KeystrokeHistoryService.swift
+++ b/Sources/KeyPathAppKit/Services/Monitoring/KeystrokeHistoryService.swift
@@ -1,0 +1,314 @@
+import Foundation
+import KeyPathCore
+import Observation
+
+@Observable
+@MainActor
+final class KeystrokeHistoryService {
+    static let shared = KeystrokeHistoryService()
+
+    private let maxEvents = 2000
+    private let deduplicationWindow: TimeInterval = 0.1
+    private let batchInterval: TimeInterval = 0.1
+
+    private(set) var segments: [TimelineSegment] = []
+    private(set) var currentLayer: String = "base"
+    var isRecording: Bool = true
+
+    @ObservationIgnored private var rawEvents: [KeystrokeTimelineEvent] = []
+    @ObservationIgnored private var pendingEvents: [KeystrokeTimelineEvent] = []
+    @ObservationIgnored private var batchTimer: Timer?
+    @ObservationIgnored private let observers = NotificationObserverManager()
+    @ObservationIgnored private let notificationCenter: NotificationCenter
+    @ObservationIgnored var thresholdLookup: (() -> (baseMs: Int, offsets: [String: Int]))?
+
+    private init(notificationCenter: NotificationCenter = .default) {
+        self.notificationCenter = notificationCenter
+        setupObservers()
+    }
+
+    #if DEBUG
+        static func makeTestInstance(
+            notificationCenter: NotificationCenter = NotificationCenter()
+        ) -> KeystrokeHistoryService {
+            KeystrokeHistoryService(notificationCenter: notificationCenter)
+        }
+    #endif
+
+    // MARK: - Notification Observers
+
+    private func setupObservers() {
+        observers.observe(.kanataKeyInput, center: notificationCenter) { [weak self] notification in
+            guard let self else { return }
+            let userInfo = notification.userInfo
+            guard let key = userInfo?["key"] as? String,
+                  let actionStr = userInfo?["action"] as? String,
+                  let action = KanataKeyAction(rawValue: actionStr.lowercased())
+            else { return }
+            let metadata = KeypressObservationMetadata.from(userInfo: userInfo)
+            let event = KeystrokeTimelineEvent(
+                id: UUID(),
+                timestamp: metadata.observedAt ?? Date(),
+                kind: .keyInput(KeyInputPayload(
+                    key: key,
+                    action: action,
+                    layer: nil,
+                    kanataTimestamp: metadata.kanataTimestamp
+                ))
+            )
+            Task { @MainActor [weak self] in
+                self?.ingest(event)
+            }
+        }
+
+        observers.observe(.kanataLayerChanged, center: notificationCenter) { [weak self] notification in
+            guard let self else { return }
+            guard let layerName = notification.userInfo?["layerName"] as? String else { return }
+            let event = KeystrokeTimelineEvent(
+                id: UUID(),
+                timestamp: Date(),
+                kind: .layerChanged(LayerChangePayload(layerName: layerName))
+            )
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                currentLayer = layerName
+                ingest(event)
+            }
+        }
+
+        observers.observe(.kanataHoldActivated, center: notificationCenter) { [weak self] notification in
+            guard let self else { return }
+            let userInfo = notification.userInfo
+            guard let key = userInfo?["key"] as? String,
+                  let action = userInfo?["action"] as? String
+            else { return }
+            let reason = userInfo?["reason"] as? String
+            let timestamp = (userInfo?["kanataTimestamp"] as? UInt64) ?? 0
+            let event = KeystrokeTimelineEvent(
+                id: UUID(),
+                timestamp: Date(),
+                kind: .holdActivated(TapHoldPayload(
+                    key: key,
+                    outputAction: action,
+                    reason: reason,
+                    kanataTimestamp: timestamp
+                ))
+            )
+            Task { @MainActor [weak self] in
+                self?.ingest(event)
+            }
+        }
+
+        observers.observe(.kanataTapActivated, center: notificationCenter) { [weak self] notification in
+            guard let self else { return }
+            let userInfo = notification.userInfo
+            guard let key = userInfo?["key"] as? String,
+                  let action = userInfo?["action"] as? String
+            else { return }
+            let reason = userInfo?["reason"] as? String
+            let timestamp = (userInfo?["kanataTimestamp"] as? UInt64) ?? 0
+            let event = KeystrokeTimelineEvent(
+                id: UUID(),
+                timestamp: Date(),
+                kind: .tapActivated(TapHoldPayload(
+                    key: key,
+                    outputAction: action,
+                    reason: reason,
+                    kanataTimestamp: timestamp
+                ))
+            )
+            Task { @MainActor [weak self] in
+                self?.ingest(event)
+            }
+        }
+
+        observers.observe(.kanataHrmTrace, center: notificationCenter) { [weak self] notification in
+            guard let self else { return }
+            let userInfo = notification.userInfo
+            guard let key = userInfo?["key"] as? String,
+                  let decisionStr = userInfo?["decision"] as? String,
+                  let decision = KanataHrmDecision(rawValue: decisionStr),
+                  let reasonStr = userInfo?["reason"] as? String,
+                  let reason = KanataHrmDecisionReason(rawValue: reasonStr)
+            else { return }
+            let latencyMs = userInfo?["decideLatencyMs"] as? Int
+            let nextKey = userInfo?["nextKey"] as? String
+            let nextKeyHandStr = userInfo?["nextKeyHand"] as? String
+            let nextKeyHand = nextKeyHandStr.flatMap { KanataHrmKeyHand(rawValue: $0) }
+
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                let threshold = lookupThreshold(for: key)
+                let isNear = Self.computeNearThreshold(
+                    latencyMs: latencyMs,
+                    thresholdMs: threshold
+                )
+                let event = KeystrokeTimelineEvent(
+                    id: UUID(),
+                    timestamp: Date(),
+                    kind: .hrmDecision(HrmDecisionPayload(
+                        key: key,
+                        decision: decision,
+                        reason: reason,
+                        decideLatencyMs: latencyMs,
+                        nextKey: nextKey,
+                        nextKeyHand: nextKeyHand,
+                        configuredThresholdMs: threshold,
+                        isNearThreshold: isNear
+                    ))
+                )
+                ingest(event)
+            }
+        }
+
+        observers.observe(.kanataOneShotActivated, center: notificationCenter) { [weak self] notification in
+            guard let self else { return }
+            let userInfo = notification.userInfo
+            guard let key = userInfo?["key"] as? String,
+                  let modifiers = userInfo?["modifiers"] as? String
+            else { return }
+            let event = KeystrokeTimelineEvent(
+                id: UUID(),
+                timestamp: Date(),
+                kind: .oneShotActivated(OneShotPayload(key: key, modifiers: modifiers))
+            )
+            Task { @MainActor [weak self] in
+                self?.ingest(event)
+            }
+        }
+
+        observers.observe(.kanataChordResolved, center: notificationCenter) { [weak self] notification in
+            guard let self else { return }
+            let userInfo = notification.userInfo
+            guard let keys = userInfo?["keys"] as? String,
+                  let action = userInfo?["action"] as? String
+            else { return }
+            let event = KeystrokeTimelineEvent(
+                id: UUID(),
+                timestamp: Date(),
+                kind: .chordResolved(ChordPayload(keys: keys, action: action))
+            )
+            Task { @MainActor [weak self] in
+                self?.ingest(event)
+            }
+        }
+
+        observers.observe(.kanataTapDanceResolved, center: notificationCenter) { [weak self] notification in
+            guard let self else { return }
+            let userInfo = notification.userInfo
+            guard let key = userInfo?["key"] as? String,
+                  let tapCount = userInfo?["tapCount"] as? UInt8,
+                  let action = userInfo?["action"] as? String
+            else { return }
+            let event = KeystrokeTimelineEvent(
+                id: UUID(),
+                timestamp: Date(),
+                kind: .tapDanceResolved(TapDancePayload(key: key, tapCount: tapCount, action: action))
+            )
+            Task { @MainActor [weak self] in
+                self?.ingest(event)
+            }
+        }
+    }
+
+    // MARK: - Event Ingestion
+
+    private func ingest(_ event: KeystrokeTimelineEvent) {
+        guard isRecording else { return }
+
+        if case let .keyInput(payload) = event.kind {
+            if isDuplicate(key: payload.key, action: payload.action, timestamp: event.timestamp) {
+                return
+            }
+        }
+
+        pendingEvents.append(event)
+        scheduleBatchFlush()
+    }
+
+    private func isDuplicate(key: String, action: KanataKeyAction, timestamp: Date) -> Bool {
+        let cutoff = timestamp.addingTimeInterval(-deduplicationWindow)
+        return rawEvents.suffix(10).contains { existing in
+            if case let .keyInput(payload) = existing.kind {
+                return payload.key == key &&
+                    payload.action == action &&
+                    existing.timestamp > cutoff
+            }
+            return false
+        }
+    }
+
+    private func scheduleBatchFlush() {
+        guard batchTimer == nil else { return }
+        batchTimer = Timer.scheduledTimer(withTimeInterval: batchInterval, repeats: false) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.flushPendingEvents()
+            }
+        }
+    }
+
+    private func flushPendingEvents() {
+        batchTimer = nil
+        guard !pendingEvents.isEmpty else { return }
+
+        let layerAtFlush = currentLayer
+        let enriched = pendingEvents.map { event -> KeystrokeTimelineEvent in
+            if case let .keyInput(payload) = event.kind, payload.layer == nil {
+                return KeystrokeTimelineEvent(
+                    id: event.id,
+                    timestamp: event.timestamp,
+                    kind: .keyInput(KeyInputPayload(
+                        key: payload.key,
+                        action: payload.action,
+                        layer: layerAtFlush,
+                        kanataTimestamp: payload.kanataTimestamp
+                    ))
+                )
+            }
+            return event
+        }
+
+        rawEvents.append(contentsOf: enriched)
+        pendingEvents.removeAll()
+
+        if rawEvents.count > maxEvents {
+            rawEvents.removeFirst(rawEvents.count - maxEvents)
+        }
+
+        rebuildSegments()
+    }
+
+    // MARK: - Threshold Lookup
+
+    private func lookupThreshold(for key: String) -> Int? {
+        guard let lookup = thresholdLookup else { return nil }
+        let config = lookup()
+        let offset = config.offsets[key] ?? 0
+        return config.baseMs + offset
+    }
+
+    static func computeNearThreshold(latencyMs: Int?, thresholdMs: Int?) -> Bool {
+        guard let latency = latencyMs, let threshold = thresholdMs else { return false }
+        return abs(latency - threshold) <= HrmDecisionPayload.nearThresholdMarginMs
+    }
+
+    // MARK: - Segment Rebuild
+
+    private func rebuildSegments() {
+        segments = TimelineGrouper.group(rawEvents, currentLayer: currentLayer)
+    }
+
+    // MARK: - Public API
+
+    func clearEvents() {
+        rawEvents.removeAll()
+        pendingEvents.removeAll()
+        batchTimer?.invalidate()
+        batchTimer = nil
+        segments = []
+    }
+
+    var eventCount: Int {
+        rawEvents.count
+    }
+}

--- a/Sources/KeyPathAppKit/Services/Monitoring/TimelineGrouper.swift
+++ b/Sources/KeyPathAppKit/Services/Monitoring/TimelineGrouper.swift
@@ -1,0 +1,234 @@
+import Foundation
+
+// MARK: - Segment Types
+
+enum TimelineSegment: Identifiable {
+    case textRun(TextRunSegment)
+    case eventCard(EventCardSegment)
+    case layerDivider(LayerDividerSegment)
+
+    var id: UUID {
+        switch self {
+        case let .textRun(s): s.id
+        case let .eventCard(s): s.id
+        case let .layerDivider(s): s.id
+        }
+    }
+
+    var timestamp: Date {
+        switch self {
+        case let .textRun(s): s.characters.first?.timestamp ?? Date()
+        case let .eventCard(s): s.timestamp
+        case let .layerDivider(s): s.timestamp
+        }
+    }
+}
+
+struct TextRunSegment: Identifiable {
+    let id = UUID()
+    let characters: [TextRunCharacter]
+}
+
+struct TextRunCharacter: Identifiable {
+    let id: UUID
+    let displayChar: String
+    let rawKey: String
+    let timestamp: Date
+    let layer: String?
+    let kanataTimestamp: UInt64?
+}
+
+struct EventCardSegment: Identifiable {
+    let id: UUID
+    let timestamp: Date
+    let cardKind: EventCardKind
+}
+
+enum EventCardKind {
+    case tapHold(TapHoldCardData)
+    case hrmDecision(HrmCardData)
+    case oneShot(OneShotPayload)
+    case chord(ChordPayload)
+    case tapDance(TapDancePayload)
+    case nonPrintableKey(key: String, action: KanataKeyAction)
+}
+
+struct TapHoldCardData {
+    let key: String
+    let outputAction: String
+    let reason: String?
+    let isHold: Bool
+}
+
+struct HrmCardData {
+    let key: String
+    let decision: KanataHrmDecision
+    let reason: KanataHrmDecisionReason
+    let decideLatencyMs: Int?
+    let configuredThresholdMs: Int?
+    let isNearThreshold: Bool
+    let nextKey: String?
+}
+
+struct LayerDividerSegment: Identifiable {
+    let id = UUID()
+    let timestamp: Date
+    let layerName: String
+}
+
+// MARK: - Grouper
+
+enum TimelineGrouper {
+    private static let printableKeys: [String: String] = {
+        var map: [String: String] = [:]
+        for c in "abcdefghijklmnopqrstuvwxyz" {
+            map[String(c)] = String(c)
+        }
+        for i in 0 ... 9 {
+            map["\(i)"] = "\(i)"
+        }
+        map["spc"] = " "
+        map["space"] = " "
+        map["min"] = "-"
+        map["minus"] = "-"
+        map["eql"] = "="
+        map["equal"] = "="
+        map["lbrc"] = "["
+        map["rbrc"] = "]"
+        map["bksl"] = "\\"
+        map["scln"] = ";"
+        map["apos"] = "'"
+        map["apostrophe"] = "'"
+        map["grv"] = "`"
+        map["grave"] = "`"
+        map["comm"] = ","
+        map["dot"] = "."
+        map["slsh"] = "/"
+        map["slash"] = "/"
+        map["tab"] = "⇥"
+        return map
+    }()
+
+    private static let modifierKeys: Set<String> = [
+        "lsft", "rsft", "lctl", "rctl", "lalt", "ralt", "lmet", "rmet",
+        "leftshift", "rightshift", "leftctrl", "rightctrl",
+        "leftalt", "rightalt", "leftmeta", "rightmeta",
+        "lshift", "rshift",
+    ]
+
+    static func group(_ events: [KeystrokeTimelineEvent], currentLayer _: String) -> [TimelineSegment] {
+        var segments: [TimelineSegment] = []
+        var currentTextRun: [TextRunCharacter] = []
+
+        func flushTextRun() {
+            guard !currentTextRun.isEmpty else { return }
+            segments.append(.textRun(TextRunSegment(characters: currentTextRun)))
+            currentTextRun = []
+        }
+
+        for event in events {
+            switch event.kind {
+            case let .keyInput(payload):
+                guard payload.action == .press else { continue }
+
+                if modifierKeys.contains(payload.key.lowercased()) {
+                    continue
+                }
+
+                if let displayChar = printableKeys[payload.key.lowercased()] {
+                    currentTextRun.append(TextRunCharacter(
+                        id: event.id,
+                        displayChar: displayChar,
+                        rawKey: payload.key,
+                        timestamp: event.timestamp,
+                        layer: payload.layer,
+                        kanataTimestamp: payload.kanataTimestamp
+                    ))
+                } else {
+                    flushTextRun()
+                    segments.append(.eventCard(EventCardSegment(
+                        id: event.id,
+                        timestamp: event.timestamp,
+                        cardKind: .nonPrintableKey(key: payload.key, action: payload.action)
+                    )))
+                }
+
+            case let .layerChanged(payload):
+                flushTextRun()
+                segments.append(.layerDivider(LayerDividerSegment(
+                    timestamp: event.timestamp,
+                    layerName: payload.layerName
+                )))
+
+            case let .tapActivated(payload):
+                flushTextRun()
+                segments.append(.eventCard(EventCardSegment(
+                    id: event.id,
+                    timestamp: event.timestamp,
+                    cardKind: .tapHold(TapHoldCardData(
+                        key: payload.key,
+                        outputAction: payload.outputAction,
+                        reason: payload.reason,
+                        isHold: false
+                    ))
+                )))
+
+            case let .holdActivated(payload):
+                flushTextRun()
+                segments.append(.eventCard(EventCardSegment(
+                    id: event.id,
+                    timestamp: event.timestamp,
+                    cardKind: .tapHold(TapHoldCardData(
+                        key: payload.key,
+                        outputAction: payload.outputAction,
+                        reason: payload.reason,
+                        isHold: true
+                    ))
+                )))
+
+            case let .hrmDecision(payload):
+                flushTextRun()
+                segments.append(.eventCard(EventCardSegment(
+                    id: event.id,
+                    timestamp: event.timestamp,
+                    cardKind: .hrmDecision(HrmCardData(
+                        key: payload.key,
+                        decision: payload.decision,
+                        reason: payload.reason,
+                        decideLatencyMs: payload.decideLatencyMs,
+                        configuredThresholdMs: payload.configuredThresholdMs,
+                        isNearThreshold: payload.isNearThreshold,
+                        nextKey: payload.nextKey
+                    ))
+                )))
+
+            case let .oneShotActivated(payload):
+                flushTextRun()
+                segments.append(.eventCard(EventCardSegment(
+                    id: event.id,
+                    timestamp: event.timestamp,
+                    cardKind: .oneShot(payload)
+                )))
+
+            case let .chordResolved(payload):
+                flushTextRun()
+                segments.append(.eventCard(EventCardSegment(
+                    id: event.id,
+                    timestamp: event.timestamp,
+                    cardKind: .chord(payload)
+                )))
+
+            case let .tapDanceResolved(payload):
+                flushTextRun()
+                segments.append(.eventCard(EventCardSegment(
+                    id: event.id,
+                    timestamp: event.timestamp,
+                    cardKind: .tapDance(payload)
+                )))
+            }
+        }
+
+        flushTextRun()
+        return segments
+    }
+}

--- a/Sources/KeyPathAppKit/UI/CommandPalette/CommandPaletteWindowController.swift
+++ b/Sources/KeyPathAppKit/UI/CommandPalette/CommandPaletteWindowController.swift
@@ -290,6 +290,7 @@ final class CommandPaletteWindowController {
             (.sounds, "Sounds", "Typing sounds", "speaker.wave.2"),
             (.launchers, "Launchers", "App and website launchers", "arrow.up.forward.app"),
             (.devices, "Devices", "Keyboard device selection", "desktopcomputer"),
+            (.history, "Keystroke History", "Timeline of key events and tap-hold decisions", "clock.arrow.trianglehead.counterclockwise.rotate.90"),
         ]
 
         return tabs.map { tab in

--- a/Sources/KeyPathAppKit/UI/Overlay/InspectorPanelToolbar.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/InspectorPanelToolbar.swift
@@ -37,6 +37,7 @@ struct InspectorPanelToolbar: View {
     @State private var isHoveringSounds = false
     @State private var isHoveringDevices = false
     @State private var isHoveringLaunchers = false
+    @State private var isHoveringHistory = false
     @State private var isHoveringSettings = false
     @State private var showMainTabs = true
     @State private var showSettingsTabs = false
@@ -230,6 +231,18 @@ struct InspectorPanelToolbar: View {
                 .accessibilityLabel("Quick Launcher")
                 .help("Quick Launcher")
             }
+
+            // Keystroke History
+            toolbarButton(
+                systemImage: "clock.arrow.trianglehead.counterclockwise.rotate.90",
+                isSelected: selectedSection == .history,
+                isHovering: isHoveringHistory,
+                onHover: { isHoveringHistory = $0 },
+                action: { onSelectSection(.history) }
+            )
+            .accessibilityIdentifier("inspector-tab-history")
+            .accessibilityLabel("Keystroke History")
+            .help("Keystroke History")
         }
     }
 

--- a/Sources/KeyPathAppKit/UI/Overlay/KeystrokeCharacterPopover.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/KeystrokeCharacterPopover.swift
@@ -1,0 +1,38 @@
+import SwiftUI
+
+struct KeystrokeCharacterPopover: View {
+    let char: TextRunCharacter
+    let previousChar: TextRunCharacter?
+
+    private static let timeFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "HH:mm:ss.SSS"
+        return f
+    }()
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            row(label: "Key", value: char.rawKey)
+            if let layer = char.layer {
+                row(label: "Layer", value: layer)
+            }
+            row(label: "Time", value: Self.timeFormatter.string(from: char.timestamp))
+            if let prev = previousChar {
+                let intervalMs = Int(char.timestamp.timeIntervalSince(prev.timestamp) * 1000)
+                row(label: "Since prev", value: "\(intervalMs)ms")
+            }
+        }
+        .padding(8)
+        .font(.system(size: 10, design: .monospaced))
+    }
+
+    private func row(label: String, value: String) -> some View {
+        HStack(spacing: 6) {
+            Text(label)
+                .foregroundStyle(.secondary)
+                .frame(width: 60, alignment: .trailing)
+            Text(value)
+                .foregroundStyle(.primary)
+        }
+    }
+}

--- a/Sources/KeyPathAppKit/UI/Overlay/KeystrokeHistorySegments.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/KeystrokeHistorySegments.swift
@@ -1,0 +1,315 @@
+import SwiftUI
+
+// MARK: - Text Run View
+
+struct TextRunView: View {
+    let segment: TextRunSegment
+    let isDark: Bool
+    @State private var hoveredCharId: UUID?
+
+    var body: some View {
+        FlowLayout(spacing: 0) {
+            ForEach(segment.characters) { char in
+                characterView(char)
+            }
+        }
+        .padding(.vertical, 2)
+    }
+
+    private func characterView(_ char: TextRunCharacter) -> some View {
+        Text(char.displayChar)
+            .font(.system(size: 13, design: .monospaced))
+            .foregroundStyle(isDark ? .white : .primary)
+            .padding(.horizontal, 0.5)
+            .background(
+                RoundedRectangle(cornerRadius: 2)
+                    .fill(hoveredCharId == char.id
+                        ? Color.accentColor.opacity(0.15)
+                        : Color.clear)
+            )
+            .onHover { isHovering in
+                hoveredCharId = isHovering ? char.id : nil
+            }
+            .popover(isPresented: Binding(
+                get: { hoveredCharId == char.id },
+                set: { if !$0 { hoveredCharId = nil } }
+            )) {
+                KeystrokeCharacterPopover(
+                    char: char,
+                    previousChar: previousChar(before: char)
+                )
+            }
+    }
+
+    private func previousChar(before char: TextRunCharacter) -> TextRunCharacter? {
+        guard let index = segment.characters.firstIndex(where: { $0.id == char.id }),
+              index > 0
+        else { return nil }
+        return segment.characters[index - 1]
+    }
+}
+
+// MARK: - Event Card View
+
+struct EventCardView: View {
+    let segment: EventCardSegment
+    let isDark: Bool
+
+    var body: some View {
+        Group {
+            switch segment.cardKind {
+            case let .tapHold(data):
+                tapHoldCard(data)
+            case let .hrmDecision(data):
+                hrmCard(data)
+            case let .oneShot(data):
+                oneShotCard(data)
+            case let .chord(data):
+                chordCard(data)
+            case let .tapDance(data):
+                tapDanceCard(data)
+            case let .nonPrintableKey(key, _):
+                nonPrintableCard(key: key)
+            }
+        }
+        .padding(.vertical, 2)
+    }
+
+    // MARK: - Tap-Hold Card
+
+    private func tapHoldCard(_ data: TapHoldCardData) -> some View {
+        HStack(spacing: 4) {
+            Text(data.isHold ? "HOLD" : "TAP")
+                .font(.system(size: 8, weight: .bold, design: .monospaced))
+                .foregroundStyle(.white)
+                .padding(.horizontal, 4)
+                .padding(.vertical, 1)
+                .background(
+                    RoundedRectangle(cornerRadius: 3)
+                        .fill(data.isHold ? Color.orange : Color.blue)
+                )
+
+            Text(data.key)
+                .font(.system(size: 11, weight: .medium, design: .monospaced))
+                .foregroundStyle(.secondary)
+
+            Image(systemName: "arrow.right")
+                .font(.system(size: 8))
+                .foregroundStyle(.tertiary)
+
+            Text(data.outputAction)
+                .font(.system(size: 11, weight: .medium, design: .monospaced))
+                .foregroundStyle(isDark ? .white : .primary)
+
+            if let reason = data.reason {
+                reasonPill(reason)
+            }
+        }
+        .padding(.horizontal, 6)
+        .padding(.vertical, 3)
+        .background(
+            RoundedRectangle(cornerRadius: 5)
+                .fill(cardBackground(for: data.isHold ? .orange : .blue))
+        )
+    }
+
+    // MARK: - HRM Decision Card
+
+    private func hrmCard(_ data: HrmCardData) -> some View {
+        HStack(spacing: 4) {
+            let isHold = data.decision == .hold
+
+            if data.isNearThreshold {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .font(.system(size: 9))
+                    .foregroundStyle(.yellow)
+            }
+
+            Text(isHold ? "HOLD" : "TAP")
+                .font(.system(size: 8, weight: .bold, design: .monospaced))
+                .foregroundStyle(.white)
+                .padding(.horizontal, 4)
+                .padding(.vertical, 1)
+                .background(
+                    RoundedRectangle(cornerRadius: 3)
+                        .fill(isHold ? Color.orange : Color.blue)
+                )
+
+            Text(data.key)
+                .font(.system(size: 11, weight: .medium, design: .monospaced))
+                .foregroundStyle(isDark ? .white : .primary)
+
+            reasonPill(data.reason.displayName)
+
+            if let latency = data.decideLatencyMs {
+                latencyBadge(latency: latency, threshold: data.configuredThresholdMs)
+            }
+        }
+        .padding(.horizontal, 6)
+        .padding(.vertical, 3)
+        .background(
+            RoundedRectangle(cornerRadius: 5)
+                .fill(data.isNearThreshold
+                    ? cardBackground(for: .yellow)
+                    : cardBackground(for: data.decision == .hold ? .orange : .blue))
+        )
+    }
+
+    // MARK: - One-Shot Card
+
+    private func oneShotCard(_ data: OneShotPayload) -> some View {
+        HStack(spacing: 4) {
+            Text("OS")
+                .font(.system(size: 8, weight: .bold, design: .monospaced))
+                .foregroundStyle(.white)
+                .padding(.horizontal, 4)
+                .padding(.vertical, 1)
+                .background(
+                    RoundedRectangle(cornerRadius: 3)
+                        .fill(Color.purple)
+                )
+
+            Text(data.modifiers)
+                .font(.system(size: 11, weight: .medium, design: .monospaced))
+                .foregroundStyle(isDark ? .white : .primary)
+        }
+        .padding(.horizontal, 6)
+        .padding(.vertical, 3)
+        .background(
+            RoundedRectangle(cornerRadius: 5)
+                .fill(cardBackground(for: .purple))
+        )
+    }
+
+    // MARK: - Chord Card
+
+    private func chordCard(_ data: ChordPayload) -> some View {
+        HStack(spacing: 4) {
+            Image(systemName: "pianokeys")
+                .font(.system(size: 9))
+                .foregroundStyle(.green)
+
+            Text(data.keys)
+                .font(.system(size: 11, weight: .medium, design: .monospaced))
+                .foregroundStyle(.secondary)
+
+            Image(systemName: "arrow.right")
+                .font(.system(size: 8))
+                .foregroundStyle(.tertiary)
+
+            Text(data.action)
+                .font(.system(size: 11, weight: .medium, design: .monospaced))
+                .foregroundStyle(isDark ? .white : .primary)
+        }
+        .padding(.horizontal, 6)
+        .padding(.vertical, 3)
+        .background(
+            RoundedRectangle(cornerRadius: 5)
+                .fill(cardBackground(for: .green))
+        )
+    }
+
+    // MARK: - Tap-Dance Card
+
+    private func tapDanceCard(_ data: TapDancePayload) -> some View {
+        HStack(spacing: 4) {
+            Text(data.key)
+                .font(.system(size: 11, weight: .medium, design: .monospaced))
+                .foregroundStyle(.secondary)
+
+            Text("\u{00D7}\(data.tapCount)")
+                .font(.system(size: 10, weight: .bold, design: .monospaced))
+                .foregroundStyle(.teal)
+
+            Image(systemName: "arrow.right")
+                .font(.system(size: 8))
+                .foregroundStyle(.tertiary)
+
+            Text(data.action)
+                .font(.system(size: 11, weight: .medium, design: .monospaced))
+                .foregroundStyle(isDark ? .white : .primary)
+        }
+        .padding(.horizontal, 6)
+        .padding(.vertical, 3)
+        .background(
+            RoundedRectangle(cornerRadius: 5)
+                .fill(cardBackground(for: .teal))
+        )
+    }
+
+    // MARK: - Non-Printable Key Card
+
+    private func nonPrintableCard(key: String) -> some View {
+        Text(key)
+            .font(.system(size: 10, weight: .medium, design: .monospaced))
+            .foregroundStyle(.secondary)
+            .padding(.horizontal, 5)
+            .padding(.vertical, 2)
+            .background(
+                RoundedRectangle(cornerRadius: 3)
+                    .fill(isDark
+                        ? Color.white.opacity(0.06)
+                        : Color.black.opacity(0.04))
+            )
+    }
+
+    // MARK: - Shared Components
+
+    private func reasonPill(_ reason: String) -> some View {
+        Text(reason)
+            .font(.system(size: 8, weight: .medium))
+            .foregroundStyle(.secondary)
+            .padding(.horizontal, 4)
+            .padding(.vertical, 1)
+            .background(
+                Capsule()
+                    .fill(isDark
+                        ? Color.white.opacity(0.08)
+                        : Color.black.opacity(0.06))
+            )
+    }
+
+    private func latencyBadge(latency: Int, threshold: Int?) -> some View {
+        let color = latencyColor(latency: latency, threshold: threshold)
+        return Text("\(latency)ms")
+            .font(.system(size: 9, weight: .semibold, design: .monospaced))
+            .foregroundStyle(color)
+    }
+
+    private func latencyColor(latency: Int, threshold: Int?) -> Color {
+        guard let threshold, threshold > 0 else { return .secondary }
+        let ratio = Double(latency) / Double(threshold)
+        if ratio < 0.5 { return .green }
+        if ratio < 0.8 { return .yellow }
+        return .red
+    }
+
+    private func cardBackground(for tint: Color) -> Color {
+        tint.opacity(isDark ? 0.1 : 0.06)
+    }
+}
+
+// MARK: - Layer Divider View
+
+struct LayerDividerView: View {
+    let segment: LayerDividerSegment
+
+    var body: some View {
+        HStack(spacing: 6) {
+            line
+            Text(segment.layerName)
+                .font(.system(size: 9, weight: .semibold))
+                .foregroundStyle(.secondary)
+                .textCase(.uppercase)
+                .tracking(0.5)
+            line
+        }
+        .padding(.vertical, 4)
+    }
+
+    private var line: some View {
+        Rectangle()
+            .fill(Color.secondary.opacity(0.2))
+            .frame(height: 0.5)
+    }
+}

--- a/Sources/KeyPathAppKit/UI/Overlay/KeystrokeHistoryView.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/KeystrokeHistoryView.swift
@@ -1,0 +1,117 @@
+import SwiftUI
+
+struct KeystrokeHistoryView: View {
+    let isDark: Bool
+    @State private var service = KeystrokeHistoryService.shared
+    @State private var autoScroll = true
+    @Namespace private var bottomAnchor
+
+    var body: some View {
+        VStack(spacing: 0) {
+            historyToolbar
+            Divider().opacity(0.3)
+            timelineContent
+        }
+    }
+
+    // MARK: - Toolbar
+
+    private var historyToolbar: some View {
+        HStack(spacing: 8) {
+            Button {
+                service.isRecording.toggle()
+            } label: {
+                Image(systemName: service.isRecording ? "pause.circle.fill" : "record.circle")
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundStyle(service.isRecording ? .red : .secondary)
+            }
+            .buttonStyle(.plain)
+            .help(service.isRecording ? "Pause recording" : "Resume recording")
+
+            Text("\(service.eventCount) events")
+                .font(.system(size: 10, weight: .medium, design: .monospaced))
+                .foregroundStyle(.secondary)
+
+            Spacer()
+
+            Button {
+                autoScroll.toggle()
+            } label: {
+                Image(systemName: autoScroll ? "arrow.down.to.line" : "arrow.down.to.line")
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(autoScroll ? Color.accentColor : .secondary)
+            }
+            .buttonStyle(.plain)
+            .help(autoScroll ? "Auto-scroll on" : "Auto-scroll off")
+
+            Button {
+                service.clearEvents()
+            } label: {
+                Image(systemName: "trash")
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(.secondary)
+            }
+            .buttonStyle(.plain)
+            .help("Clear history")
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 6)
+    }
+
+    // MARK: - Timeline
+
+    private var timelineContent: some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 4) {
+                    if service.segments.isEmpty {
+                        emptyState
+                    } else {
+                        ForEach(service.segments) { segment in
+                            segmentView(for: segment)
+                        }
+                    }
+                    Color.clear
+                        .frame(height: 1)
+                        .id("bottom")
+                }
+                .padding(.horizontal, 4)
+                .padding(.vertical, 8)
+            }
+            .onChange(of: service.segments.count) {
+                if autoScroll {
+                    withAnimation(.easeOut(duration: 0.15)) {
+                        proxy.scrollTo("bottom", anchor: .bottom)
+                    }
+                }
+            }
+        }
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 8) {
+            Image(systemName: "keyboard")
+                .font(.system(size: 24))
+                .foregroundStyle(.tertiary)
+            Text(service.isRecording ? "Start typing to see history" : "Recording paused")
+                .font(.system(size: 11))
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.top, 40)
+    }
+
+    // MARK: - Segment Dispatch
+
+    @ViewBuilder
+    private func segmentView(for segment: TimelineSegment) -> some View {
+        switch segment {
+        case let .textRun(run):
+            TextRunView(segment: run, isDark: isDark)
+        case let .eventCard(card):
+            EventCardView(segment: card, isDark: isDark)
+        case let .layerDivider(divider):
+            LayerDividerView(segment: divider)
+        }
+    }
+}

--- a/Sources/KeyPathAppKit/UI/Overlay/LiveKeyboardOverlayView+Inspector.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/LiveKeyboardOverlayView+Inspector.swift
@@ -159,6 +159,10 @@ struct OverlayInspectorPanel: View {
                         devicesContent
                             .padding(.horizontal, 12)
                             .padding(.bottom, 6)
+                    } else if selectedSection == .history {
+                        historyContent
+                            .padding(.horizontal, 12)
+                            .padding(.bottom, 6)
                     } else {
                         ScrollView {
                             VStack(alignment: .leading, spacing: 16) {
@@ -178,6 +182,8 @@ struct OverlayInspectorPanel: View {
                                 case .customRules:
                                     EmptyView() // Handled above
                                 case .devices:
+                                    EmptyView() // Handled above
+                                case .history:
                                     EmptyView() // Handled above
                                 }
                             }

--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayInspectorPanel+History.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayInspectorPanel+History.swift
@@ -1,0 +1,7 @@
+import SwiftUI
+
+extension OverlayInspectorPanel {
+    var historyContent: some View {
+        KeystrokeHistoryView(isDark: isDark)
+    }
+}

--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayInspectorTypes.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayInspectorTypes.swift
@@ -14,6 +14,7 @@ enum DrawerPanel {
 enum InspectorSection: String, CaseIterable {
     case mapper
     case customRules // Only shown when custom rules exist
+    case history
     case keyboard
     case layout
     case keycaps
@@ -27,7 +28,7 @@ extension InspectorSection {
         switch self {
         case .keycaps, .sounds, .keyboard, .layout, .devices:
             true
-        case .mapper, .customRules, .launchers:
+        case .mapper, .customRules, .launchers, .history:
             false
         }
     }

--- a/Tests/KeyPathTests/Services/KeystrokeHistoryServiceTests.swift
+++ b/Tests/KeyPathTests/Services/KeystrokeHistoryServiceTests.swift
@@ -1,0 +1,205 @@
+@testable import KeyPathAppKit
+@preconcurrency import XCTest
+
+@MainActor
+final class KeystrokeHistoryServiceTests: XCTestCase {
+    private func postKeyInput(
+        _ center: NotificationCenter,
+        key: String,
+        action: String = "press",
+        kanataTimestamp: UInt64? = nil
+    ) {
+        var userInfo: [String: Any] = [
+            "key": key,
+            "action": action,
+            "observedAt": Date(),
+        ]
+        if let ts = kanataTimestamp {
+            userInfo["kanataTimestamp"] = ts
+        }
+        center.post(name: .kanataKeyInput, object: nil, userInfo: userInfo)
+    }
+
+    private func yieldForBatch() async {
+        // Wait for notification dispatch + batch timer flush (100ms)
+        try? await Task.sleep(nanoseconds: 150_000_000)
+        await Task.yield()
+        await Task.yield()
+    }
+
+    // MARK: - Event Ingestion
+
+    func testKeyInputCreatesEvent() async {
+        let center = NotificationCenter()
+        let service = KeystrokeHistoryService.makeTestInstance(notificationCenter: center)
+        postKeyInput(center, key: "a")
+        await yieldForBatch()
+        XCTAssertEqual(service.eventCount, 1)
+    }
+
+    func testMultipleKeysGroupIntoTextRun() async {
+        let center = NotificationCenter()
+        let service = KeystrokeHistoryService.makeTestInstance(notificationCenter: center)
+        for key in ["h", "e", "l", "l", "o"] {
+            postKeyInput(center, key: key)
+        }
+        await yieldForBatch()
+        XCTAssertEqual(service.eventCount, 5)
+        XCTAssertEqual(service.segments.count, 1)
+        if case let .textRun(run) = service.segments.first {
+            XCTAssertEqual(run.characters.count, 5)
+            XCTAssertEqual(run.characters.map(\.displayChar).joined(), "hello")
+        } else {
+            XCTFail("Expected text run segment")
+        }
+    }
+
+    func testReleaseEventsAreFiltered() async {
+        let center = NotificationCenter()
+        let service = KeystrokeHistoryService.makeTestInstance(notificationCenter: center)
+        postKeyInput(center, key: "a", action: "press")
+        postKeyInput(center, key: "a", action: "release")
+        await yieldForBatch()
+        XCTAssertEqual(service.eventCount, 2)
+        // Release events are not shown in segments (filtered by grouper)
+        XCTAssertEqual(service.segments.count, 1)
+        if case let .textRun(run) = service.segments.first {
+            XCTAssertEqual(run.characters.count, 1)
+        } else {
+            XCTFail("Expected text run segment")
+        }
+    }
+
+    // MARK: - Layer Changes
+
+    func testLayerChangeUpdatesCurrentLayer() async {
+        let center = NotificationCenter()
+        let service = KeystrokeHistoryService.makeTestInstance(notificationCenter: center)
+        XCTAssertEqual(service.currentLayer, "base")
+        center.post(name: .kanataLayerChanged, object: nil, userInfo: ["layerName": "nav"])
+        await yieldForBatch()
+        XCTAssertEqual(service.currentLayer, "nav")
+    }
+
+    func testLayerChangeCreatesLayerDivider() async {
+        let center = NotificationCenter()
+        let service = KeystrokeHistoryService.makeTestInstance(notificationCenter: center)
+        postKeyInput(center, key: "a")
+        center.post(name: .kanataLayerChanged, object: nil, userInfo: ["layerName": "nav"])
+        postKeyInput(center, key: "b")
+        await yieldForBatch()
+        XCTAssertEqual(service.segments.count, 3)
+        if case let .layerDivider(divider) = service.segments[1] {
+            XCTAssertEqual(divider.layerName, "nav")
+        } else {
+            XCTFail("Expected layer divider at index 1")
+        }
+    }
+
+    // MARK: - Tap-Hold Events
+
+    func testHoldActivatedCreatesEventCard() async {
+        let center = NotificationCenter()
+        let service = KeystrokeHistoryService.makeTestInstance(notificationCenter: center)
+        center.post(name: .kanataHoldActivated, object: nil, userInfo: [
+            "key": "caps",
+            "action": "lctl+lmet+lalt+lsft",
+            "reason": "opposite-hand",
+            "kanataTimestamp": UInt64(1000),
+        ])
+        await yieldForBatch()
+        XCTAssertEqual(service.segments.count, 1)
+        if case let .eventCard(card) = service.segments.first,
+           case let .tapHold(data) = card.cardKind
+        {
+            XCTAssertEqual(data.key, "caps")
+            XCTAssertEqual(data.outputAction, "lctl+lmet+lalt+lsft")
+            XCTAssertTrue(data.isHold)
+            XCTAssertEqual(data.reason, "opposite-hand")
+        } else {
+            XCTFail("Expected tap-hold event card")
+        }
+    }
+
+    func testTapActivatedCreatesEventCard() async {
+        let center = NotificationCenter()
+        let service = KeystrokeHistoryService.makeTestInstance(notificationCenter: center)
+        center.post(name: .kanataTapActivated, object: nil, userInfo: [
+            "key": "caps",
+            "action": "esc",
+            "reason": "release-before-timeout",
+            "kanataTimestamp": UInt64(1000),
+        ])
+        await yieldForBatch()
+        XCTAssertEqual(service.segments.count, 1)
+        if case let .eventCard(card) = service.segments.first,
+           case let .tapHold(data) = card.cardKind
+        {
+            XCTAssertEqual(data.key, "caps")
+            XCTAssertEqual(data.outputAction, "esc")
+            XCTAssertFalse(data.isHold)
+        } else {
+            XCTFail("Expected tap-hold event card")
+        }
+    }
+
+    // MARK: - Recording Toggle
+
+    func testRecordingPauseSuppressesIngestion() async {
+        let center = NotificationCenter()
+        let service = KeystrokeHistoryService.makeTestInstance(notificationCenter: center)
+        service.isRecording = false
+        postKeyInput(center, key: "a")
+        await yieldForBatch()
+        XCTAssertEqual(service.eventCount, 0)
+    }
+
+    // MARK: - Clear
+
+    func testClearRemovesAllEvents() async {
+        let center = NotificationCenter()
+        let service = KeystrokeHistoryService.makeTestInstance(notificationCenter: center)
+        postKeyInput(center, key: "a")
+        await yieldForBatch()
+        XCTAssertEqual(service.eventCount, 1)
+        service.clearEvents()
+        XCTAssertEqual(service.eventCount, 0)
+        XCTAssertTrue(service.segments.isEmpty)
+    }
+
+    // MARK: - Threshold
+
+    func testNearThresholdComputation() {
+        XCTAssertTrue(KeystrokeHistoryService.computeNearThreshold(latencyMs: 190, thresholdMs: 200))
+        XCTAssertTrue(KeystrokeHistoryService.computeNearThreshold(latencyMs: 210, thresholdMs: 200))
+        XCTAssertFalse(KeystrokeHistoryService.computeNearThreshold(latencyMs: 100, thresholdMs: 200))
+        XCTAssertFalse(KeystrokeHistoryService.computeNearThreshold(latencyMs: nil, thresholdMs: 200))
+        XCTAssertFalse(KeystrokeHistoryService.computeNearThreshold(latencyMs: 190, thresholdMs: nil))
+    }
+
+    // MARK: - Non-Printable Keys
+
+    func testNonPrintableKeyBreaksTextRun() async {
+        let center = NotificationCenter()
+        let service = KeystrokeHistoryService.makeTestInstance(notificationCenter: center)
+        postKeyInput(center, key: "a")
+        postKeyInput(center, key: "b")
+        postKeyInput(center, key: "bspc")
+        postKeyInput(center, key: "c")
+        await yieldForBatch()
+        // Should be: textRun("ab"), eventCard(bspc), textRun("c")
+        XCTAssertEqual(service.segments.count, 3)
+        if case let .textRun(run) = service.segments[0] {
+            XCTAssertEqual(run.characters.map(\.displayChar).joined(), "ab")
+        } else {
+            XCTFail("Expected text run at index 0")
+        }
+        if case let .eventCard(card) = service.segments[1],
+           case let .nonPrintableKey(key, _) = card.cardKind
+        {
+            XCTAssertEqual(key, "bspc")
+        } else {
+            XCTFail("Expected non-printable key card at index 1")
+        }
+    }
+}

--- a/Tests/KeyPathTests/Services/TimelineGrouperTests.swift
+++ b/Tests/KeyPathTests/Services/TimelineGrouperTests.swift
@@ -1,0 +1,143 @@
+@testable import KeyPathAppKit
+@preconcurrency import XCTest
+
+final class TimelineGrouperTests: XCTestCase {
+    private func makeKeyInput(key: String, action: KanataKeyAction = .press, layer: String? = "base") -> KeystrokeTimelineEvent {
+        KeystrokeTimelineEvent(
+            id: UUID(),
+            timestamp: Date(),
+            kind: .keyInput(KeyInputPayload(key: key, action: action, layer: layer, kanataTimestamp: nil))
+        )
+    }
+
+    private func makeLayerChange(layer: String) -> KeystrokeTimelineEvent {
+        KeystrokeTimelineEvent(
+            id: UUID(),
+            timestamp: Date(),
+            kind: .layerChanged(LayerChangePayload(layerName: layer))
+        )
+    }
+
+    private func makeHoldActivated(key: String, action: String) -> KeystrokeTimelineEvent {
+        KeystrokeTimelineEvent(
+            id: UUID(),
+            timestamp: Date(),
+            kind: .holdActivated(TapHoldPayload(key: key, outputAction: action, reason: "timeout", kanataTimestamp: 0))
+        )
+    }
+
+    // MARK: - Text Run Grouping
+
+    func testConsecutivePrintableKeysGroupIntoTextRun() {
+        let events = ["h", "e", "l", "l", "o"].map { makeKeyInput(key: $0) }
+        let segments = TimelineGrouper.group(events, currentLayer: "base")
+        XCTAssertEqual(segments.count, 1)
+        if case let .textRun(run) = segments.first {
+            XCTAssertEqual(run.characters.map(\.displayChar).joined(), "hello")
+        } else {
+            XCTFail("Expected text run")
+        }
+    }
+
+    func testModifierKeysExcludedFromTextRun() {
+        let events = [
+            makeKeyInput(key: "a"),
+            makeKeyInput(key: "lsft"),
+            makeKeyInput(key: "b"),
+        ]
+        let segments = TimelineGrouper.group(events, currentLayer: "base")
+        XCTAssertEqual(segments.count, 1)
+        if case let .textRun(run) = segments.first {
+            XCTAssertEqual(run.characters.map(\.displayChar).joined(), "ab")
+        } else {
+            XCTFail("Expected text run")
+        }
+    }
+
+    func testReleaseEventsSkipped() {
+        let events = [
+            makeKeyInput(key: "a", action: .press),
+            makeKeyInput(key: "a", action: .release),
+            makeKeyInput(key: "b", action: .press),
+        ]
+        let segments = TimelineGrouper.group(events, currentLayer: "base")
+        XCTAssertEqual(segments.count, 1)
+        if case let .textRun(run) = segments.first {
+            XCTAssertEqual(run.characters.count, 2)
+        } else {
+            XCTFail("Expected text run")
+        }
+    }
+
+    func testNonPrintableKeyBreaksTextRun() {
+        let events = [
+            makeKeyInput(key: "a"),
+            makeKeyInput(key: "esc"),
+            makeKeyInput(key: "b"),
+        ]
+        let segments = TimelineGrouper.group(events, currentLayer: "base")
+        XCTAssertEqual(segments.count, 3)
+        if case .textRun = segments[0], case .eventCard = segments[1], case .textRun = segments[2] {
+            // correct
+        } else {
+            XCTFail("Expected textRun, eventCard, textRun")
+        }
+    }
+
+    // MARK: - Layer Dividers
+
+    func testLayerChangeCreatesLayerDivider() {
+        let events = [
+            makeKeyInput(key: "a"),
+            makeLayerChange(layer: "nav"),
+            makeKeyInput(key: "b"),
+        ]
+        let segments = TimelineGrouper.group(events, currentLayer: "nav")
+        XCTAssertEqual(segments.count, 3)
+        if case let .layerDivider(divider) = segments[1] {
+            XCTAssertEqual(divider.layerName, "nav")
+        } else {
+            XCTFail("Expected layer divider")
+        }
+    }
+
+    // MARK: - Event Cards
+
+    func testTapHoldCreatesEventCard() {
+        let events = [
+            makeKeyInput(key: "a"),
+            makeHoldActivated(key: "caps", action: "lctl"),
+            makeKeyInput(key: "b"),
+        ]
+        let segments = TimelineGrouper.group(events, currentLayer: "base")
+        XCTAssertEqual(segments.count, 3)
+        if case let .eventCard(card) = segments[1],
+           case let .tapHold(data) = card.cardKind
+        {
+            XCTAssertEqual(data.key, "caps")
+            XCTAssertTrue(data.isHold)
+        } else {
+            XCTFail("Expected tap-hold event card")
+        }
+    }
+
+    func testEmptyInputProducesNoSegments() {
+        let segments = TimelineGrouper.group([], currentLayer: "base")
+        XCTAssertTrue(segments.isEmpty)
+    }
+
+    func testSpecialCharacterMapping() {
+        let events = [
+            makeKeyInput(key: "spc"),
+            makeKeyInput(key: "comm"),
+            makeKeyInput(key: "dot"),
+        ]
+        let segments = TimelineGrouper.group(events, currentLayer: "base")
+        XCTAssertEqual(segments.count, 1)
+        if case let .textRun(run) = segments.first {
+            XCTAssertEqual(run.characters.map(\.displayChar).joined(), " ,.")
+        } else {
+            XCTFail("Expected text run")
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a new **History** tab to the overlay sidebar that shows a smart timeline of kanata events for debugging tap-hold misfires and home row mod timing
- Normal typing collapses into readable text runs with per-character hover popovers (key name, layer, timing interval)
- Interesting events (tap-hold decisions, layer switches, chords, one-shots) appear as inline cards with reason pills, color-coded latency visualization, and near-threshold warnings
- Updates kanata submodule to include ChordResolved and TapDanceResolved TCP events (fork PR #17)

### New files (9)
| File | Purpose |
|------|---------|
| `KeystrokeTimelineEvent.swift` | Unified timeline event model with 8 event kinds |
| `KeystrokeHistoryService.swift` | Event ingestion from all kanata notifications, 2000-event buffer, 100ms batch debounce, threshold lookup |
| `TimelineGrouper.swift` | Text run grouping algorithm + segment models |
| `KeystrokeHistoryView.swift` | Main scrollable timeline with auto-scroll and recording controls |
| `KeystrokeHistorySegments.swift` | TextRunView, EventCardView, LayerDividerView |
| `KeystrokeCharacterPopover.swift` | Per-character hover popover |
| `OverlayInspectorPanel+History.swift` | Tab content extension |
| `KeystrokeHistoryServiceTests.swift` | 11 service tests |
| `TimelineGrouperTests.swift` | 8 grouper tests |

### Modified files (3)
- `OverlayInspectorTypes.swift` — add `case history` to `InspectorSection`
- `InspectorPanelToolbar.swift` — add History tab button
- `LiveKeyboardOverlayView+Inspector.swift` — add content routing

## Test plan
- [x] `swift build` — compiles cleanly
- [x] `swift test` — all 19 new tests pass, no regressions
- [ ] Open overlay sidebar → History tab visible with clock icon
- [ ] Type characters → see readable text runs appearing
- [ ] Trigger a tap-hold key → see TAP/HOLD card with reason pill and latency
- [ ] Switch layers → see layer divider with name
- [ ] Hover individual characters → see popover with key, layer, time, interval
- [ ] Pause/resume recording toggle works
- [ ] Clear button empties the timeline