### PR TITLE
fix: eliminate quick-deploy signing-race crash and repair 8 red CI tests

### DIFF
--- a/Scripts/quick-deploy.sh
+++ b/Scripts/quick-deploy.sh
@@ -20,6 +20,15 @@ RESOURCES_DIR="$APP_BUNDLE/Contents/Resources"
 ENTITLEMENTS="$PROJECT_DIR/KeyPath.entitlements"
 WAS_RUNNING=0
 
+# KeepAlive LaunchAgent that runs the headless KeyPath instance. We unload it for
+# the build+sign window so launchd can't respawn KeyPath onto a bundle whose
+# signature is mid-rewrite — that race produces a crash report with
+# SIGKILL (Code Signature Invalid) / Taskgated Invalid Signature.
+AGENT_LABEL="com.keypath.agent"
+AGENT_PLIST="$HOME/Library/LaunchAgents/${AGENT_LABEL}.plist"
+AGENT_DOMAIN="gui/$(id -u)"
+AGENT_WAS_LOADED=0
+
 # Local module cache to avoid invalidations and sandboxed cache paths.
 MODULE_CACHE="$PROJECT_DIR/.build/ModuleCache.noindex"
 export CLANG_MODULECACHE_PATH="$MODULE_CACHE"
@@ -76,8 +85,22 @@ release_lock() {
     rm -f "$LOCK_FILE"
 }
 
