### PR TITLE
Fix launcher double-click-to-edit with SwiftUI tap gestures

### DIFF
--- a/Sources/KeyPathAppKit/UI/Overlay/LiveKeyboardOverlayController+KeyClickHandling.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/LiveKeyboardOverlayController+KeyClickHandling.swift
@@ -1,4 +1,4 @@
-import AppKit
+import Foundation
 import KeyPathCore
 
 extension LiveKeyboardOverlayController {
@@ -56,48 +56,14 @@ extension LiveKeyboardOverlayController {
                 return
             }
 
-            // Double-click detection: second click on same key opens the editor
-            if launcherDoubleClickKey == normalizedKey {
-                launcherDoubleClickTimer?.cancel()
-                launcherDoubleClickTimer = nil
-                launcherDoubleClickKey = nil
-                AppLogger.shared.log("🖱️ [OverlayController] Launcher key double-clicked for editing: \(normalizedKey)")
-                toggleInspectorPanel()
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
-                    NotificationCenter.default.post(
-                        name: .launcherSelectKey,
-                        object: nil,
-                        userInfo: ["key": normalizedKey]
-                    )
-                }
-                return
-            }
-
-            // First click: defer action execution to allow double-click detection
-            launcherDoubleClickKey = normalizedKey
             if let mapping = viewModel.launcherMappings[normalizedKey],
                let message = Self.launcherActionMessage(for: mapping.action)
             {
-                let work = DispatchWorkItem { [weak self] in
-                    self?.launcherDoubleClickKey = nil
-                    self?.launcherDoubleClickTimer = nil
-                    AppLogger.shared.log("🖱️ [OverlayController] Launcher key clicked: \(normalizedKey) -> \(message)")
-                    ActionDispatcher.shared.dispatch(message: message)
-                    ActionDispatcher.shared.dispatch(message: "layer:base")
-                }
-                launcherDoubleClickTimer = work
-                DispatchQueue.main.asyncAfter(deadline: .now() + NSEvent.doubleClickInterval, execute: work)
+                AppLogger.shared.log("🖱️ [OverlayController] Launcher key clicked: \(normalizedKey) -> \(message)")
+                ActionDispatcher.shared.dispatch(message: message)
+                ActionDispatcher.shared.dispatch(message: "layer:base")
                 return
             }
-
-            // Unmapped key: just track for double-click, clear after interval
-            let work = DispatchWorkItem { [weak self] in
-                self?.launcherDoubleClickKey = nil
-                self?.launcherDoubleClickTimer = nil
-            }
-            launcherDoubleClickTimer = work
-            DispatchQueue.main.asyncAfter(deadline: .now() + NSEvent.doubleClickInterval, execute: work)
-            return
         }
 
         let outputKey: String = if let simpleOutput = layerInfo?.outputKey {
@@ -148,4 +114,24 @@ extension LiveKeyboardOverlayController {
         )
     }
 
+    func handleKeyDoubleClick(key: PhysicalKey, layerInfo: LayerKeyInfo?) {
+        guard viewModel.isLauncherModeActive else { return }
+        let inputKey = OverlayKeyboardView.keyCodeToKanataName(key.keyCode)
+        let normalizedKey = inputKey.lowercased()
+
+        AppLogger.shared.log("🖱️ [OverlayController] Launcher key double-clicked for editing: \(normalizedKey)")
+
+        let inspectorOpen = uiState.isInspectorOpen || uiState.inspectorReveal > 0
+        if !inspectorOpen {
+            toggleInspectorPanel()
+        }
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+            NotificationCenter.default.post(
+                name: .launcherSelectKey,
+                object: nil,
+                userInfo: ["key": normalizedKey]
+            )
+        }
+    }
 }

