### PR TITLE
feat: generic pack config management + Quick Launcher manages Caps Lock Remap

### DIFF
--- a/Sources/KeyPathAppKit/Services/Packs/Pack.swift
+++ b/Sources/KeyPathAppKit/Services/Packs/Pack.swift
@@ -3,6 +3,32 @@
 
 import Foundation
 
+/// A collection a pack manages atomically on install/uninstall.
+/// The installer snapshots the collection's state before applying defaults
+/// and offers to restore it when the pack is removed.
+public struct ManagedCollectionDefault: Equatable, Sendable {
+    /// The collection to manage
+    public let collectionID: UUID
+    /// Whether to enable this collection on install
+    public let enableOnInstall: Bool
+    /// Configuration to apply on install (nil = just toggle, don't change config)
+    public let defaultConfiguration: RuleCollectionConfiguration?
+    /// Human-readable name for override/restore dialogs
+    public let displayName: String
+
+    public init(
+        collectionID: UUID,
+        enableOnInstall: Bool = true,
+        defaultConfiguration: RuleCollectionConfiguration? = nil,
+        displayName: String
+    ) {
+        self.collectionID = collectionID
+        self.enableOnInstall = enableOnInstall
+        self.defaultConfiguration = defaultConfiguration
+        self.displayName = displayName
+    }
+}
+
 /// A **Pack** is a named, versioned collection of mappings distributed as a
 /// unit. Users install packs from the Gallery; each installed pack contributes
 /// one or more `CustomRule`s tagged with the pack's id so uninstall can
