### PR TITLE
Add quick start intro guide to Vallack pack detail

### DIFF
--- a/Sources/KeyPathAppKit/UI/Gallery/SystemPackComponentsView.swift
+++ b/Sources/KeyPathAppKit/UI/Gallery/SystemPackComponentsView.swift
@@ -148,7 +148,6 @@ struct VallackSystemPackContent: View {
                 )
             }
 
-            // Quick start guide
             vallackQuickStart
 
             // How it works
@@ -238,7 +237,7 @@ struct VallackSystemPackContent: View {
                     .fill(Color(NSColor.controlBackgroundColor).opacity(0.3))
                     .overlay(
                         RoundedRectangle(cornerRadius: 8, style: .continuous)
-                            .strokeBorder(Color.white.opacity(0.06), lineWidth: 1)
+                            .strokeBorder(Color.primary.opacity(0.06), lineWidth: 1)
                     )
             )
         }
@@ -248,7 +247,7 @@ struct VallackSystemPackContent: View {
         HStack(alignment: .top, spacing: 10) {
             Text(emoji)
                 .font(.body)
-                .frame(width: 24)
+                .frame(width: 28)
             Text(markdown)
                 .font(.subheadline)
                 .foregroundStyle(.secondary)

--- a/Sources/KeyPathAppKit/UI/Gallery/SystemPackComponentsView.swift
+++ b/Sources/KeyPathAppKit/UI/Gallery/SystemPackComponentsView.swift
@@ -148,6 +148,9 @@ struct VallackSystemPackContent: View {
                 )
             }
 
+            // Quick start guide
+            vallackQuickStart
+
             // How it works
             VStack(alignment: .leading, spacing: 6) {
                 Text("How it works")
@@ -209,6 +212,47 @@ struct VallackSystemPackContent: View {
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
             }
+        }
+    }
+
+    // MARK: - Quick Start
+
+    private var vallackQuickStart: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Quick start")
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(.tertiary)
+                .padding(.leading, 4)
+
+            VStack(alignment: .leading, spacing: 8) {
+                quickStartRow("🤜🤛", "One hand holds, the other operates. Hold **F** to use right-hand shortcuts, or hold **J** for left-hand ones.")
+                quickStartRow("⬆️⬇️", "**Arrow keys live under your right hand** — hold F, then use H J K L to navigate. Think Vim.")
+                quickStartRow("🔀", "**Hold J for left-hand tools** — Esc, tab switching, Home/End, and app switcher are all under your left fingers.")
+                quickStartRow("📋", "**Copy and paste without ⌘** — hold F, then Y to copy and ; to paste. Backspace is U, Return is I.")
+                quickStartRow("⌨️", "**Top-row keys double as modifiers** — tap Q for q, hold Q for Control. Same idea for ⌥ and ⌘.")
+                quickStartRow("💡", "**Tap F or J normally** to type those letters — the layer only activates when you hold.")
+            }
+            .padding(12)
+            .background(
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .fill(Color(NSColor.controlBackgroundColor).opacity(0.3))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 8, style: .continuous)
+                            .strokeBorder(Color.white.opacity(0.06), lineWidth: 1)
+                    )
+            )
+        }
+    }
+
+    private func quickStartRow(_ emoji: String, _ markdown: LocalizedStringKey) -> some View {
+        HStack(alignment: .top, spacing: 10) {
+            Text(emoji)
+                .font(.body)
+                .frame(width: 24)
+            Text(markdown)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
         }
     }
 


### PR DESCRIPTION
## Summary
- Adds a 6-bullet "Quick start" visual guide to the Vallack system pack detail page
- Placed between the keyboard diagram and the "How it works" accordion cards
- Gives users a scannable mental model of the split-hand nav system: opposite-hand activation, arrow keys (HJKL), left-hand tools, clipboard shortcuts, top-row modifiers, and tap-vs-hold reassurance

## Test plan
- [ ] Open the Vallack Nav pack detail page and verify the quick start section renders between the keyboard diagram and "How it works"
- [ ] Check text is readable, bold markdown renders correctly, emoji alignment looks good
- [ ] Scroll the full detail page to confirm spacing/layout is consistent