### PR TITLE
fix: init keystroke history at startup, add recording dot

### DIFF
--- a/Sources/KeyPathAppKit/Managers/RuntimeCoordinator.swift
+++ b/Sources/KeyPathAppKit/Managers/RuntimeCoordinator.swift
@@ -437,6 +437,7 @@ public class RuntimeCoordinator: SaveCoordinatorDelegate {
                 ruleCollectionsManager.startEventMonitoring(port: PreferencesService.shared.tcpServerPort)
             }
             HrmObservabilityService.shared.startMonitoring(port: PreferencesService.shared.tcpServerPort)
+            _ = KeystrokeHistoryService.shared
         } else {
             AppLogger.shared.log("🧪 [RuntimeCoordinator] One-shot probe mode - skipping bootstrap and event monitoring")
         }

--- a/Sources/KeyPathAppKit/UI/Overlay/InspectorPanelToolbar.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/InspectorPanelToolbar.swift
@@ -240,6 +240,14 @@ struct InspectorPanelToolbar: View {
                 onHover: { isHoveringHistory = $0 },
                 action: { onSelectSection(.history) }
             )
+            .overlay(alignment: .topTrailing) {
+                if KeystrokeHistoryService.shared.isRecording {
+                    Circle()
+                        .fill(.red)
+                        .frame(width: 5, height: 5)
+                        .offset(x: -2, y: 4)
+                }
+            }
             .accessibilityIdentifier("inspector-tab-history")
             .accessibilityLabel("Keystroke History")
             .help("Keystroke History")


### PR DESCRIPTION
## Summary
- Initialize `KeystrokeHistoryService.shared` at startup in `RuntimeCoordinator` so it captures events from the beginning, not just when the tab is first opened
- Add a subtle red recording dot on the History tab icon when recording is active

## Test plan
- [x] `swift build` clean
- [ ] Open overlay → History tab shows events from typing (not 0)
- [ ] Red dot visible on History tab icon
- [ ] Pause recording → dot disappears