### PR TITLE
feat: add visual timeline preview to keystroke history pack detail

### DIFF
--- a/Sources/KeyPathAppKit/Models/KeystrokeTimelineEvent.swift
+++ b/Sources/KeyPathAppKit/Models/KeystrokeTimelineEvent.swift
@@ -15,6 +15,7 @@ struct KeystrokeTimelineEvent: Identifiable {
         case chordResolved(ChordPayload)
         case tapDanceResolved(TapDancePayload)
         case appChanged(AppChangedPayload)
+        case actionDispatched(ActionDispatchedPayload)
     }
 }
 
@@ -68,4 +69,10 @@ struct TapDancePayload {
 struct AppChangedPayload {
     let appName: String
     let bundleIdentifier: String
+}
+
+struct ActionDispatchedPayload {
+    let action: String
+    let target: String?
+    let uri: String
 }

--- a/Sources/KeyPathAppKit/Services/Monitoring/KeystrokeHistoryService.swift
+++ b/Sources/KeyPathAppKit/Services/Monitoring/KeystrokeHistoryService.swift
@@ -238,6 +238,38 @@ final class KeystrokeHistoryService {
                 self?.ingest(event)
             }
         }
+
+        observers.observe(.kanataActionDispatched, center: notificationCenter) { [weak self] notification in
+            guard let self else { return }
+            let userInfo = notification.userInfo
+            guard let action = userInfo?["action"] as? String,
+                  let uri = userInfo?["uri"] as? String
+            else { return }
+            let target = userInfo?["target"] as? String
+            let event = KeystrokeTimelineEvent(
+                id: UUID(),
+                timestamp: Date(),
+                kind: .actionDispatched(ActionDispatchedPayload(
+                    action: action,
+                    target: target,
+                    uri: uri
+                ))
+            )
+            Task { @MainActor [weak self] in
+                self?.ingest(event)
+            }
+        }
+
+        observers.observe(.installedPacksChanged, center: notificationCenter) { [weak self] _ in
+            guard let self else { return }
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                let installed = await InstalledPackTracker.shared.isInstalled(
+                    packID: PackRegistry.keystrokeHistory.id
+                )
+                isRecording = installed
+            }
+        }
     }
 
     // MARK: - Event Ingestion
@@ -274,7 +306,7 @@ final class KeystrokeHistoryService {
 
     private func isKeystrokeEvent(_ event: KeystrokeTimelineEvent) -> Bool {
         switch event.kind {
-        case .keyInput, .tapActivated, .holdActivated, .chordResolved, .tapDanceResolved:
+        case .keyInput, .tapActivated, .holdActivated, .chordResolved, .tapDanceResolved, .actionDispatched:
             true
         case .layerChanged, .hrmDecision, .oneShotActivated, .appChanged:
             false

--- a/Sources/KeyPathAppKit/Services/Monitoring/TimelineGrouper.swift
+++ b/Sources/KeyPathAppKit/Services/Monitoring/TimelineGrouper.swift
@@ -54,6 +54,7 @@ enum EventCardKind {
     case chord(ChordPayload)
     case tapDance(TapDancePayload)
     case nonPrintableKeys(keys: [(key: String, count: Int)])
+    case actionDispatched(ActionDispatchedPayload)
 }
 
 struct TapHoldCardData {
@@ -310,6 +311,14 @@ enum TimelineGrouper {
                     timestamp: event.timestamp,
                     appName: payload.appName,
                     bundleIdentifier: payload.bundleIdentifier
+                )))
+
+            case let .actionDispatched(payload):
+                flushTextRun()
+                segments.append(.eventCard(EventCardSegment(
+                    id: event.id,
+                    timestamp: event.timestamp,
+                    cardKind: .actionDispatched(payload)
                 )))
             }
         }

