### PR TITLE
test: add 31 installer engine failure path tests

### DIFF
--- a/Tests/KeyPathTests/InstallationEngine/InstallerEngineFailurePathTests.swift
+++ b/Tests/KeyPathTests/InstallationEngine/InstallerEngineFailurePathTests.swift
@@ -1,0 +1,498 @@
+@testable import KeyPathAppKit
+@testable import KeyPathInstallationWizard
+import KeyPathCore
+import KeyPathPermissions
+@testable import KeyPathWizardCore
+@preconcurrency import XCTest
+
+@MainActor
+final class InstallerEngineFailurePathTests: KeyPathAsyncTestCase {
+    var engine: InstallerEngine!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        HelperManager.testHelperFunctionalityOverride = { false }
+        engine = InstallerEngine()
+    }
+
+    override func tearDown() async throws {
+        engine = nil
+        HelperManager.testHelperFunctionalityOverride = nil
+        try await super.tearDown()
+    }
+
+    // MARK: - Blocked Plan Tests
+
+    func testExecute_BlockedPlanReturnsFailure() async {
+        let requirement = Requirement(
+            name: "Driver Compatibility",
+            status: .blocked
+        )
+        let plan = InstallPlan(
+            recipes: [],
+            status: .blocked(requirement: requirement),
+            intent: .install,
+            blockedBy: requirement
+        )
+        let broker = PrivilegeBroker(coordinator: StubPrivilegedOperationsCoordinator())
+        let report = await engine.execute(plan: plan, using: broker)
+
+        XCTAssertFalse(report.success)
+        XCTAssertEqual(report.unmetRequirements.count, 1)
+        XCTAssertEqual(report.unmetRequirements.first?.name, "Driver Compatibility")
+        XCTAssertTrue(report.failureReason?.contains("blocked") ?? false)
+        XCTAssertTrue(report.executedRecipes.isEmpty)
+    }
+
+    func testMakePlan_BlockedWhenDriverIncompatible() async {
+        let context = SystemContextBuilder(
+            permissionsStatus: .granted,
+            helperReady: true,
+            servicesHealthy: false,
+            componentsInstalled: false,
+            driverCompatible: false
+        ).build()
+
+        let plan = await engine.makePlan(for: .install, context: context)
+        if case .blocked = plan.status {
+            XCTAssertNotNil(plan.blockedBy)
+        } else {
+            XCTFail("Plan should be blocked when driver is incompatible")
+        }
+    }
+
+    // MARK: - Recipe Execution Failure Tests
+
+    func testExecute_StopsOnFirstRecipeFailure() async {
+        let stub = StubPrivilegedOperationsCoordinator()
+        stub.failOnCall = "installRequiredRuntimeServices"
+        let broker = PrivilegeBroker(coordinator: stub)
+
+        let context = SystemContextBuilder.cleanInstall()
+        let plan = await engine.makePlan(for: .install, context: context)
+
+        guard plan.status == .ready else {
+            XCTSkip("Plan is blocked — cannot test recipe execution")
+            return
+        }
+
+        let report = await engine.execute(plan: plan, using: broker)
+
+        XCTAssertFalse(report.success)
+        XCTAssertNotNil(report.failureReason)
+
+        let failedRecipes = report.executedRecipes.filter { !$0.success }
+        XCTAssertEqual(failedRecipes.count, 1, "Exactly one recipe should have failed")
+        XCTAssertNotNil(failedRecipes.first?.error)
+    }
+
+    func testExecute_SuccessfulRecipesBeforeFailureAreRecorded() async {
+        let stub = StubPrivilegedOperationsCoordinator()
+        stub.failOnCall = "repairVHIDDaemonServices"
+        let broker = PrivilegeBroker(coordinator: stub)
+
+        let context = SystemContextBuilder.degradedRepair()
+        let plan = await engine.makePlan(for: .repair, context: context)
+
+        guard plan.status == .ready, plan.recipes.count > 1 else {
+            XCTSkip("Need multi-recipe plan for this test")
+            return
+        }
+
+        let report = await engine.execute(plan: plan, using: broker)
+
+        let succeeded = report.executedRecipes.filter(\.success)
+        let failed = report.executedRecipes.filter { !$0.success }
+
+        if !failed.isEmpty {
+            XCTAssertFalse(report.success)
+            XCTAssertTrue(succeeded.count + failed.count <= plan.recipes.count)
+        }
+    }
+
+    func testExecute_FailedRecipeIncludesErrorDescription() async {
+        let stub = StubPrivilegedOperationsCoordinator()
+        stub.failOnCall = "installRequiredRuntimeServices"
+        let broker = PrivilegeBroker(coordinator: stub)
+
+        let context = SystemContextBuilder.cleanInstall()
+        let plan = await engine.makePlan(for: .install, context: context)
+
+        guard plan.status == .ready else {
+            XCTSkip("Plan is blocked")
+            return
+        }
+
+        let report = await engine.execute(plan: plan, using: broker)
+
+        let failedRecipe = report.executedRecipes.first(where: { !$0.success })
+        XCTAssertNotNil(failedRecipe?.error, "Failed recipe should include error description")
+        XCTAssertGreaterThan(failedRecipe?.error?.count ?? 0, 0)
+    }
+
+    // MARK: - Privilege Broker Failure Tests
+
+    func testBroker_ThrowsWhenCoordinatorNotConfigured() async {
+        let saved = WizardDependencies.privilegedOperations
+        WizardDependencies.privilegedOperations = nil
+        defer { WizardDependencies.privilegedOperations = saved }
+
+        let broker = PrivilegeBroker()
+        do {
+            try await broker.installRequiredRuntimeServices()
+            XCTFail("Should throw when coordinator not configured")
+        } catch {
+            XCTAssertTrue(
+                "\(error)".contains("coordinatorNotConfigured"),
+                "Should throw coordinatorNotConfigured, got: \(error)"
+            )
+        }
+    }
+
+    func testBroker_AllMethodsThrowWhenNoCoordinator() async {
+        let saved = WizardDependencies.privilegedOperations
+        WizardDependencies.privilegedOperations = nil
+        defer { WizardDependencies.privilegedOperations = saved }
+
+        let broker = PrivilegeBroker()
+
+        do { try await broker.recoverRequiredRuntimeServices(); XCTFail("Should throw") } catch {}
+        do { try await broker.installNewsyslogConfig(); XCTFail("Should throw") } catch {}
+        do { try await broker.regenerateServiceConfiguration(); XCTFail("Should throw") } catch {}
+        do { try await broker.repairVHIDDaemonServices(); XCTFail("Should throw") } catch {}
+        do { try await broker.downloadAndInstallCorrectVHIDDriver(); XCTFail("Should throw") } catch {}
+        do { try await broker.activateVirtualHIDManager(); XCTFail("Should throw") } catch {}
+        do { try await broker.killAllKanataProcesses(); XCTFail("Should throw") } catch {}
+        do { try await broker.terminateProcess(pid: 1); XCTFail("Should throw") } catch {}
+        do { try await broker.uninstallVirtualHIDDrivers(); XCTFail("Should throw") } catch {}
+        do { try await broker.disableKarabinerGrabber(); XCTFail("Should throw") } catch {}
+        do { try await broker.sudoExecuteCommand("ls", description: "test"); XCTFail("Should throw") } catch {}
+    }
+
+    func testBroker_CoordinatorErrorPropagates() async {
+        let stub = StubPrivilegedOperationsCoordinator()
+        stub.failOnCall = "installRequiredRuntimeServices"
+        let broker = PrivilegeBroker(coordinator: stub)
+
+        do {
+            try await broker.installRequiredRuntimeServices()
+            XCTFail("Should propagate coordinator error")
+        } catch is StubPrivilegedOperationsCoordinator.StubError {
+            // Expected
+        } catch {
+            XCTFail("Expected StubError, got \(error)")
+        }
+    }
+
+    // MARK: - Empty Plan Tests
+
+    func testExecute_EmptyPlanSucceeds() async {
+        let plan = InstallPlan(
+            recipes: [],
+            status: .ready,
+            intent: .inspectOnly
+        )
+        let broker = PrivilegeBroker(coordinator: StubPrivilegedOperationsCoordinator())
+        let report = await engine.execute(plan: plan, using: broker)
+
+        XCTAssertTrue(report.success)
+        XCTAssertNil(report.failureReason)
+        XCTAssertTrue(report.executedRecipes.isEmpty)
+    }
+
+    func testMakePlan_InspectOnlyProducesEmptyPlan() async {
+        let context = SystemContextBuilder.cleanInstall()
+        let plan = await engine.makePlan(for: .inspectOnly, context: context)
+
+        XCTAssertEqual(plan.intent, .inspectOnly)
+        XCTAssertTrue(plan.recipes.isEmpty, "Inspect-only should have no recipes")
+        XCTAssertEqual(plan.status, .ready)
+    }
+
+    // MARK: - Uninstall Failure Tests
+
+    func testUninstall_FailsWhenCoordinatorNotConfigured() async {
+        let savedFactory = WizardDependencies.createUninstallCoordinator
+        WizardDependencies.createUninstallCoordinator = nil
+        defer { WizardDependencies.createUninstallCoordinator = savedFactory }
+
+        let broker = PrivilegeBroker(coordinator: StubPrivilegedOperationsCoordinator())
+        let report = await engine.uninstall(deleteConfig: false, using: broker)
+
+        XCTAssertFalse(report.success)
+        XCTAssertTrue(report.failureReason?.contains("not configured") ?? false)
+    }
+
+    func testRun_UninstallDelegatesToUninstallMethod() async {
+        let savedFactory = WizardDependencies.createUninstallCoordinator
+        WizardDependencies.createUninstallCoordinator = nil
+        defer { WizardDependencies.createUninstallCoordinator = savedFactory }
+
+        let broker = PrivilegeBroker(coordinator: StubPrivilegedOperationsCoordinator())
+        let report = await engine.run(intent: .uninstall, using: broker)
+
+        XCTAssertFalse(report.success)
+        XCTAssertTrue(report.failureReason?.contains("not configured") ?? false)
+    }
+
+    // MARK: - Report Structure Tests
+
+    func testReport_FailureReasonIncludesRecipeID() async {
+        let stub = StubPrivilegedOperationsCoordinator()
+        stub.failOnCall = "installRequiredRuntimeServices"
+        let broker = PrivilegeBroker(coordinator: stub)
+
+        let context = SystemContextBuilder.cleanInstall()
+        let plan = await engine.makePlan(for: .install, context: context)
+
+        guard plan.status == .ready else {
+            XCTSkip("Plan is blocked")
+            return
+        }
+
+        let report = await engine.execute(plan: plan, using: broker)
+
+        if let reason = report.failureReason {
+            XCTAssertTrue(
+                reason.contains("Recipe") || reason.contains("recipe") || reason.contains("'"),
+                "Failure reason should reference the recipe: \(reason)"
+            )
+        }
+    }
+
+    func testReport_RecipeDurationsAreNonNegative() async {
+        let stub = StubPrivilegedOperationsCoordinator()
+        let broker = PrivilegeBroker(coordinator: stub)
+
+        let context = SystemContextBuilder.cleanInstall()
+        let plan = await engine.makePlan(for: .install, context: context)
+
+        guard plan.status == .ready else {
+            XCTSkip("Plan is blocked")
+            return
+        }
+
+        let report = await engine.execute(plan: plan, using: broker)
+
+        for result in report.executedRecipes {
+            XCTAssertGreaterThanOrEqual(
+                result.duration, 0,
+                "Recipe \(result.recipeID) duration should be non-negative"
+            )
+        }
+    }
+
+    func testReport_SuccessfulExecutionHasNoFailureReason() async {
+        let stub = StubPrivilegedOperationsCoordinator()
+        let broker = PrivilegeBroker(coordinator: stub)
+
+        let plan = InstallPlan(recipes: [], status: .ready, intent: .inspectOnly)
+        let report = await engine.execute(plan: plan, using: broker)
+
+        XCTAssertTrue(report.success)
+        XCTAssertNil(report.failureReason)
+        XCTAssertTrue(report.unmetRequirements.isEmpty)
+    }
+
+    // MARK: - Recipe Logs Tests
+
+    func testReport_FailedRecipeHasLogs() async {
+        let stub = StubPrivilegedOperationsCoordinator()
+        stub.failOnCall = "installRequiredRuntimeServices"
+        let broker = PrivilegeBroker(coordinator: stub)
+
+        let context = SystemContextBuilder.cleanInstall()
+        let plan = await engine.makePlan(for: .install, context: context)
+
+        guard plan.status == .ready else {
+            XCTSkip("Plan is blocked")
+            return
+        }
+
+        let report = await engine.execute(plan: plan, using: broker)
+
+        let failedRecipe = report.executedRecipes.first(where: { !$0.success })
+        XCTAssertNotNil(failedRecipe)
+        XCTAssertFalse(failedRecipe?.logs.isEmpty ?? true, "Failed recipe should have logs")
+        XCTAssertTrue(
+            failedRecipe?.logs.contains(where: { $0.contains("FAILED") }) ?? false,
+            "Failed recipe logs should contain 'FAILED'"
+        )
+    }
+
+    func testReport_AggregatedLogsIncludeAllRecipes() async {
+        let stub = StubPrivilegedOperationsCoordinator()
+        let broker = PrivilegeBroker(coordinator: stub)
+
+        let context = SystemContextBuilder.cleanInstall()
+        let plan = await engine.makePlan(for: .install, context: context)
+
+        guard plan.status == .ready, !plan.recipes.isEmpty else {
+            XCTSkip("Need non-empty plan")
+            return
+        }
+
+        let report = await engine.execute(plan: plan, using: broker)
+
+        XCTAssertFalse(report.logs.isEmpty, "Report should have aggregated logs")
+    }
+
+    // MARK: - SystemContext Builder Tests
+
+    func testSystemContextBuilder_CleanInstall() {
+        let context = SystemContextBuilder.cleanInstall()
+        XCTAssertFalse(context.helper.isInstalled)
+        XCTAssertFalse(context.services.kanataRunning)
+        XCTAssertFalse(context.components.kanataBinaryInstalled)
+    }
+
+    func testSystemContextBuilder_DegradedRepair() {
+        let context = SystemContextBuilder.degradedRepair()
+        XCTAssertTrue(context.helper.isInstalled)
+        XCTAssertFalse(context.services.kanataRunning)
+        XCTAssertTrue(context.components.kanataBinaryInstalled)
+    }
+
+    func testSystemContextBuilder_CustomConflicts() {
+        let conflict = SystemConflict.karabinerGrabberRunning(pid: 1234)
+        let context = SystemContextBuilder(
+            conflicts: [conflict]
+        ).build()
+
+        XCTAssertEqual(context.conflicts.conflicts.count, 1)
+        XCTAssertTrue(context.conflicts.canAutoResolve)
+    }
+
+    // MARK: - Installer Error Tests
+
+    func testInstallerError_HealthCheckFailedHasMessage() {
+        let error = InstallerError.healthCheckFailed("Service not responding")
+        XCTAssertTrue(error.localizedDescription.contains("not responding"))
+    }
+
+    func testInstallerError_UnknownRecipeHasID() {
+        let error = InstallerError.unknownRecipe("custom-recipe-123")
+        XCTAssertTrue(error.localizedDescription.contains("custom-recipe-123"))
+    }
+
+    // MARK: - RecipeResult Tests
+
+    func testRecipeResult_SuccessfulResult() {
+        let result = RecipeResult(
+            recipeID: "test-recipe",
+            success: true,
+            duration: 1.5,
+            logs: ["Started", "Completed"],
+            commandsRun: ["launchctl bootstrap"]
+        )
+        XCTAssertTrue(result.success)
+        XCTAssertNil(result.error)
+        XCTAssertEqual(result.recipeID, "test-recipe")
+        XCTAssertEqual(result.duration, 1.5)
+        XCTAssertEqual(result.logs.count, 2)
+        XCTAssertEqual(result.commandsRun.count, 1)
+    }
+
+    func testRecipeResult_FailedResult() {
+        let result = RecipeResult(
+            recipeID: "failed-recipe",
+            success: false,
+            error: "Permission denied"
+        )
+        XCTAssertFalse(result.success)
+        XCTAssertEqual(result.error, "Permission denied")
+    }
+
+    // MARK: - InstallPlan Tests
+
+    func testInstallPlan_ReadyStatus() {
+        let plan = InstallPlan(
+            recipes: [],
+            status: .ready,
+            intent: .install
+        )
+        XCTAssertEqual(plan.status, .ready)
+        XCTAssertNil(plan.blockedBy)
+        XCTAssertFalse(plan.metadata.needsReboot)
+    }
+
+    func testInstallPlan_BlockedStatus() {
+        let req = Requirement(
+            name: "Test",
+            status: .blocked
+        )
+        let plan = InstallPlan(
+            recipes: [],
+            status: .blocked(requirement: req),
+            intent: .install,
+            blockedBy: req,
+            metadata: PlanMetadata(needsReboot: true, promptsNeeded: true)
+        )
+        if case .blocked = plan.status {} else { XCTFail("Should be blocked") }
+        XCTAssertNotNil(plan.blockedBy)
+        XCTAssertTrue(plan.metadata.needsReboot)
+        XCTAssertTrue(plan.metadata.promptsNeeded)
+    }
+
+    // MARK: - Health Check Types
+
+    func testKanataHealthSnapshot_AllHealthy() {
+        let snapshot = KanataHealthSnapshot(
+            isRunning: true,
+            isResponding: true,
+            inputCaptureReady: true
+        )
+        XCTAssertTrue(snapshot.isRunning)
+        XCTAssertTrue(snapshot.isResponding)
+        XCTAssertTrue(snapshot.inputCaptureReady)
+    }
+
+    func testKanataHealthSnapshot_PartialFailure() {
+        let snapshot = KanataHealthSnapshot(
+            isRunning: true,
+            isResponding: false,
+            inputCaptureReady: false
+        )
+        XCTAssertTrue(snapshot.isRunning)
+        XCTAssertFalse(snapshot.isResponding)
+        XCTAssertFalse(snapshot.inputCaptureReady)
+    }
+
+    // MARK: - Stub Coordinator Tests
+
+    func testStubCoordinator_RecordsCalls() async throws {
+        let stub = StubPrivilegedOperationsCoordinator()
+        try await stub.installRequiredRuntimeServices()
+        try await stub.installNewsyslogConfig()
+
+        XCTAssertEqual(stub.calls, [
+            "installRequiredRuntimeServices",
+            "installNewsyslogConfig",
+        ])
+    }
+
+    func testStubCoordinator_FailOnCallThrows() async {
+        let stub = StubPrivilegedOperationsCoordinator()
+        stub.failOnCall = "installNewsyslogConfig"
+
+        try? await stub.installRequiredRuntimeServices()
+        XCTAssertEqual(stub.calls, ["installRequiredRuntimeServices"])
+
+        do {
+            try await stub.installNewsyslogConfig()
+            XCTFail("Should throw on configured failOnCall")
+        } catch is StubPrivilegedOperationsCoordinator.StubError {
+            // Expected
+        } catch {
+            XCTFail("Expected StubError, got \(error)")
+        }
+        XCTAssertEqual(stub.calls.count, 1, "Failed call should not be recorded")
+    }
+
+    func testStubCoordinator_SudoRecordsCommandName() async throws {
+        let stub = StubPrivilegedOperationsCoordinator()
+        try await stub.sudoExecuteCommand("/bin/launchctl bootout system/com.keypath.kanata", description: "Stop service")
+        XCTAssertTrue(stub.calls.first?.contains("sudoExecuteCommand") ?? false)
+        XCTAssertTrue(stub.calls.first?.contains("launchctl") ?? false)
+    }
+}


