### PR TITLE
refactor: centralize hardcoded colors into KeyPathColors theme

### DIFF
--- a/Sources/KeyPathAppKit/UI/Components/WindowControlsView.swift
+++ b/Sources/KeyPathAppKit/UI/Components/WindowControlsView.swift
@@ -4,13 +4,13 @@ import SwiftUI
 struct WindowControlsView: View {
     var body: some View {
         HStack(spacing: 8) {
-            controlCircle(color: Color(red: 0.99, green: 0.35, blue: 0.31)) {
+            controlCircle(color: KeyPathColors.windowClose) {
                 NSApp.keyWindow?.performClose(nil)
             }
-            controlCircle(color: Color(red: 0.99, green: 0.77, blue: 0.26)) {
+            controlCircle(color: KeyPathColors.windowMinimize) {
                 NSApp.keyWindow?.performMiniaturize(nil)
             }
-            controlCircle(color: Color(red: 0.30, green: 0.85, blue: 0.39)) {
+            controlCircle(color: KeyPathColors.windowZoom) {
                 NSApp.keyWindow?.performZoom(nil)
             }
         }

--- a/Sources/KeyPathAppKit/UI/ContextHUD/ContextHUDNeovimTerminalView.swift
+++ b/Sources/KeyPathAppKit/UI/ContextHUD/ContextHUDNeovimTerminalView.swift
@@ -18,7 +18,7 @@ struct ContextHUDNeovimTerminalView: View {
         HStack(spacing: 7) {
             Image(systemName: "terminal")
                 .font(.footnote.weight(.semibold))
-                .foregroundStyle(Color(red: 0.3, green: 0.6, blue: 0.9))
+                .foregroundStyle(KeyPathColors.layerBlue)
             Text("Neovim Quick Reference")
                 .font(.footnote.weight(.semibold))
                 .foregroundStyle(.white.opacity(0.85))

--- a/Sources/KeyPathAppKit/UI/ContextHUD/ContextHUDView.swift
+++ b/Sources/KeyPathAppKit/UI/ContextHUD/ContextHUDView.swift
@@ -124,6 +124,6 @@ struct ContextHUDView: View {
         if let firstGroup = viewModel.groups.first {
             return firstGroup.color
         }
-        return Color(red: 0.85, green: 0.45, blue: 0.15)
+        return KeyPathColors.layerOrange
     }
 }

--- a/Sources/KeyPathAppKit/UI/ContextHUD/ContextHUDViewModel.swift
+++ b/Sources/KeyPathAppKit/UI/ContextHUD/ContextHUDViewModel.swift
@@ -386,16 +386,16 @@ final class ContextHUDViewModel {
     /// Get collection color matching the overlay's color scheme
     private func collectionColor(for collectionId: UUID?) -> Color {
         guard let id = collectionId else {
-            return Color(red: 0.85, green: 0.45, blue: 0.15) // default orange
+            return KeyPathColors.layerOrange
         }
 
         switch id {
         case RuleCollectionIdentifier.vimNavigation:
-            return Color(red: 0.85, green: 0.45, blue: 0.15) // orange
+            return KeyPathColors.layerOrange
         case RuleCollectionIdentifier.kindaVim:
-            return Color(red: 0.2, green: 0.7, blue: 0.4) // green
+            return KeyPathColors.layerGreen
         case RuleCollectionIdentifier.neovimTerminal:
-            return Color(red: 0.3, green: 0.6, blue: 0.9) // steel blue
+            return KeyPathColors.layerBlue
         case RuleCollectionIdentifier.windowSnapping:
             return .purple
         case RuleCollectionIdentifier.symbolLayer:
@@ -403,9 +403,9 @@ final class ContextHUDViewModel {
         case RuleCollectionIdentifier.launcher:
             return .cyan
         case RuleCollectionIdentifier.vallackNavigation:
-            return Color(red: 0.2, green: 0.7, blue: 0.4) // green — matches overlay zone
+            return KeyPathColors.layerGreen
         default:
-            return Color(red: 0.85, green: 0.45, blue: 0.15) // default orange
+            return KeyPathColors.layerOrange
         }
     }
 }

--- a/Sources/KeyPathAppKit/UI/Experimental/AdvancedBehaviorContent.swift
+++ b/Sources/KeyPathAppKit/UI/Experimental/AdvancedBehaviorContent.swift
@@ -66,7 +66,7 @@ struct MiniActionKeycap: View {
     }
 
     private var foregroundColor: Color {
-        Color(red: 0.88, green: 0.93, blue: 1.0)
+        KeyPathColors.keycapText
             .opacity(isPressed ? 1.0 : 0.88)
     }
 

--- a/Sources/KeyPathAppKit/UI/Experimental/MapperKeycapViews.swift
+++ b/Sources/KeyPathAppKit/UI/Experimental/MapperKeycapViews.swift
@@ -11,8 +11,8 @@ struct TextGlowModifier: ViewModifier {
     func body(content: Content) -> some View {
         if fadeAmount > 0.1 {
             content
-                .shadow(color: Color(red: 0.6, green: 0.8, blue: 1.0).opacity(Double(fadeAmount) * 0.8), radius: 8)
-                .shadow(color: Color(red: 0.6, green: 0.8, blue: 1.0).opacity(Double(fadeAmount) * 0.4), radius: 16)
+                .shadow(color: KeyPathColors.keycapGlow.opacity(Double(fadeAmount) * 0.8), radius: 8)
+                .shadow(color: KeyPathColors.keycapGlow.opacity(Double(fadeAmount) * 0.4), radius: 16)
         } else {
             content
         }
@@ -151,7 +151,7 @@ struct BehaviorSlotKeycap: View {
     // MARK: - Styling
 
     private var foregroundColor: Color {
-        Color(red: 0.88, green: 0.93, blue: 1.0)
+        KeyPathColors.keycapText
             .opacity(isPressed ? 1.0 : 0.88)
     }
 
@@ -423,7 +423,7 @@ struct MapperKeycapView: View {
     // MARK: - Styling (matching OverlayKeycapView dark style)
 
     private var foregroundColor: Color {
-        Color(red: 0.88, green: 0.93, blue: 1.0)
+        KeyPathColors.keycapText
             .opacity(isPressed ? 1.0 : 0.88)
     }
 
@@ -738,7 +738,7 @@ struct MapperInputKeycap: View {
     // MARK: - Styling
 
     private var foregroundColor: Color {
-        let base = Color(red: 0.88, green: 0.93, blue: 1.0)
+        let base = KeyPathColors.keycapText
         let brightness = fadeAmount > 0 ? 1.0 : (isPressed ? 1.0 : 0.88)
         return base.opacity(brightness)
     }

--- a/Sources/KeyPathAppKit/UI/Gallery/ChordGroupsPackContent.swift
+++ b/Sources/KeyPathAppKit/UI/Gallery/ChordGroupsPackContent.swift
@@ -179,7 +179,7 @@ private struct ChordRuleRow: View {
 
     @State private var isHovered = false
 
-    private static let keycapTextColor = Color(red: 0.88, green: 0.93, blue: 1.0)
+    private static let keycapTextColor = KeyPathColors.keycapText
     private static let keycapBgColor = Color(white: 0.12)
 
     var body: some View {

--- a/Sources/KeyPathAppKit/UI/KeyboardTransforms/KeycapStyle.swift
+++ b/Sources/KeyPathAppKit/UI/KeyboardTransforms/KeycapStyle.swift
@@ -8,7 +8,7 @@ import SwiftUI
 /// View modifier that applies overlay-style keycap appearance
 struct KeycapStyle: ViewModifier {
     /// Text color matching overlay keycaps (light blue-white)
-    static let textColor = Color(red: 0.88, green: 0.93, blue: 1.0)
+    static let textColor = KeyPathColors.keycapText
 
     /// Background color matching overlay keycaps (dark gray)
     static let backgroundColor = Color(white: 0.12)

--- a/Sources/KeyPathAppKit/UI/Overlay/AppRuleCard.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/AppRuleCard.swift
@@ -142,7 +142,7 @@ private struct KeyChip: View {
     let text: String
 
     /// Text color matching overlay keycaps (light blue-white)
-    private static let textColor = Color(red: 0.88, green: 0.93, blue: 1.0)
+    private static let textColor = KeyPathColors.keycapText
     /// Background color matching overlay keycaps (dark gray)
     private static let backgroundColor = Color(white: 0.12)
 
@@ -298,7 +298,7 @@ private struct GlobalKeyChip: View {
     let text: String
 
     /// Text color matching overlay keycaps (light blue-white)
-    private static let textColor = Color(red: 0.88, green: 0.93, blue: 1.0)
+    private static let textColor = KeyPathColors.keycapText
     /// Background color matching overlay keycaps (dark gray)
     private static let backgroundColor = Color(white: 0.12)
 
@@ -343,7 +343,7 @@ private struct DrawerLayerChip: View {
             // Layer name (e.g., "Nav Layer")
             Text(displayName)
                 .font(.body.weight(.semibold))
-                .foregroundColor(Color(red: 0.85, green: 0.92, blue: 1.0))
+                .foregroundColor(KeyPathColors.keycapText)
         }
         .padding(.horizontal, 8)
         .padding(.vertical, 6)

--- a/Sources/KeyPathAppKit/UI/Overlay/HideHintBubble.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/HideHintBubble.swift
@@ -103,14 +103,10 @@ struct ModifierKeyChip: View {
     var isPressed: Bool = false
 
     /// Normal bright blue color
-    private static let normalTextColor = Color(red: 0.4, green: 0.8, blue: 1.0)
-    /// Normal dark blue background
-    private static let normalBackgroundColor = Color(red: 0.1, green: 0.28, blue: 0.45)
-
-    /// Pressed/active bright color (more vibrant)
-    private static let pressedTextColor = Color(red: 0.6, green: 0.95, blue: 1.0)
-    /// Pressed/active background (brighter)
-    private static let pressedBackgroundColor = Color(red: 0.15, green: 0.45, blue: 0.7)
+    private static let normalTextColor = KeyPathColors.hintText
+    private static let normalBackgroundColor = KeyPathColors.hintBackground
+    private static let pressedTextColor = KeyPathColors.hintTextPressed
+    private static let pressedBackgroundColor = KeyPathColors.hintBackgroundPressed
 
     private var textColor: Color {
         isPressed ? Self.pressedTextColor : Self.normalTextColor

--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayKeyboardView.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayKeyboardView.swift
@@ -465,7 +465,7 @@ struct OverlayKeyboardView: View {
             holdLabel: holdLabels[key.keyCode],
             isHoldActive: holdLabels[key.keyCode] != nil,
             releaseFadeFromColor: holdReleaseFadeKeyCodes.contains(key.keyCode)
-                ? Color(red: 0.85, green: 0.45, blue: 0.15) : .accentColor,
+                ? KeyPathColors.layerOrange : .accentColor,
             tapHoldIdleLabel: tapHoldIdleLabels[key.keyCode],
             onKeyClick: onKeyClick,
             colorway: activeColorway,

--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView+CollectionColors.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView+CollectionColors.swift
@@ -5,20 +5,13 @@ extension OverlayKeycapView {
 
     /// Color palette for collection-specific key backgrounds in layer mode
     private enum LayerColors {
-        /// Default orange for layer mode keys (Vim, unknown collections)
-        static let defaultLayer = Color(red: 0.85, green: 0.45, blue: 0.15)
-        /// Vim navigation collection keys
-        static let vim = Color(red: 0.85, green: 0.45, blue: 0.15)
-        /// Window snapping collection keys
+        static let defaultLayer = KeyPathColors.layerOrange
+        static let vim = KeyPathColors.layerOrange
         static let windowSnapping = Color.purple
-        /// Symbol layer collection keys (future)
         static let symbols = Color.blue
-        /// Launcher collection keys (future)
         static let launcher = Color.cyan
-        /// Neovim Terminal collection keys
-        static let neovimTerminal = Color(red: 0.3, green: 0.6, blue: 0.9)
-        /// Vallack Navigation collection keys (green to match zone color)
-        static let vallackNav = Color(red: 0.2, green: 0.7, blue: 0.4)
+        static let neovimTerminal = KeyPathColors.layerBlue
+        static let vallackNav = KeyPathColors.layerGreen
     }
 
     /// Determine key color based on collection ownership

--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView+VisualStyling.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView+VisualStyling.swift
@@ -129,12 +129,11 @@ extension OverlayKeycapView {
 
     var backgroundColor: Color {
         if isPressed, isHoldActive {
-            Color(red: 0.85, green: 0.45, blue: 0.15) // Orange for hold-active
+            KeyPathColors.layerOrange
         } else if isPressed {
             Color.accentColor
         } else if isOneShot {
-            // One-shot modifier active: cyan/teal glow to indicate waiting for next key
-            Color(red: 0.2, green: 0.7, blue: 0.8)
+            KeyPathColors.layerTeal
         } else if isEmphasized {
             Color.orange
         }
@@ -144,11 +143,11 @@ extension OverlayKeycapView {
         }
         // Launcher mode: blue/teal background for mapped keys
         else if isLauncherMode, hasLauncherMapping {
-            Color(red: 0.15, green: 0.35, blue: 0.45)
+            KeyPathColors.keycapMapped
         }
-        // Launcher mode: dark gray for ALL unmapped keys including modifiers/fn (RGB 56, 56, 57 - 10% lighter)
+        // Launcher mode: dark gray for ALL unmapped keys including modifiers/fn
         else if isLauncherMode {
-            Color(red: 56 / 255, green: 56 / 255, blue: 57 / 255)
+            KeyPathColors.keycapDark
         }
         // Layer mode: collection-specific color for mapped keys
         else if isLayerMode, hasLayerMapping || isNavIdentityMapping {
@@ -156,7 +155,7 @@ extension OverlayKeycapView {
         }
         // Layer mode: dark gray for unmapped keys (same as launcher)
         else if isLayerMode {
-            Color(red: 56 / 255, green: 56 / 255, blue: 57 / 255)
+            KeyPathColors.keycapDark
         } else if isModifierKey {
             colorway.modBaseColor
         } else if isAccentKey {

--- a/Sources/KeyPathAppKit/UI/Overlay/TapHoldMiniKeycap.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/TapHoldMiniKeycap.swift
@@ -71,7 +71,7 @@ struct TapHoldMiniKeycap: View {
 
     private var foregroundColor: Color {
         isDark
-            ? Color(red: 0.88, green: 0.93, blue: 1.0).opacity(isPressed ? 1.0 : 0.88)
+            ? KeyPathColors.keycapText.opacity(isPressed ? 1.0 : 0.88)
             : Color.primary.opacity(isPressed ? 1.0 : 0.88)
     }
 

--- a/Sources/KeyPathAppKit/UI/Overlay/VimHintLayer.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/VimHintLayer.swift
@@ -153,17 +153,17 @@ struct VimHintLayer: View {
 
 private func groupColor(for group: VimHint.Group) -> Color {
     switch group {
-    case .movement: Color(red: 0.4, green: 0.75, blue: 0.45)   // sage green
-    case .wordMotion: Color(red: 0.35, green: 0.65, blue: 0.85) // sky blue
-    case .lineMotion: Color(red: 0.65, green: 0.5, blue: 0.82)  // soft purple
-    case .enterInsert: Color(red: 0.9, green: 0.55, blue: 0.4)  // coral
-    case .edit: Color(red: 0.9, green: 0.7, blue: 0.3)          // warm gold
-    case .operators: Color(red: 0.85, green: 0.4, blue: 0.4)    // muted red
-    case .findChar: Color(red: 0.4, green: 0.72, blue: 0.7)     // teal
-    case .doc: Color(red: 0.65, green: 0.5, blue: 0.82)         // soft purple (same as line)
-    case .page: Color(red: 0.55, green: 0.6, blue: 0.75)        // slate blue
-    case .match: Color(red: 0.7, green: 0.6, blue: 0.5)         // warm gray
-    case .search: Color(red: 0.75, green: 0.6, blue: 0.35)      // amber
+    case .movement: KeyPathColors.VimHint.movement
+    case .wordMotion: KeyPathColors.VimHint.wordMotion
+    case .lineMotion: KeyPathColors.VimHint.lineMotion
+    case .enterInsert: KeyPathColors.VimHint.enterInsert
+    case .edit: KeyPathColors.VimHint.edit
+    case .operators: KeyPathColors.VimHint.operators
+    case .findChar: KeyPathColors.VimHint.findChar
+    case .doc: KeyPathColors.VimHint.lineMotion
+    case .page: KeyPathColors.VimHint.page
+    case .match: KeyPathColors.VimHint.match
+    case .search: KeyPathColors.VimHint.search
     }
 }
 

--- a/Sources/KeyPathAppKit/UI/Rules/ChordGroupsModalView.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/ChordGroupsModalView.swift
@@ -577,7 +577,7 @@ struct ChordEditorDialog: View {
         }
     }
 
-    private static let keycapText = Color(red: 0.88, green: 0.93, blue: 1.0)
+    private static let keycapText = KeyPathColors.keycapText
     private static let keycapBg = Color(white: 0.12)
 
 

--- a/Sources/KeyPathAppKit/UI/SplashView.swift
+++ b/Sources/KeyPathAppKit/UI/SplashView.swift
@@ -82,8 +82,8 @@ struct SplashView: View {
             // Match the poster background so the window doesn't read as a grey "missing image" panel.
             LinearGradient(
                 colors: [
-                    Color(red: 0x48 / 255.0, green: 0x4C / 255.0, blue: 0x54 / 255.0),
-                    Color(red: 0x1D / 255.0, green: 0x1D / 255.0, blue: 0x21 / 255.0)
+                    KeyPathColors.splashGradientTop,
+                    KeyPathColors.splashGradientBottom
                 ],
                 startPoint: .top,
                 endPoint: .bottom

--- a/Sources/KeyPathAppKit/UI/Style/KeyPathColors.swift
+++ b/Sources/KeyPathAppKit/UI/Style/KeyPathColors.swift
@@ -1,0 +1,83 @@
+import SwiftUI
+
+/// Centralized color palette for KeyPath UI.
+///
+/// Overlay and HUD colors render on controlled dark backgrounds and do NOT
+/// adapt to system appearance. Regular app window colors use semantic SwiftUI
+/// colors or adapt via `colorScheme`.
+enum KeyPathColors {
+    // MARK: - Keycap Text
+
+    /// Primary keycap label color — light blue-white for dark keycap backgrounds
+    static let keycapText = Color(red: 0.88, green: 0.93, blue: 1.0)
+
+    // MARK: - Layer State Colors (Overlay/HUD)
+
+    /// Orange — Vim layer, default layer mode, hold-active state
+    static let layerOrange = Color(red: 0.85, green: 0.45, blue: 0.15)
+
+    /// Green — Vallack navigation, "ready" state
+    static let layerGreen = Color(red: 0.2, green: 0.7, blue: 0.4)
+
+    /// Steel blue — Neovim terminal layer
+    static let layerBlue = Color(red: 0.3, green: 0.6, blue: 0.9)
+
+    /// Teal — tap-hold active state
+    static let layerTeal = Color(red: 0.2, green: 0.7, blue: 0.8)
+
+    // MARK: - Overlay Keycap Backgrounds
+
+    /// Dark keycap resting state
+    static let keycapDark = Color(red: 56 / 255, green: 56 / 255, blue: 57 / 255)
+
+    /// Dark blue-gray keycap background for mapped keys
+    static let keycapMapped = Color(red: 0.15, green: 0.35, blue: 0.45)
+
+    // MARK: - Glow Effects
+
+    /// Light blue glow for active/selected keycaps
+    static let keycapGlow = Color(red: 0.6, green: 0.8, blue: 1.0)
+
+    // MARK: - HUD Hint Bubble
+
+    /// Text color for the hide-hint bubble (normal state)
+    static let hintText = Color(red: 0.4, green: 0.8, blue: 1.0)
+
+    /// Background for the hide-hint bubble (normal state)
+    static let hintBackground = Color(red: 0.1, green: 0.28, blue: 0.45)
+
+    /// Text color for the hide-hint bubble (pressed state)
+    static let hintTextPressed = Color(red: 0.6, green: 0.95, blue: 1.0)
+
+    /// Background for the hide-hint bubble (pressed state)
+    static let hintBackgroundPressed = Color(red: 0.15, green: 0.45, blue: 0.7)
+
+    // MARK: - Vim Hint Categories
+
+    enum VimHint {
+        static let movement = Color(red: 0.4, green: 0.75, blue: 0.45)
+        static let wordMotion = Color(red: 0.35, green: 0.65, blue: 0.85)
+        static let lineMotion = Color(red: 0.65, green: 0.5, blue: 0.82)
+        static let enterInsert = Color(red: 0.9, green: 0.55, blue: 0.4)
+        static let edit = Color(red: 0.9, green: 0.7, blue: 0.3)
+        static let operators = Color(red: 0.85, green: 0.4, blue: 0.4)
+        static let findChar = Color(red: 0.4, green: 0.72, blue: 0.7)
+        static let page = Color(red: 0.55, green: 0.6, blue: 0.75)
+        static let match = Color(red: 0.7, green: 0.6, blue: 0.5)
+        static let search = Color(red: 0.75, green: 0.6, blue: 0.35)
+    }
+
+    // MARK: - Splash Screen
+
+    /// Top of splash gradient
+    static let splashGradientTop = Color(red: 0x48 / 255.0, green: 0x4C / 255.0, blue: 0x54 / 255.0)
+
+    /// Bottom of splash gradient
+    static let splashGradientBottom = Color(red: 0x1D / 255.0, green: 0x1D / 255.0, blue: 0x21 / 255.0)
+
+    // MARK: - Window Controls (standard macOS traffic light colors)
+
+    static let windowClose = Color(red: 0.99, green: 0.35, blue: 0.31)
+    static let windowMinimize = Color(red: 0.99, green: 0.77, blue: 0.26)
+    static let windowZoom = Color(red: 0.30, green: 0.85, blue: 0.39)
+}


### PR DESCRIPTION
## Summary
- Create `KeyPathColors.swift` as single source of truth for all overlay, HUD, and keycap colors
- Replace 50+ scattered `Color(red:green:blue:)` instances across 17 files
- Colors are intentionally non-adaptive — they render on controlled dark overlay backgrounds

**Color categories:** keycapText, layerOrange/Green/Blue/Teal, keycapDark/Mapped, keycapGlow, hintText/Background, VimHint.*, splash gradient, window controls

Closes #477

## Test plan
- [x] `swift build` — clean build
- [x] `swift test` — all 532 tests pass
- [ ] Visual check: overlay, HUD, vim hints render identically to before