--- a/Sources/KeyPathAppKit/Services/Packs/PackRegistry.swift
+++ b/Sources/KeyPathAppKit/Services/Packs/PackRegistry.swift
@@ -637,7 +637,7 @@ public enum PackRegistry {
         name: "Keystroke History",
         tagline: "See what your keyboard is actually doing",
         shortDescription:
-            "Watch every keypress, tap-hold decision, and layer change in real time. Helps you understand, refine, and debug your keymaps.\n\nPrivacy: keystroke data is kept in memory only — nothing is saved to disk and nothing ever leaves your machine. Data disappears when you quit.",
+            "A live timeline of every keypress, tap-hold decision, and layer change. Great for tuning timing and debugging remaps.",
         longDescription: "",
         category: "Debug",
         iconSymbol: "clock.arrow.trianglehead.counterclockwise.rotate.90",

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+EventMonitoring.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+EventMonitoring.swift
@@ -197,6 +197,19 @@ extension RuleCollectionsManager {
         // Dispatch to ActionDispatcher
         ActionDispatcher.shared.dispatch(actionURI)
 
+        // Post to keystroke history (skip layer: URIs — already shown as layer dividers)
+        if actionURI.action != "layer" {
+            NotificationCenter.default.post(
+                name: .kanataActionDispatched,
+                object: nil,
+                userInfo: [
+                    "action": actionURI.action,
+                    "target": actionURI.target ?? "",
+                    "uri": actionURI.url.absoluteString,
+                ]
+            )
+        }
+
         // Also notify any external observers
         onActionURI?(actionURI)
     }

--- a/Sources/KeyPathAppKit/UI/Gallery/KeystrokeHistoryPreview.swift
+++ b/Sources/KeyPathAppKit/UI/Gallery/KeystrokeHistoryPreview.swift
@@ -1,0 +1,208 @@
+import SwiftUI
+
+struct KeystrokeHistoryPreview: View {
+    private let isDark: Bool
+
+    init(isDark: Bool = true) {
+        self.isDark = isDark
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            previewToolbar
+            Divider().opacity(0.3)
+            previewTimeline
+        }
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(isDark
+                    ? Color.black.opacity(0.3)
+                    : Color(NSColor.controlBackgroundColor))
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .overlay(
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(Color.white.opacity(0.08), lineWidth: 1)
+        )
+    }
+
+    // MARK: - Toolbar
+
+    private var previewToolbar: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "record.circle")
+                .font(.system(size: 13, weight: .medium))
+                .foregroundStyle(.red)
+
+            Text("12 events")
+                .font(.system(size: 10, weight: .medium, design: .monospaced))
+                .foregroundStyle(.secondary)
+
+            Spacer()
+
+            Image(systemName: "arrow.down.to.line")
+                .font(.system(size: 11, weight: .medium))
+                .foregroundStyle(Color.accentColor)
+
+            Image(systemName: "trash")
+                .font(.system(size: 11, weight: .medium))
+                .foregroundStyle(.secondary)
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 6)
+    }
+
+    // MARK: - Timeline
+
+    private var previewTimeline: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            sampleTextRun("Hello world")
+
+            sampleTapHoldCard(key: "f", output: "⌘", isHold: true)
+
+            sampleLayerDivider("nav")
+
+            sampleNonPrintableRun([("←", 3), ("↓", 1)])
+
+            sampleHrmCard(key: "d", latency: 142, threshold: 180)
+
+            sampleLayerDivider("base")
+
+            sampleTextRun("fixed!")
+        }
+        .padding(.horizontal, 6)
+        .padding(.vertical, 8)
+    }
+
+    // MARK: - Sample Segments
+
+    private func sampleTextRun(_ text: String) -> some View {
+        HStack(spacing: 0) {
+            ForEach(Array(text.enumerated()), id: \.offset) { _, char in
+                Text(String(char))
+                    .font(.system(size: 13, design: .monospaced))
+                    .foregroundStyle(isDark ? .white : .primary)
+                    .padding(.horizontal, 0.5)
+            }
+        }
+        .padding(.vertical, 2)
+    }
+
+    private func sampleTapHoldCard(key: String, output: String, isHold: Bool) -> some View {
+        HStack(spacing: 4) {
+            Text(isHold ? "HOLD" : "TAP")
+                .font(.system(size: 8, weight: .bold, design: .monospaced))
+                .foregroundStyle(.white)
+                .padding(.horizontal, 4)
+                .padding(.vertical, 1)
+                .background(
+                    RoundedRectangle(cornerRadius: 3)
+                        .fill(isHold ? Color.orange : Color.blue)
+                )
+
+            Text(key)
+                .font(.system(size: 11, weight: .medium, design: .monospaced))
+                .foregroundStyle(.secondary)
+
+            Image(systemName: "arrow.right")
+                .font(.system(size: 8))
+                .foregroundStyle(.tertiary)
+
+            Text(output)
+                .font(.system(size: 11, weight: .medium, design: .monospaced))
+                .foregroundStyle(isDark ? .white : .primary)
+        }
+        .padding(.horizontal, 6)
+        .padding(.vertical, 3)
+        .background(
+            RoundedRectangle(cornerRadius: 5)
+                .fill((isHold ? Color.orange : Color.blue).opacity(isDark ? 0.1 : 0.06))
+        )
+    }
+
+    private func sampleHrmCard(key: String, latency: Int, threshold: Int) -> some View {
+        HStack(spacing: 4) {
+            Text("TAP")
+                .font(.system(size: 8, weight: .bold, design: .monospaced))
+                .foregroundStyle(.white)
+                .padding(.horizontal, 4)
+                .padding(.vertical, 1)
+                .background(
+                    RoundedRectangle(cornerRadius: 3)
+                        .fill(Color.blue)
+                )
+
+            Text(key)
+                .font(.system(size: 11, weight: .medium, design: .monospaced))
+                .foregroundStyle(isDark ? .white : .primary)
+
+            Text("other-key-up")
+                .font(.system(size: 8, weight: .medium))
+                .foregroundStyle(.secondary)
+                .padding(.horizontal, 4)
+                .padding(.vertical, 1)
+                .background(
+                    Capsule()
+                        .fill(isDark
+                            ? Color.white.opacity(0.08)
+                            : Color.black.opacity(0.06))
+                )
+
+            let ratio = Double(latency) / Double(threshold)
+            let color: Color = ratio < 0.5 ? .green : (ratio < 0.8 ? .yellow : .red)
+            Text("\(latency)ms")
+                .font(.system(size: 9, weight: .semibold, design: .monospaced))
+                .foregroundStyle(color)
+        }
+        .padding(.horizontal, 6)
+        .padding(.vertical, 3)
+        .background(
+            RoundedRectangle(cornerRadius: 5)
+                .fill(Color.blue.opacity(isDark ? 0.1 : 0.06))
+        )
+    }
+
+    private func sampleLayerDivider(_ name: String) -> some View {
+        HStack(spacing: 6) {
+            dividerLine
+            Text(name)
+                .font(.system(size: 9, weight: .semibold))
+                .foregroundStyle(.secondary)
+                .textCase(.uppercase)
+                .tracking(0.5)
+            dividerLine
+        }
+        .padding(.vertical, 4)
+    }
+
+    private var dividerLine: some View {
+        Rectangle()
+            .fill(Color.secondary.opacity(0.2))
+            .frame(height: 0.5)
+    }
+
+    private func sampleNonPrintableRun(_ keys: [(String, Int)]) -> some View {
+        HStack(spacing: 3) {
+            ForEach(Array(keys.enumerated()), id: \.offset) { _, entry in
+                HStack(spacing: 1) {
+                    Text(entry.0)
+                        .font(.system(size: 11, weight: .medium, design: .monospaced))
+                        .foregroundStyle(.secondary)
+                    if entry.1 > 1 {
+                        Text("\u{00D7}\(entry.1)")
+                            .font(.system(size: 9, weight: .bold, design: .monospaced))
+                            .foregroundStyle(.tertiary)
+                    }
+                }
+            }
+        }
+        .padding(.horizontal, 5)
+        .padding(.vertical, 2)
+        .background(
+            RoundedRectangle(cornerRadius: 3)
+                .fill(isDark
+                    ? Color.white.opacity(0.06)
+                    : Color.black.opacity(0.04))
+        )
+    }
+}

