### PR TITLE
fix: skip floating labels for zone subtitle keys

### DIFF
--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayKeyboardView.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayKeyboardView.swift
@@ -232,6 +232,11 @@ struct OverlayKeyboardView: View {
         return mappedLabel != normalizedLabel
     }
 
+    private func hasZoneSubtitle(for label: String) -> Bool {
+        guard let keyCode = labelToKeyCode[label.uppercased()] else { return false }
+        return activeZoneSubtitles[keyCode] != nil
+    }
+
     var keyboardAccessibilityLabel: String {
         "Keyboard overlay, \(layout.name), layer \(currentLayerName)"
     }
@@ -294,7 +299,8 @@ struct OverlayKeyboardView: View {
                                 && !Self.isSpecialLabel(label)
                                 && !isLauncherMode
                                 && !isLayerMode
-                                && !isRemappedLabel(label),
+                                && !isRemappedLabel(label)
+                                && !hasZoneSubtitle(for: label),
                             scale: scale,
                             colorway: activeColorway,
                             // Enable animation after initial render (prevents animation on drawer open)

--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView+LayoutContent.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView+LayoutContent.swift
@@ -9,7 +9,8 @@ extension OverlayKeycapView {
 
     @ViewBuilder
     var centeredContent: some View {
-        if useFloatingLabels, !hasSpecialLabel, !isRemappedKey {
+        let hasActiveSubtitle = zoneSubtitle != nil && !isLayerMode && !isLauncherMode
+        if useFloatingLabels, !hasSpecialLabel, !isRemappedKey, !hasActiveSubtitle {
             if let navSymbol = navOverlaySymbol {
                 navOverlayArrowOnly(arrow: navSymbol)
             } else {
@@ -151,7 +152,6 @@ extension OverlayKeycapView {
         guard zoneSubtitle != nil, !isLayerMode, !isLauncherMode else { return false }
         guard colorway.legendStyle == .standard else { return false }
         guard key.layoutRole == .centered else { return false }
-        guard !(useFloatingLabels && !hasSpecialLabel && !isRemappedKey) else { return false }
         guard navigationSFSymbol == nil else { return false }
         guard navOverlaySymbol == nil else { return false }
         guard metadata.shiftSymbol == nil || isNumpadKey else { return false }


### PR DESCRIPTION
## Summary
- Zone subtitle keys (Q/W/E with ⌃/⌥/⌘) were bypassing the VStack layout from #543 because they were in floating labels mode
- `centeredContent` rendered `Color.clear`, the letter appeared as an external floating label, and the modifier used the old cramped overlay
- Now keys with zone subtitles skip the floating labels path, rendering the letter + modifier as a proper VStack inside the keycap
- External floating labels are also suppressed for these keys via `hasZoneSubtitle(for:)` check

## Test plan
- [ ] Quick-deploy and verify modifier symbols (⌃ ⌥ ⌘) now match number row proportions
- [ ] Verify floating labels still work correctly for keys WITHOUT zone subtitles
- [ ] Check layer mode and launcher mode are unaffected
- [ ] Check non-standard legend styles (dots, blank) still work