### PR TITLE
feat: app icon on context switch, wrap non-printable key runs

### DIFF
--- a/Sources/KeyPathAppKit/Models/KeystrokeTimelineEvent.swift
+++ b/Sources/KeyPathAppKit/Models/KeystrokeTimelineEvent.swift
@@ -14,6 +14,7 @@ struct KeystrokeTimelineEvent: Identifiable {
         case oneShotActivated(OneShotPayload)
         case chordResolved(ChordPayload)
         case tapDanceResolved(TapDancePayload)
+        case appChanged(AppChangedPayload)
     }
 }
 
@@ -62,4 +63,9 @@ struct TapDancePayload {
     let key: String
     let tapCount: UInt8
     let action: String
+}
+
+struct AppChangedPayload {
+    let appName: String
+    let bundleIdentifier: String
 }

--- a/Sources/KeyPathAppKit/Services/Monitoring/KeystrokeHistoryService.swift
+++ b/Sources/KeyPathAppKit/Services/Monitoring/KeystrokeHistoryService.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 import KeyPathCore
 import Observation
@@ -20,6 +21,8 @@ final class KeystrokeHistoryService {
     @ObservationIgnored private var pendingEvents: [KeystrokeTimelineEvent] = []
     @ObservationIgnored private var batchTimer: Timer?
     @ObservationIgnored private let observers = NotificationObserverManager()
+    @ObservationIgnored private let workspaceObservers = NotificationObserverManager()
+    @ObservationIgnored private var lastBundleIdentifier: String?
     @ObservationIgnored private let notificationCenter: NotificationCenter
     @ObservationIgnored var thresholdLookup: (() -> (baseMs: Int, offsets: [String: Int]))?
 
@@ -191,6 +194,28 @@ final class KeystrokeHistoryService {
             )
             Task { @MainActor [weak self] in
                 self?.ingest(event)
+            }
+        }
+
+        workspaceObservers.observe(
+            NSWorkspace.didActivateApplicationNotification,
+            center: NSWorkspace.shared.notificationCenter
+        ) { [weak self] notification in
+            guard let self else { return }
+            guard let app = notification.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication,
+                  let bundleId = app.bundleIdentifier
+            else { return }
+            let appName = app.localizedName ?? bundleId
+            Task { @MainActor [weak self] in
+                guard let self, isRecording else { return }
+                guard bundleId != lastBundleIdentifier else { return }
+                lastBundleIdentifier = bundleId
+                let event = KeystrokeTimelineEvent(
+                    id: UUID(),
+                    timestamp: Date(),
+                    kind: .appChanged(AppChangedPayload(appName: appName, bundleIdentifier: bundleId))
+                )
+                ingest(event)
             }
         }
 

--- a/Sources/KeyPathAppKit/Services/Monitoring/TimelineGrouper.swift
+++ b/Sources/KeyPathAppKit/Services/Monitoring/TimelineGrouper.swift
@@ -6,12 +6,14 @@ enum TimelineSegment: Identifiable {
     case textRun(TextRunSegment)
     case eventCard(EventCardSegment)
     case layerDivider(LayerDividerSegment)
+    case appChanged(AppChangedSegment)
 
     var id: UUID {
         switch self {
         case let .textRun(s): s.id
         case let .eventCard(s): s.id
         case let .layerDivider(s): s.id
+        case let .appChanged(s): s.id
         }
     }
 
@@ -20,6 +22,7 @@ enum TimelineSegment: Identifiable {
         case let .textRun(s): s.characters.first?.timestamp ?? Date()
         case let .eventCard(s): s.timestamp
         case let .layerDivider(s): s.timestamp
+        case let .appChanged(s): s.timestamp
         }
     }
 }
@@ -74,6 +77,13 @@ struct LayerDividerSegment: Identifiable {
     let id = UUID()
     let timestamp: Date
     let layerName: String
+}
+
+struct AppChangedSegment: Identifiable {
+    let id = UUID()
+    let timestamp: Date
+    let appName: String
+    let bundleIdentifier: String
 }
 
 // MARK: - Grouper
@@ -292,6 +302,14 @@ enum TimelineGrouper {
                     id: event.id,
                     timestamp: event.timestamp,
                     cardKind: .tapDance(payload)
+                )))
+
+            case let .appChanged(payload):
+                flushTextRun()
+                segments.append(.appChanged(AppChangedSegment(
+                    timestamp: event.timestamp,
+                    appName: payload.appName,
+                    bundleIdentifier: payload.bundleIdentifier
                 )))
             }
         }

--- a/Sources/KeyPathAppKit/UI/Overlay/KeystrokeHistorySegments.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/KeystrokeHistorySegments.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 // MARK: - Text Run View
@@ -240,7 +241,7 @@ struct EventCardView: View {
     // MARK: - Non-Printable Key Card
 
     private func nonPrintableCard(keys: [(key: String, count: Int)]) -> some View {
-        HStack(spacing: 4) {
+        FlowLayout(spacing: 3) {
             ForEach(Array(keys.enumerated()), id: \.offset) { _, entry in
                 HStack(spacing: 1) {
                     Text(TimelineGrouper.nonPrintableDisplayNames[entry.key.lowercased()] ?? entry.key)
@@ -322,5 +323,34 @@ struct LayerDividerView: View {
         Rectangle()
             .fill(Color.secondary.opacity(0.2))
             .frame(height: 0.5)
+    }
+}
+
+// MARK: - App Changed View
+
+struct AppChangedView: View {
+    let segment: AppChangedSegment
+
+    var body: some View {
+        HStack(spacing: 6) {
+            if let icon = appIcon {
+                Image(nsImage: icon)
+                    .resizable()
+                    .frame(width: 14, height: 14)
+            }
+            Text(segment.appName)
+                .font(.system(size: 9, weight: .semibold))
+                .foregroundStyle(.secondary)
+            Spacer()
+        }
+        .padding(.vertical, 3)
+        .padding(.horizontal, 2)
+    }
+
+    private var appIcon: NSImage? {
+        guard let url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: segment.bundleIdentifier) else {
+            return nil
+        }
+        return NSWorkspace.shared.icon(forFile: url.path)
     }
 }

--- a/Sources/KeyPathAppKit/UI/Overlay/KeystrokeHistoryView.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/KeystrokeHistoryView.swift
@@ -112,6 +112,8 @@ struct KeystrokeHistoryView: View {
             EventCardView(segment: card, isDark: isDark)
         case let .layerDivider(divider):
             LayerDividerView(segment: divider)
+        case let .appChanged(app):
+            AppChangedView(segment: app)
         }
     }
 }


### PR DESCRIPTION
## Summary
- App context changes show a row with the app icon and name whenever the frontmost app changes during typing
- Non-printable key runs (arrows, backspace sequences) now wrap using FlowLayout instead of clipping at the edge

## Test plan
- [x] `swift build` clean, 19 tests pass
- [ ] Switch between apps while typing → see app icon + name appear in the timeline
- [ ] Press many arrow keys in sequence → keys wrap to next line instead of clipping