@@ -69,6 +95,11 @@ public struct Pack: Identifiable, Equatable, Sendable {
     /// Dependencies on other packs (requires + suggests).
     public let dependencies: [PackDependency]
 
+    /// Collections this pack manages atomically on install/uninstall.
+    /// Non-empty → system pack: the installer snapshots, applies defaults,
+    /// and offers restore on uninstall. Empty → standard pack behavior.
+    public let managedDefaults: [ManagedCollectionDefault]
+
     /// Keys that should trigger this pack's merchandising card when selected,
     /// independent of bindings. Used for packs like Leader Key whose input
     /// key is configurable rather than hardcoded in bindings.
@@ -90,7 +121,8 @@ public struct Pack: Identifiable, Equatable, Sendable {
         associatedCollectionID: UUID? = nil,
         visualOnly: Bool = false,
         suggestedForKeys: [String] = [],
-        dependencies: [PackDependency] = []
+        dependencies: [PackDependency] = [],
+        managedDefaults: [ManagedCollectionDefault] = []
     ) {
         self.id = id
         self.version = version
@@ -107,6 +139,7 @@ public struct Pack: Identifiable, Equatable, Sendable {
         self.associatedCollectionID = associatedCollectionID
         self.visualOnly = visualOnly
         self.dependencies = dependencies
+        self.managedDefaults = managedDefaults
         self.suggestedForKeys = suggestedForKeys
     }
 
@@ -116,25 +149,29 @@ public struct Pack: Identifiable, Equatable, Sendable {
         Array(Set(bindings.map(\.input)))
     }
 
+    /// True if this pack manages collections atomically via `managedDefaults`.
+    public var isSystemPack: Bool {
+        !managedDefaults.isEmpty
+    }
+
     /// All rule collection UUIDs this pack manages when installed.
-    /// Most packs manage their single `associatedCollectionID`.
-    /// The Vallack system pack manages three collections atomically.
-    /// Visual-only packs manage none.
+    /// System packs list their managed defaults; other packs list their
+    /// single `associatedCollectionID`. Visual-only packs manage none.
     public var managedCollectionIDs: [UUID] {
         if visualOnly { return [] }
-        if id == "com.keypath.pack.vallack-system" {
-            return [
-                RuleCollectionIdentifier.vallackNavigation,
-                RuleCollectionIdentifier.homeRowMods,
-                RuleCollectionIdentifier.homeRowLayerToggles,
-            ]
+        if !managedDefaults.isEmpty {
+            var ids = managedDefaults.map(\.collectionID)
+            if let associated = associatedCollectionID, !ids.contains(associated) {
+                ids.insert(associated, at: 0)
+            }
+            return ids
         }
         return [associatedCollectionID].compactMap { $0 }
     }
 
     /// Preferred width for Pack Detail presentation (window or sheet).
     public var preferredDetailWidth: CGFloat {
-        let widePacks: Set<String> = [
+        let widePacks: Set = [
             "com.keypath.pack.vim-navigation",
             "com.keypath.pack.window-snapping",
             "com.keypath.pack.mission-control",

--- a/Sources/KeyPathAppKit/Services/Packs/PackCollectionSnapshot.swift
+++ b/Sources/KeyPathAppKit/Services/Packs/PackCollectionSnapshot.swift
@@ -1,0 +1,108 @@
+import Foundation
+
+/// Snapshot of managed collections' state before a pack was installed.
+/// Used to restore previous configuration on uninstall.
+public struct PackCollectionSnapshot: Codable {
+    public let packID: String
+    public let snapshotDate: Date
+    public var entries: [Entry]
+
+    public struct Entry: Codable {
+        public let collectionID: UUID
+        public var wasEnabled: Bool
+        public var configurationJSON: Data
+    }
+
+    public init(packID: String, snapshotDate: Date = Date(), entries: [Entry]) {
+        self.packID = packID
+        self.snapshotDate = snapshotDate
+        self.entries = entries
+    }
+
+    // MARK: - Persistence
+
+    private static var snapshotsDirectory: URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".config", isDirectory: true)
+            .appendingPathComponent("keypath", isDirectory: true)
+            .appendingPathComponent("pack-snapshots", isDirectory: true)
+    }
+
+    static func snapshotURL(for packID: String) -> URL {
+        snapshotsDirectory.appendingPathComponent("\(packID).json")
+    }
+
+    static func save(_ snapshot: PackCollectionSnapshot) throws {
+        let dir = snapshotsDirectory
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let data = try JSONEncoder().encode(snapshot)
+        try data.write(to: snapshotURL(for: snapshot.packID), options: .atomic)
+    }
+
+    static func load(for packID: String) -> PackCollectionSnapshot? {
+        let url = snapshotURL(for: packID)
+        guard let data = try? Data(contentsOf: url) else { return nil }
+        return try? JSONDecoder().decode(PackCollectionSnapshot.self, from: data)
+    }
+
+    static func remove(for packID: String) {
+        try? FileManager.default.removeItem(at: snapshotURL(for: packID))
+    }
+
+    // MARK: - Legacy Vallack Migration
+
+    private static var legacyVallackURL: URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".config", isDirectory: true)
+            .appendingPathComponent("keypath", isDirectory: true)
+            .appendingPathComponent("vallack-system-snapshot.json")
+    }
+
+    private struct LegacyVallackSnapshot: Codable {
+        var homeRowModsConfig: HomeRowModsConfig?
+        var homeRowModsEnabled: Bool
+        var homeRowLayerTogglesConfig: HomeRowLayerTogglesConfig?
+        var homeRowLayerTogglesEnabled: Bool
+    }
+
+    static func loadLegacyVallack() -> PackCollectionSnapshot? {
+        let url = legacyVallackURL
+        guard let data = try? Data(contentsOf: url),
+              let legacy = try? JSONDecoder().decode(LegacyVallackSnapshot.self, from: data)
+        else { return nil }
+
+        var entries: [Entry] = []
+
+        let modsConfig: RuleCollectionConfiguration = legacy.homeRowModsConfig.map {
+            .homeRowMods($0)
+        } ?? .homeRowMods(HomeRowModsConfig())
+        if let modsJSON = try? JSONEncoder().encode(modsConfig) {
+            entries.append(Entry(
+                collectionID: RuleCollectionIdentifier.homeRowMods,
+                wasEnabled: legacy.homeRowModsEnabled,
+                configurationJSON: modsJSON
+            ))
+        }
+
+        let togglesConfig: RuleCollectionConfiguration = legacy.homeRowLayerTogglesConfig.map {
+            .homeRowLayerToggles($0)
+        } ?? .homeRowLayerToggles(HomeRowLayerTogglesConfig())
+        if let togglesJSON = try? JSONEncoder().encode(togglesConfig) {
+            entries.append(Entry(
+                collectionID: RuleCollectionIdentifier.homeRowLayerToggles,
+                wasEnabled: legacy.homeRowLayerTogglesEnabled,
+                configurationJSON: togglesJSON
+            ))
+        }
+
+        return PackCollectionSnapshot(
+            packID: "com.keypath.pack.vallack-system",
+            snapshotDate: Date(),
+            entries: entries
+        )
+    }
+
+    static func removeLegacyVallack() {
+        try? FileManager.default.removeItem(at: legacyVallackURL)
+    }
+}

--- a/Sources/KeyPathAppKit/Services/Packs/PackInstaller.swift
+++ b/Sources/KeyPathAppKit/Services/Packs/PackInstaller.swift
@@ -13,6 +13,13 @@ import KeyPathCore
 public final class PackInstaller {
     public static let shared = PackInstaller()
 
+    #if DEBUG
+        /// Test-only overrides for dialog responses. When set, bypasses NSAlert
+        /// and returns this value instead.
+        static var testOverrideApplyDefault: Bool?
+        static var testOverrideRestore: Bool?
+    #endif
+
     private init() {}
 
     // MARK: - Errors
@@ -602,6 +609,9 @@ public final class PackInstaller {
         }
 
         if TestEnvironment.isRunningTests {
+            #if DEBUG
+                if let override = Self.testOverrideApplyDefault { return override }
+            #endif
             return true
         }
 
@@ -650,21 +660,27 @@ public final class PackInstaller {
             }
         }
 
-        let shouldRestore: Bool = if !userModified {
-            true
+        let shouldRestore: Bool
+        if !userModified {
+            shouldRestore = true
         } else if TestEnvironment.isRunningTests {
-            true
+            #if DEBUG
+                shouldRestore = Self.testOverrideRestore ?? true
+            #else
+                shouldRestore = true
+            #endif
         } else {
-            await withCheckedContinuation { continuation in
-                let alert = NSAlert()
-                alert.messageText = "Restore Previous Settings?"
-                alert.informativeText = "You modified settings after installing \(pack.name). Restore your previous configuration, or keep the current settings?"
-                alert.alertStyle = .informational
-                alert.addButton(withTitle: "Restore Previous")
-                alert.addButton(withTitle: "Keep Current")
-                let response = alert.runModal()
-                continuation.resume(returning: response == .alertFirstButtonReturn)
-            }
+            shouldRestore =
+                await withCheckedContinuation { continuation in
+                    let alert = NSAlert()
+                    alert.messageText = "Restore Previous Settings?"
+                    alert.informativeText = "You modified settings after installing \(pack.name). Restore your previous configuration, or keep the current settings?"
+                    alert.alertStyle = .informational
+                    alert.addButton(withTitle: "Restore Previous")
+                    alert.addButton(withTitle: "Keep Current")
+                    let response = alert.runModal()
+                    continuation.resume(returning: response == .alertFirstButtonReturn)
+                }
         }
 
         if shouldRestore {

--- a/Sources/KeyPathAppKit/Services/Packs/PackInstaller.swift
+++ b/Sources/KeyPathAppKit/Services/Packs/PackInstaller.swift
@@ -90,9 +90,7 @@ public final class PackInstaller {
         }
 
         // System packs batch all collection changes into a single config regen.
-        // TODO: When a second system pack is added, replace ID matching with
-        // a Pack.systemConfig property that the installer dispatches on generically.
-        if pack.id == PackRegistry.vallackSystem.id {
+        if pack.isSystemPack {
             // Record the install BEFORE applying configs so that when
             // regenerateConfigFromCollections posts .ruleCollectionsChanged,
             // any listener querying packManagingCollection already finds
@@ -105,7 +103,7 @@ public final class PackInstaller {
             )
             try await InstalledPackTracker.shared.upsert(record)
             do {
-                try await applyVallackSystemConfigs(manager: manager)
+                try await applyManagedDefaults(pack: pack, manager: manager)
             } catch {
                 try? await InstalledPackTracker.shared.remove(packID: pack.id)
                 throw error
@@ -194,14 +192,9 @@ public final class PackInstaller {
         }
 
         // System packs batch all collection changes into a single config regen.
-        if packID == PackRegistry.vallackSystem.id {
-            let shouldRestore = await shouldRestorePreVallackSettings(manager: manager)
-            if shouldRestore {
-                await revertVallackSystemConfigs(manager: manager)
-            } else {
-                try? FileManager.default.removeItem(at: vallackSnapshotURL)
-            }
-            if let collectionID = PackRegistry.vallackSystem.associatedCollectionID,
+        if let pack = PackRegistry.pack(id: packID), pack.isSystemPack {
+            let didRestore = await restoreOrKeepOnUninstall(pack: pack, manager: manager)
+            if let collectionID = pack.associatedCollectionID,
                let i = manager.ruleCollections.firstIndex(where: { $0.id == collectionID })
             {
                 manager.ruleCollections[i].isEnabled = false
@@ -209,7 +202,7 @@ public final class PackInstaller {
             await manager.regenerateConfigFromCollections()
             try await InstalledPackTracker.shared.remove(packID: packID)
             AppLogger.shared.log(
-                "✅ [PackInstaller] Uninstalled system pack '\(packID)' (restored=\(shouldRestore))"
+                "✅ [PackInstaller] Uninstalled system pack '\(packID)' (restored=\(didRestore))"
             )
             return
         }
@@ -376,7 +369,7 @@ public final class PackInstaller {
             if let holdTimeout = resolved["holdTimeout"],
                let index = manager.ruleCollections.firstIndex(where: { $0.id == collectionID })
             {
-                if case .homeRowMods(var config) = manager.ruleCollections[index].configuration {
+                if case var .homeRowMods(config) = manager.ruleCollections[index].configuration {
                     config.timing.tapWindow = holdTimeout
                     config.timing.holdDelay = holdTimeout
                     manager.ruleCollections[index].configuration = .homeRowMods(config)
@@ -525,91 +518,86 @@ public final class PackInstaller {
     private func clamp(_ value: Int, to kind: PackQuickSetting.Kind) -> Int {
         switch kind {
         case let .slider(_, minValue, maxValue, _, _):
-            return min(max(value, minValue), maxValue)
+            min(max(value, minValue), maxValue)
         }
     }
 
-    // MARK: - Vallack System Config
+    // MARK: - Generic Managed Collection Lifecycle
 
-    private struct VallackConfigSnapshot: Codable {
-        var homeRowModsConfig: HomeRowModsConfig?
-        var homeRowModsEnabled: Bool
-        var homeRowLayerTogglesConfig: HomeRowLayerTogglesConfig?
-        var homeRowLayerTogglesEnabled: Bool
+    private func snapshotManagedCollections(
+        pack: Pack,
+        manager: RuleCollectionsManager
+    ) -> PackCollectionSnapshot {
+        let encoder = JSONEncoder()
+        var entries: [PackCollectionSnapshot.Entry] = []
+
+        for managed in pack.managedDefaults {
+            let collection = manager.ruleCollections.first { $0.id == managed.collectionID }
+            let configJSON = (try? encoder.encode(collection?.configuration ?? .list)) ?? Data()
+            entries.append(PackCollectionSnapshot.Entry(
+                collectionID: managed.collectionID,
+                wasEnabled: collection?.isEnabled ?? false,
+                configurationJSON: configJSON
+            ))
+        }
+
+        return PackCollectionSnapshot(packID: pack.id, entries: entries)
     }
 
-    private var vallackSnapshotURL: URL {
-        let home = FileManager.default.homeDirectoryForCurrentUser
-        return home
-            .appendingPathComponent(".config", isDirectory: true)
-            .appendingPathComponent("keypath", isDirectory: true)
-            .appendingPathComponent("vallack-system-snapshot.json")
-    }
-
-    private func applyVallackSystemConfigs(manager: RuleCollectionsManager) async throws {
-        let modsCollection = manager.ruleCollections.first { $0.id == RuleCollectionIdentifier.homeRowMods }
-        let togglesCollection = manager.ruleCollections.first { $0.id == RuleCollectionIdentifier.homeRowLayerToggles }
-
-        let snapshot = VallackConfigSnapshot(
-            homeRowModsConfig: modsCollection?.configuration.homeRowModsConfig,
-            homeRowModsEnabled: modsCollection?.isEnabled ?? false,
-            homeRowLayerTogglesConfig: togglesCollection?.configuration.homeRowLayerTogglesConfig,
-            homeRowLayerTogglesEnabled: togglesCollection?.isEnabled ?? false
-        )
-
-        let vallackMods = HomeRowModsConfig.vallackDefault
-        let vallackToggles = HomeRowLayerTogglesConfig(
-            enabledKeys: Set(["f", "j"]),
-            layerAssignments: HomeRowLayerTogglesConfig.vallackLayerAssignments,
-            keySelection: .custom,
-            toggleMode: .whileHeld,
-            oppositeHandMode: .press
-        )
-
-        // Check if user has customized Home Row Mods from default
-        let useVallackMods = await shouldApplyVallackMods(
-            existingCollection: modsCollection
-        )
+    private func applyManagedDefaults(
+        pack: Pack,
+        manager: RuleCollectionsManager
+    ) async throws {
+        let snapshot = snapshotManagedCollections(pack: pack, manager: manager)
 
         let catalog = RuleCollectionCatalog().defaultCollections()
-        ensureCollectionExists(id: RuleCollectionIdentifier.vallackNavigation, catalog: catalog, manager: manager)
-        ensureCollectionExists(id: RuleCollectionIdentifier.homeRowMods, catalog: catalog, manager: manager)
-        ensureCollectionExists(id: RuleCollectionIdentifier.homeRowLayerToggles, catalog: catalog, manager: manager)
 
-        if let i = manager.ruleCollections.firstIndex(where: { $0.id == RuleCollectionIdentifier.vallackNavigation }) {
-            manager.ruleCollections[i].isEnabled = true
-        }
-        if let i = manager.ruleCollections.firstIndex(where: { $0.id == RuleCollectionIdentifier.homeRowMods }) {
-            if useVallackMods {
-                manager.ruleCollections[i].configuration.updateHomeRowModsConfig(vallackMods)
+        // Ensure the pack's own associated collection exists too
+        if let associated = pack.associatedCollectionID {
+            ensureCollectionExists(id: associated, catalog: catalog, manager: manager)
+            if let i = manager.ruleCollections.firstIndex(where: { $0.id == associated }) {
+                manager.ruleCollections[i].isEnabled = true
             }
-            manager.ruleCollections[i].isEnabled = true
-        }
-        if let i = manager.ruleCollections.firstIndex(where: { $0.id == RuleCollectionIdentifier.homeRowLayerToggles }) {
-            manager.ruleCollections[i].configuration.updateHomeRowLayerTogglesConfig(vallackToggles)
-            manager.ruleCollections[i].isEnabled = true
         }
 
-        let snapshotData = try JSONEncoder().encode(snapshot)
-        try snapshotData.write(to: vallackSnapshotURL, options: .atomic)
+        for managed in pack.managedDefaults {
+            ensureCollectionExists(id: managed.collectionID, catalog: catalog, manager: manager)
+
+            guard let i = manager.ruleCollections.firstIndex(where: { $0.id == managed.collectionID }) else {
+                continue
+            }
+
+            if let defaultConfig = managed.defaultConfiguration {
+                let shouldApply = await shouldApplyManagedDefault(
+                    managed: managed,
+                    existingCollection: manager.ruleCollections[i],
+                    packName: pack.name
+                )
+                if shouldApply {
+                    manager.ruleCollections[i].configuration = defaultConfig
+                }
+            }
+
+            if managed.enableOnInstall {
+                manager.ruleCollections[i].isEnabled = true
+            }
+        }
+
+        try PackCollectionSnapshot.save(snapshot)
 
         await manager.regenerateConfigFromCollections()
-        let modsNote = useVallackMods ? "Ben's mod config" : "user's existing mod config"
-        AppLogger.shared.log("📦 [PackInstaller] Applied Vallack system configs (\(modsNote) + nav toggles)")
+        AppLogger.shared.log("📦 [PackInstaller] Applied managed defaults for '\(pack.name)'")
     }
 
-    private func shouldApplyVallackMods(
-        existingCollection: RuleCollection?
+    private func shouldApplyManagedDefault(
+        managed: ManagedCollectionDefault,
+        existingCollection: RuleCollection,
+        packName: String
     ) async -> Bool {
-        guard let collection = existingCollection,
-              collection.isEnabled,
-              let existingConfig = collection.configuration.homeRowModsConfig
+        guard existingCollection.isEnabled,
+              let defaultConfig = managed.defaultConfiguration,
+              existingCollection.configuration != defaultConfig
         else {
-            return true
-        }
-
-        let defaultConfig = HomeRowModsConfig()
-        if existingConfig == defaultConfig {
             return true
         }
 
@@ -619,76 +607,87 @@ public final class PackInstaller {
 
         return await withCheckedContinuation { continuation in
             let alert = NSAlert()
-            alert.messageText = "Switch to Ben's Modifiers?"
-            alert.informativeText = "This pack uses top-row mods instead of home row. Your current settings will be restored if you turn the pack off."
+            alert.messageText = "\(packName) will configure \(managed.displayName)"
+            alert.informativeText = "Your current \(managed.displayName) settings will be changed. Your current settings will be saved and can be restored when you uninstall \(packName)."
             alert.alertStyle = .informational
-            alert.addButton(withTitle: "Use Ben's Settings")
+            alert.addButton(withTitle: "Use Recommended")
             alert.addButton(withTitle: "Keep My Settings")
             let response = alert.runModal()
             continuation.resume(returning: response == .alertFirstButtonReturn)
         }
     }
 
-    private func shouldRestorePreVallackSettings(manager: RuleCollectionsManager) async -> Bool {
-        guard FileManager.default.fileExists(atPath: vallackSnapshotURL.path),
-              let data = try? Data(contentsOf: vallackSnapshotURL),
-              let snapshot = try? JSONDecoder().decode(VallackConfigSnapshot.self, from: data)
-        else {
+    @discardableResult
+    private func restoreOrKeepOnUninstall(
+        pack: Pack,
+        manager: RuleCollectionsManager
+    ) async -> Bool {
+        var snapshot = PackCollectionSnapshot.load(for: pack.id)
+
+        // Legacy migration for Vallack System
+        if snapshot == nil, pack.id == "com.keypath.pack.vallack-system" {
+            snapshot = PackCollectionSnapshot.loadLegacyVallack()
+        }
+
+        guard let snapshot else {
+            AppLogger.shared.log("⚠️ [PackInstaller] No snapshot found for '\(pack.id)' — skipping restore")
             return false
         }
 
-        let currentConfig = manager.ruleCollections
-            .first(where: { $0.id == RuleCollectionIdentifier.homeRowMods })?
-            .configuration.homeRowModsConfig
+        let decoder = JSONDecoder()
+        var userModified = false
 
-        if currentConfig == snapshot.homeRowModsConfig {
-            return true
+        for entry in snapshot.entries {
+            guard let i = manager.ruleCollections.firstIndex(where: { $0.id == entry.collectionID }) else {
+                continue
+            }
+
+            let managed = pack.managedDefaults.first { $0.collectionID == entry.collectionID }
+            if let appliedConfig = managed?.defaultConfiguration,
+               manager.ruleCollections[i].configuration != appliedConfig
+            {
+                userModified = true
+            }
         }
 
-        if TestEnvironment.isRunningTests {
-            return true
+        let shouldRestore: Bool = if !userModified {
+            true
+        } else if TestEnvironment.isRunningTests {
+            true
+        } else {
+            await withCheckedContinuation { continuation in
+                let alert = NSAlert()
+                alert.messageText = "Restore Previous Settings?"
+                alert.informativeText = "You modified settings after installing \(pack.name). Restore your previous configuration, or keep the current settings?"
+                alert.alertStyle = .informational
+                alert.addButton(withTitle: "Restore Previous")
+                alert.addButton(withTitle: "Keep Current")
+                let response = alert.runModal()
+                continuation.resume(returning: response == .alertFirstButtonReturn)
+            }
         }
 
-        return await withCheckedContinuation { continuation in
-            let alert = NSAlert()
-            alert.messageText = "Restore Previous Settings?"
-            alert.informativeText = "You had home row mod settings before this pack. Restore them, or keep the current configuration?"
-            alert.alertStyle = .informational
-            alert.addButton(withTitle: "Restore Previous")
-            alert.addButton(withTitle: "Keep Current")
-            let response = alert.runModal()
-            continuation.resume(returning: response == .alertFirstButtonReturn)
-        }
-    }
-
-    private func revertVallackSystemConfigs(manager: RuleCollectionsManager) async {
-        guard let data = try? Data(contentsOf: vallackSnapshotURL),
-              let snapshot = try? JSONDecoder().decode(VallackConfigSnapshot.self, from: data)
-        else {
-            AppLogger.shared.log("⚠️ [PackInstaller] No Vallack config snapshot found — skipping revert")
-            return
+        if shouldRestore {
+            for entry in snapshot.entries {
+                guard let i = manager.ruleCollections.firstIndex(where: { $0.id == entry.collectionID }) else {
+                    continue
+                }
+                if let restoredConfig = try? decoder.decode(
+                    RuleCollectionConfiguration.self, from: entry.configurationJSON
+                ) {
+                    manager.ruleCollections[i].configuration = restoredConfig
+                }
+                manager.ruleCollections[i].isEnabled = entry.wasEnabled
+            }
         }
 
-        if let config = snapshot.homeRowModsConfig,
-           let i = manager.ruleCollections.firstIndex(where: { $0.id == RuleCollectionIdentifier.homeRowMods })
-        {
-            manager.ruleCollections[i].configuration.updateHomeRowModsConfig(config)
-            manager.ruleCollections[i].isEnabled = snapshot.homeRowModsEnabled
-        } else if let i = manager.ruleCollections.firstIndex(where: { $0.id == RuleCollectionIdentifier.homeRowMods }) {
-            manager.ruleCollections[i].isEnabled = snapshot.homeRowModsEnabled
+        PackCollectionSnapshot.remove(for: pack.id)
+        if pack.id == "com.keypath.pack.vallack-system" {
+            PackCollectionSnapshot.removeLegacyVallack()
         }
 
-        if let config = snapshot.homeRowLayerTogglesConfig,
-           let i = manager.ruleCollections.firstIndex(where: { $0.id == RuleCollectionIdentifier.homeRowLayerToggles })
-        {
-            manager.ruleCollections[i].configuration.updateHomeRowLayerTogglesConfig(config)
-            manager.ruleCollections[i].isEnabled = snapshot.homeRowLayerTogglesEnabled
-        } else if let i = manager.ruleCollections.firstIndex(where: { $0.id == RuleCollectionIdentifier.homeRowLayerToggles }) {
-            manager.ruleCollections[i].isEnabled = snapshot.homeRowLayerTogglesEnabled
-        }
-
-        try? FileManager.default.removeItem(at: vallackSnapshotURL)
-        AppLogger.shared.log("📦 [PackInstaller] Reverted Vallack system configs from snapshot")
+        AppLogger.shared.log("📦 [PackInstaller] Uninstall restore for '\(pack.id)': restored=\(shouldRestore)")
+        return shouldRestore
     }
 
     private func ensureCollectionExists(id: UUID, catalog: [RuleCollection], manager: RuleCollectionsManager) {

--- a/Sources/KeyPathAppKit/Services/Packs/PackRegistry.swift
+++ b/Sources/KeyPathAppKit/Services/Packs/PackRegistry.swift
@@ -83,7 +83,7 @@ public enum PackRegistry {
         name: "Caps Lock Remap",
         tagline: "Make Caps Lock actually useful with tap and hold actions",
         shortDescription:
-            "Tap Caps Lock for a quick action (Escape, Backspace, or Hyper). Hold it for a modifier (Hyper, Control, Shift, or Meh). One key, two jobs — pick your combo below.",
+        "Tap Caps Lock for a quick action (Escape, Backspace, or Hyper). Hold it for a modifier (Hyper, Control, Shift, or Meh). One key, two jobs — pick your combo below.",
         longDescription: "",
         category: "Productivity",
         iconSymbol: "capslock",
@@ -110,7 +110,7 @@ public enum PackRegistry {
         name: "Home Row Mods",
         tagline: "Every shortcut under your fingers — no reaching for modifier keys",
         shortDescription:
-            "Tap home row keys normally. Hold them for ⌘ ⇧ ⌥ ⌃ — every shortcut stays under your fingers. Adjust the hold timing to match your typing speed.",
+        "Tap home row keys normally. Hold them for ⌘ ⇧ ⌥ ⌃ — every shortcut stays under your fingers. Adjust the hold timing to match your typing speed.",
         longDescription: "",
         category: "Ergonomics",
         iconSymbol: "keyboard",
@@ -162,7 +162,7 @@ public enum PackRegistry {
         name: "Escape Remap",
         tagline: "Move Escape to a closer key like Caps Lock or Backtick",
         shortDescription:
-            "Remap Escape to something you'll use more — Caps Lock, Backtick, or Tab. Pairs naturally with Caps Lock Remap so both keys stay useful.",
+        "Remap Escape to something you'll use more — Caps Lock, Backtick, or Tab. Pairs naturally with Caps Lock Remap so both keys stay useful.",
         longDescription: "",
         category: "Productivity",
         iconSymbol: "escape",
@@ -181,7 +181,7 @@ public enum PackRegistry {
         name: "Delete Enhancement",
         tagline: "Forward-delete, delete word, and delete line without reaching",
         shortDescription:
-            "Hold your Leader key + Delete for forward delete, delete word, or delete to line start. Regular Delete still works normally.\n\nRequires Vim Navigation or another Leader pack.",
+        "Hold your Leader key + Delete for forward delete, delete word, or delete to line start. Regular Delete still works normally.\n\nRequires Vim Navigation or another Leader pack.",
         longDescription: "",
         category: "Productivity",
         iconSymbol: "delete.left",
@@ -207,7 +207,7 @@ public enum PackRegistry {
         name: "Backup Caps Lock",
         tagline: "Press both Shift keys together to toggle Caps Lock",
         shortDescription:
-            "Get Caps Lock back by pressing both Shift keys together. Useful when Caps Lock Remap gives that key a new job.",
+        "Get Caps Lock back by pressing both Shift keys together. Useful when Caps Lock Remap gives that key a new job.",
         longDescription: "",
         category: "Productivity",
         iconSymbol: "shift",
@@ -240,7 +240,7 @@ public enum PackRegistry {
         name: "Vim Navigation",
         tagline: "Hold Space for hjkl arrows and Vim motions",
         shortDescription:
-            "Hold Space for Vim-style navigation: H/J/K/L for arrows, Y/P for copy/paste, U for undo, / for find. Release Space to type normally.",
+        "Hold Space for Vim-style navigation: H/J/K/L for arrows, Y/P for copy/paste, U for undo, / for find. Release Space to type normally.",
         longDescription: "",
         category: "Navigation",
         iconSymbol: "arrow.up.and.down.and.arrow.left.and.right",
@@ -269,7 +269,7 @@ public enum PackRegistry {
         name: "Window Snapping",
         tagline: "Snap, move, and tile windows with Leader → w",
         shortDescription:
-            "Snap windows to halves, corners, or full screen — all from the keyboard. Hold Space → W, then pick a position.\n\nRequires Vim Navigation and Accessibility permission.",
+        "Snap windows to halves, corners, or full screen — all from the keyboard. Hold Space → W, then pick a position.\n\nRequires Vim Navigation and Accessibility permission.",
         longDescription: "",
         category: "Navigation",
         iconSymbol: "rectangle.split.2x2",
@@ -298,7 +298,7 @@ public enum PackRegistry {
         name: "Mission Control",
         tagline: "Leader + single key for Exposé, Desktops, Notifications",
         shortDescription:
-            "Mission Control, Exposé, Show Desktop, and Notification Center — each one key away. Switch desktops with , and . keys.\n\nRequires Vim Navigation or another Leader pack.",
+        "Mission Control, Exposé, Show Desktop, and Notification Center — each one key away. Switch desktops with , and . keys.\n\nRequires Vim Navigation or another Leader pack.",
         longDescription: "",
         category: "Navigation",
         iconSymbol: "rectangle.3.group",
@@ -332,7 +332,7 @@ public enum PackRegistry {
         name: "Auto Shift Symbols",
         tagline: "Type shifted symbols without pressing Shift — just hold the key",
         shortDescription:
-            "Hold any symbol key slightly longer to type its shifted variant — no Shift key needed. Tap for the symbol, hold for the shifted version.",
+        "Hold any symbol key slightly longer to type its shifted variant — no Shift key needed. Tap for the symbol, hold for the shifted version.",
         longDescription: "",
         category: "Ergonomics",
         iconSymbol: "arrow.up.square",
@@ -363,7 +363,7 @@ public enum PackRegistry {
         name: "Numpad",
         tagline: "Turn your right hand into a numpad",
         shortDescription:
-            "Your right hand becomes a numpad, left hand gets operators. Hold Space → ; to activate.\n\nRequires Vim Navigation or another Leader pack.",
+        "Your right hand becomes a numpad, left hand gets operators. Hold Space → ; to activate.\n\nRequires Vim Navigation or another Leader pack.",
         longDescription: "",
         category: "Layers",
         iconSymbol: "number.square",
@@ -398,7 +398,7 @@ public enum PackRegistry {
         name: "Symbol",
         tagline: "Programming symbols under your home row",
         shortDescription:
-            "Brackets, operators, and shifted symbols all under your home row. Hold Space → S to activate. Choose from preset layouts.\n\nRequires Vim Navigation or another Leader pack.",
+        "Brackets, operators, and shifted symbols all under your home row. Hold Space → S to activate. Choose from preset layouts.\n\nRequires Vim Navigation or another Leader pack.",
         longDescription: "",
         category: "Layers",
         iconSymbol: "textformat.abc.dottedunderline",
@@ -440,7 +440,7 @@ public enum PackRegistry {
         name: "Function",
         tagline: "Right hand becomes F-keys, left hand is media/brightness",
         shortDescription:
-            "F-keys on your right hand, media controls on your left — play/pause, volume, brightness. Hold Space → F to activate.\n\nRequires Vim Navigation or another Leader pack.",
+        "F-keys on your right hand, media controls on your left — play/pause, volume, brightness. Hold Space → F to activate.\n\nRequires Vim Navigation or another Leader pack.",
         longDescription: "",
         category: "Layers",
         iconSymbol: "f.cursive",
@@ -474,7 +474,7 @@ public enum PackRegistry {
         name: "Quick Launcher",
         tagline: "Hold Hyper, press a key to launch an app or website",
         shortDescription:
-            "Launch any app or open any URL with a single key. Hold Hyper, press the key. Drag apps onto keys to assign them.",
+        "Launch any app or open any URL with a single key. Hold Hyper, press the key. Drag apps onto keys to assign them.",
         longDescription: "",
         category: "Productivity",
         iconSymbol: "arrow.up.forward.app",
@@ -483,15 +483,72 @@ public enum PackRegistry {
         associatedCollectionID: RuleCollectionIdentifier.launcher,
         dependencies: [
             PackDependency(
-                packID: "com.keypath.pack.caps-lock-to-escape",
-                kind: .enhancedBy,
-                configPredicate: .holdOutput("C-S-M-A-"),
-                description: "Hyper mode works best with Caps Lock Remap hold set to Hyper"
-            ),
-            PackDependency(
                 packID: "com.keypath.pack.vim-navigation",
                 kind: .enhancedBy,
                 description: "Required when using Leader → L activation mode"
+            ),
+        ],
+        managedDefaults: [
+            ManagedCollectionDefault(
+                collectionID: RuleCollectionIdentifier.capsLockRemap,
+                defaultConfiguration: .tapHoldPicker(TapHoldPickerConfig(
+                    inputKey: "caps",
+                    tapOptions: [
+                        SingleKeyPreset(
+                            output: "esc",
+                            label: "⎋ Escape",
+                            description: "Popular for Vim users - quick access to Escape",
+                            icon: "escape"
+                        ),
+                        SingleKeyPreset(
+                            output: "caps",
+                            label: "⇪ Caps Lock",
+                            description: "Keep original Caps Lock function on tap",
+                            icon: "capslock"
+                        ),
+                        SingleKeyPreset(
+                            output: "bspc",
+                            label: "⌫ Delete",
+                            description: "Easy access to Delete without reaching",
+                            icon: "delete.left"
+                        ),
+                        SingleKeyPreset(
+                            output: "hyper",
+                            label: "✦ Hyper",
+                            description: "Tap for Hyper (⌃⌥⇧⌘) - useful when hold is something else",
+                            icon: "bolt.circle"
+                        ),
+                    ],
+                    holdOptions: [
+                        SingleKeyPreset(
+                            output: "hyper",
+                            label: "✦ Hyper",
+                            description: "All four modifiers (⌃⌥⇧⌘) - ultimate shortcut prefix",
+                            icon: "bolt.circle"
+                        ),
+                        SingleKeyPreset(
+                            output: "meh",
+                            label: "◇ Meh",
+                            description: "Three modifiers (⌃⌥⇧) - Hyper without Command",
+                            icon: "diamond"
+                        ),
+                        SingleKeyPreset(
+                            output: "lctl",
+                            label: "⌃ Control",
+                            description: "Control modifier (common on Unix systems)",
+                            icon: "control"
+                        ),
+                        SingleKeyPreset(
+                            output: "lsft",
+                            label: "⇧ Shift",
+                            description: "Shift modifier",
+                            icon: "shift"
+                        ),
+                    ],
+                    selectedTapOutput: "esc",
+                    selectedHoldOutput: "hyper"
+                )),
+                displayName: "Caps Lock Remap"
             ),
         ]
     )
@@ -515,7 +572,7 @@ public enum PackRegistry {
         name: "Leader Key",
         tagline: "Pick which key activates the navigation layer",
         shortDescription:
-            "Choose which key activates all your layers — Space, Caps Lock, Tab, or Backtick. Applies to Vim Nav, Window Snapping, and every other layer pack.",
+        "Choose which key activates all your layers — Space, Caps Lock, Tab, or Backtick. Applies to Vim Nav, Window Snapping, and every other layer pack.",
         longDescription: "",
         category: "Productivity",
         iconSymbol: "hand.point.up.left",
@@ -540,7 +597,7 @@ public enum PackRegistry {
         name: "Fast Navigation",
         tagline: "Arrow keys and delete at 3x speed",
         shortDescription:
-            "Your arrow keys move through text at the same sluggish speed as every other key. Fast Navigation makes them 3× faster — jump through code, scroll spreadsheets, edit text at the speed your brain actually works.\n\nDelete gets faster too. Regular typing stays steady so you don't get accidental repeats.",
+        "Your arrow keys move through text at the same sluggish speed as every other key. Fast Navigation makes them 3× faster — jump through code, scroll spreadsheets, edit text at the speed your brain actually works.\n\nDelete gets faster too. Regular typing stays steady so you don't get accidental repeats.",
         longDescription: "",
         category: "Navigation",
         iconSymbol: "hare",
@@ -557,13 +614,35 @@ public enum PackRegistry {
         name: "Ben Vallack Nav",
         tagline: "Your fingers stay put, the keyboard changes",
         shortDescription:
-            "Navigate, copy, paste, and switch tabs without your fingers leaving the home row. Inspired by [Ben Vallack](https://www.youtube.com/@BenVallacksKeyboards) — hold an index finger to transform your keyboard into a navigation surface, with modifiers on the top row so nothing competes for space.",
+        "Navigate, copy, paste, and switch tabs without your fingers leaving the home row. Inspired by [Ben Vallack](https://www.youtube.com/@BenVallacksKeyboards) — hold an index finger to transform your keyboard into a navigation surface, with modifiers on the top row so nothing competes for space.",
         longDescription: "",
         category: "Navigation",
         iconSymbol: "rectangle.stack.badge.play",
         quickSettings: [],
         bindings: [],
-        associatedCollectionID: RuleCollectionIdentifier.vallackNavigation
+        associatedCollectionID: RuleCollectionIdentifier.vallackNavigation,
+        managedDefaults: [
+            ManagedCollectionDefault(
+                collectionID: RuleCollectionIdentifier.vallackNavigation,
+                displayName: "Vallack Navigation"
+            ),
+            ManagedCollectionDefault(
+                collectionID: RuleCollectionIdentifier.homeRowMods,
+                defaultConfiguration: .homeRowMods(HomeRowModsConfig.vallackDefault),
+                displayName: "Ben's Modifiers"
+            ),
+            ManagedCollectionDefault(
+                collectionID: RuleCollectionIdentifier.homeRowLayerToggles,
+                defaultConfiguration: .homeRowLayerToggles(HomeRowLayerTogglesConfig(
+                    enabledKeys: Set(["f", "j"]),
+                    layerAssignments: HomeRowLayerTogglesConfig.vallackLayerAssignments,
+                    keySelection: .custom,
+                    toggleMode: .whileHeld,
+                    oppositeHandMode: .press
+                )),
+                displayName: "Vallack Layer Toggles"
+            ),
+        ]
     )
 
     // MARK: - Pack 16: KindaVim (visual-only companion)
@@ -591,7 +670,7 @@ public enum PackRegistry {
         name: "Chord Groups",
         tagline: "Press two keys at once for instant actions",
         shortDescription:
-            "Multi-key chords let you trigger actions by pressing adjacent keys simultaneously — no modifier keys needed. Includes Ben Vallack's home row navigation and editing presets.",
+        "Multi-key chords let you trigger actions by pressing adjacent keys simultaneously — no modifier keys needed. Includes Ben Vallack's home row navigation and editing presets.",
         longDescription: "",
         category: "Productivity",
         iconSymbol: "keyboard.badge.ellipsis",
@@ -615,7 +694,7 @@ public enum PackRegistry {
         name: "KindaVim",
         tagline: "Vim-style navigation for any macOS app via KindaVim.app",
         shortDescription:
-            "Shows your KindaVim mode (Normal, Insert, Visual) in the overlay header. The overlay adapts — Vim hints in Normal mode, clean keyboard in Insert.\n\nDisplay only — no key remapping. Requires KindaVim.app.",
+        "Shows your KindaVim mode (Normal, Insert, Visual) in the overlay header. The overlay adapts — Vim hints in Normal mode, clean keyboard in Insert.\n\nDisplay only — no key remapping. Requires KindaVim.app.",
         longDescription: "",
         category: "Navigation",
         iconSymbol: "keyboard.macwindow",
@@ -637,7 +716,7 @@ public enum PackRegistry {
         name: "Keystroke History",
         tagline: "See what your keyboard is actually doing",
         shortDescription:
-            "A live timeline of every keypress, tap-hold decision, and layer change. Great for tuning timing and debugging remaps.",
+        "A live timeline of every keypress, tap-hold decision, and layer change. Great for tuning timing and debugging remaps.",
         longDescription: "",
         category: "Debug",
         iconSymbol: "clock.arrow.trianglehead.counterclockwise.rotate.90",

--- a/Tests/KeyPathTests/GenericPackConfigTests.swift
+++ b/Tests/KeyPathTests/GenericPackConfigTests.swift
@@ -191,6 +191,342 @@ final class GenericPackConfigTests: XCTestCase {
         XCTAssertEqual(snapshot?.entries.first?.collectionID, RuleCollectionIdentifier.capsLockRemap)
     }
 
+    // MARK: - Install Over Existing Customization
+
+    @MainActor
+    func testInstallOverExistingCustomCapsLockRemap() async throws {
+        TestEnvironment.forceTestMode = true
+        defer { TestEnvironment.forceTestMode = false }
+
+        let (manager, tempDir) = try makeTestManager()
+        defer {
+            try? FileManager.default.removeItem(at: tempDir)
+            PackCollectionSnapshot.remove(for: PackRegistry.launcher.id)
+        }
+
+        // Pre-customize: set caps lock to tap=Control, hold=Meh
+        let catalog = RuleCollectionCatalog().defaultCollections()
+        if let capsFromCatalog = catalog.first(where: { $0.id == RuleCollectionIdentifier.capsLockRemap }) {
+            var customCaps = capsFromCatalog
+            customCaps.configuration = .tapHoldPicker(TapHoldPickerConfig(
+                inputKey: "caps",
+                tapOptions: capsFromCatalog.configuration.tapHoldPickerConfig?.tapOptions ?? [],
+                holdOptions: capsFromCatalog.configuration.tapHoldPickerConfig?.holdOptions ?? [],
+                selectedTapOutput: "lctl",
+                selectedHoldOutput: "meh"
+            ))
+            customCaps.isEnabled = true
+            manager.ruleCollections.append(customCaps)
+        }
+
+        // Install launcher — should apply its defaults (auto-approved in test env)
+        _ = try await PackInstaller.shared.install(PackRegistry.launcher, manager: manager)
+
+        // Verify pack defaults were applied
+        let capsCollection = manager.ruleCollections.first { $0.id == RuleCollectionIdentifier.capsLockRemap }
+        XCTAssertEqual(capsCollection?.configuration.tapHoldPickerConfig?.selectedTapOutput, "esc")
+        XCTAssertEqual(capsCollection?.configuration.tapHoldPickerConfig?.selectedHoldOutput, "hyper")
+
+        // Verify snapshot captured the PRE-INSTALL custom config
+        let snapshot = PackCollectionSnapshot.load(for: PackRegistry.launcher.id)
+        XCTAssertNotNil(snapshot)
+        let capsEntry = snapshot?.entries.first { $0.collectionID == RuleCollectionIdentifier.capsLockRemap }
+        XCTAssertNotNil(capsEntry)
+        XCTAssertTrue(capsEntry?.wasEnabled ?? false, "Snapshot should record caps was enabled before install")
+        if let configJSON = capsEntry?.configurationJSON,
+           let restoredConfig = try? JSONDecoder().decode(RuleCollectionConfiguration.self, from: configJSON)
+        {
+            XCTAssertEqual(
+                restoredConfig.tapHoldPickerConfig?.selectedTapOutput, "lctl",
+                "Snapshot should capture the pre-install custom tap output"
+            )
+            XCTAssertEqual(
+                restoredConfig.tapHoldPickerConfig?.selectedHoldOutput, "meh",
+                "Snapshot should capture the pre-install custom hold output"
+            )
+        } else {
+            XCTFail("Should be able to decode snapshot config")
+        }
+    }
+
+    @MainActor
+    func testInstallOverCustomConfigThenUninstallRestoresCustomConfig() async throws {
+        TestEnvironment.forceTestMode = true
+        defer { TestEnvironment.forceTestMode = false }
+
+        let (manager, tempDir) = try makeTestManager()
+        defer {
+            try? FileManager.default.removeItem(at: tempDir)
+            PackCollectionSnapshot.remove(for: PackRegistry.launcher.id)
+        }
+
+        // Pre-customize caps lock
+        let catalog = RuleCollectionCatalog().defaultCollections()
+        if let capsFromCatalog = catalog.first(where: { $0.id == RuleCollectionIdentifier.capsLockRemap }) {
+            var customCaps = capsFromCatalog
+            customCaps.configuration = .tapHoldPicker(TapHoldPickerConfig(
+                inputKey: "caps",
+                tapOptions: capsFromCatalog.configuration.tapHoldPickerConfig?.tapOptions ?? [],
+                holdOptions: capsFromCatalog.configuration.tapHoldPickerConfig?.holdOptions ?? [],
+                selectedTapOutput: "bspc",
+                selectedHoldOutput: "lctl"
+            ))
+            customCaps.isEnabled = true
+            manager.ruleCollections.append(customCaps)
+        }
+
+        // Install, then uninstall
+        _ = try await PackInstaller.shared.install(PackRegistry.launcher, manager: manager)
+        try await PackInstaller.shared.uninstall(packID: PackRegistry.launcher.id, manager: manager)
+
+        // Should restore the pre-install custom config, not the pack defaults
+        let capsCollection = manager.ruleCollections.first { $0.id == RuleCollectionIdentifier.capsLockRemap }
+        XCTAssertEqual(capsCollection?.configuration.tapHoldPickerConfig?.selectedTapOutput, "bspc")
+        XCTAssertEqual(capsCollection?.configuration.tapHoldPickerConfig?.selectedHoldOutput, "lctl")
+        XCTAssertTrue(capsCollection?.isEnabled ?? false, "Caps lock should remain enabled (was enabled before install)")
+    }
+
+    // MARK: - Keep My Settings (Decline Override on Install)
+
+    @MainActor
+    func testKeepMySettingsSkipsConfigOverride() async throws {
+        TestEnvironment.forceTestMode = true
+        PackInstaller.testOverrideApplyDefault = false
+        defer {
+            TestEnvironment.forceTestMode = false
+            PackInstaller.testOverrideApplyDefault = nil
+        }
+
+        let (manager, tempDir) = try makeTestManager()
+        defer {
+            try? FileManager.default.removeItem(at: tempDir)
+            PackCollectionSnapshot.remove(for: PackRegistry.launcher.id)
+        }
+
+        // Pre-customize caps lock with non-default config
+        let catalog = RuleCollectionCatalog().defaultCollections()
+        if let capsFromCatalog = catalog.first(where: { $0.id == RuleCollectionIdentifier.capsLockRemap }) {
+            var customCaps = capsFromCatalog
+            customCaps.configuration = .tapHoldPicker(TapHoldPickerConfig(
+                inputKey: "caps",
+                tapOptions: capsFromCatalog.configuration.tapHoldPickerConfig?.tapOptions ?? [],
+                holdOptions: capsFromCatalog.configuration.tapHoldPickerConfig?.holdOptions ?? [],
+                selectedTapOutput: "lctl",
+                selectedHoldOutput: "meh"
+            ))
+            customCaps.isEnabled = true
+            manager.ruleCollections.append(customCaps)
+        }
+
+        // Install with "Keep My Settings"
+        _ = try await PackInstaller.shared.install(PackRegistry.launcher, manager: manager)
+
+        // Config should NOT have been overridden — user chose to keep theirs
+        let capsCollection = manager.ruleCollections.first { $0.id == RuleCollectionIdentifier.capsLockRemap }
+        XCTAssertTrue(capsCollection?.isEnabled ?? false, "Collection should still be enabled")
+        XCTAssertEqual(
+            capsCollection?.configuration.tapHoldPickerConfig?.selectedTapOutput, "lctl",
+            "Tap output should remain user's choice, not pack default"
+        )
+        XCTAssertEqual(
+            capsCollection?.configuration.tapHoldPickerConfig?.selectedHoldOutput, "meh",
+            "Hold output should remain user's choice, not pack default"
+        )
+    }
+
+    // MARK: - Nil Default Configuration (Enable-Only)
+
+    @MainActor
+    func testNilDefaultConfigOnlyEnablesWithoutChangingConfig() async throws {
+        TestEnvironment.forceTestMode = true
+        defer { TestEnvironment.forceTestMode = false }
+
+        let (manager, tempDir) = try makeTestManager()
+        defer {
+            try? FileManager.default.removeItem(at: tempDir)
+            PackCollectionSnapshot.remove(for: PackRegistry.vallackSystem.id)
+        }
+
+        // Vallack Navigation has defaultConfiguration: nil in managedDefaults.
+        // Pre-add the nav collection from catalog (disabled).
+        let catalog = RuleCollectionCatalog().defaultCollections()
+        if let navFromCatalog = catalog.first(where: { $0.id == RuleCollectionIdentifier.vallackNavigation }) {
+            var nav = navFromCatalog
+            nav.isEnabled = false
+            manager.ruleCollections.append(nav)
+        }
+
+        let configBefore = manager.ruleCollections
+            .first { $0.id == RuleCollectionIdentifier.vallackNavigation }?.configuration
+
+        _ = try await PackInstaller.shared.install(PackRegistry.vallackSystem, manager: manager)
+
+        let navCollection = manager.ruleCollections.first { $0.id == RuleCollectionIdentifier.vallackNavigation }
+        XCTAssertTrue(navCollection?.isEnabled ?? false, "Should be enabled after install")
+        XCTAssertEqual(
+            navCollection?.configuration, configBefore,
+            "Config should be unchanged — nil defaultConfiguration means enable-only"
+        )
+    }
+
+    // MARK: - Uninstall After User Modification
+
+    @MainActor
+    func testUninstallAfterUserModificationDetectsChange() async throws {
+        TestEnvironment.forceTestMode = true
+        defer { TestEnvironment.forceTestMode = false }
+
+        let (manager, tempDir) = try makeTestManager()
+        defer {
+            try? FileManager.default.removeItem(at: tempDir)
+            PackCollectionSnapshot.remove(for: PackRegistry.launcher.id)
+        }
+
+        // Install launcher (applies tap=esc, hold=hyper)
+        _ = try await PackInstaller.shared.install(PackRegistry.launcher, manager: manager)
+
+        // Simulate user modifying the config AFTER install
+        if let i = manager.ruleCollections.firstIndex(where: { $0.id == RuleCollectionIdentifier.capsLockRemap }) {
+            manager.ruleCollections[i].configuration = .tapHoldPicker(TapHoldPickerConfig(
+                inputKey: "caps",
+                tapOptions: [],
+                holdOptions: [],
+                selectedTapOutput: "bspc",
+                selectedHoldOutput: "lctl"
+            ))
+        }
+
+        // Uninstall — test env auto-approves restore even when modified
+        try await PackInstaller.shared.uninstall(packID: PackRegistry.launcher.id, manager: manager)
+
+        // Should have restored the pre-install config (whatever was there before),
+        // not kept the user's post-install modification
+        let capsCollection = manager.ruleCollections.first { $0.id == RuleCollectionIdentifier.capsLockRemap }
+        XCTAssertNotEqual(
+            capsCollection?.configuration.tapHoldPickerConfig?.selectedTapOutput, "bspc",
+            "Post-install modification should not persist after restore"
+        )
+    }
+
+    @MainActor
+    func testUninstallKeepCurrentWhenUserModified() async throws {
+        TestEnvironment.forceTestMode = true
+        PackInstaller.testOverrideRestore = false
+        defer {
+            TestEnvironment.forceTestMode = false
+            PackInstaller.testOverrideRestore = nil
+        }
+
+        let (manager, tempDir) = try makeTestManager()
+        defer {
+            try? FileManager.default.removeItem(at: tempDir)
+            PackCollectionSnapshot.remove(for: PackRegistry.launcher.id)
+        }
+
+        // Install launcher (applies tap=esc, hold=hyper)
+        _ = try await PackInstaller.shared.install(PackRegistry.launcher, manager: manager)
+
+        // Simulate user modifying after install
+        if let i = manager.ruleCollections.firstIndex(where: { $0.id == RuleCollectionIdentifier.capsLockRemap }) {
+            manager.ruleCollections[i].configuration = .tapHoldPicker(TapHoldPickerConfig(
+                inputKey: "caps",
+                tapOptions: [],
+                holdOptions: [],
+                selectedTapOutput: "bspc",
+                selectedHoldOutput: "lctl"
+            ))
+        }
+
+        // Uninstall with "Keep Current"
+        try await PackInstaller.shared.uninstall(packID: PackRegistry.launcher.id, manager: manager)
+
+        // User's modification should be preserved
+        let capsCollection = manager.ruleCollections.first { $0.id == RuleCollectionIdentifier.capsLockRemap }
+        XCTAssertEqual(
+            capsCollection?.configuration.tapHoldPickerConfig?.selectedTapOutput, "bspc",
+            "User's modification should be kept when they choose 'Keep Current'"
+        )
+        XCTAssertEqual(
+            capsCollection?.configuration.tapHoldPickerConfig?.selectedHoldOutput, "lctl",
+            "User's modification should be kept when they choose 'Keep Current'"
+        )
+    }
+
+    // MARK: - Two System Packs Simultaneously
+
+    @MainActor
+    func testTwoSystemPacksInstalledSimultaneously() async throws {
+        TestEnvironment.forceTestMode = true
+        defer { TestEnvironment.forceTestMode = false }
+
+        let (manager, tempDir) = try makeTestManager()
+        defer {
+            try? FileManager.default.removeItem(at: tempDir)
+            PackCollectionSnapshot.remove(for: PackRegistry.vallackSystem.id)
+            PackCollectionSnapshot.remove(for: PackRegistry.launcher.id)
+        }
+
+        // Install both system packs
+        _ = try await PackInstaller.shared.install(PackRegistry.vallackSystem, manager: manager)
+        _ = try await PackInstaller.shared.install(PackRegistry.launcher, manager: manager)
+
+        // Vallack collections should be enabled
+        let navCollection = manager.ruleCollections.first { $0.id == RuleCollectionIdentifier.vallackNavigation }
+        XCTAssertTrue(navCollection?.isEnabled ?? false, "Vallack nav should be enabled")
+        let modsCollection = manager.ruleCollections.first { $0.id == RuleCollectionIdentifier.homeRowMods }
+        XCTAssertTrue(modsCollection?.isEnabled ?? false, "Home Row Mods should be enabled")
+
+        // Launcher collections should be enabled
+        let launcherCollection = manager.ruleCollections.first { $0.id == RuleCollectionIdentifier.launcher }
+        XCTAssertTrue(launcherCollection?.isEnabled ?? false, "Launcher should be enabled")
+        let capsCollection = manager.ruleCollections.first { $0.id == RuleCollectionIdentifier.capsLockRemap }
+        XCTAssertTrue(capsCollection?.isEnabled ?? false, "Caps Lock Remap should be enabled")
+        XCTAssertEqual(capsCollection?.configuration.tapHoldPickerConfig?.selectedTapOutput, "esc")
+        XCTAssertEqual(capsCollection?.configuration.tapHoldPickerConfig?.selectedHoldOutput, "hyper")
+
+        // Uninstall Launcher — should not affect Vallack collections
+        try await PackInstaller.shared.uninstall(packID: PackRegistry.launcher.id, manager: manager)
+
+        let navAfter = manager.ruleCollections.first { $0.id == RuleCollectionIdentifier.vallackNavigation }
+        XCTAssertTrue(navAfter?.isEnabled ?? false, "Vallack nav should still be enabled after launcher uninstall")
+        let modsAfter = manager.ruleCollections.first { $0.id == RuleCollectionIdentifier.homeRowMods }
+        XCTAssertTrue(modsAfter?.isEnabled ?? false, "Home Row Mods should still be enabled after launcher uninstall")
+    }
+
+    // MARK: - Uninstall Without Snapshot
+
+    @MainActor
+    func testLauncherUninstallWithoutSnapshotDoesNotCrash() async throws {
+        TestEnvironment.forceTestMode = true
+        defer { TestEnvironment.forceTestMode = false }
+
+        let (manager, tempDir) = try makeTestManager()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        // Register as installed without going through install flow (no snapshot created)
+        try await InstalledPackTracker.shared.upsert(InstalledPackRecord(
+            packID: PackRegistry.launcher.id,
+            version: PackRegistry.launcher.version
+        ))
+
+        // Ensure launcher collection exists and is enabled
+        let catalog = RuleCollectionCatalog().defaultCollections()
+        if let launcherFromCatalog = catalog.first(where: { $0.id == RuleCollectionIdentifier.launcher }) {
+            var launcher = launcherFromCatalog
+            launcher.isEnabled = true
+            manager.ruleCollections.append(launcher)
+        }
+
+        // Should not crash
+        try await PackInstaller.shared.uninstall(
+            packID: PackRegistry.launcher.id,
+            manager: manager
+        )
+
+        let launcherCollection = manager.ruleCollections.first { $0.id == RuleCollectionIdentifier.launcher }
+        XCTAssertFalse(launcherCollection?.isEnabled ?? true, "Launcher should be disabled after uninstall")
+    }
+
     // MARK: - Legacy Vallack Migration
 
     func testLegacyVallackSnapshotMigration() throws {

--- a/Tests/KeyPathTests/GenericPackConfigTests.swift
+++ b/Tests/KeyPathTests/GenericPackConfigTests.swift
@@ -1,0 +1,242 @@
+@testable import KeyPathAppKit
+import KeyPathCore
+import XCTest
+
+final class GenericPackConfigTests: XCTestCase {
+    private var originalInstalledPacks: [InstalledPackRecord] = []
+
+    override func setUp() async throws {
+        try await super.setUp()
+        originalInstalledPacks = await InstalledPackTracker.shared.allInstalled()
+    }
+
+    override func tearDown() async throws {
+        let current = await InstalledPackTracker.shared.allInstalled()
+        for record in current {
+            if !originalInstalledPacks.contains(where: { $0.packID == record.packID }) {
+                try await InstalledPackTracker.shared.remove(packID: record.packID)
+            }
+        }
+        for record in originalInstalledPacks {
+            if await !(InstalledPackTracker.shared.isInstalled(packID: record.packID)) {
+                try await InstalledPackTracker.shared.upsert(record)
+            }
+        }
+        try await super.tearDown()
+    }
+
+    // MARK: - PackCollectionSnapshot Round-Trip
+
+    func testPackCollectionSnapshotRoundTrip() throws {
+        let config = RuleCollectionConfiguration.tapHoldPicker(TapHoldPickerConfig(
+            inputKey: "caps",
+            tapOptions: [],
+            holdOptions: [],
+            selectedTapOutput: "esc",
+            selectedHoldOutput: "hyper"
+        ))
+        let configJSON = try JSONEncoder().encode(config)
+
+        let snapshot = PackCollectionSnapshot(
+            packID: "test.pack",
+            entries: [
+                PackCollectionSnapshot.Entry(
+                    collectionID: RuleCollectionIdentifier.capsLockRemap,
+                    wasEnabled: true,
+                    configurationJSON: configJSON
+                ),
+            ]
+        )
+
+        try PackCollectionSnapshot.save(snapshot)
+        defer { PackCollectionSnapshot.remove(for: "test.pack") }
+
+        let loaded = PackCollectionSnapshot.load(for: "test.pack")
+        XCTAssertNotNil(loaded)
+        XCTAssertEqual(loaded?.packID, "test.pack")
+        XCTAssertEqual(loaded?.entries.count, 1)
+        XCTAssertEqual(loaded?.entries.first?.collectionID, RuleCollectionIdentifier.capsLockRemap)
+        XCTAssertEqual(loaded?.entries.first?.wasEnabled, true)
+
+        let decodedConfig = try JSONDecoder().decode(
+            RuleCollectionConfiguration.self,
+            from: XCTUnwrap(loaded?.entries.first?.configurationJSON)
+        )
+        XCTAssertEqual(decodedConfig, config)
+    }
+
+    // MARK: - Quick Launcher
+
+    func testQuickLauncherIsSystemPack() {
+        XCTAssertTrue(PackRegistry.launcher.isSystemPack)
+        XCTAssertEqual(PackRegistry.launcher.managedDefaults.count, 1)
+    }
+
+    func testQuickLauncherManagedCollectionIDs() {
+        let ids = PackRegistry.launcher.managedCollectionIDs
+        XCTAssertTrue(ids.contains(RuleCollectionIdentifier.launcher))
+        XCTAssertTrue(ids.contains(RuleCollectionIdentifier.capsLockRemap))
+    }
+
+    func testQuickLauncherManagedDefaultIsCapsLockRemap() {
+        let managed = PackRegistry.launcher.managedDefaults.first
+        XCTAssertNotNil(managed)
+        XCTAssertEqual(managed?.collectionID, RuleCollectionIdentifier.capsLockRemap)
+        XCTAssertEqual(managed?.displayName, "Caps Lock Remap")
+
+        if case let .tapHoldPicker(config) = managed?.defaultConfiguration {
+            XCTAssertEqual(config.selectedTapOutput, "esc")
+            XCTAssertEqual(config.selectedHoldOutput, "hyper")
+        } else {
+            XCTFail("Expected tapHoldPicker configuration")
+        }
+    }
+
+    @MainActor
+    func testQuickLauncherInstallConfiguresCapsLockRemap() async throws {
+        TestEnvironment.forceTestMode = true
+        defer { TestEnvironment.forceTestMode = false }
+
+        let (manager, tempDir) = try makeTestManager()
+        defer {
+            try? FileManager.default.removeItem(at: tempDir)
+            PackCollectionSnapshot.remove(for: PackRegistry.launcher.id)
+        }
+
+        let record = try await PackInstaller.shared.install(
+            PackRegistry.launcher,
+            manager: manager
+        )
+        XCTAssertEqual(record.packID, PackRegistry.launcher.id)
+
+        // Caps Lock Remap should be enabled with tap=esc, hold=hyper
+        let capsCollection = manager.ruleCollections.first { $0.id == RuleCollectionIdentifier.capsLockRemap }
+        XCTAssertTrue(capsCollection?.isEnabled ?? false, "Caps Lock Remap should be enabled")
+        if let config = capsCollection?.configuration.tapHoldPickerConfig {
+            XCTAssertEqual(config.selectedTapOutput, "esc")
+            XCTAssertEqual(config.selectedHoldOutput, "hyper")
+        } else {
+            XCTFail("Caps Lock Remap should have tapHoldPicker config after launcher install")
+        }
+
+        // Launcher collection itself should be enabled
+        let launcherCollection = manager.ruleCollections.first { $0.id == RuleCollectionIdentifier.launcher }
+        XCTAssertTrue(launcherCollection?.isEnabled ?? false, "Launcher collection should be enabled")
+    }
+
+    @MainActor
+    func testQuickLauncherUninstallRestoresCapsLockRemap() async throws {
+        TestEnvironment.forceTestMode = true
+        defer { TestEnvironment.forceTestMode = false }
+
+        let (manager, tempDir) = try makeTestManager()
+        defer {
+            try? FileManager.default.removeItem(at: tempDir)
+            PackCollectionSnapshot.remove(for: PackRegistry.launcher.id)
+        }
+
+        // Capture pre-install caps lock state
+        let preCapsEnabled = manager.ruleCollections
+            .first { $0.id == RuleCollectionIdentifier.capsLockRemap }?.isEnabled ?? false
+        let preCapsConfig = manager.ruleCollections
+            .first { $0.id == RuleCollectionIdentifier.capsLockRemap }?.configuration
+
+        // Install then uninstall
+        _ = try await PackInstaller.shared.install(PackRegistry.launcher, manager: manager)
+        try await PackInstaller.shared.uninstall(packID: PackRegistry.launcher.id, manager: manager)
+
+        // Caps Lock Remap should revert to pre-install state
+        let capsCollection = manager.ruleCollections.first { $0.id == RuleCollectionIdentifier.capsLockRemap }
+        XCTAssertEqual(
+            capsCollection?.isEnabled ?? !preCapsEnabled,
+            preCapsEnabled,
+            "Caps Lock Remap enabled state should revert"
+        )
+
+        if let preCapsConfig {
+            XCTAssertEqual(
+                capsCollection?.configuration,
+                preCapsConfig,
+                "Caps Lock Remap config should revert"
+            )
+        }
+
+        // Launcher collection should be disabled
+        let launcherCollection = manager.ruleCollections.first { $0.id == RuleCollectionIdentifier.launcher }
+        XCTAssertFalse(launcherCollection?.isEnabled ?? true, "Launcher should be disabled after uninstall")
+
+        // Snapshot file should be cleaned up
+        XCTAssertNil(
+            PackCollectionSnapshot.load(for: PackRegistry.launcher.id),
+            "Snapshot should be removed after uninstall"
+        )
+    }
+
+    @MainActor
+    func testQuickLauncherInstallCreatesSnapshotFile() async throws {
+        TestEnvironment.forceTestMode = true
+        defer { TestEnvironment.forceTestMode = false }
+
+        let (manager, tempDir) = try makeTestManager()
+        defer {
+            try? FileManager.default.removeItem(at: tempDir)
+            PackCollectionSnapshot.remove(for: PackRegistry.launcher.id)
+        }
+
+        _ = try await PackInstaller.shared.install(PackRegistry.launcher, manager: manager)
+
+        let snapshot = PackCollectionSnapshot.load(for: PackRegistry.launcher.id)
+        XCTAssertNotNil(snapshot, "Snapshot should exist after install")
+        XCTAssertEqual(snapshot?.entries.count, 1, "Should snapshot one managed collection")
+        XCTAssertEqual(snapshot?.entries.first?.collectionID, RuleCollectionIdentifier.capsLockRemap)
+    }
+
+    // MARK: - Legacy Vallack Migration
+
+    func testLegacyVallackSnapshotMigration() throws {
+        let legacyURL = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".config/keypath/vallack-system-snapshot.json")
+
+        let legacySnapshot: [String: Any] = [
+            "homeRowModsEnabled": true,
+            "homeRowLayerTogglesEnabled": false,
+        ]
+        let legacyData = try JSONSerialization.data(withJSONObject: legacySnapshot)
+        try legacyData.write(to: legacyURL, options: .atomic)
+        defer { try? FileManager.default.removeItem(at: legacyURL) }
+
+        let migrated = PackCollectionSnapshot.loadLegacyVallack()
+        XCTAssertNotNil(migrated)
+        XCTAssertEqual(migrated?.packID, "com.keypath.pack.vallack-system")
+        XCTAssertEqual(migrated?.entries.count, 2)
+
+        let modsEntry = migrated?.entries.first { $0.collectionID == RuleCollectionIdentifier.homeRowMods }
+        XCTAssertNotNil(modsEntry)
+        XCTAssertTrue(modsEntry?.wasEnabled ?? false)
+
+        let togglesEntry = migrated?.entries.first { $0.collectionID == RuleCollectionIdentifier.homeRowLayerToggles }
+        XCTAssertNotNil(togglesEntry)
+        XCTAssertFalse(togglesEntry?.wasEnabled ?? true)
+    }
+
+    // MARK: - Helpers
+
+    @MainActor
+    private func makeTestManager() throws -> (RuleCollectionsManager, URL) {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("generic-pack-test-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+
+        let manager = RuleCollectionsManager(
+            ruleCollectionStore: RuleCollectionStore(
+                fileURL: tempDir.appendingPathComponent("RuleCollections.json")
+            ),
+            customRulesStore: CustomRulesStore(
+                fileURL: tempDir.appendingPathComponent("CustomRules.json")
+            ),
+            configurationService: ConfigurationService(configDirectory: tempDir.path),
+            eventListener: KanataEventListener()
+        )
+        return (manager, tempDir)
+    }
+}

--- a/Tests/KeyPathTests/VallackSystemPackTests.swift
+++ b/Tests/KeyPathTests/VallackSystemPackTests.swift
@@ -158,6 +158,24 @@ final class VallackSystemPackTests: XCTestCase {
         XCTAssertFalse(PackRegistry.vallackSystem.visualOnly)
     }
 
+    func testVallackSystemPackIsSystemPack() {
+        XCTAssertTrue(PackRegistry.vallackSystem.isSystemPack)
+        XCTAssertEqual(PackRegistry.vallackSystem.managedDefaults.count, 3)
+    }
+
+    func testManagedCollectionIDsDerivedFromDefaults() {
+        let ids = PackRegistry.vallackSystem.managedCollectionIDs
+        XCTAssertTrue(ids.contains(RuleCollectionIdentifier.vallackNavigation))
+        XCTAssertTrue(ids.contains(RuleCollectionIdentifier.homeRowMods))
+        XCTAssertTrue(ids.contains(RuleCollectionIdentifier.homeRowLayerToggles))
+    }
+
+    func testNonSystemPackIsNotSystemPack() {
+        let pack = PackRegistry.pack(id: "com.keypath.pack.caps-lock-to-escape")
+        XCTAssertNotNil(pack)
+        XCTAssertFalse(pack?.isSystemPack ?? true)
+    }
+
     // MARK: - PackInstaller Snapshot/Restore
 
     @MainActor
@@ -215,7 +233,7 @@ final class VallackSystemPackTests: XCTestCase {
         )
 
         let snapshotURL = FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent(".config/keypath/vallack-system-snapshot.json")
+            .appendingPathComponent(".config/keypath/pack-snapshots/com.keypath.pack.vallack-system.json")
         XCTAssertTrue(
             FileManager.default.fileExists(atPath: snapshotURL.path),
             "Snapshot file should exist after install"
@@ -236,7 +254,7 @@ final class VallackSystemPackTests: XCTestCase {
         defer { try? FileManager.default.removeItem(at: tempDir) }
 
         let snapshotURL = FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent(".config/keypath/vallack-system-snapshot.json")
+            .appendingPathComponent(".config/keypath/pack-snapshots/com.keypath.pack.vallack-system.json")
         defer { try? FileManager.default.removeItem(at: snapshotURL) }
 
         // Capture pre-install state
@@ -306,7 +324,7 @@ final class VallackSystemPackTests: XCTestCase {
 
         // Ensure no snapshot file exists
         let snapshotURL = FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent(".config/keypath/vallack-system-snapshot.json")
+            .appendingPathComponent(".config/keypath/pack-snapshots/com.keypath.pack.vallack-system.json")
         try? FileManager.default.removeItem(at: snapshotURL)
 
         // Uninstall should not crash — just skip the revert


### PR DESCRIPTION
## Summary

- Replace Vallack-specific snapshot/restore code in PackInstaller (~160 lines) with a generic system where any pack declares `managedDefaults`
- Add `ManagedCollectionDefault` struct and `managedDefaults` property to `Pack`
- Add `PackCollectionSnapshot` for persisting pre-install state to `~/.config/keypath/pack-snapshots/`
- Wire Quick Launcher to auto-configure Caps Lock Remap (tap=Escape, hold=Hyper) on install
- Legacy migration reads old `vallack-system-snapshot.json` format on first uninstall after upgrade

## Test plan

- [x] All 532 existing tests pass (no behavioral regressions)
- [x] 8 new tests in `GenericPackConfigTests`: snapshot round-trip, Quick Launcher install/uninstall/restore, legacy migration
- [x] 3 new tests in `VallackSystemPackTests`: `isSystemPack`, derived `managedCollectionIDs`, non-system-pack check
- [x] Existing Vallack install/uninstall/revert tests pass through the new generic path
- [ ] Manual: install Quick Launcher, verify Caps Lock Remap set to tap=Escape, hold=Hyper
- [ ] Manual: uninstall Quick Launcher, verify Caps Lock Remap restores previous config

Closes #555