### PR TITLE
fix: eliminate spurious overlay orange — clear stale layer map + total color taxonomy

### DIFF
--- a/Sources/KeyPathAppKit/UI/KeyboardVisualization/KeyboardVisualizationViewModel+LayoutMapping.swift
+++ b/Sources/KeyPathAppKit/UI/KeyboardVisualization/KeyboardVisualizationViewModel+LayoutMapping.swift
@@ -181,6 +181,16 @@ extension KeyboardVisualizationViewModel {
         if let cached = prebuiltLayerMappings[cacheKey] {
             layerKeyMap = cached
             remapOutputMap = LayerMappingBuilder.buildRemapOutputMap(from: cached)
+        } else {
+            // Cache miss (layer not yet warmed): clear the stale previous-layer map so
+            // keys don't render with the prior layer's collection color during the async
+            // rebuild below. Otherwise F-row keys — owned by the "macOS Function Keys"
+            // collection on the base layer — flash orange when switching to a layer where
+            // they're transparent, because `currentLayerName` already flipped (isLayerMode
+            // true) while `layerKeyMap` still holds the base mapping. Restores the eager
+            // clear from PR #515 that PR #581's prebuilt-cache change dropped.
+            layerKeyMap = [:]
+            remapOutputMap = [:]
         }
 
         isLoadingLayerMap = true

--- a/Sources/KeyPathAppKit/UI/Overlay/KeycapRenderingUtilities.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/KeycapRenderingUtilities.swift
@@ -101,51 +101,75 @@ enum KeycapSymbols {
 
         let lower = label.lowercased()
 
-        if lower.contains("top") && lower.contains("left") { return .purple }
-        if lower.contains("top") && lower.contains("right") { return .purple }
-        if lower.contains("bottom") && lower.contains("left") { return .purple }
-        if lower.contains("bottom") && lower.contains("right") { return .purple }
-        if lower.contains("left") && lower.contains("half") { return .blue }
-        if lower.contains("right") && lower.contains("half") { return .blue }
-        if lower.contains("maximize") || lower.contains("fullscreen") { return .green }
-        if lower.contains("center") { return .green }
-        if lower.contains("display") || lower.contains("monitor") { return .orange }
-        if lower.contains("space") { return .cyan }
-        if lower.contains("undo") { return .gray }
+        // Window-action labels reuse the shared palette so window keys match the
+        // window/spaces family color used elsewhere (purple), with blue/green/teal
+        // accents for halves/maximize/spaces.
+        if lower.contains("top") && lower.contains("left") { return KeyPathColors.layerPurple }
+        if lower.contains("top") && lower.contains("right") { return KeyPathColors.layerPurple }
+        if lower.contains("bottom") && lower.contains("left") { return KeyPathColors.layerPurple }
+        if lower.contains("bottom") && lower.contains("right") { return KeyPathColors.layerPurple }
+        if lower.contains("left") && lower.contains("half") { return KeyPathColors.layerBlue }
+        if lower.contains("right") && lower.contains("half") { return KeyPathColors.layerBlue }
+        if lower.contains("maximize") || lower.contains("fullscreen") { return KeyPathColors.layerGreen }
+        if lower.contains("center") { return KeyPathColors.layerGreen }
+        if lower.contains("display") || lower.contains("monitor") { return KeyPathColors.layerOrange }
+        if lower.contains("space") { return KeyPathColors.layerTeal }
+        if lower.contains("undo") { return Color.gray }
 
         return nil
     }
 
+    /// Semantic color families for collection-owned keys shown on a layer.
+    ///
+    /// Every collection maps to an intentional color grouped by *what the layer does*,
+    /// rather than each color carrying an unrelated meaning. Collections without a
+    /// vibrant category fall to the calm `keycapMapped` blue-gray — NOT orange — so
+    /// simple remaps (function keys, caps/escape/delete remaps, leader, custom) don't
+    /// shout. Orange is reserved for the modifier-producing family.
     private enum LayerColors {
-        static let defaultLayer = KeyPathColors.layerOrange
-        static let vim = KeyPathColors.layerOrange
-        static let windowSnapping = Color.purple
-        static let symbols = Color.blue
-        static let launcher = Color.cyan
-        static let neovimTerminal = KeyPathColors.layerBlue
-        static let vallackNav = KeyPathColors.layerGreen
+        static let navigation = KeyPathColors.layerGreen
+        static let window = KeyPathColors.layerPurple
+        static let symbols = KeyPathColors.layerBlue
+        static let launcher = KeyPathColors.layerTeal
+        /// Editor / terminal integration — shares the blue family with symbols
+        /// (they don't appear together, so the shared hue is intentional).
+        static let editor = KeyPathColors.layerBlue
+        static let modifier = KeyPathColors.layerOrange
+        /// Calm default for everything without a vibrant category (simple remaps).
+        static let mapped = KeyPathColors.keycapMapped
     }
 
     static func collectionColor(for collectionId: UUID?) -> Color {
         guard let id = collectionId else {
-            return LayerColors.defaultLayer
+            return LayerColors.mapped
         }
 
         switch id {
-        case RuleCollectionIdentifier.vimNavigation:
-            return LayerColors.vim
-        case RuleCollectionIdentifier.windowSnapping:
-            return LayerColors.windowSnapping
-        case RuleCollectionIdentifier.symbolLayer:
+        case RuleCollectionIdentifier.vimNavigation,
+             RuleCollectionIdentifier.kindaVim,
+             RuleCollectionIdentifier.homeRowArrows,
+             RuleCollectionIdentifier.vallackNavigation:
+            return LayerColors.navigation
+        case RuleCollectionIdentifier.windowSnapping,
+             RuleCollectionIdentifier.missionControl:
+            return LayerColors.window
+        case RuleCollectionIdentifier.symbolLayer,
+             RuleCollectionIdentifier.numpadLayer,
+             RuleCollectionIdentifier.autoShiftSymbols:
             return LayerColors.symbols
-        case RuleCollectionIdentifier.launcher:
+        case RuleCollectionIdentifier.launcher,
+             RuleCollectionIdentifier.funLayer:
             return LayerColors.launcher
         case RuleCollectionIdentifier.neovimTerminal:
-            return LayerColors.neovimTerminal
-        case RuleCollectionIdentifier.vallackNavigation:
-            return LayerColors.vallackNav
+            return LayerColors.editor
+        case RuleCollectionIdentifier.homeRowMods,
+             RuleCollectionIdentifier.homeRowLayerToggles,
+             RuleCollectionIdentifier.capsLockHyperKey:
+            return LayerColors.modifier
         default:
-            return LayerColors.defaultLayer
+            // Simple remaps (function keys, caps/escape/delete remaps, leader,
+            // custom, chords, sequences, …) — calm blue-gray, not orange.
+            return LayerColors.mapped
         }
     }
 

--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView+VisualStyling.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView+VisualStyling.swift
@@ -137,7 +137,7 @@ extension OverlayKeycapView {
         } else if isOneShot {
             KeyPathColors.layerTeal
         } else if isEmphasized {
-            Color.orange
+            KeyPathColors.layerOrange
         }
         // System pack zone coloring (e.g., blue modifiers, orange activators, green nav)
         else if let color = zoneColor {

--- a/Sources/KeyPathAppKit/UI/Style/KeyPathColors.swift
+++ b/Sources/KeyPathAppKit/UI/Style/KeyPathColors.swift
@@ -22,8 +22,11 @@ enum KeyPathColors {
     /// Steel blue — Neovim terminal layer
     static let layerBlue = Color(red: 0.3, green: 0.6, blue: 0.9)
 
-    /// Teal — tap-hold active state
+    /// Teal — tap-hold active state, launcher/apps
     static let layerTeal = Color(red: 0.2, green: 0.7, blue: 0.8)
+
+    /// Purple — window management & spaces
+    static let layerPurple = Color(red: 0.55, green: 0.45, blue: 0.85)
 
     // MARK: - Overlay Keycap Backgrounds
 

--- a/Tests/KeyPathTests/UI/OverlayKeycapViewColorTests.swift
+++ b/Tests/KeyPathTests/UI/OverlayKeycapViewColorTests.swift
@@ -2,162 +2,109 @@
 import SwiftUI
 @preconcurrency import XCTest
 
-/// Tests for collection color routing in OverlayKeycapView
+/// Tests for collection color routing in OverlayKeycapView.
+///
+/// The taxonomy is semantic: keys are colored by *what their layer does*, grouped
+/// into families (navigation = green, window/spaces = purple, symbols = blue,
+/// launcher/apps = teal, editor = steel blue, modifier-producing = orange). Anything
+/// without a vibrant category falls to the calm `keycapMapped` blue-gray — NOT orange.
 @MainActor
 final class OverlayKeycapViewColorTests: XCTestCase {
-    // MARK: - Test Data
+    // MARK: - Family routing
 
-    private let vimCollectionId = RuleCollectionIdentifier.vimNavigation
-    private let windowCollectionId = RuleCollectionIdentifier.windowSnapping
-    private let symbolCollectionId = RuleCollectionIdentifier.symbolLayer
-    private let launcherCollectionId = RuleCollectionIdentifier.launcher
-    private let unknownCollectionId = UUID()
-
-    private func makeKeycapView() -> OverlayKeycapView {
-        let key = PhysicalKey(
-            keyCode: 0,
-            label: "A",
-            x: 0,
-            y: 0,
-            width: 1.0
-        )
-        return OverlayKeycapView(
-            key: key,
-            baseLabel: "A",
-            isPressed: false,
-            scale: 1.0
-        )
+    func testCollectionColor_NavigationFamilyIsGreen() {
+        for id in [
+            RuleCollectionIdentifier.vimNavigation,
+            RuleCollectionIdentifier.kindaVim,
+            RuleCollectionIdentifier.homeRowArrows,
+            RuleCollectionIdentifier.vallackNavigation
+        ] {
+            XCTAssertEqual(
+                KeycapSymbols.collectionColor(for: id),
+                KeyPathColors.layerGreen,
+                "Navigation-family collection should be green"
+            )
+        }
     }
 
-    // MARK: - Collection Color Tests
-
-    func testCollectionColor_NilReturnsDefaultOrange() {
-        let view = makeKeycapView()
-        let color = KeycapSymbols.collectionColor(for: nil)
-
-        // Default color should be orange
-        // We can't directly compare Color values, but we can verify it's not nil
-        XCTAssertNotNil(color, "Nil collection ID should return a color")
+    func testCollectionColor_WindowFamilyIsPurple() {
+        for id in [RuleCollectionIdentifier.windowSnapping, RuleCollectionIdentifier.missionControl] {
+            XCTAssertEqual(KeycapSymbols.collectionColor(for: id), KeyPathColors.layerPurple)
+        }
     }
 
-    func testCollectionColor_VimReturnsOrange() {
-        let view = makeKeycapView()
-        let color = KeycapSymbols.collectionColor(for: vimCollectionId)
-
-        // Vim collection should return orange
-        XCTAssertNotNil(color, "Vim collection should return a color")
+    func testCollectionColor_SymbolsFamilyIsBlue() {
+        for id in [
+            RuleCollectionIdentifier.symbolLayer,
+            RuleCollectionIdentifier.numpadLayer,
+            RuleCollectionIdentifier.autoShiftSymbols
+        ] {
+            XCTAssertEqual(KeycapSymbols.collectionColor(for: id), KeyPathColors.layerBlue)
+        }
     }
 
-    func testCollectionColor_WindowSnappingReturnsPurple() {
-        let view = makeKeycapView()
-        let color = KeycapSymbols.collectionColor(for: windowCollectionId)
-
-        // Window Snapping collection should return purple
-        XCTAssertNotNil(color, "Window Snapping collection should return a color")
-
-        // Verify it's purple by checking it's the same as Color.purple
-        let purple = Color.purple
-        XCTAssertEqual(color, purple, "Window Snapping should return purple")
+    func testCollectionColor_LauncherFamilyIsTeal() {
+        for id in [RuleCollectionIdentifier.launcher, RuleCollectionIdentifier.funLayer] {
+            XCTAssertEqual(KeycapSymbols.collectionColor(for: id), KeyPathColors.layerTeal)
+        }
     }
 
-    func testCollectionColor_SymbolLayerReturnsBlue() {
-        let view = makeKeycapView()
-        let color = KeycapSymbols.collectionColor(for: symbolCollectionId)
-
-        // Symbol layer collection should return blue
-        XCTAssertNotNil(color, "Symbol layer collection should return a color")
-
-        let blue = Color.blue
-        XCTAssertEqual(color, blue, "Symbol layer should return blue")
+    func testCollectionColor_ModifierFamilyIsOrange() {
+        for id in [
+            RuleCollectionIdentifier.homeRowMods,
+            RuleCollectionIdentifier.homeRowLayerToggles,
+            RuleCollectionIdentifier.capsLockHyperKey
+        ] {
+            XCTAssertEqual(KeycapSymbols.collectionColor(for: id), KeyPathColors.layerOrange)
+        }
     }
 
-    func testCollectionColor_LauncherReturnsCyan() {
-        let view = makeKeycapView()
-        let color = KeycapSymbols.collectionColor(for: launcherCollectionId)
+    // MARK: - Calm default (the orange-everywhere fix)
 
-        // Launcher collection should return cyan
-        XCTAssertNotNil(color, "Launcher collection should return a color")
-
-        let cyan = Color.cyan
-        XCTAssertEqual(color, cyan, "Launcher should return cyan")
+    func testCollectionColor_NilFallsToCalmMapped() {
+        XCTAssertEqual(KeycapSymbols.collectionColor(for: nil), KeyPathColors.keycapMapped)
     }
 
-    func testCollectionColor_UnknownCollectionReturnsDefaultOrange() {
-        let view = makeKeycapView()
-        let color = KeycapSymbols.collectionColor(for: unknownCollectionId)
-
-        // Unknown collection should fall back to default orange
-        XCTAssertNotNil(color, "Unknown collection should return a color")
+    func testCollectionColor_UnknownFallsToCalmMapped() {
+        XCTAssertEqual(KeycapSymbols.collectionColor(for: UUID()), KeyPathColors.keycapMapped)
     }
 
-    func testCollectionColor_AllKnownCollectionsHaveUniqueColors() {
-        let view = makeKeycapView()
-
-        _ = KeycapSymbols.collectionColor(for: vimCollectionId)
-        let windowColor = KeycapSymbols.collectionColor(for: windowCollectionId)
-        let symbolColor = KeycapSymbols.collectionColor(for: symbolCollectionId)
-        let launcherColor = KeycapSymbols.collectionColor(for: launcherCollectionId)
-
-        // Window, symbol, and launcher should all be different
-        XCTAssertNotEqual(windowColor, symbolColor, "Window and Symbol should have different colors")
-        XCTAssertNotEqual(windowColor, launcherColor, "Window and Launcher should have different colors")
-        XCTAssertNotEqual(symbolColor, launcherColor, "Symbol and Launcher should have different colors")
-
-        // Vim and default are both orange (same as unknown), which is acceptable
+    func testCollectionColor_SimpleRemapsAreNotOrange() {
+        // Regression: these used to fall through the switch to the orange default,
+        // making unrelated remaps (and F-keys mid-transition) flash orange.
+        for id in [
+            RuleCollectionIdentifier.macFunctionKeys,
+            RuleCollectionIdentifier.capsLockRemap,
+            RuleCollectionIdentifier.escapeRemap,
+            RuleCollectionIdentifier.deleteRemap,
+            RuleCollectionIdentifier.leaderKey,
+            RuleCollectionIdentifier.customMappings,
+            RuleCollectionIdentifier.chordGroups,
+            RuleCollectionIdentifier.sequences
+        ] {
+            let color = KeycapSymbols.collectionColor(for: id)
+            XCTAssertEqual(color, KeyPathColors.keycapMapped, "Simple remap should be calm-mapped")
+            XCTAssertNotEqual(color, KeyPathColors.layerOrange, "Simple remap must not be orange")
+        }
     }
 
-    // MARK: - LayerColors Constants Tests
+    // MARK: - Family distinctness & determinism
 
-    func testLayerColors_DefaultLayerIsDefined() {
-        // This test verifies the LayerColors enum has the expected constants
-        // We can't access the private enum directly, but we can verify behavior
-        let view = makeKeycapView()
-
-        // Nil should return a consistent color
-        let color1 = KeycapSymbols.collectionColor(for: nil)
-        let color2 = KeycapSymbols.collectionColor(for: nil)
-
-        // Should be deterministic
-        XCTAssertNotNil(color1)
-        XCTAssertNotNil(color2)
+    func testCollectionColor_FamiliesAreDistinct() {
+        let nav = KeycapSymbols.collectionColor(for: RuleCollectionIdentifier.vimNavigation)
+        let window = KeycapSymbols.collectionColor(for: RuleCollectionIdentifier.windowSnapping)
+        let symbols = KeycapSymbols.collectionColor(for: RuleCollectionIdentifier.symbolLayer)
+        let launcher = KeycapSymbols.collectionColor(for: RuleCollectionIdentifier.launcher)
+        let colors = [nav, window, symbols, launcher]
+        for (i, a) in colors.enumerated() {
+            for b in colors[(i + 1)...] {
+                XCTAssertNotEqual(a, b, "Distinct families must have distinct colors")
+            }
+        }
     }
 
-    func testLayerColors_SystemColorsAreStandard() {
-        let view = makeKeycapView()
-
-        // System colors (purple, blue, cyan) should match SwiftUI standard colors
-        let windowColor = KeycapSymbols.collectionColor(for: windowCollectionId)
-        let symbolColor = KeycapSymbols.collectionColor(for: symbolCollectionId)
-        let launcherColor = KeycapSymbols.collectionColor(for: launcherCollectionId)
-
-        XCTAssertEqual(windowColor, Color.purple)
-        XCTAssertEqual(symbolColor, Color.blue)
-        XCTAssertEqual(launcherColor, Color.cyan)
-    }
-
-    // MARK: - Integration Tests
-
-    func testCollectionColor_ConsistentAcrossMultipleCalls() {
-        let view = makeKeycapView()
-
-        // Each collection should return the same color on multiple calls
-        let vim1 = KeycapSymbols.collectionColor(for: vimCollectionId)
-        let vim2 = KeycapSymbols.collectionColor(for: vimCollectionId)
-        XCTAssertEqual(vim1, vim2, "Vim color should be consistent")
-
-        let window1 = KeycapSymbols.collectionColor(for: windowCollectionId)
-        let window2 = KeycapSymbols.collectionColor(for: windowCollectionId)
-        XCTAssertEqual(window1, window2, "Window color should be consistent")
-    }
-
-    func testCollectionColor_DifferentViewsReturnSameColors() {
-        let view1 = makeKeycapView()
-        let view2 = makeKeycapView()
-
-        // Different view instances should return the same colors for same collections
-        let color1 = KeycapSymbols.collectionColor(for: windowCollectionId)
-        let color2 = KeycapSymbols.collectionColor(for: windowCollectionId)
-
-        XCTAssertEqual(color1, color2, "Different view instances should return same color for same collection")
+    func testCollectionColor_IsDeterministic() {
+        let id = RuleCollectionIdentifier.windowSnapping
+        XCTAssertEqual(KeycapSymbols.collectionColor(for: id), KeycapSymbols.collectionColor(for: id))
     }
 }


### PR DESCRIPTION
## Summary
Eliminates the keyboard overlay rendering keys orange when they shouldn't — two root causes:

### 1. Stale layer map on transition (the F-row orange flash)
`updateLayer` flips `currentLayerName` to the new layer immediately, but on a prebuilt-cache **miss** the old `layerKeyMap` lingered until the async rebuild — so base-layer F-keys (macOS Function Keys collection) briefly rendered their collection color while `isLayerMode` was already true. Now we clear `layerKeyMap`/`remapOutputMap` on a cache miss, so unmapped keys fall to the calm `keycapDark`. (Restores the eager clear PR #581 dropped; **user-verified live** that the flash is gone.)

### 2. `collectionColor`'s orange catch-all (orange everywhere)
The switch handled only **6 of ~26** `RuleCollectionIdentifier`s; everything else (function keys, caps/escape/delete remaps, leader, custom, chords, numpad, fun, mission control, …) fell to the **orange default**. Made it **total and semantic**:
- navigation → green · window/spaces → purple · symbols/numbers → blue · launcher/apps → teal · editor → blue · modifier-producing → orange
- **calm `keycapMapped` default** for simple remaps (was orange)

Also collapsed the second orange (`Color.orange` for `isEmphasized`) into `layerOrange`, routed `windowActionColor` through the shared palette, and added `KeyPathColors.layerPurple`.

## Test plan
- `OverlayKeycapViewColorTests` rewritten to assert family routing, the calm default, and a regression guard that simple remaps are **never** orange. Plus `VallackOverlayZoneTests` — all pass (build clean, lint clean).
- Reviewed adversarially: no HIGH/MED issues.

## Note
Snapshot tests are opt-in (`KEYPATH_SNAPSHOTS=1`, skipped in CI); their recorded overlay images are now stale and will need re-recording — tracking separately, not CI-blocking.

This is **PR 1 of 4** in the overlay render/animation pipeline cleanup (taxonomy → fade unification → state model → suppression). Also folds in the user-reported F-row orange flash fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)