### PR TITLE
feat: add keystroke history row to collections list

### DIFF
--- a/Sources/KeyPathAppKit/UI/Rules/ExpandableKeystrokeHistoryRow.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/ExpandableKeystrokeHistoryRow.swift
@@ -1,0 +1,107 @@
+import AppKit
+import SwiftUI
+
+struct ExpandableKeystrokeHistoryRow: View {
+    let isPackEnabled: Bool
+    let onToggle: (Bool) -> Void
+    var onTapRow: (() -> Void)?
+
+    @State private var isHovered = false
+    @State private var showConsentDialog = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            headerView
+        }
+        .background(
+            RoundedRectangle(cornerRadius: 10)
+                .fill(isHovered ? Color(NSColor.controlBackgroundColor).opacity(0.5)
+                    : Color(NSColor.windowBackgroundColor))
+                .allowsHitTesting(false)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 10)
+                .stroke(Color.white.opacity(isHovered ? 0.15 : 0), lineWidth: 1)
+                .allowsHitTesting(false)
+        )
+        .onHover { hovering in
+            isHovered = hovering
+            if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
+        }
+        .sheet(isPresented: $showConsentDialog) {
+            KeystrokeHistoryConsentDialog(
+                onConfirm: {
+                    showConsentDialog = false
+                    onToggle(true)
+                },
+                onCancel: {
+                    showConsentDialog = false
+                }
+            )
+        }
+    }
+
+    private var headerView: some View {
+        HStack(alignment: .top, spacing: 12) {
+            Button {
+                if let onTapRow {
+                    onTapRow()
+                }
+            } label: {
+                HStack(alignment: .top, spacing: 12) {
+                    Image(systemName: PackRegistry.keystrokeHistory.iconSymbol)
+                        .font(.system(size: 14 * 0.85, weight: .regular))
+                        .foregroundColor(.secondary)
+                        .frame(width: 24 * 0.85, height: 24 * 0.85)
+                        .padding(.top, 2)
+
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(PackRegistry.keystrokeHistory.name)
+                            .font(.system(size: 14, weight: .medium))
+                            .foregroundStyle(.primary)
+                            .lineLimit(1)
+
+                        Text(PackRegistry.keystrokeHistory.tagline)
+                            .font(.system(size: 12))
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+
+                        HStack(spacing: 4) {
+                            Image(systemName: "lock.shield")
+                                .font(.system(size: 9))
+                            Text("Memory only")
+                                .font(.system(size: 10))
+                        }
+                        .foregroundStyle(.tertiary)
+                        .padding(.top, 1)
+                    }
+                }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityIdentifier("keystroke-history-row-label")
+
+            Spacer()
+
+            Toggle("", isOn: Binding(
+                get: { isPackEnabled },
+                set: { newValue in
+                    if newValue {
+                        showConsentDialog = true
+                    } else {
+                        onToggle(false)
+                    }
+                }
+            ))
+            .toggleStyle(.switch)
+            .labelsHidden()
+            .controlSize(.small)
+            .padding(.top, 6)
+            .padding(.trailing, 8)
+            .accessibilityIdentifier("keystroke-history-row-toggle")
+            .accessibilityLabel("Enable Keystroke History")
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+    }
+}

--- a/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView.swift
@@ -28,6 +28,7 @@ struct RulesTabView: View {
     @State private var sequencesEditState: SequencesEditState?
     @State private var appKeymaps: [AppKeymap] = []
     @State private var isKindaVimInstalled = false
+    @State private var isKeystrokeHistoryInstalled = false
     /// Dependency resolution: pack awaiting enable confirmation
     @State private var pendingEnablePack: Pack?
     @State private var pendingEnableUnmetDeps: [UnmetDependency] = []
@@ -652,6 +653,9 @@ struct RulesTabView: View {
                             }
                         }
 
+                        keystrokeHistoryRow
+                            .padding(.vertical, 4)
+
                         if isSearching, !hasSearchResults {
                             VStack(spacing: 10) {
                                 Text("No matching rules")
@@ -699,10 +703,12 @@ struct RulesTabView: View {
             }
             // Load app-specific keymaps
             loadAppKeymaps()
-            // Check KindaVim pack install state + collection ownership
             Task {
                 isKindaVimInstalled = await InstalledPackTracker.shared.isInstalled(
                     packID: PackRegistry.kindaVim.id
+                )
+                isKeystrokeHistoryInstalled = await InstalledPackTracker.shared.isInstalled(
+                    packID: PackRegistry.keystrokeHistory.id
                 )
                 await refreshCollectionOwnership()
             }
@@ -988,6 +994,46 @@ struct RulesTabView: View {
                             AppLogger.shared.log("⚠️ [Rules] KindaVim toggle failed: \(error.localizedDescription)")
                             isKindaVimInstalled = !newValue
                             settingsToastManager.showError("Failed to \(newValue ? "enable" : "disable") KindaVim")
+                        }
+                    }
+                },
+                onTapRow: {
+                    PackDetailWindowController.shared.showWindow(pack: pack, kanataManager: kanataManager)
+                }
+            )
+        }
+    }
+
+    @ViewBuilder
+    private var keystrokeHistoryRow: some View {
+        let pack = PackRegistry.keystrokeHistory
+        if !isSearching || pack.name.localizedCaseInsensitiveContains(trimmedSearchQuery)
+            || "keystroke history".contains(trimmedSearchQuery.lowercased())
+            || "debug".contains(trimmedSearchQuery.lowercased())
+        {
+            ExpandableKeystrokeHistoryRow(
+                isPackEnabled: isKeystrokeHistoryInstalled,
+                onToggle: { newValue in
+                    isKeystrokeHistoryInstalled = newValue
+                    Task {
+                        do {
+                            if newValue {
+                                let record = InstalledPackRecord(
+                                    packID: pack.id,
+                                    version: pack.version,
+                                    installedAt: Date(),
+                                    quickSettingValues: [:]
+                                )
+                                try await InstalledPackTracker.shared.upsert(record)
+                                KeystrokeHistoryService.shared.isRecording = true
+                            } else {
+                                try await InstalledPackTracker.shared.remove(packID: pack.id)
+                                KeystrokeHistoryService.shared.isRecording = false
+                                KeystrokeHistoryService.shared.clearEvents()
+                            }
+                        } catch {
+                            AppLogger.shared.log("⚠️ [Rules] Keystroke History toggle failed: \(error.localizedDescription)")
+                            isKeystrokeHistoryInstalled = !newValue
                         }
                     }
                 },


### PR DESCRIPTION
## Summary
- Keystroke History now appears in the rules/collections list as a toggleable row
- Toggle shows privacy consent dialog before enabling
- Row shows "Memory only" privacy badge
- Searchable by "keystroke history" and "debug"

Follow-up to #509 which made the feature opt-in but didn't surface it in the collections view.

## Test plan
- [x] `swift build` — clean
- [x] `swift test` — 532 tests pass
- [ ] Open rules tab → see Keystroke History at bottom of list
- [ ] Toggle on → consent dialog appears → confirm → recording starts
- [ ] Toggle off → recording stops, data cleared