### PR TITLE
feat: show alert dialog when kanata simulator fails for a layer

### DIFF
--- a/Sources/KeyPathAppKit/Services/LayerMapping/LayerKeyMapper+Simulation.swift
+++ b/Sources/KeyPathAppKit/Services/LayerMapping/LayerKeyMapper+Simulation.swift
@@ -73,8 +73,9 @@ extension LayerKeyMapper {
         keyToCollection: [String: UUID] = [:],
         activatorKeys: Set<String> = [],
         keyToVimLabel: [String: String] = [:]
-    ) async throws -> [UInt16: LayerKeyInfo] {
+    ) async throws -> (mapping: [UInt16: LayerKeyInfo], report: SimulationReport) {
         var mapping: [UInt16: LayerKeyInfo] = [:]
+        var failedKeys: [SimulationReport.FailedSimKey] = []
 
         // Get all physical keys from the provided layout
         let physicalKeys = layout.keys
@@ -144,7 +145,7 @@ extension LayerKeyMapper {
                     mapping[keyCode] = .layerSwitch(displayLabel: fallbackLabel, collectionId: collectionId)
                     continue
                 }
-                // Simulation failed - use physical label
+                failedKeys.append(.init(keyCode: keyCode, kanataName: simName))
                 mapping[keyCode] = LayerKeyInfo(
                     displayLabel: fallbackLabel,
                     outputKey: nil,
@@ -299,8 +300,17 @@ extension LayerKeyMapper {
             }
         }
 
+        let report = SimulationReport(
+            layerName: layer,
+            totalKeys: physicalKeys.count,
+            failedKeys: failedKeys,
+            configPath: configPath
+        )
+        if !failedKeys.isEmpty {
+            AppLogger.shared.info("⚠️ [LayerKeyMapper] \(failedKeys.count)/\(physicalKeys.count) keys failed simulation on '\(layer)'")
+        }
         AppLogger.shared.info("🗺️ [LayerKeyMapper] Built mapping: \(mapping.count) keys")
-        return mapping
+        return (mapping, report)
     }
 
     /// Derive the hold-action display label for a specific physical key by simulating a long press.

--- a/Sources/KeyPathAppKit/Services/LayerMapping/LayerKeyMapper.swift
+++ b/Sources/KeyPathAppKit/Services/LayerMapping/LayerKeyMapper.swift
@@ -170,6 +170,40 @@ struct LayerKeyInfo: Equatable, Sendable {
     }
 }
 
