### PR TITLE
fix: address PR #558 code review feedback

### DIFF
--- a/Integrations/KeyPath.spoon/init.lua
+++ b/Integrations/KeyPath.spoon/init.lua
@@ -78,7 +78,7 @@ function obj:start()
         function(name, object, userInfo)
             if not userInfo then return end
             local layer = userInfo.layer
-            local previous = userInfo.previous
+            local previous = userInfo.previous or ""
             if not layer then return end
 
             self.currentLayer = layer

--- a/Sources/KeyPathAppKit/App.swift
+++ b/Sources/KeyPathAppKit/App.swift
@@ -272,6 +272,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         AppLogger.shared.info(
             "🚪 [AppDelegate] Application will terminate - performing synchronous cleanup"
         )
+        DistributedNotificationBridge.postServiceState("stopped")
+        DistributedNotificationBridge.stop()
         kanataManager?.cleanupSync()
         AppLogger.shared.info("✅ [AppDelegate] Cleanup complete, app terminating")
     }

--- a/Sources/KeyPathAppKit/Core/DistributedNotificationBridge.swift
+++ b/Sources/KeyPathAppKit/Core/DistributedNotificationBridge.swift
@@ -21,7 +21,7 @@ enum DistributedNotificationBridge {
             queue: .main
         ) { notification in
             guard let layerName = notification.userInfo?["layerName"] as? String else { return }
-            guard layerName.lowercased() != previousLayer.lowercased() else { return }
+            guard layerName != previousLayer else { return }
 
             let previous = previousLayer
             previousLayer = layerName

--- a/Sources/KeyPathAppKit/Intents/GetCurrentLayerIntent.swift
+++ b/Sources/KeyPathAppKit/Intents/GetCurrentLayerIntent.swift
@@ -6,7 +6,8 @@ struct GetCurrentLayerIntent: AppIntent {
     static let description = IntentDescription("Returns the currently active keyboard layer.")
 
     func perform() async throws -> some IntentResult & ReturnsValue<String> {
-        let layer = await MainActor.run { DistributedNotificationBridge.currentLayer }
+        let facade = ConfigFacade()
+        let layer = try await facade.tcpGetCurrentLayer()
         return .result(value: layer)
     }
 

--- a/Sources/KeyPathAppKit/Intents/LayerEntity.swift
+++ b/Sources/KeyPathAppKit/Intents/LayerEntity.swift
@@ -15,12 +15,12 @@ struct LayerEntity: AppEntity {
 
 struct LayerEntityQuery: EntityQuery {
     func entities(for identifiers: [String]) async throws -> [LayerEntity] {
-        let allLayers = try await fetchLayers()
+        let allLayers = (try? await fetchLayers()) ?? []
         return allLayers.filter { identifiers.contains($0.id) }
     }
 
     func suggestedEntities() async throws -> [LayerEntity] {
-        try await fetchLayers()
+        (try? await fetchLayers()) ?? []
     }
 
     private func fetchLayers() async throws -> [LayerEntity] {

--- a/Sources/KeyPathAppKit/Intents/SendActionIntent.swift
+++ b/Sources/KeyPathAppKit/Intents/SendActionIntent.swift
@@ -7,12 +7,16 @@ struct SendActionIntent: AppIntent {
         "Send an action to KeyPath (e.g., launch an app, show a notification, trigger a system action)."
     )
 
-    @Parameter(title: "Action URI", description: "A keypath:// URI (e.g., keypath://launch/Obsidian)")
+    @Parameter(title: "Action URI", description: "A keypath:// URI or shorthand (e.g., keypath://launch/Obsidian or launch:obsidian)")
     var uri: String
 
     @MainActor
     func perform() async throws -> some IntentResult {
-        let result = ActionDispatcher.shared.dispatch(message: uri)
+        var normalized = uri
+        if !normalized.contains("://"), !normalized.contains(":") {
+            normalized = "keypath://\(normalized)"
+        }
+        let result = ActionDispatcher.shared.dispatch(message: normalized)
         switch result {
         case .success:
             return .result()

--- a/Sources/KeyPathAppKit/Intents/ServiceControlIntent.swift
+++ b/Sources/KeyPathAppKit/Intents/ServiceControlIntent.swift
@@ -22,9 +22,12 @@ struct ServiceControlIntent: AppIntent {
     @Parameter(title: "Action")
     var action: ServiceAction
 
+    // RuntimeCoordinator.startKanata/stopKanata/restartKanata delegate
+    // to ServiceLifecycleCoordinator internally — the CLAUDE.md anti-pattern
+    // is about calling launchctl or KanataDaemonManager directly.
     @MainActor
     func perform() async throws -> some IntentResult & ReturnsValue<String> {
-        guard let delegate = NSApp?.delegate as? AppDelegate,
+        guard let delegate = NSApp.delegate as? AppDelegate,
               let manager = delegate.kanataManager
         else {
             throw ServiceError.appNotRunning

--- a/guides/hammerspoon.md
+++ b/guides/hammerspoon.md
@@ -14,16 +14,16 @@ permalink: /guides/hammerspoon/
 
 ## Install
 
-Copy the Spoon to your Hammerspoon directory:
-
-```bash
-cp -r /Applications/KeyPath.app/../Integrations/KeyPath.spoon ~/.hammerspoon/Spoons/
-```
-
-Or if you have the KeyPath source:
+If you have the KeyPath source checkout, symlink the Spoon:
 
 ```bash
 ln -s /path/to/KeyPath/Integrations/KeyPath.spoon ~/.hammerspoon/Spoons/KeyPath.spoon
+```
+
+Or copy it directly:
+
+```bash
+cp -r /path/to/KeyPath/Integrations/KeyPath.spoon ~/.hammerspoon/Spoons/
 ```
 
 Reload Hammerspoon after installing.


### PR DESCRIPTION
## Summary

Addresses all must-fix and should-fix items from the three code reviews on PR #558.

- **GetCurrentLayerIntent**: live TCP query via `ConfigFacade.tcpGetCurrentLayer()` instead of stale cache
- **ServiceControlIntent**: confirmed `RuntimeCoordinator` delegates to `ServiceLifecycleCoordinator`; added clarifying comment; fixed `NSApp?.delegate` → `NSApp.delegate`
- **SendActionIntent**: auto-prefix `keypath://` for bare paths (consistent with Lua Spoon)
- **LayerEntityQuery**: returns `[]` instead of throwing when service is stopped
- **DistributedNotificationBridge**: wired `stop()` to `applicationWillTerminate` with final "stopped" notification; switched to case-sensitive layer comparison
- **Hammerspoon guide**: fixed install path that resolved to non-existent `/Applications/Integrations/`
- **Lua Spoon**: nil guard on `previous` in layer callback

## Test plan

- [x] `swift build` passes
- [x] All 532 tests pass