### PR TITLE
fix: improve stuck key resilience under CPU pressure

### DIFF
--- a/Sources/KeyPathApp/com.keypath.kanata.plist
+++ b/Sources/KeyPathApp/com.keypath.kanata.plist
@@ -46,9 +46,28 @@
         <integer>1024</integer>
     </dict>
 
+    <!-- Keyboard input processing is latency-critical — treat this daemon like
+         an interactive app so macOS does not throttle CPU, I/O, or timers under load.
+         Without this, the daemon runs at Standard priority and the processing thread
+         can be starved by background work (compilation, Spotlight indexing), causing
+         stuck keys when release events are delayed. -->
+    <key>ProcessType</key>
+    <string>Interactive</string>
+
+    <!-- Disable macOS timer coalescing. The kanata processing loop uses a 1ms tick
+         timer for tap-hold timeouts; coalescing adds unpredictable jitter that can
+         extend tap-hold windows long enough for macOS to fire autorepeat. -->
+    <key>LegacyTimers</key>
+    <true/>
+
+    <!-- If kanata is hung and won't respond to SIGTERM, kill it after 5s instead of
+         the default 20s. A keyboard daemon that can't shut down in 5s is stuck. -->
+    <key>ExitTimeOut</key>
+    <integer>5</integer>
+
     <key>ThrottleInterval</key>
     <integer>10</integer>
-    
+
     <key>AssociatedBundleIdentifiers</key>
     <array>
         <string>com.keypath.KeyPath</string>

--- a/Sources/KeyPathAppKit/Services/Monitoring/StuckKeyRecoveryService.swift
+++ b/Sources/KeyPathAppKit/Services/Monitoring/StuckKeyRecoveryService.swift
@@ -54,6 +54,8 @@ final class StuckKeyRecoveryService {
             guard let self else { return }
             defer { self.isRecovering = false }
 
+            await writeDiagnosticSnapshot(correlation)
+
             if let restart = restartKanata {
                 let success = await restart("Stuck key recovery (\(correlation.key))")
                 lastRecoveryAt = Date()
@@ -67,4 +69,106 @@ final class StuckKeyRecoveryService {
             }
         }
     }
+
+    // MARK: - Diagnostic Snapshot
+
+    private func writeDiagnosticSnapshot(_ correlation: InvestigationSystemEventCorrelation) async {
+        let tracker = await DuplicateKeyInvestigationTracker.shared.snapshot(
+            phase: "stuck-key-recovery",
+            reason: "key=\(correlation.key) ms_since_kanata=\(correlation.msSinceAnyKanataEvent ?? -1)"
+        )
+
+        let lastRecoveryDescription = lastRecoveryAt.map { ISO8601DateFormatter().string(from: $0) } ?? "never"
+
+        let snapshot = DiagnosticSnapshotData(
+            correlation: correlation,
+            tracker: tracker,
+            lastRecoveryDescription: lastRecoveryDescription
+        )
+
+        await Task.detached(priority: .utility) {
+            Self.writeSnapshotToDisk(snapshot)
+        }.value
+    }
+
+    private nonisolated static func writeSnapshotToDisk(_ snapshot: DiagnosticSnapshotData) {
+        let diagnosticsDir = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Logs/KeyPath/stuck-key-incidents")
+
+        let timestamp = ISO8601DateFormatter().string(from: Date())
+        let safeTimestamp = timestamp.replacingOccurrences(of: ":", with: "-")
+        let filename = "stuck-key-\(safeTimestamp).log"
+        let fileURL = diagnosticsDir.appendingPathComponent(filename)
+
+        var lines: [String] = []
+        lines.append("=== Stuck Key Incident ===")
+        lines.append("timestamp: \(timestamp)")
+        lines.append("stuck_key: \(snapshot.correlation.key) (keycode \(snapshot.correlation.keyCode))")
+        lines.append("ms_since_any_kanata_event: \(snapshot.correlation.msSinceAnyKanataEvent ?? -1)")
+        lines.append("same_key_gap_ms: \(snapshot.correlation.sameKeyGapMs.map(String.init) ?? "nil")")
+        lines.append("previous_kanata_action: \(snapshot.correlation.previousKanataAction?.rawValue ?? "none")")
+        lines.append("previous_kanata_session: \(snapshot.correlation.previousKanataSessionID.map(String.init) ?? "none")")
+        lines.append("event_type: \(snapshot.correlation.eventType)")
+        lines.append("is_autorepeat: \(snapshot.correlation.isAutorepeat)")
+        lines.append("source_pid: \(snapshot.correlation.sourcePID.map(String.init) ?? "none")")
+        lines.append("")
+        lines.append("=== Held Keys at Recovery ===")
+        if snapshot.tracker.heldKeys.isEmpty {
+            lines.append("(none tracked)")
+        } else {
+            for held in snapshot.tracker.heldKeys {
+                lines.append("  \(held.key): held for \(held.heldDurationMs)ms")
+            }
+        }
+        lines.append("ms_since_last_key_event: \(snapshot.tracker.msSinceLastEvent.map(String.init) ?? "nil")")
+        lines.append("session_id: \(snapshot.tracker.sessionID.map(String.init) ?? "none")")
+        lines.append("")
+
+        lines.append("=== Kanata Stderr (last 50 lines) ===")
+        if let data = FileManager.default.contents(atPath: "/var/log/com.keypath.kanata.stderr.log"),
+           let content = String(data: data, encoding: .utf8) {
+            lines.append(contentsOf: content.components(separatedBy: .newlines).suffix(50))
+        } else {
+            lines.append("(file not readable)")
+        }
+        lines.append("")
+
+        lines.append("=== Recovery History ===")
+        lines.append("last_recovery_at: \(snapshot.lastRecoveryDescription)")
+        lines.append("")
+
+        do {
+            try FileManager.default.createDirectory(at: diagnosticsDir, withIntermediateDirectories: true)
+            try lines.joined(separator: "\n").write(to: fileURL, atomically: true, encoding: .utf8)
+            AppLogger.shared.info("[StuckKeyRecovery] Diagnostic snapshot written to \(fileURL.path)")
+        } catch {
+            AppLogger.shared.error("[StuckKeyRecovery] Failed to write diagnostic snapshot: \(error)")
+        }
+
+        // Keep at most 20 incident files
+        if let files = try? FileManager.default.contentsOfDirectory(
+            at: diagnosticsDir,
+            includingPropertiesForKeys: [.creationDateKey],
+            options: .skipsHiddenFiles
+        ) {
+            let sorted = files
+                .compactMap { url -> (URL, Date)? in
+                    guard let date = (try? url.resourceValues(forKeys: [.creationDateKey]))?.creationDate else {
+                        return nil
+                    }
+                    return (url, date)
+                }
+                .sorted { $0.1 > $1.1 }
+
+            for (url, _) in sorted.dropFirst(20) {
+                try? FileManager.default.removeItem(at: url)
+            }
+        }
+    }
+}
+
+private struct DiagnosticSnapshotData: Sendable {
+    let correlation: InvestigationSystemEventCorrelation
+    let tracker: InvestigationReloadSnapshot
+    let lastRecoveryDescription: String
 }


