### PR TITLE
feat: Distributed Notifications, App Intents, KeyPath.spoon, and CLI guide

### DIFF
--- a/Integrations/KeyPath.spoon/README.md
+++ b/Integrations/KeyPath.spoon/README.md
@@ -1,0 +1,135 @@
+# KeyPath.spoon
+
+A [Hammerspoon](https://www.hammerspoon.org/) Spoon that lets you react to KeyPath keyboard layer changes and service state. Uses macOS Distributed Notifications — no sockets, no polling, no configuration.
+
+## Install
+
+Copy `KeyPath.spoon` to your Spoons directory:
+
+```bash
+cp -r Integrations/KeyPath.spoon ~/.hammerspoon/Spoons/
+```
+
+Or symlink it for development:
+
+```bash
+ln -s "$(pwd)/Integrations/KeyPath.spoon" ~/.hammerspoon/Spoons/KeyPath.spoon
+```
+
+Then reload Hammerspoon (`Cmd+Shift+R` or `hs.reload()`).
+
+## Quick Start
+
+Add to your `~/.hammerspoon/init.lua`:
+
+```lua
+hs.loadSpoon("KeyPath")
+
+spoon.KeyPath:onLayerChange(function(layer, previous)
+    print("Layer: " .. layer .. " (was " .. previous .. ")")
+end):start()
+```
+
+## API
+
+### `spoon.KeyPath:onLayerChange(fn)`
+
+Register a callback for layer changes. `fn` receives `(layerName, previousLayerName)`. Returns `self` for chaining.
+
+### `spoon.KeyPath:onServiceState(fn)`
+
+Register a callback for service start/stop. `fn` receives `(state)` where state is `"running"` or `"stopped"`. Returns `self` for chaining.
+
+### `spoon.KeyPath:start()`
+
+Start listening for KeyPath events. Returns `self`.
+
+### `spoon.KeyPath:stop()`
+
+Stop listening. Returns `self`.
+
+### `spoon.KeyPath:sendAction(uri)`
+
+Send a `keypath://` action URI to KeyPath. Accepts full URIs or shorthand (auto-prefixes `keypath://`).
+
+```lua
+spoon.KeyPath:sendAction("launch/Obsidian")
+spoon.KeyPath:sendAction("keypath://notify?title=Hello")
+```
+
+### `spoon.KeyPath.currentLayer`
+
+The most recently reported layer name. `nil` until the first layer change.
+
+### `spoon.KeyPath.serviceState`
+
+The most recently reported service state. `nil` until first report.
+
+## Examples
+
+### Show a notification on layer change
+
+```lua
+hs.loadSpoon("KeyPath")
+
+spoon.KeyPath:onLayerChange(function(layer, previous)
+    if layer ~= "base" then
+        hs.notify.show("KeyPath", "", "Layer: " .. layer)
+    end
+end):start()
+```
+
+### Layer-aware window management
+
+```lua
+hs.loadSpoon("KeyPath")
+
+spoon.KeyPath:onLayerChange(function(layer)
+    if layer == "window" then
+        -- Show a window grid overlay
+        hs.grid.show()
+    end
+end):start()
+```
+
+### Route URLs based on active layer
+
+Combine with [ProfileRouter.spoon](https://github.com/malpern/ProfileRouter):
+
+```lua
+hs.loadSpoon("KeyPath")
+hs.loadSpoon("ProfileRouter")
+
+-- When in "work" layer, cycle to work profile
+spoon.KeyPath:onLayerChange(function(layer)
+    if layer == "work" then
+        -- Your work-layer automation here
+    end
+end):start()
+
+spoon.ProfileRouter:start()
+```
+
+### Send KeyPath actions from Hammerspoon hotkeys
+
+```lua
+hs.loadSpoon("KeyPath")
+
+-- Ctrl+Shift+M → launch Mission Control via KeyPath
+hs.hotkey.bind({"ctrl", "shift"}, "m", function()
+    spoon.KeyPath:sendAction("system/mission-control")
+end)
+
+spoon.KeyPath:start()
+```
+
+## Requirements
+
+- [Hammerspoon](https://www.hammerspoon.org/) 0.9.93+
+- [KeyPath](https://github.com/malpern/KeyPath) with distributed notification support
+
+## How It Works
+
+KeyPath broadcasts layer changes and service state via macOS Distributed Notifications (`NSDistributedNotificationCenter`). This Spoon subscribes to those notifications using `hs.distributednotifications`. No network connections or configuration needed — if KeyPath is running, events flow automatically.
+
+See [Distributed Notifications](../../docs/DISTRIBUTED_NOTIFICATIONS.md) for the full protocol reference.

--- a/Integrations/KeyPath.spoon/init.lua
+++ b/Integrations/KeyPath.spoon/init.lua
@@ -1,0 +1,142 @@
+--- === KeyPath ===
+---
+--- React to KeyPath keyboard layer changes and service state in Hammerspoon.
+--- Uses macOS Distributed Notifications — no sockets, no polling.
+---
+--- Usage:
+---   hs.loadSpoon("KeyPath")
+---   spoon.KeyPath:onLayerChange(function(layer, previous)
+---       if layer == "nav" then
+---           -- show navigation overlay
+---       end
+---   end):start()
+---
+--- [KeyPath](https://github.com/malpern/KeyPath)
+
+local obj = {}
+obj.__index = obj
+
+obj.name = "KeyPath"
+obj.version = "1.0"
+obj.author = "Micah Alpern <malpern@gmail.com>"
+obj.license = "MIT - https://opensource.org/licenses/MIT"
+obj.homepage = "https://github.com/malpern/KeyPath"
+
+obj._watchers = {}
+obj._layerCallbacks = {}
+obj._serviceCallbacks = {}
+
+--- KeyPath.currentLayer
+--- Variable
+--- The most recently reported layer name. Nil until the first layer change is received.
+obj.currentLayer = nil
+
+--- KeyPath.serviceState
+--- Variable
+--- The most recently reported service state ("running" or "stopped"). Nil until first report.
+obj.serviceState = nil
+
+--- KeyPath:onLayerChange(fn)
+--- Method
+--- Register a callback for layer change events.
+---
+--- Parameters:
+---  * fn - A function that receives (layerName, previousLayerName)
+---
+--- Returns:
+---  * The KeyPath object (for chaining)
+function obj:onLayerChange(fn)
+    self._layerCallbacks[#self._layerCallbacks + 1] = fn
+    return self
+end
+
+--- KeyPath:onServiceState(fn)
+--- Method
+--- Register a callback for service state changes.
+---
+--- Parameters:
+---  * fn - A function that receives (state) where state is "running" or "stopped"
+---
+--- Returns:
+---  * The KeyPath object (for chaining)
+function obj:onServiceState(fn)
+    self._serviceCallbacks[#self._serviceCallbacks + 1] = fn
+    return self
+end
+
+--- KeyPath:start()
+--- Method
+--- Start listening for KeyPath events via macOS Distributed Notifications.
+---
+--- Parameters:
+---  * None
+---
+--- Returns:
+---  * The KeyPath object
+function obj:start()
+    self._watchers.layer = hs.distributednotifications.new(
+        function(name, object, userInfo)
+            if not userInfo then return end
+            local layer = userInfo.layer
+            local previous = userInfo.previous
+            if not layer then return end
+
+            self.currentLayer = layer
+
+            for _, fn in ipairs(self._layerCallbacks) do
+                fn(layer, previous)
+            end
+        end, "com.keypath.layerChanged"
+    ):start()
+
+    self._watchers.service = hs.distributednotifications.new(
+        function(name, object, userInfo)
+            if not userInfo then return end
+            local state = userInfo.state
+            if not state then return end
+
+            self.serviceState = state
+
+            for _, fn in ipairs(self._serviceCallbacks) do
+                fn(state)
+            end
+        end, "com.keypath.serviceStateChanged"
+    ):start()
+
+    return self
+end
+
+--- KeyPath:stop()
+--- Method
+--- Stop listening for KeyPath events.
+---
+--- Parameters:
+---  * None
+---
+--- Returns:
+---  * The KeyPath object
+function obj:stop()
+    for _, w in pairs(self._watchers) do
+        w:stop()
+    end
+    self._watchers = {}
+    return self
+end
+
+--- KeyPath:sendAction(uri)
+--- Method
+--- Send a keypath:// action URI to KeyPath.
+---
+--- Parameters:
+---  * uri - A keypath:// URI string (e.g., "keypath://launch/Obsidian")
+---
+--- Returns:
+---  * None
+function obj:sendAction(uri)
+    if not uri:match("^keypath://") then
+        uri = "keypath://" .. uri
+    end
+    hs.urlevent.openURL(uri)
+end
+
+return obj

--- a/Sources/KeyPathAppKit/CLI/ConfigFacade.swift
+++ b/Sources/KeyPathAppKit/CLI/ConfigFacade.swift
@@ -78,6 +78,11 @@ public struct ConfigFacade: Sendable {
         return await client.checkServerStatus()
     }
 
+    public func tcpGetCurrentLayer() async throws -> String {
+        let client = await tcpClient()
+        return try await client.requestCurrentLayerName()
+    }
+
     public func tcpGetLayers() async throws -> [String] {
         let client = await tcpClient()
         return try await client.requestLayerNames()

--- a/Sources/KeyPathAppKit/Core/AppNotificationWiring.swift
+++ b/Sources/KeyPathAppKit/Core/AppNotificationWiring.swift
@@ -16,6 +16,7 @@ enum AppNotificationWiring {
         registerFeedbackNotifications()
         registerServiceNotifications(on: delegate)
         registerActionDispatcherCallbacks()
+        DistributedNotificationBridge.start()
     }
 
     // MARK: - Wizard Notifications

--- a/Sources/KeyPathAppKit/Core/DistributedNotificationBridge.swift
+++ b/Sources/KeyPathAppKit/Core/DistributedNotificationBridge.swift
@@ -8,6 +8,7 @@ enum DistributedNotificationBridge {
     static let layerChangedName = NSNotification.Name("com.keypath.layerChanged")
     static let serviceStateChangedName = NSNotification.Name("com.keypath.serviceStateChanged")
 
+    private(set) static var currentLayer: String = "base"
     private static var previousLayer: String = "base"
     private static var observer: NSObjectProtocol?
 
@@ -24,6 +25,7 @@ enum DistributedNotificationBridge {
 
             let previous = previousLayer
             previousLayer = layerName
+            currentLayer = layerName
 
             DistributedNotificationCenter.default().postNotificationName(
                 layerChangedName,

--- a/Sources/KeyPathAppKit/Core/DistributedNotificationBridge.swift
+++ b/Sources/KeyPathAppKit/Core/DistributedNotificationBridge.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+/// Bridges internal layer-change notifications to macOS Distributed Notifications,
+/// enabling external tools (Hammerspoon, Keyboard Maestro, Shortcuts) to react
+/// to KeyPath state changes.
+@MainActor
+enum DistributedNotificationBridge {
+    static let layerChangedName = NSNotification.Name("com.keypath.layerChanged")
+    static let serviceStateChangedName = NSNotification.Name("com.keypath.serviceStateChanged")
+
+    private static var previousLayer: String = "base"
+    private static var observer: NSObjectProtocol?
+
+    static func start() {
+        guard observer == nil else { return }
+
+        observer = NotificationCenter.default.addObserver(
+            forName: .kanataLayerChanged,
+            object: nil,
+            queue: .main
+        ) { notification in
+            guard let layerName = notification.userInfo?["layerName"] as? String else { return }
+            guard layerName.lowercased() != previousLayer.lowercased() else { return }
+
+            let previous = previousLayer
+            previousLayer = layerName
+
+            DistributedNotificationCenter.default().postNotificationName(
+                layerChangedName,
+                object: "com.keypath.app",
+                userInfo: [
+                    "layer": layerName,
+                    "previous": previous,
+                ],
+                deliverImmediately: true
+            )
+        }
+    }
+
+    static func postServiceState(_ state: String) {
+        DistributedNotificationCenter.default().postNotificationName(
+            serviceStateChangedName,
+            object: "com.keypath.app",
+            userInfo: ["state": state],
+            deliverImmediately: true
+        )
+    }
+
+    static func stop() {
+        if let observer {
+            NotificationCenter.default.removeObserver(observer)
+        }
+        observer = nil
+    }
+}

--- a/Sources/KeyPathAppKit/Intents/GetCurrentLayerIntent.swift
+++ b/Sources/KeyPathAppKit/Intents/GetCurrentLayerIntent.swift
@@ -1,0 +1,14 @@
+import AppIntents
+import Foundation
+
+struct GetCurrentLayerIntent: AppIntent {
+    static let title: LocalizedStringResource = "Get Current Layer"
+    static let description = IntentDescription("Returns the currently active keyboard layer.")
+
+    func perform() async throws -> some IntentResult & ReturnsValue<String> {
+        let layer = await MainActor.run { DistributedNotificationBridge.currentLayer }
+        return .result(value: layer)
+    }
+
+    static let openAppWhenRun: Bool = false
+}

--- a/Sources/KeyPathAppKit/Intents/KeyPathShortcuts.swift
+++ b/Sources/KeyPathAppKit/Intents/KeyPathShortcuts.swift
@@ -1,0 +1,33 @@
+import AppIntents
+
+struct KeyPathShortcuts: AppShortcutsProvider {
+    static var appShortcuts: [AppShortcut] {
+        AppShortcut(
+            intent: GetCurrentLayerIntent(),
+            phrases: [
+                "What layer am I on in \(.applicationName)",
+                "Get current layer in \(.applicationName)",
+                "\(.applicationName) current layer",
+            ],
+            shortTitle: "Current Layer",
+            systemImageName: "keyboard"
+        )
+        AppShortcut(
+            intent: ServiceControlIntent(),
+            phrases: [
+                "\(\.$action) \(.applicationName)",
+                "\(\.$action) \(.applicationName) service",
+            ],
+            shortTitle: "Control Service",
+            systemImageName: "power"
+        )
+        AppShortcut(
+            intent: SendActionIntent(),
+            phrases: [
+                "Send action to \(.applicationName)",
+            ],
+            shortTitle: "Send Action",
+            systemImageName: "arrow.right.circle"
+        )
+    }
+}

--- a/Sources/KeyPathAppKit/Intents/LayerEntity.swift
+++ b/Sources/KeyPathAppKit/Intents/LayerEntity.swift
@@ -1,0 +1,31 @@
+import AppIntents
+import Foundation
+
+struct LayerEntity: AppEntity {
+    static let typeDisplayRepresentation = TypeDisplayRepresentation(name: "Layer")
+    static let defaultQuery = LayerEntityQuery()
+
+    var id: String
+    var name: String
+
+    var displayRepresentation: DisplayRepresentation {
+        DisplayRepresentation(title: "\(name)")
+    }
+}
+
+struct LayerEntityQuery: EntityQuery {
+    func entities(for identifiers: [String]) async throws -> [LayerEntity] {
+        let allLayers = try await fetchLayers()
+        return allLayers.filter { identifiers.contains($0.id) }
+    }
+
+    func suggestedEntities() async throws -> [LayerEntity] {
+        try await fetchLayers()
+    }
+
+    private func fetchLayers() async throws -> [LayerEntity] {
+        let facade = ConfigFacade()
+        let names = try await facade.tcpGetLayers()
+        return names.map { LayerEntity(id: $0, name: $0) }
+    }
+}

--- a/Sources/KeyPathAppKit/Intents/SendActionIntent.swift
+++ b/Sources/KeyPathAppKit/Intents/SendActionIntent.swift
@@ -1,0 +1,46 @@
+import AppIntents
+import Foundation
+
+struct SendActionIntent: AppIntent {
+    static let title: LocalizedStringResource = "Send KeyPath Action"
+    static let description = IntentDescription(
+        "Send an action to KeyPath (e.g., launch an app, show a notification, trigger a system action)."
+    )
+
+    @Parameter(title: "Action URI", description: "A keypath:// URI (e.g., keypath://launch/Obsidian)")
+    var uri: String
+
+    @MainActor
+    func perform() async throws -> some IntentResult {
+        let result = ActionDispatcher.shared.dispatch(message: uri)
+        switch result {
+        case .success:
+            return .result()
+        case let .unknownAction(action):
+            throw ActionError.unknownAction(action)
+        case let .missingTarget(action):
+            throw ActionError.missingTarget(action)
+        case let .failed(action, error):
+            throw ActionError.failed(action, error.localizedDescription)
+        }
+    }
+
+    static let openAppWhenRun: Bool = false
+
+    enum ActionError: Swift.Error, CustomLocalizedStringResourceConvertible {
+        case unknownAction(String)
+        case missingTarget(String)
+        case failed(String, String)
+
+        var localizedStringResource: LocalizedStringResource {
+            switch self {
+            case let .unknownAction(action):
+                "Unknown action: \(action)"
+            case let .missingTarget(action):
+                "Missing target for action: \(action)"
+            case let .failed(action, message):
+                "Action '\(action)' failed: \(message)"
+            }
+        }
+    }
+}

--- a/Sources/KeyPathAppKit/Intents/ServiceControlIntent.swift
+++ b/Sources/KeyPathAppKit/Intents/ServiceControlIntent.swift
@@ -1,0 +1,65 @@
+import AppIntents
+import AppKit
+import Foundation
+
+enum ServiceAction: String, AppEnum {
+    case start
+    case stop
+    case restart
+
+    static let typeDisplayRepresentation = TypeDisplayRepresentation(name: "Service Action")
+    static let caseDisplayRepresentations: [ServiceAction: DisplayRepresentation] = [
+        .start: "Start",
+        .stop: "Stop",
+        .restart: "Restart",
+    ]
+}
+
+struct ServiceControlIntent: AppIntent {
+    static let title: LocalizedStringResource = "Control KeyPath Service"
+    static let description = IntentDescription("Start, stop, or restart the KeyPath keyboard remapping service.")
+
+    @Parameter(title: "Action")
+    var action: ServiceAction
+
+    @MainActor
+    func perform() async throws -> some IntentResult & ReturnsValue<String> {
+        guard let delegate = NSApp?.delegate as? AppDelegate,
+              let manager = delegate.kanataManager
+        else {
+            throw ServiceError.appNotRunning
+        }
+
+        let success: Bool
+        switch action {
+        case .start:
+            success = await manager.startKanata(reason: "Siri / App Intent")
+        case .stop:
+            success = await manager.stopKanata(reason: "Siri / App Intent")
+        case .restart:
+            success = await manager.restartKanata(reason: "Siri / App Intent")
+        }
+
+        if success {
+            return .result(value: "KeyPath service \(action.rawValue) succeeded.")
+        } else {
+            throw ServiceError.operationFailed(action.rawValue)
+        }
+    }
+
+    static let openAppWhenRun: Bool = false
+
+    enum ServiceError: Swift.Error, CustomLocalizedStringResourceConvertible {
+        case appNotRunning
+        case operationFailed(String)
+
+        var localizedStringResource: LocalizedStringResource {
+            switch self {
+            case .appNotRunning:
+                "KeyPath is not running."
+            case let .operationFailed(action):
+                "Service \(action) failed."
+            }
+        }
+    }
+}

--- a/Sources/KeyPathAppKit/Managers/ServiceLifecycleCoordinator.swift
+++ b/Sources/KeyPathAppKit/Managers/ServiceLifecycleCoordinator.swift
@@ -120,6 +120,7 @@ final class ServiceLifecycleCoordinator {
             onError?(nil)
             onWarning?(nil)
             onStateChanged?()
+            DistributedNotificationBridge.postServiceState("running")
             return true
         } catch {
             let message = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
@@ -139,6 +140,7 @@ final class ServiceLifecycleCoordinator {
             _ = try await kanataDaemonService.stopIfRunning()
             onWarning?(nil)
             onStateChanged?()
+            DistributedNotificationBridge.postServiceState("stopped")
             return true
         } catch {
             let message = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription

--- a/Sources/KeyPathAppKit/Services/Networking/KanataTCPClient+Operations.swift
+++ b/Sources/KeyPathAppKit/Services/Networking/KanataTCPClient+Operations.swift
@@ -114,6 +114,20 @@ extension KanataTCPClient {
         }
     }
 
+    /// Request the current active layer name from Kanata
+    func requestCurrentLayerName() async throws -> String {
+        try await withErrorRecovery {
+            let requestData = try JSONEncoder().encode(["RequestCurrentLayerName": [:] as [String: String]])
+            let responseData = try await send(requestData)
+            if let response = try extractMessage(
+                named: "CurrentLayerName", into: TcpCurrentLayerName.self, from: responseData
+            ) {
+                return response.name
+            }
+            throw KeyPathError.communication(.invalidResponse)
+        }
+    }
+
     /// Request available layer names from Kanata
     func requestLayerNames() async throws -> [String] {
         try await withErrorRecovery {

--- a/Sources/KeyPathAppKit/Services/Networking/KanataTCPClient+Protocol.swift
+++ b/Sources/KeyPathAppKit/Services/Networking/KanataTCPClient+Protocol.swift
@@ -77,6 +77,10 @@ extension KanataTCPClient {
         let request_id: UInt64?
     }
 
+    struct TcpCurrentLayerName: Codable, Sendable {
+        let name: String
+    }
+
     struct TcpLayerNames: Codable, Sendable {
         let names: [String]
         let request_id: UInt64?

--- a/Sources/KeyPathCLI/Commands/Help/HelpExamplesCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Help/HelpExamplesCommand.swift
@@ -146,6 +146,10 @@ struct HelpExamples: AsyncParsableCommand {
             ]
         ),
         ExampleEntry(
+            description: "Check which layer is active",
+            commands: ["keypath layer current"]
+        ),
+        ExampleEntry(
             description: "Switch to a layer at runtime",
             commands: ["keypath layer switch nav"]
         ),

--- a/Sources/KeyPathCLI/Commands/Layer/LayerCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Layer/LayerCommand.swift
@@ -6,6 +6,7 @@ struct Layer: AsyncParsableCommand {
         abstract: "List or switch Kanata layers",
         subcommands: [
             LayerList.self,
+            LayerCurrent.self,
             LayerCreate.self,
             LayerDelete.self,
             LayerRename.self,

--- a/Sources/KeyPathCLI/Commands/Layer/LayerCurrentCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Layer/LayerCurrentCommand.swift
@@ -1,0 +1,30 @@
+import ArgumentParser
+import Foundation
+import KeyPathAppKit
+
+struct LayerCurrent: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "current",
+        abstract: "Show the currently active layer"
+    )
+
+    @OptionGroup var globals: GlobalOptions
+
+    mutating func run() async throws {
+        let ctx = globals.outputContext
+        let facade = ConfigFacade()
+
+        let layer: String
+        do {
+            layer = try await facade.tcpGetCurrentLayer()
+        } catch {
+            let cliError = CLIError.serviceUnreachable()
+            CLIOutput.writeError(cliError, context: ctx)
+            throw cliError.code.exitCode
+        }
+
+        CLIOutput.write(["layer": layer], context: ctx) {
+            layer
+        }
+    }
+}

--- a/Tests/KeyPathTests/CLI/CommandStructureTests.swift
+++ b/Tests/KeyPathTests/CLI/CommandStructureTests.swift
@@ -37,7 +37,7 @@ final class CommandStructureTests: XCTestCase {
 
     func testLayerHasExpectedVerbs() {
         let names = subcommandNames(of: Layer.self)
-        XCTAssertEqual(Set(names), ["list", "create", "delete", "rename", "switch"])
+        XCTAssertEqual(Set(names), ["list", "current", "create", "delete", "rename", "switch"])
     }
 
     func testPackHasExpectedVerbs() {

--- a/docs/APP_INTENTS.md
+++ b/docs/APP_INTENTS.md
@@ -1,0 +1,78 @@
+# App Intents (Siri & Shortcuts)
+
+KeyPath exposes its core functionality via the App Intents framework, making it available to Siri, Shortcuts, Spotlight, and Apple Intelligence.
+
+## Available Intents
+
+### Get Current Layer
+
+Returns the currently active keyboard layer as a string.
+
+**Siri:** "What layer am I on in KeyPath?"
+
+**Shortcuts:** Use the "Get Current Layer" action — returns a string you can use in conditions or display.
+
+### Control Service
+
+Start, stop, or restart the KeyPath keyboard remapping service.
+
+**Siri:** "Start KeyPath" / "Stop KeyPath" / "Restart KeyPath"
+
+**Shortcuts:** Use the "Control KeyPath Service" action and pick Start, Stop, or Restart.
+
+### Send Action
+
+Send any `keypath://` action URI. This exposes the full [Action URI System](ACTION_URI_SYSTEM.md) to Shortcuts.
+
+**Shortcuts:** Use the "Send KeyPath Action" action with a URI like `keypath://launch/Obsidian`.
+
+Examples:
+- `keypath://launch/Terminal` — launch an app
+- `keypath://system/mission-control` — trigger Mission Control
+- `keypath://window/left` — snap window to left half
+- `keypath://notify?title=Hello&body=World` — show a notification
+- `keypath://script/~/scripts/my-script.sh` — run a script
+
+## Shortcuts Recipes
+
+### Toggle keyboard service on schedule
+
+Create a Shortcut with a Time of Day automation:
+1. At 9 AM → "Control KeyPath Service" → Start
+2. At 6 PM → "Control KeyPath Service" → Stop
+
+### Layer-conditional automation
+
+Use "Get Current Layer" with an If action:
+1. Get Current Layer
+2. If result is "work" → open your work apps
+3. Otherwise → do nothing
+
+### Quick action from menu bar
+
+Add any KeyPath Shortcut to your menu bar for one-click access:
+1. Create a Shortcut with "Send KeyPath Action"
+2. Set the URI (e.g., `keypath://system/mission-control`)
+3. Pin the Shortcut to your menu bar
+
+## Layer Entity
+
+Layers are exposed as App Entities, which means Shortcuts can enumerate available layers dynamically. The layer list is fetched from the running Kanata instance via TCP — if the service is stopped, the query will fail gracefully.
+
+## Implementation
+
+App Intents are defined in `Sources/KeyPathAppKit/Intents/`:
+
+| File | Purpose |
+|------|---------|
+| `GetCurrentLayerIntent.swift` | Query the current active layer |
+| `ServiceControlIntent.swift` | Start/stop/restart the service |
+| `SendActionIntent.swift` | Dispatch any `keypath://` action URI |
+| `LayerEntity.swift` | App Entity for layers with dynamic query |
+| `KeyPathShortcuts.swift` | `AppShortcutsProvider` — registers Siri phrases |
+
+All intents delegate to existing infrastructure:
+- `DistributedNotificationBridge.currentLayer` for current layer state
+- `ActionDispatcher.shared` for action dispatch
+- `RuntimeCoordinator` (via `AppDelegate`) for service lifecycle
+- `ConfigFacade` for TCP layer queries

--- a/docs/DISTRIBUTED_NOTIFICATIONS.md
+++ b/docs/DISTRIBUTED_NOTIFICATIONS.md
@@ -71,9 +71,9 @@ tail -f ~/Library/Logs/KeyPath/keypath-debug.log | grep "Layer change"
 
 Keyboard Maestro can trigger macros from Distributed Notifications. Create a macro with the trigger "Distributed Notification Received" and set the notification name to `com.keypath.layerChanged`.
 
-### Shortcuts
+### Shortcuts / Siri / Apple Intelligence
 
-Shortcuts cannot directly listen for Distributed Notifications, but you can bridge them using a Hammerspoon callback that runs a Shortcut:
+KeyPath exposes [App Intents](APP_INTENTS.md) for direct Shortcuts and Siri integration — query the current layer, control the service, or send any action URI. For event-driven automation (reacting to layer changes), bridge via Hammerspoon:
 
 ```lua
 spoon.KeyPath:onLayerChange(function(layer)

--- a/docs/DISTRIBUTED_NOTIFICATIONS.md
+++ b/docs/DISTRIBUTED_NOTIFICATIONS.md
@@ -1,0 +1,98 @@
+# Distributed Notifications
+
+KeyPath broadcasts state changes via macOS Distributed Notifications (`NSDistributedNotificationCenter`), allowing any process on the system to react to keyboard events without sockets, polling, or configuration.
+
+## Why Distributed Notifications?
+
+| Transport | Pros | Cons |
+|-----------|------|------|
+| TCP socket | Cross-platform, structured | Requires port discovery, reconnection logic |
+| **Distributed Notifications** | **Zero-config, any process can listen** | macOS-only, fire-and-forget |
+| URL scheme | Works from everything | Inbound only (to KeyPath) |
+
+KeyPath uses Distributed Notifications for outbound events (KeyPath to the world) and the `keypath://` URL scheme for inbound commands (world to KeyPath). See [ACTION_URI_SYSTEM.md](ACTION_URI_SYSTEM.md) for the inbound side.
+
+## Events
+
+### `com.keypath.layerChanged`
+
+Posted when the active keyboard layer changes. Deduplicated — repeated notifications for the same layer are suppressed.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `layer` | String | The new active layer name (e.g., `"nav"`, `"base"`) |
+| `previous` | String | The layer that was active before this change |
+
+Sources: Kanata TCP `LayerChange` events and `push-msg` layer action URIs.
+
+### `com.keypath.serviceStateChanged`
+
+Posted when the Kanata service starts or stops successfully.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `state` | String | `"running"` or `"stopped"` |
+
+## Listening from Different Tools
+
+### Hammerspoon
+
+Use the [KeyPath.spoon](../Integrations/KeyPath.spoon/) for a clean API, or listen directly:
+
+```lua
+hs.distributednotifications.new(function(name, object, userInfo)
+    print("Layer: " .. userInfo.layer .. " (was " .. userInfo.previous .. ")")
+end, "com.keypath.layerChanged"):start()
+```
+
+### Swift
+
+```swift
+DistributedNotificationCenter.default().addObserver(
+    forName: NSNotification.Name("com.keypath.layerChanged"),
+    object: "com.keypath.app",
+    suspensionBehavior: .deliverImmediately
+) { notification in
+    let layer = notification.userInfo?["layer"] as? String
+    let previous = notification.userInfo?["previous"] as? String
+    print("Layer changed: \(previous ?? "?") -> \(layer ?? "?")")
+}
+```
+
+### Terminal (for debugging)
+
+The system does not include a built-in CLI listener, but you can observe notifications using Hammerspoon's console or by writing a small Swift script. To verify notifications are being posted, check the KeyPath debug log:
+
+```bash
+tail -f ~/Library/Logs/KeyPath/keypath-debug.log | grep "Layer change"
+```
+
+### Keyboard Maestro
+
+Keyboard Maestro can trigger macros from Distributed Notifications. Create a macro with the trigger "Distributed Notification Received" and set the notification name to `com.keypath.layerChanged`.
+
+### Shortcuts
+
+Shortcuts cannot directly listen for Distributed Notifications, but you can bridge them using a Hammerspoon callback that runs a Shortcut:
+
+```lua
+spoon.KeyPath:onLayerChange(function(layer)
+    if layer == "media" then
+        hs.shortcuts.run("My Media Shortcut")
+    end
+end)
+```
+
+## Implementation
+
+The bridge is implemented in `DistributedNotificationBridge.swift`. It observes the internal `NotificationCenter` event `.kanataLayerChanged` (which consolidates both TCP and push-msg sources) and rebroadcasts via `DistributedNotificationCenter`.
+
+Key details:
+- `deliverImmediately: true` — bypasses macOS notification coalescing so rapid hold-release layer switches are not missed
+- Previous layer is tracked internally and included in every notification
+- Duplicate layer names are suppressed (no notification if layer hasn't actually changed)
+- Started once during `applicationDidFinishLaunching` via `AppNotificationWiring`
+
+## Privacy
+
+Only layer names and service state are broadcast. Keystrokes, key input events, and HRM trace data are never sent over Distributed Notifications.

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -117,6 +117,34 @@ KeyPath communicates with Kanata via TCP (port 37001):
 - Layer state queries
 - Virtual key control
 
+## External Integration
+
+KeyPath exposes its state and actions to external tools through multiple transports:
+
+```
+                    ┌──────────────────────────────────────┐
+                    │         External Consumers           │
+                    │  Siri, Shortcuts, Hammerspoon, KM    │
+                    └───────┬──────────┬──────────┬────────┘
+                            │          │          │
+              ┌─────────────┘          │          └───────────────┐
+              ▼                        ▼                          ▼
+  ┌───────────────────┐  ┌───────────────────────┐  ┌────────────────────┐
+  │  App Intents      │  │  Distributed Notifs   │  │  keypath:// URLs   │
+  │  (query + action) │  │  (outbound events)    │  │  (inbound actions) │
+  │  Siri, Shortcuts  │  │  Hammerspoon, KM      │  │  Terminal, any app │
+  └───────────────────┘  └───────────────────────┘  └────────────────────┘
+```
+
+| Direction | Transport | Implementation |
+|-----------|-----------|----------------|
+| **Outbound events** | Distributed Notifications | `DistributedNotificationBridge` |
+| **Inbound commands** | `keypath://` URL scheme | `DeepLinkRouter` → `ActionDispatcher` |
+| **Query + action** | App Intents | `Intents/` — delegates to existing services |
+| **CLI** | `keypath` command | `ConfigFacade`, `SystemFacade` |
+
+See [DISTRIBUTED_NOTIFICATIONS.md](../DISTRIBUTED_NOTIFICATIONS.md), [APP_INTENTS.md](../APP_INTENTS.md), and [ACTION_URI_SYSTEM.md](../ACTION_URI_SYSTEM.md).
+
 ## Key Design Decisions
 
 ### No Config Parsing

--- a/guides/action-uri-reference.md
+++ b/guides/action-uri-reference.md
@@ -119,12 +119,22 @@ open "keypath://launch/Safari"
 
 Use an Alfred workflow "Open URL" action with `keypath://launch/{query}`.
 
-### Shortcuts.app
+### Shortcuts.app / Siri
 
-Add a "Run Shell Script" action:
+KeyPath has native Shortcuts integration — no shell scripts needed. Use the "Send KeyPath Action" action directly, or ask Siri to start/stop KeyPath or check your current layer. See the [Siri & Shortcuts guide]({{ '/guides/siri-and-shortcuts/' | relative_url }}).
+
+You can also use a "Run Shell Script" action:
 
 ```bash
 open "keypath://launch/Safari"
+```
+
+### Hammerspoon
+
+Use the [KeyPath.spoon]({{ '/guides/hammerspoon/' | relative_url }}) to react to layer changes and send actions:
+
+```lua
+spoon.KeyPath:sendAction("launch/Safari")
 ```
 
 ### Shell scripts
@@ -160,6 +170,8 @@ If an action fails (e.g., app not found), KeyPath logs the error but doesn't cra
 ## Related guides
 
 - **[Launching Apps]({{ '/guides/action-uri/' | relative_url }})** — Set up app launching through KeyPath's UI
+- **[Siri & Shortcuts]({{ '/guides/siri-and-shortcuts/' | relative_url }})** — Voice control and Shortcuts automations
+- **[Hammerspoon]({{ '/guides/hammerspoon/' | relative_url }})** — Layer-aware desktop automation
 - **[Windows & App Shortcuts]({{ '/guides/window-management/' | relative_url }})** — App-specific keymaps and window snapping
 - **[From Kanata]({{ '/migration/kanata-users/' | relative_url }})** — Using Action URIs in your Kanata config
 - **[Back to Docs](https://malpern.github.io/KeyPath/docs)** — See all available guides

--- a/guides/cli.md
+++ b/guides/cli.md
@@ -1,0 +1,250 @@
+---
+layout: default
+title: "Command Line"
+description: "Control KeyPath from Terminal with the keypath CLI"
+theme: parchment
+permalink: /guides/cli/
+---
+
+# Command Line
+
+KeyPath includes a CLI tool (`keypath`) for managing your keyboard from Terminal. Everything you can do in the app — remapping keys, managing layers, controlling the service — you can also do from the command line.
+
+Install it with Homebrew:
+
+```bash
+brew install keypath
+```
+
+Or use the CLI bundled with the app at `/Applications/KeyPath.app/Contents/MacOS/keypath-cli`.
+
+All commands support `--json` for machine-readable output, making them easy to use in scripts, Shortcuts, and automation tools.
+
+---
+
+## Quick reference
+
+### Service control
+
+```bash
+keypath status                    # System health check
+keypath start                     # Start the remapping service
+keypath stop                      # Stop the remapping service
+keypath restart                   # Restart the service
+keypath logs                      # Show recent service logs
+keypath service reload            # Hot-reload config without restart
+```
+
+### Layers
+
+```bash
+keypath layer list                # List all layers
+keypath layer current             # Show the active layer
+keypath layer switch nav          # Switch to a layer
+keypath layer create window       # Create a new layer
+keypath layer rename nav arrow    # Rename a layer
+keypath layer delete window       # Delete a layer and its rules
+```
+
+### Key remapping
+
+```bash
+keypath remap caps_lock esc       # Remap a key (shortcut)
+keypath unmap caps_lock           # Remove a mapping (shortcut)
+
+keypath rule add caps_lock esc                    # Add a rule
+keypath rule add --layer nav h left               # Layer-specific rule
+keypath rule add --type tap-hold caps_lock esc lctl  # Tap-hold rule
+keypath rule ensure caps_lock esc                 # Idempotent add
+keypath rule list                                 # List all rules
+keypath rule show caps_lock                       # Show a rule's details
+keypath rule enable caps_lock                     # Enable a rule
+keypath rule disable caps_lock                    # Disable a rule
+keypath rule remove caps_lock                     # Remove a rule
+```
+
+### Collections
+
+```bash
+keypath collection list           # List all rule collections
+keypath collection show "My Rules"  # Show collection details
+keypath collection create "Gaming"  # Create a new collection
+keypath collection enable "Gaming"  # Enable a collection
+keypath collection disable "Gaming" # Disable a collection
+keypath collection rename "Gaming" "FPS"  # Rename
+keypath collection reorder "Gaming" 0     # Move to top
+keypath collection duplicate "My Rules"   # Duplicate
+keypath collection delete "Gaming"        # Delete
+```
+
+### Packs
+
+```bash
+keypath pack list                 # List available packs
+keypath pack show vim-navigation  # Show pack details
+keypath pack install vim-navigation  # Install a pack
+keypath pack uninstall vim-navigation  # Uninstall
+keypath pack configure vim-navigation --set key=value  # Configure
+```
+
+### Configuration
+
+```bash
+keypath config show               # Print the generated .kbd config
+keypath config path               # Print the config file path
+keypath config check              # Validate config with kanata --check
+keypath config apply              # Regenerate config and reload
+```
+
+### Import / Export
+
+```bash
+keypath import karabiner ~/karabiner.json   # Import from Karabiner
+keypath import collection rules.json        # Import a collection
+keypath export all                          # Export all collections
+keypath export collection "My Rules"        # Export one collection
+```
+
+### System
+
+```bash
+keypath system inspect            # Inspect system state
+keypath system install            # Install services
+keypath system repair             # Fix broken services
+keypath system uninstall          # Remove everything
+```
+
+### Simulation
+
+```bash
+keypath simulate "caps h"         # Simulate a key sequence
+```
+
+---
+
+## JSON output
+
+Every command supports `--json` for machine-readable output:
+
+```bash
+keypath status --json
+keypath layer current --json
+keypath rule list --json
+keypath layer list --json
+```
+
+This makes the CLI a first-class integration point for scripts, Shortcuts, Hammerspoon, and any other automation tool.
+
+### Scripting examples
+
+Check if service is running:
+
+```bash
+if keypath status --json | jq -e '.kanataRunning' > /dev/null 2>&1; then
+    echo "KeyPath is running"
+fi
+```
+
+Get the current layer in a script:
+
+```bash
+LAYER=$(keypath layer current)
+echo "Active layer: $LAYER"
+```
+
+Conditional logic based on layer:
+
+```bash
+LAYER=$(keypath layer current)
+case "$LAYER" in
+    nav)    echo "Navigation mode" ;;
+    window) echo "Window management mode" ;;
+    base)   echo "Default mode" ;;
+esac
+```
+
+### AppleScript
+
+Use the CLI from AppleScript to query KeyPath state:
+
+```applescript
+-- Get the current layer
+set currentLayer to do shell script "/usr/local/bin/keypath layer current"
+
+-- Conditional logic based on layer
+if currentLayer is "nav" then
+    display notification "Navigation layer active" with title "KeyPath"
+end if
+
+-- Check if service is running
+try
+    do shell script "/usr/local/bin/keypath status --json"
+    -- service is reachable
+on error
+    -- service is down
+end try
+```
+
+Send actions to KeyPath from AppleScript:
+
+```applescript
+-- Launch an app through KeyPath
+do shell script "open 'keypath://launch/Obsidian'"
+
+-- Switch layers
+do shell script "/usr/local/bin/keypath layer switch nav"
+```
+
+### Hammerspoon
+
+Use the CLI alongside the [KeyPath.spoon]({{ '/guides/hammerspoon/' | relative_url }}):
+
+```lua
+-- Query current layer via CLI (synchronous)
+local layer = hs.execute("/usr/local/bin/keypath layer current"):gsub("%s+$", "")
+
+-- Get all layers as JSON
+local output = hs.execute("/usr/local/bin/keypath layer list --json")
+local layers = hs.json.decode(output)
+```
+
+For reactive layer-change events, use the Spoon's `onLayerChange` callback instead of polling the CLI.
+
+---
+
+## Shell completions
+
+Install tab completions for your shell:
+
+```bash
+keypath completions install        # Auto-detect shell
+keypath completions install-man    # Install man pages
+```
+
+Or generate completions manually:
+
+```bash
+keypath completions zsh > ~/.zsh/completions/_keypath
+keypath completions bash > /etc/bash_completion.d/keypath
+keypath completions fish > ~/.config/fish/completions/keypath.fish
+```
+
+---
+
+## Help
+
+```bash
+keypath --help                     # Top-level help
+keypath rule --help                # Help for a subcommand group
+keypath help-topics examples       # Curated workflow examples
+keypath help-topics examples rule  # Examples for a specific topic
+keypath help-topics schemas        # JSON schema discovery
+```
+
+---
+
+## Related guides
+
+- **[Siri & Shortcuts]({{ '/guides/siri-and-shortcuts/' | relative_url }})** — Voice control and Shortcuts automations
+- **[Hammerspoon]({{ '/guides/hammerspoon/' | relative_url }})** — Layer-aware desktop automation
+- **[Action URI Reference]({{ '/guides/action-uri-reference/' | relative_url }})** — Deep link reference for `keypath://` URIs

--- a/guides/hammerspoon.md
+++ b/guides/hammerspoon.md
@@ -1,0 +1,134 @@
+---
+layout: default
+title: "Hammerspoon Integration"
+description: "React to KeyPath layer changes in Hammerspoon for layer-aware desktop automation"
+theme: parchment
+permalink: /guides/hammerspoon/
+---
+
+# Hammerspoon Integration
+
+[Hammerspoon](https://www.hammerspoon.org/) is a macOS automation tool that uses Lua scripting. KeyPath ships a Hammerspoon Spoon that lets your scripts react to keyboard layer changes — show an overlay when you enter a window management layer, switch audio devices on a media layer, or anything else Hammerspoon can do.
+
+---
+
+## Install
+
+Copy the Spoon to your Hammerspoon directory:
+
+```bash
+cp -r /Applications/KeyPath.app/../Integrations/KeyPath.spoon ~/.hammerspoon/Spoons/
+```
+
+Or if you have the KeyPath source:
+
+```bash
+ln -s /path/to/KeyPath/Integrations/KeyPath.spoon ~/.hammerspoon/Spoons/KeyPath.spoon
+```
+
+Reload Hammerspoon after installing.
+
+---
+
+## Quick start
+
+Add to your `~/.hammerspoon/init.lua`:
+
+```lua
+hs.loadSpoon("KeyPath")
+
+spoon.KeyPath:onLayerChange(function(layer, previous)
+    print("Layer: " .. layer .. " (was " .. previous .. ")")
+end):start()
+```
+
+Every time you switch layers in KeyPath, your callback fires.
+
+---
+
+## What you can do
+
+### Show a notification on layer change
+
+```lua
+spoon.KeyPath:onLayerChange(function(layer, previous)
+    if layer ~= "base" then
+        hs.notify.show("KeyPath", "", "Layer: " .. layer)
+    end
+end)
+```
+
+### Window grid on your window layer
+
+```lua
+spoon.KeyPath:onLayerChange(function(layer)
+    if layer == "window" then
+        hs.grid.show()
+    end
+end)
+```
+
+### React to service start/stop
+
+```lua
+spoon.KeyPath:onServiceState(function(state)
+    hs.notify.show("KeyPath", "", "Service " .. state)
+end)
+```
+
+### Send actions back to KeyPath
+
+The Spoon can also send actions to KeyPath:
+
+```lua
+-- Launch an app through KeyPath
+spoon.KeyPath:sendAction("launch/Obsidian")
+
+-- Trigger Mission Control
+spoon.KeyPath:sendAction("system/mission-control")
+```
+
+### Check current state
+
+```lua
+-- These update automatically as events arrive
+print(spoon.KeyPath.currentLayer)   -- "nav", "base", etc.
+print(spoon.KeyPath.serviceState)   -- "running" or "stopped"
+```
+
+---
+
+## API reference
+
+| Method | Description |
+|--------|-------------|
+| `:onLayerChange(fn)` | Register callback `fn(layer, previous)` for layer changes |
+| `:onServiceState(fn)` | Register callback `fn(state)` for service start/stop |
+| `:start()` | Start listening for KeyPath events |
+| `:stop()` | Stop listening |
+| `:sendAction(uri)` | Send a `keypath://` action URI to KeyPath |
+| `.currentLayer` | Most recent layer name (nil until first event) |
+| `.serviceState` | Most recent service state (nil until first event) |
+
+All registration methods return `self` for chaining.
+
+---
+
+## How it works
+
+KeyPath broadcasts layer changes and service state via macOS Distributed Notifications. The Spoon subscribes using `hs.distributednotifications`. No network connections, no polling, no configuration — if KeyPath is running, events flow automatically.
+
+You can also listen directly without the Spoon:
+
+```lua
+hs.distributednotifications.new(function(name, object, userInfo)
+    print("Layer: " .. userInfo.layer)
+end, "com.keypath.layerChanged"):start()
+```
+
+---
+
+## Requirements
+
+- [Hammerspoon](https://www.hammerspoon.org/) 0.9.93 or later
+- KeyPath with distributed notification support

--- a/guides/siri-and-shortcuts.md
+++ b/guides/siri-and-shortcuts.md
@@ -1,0 +1,84 @@
+---
+layout: default
+title: "Siri & Shortcuts"
+description: "Control KeyPath with your voice or automate it with Shortcuts"
+theme: parchment
+permalink: /guides/siri-and-shortcuts/
+---
+
+# Siri & Shortcuts
+
+KeyPath works with Siri and the Shortcuts app. Ask what layer you're on, start or stop the service, or trigger any KeyPath action — by voice or as part of an automation.
+
+---
+
+## What you can do with Siri
+
+### "What layer am I on?"
+
+Ask Siri which keyboard layer is active right now.
+
+> "Hey Siri, what layer am I on in KeyPath?"
+
+Siri responds with the layer name (e.g., "base", "nav", "window").
+
+### Start, stop, or restart
+
+Control the KeyPath remapping service without opening the app.
+
+> "Hey Siri, start KeyPath"
+> "Hey Siri, stop KeyPath"
+> "Hey Siri, restart KeyPath"
+
+### Send an action
+
+Trigger any [KeyPath action]({{ '/guides/action-uri-reference/' | relative_url }}) through Siri.
+
+> "Hey Siri, send action to KeyPath"
+
+Siri will ask for the action URI (e.g., `keypath://launch/Obsidian`).
+
+---
+
+## Shortcuts app
+
+KeyPath actions appear in the Shortcuts app under "KeyPath" in the action picker. You can combine them with any other Shortcut action.
+
+### Get Current Layer
+
+Returns the active layer as text. Use this with an "If" action to build layer-conditional automations:
+
+1. Add "Get Current Layer" (KeyPath)
+2. Add "If" — set condition to "is" and type the layer name
+3. Add whatever actions you want inside the If block
+
+**Example:** If the current layer is "work", open your work apps.
+
+### Control Service
+
+Start, stop, or restart the remapping service. Useful for scheduled automations:
+
+1. Add "Control KeyPath Service" (KeyPath)
+2. Choose Start, Stop, or Restart
+
+**Example:** Create a Time of Day automation to stop KeyPath at 6 PM and start it at 9 AM.
+
+### Send Action
+
+Dispatch any `keypath://` action URI. This gives Shortcuts access to everything KeyPath can do:
+
+- `keypath://launch/Terminal` — launch an app
+- `keypath://system/mission-control` — trigger Mission Control
+- `keypath://window/left` — snap window to left half
+- `keypath://notify?title=Done&body=Build complete` — show a notification
+
+See the [Action URI Reference]({{ '/guides/action-uri-reference/' | relative_url }}) for the full list.
+
+---
+
+## Tips
+
+- KeyPath must be running for Siri and Shortcuts to work. The "Get Current Layer" and "Control Service" actions connect to the running app.
+- The layer list is dynamic — it comes from your active Kanata configuration. If you add a new layer, it shows up in Shortcuts automatically.
+- You can pin KeyPath Shortcuts to your menu bar for one-click access.
+- Shortcuts automations can run KeyPath actions on a schedule, when you connect to a Wi-Fi network, when you open an app, and more.


### PR DESCRIPTION
## Summary

- **Distributed Notifications**: `DistributedNotificationBridge` broadcasts `com.keypath.layerChanged` and `com.keypath.serviceStateChanged` via `NSDistributedNotificationCenter`, enabling Hammerspoon, Keyboard Maestro, and any macOS process to react to KeyPath state
- **App Intents**: Get Current Layer, Control Service, Send Action intents with Siri phrase registration — positions KeyPath for Shortcuts and Apple Intelligence
- **KeyPath.spoon**: Hammerspoon Spoon with `onLayerChange`/`onServiceState` callbacks and `sendAction` helper
- **`keypath layer current`**: New CLI command to query the active layer via TCP
- **User guides**: `guides/cli.md`, `guides/siri-and-shortcuts.md`, `guides/hammerspoon.md`
- **Developer docs**: `docs/DISTRIBUTED_NOTIFICATIONS.md`, `docs/APP_INTENTS.md`, updated architecture overview

## Test plan

- [x] `swift build` passes
- [x] All 532 tests pass
- [x] No new warnings