### PR TITLE
fix: prevent zone subtitle overlapping letter on overlay

### DIFF
--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView+ContentAndStyling.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView+ContentAndStyling.swift
@@ -66,7 +66,7 @@ extension OverlayKeycapView {
                     Text(subtitle)
                         .font(.system(size: 9 * scale, weight: .medium))
                         .foregroundStyle(Color.white.opacity(0.45))
-                        .padding(.bottom, 2.5 * scale)
+                        .padding(.bottom, 1 * scale)
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
             }

--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView+LayoutContent.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView+LayoutContent.swift
@@ -42,7 +42,7 @@ extension OverlayKeycapView {
                 Text(isNumpadKey ? displayText : displayText.uppercased())
                     .font(.system(size: isNumpadKey ? 14 * scale : 12 * scale, weight: .medium))
                     .foregroundStyle(foregroundColor)
-                    .offset(y: hasSubtitle ? -2.5 * scale : 0)
+                    .offset(y: hasSubtitle ? -2 * scale : 0)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
         }
@@ -97,7 +97,7 @@ extension OverlayKeycapView {
                 .offset(y: mainAdj.verticalOffset * scale)
                 .foregroundStyle(foregroundColor)
         }
-        .offset(y: hasSubtitle ? -2.5 * scale : 0)
+        .offset(y: hasSubtitle ? -2 * scale : 0)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 


### PR DESCRIPTION
## Summary
- Restore zone subtitle bottom padding to 1pt (was 2.5pt from #527) — the increased padding pushed the modifier symbol upward into the letter
- Reduce letter upward offset from -2.5 to -2 for better balance
- Keeps the 9pt subtitle font from #527 (larger modifier symbols)

Net effect vs pre-#527: subtitle is 9pt (was 7pt), letter nudged up 2pt, subtitle stays anchored at keycap bottom.

## Test plan
- [ ] Quick-deploy and verify modifier symbols (⌃ ⌥ ⌘) don't overlap letters
- [ ] Check number row keys with shift symbols + zone subtitles
- [ ] Verify keys without subtitles are unaffected