### PR TITLE
fix: propagate errors from PID file ops and process detection

### DIFF
--- a/Sources/KeyPathAppKit/Managers/RuntimeCoordinator.swift
+++ b/Sources/KeyPathAppKit/Managers/RuntimeCoordinator.swift
@@ -310,7 +310,11 @@ public class RuntimeCoordinator: SaveCoordinatorDelegate {
         if !TestEnvironment.isRunningTests, !isOneShotProbeMode {
             Task { [weak self] in
                 // Clean up any orphaned processes first
-                await self?.processLifecycleManager.cleanupOrphanedProcesses()
+                do {
+                    try await self?.processLifecycleManager.cleanupOrphanedProcesses()
+                } catch {
+                    AppLogger.shared.log("❌ [RuntimeCoordinator] Orphaned process cleanup failed: \(error)")
+                }
                 await self?.performInitialization()
             }
         } else {
@@ -620,14 +624,22 @@ public class RuntimeCoordinator: SaveCoordinatorDelegate {
         )
 
         // Clean up PID file
-        try? PIDFileManager.removePID()
+        do {
+            try PIDFileManager.removePID()
+        } catch {
+            AppLogger.shared.log("❌ [Cleanup] Failed to remove PID file: \(error)")
+        }
         AppLogger.shared.info("✅ [Cleanup] Synchronous cleanup complete")
     }
 
     private func checkExternalKanataProcess() async -> Bool {
-        // Delegate to ProcessLifecycleManager for conflict detection
-        let conflicts = await processLifecycleManager.detectConflicts()
-        return !conflicts.externalProcesses.isEmpty
+        do {
+            let conflicts = try await processLifecycleManager.detectConflicts()
+            return !conflicts.externalProcesses.isEmpty
+        } catch {
+            AppLogger.shared.log("❌ [RuntimeCoordinator] Process detection failed: \(error)")
+            return false
+        }
     }
 
     // MARK: - Installation and Permissions (delegates to SystemRequirementsChecker)

--- a/Sources/KeyPathAppKit/Services/Monitoring/DiagnosticsService.swift
+++ b/Sources/KeyPathAppKit/Services/Monitoring/DiagnosticsService.swift
@@ -425,7 +425,13 @@ final class DiagnosticsService: DiagnosticsServiceProtocol, @unchecked Sendable 
 
     func checkProcessConflicts() async -> [KanataDiagnostic] {
         var diagnostics: [KanataDiagnostic] = []
-        let conflicts = await processLifecycleManager.detectConflicts()
+        let conflicts: ProcessLifecycleManager.ConflictResolution
+        do {
+            conflicts = try await processLifecycleManager.detectConflicts()
+        } catch {
+            AppLogger.shared.log("❌ [Diagnostics] Process conflict detection failed: \(error)")
+            return diagnostics
+        }
 
         // Show managed processes (informational)
         if !conflicts.managedProcesses.isEmpty {

--- a/Sources/KeyPathAppKit/Services/Monitoring/ServiceHealthMonitor.swift
+++ b/Sources/KeyPathAppKit/Services/Monitoring/ServiceHealthMonitor.swift
@@ -484,7 +484,13 @@ final class ServiceHealthMonitor: ServiceHealthMonitorProtocol {
         }
 
         // Check process conflicts
-        let conflicts = await processLifecycle.detectConflicts()
+        let conflicts: ProcessLifecycleManager.ConflictResolution
+        do {
+            conflicts = try await processLifecycle.detectConflicts()
+        } catch {
+            AppLogger.shared.log("❌ [HealthMonitor] Process conflict detection failed: \(error)")
+            return .simpleRestart
+        }
         if conflicts.hasConflicts {
             AppLogger.shared.warn(
                 "[HealthMonitor] Process conflicts detected - recommend kill and restart"

--- a/Sources/KeyPathAppKit/Services/System/SystemValidator.swift
+++ b/Sources/KeyPathAppKit/Services/System/SystemValidator.swift
@@ -444,12 +444,18 @@ public class SystemValidator {
         var allConflicts: [SystemConflict] = []
 
         // Check for external kanata processes
-        let conflictResolution = await processLifecycleManager.detectConflicts()
-        allConflicts.append(
-            contentsOf: conflictResolution.externalProcesses.map { process in
-                .kanataProcessRunning(pid: Int(process.pid), command: process.command)
-            }
-        )
+        let conflictResolution: ProcessLifecycleManager.ConflictResolution
+        do {
+            conflictResolution = try await processLifecycleManager.detectConflicts()
+            allConflicts.append(
+                contentsOf: conflictResolution.externalProcesses.map { process in
+                    .kanataProcessRunning(pid: Int(process.pid), command: process.command)
+                }
+            )
+        } catch {
+            AppLogger.shared.log("❌ [SystemValidator] Process conflict detection failed: \(error)")
+            conflictResolution = .init(externalProcesses: [], managedProcesses: [], canAutoResolve: true)
+        }
 
         // Check for Karabiner-Elements conflicts
         if let manager = kanataManager {

--- a/Sources/KeyPathDaemonLifecycle/PIDFileManager.swift
+++ b/Sources/KeyPathDaemonLifecycle/PIDFileManager.swift
@@ -68,8 +68,12 @@ public enum PIDFileManager {
             return record
         } catch {
             AppLogger.shared.log("❌ [PIDFile] Failed to read PID file: \(error)")
-            // Corrupted PID file, remove it
-            try? removePID()
+            // Corrupted PID file — best-effort removal; log if that also fails
+            do {
+                try removePID()
+            } catch {
+                AppLogger.shared.log("❌ [PIDFile] Failed to remove corrupted PID file: \(error)")
+            }
             return nil
         }
     }
@@ -100,7 +104,11 @@ public enum PIDFileManager {
         // Check if the process is still running
         if !isProcessRunning(pid: record.pid) {
             AppLogger.shared.log("💀 [PIDFile] Process \(record.pid) is dead - cleaning up PID file")
-            try? removePID()
+            do {
+                try removePID()
+            } catch {
+                AppLogger.shared.log("❌ [PIDFile] Failed to remove stale PID file: \(error)")
+            }
             return (false, nil)
         }
 
@@ -118,7 +126,7 @@ public enum PIDFileManager {
     }
 
     /// Kill orphaned process and clean up
-    public static func killOrphanedProcess() async {
+    public static func killOrphanedProcess() async throws {
         guard let record = readPID() else { return }
 
         if isProcessRunning(pid: record.pid) {
@@ -128,7 +136,7 @@ public enum PIDFileManager {
             kill(record.pid, SIGTERM)
 
             // Wait a moment
-            try? await Task.sleep(for: .milliseconds(500)) // 0.5 seconds
+            try await Task.sleep(for: .milliseconds(500))
 
             // Force kill if still running
             if isProcessRunning(pid: record.pid) {
@@ -136,18 +144,22 @@ public enum PIDFileManager {
             }
         }
 
-        try? removePID()
+        try removePID()
     }
 
     // MARK: - Private Helpers
 
-    private static func ensureDirectoryExists() {
+    static func ensureDirectoryExists() {
         if !FileManager.default.fileExists(atPath: pidDirectory) {
-            try? FileManager.default.createDirectory(
-                atPath: pidDirectory,
-                withIntermediateDirectories: true,
-                attributes: [.posixPermissions: 0o755]
-            )
+            do {
+                try FileManager.default.createDirectory(
+                    atPath: pidDirectory,
+                    withIntermediateDirectories: true,
+                    attributes: [.posixPermissions: 0o755]
+                )
+            } catch {
+                AppLogger.shared.log("❌ [PIDFile] Failed to create PID directory: \(error)")
+            }
         }
     }
 }

--- a/Sources/KeyPathDaemonLifecycle/ProcessLifecycleManager.swift
+++ b/Sources/KeyPathDaemonLifecycle/ProcessLifecycleManager.swift
@@ -97,33 +97,23 @@ public final class ProcessLifecycleManager {
     // MARK: - Public API
 
     /// Register that we started a kanata process
-    public func registerStartedProcess(pid: pid_t, command: String) async {
-        do {
-            try PIDFileManager.writePID(pid, command: command)
-            ownedPID = pid
-            // Invalidate cache since we changed process state
-            await pidCache.invalidateCache()
-            AppLogger.shared.log("📝 [ProcessLifecycleManager] Registered process PID: \(pid)")
-        } catch {
-            AppLogger.shared.log("❌ [ProcessLifecycleManager] Failed to register process: \(error)")
-        }
+    public func registerStartedProcess(pid: pid_t, command: String) async throws {
+        try PIDFileManager.writePID(pid, command: command)
+        ownedPID = pid
+        await pidCache.invalidateCache()
+        AppLogger.shared.log("📝 [ProcessLifecycleManager] Registered process PID: \(pid)")
     }
 
     /// Unregister our process (on stop or cleanup)
-    public func unregisterProcess() async {
-        do {
-            try PIDFileManager.removePID()
-            ownedPID = nil
-            // Invalidate cache since we changed process state
-            await pidCache.invalidateCache()
-            AppLogger.shared.log("🗑️ [ProcessLifecycleManager] Unregistered process")
-        } catch {
-            AppLogger.shared.log("❌ [ProcessLifecycleManager] Failed to unregister process: \(error)")
-        }
+    public func unregisterProcess() async throws {
+        try PIDFileManager.removePID()
+        ownedPID = nil
+        await pidCache.invalidateCache()
+        AppLogger.shared.log("🗑️ [ProcessLifecycleManager] Unregistered process")
     }
 
     /// Check for conflicts (external kanata processes)
-    public func detectConflicts() async -> ConflictResolution {
+    public func detectConflicts() async throws -> ConflictResolution {
         AppLogger.shared.log("🔍 [ProcessLifecycleManager] Detecting conflicts...")
 
         // Skip process detection in test environment
@@ -143,7 +133,7 @@ public final class ProcessLifecycleManager {
         ownedPID = ownership.pid
 
         // Get all running kanata processes
-        let allProcesses = await detectKanataProcesses()
+        let allProcesses = try await detectKanataProcesses()
 
         // Separate managed processes from external conflicts
         var managedProcesses: [ProcessInfo] = []
@@ -189,7 +179,7 @@ public final class ProcessLifecycleManager {
 
     /// Kill all external kanata processes
     public func terminateExternalProcesses() async throws {
-        let conflicts = await detectConflicts()
+        let conflicts = try await detectConflicts()
 
         for process in conflicts.externalProcesses {
             AppLogger.shared.log(
@@ -204,7 +194,7 @@ public final class ProcessLifecycleManager {
         try? await Task.sleep(for: .seconds(1)) // 1 second
 
         // Force kill any remaining
-        let remainingConflicts = await detectConflicts()
+        let remainingConflicts = try await detectConflicts()
         for process in remainingConflicts.externalProcesses {
             AppLogger.shared.log("💀 [ProcessLifecycleManager] Force killing process PID: \(process.pid)")
             Foundation.kill(process.pid, SIGKILL)
@@ -212,7 +202,7 @@ public final class ProcessLifecycleManager {
     }
 
     /// Clean up orphaned processes on app startup
-    public func cleanupOrphanedProcesses() async {
+    public func cleanupOrphanedProcesses() async throws {
         AppLogger.shared.log("🧹 [ProcessLifecycleManager] Checking for orphaned processes...")
 
         // Check if we have a PID file from a previous run
@@ -223,12 +213,12 @@ public final class ProcessLifecycleManager {
                 )
 
                 // Kill the orphaned process
-                await PIDFileManager.killOrphanedProcess()
+                try await PIDFileManager.killOrphanedProcess()
                 // Invalidate cache since we changed process state
                 await pidCache.invalidateCache()
             } else {
                 // Process is dead, just clean up the PID file
-                try? PIDFileManager.removePID()
+                try PIDFileManager.removePID()
             }
         }
     }
@@ -243,30 +233,26 @@ public final class ProcessLifecycleManager {
     // MARK: - Process Detection
 
     /// Detect all kanata processes currently running
-    private func detectKanataProcesses() async -> [ProcessInfo] {
+    private func detectKanataProcesses() async throws -> [ProcessInfo] {
         AppLogger.shared.log("🔍 [ProcessLifecycleManager] Detecting kanata processes...")
 
         var processes: [ProcessInfo] = []
 
-        do {
-            let result = try await SubprocessRunner.shared.run("/usr/bin/pgrep", args: ["-fl", "kanata"])
-            if result.exitCode == 0 {
-                let lines = result.stdout.components(separatedBy: "\n").filter { !$0.isEmpty }
-                for line in lines {
-                    let components = line.components(separatedBy: " ")
-                    guard let pidString = components.first,
-                          let pid = pid_t(pidString),
-                          components.count > 1
-                    else { continue }
-                    let command = components.dropFirst().joined(separator: " ")
-                    if isKanataBinary(command) {
-                        processes.append(ProcessInfo(pid: pid, command: command))
-                        AppLogger.shared.log("🔍 [ProcessLifecycleManager] Found kanata process: PID=\(pid)")
-                    }
+        let result = try await SubprocessRunner.shared.run("/usr/bin/pgrep", args: ["-fl", "kanata"])
+        if result.exitCode == 0 {
+            let lines = result.stdout.components(separatedBy: "\n").filter { !$0.isEmpty }
+            for line in lines {
+                let components = line.components(separatedBy: " ")
+                guard let pidString = components.first,
+                      let pid = pid_t(pidString),
+                      components.count > 1
+                else { continue }
+                let command = components.dropFirst().joined(separator: " ")
+                if isKanataBinary(command) {
+                    processes.append(ProcessInfo(pid: pid, command: command))
+                    AppLogger.shared.log("🔍 [ProcessLifecycleManager] Found kanata process: PID=\(pid)")
                 }
             }
-        } catch {
-            AppLogger.shared.log("❌ [ProcessLifecycleManager] Error detecting processes: \(error)")
         }
 
         AppLogger.shared.log("🔍 [ProcessLifecycleManager] Found \(processes.count) kanata processes")

--- a/Tests/KeyPathTests/ProcessLifecycleIntegrationTests.swift
+++ b/Tests/KeyPathTests/ProcessLifecycleIntegrationTests.swift
@@ -22,70 +22,44 @@ final class ProcessLifecycleIntegrationTests: XCTestCase {
 
     // MARK: - Basic Operations Tests
 
-    func testProcessLifecycleManagerBasicOperations() async {
-        // Test the basic operations available in the current ProcessLifecycleManager
-
-        // Test intent setting
+    func testProcessLifecycleManagerBasicOperations() async throws {
         processManager.setIntent(.shouldBeRunning(source: "test_basic_operations"))
 
-        // Test process registration
-        await processManager.registerStartedProcess(pid: pid_t(1234), command: "test command")
-
-        // Test process unregistration
-        await processManager.unregisterProcess()
-
-        // Test orphaned process cleanup (replaces recoverFromCrash)
-        await processManager.cleanupOrphanedProcesses()
-
-        XCTAssertTrue(true, "Basic ProcessLifecycleManager operations should complete without errors")
+        try await processManager.registerStartedProcess(pid: pid_t(1234), command: "test command")
+        try await processManager.unregisterProcess()
+        try await processManager.cleanupOrphanedProcesses()
     }
 
     // MARK: - Conflict Detection Tests
 
-    func testConflictDetection() async {
-        // Test that conflict detection works with the current ProcessLifecycleManager
-
-        // Set intent to run
+    func testConflictDetection() async throws {
         processManager.setIntent(.shouldBeRunning(source: "test_conflict_detection"))
 
-        // Register a process as started by KeyPath
-        await processManager.registerStartedProcess(pid: pid_t(1234), command: "kanata command")
+        try await processManager.registerStartedProcess(pid: pid_t(1234), command: "kanata command")
 
-        // Detect conflicts
-        let conflicts = await processManager.detectConflicts()
+        let conflicts = try await processManager.detectConflicts()
 
-        // Should have basic conflict resolution structure
         XCTAssertNotNil(conflicts.externalProcesses, "Should return external processes array")
         XCTAssertNotNil(conflicts.canAutoResolve, "Should indicate if conflicts can be auto-resolved")
     }
 
     func testProcessTermination() async throws {
-        // Test that ProcessLifecycleManager can handle process termination
-
         processManager.setIntent(.shouldBeRunning(source: "test_termination"))
 
-        // Test terminating external processes
         do {
             try await processManager.terminateExternalProcesses()
-            XCTAssertTrue(true, "Process termination should complete without errors")
         } catch {
-            // It's okay if this fails in test environment - just testing that the method exists
-            XCTAssertTrue(true, "Process termination method exists and can be called")
+            // It's okay if this fails in test environment
         }
     }
 
-    func testOrphanedProcessCleanup() async {
-        // Test that ProcessLifecycleManager can clean up orphaned processes
-
-        await processManager.cleanupOrphanedProcesses()
-        XCTAssertTrue(true, "Orphaned process cleanup should complete without errors")
+    func testOrphanedProcessCleanup() async throws {
+        try await processManager.cleanupOrphanedProcesses()
     }
 
     // MARK: - Performance Tests
 
-    func testProcessDetectionPerformance() async {
-        // Test that process detection remains efficient while being robust to machine load variance.
-        // We sample multiple runs and assert against median duration.
+    func testProcessDetectionPerformance() async throws {
         let operationsPerRun = 100
         let runCount = 5
         var samples: [Double] = []
@@ -96,10 +70,10 @@ final class ProcessLifecycleIntegrationTests: XCTestCase {
 
             for testIndex in 0 ..< operationsPerRun {
                 processManager.setIntent(.shouldBeRunning(source: "perf_test_\(run)_\(testIndex)"))
-                await processManager.registerStartedProcess(
+                try await processManager.registerStartedProcess(
                     pid: pid_t(10000 + testIndex), command: "test command"
                 )
-                await processManager.unregisterProcess()
+                try await processManager.unregisterProcess()
             }
 
             let duration = CFAbsoluteTimeGetCurrent() - startTime
@@ -109,18 +83,14 @@ final class ProcessLifecycleIntegrationTests: XCTestCase {
         let sorted = samples.sorted()
         let median = sorted[sorted.count / 2]
 
-        // Baseline in local runs is below this; threshold allows transient CI/host jitter.
         XCTAssertLessThan(median, 1.25, "Median process operation duration regressed: \(median)s from samples \(samples)")
     }
 
     // MARK: - Error Handling Tests
 
     func testProcessErrorTypes() {
-        // Test that error types exist and work correctly (migrated to KeyPathError)
-
         let error = KeyPathError.process(.noManager)
 
-        // Test that we can pattern match on the new error type
         if case let .process(processError) = error {
             switch processError {
             case .noManager:
@@ -140,69 +110,43 @@ final class ProcessLifecycleIntegrationTests: XCTestCase {
     // MARK: - Thread Safety Tests
 
     func testConcurrentProcessManagement() async throws {
-        // Test concurrent access to ProcessLifecycleManager (real implementation)
         let manager = try XCTUnwrap(processManager)
 
         let concurrentTasks = (1 ... 10).map { taskId in
             Task {
-                // Test concurrent operations on real ProcessLifecycleManager
                 manager.setIntent(.shouldBeRunning(source: "concurrent_\(taskId)"))
-
-                // Test basic operations on ProcessLifecycleManager
-                await manager.registerStartedProcess(pid: pid_t(20000 + taskId), command: "test command")
-
-                await manager.unregisterProcess()
+                try await manager.registerStartedProcess(pid: pid_t(20000 + taskId), command: "test command")
+                try await manager.unregisterProcess()
             }
         }
 
-        // Wait for all concurrent tasks
         for task in concurrentTasks {
-            await task.value
+            try await task.value
         }
-
-        // Should complete without crashes or data corruption
-        XCTAssertTrue(true, "Concurrent operations completed successfully")
     }
 
     // MARK: - Real-World Integration Tests
 
-    func testProcessLifecycleManagerInitialization() async {
-        // Test that ProcessLifecycleManager can be initialized without issues
-
+    func testProcessLifecycleManagerInitialization() async throws {
         let manager = ProcessLifecycleManager()
-
-        // Should be able to set intent
         manager.setIntent(.shouldBeRunning(source: "initialization_test"))
-
-        // Should be able to clean up orphaned processes
-        await manager.cleanupOrphanedProcesses()
-
-        XCTAssertTrue(true, "ProcessLifecycleManager initializes and operates correctly")
+        try await manager.cleanupOrphanedProcesses()
     }
 
-    func testConflictResolutionStructure() async {
-        // Test conflict resolution returns the expected structure
+    func testConflictResolutionStructure() async throws {
+        let conflicts = try await processManager.detectConflicts()
 
-        let conflicts = await processManager.detectConflicts()
-
-        // Should have expected properties
         _ = conflicts.externalProcesses
         _ = conflicts.canAutoResolve
-
-        XCTAssertTrue(true, "ConflictResolution has expected structure")
     }
 
     func testIntentReconciliation() async throws {
-        // Test that intent reconciliation works
-
         processManager.setIntent(.shouldBeRunning(source: "test_intent"))
 
         do {
             try await processManager.reconcileWithIntent()
-            XCTAssertTrue(true, "Intent reconciliation should complete")
         } catch {
-            // It's okay if this fails in test environment - just testing that the method exists
-            XCTAssertTrue(true, "Intent reconciliation method exists and can be called")
+            // It's okay if this fails in test environment
         }
     }
 }


### PR DESCRIPTION
## Summary
- Make `ProcessLifecycleManager.registerStartedProcess`, `unregisterProcess`, `detectConflicts`, and `cleanupOrphanedProcesses` throw instead of silently swallowing errors
- Make `PIDFileManager.killOrphanedProcess` throw instead of using `try?`
- Add explicit error logging in `PIDFileManager.readPID` and `checkOwnership` when best-effort cleanup fails
- Update all callers (RuntimeCoordinator, SystemValidator, DiagnosticsService, ServiceHealthMonitor) with `do/catch` blocks that log failures instead of silent suppression

Closes #480

## Context
These catch blocks were identified in a code audit (§5.6) as masking real failures in the daemon lifecycle layer — PID file write/remove failures could cause orphaned processes, stale ownership, or blind conflict detection.

## Test plan
- [x] `swift build` passes
- [x] All 532 tests pass
- [x] Tests updated to use `throws` signatures matching new API