### PR TITLE
fix: resilient config decode preserves user settings across builds

### DIFF
--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionStore.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionStore.swift
@@ -13,9 +13,36 @@ actor RuleCollectionStore {
     private let fileManager: FileManager
     private let catalog: RuleCollectionCatalog
 
+    struct LoadResult: Sendable {
+        var collections: [RuleCollection]
+        var failedCollectionNames: [String]
+        var wasFullReset: Bool
+        var backupPath: String?
+    }
+
     private struct VersionedCollections: Codable {
         var schemaVersion: Int
         var collections: [RuleCollection]
+    }
+
+    private struct PartialCollection: Decodable {
+        var id: UUID?
+        var name: String?
+
+        private enum CodingKeys: String, CodingKey {
+            case id, name
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            id = try? container.decode(UUID.self, forKey: .id)
+            name = try? container.decode(String.self, forKey: .name)
+        }
+    }
+
+    private struct VersionedPartial: Decodable {
+        var schemaVersion: Int?
+        var collections: [FailableDecodable<RuleCollection>]
     }
 
     init(
@@ -37,34 +64,129 @@ actor RuleCollectionStore {
     }
 
     func loadCollections() -> [RuleCollection] {
+        loadCollectionsDetailed().collections
+    }
+
+    func loadCollectionsDetailed() -> LoadResult {
         guard fileManager.fileExists(atPath: fileURL.path) else {
-            return catalog.defaultCollections()
+            return LoadResult(collections: catalog.defaultCollections(), failedCollectionNames: [], wasFullReset: false)
         }
 
+        let data: Data
         do {
-            let data = try Data(contentsOf: fileURL)
-            let collections: [RuleCollection]
-            if let versioned = try? decoder.decode(VersionedCollections.self, from: data) {
-                collections = versioned.collections
-            } else {
-                collections = try decoder.decode([RuleCollection].self, from: data)
-            }
-
-            var upgraded = collections
-                .filter { $0.id != RuleCollectionIdentifier.typingSounds }
-                .map { catalog.upgradedCollection(from: $0) }
-
-            let defaults = catalog.defaultCollections()
-            for collection in defaults where !upgraded.contains(where: { $0.id == collection.id }) {
-                upgraded.append(collection)
-            }
-
-            return upgraded
+            data = try Data(contentsOf: fileURL)
         } catch {
             AppLogger.shared.log(
-                "⚠️ [RuleCollectionStore] Failed to load collections: \(error). Falling back to defaults."
+                "⚠️ [RuleCollectionStore] Failed to read file: \(error). Falling back to defaults."
             )
-            return catalog.defaultCollections()
+            return LoadResult(collections: catalog.defaultCollections(), failedCollectionNames: [], wasFullReset: true)
+        }
+
+        // Fast path: try atomic decode of all collections
+        if let result = try? decodeAllCollections(from: data) {
+            return LoadResult(collections: result, failedCollectionNames: [], wasFullReset: false)
+        }
+
+        // Slow path: per-collection resilient decode
+        AppLogger.shared.log("⚠️ [RuleCollectionStore] Atomic decode failed, trying per-collection recovery...")
+        let backupPath = backupBeforeFallback()
+        var result = decodeCollectionsResiliently(from: data)
+        result.backupPath = backupPath
+        return result
+    }
+
+    private func decodeAllCollections(from data: Data) throws -> [RuleCollection] {
+        let collections: [RuleCollection] = if let versioned = try? decoder.decode(VersionedCollections.self, from: data) {
+            versioned.collections
+        } else {
+            try decoder.decode([RuleCollection].self, from: data)
+        }
+        return upgradeAndMergeDefaults(collections)
+    }
+
+    private func decodeCollectionsResiliently(from data: Data) -> LoadResult {
+        var recovered: [RuleCollection] = []
+        var failedNames: [String] = []
+
+        // Try versioned wrapper with per-element failable decode
+        let elements: [FailableDecodable<RuleCollection>]
+        if let versioned = try? decoder.decode(VersionedPartial.self, from: data) {
+            elements = versioned.collections
+        } else if let plain = try? decoder.decode([FailableDecodable<RuleCollection>].self, from: data) {
+            elements = plain
+        } else {
+            // JSON structure itself is broken — try to extract names for reporting
+            let partialNames = extractPartialNames(from: data)
+            AppLogger.shared.log(
+                "⚠️ [RuleCollectionStore] JSON structure unreadable. Full reset to defaults."
+            )
+            return LoadResult(
+                collections: catalog.defaultCollections(),
+                failedCollectionNames: partialNames,
+                wasFullReset: true
+            )
+        }
+
+        // Pair each failable result with a partial decode for the name
+        let partials = (try? decoder.decode(VersionedPartialNames.self, from: data))?.collections
+            ?? (try? decoder.decode([PartialCollection].self, from: data))
+            ?? []
+
+        for (index, element) in elements.enumerated() {
+            if let collection = element.value {
+                recovered.append(collection)
+            } else {
+                let name = (index < partials.count ? partials[index].name : nil) ?? "Unknown (#\(index + 1))"
+                failedNames.append(name)
+                AppLogger.shared.log(
+                    "⚠️ [RuleCollectionStore] Failed to decode collection '\(name)' — using catalog default"
+                )
+            }
+        }
+
+        let upgraded = upgradeAndMergeDefaults(recovered)
+        return LoadResult(collections: upgraded, failedCollectionNames: failedNames, wasFullReset: false)
+    }
+
+    private func extractPartialNames(from data: Data) -> [String] {
+        if let versioned = try? decoder.decode(VersionedPartialNames.self, from: data) {
+            return versioned.collections.compactMap(\.name)
+        }
+        if let partials = try? decoder.decode([PartialCollection].self, from: data) {
+            return partials.compactMap(\.name)
+        }
+        return []
+    }
+
+    private func upgradeAndMergeDefaults(_ collections: [RuleCollection]) -> [RuleCollection] {
+        var upgraded = collections
+            .filter { $0.id != RuleCollectionIdentifier.typingSounds }
+            .map { catalog.upgradedCollection(from: $0) }
+
+        let defaults = catalog.defaultCollections()
+        for collection in defaults where !upgraded.contains(where: { $0.id == collection.id }) {
+            upgraded.append(collection)
+        }
+        return upgraded
+    }
+
+    @discardableResult
+    private func backupBeforeFallback() -> String? {
+        guard fileManager.fileExists(atPath: fileURL.path) else { return nil }
+        let backupDir = fileURL.deletingLastPathComponent().appendingPathComponent(".backups")
+        try? fileManager.createDirectory(at: backupDir, withIntermediateDirectories: true)
+
+        let timestamp = ISO8601DateFormatter().string(from: Date())
+            .replacingOccurrences(of: ":", with: "-")
+        let backupURL = backupDir.appendingPathComponent("RuleCollections-\(timestamp).json")
+
+        do {
+            try fileManager.copyItem(at: fileURL, to: backupURL)
+            AppLogger.shared.log("📦 [RuleCollectionStore] Backed up config to \(backupURL.lastPathComponent)")
+            return backupURL.path
+        } catch {
+            AppLogger.shared.log("⚠️ [RuleCollectionStore] Failed to backup: \(error)")
+            return nil
         }
     }
 
@@ -77,6 +199,23 @@ actor RuleCollectionStore {
         )
         let data = try encoder.encode(versioned)
         try data.write(to: fileURL, options: .atomic)
+    }
+
+    // MARK: - Helper Types
+
+    private struct VersionedPartialNames: Decodable {
+        var collections: [PartialCollection]
+    }
+}
+
+/// Wraps a Decodable type so that individual elements in an array can fail without
+/// breaking the entire array decode.
+struct FailableDecodable<T: Decodable>: Decodable {
+    let value: T?
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        value = try? container.decode(T.self)
     }
 }
 

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+Bootstrap.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+Bootstrap.swift
@@ -10,15 +10,19 @@ extension RuleCollectionsManager {
         // Restore keymap state first (before loading collections)
         restoreKeymapState()
 
-        async let storedCollectionsTask = ruleCollectionStore.loadCollections()
+        async let storedCollectionsTask = ruleCollectionStore.loadCollectionsDetailed()
         async let storedCustomRulesTask = customRulesStore.loadRules()
 
-        let storedCollections = await storedCollectionsTask
+        let loadResult = await storedCollectionsTask
         let storedCustomRules = await storedCustomRulesTask
 
-        ruleCollections = RuleCollectionDeduplicator.dedupe(storedCollections)
+        ruleCollections = RuleCollectionDeduplicator.dedupe(loadResult.collections)
         customRules = storedCustomRules
         AppLogger.shared.log("📊 [RuleCollectionsManager] bootstrap: loaded \(customRules.count) custom rules from store")
+
+        if !loadResult.failedCollectionNames.isEmpty || loadResult.wasFullReset {
+            notifyConfigRecovery(loadResult)
+        }
 
         ensureDefaultCollectionsIfNeeded()
 
@@ -75,6 +79,38 @@ extension RuleCollectionsManager {
 
         if fixedCount > 0 {
             AppLogger.shared.log("🔧 [Bootstrap] Pack reconciliation fixed \(fixedCount) collection(s)")
+        }
+    }
+
+    // MARK: - Config Recovery Notification
+
+    private func notifyConfigRecovery(_ result: RuleCollectionStore.LoadResult) {
+        let backupNote = result.backupPath != nil ? " Your previous config was backed up." : ""
+
+        if result.wasFullReset {
+            let body = "All rule configurations were reset to defaults.\(backupNote)"
+            AppLogger.shared.log("⚠️ [Bootstrap] Full config reset. Backup: \(result.backupPath ?? "none")")
+            Task { @MainActor in
+                UserNotificationService.shared.notifyConfigEvent(
+                    "Configuration Reset",
+                    body: body,
+                    key: "config.reset.full"
+                )
+            }
+        } else {
+            let names = result.failedCollectionNames
+            let summary = names.count <= 3
+                ? names.joined(separator: ", ")
+                : "\(names.prefix(3).joined(separator: ", ")) and \(names.count - 3) more"
+            let body = "\(summary) reset to defaults after an update.\(backupNote)"
+            AppLogger.shared.log("⚠️ [Bootstrap] Partial config recovery: \(names.joined(separator: ", "))")
+            Task { @MainActor in
+                UserNotificationService.shared.notifyConfigEvent(
+                    "\(names.count) Rule\(names.count == 1 ? "" : "s") Reset",
+                    body: body,
+                    key: "config.reset.partial"
+                )
+            }
         }
     }
 }

