### PR TITLE
fix: optimistic UI for Home Row Arrows preset picker

### DIFF
--- a/Sources/KeyPathAppKit/UI/Gallery/HomeRowArrowsView.swift
+++ b/Sources/KeyPathAppKit/UI/Gallery/HomeRowArrowsView.swift
@@ -4,8 +4,12 @@ struct HomeRowArrowsView: View {
     let config: LayerPresetPickerConfig
     let onSelectPreset: (String) -> Void
 
-    private var selectedPresetId: String {
-        config.selectedPresetId ?? "inverted-t"
+    @State private var selectedPresetId: String
+
+    init(config: LayerPresetPickerConfig, onSelectPreset: @escaping (String) -> Void) {
+        self.config = config
+        self.onSelectPreset = onSelectPreset
+        _selectedPresetId = State(initialValue: config.selectedPresetId ?? "inverted-t")
     }
 
     private var isVim: Bool {
@@ -120,6 +124,7 @@ struct HomeRowArrowsView: View {
                 subtitle: "Arrow key layout",
                 isSelected: !isVim
             ) {
+                selectedPresetId = "inverted-t"
                 onSelectPreset("inverted-t")
             }
             SettingsOptionCard(
@@ -128,6 +133,7 @@ struct HomeRowArrowsView: View {
                 subtitle: "HJKL layout",
                 isSelected: isVim
             ) {
+                selectedPresetId = "vim"
                 onSelectPreset("vim")
             }
         }

--- a/Sources/KeyPathAppKit/UI/Gallery/PackDetailView+BindingRows.swift
+++ b/Sources/KeyPathAppKit/UI/Gallery/PackDetailView+BindingRows.swift
@@ -117,7 +117,6 @@ extension PackDetailView {
                             Task { await applyLayerPresetEdit(presetId: presetId, collectionID: homeRowArrowsCollection.id) }
                         }
                     )
-                    .id(selectedLayerPresetId ?? "inverted-t")
                 }
             }
         } else if let layerPresetCollection = associatedLayerPresetCollection {


### PR DESCRIPTION
## Summary

Preset switching (Inverted-T ↔ Vim-Style) now updates instantly. Local `@State` drives the hero visualization and card selection on tap. The async config save runs in the background.

## Test plan

- [x] `swift build` passes
- [x] All 532 tests pass
- [ ] Visual: tap between Inverted-T and Vim-Style — hero keycaps and text should animate immediately