### PR TITLE
feat: inline overlay style for Home Row Arrows

### DIFF
--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView+VisualStyling.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView+VisualStyling.swift
@@ -160,6 +160,10 @@ extension OverlayKeycapView {
         // Layer mode: dark gray for unmapped keys (same as launcher)
         else if isLayerMode {
             KeyPathColors.keycapDark
+        }
+        // Inline layer: mapped keys get accent highlight, unmapped keys stay normal
+        else if isInlineLayer, hasLayerMapping {
+            collectionColor(for: layerKeyInfo?.collectionId)
         } else if isModifierKey {
             colorway.modBaseColor
         } else if isAccentKey {

--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView.swift
@@ -80,8 +80,17 @@ struct OverlayKeycapView: View {
 
     /// Whether we're in a non-base layer (e.g., nav, vim) but not launcher mode
     var isLayerMode: Bool {
-        !isLauncherMode && currentLayerName.lowercased() != "base" && currentLayerName.lowercased() != "Base"
+        !isLauncherMode && !isInlineLayer && currentLayerName.lowercased() != "base"
     }
+
+    /// "Inline" layers render like the base layer — unmapped keys keep their
+    /// normal appearance, mapped keys swap in their action. Use for simple
+    /// layers where most of the keyboard stays the same (e.g., Home Row Arrows).
+    var isInlineLayer: Bool {
+        Self.inlineLayerNames.contains(currentLayerName.lowercased())
+    }
+
+    static let inlineLayerNames: Set<String> = ["home-arrows"]
 
     /// Whether this key has a meaningful layer mapping (not transparent/identity)
     var hasLayerMapping: Bool {


### PR DESCRIPTION
## Summary

New "inline" overlay rendering style. Inline layers look like the base layer — unmapped keys keep their normal appearance, mapped keys swap in their action with a collection-color highlight. No nav-mode dimming.

Named concept: `isInlineLayer` / `inlineLayerNames` — other simple layers can opt in.

Before: Home Row Arrows showed full nav-mode styling (all keys dimmed, small labels)
After: Base layer appearance with only IJKL/H;UO highlighted and relabeled

## Test plan

- [x] `swift build` passes
- [x] All 532 tests pass
- [ ] Visual: hold F — keyboard should look like base layer with arrow keys highlighted