### PR TITLE
fix: render zone subtitle as VStack matching number row layout

### DIFF
--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView+ContentAndStyling.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView+ContentAndStyling.swift
@@ -60,7 +60,10 @@ extension OverlayKeycapView {
             keyContent
 
             // Zone subtitle overlay (e.g., ⌃ under Q for hold modifier)
-            if let subtitle = zoneSubtitle, !isLayerMode, !isLauncherMode {
+            // Skip when subtitle is rendered inline as a VStack in centeredContent
+            if let subtitle = zoneSubtitle, !isLayerMode, !isLauncherMode,
+               !zoneSubtitleRenderedInline
+            {
                 VStack(spacing: 0) {
                     Spacer()
                     Text(subtitle)

--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView+LayoutContent.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView+LayoutContent.swift
@@ -38,12 +38,27 @@ extension OverlayKeycapView {
                 layerKeyContent(label: key.label)
             } else {
                 let displayText = effectiveLabel.isEmpty ? key.label : effectiveLabel
-                let hasSubtitle = zoneSubtitle != nil && !isLayerMode && !isLauncherMode
-                Text(isNumpadKey ? displayText : displayText.uppercased())
-                    .font(.system(size: isNumpadKey ? 14 * scale : 12 * scale, weight: .medium))
-                    .foregroundStyle(foregroundColor)
-                    .offset(y: hasSubtitle ? -2 * scale : 0)
+                if let subtitle = zoneSubtitle, !isLayerMode, !isLauncherMode {
+                    let adj = OpticalAdjustments.forLabel(displayText)
+                    VStack(spacing: dualSymbolSpacing(for: displayText)) {
+                        Text(displayText.uppercased())
+                            .font(.system(
+                                size: 12.5 * scale * adj.fontScale,
+                                weight: adj.fontWeight ?? .medium
+                            ))
+                            .offset(y: adj.verticalOffset * scale)
+                            .foregroundStyle(foregroundColor)
+                        Text(subtitle)
+                            .font(.system(size: 8.5 * scale, weight: .light))
+                            .foregroundStyle(foregroundColor.opacity(isSmallSize ? 0 : 0.65))
+                    }
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
+                } else {
+                    Text(isNumpadKey ? displayText : displayText.uppercased())
+                        .font(.system(size: isNumpadKey ? 14 * scale : 12 * scale, weight: .medium))
+                        .foregroundStyle(foregroundColor)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                }
             }
         }
     }
@@ -79,7 +94,6 @@ extension OverlayKeycapView {
     func dualSymbolContent(main: String, shift: String) -> some View {
         let shiftAdj = OpticalAdjustments.forLabel(shift)
         let mainAdj = OpticalAdjustments.forLabel(main)
-        let hasSubtitle = zoneSubtitle != nil && !isLayerMode && !isLauncherMode
 
         VStack(spacing: dualSymbolSpacing(for: main)) {
             Text(shift)
@@ -97,7 +111,6 @@ extension OverlayKeycapView {
                 .offset(y: mainAdj.verticalOffset * scale)
                 .foregroundStyle(foregroundColor)
         }
-        .offset(y: hasSubtitle ? -2 * scale : 0)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
@@ -132,6 +145,17 @@ extension OverlayKeycapView {
             .foregroundStyle(Color.white.opacity(isPressed ? 1.0 : 0.9))
             .shadow(color: Color.black.opacity(0.25), radius: 1.5 * scale, y: 1 * scale)
             .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    var zoneSubtitleRenderedInline: Bool {
+        guard zoneSubtitle != nil, !isLayerMode, !isLauncherMode else { return false }
+        guard colorway.legendStyle == .standard else { return false }
+        guard key.layoutRole == .centered else { return false }
+        guard !(useFloatingLabels && !hasSpecialLabel && !isRemappedKey) else { return false }
+        guard navigationSFSymbol == nil else { return false }
+        guard navOverlaySymbol == nil else { return false }
+        guard metadata.shiftSymbol == nil || isNumpadKey else { return false }
+        return true
     }
 
     func dualSymbolSpacing(for label: String) -> CGFloat {


### PR DESCRIPTION
## Summary
- Renders letter + modifier symbol as a proper VStack pair (letter on top, modifier on bottom) instead of separate ZStack layers
- Uses identical sizing to `dualSymbolContent` but inverted: letter at 12.5pt/.medium, modifier at 8.5pt/.light/0.65 opacity, 2pt spacing
- Removes the hacky offset approach from #527/#536 — the VStack handles spacing naturally
- Adds `zoneSubtitleRenderedInline` to suppress the separate overlay when already rendered inline

## Test plan
- [ ] Quick-deploy and compare letter+modifier spacing to number row (should match proportions)
- [ ] Verify modifiers (⌃ ⌥ ⌘) are visually consistent with shift symbols (! @ # $ %)
- [ ] Check keys without zone subtitles are unaffected
- [ ] Check non-standard legend styles (dots, blank, iconMods) still show subtitle overlay
- [ ] Check floating labels mode doesn't break