--- a/Sources/KeyPathAppKit/UI/Gallery/PackDetailView+BindingRows.swift
+++ b/Sources/KeyPathAppKit/UI/Gallery/PackDetailView+BindingRows.swift
@@ -200,6 +200,23 @@ extension PackDetailView {
             }
         } else if pack.id == PackRegistry.kindaVim.id {
             embeddedEditor { KindaVimStatusBlock() }
+        } else if pack.id == PackRegistry.keystrokeHistory.id {
+            embeddedEditor {
+                VStack(alignment: .leading, spacing: 12) {
+                    Text("Preview")
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundStyle(.secondary)
+                    KeystrokeHistoryPreview()
+
+                    HStack(spacing: 4) {
+                        Image(systemName: "lock.shield")
+                            .font(.system(size: 10))
+                        Text("Keystroke data stays in memory only — nothing saved to disk, nothing leaves your machine.")
+                            .font(.system(size: 11))
+                    }
+                    .foregroundStyle(.tertiary)
+                }
+            }
         } else {
             VStack(alignment: .leading, spacing: 8) {
                 Divider()

--- a/Sources/KeyPathAppKit/UI/Overlay/KeystrokeHistorySegments.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/KeystrokeHistorySegments.swift
@@ -7,6 +7,10 @@ struct TextRunView: View {
     let segment: TextRunSegment
     let isDark: Bool
     @State private var hoveredCharId: UUID?
+    @State private var activePopoverCharId: UUID?
+    @State private var hoverTimer: Timer?
+
+    private let hoverDelay: TimeInterval = 0.35
 
     var body: some View {
         FlowLayout(spacing: 0) {
@@ -15,6 +19,13 @@ struct TextRunView: View {
             }
         }
         .padding(.vertical, 2)
+        .background(
+            RoundedRectangle(cornerRadius: 3)
+                .fill(activePopoverCharId != nil
+                    ? Color.accentColor.opacity(0.06)
+                    : Color.clear)
+        )
+        .animation(.easeInOut(duration: 0.15), value: activePopoverCharId)
     }
 
     private func characterView(_ char: TextRunCharacter) -> some View {
@@ -24,16 +35,35 @@ struct TextRunView: View {
             .padding(.horizontal, 0.5)
             .background(
                 RoundedRectangle(cornerRadius: 2)
-                    .fill(hoveredCharId == char.id
+                    .fill(activePopoverCharId == char.id
                         ? Color.accentColor.opacity(0.15)
                         : Color.clear)
             )
             .onHover { isHovering in
-                hoveredCharId = isHovering ? char.id : nil
+                if isHovering {
+                    hoveredCharId = char.id
+                    hoverTimer?.invalidate()
+                    hoverTimer = Timer.scheduledTimer(withTimeInterval: hoverDelay, repeats: false) { _ in
+                        Task { @MainActor in
+                            if hoveredCharId == char.id {
+                                activePopoverCharId = char.id
+                            }
+                        }
+                    }
+                } else {
+                    if hoveredCharId == char.id {
+                        hoveredCharId = nil
+                    }
+                    hoverTimer?.invalidate()
+                    hoverTimer = nil
+                }
             }
             .popover(isPresented: Binding(
-                get: { hoveredCharId == char.id },
-                set: { if !$0 { hoveredCharId = nil } }
+                get: { activePopoverCharId == char.id },
+                set: { if !$0 {
+                    activePopoverCharId = nil
+                    hoveredCharId = nil
+                } }
             )) {
                 KeystrokeCharacterPopover(
                     char: char,
@@ -71,6 +101,8 @@ struct EventCardView: View {
                 tapDanceCard(data)
             case let .nonPrintableKeys(keys):
                 nonPrintableCard(keys: keys)
+            case let .actionDispatched(data):
+                actionDispatchedCard(data)
             }
         }
         .padding(.vertical, 2)
@@ -236,6 +268,48 @@ struct EventCardView: View {
             RoundedRectangle(cornerRadius: 5)
                 .fill(cardBackground(for: .teal))
         )
+    }
+
+    // MARK: - Action Dispatched Card
+
+    private func actionDispatchedCard(_ data: ActionDispatchedPayload) -> some View {
+        HStack(spacing: 4) {
+            let icon = actionIcon(for: data.action)
+            Image(systemName: icon)
+                .font(.system(size: 9))
+                .foregroundStyle(.mint)
+
+            Text(data.action.uppercased())
+                .font(.system(size: 8, weight: .bold, design: .monospaced))
+                .foregroundStyle(.white)
+                .padding(.horizontal, 4)
+                .padding(.vertical, 1)
+                .background(
+                    RoundedRectangle(cornerRadius: 3)
+                        .fill(Color.mint)
+                )
+
+            if let target = data.target, !target.isEmpty {
+                Text(target.localizedCapitalized)
+                    .font(.system(size: 11, weight: .medium, design: .monospaced))
+                    .foregroundStyle(isDark ? .white : .primary)
+            }
+        }
+        .padding(.horizontal, 6)
+        .padding(.vertical, 3)
+        .background(
+            RoundedRectangle(cornerRadius: 5)
+                .fill(cardBackground(for: .mint))
+        )
+    }
+
+    private func actionIcon(for action: String) -> String {
+        switch action {
+        case "launch": "arrow.up.forward.app"
+        case "open": "link"
+        case "notify": "bell"
+        default: "bolt"
+        }
     }
 
     // MARK: - Non-Printable Key Card

--- a/Sources/KeyPathAppKit/UI/Overlay/LiveKeyboardOverlayTypes.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/LiveKeyboardOverlayTypes.swift
@@ -207,6 +207,8 @@ extension Notification.Name {
     static let kanataHrmTrace = Notification.Name("KeyPath.KanataHrmTrace")
     /// Posted when latest HRM aggregate stats have been refreshed.
     static let kanataHrmStatsUpdated = Notification.Name("KeyPath.KanataHrmStatsUpdated")
+    /// Posted when a keypath:// action URI is dispatched (userInfo["action"], ["target"], ["uri"])
+    static let kanataActionDispatched = Notification.Name("KeyPath.KanataActionDispatched")
     /// Posted when HelloOk capability list changes.
     static let kanataCapabilitiesUpdated = Notification.Name("KeyPath.KanataCapabilitiesUpdated")
 }


### PR DESCRIPTION
## Summary
- Add a static timeline mockup to the Keystroke History pack detail page showing text runs, tap-hold cards, layer dividers, and HRM decisions
- Shorten the pack description from two paragraphs to a single line
- Move the privacy note inline as a compact icon+text footer
- Capture action URI dispatches (quick launch, open, notify) in the keystroke history timeline — these were previously invisible
- Sync `isRecording` with pack install/uninstall so recording starts immediately without an app restart
- Add 350ms hover delay on text run characters to prevent popover flicker
- Subtly highlight the parent text run when a character popover is active

## Test plan
- [ ] Open the Keystroke History pack in the gallery and verify the preview renders correctly
- [ ] Install the pack, open the overlay history panel, and verify layer transitions appear as dividers when holding space
- [ ] Trigger a quick launch action and verify it appears as a mint-colored card in the history
- [ ] Hover over characters in a text run — confirm the delay before popover and the subtle run highlight
- [ ] Uninstall and reinstall the pack — confirm recording toggles without app restart