### PR TITLE
Remove redundant Quick Launcher promo, add double-click-to-edit

### DIFF
--- a/Sources/KeyPathAppKit/UI/Overlay/LiveKeyboardOverlayController+KeyClickHandling.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/LiveKeyboardOverlayController+KeyClickHandling.swift
@@ -1,4 +1,4 @@
-import Foundation
+import AppKit
 import KeyPathCore
 
 extension LiveKeyboardOverlayController {
@@ -56,14 +56,48 @@ extension LiveKeyboardOverlayController {
                 return
             }
 
+            // Double-click detection: second click on same key opens the editor
+            if launcherDoubleClickKey == normalizedKey {
+                launcherDoubleClickTimer?.cancel()
+                launcherDoubleClickTimer = nil
+                launcherDoubleClickKey = nil
+                AppLogger.shared.log("🖱️ [OverlayController] Launcher key double-clicked for editing: \(normalizedKey)")
+                toggleInspectorPanel()
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+                    NotificationCenter.default.post(
+                        name: .launcherSelectKey,
+                        object: nil,
+                        userInfo: ["key": normalizedKey]
+                    )
+                }
+                return
+            }
+
+            // First click: defer action execution to allow double-click detection
+            launcherDoubleClickKey = normalizedKey
             if let mapping = viewModel.launcherMappings[normalizedKey],
                let message = Self.launcherActionMessage(for: mapping.action)
             {
-                AppLogger.shared.log("🖱️ [OverlayController] Launcher key clicked: \(normalizedKey) -> \(message)")
-                ActionDispatcher.shared.dispatch(message: message)
-                ActionDispatcher.shared.dispatch(message: "layer:base")
+                let work = DispatchWorkItem { [weak self] in
+                    self?.launcherDoubleClickKey = nil
+                    self?.launcherDoubleClickTimer = nil
+                    AppLogger.shared.log("🖱️ [OverlayController] Launcher key clicked: \(normalizedKey) -> \(message)")
+                    ActionDispatcher.shared.dispatch(message: message)
+                    ActionDispatcher.shared.dispatch(message: "layer:base")
+                }
+                launcherDoubleClickTimer = work
+                DispatchQueue.main.asyncAfter(deadline: .now() + NSEvent.doubleClickInterval, execute: work)
                 return
             }
+
+            // Unmapped key: just track for double-click, clear after interval
+            let work = DispatchWorkItem { [weak self] in
+                self?.launcherDoubleClickKey = nil
+                self?.launcherDoubleClickTimer = nil
+            }
+            launcherDoubleClickTimer = work
+            DispatchQueue.main.asyncAfter(deadline: .now() + NSEvent.doubleClickInterval, execute: work)
+            return
         }
 
         let outputKey: String = if let simpleOutput = layerInfo?.outputKey {
@@ -113,4 +147,5 @@ extension LiveKeyboardOverlayController {
             userInfo: userInfo
         )
     }
+
 }

--- a/Sources/KeyPathAppKit/UI/Overlay/LiveKeyboardOverlayController.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/LiveKeyboardOverlayController.swift
@@ -84,6 +84,10 @@ final class LiveKeyboardOverlayController: NSObject, NSWindowDelegate {
     /// Timer for smooth inspector reveal animation (windowDidResize doesn't fire continuously)
     var inspectorAnimationTimer: Timer?
 
+    /// Double-click detection for launcher keys
+    var launcherDoubleClickKey: String?
+    var launcherDoubleClickTimer: DispatchWorkItem?
+
     private var minWindowHeight: CGFloat {
         OverlayLayoutMetrics.verticalChrome + minKeyboardHeight
     }

--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView+ContentAndStyling.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView+ContentAndStyling.swift
@@ -106,7 +106,7 @@ extension OverlayKeycapView {
             iconVisible = isLauncherMode
         }
         .animation(nil, value: currentLayerName)
-        .allowsHitTesting(isInspectorVisible || key.layoutRole == .touchId)
+        .allowsHitTesting(isInspectorVisible || isLauncherMode || key.layoutRole == .touchId)
         // Hover detection (must be before contentShape for hit testing)
         .contentShape(Rectangle())
         .onHover { hovering in
@@ -140,8 +140,7 @@ extension OverlayKeycapView {
                     guard key.layoutRole != .touchId, let onKeyClick else { return }
                     onKeyClick(key, layerKeyInfo)
                 },
-            // Only capture gestures when drawer is open (Touch ID handled by highPriorityGesture above)
-            including: isInspectorVisible ? .all : .none
+            including: isInspectorVisible || isLauncherMode ? .all : .none
         )
         .onAppear {
             loadAppIconIfNeeded()

--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayLaunchersSection.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayLaunchersSection.swift
@@ -61,9 +61,6 @@ struct OverlayLaunchersSection: View {
 
             Spacer(minLength: 0)
 
-            // Promo card linking to full Pack Detail editor
-            launcherPromoCard
-
             // Bottom controls: Add/Edit (left) and Settings (right)
             HStack(spacing: 8) {
                 Button {
@@ -171,38 +168,6 @@ struct OverlayLaunchersSection: View {
                 editingMapping = LauncherMapping(key: normalized, action: .launchApp(name: "", bundleId: nil))
             }
         }
-    }
-
-    private var launcherPromoCard: some View {
-        Button { openLauncherPackDetail() } label: {
-            HStack(spacing: 8) {
-                Image(systemName: "arrow.up.forward.app")
-                    .font(.system(size: 11))
-                    .foregroundStyle(.tint)
-                    .symbolRenderingMode(.hierarchical)
-                Text("Edit in Quick Launcher")
-                    .font(.system(size: 11, weight: .medium))
-                    .foregroundStyle(.primary)
-                Spacer()
-                Image(systemName: "chevron.right")
-                    .font(.system(size: 8, weight: .semibold))
-                    .foregroundStyle(.secondary)
-            }
-            .padding(.horizontal, 10)
-            .padding(.vertical, 8)
-            .background(
-                RoundedRectangle(cornerRadius: 6, style: .continuous)
-                    .fill(Color.accentColor.opacity(0.06))
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: 6, style: .continuous)
-                    .strokeBorder(Color.accentColor.opacity(0.12), lineWidth: 0.5)
-            )
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-        .padding(.top, 8)
-        .accessibilityIdentifier("overlay-launcher-promo-card")
     }
 
     private var emptyState: some View {


### PR DESCRIPTION
## Summary
- Removed the "Edit in Quick Launcher >" button from the overlay sidebar — it was redundant with direct key interaction
- Added double-click detection on launcher keycaps: double-clicking a key in the overlay opens the inspector and selects that key for editing
- Single-click behavior preserved — shortcut execution is deferred by the system double-click interval to allow disambiguation
- Keycaps in launcher mode are now hit-testable even when the inspector is closed (required for double-click to work)

## Test plan
- [x] Build succeeds
- [x] 573 tests pass
- [ ] Verify "Edit in Quick Launcher >" button is gone from sidebar
- [ ] Verify scrolling list uses the reclaimed space
- [ ] Double-click a mapped launcher key → inspector opens with that key's edit panel
- [ ] Double-click an unmapped launcher key → inspector opens with new mapping for that key
- [ ] Single-click a mapped launcher key → shortcut still executes (after brief delay)
- [ ] Existing single-click editing with inspector open still works