### PR TITLE
fix: reliable privileged-helper repair + hermetic daemon tests

### DIFF
--- a/Scripts/quick-deploy.sh
+++ b/Scripts/quick-deploy.sh
@@ -333,9 +333,31 @@ fi
 # Developer ID identity to every artifact.
 echo "✍️  Signing..."
 SIGNING_IDENTITY="${CODESIGN_IDENTITY:-Developer ID Application: Micah Alpern (X2RKZ5TG99)}"
+HELPER_EXEC="$APP_BUNDLE/Contents/Library/HelperTools/KeyPathHelper"
+HELPER_ENTITLEMENTS="$PROJECT_DIR/Sources/KeyPathHelper/KeyPathHelper.entitlements"
+
+# Re-sign the embedded privileged helper with its REQUIRED signing identifier and
+# re-seal the app afterwards. `codesign --deep` on the app re-signs nested
+# executables with a filename-derived identifier ("KeyPathHelper"), but the app's
+# SMPrivilegedExecutables entry requires identifier "com.keypath.helper". A mismatch
+# makes the helper fail validation — the setup wizard reports a privileged-helper
+# error it "can't fix". So after the --deep pass we re-sign the helper with the
+# correct identifier, then re-seal the OUTER app WITHOUT --deep so the corrected
+# helper signature is preserved. $1 = signing identity ("-" for ad-hoc).
+resign_helper_identifier() {
+    local sign_id="$1"
+    [[ -f "$HELPER_EXEC" && -f "$HELPER_ENTITLEMENTS" ]] || return 0
+    codesign --force --options=runtime \
+        --identifier "com.keypath.helper" \
+        --entitlements "$HELPER_ENTITLEMENTS" \
+        --sign "$sign_id" \
+        "$HELPER_EXEC" || echo "⚠️  Failed to re-sign helper with com.keypath.helper identifier"
+    codesign --force --options=runtime --sign "$sign_id" --entitlements "$ENTITLEMENTS" "$APP_BUNDLE"
+}
+
 if security find-identity -v -p codesigning | grep -Fq "$SIGNING_IDENTITY"; then
-    if [[ -f "$APP_BUNDLE/Contents/Library/HelperTools/KeyPathHelper" ]]; then
-        codesign --force --options=runtime --sign "$SIGNING_IDENTITY" "$APP_BUNDLE/Contents/Library/HelperTools/KeyPathHelper" 2>/dev/null || true
+    if [[ -f "$HELPER_EXEC" ]]; then
+        codesign --force --options=runtime --sign "$SIGNING_IDENTITY" "$HELPER_EXEC" 2>/dev/null || true
     fi
     if [[ -d "$APP_BUNDLE/Contents/Library/KeyPath/Kanata Engine.app" ]]; then
         codesign --force --options=runtime --sign "$SIGNING_IDENTITY" "$APP_BUNDLE/Contents/Library/KeyPath/Kanata Engine.app/Contents/MacOS/kanata" || echo "⚠️  Failed to sign Kanata Engine kanata binary"
@@ -348,9 +370,11 @@ if security find-identity -v -p codesigning | grep -Fq "$SIGNING_IDENTITY"; then
         codesign --force --options=runtime --sign "$SIGNING_IDENTITY" "$APP_BUNDLE/Contents/Library/KeyPath/libkeypath_kanata_host_bridge.dylib" 2>/dev/null || true
     fi
     codesign --force --options=runtime --sign "$SIGNING_IDENTITY" --entitlements "$ENTITLEMENTS" --deep "$APP_BUNDLE"
+    resign_helper_identifier "$SIGNING_IDENTITY"
 else
     echo "⚠️  Developer ID identity not found; using ad-hoc signing (helper may reject this build)."
     codesign --force --sign - --entitlements "$ENTITLEMENTS" --deep "$APP_BUNDLE"
+    resign_helper_identifier "-"
 fi
 
 # Verify signature is valid before restarting — catch any silent corruption.

--- a/Sources/KeyPathAppKit/Managers/HelperMaintenance.swift
+++ b/Sources/KeyPathAppKit/Managers/HelperMaintenance.swift
@@ -73,48 +73,76 @@ public final class HelperMaintenance {
             log("✅ App copy check: OK (\(copies.first ?? "unknown"))")
         }
 
-        // Step 1: Try to refresh/register the helper in-place first.
+        // Step 1: Try an idempotent register/refresh first. If the helper is already
+        // healthy, tearing it down first can introduce its own SMAppService failure
+        // modes and makes fast iteration harder.
         //
