### PR TITLE
fix: group non-printable key runs, inline tap-activated space

### DIFF
--- a/Sources/KeyPathAppKit/Services/Monitoring/TimelineGrouper.swift
+++ b/Sources/KeyPathAppKit/Services/Monitoring/TimelineGrouper.swift
@@ -50,7 +50,7 @@ enum EventCardKind {
     case oneShot(OneShotPayload)
     case chord(ChordPayload)
     case tapDance(TapDancePayload)
-    case nonPrintableKey(key: String, count: Int)
+    case nonPrintableKeys(keys: [(key: String, count: Int)])
 }
 
 struct TapHoldCardData {
@@ -150,6 +150,30 @@ enum TimelineGrouper {
             currentTextRun = []
         }
 
+        func appendNonPrintable(key: String, id: UUID, timestamp: Date) {
+            if let last = segments.last,
+               case let .eventCard(card) = last,
+               case var .nonPrintableKeys(keys) = card.cardKind
+            {
+                if let lastIdx = keys.indices.last, keys[lastIdx].key == key {
+                    keys[lastIdx].count += 1
+                } else {
+                    keys.append((key: key, count: 1))
+                }
+                segments[segments.count - 1] = .eventCard(EventCardSegment(
+                    id: card.id,
+                    timestamp: card.timestamp,
+                    cardKind: .nonPrintableKeys(keys: keys)
+                ))
+            } else {
+                segments.append(.eventCard(EventCardSegment(
+                    id: id,
+                    timestamp: timestamp,
+                    cardKind: .nonPrintableKeys(keys: [(key: key, count: 1)])
+                )))
+            }
+        }
+
         for event in events {
             switch event.kind {
             case let .keyInput(payload):
@@ -170,23 +194,7 @@ enum TimelineGrouper {
                     ))
                 } else {
                     flushTextRun()
-                    if let last = segments.last,
-                       case let .eventCard(card) = last,
-                       case let .nonPrintableKey(lastKey, lastCount) = card.cardKind,
-                       lastKey == payload.key
-                    {
-                        segments[segments.count - 1] = .eventCard(EventCardSegment(
-                            id: card.id,
-                            timestamp: card.timestamp,
-                            cardKind: .nonPrintableKey(key: payload.key, count: lastCount + 1)
-                        ))
-                    } else {
-                        segments.append(.eventCard(EventCardSegment(
-                            id: event.id,
-                            timestamp: event.timestamp,
-                            cardKind: .nonPrintableKey(key: payload.key, count: 1)
-                        )))
-                    }
+                    appendNonPrintable(key: payload.key, id: event.id, timestamp: event.timestamp)
                 }
 
             case let .layerChanged(payload):
@@ -197,17 +205,28 @@ enum TimelineGrouper {
                 )))
 
             case let .tapActivated(payload):
-                flushTextRun()
-                segments.append(.eventCard(EventCardSegment(
-                    id: event.id,
-                    timestamp: event.timestamp,
-                    cardKind: .tapHold(TapHoldCardData(
-                        key: payload.key,
-                        outputAction: payload.outputAction,
-                        reason: payload.reason,
-                        isHold: false
+                if let displayChar = printableKeys[payload.outputAction.lowercased()] {
+                    currentTextRun.append(TextRunCharacter(
+                        id: event.id,
+                        displayChar: displayChar,
+                        rawKey: payload.key,
+                        timestamp: event.timestamp,
+                        layer: nil,
+                        kanataTimestamp: payload.kanataTimestamp
                     ))
-                )))
+                } else {
+                    flushTextRun()
+                    segments.append(.eventCard(EventCardSegment(
+                        id: event.id,
+                        timestamp: event.timestamp,
+                        cardKind: .tapHold(TapHoldCardData(
+                            key: payload.key,
+                            outputAction: payload.outputAction,
+                            reason: payload.reason,
+                            isHold: false
+                        ))
+                    )))
+                }
 
             case let .holdActivated(payload):
                 flushTextRun()

--- a/Sources/KeyPathAppKit/UI/Overlay/KeystrokeHistorySegments.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/KeystrokeHistorySegments.swift
@@ -68,8 +68,8 @@ struct EventCardView: View {
                 chordCard(data)
             case let .tapDance(data):
                 tapDanceCard(data)
-            case let .nonPrintableKey(key, count):
-                nonPrintableCard(key: key, count: count)
+            case let .nonPrintableKeys(keys):
+                nonPrintableCard(keys: keys)
             }
         }
         .padding(.vertical, 2)
@@ -239,16 +239,19 @@ struct EventCardView: View {
 
     // MARK: - Non-Printable Key Card
 
-    private func nonPrintableCard(key: String, count: Int) -> some View {
-        let displayName = TimelineGrouper.nonPrintableDisplayNames[key.lowercased()] ?? key
-        return HStack(spacing: 2) {
-            Text(displayName)
-                .font(.system(size: 11, weight: .medium, design: .monospaced))
-                .foregroundStyle(.secondary)
-            if count > 1 {
-                Text("\u{00D7}\(count)")
-                    .font(.system(size: 9, weight: .bold, design: .monospaced))
-                    .foregroundStyle(.tertiary)
+    private func nonPrintableCard(keys: [(key: String, count: Int)]) -> some View {
+        HStack(spacing: 4) {
+            ForEach(Array(keys.enumerated()), id: \.offset) { _, entry in
+                HStack(spacing: 1) {
+                    Text(TimelineGrouper.nonPrintableDisplayNames[entry.key.lowercased()] ?? entry.key)
+                        .font(.system(size: 11, weight: .medium, design: .monospaced))
+                        .foregroundStyle(.secondary)
+                    if entry.count > 1 {
+                        Text("\u{00D7}\(entry.count)")
+                            .font(.system(size: 9, weight: .bold, design: .monospaced))
+                            .foregroundStyle(.tertiary)
+                    }
+                }
             }
         }
         .padding(.horizontal, 5)

--- a/Tests/KeyPathTests/Services/KeystrokeHistoryServiceTests.swift
+++ b/Tests/KeyPathTests/Services/KeystrokeHistoryServiceTests.swift
@@ -195,9 +195,9 @@ final class KeystrokeHistoryServiceTests: XCTestCase {
             XCTFail("Expected text run at index 0")
         }
         if case let .eventCard(card) = service.segments[1],
-           case let .nonPrintableKey(key, _count) = card.cardKind
+           case let .nonPrintableKeys(keys) = card.cardKind
         {
-            XCTAssertEqual(key, "bspc")
+            XCTAssertEqual(keys.first?.key, "bspc")
         } else {
             XCTFail("Expected non-printable key card at index 1")
         }


### PR DESCRIPTION
## Summary
- Consecutive non-printable keys merge into a single card: `← ×2 ↑ →` on one line
- Tap-activated events with printable output (e.g., space from tap-hold) fold into text runs — "hi guys" stays on one line instead of breaking at each space

## Test plan
- [x] `swift build` clean, 19 tests pass
- [ ] Press arrows in different directions → see `← ×2 ↑ →` on one card
- [ ] Type "hi guys" with space as tap-hold → appears on one line