### PR TITLE
fix: inline tap-activated space into text runs

### DIFF
--- a/Sources/KeyPathAppKit/Services/Monitoring/TimelineGrouper.swift
+++ b/Sources/KeyPathAppKit/Services/Monitoring/TimelineGrouper.swift
@@ -205,7 +205,8 @@ enum TimelineGrouper {
                 )))
 
             case let .tapActivated(payload):
-                if let displayChar = printableKeys[payload.outputAction.lowercased()] {
+                let tapOutput = payload.outputAction.isEmpty ? payload.key : payload.outputAction
+                if let displayChar = printableKeys[tapOutput.lowercased()] {
                     currentTextRun.append(TextRunCharacter(
                         id: event.id,
                         displayChar: displayChar,


### PR DESCRIPTION
## Summary
- When kanata sends TapActivated with an empty `action` field (fork behavior — only sends `key`), fall back to the key name for printable character lookup
- Fixes "the quick" breaking into separate lines at each space tap

## Test plan
- [x] `swift build` clean, 19 tests pass
- [ ] Type "the quick brown fox" → appears on one line with spaces inline