### PR TITLE
fix: detect kanata 'up but not grabbing the keyboard' so status stops lying (#624)

### DIFF
--- a/Sources/KeyPathInstallationWizard/Core/ServiceHealthChecker.swift
+++ b/Sources/KeyPathInstallationWizard/Core/ServiceHealthChecker.swift
@@ -676,6 +676,21 @@ public final class ServiceHealthChecker: @unchecked Sendable {
             }
         }
 
+        // Check for kanata aborting/panicking during Karabiner virtual-HID / input
+        // initialization. kanata prints "aborted while talking to the Karabiner virtual
+        // HID daemon" (often after a Rust panic, e.g. a CString NulError), followed by a
+        // numbered causes list that includes "Another process is already grabbing your
+        // keyboard exclusively". When this happens kanata is up (process + TCP), but it
+        // never grabs the keyboard — it's crash-looping or running degraded, with NO
+        // remapping. This was previously invisible to the health check (#624), so status
+        // read green while the core feature was dead.
+        if inputCaptureIssue.isReady, !permissionRejected, Self.detectsInputGrabFailure(in: logChunk) {
+            inputCaptureIssue = KanataInputCaptureStatus(
+                isReady: false,
+                issue: "kanata-failed-to-grab-keyboard"
+            )
+        }
+
         // Check for configuration parse errors (e.g., duplicate aliases, syntax errors).
         // These cause kanata to exit immediately and crash-loop via launchd.
         let configParseError = Self.extractConfigParseError(from: logChunk)
@@ -685,6 +700,17 @@ public final class ServiceHealthChecker: @unchecked Sendable {
             inputCapture: inputCaptureIssue,
             configParseError: configParseError
         )
+    }
+
+    /// Detect kanata aborting/panicking during Karabiner virtual-HID / input
+    /// initialization — meaning it is up (process + TCP) but never grabbed the
+    /// keyboard, so no remapping occurs. Matches kanata's abort epilogue and the
+    /// underlying panic. Pure function over a stderr chunk so it can be unit-tested.
+    static func detectsInputGrabFailure(in logChunk: String) -> Bool {
+        let lower = logChunk.lowercased()
+        return lower.contains("aborted while talking to the karabiner virtual hid daemon")
+            || lower.contains("grabbing your keyboard exclusively")
+            || (lower.contains("panicked at") && lower.contains("karabiner-driverkit"))
     }
 
     /// Extract a user-facing config parse error from kanata stderr output.