+struct SimulationReport: Sendable {
+    let layerName: String
+    let totalKeys: Int
+    let failedKeys: [FailedSimKey]
+    let configPath: String
+
+    struct FailedSimKey: Sendable {
+        let keyCode: UInt16
+        let kanataName: String
+    }
+
+    var failureCount: Int { failedKeys.count }
+    var hasSignificantFailures: Bool { failedKeys.count > 5 }
+
+    func copyableText() -> String {
+        var lines: [String] = []
+        lines.append("## Kanata Simulator Failure Report")
+        lines.append("Layer: \(layerName)")
+        lines.append("Config: \(configPath)")
+        lines.append("Result: \(failedKeys.count)/\(totalKeys) keys failed simulation")
+        lines.append("")
+        lines.append("### Failed keys")
+        for key in failedKeys {
+            lines.append("- keyCode \(key.keyCode) (\(key.kanataName))")
+        }
+        lines.append("")
+        lines.append("### What this means")
+        lines.append("The kanata-simulator could not resolve what these keys output on the '\(layerName)' layer.")
+        lines.append("Overlay icons for these keys will fall back to zone subtitles or base-layer labels.")
+        lines.append("The sim command format is: `ls:\(layerName) d:<key> t:50 u:<key> t:250`")
+        return lines.joined(separator: "\n")
+    }
+}
+
 /// Service that builds key mappings for each layer using the kanata-simulator.
 /// Maps physical key codes to what they output in each layer.
 actor LayerKeyMapper {
@@ -199,7 +233,7 @@ actor LayerKeyMapper {
         layout: PhysicalLayout,
         collections: [RuleCollection] = [],
         cacheKeySuffix: String = "default"
-    ) async throws -> [UInt16: LayerKeyInfo] {
+    ) async throws -> (mapping: [UInt16: LayerKeyInfo], report: SimulationReport?) {
         // Normalize layer name to lowercase for consistent cache keys
         let normalizedLayer = layer.lowercased()
         let cacheKey = "\(normalizedLayer)|\(cacheKeySuffix)"
@@ -210,7 +244,7 @@ actor LayerKeyMapper {
             AppLogger.shared.info("🗺️ [LayerKeyMapper] Simulator disabled; using fallback mapping")
             let mapping = buildFallbackMapping(layout: layout)
             cache[cacheKey] = mapping
-            return mapping
+            return (mapping, nil)
         }
 
         // Check if config changed (invalidate cache)
@@ -221,10 +255,9 @@ actor LayerKeyMapper {
             configHash = currentHash
         }
 
-        // Return cached if available (use normalized key)
         if let cached = cache[cacheKey] {
             AppLogger.shared.debug("🗺️ [LayerKeyMapper] Returning cached mapping (\(cached.count) keys)")
-            return cached
+            return (cached, nil)
         }
 
         AppLogger.shared.info("🗺️ [LayerKeyMapper] Building new mapping for '\(normalizedLayer)'...")
@@ -235,9 +268,7 @@ actor LayerKeyMapper {
         let keyToVimLabel = buildKeyVimLabelMap(for: normalizedLayer, collections: collections)
         AppLogger.shared.debug("🗺️ [LayerKeyMapper] Built key→collection map: \(keyToCollection.count) keys")
 
-        // Use batch simulation for accurate key mapping
-        // This handles aliases, tap-hold, forks, macros, etc.
-        let mapping = try await buildMappingWithSimulator(
+        let (mapping, report) = try await buildMappingWithSimulator(
             for: normalizedLayer,
             configPath: configPath,
             layout: layout,
@@ -248,7 +279,7 @@ actor LayerKeyMapper {
 
         cache[cacheKey] = mapping
         AppLogger.shared.info("🗺️ [LayerKeyMapper] Built mapping: \(mapping.count) keys")
-        return mapping
+        return (mapping, report)
     }
 
     /// Invalidate all cached mappings (call when config changes)
@@ -305,7 +336,7 @@ actor LayerKeyMapper {
                         let keyToCollection = self.buildKeyCollectionMap(for: layer, collections: collectionsWithoutNeovim)
                         let activatorKeys = self.buildActivatorKeySet(for: layer, collections: collectionsWithoutNeovim)
                         let keyToVimLabel = self.buildKeyVimLabelMap(for: layer, collections: collectionsWithoutNeovim)
-                        let mapping = try await self.buildMappingWithSimulator(
+                        let (mapping, _) = try await self.buildMappingWithSimulator(
                             for: layer,
                             configPath: configPath,
                             layout: layout,
@@ -327,7 +358,7 @@ actor LayerKeyMapper {
                             let keyToCollection = self.buildKeyCollectionMap(for: layer, collections: allEnabledCollections)
                             let activatorKeys = self.buildActivatorKeySet(for: layer, collections: allEnabledCollections)
                             let keyToVimLabel = self.buildKeyVimLabelMap(for: layer, collections: allEnabledCollections)
-                            let mapping = try await self.buildMappingWithSimulator(
+                            let (mapping, _) = try await self.buildMappingWithSimulator(
                                 for: layer,
                                 configPath: configPath,
                                 layout: layout,

--- a/Sources/KeyPathAppKit/UI/ContextHUD/ContextHUDController.swift
+++ b/Sources/KeyPathAppKit/UI/ContextHUD/ContextHUDController.swift
@@ -356,7 +356,7 @@ final class ContextHUDController {
                         AppLogger.shared.info("🎯 [ContextHUD] Precomputed launcher icons")
                     } else {
                         // Warm the simulator cache
-                        let keyMap = try await layerKeyMapper.getMapping(
+                        let (keyMap, _) = try await layerKeyMapper.getMapping(
                             for: layerName,
                             configPath: configPath,
                             layout: layout,
@@ -449,7 +449,7 @@ final class ContextHUDController {
                         layout: layout,
                         collections: scopedEnabledCollections,
                         cacheKeySuffix: "neovim-scope-\(isApprovedNeovimTerminal ? "approved" : "fallback")"
-                    )
+                    ).mapping
                 }
 
                 guard !Task.isCancelled else { return }

--- a/Sources/KeyPathAppKit/UI/KeyboardVisualization/KeyboardVisualizationViewModel+LayoutMapping.swift
+++ b/Sources/KeyPathAppKit/UI/KeyboardVisualization/KeyboardVisualizationViewModel+LayoutMapping.swift
@@ -186,13 +186,14 @@ extension KeyboardVisualizationViewModel {
                 }
 
                 // Build mapping for target layer
-                var mapping = try await layerKeyMapper.getMapping(
+                let (rawMapping, simReport) = try await layerKeyMapper.getMapping(
                     for: targetLayerName,
                     configPath: configPath,
                     layout: layout,
                     collections: scopedRuleCollections,
                     cacheKeySuffix: "neovim-scope-\(isApprovedNeovimTerminal ? "approved" : "fallback")"
                 )
+                var mapping = rawMapping
 
                 // DEBUG: Log what simulator returned
                 AppLogger.shared.info("🗺️ [KeyboardViz] Simulator returned \(mapping.count) entries for '\(targetLayerName)'")
@@ -241,6 +242,15 @@ extension KeyboardVisualizationViewModel {
                 // Log a few sample mappings for debugging
                 for (keyCode, info) in mapping.prefix(5) {
                     AppLogger.shared.debug("  keyCode \(keyCode) -> '\(info.displayLabel)'")
+                }
+
+                // Show alert if simulator had significant failures on a non-base layer
+                if let report = simReport, report.hasSignificantFailures,
+                   targetLayerName.lowercased() != "base"
+                {
+                    await MainActor.run {
+                        Self.showSimulationFailureAlert(report)
+                    }
                 }
             } catch {
                 AppLogger.shared.error("❌ [KeyboardViz] Failed to build layer mapping: \(error)")
@@ -616,6 +626,29 @@ extension KeyboardVisualizationViewModel {
             )
 
             AppLogger.shared.info("🗺️ [KeyboardViz] Background prebuild complete")
+        }
+    }
+
+    /// Layers that have already shown the simulation failure alert (don't repeat)
+    private static var alertedLayers: Set<String> = []
+
+    @MainActor
+    private static func showSimulationFailureAlert(_ report: SimulationReport) {
+        let layer = report.layerName
+        guard !alertedLayers.contains(layer) else { return }
+        alertedLayers.insert(layer)
+
+        let alert = NSAlert()
+        alert.alertStyle = .warning
+        alert.messageText = "Simulator failed for '\(layer)' layer"
+        alert.informativeText = "\(report.failureCount)/\(report.totalKeys) keys could not be resolved. Overlay icons may be missing.\n\nClick \"Copy Error\" and paste into Claude Code to debug."
+        alert.addButton(withTitle: "Copy Error")
+        alert.addButton(withTitle: "Dismiss")
+
+        let response = alert.runModal()
+        if response == .alertFirstButtonReturn {
+            NSPasteboard.general.clearContents()
+            NSPasteboard.general.setString(report.copyableText(), forType: .string)
         }
     }
 

--- a/Tests/KeyPathTests/Services/LayerKeyMapperCollectionTests.swift
+++ b/Tests/KeyPathTests/Services/LayerKeyMapperCollectionTests.swift
@@ -135,7 +135,7 @@ final class LayerKeyMapperCollectionTests: XCTestCase {
         let collections = [vim, window]
 
         // Test navigation layer
-        let navMapping = try await mapper.getMapping(
+        let (navMapping, _) = try await mapper.getMapping(
             for: "nav",
             configPath: configPath,
             layout: PhysicalLayout.macBookUS,
@@ -155,7 +155,7 @@ final class LayerKeyMapperCollectionTests: XCTestCase {
         XCTAssertTrue(wKey?.isLayerSwitch ?? false, "W key should be detected as layer switch")
 
         // Test window layer
-        let windowMapping = try await mapper.getMapping(
+        let (windowMapping, _) = try await mapper.getMapping(
             for: "window",
             configPath: configPath,
             layout: PhysicalLayout.macBookUS,
@@ -186,7 +186,7 @@ final class LayerKeyMapperCollectionTests: XCTestCase {
         let mapper = LayerKeyMapper(simulatorService: simulatorService)
 
         // Call with empty collections array
-        let mapping = try await mapper.getMapping(
+        let (mapping, _) = try await mapper.getMapping(
             for: "base",
             configPath: configPath,
             layout: PhysicalLayout.macBookUS,
@@ -220,7 +220,7 @@ final class LayerKeyMapperCollectionTests: XCTestCase {
         var vim = makeVimCollection()
         vim.isEnabled = false
 
-        let mapping = try await mapper.getMapping(
+        let (mapping, _) = try await mapper.getMapping(
             for: "nav",
             configPath: configPath,
             layout: PhysicalLayout.macBookUS,
@@ -253,7 +253,7 @@ final class LayerKeyMapperCollectionTests: XCTestCase {
         let vim = makeVimCollection()
         let custom = makeCustomCollection()
 
-        let mapping = try await mapper.getMapping(
+        let (mapping, _) = try await mapper.getMapping(
             for: "nav",
             configPath: configPath,
             layout: PhysicalLayout.macBookUS,

--- a/Tests/KeyPathTests/Services/LayerKeyMapperPrebuildTests.swift
+++ b/Tests/KeyPathTests/Services/LayerKeyMapperPrebuildTests.swift
@@ -56,7 +56,7 @@ final class LayerKeyMapperPrebuildTests: XCTestCase {
 
         let prebuiltCount = await mapper.cache.count
 
-        let mapping = try await mapper.getMapping(
+        let (mapping, _) = try await mapper.getMapping(
             for: "nav",
             configPath: configPath,
             layout: .macBookUS,

--- a/Tests/KeyPathTests/Services/LayerKeyMapperTests.swift
+++ b/Tests/KeyPathTests/Services/LayerKeyMapperTests.swift
@@ -42,7 +42,7 @@ final class LayerKeyMapperTests: XCTestCase {
 
         let simulatorService = SimulatorService.forTesting(simulatorPath: simulatorPath)
         let mapper = LayerKeyMapper(simulatorService: simulatorService)
-        let mapping = try await mapper.getMapping(for: "base", configPath: configPath, layout: .macBookUS)
+        let (mapping, _) = try await mapper.getMapping(for: "base", configPath: configPath, layout: .macBookUS)
 
         // Should have mapping for key 1 (keycode 18)
         let key1Mapping = mapping[18]
@@ -69,7 +69,7 @@ final class LayerKeyMapperTests: XCTestCase {
 
         let simulatorService = SimulatorService.forTesting(simulatorPath: simulatorPath)
         let mapper = LayerKeyMapper(simulatorService: simulatorService)
-        let mapping = try await mapper.getMapping(for: "base", configPath: configPath, layout: .macBookUS)
+        let (mapping, _) = try await mapper.getMapping(for: "base", configPath: configPath, layout: .macBookUS)
 
         // Caps Lock (keycode 57) should have some mapping
         // With tap-hold, a 50ms tap may not produce output (waits for timeout)
@@ -94,7 +94,7 @@ final class LayerKeyMapperTests: XCTestCase {
 
         let simulatorService = SimulatorService.forTesting(simulatorPath: simulatorPath)
         let mapper = LayerKeyMapper(simulatorService: simulatorService)
-        let mapping = try await mapper.getMapping(for: "base", configPath: configPath, layout: .macBookUS)
+        let (mapping, _) = try await mapper.getMapping(for: "base", configPath: configPath, layout: .macBookUS)
 
         // Check 1->2 mapping (keycode 18)
         let key1Mapping = mapping[18]
@@ -122,7 +122,7 @@ final class LayerKeyMapperTests: XCTestCase {
 
         let simulatorService = SimulatorService.forTesting(simulatorPath: simulatorPath)
         let mapper = LayerKeyMapper(simulatorService: simulatorService)
-        let mapping = try await mapper.getMapping(for: "base", configPath: configPath, layout: .macBookUS)
+        let (mapping, _) = try await mapper.getMapping(for: "base", configPath: configPath, layout: .macBookUS)
 
         // Key a (keycode 0) should NOT be marked as remapped since it maps to itself
         let keyAMapping = mapping[0]

--- a/Tests/KeyPathTests/Services/RemapEndToEndTests.swift
+++ b/Tests/KeyPathTests/Services/RemapEndToEndTests.swift
@@ -32,7 +32,7 @@ final class RemapEndToEndTests: XCTestCase {
         // 4. Run through simulator and get key mapping
         let simulatorService = SimulatorService.forTesting(simulatorPath: simulatorPath)
         let mapper = LayerKeyMapper(simulatorService: simulatorService)
-        let layerMapping = try await mapper.getMapping(
+        let (layerMapping, _) = try await mapper.getMapping(
             for: "base",
             configPath: configPath,
             layout: .macBookUS
@@ -65,7 +65,7 @@ final class RemapEndToEndTests: XCTestCase {
 
         let simulatorService = SimulatorService.forTesting(simulatorPath: simulatorPath)
         let mapper = LayerKeyMapper(simulatorService: simulatorService)
-        let layerMapping = try await mapper.getMapping(
+        let (layerMapping, _) = try await mapper.getMapping(
             for: "base",
             configPath: configPath,
             layout: .macBookUS


### PR DESCRIPTION
## Summary
- Adds `SimulationReport` struct that tracks which keys failed simulation during layer mapping
- When >5 keys fail on a non-base layer, shows an in-your-face macOS `NSAlert` with a "Copy Error" button
- The copied text is structured markdown designed for pasting into Claude Code: includes layer name, config path, failed key list, and the sim command format
- Alert only fires once per layer per session (no spam on repeated layer switches)

## Test plan
- [ ] Hold F to enter vallack-nav layer → alert should appear if simulator fails
- [ ] Click "Copy Error" → paste into a text editor and verify structured debug info
- [ ] Click "Dismiss" → alert goes away, doesn't reappear for same layer
- [ ] `swift test` passes (532 tests)