+# Re-load the KeepAlive agent we unloaded for the signing window. Idempotent:
+# only bootstraps when we actually unloaded it and it isn't already loaded.
+# RunAtLoad=true makes launchd relaunch the headless KeyPath instance.
+reload_agent() {
+    if [[ "$AGENT_WAS_LOADED" == "1" ]] && [[ -f "$AGENT_PLIST" ]]; then
+        if ! launchctl print "${AGENT_DOMAIN}/${AGENT_LABEL}" >/dev/null 2>&1; then
+            echo "▶️  Reloading ${AGENT_LABEL}..."
+            launchctl bootstrap "${AGENT_DOMAIN}" "$AGENT_PLIST" 2>/dev/null || true
+        fi
+    fi
+}
+
 cleanup() {
     local exit_code=$?
+    # Always restore the agent, even on failure, so KeyPath is never left disabled.
+    reload_agent
     release_lock
 
     if [[ $exit_code -ne 0 ]] && [[ $exit_code -ne 130 ]]; then
@@ -113,6 +136,22 @@ if [[ -f "$SWIFTPM_LOCK" ]] && lsof "$SWIFTPM_LOCK" 2>/dev/null | grep -q swift;
     echo "⏭️  SwiftPM build in progress, skipping..."
     log_build_event "SKIPPED_SWIFTPM_BUSY"
     exit 0
+fi
+
+# Unload the KeepAlive LaunchAgent first. Without this, the up-front kill below is
+# futile: launchd respawns KeyPath within ThrottleInterval, and the respawned
+# process is alive during the in-place re-sign — producing a crash report with
+# SIGKILL (Code Signature Invalid) / Taskgated Invalid Signature. The agent is
+# restored in cleanup() (runs on every exit path), so a failed deploy never leaves
+# KeyPath disabled.
+if launchctl print "${AGENT_DOMAIN}/${AGENT_LABEL}" >/dev/null 2>&1; then
+    AGENT_WAS_LOADED=1
+    echo "⏸️  Unloading ${AGENT_LABEL} so launchd won't respawn KeyPath during signing..."
+    launchctl bootout "${AGENT_DOMAIN}/${AGENT_LABEL}" 2>/dev/null || true
+    for _ in {1..40}; do
+        launchctl print "${AGENT_DOMAIN}/${AGENT_LABEL}" >/dev/null 2>&1 || break
+        sleep 0.05
+    done
 fi
 
 # Stop the currently running app before mutating the bundle on disk.

--- a/Tests/KeyPathTests/Services/StuckKeyRecoveryServiceTests.swift
+++ b/Tests/KeyPathTests/Services/StuckKeyRecoveryServiceTests.swift
@@ -6,15 +6,22 @@ final class StuckKeyRecoveryServiceTests: KeyPathTestCase {
     private var service: StuckKeyRecoveryService!
     private var restartCallCount = 0
     private var lastRestartReason: String?
+    /// Fulfilled each time the (default) restart handler runs, so positive tests can
+    /// wait for the recovery Task to actually reach the restart instead of sleeping a
+    /// fixed interval. The recovery Task now does an awaited diagnostic snapshot before
+    /// restarting (StuckKeyRecoveryService.swift:57), so fixed sleeps are racy.
+    private var restartExpectation: XCTestExpectation?
 
     override func setUp() async throws {
         try await super.setUp()
         service = StuckKeyRecoveryService()
         restartCallCount = 0
         lastRestartReason = nil
+        restartExpectation = nil
         service.restartKanata = { [weak self] reason in
             self?.restartCallCount += 1
             self?.lastRestartReason = reason
+            self?.restartExpectation?.fulfill()
             return true
         }
     }
@@ -46,6 +53,9 @@ final class StuckKeyRecoveryServiceTests: KeyPathTestCase {
     }
 
     func testTriggersRecoveryForStuckKey() async {
+        let expectation = expectation(description: "restart triggered for stuck key")
+        restartExpectation = expectation
+
         let correlation = makeCorrelation(
             key: "t",
             suggestsUnmatchedAutorepeat: true,
@@ -53,7 +63,7 @@ final class StuckKeyRecoveryServiceTests: KeyPathTestCase {
         )
 
         service.handleAutorepeatMismatch(correlation)
-        try? await Task.sleep(for: .milliseconds(100))
+        await fulfillment(of: [expectation], timeout: 5.0)
 
         XCTAssertEqual(restartCallCount, 1)
         XCTAssertTrue(lastRestartReason?.contains("t") == true)
@@ -74,25 +84,37 @@ final class StuckKeyRecoveryServiceTests: KeyPathTestCase {
     // MARK: - Debouncing
 
     func testDebouncesPreviousRecoveries() async {
+        let firstRestart = expectation(description: "first restart")
+        restartExpectation = firstRestart
+
         let correlation = makeCorrelation(
             suggestsUnmatchedAutorepeat: true,
             msSinceAnyKanataEvent: 5000
         )
 
         service.handleAutorepeatMismatch(correlation)
-        try? await Task.sleep(for: .milliseconds(100))
+        await fulfillment(of: [firstRestart], timeout: 5.0)
         XCTAssertEqual(restartCallCount, 1)
 
+        // Give the first recovery Task time to settle, then fire a second mismatch. It is
+        // suppressed either by the in-flight guard (if the Task tail hasn't run) or by the
+        // 30s cooldown (once lastRecoveryAt is set) — either way no second restart fires.
+        restartExpectation = nil
+        for _ in 0 ..< 10 {
+            await Task.yield()
+        }
         service.handleAutorepeatMismatch(correlation)
-        try? await Task.sleep(for: .milliseconds(100))
+        try? await Task.sleep(for: .milliseconds(150))
         XCTAssertEqual(restartCallCount, 1, "Should not restart again within cooldown period")
     }
 
     func testDoesNotDoubleFireWhileRecovering() async {
+        let firstRestartEntered = expectation(description: "first restart entered")
         var continueRestart: CheckedContinuation<Void, Never>?
         service.restartKanata = { [weak self] reason in
             self?.restartCallCount += 1
             self?.lastRestartReason = reason
+            firstRestartEntered.fulfill()
             await withCheckedContinuation { continuation in
                 continueRestart = continuation
             }
@@ -104,15 +126,16 @@ final class StuckKeyRecoveryServiceTests: KeyPathTestCase {
             msSinceAnyKanataEvent: 5000
         )
 
+        // Wait until the first restart is actually in-flight (isRecovering == true) before
+        // sending the second mismatch — deterministic regardless of snapshot latency.
         service.handleAutorepeatMismatch(correlation)
-        try? await Task.sleep(for: .milliseconds(50))
+        await fulfillment(of: [firstRestartEntered], timeout: 5.0)
 
+        // Second mismatch while the first restart is still suspended must be ignored.
         service.handleAutorepeatMismatch(correlation)
-        try? await Task.sleep(for: .milliseconds(50))
+        try? await Task.sleep(for: .milliseconds(150))
 
         continueRestart?.resume()
-        try? await Task.sleep(for: .milliseconds(50))
-
         XCTAssertEqual(restartCallCount, 1, "Should not fire second restart while first is in progress")
     }
 

--- a/Tests/KeyPathTests/UI/MapperActiveRulesTests.swift
+++ b/Tests/KeyPathTests/UI/MapperActiveRulesTests.swift
@@ -4,11 +4,12 @@ import XCTest
 /// Tests for the mapper sidebar active rules footer logic.
 @MainActor
 final class MapperActiveRulesTests: XCTestCase {
-
-    func testDefaultEnabledCollections_CountIs5() {
+    func testDefaultEnabledCollections_CountIs6() {
         let defaults = RuleCollectionCatalog().defaultCollections()
         let enabledCount = defaults.filter(\.isEnabled).count
-        XCTAssertEqual(enabledCount, 5, "Should have 5 default-enabled collections")
+        // 6 default-on collections: macOS Function Keys, Vim, Caps Lock Remap,
+        // Fast Navigation, Home Row Arrows (added in f946842b), Quick Launcher.
+        XCTAssertEqual(enabledCount, 6, "Should have 6 default-enabled collections")
     }
 
     func testDefaultEnabledCollections_IncludesExpectedPacks() {
@@ -73,9 +74,11 @@ final class MapperActiveRulesTests: XCTestCase {
                           "Disabling a default pack should count as customized")
     }
 
-    func testMerchandisingThreshold_Under5ShowsHero() {
-        // With 4 defaults, 3 are user-facing (excluding macOS Function Keys)
-        // 3 < 5 → merchandising hero card should show
+    func testMerchandisingThreshold_Under6ShowsHero() {
+        // Default user-facing packs (excluding the macOS Function Keys system default)
+        // must stay below the merchandising-hero threshold, which production sets at
+        // `< 6` (OverlayInspectorPanel+CustomRules.swift). The Home Row Arrows pack
+        // brought the default user-facing count to 5, so the hero card still shows.
         let defaults = RuleCollectionCatalog().defaultCollections()
         let enabledIDs = Set(defaults.filter(\.isEnabled).map(\.id))
 
@@ -85,7 +88,7 @@ final class MapperActiveRulesTests: XCTestCase {
             return enabledIDs.contains(collectionID)
         }
 
-        XCTAssertLessThan(userFacingPacks.count, 5,
-                          "Default user-facing pack count should be under 5 for merchandising")
+        XCTAssertLessThan(userFacingPacks.count, 6,
+                          "Default user-facing pack count should be under 6 for merchandising")
     }
 }

--- a/Tests/KeyPathTests/UI/OverlayHoldLabelTests.swift
+++ b/Tests/KeyPathTests/UI/OverlayHoldLabelTests.swift
@@ -1,22 +1,25 @@
 @testable import KeyPathAppKit
-import KeyPathCore
 import XCTest
 
 /// Regression tests for hold-label resolution and rendering inputs.
 @MainActor
 final class OverlayHoldLabelTests: XCTestCase {
-    func testHoldDisplayLabelHyperUsesStar() async throws {
-        let mapper = LayerKeyMapper()
-        let keyCode: UInt16 = 57
-        let config = WizardSystemPaths.userConfigPath
-        let layer = "base"
+    func testHoldDisplayLabelHyperUsesStar() {
+        // When a hold resolves to all four modifiers (Ctrl+Cmd+Alt+Shift) the overlay
+        // labels it with the Hyper star. This exercises the label-resolution contract
+        // directly rather than driving the kanata simulator against the live user
+        // config, which made the test non-deterministic (skip locally when the bundled
+        // simulator is absent, fail in CI when the config has no caps→Hyper mapping).
+        let hyperOutputs: Set = ["lctl", "lmet", "lalt", "lsft"]
+        let label = LayerKeyMapper.labelForOutputKeys(hyperOutputs) { $0 }
+        XCTAssertEqual(label, "✦", "Hyper (Ctrl+Cmd+Alt+Shift) should resolve to the star symbol")
+    }
 
-        do {
-            let label = try await mapper.holdDisplayLabel(for: keyCode, configPath: config, startLayer: layer)
-            XCTAssertEqual(label, "✦", "Hyper should resolve to star symbol for capslock hold")
-        } catch is SimulatorError {
-            throw XCTSkip("Kanata simulator binary not available in test environment")
-        }
+    func testHoldDisplayLabelHyperUsesStarWithModifierAliases() {
+        // Right-side and spelled-out modifier aliases normalize to the same Hyper set.
+        let hyperOutputs: Set = ["rctl", "cmd", "ralt", "shift"]
+        let label = LayerKeyMapper.labelForOutputKeys(hyperOutputs) { $0 }
+        XCTAssertEqual(label, "✦", "Aliased Hyper modifiers should still resolve to the star symbol")
     }
 
     func testSimulatorEmitsCanonicalNameForCaps() {

--- a/Tests/KeyPathTests/VallackOverlayZoneTests.swift
+++ b/Tests/KeyPathTests/VallackOverlayZoneTests.swift
@@ -150,7 +150,10 @@ final class VallackOverlayZoneTests: XCTestCase {
 
     // MARK: - backgroundColor Priority
 
-    func testZoneColorYieldsToPressedState() {
+    func testPressedZoneKeyStaysInZoneColor() {
+        // PR #515 (eliminate orange flash on nav layer): a pressed key that belongs to
+        // a zone keeps its in-palette zone color instead of switching to the accent
+        // color, so the pressed background equals the zone color.
         let view = OverlayKeycapView(
             key: PhysicalKey(keyCode: 12, label: "Q", x: 0, y: 0, width: 1, height: 1),
             baseLabel: "Q",
@@ -159,10 +162,10 @@ final class VallackOverlayZoneTests: XCTestCase {
             zoneColor: Color.blue.opacity(0.45)
         )
         let bg = view.backgroundColor
-        XCTAssertNotEqual(
+        XCTAssertEqual(
             String(describing: bg),
             String(describing: Color.blue.opacity(0.45)),
-            "Pressed state should override zone color"
+            "Pressed zone key should stay in its zone color"
         )
     }
 
@@ -302,12 +305,17 @@ final class VallackOverlayZoneTests: XCTestCase {
         XCTAssertEqual(subs.count, 6)
     }
 
-    func testResolverReturnsNoSubtitlesOnNavLayer() {
+    func testResolverReturnsNavSubtitlesOnNavLayer() {
+        // PR #519 wired up nav subtitles for the vallack-nav layer overlay, so the
+        // resolver now returns the populated VallackZoneMap.navSubtitles here.
         let subs = PackZoneResolver.activeZoneSubtitles(
             installedPackIDs: [PackRegistry.vallackSystem.id],
             layerName: "vallack-nav"
         )
-        XCTAssertTrue(subs.isEmpty, "Nav layer should not have subtitles")
+        XCTAssertFalse(subs.isEmpty, "Nav layer should expose nav subtitles")
+        XCTAssertEqual(subs[4], "←")
+        XCTAssertEqual(subs[40], "↑")
+        XCTAssertEqual(subs[12], "tab")
     }
 
     func testResolverReturnsNoSubtitlesWithoutPack() {


### PR DESCRIPTION
## Summary

Two fixes that together make fast deploy crash-free **and** turn `build-and-test` green:

### 1. `quick-deploy.sh` — stop the SIGKILL (Code Signature Invalid) crash
On fast deploy, KeyPath was crashing with `EXC_CRASH (SIGKILL (Code Signature Invalid)) / Taskgated Invalid Signature`. Root cause: the `com.keypath.agent` KeepAlive LaunchAgent respawns KeyPath during the in-place re-sign window. Because `KeepAlive.SuccessfulExit=false`, the script's up-front `pkill` looks like a crash and launchd relaunches within `ThrottleInterval` — and the respawned process is live when `codesign --deep` rewrites the bundle, so taskgated kills it.

**Fix:** `bootout` the agent for the build+sign window and restore it idempotently from the EXIT `cleanup` trap (every exit path, including failures). No sudo needed — it's the user's own `gui/<uid>` domain. Verified end-to-end: zero new crashes across repeated deploys, agent + kanata restored cleanly.

### 2. Repair the 8 `build-and-test` failures (all test bugs, no prod regressions)
| Test | Cause | Fix |
|------|-------|-----|
| `MapperActiveRules` (×2) | Home Row Arrows became default-on (`f946842b`) | expect `6`; threshold `< 6` (matches prod) |
| `VallackOverlayZone` (×2) | nav subtitles populated (#519); pressed zone key keeps color (#515) | assertions updated to intended behavior |
| `StuckKeyRecovery` (×3) | #614 added an awaited diagnostic snapshot before restart → fixed `Task.sleep` windows became racy | converted to event-driven `XCTestExpectation` (no-real-sleep rule) |
| `OverlayHoldLabel` (×1) | drove the kanata simulator against the **live** user config (skipped locally, failed in CI) | direct deterministic `labelForOutputKeys` test |

Production code unchanged.

## Test plan
- All affected suites pass locally (65 tests, 0 failures); StuckKey suite run 3× for determinism.
- Diff reviewed by two independent adversarial reviewers (shell-correctness + test-correctness) — no HIGH/MED/LOW issues.

## Note
`build-and-test` runs on a self-hosted runner that is the dev Mac. A separate *environmental* failure mode exists (a live kanata daemon answering port 37001 contaminates `KanataDaemonService`/`KeyboardCapture` integration tests); kanata is stopped before this PR's CI run. Making those integration tests daemon-independent is a tracked follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)