### PR TITLE
feat(overlay): setting for unmapped-key rendering on layers

### DIFF
--- a/Sources/KeyPathAppKit/Services/Configuration/PreferencesService.swift
+++ b/Sources/KeyPathAppKit/Services/Configuration/PreferencesService.swift
@@ -25,6 +25,31 @@ public enum KeyLabelStyle: String, CaseIterable, Sendable {
     }
 }
 
+/// How the keyboard overlay renders keys that have NO mapping on a non-base
+/// layer (e.g. the unmapped letters while the Nav layer is active).
+public enum UnmappedLayerKeyStyle: String, CaseIterable, Sendable {
+    /// Render unmapped keys exactly like the base layer — full labels, shifted
+    /// symbols, normal keycap colors. Mapped keys still show their mapping.
+    case baseLayer
+    /// Dim unmapped keys to a dark keycap with a plain single label, so the
+    /// layer's actual mappings stand out.
+    case dimmed
+
+    public var displayName: String {
+        switch self {
+        case .baseLayer: "Base layer"
+        case .dimmed: "Dimmed"
+        }
+    }
+
+    public var description: String {
+        switch self {
+        case .baseLayer: "Unmapped keys look like the base layer"
+        case .dimmed: "Unmapped keys dim so mappings stand out"
+        }
+    }
+}
+
 /// Communication protocol for Kanata integration
 /// TCP is the only supported protocol (Kanata v1.9.0 - see ADR-013)
 enum CommunicationProtocol: String, CaseIterable {
@@ -231,6 +256,14 @@ final class PreferencesService: @unchecked Sendable {
         }
     }
 
+    /// How unmapped keys render on non-base layers (base-layer style vs dimmed).
+    var unmappedLayerKeyStyle: UnmappedLayerKeyStyle {
+        didSet {
+            UserDefaults.standard.set(unmappedLayerKeyStyle.rawValue, forKey: Keys.unmappedLayerKeyStyle)
+            AppLogger.shared.log("🎨 [Preferences] unmappedLayerKeyStyle = \(unmappedLayerKeyStyle.rawValue)")
+        }
+    }
+
     // MARK: - Leader Key Configuration
 
     /// Primary leader key preference (Space → Nav by default)
@@ -379,6 +412,7 @@ final class PreferencesService: @unchecked Sendable {
         static let neovimReferenceTopics = "KeyPath.Neovim.ReferenceTopics"
         static let neovimReferenceTopicsVersion = "KeyPath.Neovim.ReferenceTopicsVersion"
         static let keyLabelStyle = "KeyPath.Display.KeyLabelStyle"
+        static let unmappedLayerKeyStyle = "KeyPath.Overlay.UnmappedLayerKeyStyle"
         static let overlayHiddenHintShowCount = "KeyPath.Education.OverlayHiddenHintShowCount"
         static let overlaySuppressedBundleIDs = "KeyPath.Overlay.SuppressedBundleIDs"
     }