### PR DESCRIPTION
## Summary

- Add `ProcessType=Interactive`, `LegacyTimers=true`, and `ExitTimeOut=5` to the kanata LaunchDaemon plist so macOS treats the keyboard daemon as latency-critical and doesn't throttle CPU/IO/timers under load
- Add automatic diagnostic snapshots to `StuckKeyRecoveryService` — when a stuck key is detected, a snapshot is written to `~/Library/Logs/KeyPath/stuck-key-incidents/` *before* restarting kanata, capturing the correlation data, held keys, kanata stderr, and recovery history for post-incident analysis
- Snapshots are pruned to keep at most 20 files

## Context

Under CPU/memory pressure (compilation, Spotlight indexing), kanata's processing thread can be starved, causing key release events to be delayed long enough for macOS to fire autorepeat — the "stuck key" problem. Investigation identified two KeyPath-side gaps:

1. **Missing launchd scheduling priority**: The plist had no `ProcessType`, so launchd treated kanata as a Standard-priority daemon. `ProcessType=Interactive` tells launchd to give it the same scheduling treatment as apps — no CPU/IO throttling. `LegacyTimers` disables timer coalescing that adds jitter to the 1ms tick loop.

2. **No diagnostic data during incidents**: When stuck keys occurred, the only data was the single log line from `StuckKeyRecoveryService`. Now each incident produces a structured snapshot file with all the context needed to determine whether the fix is working and what further mitigation (kanata-side idle-state clearing, graceful degradation) may be needed.

## Follow-up (kanata-side, separate PRs)

- Port Windows `clear_states_from_inactivity()` to macOS — the direct equivalent of "release stuck keys after N seconds of no input"
- Add processing loop latency canary — log warnings when a single loop iteration exceeds 10ms
- Graceful degradation — release HID device and pass through when overwhelmed

## Test plan

- [x] `swift build` passes
- [x] `swift test` passes (pre-existing flaky `AutoDetectKeyboardControllerTests` failure unrelated)
- [x] `swiftformat` / `swiftlint` clean
- [ ] Deploy and observe stuck key frequency under normal usage
- [ ] If stuck keys still occur, review diagnostic snapshots in `~/Library/Logs/KeyPath/stuck-key-incidents/`