### PR TITLE
fix: prevent code signature crash by force-killing app before binary replacement

### DIFF
--- a/Scripts/quick-deploy.sh
+++ b/Scripts/quick-deploy.sh
@@ -127,12 +127,21 @@ if pgrep -x "$APP_NAME" > /dev/null; then
     WAS_RUNNING=1
     echo "🛑 Stopping running $APP_NAME before deploy..."
     pkill -x "$APP_NAME" 2>/dev/null || true
+    # Wait up to 6s for graceful shutdown
     for _ in {1..120}; do
         if ! pgrep -x "$APP_NAME" >/dev/null; then
             break
         fi
         sleep 0.05
     done
+    # Force-kill if still alive — proceeding with the process running causes
+    # SIGKILL (Code Signature Invalid) when the replaced binary invalidates
+    # mapped pages in the old process.
+    if pgrep -x "$APP_NAME" >/dev/null; then
+        echo "⚠️  $APP_NAME did not exit in time, sending SIGKILL..."
+        pkill -9 -x "$APP_NAME" 2>/dev/null || true
+        sleep 0.2
+    fi
 fi
 
 # Build debug (fast - incremental)
@@ -299,10 +308,19 @@ if security find-identity -v -p codesigning | grep -Fq "$SIGNING_IDENTITY"; then
     if [[ -f "$APP_BUNDLE/Contents/Library/KeyPath/libkeypath_kanata_host_bridge.dylib" ]]; then
         codesign --force --options=runtime --sign "$SIGNING_IDENTITY" "$APP_BUNDLE/Contents/Library/KeyPath/libkeypath_kanata_host_bridge.dylib" 2>/dev/null || true
     fi
-    codesign --force --options=runtime --sign "$SIGNING_IDENTITY" --entitlements "$ENTITLEMENTS" --deep "$APP_BUNDLE" 2>/dev/null
+    codesign --force --options=runtime --sign "$SIGNING_IDENTITY" --entitlements "$ENTITLEMENTS" --deep "$APP_BUNDLE"
 else
     echo "⚠️  Developer ID identity not found; using ad-hoc signing (helper may reject this build)."
-    codesign --force --sign - --entitlements "$ENTITLEMENTS" --deep "$APP_BUNDLE" 2>/dev/null
+    codesign --force --sign - --entitlements "$ENTITLEMENTS" --deep "$APP_BUNDLE"
+fi
+
+# Verify signature is valid before restarting — catch any silent corruption.
+if ! codesign --verify --strict "$APP_BUNDLE" 2>/dev/null; then
+    echo "❌ Code signature verification failed after signing!"
+    echo "   The app may crash with 'Code Signature Invalid' if launched."
+    echo "   Try a full build: ./build.sh"
+    log_build_event "SIGN_VERIFY_FAILED"
+    exit 1
 fi
 
 # Restart the app only if it was running when deploy began.


### PR DESCRIPTION
## Summary
- Adds SIGKILL fallback if the app doesn't terminate within 6s of SIGTERM — prevents the binary replacement race that causes `SIGKILL (Code Signature Invalid)` crashes
- Removes `2>/dev/null` from the main `codesign` call so signing failures are visible in output
- Adds `codesign --verify --strict` post-sign check to catch broken signatures before relaunch

## Context
Crash report showed `EXC_BAD_ACCESS (SIGKILL (Code Signature Invalid))` / `Termination Reason: CODESIGNING, Code 2, Invalid Page` with `codeSigningID: ""`. The root cause: `quick-deploy.sh` continued copying binaries after the 6s SIGTERM grace period even if the old process was still running, invalidating its mapped `__TEXT` pages.

## Test plan
- [ ] Run `./Scripts/quick-deploy.sh` while the app is running — verify clean shutdown
- [ ] Simulate slow shutdown (e.g., add a sleep in `applicationWillTerminate`) — verify SIGKILL fallback fires
- [ ] Remove signing identity from keychain, run deploy — verify error message appears (no silent `2>/dev/null`)