-        // If the helper is already healthy, tearing it down first can introduce its own
-        // SMAppService failure modes and makes fast iteration harder. Prefer an idempotent
-        // register/refresh attempt, then fall back to full unregister/cleanup only if needed.
-        if await registerHelper() {
-            log("✅ Helper registered via SMAppService on first attempt")
-        } else {
-            log("⚠️ Direct helper refresh failed; attempting cleanup then retry")
-
-            // Step 2: Best-effort unregister via SMAppService
-            await unregisterHelperIfPresent()
-
-            // Step 3: Stop/bootout any launchd job remnants
-            await bootoutHelperJob()
-
-            // Step 4: Remove residual files (legacy paths) – AppleScript fallback optional
-            let cleanupResult = await removeLegacyHelperArtifacts(
-                useAppleScriptFallback: useAppleScriptFallback
-            )
-            switch cleanupResult {
-            case .removed:
-                break
-            case .skipped:
-                log("ℹ️ No legacy helper artifacts removed or operation skipped")
-            case .failed:
-                log("❌ Legacy helper cleanup failed; aborting repair")
-                isRunning = false
-                return false
-            }
-
-            // Step 5: Retry registration after cleanup
-            let registered = await registerHelper()
-            if !registered {
-                log("❌ Register failed after cleanup – see logs above")
-                isRunning = false
-                return false
-            }
+        // CRITICAL: SMAppService.register() reports success even when the helper is
+        // already registered but cannot actually run. After the helper binary's code
+        // signature changes (new cdhash / identifier — e.g. a re-sign or update),
+        // launchd keeps the previously recorded launch constraint (LWCR) and refuses
+        // to spawn the new binary (EX_CONFIG / "needs LWCR update"). A bare register()
+        // then "succeeds" while the helper stays dead. So we trust the first attempt
+        // only if the helper actually answers via XPC; otherwise we fall through to a
+        // full unregister → bootout → re-register, which is what resets the launch
+        // constraint. This is what makes "Fix" reliable across re-signs and updates.
+        let firstRegisterOK = await registerHelper()
+        if firstRegisterOK, await HelperManager.shared.testHelperFunctionality() {
+            log("✅ Helper registered and responding via XPC on first attempt")
+            return true
         }
 
-        // Step 6: Health check (XPC hello/version)
-        let healthy = await HelperManager.shared.testHelperFunctionality()
+        log(firstRegisterOK
+            ? "⚠️ Helper registered but not responding via XPC (likely stale launch constraint); forcing full reinstall"
+            : "⚠️ Direct helper refresh failed; attempting cleanup then retry")
+
+        // Step 2: Best-effort unregister via SMAppService (clears the stale launch constraint)
+        await unregisterHelperIfPresent()
+
+        // Step 3: Stop/bootout any launchd job remnants
+        await bootoutHelperJob()
+
+        // Step 4: Remove residual files (legacy paths) – AppleScript fallback optional
+        let cleanupResult = await removeLegacyHelperArtifacts(
+            useAppleScriptFallback: useAppleScriptFallback
+        )
+        switch cleanupResult {
+        case .removed:
+            break
+        case .skipped:
+            log("ℹ️ No legacy helper artifacts removed or operation skipped")
+        case .failed:
+            log("❌ Legacy helper cleanup failed; aborting repair")
+            return false
+        }
+
+        // Step 5: Retry registration after cleanup (records a fresh launch constraint)
+        let registered = await registerHelper()
+        if !registered {
+            log("❌ Register failed after cleanup – see logs above")
+            return false
+        }
+
+        // Step 6: Final health check (XPC hello/version).
+        //
+        // A freshly (re-)registered SMAppService daemon spawns lazily on first XPC
+        // contact, and launchd needs a brief moment to apply the new registration and
+        // launch constraint. A single eager check here is exactly why "Fix" used to
+        // need a second click: the first click did the real repair but reported failure
+        // before the helper had spawned. Poll for a few seconds so a single Fix click
+        // succeeds.
+        var healthy = false
+        let maxAttempts = 6
+        for attempt in 1 ... maxAttempts {
+            if await HelperManager.shared.testHelperFunctionality() {
+                healthy = true
+                break
+            }
+            if attempt < maxAttempts {
+                log("⏳ Helper not responding yet (attempt \(attempt)/\(maxAttempts)); waiting for spawn…")
+                try? await Task.sleep(for: .milliseconds(500))
+            }
+        }
         log(healthy ? "✅ Helper responding via XPC" : "❌ Helper still not responding via XPC")
 
         return healthy

--- a/Sources/KeyPathAppKit/Services/Kanata/KanataDaemonService.swift
+++ b/Sources/KeyPathAppKit/Services/Kanata/KanataDaemonService.swift
@@ -40,6 +40,15 @@ final class KanataDaemonService {
         }
     #endif
 
+    // Test seam for the last-resort TCP liveness probe. Without this, integration
+    // tests that assert a "failed" status get contaminated by a real kanata daemon
+    // answering on the default port (the CI runner is a dev Mac with kanata running).
+    // Tests inject `{ _, _ in false }` so the probe is deterministic regardless of
+    // whatever is listening on the machine. DEBUG-only — production always probes.
+    #if DEBUG
+        nonisolated(unsafe) static var tcpProbeOverride: ((Int, Int) -> Bool)?
+    #endif
+
     // MARK: - Internal Dependencies (Hidden from consumers)
 
     @ObservationIgnored private let pidCache = LaunchDaemonPIDCache()
@@ -226,9 +235,20 @@ final class KanataDaemonService {
 
             // Before declaring failure, probe the Kanata TCP server as a last resort.
             let tcpPort = PreferencesService.shared.tcpServerPort
-            let tcpAlive = await Task.detached(priority: .utility) {
-                TCPProbe.probe(port: tcpPort, timeoutMs: 300)
-            }.value
+            let tcpAlive: Bool
+            #if DEBUG
+                if let override = Self.tcpProbeOverride {
+                    tcpAlive = override(tcpPort, 300)
+                } else {
+                    tcpAlive = await Task.detached(priority: .utility) {
+                        TCPProbe.probe(port: tcpPort, timeoutMs: 300)
+                    }.value
+                }
+            #else
+                tcpAlive = await Task.detached(priority: .utility) {
+                    TCPProbe.probe(port: tcpPort, timeoutMs: 300)
+                }.value
+            #endif
 
             if tcpAlive {
                 AppLogger.shared.log(
@@ -268,7 +288,6 @@ final class KanataDaemonService {
                 )
             }
         }
-
     }
 
     /// Log service state failures to persistent crash log for later analysis

--- a/Tests/KeyPathTests/KeyboardCaptureTests.swift
+++ b/Tests/KeyPathTests/KeyboardCaptureTests.swift
@@ -131,8 +131,17 @@ final class KeyboardCaptureTests: XCTestCase {
 
             wait(for: [expectation], timeout: 1.0)
 
-            XCTAssertEqual(receivedNotifications.count, 1, "Should post permission notification")
-            XCTAssertEqual(receivedNotifications[0].name.rawValue, "KeyboardCapturePermissionNeeded")
+            // Production suppresses the permission notification under tests
+            // (KeyboardCapture.startCapture guards on TestEnvironment.isRunningTests),
+            // so the notification count is 0 in CI/test runs and 1 only in a real app
+            // run lacking Accessibility. Matches the sibling capture-lifecycle tests.
+            if TestEnvironment.isRunningTests {
+                XCTAssertEqual(receivedNotifications.count, 0, "Test environment should skip the permission notification")
+            } else {
+                XCTAssertEqual(receivedNotifications.count, 1, "Should post permission notification")
+                XCTAssertEqual(receivedNotifications[0].name.rawValue, "KeyboardCapturePermissionNeeded")
+            }
+            // The warning key callback fires regardless of test environment.
             XCTAssertEqual(capturedKeys.count, 1, "Should capture permission warning")
             XCTAssertTrue(capturedKeys[0].contains("⚠️"), "Should contain warning emoji")
         } else {

--- a/Tests/KeyPathTests/Managers/HelperMaintenanceTests.swift
+++ b/Tests/KeyPathTests/Managers/HelperMaintenanceTests.swift
@@ -127,6 +127,46 @@ final class HelperMaintenanceTests: XCTestCase {
         )
     }
 
+    func testRepairForcesReinstallWhenRegisteredButUnresponsive() async {
+        // Regression: SMAppService.register() reports success even when the helper is
+        // registered-but-wedged (stale launch constraint after a re-sign), so the bare
+        // first-attempt success must NOT be trusted. The repair has to fall through to
+        // unregister → bootout → re-register, then succeed once the helper responds.
+        HelperMaintenance.testDuplicateAppPathsOverride = { ["/Applications/KeyPath.app"] }
+
+        var unregisterCalled = false
+        var bootoutCalled = false
+        var registerAttempts = 0
+        let hooks = HelperMaintenance.TestHooks(
+            unregisterHelper: { unregisterCalled = true },
+            bootoutHelperJob: { bootoutCalled = true },
+            removeLegacyHelperArtifacts: { _ in .removed },
+            registerHelper: {
+                registerAttempts += 1
+                return true // register always "succeeds" — even while wedged
+            }
+        )
+        HelperMaintenance.shared.applyTestHooks(hooks)
+
+        // XPC health: unresponsive on the first-attempt gate, responsive after reinstall.
+        var healthChecks = 0
+        HelperManager.testHelperFunctionalityOverride = {
+            healthChecks += 1
+            return healthChecks > 1
+        }
+
+        let success = await HelperMaintenance.shared.runCleanupAndRepair(useAppleScriptFallback: false)
+
+        XCTAssertTrue(success, "Repair should succeed after forcing a full reinstall")
+        XCTAssertTrue(unregisterCalled, "Wedged-but-registered helper must be unregistered")
+        XCTAssertTrue(bootoutCalled, "Wedged helper job must be booted out")
+        XCTAssertGreaterThanOrEqual(registerAttempts, 2, "Helper must be re-registered after cleanup")
+        XCTAssertTrue(
+            HelperMaintenance.shared.logLines.contains { $0.localizedCaseInsensitiveContains("forcing full reinstall") },
+            "Should log that it forced a reinstall despite register() succeeding"
+        )
+    }
+
     func testRunCleanupIsIdempotentWithoutDuplicates() async {
         HelperMaintenance.testDuplicateAppPathsOverride = { ["/Applications/KeyPath.app"] }
         let hooks = HelperMaintenance.TestHooks(

--- a/Tests/KeyPathTests/Services/KanataDaemonServiceIntegrationTests.swift
+++ b/Tests/KeyPathTests/Services/KanataDaemonServiceIntegrationTests.swift
@@ -43,12 +43,18 @@ final class KanataDaemonServiceIntegrationTests: KeyPathAsyncTestCase {
             MockSMAppService(status: .notRegistered)
         }
 
+        // 1b. Force the last-resort TCP liveness probe to report "no server". The CI
+        // runner is a dev Mac with a real kanata listening on the default port, which
+        // would otherwise make the probe succeed and contaminate these status tests.
+        KanataDaemonService.tcpProbeOverride = { _, _ in false }
+
         // 2. Create Service under test
         service = KanataDaemonService()
     }
 
     override func tearDown() async throws {
         KanataDaemonService.smServiceFactory = originalFactory
+        KanataDaemonService.tcpProbeOverride = nil
         service = nil
         try await super.tearDown()
     }
@@ -84,7 +90,8 @@ final class KanataDaemonServiceIntegrationTests: KeyPathAsyncTestCase {
 
     func testEvaluateStatus_WhenPIDAndTCPBothFail_ShouldReportFailed() async {
         // Given: SMAppService reports .enabled but no process is running
-        // and no kanata TCP server is listening (default in test env)
+        // and the TCP probe is forced to report "no server" (see setUp) so a live
+        // kanata on the machine cannot mask the failure.
         KanataDaemonService.smServiceFactory = { _ in
             MockSMAppService(status: .enabled)
         }


### PR DESCRIPTION
## Summary

The privileged helper broke after a fast deploy and the wizard's **Fix** button couldn't recover it. This fixes the root cause, makes **Fix** reliable in one click, and removes the recurring need to stop kanata before CI.

### 1. `quick-deploy.sh` — stop clobbering the helper identity
`codesign --deep` re-signed the embedded helper with a filename-derived identifier (`KeyPathHelper`) instead of the required `com.keypath.helper`, so it no longer satisfied `SMPrivilegedExecutables` and launchd refused to spawn it (`EX_CONFIG` / stale launch constraint). Now the helper is re-signed with the correct identifier and the app re-sealed without `--deep` (both Developer-ID and ad-hoc branches).

### 2. `HelperMaintenance.repair()` — make "Fix" reliable in one click
- It used to trust `SMAppService.register()` success, but `register()` is a no-op success when the helper is already registered-but-wedged — so it **skipped** the cleanup that resets the launch constraint. Now it only takes the fast path if the helper **actually answers via XPC**; otherwise it forces unregister → bootout → re-register.
- The final health check now **polls** for the lazily-spawned SMAppService daemon instead of checking once. That single eager check is exactly why **Fix** previously needed a *second* click (first click did the repair, but reported failure before the helper had spawned).
- Adds regression test `testRepairForcesReinstallWhenRegisteredButUnresponsive`.

### 3. Hermetic CI — no more stopping kanata before runs
Two tests were contaminated by a live kanata daemon on the self-hosted runner (a dev Mac):
- `KanataDaemonService`'s last-resort TCP probe hit the real port 37001. Added a DEBUG `tcpProbeOverride` seam (mirrors the existing `smServiceFactory`) so status tests force "no server" and pass regardless of what's running.
- `KeyboardCaptureTests.testSingleKeyCaptureLifecycle` asserted a permission notification that production suppresses under tests; gated on `TestEnvironment.isRunningTests` to match its sibling tests.

## Test plan
- All affected suites pass **with kanata running** (the condition that used to break CI): `KanataDaemonServiceIntegrationTests`, `KeyboardCaptureTests`, `HelperMaintenanceTests` — 0 failures.
- Full local suite run with kanata live is green (the lone perf-test blip is load-sensitive flakiness, unrelated — passes 3/3 in isolation at ~0.09s vs a 1.25s threshold).
- Helper-identifier fix verified live: helper re-signs to `com.keypath.helper`, app signature valid, helper spawns and responds via XPC.
- Two independent adversarial reviewers (production logic + tests/shell) found no HIGH/MED issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)