### PR TITLE
fix: window snap focus + clean HJKL arrows on all layers (#583)

### DIFF
--- a/Sources/KeyPathAppKit/Services/System/WindowManager.swift
+++ b/Sources/KeyPathAppKit/Services/System/WindowManager.swift
@@ -57,6 +57,11 @@ public final class WindowManager {
     private var previousFrame: CGRect?
     private var previousWindowRef: AXUIElement?
 
+    /// Last frontmost app that isn't KeyPath — used as the snap target
+    /// when the overlay makes KeyPath frontmost during a snap action.
+    private var lastNonKeyPathApp: NSRunningApplication?
+    private var appActivationObserver: NSObjectProtocol?
+
     /// Track if we've shown the Space API unavailable warning (once per session)
     private var hasShownSpaceAPIWarning = false
 
@@ -75,6 +80,26 @@ public final class WindowManager {
     ) {
         self.spaceManager = spaceManager
         self.notificationService = notificationService
+        startTrackingFrontmostApp()
+    }
+
+    private func startTrackingFrontmostApp() {
+        let ownBundleId = Bundle.main.bundleIdentifier
+        if let current = NSWorkspace.shared.frontmostApplication,
+           current.bundleIdentifier != ownBundleId
+        {
+            lastNonKeyPathApp = current
+        }
+        appActivationObserver = NSWorkspace.shared.notificationCenter.addObserver(
+            forName: NSWorkspace.didActivateApplicationNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            guard let app = notification.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication,
+                  app.bundleIdentifier != ownBundleId
+            else { return }
+            self?.lastNonKeyPathApp = app
+        }
     }
 
     // MARK: - API Status
@@ -444,14 +469,23 @@ public final class WindowManager {
 
     // MARK: - Accessibility Helpers
 
-    /// Get the currently focused window and its frame
+    /// Get the currently focused window and its frame.
+    /// Skips KeyPath's own windows — if KeyPath is frontmost (e.g., overlay is showing),
+    /// targets the last non-KeyPath app the user was working in.
     private func getFocusedWindow() -> (AXUIElement, CGRect)? {
-        // Get frontmost application
-        guard let frontApp = NSWorkspace.shared.frontmostApplication else {
-            return nil
+        let frontApp = NSWorkspace.shared.frontmostApplication
+        let ownBundleId = Bundle.main.bundleIdentifier
+
+        let targetApp: NSRunningApplication?
+        if frontApp?.bundleIdentifier == ownBundleId {
+            targetApp = lastNonKeyPathApp
+        } else {
+            targetApp = frontApp
         }
 
-        let pid = frontApp.processIdentifier
+        guard let app = targetApp else { return nil }
+
+        let pid = app.processIdentifier
         let axApp = AXUIElementCreateApplication(pid)
 
         // Get focused window

--- a/Sources/KeyPathAppKit/UI/Overlay/LiveKeyboardOverlayView+ContentBuilders.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/LiveKeyboardOverlayView+ContentBuilders.swift
@@ -173,7 +173,7 @@ extension LiveKeyboardOverlayView {
                     onKeyClick: onKeyClick,
                     selectedKeyCode: viewModel.selectedKeyCode,
                     hoveredRuleKeyCode: viewModel.hoveredRuleKeyCode,
-                    vimHintsActive: kindaVimPackInstalled,
+                    vimHintsActive: kindaVimPackInstalled && VimHintLayer.isCurrentlyRendering,
                     isLauncherMode: viewModel.isLauncherModeActive || (uiState.isInspectorOpen && inspectorSection == .launchers),
                     launcherMappings: viewModel.launcherMappings,
                     isInspectorVisible: inspectorVisible,

--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayKeyboardView.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayKeyboardView.swift
@@ -217,6 +217,10 @@ struct OverlayKeyboardView: View {
     /// (e.g., "A" -> "B" mapping means we should hide the floating "A" label)
     /// The keycap will show the mapped output instead via layerKeyInfo
     /// During keymap transitions, always returns false to allow floating label animation
+    private func isLoudVimHintLabel(_ label: String) -> Bool {
+        ["H", "J", "K", "L"].contains(label.uppercased())
+    }
+
     private func isRemappedLabel(_ label: String) -> Bool {
         // During keymap transition window, bypass remap gating to allow animation
         // (keymap switches like QWERTY → Dvorak are implemented as remaps)
@@ -304,7 +308,8 @@ struct OverlayKeyboardView: View {
                                 && !isLauncherMode
                                 && !isLayerMode
                                 && !isRemappedLabel(label)
-                                && !hasZoneSubtitle(for: label),
+                                && !hasZoneSubtitle(for: label)
+                                && !(vimHintsActive && isLoudVimHintLabel(label)),
                             scale: scale,
                             colorway: activeColorway,
                             // Enable animation after initial render (prevents animation on drawer open)

--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView+ModeContent.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView+ModeContent.swift
@@ -165,11 +165,14 @@ extension OverlayKeycapView {
                     }
                 } else {
                     // Default: action in center, key letter in top-left (except arrows)
+                    let arrowLabels: Set<String> = ["←", "→", "↑", "↓"]
+                    let isArrowAction = arrowLabels.contains(layerKeyInfo?.vimLabel ?? "")
+                        || arrowLabels.contains(layerKeyInfo?.displayLabel ?? "")
                     let hasActionSymbol = sfSymbolForAction(layerKeyInfo?.displayLabel ?? "") != nil
                         || LabelMetadata.sfSymbol(forOutputLabel: layerKeyInfo?.displayLabel ?? "") != nil
                     ZStack(alignment: .topLeading) {
-                        // Key letter behind (dimmed when an icon overlays it)
-                        if !isArrowKey {
+                        // Key letter behind — hidden for arrow actions (arrow symbol is self-explanatory)
+                        if !isArrowKey, !isArrowAction {
                             Text(layerKeyLabel.uppercased())
                                 .font(.system(size: 8 * scale, weight: .medium, design: .rounded))
                                 .foregroundStyle(Color.white.opacity(hasActionSymbol ? 0.25 : 0.7))

--- a/Sources/KeyPathAppKit/UI/Overlay/VimHintLayer.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/VimHintLayer.swift
@@ -65,6 +65,19 @@ struct VimHintLayer: View {
         }
     }
 
+    /// Whether the hint layer is currently rendering (for external consumers
+    /// that need to suppress overlapping content like floating labels).
+    @MainActor
+    static var isCurrentlyRendering: Bool {
+        let adapter = KindaVimStateAdapter.shared
+        let monitor = KindaVimStrategyMonitor.shared
+        if monitor.currentStrategy == .ignored { return false }
+        switch adapter.state.mode {
+        case .normal, .operatorPending, .visual: return true
+        case .insert, .unknown: return false
+        }
+    }
+
     // MARK: - Per-key hint resolution
 
     /// Public-friendly lookup helper (also used by tests) that resolves
@@ -221,7 +234,7 @@ private struct VimHintLabel: View {
     var body: some View {
         if isLoud {
             ZStack {
-                // Fully opaque base to cover the keycap letter
+                // Fully opaque base to cover the keycap background
                 RoundedRectangle(cornerRadius: max(4, 6 * scale), style: .continuous)
                     .fill(.black)
                 // Group-colored tint on top


### PR DESCRIPTION
## Summary
- **Window snap focus (#583)**: Tracks last non-KeyPath frontmost app so snap actions target the user's app, not the overlay
- **Nav layer arrows**: HJKL show ← ↓ ↑ → without top-left key letter; prebuilt cache for instant switching
- **KindaVim arrows**: Floating labels hidden for HJKL only when VimHintLayer actually renders (not just when pack is installed), preventing blank keys on base layer in insert mode

Closes #583

## Test plan
- [ ] Window snap targets browser/app, not KeyPath overlay
- [ ] Nav layer (hold Space): HJKL show orange arrows, other vim keys show labels
- [ ] KindaVim normal mode: HJKL show clean green arrows, no letter bleed
- [ ] Base layer (insert mode): HJKL show normal H, J, K, L letters
- [ ] 537 tests pass