### PR TITLE
fix: nav layer shows arrow symbols instead of text labels

### DIFF
--- a/Sources/KeyPathAppKit/UI/KeyboardVisualization/KeyboardVisualizationViewModel+LayoutMapping.swift
+++ b/Sources/KeyPathAppKit/UI/KeyboardVisualization/KeyboardVisualizationViewModel+LayoutMapping.swift
@@ -177,7 +177,8 @@ extension KeyboardVisualizationViewModel {
 
         // Use prebuilt mapping immediately if available (from startup prebuild).
         // This prevents the overlay from flashing empty during the async rebuild.
-        if let cached = prebuiltLayerMappings[targetLayerName.lowercased()] {
+        let cacheKey = targetLayerName.lowercased()
+        if let cached = prebuiltLayerMappings[cacheKey] {
             layerKeyMap = cached
             remapOutputMap = buildRemapOutputMap(from: cached)
         }
@@ -227,9 +228,6 @@ extension KeyboardVisualizationViewModel {
 
                 // DEBUG: Log what simulator returned
                 AppLogger.shared.info("🗺️ [KeyboardViz] Simulator returned \(mapping.count) entries for '\(targetLayerName)'")
-                for (keyCode, info) in mapping.prefix(20) {
-                    AppLogger.shared.debug("  [\(targetLayerName)] keyCode \(keyCode) -> '\(info.displayLabel)'")
-                }
 
                 // Outside approved terminals, strip Neovim-owned entries from display mappings.
                 // This keeps layer behavior untouched while suppressing Neovim educational UI content.
@@ -457,33 +455,36 @@ extension KeyboardVisualizationViewModel {
         for (keyCode, originalInfo) in mapping {
             let keyName = OverlayKeyboardView.keyCodeToKanataName(keyCode).lowercased()
             if let info = actionByInput[keyName] {
-                let resolvedInfo = Self.attachCollectionId(info, from: originalInfo)
+                let resolvedInfo = Self.mergeAugmentation(info, with: originalInfo)
                 augmented[keyCode] = resolvedInfo
-                AppLogger.shared.debug("🗺️ [KeyboardViz] Key \(keyName)(\(keyCode)) -> '\(resolvedInfo.displayLabel)'")
             }
         }
 
         return augmented
     }
 
-    /// Preserve collection ownership when augmenting with push-msg or remap actions.
-    private nonisolated static func attachCollectionId(
-        _ info: LayerKeyInfo,
-        from originalInfo: LayerKeyInfo
+    /// Merge augmented info with the original simulator entry, preserving vimLabel
+    /// and preferring the simulator's displayLabel when a vimLabel exists (so arrow
+    /// keys show "←" instead of description text like "h — left").
+    private nonisolated static func mergeAugmentation(
+        _ augmented: LayerKeyInfo,
+        with original: LayerKeyInfo
     ) -> LayerKeyInfo {
-        let collectionId = originalInfo.collectionId ?? info.collectionId
-        guard collectionId != info.collectionId else { return info }
+        let collectionId = original.collectionId ?? augmented.collectionId
+        let vimLabel = original.vimLabel ?? augmented.vimLabel
+        let displayLabel = vimLabel != nil ? (original.displayLabel.isEmpty ? augmented.displayLabel : original.displayLabel) : augmented.displayLabel
 
         return LayerKeyInfo(
-            displayLabel: info.displayLabel,
-            outputKey: info.outputKey,
-            outputKeyCode: info.outputKeyCode,
-            isTransparent: info.isTransparent,
-            isLayerSwitch: info.isLayerSwitch,
-            appLaunchIdentifier: info.appLaunchIdentifier,
-            systemActionIdentifier: info.systemActionIdentifier,
-            urlIdentifier: info.urlIdentifier,
-            collectionId: collectionId
+            displayLabel: displayLabel,
+            outputKey: augmented.outputKey ?? original.outputKey,
+            outputKeyCode: augmented.outputKeyCode ?? original.outputKeyCode,
+            isTransparent: augmented.isTransparent,
+            isLayerSwitch: augmented.isLayerSwitch,
+            appLaunchIdentifier: augmented.appLaunchIdentifier,
+            systemActionIdentifier: augmented.systemActionIdentifier,
+            urlIdentifier: augmented.urlIdentifier,
+            collectionId: collectionId,
+            vimLabel: vimLabel
         )
     }
 
@@ -654,10 +655,21 @@ extension KeyboardVisualizationViewModel {
                 allEnabledCollections: enabledCollections
             )
 
-            // Copy prebuilt mappings to a synchronous cache for instant layer switching
+            // Copy prebuilt mappings to a synchronous cache for instant layer switching.
+            // Augment each mapping with push-msg actions (app launches, system actions, etc.)
+            // so the cache includes the same data the async rebuild produces.
+            let customRules = await CustomRulesStore.shared.loadRules()
             var localCache: [String: [UInt16: LayerKeyInfo]] = [:]
             for layer in layerNames {
-                if let mapping = await layerKeyMapper.getCachedMapping(for: layer) {
+                if var mapping = await layerKeyMapper.getCachedMapping(for: layer) {
+                    mapping = await MainActor.run {
+                        self.augmentWithPushMsgActions(
+                            mapping: mapping,
+                            customRules: customRules,
+                            ruleCollections: enabledCollections,
+                            currentLayerName: layer
+                        )
+                    }
                     localCache[layer] = mapping
                 }
             }

--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView+ModeContent.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView+ModeContent.swift
@@ -265,12 +265,13 @@ extension OverlayKeycapView {
                 .font(.system(size: 14 * scale, weight: .medium))
                 .foregroundStyle(Color.white.opacity(0.9))
         }
-        // Check for navigation arrows (Vim style) — keep arrows for hjkl
+        // Check for navigation arrows — from displayLabel or vimLabel
         else if let info = layerKeyInfo {
             let arrowLabels: Set<String> = ["←", "→", "↑", "↓"]
-            if arrowLabels.contains(info.displayLabel) {
+            if arrowLabels.contains(info.displayLabel) || arrowLabels.contains(info.vimLabel ?? "") {
                 // Large centered arrow
-                Text(info.displayLabel)
+                let arrow = arrowLabels.contains(info.displayLabel) ? info.displayLabel : info.vimLabel!
+                Text(arrow)
                     .font(.system(size: 16 * scale, weight: .semibold))
                     .foregroundStyle(Color.white.opacity(0.9))
             }


### PR DESCRIPTION
## Summary
The nav layer overlay showed "H — Left" text instead of ← arrow symbols on HJKL. Two issues:

1. **Augmentation overwrote simulator data**: The push-msg augmentation pass replaced the simulator's `displayLabel: "←"` with the collection's description `"h — left"` and dropped the `vimLabel: "←"` entirely.
2. **No instant cache for layer switching**: The overlay cleared `layerKeyMap` on layer switch and waited for async rebuild, causing blank keys during the 50ms preview.

**Fixes:**
- `mergeAugmentation` preserves `vimLabel` from the original simulator entry and uses the simulator's `displayLabel` when a vimLabel exists
- Arrow rendering checks both `displayLabel` and `vimLabel` for arrow symbols
- Prebuilt layer cache with augmented data enables instant layer switching
- `Task.isCancelled` guard prevents stale async rebuilds from overwriting

## Test plan
- [ ] Hold Space → nav layer shows ← ↓ ↑ → on HJKL (not "H — Left" text)
- [ ] Other vim keys show correctly (Redo, Yank, Undo, Put, etc.)
- [ ] Hold F → home-arrows shows arrows
- [ ] Hold Caps → launcher shows app icons
- [ ] 537 tests pass