### PR TITLE
fix: collapse repeat keys, fix event counter, add key symbols

### DIFF
--- a/Sources/KeyPathAppKit/Services/Monitoring/KeystrokeHistoryService.swift
+++ b/Sources/KeyPathAppKit/Services/Monitoring/KeystrokeHistoryService.swift
@@ -13,6 +13,7 @@ final class KeystrokeHistoryService {
 
     private(set) var segments: [TimelineSegment] = []
     private(set) var currentLayer: String = "base"
+    private(set) var eventCount: Int = 0
     var isRecording: Bool = true
 
     @ObservationIgnored private var rawEvents: [KeystrokeTimelineEvent] = []
@@ -275,6 +276,7 @@ final class KeystrokeHistoryService {
             rawEvents.removeFirst(rawEvents.count - maxEvents)
         }
 
+        eventCount = rawEvents.count
         rebuildSegments()
     }
 
@@ -305,10 +307,7 @@ final class KeystrokeHistoryService {
         pendingEvents.removeAll()
         batchTimer?.invalidate()
         batchTimer = nil
+        eventCount = 0
         segments = []
-    }
-
-    var eventCount: Int {
-        rawEvents.count
     }
 }

--- a/Sources/KeyPathAppKit/Services/Monitoring/TimelineGrouper.swift
+++ b/Sources/KeyPathAppKit/Services/Monitoring/TimelineGrouper.swift
@@ -50,7 +50,7 @@ enum EventCardKind {
     case oneShot(OneShotPayload)
     case chord(ChordPayload)
     case tapDance(TapDancePayload)
-    case nonPrintableKey(key: String, action: KanataKeyAction)
+    case nonPrintableKey(key: String, count: Int)
 }
 
 struct TapHoldCardData {
@@ -79,6 +79,30 @@ struct LayerDividerSegment: Identifiable {
 // MARK: - Grouper
 
 enum TimelineGrouper {
+    static let nonPrintableDisplayNames: [String: String] = [
+        "bspc": "⌫",
+        "backspace": "⌫",
+        "del": "⌦",
+        "delete": "⌦",
+        "esc": "⎋",
+        "escape": "⎋",
+        "ret": "↩",
+        "enter": "↩",
+        "return": "↩",
+        "left": "←",
+        "right": "→",
+        "up": "↑",
+        "down": "↓",
+        "home": "⇱",
+        "end": "⇲",
+        "pgup": "⇞",
+        "pgdn": "⇟",
+        "caps": "⇪",
+        "f1": "F1", "f2": "F2", "f3": "F3", "f4": "F4",
+        "f5": "F5", "f6": "F6", "f7": "F7", "f8": "F8",
+        "f9": "F9", "f10": "F10", "f11": "F11", "f12": "F12",
+    ]
+
     private static let printableKeys: [String: String] = {
         var map: [String: String] = [:]
         for c in "abcdefghijklmnopqrstuvwxyz" {
@@ -146,11 +170,23 @@ enum TimelineGrouper {
                     ))
                 } else {
                     flushTextRun()
-                    segments.append(.eventCard(EventCardSegment(
-                        id: event.id,
-                        timestamp: event.timestamp,
-                        cardKind: .nonPrintableKey(key: payload.key, action: payload.action)
-                    )))
+                    if let last = segments.last,
+                       case let .eventCard(card) = last,
+                       case let .nonPrintableKey(lastKey, lastCount) = card.cardKind,
+                       lastKey == payload.key
+                    {
+                        segments[segments.count - 1] = .eventCard(EventCardSegment(
+                            id: card.id,
+                            timestamp: card.timestamp,
+                            cardKind: .nonPrintableKey(key: payload.key, count: lastCount + 1)
+                        ))
+                    } else {
+                        segments.append(.eventCard(EventCardSegment(
+                            id: event.id,
+                            timestamp: event.timestamp,
+                            cardKind: .nonPrintableKey(key: payload.key, count: 1)
+                        )))
+                    }
                 }
 
             case let .layerChanged(payload):

--- a/Sources/KeyPathAppKit/UI/Overlay/KeystrokeHistorySegments.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/KeystrokeHistorySegments.swift
@@ -68,8 +68,8 @@ struct EventCardView: View {
                 chordCard(data)
             case let .tapDance(data):
                 tapDanceCard(data)
-            case let .nonPrintableKey(key, _):
-                nonPrintableCard(key: key)
+            case let .nonPrintableKey(key, count):
+                nonPrintableCard(key: key, count: count)
             }
         }
         .padding(.vertical, 2)
@@ -239,18 +239,26 @@ struct EventCardView: View {
 
     // MARK: - Non-Printable Key Card
 
-    private func nonPrintableCard(key: String) -> some View {
-        Text(key)
-            .font(.system(size: 10, weight: .medium, design: .monospaced))
-            .foregroundStyle(.secondary)
-            .padding(.horizontal, 5)
-            .padding(.vertical, 2)
-            .background(
-                RoundedRectangle(cornerRadius: 3)
-                    .fill(isDark
-                        ? Color.white.opacity(0.06)
-                        : Color.black.opacity(0.04))
-            )
+    private func nonPrintableCard(key: String, count: Int) -> some View {
+        let displayName = TimelineGrouper.nonPrintableDisplayNames[key.lowercased()] ?? key
+        return HStack(spacing: 2) {
+            Text(displayName)
+                .font(.system(size: 11, weight: .medium, design: .monospaced))
+                .foregroundStyle(.secondary)
+            if count > 1 {
+                Text("\u{00D7}\(count)")
+                    .font(.system(size: 9, weight: .bold, design: .monospaced))
+                    .foregroundStyle(.tertiary)
+            }
+        }
+        .padding(.horizontal, 5)
+        .padding(.vertical, 2)
+        .background(
+            RoundedRectangle(cornerRadius: 3)
+                .fill(isDark
+                    ? Color.white.opacity(0.06)
+                    : Color.black.opacity(0.04))
+        )
     }
 
     // MARK: - Shared Components

--- a/Tests/KeyPathTests/Services/KeystrokeHistoryServiceTests.swift
+++ b/Tests/KeyPathTests/Services/KeystrokeHistoryServiceTests.swift
@@ -195,7 +195,7 @@ final class KeystrokeHistoryServiceTests: XCTestCase {
             XCTFail("Expected text run at index 0")
         }
         if case let .eventCard(card) = service.segments[1],
-           case let .nonPrintableKey(key, _) = card.cardKind
+           case let .nonPrintableKey(key, _count) = card.cardKind
         {
             XCTAssertEqual(key, "bspc")
         } else {


### PR DESCRIPTION
## Summary
- Consecutive non-printable keys (backspace, arrows, esc) collapse into a single card with count (e.g., `⌫ ×6` instead of 6 separate cards)
- Fix event counter showing "0 events" — was computed from `@ObservationIgnored` field, now a tracked `@Observable` property
- Add symbolic display names: `⌫` `⌦` `⎋` `↩` `←` `→` `↑` `↓` `⇪` `F1`–`F12`

## Test plan
- [x] `swift build` clean
- [x] 19 tests pass
- [ ] Type then press backspace several times → see `⌫ ×N` instead of repeated cards
- [ ] Event counter updates in real time
- [ ] Arrow keys show `← ×3` etc.