### PR TITLE
fix: Fast Navigation defrepeat + Window Snapping activation mode

### DIFF
--- a/Sources/KeyPathAppKit/Infrastructure/Config/KanataConfiguration+BlockBuilders.swift
+++ b/Sources/KeyPathAppKit/Infrastructure/Config/KanataConfiguration+BlockBuilders.swift
@@ -503,8 +503,10 @@ extension KanataConfiguration {
             generateLauncherGridMappings(from: config)
         case let .autoShiftSymbols(config):
             generateAutoShiftSymbolsMappings(from: config)
-        case .keyRepeatControl:
-            []
+        case let .keyRepeatControl(config):
+            config.perKeyOverrides.map { override in
+                KeyMapping(input: override.key, action: .keystroke(key: override.key))
+            }
         case .list, .table, .singleKeyPicker:
             collection.mappings
         }

--- a/Sources/KeyPathAppKit/Infrastructure/Config/KanataConfiguration+BlockBuilders.swift
+++ b/Sources/KeyPathAppKit/Infrastructure/Config/KanataConfiguration+BlockBuilders.swift
@@ -507,6 +507,8 @@ extension KanataConfiguration {
             config.perKeyOverrides.map { override in
                 KeyMapping(input: override.key, action: .keystroke(key: override.key))
             }
+        case .windowSnapping:
+            collection.mappings
         case .list, .table, .singleKeyPicker:
             collection.mappings
         }
