### PR TITLE
fix: suppress orange flash on overlay during layer switch

### DIFF
--- a/Sources/KeyPathAppKit/UI/KeyboardVisualization/KeyboardVisualizationViewModel+LayoutMapping.swift
+++ b/Sources/KeyPathAppKit/UI/KeyboardVisualization/KeyboardVisualizationViewModel+LayoutMapping.swift
@@ -25,9 +25,13 @@ extension KeyboardVisualizationViewModel {
 
         // Set layer name immediately so computed properties (isLauncherModeActive,
         // layer indicators) update without waiting for the async mapping rebuild.
-        // The key map refreshes in the background — a brief stale-label window is
-        // far less noticeable than a 500ms+ frozen overlay.
         currentLayerName = targetLayerName
+
+        // Clear stale layer mappings so keys without zone colors don't briefly
+        // render with the previous layer's collection color (e.g., F1-F12
+        // flashing orange when entering a nav layer).
+        layerKeyMap = [:]
+        remapOutputMap = [:]
 
         // Clear tap-hold sources on layer change to prevent stale suppressions
         // (e.g., user switches layers while holding a tap-hold key)

--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView+VisualStyling.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView+VisualStyling.swift
@@ -130,6 +130,8 @@ extension OverlayKeycapView {
     var backgroundColor: Color {
         if isPressed, isHoldActive {
             KeyPathColors.layerOrange
+        } else if isPressed, let zc = zoneColor {
+            zc
         } else if isPressed {
             Color.accentColor
         } else if isOneShot {
@@ -149,8 +151,8 @@ extension OverlayKeycapView {
         else if isLauncherMode {
             KeyPathColors.keycapDark
         }
-        // Layer mode: collection-specific color for mapped keys
-        else if isLayerMode, hasLayerMapping || isNavIdentityMapping {
+        // Layer mode: collection-specific color for keys that belong to a collection
+        else if isLayerMode, layerKeyInfo?.collectionId != nil, hasLayerMapping || isNavIdentityMapping {
             collectionColor(for: layerKeyInfo?.collectionId)
         }
         // Layer mode: dark gray for unmapped keys (same as launcher)


### PR DESCRIPTION
## Summary
- Clear stale `layerKeyMap`/`remapOutputMap` on layer switch so keys from the previous layer don't briefly flash with collection colors (F1-F12 and space bar flashing orange when holding F to enter nav layer with ben pack)
- Gate layer-mode collection coloring on `collectionId != nil` so pass-through keys without a collection fall to dark gray instead of default orange
- Pressed keys with a zone color keep that color instead of turning blue

## Test plan
- [x] 532 tests pass
- [ ] Enable ben pack, hold F — verify no orange flash on F1-F12 or space bar
- [ ] Verify nav layer keys still show correct collection colors
- [ ] Verify activator key (F) stays its zone color when pressed