--- a/Tests/KeyPathTests/Services/KanataInputGrabDetectionTests.swift
+++ b/Tests/KeyPathTests/Services/KanataInputGrabDetectionTests.swift
@@ -1,0 +1,70 @@
+@testable import KeyPathInstallationWizard
+import XCTest
+
+/// Tests for detecting kanata "up but not grabbing the keyboard" from stderr.
+///
+/// Regression for #624: kanata can panic/abort while initializing the Karabiner
+/// virtual-HID input path — it stays alive (process + TCP) but never grabs the
+/// keyboard, so no remapping happens, yet the health check reported green. The fix
+/// teaches `diagnoseDaemonStderr` to recognize this via `detectsInputGrabFailure`,
+/// which flips `inputCaptureReady` false → the existing health decision marks it
+/// unhealthy (recoverable).
+final class KanataInputGrabDetectionTests: XCTestCase {
+    /// Verbatim stderr block captured from the live failure (2026-05-29).
+    private let realCrashBlock = """
+    [kanata-launcher] Using kanata binary: /Applications/KeyPath.app/Contents/Library/KeyPath/Kanata Engine.app/Contents/MacOS/kanata
+
+    thread 'main' (322660) panicked at /Users/malpern/.cargo/registry/src/index.crates.io/karabiner-driverkit-0.1.0/src/lib.rs:42:
+    CString::new failed: NulError(12, [49, 239, 191, 189, 43, 239, 191, 189, 43, 239, 191, 189, 0, 0])
+    note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+
+    kanata: aborted while talking to the Karabiner virtual HID daemon.
+    The most likely causes, in order:
+    1) kanata is not running as root.
+    2) Karabiner-DriverKit-VirtualHIDDevice is not installed or its
+    system extension has not been approved.
+    3) Another process is already grabbing your keyboard exclusively.
+    """
+
+    func testDetectsFullAbortBlock() {
+        XCTAssertTrue(ServiceHealthChecker.detectsInputGrabFailure(in: realCrashBlock))
+    }
+
+    func testDetectsAbortLineAlone() {
+        let log = "kanata: aborted while talking to the Karabiner virtual HID daemon."
+        XCTAssertTrue(ServiceHealthChecker.detectsInputGrabFailure(in: log))
+    }
+
+    func testDetectsExclusiveGrabCause() {
+        let log = "3) Another process is already grabbing your keyboard exclusively."
+        XCTAssertTrue(ServiceHealthChecker.detectsInputGrabFailure(in: log))
+    }
+
+    func testDetectsDriverkitPanic() {
+        let log = "thread 'main' panicked at .../karabiner-driverkit-0.1.0/src/lib.rs:42:"
+        XCTAssertTrue(ServiceHealthChecker.detectsInputGrabFailure(in: log))
+    }
+
+    func testHealthyLogIsNotFlagged() {
+        let log = """
+        [kanata-launcher] Launching Kanata for user=malpern config=/Users/malpern/.config/keypath/keypath.kbd
+        [kanata-launcher] Host bridge validated config successfully
+        [kanata-launcher] Host bridge created runtime successfully: layer_count=2
+        14:41:22 [INFO] listening for incoming messages 127.0.0.1:60819
+        virtual_hid_keyboard_ready true
+        """
+        XCTAssertFalse(ServiceHealthChecker.detectsInputGrabFailure(in: log))
+    }
+
+    func testUnrelatedPanicIsNotFlagged() {
+        // A panic NOT in the karabiner-driverkit path should not be mistaken for a
+        // keyboard-grab failure (avoids over-matching generic Rust panics).
+        let log = "thread 'main' panicked at src/main.rs:10: some unrelated error"
+        XCTAssertFalse(ServiceHealthChecker.detectsInputGrabFailure(in: log))
+    }
+
+    func testConfigParseErrorIsNotGrabFailure() {
+        let log = "[ERROR] Error in configuration\nhelp: Duplicate alias: foo\nfailed to parse file"
+        XCTAssertFalse(ServiceHealthChecker.detectsInputGrabFailure(in: log))
+    }
+}


### PR DESCRIPTION
## Summary
kanata can panic/abort while initializing the Karabiner virtual-HID input path (a `CString` NulError, *"aborted while talking to the Karabiner virtual HID daemon"*, or *"Another process is already grabbing your keyboard exclusively"*). When that happens kanata stays **alive** — process running, TCP answering — but it **never grabs the keyboard**, so **no remapping occurs**. The health check only looked at process + TCP + a narrow `IOHIDDeviceOpen` pattern, so it reported **green while the core feature was dead** (#624).

This adds `detectsInputGrabFailure(in:)` and calls it in `diagnoseDaemonStderr`. On a match it sets `inputCaptureReady = false`, which the **existing** health decision already turns into `.unhealthy(reason: "kanata-failed-to-grab-keyboard")` — so status reflects reality and the wizard's Fix path can act.

## Why it's safe / correct
- **No stale false-positives:** runs against the most-recent-launch log chunk only.
- **Right precedence:** gated behind the permission / built-in-keyboard checks (more specific issues win).
- **No over-match:** the panic pattern uses AND (`panicked at` && `karabiner-driverkit`), so generic Rust panics aren't flagged. Trigger strings verified against the kanata fork source (`oskbd/macos.rs`).
- **VNC-safe:** pure log-pattern matching, independent of key-event flow — unlike a functional check, it won't false-positive during a VNC/remote session (which bypasses kanata). See the VNC design note on #624.

## Test plan
- 7 unit tests against the **verbatim captured crash block** + negatives (unrelated panic, config-parse error, healthy log). All pass; build clean; lint clean.
- Adversarially reviewed end-to-end (detection → `inputCaptureReady` → `.unhealthy`); no issues.

## Follow-ups (filed)
Recovery #625 · authoritative kanata-side grab-status signal #630 · underlying driverkit crash #631.

🤖 Generated with [Claude Code](https://claude.com/claude-code)