### PR TITLE
fix: enlarge zone subtitle modifiers and shift letter up

### DIFF
--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView+ContentAndStyling.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView+ContentAndStyling.swift
@@ -64,9 +64,9 @@ extension OverlayKeycapView {
                 VStack(spacing: 0) {
                     Spacer()
                     Text(subtitle)
-                        .font(.system(size: 7 * scale, weight: .medium))
+                        .font(.system(size: 9 * scale, weight: .medium))
                         .foregroundStyle(Color.white.opacity(0.45))
-                        .padding(.bottom, 1 * scale)
+                        .padding(.bottom, 2.5 * scale)
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
             }

--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView+LayoutContent.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView+LayoutContent.swift
@@ -38,9 +38,11 @@ extension OverlayKeycapView {
                 layerKeyContent(label: key.label)
             } else {
                 let displayText = effectiveLabel.isEmpty ? key.label : effectiveLabel
+                let hasSubtitle = zoneSubtitle != nil && !isLayerMode && !isLauncherMode
                 Text(isNumpadKey ? displayText : displayText.uppercased())
                     .font(.system(size: isNumpadKey ? 14 * scale : 12 * scale, weight: .medium))
                     .foregroundStyle(foregroundColor)
+                    .offset(y: hasSubtitle ? -2.5 * scale : 0)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
         }
@@ -77,6 +79,7 @@ extension OverlayKeycapView {
     func dualSymbolContent(main: String, shift: String) -> some View {
         let shiftAdj = OpticalAdjustments.forLabel(shift)
         let mainAdj = OpticalAdjustments.forLabel(main)
+        let hasSubtitle = zoneSubtitle != nil && !isLayerMode && !isLauncherMode
 
         VStack(spacing: dualSymbolSpacing(for: main)) {
             Text(shift)
@@ -94,6 +97,7 @@ extension OverlayKeycapView {
                 .offset(y: mainAdj.verticalOffset * scale)
                 .foregroundStyle(foregroundColor)
         }
+        .offset(y: hasSubtitle ? -2.5 * scale : 0)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 


### PR DESCRIPTION
## Summary
- Increased zone subtitle modifier symbols (⌃ ⌥ ⌘) font size from 7pt to 9pt
- Added more bottom padding (1pt → 2.5pt) for proper breathing room
- Shifted letter content upward by 2.5pt when a zone subtitle is present, applies to both plain letters and dual-symbol (shift+main) keycaps

## Test plan
- [ ] Quick-deploy and check overlay with a pack that uses zone subtitles (e.g., Vallack)
- [ ] Verify modifier symbols are larger and not squished
- [ ] Verify letters are shifted up slightly, giving room for the subtitle
- [ ] Check keys with shift symbols + zone subtitle (number row) still look balanced
- [ ] Check keys without zone subtitles are unchanged