### PR TITLE
test: de-flake ProcessLifecycleManager perf test under shared-runner load

### DIFF
--- a/Tests/KeyPathTests/ProcessLifecycleIntegrationTests.swift
+++ b/Tests/KeyPathTests/ProcessLifecycleIntegrationTests.swift
@@ -80,10 +80,16 @@ final class ProcessLifecycleIntegrationTests: XCTestCase {
             samples.append(duration)
         }
 
-        let sorted = samples.sorted()
-        let median = sorted[sorted.count / 2]
+        // Assert on the best (minimum) sample, not the median. The CI runner is a
+        // shared dev Mac and machine load only ever makes runs *slower*, so the fastest
+        // run is the least-contaminated measure of the code's actual speed. Using the
+        // median made this test flaky under load (e.g. a full suite run alongside other
+        // work). Because min already removes the load noise, the threshold can stay
+        // tight — a healthy run is ~0.1s, so 1.0s catches a >10x regression while
+        // still tolerating transient load (a single unobstructed run suffices).
+        let best = samples.min() ?? .infinity
 
-        XCTAssertLessThan(median, 1.25, "Median process operation duration regressed: \(median)s from samples \(samples)")
+        XCTAssertLessThan(best, 1.0, "Process operation perf regressed (best run): \(best)s from samples \(samples)")
     }
 
     // MARK: - Error Handling Tests


### PR DESCRIPTION
## Summary
`ProcessLifecycleIntegrationTests.testProcessDetectionPerformance` asserted on the **median** of 5 timing samples (`< 1.25s`), which made it flaky on the self-hosted CI runner (a shared dev Mac): machine load only ever slows runs down, so the median regressed past the threshold under contention even though the code was unchanged. (It tripped once during a full-suite run alongside parallel test invocations.)

**Fix:** assert on the **best (minimum)** sample — the fastest run is the least-contaminated measure of the code's actual speed. With load noise removed, the threshold tightens to `1.0s` (a healthy run is ~0.1s), so it still catches a >10× regression while no longer flaking under transient load.

## Test plan
- Passes repeatedly at ~0.08–0.1s (10× under the new threshold).
- Reviewed: min-of-N is the standard microbenchmark technique for noisy shared hardware; the empty-samples guard (`?? .infinity`) fails loudly rather than passing silently; still catches gross/algorithmic regressions.

This was the last of the three follow-ups from the helper-reliability work (the other two: the 8 master tests were already fixed in #618; runner persistence is an ops task handled separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)