### PR TITLE
fix: pack tests save/restore tracker state to avoid clobbering user config

### DIFF
--- a/Tests/KeyPathTests/PackOwnershipTests.swift
+++ b/Tests/KeyPathTests/PackOwnershipTests.swift
@@ -18,7 +18,7 @@ final class PackOwnershipTests: XCTestCase {
             }
         }
         for record in originalInstalledPacks {
-            if !(await InstalledPackTracker.shared.isInstalled(packID: record.packID)) {
+            if await !(InstalledPackTracker.shared.isInstalled(packID: record.packID)) {
                 try await InstalledPackTracker.shared.upsert(record)
             }
         }
@@ -27,13 +27,13 @@ final class PackOwnershipTests: XCTestCase {
 
     // MARK: - managedCollectionIDs
 
-    func testManagedCollectionIDsSinglePack() {
-        let pack = PackRegistry.pack(id: "com.keypath.pack.home-row-mods")!
+    func testManagedCollectionIDsSinglePack() throws {
+        let pack = try XCTUnwrap(PackRegistry.pack(id: "com.keypath.pack.home-row-mods"))
         XCTAssertEqual(pack.managedCollectionIDs, [RuleCollectionIdentifier.homeRowMods])
     }
 
-    func testManagedCollectionIDsVallack() {
-        let pack = PackRegistry.pack(id: "com.keypath.pack.vallack-system")!
+    func testManagedCollectionIDsVallack() throws {
+        let pack = try XCTUnwrap(PackRegistry.pack(id: "com.keypath.pack.vallack-system"))
         let ids = Set(pack.managedCollectionIDs)
         XCTAssertEqual(ids.count, 3)
         XCTAssertTrue(ids.contains(RuleCollectionIdentifier.vallackNavigation))
@@ -41,14 +41,17 @@ final class PackOwnershipTests: XCTestCase {
         XCTAssertTrue(ids.contains(RuleCollectionIdentifier.homeRowLayerToggles))
     }
 
-    func testManagedCollectionIDsVisualOnly() {
-        let pack = PackRegistry.pack(id: "com.keypath.pack.kindavim")!
+    func testManagedCollectionIDsVisualOnly() throws {
+        let pack = try XCTUnwrap(PackRegistry.pack(id: "com.keypath.pack.kindavim"))
         XCTAssertTrue(pack.managedCollectionIDs.isEmpty)
     }
 
     // MARK: - packManagingCollection
 
     func testPackManagingCollectionWhenInstalled() async throws {
+        // Ensure vallack-system is not installed so HRM is self-managed
+        try? await InstalledPackTracker.shared.remove(packID: "com.keypath.pack.vallack-system")
+
         let record = InstalledPackRecord(
             packID: "com.keypath.pack.home-row-mods",
             version: "1.0.0"
@@ -90,9 +93,9 @@ final class PackOwnershipTests: XCTestCase {
             RuleCollectionIdentifier.homeRowLayerToggles
         )
 
-        XCTAssertEqual(navOwner?.packName, "Ben Vallack Approach")
-        XCTAssertEqual(hrmOwner?.packName, "Ben Vallack Approach")
-        XCTAssertEqual(togglesOwner?.packName, "Ben Vallack Approach")
+        XCTAssertEqual(navOwner?.packName, "Ben Vallack Nav")
+        XCTAssertEqual(hrmOwner?.packName, "Ben Vallack Nav")
+        XCTAssertEqual(togglesOwner?.packName, "Ben Vallack Nav")
     }
 
     // MARK: - Self-managed badge filtering
@@ -106,7 +109,7 @@ final class PackOwnershipTests: XCTestCase {
         let owner = await InstalledPackTracker.shared.packManagingCollection(collectionID)
         XCTAssertNotNil(owner, "Pack should report owning its collection")
 
-        let pack = PackRegistry.pack(id: owner!.packID)
+        let pack = try PackRegistry.pack(id: XCTUnwrap(owner?.packID))
         XCTAssertEqual(
             pack?.associatedCollectionID, collectionID,
             "Fast Navigation's associatedCollectionID should match its own collection — badge must be hidden"
@@ -125,17 +128,17 @@ final class PackOwnershipTests: XCTestCase {
         )
         XCTAssertNotNil(owner)
 
-        let pack = PackRegistry.pack(id: owner!.packID)!
+        let pack = try XCTUnwrap(try PackRegistry.pack(id: XCTUnwrap(owner?.packID)))
         XCTAssertNotEqual(
             pack.associatedCollectionID, RuleCollectionIdentifier.homeRowMods,
             "Vallack's associatedCollectionID is vallackNavigation, not homeRowMods — badge should show"
         )
     }
 
-    func testAllPacksWithAssociatedCollectionAreSelfManaged() {
+    func testAllPacksWithAssociatedCollectionAreSelfManaged() throws {
         for pack in PackRegistry.starterKit where pack.associatedCollectionID != nil {
             XCTAssertTrue(
-                pack.managedCollectionIDs.contains(pack.associatedCollectionID!),
+                try pack.managedCollectionIDs.contains(XCTUnwrap(pack.associatedCollectionID)),
                 "\(pack.name) manages collections \(pack.managedCollectionIDs) but its associatedCollectionID \(pack.associatedCollectionID!) is missing"
             )
         }

--- a/Tests/KeyPathTests/VallackSystemPackTests.swift
+++ b/Tests/KeyPathTests/VallackSystemPackTests.swift
@@ -3,6 +3,27 @@ import KeyPathCore
 import XCTest
 
 final class VallackSystemPackTests: XCTestCase {
+    private var originalInstalledPacks: [InstalledPackRecord] = []
+
+    override func setUp() async throws {
+        try await super.setUp()
+        originalInstalledPacks = await InstalledPackTracker.shared.allInstalled()
+    }
+
+    override func tearDown() async throws {
+        let current = await InstalledPackTracker.shared.allInstalled()
+        for record in current {
+            if !originalInstalledPacks.contains(where: { $0.packID == record.packID }) {
+                try await InstalledPackTracker.shared.remove(packID: record.packID)
+            }
+        }
+        for record in originalInstalledPacks {
+            if await !(InstalledPackTracker.shared.isInstalled(packID: record.packID)) {
+                try await InstalledPackTracker.shared.upsert(record)
+            }
+        }
+        try await super.tearDown()
+    }
 
     // MARK: - Nav Layer Collection
 
@@ -12,37 +33,37 @@ final class VallackSystemPackTests: XCTestCase {
         XCTAssertNotNil(collection, "Vallack Navigation collection must exist in catalog")
     }
 
-    func testVallackNavigationHas18Mappings() {
+    func testVallackNavigationHas18Mappings() throws {
         let catalog = RuleCollectionCatalog().defaultCollections()
-        let collection = catalog.first { $0.id == RuleCollectionIdentifier.vallackNavigation }!
+        let collection = try XCTUnwrap(catalog.first { $0.id == RuleCollectionIdentifier.vallackNavigation })
         XCTAssertEqual(collection.mappings.count, 18, "Should have 18 key mappings (10 right hand + 8 left hand)")
     }
 
-    func testVallackNavigationTargetsCustomLayer() {
+    func testVallackNavigationTargetsCustomLayer() throws {
         let catalog = RuleCollectionCatalog().defaultCollections()
-        let collection = catalog.first { $0.id == RuleCollectionIdentifier.vallackNavigation }!
+        let collection = try XCTUnwrap(catalog.first { $0.id == RuleCollectionIdentifier.vallackNavigation })
         XCTAssertEqual(collection.targetLayer, .custom("vallack-nav"))
     }
 
-    func testVallackNavigationHasNoMomentaryActivator() {
+    func testVallackNavigationHasNoMomentaryActivator() throws {
         let catalog = RuleCollectionCatalog().defaultCollections()
-        let collection = catalog.first { $0.id == RuleCollectionIdentifier.vallackNavigation }!
+        let collection = try XCTUnwrap(catalog.first { $0.id == RuleCollectionIdentifier.vallackNavigation })
         XCTAssertNil(
             collection.momentaryActivator,
             "Activation is handled by homeRowLayerToggles (F/J), not a momentaryActivator"
         )
     }
 
-    func testVallackNavigationIsDisabledByDefault() {
+    func testVallackNavigationIsDisabledByDefault() throws {
         let catalog = RuleCollectionCatalog().defaultCollections()
-        let collection = catalog.first { $0.id == RuleCollectionIdentifier.vallackNavigation }!
+        let collection = try XCTUnwrap(catalog.first { $0.id == RuleCollectionIdentifier.vallackNavigation })
         XCTAssertFalse(collection.isEnabled)
         XCTAssertFalse(collection.isSystemDefault)
     }
 
-    func testVallackNavigationContainsExpectedArrowMappings() {
+    func testVallackNavigationContainsExpectedArrowMappings() throws {
         let catalog = RuleCollectionCatalog().defaultCollections()
-        let collection = catalog.first { $0.id == RuleCollectionIdentifier.vallackNavigation }!
+        let collection = try XCTUnwrap(catalog.first { $0.id == RuleCollectionIdentifier.vallackNavigation })
         let mappingsByInput = Dictionary(uniqueKeysWithValues: collection.mappings.map { ($0.input, $0) })
 
         XCTAssertEqual(mappingsByInput["h"]?.action, .keystroke(key: "left"))
@@ -51,9 +72,9 @@ final class VallackSystemPackTests: XCTestCase {
         XCTAssertEqual(mappingsByInput["l"]?.action, .keystroke(key: "right"))
     }
 
-    func testVallackNavigationContainsClipboardAndEditing() {
+    func testVallackNavigationContainsClipboardAndEditing() throws {
         let catalog = RuleCollectionCatalog().defaultCollections()
-        let collection = catalog.first { $0.id == RuleCollectionIdentifier.vallackNavigation }!
+        let collection = try XCTUnwrap(catalog.first { $0.id == RuleCollectionIdentifier.vallackNavigation })
         let mappingsByInput = Dictionary(uniqueKeysWithValues: collection.mappings.map { ($0.input, $0) })
 
         XCTAssertEqual(mappingsByInput["y"]?.action, .keystroke(key: "M-c"), "y should be Copy")
@@ -62,9 +83,9 @@ final class VallackSystemPackTests: XCTestCase {
         XCTAssertEqual(mappingsByInput["i"]?.action, .keystroke(key: "ret"), "i should be Enter")
     }
 
-    func testVallackNavigationInputKeysAreUnique() {
+    func testVallackNavigationInputKeysAreUnique() throws {
         let catalog = RuleCollectionCatalog().defaultCollections()
-        let collection = catalog.first { $0.id == RuleCollectionIdentifier.vallackNavigation }!
+        let collection = try XCTUnwrap(catalog.first { $0.id == RuleCollectionIdentifier.vallackNavigation })
         let inputs = collection.mappings.map(\.input)
         XCTAssertEqual(Set(inputs).count, inputs.count, "No duplicate input keys")
     }
@@ -78,12 +99,12 @@ final class VallackSystemPackTests: XCTestCase {
 
     func testVallackTwoRowSplitUsesTopRowKeys() {
         let preset = HomeRowModsConfig.vallackTwoRowSplit
-        let expectedKeys: Set<String> = ["q", "w", "e", "u", "i", "o"]
+        let expectedKeys: Set = ["q", "w", "e", "u", "i", "o"]
         XCTAssertEqual(Set(preset.keys), expectedKeys)
     }
 
     func testVallackTwoRowSplitMapsToValidModifiers() {
-        let validModifiers: Set<String> = ["lctl", "lalt", "lmet", "lsft", "rctl", "ralt", "rmet", "rsft"]
+        let validModifiers: Set = ["lctl", "lalt", "lmet", "lsft", "rctl", "ralt", "rmet", "rsft"]
         for (key, modifier) in HomeRowModsConfig.vallackTwoRowSplit {
             XCTAssertTrue(
                 validModifiers.contains(modifier),
@@ -265,6 +286,10 @@ final class VallackSystemPackTests: XCTestCase {
         let (manager, tempDir) = try makeTestManager()
         defer { try? FileManager.default.removeItem(at: tempDir) }
 
+        // Temporarily remove vallack-system from tracker so the direct
+        // toggleCollection call below isn't blocked by the ownership check.
+        try? await InstalledPackTracker.shared.remove(packID: PackRegistry.vallackSystem.id)
+
         // Manually enable the nav collection without going through the installer
         // (simulates a corrupted state where snapshot file is missing)
         _ = await manager.toggleCollection(
@@ -273,14 +298,11 @@ final class VallackSystemPackTests: XCTestCase {
             autoResolveConflicts: true
         )
 
-        // Register as installed in the tracker
+        // Register as installed in the tracker (tearDown restores original state)
         try await InstalledPackTracker.shared.upsert(InstalledPackRecord(
             packID: PackRegistry.vallackSystem.id,
             version: PackRegistry.vallackSystem.version
         ))
-        defer {
-            Task { try? await InstalledPackTracker.shared.remove(packID: PackRegistry.vallackSystem.id) }
-        }
 
         // Ensure no snapshot file exists
         let snapshotURL = FileManager.default.homeDirectoryForCurrentUser


### PR DESCRIPTION
## Summary
- `VallackSystemPackTests` used `InstalledPackTracker.shared` (which writes to `~/.config/keypath/installed-packs.json`) without saving/restoring state — running `swift test` would remove the vallack-system pack record, causing the app to lose Ben Vallack's pack on next boot
- Added setUp/tearDown save/restore pattern (matching `PackOwnershipTests`) so tests leave the real tracker file untouched
- Fixed stale pack name "Ben Vallack Approach" → "Ben Vallack Nav" in `PackOwnershipTests`
- Fixed `testPackManagingCollectionWhenInstalled` to handle vallack-system being in the real tracker

## Test plan
- [x] All 34 pack tests pass (`PackOwnershipTests` + `VallackSystemPackTests`)
- [x] Full test suite (532 tests) passes
- [x] `installed-packs.json` preserves vallack-system record after test run
- [x] swiftformat + swiftlint clean