### PR TITLE
fix: inline layer shows floating labels + subtle keycap tint

### DIFF
--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayKeyboardView.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayKeyboardView.swift
@@ -68,7 +68,11 @@ struct OverlayKeyboardView: View {
 
     /// Whether we're in a non-base layer (e.g., nav, vim) but not launcher mode
     private var isLayerMode: Bool {
-        !isLauncherMode && currentLayerName.lowercased() != "base"
+        !isLauncherMode && !isInlineLayer && currentLayerName.lowercased() != "base"
+    }
+
+    private var isInlineLayer: Bool {
+        OverlayKeycapView.inlineLayerNames.contains(currentLayerName.lowercased())
     }
 
     /// Track caps lock state from system

--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView+VisualStyling.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView+VisualStyling.swift
@@ -161,9 +161,9 @@ extension OverlayKeycapView {
         else if isLayerMode {
             KeyPathColors.keycapDark
         }
-        // Inline layer: mapped keys get accent highlight, unmapped keys stay normal
+        // Inline layer: mapped keys get a subtle accent tint, unmapped keys stay normal
         else if isInlineLayer, hasLayerMapping {
-            collectionColor(for: layerKeyInfo?.collectionId)
+            Color.accentColor.opacity(0.15)
         } else if isModifierKey {
             colorway.modBaseColor
         } else if isAccentKey {


### PR DESCRIPTION
## Summary

Fixes inline overlay style: floating labels stay visible for unmapped keys, mapped keys use subtle blue tint instead of loud orange.

## Test plan

- [x] `swift build` passes
- [x] All 532 tests pass
- [ ] Visual: hold F — unmapped keys show letters, mapped keys have subtle tint