@@ -397,6 +431,7 @@ final class PreferencesService: @unchecked Sendable {
             static let verboseKanataLogging = false // Release builds favor smaller logs
         #endif
         static let keyLabelStyle = KeyLabelStyle.symbols
+        static let unmappedLayerKeyStyle = UnmappedLayerKeyStyle.baseLayer
         static let accessibilityTestMode = false
         static let contextHUDDisplayMode = ContextHUDDisplayMode.overlayOnly
         static let contextHUDTriggerMode = ContextHUDTriggerMode.holdToShow
@@ -463,6 +498,11 @@ final class PreferencesService: @unchecked Sendable {
         let keyLabelStyleString = UserDefaults.standard.string(forKey: Keys.keyLabelStyle)
             ?? Defaults.keyLabelStyle.rawValue
         keyLabelStyle = KeyLabelStyle(rawValue: keyLabelStyleString) ?? Defaults.keyLabelStyle
+
+        // Unmapped-key rendering on non-base layers
+        let unmappedLayerKeyStyleString = UserDefaults.standard.string(forKey: Keys.unmappedLayerKeyStyle)
+            ?? Defaults.unmappedLayerKeyStyle.rawValue
+        unmappedLayerKeyStyle = UnmappedLayerKeyStyle(rawValue: unmappedLayerKeyStyleString) ?? Defaults.unmappedLayerKeyStyle
 
         // Testing preferences
         accessibilityTestMode =

--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayKeyboardView.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayKeyboardView.swift
@@ -210,6 +210,9 @@ struct OverlayKeyboardView: View {
         // by remappedLabels / zoneSubtitleLabels, so only unmapped keys gain them.
         // Read via the same injected `services` the keycaps use, so both halves
         // of the feature always agree on the preference instance.
+        // TODO: an identity-style mapping whose output label equals its base
+        // label is filtered out of `remapped`, so it could show a stray floating
+        // legend here. Uncommon; revisit if it surfaces in practice.
         let baseStyleUnmapped = services.preferences.unmappedLayerKeyStyle == .baseLayer
         return FloatingLabelVisibility(
             labelToKeyCode: ltk,

--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayKeyboardView.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayKeyboardView.swift
@@ -99,6 +99,7 @@ struct OverlayKeyboardView: View {
     @State private var cachedAllLabels: [String] = []
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.services) private var services
 
     /// Selected colorway ID from user preferences
     @AppStorage("overlayColorwayId") private var selectedColorwayId: String = GMKColorway.default.id
@@ -204,10 +205,16 @@ struct OverlayKeyboardView: View {
             }
         }
 
+        // When unmapped keys render base-style, let their floating shift legends
+        // (e.g. "!" over "1") show again. Mapped/remapped/zone keys are excluded
+        // by remappedLabels / zoneSubtitleLabels, so only unmapped keys gain them.
+        // Read via the same injected `services` the keycaps use, so both halves
+        // of the feature always agree on the preference instance.
+        let baseStyleUnmapped = services.preferences.unmappedLayerKeyStyle == .baseLayer
         return FloatingLabelVisibility(
             labelToKeyCode: ltk,
             isLauncherMode: isLauncherMode,
-            isLayerMode: isLayerMode,
+            isLayerMode: baseStyleUnmapped ? false : isLayerMode,
             vimHintsActive: vimHintsActive,
             remappedLabels: remapped,
             zoneSubtitleLabels: zoneSubs

--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView.swift
@@ -85,13 +85,10 @@ struct OverlayKeycapView: View {
         guard !isLauncherMode, !isInlineLayer, currentLayerName.lowercased() != "base" else {
             return false
         }
-        // When the user prefers base-layer rendering for unmapped keys, a key
-        // with no mapping on this layer renders like the base layer — same as an
-        // inline layer — instead of dimming. "Unmapped" is either a transparent
-        // LayerKeyInfo (production: the simulator emits one per physical key) or
-        // a nil entry (hand-built maps / passthrough). Keys that carry a zone
-        // subtitle (nav hint glyph) keep layer styling so the subtitle still
-        // renders. Mapped keys keep full layer styling (zone/collection colors).
+        // Under base-style, an unmapped key leaves layer mode so it renders
+        // like the base/inline layer instead of dimming. Unmapped = transparent
+        // (production) or nil (hand-built maps). The zoneSubtitle guard keeps
+        // nav-hint keys in layer mode so their subtitle still renders.
         if services.preferences.unmappedLayerKeyStyle == .baseLayer,
            zoneSubtitle == nil,
            layerKeyInfo == nil || layerKeyInfo?.isTransparent == true

--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView.swift
@@ -82,7 +82,23 @@ struct OverlayKeycapView: View {
 
     /// Whether we're in a non-base layer (e.g., nav, vim) but not launcher mode
     var isLayerMode: Bool {
-        !isLauncherMode && !isInlineLayer && currentLayerName.lowercased() != "base"
+        guard !isLauncherMode, !isInlineLayer, currentLayerName.lowercased() != "base" else {
+            return false
+        }
+        // When the user prefers base-layer rendering for unmapped keys, a key
+        // with no mapping on this layer renders like the base layer — same as an
+        // inline layer — instead of dimming. "Unmapped" is either a transparent
+        // LayerKeyInfo (production: the simulator emits one per physical key) or
+        // a nil entry (hand-built maps / passthrough). Keys that carry a zone
+        // subtitle (nav hint glyph) keep layer styling so the subtitle still
+        // renders. Mapped keys keep full layer styling (zone/collection colors).
+        if services.preferences.unmappedLayerKeyStyle == .baseLayer,
+           zoneSubtitle == nil,
+           layerKeyInfo == nil || layerKeyInfo?.isTransparent == true
+        {
+            return false
+        }
+        return true
     }
 
     /// "Inline" layers render like the base layer — unmapped keys keep their

--- a/Sources/KeyPathAppKit/UI/Settings/SettingsView+General.swift
+++ b/Sources/KeyPathAppKit/UI/Settings/SettingsView+General.swift
@@ -78,7 +78,7 @@ struct GeneralSettingsTabView: View {
                         .accessibilityLabel("Unmapped layer keys look like the base layer")
 
                         SettingsOptionCard(
-                            icon: "moon",
+                            icon: "eye.slash",
                             title: "Dimmed",
                             subtitle: "Dim so mappings stand out",
                             isSelected: services.preferences.unmappedLayerKeyStyle == .dimmed

--- a/Sources/KeyPathAppKit/UI/Settings/SettingsView+General.swift
+++ b/Sources/KeyPathAppKit/UI/Settings/SettingsView+General.swift
@@ -59,6 +59,38 @@ struct GeneralSettingsTabView: View {
                     .accessibilityIdentifier("settings-key-label-style-picker")
                 }
 
+                // Unmapped keys on layers (Nav, Vim, etc.)
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Unmapped Keys on Layers")
+                        .font(.headline)
+                        .foregroundColor(.secondary)
+
+                    HStack(spacing: 10) {
+                        SettingsOptionCard(
+                            icon: "keyboard",
+                            title: "Base layer",
+                            subtitle: "Look like the base layer",
+                            isSelected: services.preferences.unmappedLayerKeyStyle == .baseLayer
+                        ) {
+                            services.preferences.unmappedLayerKeyStyle = .baseLayer
+                        }
+                        .accessibilityIdentifier("settings-unmapped-layer-keys-base")
+                        .accessibilityLabel("Unmapped layer keys look like the base layer")
+
+                        SettingsOptionCard(
+                            icon: "moon",
+                            title: "Dimmed",
+                            subtitle: "Dim so mappings stand out",
+                            isSelected: services.preferences.unmappedLayerKeyStyle == .dimmed
+                        ) {
+                            services.preferences.unmappedLayerKeyStyle = .dimmed
+                        }
+                        .accessibilityIdentifier("settings-unmapped-layer-keys-dimmed")
+                        .accessibilityLabel("Dim unmapped layer keys")
+                    }
+                    .accessibilityIdentifier("settings-unmapped-layer-keys-picker")
+                }
+
                 // Capture Mode
                 VStack(alignment: .leading, spacing: 8) {
                     Text("Capture Mode")

--- a/Tests/KeyPathTests/Services/UnmappedLayerKeyStyleTests.swift
+++ b/Tests/KeyPathTests/Services/UnmappedLayerKeyStyleTests.swift
@@ -83,4 +83,45 @@ final class UnmappedLayerKeyStyleTests: XCTestCase {
         let view = keycap(layer: "base", info: .transparent(fallbackLabel: "Q"))
         XCTAssertFalse(view.isLayerMode, "The base layer is never in layer mode")
     }
+
+    // MARK: - FloatingLabelVisibility (the keyboard-view half)
+
+    /// Under base-style the keyboard view forces `isLayerMode: false` into
+    /// FloatingLabelVisibility so unmapped keys' floating legends return —
+    /// while mapped keys stay hidden via `remappedLabels`.
+    func testFloatingLabels_baseStyle_showsUnmapped_hidesRemapped() {
+        let visibility = FloatingLabelVisibility(
+            labelToKeyCode: ["A": 0, "S": 1],
+            isLauncherMode: false,
+            isLayerMode: false, // what baseStyleUnmapped forces
+            vimHintsActive: false,
+            remappedLabels: ["S"], // S is mapped on this layer
+            zoneSubtitleLabels: []
+        )
+        XCTAssertTrue(visibility.isVisible("A"), "Unmapped key's floating legend shows under base-style")
+        XCTAssertFalse(visibility.isVisible("S"), "Mapped key stays excluded via remappedLabels")
+    }
+
+    func testFloatingLabels_dimmed_suppressesAll() {
+        let visibility = FloatingLabelVisibility(
+            labelToKeyCode: ["A": 0],
+            isLauncherMode: false,
+            isLayerMode: true, // dimmed style keeps real layer mode
+            vimHintsActive: false,
+            remappedLabels: [],
+            zoneSubtitleLabels: []
+        )
+        XCTAssertFalse(visibility.isVisible("A"), "Dimmed style keeps floating legends suppressed on layers")
+    }
+
+    // MARK: - Persistence
+
+    func testPreference_persistsAcrossReload() {
+        let writer = PreferencesService()
+        writer.unmappedLayerKeyStyle = .dimmed
+        // A fresh instance hydrates from UserDefaults in init().
+        let reloaded = PreferencesService()
+        XCTAssertEqual(reloaded.unmappedLayerKeyStyle, .dimmed, "Value should survive a UserDefaults round-trip")
+        writer.unmappedLayerKeyStyle = .baseLayer // restore default-backed state
+    }
 }

--- a/Tests/KeyPathTests/Services/UnmappedLayerKeyStyleTests.swift
+++ b/Tests/KeyPathTests/Services/UnmappedLayerKeyStyleTests.swift
@@ -1,0 +1,86 @@
+@testable import KeyPathAppKit
+import KeyPathCore
+import SwiftUI
+import XCTest
+
+/// Tests for the "unmapped keys on layers" overlay setting: a transparent
+/// (unmapped) key leaves layer mode — rendering base-style — when the user
+/// prefers `.baseLayer`, while mapped keys keep full layer styling.
+@MainActor
+final class UnmappedLayerKeyStyleTests: XCTestCase {
+    private var savedStyle: UnmappedLayerKeyStyle!
+
+    override func setUp() {
+        super.setUp()
+        savedStyle = PreferencesService.shared.unmappedLayerKeyStyle
+    }
+
+    override func tearDown() {
+        PreferencesService.shared.unmappedLayerKeyStyle = savedStyle
+        super.tearDown()
+    }
+
+    private func keycap(layer: String, info: LayerKeyInfo?, zoneSubtitle: String? = nil) -> OverlayKeycapView {
+        OverlayKeycapView(
+            key: PhysicalKey(keyCode: 12, label: "Q", x: 1, y: 2, width: 1, height: 1),
+            baseLabel: "Q",
+            isPressed: false,
+            scale: 1.0,
+            currentLayerName: layer,
+            layerKeyInfo: info,
+            zoneSubtitle: zoneSubtitle
+        )
+    }
+
+    func testUnmappedKey_baseLayerPref_leavesLayerMode() {
+        PreferencesService.shared.unmappedLayerKeyStyle = .baseLayer
+        let view = keycap(layer: "nav", info: .transparent(fallbackLabel: "Q"))
+        XCTAssertFalse(
+            view.isLayerMode,
+            "An unmapped key should render base-style (not layer mode) when base-style is preferred"
+        )
+    }
+
+    func testUnmappedKey_nilInfo_baseLayerPref_leavesLayerMode() {
+        // Production emits transparent LayerKeyInfo per key, but hand-built maps
+        // (and passthrough) use nil — both mean "unmapped" and should render base.
+        PreferencesService.shared.unmappedLayerKeyStyle = .baseLayer
+        let view = keycap(layer: "nav", info: nil)
+        XCTAssertFalse(view.isLayerMode, "A nil-info (unmapped) key should also render base-style")
+    }
+
+    func testUnmappedKey_withZoneSubtitle_staysInLayerMode() {
+        // A key carrying a nav-hint subtitle keeps layer styling so the subtitle
+        // still renders (avoids a stray subtitle on a base-styled keycap).
+        PreferencesService.shared.unmappedLayerKeyStyle = .baseLayer
+        let view = keycap(layer: "nav", info: .transparent(fallbackLabel: "Q"), zoneSubtitle: "◀")
+        XCTAssertTrue(view.isLayerMode, "Keys with a zone subtitle keep layer styling even under base-style")
+    }
+
+    func testUnmappedKey_dimmedPref_staysInLayerMode() {
+        PreferencesService.shared.unmappedLayerKeyStyle = .dimmed
+        let view = keycap(layer: "nav", info: .transparent(fallbackLabel: "Q"))
+        XCTAssertTrue(
+            view.isLayerMode,
+            "An unmapped key should stay dimmed (layer mode) when dimmed is preferred"
+        )
+    }
+
+    func testMappedKey_baseLayerPref_staysInLayerMode() {
+        PreferencesService.shared.unmappedLayerKeyStyle = .baseLayer
+        let view = keycap(
+            layer: "nav",
+            info: .mapped(displayLabel: "←", outputKey: "left", outputKeyCode: 123)
+        )
+        XCTAssertTrue(
+            view.isLayerMode,
+            "Mapped keys keep full layer styling regardless of the unmapped-key preference"
+        )
+    }
+
+    func testBaseLayer_isNeverLayerMode() {
+        PreferencesService.shared.unmappedLayerKeyStyle = .dimmed
+        let view = keycap(layer: "base", info: .transparent(fallbackLabel: "Q"))
+        XCTAssertFalse(view.isLayerMode, "The base layer is never in layer mode")
+    }
+}

--- a/Tests/KeyPathTests/Services/UnmappedLayerKeyStyleTests.swift
+++ b/Tests/KeyPathTests/Services/UnmappedLayerKeyStyleTests.swift
@@ -6,12 +6,19 @@ import XCTest
 /// Tests for the "unmapped keys on layers" overlay setting: a transparent
 /// (unmapped) key leaves layer mode — rendering base-style — when the user
 /// prefers `.baseLayer`, while mapped keys keep full layer styling.
-@MainActor
-final class UnmappedLayerKeyStyleTests: XCTestCase {
+final class UnmappedLayerKeyStyleTests: KeyPathTestCase {
     private var savedStyle: UnmappedLayerKeyStyle!
 
     override func setUp() {
         super.setUp()
+        // Tripwire: the isLayerMode tests drive the view through
+        // PreferencesService.shared, which only works because the default
+        // @Environment(\.services) ServiceContainer uses `.shared` for its
+        // preferences. Fail loudly (not silently) if that ever decouples.
+        XCTAssertTrue(
+            ServiceContainer().preferences === PreferencesService.shared,
+            "Tests assume the default ServiceContainer uses PreferencesService.shared"
+        )
         savedStyle = PreferencesService.shared.unmappedLayerKeyStyle
     }
 


### PR DESCRIPTION
## Summary

Adds a **Settings → General → "Unmapped Keys on Layers"** toggle controlling how the live keyboard overlay draws keys that have *no mapping* on a non-base layer (e.g. Nav/Vim):

- **Base layer** (new default): unmapped keys render like the base layer — base colors + labels, with floating shift legends restored. *Mapped* keys keep full layer styling (zone/collection colors, nav subtitles).
- **Dimmed**: the previous behavior — unmapped keys dim to a dark keycap so the layer's mappings stand out.

| Dimmed (old default) | Base layer (new default) |
|---|---|
| Unmapped keys dark/dimmed, single labels | Unmapped keys bright, base labels + shift legends |

## Approach

Reuses the existing **inline-layer** render path instead of a parallel branch (right-altitude): a key with no mapping (transparent `LayerKeyInfo`, or nil) and no zone subtitle simply *leaves layer mode* when base-style is preferred, so it renders through the same path the base layer/inline layers already use. The view-wide `FloatingLabelVisibility` honors the same preference to bring shift legends back on unmapped keys; mapped/remapped/zone keys are excluded by its existing filters.

Both the keycap and the keyboard view read the preference via the **same injected `services`**, so the per-key styling and the floating-label visibility can never disagree.

## ⚠️ Default behavior change

This makes **Base layer** the default. Existing users' layers previously rendered unmapped keys *dimmed* and will now render them base-style until they pick **Dimmed** in Settings. This is intentional (the requested default).

## Review gate

Ran adversarial review; fixed the real findings before this PR:
- **Two preference sources** (keycap `services.preferences` vs keyboard `PreferencesService.shared`) could diverge under an injected `ServiceContainer` → unified on injected `services`.
- **Unmapped-key representation**: production emits a *transparent* `LayerKeyInfo` per physical key, but hand-built maps use `nil` — the condition now handles **both**.
- **Stray subtitle**: a transparent key carrying a nav-hint subtitle now keeps layer styling (guarded on `zoneSubtitle == nil`) so the subtitle still renders.

## Testing

- `UnmappedLayerKeyStyleTests`: pref persistence + the `isLayerMode` decision across transparent / nil / mapped / zone-subtitle / base-layer cases.
- Existing `VallackOverlayZoneTests` + `PreferencesService` suites still green.

## Follow-ups / verify
- **Overlay snapshot goldens** (opt-in, `KEYPATH_SNAPSHOTS=1`, not CI-blocking) need re-recording for the new default.
- An identity-style mapping whose output label equals its base label could show a stray floating legend — uncommon; flagged for **physical/visual verification** (overlay visuals can't be confirmed in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)