@@ -525,7 +527,10 @@ extension KanataConfiguration {
 
         for alias in aliases {
             if let existingIndex = seen[alias.aliasName] {
-                AppLogger.shared.error("🚨 [ConfigGen] Duplicate alias '\(alias.aliasName)' — this should have been caught by conflict detection. Keeping last definition as safety fallback. First: '\(result[existingIndex].definition.prefix(80))' → Replaced by: '\(alias.definition.prefix(80))'")
+                AppLogger.shared
+                    .error(
+                        "🚨 [ConfigGen] Duplicate alias '\(alias.aliasName)' — this should have been caught by conflict detection. Keeping last definition as safety fallback. First: '\(result[existingIndex].definition.prefix(80))' → Replaced by: '\(alias.definition.prefix(80))'"
+                    )
                 result[existingIndex] = alias
             } else {
                 seen[alias.aliasName] = result.count
@@ -620,7 +625,7 @@ extension KanataConfiguration {
         layout: PhysicalLayout = .macBookUS
     ) -> [String] {
         // Skip modifier/utility keys and any explicitly provided skips (e.g., activator key)
-        let defaultSkips: Set<String> = [
+        let defaultSkips: Set = [
             "leftmeta", "rightmeta", "leftctrl", "rightctrl",
             "leftalt", "rightalt", "leftshift", "rightshift",
             "capslock", "fn"

--- a/Sources/KeyPathAppKit/Managers/RuleCollectionsCoordinator.swift
+++ b/Sources/KeyPathAppKit/Managers/RuleCollectionsCoordinator.swift
@@ -179,6 +179,13 @@ final class RuleCollectionsCoordinator {
         return wasNewlyEnabled
     }
 
+    func updateWindowSnappingConfig(id: UUID, config: WindowSnappingConfig) async -> String? {
+        let autoEnabled = await ruleCollectionsManager.updateWindowSnappingConfig(id: id, config: config)
+        applyMappings(ruleCollectionsManager.enabledMappings())
+        notifyStateChanged()
+        return autoEnabled
+    }
+
     /// Update the leader key for all collections that use momentary activation
     func updateLeaderKey(_ newKey: String) async {
         await ruleCollectionsManager.updateLeaderKey(newKey)

--- a/Sources/KeyPathAppKit/Managers/RuntimeCoordinator+RuleCollections.swift
+++ b/Sources/KeyPathAppKit/Managers/RuntimeCoordinator+RuleCollections.swift
@@ -93,6 +93,10 @@ extension RuntimeCoordinator {
         await ruleCollectionsCoordinator.updateKeyRepeatControlConfig(id: collectionId, config: config)
     }
 
+    func updateWindowSnappingConfig(collectionId: UUID, config: WindowSnappingConfig) async -> String? {
+        await ruleCollectionsCoordinator.updateWindowSnappingConfig(id: collectionId, config: config)
+    }
+
     func updateLeaderKey(_ newKey: String) async {
         await ruleCollectionsCoordinator.updateLeaderKey(newKey)
     }

--- a/Sources/KeyPathAppKit/Models/RuleCollectionConfiguration.swift
+++ b/Sources/KeyPathAppKit/Models/RuleCollectionConfiguration.swift
@@ -55,6 +55,9 @@ public enum RuleCollectionConfiguration: Codable, Equatable, Sendable {
     /// Key Repeat Control: kanata-managed key repeat with per-key overrides
     case keyRepeatControl(KeyRepeatControlConfig)
 
+    /// Window Snapping: table display with configurable activation mode
+    case windowSnapping(WindowSnappingConfig)
+
     // MARK: - Convenience Accessors
 
     /// The display style enum value (for compatibility with existing UI code)
@@ -72,6 +75,7 @@ public enum RuleCollectionConfiguration: Codable, Equatable, Sendable {
         case .launcherGrid: .launcherGrid
         case .autoShiftSymbols: .autoShiftSymbols
         case .keyRepeatControl: .keyRepeatControl
+        case .windowSnapping: .table
         }
     }
 
@@ -132,6 +136,12 @@ public enum RuleCollectionConfiguration: Codable, Equatable, Sendable {
     /// Extract key repeat control config if this is a `.keyRepeatControl` case
     public var keyRepeatControlConfig: KeyRepeatControlConfig? {
         if case let .keyRepeatControl(config) = self { return config }
+        return nil
+    }
+
+    /// Extract window snapping config if this is a `.windowSnapping` case
+    public var windowSnappingConfig: WindowSnappingConfig? {
+        if case let .windowSnapping(config) = self { return config }
         return nil
     }
 
@@ -322,6 +332,12 @@ public enum RuleCollectionConfiguration: Codable, Equatable, Sendable {
         }
     }
 
+    public mutating func updateWindowSnappingConfig(_ newConfig: WindowSnappingConfig) {
+        if case .windowSnapping = self {
+            self = .windowSnapping(newConfig)
+        }
+    }
+
     // MARK: - Codable
 
     private enum CodingKeys: String, CodingKey {
@@ -341,6 +357,7 @@ public enum RuleCollectionConfiguration: Codable, Equatable, Sendable {
         case launcherGrid
         case autoShiftSymbols
         case keyRepeatControl
+        case windowSnapping
     }
 
     public init(from decoder: Decoder) throws {
@@ -382,6 +399,9 @@ public enum RuleCollectionConfiguration: Codable, Equatable, Sendable {
         case .keyRepeatControl:
             let config = try KeyRepeatControlConfig(from: decoder)
             self = .keyRepeatControl(config)
+        case .windowSnapping:
+            let config = try WindowSnappingConfig(from: decoder)
+            self = .windowSnapping(config)
         }
     }
 
@@ -422,6 +442,9 @@ public enum RuleCollectionConfiguration: Codable, Equatable, Sendable {
             try config.encode(to: encoder)
         case let .keyRepeatControl(config):
             try container.encode(ConfigType.keyRepeatControl, forKey: .type)
+            try config.encode(to: encoder)
+        case let .windowSnapping(config):
+            try container.encode(ConfigType.windowSnapping, forKey: .type)
             try config.encode(to: encoder)
         }
     }
@@ -917,5 +940,27 @@ public struct KeyRepeatControlConfig: Codable, Equatable, Sendable {
                 )
             }
         }
+    }
+}
+
+// MARK: - Window Snapping Configuration
+
+public enum WindowSnappingActivationMode: String, Codable, Equatable, Sendable {
+    case leader
+    case quickLauncher
+
+    public var displayName: String {
+        switch self {
+        case .leader: "Leader Key"
+        case .quickLauncher: "Quick Launcher"
+        }
+    }
+}
+
+public struct WindowSnappingConfig: Codable, Equatable, Sendable {
+    public var activationMode: WindowSnappingActivationMode
+
+    public init(activationMode: WindowSnappingActivationMode = .leader) {
+        self.activationMode = activationMode
     }
 }

--- a/Sources/KeyPathAppKit/Services/Packs/PackRegistry.swift
+++ b/Sources/KeyPathAppKit/Services/Packs/PackRegistry.swift
@@ -321,7 +321,12 @@ public enum PackRegistry {
             PackDependency(
                 packID: "com.keypath.pack.vim-navigation",
                 kind: .enhancedBy,
-                description: "Adds Leader key layer activation when Vim Navigation is enabled"
+                description: "Required for Leader Key activation mode (default)"
+            ),
+            PackDependency(
+                packID: "com.keypath.pack.quick-launcher",
+                kind: .enhancedBy,
+                description: "Required for Quick Launcher activation mode"
             ),
         ]
     )

--- a/Sources/KeyPathAppKit/Services/Packs/PackSummaryProvider.swift
+++ b/Sources/KeyPathAppKit/Services/Packs/PackSummaryProvider.swift
@@ -14,7 +14,7 @@ import Foundation
 ///   misleading).
 /// * No associated collection → fall back to the pack's first binding
 ///   template (legacy rule-based packs).
-struct PackSummaryProvider {
+enum PackSummaryProvider {
     /// A minimal view of what the Pack Detail caller knows: the pack
     /// itself, the live-looked-up rule collection (if any), and the
     /// user's in-flight picker overrides (if any).
@@ -35,7 +35,7 @@ struct PackSummaryProvider {
                 return singleKeySummary(for: input, collection: collection)
             case .homeRowMods, .homeRowLayerToggles, .chordGroups, .sequences,
                  .launcherGrid, .layerPresetPicker, .autoShiftSymbols,
-                 .keyRepeatControl, .table, .list:
+                 .keyRepeatControl, .windowSnapping, .table, .list:
                 // Multi-binding or complex configs — the embedded editor
                 // shows everything; a one-liner would misrepresent state.
                 return nil

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionCatalog.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionCatalog.swift
@@ -18,7 +18,10 @@ struct RuleCollectionCatalog {
         // Preserve user's configuration for configurable collections
         // (e.g., launcher mappings, home row mods settings, etc.)
         // Only if the configuration type matches - otherwise use catalog default
-        if existing.configuration.displayStyle == updated.configuration.displayStyle {
+        // Migrate .table → .windowSnapping for Window Snapping collections
+        if case .table = existing.configuration, case let .windowSnapping(catalogConfig) = updated.configuration {
+            merged.configuration = .windowSnapping(catalogConfig)
+        } else if existing.configuration.displayStyle == updated.configuration.displayStyle {
             // For tapHoldPicker: preserve user's selections but use catalog's options
             // This ensures removed options (like "None") don't persist
             if case let .tapHoldPicker(existingConfig) = existing.configuration,
@@ -328,7 +331,7 @@ struct RuleCollectionCatalog {
                 sourceLayer: .navigation // Activated from within navigation layer
             ),
             activationHint: "Leader → w → action key",
-            configuration: .table,
+            configuration: .windowSnapping(WindowSnappingConfig()),
             windowKeyConvention: .standard
         )
     }

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+PublicAPI.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+PublicAPI.swift
@@ -648,6 +648,76 @@ extension RuleCollectionsManager {
         return wasNewlyEnabled
     }
 
+    /// Update window snapping configuration (activation mode)
+    /// - Returns: name of auto-enabled dependency, or nil
+    func updateWindowSnappingConfig(id: UUID, config: WindowSnappingConfig) async -> String? {
+        guard let index = ruleCollections.firstIndex(where: { $0.id == id }) else {
+            let catalog = RuleCollectionCatalog()
+            if var catalogCollection = catalog.defaultCollections().first(where: { $0.id == id }) {
+                catalogCollection.configuration = .windowSnapping(config)
+                catalogCollection.momentaryActivator = Self.momentaryActivatorForWindowSnapping(config)
+                catalogCollection.activationHint = Self.activationHintForWindowSnapping(config)
+                catalogCollection.isEnabled = true
+                ruleCollections.append(catalogCollection)
+                let autoEnabled = autoEnableWindowSnappingDependency(config)
+                dedupeRuleCollectionsInPlace()
+                refreshLayerIndicatorState()
+                await regenerateConfigFromCollections()
+                return autoEnabled
+            }
+            return nil
+        }
+
+        ruleCollections[index].configuration = .windowSnapping(config)
+        ruleCollections[index].momentaryActivator = Self.momentaryActivatorForWindowSnapping(config)
+        ruleCollections[index].activationHint = Self.activationHintForWindowSnapping(config)
+
+        let autoEnabled = autoEnableWindowSnappingDependency(config)
+        dedupeRuleCollectionsInPlace()
+        refreshLayerIndicatorState()
+        await regenerateConfigFromCollections()
+        return autoEnabled
+    }
+
+    private static func momentaryActivatorForWindowSnapping(_ config: WindowSnappingConfig) -> MomentaryActivator {
+        switch config.activationMode {
+        case .leader:
+            MomentaryActivator(input: "w", targetLayer: .custom("window"), sourceLayer: .navigation)
+        case .quickLauncher:
+            MomentaryActivator(input: "w", targetLayer: .custom("window"), sourceLayer: .custom("launcher"))
+        }
+    }
+
+    private static func activationHintForWindowSnapping(_ config: WindowSnappingConfig) -> String {
+        switch config.activationMode {
+        case .leader: "Leader → w → action key"
+        case .quickLauncher: "Hyper + w → action key"
+        }
+    }
+
+    private func autoEnableWindowSnappingDependency(_ config: WindowSnappingConfig) -> String? {
+        switch config.activationMode {
+        case .leader:
+            let navID = RuleCollectionIdentifier.leaderKey
+            if !ruleCollections.contains(where: { $0.id == navID && $0.isEnabled }) {
+                if let idx = ruleCollections.firstIndex(where: { $0.id == navID }) {
+                    ruleCollections[idx].isEnabled = true
+                    return "Leader Key"
+                }
+            }
+            return nil
+        case .quickLauncher:
+            let launcherID = RuleCollectionIdentifier.launcher
+            if !ruleCollections.contains(where: { $0.id == launcherID && $0.isEnabled }) {
+                if let idx = ruleCollections.firstIndex(where: { $0.id == launcherID }) {
+                    ruleCollections[idx].isEnabled = true
+                    return "Quick Launcher"
+                }
+            }
+            return nil
+        }
+    }
+
     /// Pre-cache icons for launcher mappings (called when config changes)
     func warmLauncherIconCache(for config: LauncherGridConfig) async {
         let enabledMappings = config.mappings.filter(\.isEnabled)

--- a/Sources/KeyPathAppKit/UI/Gallery/PackDetailView+BindingRows.swift
+++ b/Sources/KeyPathAppKit/UI/Gallery/PackDetailView+BindingRows.swift
@@ -7,10 +7,9 @@ extension PackDetailView {
     /// Wraps embedded editors in `InsetBackPlane` with the same padding the
     /// Rules tab uses, so Pack Detail editors visually match their Rules
     /// counterparts (subtle inner-shadow container, consistent insets).
-    @ViewBuilder
-    func embeddedEditor<Content: View>(
+    func embeddedEditor(
         horizontalPadding: CGFloat = 16,
-        @ViewBuilder content: () -> Content
+        @ViewBuilder content: () -> some View
     ) -> some View {
         InsetBackPlane {
             content()
@@ -166,7 +165,8 @@ extension PackDetailView {
                 .id(chordGroupsCollection.id)
             }
         } else if let collection = liveAssociatedCollection,
-                  collection.id == RuleCollectionIdentifier.windowSnapping {
+                  collection.id == RuleCollectionIdentifier.windowSnapping
+        {
             // Window Snapping has a custom visual editor in Rules — convention
             // picker + monitor canvas + floating action cards. Pack Detail
             // embeds the same view so the experience is identical.
@@ -175,8 +175,15 @@ extension PackDetailView {
                 WindowSnappingView(
                     mappings: collection.mappings,
                     convention: collection.windowKeyConvention ?? .standard,
+                    activationMode: collection.configuration.windowSnappingConfig?.activationMode ?? .leader,
                     onConventionChange: { convention in
                         Task { await applyWindowConventionEdit(convention, collectionID: collection.id) }
+                    },
+                    onActivationModeChange: { mode in
+                        Task {
+                            let config = WindowSnappingConfig(activationMode: mode)
+                            _ = await kanataManager.updateWindowSnappingConfig(collectionId: collection.id, config: config)
+                        }
                     }
                 )
             }
@@ -190,7 +197,8 @@ extension PackDetailView {
                 )
             }
         } else if pack.bindings.isEmpty, let collection = liveAssociatedCollection,
-                  !collection.mappings.isEmpty {
+                  !collection.mappings.isEmpty
+        {
             // Collection-backed pack with no explicit bindings and a plain
             // `.table` config (Vim Navigation, Mission Control, Numpad).
             // Uses the same MappingTableContent view Rules uses so the

--- a/Sources/KeyPathAppKit/UI/Gallery/PackDetailView+LiveState.swift
+++ b/Sources/KeyPathAppKit/UI/Gallery/PackDetailView+LiveState.swift
@@ -7,6 +7,22 @@ extension PackDetailView {
         var installed = await PackInstaller.shared.isInstalled(packID: pack.id)
         let saved = await PackInstaller.shared.quickSettings(for: pack.id)
 
+        // Resilience: if collection is enabled but tracker has no record, backfill
+        if !installed, let collectionID = pack.associatedCollectionID {
+            let collections = await kanataManager.underlyingManager
+                .ruleCollectionsManager.ruleCollections
+            if let match = collections.first(where: { $0.id == collectionID }), match.isEnabled {
+                let record = InstalledPackRecord(
+                    packID: pack.id,
+                    version: pack.version,
+                    installedAt: Date(),
+                    quickSettingValues: [:]
+                )
+                try? await InstalledPackTracker.shared.upsert(record)
+                installed = true
+            }
+        }
+
         // Check if this pack's collection is managed by a different installed
         // pack (e.g. Home Row Mods managed by Vallack). If so, lock the
         // toggle and show the "Part of" tag.

--- a/Sources/KeyPathAppKit/UI/Rules/ActiveRulesView.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/ActiveRulesView.swift
@@ -177,6 +177,7 @@ private extension RuleCollectionRow {
             WindowSnappingView(
                 mappings: collection.mappings,
                 convention: collection.windowKeyConvention ?? .standard,
+                activationMode: collection.configuration.windowSnappingConfig?.activationMode ?? .leader,
                 onConventionChange: { convention in
                     onWindowConventionChanged?(convention)
                 }

--- a/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView+CollectionRow.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView+CollectionRow.swift
@@ -13,7 +13,18 @@ struct ExpandableCollectionRow: View {
     let icon: String
     let count: Int
     let isEnabled: Bool
-    let mappings: [(input: String, output: String, shiftedOutput: String?, ctrlOutput: String?, description: String?, sectionBreak: Bool, sectionLabel: String?, enabled: Bool, id: UUID, behavior: MappingBehavior?)]
+    let mappings: [(
+        input: String,
+        output: String,
+        shiftedOutput: String?,
+        ctrlOutput: String?,
+        description: String?,
+        sectionBreak: Bool,
+        sectionLabel: String?,
+        enabled: Bool,
+        id: UUID,
+        behavior: MappingBehavior?
+    )]
     var appKeymaps: [AppKeymap] = []
     let onToggle: (Bool) -> Void
     let onEditMapping: ((UUID) -> Void)?
@@ -29,7 +40,7 @@ struct ExpandableCollectionRow: View {
     var leaderKeyDisplay: String = "␣ Space"
     /// Optional activation hint from collection (overrides default formatting)
     var activationHint: String?
-    var managingPackName: String? = nil
+    var managingPackName: String?
     var onManagedToggleTapped: (() -> Void)?
     var defaultExpanded: Bool = false
     var displayStyle: RuleCollectionDisplayStyle = .list
@@ -70,6 +81,8 @@ struct ExpandableCollectionRow: View {
     var onSelectLayerPreset: ((String) -> Void)?
     /// For windowSnapping: callback to change key convention
     var onSelectWindowConvention: ((WindowKeyConvention) -> Void)?
+    /// For windowSnapping: callback to change activation mode
+    var onWindowSnappingActivationModeChange: ((WindowSnappingActivationMode) -> Void)?
     /// For functionKeys: callback to change mode (media keys vs function keys)
     var onSelectFunctionKeyMode: ((FunctionKeyMode) -> Void)?
     /// For launcherGrid: callback to update launcher config
@@ -114,7 +127,7 @@ struct ExpandableCollectionRow: View {
         return normalized == "neovimterminal"
     }
 
-private var fallbackKeyMappings: [KeyMapping] {
+    private var fallbackKeyMappings: [KeyMapping] {
         mappings.map { mapping in
             let action: KeyAction = mapping.output.hasPrefix("(") ? .rawKanata(mapping.output) : .keystroke(key: mapping.output)
             return KeyMapping(
@@ -558,8 +571,12 @@ private var fallbackKeyMappings: [KeyMapping] {
                         WindowSnappingView(
                             mappings: collection?.mappings ?? [],
                             convention: collection?.windowKeyConvention ?? .standard,
+                            activationMode: collection?.configuration.windowSnappingConfig?.activationMode ?? .leader,
                             onConventionChange: { convention in
                                 onSelectWindowConvention?(convention)
+                            },
+                            onActivationModeChange: { mode in
+                                onWindowSnappingActivationModeChange?(mode)
                             }
                         )
                         .padding(.top, 8)

--- a/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView+DynamicDisplay.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView+DynamicDisplay.swift
@@ -98,6 +98,12 @@ extension RulesTabView {
         if case let .autoShiftSymbols(config) = collection.configuration {
             return "\(config.enabledKeys.count) keys \u{00B7} \(config.timeoutMs)ms hold"
         }
+        if case let .windowSnapping(config) = collection.configuration {
+            switch config.activationMode {
+            case .leader: return "\(currentLeaderKeyDisplay) → w → action key"
+            case .quickLauncher: return "Hyper + w → action key"
+            }
+        }
         return collection.activationHint
     }
 

--- a/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView.swift
@@ -312,6 +312,14 @@ struct RulesTabView: View {
             onSelectWindowConvention: collection.id == RuleCollectionIdentifier.windowSnapping ? { convention in
                 Task { await kanataManager.updateWindowKeyConvention(collection.id, convention: convention) }
             } : nil,
+            onWindowSnappingActivationModeChange: collection.id == RuleCollectionIdentifier.windowSnapping ? { mode in
+                Task {
+                    let config = WindowSnappingConfig(activationMode: mode)
+                    if let autoEnabled = await kanataManager.updateWindowSnappingConfig(collectionId: collection.id, config: config) {
+                        settingsToastManager.showSuccess("Also enabled \(autoEnabled)")
+                    }
+                }
+            } : nil,
             onSelectFunctionKeyMode: collection.id == RuleCollectionIdentifier.macFunctionKeys ? { mode in
                 Task { await kanataManager.updateFunctionKeyMode(collection.id, mode: mode) }
             } : nil,
@@ -332,7 +340,7 @@ struct RulesTabView: View {
             // Orange border for collections that need a Pack Detail view built
             packForCollection(collection) == nil && !collection.isSystemDefault
                 ? RoundedRectangle(cornerRadius: 10)
-                    .strokeBorder(Color.orange.opacity(0.35), lineWidth: 1.5)
+                .strokeBorder(Color.orange.opacity(0.35), lineWidth: 1.5)
                 : nil
         )
     }
@@ -368,17 +376,15 @@ struct RulesTabView: View {
                 let allAutoResolvable = unmet.allSatisfy { $0.reason == .notEnabled }
 
                 if allAutoResolvable {
-                    // Auto-enable dependencies and the pack
+                    // Auto-enable dependencies and the pack via PackInstaller to keep InstalledPackTracker in sync
                     pendingToggles[collection.id] = true
                     Task {
                         for dep in unmet {
-                            if let depPack = PackRegistry.pack(id: dep.dependency.packID),
-                               let depCollectionID = depPack.associatedCollectionID
-                            {
-                                await kanataManager.toggleRuleCollection(depCollectionID, enabled: true)
+                            if let depPack = PackRegistry.pack(id: dep.dependency.packID) {
+                                await toggleViaPack(depPack, isOn: true)
                             }
                         }
-                        await kanataManager.toggleRuleCollection(collection.id, enabled: true)
+                        await toggleViaPack(pack, isOn: true)
                         pendingToggles.removeValue(forKey: collection.id)
                         refreshUnmetDependencies()
                         let depNames = unmet.map { PackRegistry.pack(id: $0.dependency.packID)?.name ?? $0.dependency.packID }
@@ -559,7 +565,18 @@ struct RulesTabView: View {
                                 count: isSearching ? (filteredCustomRules.count + filteredAppKeymaps.flatMap(\.overrides).count) : totalCustomRulesCount,
                                 isEnabled: filteredCustomRules.isEmpty
                                     || filteredCustomRules.allSatisfy(\.isEnabled),
-                                mappings: filteredCustomRules.map { ($0.input, $0.action.outputString, $0.shiftedOutput, nil, $0.title.isEmpty ? nil : $0.title, false, nil as String?, $0.isEnabled, $0.id, $0.behavior) },
+                                mappings: filteredCustomRules.map { (
+                                    $0.input,
+                                    $0.action.outputString,
+                                    $0.shiftedOutput,
+                                    nil,
+                                    $0.title.isEmpty ? nil : $0.title,
+                                    false,
+                                    nil as String?,
+                                    $0.isEnabled,
+                                    $0.id,
+                                    $0.behavior
+                                ) },
                                 appKeymaps: filteredAppKeymaps,
                                 onToggle: { isOn in
                                     Task {
@@ -916,7 +933,6 @@ struct RulesTabView: View {
         }
     }
 
-
     private func collectionMatchesSearch(_ collection: RuleCollection) -> Bool {
         let query = trimmedSearchQuery.lowercased()
 
@@ -1077,4 +1093,3 @@ struct RulesTabView: View {
         }
     }
 }
-

--- a/Sources/KeyPathAppKit/UI/ViewModels/KanataViewModel.swift
+++ b/Sources/KeyPathAppKit/UI/ViewModels/KanataViewModel.swift
@@ -408,6 +408,10 @@ class KanataViewModel {
         }
     }
 
+    func updateWindowSnappingConfig(collectionId: UUID, config: WindowSnappingConfig) async -> String? {
+        await manager.updateWindowSnappingConfig(collectionId: collectionId, config: config)
+    }
+
     /// Update the leader key for all collections that use momentary activation
     func updateLeaderKey(_ newKey: String) async {
         await manager.updateLeaderKey(newKey)

--- a/Sources/KeyPathAppKit/UI/WindowSnapping/WindowSnappingView.swift
+++ b/Sources/KeyPathAppKit/UI/WindowSnapping/WindowSnappingView.swift
@@ -7,10 +7,34 @@ import SwiftUI
 struct WindowSnappingView: View {
     let mappings: [KeyMapping]
     let convention: WindowKeyConvention
+    let activationMode: WindowSnappingActivationMode
     let onConventionChange: (WindowKeyConvention) -> Void
+    var onActivationModeChange: ((WindowSnappingActivationMode) -> Void)?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
+            // Activation mode picker
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Activation")
+                    .font(.headline)
+                Picker("Activation Mode", selection: Binding(
+                    get: { activationMode },
+                    set: { onActivationModeChange?($0) }
+                )) {
+                    Text(WindowSnappingActivationMode.leader.displayName)
+                        .tag(WindowSnappingActivationMode.leader)
+                    Text(WindowSnappingActivationMode.quickLauncher.displayName)
+                        .tag(WindowSnappingActivationMode.quickLauncher)
+                }
+                .pickerStyle(.segmented)
+                .labelsHidden()
+                .accessibilityIdentifier("window-snapping-activation-mode-picker")
+
+                Text(activationDescription)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+
             // Convention picker (leader key style)
             ConventionPicker(
                 convention: convention,
@@ -31,12 +55,30 @@ struct WindowSnappingView: View {
                 Image(systemName: "lightbulb.fill")
                     .foregroundColor(.yellow)
                     .font(.caption)
-                Text("Activate via Leader → w, then press the action key")
+                Text(tipText)
                     .font(.caption)
                     .foregroundColor(.secondary)
             }
         }
         .padding(.vertical, 8)
+    }
+
+    private var activationDescription: String {
+        switch activationMode {
+        case .leader:
+            "Press Leader → W, then press an action key."
+        case .quickLauncher:
+            "Hold Hyper, press W, then press an action key."
+        }
+    }
+
+    private var tipText: String {
+        switch activationMode {
+        case .leader:
+            "Activate via Leader → w, then press the action key"
+        case .quickLauncher:
+            "Activate via Hyper + w, then press the action key"
+        }
     }
 }
 
@@ -46,16 +88,18 @@ struct WindowSnappingView: View {
     WindowSnappingView(
         mappings: [],
         convention: .standard,
+        activationMode: .leader,
         onConventionChange: { _ in }
     )
     .frame(width: 400)
     .padding()
 }
 
-#Preview("Window Snapping - Vim") {
+#Preview("Window Snapping - Quick Launcher") {
     WindowSnappingView(
         mappings: [],
-        convention: .vim,
+        convention: .standard,
+        activationMode: .quickLauncher,
         onConventionChange: { _ in }
     )
     .frame(width: 400)

--- a/Tests/KeyPathTests/Integration/GoldenConfigs/caps-escape-hyper.actual.kbd
+++ b/Tests/KeyPathTests/Integration/GoldenConfigs/caps-escape-hyper.actual.kbd
@@ -71,8 +71,7 @@ PHYSICAL KEYBOARD LAYOUT - DEFSRC
   ;; === Collection: Fast Navigation (enabled) ===
   ;; UUID: <UUID>
   ;; Description: Arrow keys and delete repeat 3× faster. Regular keys stay steady.
-  ;; (no mappings)
-  ;; (no mappings)
+  del
 
   ;; === Collection: Home Row Arrows (enabled) ===
   ;; UUID: <UUID>
@@ -183,8 +182,7 @@ LAYER DEFINITIONS
   ;; === Collection: Fast Navigation (enabled) ===
   ;; UUID: <UUID>
   ;; Description: Arrow keys and delete repeat 3× faster. Regular keys stay steady.
-  ;; (no mappings)
-  ;; (no mappings)
+  del
 
   ;; === Collection: Home Row Arrows (enabled) ===
   ;; UUID: <UUID>
@@ -234,8 +232,7 @@ LAYER DEFINITIONS
   ;; === Collection: Fast Navigation (enabled) ===
   ;; UUID: <UUID>
   ;; Description: Arrow keys and delete repeat 3× faster. Regular keys stay steady.
-  ;; (no mappings)
-  ;; (no mappings)
+  _
 
   ;; === Collection: Home Row Arrows (enabled) ===
   ;; UUID: <UUID>
@@ -285,8 +282,7 @@ LAYER DEFINITIONS
   ;; === Collection: Fast Navigation (enabled) ===
   ;; UUID: <UUID>
   ;; Description: Arrow keys and delete repeat 3× faster. Regular keys stay steady.
-  ;; (no mappings)
-  ;; (no mappings)
+  _
 
   ;; === Collection: Home Row Arrows (enabled) ===
   ;; UUID: <UUID>
@@ -336,8 +332,7 @@ LAYER DEFINITIONS
   ;; === Collection: Fast Navigation (enabled) ===
   ;; UUID: <UUID>
   ;; Description: Arrow keys and delete repeat 3× faster. Regular keys stay steady.
-  ;; (no mappings)
-  ;; (no mappings)
+  _
 
   ;; === Collection: Home Row Arrows (enabled) ===
   ;; UUID: <UUID>

--- a/Tests/KeyPathTests/Integration/GoldenConfigs/caps-escape-hyper.kbd
+++ b/Tests/KeyPathTests/Integration/GoldenConfigs/caps-escape-hyper.kbd
@@ -71,8 +71,7 @@ PHYSICAL KEYBOARD LAYOUT - DEFSRC
   ;; === Collection: Fast Navigation (enabled) ===
   ;; UUID: <UUID>
   ;; Description: Arrow keys and delete repeat 3× faster. Regular keys stay steady.
-  ;; (no mappings)
-  ;; (no mappings)
+  del
 
   ;; === Collection: Home Row Arrows (enabled) ===
   ;; UUID: <UUID>
@@ -183,8 +182,7 @@ LAYER DEFINITIONS
   ;; === Collection: Fast Navigation (enabled) ===
   ;; UUID: <UUID>
   ;; Description: Arrow keys and delete repeat 3× faster. Regular keys stay steady.
-  ;; (no mappings)
-  ;; (no mappings)
+  del
 
   ;; === Collection: Home Row Arrows (enabled) ===
   ;; UUID: <UUID>
@@ -234,8 +232,7 @@ LAYER DEFINITIONS
   ;; === Collection: Fast Navigation (enabled) ===
   ;; UUID: <UUID>
   ;; Description: Arrow keys and delete repeat 3× faster. Regular keys stay steady.
-  ;; (no mappings)
-  ;; (no mappings)
+  _
 
   ;; === Collection: Home Row Arrows (enabled) ===
   ;; UUID: <UUID>
@@ -285,8 +282,7 @@ LAYER DEFINITIONS
   ;; === Collection: Fast Navigation (enabled) ===
   ;; UUID: <UUID>
   ;; Description: Arrow keys and delete repeat 3× faster. Regular keys stay steady.
-  ;; (no mappings)
-  ;; (no mappings)
+  _
 
   ;; === Collection: Home Row Arrows (enabled) ===
   ;; UUID: <UUID>
@@ -336,8 +332,7 @@ LAYER DEFINITIONS
   ;; === Collection: Fast Navigation (enabled) ===
   ;; UUID: <UUID>
   ;; Description: Arrow keys and delete repeat 3× faster. Regular keys stay steady.
-  ;; (no mappings)
-  ;; (no mappings)
+  _
 
   ;; === Collection: Home Row Arrows (enabled) ===
   ;; UUID: <UUID>

--- a/Tests/KeyPathTests/Integration/GoldenConfigs/default.actual.kbd
+++ b/Tests/KeyPathTests/Integration/GoldenConfigs/default.actual.kbd
@@ -71,8 +71,7 @@ PHYSICAL KEYBOARD LAYOUT - DEFSRC
   ;; === Collection: Fast Navigation (enabled) ===
   ;; UUID: <UUID>
   ;; Description: Arrow keys and delete repeat 3× faster. Regular keys stay steady.
-  ;; (no mappings)
-  ;; (no mappings)
+  del
 
   ;; === Collection: Home Row Arrows (enabled) ===
   ;; UUID: <UUID>
@@ -183,8 +182,7 @@ LAYER DEFINITIONS
   ;; === Collection: Fast Navigation (enabled) ===
   ;; UUID: <UUID>
   ;; Description: Arrow keys and delete repeat 3× faster. Regular keys stay steady.
-  ;; (no mappings)
-  ;; (no mappings)
+  del
 
   ;; === Collection: Home Row Arrows (enabled) ===
   ;; UUID: <UUID>
@@ -234,8 +232,7 @@ LAYER DEFINITIONS
   ;; === Collection: Fast Navigation (enabled) ===
   ;; UUID: <UUID>
   ;; Description: Arrow keys and delete repeat 3× faster. Regular keys stay steady.
-  ;; (no mappings)
-  ;; (no mappings)
+  _
 
   ;; === Collection: Home Row Arrows (enabled) ===
   ;; UUID: <UUID>
@@ -285,8 +282,7 @@ LAYER DEFINITIONS
   ;; === Collection: Fast Navigation (enabled) ===
   ;; UUID: <UUID>
   ;; Description: Arrow keys and delete repeat 3× faster. Regular keys stay steady.
-  ;; (no mappings)
-  ;; (no mappings)
+  _
 
   ;; === Collection: Home Row Arrows (enabled) ===
   ;; UUID: <UUID>
@@ -336,8 +332,7 @@ LAYER DEFINITIONS
   ;; === Collection: Fast Navigation (enabled) ===
   ;; UUID: <UUID>
   ;; Description: Arrow keys and delete repeat 3× faster. Regular keys stay steady.
-  ;; (no mappings)
-  ;; (no mappings)
+  _
 
   ;; === Collection: Home Row Arrows (enabled) ===
   ;; UUID: <UUID>

--- a/Tests/KeyPathTests/Integration/GoldenConfigs/default.kbd
+++ b/Tests/KeyPathTests/Integration/GoldenConfigs/default.kbd
@@ -71,8 +71,7 @@ PHYSICAL KEYBOARD LAYOUT - DEFSRC
   ;; === Collection: Fast Navigation (enabled) ===
   ;; UUID: <UUID>
   ;; Description: Arrow keys and delete repeat 3× faster. Regular keys stay steady.
-  ;; (no mappings)
-  ;; (no mappings)
+  del
 
   ;; === Collection: Home Row Arrows (enabled) ===
   ;; UUID: <UUID>
@@ -183,8 +182,7 @@ LAYER DEFINITIONS
   ;; === Collection: Fast Navigation (enabled) ===
   ;; UUID: <UUID>
   ;; Description: Arrow keys and delete repeat 3× faster. Regular keys stay steady.
-  ;; (no mappings)
-  ;; (no mappings)
+  del
 
   ;; === Collection: Home Row Arrows (enabled) ===
   ;; UUID: <UUID>
@@ -234,8 +232,7 @@ LAYER DEFINITIONS
   ;; === Collection: Fast Navigation (enabled) ===
   ;; UUID: <UUID>
   ;; Description: Arrow keys and delete repeat 3× faster. Regular keys stay steady.
-  ;; (no mappings)
-  ;; (no mappings)
+  _
 
   ;; === Collection: Home Row Arrows (enabled) ===
   ;; UUID: <UUID>
@@ -285,8 +282,7 @@ LAYER DEFINITIONS
   ;; === Collection: Fast Navigation (enabled) ===
   ;; UUID: <UUID>
   ;; Description: Arrow keys and delete repeat 3× faster. Regular keys stay steady.
-  ;; (no mappings)
-  ;; (no mappings)
+  _
 
   ;; === Collection: Home Row Arrows (enabled) ===
   ;; UUID: <UUID>
@@ -336,8 +332,7 @@ LAYER DEFINITIONS
   ;; === Collection: Fast Navigation (enabled) ===
   ;; UUID: <UUID>
   ;; Description: Arrow keys and delete repeat 3× faster. Regular keys stay steady.
-  ;; (no mappings)
-  ;; (no mappings)
+  _
 
   ;; === Collection: Home Row Arrows (enabled) ===
   ;; UUID: <UUID>

--- a/Tests/KeyPathTests/Integration/GoldenConfigs/home-row-mods.actual.kbd
+++ b/Tests/KeyPathTests/Integration/GoldenConfigs/home-row-mods.actual.kbd
@@ -81,8 +81,7 @@ PHYSICAL KEYBOARD LAYOUT - DEFSRC
   ;; === Collection: Fast Navigation (enabled) ===
   ;; UUID: <UUID>
   ;; Description: Arrow keys and delete repeat 3× faster. Regular keys stay steady.
-  ;; (no mappings)
-  ;; (no mappings)
+  del
 
   ;; === Collection: Home Row Arrows (enabled) ===
   ;; UUID: <UUID>
@@ -206,8 +205,7 @@ LAYER DEFINITIONS
   ;; === Collection: Fast Navigation (enabled) ===
   ;; UUID: <UUID>
   ;; Description: Arrow keys and delete repeat 3× faster. Regular keys stay steady.
-  ;; (no mappings)
-  ;; (no mappings)
+  del
 
   ;; === Collection: Home Row Arrows (enabled) ===
   ;; UUID: <UUID>
@@ -262,8 +260,7 @@ LAYER DEFINITIONS
   ;; === Collection: Fast Navigation (enabled) ===
   ;; UUID: <UUID>
   ;; Description: Arrow keys and delete repeat 3× faster. Regular keys stay steady.
-  ;; (no mappings)
-  ;; (no mappings)
+  _
 
   ;; === Collection: Home Row Arrows (enabled) ===
   ;; UUID: <UUID>
@@ -318,8 +315,7 @@ LAYER DEFINITIONS
   ;; === Collection: Fast Navigation (enabled) ===
   ;; UUID: <UUID>
   ;; Description: Arrow keys and delete repeat 3× faster. Regular keys stay steady.
-  ;; (no mappings)
-  ;; (no mappings)
+  _
 
   ;; === Collection: Home Row Arrows (enabled) ===
   ;; UUID: <UUID>
@@ -374,8 +370,7 @@ LAYER DEFINITIONS
   ;; === Collection: Fast Navigation (enabled) ===
   ;; UUID: <UUID>
   ;; Description: Arrow keys and delete repeat 3× faster. Regular keys stay steady.
-  ;; (no mappings)
-  ;; (no mappings)
+  _
 
   ;; === Collection: Home Row Arrows (enabled) ===
   ;; UUID: <UUID>

--- a/Tests/KeyPathTests/Integration/GoldenConfigs/home-row-mods.kbd
+++ b/Tests/KeyPathTests/Integration/GoldenConfigs/home-row-mods.kbd
@@ -81,8 +81,7 @@ PHYSICAL KEYBOARD LAYOUT - DEFSRC
   ;; === Collection: Fast Navigation (enabled) ===
   ;; UUID: <UUID>
   ;; Description: Arrow keys and delete repeat 3× faster. Regular keys stay steady.
-  ;; (no mappings)
-  ;; (no mappings)
+  del
 
   ;; === Collection: Home Row Arrows (enabled) ===
   ;; UUID: <UUID>
@@ -206,8 +205,7 @@ LAYER DEFINITIONS
   ;; === Collection: Fast Navigation (enabled) ===
   ;; UUID: <UUID>
   ;; Description: Arrow keys and delete repeat 3× faster. Regular keys stay steady.
-  ;; (no mappings)
-  ;; (no mappings)
+  del
 
   ;; === Collection: Home Row Arrows (enabled) ===
   ;; UUID: <UUID>
@@ -262,8 +260,7 @@ LAYER DEFINITIONS
   ;; === Collection: Fast Navigation (enabled) ===
   ;; UUID: <UUID>
   ;; Description: Arrow keys and delete repeat 3× faster. Regular keys stay steady.
-  ;; (no mappings)
-  ;; (no mappings)
+  _
 
   ;; === Collection: Home Row Arrows (enabled) ===
   ;; UUID: <UUID>
@@ -318,8 +315,7 @@ LAYER DEFINITIONS
   ;; === Collection: Fast Navigation (enabled) ===
   ;; UUID: <UUID>
   ;; Description: Arrow keys and delete repeat 3× faster. Regular keys stay steady.
-  ;; (no mappings)
-  ;; (no mappings)
+  _
 
   ;; === Collection: Home Row Arrows (enabled) ===
   ;; UUID: <UUID>
@@ -374,8 +370,7 @@ LAYER DEFINITIONS
   ;; === Collection: Fast Navigation (enabled) ===
   ;; UUID: <UUID>
   ;; Description: Arrow keys and delete repeat 3× faster. Regular keys stay steady.
-  ;; (no mappings)
-  ;; (no mappings)
+  _
 
   ;; === Collection: Home Row Arrows (enabled) ===
   ;; UUID: <UUID>

--- a/Tests/KeyPathTests/Integration/GoldenConfigs/remap-with-shifted-output.actual.kbd
+++ b/Tests/KeyPathTests/Integration/GoldenConfigs/remap-with-shifted-output.actual.kbd
@@ -71,8 +71,7 @@ PHYSICAL KEYBOARD LAYOUT - DEFSRC
   ;; === Collection: Fast Navigation (enabled) ===
   ;; UUID: <UUID>
   ;; Description: Arrow keys and delete repeat 3× faster. Regular keys stay steady.
-  ;; (no mappings)
-  ;; (no mappings)
+  del
 
   ;; === Collection: Home Row Arrows (enabled) ===
   ;; UUID: <UUID>
@@ -189,8 +188,7 @@ LAYER DEFINITIONS
   ;; === Collection: Fast Navigation (enabled) ===
   ;; UUID: <UUID>
   ;; Description: Arrow keys and delete repeat 3× faster. Regular keys stay steady.
-  ;; (no mappings)
-  ;; (no mappings)
+  del
 
   ;; === Collection: Home Row Arrows (enabled) ===
   ;; UUID: <UUID>
@@ -245,8 +243,7 @@ LAYER DEFINITIONS
   ;; === Collection: Fast Navigation (enabled) ===
   ;; UUID: <UUID>
   ;; Description: Arrow keys and delete repeat 3× faster. Regular keys stay steady.
-  ;; (no mappings)
-  ;; (no mappings)
+  _
 
   ;; === Collection: Home Row Arrows (enabled) ===
   ;; UUID: <UUID>
@@ -301,8 +298,7 @@ LAYER DEFINITIONS
   ;; === Collection: Fast Navigation (enabled) ===
   ;; UUID: <UUID>
   ;; Description: Arrow keys and delete repeat 3× faster. Regular keys stay steady.
-  ;; (no mappings)
-  ;; (no mappings)
+  _
 
   ;; === Collection: Home Row Arrows (enabled) ===
   ;; UUID: <UUID>
@@ -357,8 +353,7 @@ LAYER DEFINITIONS
   ;; === Collection: Fast Navigation (enabled) ===
   ;; UUID: <UUID>
   ;; Description: Arrow keys and delete repeat 3× faster. Regular keys stay steady.
-  ;; (no mappings)
-  ;; (no mappings)
+  _
 
   ;; === Collection: Home Row Arrows (enabled) ===
   ;; UUID: <UUID>

--- a/Tests/KeyPathTests/Integration/GoldenConfigs/remap-with-shifted-output.kbd
+++ b/Tests/KeyPathTests/Integration/GoldenConfigs/remap-with-shifted-output.kbd
@@ -71,8 +71,7 @@ PHYSICAL KEYBOARD LAYOUT - DEFSRC
   ;; === Collection: Fast Navigation (enabled) ===
   ;; UUID: <UUID>
   ;; Description: Arrow keys and delete repeat 3× faster. Regular keys stay steady.
-  ;; (no mappings)
-  ;; (no mappings)
+  del
 
   ;; === Collection: Home Row Arrows (enabled) ===
   ;; UUID: <UUID>
@@ -189,8 +188,7 @@ LAYER DEFINITIONS
   ;; === Collection: Fast Navigation (enabled) ===
   ;; UUID: <UUID>
   ;; Description: Arrow keys and delete repeat 3× faster. Regular keys stay steady.
-  ;; (no mappings)
-  ;; (no mappings)
+  del
 
   ;; === Collection: Home Row Arrows (enabled) ===
   ;; UUID: <UUID>
@@ -245,8 +243,7 @@ LAYER DEFINITIONS
   ;; === Collection: Fast Navigation (enabled) ===
   ;; UUID: <UUID>
   ;; Description: Arrow keys and delete repeat 3× faster. Regular keys stay steady.
-  ;; (no mappings)
-  ;; (no mappings)
+  _
 
   ;; === Collection: Home Row Arrows (enabled) ===
   ;; UUID: <UUID>
@@ -301,8 +298,7 @@ LAYER DEFINITIONS
   ;; === Collection: Fast Navigation (enabled) ===
   ;; UUID: <UUID>
   ;; Description: Arrow keys and delete repeat 3× faster. Regular keys stay steady.
-  ;; (no mappings)
-  ;; (no mappings)
+  _
 
   ;; === Collection: Home Row Arrows (enabled) ===
   ;; UUID: <UUID>
@@ -357,8 +353,7 @@ LAYER DEFINITIONS
   ;; === Collection: Fast Navigation (enabled) ===
   ;; UUID: <UUID>
   ;; Description: Arrow keys and delete repeat 3× faster. Regular keys stay steady.
-  ;; (no mappings)
-  ;; (no mappings)
+  _
 
   ;; === Collection: Home Row Arrows (enabled) ===
   ;; UUID: <UUID>

--- a/Tests/KeyPathTests/Integration/GoldenConfigs/simple-remap-a-to-b.actual.kbd
+++ b/Tests/KeyPathTests/Integration/GoldenConfigs/simple-remap-a-to-b.actual.kbd
@@ -71,8 +71,7 @@ PHYSICAL KEYBOARD LAYOUT - DEFSRC
   ;; === Collection: Fast Navigation (enabled) ===
   ;; UUID: <UUID>
   ;; Description: Arrow keys and delete repeat 3× faster. Regular keys stay steady.
-  ;; (no mappings)
-  ;; (no mappings)
+  del
 
   ;; === Collection: Home Row Arrows (enabled) ===
   ;; UUID: <UUID>
@@ -188,8 +187,7 @@ LAYER DEFINITIONS
   ;; === Collection: Fast Navigation (enabled) ===
   ;; UUID: <UUID>
   ;; Description: Arrow keys and delete repeat 3× faster. Regular keys stay steady.
-  ;; (no mappings)
-  ;; (no mappings)
+  del
 
   ;; === Collection: Home Row Arrows (enabled) ===
   ;; UUID: <UUID>
@@ -244,8 +242,7 @@ LAYER DEFINITIONS
   ;; === Collection: Fast Navigation (enabled) ===
   ;; UUID: <UUID>
   ;; Description: Arrow keys and delete repeat 3× faster. Regular keys stay steady.
-  ;; (no mappings)
-  ;; (no mappings)
+  _
 
   ;; === Collection: Home Row Arrows (enabled) ===
   ;; UUID: <UUID>
@@ -300,8 +297,7 @@ LAYER DEFINITIONS
   ;; === Collection: Fast Navigation (enabled) ===
   ;; UUID: <UUID>
   ;; Description: Arrow keys and delete repeat 3× faster. Regular keys stay steady.
-  ;; (no mappings)
-  ;; (no mappings)
+  _
 
   ;; === Collection: Home Row Arrows (enabled) ===
   ;; UUID: <UUID>
@@ -356,8 +352,7 @@ LAYER DEFINITIONS
   ;; === Collection: Fast Navigation (enabled) ===
   ;; UUID: <UUID>
   ;; Description: Arrow keys and delete repeat 3× faster. Regular keys stay steady.
-  ;; (no mappings)
-  ;; (no mappings)
+  _
 
   ;; === Collection: Home Row Arrows (enabled) ===
   ;; UUID: <UUID>

--- a/Tests/KeyPathTests/Integration/GoldenConfigs/simple-remap-a-to-b.kbd
+++ b/Tests/KeyPathTests/Integration/GoldenConfigs/simple-remap-a-to-b.kbd
@@ -71,8 +71,7 @@ PHYSICAL KEYBOARD LAYOUT - DEFSRC
   ;; === Collection: Fast Navigation (enabled) ===
   ;; UUID: <UUID>
   ;; Description: Arrow keys and delete repeat 3× faster. Regular keys stay steady.
-  ;; (no mappings)
-  ;; (no mappings)
+  del
 
   ;; === Collection: Home Row Arrows (enabled) ===
   ;; UUID: <UUID>
@@ -188,8 +187,7 @@ LAYER DEFINITIONS
   ;; === Collection: Fast Navigation (enabled) ===
   ;; UUID: <UUID>
   ;; Description: Arrow keys and delete repeat 3× faster. Regular keys stay steady.
-  ;; (no mappings)
-  ;; (no mappings)
+  del
 
   ;; === Collection: Home Row Arrows (enabled) ===
   ;; UUID: <UUID>
@@ -244,8 +242,7 @@ LAYER DEFINITIONS
   ;; === Collection: Fast Navigation (enabled) ===
   ;; UUID: <UUID>
   ;; Description: Arrow keys and delete repeat 3× faster. Regular keys stay steady.
-  ;; (no mappings)
-  ;; (no mappings)
+  _
 
   ;; === Collection: Home Row Arrows (enabled) ===
   ;; UUID: <UUID>
@@ -300,8 +297,7 @@ LAYER DEFINITIONS
   ;; === Collection: Fast Navigation (enabled) ===
   ;; UUID: <UUID>
   ;; Description: Arrow keys and delete repeat 3× faster. Regular keys stay steady.
-  ;; (no mappings)
-  ;; (no mappings)
+  _
 
   ;; === Collection: Home Row Arrows (enabled) ===
   ;; UUID: <UUID>
@@ -356,8 +352,7 @@ LAYER DEFINITIONS
   ;; === Collection: Fast Navigation (enabled) ===
   ;; UUID: <UUID>
   ;; Description: Arrow keys and delete repeat 3× faster. Regular keys stay steady.
-  ;; (no mappings)
-  ;; (no mappings)
+  _
 
   ;; === Collection: Home Row Arrows (enabled) ===
   ;; UUID: <UUID>

--- a/Tests/KeyPathTests/Integration/GoldenConfigs/vim-navigation.actual.kbd
+++ b/Tests/KeyPathTests/Integration/GoldenConfigs/vim-navigation.actual.kbd
@@ -71,8 +71,7 @@ PHYSICAL KEYBOARD LAYOUT - DEFSRC
   ;; === Collection: Fast Navigation (enabled) ===
   ;; UUID: <UUID>
   ;; Description: Arrow keys and delete repeat 3× faster. Regular keys stay steady.
-  ;; (no mappings)
-  ;; (no mappings)
+  del
 
   ;; === Collection: Home Row Arrows (enabled) ===
   ;; UUID: <UUID>
@@ -183,8 +182,7 @@ LAYER DEFINITIONS
   ;; === Collection: Fast Navigation (enabled) ===
   ;; UUID: <UUID>
   ;; Description: Arrow keys and delete repeat 3× faster. Regular keys stay steady.
-  ;; (no mappings)
-  ;; (no mappings)
+  del
 
   ;; === Collection: Home Row Arrows (enabled) ===
   ;; UUID: <UUID>
@@ -234,8 +232,7 @@ LAYER DEFINITIONS
   ;; === Collection: Fast Navigation (enabled) ===
   ;; UUID: <UUID>
   ;; Description: Arrow keys and delete repeat 3× faster. Regular keys stay steady.
-  ;; (no mappings)
-  ;; (no mappings)
+  _
 
   ;; === Collection: Home Row Arrows (enabled) ===
   ;; UUID: <UUID>
@@ -285,8 +282,7 @@ LAYER DEFINITIONS
   ;; === Collection: Fast Navigation (enabled) ===
   ;; UUID: <UUID>
   ;; Description: Arrow keys and delete repeat 3× faster. Regular keys stay steady.
-  ;; (no mappings)
-  ;; (no mappings)
+  _
 
   ;; === Collection: Home Row Arrows (enabled) ===
   ;; UUID: <UUID>
@@ -336,8 +332,7 @@ LAYER DEFINITIONS
   ;; === Collection: Fast Navigation (enabled) ===
   ;; UUID: <UUID>
   ;; Description: Arrow keys and delete repeat 3× faster. Regular keys stay steady.
-  ;; (no mappings)
-  ;; (no mappings)
+  _
 
   ;; === Collection: Home Row Arrows (enabled) ===
   ;; UUID: <UUID>

--- a/Tests/KeyPathTests/Integration/GoldenConfigs/vim-navigation.kbd
+++ b/Tests/KeyPathTests/Integration/GoldenConfigs/vim-navigation.kbd
@@ -71,8 +71,7 @@ PHYSICAL KEYBOARD LAYOUT - DEFSRC
   ;; === Collection: Fast Navigation (enabled) ===
   ;; UUID: <UUID>
   ;; Description: Arrow keys and delete repeat 3× faster. Regular keys stay steady.
-  ;; (no mappings)
-  ;; (no mappings)
+  del
 
   ;; === Collection: Home Row Arrows (enabled) ===
   ;; UUID: <UUID>
@@ -183,8 +182,7 @@ LAYER DEFINITIONS
   ;; === Collection: Fast Navigation (enabled) ===
   ;; UUID: <UUID>
   ;; Description: Arrow keys and delete repeat 3× faster. Regular keys stay steady.
-  ;; (no mappings)
-  ;; (no mappings)
+  del
 
   ;; === Collection: Home Row Arrows (enabled) ===
   ;; UUID: <UUID>
@@ -234,8 +232,7 @@ LAYER DEFINITIONS
   ;; === Collection: Fast Navigation (enabled) ===
   ;; UUID: <UUID>
   ;; Description: Arrow keys and delete repeat 3× faster. Regular keys stay steady.
-  ;; (no mappings)
-  ;; (no mappings)
+  _
 
   ;; === Collection: Home Row Arrows (enabled) ===
   ;; UUID: <UUID>
@@ -285,8 +282,7 @@ LAYER DEFINITIONS
   ;; === Collection: Fast Navigation (enabled) ===
   ;; UUID: <UUID>
   ;; Description: Arrow keys and delete repeat 3× faster. Regular keys stay steady.
-  ;; (no mappings)
-  ;; (no mappings)
+  _
 
   ;; === Collection: Home Row Arrows (enabled) ===
   ;; UUID: <UUID>
@@ -336,8 +332,7 @@ LAYER DEFINITIONS
   ;; === Collection: Fast Navigation (enabled) ===
   ;; UUID: <UUID>
   ;; Description: Arrow keys and delete repeat 3× faster. Regular keys stay steady.
-  ;; (no mappings)
-  ;; (no mappings)
+  _
 
   ;; === Collection: Home Row Arrows (enabled) ===
   ;; UUID: <UUID>


### PR DESCRIPTION
## Summary
- **Fast Navigation fix**: Arrow keys and delete weren't in kanata's `defsrc`, so `defrepeat` custom repeat rates were silently ignored. Keys now get identity mappings from `perKeyOverrides`.
- **Window Snapping activation mode**: New segmented picker lets users choose Leader Key (Leader → W) or Quick Launcher (Hyper + W) activation. Changing mode auto-enables the required dependency.
- **State sync fix**: The dependency auto-resolve path now routes through `PackInstaller` so `InstalledPackTracker` stays in sync with `collection.isEnabled`. Added read-path resilience backfill in Pack Detail.

## Test plan
- [ ] Verify arrow keys repeat at 3× speed with Fast Navigation enabled
- [ ] Open Rules → Window Snapping → verify activation mode picker appears
- [ ] Switch to Quick Launcher mode → hold Hyper + W → verify window layer activates
- [ ] Switch back to Leader mode → Leader → W → verify it still works
- [ ] Toggle Window Snapping on/off in Rules list, open Pack Detail → states should match
- [ ] All 532 tests pass