### PR TITLE
feat: custom hero view for Home Row Arrows pack

### DIFF
--- a/Sources/KeyPathAppKit/UI/Gallery/HomeRowArrowsView.swift
+++ b/Sources/KeyPathAppKit/UI/Gallery/HomeRowArrowsView.swift
@@ -1,0 +1,135 @@
+import SwiftUI
+
+struct HomeRowArrowsView: View {
+    let config: LayerPresetPickerConfig
+    let onSelectPreset: (String) -> Void
+
+    private var selectedPresetId: String {
+        config.selectedPresetId ?? "inverted-t"
+    }
+
+    private var isVim: Bool {
+        selectedPresetId == "vim"
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            hero
+            presetCards
+        }
+        .animation(.easeInOut(duration: 0.2), value: selectedPresetId)
+    }
+
+    // MARK: - Hero
+
+    private var hero: some View {
+        HStack(spacing: 20) {
+            keycapCluster
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text(heroHeadline)
+                    .font(.body.weight(.medium))
+                    .lineSpacing(2)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .contentTransition(.numericText())
+
+                Text(heroSubhead)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .lineSpacing(2)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .padding(16)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .fill(Color.accentColor.opacity(0.06))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .stroke(Color.accentColor.opacity(0.15), lineWidth: 1)
+        )
+    }
+
+    @ViewBuilder
+    private var keycapCluster: some View {
+        if isVim {
+            HStack(spacing: 3) {
+                keycap("←", label: "H")
+                keycap("↓", label: "J")
+                keycap("↑", label: "K")
+                keycap("→", label: "L")
+            }
+        } else {
+            VStack(spacing: 3) {
+                keycap("↑", label: "I")
+                HStack(spacing: 3) {
+                    keycap("←", label: "J")
+                    keycap("↓", label: "K")
+                    keycap("→", label: "L")
+                }
+            }
+        }
+    }
+
+    private var heroHeadline: String {
+        if isVim {
+            "Hold F for Vim-style\nHJKL arrow keys."
+        } else {
+            "Hold F for arrow keys\nright under your fingers."
+        }
+    }
+
+    private var heroSubhead: String {
+        if isVim {
+            "Classic Vim navigation.\nTap F normally to type."
+        } else {
+            "Matches your arrow key layout.\nTap F normally to type."
+        }
+    }
+
+    private func keycap(_ arrow: String, label: String) -> some View {
+        VStack(spacing: 1) {
+            Text(arrow)
+                .font(.caption.weight(.semibold))
+            Text(label)
+                .font(.system(size: 9, weight: .medium))
+                .foregroundStyle(.secondary)
+        }
+        .frame(width: 42, height: 38)
+        .background(
+            RoundedRectangle(cornerRadius: 7, style: .continuous)
+                .fill(Color.accentColor.opacity(0.1))
+                .shadow(color: Color.accentColor.opacity(0.1), radius: 2, y: 1)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 7, style: .continuous)
+                .stroke(Color.accentColor.opacity(0.25), lineWidth: 1)
+        )
+        .foregroundStyle(Color.accentColor)
+    }
+
+    // MARK: - Preset Cards
+
+    private var presetCards: some View {
+        HStack(spacing: 8) {
+            SettingsOptionCard(
+                icon: "arrow.up.and.down.and.arrow.left.and.right",
+                title: "Inverted-T",
+                subtitle: "Arrow key layout",
+                isSelected: !isVim
+            ) {
+                onSelectPreset("inverted-t")
+            }
+            SettingsOptionCard(
+                icon: "chevron.left.forwardslash.chevron.right",
+                title: "Vim-Style",
+                subtitle: "HJKL layout",
+                isSelected: isVim
+            ) {
+                onSelectPreset("vim")
+            }
+        }
+    }
+}

--- a/Sources/KeyPathAppKit/UI/Gallery/PackDetailView+BindingRows.swift
+++ b/Sources/KeyPathAppKit/UI/Gallery/PackDetailView+BindingRows.swift
@@ -107,6 +107,19 @@ extension PackDetailView {
                 )
                 .id(autoShiftCollection.id)
             }
+        } else if let homeRowArrowsCollection = associatedHomeRowArrowsCollection {
+            if case let .layerPresetPicker(arrowsConfig) = homeRowArrowsCollection.configuration {
+                embeddedEditor {
+                    HomeRowArrowsView(
+                        config: arrowsConfig,
+                        onSelectPreset: { presetId in
+                            selectedLayerPresetId = presetId
+                            Task { await applyLayerPresetEdit(presetId: presetId, collectionID: homeRowArrowsCollection.id) }
+                        }
+                    )
+                    .id(selectedLayerPresetId ?? "inverted-t")
+                }
+            }
         } else if let layerPresetCollection = associatedLayerPresetCollection {
             // Layer preset picker — Symbol/Fun layers. Users choose a preset
             // (e.g. Mirrored, Alphabetical) that redefines the layer's

--- a/Sources/KeyPathAppKit/UI/Gallery/PackDetailView.swift
+++ b/Sources/KeyPathAppKit/UI/Gallery/PackDetailView.swift
@@ -422,10 +422,20 @@ struct PackDetailView: View {
         return collection
     }
 
+    /// Collection backing the Home Row Arrows pack specifically.
+    var associatedHomeRowArrowsCollection: RuleCollection? {
+        guard let collection = liveAssociatedCollection,
+              collection.id == RuleCollectionIdentifier.homeRowArrows,
+              case .layerPresetPicker = collection.configuration
+        else { return nil }
+        return collection
+    }
+
     /// Collection backing a layer-preset pack (Symbol, Fun). Matches the
     /// `.layerPresetPicker` configuration case.
     var associatedLayerPresetCollection: RuleCollection? {
         guard let collection = liveAssociatedCollection,
+              collection.id != RuleCollectionIdentifier.homeRowArrows,
               case .layerPresetPicker = collection.configuration
         else { return nil }
         return collection


### PR DESCRIPTION
## Summary

Replace the default dual-keyboard `LayerPresetPicker` for Home Row Arrows with a focused hero view matching the Fast Navigation pattern:

- Arrow keycap visualization (inverted-T or horizontal HJKL depending on selected preset)
- Headline + subtitle text in a rounded accent card
- Two clean `SettingsOptionCard` preset cards (Inverted-T / Vim-Style)

Before: full keyboard comparison with "Physical Position → Becomes" dual layout
After: focused hero + preset cards (same pattern as Fast Navigation)

## Test plan

- [x] `swift build` passes
- [x] All 532 tests pass
- [ ] Visual: open Pack Gallery → Home Row Arrows, verify hero renders
- [ ] Visual: toggle between Inverted-T and Vim-Style, verify hero updates