### PR TITLE
fix: calm OFF state, TCP port migration, and dark-mode Sparkle notes

### DIFF
--- a/Sources/KeyPathAppKit/Services/Configuration/PreferencesService.swift
+++ b/Sources/KeyPathAppKit/Services/Configuration/PreferencesService.swift
@@ -425,8 +425,22 @@ final class PreferencesService: @unchecked Sendable {
         communicationProtocol =
             CommunicationProtocol(rawValue: protocolString) ?? Defaults.communicationProtocol
 
-        tcpServerPort =
-            UserDefaults.standard.object(forKey: Keys.tcpServerPort) as? Int ?? Defaults.tcpServerPort
+        // TCP server port. Migrate the legacy UDP-era port (54141) to the
+        // current default. PR #500 changed the default to 37001, but existing
+        // installs kept 54141 in UserDefaults while the kanata daemon was
+        // (re)launched on the new default — so the app dialed a port nothing was
+        // listening on and reported "no TCP". Clear the stale key so it tracks
+        // the current default; preserve any deliberately-set non-legacy port.
+        let storedTCPPort = UserDefaults.standard.object(forKey: Keys.tcpServerPort) as? Int
+        if let storedTCPPort, storedTCPPort == KeyPathConstants.Networking.legacyUDPEraPort {
+            UserDefaults.standard.removeObject(forKey: Keys.tcpServerPort)
+            tcpServerPort = Defaults.tcpServerPort
+            AppLogger.shared.log(
+                "🔧 [PreferencesService] Migrated legacy TCP port \(storedTCPPort) → \(Defaults.tcpServerPort)"
+            )
+        } else {
+            tcpServerPort = storedTCPPort ?? Defaults.tcpServerPort
+        }
 
         notificationsEnabled =
             UserDefaults.standard.object(forKey: Keys.notificationsEnabled) as? Bool

--- a/Sources/KeyPathAppKit/UI/Settings/SettingsView+StatusDetails.swift
+++ b/Sources/KeyPathAppKit/UI/Settings/SettingsView+StatusDetails.swift
@@ -12,9 +12,19 @@ extension StatusSettingsTabView {
         case warning = 1
         case critical = 2
         case checking = 3
+        case disabled = 4
     }
 
     var overallHealthLevel: OverallHealthLevel {
+        // The user deliberately switched the service off. This is a calm,
+        // intentional state — not a fault — so it takes precedence over both the
+        // loading guard and the health checks below (which all assume the
+        // service should be running). Checked before the guard so the icon/tint
+        // stay in sync with systemHealthMessage's "KeyPath is Off".
+        if isIntentionallyDisabled {
+            return .disabled
+        }
+
         guard let context = systemContext, permissionSnapshot != nil else { return .checking }
 
         let hasBlockingIssues = wizardIssues.contains { $0.severity == .critical || $0.severity == .error }
@@ -47,6 +57,8 @@ extension StatusSettingsTabView {
             "xmark.circle.fill"
         case .checking:
             "gear"
+        case .disabled:
+            "power.circle.fill"
         }
     }
 
@@ -60,10 +72,15 @@ extension StatusSettingsTabView {
             .red
         case .checking:
             .secondary
+        case .disabled:
+            .secondary
         }
     }
 
     var systemHealthMessage: String {
+        if isIntentionallyDisabled {
+            return "KeyPath is Off"
+        }
         guard let context = systemContext else { return "Checking status…" }
         if !context.services.kanataRunning {
             return kanataServiceStatus
@@ -137,6 +154,15 @@ extension StatusSettingsTabView {
                 title: "KeyPath Runtime",
                 message: "Checking current status…",
                 icon: "ellipsis.circle",
+                level: .info
+            )
+        }
+
+        if isIntentionallyDisabled {
+            return StatusDetail(
+                title: "KeyPath Runtime",
+                message: "Turned off. Flip the switch above to resume remapping.",
+                icon: "power",
                 level: .info
             )
         }
@@ -342,6 +368,9 @@ extension StatusSettingsTabView {
 
     var kanataLogsDetail: StatusDetail? {
         // Show logs affordance when service isn't healthy or has daemon issues.
+        // Not when the user simply turned the service off — there's nothing to
+        // troubleshoot.
+        guard !isIntentionallyDisabled else { return nil }
         guard serviceStatusDetail.level != .success else { return nil }
         return StatusDetail(
             title: "Kanata Logs",

--- a/Sources/KeyPathAppKit/UI/Settings/SettingsView.swift
+++ b/Sources/KeyPathAppKit/UI/Settings/SettingsView.swift
@@ -23,6 +23,14 @@ struct StatusSettingsTabView: View {
     @State var showingPermissionAlert = false
     @State private var localServiceRunning: Bool? // Optimistic local state for instant toggle feedback
 
+    /// Persisted record that the user explicitly switched the service off (as
+    /// opposed to it being unexpectedly down). Drives the calm "KeyPath is Off"
+    /// presentation, survives relaunch, and — unlike the optimistic
+    /// `localServiceRunning` — is NOT cleared when the actual service state
+    /// changes (see the `onChange(of: isServiceRunning)` handler). Cleared when
+    /// the user switches the service back on.
+    @AppStorage("KeyPath.Status.UserDisabledService") private var userDisabledService = false
+
     private var isServiceRunning: Bool {
         systemContext?.services.kanataRunning ?? false
     }
@@ -38,6 +46,17 @@ struct StatusSettingsTabView: View {
 
     private var isSystemHealthy: Bool {
         overallHealthLevel == .success
+    }
+
+    /// True when the user has deliberately switched the service off, as opposed
+    /// to the service being unexpectedly down. Drives the calm "disabled"
+    /// presentation (gray, no "Fix it") instead of treating an intentional OFF
+    /// as a fault. Uses the optimistic `effectiveServiceRunning` so the calm
+    /// state appears the instant the toggle flips, and only asserts while the
+    /// service is actually not running. Accessible from the StatusDetails
+    /// extension.
+    var isIntentionallyDisabled: Bool {
+        userDisabledService && !effectiveServiceRunning
     }
 
     /// True when the only permission issue is unverified kanata (no FDA to check)
@@ -107,8 +126,10 @@ struct StatusSettingsTabView: View {
                         }
                     }
 
-                    // Action button when there are problems
-                    if !isSystemHealthy {
+                    // Action button when there are problems. Suppressed when the
+                    // user has intentionally turned the service off — nothing is
+                    // broken, so there's nothing to fix.
+                    if !isSystemHealthy, !isIntentionallyDisabled {
                         if isOnlyKanataUnverified {
                             // Only issue is unverified kanata — lead with FDA
                             Button(action: { SystemDiagnostics.open(.fullDiskAccess) }) {
@@ -141,6 +162,9 @@ struct StatusSettingsTabView: View {
                                 set: { newValue in
                                     // Optimistic update: change UI immediately
                                     localServiceRunning = newValue
+                                    // Record explicit user intent (persists across
+                                    // relaunch and the isServiceRunning onChange reset).
+                                    userDisabledService = !newValue
                                     // Then trigger async operation
                                     Task {
                                         if newValue {

--- a/Sources/KeyPathCore/KeyPathConstants.swift
+++ b/Sources/KeyPathCore/KeyPathConstants.swift
@@ -76,6 +76,13 @@ public enum KeyPathConstants {
 
     public enum Networking {
         public static let defaultTCPPort = 37001
+
+        /// The port used during the old UDP-era architecture. PR #500 introduced
+        /// `defaultTCPPort = 37001`, but existing installs kept this value in
+        /// UserDefaults — leaving the app dialing a port the kanata daemon (now
+        /// launched on the new default) doesn't listen on. PreferencesService
+        /// migrates this value to `defaultTCPPort` on load.
+        public static let legacyUDPEraPort = 54141
     }
 
     public enum URLs {

--- a/Tests/KeyPathTests/Services/PreferencesServicePersistenceTests.swift
+++ b/Tests/KeyPathTests/Services/PreferencesServicePersistenceTests.swift
@@ -106,6 +106,49 @@ final class PreferencesServicePersistenceTests: XCTestCase {
         XCTAssertFalse(prefs.isValidPort(65536))
     }
 
+    // MARK: - Legacy TCP Port Migration
+
+    /// An old install that still has the UDP-era port (54141) stored should be
+    /// migrated to the current default (37001) on load, and the stale key
+    /// cleared so it tracks the default going forward. This is the fix for the
+    /// "no TCP" mismatch where the app dialed 54141 while kanata listened on 37001.
+    func testTcpServerPort_LegacyUDPEraPortMigratesToDefault() {
+        let key = "KeyPath.TCP.ServerPort"
+        let saved = UserDefaults.standard.object(forKey: key)
+        defer {
+            if let saved { UserDefaults.standard.set(saved, forKey: key) } else {
+                UserDefaults.standard.removeObject(forKey: key)
+            }
+        }
+
+        UserDefaults.standard.set(54141, forKey: key)
+
+        let prefs = PreferencesService()
+
+        XCTAssertEqual(prefs.tcpServerPort, 37001, "Legacy port should migrate to current default")
+        XCTAssertNil(
+            UserDefaults.standard.object(forKey: key),
+            "Stale key should be cleared so the port tracks the default going forward"
+        )
+    }
+
+    /// A deliberately-chosen non-legacy port must NOT be clobbered by the migration.
+    func testTcpServerPort_DeliberateCustomPortPreserved() {
+        let key = "KeyPath.TCP.ServerPort"
+        let saved = UserDefaults.standard.object(forKey: key)
+        defer {
+            if let saved { UserDefaults.standard.set(saved, forKey: key) } else {
+                UserDefaults.standard.removeObject(forKey: key)
+            }
+        }
+
+        UserDefaults.standard.set(8123, forKey: key)
+
+        let prefs = PreferencesService()
+
+        XCTAssertEqual(prefs.tcpServerPort, 8123, "A non-legacy custom port must be preserved")
+    }
+
     // MARK: - LeaderKeyPreference Codable Tests
 
     func testLeaderKeyPreference_DefaultValues() {

--- a/appcast.xml
+++ b/appcast.xml
@@ -36,6 +36,7 @@
                 type="application/octet-stream"/>
             <description><![CDATA[
                 <style>
+                    :root { color-scheme: light dark; }
                     body { font-family: -apple-system, BlinkMacSystemFont, sans-serif; font-size: 13px; line-height: 1.6; color: #333; padding: 8px; }
                     h2 { font-size: 18px; margin-top: 0; margin-bottom: 8px; }
                     p { margin: 6px 0; }
@@ -43,7 +44,18 @@
                     .section-title { font-size: 13px; font-weight: 700; margin-bottom: 2px; }
                     .muted { color: #888; font-size: 12px; }
                     .tag { display: inline-block; background: #f0f0f0; padding: 1px 6px; border-radius: 4px; font-size: 11px; font-weight: 500; margin-right: 2px; }
+                    code { background: rgba(127,127,127,0.18); padding: 1px 4px; border-radius: 3px; font-size: 12px; }
                     a { color: #D97706; }
+
+                    /* Sparkle's release-notes WebView follows the system appearance.
+                       Without these overrides the hardcoded light-mode colors (#333
+                       text, light tags) render as grey-on-black and are unreadable. */
+                    @media (prefers-color-scheme: dark) {
+                        body { color: #e8e8e8; }
+                        .muted { color: #a0a0a0; }
+                        .tag { background: #3a3a3a; color: #e8e8e8; }
+                        a { color: #F59E0B; }
+                    }
                 </style>
 
                 <h2>Beta 3 🧡</h2>

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -25,6 +25,20 @@ To publish a new release, run:
 
 **Sparkle auto-update:** Existing users get notified within 24 hours. The appcast is served from `raw.githubusercontent.com/malpern/KeyPath/master/appcast.xml`. All releases currently omit `sparkle:channel` so all users see them (no stable/beta split yet).
 
+**Inline release notes & dark mode:** The generated appcast entry links to the GitHub release page (`<sparkle:releaseNotesLink>`), which handles dark mode on its own. If you instead hand-author rich inline notes in a `<description><![CDATA[…]]></description>` block, you **must** include dark-mode CSS — Sparkle's WebView follows the system appearance, and hardcoded light colors render as unreadable grey-on-black. Always add:
+
+```css
+:root { color-scheme: light dark; }
+@media (prefers-color-scheme: dark) {
+    body { color: #e8e8e8; }
+    .muted { color: #a0a0a0; }
+    .tag { background: #3a3a3a; color: #e8e8e8; }
+    a { color: #F59E0B; }
+}
+```
+
+(Mirror this for any other elements with hardcoded `color`/`background`.) See the v1.0.0-beta3 entry in `appcast.xml` for a complete example.
+
 **Marketing site:** The download button on keypath-app.com links to the DMG. The release script updates this automatically via a gh-pages worktree commit. Never hardcode a version-specific download URL in index.md manually.
 
 **Homebrew cask:** Users can install via `brew install --cask malpern/tap/keypath`. The cask lives in `github.com/malpern/homebrew-tap/Casks/keypath.rb`. The release script updates the version and SHA256 automatically.


### PR DESCRIPTION
## Summary

Three related Status/runtime fixes, each user-reported:

### 1. Status tab: turning the service OFF looked like a crash
Flipping the toggle OFF showed a red-✕ **"Service Starting"** header with a **"Fix it"** button — as if something broke. Now it shows a calm gray **power icon + "KeyPath is Off"** with no "Fix it". Adds an explicit `.disabled` level to `OverallHealthLevel`, driven by a persisted user-intent flag (`userDisabledService` via `@AppStorage`) rather than the optimistic toggle state — so the calm state appears instantly, survives the `onChange(of: isServiceRunning)` reset, and persists across relaunch. Also stops mislabeling a stopped kanata as "Service Starting" just because the Karabiner daemon is still alive.

### 2. "No TCP" caused by a stale port preference
Existing installs kept the legacy UDP-era port `54141` in UserDefaults, while the kanata daemon was (re)launched on the current default `37001` (changed in #500). The app dialed the dead port and reported "no TCP" in a connection-refused loop. `PreferencesService` now migrates the legacy `54141` → current default on load, clearing the stale key so it tracks the default going forward; deliberately-set custom ports are preserved. Adds migration tests.

### 3. Sparkle release notes unreadable in dark mode
The inline release-notes HTML in `appcast.xml` hardcoded light colors (`#333` text, light tags), so Sparkle's WebView rendered grey-on-black. Added a `@media (prefers-color-scheme: dark)` block covering every problematic color, plus `color-scheme: light dark`. Documented the requirement for future hand-authored notes in `release-process.md`.

## Test plan
- `swift build` — clean
- `swift test --filter PreferencesServicePersistenceTests` — 52/52 pass, including two new migration tests (legacy port migrates; deliberate custom port preserved)
- `xmllint --noout appcast.xml` — well-formed
- Manual: toggling the Status switch OFF shows the calm "KeyPath is Off" state; TCP reconnects on `37001` after migration
- Pre-existing/environmental test failures on master (Mapper collection-count drift, StuckKeyRecovery timing, daemon-status tests contaminated by a live local daemon) are unaffected — verified identical on clean master.

## Review
Ran a multi-angle review of the branch diff (`/thermo-nuclear-swift-review` is not installed; used `/code-review high`). It caught a high-severity bug — the OFF state was unreachable because the intent signal was cleared by `onChange(of: isServiceRunning)` — now fixed via the persisted `userDisabledService` flag, plus an icon/message consistency fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)