### PR TITLE
fix: use prebuilt layer cache for instant overlay switching

### DIFF
--- a/Sources/KeyPathAppKit/Services/LayerMapping/LayerKeyMapper.swift
+++ b/Sources/KeyPathAppKit/Services/LayerMapping/LayerKeyMapper.swift
@@ -282,6 +282,11 @@ actor LayerKeyMapper {
         return (mapping, report)
     }
 
+    /// Return a cached mapping if available, nil otherwise.
+    func getCachedMapping(for layer: String, cacheKeySuffix: String = "neovim-scope-fallback") -> [UInt16: LayerKeyInfo]? {
+        cache["\(layer.lowercased())|\(cacheKeySuffix)"]
+    }
+
     /// Invalidate all cached mappings (call when config changes)
     func invalidateCache() {
         cache.removeAll()

--- a/Sources/KeyPathAppKit/UI/KeyboardVisualization/KeyboardVisualizationViewModel+LayoutMapping.swift
+++ b/Sources/KeyPathAppKit/UI/KeyboardVisualization/KeyboardVisualizationViewModel+LayoutMapping.swift
@@ -27,12 +27,6 @@ extension KeyboardVisualizationViewModel {
         // layer indicators) update without waiting for the async mapping rebuild.
         currentLayerName = targetLayerName
 
-        // Clear stale layer mappings so keys without zone colors don't briefly
-        // render with the previous layer's collection color and icons (e.g.,
-        // F1-F12 flashing orange when entering a nav layer).
-        layerKeyMap = [:]
-        remapOutputMap = [:]
-
         // Clear tap-hold sources on layer change to prevent stale suppressions
         // (e.g., user switches layers while holding a tap-hold key)
         activeTapHoldSources.removeAll()
@@ -181,6 +175,13 @@ extension KeyboardVisualizationViewModel {
             return
         }
 
+        // Use prebuilt mapping immediately if available (from startup prebuild).
+        // This prevents the overlay from flashing empty during the async rebuild.
+        if let cached = prebuiltLayerMappings[targetLayerName.lowercased()] {
+            layerKeyMap = cached
+            remapOutputMap = buildRemapOutputMap(from: cached)
+        }
+
         isLoadingLayerMap = true
         AppLogger.shared.info("🗺️ [KeyboardViz] Starting layer mapping build for '\(targetLayerName)'...")
 
@@ -257,6 +258,7 @@ extension KeyboardVisualizationViewModel {
 
                 // Update mapping (layer name was already set eagerly in updateLayer;
                 // re-assign here for the rebuildLayerMapping() path from setLayout)
+                guard !Task.isCancelled else { return }
                 await MainActor.run {
                     self.currentLayerName = targetLayerName
                     self.layerKeyMap = mapping
@@ -652,7 +654,18 @@ extension KeyboardVisualizationViewModel {
                 allEnabledCollections: enabledCollections
             )
 
-            AppLogger.shared.info("🗺️ [KeyboardViz] Background prebuild complete")
+            // Copy prebuilt mappings to a synchronous cache for instant layer switching
+            var localCache: [String: [UInt16: LayerKeyInfo]] = [:]
+            for layer in layerNames {
+                if let mapping = await layerKeyMapper.getCachedMapping(for: layer) {
+                    localCache[layer] = mapping
+                }
+            }
+            await MainActor.run {
+                self.prebuiltLayerMappings = localCache
+            }
+
+            AppLogger.shared.info("🗺️ [KeyboardViz] Background prebuild complete (\(localCache.count) layers cached)")
         }
     }
 

--- a/Sources/KeyPathAppKit/UI/KeyboardVisualization/KeyboardVisualizationViewModel.swift
+++ b/Sources/KeyPathAppKit/UI/KeyboardVisualization/KeyboardVisualizationViewModel.swift
@@ -79,6 +79,9 @@ class KeyboardVisualizationViewModel {
     var launcherMappings: [String: LauncherMapping] = [:]
     /// Pre-computed launcher mappings cache, ready before layer switch
     @ObservationIgnored var cachedLauncherMappings: [String: LauncherMapping]?
+    /// Pre-built layer mappings from startup prebuild, keyed by layer name.
+    /// Used for instant layer switching without waiting for async simulator.
+    @ObservationIgnored var prebuiltLayerMappings: [String: [UInt16: LayerKeyInfo]] = [:]
 
     // MARK: - Optional Feature Collections
 


### PR DESCRIPTION
## Summary
The overlay flashed empty when switching to the nav layer because `updateLayer` cleared `layerKeyMap` before the async simulator rebuild completed. The 50ms preview cancel on key release then reverted to base, so the nav mapping never displayed.

**Fix:** Store prebuilt layer mappings in a synchronous `@MainActor` dictionary on the ViewModel. On layer switch, use the cached mapping immediately — no async hop, no actor boundary, no race. The async rebuild still runs and overwrites with the latest data (custom rules, push-msg augmentations).

Also adds `Task.isCancelled` guard before writing async rebuild results to prevent a cancelled task from overwriting a subsequent layer switch.

## Test plan
- [ ] Hold Space → nav layer shows full Vim keys (arrows on hjkl, undo, redo, yank, etc.) instantly
- [ ] Hold F → home-arrows layer shows arrows instantly
- [ ] Hold Caps (Hyper) → launcher layer shows app icons instantly
- [ ] Release keys → overlay returns to base cleanly
- [ ] 537 tests pass