--- a/Sources/KeyPathAppKit/UI/Overlay/LiveKeyboardOverlayController.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/LiveKeyboardOverlayController.swift
@@ -84,10 +84,6 @@ final class LiveKeyboardOverlayController: NSObject, NSWindowDelegate {
     /// Timer for smooth inspector reveal animation (windowDidResize doesn't fire continuously)
     var inspectorAnimationTimer: Timer?
 
-    /// Double-click detection for launcher keys
-    var launcherDoubleClickKey: String?
-    var launcherDoubleClickTimer: DispatchWorkItem?
-
     private var minWindowHeight: CGFloat {
         OverlayLayoutMetrics.verticalChrome + minKeyboardHeight
     }
@@ -718,6 +714,9 @@ final class LiveKeyboardOverlayController: NSObject, NSWindowDelegate {
             kanataViewModel: kanataViewModel,
             onKeyClick: { [weak self] key, layerInfo in
                 self?.handleKeyClick(key: key, layerInfo: layerInfo)
+            },
+            onKeyDoubleClick: { [weak self] key, layerInfo in
+                self?.handleKeyDoubleClick(key: key, layerInfo: layerInfo)
             },
             onClose: { [weak self] in
                 self?.isVisible = false

--- a/Sources/KeyPathAppKit/UI/Overlay/LiveKeyboardOverlayView+ContentBuilders.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/LiveKeyboardOverlayView+ContentBuilders.swift
@@ -171,6 +171,7 @@ extension LiveKeyboardOverlayView {
                     holdReleaseFadeKeyCodes: viewModel.holdReleaseFadeKeyCodes,
                     customIcons: viewModel.customIcons,
                     onKeyClick: onKeyClick,
+                    onKeyDoubleClick: onKeyDoubleClick,
                     selectedKeyCode: viewModel.selectedKeyCode,
                     hoveredRuleKeyCode: viewModel.hoveredRuleKeyCode,
                     vimHintsActive: kindaVimPackInstalled && VimHintLayer.isCurrentlyRendering,

--- a/Sources/KeyPathAppKit/UI/Overlay/LiveKeyboardOverlayView.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/LiveKeyboardOverlayView.swift
@@ -14,6 +14,8 @@ struct LiveKeyboardOverlayView: View {
     let kanataViewModel: KanataViewModel?
     /// Callback when a key is clicked (not dragged) - selects key in drawer mapper when visible
     var onKeyClick: ((PhysicalKey, LayerKeyInfo?) -> Void)?
+    /// Callback when a key is double-clicked in launcher mode (opens edit panel)
+    var onKeyDoubleClick: ((PhysicalKey, LayerKeyInfo?) -> Void)?
     /// Callback when the overlay close button is pressed
     var onClose: (() -> Void)?
     /// Callback when the inspector button is pressed

--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayKeyboardView.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayKeyboardView.swift
@@ -40,6 +40,8 @@ struct OverlayKeyboardView: View {
     var customIcons: [UInt16: String] = [:]
     /// Callback when a key is clicked (not dragged) - selects key in drawer mapper when visible
     var onKeyClick: ((PhysicalKey, LayerKeyInfo?) -> Void)?
+    /// Callback when a key is double-clicked in launcher mode (opens edit panel)
+    var onKeyDoubleClick: ((PhysicalKey, LayerKeyInfo?) -> Void)?
     /// Key code of currently selected key in mapper drawer (shows selection highlight)
     var selectedKeyCode: UInt16?
     /// Key code being hovered in rules/launcher tabs (for secondary highlight)
@@ -440,6 +442,7 @@ struct OverlayKeyboardView: View {
                 ? KeyPathColors.layerOrange : .accentColor,
             tapHoldIdleLabel: tapHoldIdleLabels[key.keyCode],
             onKeyClick: onKeyClick,
+            onKeyDoubleClick: onKeyDoubleClick,
             colorway: activeColorway,
             // Pass layout width for rainbow gradient calculation
             layoutTotalWidth: layout.totalWidth,

--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView+ContentAndStyling.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView+ContentAndStyling.swift
@@ -121,11 +121,11 @@ extension OverlayKeycapView {
             }
         }
         // Click behavior based on drawer state:
-        // - Drawer CLOSED: only Touch ID key captures clicks (opens drawer), all other keys pass through for window drag
-        // - Drawer OPEN: all keys capture clicks for mapping
+        // - Drawer CLOSED + launcher mode: tap gestures with count disambiguation (double-click edits, single-click executes)
+        // - Drawer CLOSED + base mode: only Touch ID key captures clicks, all other keys pass through for window drag
+        // - Drawer OPEN: all keys capture clicks for mapping via DragGesture
         // Touch ID uses highPriorityGesture(TapGesture) so it wins over the parent keyboard's
         // highPriorityGesture(DragGesture) which would otherwise swallow tap events.
-        // Other keys use simultaneousGesture(DragGesture) so they coexist with keyboard drag.
         .highPriorityGesture(
             TapGesture()
                 .onEnded {
@@ -134,13 +134,26 @@ extension OverlayKeycapView {
                 },
             including: key.layoutRole == .touchId ? .all : .none
         )
+        // Launcher mode (inspector closed): double-click opens edit panel, single-click executes shortcut.
+        // onTapGesture(count:2) before count:1 makes SwiftUI delay the single tap to disambiguate.
+        .onTapGesture(count: 2) {
+            guard isLauncherMode, !isInspectorVisible, key.layoutRole != .touchId,
+                  let onKeyDoubleClick else { return }
+            onKeyDoubleClick(key, layerKeyInfo)
+        }
+        .onTapGesture {
+            guard isLauncherMode, !isInspectorVisible, key.layoutRole != .touchId,
+                  let onKeyClick else { return }
+            onKeyClick(key, layerKeyInfo)
+        }
+        // Inspector open: DragGesture for key selection (coexists with keyboard drag)
         .simultaneousGesture(
             DragGesture(minimumDistance: 0)
                 .onEnded { _ in
                     guard key.layoutRole != .touchId, let onKeyClick else { return }
                     onKeyClick(key, layerKeyInfo)
                 },
-            including: isInspectorVisible || isLauncherMode ? .all : .none
+            including: isInspectorVisible ? .all : .none
         )
         .onAppear {
             loadAppIconIfNeeded()

--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView.swift
@@ -39,6 +39,8 @@ struct OverlayKeycapView: View {
     var tapHoldIdleLabel: String?
     /// Callback when key is clicked (not dragged)
     var onKeyClick: ((PhysicalKey, LayerKeyInfo?) -> Void)?
+    /// Callback when key is double-clicked in launcher mode (opens edit panel)
+    var onKeyDoubleClick: ((PhysicalKey, LayerKeyInfo?) -> Void)?
     /// GMK colorway for keycap styling
     var colorway: GMKColorway = .default
     /// Layout total width for rainbow gradient calculation (default 15 for standard keyboards)


### PR DESCRIPTION
## Summary
- Fixes double-click-to-edit on launcher overlay keys (broken in #600)
- Replaced controller-based `DragGesture` double-click detection with SwiftUI native `onTapGesture(count: 2)` + `onTapGesture(count: 1)` disambiguation
- `DragGesture(minimumDistance: 0)` fires eagerly on every mouse-up without tap-count awareness, preventing double-click detection
- SwiftUI natively delays the single tap when `count: 2` is registered before `count: 1`
- Single-click executes the shortcut, double-click opens the inspector with the key's edit panel

## Test plan
- [x] Build succeeds
- [ ] Double-click a mapped launcher key → inspector opens, edit panel shows for that key
- [ ] Double-click an unmapped launcher key → inspector opens, new mapping panel for that key
- [ ] Single-click a mapped launcher key → shortcut executes (slight delay from tap disambiguation)
- [ ] Existing inspector-open click behavior unchanged