### PR DESCRIPTION
## Summary

Closes #531

- **Blocked plan handling** (2 tests): blocked plan returns failure with requirements, driver incompatibility blocks plan
- **Recipe execution failures** (3 tests): stops on first failure, successful recipes before failure are recorded, failed recipe includes error description
- **Privilege broker errors** (3 tests): throws when coordinator not configured, all 11 broker methods throw without coordinator, coordinator errors propagate
- **Empty/inspect plans** (2 tests): empty plan succeeds, inspect-only produces empty plan
- **Uninstall failures** (2 tests): fails when coordinator not configured, run(intent: .uninstall) delegates correctly
- **Report structure** (5 tests): failure reason includes recipe ID, durations are non-negative, successful execution has no failure reason, failed recipe has logs with FAILED marker, aggregated logs include all recipes
- **SystemContext builder** (3 tests): cleanInstall, degradedRepair, custom conflicts
- **Type coverage** (6 tests): InstallerError messages, RecipeResult success/failure, InstallPlan ready/blocked, KanataHealthSnapshot healthy/partial
- **Stub coordinator** (3 tests): records calls, failOnCall throws, sudo records command name

## Test plan

- [x] All 31 new tests pass
- [x] Build passes
- [x] Tests run in <1s (no real XPC or system calls)