### PR TITLE
feat(health): consume kanata's authoritative InputGrab status (#630)

### DIFF
--- a/Sources/KeyPathAppKit/Services/Monitoring/KanataEventListener.swift
+++ b/Sources/KeyPathAppKit/Services/Monitoring/KanataEventListener.swift
@@ -426,6 +426,9 @@ actor KanataEventListener {
         isAwaitingHrmTraceSubscribeAck = false
         activeConnection = nil
         currentSessionID = nil
+        // No live connection → drop any authoritative grab status so it can't
+        // outlive the session that produced it.
+        KanataGrabStatusStore.shared.reset()
     }
 
     private func listenLoop() async {
@@ -459,6 +462,11 @@ actor KanataEventListener {
             currentSessionID = nil
             isHrmTraceSubscribed = false
             isAwaitingHrmTraceSubscribeAck = false
+            // Connection dropped: a previously-authoritative grab status no
+            // longer reflects reality (e.g. kanata crashed). Reset so the health
+            // checker falls back to log-pattern detection until we reconnect and
+            // kanata emits a fresh InputGrab.
+            KanataGrabStatusStore.shared.reset()
         }
 
         try await waitForReady(connection)
@@ -702,6 +710,23 @@ actor KanataEventListener {
             return
         }
 
+        // Handle InputGrab events (authoritative keyboard-grab status from the
+        // bundled kanata fork, #630).
+        // Format: {"InputGrab":{"active":true,"devices":["..."]}}
+        //         {"InputGrab":{"active":false,"devices":[],"reason":"..."}}
+        // Ground truth from kanata's OS grab layer — immune to the VNC/"no keys
+        // seen" ambiguity. Recorded into the process-wide store that the health
+        // checker reads (ServiceHealthChecker.resolveInputCaptureStatus).
+        if let inputGrab = json["InputGrab"] as? [String: Any],
+           let status = Self.parseInputGrab(from: inputGrab, observedAt: Date())
+        {
+            AppLogger.shared.log(
+                "🎛️ [EventListener] InputGrab active=\(status.active) devices=\(status.devices.count) reason=\(status.reason ?? "none")"
+            )
+            KanataGrabStatusStore.shared.record(status)
+            return
+        }
+
         // Handle HoldActivated events (tap-hold key transitioned to hold state)
         // Format from Kanata: {"HoldActivated":{"key":"caps"}}
         // Note: upstream only sends "key"; "action" and "t" are not included
@@ -906,6 +931,20 @@ actor KanataEventListener {
             set.insert(normalized)
         }
         return set.sorted()
+    }
+
+    /// Parse the body of an `InputGrab` TCP message (#630).
+    /// Expects `{"active": Bool, "devices": [String], "reason": String?}`.
+    /// Returns nil when `active` is missing/malformed (defensive against an
+    /// older or unexpected schema). `devices` defaults to empty.
+    static func parseInputGrab(from body: [String: Any], observedAt: Date) -> KanataInputGrabStatus? {
+        guard let active = body["active"] as? Bool else { return nil }
+        return KanataInputGrabStatus(
+            active: active,
+            devices: (body["devices"] as? [String]) ?? [],
+            reason: body["reason"] as? String,
+            observedAt: observedAt
+        )
     }
 
     static func extractMessagePushMessages(from push: [String: Any]) -> [String]? {

--- a/Sources/KeyPathAppKit/Services/System/SystemValidator.swift
+++ b/Sources/KeyPathAppKit/Services/System/SystemValidator.swift
@@ -517,7 +517,7 @@ public class SystemValidator {
         let inputCapture = ServiceHealthChecker.resolveInputCaptureStatus(stderrFallback: stderrDiagnosis.inputCapture)
         let kanataDuration = Date().timeIntervalSince(kanataStart)
         AppLogger.shared.log(
-            "🔍 [SystemValidator] checkHealth() - Kanata service check complete: hostRunning=\(kanataHealth.isRunning), tcpResponding=\(kanataHealth.isResponding), healthy=\(kanataRunning), inputCaptureReady=\(stderrDiagnosis.inputCapture.isReady), permRejected=\(stderrDiagnosis.permissionRejected) (took \(String(format: "%.3f", kanataDuration))s)"
+            "🔍 [SystemValidator] checkHealth() - Kanata service check complete: hostRunning=\(kanataHealth.isRunning), tcpResponding=\(kanataHealth.isResponding), healthy=\(kanataRunning), inputCaptureReady=\(inputCapture.isReady), permRejected=\(stderrDiagnosis.permissionRejected) (took \(String(format: "%.3f", kanataDuration))s)"
         )
 
         // Use launchctl-based check instead of unreliable pgrep

--- a/Sources/KeyPathAppKit/Services/System/SystemValidator.swift
+++ b/Sources/KeyPathAppKit/Services/System/SystemValidator.swift
@@ -511,6 +511,10 @@ public class SystemValidator {
         )
         let kanataRunning = kanataHealth.isRunning
         let stderrDiagnosis = await ServiceHealthChecker.shared.diagnoseDaemonStderr()
+        // Layer kanata's authoritative InputGrab signal (#630) over the stderr
+        // detector, identical to checkKanataServiceRuntimeSnapshot, so both
+        // health pipelines agree on input-capture readiness.
+        let inputCapture = ServiceHealthChecker.resolveInputCaptureStatus(stderrFallback: stderrDiagnosis.inputCapture)
         let kanataDuration = Date().timeIntervalSince(kanataStart)
         AppLogger.shared.log(
             "🔍 [SystemValidator] checkHealth() - Kanata service check complete: hostRunning=\(kanataHealth.isRunning), tcpResponding=\(kanataHealth.isResponding), healthy=\(kanataRunning), inputCaptureReady=\(stderrDiagnosis.inputCapture.isReady), permRejected=\(stderrDiagnosis.permissionRejected) (took \(String(format: "%.3f", kanataDuration))s)"
@@ -550,8 +554,8 @@ public class SystemValidator {
             kanataRunning: kanataRunning,
             karabinerDaemonRunning: karabinerDaemonRunning,
             vhidHealthy: vhidHealthy,
-            kanataInputCaptureReady: stderrDiagnosis.inputCapture.isReady,
-            kanataInputCaptureIssue: stderrDiagnosis.inputCapture.issue,
+            kanataInputCaptureReady: inputCapture.isReady,
+            kanataInputCaptureIssue: inputCapture.issue,
             kanataPermissionRejected: stderrDiagnosis.permissionRejected,
             configParseError: stderrDiagnosis.configParseError
         )

--- a/Sources/KeyPathCore/KanataGrabStatus.swift
+++ b/Sources/KeyPathCore/KanataGrabStatus.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+/// Authoritative input-grab status reported by kanata over its TCP channel
+/// (`ServerMessage::InputGrab`, added in the bundled fork for KeyPath #630).
+///
+/// This is ground truth straight from kanata's OS grab layer — it is NOT
+/// inferred from key-event flow, so it is immune to the "no keys seen"
+/// ambiguity (idle user vs. failed grab vs. synthetic/VNC input that bypasses
+/// the physical seize).
+public struct KanataInputGrabStatus: Sendable, Equatable {
+    /// True when kanata currently has at least one physical device seized.
+    public let active: Bool
+    /// Names of the currently seized devices. Empty when `active` is false.
+    public let devices: [String]
+    /// Optional human-readable explanation, typically populated on failure
+    /// (e.g. another process holds an exclusive grab, not running as root).
+    public let reason: String?
+    /// Wall-clock time KeyPath observed the status.
+    public let observedAt: Date
+
+    public init(active: Bool, devices: [String], reason: String?, observedAt: Date) {
+        self.active = active
+        self.devices = devices
+        self.reason = reason
+        self.observedAt = observedAt
+    }
+}
+
+/// Process-wide store for the latest authoritative `InputGrab` status.
+///
+/// The TCP event listener records into this store and resets it whenever the
+/// kanata connection drops, so a non-nil `latest` always means "received on the
+/// current live TCP session." The health checker reads it as the **primary**
+/// input-capture signal; when it is nil (old kanata that never emits
+/// `InputGrab`, or no grab-state transition since connect — kanata does not
+/// replay on connect) the checker falls back to the stderr log-pattern detector
+/// (#632). Belt-and-suspenders: an authoritative signal that never lies, backed
+/// by inference when the signal is simply absent.
+public final class KanataGrabStatusStore: @unchecked Sendable {
+    public static let shared = KanataGrabStatusStore()
+
+    private let lock = NSLock()
+    private var _latest: KanataInputGrabStatus?
+
+    public init() {}
+
+    /// The most recent status received on the current live connection, or nil
+    /// if none has been received (or the connection has since dropped).
+    public var latest: KanataInputGrabStatus? {
+        lock.withLock { _latest }
+    }
+
+    /// Record an authoritative status received from kanata.
+    public func record(_ status: KanataInputGrabStatus) {
+        lock.withLock { _latest = status }
+    }
+
+    /// Clear the stored status. Called when the kanata connection drops so a
+    /// stale value can never outlive the session it belonged to.
+    public func reset() {
+        lock.withLock { _latest = nil }
+    }
+}

--- a/Sources/KeyPathCore/KanataGrabStatus.swift
+++ b/Sources/KeyPathCore/KanataGrabStatus.swift
@@ -15,7 +15,10 @@ public struct KanataInputGrabStatus: Sendable, Equatable {
     /// Optional human-readable explanation, typically populated on failure
     /// (e.g. another process holds an exclusive grab, not running as root).
     public let reason: String?
-    /// Wall-clock time KeyPath observed the status.
+    /// Wall-clock time KeyPath observed the status. Diagnostics/logging only —
+    /// NOT used in health decisions. Staleness is handled structurally (the
+    /// store is reset when the TCP connection drops), not by age-out, so there
+    /// is no timestamp-expiry check on this field.
     public let observedAt: Date
 
     public init(active: Bool, devices: [String], reason: String?, observedAt: Date) {
@@ -42,7 +45,7 @@ public final class KanataGrabStatusStore: @unchecked Sendable {
     private let lock = NSLock()
     private var _latest: KanataInputGrabStatus?
 
-    public init() {}
+    private init() {}
 
     /// The most recent status received on the current live connection, or nil
     /// if none has been received (or the connection has since dropped).

--- a/Sources/KeyPathInstallationWizard/Core/ServiceHealthChecker.swift
+++ b/Sources/KeyPathInstallationWizard/Core/ServiceHealthChecker.swift
@@ -513,6 +513,7 @@ public final class ServiceHealthChecker: @unchecked Sendable {
         let targets = await getDaemonManager()?.preferredLaunchctlTargets(for: managementState) ?? []
         let runningState = await evaluateKanataLaunchctlRunningState(managementState: managementState, launchctlTargets: targets)
         let stderrDiagnosis = await diagnoseDaemonStderr()
+        let inputCapture = Self.resolveInputCaptureStatus(stderrFallback: stderrDiagnosis.inputCapture)
         let tcpOK = await Task.detached { [self] in
             if let portEnv = ProcessInfo.processInfo.environment["KEYPATH_TCP_PORT"],
                let overridePort = Int(portEnv)
@@ -526,8 +527,8 @@ public final class ServiceHealthChecker: @unchecked Sendable {
             managementState: managementState,
             isRunning: runningState.isRunning,
             isResponding: tcpOK,
-            inputCaptureReady: stderrDiagnosis.inputCapture.isReady,
-            inputCaptureIssue: stderrDiagnosis.inputCapture.issue,
+            inputCaptureReady: inputCapture.isReady,
+            inputCaptureIssue: inputCapture.issue,
             launchctlExitCode: runningState.exitCode,
             staleEnabledRegistration: staleEnabledRegistration,
             recentlyRestarted: Self.wasRecentlyRestarted(
@@ -565,6 +566,37 @@ public final class ServiceHealthChecker: @unchecked Sendable {
             }
         }
         return (false, lastExitCode)
+    }
+
+    /// Resolve the input-capture status, layering kanata's authoritative
+    /// `InputGrab` signal (#630) on top of the stderr log-pattern detector
+    /// (#632).
+    ///
+    /// The signal is **strictly additive**: only an authoritative grab
+    /// *failure* (`active:false`) overrides the stderr fallback. We deliberately
+    /// do NOT let an authoritative `active:true` suppress a failure the stderr
+    /// detector found — the grab bit is coarser than stderr (kanata can seize an
+    /// external keyboard while failing to open the built-in one), and a cached
+    /// `active:true` could outlive a silent grab loss. So this can only make
+    /// status MORE truthful (catch a VNC-masked failure stderr missed), never
+    /// less. A recovery transition (`active:true` after a prior `active:false`)
+    /// still clears the failure by falling back to the now-clean stderr.
+    ///
+    /// `KanataGrabStatusStore` is recorded by the TCP listener and reset when
+    /// the connection drops, so a non-nil failure is always ground truth from
+    /// the current live session. When absent (old kanata, no grab-state
+    /// transition since connect — kanata does not replay on connect, or no live
+    /// connection) we use the stderr detector. Belt-and-suspenders.
+    public nonisolated static func resolveInputCaptureStatus(
+        stderrFallback: KanataInputCaptureStatus
+    ) -> KanataInputCaptureStatus {
+        guard let grab = KanataGrabStatusStore.shared.latest, !grab.active else {
+            return stderrFallback
+        }
+        return KanataInputCaptureStatus(
+            isReady: false,
+            issue: grab.reason ?? "kanata-failed-to-grab-keyboard"
+        )
     }
 
     public nonisolated static func decideKanataHealth(

--- a/Tests/KeyPathTests/Services/KanataInputGrabConsumerTests.swift
+++ b/Tests/KeyPathTests/Services/KanataInputGrabConsumerTests.swift
@@ -6,17 +6,12 @@ import KeyPathCore
 /// Tests for the KeyPath consumer of kanata's authoritative `InputGrab` TCP
 /// status (#630): parsing the message, the shared status store, and the health
 /// checker preferring it over the stderr log-pattern detector (#632).
-final class KanataInputGrabConsumerTests: XCTestCase {
-    override func setUp() {
-        super.setUp()
-        KanataGrabStatusStore.shared.reset()
-    }
-
-    override func tearDown() {
-        KanataGrabStatusStore.shared.reset()
-        super.tearDown()
-    }
-
+///
+/// Extends `KeyPathTestCase` for defensive isolation: its `TestSingletonReset`
+/// resets `KanataGrabStatusStore.shared` in setUp/tearDown, so the global store
+/// these tests mutate can't bleed into (or out of) other suites.
+@MainActor
+final class KanataInputGrabConsumerTests: KeyPathTestCase {
     // MARK: - parseInputGrab
 
     func testParseInputGrab_active_withDevices() {

--- a/Tests/KeyPathTests/Services/KanataInputGrabConsumerTests.swift
+++ b/Tests/KeyPathTests/Services/KanataInputGrabConsumerTests.swift
@@ -1,0 +1,164 @@
+@testable import KeyPathAppKit
+import KeyPathCore
+@testable import KeyPathInstallationWizard
+@preconcurrency import XCTest
+
+/// Tests for the KeyPath consumer of kanata's authoritative `InputGrab` TCP
+/// status (#630): parsing the message, the shared status store, and the health
+/// checker preferring it over the stderr log-pattern detector (#632).
+final class KanataInputGrabConsumerTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        KanataGrabStatusStore.shared.reset()
+    }
+
+    override func tearDown() {
+        KanataGrabStatusStore.shared.reset()
+        super.tearDown()
+    }
+
+    // MARK: - parseInputGrab
+
+    func testParseInputGrab_active_withDevices() {
+        let body: [String: Any] = [
+            "active": true,
+            "devices": ["Apple Internal Keyboard / Trackpad", "HHKB-Hybrid"]
+        ]
+        let status = KanataEventListener.parseInputGrab(from: body, observedAt: Date())
+        XCTAssertNotNil(status)
+        XCTAssertEqual(status?.active, true)
+        XCTAssertEqual(status?.devices, ["Apple Internal Keyboard / Trackpad", "HHKB-Hybrid"])
+        XCTAssertNil(status?.reason)
+    }
+
+    func testParseInputGrab_inactive_withReason() {
+        let body: [String: Any] = [
+            "active": false,
+            "devices": [String](),
+            "reason": "another process has exclusive grab"
+        ]
+        let status = KanataEventListener.parseInputGrab(from: body, observedAt: Date())
+        XCTAssertEqual(status?.active, false)
+        XCTAssertEqual(status?.devices, [])
+        XCTAssertEqual(status?.reason, "another process has exclusive grab")
+    }
+
+    func testParseInputGrab_inactive_noReason_defaultsEmptyDevices() {
+        let body: [String: Any] = ["active": false]
+        let status = KanataEventListener.parseInputGrab(from: body, observedAt: Date())
+        XCTAssertEqual(status?.active, false)
+        XCTAssertEqual(status?.devices, [])
+        XCTAssertNil(status?.reason)
+    }
+
+    func testParseInputGrab_missingActive_returnsNil() {
+        let body: [String: Any] = ["devices": ["a"]]
+        XCTAssertNil(KanataEventListener.parseInputGrab(from: body, observedAt: Date()))
+    }
+
+    // MARK: - KanataGrabStatusStore
+
+    func testStore_recordAndReset() {
+        XCTAssertNil(KanataGrabStatusStore.shared.latest)
+        let status = KanataInputGrabStatus(active: true, devices: ["kbd"], reason: nil, observedAt: Date())
+        KanataGrabStatusStore.shared.record(status)
+        XCTAssertEqual(KanataGrabStatusStore.shared.latest, status)
+        KanataGrabStatusStore.shared.reset()
+        XCTAssertNil(KanataGrabStatusStore.shared.latest)
+    }
+
+    // MARK: - resolveInputCaptureStatus (primary signal vs. fallback)
+
+    func testResolve_noStore_usesStderrFallback() {
+        // Store empty → fall back to the #632 stderr detector verbatim.
+        let failedFallback = ServiceHealthChecker.KanataInputCaptureStatus(isReady: false, issue: "kanata-failed-to-grab-keyboard")
+        XCTAssertEqual(
+            ServiceHealthChecker.resolveInputCaptureStatus(stderrFallback: failedFallback),
+            failedFallback
+        )
+        XCTAssertEqual(
+            ServiceHealthChecker.resolveInputCaptureStatus(stderrFallback: .ready),
+            .ready
+        )
+    }
+
+    func testResolve_storeActive_doesNotMaskStderrFailure() {
+        // active:true is strictly additive — it must NOT suppress a failure the
+        // stderr detector found (the grab bit is coarser than stderr; a cached
+        // active:true could be stale). The fallback passes through unchanged.
+        KanataGrabStatusStore.shared.record(
+            KanataInputGrabStatus(active: true, devices: ["kbd"], reason: nil, observedAt: Date())
+        )
+        let stderrFailure = ServiceHealthChecker.KanataInputCaptureStatus(
+            isReady: false, issue: "kanata-cannot-open-built-in-keyboard"
+        )
+        XCTAssertEqual(
+            ServiceHealthChecker.resolveInputCaptureStatus(stderrFallback: stderrFailure),
+            stderrFailure
+        )
+        // When stderr is clean, active:true resolves ready.
+        XCTAssertEqual(
+            ServiceHealthChecker.resolveInputCaptureStatus(stderrFallback: .ready),
+            .ready
+        )
+    }
+
+    func testResolve_recoveryClearsPriorFailure() {
+        // An authoritative failure marks unhealthy...
+        KanataGrabStatusStore.shared.record(
+            KanataInputGrabStatus(active: false, devices: [], reason: "exclusive grab", observedAt: Date())
+        )
+        XCTAssertFalse(ServiceHealthChecker.resolveInputCaptureStatus(stderrFallback: .ready).isReady)
+        // ...then a recovery transition (active:true) overwrites it in the store,
+        // so a now-clean stderr resolves ready — no stuck-unhealthy.
+        KanataGrabStatusStore.shared.record(
+            KanataInputGrabStatus(active: true, devices: ["kbd"], reason: nil, observedAt: Date())
+        )
+        XCTAssertEqual(
+            ServiceHealthChecker.resolveInputCaptureStatus(stderrFallback: .ready),
+            .ready
+        )
+    }
+
+    func testResolve_storeInactive_overridesReadyFallback() {
+        // Authoritative grab failure beats a stderr that looks clean (e.g. the
+        // failure never produced a recognizable log line, or VNC masked it).
+        KanataGrabStatusStore.shared.record(
+            KanataInputGrabStatus(active: false, devices: [], reason: "not running as root", observedAt: Date())
+        )
+        let resolved = ServiceHealthChecker.resolveInputCaptureStatus(stderrFallback: .ready)
+        XCTAssertFalse(resolved.isReady)
+        XCTAssertEqual(resolved.issue, "not running as root")
+    }
+
+    func testResolve_storeInactive_noReason_usesDefaultIssue() {
+        KanataGrabStatusStore.shared.record(
+            KanataInputGrabStatus(active: false, devices: [], reason: nil, observedAt: Date())
+        )
+        let resolved = ServiceHealthChecker.resolveInputCaptureStatus(stderrFallback: .ready)
+        XCTAssertFalse(resolved.isReady)
+        XCTAssertEqual(resolved.issue, "kanata-failed-to-grab-keyboard")
+    }
+
+    // MARK: - end-to-end decision
+
+    func testDecideHealth_inactiveGrab_marksUnhealthy() {
+        KanataGrabStatusStore.shared.record(
+            KanataInputGrabStatus(active: false, devices: [], reason: "exclusive grab", observedAt: Date())
+        )
+        let inputCapture = ServiceHealthChecker.resolveInputCaptureStatus(stderrFallback: .ready)
+        let snapshot = ServiceHealthChecker.KanataServiceRuntimeSnapshot(
+            managementState: .smappserviceActive,
+            isRunning: true,
+            isResponding: true,
+            inputCaptureReady: inputCapture.isReady,
+            inputCaptureIssue: inputCapture.issue,
+            launchctlExitCode: 0,
+            staleEnabledRegistration: false,
+            recentlyRestarted: false
+        )
+        let decision = ServiceHealthChecker.decideKanataHealth(for: snapshot)
+        XCTAssertFalse(decision.isHealthy)
+        XCTAssertEqual(decision, .unhealthy(reason: "exclusive grab"))
+    }
+}

--- a/Tests/KeyPathTests/Support/GlobalTestSetup.swift
+++ b/Tests/KeyPathTests/Support/GlobalTestSetup.swift
@@ -21,6 +21,10 @@ enum TestSingletonReset {
         DeviceSelectionCache.shared.reset()
         KeyboardDetectionIndex.resetCache()
 
+        // Authoritative kanata grab status (#630) — read by ServiceHealthChecker,
+        // so a value left by one test must not bleed into another's health check.
+        KanataGrabStatusStore.shared.reset()
+
         // TestEnvironment flags
         TestEnvironment.forceTestMode = false
     }


### PR DESCRIPTION
## Summary

Wires KeyPath to consume the bundled kanata fork's new authoritative `InputGrab` TCP status as the **primary, VNC-immune** input-capture health signal. Closes the consumer half of #630.

Today kanata's health is entirely **inferential** — process + TCP + stderr log-scrape + "are `KeyInput` events flowing." The functional check is ambiguous: no key events can mean kanata-not-grabbing, user-not-typing, **or user-on-VNC** (synthetic events bypass the physical grab — the long misdiagnosis from last session). kanata itself knows the ground truth: it just succeeded or failed at seizing the keyboard. The fork now emits that over TCP (`{"InputGrab":{"active":bool,"devices":[...],"reason":...}}`, commit `cd2a1e5` on `keypath/bundled`); this PR consumes it.

## What's here

- **`KanataGrabStatusStore`** (KeyPathCore): process-wide store of the latest `InputGrab`, recorded by the TCP listener and **reset when the connection drops**, so a non-nil value is always ground truth from the *current live session*.
- **`KanataEventListener`**: parses the `InputGrab` message and records it (`parseInputGrab` is a unit-testable static helper, matching the existing `extractMessagePushMessages` / `normalizedCapabilities` pattern).
- **`ServiceHealthChecker.resolveInputCaptureStatus`**: layers the signal over the #632 stderr detector, **strictly additive** — only an authoritative `active:false` overrides the fallback; `active:true` never suppresses a stderr-detected failure (the grab bit is coarser than stderr; a cached `active:true` could outlive a silent grab loss). A recovery `active:true` clears a prior failure by deferring to the now-clean stderr. Wired into **both** health pipelines (`checkKanataServiceRuntimeSnapshot` **and** `SystemValidator.checkHealth`) so they agree.
- **Submodule pin** bumped to `cd2a1e5`.

## Design notes (belt-and-suspenders)

The authoritative signal can only make status **more** truthful (catch a VNC-masked failure stderr missed), **never less**. kanata does *not* replay `InputGrab` on connect, so on a fresh connect to an already-grabbing kanata the store stays empty and the #632 stderr detector remains the backstop — exactly the intended layering.

## Review gate

Ran the mandatory adversarial review (correctness + concurrency + cleanup/altitude angles). It caught two real issues that are fixed in this PR:
1. **Half-wired path** — `SystemValidator.checkHealth` (a primary production pipeline feeding `SystemSnapshot`/`SystemInspector`/`InstallerEngine`) bypassed the new signal. Now routed through the same chokepoint.
2. **Status could become *less* truthful** — an earlier version let `active:true` mask a stderr-detected failure / go stale. Fixed by making the override `active:false`-only (strictly additive).
Also removed a speculative unused NotificationCenter broadcast the review flagged.

## Testing

- New `KanataInputGrabConsumerTests` (parse, store record/reset, resolver precedence incl. the no-mask + recovery invariants, end-to-end decision).
- Existing `KanataInputGrabDetectionTests` (#632) and `ServiceHealthCheckerTests` still green.
- Full XCTest suite passes (the swift-testing SIGTRAP flake is pre-existing — reproduces on a clean tree without these changes).

## Follow-ups
- #624 (honest VNC-aware status UI) and #625 (auto-recovery) build on this.
- Upstreaming the fork side to jtroo/kanata is tracked in `malpern/kanata#20` (needs Linux/Windows emit sites + a `RequestInputGrab` query path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)