### PR TITLE
feat: make keystroke history opt-in with privacy consent

### DIFF
--- a/Sources/KeyPathAppKit/Services/Monitoring/KeystrokeHistoryService.swift
+++ b/Sources/KeyPathAppKit/Services/Monitoring/KeystrokeHistoryService.swift
@@ -15,7 +15,7 @@ final class KeystrokeHistoryService {
     private(set) var segments: [TimelineSegment] = []
     private(set) var currentLayer: String = "base"
     private(set) var eventCount: Int = 0
-    var isRecording: Bool = true
+    var isRecording: Bool = false
 
     @ObservationIgnored private var rawEvents: [KeystrokeTimelineEvent] = []
     @ObservationIgnored private var pendingEvents: [KeystrokeTimelineEvent] = []
@@ -31,13 +31,20 @@ final class KeystrokeHistoryService {
     private init(notificationCenter: NotificationCenter = .default) {
         self.notificationCenter = notificationCenter
         setupObservers()
+        Task { @MainActor in
+            self.isRecording = await InstalledPackTracker.shared.isInstalled(
+                packID: PackRegistry.keystrokeHistory.id
+            )
+        }
     }
 
     #if DEBUG
         static func makeTestInstance(
             notificationCenter: NotificationCenter = NotificationCenter()
         ) -> KeystrokeHistoryService {
-            KeystrokeHistoryService(notificationCenter: notificationCenter)
+            let instance = KeystrokeHistoryService(notificationCenter: notificationCenter)
+            instance.isRecording = true
+            return instance
         }
     #endif
 

--- a/Sources/KeyPathAppKit/Services/Packs/PackRegistry.swift
+++ b/Sources/KeyPathAppKit/Services/Packs/PackRegistry.swift
@@ -26,7 +26,8 @@ public enum PackRegistry {
         keyRepeatControl,
         chordGroups,
         vallackSystem,
-        kindaVim
+        kindaVim,
+        keystrokeHistory
     ]
 
     /// Look up a pack by id. Returns nil if unknown.
@@ -626,5 +627,22 @@ public enum PackRegistry {
             "i", "esc",
             "w", "b", "d", "y", "p", "u", "v",
         ]
+    )
+
+    // MARK: - Pack: Keystroke History
+
+    public static let keystrokeHistory = Pack(
+        id: "com.keypath.pack.keystroke-history",
+        version: "1.0.0",
+        name: "Keystroke History",
+        tagline: "See what your keyboard is actually doing",
+        shortDescription:
+            "Watch every keypress, tap-hold decision, and layer change in real time. Helps you understand, refine, and debug your keymaps.\n\nPrivacy: keystroke data is kept in memory only — nothing is saved to disk and nothing ever leaves your machine. Data disappears when you quit.",
+        longDescription: "",
+        category: "Debug",
+        iconSymbol: "clock.arrow.trianglehead.counterclockwise.rotate.90",
+        quickSettings: [],
+        bindings: [],
+        visualOnly: true
     )
 }

