### PR TITLE
feat: add thermonuclear review gate to PR pipeline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,8 @@ Follow the invariants in [`docs/agent-pr-invariants.md`](docs/agent-pr-invariant
 
 **Key rule:** After merging a PR, always pull master and deploy from master before reporting done.
 
+**Mandatory review gate:** Before creating any PR, run `/thermo-nuclear-swift-review` against the branch diff and address all findings. See Phase 2.5 in the workflow doc.
+
 Git guardrail hooks in `.claude/settings.json` block: commits on master, force-push to master, `reset --hard`, `clean -f`.
 
 **Kanata fork safety:** The kanata submodule (`External/kanata`) tracks `keypath/bundled` on `malpern/kanata`. Treat `keypath/bundled` like master — **never force-push** to it. Before pushing to any remote branch in the fork, verify the push is a fast-forward: `git log --oneline <source>..<target>`. If commits would be lost, cherry-pick instead. The `main` branch in kanata-pr may diverge from `keypath/bundled` — they are NOT interchangeable.

--- a/docs/agent-pr-invariants.md
+++ b/docs/agent-pr-invariants.md
@@ -13,6 +13,11 @@ What must be true at each phase boundary. The agent's job is to make these true 
 - [ ] `swift test` passes (all tests, zero failures)
 - [ ] Changes are committed with descriptive messages
 
+## After Thermonuclear Review
+
+- [ ] `/thermo-nuclear-swift-review` run against the branch diff
+- [ ] All CONFIRMED and PLAUSIBLE findings addressed or explicitly justified
+
 ## After PR Creation
 
 - [ ] Single squashed commit on the branch

--- a/docs/agent-pr-workflow.md
+++ b/docs/agent-pr-workflow.md
@@ -14,6 +14,10 @@ End-to-end process for shepherding code from initial request through to a clean 
 5. **Test** — `swift test` must pass (all 532+ tests). Never commit code that breaks tests.
 6. **Commit** — commit frequently as you work. Use descriptive messages. Include `Co-Authored-By` tag.
 
+## Phase 2.5: Thermonuclear Review
+
+6b. **Run `/thermo-nuclear-swift-review`** — before creating the PR, run the thermonuclear review skill against the branch diff. Address all CONFIRMED and PLAUSIBLE findings before proceeding. This is not optional — no PR goes out without passing the thermonuclear bar.
+
 ## Phase 3: PR Creation
 
 7. **Squash commits** — `git reset --soft master && git commit` with a comprehensive message covering all changes.


### PR DESCRIPTION
## Summary
- Added Phase 2.5 (Thermonuclear Review) to the agent PR workflow — `/thermo-nuclear-swift-review` must be run and all findings addressed before any PR is created
- Added corresponding invariant checkpoint to `agent-pr-invariants.md`
- Added visible callout in `CLAUDE.md` PR Workflow section
- Rewrote the skill's Review Tone section to channel angry Steve Jobs focused on product quality, functional correctness, and UX impact (skill file lives in `~/.claude/skills/`, not in this repo)

## Test plan
- [ ] Verify `/thermo-nuclear-swift-review` is referenced in Phase 2.5 of `docs/agent-pr-workflow.md`
- [ ] Verify new invariant checkpoint appears in `docs/agent-pr-invariants.md`
- [ ] Verify `CLAUDE.md` mentions the mandatory review gate
- [ ] Run `/thermo-nuclear-swift-review` on a future PR and confirm the angry Steve Jobs tone