### PR TITLE
fix: wire up nav subtitles for vallack-nav layer overlay

### DIFF
--- a/Sources/KeyPathAppKit/Services/Packs/PackZoneResolver.swift
+++ b/Sources/KeyPathAppKit/Services/Packs/PackZoneResolver.swift
@@ -51,7 +51,7 @@ enum PackZoneResolver {
         switch packID {
         case PackRegistry.vallackSystem.id:
             let lower = layerName.lowercased()
-            if lower.contains("vallack-nav") { return nil }
+            if lower.contains("vallack-nav") { return VallackZoneMap.navSubtitles }
             return VallackZoneMap.homeSubtitles
         default:
             return nil


### PR DESCRIPTION
## Summary
- `PackZoneResolver.zoneSubtitles` returned `nil` for vallack-nav, so nav icons (←, ↓, Tab, Esc, ⌘C, ⌘[, etc.) were never passed to keycap views
- One-line fix: return `VallackZoneMap.navSubtitles` instead of `nil` on the vallack-nav layer
- Completes the icon rendering from #515 — `effectiveLabel` already consumes `zoneSubtitle` in layer mode, it just wasn't getting data

## Test plan
- [ ] Hold F in Ben's pack — all nav keys (including T=⌘[, Y=⌘C, V=⌘]) should show icons
- [ ] Base layer should still show home subtitles (⌃, ⌥, ⌘ under Q, W, E)
- [ ] `swift test` passes (521 tests)