### PR TITLE
fix: auto-recover from stuck key when kanata dies mid-keystroke

### DIFF
--- a/Sources/KeyPathAppKit/App.swift
+++ b/Sources/KeyPathAppKit/App.swift
@@ -93,8 +93,7 @@ func openPreferencesTab(_ notification: Notification.Name) {
         for item in appMenu.items {
             // Look for the "Settings..." menu item (standard name on macOS)
             if item.title.contains("Settings") || item.title.contains("Preferences"),
-               let action = item.action
-            {
+               let action = item.action {
                 AppLogger.shared.log("✅ [App] Found Settings menu item, triggering it")
                 NSApp.activate(ignoringOtherApps: true)
                 NSApp.sendAction(action, to: item.target, from: item)
@@ -119,8 +118,7 @@ func openPreferencesTab(_ notification: Notification.Name) {
 @MainActor
 class AppDelegate: NSObject, NSApplicationDelegate {
     static func isOneShotProbeEnvironment(_ environment: [String: String] = ProcessInfo.processInfo.environment)
-        -> Bool
-    {
+        -> Bool {
         OneShotProbeEnvironment.isActive(environment)
     }
 
@@ -186,6 +184,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // Start investigation event tap if duplicate key investigation is enabled
         InvestigationEventTapService.shared.startIfNeeded()
 
+        // Wire up stuck key recovery: AutorepeatMismatch → kanata restart
+        StuckKeyRecoveryService.shared.restartKanata = { [weak self] reason in
+            await self?.kanataManager?.restartKanata(reason: reason) ?? false
+        }
+
         // Set smart default keyboard layout on first launch
         setSmartKeyboardLayoutDefault()
 
@@ -199,8 +202,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
            let bundleIdentifier = Bundle.main.bundleIdentifier,
            SingleInstanceCoordinator.activateExistingAndTerminateIfNeeded(
                bundleIdentifier: bundleIdentifier
-           )
-        {
+           ) {
             AppLogger.shared.info("🪟 [AppDelegate] Duplicate normal app launch detected; exiting early")
             return
         }
@@ -402,8 +404,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     private func handleSubsequentActivation() {
         if !LiveKeyboardOverlayController.shared.isVisible,
-           LiveKeyboardOverlayController.shared.canAutoShow
-        {
+           LiveKeyboardOverlayController.shared.canAutoShow {
             LiveKeyboardOverlayController.shared.showForStartup()
             AppLogger.shared.debug("🪟 [AppDelegate] Subsequent activation - showing overlay")
         } else if !LiveKeyboardOverlayController.shared.isVisible {

--- a/Sources/KeyPathAppKit/Services/Monitoring/InvestigationEventTapService.swift
+++ b/Sources/KeyPathAppKit/Services/Monitoring/InvestigationEventTapService.swift
@@ -99,6 +99,7 @@ final class InvestigationEventTapService {
             let correlation = await DuplicateKeyInvestigationTracker.shared.recordSystemEvent(observed)
             if correlation.suggestsUnmatchedAutorepeat {
                 AppLogger.shared.info(DuplicateInvestigationSupport.makeAutorepeatMismatchLog(correlation))
+                await StuckKeyRecoveryService.shared.handleAutorepeatMismatch(correlation)
             }
         }
     }

--- a/Sources/KeyPathAppKit/Services/Monitoring/StuckKeyRecoveryService.swift
+++ b/Sources/KeyPathAppKit/Services/Monitoring/StuckKeyRecoveryService.swift
@@ -1,0 +1,70 @@
+import Foundation
+import KeyPathCore
+
+/// Detects stuck keys (infinite autorepeat after kanata dies) and triggers automatic recovery.
+///
+/// When kanata crashes or hangs while a key is held, vhiddaemon never receives the key-up
+/// event, causing macOS to generate infinite autorepeat. This service monitors for that
+/// condition via AutorepeatMismatch correlations and triggers a kanata restart to clear the
+/// stale virtual HID state (kanata's startup F24 flush handles the actual key release).
+@MainActor
+final class StuckKeyRecoveryService {
+    static let shared = StuckKeyRecoveryService()
+
+    /// Minimum time since last kanata event before we consider a mismatch "stuck" (not normal repeat).
+    private static let kanataUnresponsiveThresholdMs = 3000
+
+    /// Minimum cooldown between recovery attempts to avoid restart loops.
+    private static let recoveryCooldownSeconds: TimeInterval = 30
+
+    private var lastRecoveryAt: Date?
+    private var isRecovering = false
+
+    /// Called to restart kanata. Wired up by RuntimeCoordinator during bootstrap.
+    var restartKanata: ((String) async -> Bool)?
+
+    /// Evaluate an AutorepeatMismatch correlation and trigger recovery if the key is truly stuck.
+    ///
+    /// A stuck key is distinguished from normal autorepeat by checking that kanata has been
+    /// unresponsive for a significant period — normal repeat events flow through kanata and
+    /// show low `msSinceAnyKanataEvent`.
+    func handleAutorepeatMismatch(_ correlation: InvestigationSystemEventCorrelation) {
+        guard correlation.suggestsUnmatchedAutorepeat else { return }
+
+        guard let msSinceKanata = correlation.msSinceAnyKanataEvent,
+              msSinceKanata >= Self.kanataUnresponsiveThresholdMs
+        else {
+            return
+        }
+
+        guard !isRecovering else { return }
+
+        if let lastRecovery = lastRecoveryAt,
+           Date().timeIntervalSince(lastRecovery) < Self.recoveryCooldownSeconds {
+            return
+        }
+
+        isRecovering = true
+
+        AppLogger.shared.error(
+            "🚨 [StuckKeyRecovery] Stuck key detected: \(correlation.key) repeating with kanata unresponsive for \(msSinceKanata)ms — triggering automatic restart"
+        )
+
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            defer { self.isRecovering = false }
+
+            if let restart = restartKanata {
+                let success = await restart("Stuck key recovery (\(correlation.key))")
+                lastRecoveryAt = Date()
+                if success {
+                    AppLogger.shared.info("✅ [StuckKeyRecovery] Kanata restarted — stuck key should be cleared")
+                } else {
+                    AppLogger.shared.error("❌ [StuckKeyRecovery] Kanata restart failed — user may need to intervene")
+                }
+            } else {
+                AppLogger.shared.error("❌ [StuckKeyRecovery] No restart handler configured — cannot recover")
+            }
+        }
+    }
+}

--- a/Tests/KeyPathTests/Services/StuckKeyRecoveryServiceTests.swift
+++ b/Tests/KeyPathTests/Services/StuckKeyRecoveryServiceTests.swift
@@ -1,0 +1,141 @@
+@testable import KeyPathAppKit
+import XCTest
+
+@MainActor
+final class StuckKeyRecoveryServiceTests: KeyPathTestCase {
+    private var service: StuckKeyRecoveryService!
+    private var restartCallCount = 0
+    private var lastRestartReason: String?
+
+    override func setUp() async throws {
+        try await super.setUp()
+        service = StuckKeyRecoveryService()
+        restartCallCount = 0
+        lastRestartReason = nil
+        service.restartKanata = { [weak self] reason in
+            self?.restartCallCount += 1
+            self?.lastRestartReason = reason
+            return true
+        }
+    }
+
+    // MARK: - Detection Threshold
+
+    func testIgnoresNormalAutorepeat() async {
+        let correlation = makeCorrelation(
+            suggestsUnmatchedAutorepeat: true,
+            msSinceAnyKanataEvent: 100
+        )
+
+        service.handleAutorepeatMismatch(correlation)
+        try? await Task.sleep(for: .milliseconds(50))
+
+        XCTAssertEqual(restartCallCount, 0, "Should not restart for normal autorepeat with active kanata")
+    }
+
+    func testIgnoresNonAutorepeat() async {
+        let correlation = makeCorrelation(
+            suggestsUnmatchedAutorepeat: false,
+            msSinceAnyKanataEvent: 5000
+        )
+
+        service.handleAutorepeatMismatch(correlation)
+        try? await Task.sleep(for: .milliseconds(50))
+
+        XCTAssertEqual(restartCallCount, 0, "Should not restart if not an unmatched autorepeat")
+    }
+
+    func testTriggersRecoveryForStuckKey() async {
+        let correlation = makeCorrelation(
+            key: "t",
+            suggestsUnmatchedAutorepeat: true,
+            msSinceAnyKanataEvent: 5000
+        )
+
+        service.handleAutorepeatMismatch(correlation)
+        try? await Task.sleep(for: .milliseconds(100))
+
+        XCTAssertEqual(restartCallCount, 1)
+        XCTAssertTrue(lastRestartReason?.contains("t") == true)
+    }
+
+    func testIgnoresNilKanataEventTime() async {
+        let correlation = makeCorrelation(
+            suggestsUnmatchedAutorepeat: true,
+            msSinceAnyKanataEvent: nil
+        )
+
+        service.handleAutorepeatMismatch(correlation)
+        try? await Task.sleep(for: .milliseconds(50))
+
+        XCTAssertEqual(restartCallCount, 0, "Should not restart if kanata event time is unknown")
+    }
+
+    // MARK: - Debouncing
+
+    func testDebouncesPreviousRecoveries() async {
+        let correlation = makeCorrelation(
+            suggestsUnmatchedAutorepeat: true,
+            msSinceAnyKanataEvent: 5000
+        )
+
+        service.handleAutorepeatMismatch(correlation)
+        try? await Task.sleep(for: .milliseconds(100))
+        XCTAssertEqual(restartCallCount, 1)
+
+        service.handleAutorepeatMismatch(correlation)
+        try? await Task.sleep(for: .milliseconds(100))
+        XCTAssertEqual(restartCallCount, 1, "Should not restart again within cooldown period")
+    }
+
+    func testDoesNotDoubleFireWhileRecovering() async {
+        var continueRestart: CheckedContinuation<Void, Never>?
+        service.restartKanata = { [weak self] reason in
+            self?.restartCallCount += 1
+            self?.lastRestartReason = reason
+            await withCheckedContinuation { continuation in
+                continueRestart = continuation
+            }
+            return true
+        }
+
+        let correlation = makeCorrelation(
+            suggestsUnmatchedAutorepeat: true,
+            msSinceAnyKanataEvent: 5000
+        )
+
+        service.handleAutorepeatMismatch(correlation)
+        try? await Task.sleep(for: .milliseconds(50))
+
+        service.handleAutorepeatMismatch(correlation)
+        try? await Task.sleep(for: .milliseconds(50))
+
+        continueRestart?.resume()
+        try? await Task.sleep(for: .milliseconds(50))
+
+        XCTAssertEqual(restartCallCount, 1, "Should not fire second restart while first is in progress")
+    }
+
+    // MARK: - Helpers
+
+    private func makeCorrelation(
+        key: String = "t",
+        suggestsUnmatchedAutorepeat: Bool,
+        msSinceAnyKanataEvent: Int?
+    ) -> InvestigationSystemEventCorrelation {
+        InvestigationSystemEventCorrelation(
+            key: key,
+            keyCode: 17,
+            eventType: "keyDown",
+            isAutorepeat: suggestsUnmatchedAutorepeat,
+            flagsRawValue: 0,
+            sourcePID: nil,
+            observedAt: Date(),
+            previousKanataAction: .press,
+            previousKanataSessionID: 1,
+            sameKeyGapMs: 33,
+            msSinceAnyKanataEvent: msSinceAnyKanataEvent,
+            suggestsUnmatchedAutorepeat: suggestsUnmatchedAutorepeat
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `StuckKeyRecoveryService` that monitors `AutorepeatMismatch` events and auto-restarts kanata when a stuck key is detected (kanata unresponsive >3s while a key is repeating)
- Kanata's existing startup F24 flush clears the stale virtual HID state on restart, resolving the infinite repeat
- Includes 30s debounce cooldown to prevent restart loops
- 6 new tests covering detection thresholds, debouncing, and double-fire prevention

Closes #546
Related: #547, #548, #549, #550

## Context

When kanata crashes or hangs while a key is held, the virtual HID daemon never receives the key-up event. macOS sees the key as permanently pressed and generates infinite autorepeat. The `InvestigationEventTapService` already detected this via `AutorepeatMismatch` logging but took no corrective action. This PR makes it actionable.

## Test plan

- [x] `swift test --filter StuckKeyRecoveryServiceTests` — 6 tests pass
- [x] `swift test` — all 532 existing tests still pass
- [x] `swift build` — clean build
- [ ] Manual: deploy, wait for stuck key scenario (or simulate by killing kanata while holding a key), verify auto-restart clears the stuck key within ~3s