### PR TITLE
fix: nav layer overlay blank when holding Space (#578)

### DIFF
--- a/Sources/KeyPathAppKit/UI/Overlay/LiveKeyboardOverlayView.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/LiveKeyboardOverlayView.swift
@@ -244,11 +244,13 @@ struct LiveKeyboardOverlayView: View {
         let packConfig = PackZoneResolver.layerPreviewConfig(installedPackIDs: packIDs)
         let capsConfig = await Self.capsLockLayerPreviewTargets()
         let momentaryConfig = await Self.momentaryActivatorLayerPreviewTargets()
+        let leaderConfig = await Self.leaderKeyPreviewTargets()
 
         await MainActor.run {
             var merged = packConfig?.targets ?? [:]
             merged.merge(capsConfig) { existing, _ in existing }
             merged.merge(momentaryConfig) { existing, _ in existing }
+            merged.merge(leaderConfig) { existing, _ in existing }
             viewModel.layerPreviewTargets = merged
             viewModel.layerPreviewActivators = Set(merged.keys)
         }
@@ -293,6 +295,23 @@ struct LiveKeyboardOverlayView: View {
         }
 
         return result
+    }
+
+    /// Add the leader key (e.g., Space → nav) to preview targets.
+    /// The leader key activator is driven by LeaderKeyPreference, not by a collection's
+    /// momentaryActivator, so it needs its own lookup.
+    private static func leaderKeyPreviewTargets() async -> [UInt16: String] {
+        let pref: LeaderKeyPreference
+        if let data = UserDefaults.standard.data(forKey: "KeyPath.LeaderKey.Preference"),
+           let stored = try? JSONDecoder().decode(LeaderKeyPreference.self, from: data)
+        {
+            pref = stored
+        } else {
+            pref = .default
+        }
+        guard pref.enabled else { return [:] }
+        guard let keyCode = KeyboardVisualizationViewModel.kanataNameToKeyCode(pref.key) else { return [:] }
+        return [keyCode: pref.targetLayer.kanataName]
     }
 
     private func copyValidationErrorsToClipboard() {


### PR DESCRIPTION
## Summary
The overlay showed "Nav" label when holding Space but all keys were blank — only W (window activator) and backspace were highlighted. The nav layer's full key mapping (arrows, undo, redo, yank, etc.) never loaded.

**Root cause:** The overlay's 50ms layer preview system builds a map of activator keys → target layers by scanning collection `momentaryActivator` properties. Space → nav was missing because the nav layer activator comes from `LeaderKeyPreference` (a system-level UserDefaults setting), not from any collection's activator.

**Fix:** Added `leaderKeyPreviewTargets()` that reads `LeaderKeyPreference` and registers the leader key (default: Space → nav) in the preview targets map.

Closes #578

## Test plan
- [ ] Hold Space with overlay open → nav layer should show all Vim keys (arrows on hjkl, undo, redo, yank, put, etc.)
- [ ] Hold F → home-arrows layer still works
- [ ] Hold Caps (Hyper) → launcher layer still works
- [ ] Change leader key to Tab or Caps → overlay should adapt