### PR TITLE
fix: replace hardcoded font sizes with semantic text styles

### DIFF
--- a/Sources/KeyPathAppKit/UI/CommandPalette/CommandPaletteView.swift
+++ b/Sources/KeyPathAppKit/UI/CommandPalette/CommandPaletteView.swift
@@ -89,12 +89,12 @@ struct CommandPaletteView: View {
     private var searchField: some View {
         HStack(spacing: 8) {
             Image(systemName: "command")
-                .font(.system(size: 14, weight: .medium))
+                .font(.body.weight(.medium))
                 .foregroundStyle(.secondary)
 
             TextField("Type a command\u{2026}", text: $searchText)
                 .textFieldStyle(.plain)
-                .font(.system(size: 15))
+                .font(.title3)
                 .focused($isSearchFocused)
                 .onSubmit {
                     if selectedIndex < filtered.count {
@@ -170,7 +170,7 @@ struct CommandPaletteView: View {
                             }
                         } header: {
                             Text(group.group)
-                                .font(.system(size: 11, weight: .semibold))
+                                .font(.subheadline.weight(.semibold))
                                 .foregroundStyle(.secondary)
                                 .padding(.horizontal, 16)
                                 .padding(.top, groupIdx == 0 ? 6 : 12)
@@ -229,17 +229,17 @@ private struct CommandPaletteRow: View {
         Button(action: onSelect) {
             HStack(spacing: 10) {
                 Image(systemName: item.icon)
-                    .font(.system(size: 14))
+                    .font(.body)
                     .foregroundStyle(isSelected ? .white : .secondary)
                     .frame(width: 22, alignment: .center)
 
                 VStack(alignment: .leading, spacing: 1) {
                     Text(item.title)
-                        .font(.system(size: 13, weight: .medium))
+                        .font(.body.weight(.medium))
                         .foregroundStyle(isSelected ? .white : .primary)
                     if let subtitle = item.subtitle {
                         Text(subtitle)
-                            .font(.system(size: 11))
+                            .font(.subheadline)
                             .foregroundStyle(isSelected ? .white.opacity(0.7) : .secondary)
                     }
                 }
@@ -248,7 +248,7 @@ private struct CommandPaletteRow: View {
 
                 if let shortcut = item.shortcut {
                     Text(shortcut)
-                        .font(.system(size: 11, design: .rounded))
+                        .font(.subheadline.monospaced())
                         .foregroundColor(isSelected ? .white.opacity(0.6) : .secondary.opacity(0.5))
                         .padding(.horizontal, 6)
                         .padding(.vertical, 2)

--- a/Sources/KeyPathAppKit/UI/Components/HomeRowKeyChipSmall.swift
+++ b/Sources/KeyPathAppKit/UI/Components/HomeRowKeyChipSmall.swift
@@ -9,10 +9,10 @@ struct HomeRowKeyChipSmall: View {
     var body: some View {
         VStack(spacing: 2) {
             Text(letter)
-                .font(.system(size: 14, weight: .medium))
+                .font(.body.weight(.medium))
             if !symbol.isEmpty {
                 Text(symbol)
-                    .font(.system(size: 12))
+                    .font(.callout)
                     .foregroundColor(isHovered ? Color(NSColor.windowBackgroundColor).opacity(0.8) : Color.secondary)
             }
         }

--- a/Sources/KeyPathAppKit/UI/Components/KeystrokePresetGridView.swift
+++ b/Sources/KeyPathAppKit/UI/Components/KeystrokePresetGridView.swift
@@ -23,9 +23,9 @@ struct KeystrokePresetGridView: View {
                 Button { onSelect(item.key) } label: {
                     HStack(spacing: 3) {
                         Image(systemName: item.icon)
-                            .font(.system(size: 9))
+                            .font(.caption2)
                         Text(item.label)
-                            .font(.system(size: 10))
+                            .font(.caption)
                     }
                     .frame(maxWidth: .infinity)
                     .padding(.vertical, 4)

--- a/Sources/KeyPathAppKit/UI/Components/StandardKeyBadge.swift
+++ b/Sources/KeyPathAppKit/UI/Components/StandardKeyBadge.swift
@@ -7,7 +7,7 @@ struct StandardKeyBadge: View {
 
     var body: some View {
         Text(uppercase ? key.uppercased() : key)
-            .font(.system(size: 14, weight: .semibold, design: .monospaced))
+            .font(.body.weight(.semibold).monospaced())
             .foregroundColor(color)
             .frame(minWidth: 26, minHeight: 26)
             .padding(.horizontal, 4)

--- a/Sources/KeyPathAppKit/UI/Components/SystemActionGridView.swift
+++ b/Sources/KeyPathAppKit/UI/Components/SystemActionGridView.swift
@@ -82,7 +82,7 @@ struct SystemActionGridView: View {
         VStack(alignment: .leading, spacing: 8) {
             ForEach(groups) { group in
                 Text(group.title)
-                    .font(.system(size: 10, weight: .semibold))
+                    .font(.caption.weight(.semibold))
                     .foregroundStyle(.tertiary)
                 LazyVGrid(columns: [GridItem(.adaptive(minimum: minWidth))], spacing: 4) {
                     ForEach(group.actions) { action in
@@ -101,9 +101,9 @@ struct SystemActionGridView: View {
         } label: {
             HStack(spacing: 3) {
                 Image(systemName: action.sfSymbol)
-                    .font(.system(size: 9))
+                    .font(.caption2)
                 Text(action.name)
-                    .font(.system(size: 10))
+                    .font(.caption)
                     .lineLimit(1)
             }
             .frame(maxWidth: .infinity)

--- a/Sources/KeyPathAppKit/UI/Gallery/ChordGroupsPackContent.swift
+++ b/Sources/KeyPathAppKit/UI/Gallery/ChordGroupsPackContent.swift
@@ -51,14 +51,14 @@ struct ChordGroupsPackContent: View {
         VStack(alignment: .leading, spacing: 6) {
             HStack(spacing: 6) {
                 Image(systemName: group.category.icon)
-                    .font(.system(size: 10))
+                    .font(.caption)
                     .foregroundStyle(.secondary)
                 Text(group.name)
-                    .font(.system(size: 11, weight: .semibold))
+                    .font(.subheadline.weight(.semibold))
                     .foregroundStyle(.secondary)
                 Spacer()
                 Text("\(group.timeout)ms")
-                    .font(.system(size: 10, design: .monospaced))
+                    .font(.caption.monospaced())
                     .foregroundStyle(.tertiary)
             }
 
@@ -93,9 +93,9 @@ struct ChordGroupsPackContent: View {
             } label: {
                 HStack(spacing: 4) {
                     Image(systemName: "plus")
-                        .font(.system(size: 9, weight: .semibold))
+                        .font(.caption2.weight(.semibold))
                     Text("Add chord")
-                        .font(.system(size: 11))
+                        .font(.subheadline)
                 }
                 .foregroundStyle(Color.accentColor)
             }
@@ -121,9 +121,9 @@ struct ChordGroupsPackContent: View {
         } label: {
             HStack(spacing: 4) {
                 Image(systemName: "plus")
-                    .font(.system(size: 9, weight: .semibold))
+                    .font(.caption2.weight(.semibold))
                 Text("Add group")
-                    .font(.system(size: 11))
+                    .font(.subheadline)
             }
             .foregroundStyle(Color.accentColor)
         }
@@ -187,7 +187,7 @@ private struct ChordRuleRow: View {
             // Checkbox — separate button to avoid gesture conflict
             Button(action: onToggle) {
                 Image(systemName: chord.isEnabled ? "checkmark.circle.fill" : "circle")
-                    .font(.system(size: 14))
+                    .font(.body)
                     .foregroundStyle(chord.isEnabled ? Color.accentColor : Color.secondary.opacity(0.4))
                     .frame(width: 30, height: 30)
                     .contentShape(Rectangle())
@@ -284,7 +284,7 @@ private struct ChordRuleRow: View {
         HStack(spacing: 4) {
             if let info = action.commonDisplayInfo, let icon = info.icon {
                 Image(systemName: icon)
-                    .font(.system(size: 12, weight: .semibold))
+                    .font(.callout.weight(.semibold))
             }
             Text(action.commonDisplayInfo?.label ?? action.displayName)
                 .font(.body.weight(.semibold))

--- a/Sources/KeyPathAppKit/UI/Gallery/HoldTimingSliderRow.swift
+++ b/Sources/KeyPathAppKit/UI/Gallery/HoldTimingSliderRow.swift
@@ -29,7 +29,7 @@ struct HoldTimingSliderRow: View {
     var body: some View {
         HStack(spacing: 8) {
             Label("Prefer letters", systemImage: "character.cursor.ibeam")
-                .font(.system(size: 11))
+                .font(.subheadline)
                 .foregroundStyle(.secondary)
                 .lineLimit(1)
 
@@ -52,7 +52,7 @@ struct HoldTimingSliderRow: View {
                         let thumbX = trackInset + trackWidth * fraction
 
                         Text("\(currentValue) ms")
-                            .font(.system(size: 10, weight: .semibold, design: .rounded))
+                            .font(.caption.weight(.semibold).width(.condensed))
                             .foregroundStyle(.white)
                             .padding(.horizontal, 6)
                             .padding(.vertical, 2)
@@ -66,7 +66,7 @@ struct HoldTimingSliderRow: View {
             }
 
             Label("Prefer modifiers", systemImage: "command")
-                .font(.system(size: 11))
+                .font(.subheadline)
                 .foregroundStyle(.secondary)
                 .lineLimit(1)
         }

--- a/Sources/KeyPathAppKit/UI/Gallery/KeystrokeHistoryConsentDialog.swift
+++ b/Sources/KeyPathAppKit/UI/Gallery/KeystrokeHistoryConsentDialog.swift
@@ -7,7 +7,7 @@ struct KeystrokeHistoryConsentDialog: View {
     var body: some View {
         VStack(spacing: 16) {
             Image(systemName: "clock.arrow.trianglehead.counterclockwise.rotate.90")
-                .font(.system(size: 36))
+                .font(.largeTitle)
                 .foregroundStyle(.secondary)
                 .accessibilityHidden(true)
 

--- a/Sources/KeyPathAppKit/UI/Gallery/KindaVimInsightsView.swift
+++ b/Sources/KeyPathAppKit/UI/Gallery/KindaVimInsightsView.swift
@@ -57,7 +57,7 @@ struct KindaVimInsightsView: View {
             VStack(alignment: .leading, spacing: 2) {
                 sectionHeader("Arrow-key reliance · last 30 days")
                 Text("Lower is better — less reaching for the arrow keys.")
-                    .font(.system(size: 11))
+                    .font(.subheadline)
                     .foregroundStyle(.secondary)
             }
             if series.count < 2 {
@@ -66,7 +66,7 @@ struct KindaVimInsightsView: View {
                 chart(for: series)
                     .frame(height: 110)
                 Text(chartSubtitle(series: series))
-                    .font(.system(size: 11, weight: .medium))
+                    .font(.subheadline.weight(.medium))
                     .foregroundStyle(.primary)
             }
         }
@@ -74,7 +74,7 @@ struct KindaVimInsightsView: View {
 
     private var emptyChartCard: some View {
         Text("Use vim for a few days and a chart will appear here.")
-            .font(.system(size: 12))
+            .font(.callout)
             .foregroundStyle(.secondary)
             .padding(.vertical, 12)
             .frame(maxWidth: .infinity, alignment: .center)
@@ -154,7 +154,7 @@ struct KindaVimInsightsView: View {
                 AxisValueLabel {
                     if let percent = value.as(Int.self) {
                         Text("\(percent)%")
-                            .font(.system(size: 9))
+                            .font(.caption2)
                             .foregroundStyle(.secondary)
                     }
                 }
@@ -233,7 +233,7 @@ struct KindaVimInsightsView: View {
             sectionHeader("What you're using")
             if all.isEmpty {
                 Text("No commands recorded yet.")
-                    .font(.system(size: 12))
+                    .font(.callout)
                     .foregroundStyle(.secondary)
             } else {
                 let maxCount = all.first?.count ?? 1
@@ -247,7 +247,7 @@ struct KindaVimInsightsView: View {
                         }
                     } label: {
                         Text(showAllCommands ? "Show less" : "Show more (\(all.count - 8) more)")
-                            .font(.system(size: 11, weight: .medium))
+                            .font(.subheadline.weight(.medium))
                             .foregroundStyle(.secondary)
                     }
                     .buttonStyle(.plain)
@@ -333,7 +333,7 @@ struct KindaVimInsightsView: View {
     private func usageRow(entry: UsageEntry, maxCount: Int) -> some View {
         HStack(spacing: 10) {
             Text(entry.displayLabel)
-                .font(.system(size: 13, weight: .heavy, design: .monospaced))
+                .font(.body.weight(.heavy).monospaced())
                 .frame(width: 36, alignment: .leading)
             GeometryReader { geo in
                 let fraction = CGFloat(entry.count) / CGFloat(max(maxCount, 1))
@@ -356,13 +356,13 @@ struct KindaVimInsightsView: View {
             .frame(height: 6)
             .animation(.spring(response: 0.55, dampingFraction: 0.8), value: entry.count)
             Text("\(entry.count)")
-                .font(.system(size: 11, design: .monospaced))
+                .font(.subheadline.monospaced())
                 .foregroundStyle(.secondary)
                 .frame(width: 44, alignment: .trailing)
                 .contentTransition(.numericText())
                 .animation(.easeOut(duration: 0.4), value: entry.count)
             Text(entry.tier.rawValue)
-                .font(.system(size: 10, weight: .medium))
+                .font(.caption.weight(.medium))
                 .foregroundStyle(tierColor(entry.tier))
                 .frame(width: 80, alignment: .leading)
         }
@@ -398,7 +398,7 @@ struct KindaVimInsightsView: View {
             sectionHeader("What to try next")
             if insights.isEmpty {
                 Text("No suggestions yet — keep using the pack and tips will appear here.")
-                    .font(.system(size: 12))
+                    .font(.callout)
                     .foregroundStyle(.secondary)
             } else {
                 ForEach(insights) { insight in
@@ -411,12 +411,12 @@ struct KindaVimInsightsView: View {
     private func insightCard(_ insight: VimInsight) -> some View {
         HStack(alignment: .top, spacing: 8) {
             Text(insight.glyph.rawValue)
-                .font(.system(size: 14))
+                .font(.body)
             VStack(alignment: .leading, spacing: 2) {
                 Text(insight.title)
-                    .font(.system(size: 12, weight: .semibold))
+                    .font(.callout.weight(.semibold))
                 Text(insight.body)
-                    .font(.system(size: 11))
+                    .font(.subheadline)
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
             }
@@ -455,10 +455,10 @@ struct KindaVimInsightsView: View {
     private func statChip(label: String, value: String) -> some View {
         VStack(alignment: .leading, spacing: 2) {
             Text(label)
-                .font(.system(size: 10))
+                .font(.caption)
                 .foregroundStyle(.secondary)
             Text(value)
-                .font(.system(size: 12, weight: .semibold))
+                .font(.callout.weight(.semibold))
         }
     }
 
@@ -466,7 +466,7 @@ struct KindaVimInsightsView: View {
 
     private func sectionHeader(_ text: String) -> some View {
         Text(text)
-            .font(.system(size: 11, weight: .semibold))
+            .font(.subheadline.weight(.semibold))
             .foregroundStyle(.secondary)
             .textCase(.uppercase)
             .tracking(0.6)

--- a/Sources/KeyPathAppKit/UI/Gallery/KindaVimStatusBlock.swift
+++ b/Sources/KeyPathAppKit/UI/Gallery/KindaVimStatusBlock.swift
@@ -71,10 +71,10 @@ struct KindaVimStatusBlock: View {
             } label: {
                 HStack(spacing: 6) {
                     Image(systemName: "chevron.right")
-                        .font(.system(size: 9, weight: .semibold))
+                        .font(.caption2.weight(.semibold))
                         .rotationEffect(.degrees(showTerminalInfo ? 90 : 0))
                     Text("Setting up vim mode in Terminal")
-                        .font(.system(size: 11, weight: .medium))
+                        .font(.subheadline.weight(.medium))
                     Spacer()
                 }
                 .foregroundStyle(.secondary)
@@ -85,7 +85,7 @@ struct KindaVimStatusBlock: View {
 
             if showTerminalInfo {
                 Text("Terminal apps are usually in KindaVim's ignore list. To practice vim motions there, add `bindkey -v` to your ~/.zshrc to enable zsh's built-in vi mode, then turn on \"Show vim hints in terminal apps\" above.")
-                    .font(.system(size: 11))
+                    .font(.subheadline)
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
                     .padding(.leading, 15)
@@ -96,7 +96,7 @@ struct KindaVimStatusBlock: View {
             Text(
                 "This pack adds no remappings. KindaVim itself handles every keypress; KeyPath just shows you the current mode in the overlay."
             )
-            .font(.system(size: 12))
+            .font(.callout)
             .foregroundStyle(.secondary)
             .fixedSize(horizontal: false, vertical: true)
         }
@@ -136,7 +136,7 @@ struct KindaVimStatusBlock: View {
                 showClearTelemetryConfirmation = true
             } label: {
                 Label("Clear all usage data…", systemImage: "trash")
-                    .font(.system(size: 11))
+                    .font(.subheadline)
             }
             .buttonStyle(.bordered)
             .controlSize(.small)
@@ -153,9 +153,9 @@ struct KindaVimStatusBlock: View {
         HStack(alignment: .top, spacing: 12) {
             VStack(alignment: .leading, spacing: 2) {
                 Text(title)
-                    .font(.system(size: 12, weight: .medium))
+                    .font(.callout.weight(.medium))
                 Text(subtitle)
-                    .font(.system(size: 11))
+                    .font(.subheadline)
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
             }
@@ -173,11 +173,11 @@ struct KindaVimStatusBlock: View {
     private func row(label: String, value: String, tint: Color) -> some View {
         HStack {
             Text(label)
-                .font(.system(size: 12))
+                .font(.callout)
                 .foregroundStyle(.secondary)
             Spacer()
             Text(value)
-                .font(.system(size: 12, weight: .medium))
+                .font(.callout.weight(.medium))
                 .foregroundStyle(tint)
         }
     }

--- a/Sources/KeyPathAppKit/UI/Gallery/PackConflictResolutionDialog.swift
+++ b/Sources/KeyPathAppKit/UI/Gallery/PackConflictResolutionDialog.swift
@@ -52,7 +52,7 @@ struct PackConflictResolutionDialog: View {
                 onCancel()
             } label: {
                 Image(systemName: "xmark")
-                    .font(.system(size: 11, weight: .semibold))
+                    .font(.subheadline.weight(.semibold))
                     .foregroundColor(.secondary)
                     .frame(width: 22, height: 22)
                     .background(

--- a/Sources/KeyPathAppKit/UI/Gallery/PackDetailView+BindingRows.swift
+++ b/Sources/KeyPathAppKit/UI/Gallery/PackDetailView+BindingRows.swift
@@ -187,7 +187,7 @@ extension PackDetailView {
                 VStack(alignment: .leading, spacing: 8) {
                     if let hint = collection.activationHint, !hint.isEmpty {
                         Text(hint)
-                            .font(.system(size: 12, weight: .medium))
+                            .font(.callout.weight(.medium))
                             .foregroundStyle(.secondary)
                     }
                     MappingTableContent(
@@ -204,7 +204,7 @@ extension PackDetailView {
             VStack(alignment: .leading, spacing: 8) {
                 Divider()
                 Text("What this will change")
-                    .font(.system(size: 12, weight: .semibold))
+                    .font(.callout.weight(.semibold))
                     .foregroundStyle(.secondary)
                 ForEach(Array(pack.bindings.enumerated()), id: \.offset) { _, template in
                     bindingRow(template)

--- a/Sources/KeyPathAppKit/UI/Gallery/PackDetailView+Toast.swift
+++ b/Sources/KeyPathAppKit/UI/Gallery/PackDetailView+Toast.swift
@@ -54,7 +54,7 @@ extension PackDetailView {
             Image(systemName: icon)
                 .foregroundStyle(iconColor)
             Text(message)
-                .font(.system(size: 12))
+                .font(.callout)
                 .foregroundStyle(.primary)
             if let action {
                 Button(action.label, action: action.handler)

--- a/Sources/KeyPathAppKit/UI/Gallery/PackDetailView.swift
+++ b/Sources/KeyPathAppKit/UI/Gallery/PackDetailView.swift
@@ -178,9 +178,9 @@ struct PackDetailView: View {
                     } label: {
                         HStack(spacing: 4) {
                             Image(systemName: "chevron.left")
-                                .font(.system(size: 10, weight: .semibold))
+                                .font(.caption.weight(.semibold))
                             Text("All Rules")
-                                .font(.system(size: 12, weight: .medium))
+                                .font(.callout.weight(.medium))
                         }
                         .foregroundStyle(.secondary)
                         .padding(.vertical, 4)
@@ -196,7 +196,7 @@ struct PackDetailView: View {
                 if showBackToRules {
                     Button(action: { PackDetailWindowController.shared.closeWindow() }) {
                         Image(systemName: "xmark.circle.fill")
-                            .font(.system(size: 16))
+                            .font(.title3)
                             .foregroundStyle(.secondary)
                     }
                     .buttonStyle(.plain)
@@ -211,7 +211,7 @@ struct PackDetailView: View {
                 VStack(alignment: .leading, spacing: 4) {
                     HStack(alignment: .firstTextBaseline, spacing: 6) {
                         Text(displayName)
-                            .font(.system(size: 20, weight: .semibold))
+                            .font(.title2.weight(.semibold))
                         if helpResourceName != nil {
                             Button {
                                 if helpResourceName != nil {
@@ -219,7 +219,7 @@ struct PackDetailView: View {
                                 }
                             } label: {
                                 Image(systemName: "questionmark.circle")
-                                    .font(.system(size: 14))
+                                    .font(.body)
                                     .foregroundStyle(.secondary)
                             }
                             .buttonStyle(.plain)
@@ -230,14 +230,14 @@ struct PackDetailView: View {
                     }
                     if let managingPackName {
                         Text("Part of \(managingPackName)")
-                            .font(.system(size: 11, weight: .medium))
+                            .font(.subheadline.weight(.medium))
                             .foregroundStyle(.white)
                             .padding(.horizontal, 8)
                             .padding(.vertical, 3)
                             .background(Capsule().fill(Color.accentColor))
                     }
                     Text(pack.tagline)
-                        .font(.system(size: 13))
+                        .font(.body)
                         .foregroundStyle(.secondary)
                         .fixedSize(horizontal: false, vertical: true)
                     currentConfigRow
@@ -285,10 +285,10 @@ struct PackDetailView: View {
         if let summary = currentConfigSummary {
             HStack(spacing: 6) {
                 Image(systemName: "hand.point.up.left.fill")
-                    .font(.system(size: 10))
+                    .font(.caption)
                     .foregroundStyle(Color.accentColor)
                 Text(summary)
-                    .font(.system(size: 11, weight: .medium))
+                    .font(.subheadline.weight(.medium))
                     .foregroundStyle(Color.accentColor)
             }
             .padding(.top, 2)
@@ -330,20 +330,20 @@ struct PackDetailView: View {
             if let secondary = pack.iconSecondarySymbol {
                 HStack(spacing: 3) {
                     Image(systemName: pack.iconSymbol)
-                        .font(.system(size: 22, weight: .semibold))
+                        .font(.title.weight(.semibold))
                         .foregroundStyle(.tint)
                         .symbolRenderingMode(.hierarchical)
                     Image(systemName: "arrow.right")
-                        .font(.system(size: 9, weight: .semibold))
+                        .font(.caption2.weight(.semibold))
                         .foregroundStyle(.secondary)
                     Image(systemName: secondary)
-                        .font(.system(size: 22, weight: .semibold))
+                        .font(.title.weight(.semibold))
                         .foregroundStyle(.tint)
                         .symbolRenderingMode(.hierarchical)
                 }
             } else {
                 Image(systemName: pack.iconSymbol)
-                    .font(.system(size: 30, weight: .semibold))
+                    .font(.largeTitle.weight(.semibold))
                     .foregroundStyle(.tint)
                     .symbolRenderingMode(.hierarchical)
             }
@@ -483,7 +483,7 @@ struct PackDetailView: View {
 
     var descriptionBlock: some View {
         Text(pack.shortDescription)
-            .font(.system(size: 13))
+            .font(.body)
             .foregroundStyle(.primary)
             .fixedSize(horizontal: false, vertical: true)
             .lineSpacing(2)
@@ -557,7 +557,7 @@ struct PackDetailView: View {
     ) -> some View {
         VStack(alignment: .leading, spacing: 8) {
             Label(label, systemImage: icon)
-                .font(.system(size: 11, weight: .semibold))
+                .font(.subheadline.weight(.semibold))
                 .foregroundStyle(tint)
 
             ForEach(items, id: \.pack.id) { item in
@@ -569,17 +569,17 @@ struct PackDetailView: View {
                 } label: {
                     HStack(spacing: 8) {
                         Image(systemName: item.pack.iconSymbol)
-                            .font(.system(size: 11))
+                            .font(.subheadline)
                             .foregroundStyle(.secondary)
                             .frame(width: 16)
 
                         VStack(alignment: .leading, spacing: 1) {
                             Text(item.pack.name)
-                                .font(.system(size: 12, weight: .medium))
+                                .font(.callout.weight(.medium))
                                 .foregroundStyle(.primary)
                             if !item.description.isEmpty {
                                 Text(item.description)
-                                    .font(.system(size: 10))
+                                    .font(.caption)
                                     .foregroundStyle(.secondary)
                                     .lineLimit(1)
                             }
@@ -588,7 +588,7 @@ struct PackDetailView: View {
                         Spacer(minLength: 0)
 
                         Image(systemName: "chevron.right")
-                            .font(.system(size: 9, weight: .semibold))
+                            .font(.caption2.weight(.semibold))
                             .foregroundStyle(.tertiary)
                     }
                     .padding(.horizontal, 10)
@@ -645,7 +645,7 @@ struct PackDetailView: View {
         case let .slider(_, min: lo, max: hi, step: step, unitSuffix: suffix):
             HStack(spacing: 8) {
                 Text(setting.label)
-                    .font(.system(size: 12))
+                    .font(.callout)
                 Slider(
                     value: sliderBinding(for: setting.id),
                     in: Double(lo) ... Double(hi),
@@ -655,7 +655,7 @@ struct PackDetailView: View {
                 .accessibilityLabel(setting.label)
                 .accessibilityValue("\(quickSettingValues[setting.id] ?? 0)\(suffix)")
                 Text("\(quickSettingValues[setting.id] ?? 0)\(suffix)")
-                    .font(.system(size: 11, design: .monospaced))
+                    .font(.subheadline.monospaced())
                     .foregroundStyle(.secondary)
                     .frame(width: 50, alignment: .trailing)
             }

--- a/Sources/KeyPathAppKit/UI/Gallery/SystemPackComponentsView.swift
+++ b/Sources/KeyPathAppKit/UI/Gallery/SystemPackComponentsView.swift
@@ -19,21 +19,21 @@ struct SystemPackComponentCard: View {
             Button(action: onToggle) {
                 HStack(spacing: 10) {
                     Image(systemName: icon)
-                        .font(.system(size: 14, weight: .medium))
+                        .font(.body.weight(.medium))
                         .foregroundStyle(.secondary)
                         .frame(width: 20)
                     VStack(alignment: .leading, spacing: 2) {
                         Text(title)
-                            .font(.system(size: 13, weight: .semibold))
+                            .font(.body.weight(.semibold))
                             .foregroundStyle(.primary)
                         Text(summary)
-                            .font(.system(size: 11))
+                            .font(.subheadline)
                             .foregroundStyle(.secondary)
                             .lineLimit(isExpanded ? nil : 1)
                     }
                     Spacer(minLength: 0)
                     Image(systemName: "chevron.right")
-                        .font(.system(size: 11, weight: .semibold))
+                        .font(.subheadline.weight(.semibold))
                         .foregroundStyle(.tertiary)
                         .rotationEffect(.degrees(isExpanded ? 90 : 0))
                         .animation(.easeInOut(duration: 0.2), value: isExpanded)
@@ -151,7 +151,7 @@ struct VallackSystemPackContent: View {
             // How it works
             VStack(alignment: .leading, spacing: 6) {
                 Text("How it works")
-                    .font(.system(size: 11, weight: .semibold))
+                    .font(.subheadline.weight(.semibold))
                     .foregroundStyle(.tertiary)
                     .padding(.leading, 4)
 
@@ -192,21 +192,21 @@ struct VallackSystemPackContent: View {
         if selectedLayer == "nav" {
             HStack(spacing: 6) {
                 Text("Hold")
-                    .font(.system(size: 11))
+                    .font(.subheadline)
                     .foregroundStyle(.secondary)
                 ZonedKeycap(label: "F", zone: .activator, size: 20)
                 Text("or")
-                    .font(.system(size: 11))
+                    .font(.subheadline)
                     .foregroundStyle(.secondary)
                 ZonedKeycap(label: "J", zone: .activator, size: 20)
                 Text("to enter  ·  release to exit")
-                    .font(.system(size: 11))
+                    .font(.subheadline)
                     .foregroundStyle(.secondary)
             }
         } else {
             HStack(spacing: 6) {
                 Text("Normal typing with dual-role keys")
-                    .font(.system(size: 11))
+                    .font(.subheadline)
                     .foregroundStyle(.secondary)
             }
         }
@@ -221,9 +221,9 @@ struct VallackSystemPackContent: View {
         } label: {
             HStack(spacing: 5) {
                 Image(systemName: icon)
-                    .font(.system(size: 11, weight: .medium))
+                    .font(.subheadline.weight(.medium))
                 Text(label)
-                    .font(.system(size: 12, weight: .semibold))
+                    .font(.callout.weight(.semibold))
             }
             .foregroundStyle(isSelected ? .primary : .secondary)
             .padding(.horizontal, 14)
@@ -262,7 +262,7 @@ struct VallackSystemPackContent: View {
     private var modsCardContent: some View {
         VStack(alignment: .leading, spacing: 8) {
             Text("Modifiers move to the top row so the home row is free for layer toggles. Tap for the letter, hold for the modifier.")
-                .font(.system(size: 11))
+                .font(.subheadline)
                 .foregroundStyle(.secondary)
             MappingTableContent(
                 mappings: [
@@ -281,19 +281,19 @@ struct VallackSystemPackContent: View {
     private var activatorCardContent: some View {
         VStack(alignment: .leading, spacing: 10) {
             Text("Hold either index finger to activate the navigation layer. Release to return to normal typing. Both activate the same layer — use whichever hand is free.")
-                .font(.system(size: 11))
+                .font(.subheadline)
                 .foregroundStyle(.secondary)
             HStack(spacing: 8) {
                 Text("Hold")
-                    .font(.system(size: 12))
+                    .font(.callout)
                     .foregroundStyle(.secondary)
                 StandardKeyBadge(key: "F", color: .orange)
                 Text("or")
-                    .font(.system(size: 12))
+                    .font(.callout)
                     .foregroundStyle(.secondary)
                 StandardKeyBadge(key: "J", color: .orange)
                 Text("→ navigation layer")
-                    .font(.system(size: 12))
+                    .font(.callout)
                     .foregroundStyle(.secondary)
             }
         }
@@ -304,7 +304,7 @@ struct VallackSystemPackContent: View {
         if let collection = navCollection {
             VStack(alignment: .leading, spacing: 8) {
                 Text("Right hand navigates (HJKL arrows, backspace, enter). Left hand switches and edits (tabs, clipboard, escape).")
-                    .font(.system(size: 11))
+                    .font(.subheadline)
                     .foregroundStyle(.secondary)
                 MappingTableContent(
                     mappings: collection.mappings.map {

--- a/Sources/KeyPathAppKit/UI/Help/HelpBrowserView.swift
+++ b/Sources/KeyPathAppKit/UI/Help/HelpBrowserView.swift
@@ -222,7 +222,7 @@ struct HelpBrowserView: View {
                     } label: {
                         HStack(spacing: 4) {
                             Image(systemName: "chevron.left")
-                                .font(.system(size: 12, weight: .semibold))
+                                .font(.callout.weight(.semibold))
                             Text("Help")
                                 .font(.callout)
                         }
@@ -239,7 +239,7 @@ struct HelpBrowserView: View {
                     // Prev / Next
                     Button { navigateBack() } label: {
                         Image(systemName: "chevron.left")
-                            .font(.system(size: 12, weight: .medium))
+                            .font(.callout.weight(.medium))
                             .frame(width: 28, height: 24)
                             .contentShape(Rectangle())
                     }
@@ -251,7 +251,7 @@ struct HelpBrowserView: View {
 
                     Button { navigateForward() } label: {
                         Image(systemName: "chevron.right")
-                            .font(.system(size: 12, weight: .medium))
+                            .font(.callout.weight(.medium))
                             .frame(width: 28, height: 24)
                             .contentShape(Rectangle())
                     }
@@ -380,7 +380,7 @@ struct HelpBrowserView: View {
                 // Number hint, vertically aligned with title
                 if number <= 9 {
                     Text("\(number)")
-                        .font(.system(size: 10, weight: .medium, design: .rounded))
+                        .font(.caption.weight(.medium).width(.condensed))
                         .foregroundColor(Color(nsColor: .init(red: 0.55, green: 0.45, blue: 0.35, alpha: 0.4)))
                 }
             }

--- a/Sources/KeyPathAppKit/UI/Rules/ChordGroupsModalView.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/ChordGroupsModalView.swift
@@ -595,7 +595,7 @@ struct ChordEditorDialog: View {
                 // Keys
                 HStack(alignment: .center) {
                     Text("Keys")
-                        .font(.system(size: 12, weight: .medium))
+                        .font(.callout.weight(.medium))
                         .foregroundStyle(.secondary)
                         .frame(width: 56, alignment: .trailing)
 
@@ -605,7 +605,7 @@ struct ChordEditorDialog: View {
                                 Button { keys.remove(at: index) } label: {
                                     HStack(spacing: 3) {
                                         Text(key.uppercased())
-                                            .font(.system(size: 12, weight: .semibold, design: .monospaced))
+                                            .font(.callout.weight(.semibold).monospaced())
                                         Image(systemName: "xmark")
                                             .font(.system(size: 8, weight: .bold))
                                             .foregroundStyle(.secondary)
@@ -620,7 +620,7 @@ struct ChordEditorDialog: View {
                         if keys.filter({ !$0.isEmpty }).count < 4 {
                             TextField("key", text: $newKeyInput)
                                 .textFieldStyle(.roundedBorder)
-                                .font(.system(size: 12, design: .monospaced))
+                                .font(.callout.monospaced())
                                 .frame(width: 60)
                                 .onSubmit {
                                     let trimmed = newKeyInput.trimmingCharacters(in: .whitespaces).lowercased()
@@ -637,7 +637,7 @@ struct ChordEditorDialog: View {
                 // Output type picker
                 HStack(alignment: .top) {
                     Text("Action")
-                        .font(.system(size: 12, weight: .medium))
+                        .font(.callout.weight(.medium))
                         .foregroundStyle(.secondary)
                         .frame(width: 56, alignment: .trailing)
                         .padding(.top, 4)
@@ -658,13 +658,13 @@ struct ChordEditorDialog: View {
                 // Note
                 HStack(alignment: .firstTextBaseline) {
                     Text("Note")
-                        .font(.system(size: 12, weight: .medium))
+                        .font(.callout.weight(.medium))
                         .foregroundStyle(.secondary)
                         .frame(width: 56, alignment: .trailing)
 
                     TextField("Optional description", text: $description)
                         .textFieldStyle(.roundedBorder)
-                        .font(.system(size: 13))
+                        .font(.body)
                 }
             }
             .padding(.horizontal, 24)
@@ -718,7 +718,7 @@ struct ChordEditorDialog: View {
         case .appLaunch:
             VStack(alignment: .leading, spacing: 6) {
                 Text("Enter app name or bundle ID:")
-                    .font(.system(size: 11))
+                    .font(.subheadline)
                     .foregroundStyle(.secondary)
                 TextField("Safari", text: Binding(
                     get: {
@@ -728,17 +728,17 @@ struct ChordEditorDialog: View {
                     set: { selectedAction = .launchApp(name: $0, bundleId: nil) }
                 ))
                 .textFieldStyle(.roundedBorder)
-                .font(.system(size: 13))
+                .font(.body)
             }
 
         case .custom:
             VStack(alignment: .leading, spacing: 6) {
                 Text("Kanata expression:")
-                    .font(.system(size: 11))
+                    .font(.subheadline)
                     .foregroundStyle(.secondary)
                 TextField("C-x", text: $customOutput)
                     .textFieldStyle(.roundedBorder)
-                    .font(.system(size: 13, design: .monospaced))
+                    .font(.body.monospaced())
                     .onChange(of: customOutput) { _, newValue in
                         if !newValue.isEmpty {
                             selectedAction = .rawKanata(newValue)
@@ -777,7 +777,7 @@ struct ChordEditorDialog: View {
 
     private func keycap(_ text: String) -> some View {
         Text(text)
-            .font(.system(size: 16, weight: .semibold, design: .monospaced))
+            .font(.title3.weight(.semibold).monospaced())
             .foregroundStyle(Self.keycapText)
             .padding(.horizontal, 14)
             .padding(.vertical, 10)
@@ -793,7 +793,7 @@ struct ChordEditorDialog: View {
 
     private func placeholderKeycap(_ text: String) -> some View {
         Text(text)
-            .font(.system(size: 16, weight: .semibold, design: .monospaced))
+            .font(.title3.weight(.semibold).monospaced())
             .foregroundStyle(.secondary.opacity(0.4))
             .padding(.horizontal, 14)
             .padding(.vertical, 10)

--- a/Sources/KeyPathAppKit/UI/Rules/ExpandableKeystrokeHistoryRow.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/ExpandableKeystrokeHistoryRow.swift
@@ -57,20 +57,20 @@ struct ExpandableKeystrokeHistoryRow: View {
 
                     VStack(alignment: .leading, spacing: 2) {
                         Text(PackRegistry.keystrokeHistory.name)
-                            .font(.system(size: 14, weight: .medium))
+                            .font(.body.weight(.medium))
                             .foregroundStyle(.primary)
                             .lineLimit(1)
 
                         Text(PackRegistry.keystrokeHistory.tagline)
-                            .font(.system(size: 12))
+                            .font(.callout)
                             .foregroundStyle(.secondary)
                             .lineLimit(1)
 
                         HStack(spacing: 4) {
                             Image(systemName: "lock.shield")
-                                .font(.system(size: 9))
+                                .font(.caption2)
                             Text("Memory only")
-                                .font(.system(size: 10))
+                                .font(.caption)
                         }
                         .foregroundStyle(.tertiary)
                         .padding(.top, 1)

--- a/Sources/KeyPathAppKit/UI/Rules/ExpandableKindaVimRow.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/ExpandableKindaVimRow.swift
@@ -139,10 +139,10 @@ struct ExpandableKindaVimRow: View {
     private func staticModeBadge(_ label: String, tint: Color) -> some View {
         HStack(spacing: 4) {
             Text("VIM")
-                .font(.system(size: 9, weight: .heavy))
+                .font(.caption2.weight(.heavy))
                 .foregroundStyle(.secondary)
             Text(label)
-                .font(.system(size: 9, weight: .heavy))
+                .font(.caption2.weight(.heavy))
                 .foregroundStyle(tint)
         }
         .padding(.horizontal, 6)

--- a/Sources/KeyPathAppKit/UI/Rules/HomeRowKeyboardView.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/HomeRowKeyboardView.swift
@@ -433,9 +433,9 @@ private struct HomeRowLayerTargetChip: View {
     var body: some View {
         HStack(spacing: 3) {
             Image(systemName: LayerInfo.iconName(for: layerName))
-                .font(.system(size: 9, weight: .semibold))
+                .font(.caption2.weight(.semibold))
             Text(LayerInfo.displayName(for: layerName))
-                .font(.system(size: 9, weight: .semibold))
+                .font(.caption2.weight(.semibold))
                 .lineLimit(1)
                 .minimumScaleFactor(0.7)
         }

--- a/Sources/KeyPathAppKit/UI/Rules/HomeRowTimingSection.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/HomeRowTimingSection.swift
@@ -140,7 +140,7 @@ struct HomeRowTimingSection: View {
                 .overlay(alignment: .top) {
                     if isEditingHoldDuration {
                         Text("\(config.timing.holdDelay)ms")
-                            .font(.system(size: 10, weight: .semibold, design: .rounded))
+                            .font(.caption.weight(.semibold).width(.condensed))
                             .foregroundStyle(.white)
                             .padding(.horizontal, 6)
                             .padding(.vertical, 2)
@@ -233,7 +233,7 @@ struct HomeRowTimingSection: View {
                             .overlay(alignment: .top) {
                                 if isEditingIdleWindow {
                                     Text("\(config.timing.requirePriorIdleMs)ms")
-                                        .font(.system(size: 10, weight: .semibold, design: .rounded))
+                                        .font(.caption.weight(.semibold).width(.condensed))
                                         .foregroundStyle(.white)
                                         .padding(.horizontal, 6)
                                         .padding(.vertical, 2)

--- a/Sources/KeyPathAppKit/UI/Rules/KeyRepeatControlView.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/KeyRepeatControlView.swift
@@ -88,13 +88,13 @@ struct KeyRepeatControlView: View {
 
             VStack(alignment: .leading, spacing: 6) {
                 Text(heroHeadline)
-                    .font(.system(size: 13, weight: .medium))
+                    .font(.body.weight(.medium))
                     .lineSpacing(2)
                     .fixedSize(horizontal: false, vertical: true)
                     .contentTransition(.numericText())
 
                 Text(heroSubhead)
-                    .font(.system(size: 11))
+                    .font(.subheadline)
                     .foregroundStyle(.secondary)
                     .lineSpacing(2)
                     .fixedSize(horizontal: false, vertical: true)
@@ -136,7 +136,7 @@ struct KeyRepeatControlView: View {
 
     private func heroKeycap(_ label: String) -> some View {
         Text(label)
-            .font(.system(size: 20, weight: .medium))
+            .font(.title2.weight(.medium))
             .frame(width: 42, height: 38)
             .background(
                 RoundedRectangle(cornerRadius: 7, style: .continuous)
@@ -231,11 +231,11 @@ struct KeyRepeatControlView: View {
         VStack(alignment: .leading, spacing: 8) {
             HStack {
                 Text("All keys")
-                    .font(.system(size: 11, weight: .semibold))
+                    .font(.subheadline.weight(.semibold))
                     .foregroundStyle(.secondary)
                 Spacer()
                 Text("\(globalDelayMs)ms delay · \(KeyRepeatControlConfig.keysPerSecond(fromIntervalMs: globalIntervalMs))")
-                    .font(.system(size: 10, design: .monospaced))
+                    .font(.caption.monospaced())
                     .foregroundStyle(.tertiary)
             }
             cleanSlider(label: "Delay", value: $globalDelayMs, range: 50...2000, snap: 10, id: "global-delay")
@@ -247,13 +247,13 @@ struct KeyRepeatControlView: View {
         VStack(alignment: .leading, spacing: 8) {
             HStack {
                 Toggle("Arrow keys", isOn: $arrowEnabled)
-                    .font(.system(size: 11, weight: .semibold))
+                    .font(.subheadline.weight(.semibold))
                     .toggleStyle(.checkbox)
                     .accessibilityIdentifier("key-repeat-arrow-toggle")
                 Spacer()
                 if arrowEnabled {
                     Text("\(arrowDelayMs)ms · \(KeyRepeatControlConfig.keysPerSecond(fromIntervalMs: arrowIntervalMs))")
-                        .font(.system(size: 10, design: .monospaced))
+                        .font(.caption.monospaced())
                         .foregroundStyle(.tertiary)
                 }
             }
@@ -267,7 +267,7 @@ struct KeyRepeatControlView: View {
     private var deleteSection: some View {
         VStack(alignment: .leading, spacing: 8) {
             Toggle("Delete ⌫", isOn: $deleteEnabled)
-                .font(.system(size: 11, weight: .semibold))
+                .font(.subheadline.weight(.semibold))
                 .toggleStyle(.checkbox)
                 .accessibilityIdentifier("key-repeat-delete-toggle")
             if deleteEnabled {
@@ -281,7 +281,7 @@ struct KeyRepeatControlView: View {
     private var fwdDeleteSection: some View {
         VStack(alignment: .leading, spacing: 8) {
             Toggle("Fwd Delete ⌦", isOn: $fwdDeleteEnabled)
-                .font(.system(size: 11, weight: .semibold))
+                .font(.subheadline.weight(.semibold))
                 .toggleStyle(.checkbox)
                 .accessibilityIdentifier("key-repeat-fwd-delete-toggle")
             if fwdDeleteEnabled {
@@ -299,7 +299,7 @@ struct KeyRepeatControlView: View {
             ForEach(Array(customOverrides.enumerated()), id: \.element.id) { index, entry in
                 HStack(alignment: .top, spacing: 8) {
                     Text(entry.key)
-                        .font(.system(size: 11, weight: .semibold, design: .monospaced))
+                        .font(.subheadline.weight(.semibold).monospaced())
                         .padding(.horizontal, 6).padding(.vertical, 3)
                         .background(RoundedRectangle(cornerRadius: 4).fill(Color.accentColor.opacity(0.1)))
                         .foregroundStyle(Color.accentColor)
@@ -316,7 +316,7 @@ struct KeyRepeatControlView: View {
                     }
 
                     Button { customOverrides.remove(at: index) } label: {
-                        Image(systemName: "xmark.circle.fill").font(.system(size: 11)).foregroundStyle(.tertiary)
+                        Image(systemName: "xmark.circle.fill").font(.subheadline).foregroundStyle(.tertiary)
                     }.buttonStyle(.plain)
                     .accessibilityIdentifier("key-repeat-remove-custom-\(entry.key)")
                 }
@@ -329,7 +329,7 @@ struct KeyRepeatControlView: View {
             if showingAddCustom {
                 HStack(spacing: 8) {
                     TextField("Key name (e.g. a, spc)", text: $newKeyText)
-                        .textFieldStyle(.roundedBorder).font(.system(size: 11)).frame(maxWidth: 160)
+                        .textFieldStyle(.roundedBorder).font(.subheadline).frame(maxWidth: 160)
                         .onSubmit { commitCustomKey() }
                         .accessibilityIdentifier("key-repeat-custom-key-field")
                     Button("Add") { commitCustomKey() }
@@ -341,7 +341,7 @@ struct KeyRepeatControlView: View {
             } else {
                 Button { showingAddCustom = true } label: {
                     Label("Add custom key", systemImage: "plus.circle")
-                        .font(.system(size: 11, weight: .medium))
+                        .font(.subheadline.weight(.medium))
                 }.buttonStyle(.plain).foregroundStyle(Color.accentColor)
                 .accessibilityIdentifier("key-repeat-add-custom-key-button")
             }
@@ -361,11 +361,11 @@ struct KeyRepeatControlView: View {
     private var testArea: some View {
         VStack(alignment: .leading, spacing: 5) {
             Text("Test area")
-                .font(.system(size: 11, weight: .medium))
+                .font(.subheadline.weight(.medium))
                 .foregroundStyle(.tertiary)
 
             TextEditor(text: $testText)
-                .font(.system(size: 12))
+                .font(.callout)
                 .frame(height: 56)
                 .scrollContentBackground(.hidden)
                 .padding(8)
@@ -384,7 +384,7 @@ struct KeyRepeatControlView: View {
             : "\(value.wrappedValue) \(unit)"
         return HStack(spacing: 8) {
             Text(label)
-                .font(.system(size: 10))
+                .font(.caption)
                 .foregroundStyle(.tertiary)
                 .frame(width: 36, alignment: .trailing)
             Slider(value: Binding(

--- a/Sources/KeyPathAppKit/UI/Rules/LauncherCollectionView.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/LauncherCollectionView.swift
@@ -525,7 +525,7 @@ struct LauncherMappingEditor: View {
                     .shadow(color: .black.opacity(0.15), radius: 3, y: 1)
             } else {
                 Image(systemName: targetType.iconName)
-                    .font(.system(size: 24))
+                    .font(.title)
                     .foregroundColor(.secondary)
                     .frame(width: 56, height: 56)
                     .background(
@@ -536,7 +536,7 @@ struct LauncherMappingEditor: View {
 
             VStack(alignment: .leading, spacing: 3) {
                 Text(currentDisplayName.isEmpty ? "New Launcher" : currentDisplayName)
-                    .font(.system(size: 15, weight: .medium))
+                    .font(.title3.weight(.medium))
                     .lineLimit(1)
                     .foregroundColor(currentDisplayName.isEmpty ? .secondary : .primary)
                 Text(targetType.rawValue)
@@ -548,7 +548,7 @@ struct LauncherMappingEditor: View {
 
             if !normalizedKey.isEmpty {
                 Text(displayKey.uppercased())
-                    .font(.system(size: 20, weight: .bold, design: .monospaced))
+                    .font(.title2.bold().monospaced())
                     .foregroundColor(.white)
                     .frame(minWidth: 40)
                     .padding(.horizontal, 12)
@@ -642,7 +642,7 @@ struct LauncherMappingEditor: View {
                 formRow("") {
                     VStack(alignment: .leading, spacing: 6) {
                         Text(coloredScriptPreview(preview))
-                            .font(.system(size: 10, design: .monospaced))
+                            .font(.caption.monospaced())
                             .lineLimit(10)
                             .frame(maxWidth: .infinity, alignment: .leading)
                             .padding(8)
@@ -727,7 +727,7 @@ struct LauncherMappingEditor: View {
     private func formRow<Content: View>(_ label: String, @ViewBuilder content: () -> Content) -> some View {
         HStack(alignment: .firstTextBaseline, spacing: 12) {
             Text(label)
-                .font(.system(size: 12))
+                .font(.callout)
                 .foregroundColor(.secondary)
                 .frame(width: 72, alignment: .trailing)
             content()

--- a/Sources/KeyPathAppKit/UI/Rules/LauncherDrawerView.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/LauncherDrawerView.swift
@@ -233,14 +233,14 @@ private struct LauncherMappingCard: View {
 
             VStack(alignment: .leading, spacing: 3) {
                 Text(mapping.userDescription ?? mapping.action.displayName)
-                    .font(.system(size: 13, weight: .medium))
+                    .font(.body.weight(.medium))
                     .lineLimit(1)
                     .foregroundColor(mapping.isEnabled ? .primary : .secondary)
                     .strikethrough(!mapping.isEnabled, color: .secondary)
 
                 HStack(spacing: 4) {
                     Image(systemName: typeIconName)
-                        .font(.system(size: 9))
+                        .font(.caption2)
                     Text(typeLabel)
                         .font(.caption2)
                     if !mapping.isEnabled {
@@ -254,7 +254,7 @@ private struct LauncherMappingCard: View {
             Spacer(minLength: 4)
 
             Text(displayKey.uppercased())
-                .font(.system(size: 14, weight: .bold, design: .monospaced))
+                .font(.body.bold().monospaced())
                 .foregroundColor(.white)
                 .frame(minWidth: 28)
                 .padding(.horizontal, 8)
@@ -307,7 +307,7 @@ private struct LauncherMappingCard: View {
                 .saturation(mapping.isEnabled ? 1.0 : 0.3)
         } else {
             Image(systemName: typeIconName)
-                .font(.system(size: 20))
+                .font(.title2)
                 .foregroundColor(.secondary)
                 .frame(width: 44, height: 44)
                 .background(

--- a/Sources/KeyPathAppKit/UI/Rules/RecommendedRulesSection.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/RecommendedRulesSection.swift
@@ -49,12 +49,12 @@ struct RecommendedRulesSection: View {
                 // Title + reason
                 VStack(alignment: .leading, spacing: 3) {
                     Text(pack?.name ?? item.collection.name)
-                        .font(.system(size: 13, weight: .semibold))
+                        .font(.body.weight(.semibold))
                         .foregroundStyle(.primary)
                         .lineLimit(1)
 
                     Text(item.reason)
-                        .font(.system(size: 11))
+                        .font(.subheadline)
                         .foregroundStyle(.secondary)
                         .lineLimit(2)
                         .fixedSize(horizontal: false, vertical: true)
@@ -84,20 +84,20 @@ struct RecommendedRulesSection: View {
         if let secondary = pack?.iconSecondarySymbol {
             HStack(spacing: 6) {
                 Image(systemName: symbol)
-                    .font(.system(size: 24, weight: .semibold))
+                    .font(.title.weight(.semibold))
                     .foregroundStyle(.tint)
                     .symbolRenderingMode(.hierarchical)
                 Image(systemName: "arrow.right")
-                    .font(.system(size: 10, weight: .semibold))
+                    .font(.caption.weight(.semibold))
                     .foregroundStyle(.secondary)
                 Image(systemName: secondary)
-                    .font(.system(size: 24, weight: .semibold))
+                    .font(.title.weight(.semibold))
                     .foregroundStyle(.tint)
                     .symbolRenderingMode(.hierarchical)
             }
         } else {
             Image(systemName: symbol)
-                .font(.system(size: 30, weight: .semibold))
+                .font(.largeTitle.weight(.semibold))
                 .foregroundStyle(.tint)
                 .symbolRenderingMode(.hierarchical)
         }

--- a/Sources/KeyPathAppKit/UI/Rules/RuleConflictResolutionDialog.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/RuleConflictResolutionDialog.swift
@@ -117,7 +117,7 @@ struct RuleConflictResolutionDialog: View {
                 onCancel()
             } label: {
                 Image(systemName: "xmark")
-                    .font(.system(size: 11, weight: .semibold))
+                    .font(.subheadline.weight(.semibold))
                     .foregroundColor(.secondary)
                     .frame(width: 22, height: 22)
                     .background(

--- a/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView+MappingTable.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView+MappingTable.swift
@@ -122,7 +122,7 @@ struct MappingTableContent: View {
 
     private func actionCell(_ text: String) -> some View {
         StandardKeyBadge(key: text, color: .secondary, uppercase: false)
-            .font(.system(size: 15, weight: .semibold, design: .monospaced))
+            .font(.title3.weight(.semibold).monospaced())
             .fixedSize(horizontal: true, vertical: false)
             .frame(maxWidth: .infinity)
     }

--- a/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView.swift
@@ -625,7 +625,7 @@ struct RulesTabView: View {
                             case let .header(category):
                                 HStack(spacing: 6) {
                                     Text(category.displayName.uppercased())
-                                        .font(.system(size: 11, weight: .semibold))
+                                        .font(.subheadline.weight(.semibold))
                                         .foregroundStyle(.secondary)
                                         .tracking(0.8)
 

--- a/Sources/KeyPathAppKit/UI/Settings/ExperimentalSettingsSection.swift
+++ b/Sources/KeyPathAppKit/UI/Settings/ExperimentalSettingsSection.swift
@@ -81,9 +81,9 @@ struct ExperimentalSettingsSection: View {
                                         .frame(width: 16)
                                     VStack(alignment: .leading, spacing: 1) {
                                         Text(appDisplayName(for: bundleID))
-                                            .font(.system(size: 12, weight: .medium))
+                                            .font(.callout.weight(.medium))
                                         Text(bundleID)
-                                            .font(.system(size: 10, design: .monospaced))
+                                            .font(.caption.monospaced())
                                             .foregroundStyle(.secondary)
                                     }
                                     Spacer()
@@ -116,7 +116,7 @@ struct ExperimentalSettingsSection: View {
                             addAppViaPicker()
                         } label: {
                             Label("Add App…", systemImage: "plus")
-                                .font(.system(size: 12, weight: .medium))
+                                .font(.callout.weight(.medium))
                         }
                         .buttonStyle(.bordered)
                         .controlSize(.small)

--- a/Sources/KeyPathAppKit/UI/Settings/SettingsView+General.swift
+++ b/Sources/KeyPathAppKit/UI/Settings/SettingsView+General.swift
@@ -231,9 +231,9 @@ struct LayerIndicatorToggle: View {
         HStack(alignment: .top, spacing: 12) {
             VStack(alignment: .leading, spacing: 2) {
                 Text("Layer change notification")
-                    .font(.system(size: 13, weight: .medium))
+                    .font(.body.weight(.medium))
                 Text("Shows a banner and plays a sound when switching layers.")
-                    .font(.system(size: 11))
+                    .font(.subheadline)
                     .foregroundStyle(.secondary)
             }
             Spacer()

--- a/Sources/KeyPathAppKit/UI/Settings/SettingsView.swift
+++ b/Sources/KeyPathAppKit/UI/Settings/SettingsView.swift
@@ -324,7 +324,7 @@ struct StatusSettingsTabView: View {
                     // Hero: icon + name + status
                     HStack(spacing: 14) {
                         Image(systemName: "keyboard.fill")
-                            .font(.system(size: 28))
+                            .font(.largeTitle)
                             .foregroundStyle(.secondary)
                             .frame(width: 44, height: 44)
                             .background(.quaternary.opacity(0.5), in: RoundedRectangle(cornerRadius: 10, style: .continuous))
@@ -414,7 +414,7 @@ struct StatusSettingsTabView: View {
             } else {
                 HStack(spacing: 14) {
                     Image(systemName: "keyboard")
-                        .font(.system(size: 28))
+                        .font(.largeTitle)
                         .foregroundStyle(.tertiary)
                         .frame(width: 44, height: 44)
 

--- a/Sources/KeyPathAppKit/UI/Vim/NeovimTerminalCollectionView.swift
+++ b/Sources/KeyPathAppKit/UI/Vim/NeovimTerminalCollectionView.swift
@@ -181,7 +181,7 @@ struct NeovimTerminalCollectionView: View {
                 .animation(.spring(response: 0.3, dampingFraction: 0.7), value: isHovered)
 
                 Image(systemName: selectedTopics.contains(category.rawValue) ? "checkmark.square.fill" : "square")
-                    .font(.system(size: 20, weight: .semibold))
+                    .font(.title2.weight(.semibold))
                     .foregroundColor(selectedTopics.contains(category.rawValue) ? category.accentColor : .secondary)
                     .padding(10)
             }

--- a/Sources/KeyPathAppKit/UI/Vim/VimKeyBadge.swift
+++ b/Sources/KeyPathAppKit/UI/Vim/VimKeyBadge.swift
@@ -8,7 +8,7 @@ struct VimKeyBadge: View {
 
     var body: some View {
         Text(key)
-            .font(.system(size: 14, weight: .semibold, design: .monospaced))
+            .font(.body.weight(.semibold).monospaced())
             .foregroundColor(isHovered ? .white : color)
             .frame(width: 28, height: 28)
             .background(


### PR DESCRIPTION
## Summary
- Replace ~160 instances of `.font(.system(size: N))` with semantic SwiftUI text styles
- 33 files updated across Gallery, Rules, Settings, Help, CommandPalette, Components, Vim
- Overlay keycap rendering excluded (pixel-precise keyboard geometry)
- Remaining ~45 instances are dynamic sizes or overlay-specific

**Size mapping:** 9→caption2, 10→caption, 11→subheadline, 12→callout, 13-14→body, 15-16→title3, 18-20→title2, 22-24→title, 28+→largeTitle

Closes #478

## Test plan
- [x] `swift build` — clean
- [x] `swift test` — 532 tests pass
- [ ] Visual check: text sizes look correct across Gallery, Rules, Settings
- [ ] Enable Dynamic Type in System Settings → text scales appropriately