### PR TITLE
fix: restrict Vallack zone colors to base and nav layers only

### DIFF
--- a/Sources/KeyPathAppKit/Models/VallackZoneMap.swift
+++ b/Sources/KeyPathAppKit/Models/VallackZoneMap.swift
@@ -42,6 +42,9 @@ enum VallackZoneMap {
         if lower.contains("vallack-nav") {
             return navZones()
         }
-        return homeZones()
+        if lower == "base" {
+            return homeZones()
+        }
+        return nil
     }
 }

--- a/Sources/KeyPathAppKit/Services/Packs/PackZoneResolver.swift
+++ b/Sources/KeyPathAppKit/Services/Packs/PackZoneResolver.swift
@@ -52,7 +52,8 @@ enum PackZoneResolver {
         case PackRegistry.vallackSystem.id:
             let lower = layerName.lowercased()
             if lower.contains("vallack-nav") { return VallackZoneMap.navSubtitles }
-            return VallackZoneMap.homeSubtitles
+            if lower == "base" { return VallackZoneMap.homeSubtitles }
+            return nil
         default:
             return nil
         }

--- a/Tests/KeyPathTests/VallackOverlayZoneTests.swift
+++ b/Tests/KeyPathTests/VallackOverlayZoneTests.swift
@@ -57,6 +57,32 @@ final class VallackOverlayZoneTests: XCTestCase {
         XCTAssertEqual(zones?[4], .navMapping)
     }
 
+    func testZonesForLayerReturnsNilOnLauncherLayer() {
+        let zones = VallackZoneMap.zones(forLayer: "launcher")
+        XCTAssertNil(zones, "Launcher layer should not get Vallack zone colors")
+    }
+
+    func testZonesForLayerReturnsNilOnArbitraryLayer() {
+        let zones = VallackZoneMap.zones(forLayer: "vim")
+        XCTAssertNil(zones, "Non-base, non-nav layers should not get Vallack zone colors")
+    }
+
+    func testResolverReturnsNoColorsOnLauncherLayer() {
+        let colors = PackZoneResolver.activeZoneColors(
+            installedPackIDs: [PackRegistry.vallackSystem.id],
+            layerName: "launcher"
+        )
+        XCTAssertTrue(colors.isEmpty, "Launcher layer should have no zone colors")
+    }
+
+    func testResolverReturnsNoSubtitlesOnLauncherLayer() {
+        let subs = PackZoneResolver.activeZoneSubtitles(
+            installedPackIDs: [PackRegistry.vallackSystem.id],
+            layerName: "launcher"
+        )
+        XCTAssertTrue(subs.isEmpty, "Launcher layer should have no zone subtitles")
+    }
+
     // MARK: - PackZoneResolver (generic overlay interface)
 
     func testResolverReturnsColorsWhenVallackInstalled() {


### PR DESCRIPTION
## Summary

- `VallackZoneMap.zones(forLayer:)` now returns `nil` for layers that aren't "base" or "vallack-nav"
- Same fix applied to subtitle routing in `PackZoneResolver`
- Previously, blue top-row modifier highlights and orange F/J activator colors bled through to the launcher layer and all other layers

## Test plan

- [x] 4 new tests: launcher and arbitrary layers return no zone colors/subtitles
- [x] Existing zone tests still pass (2 pre-existing failures on master unrelated to this change)
- [ ] Visual: activate launcher layer — top row should NOT show blue Vallack highlighting