### PR TITLE
fix: store fire-and-forget Task references for cancellation tracking

### DIFF
--- a/Sources/KeyPathAppKit/Services/ActionDispatcher.swift
+++ b/Sources/KeyPathAppKit/Services/ActionDispatcher.swift
@@ -66,6 +66,13 @@ public final class ActionDispatcher {
     /// Parameter: callback to open settings
     public var onScriptExecutionDisabled: ((@escaping () -> Void) -> Void)?
 
+    // MARK: - Active Tasks
+
+    private var fakeKeyTask: Task<Void, Never>?
+    private var notifyTask: Task<Void, Never>?
+    private var scriptTask: Task<Void, Never>?
+    private var repairHelperTask: Task<Void, Never>?
+
     // MARK: - Initialization
 
     private init() {}
@@ -237,8 +244,8 @@ public final class ActionDispatcher {
 
         AppLogger.shared.log("🔔 [ActionDispatcher] Notify: \(title) - \(body)")
 
-        // Use UserNotificationService if available, otherwise just log
-        Task {
+        notifyTask?.cancel()
+        notifyTask = Task {
             await showNotification(title: title, body: body, sound: sound)
         }
 
@@ -323,8 +330,8 @@ public final class ActionDispatcher {
         // Get TCP port from preferences
         let port = PreferencesService.shared.tcpServerPort
 
-        // Fire-and-forget the TCP command (create client on-demand like other services)
-        Task {
+        fakeKeyTask?.cancel()
+        fakeKeyTask = Task {
             let client = KanataTCPClient(port: port, timeout: 3.0)
 
             // Quick check if server is reachable
@@ -402,7 +409,8 @@ public final class ActionDispatcher {
                 || useAppleScriptFallbackRaw == "true"
                 || useAppleScriptFallbackRaw == "yes"
 
-            Task { @MainActor in
+            repairHelperTask?.cancel()
+            repairHelperTask = Task { @MainActor in
                 let repaired = await HelperMaintenance.shared.runCleanupAndRepair(
                     useAppleScriptFallback: useAppleScriptFallback
                 )
@@ -734,16 +742,14 @@ public final class ActionDispatcher {
         let isAppleScriptFile = securityService.isAppleScript(path)
         let isInterpretedScript = securityService.isInterpretedScript(path)
 
-        Task { [weak self] in
+        scriptTask?.cancel()
+        scriptTask = Task { [weak self] in
             do {
                 if isAppleScriptFile {
-                    // Execute AppleScript
                     try await self?.executeAppleScript(at: path)
                 } else if isInterpretedScript {
-                    // Execute interpreted script (Python, Ruby, Perl, Lua)
                     try await self?.executeInterpretedScript(at: path)
                 } else {
-                    // Execute shell script or executable
                     try await self?.executeShellScript(at: path)
                 }
 

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+EventMonitoring.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+EventMonitoring.swift
@@ -13,7 +13,8 @@ extension RuleCollectionsManager {
             return
         }
 
-        Task.detached(priority: .background) { [weak self] in
+        eventMonitoringTask?.cancel()
+        eventMonitoringTask = Task.detached(priority: .background) { [weak self] in
             guard let self else { return }
             await eventListener.start(
                 port: port,
@@ -229,6 +230,14 @@ extension RuleCollectionsManager {
         let payloadStart = message.index(message.startIndex, offsetBy: 5)
         let payload = String(message[payloadStart...]).trimmingCharacters(in: .whitespacesAndNewlines)
         return payload.isEmpty ? nil : payload
+    }
+
+    /// Stop the event monitoring task and its underlying listener
+    func stopEventMonitoring() async {
+        eventMonitoringTask?.cancel()
+        eventMonitoringTask = nil
+        await eventListener.stop()
+        AppLogger.shared.log("🌐 [RuleCollectionsManager] Stopped event monitoring")
     }
 
     /// Deprecated: Use startEventMonitoring instead

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager.swift
@@ -52,6 +52,10 @@ final class RuleCollectionsManager {
     /// Whether to include punctuation in keymap remapping
     var keymapIncludesPunctuation: Bool = false
 
+    // MARK: - Active Tasks
+
+    var eventMonitoringTask: Task<Void, Never>?
+
     // MARK: - Dependencies
 
     let ruleCollectionStore: RuleCollectionStore
@@ -99,6 +103,7 @@ final class RuleCollectionsManager {
     }
 
     deinit {
+        eventMonitoringTask?.cancel()
         let listener = eventListener
         Task.detached(priority: .background) {
             await listener.stop()


### PR DESCRIPTION
## Summary
- Store `Task` references in ActionDispatcher for fakekey, notify, script, and repair-helper operations so they can be cancelled when superseded by new operations
- Store event monitoring task in RuleCollectionsManager with cancel-before-restart semantics and deinit cleanup
- Add `stopEventMonitoring()` method for explicit lifecycle control

Closes #479

## Test plan
- [x] Build passes (`swift build`)
- [x] All 532 tests pass (`swift test`)
- [x] ActionDispatcher routing tests (53 tests) pass
- [ ] Verify rapid fakekey actions don't pile up TCP connections (manual)