### PR TITLE
fix: eliminate orange flash and missing icons on nav layer overlay

### DIFF
--- a/Sources/KeyPathAppKit/UI/KeyboardVisualization/KeyboardVisualizationViewModel+LayoutMapping.swift
+++ b/Sources/KeyPathAppKit/UI/KeyboardVisualization/KeyboardVisualizationViewModel+LayoutMapping.swift
@@ -25,9 +25,13 @@ extension KeyboardVisualizationViewModel {
 
         // Set layer name immediately so computed properties (isLauncherModeActive,
         // layer indicators) update without waiting for the async mapping rebuild.
-        // The key map refreshes in the background — a brief stale-label window is
-        // far less noticeable than a 500ms+ frozen overlay.
         currentLayerName = targetLayerName
+
+        // Clear stale layer mappings so keys without zone colors don't briefly
+        // render with the previous layer's collection color and icons (e.g.,
+        // F1-F12 flashing orange when entering a nav layer).
+        layerKeyMap = [:]
+        remapOutputMap = [:]
 
         // Clear tap-hold sources on layer change to prevent stale suppressions
         // (e.g., user switches layers while holding a tap-hold key)

--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView+VisualStyling.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView+VisualStyling.swift
@@ -130,6 +130,8 @@ extension OverlayKeycapView {
     var backgroundColor: Color {
         if isPressed, isHoldActive {
             Color(red: 0.85, green: 0.45, blue: 0.15) // Orange for hold-active
+        } else if isPressed, let zc = zoneColor {
+            zc // Pressed key with zone color stays in-palette instead of jarring blue
         } else if isPressed {
             Color.accentColor
         } else if isOneShot {
@@ -150,8 +152,8 @@ extension OverlayKeycapView {
         else if isLauncherMode {
             Color(red: 56 / 255, green: 56 / 255, blue: 57 / 255)
         }
-        // Layer mode: collection-specific color for mapped keys
-        else if isLayerMode, hasLayerMapping || isNavIdentityMapping {
+        // Layer mode: collection-specific color for keys owned by a pack/collection
+        else if isLayerMode, layerKeyInfo?.collectionId != nil, hasLayerMapping || isNavIdentityMapping {
             collectionColor(for: layerKeyInfo?.collectionId)
         }
         // Layer mode: dark gray for unmapped keys (same as launcher)

--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView+VisualStyling.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView+VisualStyling.swift
@@ -131,7 +131,7 @@ extension OverlayKeycapView {
         if isPressed, isHoldActive {
             Color(red: 0.85, green: 0.45, blue: 0.15) // Orange for hold-active
         } else if isPressed, let zc = zoneColor {
-            zc // Pressed key with zone color stays in-palette instead of jarring blue
+            zc // Pressed activator/zone key stays in-palette
         } else if isPressed {
             Color.accentColor
         } else if isOneShot {
@@ -152,7 +152,9 @@ extension OverlayKeycapView {
         else if isLauncherMode {
             Color(red: 56 / 255, green: 56 / 255, blue: 57 / 255)
         }
-        // Layer mode: collection-specific color for keys owned by a pack/collection
+        // Layer mode: collection-specific color for mapped keys that belong to a collection
+        // or have a zone color (zone-colored keys already handled above, so this catches
+        // collection-owned keys like vim nav that don't use zone coloring)
         else if isLayerMode, layerKeyInfo?.collectionId != nil, hasLayerMapping || isNavIdentityMapping {
             collectionColor(for: layerKeyInfo?.collectionId)
         }

--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView.swift
@@ -172,11 +172,16 @@ struct OverlayKeycapView: View {
             return true
         }
 
+        // Zone subtitle as primary label in layer mode (e.g., nav icons from pack zone maps)
+        if isLayerMode, zoneSubtitle != nil {
+            return true
+        }
+
         // Otherwise, content is Color.clear (floating labels handle it)
         return false
     }
 
-    /// The effective label to display (hold label > layer mapping > keymap/physical)
+    /// The effective label to display (hold label > zone subtitle (layer mode) > layer mapping > keymap/physical)
     var effectiveLabel: String {
         // When key is pressed with a hold label, show the hold label
         if isPressed, let holdLabel {
@@ -185,6 +190,11 @@ struct OverlayKeycapView: View {
 
         if !isPressed, let tapHoldIdleLabel, shouldShowTapHoldIdleLabel {
             return tapHoldIdleLabel
+        }
+
+        // In layer mode, zone subtitles become the primary label (e.g., nav icons)
+        if isLayerMode, let subtitle = zoneSubtitle {
+            return subtitle
         }
 
         guard let info = layerKeyInfo else {


### PR DESCRIPTION
## Summary
- Clear stale `layerKeyMap` on layer switch so F1-F12 and non-alpha keys don't briefly flash orange from previous layer's collection colors
- Use zone subtitles (`VallackZoneMap.navSubtitles`) as effective labels in layer mode, providing nav icons (←, ↓, Tab, Esc) from a synchronous source
- Suppress default-orange collection color for keys without a `collectionId` — only collection-owned keys get collection coloring
- Pressed keys with a zone color use that color instead of blue `accentColor`

## Test plan
- [ ] Hold F in Ben's pack — nav keys should be green with icons, F should be green (not blue), non-mapped keys dark gray
- [ ] Release F — should return to base layer cleanly
- [ ] Hold F on vim nav layer — mapped keys should still show collection colors and icons
- [ ] Verify F1-F12 row doesn't flash orange during layer transitions
- [ ] `swift test` passes (521 tests)