### PR TITLE
Launcher overlay: Right Shift target, mapping display fix, click-to-edit

### DIFF
--- a/Sources/KeyPathAppKit/Models/RuleCollectionConfiguration.swift
+++ b/Sources/KeyPathAppKit/Models/RuleCollectionConfiguration.swift
@@ -646,7 +646,8 @@ public struct LauncherGridConfig: Codable, Equatable, Sendable {
     public static let allowedKeyOrder: [String] = suggestionKeyOrder + manualOnlyKeys
 
     private static let manualOnlyKeys: [String] = [
-        "enter", "tab", "space", "backspace"
+        "enter", "tab", "space", "backspace",
+        "rightshift"
     ]
 
     private static let allowedKeySet = Set(allowedKeyOrder)

--- a/Sources/KeyPathAppKit/UI/ContextHUD/ContextHUDViewModel.swift
+++ b/Sources/KeyPathAppKit/UI/ContextHUD/ContextHUDViewModel.swift
@@ -304,6 +304,11 @@ final class ContextHUDViewModel {
         "EQUAL": "=",
         "MINUS": "-",
         "GRAVE": "`",
+        "ENTER": "↩",
+        "TAB": "⇥",
+        "SPACE": "␣",
+        "BACKSPACE": "⌫",
+        "RIGHTSHIFT": "⇧R",
     ]
 
     /// VIM keycap overrides — show vim motion instead of physical key

--- a/Sources/KeyPathAppKit/UI/Gallery/PackDetailWindowController.swift
+++ b/Sources/KeyPathAppKit/UI/Gallery/PackDetailWindowController.swift
@@ -8,7 +8,7 @@ final class PackDetailWindowController: NSObject {
 
     private var window: NSWindow?
     private var willCloseObserver: NSObjectProtocol?
-    private var currentPackID: String?
+    private(set) var currentPackID: String?
     private(set) var openedFromOverlay = false
 
     func showWindow(pack: Pack, kanataManager: KanataViewModel, fromOverlay: Bool = false) {

--- a/Sources/KeyPathAppKit/UI/Overlay/LiveKeyboardOverlayController+KeyClickHandling.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/LiveKeyboardOverlayController+KeyClickHandling.swift
@@ -43,9 +43,10 @@ extension LiveKeyboardOverlayController {
                 return
             }
 
-            // When inspector is open, clicking a launcher key opens the editor
+            // When inspector or Pack Detail window is open, clicking a launcher key opens the editor
             let inspectorOpen = uiState.isInspectorOpen || uiState.inspectorReveal > 0
-            if inspectorOpen {
+            let packDetailOpen = PackDetailWindowController.shared.currentPackID == PackRegistry.launcher.id
+            if inspectorOpen || packDetailOpen {
                 AppLogger.shared.log("🖱️ [OverlayController] Launcher key clicked for editing: \(normalizedKey)")
                 NotificationCenter.default.post(
                     name: .launcherSelectKey,

--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayKeyboardView.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayKeyboardView.swift
@@ -444,8 +444,11 @@ struct OverlayKeyboardView: View {
             includeExtraKeys: includeKeymapPunctuation
         )
 
-        // Look up launcher mapping for this key (lowercase key name)
-        let launcherMapping = launcherMappings[baseLabel.lowercased()]
+        // Look up launcher mapping for this key by kanata name first (handles special keys
+        // like enter/rightshift whose display labels differ from their mapping keys),
+        // then fall back to display label for standard letter/number/punctuation keys
+        let kanataName = OverlayKeyboardView.keyCodeToKanataName(key.keyCode).lowercased()
+        let launcherMapping = launcherMappings[kanataName] ?? launcherMappings[baseLabel.lowercased()]
 
         // Look up per-key shift label from system keymap when active
         let shiftOverride: String? = if keymap.id == LogicalKeymap.systemId {

--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView+ContentAndStyling.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView+ContentAndStyling.swift
@@ -280,7 +280,8 @@ extension OverlayKeycapView {
     // MARK: - Launcher Mode Exclusions
 
     var preservesBaseInLauncher: Bool {
-        switch key.keyCode {
+        if launcherMapping != nil { return false }
+        return switch key.keyCode {
         case 36, 48, 49, 51, 53: true // Return, Tab, Space, Delete, Esc
         case 54, 55, 56, 58, 59, 60, 61, 63: true // Modifiers: Cmd, Shift, Opt, Ctrl, Fn
         case 123, 124, 125, 126: true // Arrow keys

--- a/Sources/KeyPathAppKit/UI/Rules/LauncherKeymapTranslator.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/LauncherKeymapTranslator.swift
@@ -60,7 +60,9 @@ private extension LauncherKeymapTranslator {
         // Brackets and backslash
         33, 30, 42,
         // Special keys (manually assignable)
-        36, 48, 49, 51
+        36, 48, 49, 51,
+        // Modifier keys (manually assignable)
+        60
     ]
 
     static let canonicalFallbackLabel: [String: String] = [
@@ -78,6 +80,7 @@ private extension LauncherKeymapTranslator {
         "enter": "↩",
         "tab": "⇥",
         "space": "␣",
-        "backspace": "⌫"
+        "backspace": "⌫",
+        "rightshift": "⇧R"
     ]
 }


### PR DESCRIPTION
## Summary
- **Right Shift as launcher target**: Can now be clicked and assigned in the launcher keyboard config
- **Fix mapped key display**: Overlay and HUD side panel now correctly show launcher mappings for Return, Tab, Space, Backspace, and Right Shift (was looking up by display label instead of kanata name)
- **Overlay click-to-edit**: Clicking keys on the overlay while Pack Detail window is open opens the launcher mapping editor
- **Smart base-label preserve**: Utility keys keep normal appearance in launcher mode only when unmapped — mapped ones show their app icon

## Test plan
- [x] `swift test` — 532 tests pass
- [x] `swift build` compiles clean
- [ ] Assign Return/Right Shift to apps in launcher config, verify icons show in overlay
- [ ] Verify HUD side panel shows ↩ and ⇧R for those mappings
- [ ] Open Pack Detail, click mapped key on overlay → edit dialog opens
- [ ] Click unmapped key on overlay → new mapping dialog opens