--- a/Tests/KeyPathTests/RuleCollections/RuleCollectionStoreTests.swift
+++ b/Tests/KeyPathTests/RuleCollections/RuleCollectionStoreTests.swift
@@ -132,6 +132,154 @@ final class RuleCollectionStoreTests: XCTestCase {
         XCTAssertEqual(loadedIDs, defaultIDs, "Versioned round-trip should preserve all collections")
     }
 
+    // MARK: - Resilient Decode Tests
+
+    func testLoadRecoversSurvivingCollectionsWhenOneIsBroken() async throws {
+        let tempDir = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("rule-collections-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        let fileURL = tempDir.appendingPathComponent("collections.json")
+
+        // Build a versioned JSON with one valid collection and one broken one
+        let catalog = RuleCollectionCatalog()
+        let validCollection = try XCTUnwrap(catalog.defaultCollections().first { $0.id == RuleCollectionIdentifier.macFunctionKeys })
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let validData = try encoder.encode(validCollection)
+        let validJSON = try XCTUnwrap(try JSONSerialization.jsonObject(with: validData) as? [String: Any])
+
+        // Broken collection: category is an int (should be string), causing decode failure
+        let brokenCollection: [String: Any] = [
+            "id": RuleCollectionIdentifier.homeRowMods.uuidString,
+            "name": "Home Row Mods",
+            "summary": "Test",
+            "category": 999,
+            "mappings": [],
+            "isEnabled": true,
+            "isSystemDefault": false
+        ]
+
+        let versioned: [String: Any] = [
+            "schemaVersion": 1,
+            "collections": [validJSON, brokenCollection]
+        ]
+        let data = try JSONSerialization.data(withJSONObject: versioned)
+        try data.write(to: fileURL)
+
+        let store = RuleCollectionStore.testStore(at: fileURL)
+        let result = await store.loadCollectionsDetailed()
+
+        // The valid collection should survive
+        XCTAssertTrue(
+            result.collections.contains { $0.id == RuleCollectionIdentifier.macFunctionKeys },
+            "Valid collection should be preserved"
+        )
+        // The broken one should be reported
+        XCTAssertEqual(result.failedCollectionNames, ["Home Row Mods"])
+        XCTAssertFalse(result.wasFullReset)
+    }
+
+    func testLoadCreatesBackupWhenDecodePartiallyFails() async throws {
+        let tempDir = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("rule-collections-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        let fileURL = tempDir.appendingPathComponent("collections.json")
+
+        // Write versioned JSON with a broken collection (category is wrong type)
+        let brokenCollection: [String: Any] = [
+            "id": UUID().uuidString,
+            "name": "Broken Rule",
+            "summary": "Will fail",
+            "category": 999,
+            "mappings": [],
+            "isEnabled": true,
+            "isSystemDefault": false
+        ]
+        let versioned: [String: Any] = [
+            "schemaVersion": 1,
+            "collections": [brokenCollection]
+        ]
+        let data = try JSONSerialization.data(withJSONObject: versioned)
+        try data.write(to: fileURL)
+
+        let store = RuleCollectionStore.testStore(at: fileURL)
+        let result = await store.loadCollectionsDetailed()
+
+        XCTAssertNotNil(result.backupPath, "Backup should be created when decode fails")
+        if let path = result.backupPath {
+            XCTAssertTrue(FileManager.default.fileExists(atPath: path), "Backup file should exist on disk")
+        }
+    }
+
+    func testLoadReturnsDefaultsForCompletelyCorruptFile() async throws {
+        let tempDir = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("rule-collections-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        let fileURL = tempDir.appendingPathComponent("collections.json")
+
+        // Write garbage data
+        try try XCTUnwrap("this is not json at all".data(using: .utf8)?.write(to: fileURL))
+
+        let store = RuleCollectionStore.testStore(at: fileURL)
+        let result = await store.loadCollectionsDetailed()
+
+        XCTAssertFalse(result.collections.isEmpty, "Should fall back to catalog defaults")
+        XCTAssertTrue(result.wasFullReset, "Should report full reset for unreadable file")
+        XCTAssertNotNil(result.backupPath, "Should backup even on full reset")
+    }
+
+    func testLoadPreservesEnabledStateWhenSiblingCollectionFails() async throws {
+        let tempDir = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("rule-collections-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        let fileURL = tempDir.appendingPathComponent("collections.json")
+
+        let catalog = RuleCollectionCatalog()
+        // Take a normally-disabled collection and enable it
+        var capsLock = try XCTUnwrap(catalog.defaultCollections().first { $0.id == RuleCollectionIdentifier.capsLockRemap })
+        capsLock = RuleCollection(
+            id: capsLock.id,
+            name: capsLock.name,
+            summary: capsLock.summary,
+            category: capsLock.category,
+            mappings: capsLock.mappings,
+            isEnabled: true,
+            isSystemDefault: capsLock.isSystemDefault,
+            icon: capsLock.icon,
+            configuration: capsLock.configuration
+        )
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let validJSON = try XCTUnwrap(try JSONSerialization.jsonObject(
+            with: encoder.encode(capsLock)
+        ) as? [String: Any])
+
+        let brokenJSON: [String: Any] = [
+            "id": UUID().uuidString,
+            "name": "Broken",
+            "summary": "x",
+            "category": 999,
+            "mappings": [],
+            "isEnabled": true,
+            "isSystemDefault": false
+        ]
+
+        let versioned: [String: Any] = [
+            "schemaVersion": 1,
+            "collections": [validJSON, brokenJSON]
+        ]
+        try JSONSerialization.data(withJSONObject: versioned).write(to: fileURL)
+
+        let store = RuleCollectionStore.testStore(at: fileURL)
+        let result = await store.loadCollectionsDetailed()
+
+        let capsResult = result.collections.first { $0.id == RuleCollectionIdentifier.capsLockRemap }
+        XCTAssertNotNil(capsResult)
+        XCTAssertTrue(capsResult?.isEnabled == true, "Enabled state should survive sibling decode failure")
+    }
+
     func testLoadAddsMissingCatalogDefaultsWhenFileHasSubset() async throws {
         let tempDir = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
             .appendingPathComponent("rule-collections-\(UUID().uuidString)")


### PR DESCRIPTION
## Summary
- **Per-collection resilient decoding**: If any `RuleCollection` fails to decode (e.g., after a model change between builds), only that collection resets to defaults — surviving collections keep their user config (enabled state, HRM timing, pack customizations)
- **Automatic backup**: Before any fallback, the existing `RuleCollections.json` is copied to `~/.config/keypath/.backups/RuleCollections-<timestamp>.json`
- **User notification**: A macOS notification tells the user which rules were reset (e.g., "Home Row Mods reset to defaults after an update")

## Problem
Previously, a single decode failure in _any_ collection caused the _entire_ `RuleCollections.json` to be silently discarded and replaced with catalog defaults. This meant every dev build that changed a Codable model would wipe all user settings.

## Test plan
- [x] New test: surviving collections preserved when a sibling fails to decode
- [x] New test: backup file created on partial decode failure
- [x] New test: full defaults returned for completely corrupt JSON
- [x] New test: enabled state preserved across sibling decode failure
- [x] All 532+ existing tests pass
- [x] Build succeeds with no new warnings