### PR TITLE
refactor: extract FloatingLabelVisibility and LayerMappingBuilder (overlay phases 1-2)

### DIFF
--- a/Sources/KeyPathAppKit/Services/LayerMapping/LayerMappingBuilder.swift
+++ b/Sources/KeyPathAppKit/Services/LayerMapping/LayerMappingBuilder.swift
@@ -1,0 +1,292 @@
+import Foundation
+import KeyPathCore
+
+enum LayerMappingBuilder {
+    // MARK: - Pipeline Steps
+
+    static func augmentWithPushMsgActions(
+        mapping: [UInt16: LayerKeyInfo],
+        customRules: [CustomRule],
+        ruleCollections: [RuleCollection],
+        currentLayerName: String
+    ) -> [UInt16: LayerKeyInfo] {
+        var augmented = mapping
+        var actionByInput: [String: LayerKeyInfo] = [:]
+
+        for collection in ruleCollections where collection.isEnabled {
+            let collectionLayerName = collection.targetLayer.kanataName.lowercased()
+            let currentLayer = currentLayerName.lowercased()
+
+            guard collectionLayerName == currentLayer else {
+                AppLogger.shared.debug("🗺️ [LayerMappingBuilder] Skipping collection '\(collection.name)' (targets '\(collectionLayerName)', current layer '\(currentLayer)')")
+                continue
+            }
+
+            for keyMapping in collection.mappings {
+                let input = keyMapping.input.lowercased()
+                if let info = extractPushMsgInfo(from: keyMapping.action.kanataOutput, description: keyMapping.description) {
+                    actionByInput[input] = info
+                } else {
+                    let outputKey = keyMapping.action.outputString.lowercased()
+                    if let description = keyMapping.description,
+                       let outputKeyCode = KeyboardVisualizationViewModel.kanataNameToKeyCode(outputKey) {
+                        actionByInput[input] = .mapped(
+                            displayLabel: description,
+                            outputKey: outputKey,
+                            outputKeyCode: outputKeyCode,
+                            collectionId: collection.id
+                        )
+                    } else if let systemAction = SystemActionInfo.find(byOutput: outputKey) {
+                        actionByInput[input] = .systemAction(
+                            action: systemAction.id,
+                            description: keyMapping.description ?? systemAction.name,
+                            collectionId: collection.id
+                        )
+                    } else if let outputKeyCode = KeyboardVisualizationViewModel.kanataNameToKeyCode(outputKey) {
+                        let displayLabel = outputKey.count == 1 ? outputKey.uppercased() : outputKey.capitalized
+                        actionByInput[input] = .mapped(
+                            displayLabel: displayLabel,
+                            outputKey: outputKey,
+                            outputKeyCode: outputKeyCode,
+                            collectionId: collection.id
+                        )
+                    }
+                }
+            }
+        }
+
+        for rule in customRules where rule.isEnabled {
+            let ruleLayerName = rule.targetLayer.kanataName.lowercased()
+            let currentLayer = currentLayerName.lowercased()
+
+            guard ruleLayerName == currentLayer else {
+                continue
+            }
+
+            let input = rule.input.lowercased()
+            if let info = extractPushMsgInfo(from: rule.action.kanataOutput, description: rule.notes) {
+                actionByInput[input] = info
+            } else {
+                let outputKey = rule.action.outputString.lowercased()
+
+                if let systemAction = SystemActionInfo.find(byOutput: outputKey) {
+                    actionByInput[input] = .systemAction(
+                        action: systemAction.id,
+                        description: systemAction.name
+                    )
+                } else if let outputKeyCode = KeyboardVisualizationViewModel.kanataNameToKeyCode(outputKey) {
+                    let displayLabel = outputKey.count == 1 ? outputKey.uppercased() : outputKey.capitalized
+                    actionByInput[input] = .mapped(
+                        displayLabel: displayLabel,
+                        outputKey: outputKey,
+                        outputKeyCode: outputKeyCode
+                    )
+                }
+            }
+        }
+
+        AppLogger.shared.info("🗺️ [LayerMappingBuilder] Found \(actionByInput.count) actions (push-msg + simple remaps)")
+
+        for (keyCode, originalInfo) in mapping {
+            let keyName = OverlayKeyboardView.keyCodeToKanataName(keyCode).lowercased()
+            if let info = actionByInput[keyName] {
+                let resolvedInfo = mergeAugmentation(info, with: originalInfo)
+                augmented[keyCode] = resolvedInfo
+            }
+        }
+
+        return augmented
+    }
+
+    static func enrichWithCustomShiftLabels(
+        mapping: [UInt16: LayerKeyInfo],
+        customRules: [CustomRule]
+    ) -> [UInt16: LayerKeyInfo] {
+        var shiftOverrides: [String: String] = [:]
+        for rule in customRules where rule.isEnabled {
+            guard let shiftedOutput = rule.shiftedOutput, !shiftedOutput.isEmpty else { continue }
+            shiftOverrides[rule.input.lowercased()] = KeyDisplayFormatter.format(shiftedOutput)
+        }
+        guard !shiftOverrides.isEmpty else { return mapping }
+
+        var result = mapping
+        for (keyCode, info) in mapping {
+            let kanataName = OverlayKeyboardView.keyCodeToKanataName(keyCode)
+            if let customShift = shiftOverrides[kanataName.lowercased()] {
+                result[keyCode] = LayerKeyInfo(
+                    displayLabel: info.displayLabel,
+                    outputKey: info.outputKey,
+                    outputKeyCode: info.outputKeyCode,
+                    isTransparent: info.isTransparent,
+                    isLayerSwitch: info.isLayerSwitch,
+                    appLaunchIdentifier: info.appLaunchIdentifier,
+                    systemActionIdentifier: info.systemActionIdentifier,
+                    urlIdentifier: info.urlIdentifier,
+                    collectionId: info.collectionId,
+                    vimLabel: info.vimLabel,
+                    customShiftLabel: customShift
+                )
+            }
+        }
+        return result
+    }
+
+    static func buildRemapOutputMap(from mapping: [UInt16: LayerKeyInfo]) -> [UInt16: UInt16] {
+        var result: [UInt16: UInt16] = [:]
+        for (inputKeyCode, info) in mapping {
+            guard let outputKeyCode = info.outputKeyCode,
+                  outputKeyCode != inputKeyCode,
+                  !info.isTransparent
+            else {
+                continue
+            }
+            result[inputKeyCode] = outputKeyCode
+        }
+        return result
+    }
+
+    // MARK: - Merge
+
+    static func mergeAugmentation(
+        _ augmented: LayerKeyInfo,
+        with original: LayerKeyInfo
+    ) -> LayerKeyInfo {
+        let collectionId = original.collectionId ?? augmented.collectionId
+        let vimLabel = original.vimLabel ?? augmented.vimLabel
+        let displayLabel = vimLabel != nil
+            ? (original.displayLabel.isEmpty ? augmented.displayLabel : original.displayLabel)
+            : augmented.displayLabel
+
+        return LayerKeyInfo(
+            displayLabel: displayLabel,
+            outputKey: augmented.outputKey ?? original.outputKey,
+            outputKeyCode: augmented.outputKeyCode ?? original.outputKeyCode,
+            isTransparent: augmented.isTransparent,
+            isLayerSwitch: augmented.isLayerSwitch,
+            appLaunchIdentifier: augmented.appLaunchIdentifier,
+            systemActionIdentifier: augmented.systemActionIdentifier,
+            urlIdentifier: augmented.urlIdentifier,
+            collectionId: collectionId,
+            vimLabel: vimLabel
+        )
+    }
+
+    // MARK: - Push-Msg Parsing
+
+    private static let pushMsgTypeValueRegex = try! NSRegularExpression(
+        pattern: #"\(push-msg\s+\"([^:\"]+):([^\"]+)\"\)"#,
+        options: [.caseInsensitive]
+    )
+
+    private static let pushMsgLaunchRegex = try! NSRegularExpression(
+        pattern: #"\(push-msg\s+\"launch:([^\"]+)\"\)"#,
+        options: [.caseInsensitive]
+    )
+
+    private static let pushMsgOpenRegex = try! NSRegularExpression(
+        pattern: #"\(push-msg\s+\"open:([^\"]+)\"\)"#,
+        options: [.caseInsensitive]
+    )
+
+    private static let pushMsgSystemRegex = try! NSRegularExpression(
+        pattern: #"\(push-msg\s+\"system:([^\"]+)\"\)"#,
+        options: [.caseInsensitive]
+    )
+
+    static func extractPushMsgInfo(from output: String, description: String?) -> LayerKeyInfo? {
+        guard let match = pushMsgTypeValueRegex.firstMatch(in: output, range: NSRange(output.startIndex..., in: output)),
+              let typeRange = Range(match.range(at: 1), in: output),
+              let valueRange = Range(match.range(at: 2), in: output)
+        else {
+            return nil
+        }
+
+        let msgType = String(output[typeRange]).lowercased()
+        let msgValue = String(output[valueRange])
+
+        switch msgType {
+        case "launch":
+            return .appLaunch(appIdentifier: msgValue)
+        case "system":
+            let displayLabel = description ?? systemActionDisplayLabel(msgValue)
+            return .systemAction(action: msgValue, description: displayLabel)
+        case "open":
+            return .webURL(url: URLMappingFormatter.decodeFromPushMessage(msgValue))
+        default:
+            return .pushMsg(message: description ?? msgValue)
+        }
+    }
+
+    static func extractAppLaunchIdentifier(from output: String) -> String? {
+        guard let match = pushMsgLaunchRegex.firstMatch(
+            in: output,
+            range: NSRange(output.startIndex..., in: output)
+        ),
+            let range = Range(match.range(at: 1), in: output)
+        else {
+            return nil
+        }
+        let value = String(output[range])
+        return URLMappingFormatter.decodeFromPushMessage(value)
+    }
+
+    static func extractUrlIdentifier(from output: String) -> String? {
+        guard let match = pushMsgOpenRegex.firstMatch(
+            in: output,
+            range: NSRange(output.startIndex..., in: output)
+        ),
+            let range = Range(match.range(at: 1), in: output)
+        else {
+            return nil
+        }
+        let value = String(output[range])
+        return URLMappingFormatter.decodeFromPushMessage(value)
+    }
+
+    static func extractSystemActionIdentifier(from output: String) -> String? {
+        guard let match = pushMsgSystemRegex.firstMatch(
+            in: output,
+            range: NSRange(output.startIndex..., in: output)
+        ),
+            let range = Range(match.range(at: 1), in: output)
+        else {
+            return nil
+        }
+        return String(output[range]).trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    static func systemActionDisplayLabel(_ action: String) -> String {
+        switch action.lowercased() {
+        case "dnd", "do-not-disturb", "donotdisturb", "focus":
+            "Do Not Disturb"
+        case "spotlight":
+            "Spotlight"
+        case "dictation":
+            "Dictation"
+        case "mission-control", "missioncontrol":
+            "Mission Control"
+        case "launchpad":
+            "Launchpad"
+        case "notification-center", "notificationcenter":
+            "Notification Center"
+        case "siri":
+            "Siri"
+        default:
+            action.capitalized
+        }
+    }
+
+    static func mediaKeyDisplayLabel(_ kanataKey: String) -> String? {
+        switch kanataKey.lowercased() {
+        case "brup": "Brightness Up"
+        case "brdn", "brdown": "Brightness Down"
+        case "volu": "Volume Up"
+        case "vold", "voldwn": "Volume Down"
+        case "mute": "Mute"
+        case "pp": "Play/Pause"
+        case "next": "Next Track"
+        case "prev": "Previous Track"
+        default: nil
+        }
+    }
+}

--- a/Sources/KeyPathAppKit/UI/KeyboardVisualization/KeyboardVisualizationViewModel+LayoutMapping.swift
+++ b/Sources/KeyPathAppKit/UI/KeyboardVisualization/KeyboardVisualizationViewModel+LayoutMapping.swift
@@ -180,7 +180,7 @@ extension KeyboardVisualizationViewModel {
         let cacheKey = targetLayerName.lowercased()
         if let cached = prebuiltLayerMappings[cacheKey] {
             layerKeyMap = cached
-            remapOutputMap = buildRemapOutputMap(from: cached)
+            remapOutputMap = LayerMappingBuilder.buildRemapOutputMap(from: cached)
         }
 
         isLoadingLayerMap = true
@@ -237,22 +237,21 @@ extension KeyboardVisualizationViewModel {
                     }
                 }
 
-                // Augment mapping with push-msg actions from custom rules and rule collections
-                // Only include actions targeting this specific layer
                 let customRules = await CustomRulesStore.shared.loadRules()
                 AppLogger.shared.info("🗺️ [KeyboardViz] Augmenting '\(targetLayerName)' with \(customRules.count) custom rules and \(scopedRuleCollections.count) collections")
-                mapping = augmentWithPushMsgActions(
+                mapping = LayerMappingBuilder.augmentWithPushMsgActions(
                     mapping: mapping,
                     customRules: customRules,
                     ruleCollections: scopedRuleCollections,
                     currentLayerName: targetLayerName
                 )
 
-                // Apply app-specific overrides for the current frontmost app
                 mapping = await applyAppSpecificOverrides(to: mapping)
 
-                // Enrich mapping with custom shift labels from custom rules
-                mapping = enrichWithCustomShiftLabels(mapping: mapping, customRules: customRules)
+                mapping = LayerMappingBuilder.enrichWithCustomShiftLabels(
+                    mapping: mapping,
+                    customRules: customRules
+                )
 
                 // Update mapping (layer name was already set eagerly in updateLayer;
                 // re-assign here for the rebuildLayerMapping() path from setLayout)
@@ -260,7 +259,7 @@ extension KeyboardVisualizationViewModel {
                 await MainActor.run {
                     self.currentLayerName = targetLayerName
                     self.layerKeyMap = mapping
-                    self.remapOutputMap = self.buildRemapOutputMap(from: mapping)
+                    self.remapOutputMap = LayerMappingBuilder.buildRemapOutputMap(from: mapping)
                     self.isLoadingLayerMap = false
                     AppLogger.shared
                         .info("🗺️ [KeyboardViz] Updated currentLayerName to '\(targetLayerName)' and layerKeyMap with \(mapping.count) entries, remapOutputMap with \(self.remapOutputMap.count) remaps")
@@ -275,7 +274,8 @@ extension KeyboardVisualizationViewModel {
 
                 // Show alert if simulator had significant failures on a non-base layer
                 if let report = simReport, report.hasSignificantFailures,
-                   targetLayerName.lowercased() != "base" {
+                   targetLayerName.lowercased() != "base"
+                {
                     await MainActor.run {
                         Self.showSimulationFailureAlert(report)
                     }
@@ -289,346 +289,37 @@ extension KeyboardVisualizationViewModel {
         }
     }
 
-    /// Build a map from input keyCode -> output keyCode for simple remaps.
-    /// Used to suppress output key highlighting when the input key is pressed.
-    /// - Parameter mapping: The layer key mapping to extract remap info from
-    /// - Returns: Dictionary mapping input keyCodes to their output keyCodes
-    func buildRemapOutputMap(from mapping: [UInt16: LayerKeyInfo]) -> [UInt16: UInt16] {
-        var result: [UInt16: UInt16] = [:]
-        for (inputKeyCode, info) in mapping {
-            guard let outputKeyCode = info.outputKeyCode,
-                  outputKeyCode != inputKeyCode, // Only actual remaps (A->B, not A->A)
-                  !info.isTransparent // Transparent keys pass through, not remaps
-            else {
-                continue
-            }
-            result[inputKeyCode] = outputKeyCode
-        }
-        return result
-    }
+    // MARK: - Forwarding to LayerMappingBuilder
 
-    /// Enrich layer mapping with custom shift labels from custom rules that have shiftedOutput.
-    /// This lets the overlay keyboard show the custom shifted character instead of the system default.
-    func enrichWithCustomShiftLabels(
-        mapping: [UInt16: LayerKeyInfo],
-        customRules: [CustomRule]
-    ) -> [UInt16: LayerKeyInfo] {
-        // Build lookup: kanata input name → custom shiftedOutput
-        var shiftOverrides: [String: String] = [:]
-        for rule in customRules where rule.isEnabled {
-            guard let shiftedOutput = rule.shiftedOutput, !shiftedOutput.isEmpty else { continue }
-            shiftOverrides[rule.input.lowercased()] = KeyDisplayFormatter.format(shiftedOutput)
-        }
-        guard !shiftOverrides.isEmpty else { return mapping }
-
-        var result = mapping
-        for (keyCode, info) in mapping {
-            let kanataName = OverlayKeyboardView.keyCodeToKanataName(keyCode)
-            if let customShift = shiftOverrides[kanataName.lowercased()] {
-                result[keyCode] = LayerKeyInfo(
-                    displayLabel: info.displayLabel,
-                    outputKey: info.outputKey,
-                    outputKeyCode: info.outputKeyCode,
-                    isTransparent: info.isTransparent,
-                    isLayerSwitch: info.isLayerSwitch,
-                    appLaunchIdentifier: info.appLaunchIdentifier,
-                    systemActionIdentifier: info.systemActionIdentifier,
-                    urlIdentifier: info.urlIdentifier,
-                    collectionId: info.collectionId,
-                    vimLabel: info.vimLabel,
-                    customShiftLabel: customShift
-                )
-            }
-        }
-        return result
-    }
-
-    /// Augment layer mapping with push-msg actions from custom rules and rule collections
-    /// Handles app launches, system actions, and other push-msg patterns
-    /// - Parameters:
-    ///   - mapping: The base layer key mapping from the simulator
-    ///   - customRules: Custom rules to check for push-msg patterns
-    ///   - ruleCollections: Preset rule collections to check for push-msg patterns
-    ///   - currentLayerName: The layer name to filter collections/rules by (only include matching layers)
-    /// - Returns: Mapping with action info added where applicable
-    func augmentWithPushMsgActions(
-        mapping: [UInt16: LayerKeyInfo],
-        customRules: [CustomRule],
-        ruleCollections: [RuleCollection],
-        currentLayerName: String
-    ) -> [UInt16: LayerKeyInfo] {
-        var augmented = mapping
-
-        // Build lookups from input key -> LayerKeyInfo
-        var actionByInput: [String: LayerKeyInfo] = [:]
-
-        // First, process rule collections (lower priority - can be overridden by custom rules)
-        // Only process collections that target the current layer or base layer
-        for collection in ruleCollections where collection.isEnabled {
-            // Check if this collection targets the current layer
-            let collectionLayerName = collection.targetLayer.kanataName.lowercased()
-            let currentLayer = currentLayerName.lowercased()
-
-            // Only include mappings from collections targeting this layer
-            // Exception: base layer gets base-layer collections only
-            guard collectionLayerName == currentLayer else {
-                AppLogger.shared.debug("🗺️ [KeyboardViz] Skipping collection '\(collection.name)' (targets '\(collectionLayerName)', current layer '\(currentLayer)')")
-                continue
-            }
-
-            for keyMapping in collection.mappings {
-                let input = keyMapping.input.lowercased()
-                if let info = Self.extractPushMsgInfo(from: keyMapping.action.kanataOutput, description: keyMapping.description) {
-                    actionByInput[input] = info
-                } else {
-                    let outputKey = keyMapping.action.outputString.lowercased()
-                    if let description = keyMapping.description,
-                       let outputKeyCode = Self.kanataNameToKeyCode(outputKey) {
-                        actionByInput[input] = .mapped(
-                            displayLabel: description,
-                            outputKey: outputKey,
-                            outputKeyCode: outputKeyCode,
-                            collectionId: collection.id
-                        )
-                    } else if let systemAction = SystemActionInfo.find(byOutput: outputKey) {
-                        actionByInput[input] = .systemAction(
-                            action: systemAction.id,
-                            description: keyMapping.description ?? systemAction.name,
-                            collectionId: collection.id
-                        )
-                    } else if let outputKeyCode = Self.kanataNameToKeyCode(outputKey) {
-                        let displayLabel = outputKey.count == 1 ? outputKey.uppercased() : outputKey.capitalized
-                        actionByInput[input] = .mapped(
-                            displayLabel: displayLabel,
-                            outputKey: outputKey,
-                            outputKeyCode: outputKeyCode,
-                            collectionId: collection.id
-                        )
-                    }
-                }
-            }
-        }
-
-        // Then, process custom rules (higher priority - overrides collections)
-        for rule in customRules where rule.isEnabled {
-            // Check if this rule targets the current layer
-            let ruleLayerName = rule.targetLayer.kanataName.lowercased()
-            let currentLayer = currentLayerName.lowercased()
-
-            // Only include rules targeting this layer
-            guard ruleLayerName == currentLayer else {
-                continue
-            }
-
-            let input = rule.input.lowercased()
-            // First try push-msg pattern (apps, system actions, URLs)
-            if let info = Self.extractPushMsgInfo(from: rule.action.kanataOutput, description: rule.notes) {
-                actionByInput[input] = info
-            } else {
-                // Simple key remap (e.g., "a" -> "b") or media key (e.g., "brup", "volu")
-                let outputKey = rule.action.outputString.lowercased()
-
-                // Check if this is a known system action/media key (brup, volu, pp, etc.)
-                // If so, create a systemAction LayerKeyInfo so the SF Symbol renders correctly
-                if let systemAction = SystemActionInfo.find(byOutput: outputKey) {
-                    actionByInput[input] = .systemAction(
-                        action: systemAction.id,
-                        description: systemAction.name
-                    )
-                } else if let outputKeyCode = Self.kanataNameToKeyCode(outputKey) {
-                    // Regular key remap (e.g., "a" -> "b")
-                    let displayLabel = outputKey.count == 1 ? outputKey.uppercased() : outputKey.capitalized
-                    actionByInput[input] = .mapped(
-                        displayLabel: displayLabel,
-                        outputKey: outputKey,
-                        outputKeyCode: outputKeyCode
-                    )
-                }
-            }
-        }
-
-        AppLogger.shared.info("🗺️ [KeyboardViz] Found \(actionByInput.count) actions (push-msg + simple remaps)")
-
-        // Update mapping entries
-        // IMPORTANT: Only augment keys that are NOT transparent (XX)
-        // Transparent keys should pass through without showing action labels
-        for (keyCode, originalInfo) in mapping {
-            let keyName = OverlayKeyboardView.keyCodeToKanataName(keyCode).lowercased()
-            if let info = actionByInput[keyName] {
-                let resolvedInfo = Self.mergeAugmentation(info, with: originalInfo)
-                augmented[keyCode] = resolvedInfo
-            }
-        }
-
-        return augmented
-    }
-
-    /// Merge augmented info with the original simulator entry, preserving vimLabel
-    /// and preferring the simulator's displayLabel when a vimLabel exists (so arrow
-    /// keys show "←" instead of description text like "h — left").
     nonisolated static func mergeAugmentation(
         _ augmented: LayerKeyInfo,
         with original: LayerKeyInfo
     ) -> LayerKeyInfo {
-        let collectionId = original.collectionId ?? augmented.collectionId
-        let vimLabel = original.vimLabel ?? augmented.vimLabel
-        let displayLabel = vimLabel != nil ? (original.displayLabel.isEmpty ? augmented.displayLabel : original.displayLabel) : augmented.displayLabel
-
-        return LayerKeyInfo(
-            displayLabel: displayLabel,
-            outputKey: augmented.outputKey ?? original.outputKey,
-            outputKeyCode: augmented.outputKeyCode ?? original.outputKeyCode,
-            isTransparent: augmented.isTransparent,
-            isLayerSwitch: augmented.isLayerSwitch,
-            appLaunchIdentifier: augmented.appLaunchIdentifier,
-            systemActionIdentifier: augmented.systemActionIdentifier,
-            urlIdentifier: augmented.urlIdentifier,
-            collectionId: collectionId,
-            vimLabel: vimLabel
-        )
+        LayerMappingBuilder.mergeAugmentation(augmented, with: original)
     }
 
-    // MARK: - Cached Regex Patterns
-
-    /// Cached regex for extracting push-msg type:value patterns
-    /// Pattern: (push-msg "type:value")
-    private nonisolated static let pushMsgTypeValueRegex = try! NSRegularExpression(
-        pattern: #"\(push-msg\s+\"([^:\"]+):([^\"]+)\"\)"#,
-        options: [.caseInsensitive]
-    )
-
-    /// Cached regex for extracting app launch identifiers
-    /// Pattern: (push-msg "launch:AppName")
-    private nonisolated static let pushMsgLaunchRegex = try! NSRegularExpression(
-        pattern: #"\(push-msg\s+\"launch:([^\"]+)\"\)"#,
-        options: [.caseInsensitive]
-    )
-
-    /// Cached regex for extracting URL identifiers
-    /// Pattern: (push-msg "open:domain.com")
-    private nonisolated static let pushMsgOpenRegex = try! NSRegularExpression(
-        pattern: #"\(push-msg\s+\"open:([^\"]+)\"\)"#,
-        options: [.caseInsensitive]
-    )
-
-    /// Cached regex for extracting system action identifiers
-    /// Pattern: (push-msg "system:notification-center")
-    private nonisolated static let pushMsgSystemRegex = try! NSRegularExpression(
-        pattern: #"\(push-msg\s+\"system:([^\"]+)\"\)"#,
-        options: [.caseInsensitive]
-    )
-
-    /// Extract LayerKeyInfo from a push-msg output string
-    /// Handles: launch:, system:, and generic push-msg patterns
     nonisolated static func extractPushMsgInfo(from output: String, description: String?) -> LayerKeyInfo? {
-        guard let match = pushMsgTypeValueRegex.firstMatch(in: output, range: NSRange(output.startIndex..., in: output)),
-              let typeRange = Range(match.range(at: 1), in: output),
-              let valueRange = Range(match.range(at: 2), in: output)
-        else {
-            return nil
-        }
-
-        let msgType = String(output[typeRange]).lowercased()
-        let msgValue = String(output[valueRange])
-
-        switch msgType {
-        case "launch":
-            return .appLaunch(appIdentifier: msgValue)
-        case "system":
-            // Use description if available, otherwise format the system action
-            let displayLabel = description ?? Self.systemActionDisplayLabel(msgValue)
-            return .systemAction(action: msgValue, description: displayLabel)
-        case "open":
-            return .webURL(url: URLMappingFormatter.decodeFromPushMessage(msgValue))
-        default:
-            // Generic push-msg - use description or message value
-            return .pushMsg(message: description ?? msgValue)
-        }
+        LayerMappingBuilder.extractPushMsgInfo(from: output, description: description)
     }
 
-    /// Get a human-readable label for a system action
-    nonisolated static func systemActionDisplayLabel(_ action: String) -> String {
-        switch action.lowercased() {
-        case "dnd", "do-not-disturb", "donotdisturb", "focus":
-            "Do Not Disturb"
-        case "spotlight":
-            "Spotlight"
-        case "dictation":
-            "Dictation"
-        case "mission-control", "missioncontrol":
-            "Mission Control"
-        case "launchpad":
-            "Launchpad"
-        case "notification-center", "notificationcenter":
-            "Notification Center"
-        case "siri":
-            "Siri"
-        default:
-            action.capitalized
-        }
-    }
-
-    /// Get a human-readable label for media/function keys (returns nil if not a recognized media key)
-    /// These labels match what LabelMetadata.sfSymbol(forOutputLabel:) expects for icon lookup
-    nonisolated static func mediaKeyDisplayLabel(_ kanataKey: String) -> String? {
-        switch kanataKey.lowercased() {
-        case "brup": "Brightness Up"
-        case "brdn", "brdown": "Brightness Down"
-        case "volu": "Volume Up"
-        case "vold", "voldwn": "Volume Down"
-        case "mute": "Mute"
-        case "pp": "Play/Pause"
-        case "next": "Next Track"
-        case "prev": "Previous Track"
-        default: nil
-        }
-    }
-
-    /// Extract app identifier from a push-msg launch output string
-    /// - Parameter output: The kanata output string (e.g., "(push-msg \"launch:Safari\")")
-    /// - Returns: The app identifier if this is a launch action, nil otherwise
     nonisolated static func extractAppLaunchIdentifier(from output: String) -> String? {
-        guard let match = pushMsgLaunchRegex.firstMatch(
-            in: output,
-            range: NSRange(output.startIndex..., in: output)
-        ),
-            let range = Range(match.range(at: 1), in: output)
-        else {
-            return nil
-        }
-        let value = String(output[range])
-        return URLMappingFormatter.decodeFromPushMessage(value)
+        LayerMappingBuilder.extractAppLaunchIdentifier(from: output)
     }
 
-    /// Extract URL from a push-msg open output string
-    /// - Parameter output: The kanata output string (e.g., "(push-msg \"open:github.com\")")
-    /// - Returns: The URL string if this is an open action, nil otherwise
     nonisolated static func extractUrlIdentifier(from output: String) -> String? {
-        guard let match = pushMsgOpenRegex.firstMatch(
-            in: output,
-            range: NSRange(output.startIndex..., in: output)
-        ),
-            let range = Range(match.range(at: 1), in: output)
-        else {
-            return nil
-        }
-        let value = String(output[range])
-        return URLMappingFormatter.decodeFromPushMessage(value)
+        LayerMappingBuilder.extractUrlIdentifier(from: output)
     }
 
-    /// Extract system action ID from a push-msg system output string
-    /// - Parameter output: The kanata output string (e.g., "(push-msg \"system:notification-center\")")
-    /// - Returns: The action identifier if this is a system action, nil otherwise
     nonisolated static func extractSystemActionIdentifier(from output: String) -> String? {
-        guard let match = pushMsgSystemRegex.firstMatch(
-            in: output,
-            range: NSRange(output.startIndex..., in: output)
-        ),
-            let range = Range(match.range(at: 1), in: output)
-        else {
-            return nil
-        }
-        return String(output[range]).trimmingCharacters(in: .whitespacesAndNewlines)
+        LayerMappingBuilder.extractSystemActionIdentifier(from: output)
+    }
+
+    nonisolated static func systemActionDisplayLabel(_ action: String) -> String {
+        LayerMappingBuilder.systemActionDisplayLabel(action)
+    }
+
+    nonisolated static func mediaKeyDisplayLabel(_ kanataKey: String) -> String? {
+        LayerMappingBuilder.mediaKeyDisplayLabel(kanataKey)
     }
 
     /// Fire-and-forget prebuild of all layer mappings so first layer switches hit cache.
@@ -662,14 +353,12 @@ extension KeyboardVisualizationViewModel {
             var localCache: [String: [UInt16: LayerKeyInfo]] = [:]
             for layer in layerNames {
                 if var mapping = await layerKeyMapper.getCachedMapping(for: layer) {
-                    mapping = await MainActor.run {
-                        self.augmentWithPushMsgActions(
-                            mapping: mapping,
-                            customRules: customRules,
-                            ruleCollections: enabledCollections,
-                            currentLayerName: layer
-                        )
-                    }
+                    mapping = LayerMappingBuilder.augmentWithPushMsgActions(
+                        mapping: mapping,
+                        customRules: customRules,
+                        ruleCollections: enabledCollections,
+                        currentLayerName: layer
+                    )
                     localCache[layer] = mapping
                 }
             }

--- a/Sources/KeyPathAppKit/UI/Overlay/FloatingLabelVisibility.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/FloatingLabelVisibility.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+struct FloatingLabelVisibility {
+    let labelToKeyCode: [String: UInt16]
+    let isLauncherMode: Bool
+    let isLayerMode: Bool
+    let vimHintsActive: Bool
+    let remappedLabels: Set<String>
+    let zoneSubtitleLabels: Set<String>
+
+    func isVisible(_ label: String) -> Bool {
+        let normalized = label.uppercased()
+        return labelToKeyCode[normalized] != nil
+            && !Self.isSpecialLabel(label)
+            && !isLauncherMode
+            && !isLayerMode
+            && !remappedLabels.contains(normalized)
+            && !zoneSubtitleLabels.contains(normalized)
+            && !(vimHintsActive && Self.isLoudVimHintLabel(normalized))
+    }
+
+    private static func isLoudVimHintLabel(_ label: String) -> Bool {
+        ["H", "J", "K", "L"].contains(label)
+    }
+
+    private static let specialLabels: Set<String> = [
+        "Home", "End", "PgUp", "PgDn", "Del", "␣", "Lyr", "Fn", "Mod", "✦", "◆",
+        "↩", "⌫", "⇥", "⇪", "esc", "ESC", "⎋", "🔒",
+        "⇧", "⌃", "⌥", "⌘",
+        "◀", "▶", "▲", "▼", "←", "→", "↑", "↓",
+        "`", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "-", "=",
+        "F1", "F2", "F3", "F4", "F5", "F6", "F7", "F8", "F9", "F10", "F11", "F12",
+        "prt", "scr", "pse",
+        "ins", "del", "home", "end", "pgup", "pgdn",
+        "INS", "DEL", "HOME", "END", "PGUP", "PGDN",
+        "clr", "CLR", "/", "*", "+", ".",
+        "¥", "英数", "かな", "_", "^", ":", "@", "fn",
+        "☰", "▤",
+        "⏎", "⌅"
+    ]
+
+    static func isSpecialLabel(_ label: String) -> Bool {
+        specialLabels.contains(label) || specialLabels.contains(label.lowercased())
+    }
+}

--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayKeyboardView.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayKeyboardView.swift
@@ -179,70 +179,36 @@ struct OverlayKeyboardView: View {
         return labels.sorted()
     }
 
-    /// Special labels that should always render in keycaps (not as floating labels)
-    /// Matches the special labels set in OverlayKeycapView.hasSpecialLabel
-    private static let specialLabels: Set<String> = [
-        "Home", "End", "PgUp", "PgDn", "Del", "␣", "Lyr", "Fn", "Mod", "✦", "◆",
-        "↩", "⌫", "⇥", "⇪", "esc", "ESC", "⎋", "🔒",
-        // Modifier symbols (rendered by keycap bottomAlignedContent, not floating labels)
-        "⇧", "⌃", "⌥", "⌘",
-        // Arrow symbols (both solid and outline variants)
-        "◀", "▶", "▲", "▼", "←", "→", "↑", "↓",
-        // Number row (not in standard keymaps, render directly)
-        "`", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "-", "=",
-        // Function row (rendered by functionKeyWithMappingContent, not floating labels)
-        "F1", "F2", "F3", "F4", "F5", "F6", "F7", "F8", "F9", "F10", "F11", "F12",
-        // Function row extras (Print Screen, Scroll Lock, Pause)
-        "prt", "scr", "pse",
-        // Navigation cluster keys (both cases for matching)
-        "ins", "del", "home", "end", "pgup", "pgdn",
-        "INS", "DEL", "HOME", "END", "PGUP", "PGDN",
-        // Numpad keys (not in standard keymaps)
-        "clr", "CLR", "/", "*", "+", ".",
-        // JIS-specific keys (not in standard keymaps)
-        "¥", "英数", "かな", "_", "^", ":", "@", "fn",
-        // Menu/Application key
-        "☰", "▤",
-        // Numpad enter
-        "⏎", "⌅"
-    ]
+    // MARK: - Floating Label Visibility
+    private var floatingLabelVisibility: FloatingLabelVisibility {
+        let ltk = labelToKeyCode
 
-    /// Check if a label is special (should render in keycap, not as floating label)
-    /// Checks both original and lowercased to handle labels that arrive uppercased from labelToKeyCode
-    private static func isSpecialLabel(_ label: String) -> Bool {
-        specialLabels.contains(label) || specialLabels.contains(label.lowercased())
-    }
-
-    /// Check if a label's key has been remapped to a different output
-    /// (e.g., "A" -> "B" mapping means we should hide the floating "A" label)
-    /// The keycap will show the mapped output instead via layerKeyInfo
-    /// During keymap transitions, always returns false to allow floating label animation
-    private func isLoudVimHintLabel(_ label: String) -> Bool {
-        ["H", "J", "K", "L"].contains(label.uppercased())
-    }
-
-    private func isRemappedLabel(_ label: String) -> Bool {
-        // During keymap transition window, bypass remap gating to allow animation
-        // (keymap switches like QWERTY → Dvorak are implemented as remaps)
-        if isKeymapTransitioning {
-            return false
+        var remapped = Set<String>()
+        if !isKeymapTransitioning {
+            for (label, keyCode) in ltk {
+                if let layerInfo = layerKeyMap[keyCode],
+                   layerInfo.displayLabel.uppercased() != label
+                {
+                    remapped.insert(label)
+                }
+            }
         }
 
-        let normalizedLabel = label.uppercased()
-        guard let keyCode = labelToKeyCode[normalizedLabel],
-              let layerInfo = layerKeyMap[keyCode]
-        else {
-            return false
+        var zoneSubs = Set<String>()
+        for (label, keyCode) in ltk {
+            if activeZoneSubtitles[keyCode] != nil {
+                zoneSubs.insert(label)
+            }
         }
-        // Compare the layer's display label with the expected label for this key
-        // If they differ, this key has been remapped
-        let mappedLabel = layerInfo.displayLabel.uppercased()
-        return mappedLabel != normalizedLabel
-    }
 
-    private func hasZoneSubtitle(for label: String) -> Bool {
-        guard let keyCode = labelToKeyCode[label.uppercased()] else { return false }
-        return activeZoneSubtitles[keyCode] != nil
+        return FloatingLabelVisibility(
+            labelToKeyCode: ltk,
+            isLauncherMode: isLauncherMode,
+            isLayerMode: isLayerMode,
+            vimHintsActive: vimHintsActive,
+            remappedLabels: remapped,
+            zoneSubtitleLabels: zoneSubs
+        )
     }
 
     var keyboardAccessibilityLabel: String {
@@ -292,24 +258,12 @@ struct OverlayKeyboardView: View {
                 // Note: frames are calculated directly from layout, no GeometryReader needed.
                 // Skip floating labels for non-standard legend styles (dots show circles, not letters)
                 if !reduceMotion, activeColorway.legendStyle == .standard {
+                    let visibility = floatingLabelVisibility
                     ForEach(allLabels, id: \.self) { label in
-                        // In launcher mode or layer mode, hide ALL floating labels for a clean look
-                        // (mapped keys show icon + small letter, unmapped keys show small label)
                         FloatingKeymapLabel(
                             label: label,
                             targetFrame: targetFrameFor(label, scale: scale),
-                            // Visible when label exists in current keymap AND not special AND not in launcher/layer mode
-                            // Special labels render in keycaps, not as floating labels
-                            // Also hide floating label if the key has been remapped to a different output
-                            // (the keycap will show the mapped output instead)
-                            // Normalize to uppercase for consistent lookup (allLabels contains uppercase)
-                            isVisible: labelToKeyCode[label.uppercased()] != nil
-                                && !Self.isSpecialLabel(label)
-                                && !isLauncherMode
-                                && !isLayerMode
-                                && !isRemappedLabel(label)
-                                && !hasZoneSubtitle(for: label)
-                                && !(vimHintsActive && isLoudVimHintLabel(label)),
+                            isVisible: visibility.isVisible(label),
                             scale: scale,
                             colorway: activeColorway,
                             // Enable animation after initial render (prevents animation on drawer open)

--- a/Tests/KeyPathTests/Services/LayerMappingBuilderTests.swift
+++ b/Tests/KeyPathTests/Services/LayerMappingBuilderTests.swift
@@ -1,0 +1,187 @@
+@testable import KeyPathAppKit
+import KeyPathCore
+import Testing
+
+@Suite("LayerMappingBuilder")
+struct LayerMappingBuilderTests {
+    // MARK: - mergeAugmentation
+
+    @Test("vimLabel preserved from original through merge")
+    func mergePreservesVimLabel() {
+        let original = LayerKeyInfo.mapped(
+            displayLabel: "←",
+            outputKey: "left",
+            outputKeyCode: 123,
+            vimLabel: "←"
+        )
+        let augmented = LayerKeyInfo(
+            displayLabel: "h — left",
+            outputKey: "left",
+            outputKeyCode: 123,
+            isTransparent: false,
+            isLayerSwitch: false
+        )
+
+        let result = LayerMappingBuilder.mergeAugmentation(augmented, with: original)
+
+        #expect(result.vimLabel == "←")
+        #expect(result.displayLabel == "←")
+    }
+
+    @Test("collectionId preserved from original through merge")
+    func mergePreservesCollectionId() {
+        let id = RuleCollectionIdentifier.vimNavigation
+        let original = LayerKeyInfo.mapped(
+            displayLabel: "←",
+            outputKey: "left",
+            outputKeyCode: 123,
+            collectionId: id,
+            vimLabel: "←"
+        )
+        let augmented = LayerKeyInfo(
+            displayLabel: "h — left",
+            outputKey: "left",
+            outputKeyCode: 123,
+            isTransparent: false,
+            isLayerSwitch: false
+        )
+
+        let result = LayerMappingBuilder.mergeAugmentation(augmented, with: original)
+
+        #expect(result.collectionId == id)
+    }
+
+    // MARK: - buildRemapOutputMap
+
+    @Test("remapped keys appear in output map")
+    func remapOutputMapIncludesRemaps() {
+        let mapping: [UInt16: LayerKeyInfo] = [
+            0: .mapped(displayLabel: "B", outputKey: "b", outputKeyCode: 11)
+        ]
+
+        let result = LayerMappingBuilder.buildRemapOutputMap(from: mapping)
+
+        #expect(result[0] == 11)
+    }
+
+    @Test("identity mappings excluded from output map")
+    func remapOutputMapExcludesIdentity() {
+        let mapping: [UInt16: LayerKeyInfo] = [
+            0: .mapped(displayLabel: "A", outputKey: "a", outputKeyCode: 0)
+        ]
+
+        let result = LayerMappingBuilder.buildRemapOutputMap(from: mapping)
+
+        #expect(result.isEmpty)
+    }
+
+    @Test("transparent keys excluded from output map")
+    func remapOutputMapExcludesTransparent() {
+        let mapping: [UInt16: LayerKeyInfo] = [
+            0: LayerKeyInfo(
+                displayLabel: "B",
+                outputKey: "b",
+                outputKeyCode: 11,
+                isTransparent: true,
+                isLayerSwitch: false
+            )
+        ]
+
+        let result = LayerMappingBuilder.buildRemapOutputMap(from: mapping)
+
+        #expect(result.isEmpty)
+    }
+
+    // MARK: - extractPushMsgInfo
+
+    @Test("extracts app launch from push-msg")
+    func extractAppLaunch() {
+        let output = #"(push-msg "launch:Safari")"#
+        let result = LayerMappingBuilder.extractPushMsgInfo(from: output, description: nil)
+
+        #expect(result?.appLaunchIdentifier == "Safari")
+    }
+
+    @Test("extracts system action from push-msg")
+    func extractSystemAction() {
+        let output = #"(push-msg "system:spotlight")"#
+        let result = LayerMappingBuilder.extractPushMsgInfo(from: output, description: nil)
+
+        #expect(result?.systemActionIdentifier == "spotlight")
+    }
+
+    @Test("extracts URL from push-msg")
+    func extractURL() {
+        let output = #"(push-msg "open:github.com")"#
+        let result = LayerMappingBuilder.extractPushMsgInfo(from: output, description: nil)
+
+        #expect(result?.urlIdentifier != nil)
+    }
+
+    @Test("returns nil for non-push-msg output")
+    func nonPushMsgReturnsNil() {
+        let result = LayerMappingBuilder.extractPushMsgInfo(from: "a", description: nil)
+
+        #expect(result == nil)
+    }
+
+    // MARK: - Pipeline invariant: vimLabels survive augmentation
+
+    @Test("all four HJKL vimLabels survive mergeAugmentation")
+    func allArrowVimLabelsSurviveMerge() {
+        let arrows: [(key: String, label: String, code: UInt16)] = [
+            ("left", "←", 123), ("down", "↓", 125),
+            ("up", "↑", 126), ("right", "→", 124)
+        ]
+
+        for arrow in arrows {
+            let original = LayerKeyInfo.mapped(
+                displayLabel: arrow.label,
+                outputKey: arrow.key,
+                outputKeyCode: arrow.code,
+                vimLabel: arrow.label
+            )
+            let augmented = LayerKeyInfo(
+                displayLabel: "\(arrow.key) — \(arrow.key)",
+                outputKey: arrow.key,
+                outputKeyCode: arrow.code,
+                isTransparent: false,
+                isLayerSwitch: false
+            )
+
+            let result = LayerMappingBuilder.mergeAugmentation(augmented, with: original)
+
+            #expect(result.vimLabel == arrow.label, "vimLabel for \(arrow.key) should survive")
+            #expect(result.displayLabel == arrow.label, "displayLabel for \(arrow.key) should use original")
+        }
+    }
+
+    // MARK: - systemActionDisplayLabel
+
+    @Test("known system actions get friendly names")
+    func systemActionLabels() {
+        #expect(LayerMappingBuilder.systemActionDisplayLabel("spotlight") == "Spotlight")
+        #expect(LayerMappingBuilder.systemActionDisplayLabel("dnd") == "Do Not Disturb")
+        #expect(LayerMappingBuilder.systemActionDisplayLabel("mission-control") == "Mission Control")
+        #expect(LayerMappingBuilder.systemActionDisplayLabel("notification-center") == "Notification Center")
+    }
+
+    @Test("unknown system actions get capitalized")
+    func unknownSystemActionCapitalized() {
+        #expect(LayerMappingBuilder.systemActionDisplayLabel("custom-thing") == "Custom-Thing")
+    }
+
+    // MARK: - mediaKeyDisplayLabel
+
+    @Test("media keys get display labels")
+    func mediaKeyLabels() {
+        #expect(LayerMappingBuilder.mediaKeyDisplayLabel("brup") == "Brightness Up")
+        #expect(LayerMappingBuilder.mediaKeyDisplayLabel("volu") == "Volume Up")
+        #expect(LayerMappingBuilder.mediaKeyDisplayLabel("pp") == "Play/Pause")
+    }
+
+    @Test("non-media keys return nil")
+    func nonMediaKeyReturnsNil() {
+        #expect(LayerMappingBuilder.mediaKeyDisplayLabel("a") == nil)
+    }
+}

--- a/Tests/KeyPathTests/UI/FloatingLabelVisibilityTests.swift
+++ b/Tests/KeyPathTests/UI/FloatingLabelVisibilityTests.swift
@@ -1,0 +1,153 @@
+@testable import KeyPathAppKit
+import Testing
+
+@Suite("FloatingLabelVisibility")
+struct FloatingLabelVisibilityTests {
+    private static let standardLabelToKeyCode: [String: UInt16] = [
+        "A": 0, "B": 11, "C": 8, "D": 2, "E": 14, "F": 3,
+        "G": 5, "H": 4, "J": 38, "K": 40, "L": 37,
+        "Q": 12, "W": 13, "S": 1, "R": 15, "T": 17
+    ]
+
+    private static func base(
+        labelToKeyCode: [String: UInt16] = standardLabelToKeyCode,
+        isLauncherMode: Bool = false,
+        isLayerMode: Bool = false,
+        vimHintsActive: Bool = false,
+        remappedLabels: Set<String> = [],
+        zoneSubtitleLabels: Set<String> = []
+    ) -> FloatingLabelVisibility {
+        FloatingLabelVisibility(
+            labelToKeyCode: labelToKeyCode,
+            isLauncherMode: isLauncherMode,
+            isLayerMode: isLayerMode,
+            vimHintsActive: vimHintsActive,
+            remappedLabels: remappedLabels,
+            zoneSubtitleLabels: zoneSubtitleLabels
+        )
+    }
+
+    // MARK: - Base case
+
+    @Test("normal letter visible on base layer")
+    func normalLetterVisible() {
+        let vis = Self.base()
+        #expect(vis.isVisible("A"))
+        #expect(vis.isVisible("Q"))
+        #expect(vis.isVisible("F"))
+    }
+
+    @Test("lowercase input still matches uppercase keyCode map")
+    func lowercaseInput() {
+        let vis = Self.base()
+        #expect(vis.isVisible("a"))
+        #expect(vis.isVisible("h"))
+    }
+
+    // MARK: - Label not in keymap
+
+    @Test("label not in keymap is hidden")
+    func labelNotInKeymap() {
+        let vis = Self.base()
+        #expect(!vis.isVisible("Z"))
+        #expect(!vis.isVisible("X"))
+    }
+
+    // MARK: - Special labels
+
+    @Test("special labels are hidden")
+    func specialLabelsHidden() {
+        let vis = Self.base(labelToKeyCode: ["ESC": 53, "⌫": 51, "⇧": 56, "F1": 122])
+        #expect(!vis.isVisible("ESC"))
+        #expect(!vis.isVisible("⌫"))
+        #expect(!vis.isVisible("⇧"))
+        #expect(!vis.isVisible("F1"))
+    }
+
+    @Test("special labels hidden regardless of case")
+    func specialLabelsCaseInsensitive() {
+        let vis = Self.base(labelToKeyCode: ["HOME": 115, "PGUP": 116])
+        #expect(!vis.isVisible("home"))
+        #expect(!vis.isVisible("PGUP"))
+    }
+
+    // MARK: - Launcher mode
+
+    @Test("all labels hidden in launcher mode")
+    func launcherModeHidesAll() {
+        let vis = Self.base(isLauncherMode: true)
+        #expect(!vis.isVisible("A"))
+        #expect(!vis.isVisible("H"))
+        #expect(!vis.isVisible("Q"))
+    }
+
+    // MARK: - Layer mode
+
+    @Test("all labels hidden in layer mode")
+    func layerModeHidesAll() {
+        let vis = Self.base(isLayerMode: true)
+        #expect(!vis.isVisible("A"))
+        #expect(!vis.isVisible("H"))
+    }
+
+    // MARK: - Remapped labels
+
+    @Test("remapped labels are hidden")
+    func remappedLabelsHidden() {
+        let vis = Self.base(remappedLabels: ["A", "S"])
+        #expect(!vis.isVisible("A"))
+        #expect(!vis.isVisible("S"))
+        #expect(vis.isVisible("D"))
+    }
+
+    // MARK: - Zone subtitle labels
+
+    @Test("labels with zone subtitles are hidden")
+    func zoneSubtitleLabelsHidden() {
+        let vis = Self.base(zoneSubtitleLabels: ["A", "S", "D", "F"])
+        #expect(!vis.isVisible("A"))
+        #expect(!vis.isVisible("F"))
+        #expect(vis.isVisible("G"))
+    }
+
+    // MARK: - Vim hints (HJKL regression)
+
+    @Test("HJKL hidden when vim hints active")
+    func hjklHiddenDuringVimHints() {
+        let vis = Self.base(vimHintsActive: true)
+        #expect(!vis.isVisible("H"))
+        #expect(!vis.isVisible("J"))
+        #expect(!vis.isVisible("K"))
+        #expect(!vis.isVisible("L"))
+    }
+
+    @Test("HJKL visible when vim hints inactive")
+    func hjklVisibleWithoutVimHints() {
+        let vis = Self.base(vimHintsActive: false)
+        #expect(vis.isVisible("H"))
+        #expect(vis.isVisible("J"))
+        #expect(vis.isVisible("K"))
+        #expect(vis.isVisible("L"))
+    }
+
+    @Test("non-HJKL visible even when vim hints active")
+    func nonHjklVisibleDuringVimHints() {
+        let vis = Self.base(vimHintsActive: true)
+        #expect(vis.isVisible("A"))
+        #expect(vis.isVisible("S"))
+        #expect(vis.isVisible("D"))
+        #expect(vis.isVisible("F"))
+        #expect(vis.isVisible("Q"))
+    }
+
+    // MARK: - Condition independence
+
+    @Test("each condition independently hides a label")
+    func eachConditionIndependent() {
+        #expect(!Self.base(isLauncherMode: true).isVisible("A"))
+        #expect(!Self.base(isLayerMode: true).isVisible("A"))
+        #expect(!Self.base(remappedLabels: ["A"]).isVisible("A"))
+        #expect(!Self.base(zoneSubtitleLabels: ["A"]).isVisible("A"))
+        #expect(!Self.base(vimHintsActive: true).isVisible("H"))
+    }
+}


### PR DESCRIPTION
## Summary

- **Phase 1 — FloatingLabelVisibility**: Extract the 7-condition floating label visibility chain from `OverlayKeyboardView` into a testable pure struct. Removes `specialLabels`, `isSpecialLabel`, `isRemappedLabel`, `hasZoneSubtitle`, and `isLoudVimHintLabel` from the view body. The view now calls `visibility.isVisible(label)` instead of an inline boolean chain.

- **Phase 2 — LayerMappingBuilder**: Extract pipeline functions (`augmentWithPushMsgActions`, `enrichWithCustomShiftLabels`, `mergeAugmentation`, `buildRemapOutputMap`) and all push-msg parsing (regexes, extract helpers, display label formatters) from `KeyboardVisualizationViewModel+LayoutMapping` into a focused `LayerMappingBuilder` enum. ViewModel retains thin forwarding wrappers so external callers are unchanged. Reduces ViewModel file by 339 lines.

Phases 1-2 from the [overlay rendering refactor plan](docs/architecture/overlay-refactor-plan.md). Pure structural refactoring — no behavior changes.

## Test plan

- [x] 13 new tests for `FloatingLabelVisibility` (all conditions, HJKL regression, case handling)
- [x] 14 new tests for `LayerMappingBuilder` (merge invariants, remap output map, push-msg extraction, vimLabel survival)
- [x] All 573 tests pass (`swift test`)
- [ ] Manual: hold Space (nav layer), hold Caps (launcher), KindaVim normal/insert, base layer floating labels