### PR TITLE
fix: show app icon only on first keystroke in new app

### DIFF
--- a/Sources/KeyPathAppKit/Services/Monitoring/KeystrokeHistoryService.swift
+++ b/Sources/KeyPathAppKit/Services/Monitoring/KeystrokeHistoryService.swift
@@ -22,7 +22,9 @@ final class KeystrokeHistoryService {
     @ObservationIgnored private var batchTimer: Timer?
     @ObservationIgnored private let observers = NotificationObserverManager()
     @ObservationIgnored private let workspaceObservers = NotificationObserverManager()
-    @ObservationIgnored private var lastBundleIdentifier: String?
+    @ObservationIgnored private var currentAppBundleId: String?
+    @ObservationIgnored private var currentAppName: String?
+    @ObservationIgnored private var lastTypedAppBundleId: String?
     @ObservationIgnored private let notificationCenter: NotificationCenter
     @ObservationIgnored var thresholdLookup: (() -> (baseMs: Int, offsets: [String: Int]))?
 
@@ -207,15 +209,9 @@ final class KeystrokeHistoryService {
             else { return }
             let appName = app.localizedName ?? bundleId
             Task { @MainActor [weak self] in
-                guard let self, isRecording else { return }
-                guard bundleId != lastBundleIdentifier else { return }
-                lastBundleIdentifier = bundleId
-                let event = KeystrokeTimelineEvent(
-                    id: UUID(),
-                    timestamp: Date(),
-                    kind: .appChanged(AppChangedPayload(appName: appName, bundleIdentifier: bundleId))
-                )
-                ingest(event)
+                guard let self else { return }
+                currentAppBundleId = bundleId
+                currentAppName = appName
             }
         }
 
@@ -248,8 +244,34 @@ final class KeystrokeHistoryService {
             }
         }
 
+        // Insert app context divider when first keystroke arrives in a different app
+        if isKeystrokeEvent(event),
+           let appId = currentAppBundleId,
+           appId != lastTypedAppBundleId
+        {
+            lastTypedAppBundleId = appId
+            let appEvent = KeystrokeTimelineEvent(
+                id: UUID(),
+                timestamp: event.timestamp,
+                kind: .appChanged(AppChangedPayload(
+                    appName: currentAppName ?? appId,
+                    bundleIdentifier: appId
+                ))
+            )
+            pendingEvents.append(appEvent)
+        }
+
         pendingEvents.append(event)
         scheduleBatchFlush()
+    }
+
+    private func isKeystrokeEvent(_ event: KeystrokeTimelineEvent) -> Bool {
+        switch event.kind {
+        case .keyInput, .tapActivated, .holdActivated, .chordResolved, .tapDanceResolved:
+            true
+        case .layerChanged, .hrmDecision, .oneShotActivated, .appChanged:
+            false
+        }
     }
 
     private func isDuplicate(key: String, action: KanataKeyAction, timestamp: Date) -> Bool {


### PR DESCRIPTION
## Summary
App indicator now only appears when you actually type in a different app, not on every cmd-tab. The workspace observer tracks the frontmost app silently; the divider is inserted when the first keystroke event arrives in a new app context.

## Test plan
- [x] `swift build` clean, 19 tests pass
- [ ] Cmd-tab between apps without typing → no app dividers appear
- [ ] Switch to a different app and start typing → app icon + name appears once before the text