--- a/Sources/KeyPathAppKit/UI/Gallery/KeystrokeHistoryConsentDialog.swift
+++ b/Sources/KeyPathAppKit/UI/Gallery/KeystrokeHistoryConsentDialog.swift
@@ -1,0 +1,75 @@
+import SwiftUI
+
+struct KeystrokeHistoryConsentDialog: View {
+    let onConfirm: () -> Void
+    let onCancel: () -> Void
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "clock.arrow.trianglehead.counterclockwise.rotate.90")
+                .font(.system(size: 36))
+                .foregroundStyle(.secondary)
+                .accessibilityHidden(true)
+
+            Text("Enable Keystroke History?")
+                .font(.headline)
+
+            Text("This shows every keypress, tap-hold decision, and layer change in real time — helping you understand, refine, and debug your keymaps.")
+                .font(.body)
+                .multilineTextAlignment(.center)
+                .foregroundStyle(.secondary)
+
+            privacyNotice
+
+            HStack(spacing: 12) {
+                Button("Cancel") {
+                    onCancel()
+                }
+                .keyboardShortcut(.cancelAction)
+                .accessibilityIdentifier("keystroke-history-consent-cancel")
+
+                Button("Enable Keystroke History") {
+                    onConfirm()
+                }
+                .keyboardShortcut(.defaultAction)
+                .buttonStyle(.borderedProminent)
+                .accessibilityIdentifier("keystroke-history-consent-confirm")
+            }
+            .padding(.top, 4)
+        }
+        .padding(24)
+        .frame(width: 380)
+    }
+
+    private var privacyNotice: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            privacyRow(
+                icon: "memorychip",
+                text: "Kept in memory only — nothing is saved to disk"
+            )
+            privacyRow(
+                icon: "lock.shield",
+                text: "Never leaves your machine"
+            )
+            privacyRow(
+                icon: "xmark.circle",
+                text: "Disappears when you quit KeyPath"
+            )
+        }
+        .padding(12)
+        .background(.quaternary.opacity(0.5))
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+    }
+
+    private func privacyRow(icon: String, text: String) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: icon)
+                .font(.caption)
+                .foregroundStyle(.green)
+                .frame(width: 16)
+                .accessibilityHidden(true)
+            Text(text)
+                .font(.callout)
+        }
+    }
+}

--- a/Sources/KeyPathAppKit/UI/Gallery/PackDetailView+PackActions.swift
+++ b/Sources/KeyPathAppKit/UI/Gallery/PackDetailView+PackActions.swift
@@ -8,6 +8,10 @@ extension PackDetailView {
         guard newValue != isInstalled else { return }
         isInstalled = newValue
         toggleTask?.cancel()
+        if newValue, pack.id == PackRegistry.keystrokeHistory.id {
+            showKeystrokeHistoryConsent = true
+            return
+        }
         toggleTask = Task { newValue ? await install() : await uninstall() }
     }
 
@@ -23,6 +27,9 @@ extension PackDetailView {
                 skipFinalReload: skipFinalReload
             )
             kanataManager.underlyingManager.notifyStateChanged()
