### PR TITLE
fix: inline layer shows floating labels + subtle keycap tint

### DIFF
--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayKeyboardView.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayKeyboardView.swift
@@ -68,7 +68,11 @@ struct OverlayKeyboardView: View {
 
     /// Whether we're in a non-base layer (e.g., nav, vim) but not launcher mode
     private var isLayerMode: Bool {
-        !isLauncherMode && currentLayerName.lowercased() != "base"
+        !isLauncherMode && !isInlineLayer && currentLayerName.lowercased() != "base"
+    }
+
+    private var isInlineLayer: Bool {
+        OverlayKeycapView.inlineLayerNames.contains(currentLayerName.lowercased())
     }
 
     /// Track caps lock state from system

--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView+VisualStyling.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView+VisualStyling.swift
@@ -160,6 +160,10 @@ extension OverlayKeycapView {
         // Layer mode: dark gray for unmapped keys (same as launcher)
         else if isLayerMode {
             KeyPathColors.keycapDark
+        }
+        // Inline layer: mapped keys get a subtle accent tint, unmapped keys stay normal
+        else if isInlineLayer, hasLayerMapping {
+            Color.accentColor.opacity(0.15)
         } else if isModifierKey {
             colorway.modBaseColor
         } else if isAccentKey {

--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView.swift
@@ -80,8 +80,17 @@ struct OverlayKeycapView: View {
 
     /// Whether we're in a non-base layer (e.g., nav, vim) but not launcher mode
     var isLayerMode: Bool {
-        !isLauncherMode && currentLayerName.lowercased() != "base" && currentLayerName.lowercased() != "Base"
+        !isLauncherMode && !isInlineLayer && currentLayerName.lowercased() != "base"
     }
+
+    /// "Inline" layers render like the base layer — unmapped keys keep their
+    /// normal appearance, mapped keys swap in their action. Use for simple
+    /// layers where most of the keyboard stays the same (e.g., Home Row Arrows).
+    var isInlineLayer: Bool {
+        Self.inlineLayerNames.contains(currentLayerName.lowercased())
+    }
+
+    static let inlineLayerNames: Set<String> = ["home-arrows"]
 
     /// Whether this key has a meaningful layer mapping (not transparent/identity)
     var hasLayerMapping: Bool {


### PR DESCRIPTION
## Summary

Fixes two issues with the inline overlay style from PR #569:

1. **Missing alphas**: `OverlayKeyboardView.isLayerMode` didn't check for inline layers, so floating labels were hidden for all non-base layers. Now inline layers keep floating labels visible.
2. **Loud keycap color**: mapped keys used the full collection color (orange). Now uses a subtle `accentColor.opacity(0.15)` tint that blends with the base layer.

## Test plan

- [x] `swift build` passes
- [x] All 532 tests pass
- [ ] Visual: hold F — unmapped keys should show their normal letters, mapped keys should have a subtle blue tint with their action label