### PR TITLE
perf: pre-cache launcher mappings and icons for instant layer switch

### DIFF
--- a/Sources/KeyPathAppKit/Services/Icons/AppIconResolver.swift
+++ b/Sources/KeyPathAppKit/Services/Icons/AppIconResolver.swift
@@ -6,9 +6,16 @@ import UniformTypeIdentifiers
 /// Uses `NSWorkspace` to locate apps and retrieve their icons.
 /// Falls back to generic icons if actions cannot be found.
 enum AppIconResolver {
-    /// Get icon for any key action type
+    private nonisolated(unsafe) static var iconCache: [String: NSImage] = [:]
+
+    /// Get icon for any key action type, using cache when available.
     static func icon(for action: KeyAction) -> NSImage? {
-        switch action {
+        let cacheKey = Self.cacheKey(for: action)
+        if let cacheKey, let cached = iconCache[cacheKey] {
+            return cached
+        }
+
+        let image: NSImage? = switch action {
         case let .launchApp(name, bundleId):
             appIcon(name: name, bundleId: bundleId)
         case .openURL:
@@ -20,6 +27,31 @@ enum AppIconResolver {
         default:
             nil
         }
+
+        if let cacheKey, let image {
+            iconCache[cacheKey] = image
+        }
+        return image
+    }
+
+    /// Pre-warm the icon cache for a key action (called at startup).
+    static func prewarmIcon(for action: KeyAction) {
+        _ = icon(for: action)
+    }
+
+    private static func cacheKey(for action: KeyAction) -> String? {
+        switch action {
+        case let .launchApp(name, bundleId):
+            "app:\(bundleId ?? name)"
+        case let .openURL(url):
+            "url:\(url)"
+        case let .openFolder(path, _):
+            "folder:\(path)"
+        case let .runScript(path, _):
+            "script:\(path)"
+        default:
+            nil
+        }
     }
 
     // MARK: - App Icons
@@ -28,8 +60,7 @@ enum AppIconResolver {
     private static func appIcon(name: String, bundleId: String?) -> NSImage? {
         // Try bundle ID first (most reliable)
         if let bundleId,
-           let appURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleId)
-        {
+           let appURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleId) {
             return NSWorkspace.shared.icon(forFile: appURL.path)
         }
 

--- a/Sources/KeyPathAppKit/UI/KeyboardVisualization/KeyboardVisualizationViewModel+Capture.swift
+++ b/Sources/KeyPathAppKit/UI/KeyboardVisualization/KeyboardVisualizationViewModel+Capture.swift
@@ -31,6 +31,7 @@ extension KeyboardVisualizationViewModel {
         loadFeatureCollectionStates() // Load optional feature collection states
         preloadAllIcons() // Pre-cache launcher and layer icons
         prebuildLayerMappingsInBackground() // Warm cache for all layers
+        prewarmLauncherMappings() // Pre-cache launcher mappings + icons for instant layer switch
 
         AppLogger.shared.info("✅ [KeyboardViz] TCP-based key capture started")
     }

--- a/Sources/KeyPathAppKit/UI/KeyboardVisualization/KeyboardVisualizationViewModel+LayoutMapping.swift
+++ b/Sources/KeyPathAppKit/UI/KeyboardVisualization/KeyboardVisualizationViewModel+LayoutMapping.swift
@@ -68,45 +68,61 @@ extension KeyboardVisualizationViewModel {
         rebuildLayerMappingForLayer(targetLayerName)
     }
 
-    /// Load launcher mappings from the Quick Launcher rule collection
+    /// Load launcher mappings, using pre-warmed cache if available.
     func loadLauncherMappings() {
-        Task { @MainActor in
-            let collections = await RuleCollectionStore.shared.loadCollections()
-
-            // Find the launcher collection and extract its mappings
-            guard let launcherCollection = collections.first(where: { $0.id == RuleCollectionIdentifier.launcher }),
-                  let config = launcherCollection.configuration.launcherGridConfig
-            else {
-                AppLogger.shared.debug("🚀 [KeyboardViz] No launcher config found")
-                return
-            }
-
-            // Build key -> mapping dictionary (lowercase key names)
-            // Filter out apps that aren't installed on this system
-            let enabledMappings = config.mappings.filter { mapping in
-                guard mapping.isEnabled else { return false }
-
-                // URLs are always included (browser handles them)
-                if case .openURL = mapping.action { return true }
-
-                // Apps: check if installed
-                if case let .launchApp(name, bundleId) = mapping.action {
-                    let isInstalled = Self.isAppInstalled(name: name, bundleId: bundleId)
-                    if !isInstalled {
-                        AppLogger.shared.debug("🚀 [KeyboardViz] Skipping \(name) - not installed")
-                    }
-                    return isInstalled
-                }
-
-                return true
-            }
-
-            launcherMappings = Dictionary(
-                uniqueKeysWithValues: enabledMappings.map { ($0.key.lowercased(), $0) }
-            )
-
-            AppLogger.shared.info("🚀 [KeyboardViz] Loaded \(launcherMappings.count) launcher mappings (filtered for installed apps)")
+        if let cached = cachedLauncherMappings {
+            launcherMappings = cached
+            AppLogger.shared.info("🚀 [KeyboardViz] Loaded \(cached.count) launcher mappings from cache (instant)")
+            return
         }
+
+        Task { @MainActor in
+            let mappings = await Self.buildLauncherMappings()
+            launcherMappings = mappings
+            cachedLauncherMappings = mappings
+        }
+    }
+
+    /// Pre-warm launcher mappings cache at startup so layer switch is instant.
+    func prewarmLauncherMappings() {
+        Task {
+            let mappings = await Self.buildLauncherMappings()
+            await MainActor.run {
+                cachedLauncherMappings = mappings
+                AppLogger.shared.info("🚀 [KeyboardViz] Pre-warmed \(mappings.count) launcher mappings")
+            }
+
+            for (_, mapping) in mappings {
+                AppIconResolver.prewarmIcon(for: mapping.action)
+            }
+        }
+    }
+
+    /// Build launcher mappings from rule collections (shared by load and prewarm).
+    private static func buildLauncherMappings() async -> [String: LauncherMapping] {
+        let collections = await RuleCollectionStore.shared.loadCollections()
+
+        guard let launcherCollection = collections.first(where: { $0.id == RuleCollectionIdentifier.launcher }),
+              let config = launcherCollection.configuration.launcherGridConfig
+        else {
+            AppLogger.shared.debug("🚀 [KeyboardViz] No launcher config found")
+            return [:]
+        }
+
+        let enabledMappings = config.mappings.filter { mapping in
+            guard mapping.isEnabled else { return false }
+            if case .openURL = mapping.action { return true }
+            if case let .launchApp(name, bundleId) = mapping.action {
+                return isAppInstalled(name: name, bundleId: bundleId)
+            }
+            return true
+        }
+
+        let result = Dictionary(
+            uniqueKeysWithValues: enabledMappings.map { ($0.key.lowercased(), $0) }
+        )
+        AppLogger.shared.info("🚀 [KeyboardViz] Built \(result.count) launcher mappings (filtered for installed apps)")
+        return result
     }
 
     /// Check if an app is installed on the system
@@ -246,8 +262,7 @@ extension KeyboardVisualizationViewModel {
 
                 // Show alert if simulator had significant failures on a non-base layer
                 if let report = simReport, report.hasSignificantFailures,
-                   targetLayerName.lowercased() != "base"
-                {
+                   targetLayerName.lowercased() != "base" {
                     await MainActor.run {
                         Self.showSimulationFailureAlert(report)
                     }
@@ -355,8 +370,7 @@ extension KeyboardVisualizationViewModel {
                 } else {
                     let outputKey = keyMapping.action.outputString.lowercased()
                     if let description = keyMapping.description,
-                       let outputKeyCode = Self.kanataNameToKeyCode(outputKey)
-                    {
+                       let outputKeyCode = Self.kanataNameToKeyCode(outputKey) {
                         actionByInput[input] = .mapped(
                             displayLabel: description,
                             outputKey: outputKey,
@@ -656,12 +670,14 @@ extension KeyboardVisualizationViewModel {
     func invalidateLayerMappings() {
         AppLogger.shared.info("🔔 [KeyboardViz] invalidateLayerMappings called - will rebuild layer mapping for '\(currentLayerName)'")
         AppLogger.shared.info("🔔 [KeyboardViz] Current layerKeyMap has \(layerKeyMap.count) entries, keyCode 0 = '\(layerKeyMap[0]?.displayLabel ?? "nil")'")
+        cachedLauncherMappings = nil
         Task {
             await layerKeyMapper.invalidateCache()
             AppLogger.shared.info("🔔 [KeyboardViz] Cache invalidated, now calling rebuildLayerMapping()")
 
             rebuildLayerMapping()
             prebuildLayerMappingsInBackground()
+            prewarmLauncherMappings()
         }
     }
 }

--- a/Sources/KeyPathAppKit/UI/KeyboardVisualization/KeyboardVisualizationViewModel.swift
+++ b/Sources/KeyPathAppKit/UI/KeyboardVisualization/KeyboardVisualizationViewModel.swift
@@ -76,8 +76,9 @@ class KeyboardVisualizationViewModel {
     // MARK: - Launcher Mode State
 
     /// Launcher mappings for overlay display (key -> LauncherMapping)
-    /// Loaded when entering launcher layer
     var launcherMappings: [String: LauncherMapping] = [:]
+    /// Pre-computed launcher mappings cache, ready before layer switch
+    @ObservationIgnored var cachedLauncherMappings: [String: LauncherMapping]?
 
     // MARK: - Optional Feature Collections
 


### PR DESCRIPTION
## Summary

- Pre-compute launcher mappings at startup and on config change (was loading from disk on every layer entry)
- Add icon cache to `AppIconResolver` so NSWorkspace lookups happen once, not per-activation
- Pre-warm icon cache during startup alongside launcher mapping prewarm
- Invalidate caches on config change so new mappings pick up immediately

The existing 100ms layer preview for hyper/caps already fires before kanata's 200ms hold-timeout. With cached mappings and icons, the icons now appear with the preview instead of loading async after it.

## Test plan

- [x] `swift build` — clean
- [x] `swift test` — all 532 tests pass
- [ ] Manual: hold hyper key — launcher icons should appear ~100ms faster than before
- [ ] Manual: change launcher config — icons should update on next activation