### PR TITLE
fix: include zone-subtitle keys in layer mode icon rendering

### DIFF
--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView+ModeContent.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView+ModeContent.swift
@@ -123,7 +123,7 @@ extension OverlayKeycapView {
 
         if isNavIdentityMapping {
             navIdentityContent
-        } else if hasLayerMapping {
+        } else if hasLayerMapping || zoneSubtitle != nil {
             // Special case: fn key should always show globe + "fn" even when mapped
             if key.label == "fn" {
                 fnKeyContent


### PR DESCRIPTION
## Summary
- `layerModeContent` gated icon rendering on `hasLayerMapping`, which requires collection-augmented `layerKeyInfo`
- Keys with zone subtitles (T=⌘[, Y=⌘C, V=⌘]) but no collection augmentation fell through to the unmapped-key path
- One-line fix: `|| zoneSubtitle != nil` lets zone-subtitle keys enter the icon rendering path

## Test plan
- [ ] Hold F in Ben's pack — T, Y, V should now show ⌘[, ⌘C, ⌘] icons
- [ ] Other nav keys (H=←, J=↓, K=↑, L=→, Q=Tab, W=Esc) should still show icons
- [ ] `swift test` passes (521 tests)