### PR TITLE
docs: add kanata fork safety rules to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,8 @@ Follow the invariants in [`docs/agent-pr-invariants.md`](docs/agent-pr-invariant
 
 Git guardrail hooks in `.claude/settings.json` block: commits on master, force-push to master, `reset --hard`, `clean -f`.
 
+**Kanata fork safety:** The kanata submodule (`External/kanata`) tracks `keypath/bundled` on `malpern/kanata`. Treat `keypath/bundled` like master — **never force-push** to it. Before pushing to any remote branch in the fork, verify the push is a fast-forward: `git log --oneline <source>..<target>`. If commits would be lost, cherry-pick instead. The `main` branch in kanata-pr may diverge from `keypath/bundled` — they are NOT interchangeable.
+
 ## Build & Deploy
 
 ```bash


### PR DESCRIPTION
## Summary
Add explicit safety rules for the kanata fork after a near-miss where force-pushing `main` over `keypath/bundled` almost dropped 17 fork-only commits.

Rules added:
- Never force-push to `keypath/bundled`
- Verify fast-forward before any push to fork remote branches
- `main` and `keypath/bundled` are NOT interchangeable