### PR TITLE
feat: Window Snapping launcher overlay + activation mode simplification

### DIFF
--- a/Sources/KeyPathAppKit/Infrastructure/Config/KanataConfiguration+BlockBuilders.swift
+++ b/Sources/KeyPathAppKit/Infrastructure/Config/KanataConfiguration+BlockBuilders.swift
@@ -507,8 +507,6 @@ extension KanataConfiguration {
             config.perKeyOverrides.map { override in
                 KeyMapping(input: override.key, action: .keystroke(key: override.key))
             }
-        case .windowSnapping:
-            collection.mappings
         case .list, .table, .singleKeyPicker:
             collection.mappings
         }

--- a/Sources/KeyPathAppKit/Managers/RuleCollectionsCoordinator.swift
+++ b/Sources/KeyPathAppKit/Managers/RuleCollectionsCoordinator.swift
@@ -179,8 +179,8 @@ final class RuleCollectionsCoordinator {
         return wasNewlyEnabled
     }
 
-    func updateWindowSnappingConfig(id: UUID, config: WindowSnappingConfig) async -> String? {
-        let autoEnabled = await ruleCollectionsManager.updateWindowSnappingConfig(id: id, config: config)
+    func updateWindowSnappingActivationMode(id: UUID, mode: WindowSnappingActivationMode) async -> String? {
+        let autoEnabled = await ruleCollectionsManager.updateWindowSnappingActivationMode(id: id, mode: mode)
         applyMappings(ruleCollectionsManager.enabledMappings())
         notifyStateChanged()
         return autoEnabled

--- a/Sources/KeyPathAppKit/Managers/RuntimeCoordinator+RuleCollections.swift
+++ b/Sources/KeyPathAppKit/Managers/RuntimeCoordinator+RuleCollections.swift
@@ -93,8 +93,8 @@ extension RuntimeCoordinator {
         await ruleCollectionsCoordinator.updateKeyRepeatControlConfig(id: collectionId, config: config)
     }
 
-    func updateWindowSnappingConfig(collectionId: UUID, config: WindowSnappingConfig) async -> String? {
-        await ruleCollectionsCoordinator.updateWindowSnappingConfig(id: collectionId, config: config)
+    func updateWindowSnappingActivationMode(collectionId: UUID, mode: WindowSnappingActivationMode) async -> String? {
+        await ruleCollectionsCoordinator.updateWindowSnappingActivationMode(id: collectionId, mode: mode)
     }
 
     func updateLeaderKey(_ newKey: String) async {

--- a/Sources/KeyPathAppKit/Models/RuleCollectionConfiguration.swift
+++ b/Sources/KeyPathAppKit/Models/RuleCollectionConfiguration.swift
@@ -341,6 +341,8 @@ public enum RuleCollectionConfiguration: Codable, Equatable, Sendable {
         case launcherGrid
         case autoShiftSymbols
         case keyRepeatControl
+        // Legacy: briefly shipped as a config type, now a plain field on RuleCollection
+        case windowSnapping
     }
 
     public init(from decoder: Decoder) throws {
@@ -382,6 +384,8 @@ public enum RuleCollectionConfiguration: Codable, Equatable, Sendable {
         case .keyRepeatControl:
             let config = try KeyRepeatControlConfig(from: decoder)
             self = .keyRepeatControl(config)
+        case .windowSnapping:
+            self = .table
         }
     }
 

--- a/Sources/KeyPathAppKit/Models/RuleCollectionConfiguration.swift
+++ b/Sources/KeyPathAppKit/Models/RuleCollectionConfiguration.swift
@@ -55,9 +55,6 @@ public enum RuleCollectionConfiguration: Codable, Equatable, Sendable {
     /// Key Repeat Control: kanata-managed key repeat with per-key overrides
     case keyRepeatControl(KeyRepeatControlConfig)
 
-    /// Window Snapping: table display with configurable activation mode
-    case windowSnapping(WindowSnappingConfig)
-
     // MARK: - Convenience Accessors
 
     /// The display style enum value (for compatibility with existing UI code)
@@ -75,7 +72,6 @@ public enum RuleCollectionConfiguration: Codable, Equatable, Sendable {
         case .launcherGrid: .launcherGrid
         case .autoShiftSymbols: .autoShiftSymbols
         case .keyRepeatControl: .keyRepeatControl
-        case .windowSnapping: .table
         }
     }
 
@@ -136,12 +132,6 @@ public enum RuleCollectionConfiguration: Codable, Equatable, Sendable {
     /// Extract key repeat control config if this is a `.keyRepeatControl` case
     public var keyRepeatControlConfig: KeyRepeatControlConfig? {
         if case let .keyRepeatControl(config) = self { return config }
-        return nil
-    }
-
-    /// Extract window snapping config if this is a `.windowSnapping` case
-    public var windowSnappingConfig: WindowSnappingConfig? {
-        if case let .windowSnapping(config) = self { return config }
         return nil
     }
 
@@ -332,12 +322,6 @@ public enum RuleCollectionConfiguration: Codable, Equatable, Sendable {
         }
     }
 
-    public mutating func updateWindowSnappingConfig(_ newConfig: WindowSnappingConfig) {
-        if case .windowSnapping = self {
-            self = .windowSnapping(newConfig)
-        }
-    }
-
     // MARK: - Codable
 
     private enum CodingKeys: String, CodingKey {
@@ -357,7 +341,6 @@ public enum RuleCollectionConfiguration: Codable, Equatable, Sendable {
         case launcherGrid
         case autoShiftSymbols
         case keyRepeatControl
-        case windowSnapping
     }
 
     public init(from decoder: Decoder) throws {
@@ -399,9 +382,6 @@ public enum RuleCollectionConfiguration: Codable, Equatable, Sendable {
         case .keyRepeatControl:
             let config = try KeyRepeatControlConfig(from: decoder)
             self = .keyRepeatControl(config)
-        case .windowSnapping:
-            let config = try WindowSnappingConfig(from: decoder)
-            self = .windowSnapping(config)
         }
     }
 
@@ -442,9 +422,6 @@ public enum RuleCollectionConfiguration: Codable, Equatable, Sendable {
             try config.encode(to: encoder)
         case let .keyRepeatControl(config):
             try container.encode(ConfigType.keyRepeatControl, forKey: .type)
-            try config.encode(to: encoder)
-        case let .windowSnapping(config):
-            try container.encode(ConfigType.windowSnapping, forKey: .type)
             try config.encode(to: encoder)
         }
     }
@@ -957,17 +934,3 @@ public enum WindowSnappingActivationMode: String, Codable, Equatable, Sendable {
     }
 }
 
-public struct WindowSnappingConfig: Codable, Equatable, Sendable {
-    public var activationMode: WindowSnappingActivationMode
-    /// Stashed launcher mapping that was displaced when switching to Quick Launcher mode.
-    /// Restored when switching back to Leader mode.
-    public var displacedLauncherMapping: LauncherMapping?
-
-    public init(
-        activationMode: WindowSnappingActivationMode = .leader,
-        displacedLauncherMapping: LauncherMapping? = nil
-    ) {
-        self.activationMode = activationMode
-        self.displacedLauncherMapping = displacedLauncherMapping
-    }
-}

--- a/Sources/KeyPathAppKit/Models/RuleCollectionConfiguration.swift
+++ b/Sources/KeyPathAppKit/Models/RuleCollectionConfiguration.swift
@@ -959,8 +959,15 @@ public enum WindowSnappingActivationMode: String, Codable, Equatable, Sendable {
 
 public struct WindowSnappingConfig: Codable, Equatable, Sendable {
     public var activationMode: WindowSnappingActivationMode
+    /// Stashed launcher mapping that was displaced when switching to Quick Launcher mode.
+    /// Restored when switching back to Leader mode.
+    public var displacedLauncherMapping: LauncherMapping?
 
-    public init(activationMode: WindowSnappingActivationMode = .leader) {
+    public init(
+        activationMode: WindowSnappingActivationMode = .leader,
+        displacedLauncherMapping: LauncherMapping? = nil
+    ) {
         self.activationMode = activationMode
+        self.displacedLauncherMapping = displacedLauncherMapping
     }
 }

--- a/Sources/KeyPathAppKit/Models/RuleCollectionModels.swift
+++ b/Sources/KeyPathAppKit/Models/RuleCollectionModels.swift
@@ -56,6 +56,9 @@ public struct RuleCollection: Identifiable, Codable, Equatable, Sendable {
     /// For windowSnapping: which key convention to use (standard mnemonic vs vim)
     public var windowKeyConvention: WindowKeyConvention?
 
+    /// For windowSnapping: how the window layer is activated
+    public var windowSnappingActivationMode: WindowSnappingActivationMode?
+
     /// For macFunctionKeys: media keys (default Mac) or standard F-keys
     public var functionKeyMode: FunctionKeyMode?
 
@@ -84,6 +87,7 @@ public struct RuleCollection: Identifiable, Codable, Equatable, Sendable {
         activationHint: String? = nil,
         configuration: RuleCollectionConfiguration = .list,
         windowKeyConvention: WindowKeyConvention? = nil,
+        windowSnappingActivationMode: WindowSnappingActivationMode? = nil,
         functionKeyMode: FunctionKeyMode? = nil
     ) {
         self.id = id
@@ -101,6 +105,7 @@ public struct RuleCollection: Identifiable, Codable, Equatable, Sendable {
         self.activationHint = activationHint
         self.configuration = configuration
         self.windowKeyConvention = windowKeyConvention
+        self.windowSnappingActivationMode = windowSnappingActivationMode
         self.functionKeyMode = functionKeyMode
     }
 
@@ -109,7 +114,7 @@ public struct RuleCollection: Identifiable, Codable, Equatable, Sendable {
     enum CodingKeys: String, CodingKey {
         case id, name, summary, category, mappings, isEnabled, isSystemDefault, owningPackID
         case icon, tags, targetLayer, momentaryActivator, activationHint
-        case configuration, windowKeyConvention, functionKeyMode
+        case configuration, windowKeyConvention, windowSnappingActivationMode, functionKeyMode
         // Legacy keys for migration
         case displayStyle, pickerInputKey, presetOptions, selectedOutput
         case homeRowModsConfig, tapHoldOptions, selectedTapOutput, selectedHoldOutput
@@ -134,6 +139,7 @@ public struct RuleCollection: Identifiable, Codable, Equatable, Sendable {
         momentaryActivator = try container.decodeIfPresent(MomentaryActivator.self, forKey: .momentaryActivator)
         activationHint = try container.decodeIfPresent(String.self, forKey: .activationHint)
         windowKeyConvention = try container.decodeIfPresent(WindowKeyConvention.self, forKey: .windowKeyConvention)
+        windowSnappingActivationMode = try container.decodeIfPresent(WindowSnappingActivationMode.self, forKey: .windowSnappingActivationMode)
         functionKeyMode = try container.decodeIfPresent(FunctionKeyMode.self, forKey: .functionKeyMode)
 
         // Try new format first (configuration object)
@@ -218,6 +224,7 @@ public struct RuleCollection: Identifiable, Codable, Equatable, Sendable {
         try container.encodeIfPresent(activationHint, forKey: .activationHint)
         try container.encode(configuration, forKey: .configuration)
         try container.encodeIfPresent(windowKeyConvention, forKey: .windowKeyConvention)
+        try container.encodeIfPresent(windowSnappingActivationMode, forKey: .windowSnappingActivationMode)
         try container.encodeIfPresent(functionKeyMode, forKey: .functionKeyMode)
     }
 }

--- a/Sources/KeyPathAppKit/Services/Packs/PackSummaryProvider.swift
+++ b/Sources/KeyPathAppKit/Services/Packs/PackSummaryProvider.swift
@@ -35,7 +35,7 @@ enum PackSummaryProvider {
                 return singleKeySummary(for: input, collection: collection)
             case .homeRowMods, .homeRowLayerToggles, .chordGroups, .sequences,
                  .launcherGrid, .layerPresetPicker, .autoShiftSymbols,
-                 .keyRepeatControl, .windowSnapping, .table, .list:
+                 .keyRepeatControl, .table, .list:
                 // Multi-binding or complex configs — the embedded editor
                 // shows everything; a one-liner would misrepresent state.
                 return nil

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionCatalog.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionCatalog.swift
@@ -18,10 +18,7 @@ struct RuleCollectionCatalog {
         // Preserve user's configuration for configurable collections
         // (e.g., launcher mappings, home row mods settings, etc.)
         // Only if the configuration type matches - otherwise use catalog default
-        // Migrate .table → .windowSnapping for Window Snapping collections
-        if case .table = existing.configuration, case let .windowSnapping(catalogConfig) = updated.configuration {
-            merged.configuration = .windowSnapping(catalogConfig)
-        } else if existing.configuration.displayStyle == updated.configuration.displayStyle {
+        if existing.configuration.displayStyle == updated.configuration.displayStyle {
             // For tapHoldPicker: preserve user's selections but use catalog's options
             // This ensures removed options (like "None") don't persist
             if case let .tapHoldPicker(existingConfig) = existing.configuration,
@@ -331,7 +328,7 @@ struct RuleCollectionCatalog {
                 sourceLayer: .navigation // Activated from within navigation layer
             ),
             activationHint: "Leader → w → action key",
-            configuration: .windowSnapping(WindowSnappingConfig()),
+            configuration: .table,
             windowKeyConvention: .standard
         )
     }

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+PublicAPI.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+PublicAPI.swift
@@ -651,15 +651,18 @@ extension RuleCollectionsManager {
     /// Update window snapping configuration (activation mode)
     /// - Returns: name of auto-enabled dependency, or nil
     func updateWindowSnappingConfig(id: UUID, config: WindowSnappingConfig) async -> String? {
+        var resolvedConfig = config
+
         guard let index = ruleCollections.firstIndex(where: { $0.id == id }) else {
             let catalog = RuleCollectionCatalog()
             if var catalogCollection = catalog.defaultCollections().first(where: { $0.id == id }) {
-                catalogCollection.configuration = .windowSnapping(config)
-                catalogCollection.momentaryActivator = Self.momentaryActivatorForWindowSnapping(config)
-                catalogCollection.activationHint = Self.activationHintForWindowSnapping(config)
+                handleLauncherKeyConflict(config: &resolvedConfig)
+                catalogCollection.configuration = .windowSnapping(resolvedConfig)
+                catalogCollection.momentaryActivator = Self.momentaryActivatorForWindowSnapping(resolvedConfig)
+                catalogCollection.activationHint = Self.activationHintForWindowSnapping(resolvedConfig)
                 catalogCollection.isEnabled = true
                 ruleCollections.append(catalogCollection)
-                let autoEnabled = autoEnableWindowSnappingDependency(config)
+                let autoEnabled = autoEnableWindowSnappingDependency(resolvedConfig)
                 dedupeRuleCollectionsInPlace()
                 refreshLayerIndicatorState()
                 await regenerateConfigFromCollections()
@@ -668,15 +671,49 @@ extension RuleCollectionsManager {
             return nil
         }
 
-        ruleCollections[index].configuration = .windowSnapping(config)
-        ruleCollections[index].momentaryActivator = Self.momentaryActivatorForWindowSnapping(config)
-        ruleCollections[index].activationHint = Self.activationHintForWindowSnapping(config)
+        // Carry forward existing displaced mapping when not changing modes
+        if let existing = ruleCollections[index].configuration.windowSnappingConfig {
+            resolvedConfig.displacedLauncherMapping = existing.displacedLauncherMapping
+        }
+        handleLauncherKeyConflict(config: &resolvedConfig)
 
-        let autoEnabled = autoEnableWindowSnappingDependency(config)
+        ruleCollections[index].configuration = .windowSnapping(resolvedConfig)
+        ruleCollections[index].momentaryActivator = Self.momentaryActivatorForWindowSnapping(resolvedConfig)
+        ruleCollections[index].activationHint = Self.activationHintForWindowSnapping(resolvedConfig)
+
+        let autoEnabled = autoEnableWindowSnappingDependency(resolvedConfig)
         dedupeRuleCollectionsInPlace()
         refreshLayerIndicatorState()
         await regenerateConfigFromCollections()
         return autoEnabled
+    }
+
+    /// Displace or restore the `w` launcher mapping when switching Window Snapping activation modes.
+    private func handleLauncherKeyConflict(config: inout WindowSnappingConfig) {
+        guard let launcherIdx = ruleCollections.firstIndex(where: { $0.id == RuleCollectionIdentifier.launcher }),
+              case var .launcherGrid(launcherConfig) = ruleCollections[launcherIdx].configuration
+        else { return }
+
+        switch config.activationMode {
+        case .quickLauncher:
+            if let wIdx = launcherConfig.mappings.firstIndex(where: { $0.key.lowercased() == "w" && $0.isEnabled }) {
+                config.displacedLauncherMapping = launcherConfig.mappings[wIdx]
+                launcherConfig.mappings[wIdx].isEnabled = false
+                ruleCollections[launcherIdx].configuration = .launcherGrid(launcherConfig)
+                AppLogger.shared.log("🪟 [WindowSnapping] Displaced launcher mapping for 'w': \(config.displacedLauncherMapping!.action.displayName)")
+            }
+        case .leader:
+            if let displaced = config.displacedLauncherMapping {
+                if let wIdx = launcherConfig.mappings.firstIndex(where: { $0.key.lowercased() == "w" }) {
+                    launcherConfig.mappings[wIdx] = displaced
+                } else {
+                    launcherConfig.mappings.append(displaced)
+                }
+                ruleCollections[launcherIdx].configuration = .launcherGrid(launcherConfig)
+                AppLogger.shared.log("🪟 [WindowSnapping] Restored launcher mapping for 'w': \(displaced.action.displayName)")
+                config.displacedLauncherMapping = nil
+            }
+        }
     }
 
     private static func momentaryActivatorForWindowSnapping(_ config: WindowSnappingConfig) -> MomentaryActivator {

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+PublicAPI.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+PublicAPI.swift
@@ -648,76 +648,24 @@ extension RuleCollectionsManager {
         return wasNewlyEnabled
     }
 
-    /// Update window snapping configuration (activation mode)
+    /// Update window snapping activation mode
     /// - Returns: name of auto-enabled dependency, or nil
-    func updateWindowSnappingConfig(id: UUID, config: WindowSnappingConfig) async -> String? {
-        var resolvedConfig = config
+    func updateWindowSnappingActivationMode(id: UUID, mode: WindowSnappingActivationMode) async -> String? {
+        guard let index = ruleCollections.firstIndex(where: { $0.id == id }) else { return nil }
 
-        guard let index = ruleCollections.firstIndex(where: { $0.id == id }) else {
-            let catalog = RuleCollectionCatalog()
-            if var catalogCollection = catalog.defaultCollections().first(where: { $0.id == id }) {
-                handleLauncherKeyConflict(config: &resolvedConfig)
-                catalogCollection.configuration = .windowSnapping(resolvedConfig)
-                catalogCollection.momentaryActivator = Self.momentaryActivatorForWindowSnapping(resolvedConfig)
-                catalogCollection.activationHint = Self.activationHintForWindowSnapping(resolvedConfig)
-                catalogCollection.isEnabled = true
-                ruleCollections.append(catalogCollection)
-                let autoEnabled = autoEnableWindowSnappingDependency(resolvedConfig)
-                dedupeRuleCollectionsInPlace()
-                refreshLayerIndicatorState()
-                await regenerateConfigFromCollections()
-                return autoEnabled
-            }
-            return nil
-        }
+        ruleCollections[index].windowSnappingActivationMode = mode
+        ruleCollections[index].momentaryActivator = Self.momentaryActivatorForWindowSnapping(mode)
+        ruleCollections[index].activationHint = Self.activationHintForWindowSnapping(mode)
 
-        // Carry forward existing displaced mapping when not changing modes
-        if let existing = ruleCollections[index].configuration.windowSnappingConfig {
-            resolvedConfig.displacedLauncherMapping = existing.displacedLauncherMapping
-        }
-        handleLauncherKeyConflict(config: &resolvedConfig)
-
-        ruleCollections[index].configuration = .windowSnapping(resolvedConfig)
-        ruleCollections[index].momentaryActivator = Self.momentaryActivatorForWindowSnapping(resolvedConfig)
-        ruleCollections[index].activationHint = Self.activationHintForWindowSnapping(resolvedConfig)
-
-        let autoEnabled = autoEnableWindowSnappingDependency(resolvedConfig)
+        let autoEnabled = autoEnableWindowSnappingDependency(mode)
         dedupeRuleCollectionsInPlace()
         refreshLayerIndicatorState()
         await regenerateConfigFromCollections()
         return autoEnabled
     }
 
-    /// Displace or restore the `w` launcher mapping when switching Window Snapping activation modes.
-    private func handleLauncherKeyConflict(config: inout WindowSnappingConfig) {
-        guard let launcherIdx = ruleCollections.firstIndex(where: { $0.id == RuleCollectionIdentifier.launcher }),
-              case var .launcherGrid(launcherConfig) = ruleCollections[launcherIdx].configuration
-        else { return }
-
-        switch config.activationMode {
-        case .quickLauncher:
-            if let wIdx = launcherConfig.mappings.firstIndex(where: { $0.key.lowercased() == "w" && $0.isEnabled }) {
-                config.displacedLauncherMapping = launcherConfig.mappings[wIdx]
-                launcherConfig.mappings[wIdx].isEnabled = false
-                ruleCollections[launcherIdx].configuration = .launcherGrid(launcherConfig)
-                AppLogger.shared.log("🪟 [WindowSnapping] Displaced launcher mapping for 'w': \(config.displacedLauncherMapping!.action.displayName)")
-            }
-        case .leader:
-            if let displaced = config.displacedLauncherMapping {
-                if let wIdx = launcherConfig.mappings.firstIndex(where: { $0.key.lowercased() == "w" }) {
-                    launcherConfig.mappings[wIdx] = displaced
-                } else {
-                    launcherConfig.mappings.append(displaced)
-                }
-                ruleCollections[launcherIdx].configuration = .launcherGrid(launcherConfig)
-                AppLogger.shared.log("🪟 [WindowSnapping] Restored launcher mapping for 'w': \(displaced.action.displayName)")
-                config.displacedLauncherMapping = nil
-            }
-        }
-    }
-
-    private static func momentaryActivatorForWindowSnapping(_ config: WindowSnappingConfig) -> MomentaryActivator {
-        switch config.activationMode {
+    private static func momentaryActivatorForWindowSnapping(_ mode: WindowSnappingActivationMode) -> MomentaryActivator {
+        switch mode {
         case .leader:
             MomentaryActivator(input: "w", targetLayer: .custom("window"), sourceLayer: .navigation)
         case .quickLauncher:
@@ -725,15 +673,15 @@ extension RuleCollectionsManager {
         }
     }
 
-    private static func activationHintForWindowSnapping(_ config: WindowSnappingConfig) -> String {
-        switch config.activationMode {
+    private static func activationHintForWindowSnapping(_ mode: WindowSnappingActivationMode) -> String {
+        switch mode {
         case .leader: "Leader → w → action key"
         case .quickLauncher: "Hyper + w → action key"
         }
     }
 
-    private func autoEnableWindowSnappingDependency(_ config: WindowSnappingConfig) -> String? {
-        switch config.activationMode {
+    private func autoEnableWindowSnappingDependency(_ mode: WindowSnappingActivationMode) -> String? {
+        switch mode {
         case .leader:
             let navID = RuleCollectionIdentifier.leaderKey
             if !ruleCollections.contains(where: { $0.id == navID && $0.isEnabled }) {

--- a/Sources/KeyPathAppKit/UI/Gallery/PackDetailView+BindingRows.swift
+++ b/Sources/KeyPathAppKit/UI/Gallery/PackDetailView+BindingRows.swift
@@ -175,14 +175,13 @@ extension PackDetailView {
                 WindowSnappingView(
                     mappings: collection.mappings,
                     convention: collection.windowKeyConvention ?? .standard,
-                    activationMode: collection.configuration.windowSnappingConfig?.activationMode ?? .leader,
+                    activationMode: collection.windowSnappingActivationMode ?? .leader,
                     onConventionChange: { convention in
                         Task { await applyWindowConventionEdit(convention, collectionID: collection.id) }
                     },
                     onActivationModeChange: { mode in
                         Task {
-                            let config = WindowSnappingConfig(activationMode: mode)
-                            _ = await kanataManager.updateWindowSnappingConfig(collectionId: collection.id, config: config)
+                            _ = await kanataManager.updateWindowSnappingActivationMode(collectionId: collection.id, mode: mode)
                         }
                     }
                 )

--- a/Sources/KeyPathAppKit/UI/KeyboardVisualization/KeyboardVisualizationViewModel+LayoutMapping.swift
+++ b/Sources/KeyPathAppKit/UI/KeyboardVisualization/KeyboardVisualizationViewModel+LayoutMapping.swift
@@ -125,8 +125,7 @@ extension KeyboardVisualizationViewModel {
         // Inject synthetic "Windows" entry when Window Snapping uses Quick Launcher mode
         if let wsCollection = collections.first(where: { $0.id == RuleCollectionIdentifier.windowSnapping }),
            wsCollection.isEnabled,
-           let wsConfig = wsCollection.configuration.windowSnappingConfig,
-           wsConfig.activationMode == .quickLauncher
+           wsCollection.windowSnappingActivationMode == .quickLauncher
         {
             result["w"] = LauncherMapping(
                 key: "w",

--- a/Sources/KeyPathAppKit/UI/KeyboardVisualization/KeyboardVisualizationViewModel+LayoutMapping.swift
+++ b/Sources/KeyPathAppKit/UI/KeyboardVisualization/KeyboardVisualizationViewModel+LayoutMapping.swift
@@ -118,9 +118,23 @@ extension KeyboardVisualizationViewModel {
             return true
         }
 
-        let result = Dictionary(
+        var result = Dictionary(
             uniqueKeysWithValues: enabledMappings.map { ($0.key.lowercased(), $0) }
         )
+
+        // Inject synthetic "Windows" entry when Window Snapping uses Quick Launcher mode
+        if let wsCollection = collections.first(where: { $0.id == RuleCollectionIdentifier.windowSnapping }),
+           wsCollection.isEnabled,
+           let wsConfig = wsCollection.configuration.windowSnappingConfig,
+           wsConfig.activationMode == .quickLauncher
+        {
+            result["w"] = LauncherMapping(
+                key: "w",
+                action: .systemAction(id: "window-snapping"),
+                userDescription: "Window Snapping"
+            )
+        }
+
         AppLogger.shared.info("🚀 [KeyboardViz] Built \(result.count) launcher mappings (filtered for installed apps)")
         return result
     }

--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView+LauncherMode.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView+LauncherMode.swift
@@ -40,7 +40,7 @@ extension OverlayKeycapView {
                         .opacity((iconVisible ? 1.0 : 0) * fadeFactor)
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
                     } else {
-                        Image(systemName: mapping.action.isLaunchApp ? "app.fill" : "globe")
+                        Image(systemName: launcherFallbackSymbol(for: mapping))
                             .font(.system(size: 14 * scale))
                             .foregroundStyle(foregroundColor.opacity(0.6))
                             .scaleEffect(iconVisible ? 1.0 : 0.3)
@@ -90,5 +90,12 @@ extension OverlayKeycapView {
 
     var launcherAppIcon: NSImage? {
         appIcon ?? faviconImage
+    }
+
+    private func launcherFallbackSymbol(for mapping: LauncherMapping) -> String {
+        if case let .systemAction(id) = mapping.action, id == "window-snapping" {
+            return "rectangle.split.2x2"
+        }
+        return mapping.action.isLaunchApp ? "app.fill" : "globe"
     }
 }

--- a/Sources/KeyPathAppKit/UI/Rules/ActiveRulesView.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/ActiveRulesView.swift
@@ -177,7 +177,7 @@ private extension RuleCollectionRow {
             WindowSnappingView(
                 mappings: collection.mappings,
                 convention: collection.windowKeyConvention ?? .standard,
-                activationMode: collection.configuration.windowSnappingConfig?.activationMode ?? .leader,
+                activationMode: collection.windowSnappingActivationMode ?? .leader,
                 onConventionChange: { convention in
                     onWindowConventionChanged?(convention)
                 }

--- a/Sources/KeyPathAppKit/UI/Rules/LauncherCollectionView.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/LauncherCollectionView.swift
@@ -10,6 +10,7 @@ import UniformTypeIdentifiers
 struct LauncherCollectionView: View {
     @Binding var config: LauncherGridConfig
     let onConfigChanged: (LauncherGridConfig) -> Void
+    var windowSnappingActive: Bool = false
 
     @State private var selectedKey: String?
     @State private var showBrowserHistory = false
@@ -59,7 +60,8 @@ struct LauncherCollectionView: View {
             LauncherDrawerView(
                 config: $config,
                 selectedKey: $selectedKey,
-                onConfigChanged: onConfigChanged
+                onConfigChanged: onConfigChanged,
+                windowSnappingActive: windowSnappingActive
             )
             .onChange(of: config) { _, newValue in
                 onConfigChanged(newValue)

--- a/Sources/KeyPathAppKit/UI/Rules/LauncherDrawerView.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/LauncherDrawerView.swift
@@ -9,12 +9,27 @@ struct LauncherDrawerView: View {
     @Binding var config: LauncherGridConfig
     @Binding var selectedKey: String?
     var onConfigChanged: ((LauncherGridConfig) -> Void)?
+    var windowSnappingActive: Bool = false
 
     @State private var editingMapping: LauncherMapping?
     @State private var showAddMapping = false
 
     private var sortedMappings: [LauncherMapping] {
-        config.mappings.sorted { $0.key < $1.key }
+        var mappings = config.mappings.sorted { $0.key < $1.key }
+        if windowSnappingActive {
+            let synthetic = LauncherMapping(
+                key: "w",
+                action: .systemAction(id: "window-snapping"),
+                userDescription: "Window Snapping"
+            )
+            mappings.insert(synthetic, at: mappings.firstIndex(where: { $0.key > "w" }) ?? mappings.endIndex)
+        }
+        return mappings
+    }
+
+    private func isWindowSnappingEntry(_ mapping: LauncherMapping) -> Bool {
+        if case let .systemAction(id) = mapping.action, id == "window-snapping" { return true }
+        return false
     }
 
     private let columns = [
@@ -61,15 +76,17 @@ struct LauncherDrawerView: View {
                 ScrollView {
                     LazyVGrid(columns: columns, spacing: 10) {
                         ForEach(sortedMappings) { mapping in
+                            let isSynthetic = isWindowSnappingEntry(mapping)
                             LauncherMappingCard(
                                 mapping: mapping,
-                                isSelected: selectedKey?.lowercased() == mapping.key.lowercased(),
+                                isSelected: !isSynthetic && selectedKey?.lowercased() == mapping.key.lowercased(),
                                 onEdit: {
+                                    guard !isSynthetic else { return }
                                     selectedKey = mapping.key
                                     editingMapping = mapping
                                 },
-                                onDelete: { deleteMapping(id: mapping.id) },
-                                onToggleEnabled: { newValue in
+                                onDelete: { guard !isSynthetic else { return }; deleteMapping(id: mapping.id) },
+                                onToggleEnabled: isSynthetic ? nil : { newValue in
                                     toggleMapping(mapping, enabled: newValue)
                                 }
                             )
@@ -207,6 +224,7 @@ private struct LauncherMappingCard: View {
         case .openURL: "Website"
         case .openFolder: "Folder"
         case .runScript: "Script"
+        case let .systemAction(id) where id == "window-snapping": "Layer"
         default: "Action"
         }
     }
@@ -352,6 +370,7 @@ private struct LauncherMappingCard: View {
         case .openURL: "globe"
         case .openFolder: "folder.fill"
         case .runScript: "terminal.fill"
+        case let .systemAction(id) where id == "window-snapping": "rectangle.split.2x2"
         default: "questionmark.circle"
         }
     }

--- a/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView+CollectionRow.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView+CollectionRow.swift
@@ -87,6 +87,8 @@ struct ExpandableCollectionRow: View {
     var onSelectFunctionKeyMode: ((FunctionKeyMode) -> Void)?
     /// For launcherGrid: callback to update launcher config
     var onLauncherConfigChanged: ((LauncherGridConfig) -> Void)?
+    /// For launcherGrid: whether Window Snapping uses Quick Launcher activation
+    var windowSnappingActive: Bool = false
     /// For autoShiftSymbols: callback to update config
     var onAutoShiftConfigChanged: ((AutoShiftSymbolsConfig) -> Void)?
     /// Optional help button callback — when non-nil, a `?` button appears in the header
@@ -465,7 +467,8 @@ struct ExpandableCollectionRow: View {
                             ),
                             onConfigChanged: { newConfig in
                                 onLauncherConfigChanged?(newConfig)
-                            }
+                            },
+                            windowSnappingActive: windowSnappingActive
                         )
                         .padding(.top, 8)
                         .padding(.bottom, 12)

--- a/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView+CollectionRow.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView+CollectionRow.swift
@@ -574,7 +574,7 @@ struct ExpandableCollectionRow: View {
                         WindowSnappingView(
                             mappings: collection?.mappings ?? [],
                             convention: collection?.windowKeyConvention ?? .standard,
-                            activationMode: collection?.configuration.windowSnappingConfig?.activationMode ?? .leader,
+                            activationMode: collection?.windowSnappingActivationMode ?? .leader,
                             onConventionChange: { convention in
                                 onSelectWindowConvention?(convention)
                             },

--- a/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView+DynamicDisplay.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView+DynamicDisplay.swift
@@ -98,8 +98,8 @@ extension RulesTabView {
         if case let .autoShiftSymbols(config) = collection.configuration {
             return "\(config.enabledKeys.count) keys \u{00B7} \(config.timeoutMs)ms hold"
         }
-        if case let .windowSnapping(config) = collection.configuration {
-            switch config.activationMode {
+        if let wsMode = collection.windowSnappingActivationMode {
+            switch wsMode {
             case .leader: return "\(currentLeaderKeyDisplay) → w → action key"
             case .quickLauncher: return "Hyper + w → action key"
             }

--- a/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView.swift
@@ -44,6 +44,14 @@ struct RulesTabView: View {
     private let catalog = RuleCollectionCatalog()
 
     /// Total count of custom rules (everywhere + app-specific)
+    private var isWindowSnappingOnLauncher: Bool {
+        guard let ws = kanataManager.ruleCollections.first(where: { $0.id == RuleCollectionIdentifier.windowSnapping }),
+              ws.isEnabled,
+              let config = ws.configuration.windowSnappingConfig
+        else { return false }
+        return config.activationMode == .quickLauncher
+    }
+
     private var totalCustomRulesCount: Int {
         kanataManager.customRules.count + appKeymaps.flatMap(\.overrides).count
     }
@@ -326,6 +334,7 @@ struct RulesTabView: View {
             onLauncherConfigChanged: collection.id == RuleCollectionIdentifier.launcher ? { config in
                 Task { await kanataManager.updateLauncherConfig(collection.id, config: config) }
             } : nil,
+            windowSnappingActive: isWindowSnappingOnLauncher,
             onAutoShiftConfigChanged: collection.id == RuleCollectionIdentifier.autoShiftSymbols ? { config in
                 pendingToggles[collection.id] = true
                 Task { await kanataManager.updateAutoShiftSymbolsConfig(collectionId: collection.id, config: config) }

--- a/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView.swift
@@ -46,10 +46,9 @@ struct RulesTabView: View {
     /// Total count of custom rules (everywhere + app-specific)
     private var isWindowSnappingOnLauncher: Bool {
         guard let ws = kanataManager.ruleCollections.first(where: { $0.id == RuleCollectionIdentifier.windowSnapping }),
-              ws.isEnabled,
-              let config = ws.configuration.windowSnappingConfig
+              ws.isEnabled
         else { return false }
-        return config.activationMode == .quickLauncher
+        return ws.windowSnappingActivationMode == .quickLauncher
     }
 
     private var totalCustomRulesCount: Int {
@@ -322,8 +321,7 @@ struct RulesTabView: View {
             } : nil,
             onWindowSnappingActivationModeChange: collection.id == RuleCollectionIdentifier.windowSnapping ? { mode in
                 Task {
-                    let config = WindowSnappingConfig(activationMode: mode)
-                    if let autoEnabled = await kanataManager.updateWindowSnappingConfig(collectionId: collection.id, config: config) {
+                    if let autoEnabled = await kanataManager.updateWindowSnappingActivationMode(collectionId: collection.id, mode: mode) {
                         settingsToastManager.showSuccess("Also enabled \(autoEnabled)")
                     }
                 }

--- a/Sources/KeyPathAppKit/UI/ViewModels/KanataViewModel.swift
+++ b/Sources/KeyPathAppKit/UI/ViewModels/KanataViewModel.swift
@@ -408,8 +408,8 @@ class KanataViewModel {
         }
     }
 
-    func updateWindowSnappingConfig(collectionId: UUID, config: WindowSnappingConfig) async -> String? {
-        await manager.updateWindowSnappingConfig(collectionId: collectionId, config: config)
+    func updateWindowSnappingActivationMode(collectionId: UUID, mode: WindowSnappingActivationMode) async -> String? {
+        await manager.updateWindowSnappingActivationMode(collectionId: collectionId, mode: mode)
     }
 
     /// Update the leader key for all collections that use momentary activation


### PR DESCRIPTION
## Summary
- Window Snapping activation mode stored as a simple field on `RuleCollection` (like `windowKeyConvention`), not a custom config type
- When Quick Launcher mode is active, overlay shows W keycap with window icon on the launcher layer
- Launcher sidebar shows a non-editable "Window Snapping" card for the W key
- Auto-enables Quick Launcher or Leader Key when switching modes

## Test plan
- [ ] Rules → Window Snapping → switch to Quick Launcher mode
- [ ] Rules → Quick Launcher → verify "Window Snapping" card appears in drawer for W key
- [ ] Hold Hyper → verify W shows window icon in overlay
- [ ] Press Hyper + W → verify window layer activates, overlay shows window action keys
- [ ] Switch back to Leader mode → verify Leader → W still works
- [ ] All 532 tests pass