### PR TITLE
fix: update kanata submodule for macOS stuck-key resilience

### DIFF
--- a/Rust/KeyPathKanataHostBridge/Cargo.lock
+++ b/Rust/KeyPathKanataHostBridge/Cargo.lock
@@ -652,6 +652,7 @@ dependencies = [
  "radix_trie",
  "rustc-hash",
  "sd-notify",
+ "serde",
  "serde_json",
  "signal-hook",
  "simplelog",


### PR DESCRIPTION
## Summary
- Updates kanata submodule from `7fc2758` to `84cca3d` (3 commits on `keypath/bundled`)
- Picks up macOS stuck-key resilience: idle-clearing of stuck key states, processing loop latency canary, and soft-reset under sustained latency
- Companion to #614 (launchd tuning and diagnostics on the Swift side)

## Test plan
- [x] `SKIP_NOTARIZE=1 ./build.sh` passes and deploys
- [x] Kanata binary version confirmed: `kanata 1.12.0-prerelease-2`
- [ ] CI green