+            if pack.id == PackRegistry.keystrokeHistory.id {
+                KeystrokeHistoryService.shared.isRecording = true
+            }
             lastUndoSnapshot = .init(quickSettingValues: quickSettingValues)
             await refreshInstallState()
             withAnimation(.spring(response: 0.4, dampingFraction: 0.85)) {
@@ -58,6 +65,10 @@ extension PackDetailView {
             let manager = kanataManager.underlyingManager.ruleCollectionsManager
             try await PackInstaller.shared.uninstall(packID: pack.id, manager: manager)
             kanataManager.underlyingManager.notifyStateChanged()
+            if pack.id == PackRegistry.keystrokeHistory.id {
+                KeystrokeHistoryService.shared.isRecording = false
+                KeystrokeHistoryService.shared.clearEvents()
+            }
             await refreshInstallState()
             withAnimation(.spring(response: 0.4, dampingFraction: 0.85)) {
                 justUninstalled = true

--- a/Sources/KeyPathAppKit/UI/Gallery/PackDetailView.swift
+++ b/Sources/KeyPathAppKit/UI/Gallery/PackDetailView.swift
@@ -37,6 +37,7 @@ struct PackDetailView: View {
     @State var packConflict: PackConflictState?
     @State var quickSettingValues: [String: Int] = [:]
     @State var lastUndoSnapshot: UndoSnapshot?
+    @State var showKeystrokeHistoryConsent = false
 
     /// Live tap/hold selection mirrored from the embedded picker. Drives
     /// the blue "Tap: X · Hold: Y" status line so it updates the moment
@@ -116,6 +117,18 @@ struct PackDetailView: View {
         .overlay(toastOverlay, alignment: .bottom)
         .sheet(isPresented: $showingHomeRowModsHelp) {
             MarkdownHelpSheet(resource: "home-row-mods", title: "Home Row Mods")
+        }
+        .sheet(isPresented: $showKeystrokeHistoryConsent) {
+            KeystrokeHistoryConsentDialog(
+                onConfirm: {
+                    showKeystrokeHistoryConsent = false
+                    toggleTask = Task { await install() }
+                },
+                onCancel: {
+                    showKeystrokeHistoryConsent = false
+                    isInstalled = false
+                }
+            )
         }
         .sheet(item: $packConflict) { conflict in
             PackConflictResolutionDialog(

--- a/Sources/KeyPathAppKit/UI/Overlay/InspectorPanelToolbar.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/InspectorPanelToolbar.swift
@@ -26,6 +26,7 @@ struct InspectorPanelToolbar: View {
     let healthIndicatorState: HealthIndicatorState
     let hasCustomRules: Bool
     let isLauncherEnabled: Bool
+    let isKeystrokeHistoryEnabled: Bool
     let isSettingsShelfActive: Bool
     let onToggleSettingsShelf: () -> Void
     private let buttonSize: CGFloat = 32
@@ -232,25 +233,26 @@ struct InspectorPanelToolbar: View {
                 .help("Quick Launcher")
             }
 
-            // Keystroke History
-            toolbarButton(
-                systemImage: "clock.arrow.trianglehead.counterclockwise.rotate.90",
-                isSelected: selectedSection == .history,
-                isHovering: isHoveringHistory,
-                onHover: { isHoveringHistory = $0 },
-                action: { onSelectSection(.history) }
-            )
-            .overlay(alignment: .topTrailing) {
-                if KeystrokeHistoryService.shared.isRecording {
-                    Circle()
-                        .fill(.red)
-                        .frame(width: 5, height: 5)
-                        .offset(x: -2, y: 4)
+            if isKeystrokeHistoryEnabled {
+                toolbarButton(
+                    systemImage: "clock.arrow.trianglehead.counterclockwise.rotate.90",
+                    isSelected: selectedSection == .history,
+                    isHovering: isHoveringHistory,
+                    onHover: { isHoveringHistory = $0 },
+                    action: { onSelectSection(.history) }
+                )
+                .overlay(alignment: .topTrailing) {
+                    if KeystrokeHistoryService.shared.isRecording {
+                        Circle()
+                            .fill(.red)
+                            .frame(width: 5, height: 5)
+                            .offset(x: -2, y: 4)
+                    }
                 }
+                .accessibilityIdentifier("inspector-tab-history")
+                .accessibilityLabel("Keystroke History")
+                .help("Keystroke History")
             }
-            .accessibilityIdentifier("inspector-tab-history")
-            .accessibilityLabel("Keystroke History")
-            .help("Keystroke History")
         }
     }
 

--- a/Sources/KeyPathAppKit/UI/Overlay/LiveKeyboardOverlayView+Inspector.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/LiveKeyboardOverlayView+Inspector.swift
@@ -132,6 +132,7 @@ struct OverlayInspectorPanel: View {
                         healthIndicatorState: healthIndicatorState,
                         hasCustomRules: hasCustomRules,
                         isLauncherEnabled: isLauncherCollectionEnabled,
+                        isKeystrokeHistoryEnabled: KeystrokeHistoryService.shared.isRecording,
                         isSettingsShelfActive: isSettingsShelfActive,
                         onToggleSettingsShelf: onToggleSettingsShelf
                     )


### PR DESCRIPTION
## Summary
- Keystroke history is now a visual-only pack requiring explicit user opt-in
- Privacy consent dialog shown on first install explaining data handling
- Inspector history tab gated on pack installation — invisible until enabled
- Uninstall stops recording and clears all data immediately

## Privacy guarantees (shown in consent dialog)
- Kept in memory only — nothing saved to disk
- Never leaves your machine
- Disappears when you quit KeyPath

## Test plan
- [x] `swift build` — clean build
- [x] `swift test` — 532 Swift Testing tests + 11 XCTest keystroke history tests pass
- [ ] Install keystroke history pack → consent dialog appears
- [ ] Confirm → history tab appears in overlay inspector, recording starts
- [ ] Uninstall → tab disappears, data cleared
- [ ] Relaunch after install → recording auto-resumes