### PR TITLE
feat(health): request InputGrab status on connect (fork#20)

### DIFF
--- a/Sources/KeyPathAppKit/Services/Monitoring/KanataEventListener.swift
+++ b/Sources/KeyPathAppKit/Services/Monitoring/KanataEventListener.swift
@@ -904,15 +904,7 @@ actor KanataEventListener {
         AppLogger.shared.debug("🌐 [EventListener] Unhandled message type")
     }
 
-    /// Ask kanata for the current input-grab status once, after the HelloOk
-    /// handshake. kanata only emits `InputGrab` on grab-state transitions and
-    /// does not replay on connect, so without this a fresh connection never
-    /// learns the startup grab result. Gated on the `input-grab` capability so
-    /// an older bundled kanata (which would treat the unknown message as
-    /// malformed and disconnect, breaking ALL event listening) is never sent it.
-    /// The reply is a normal `InputGrab` message handled by `handleLine`; if the
-    /// grab hasn't resolved yet kanata stays silent and the health checker falls
-    /// back to its stderr detector.
+    /// Ask kanata for current grab status after HelloOk; gated on the `input-grab` capability so older kanata is never sent the unknown message (it would disconnect).
     private func requestInputGrabIfSupported() async {
         guard capabilities.contains("input-grab") else { return }
         guard let activeConnection else { return }

--- a/Sources/KeyPathAppKit/Services/Monitoring/KanataEventListener.swift
+++ b/Sources/KeyPathAppKit/Services/Monitoring/KanataEventListener.swift
@@ -707,6 +707,7 @@ actor KanataEventListener {
                 await handler(normalizedCaps)
             }
             await subscribeToHrmTraceIfSupported()
+            await requestInputGrabIfSupported()
             return
         }
 
@@ -901,6 +902,27 @@ actor KanataEventListener {
         }
 
         AppLogger.shared.debug("🌐 [EventListener] Unhandled message type")
+    }
+
+    /// Ask kanata for the current input-grab status once, after the HelloOk
+    /// handshake. kanata only emits `InputGrab` on grab-state transitions and
+    /// does not replay on connect, so without this a fresh connection never
+    /// learns the startup grab result. Gated on the `input-grab` capability so
+    /// an older bundled kanata (which would treat the unknown message as
+    /// malformed and disconnect, breaking ALL event listening) is never sent it.
+    /// The reply is a normal `InputGrab` message handled by `handleLine`; if the
+    /// grab hasn't resolved yet kanata stays silent and the health checker falls
+    /// back to its stderr detector.
+    private func requestInputGrabIfSupported() async {
+        guard capabilities.contains("input-grab") else { return }
+        guard let activeConnection else { return }
+        do {
+            try await send(jsonObject: ["RequestInputGrab": [:] as [String: String]], over: activeConnection)
+            AppLogger.shared.debug("🌐 [EventListener] Requested current InputGrab status")
+        } catch {
+            // Failing this query must not break layer/key event listening.
+            AppLogger.shared.debug("🌐 [EventListener] RequestInputGrab failed: \(error.localizedDescription)")
+        }
     }
 
     private func subscribeToHrmTraceIfSupported() async {

--- a/Tests/KeyPathTests/Services/KanataEventListenerTests.swift
+++ b/Tests/KeyPathTests/Services/KanataEventListenerTests.swift
@@ -93,6 +93,14 @@ final class KanataEventListenerTests: XCTestCase {
         )
         XCTAssertEqual(normalized, ["hrm-trace", "tap-activated"])
     }
+
+    /// The RequestInputGrab safety gate matches on "input-grab"; ensure both the
+    /// hyphen and underscore forms normalize to it so the gate can't silently miss.
+    func testNormalizedCapabilities_inputGrab_normalizes() {
+        XCTAssertEqual(KanataEventListener.normalizedCapabilities(["input-grab"]), ["input-grab"])
+        XCTAssertEqual(KanataEventListener.normalizedCapabilities(["input_grab"]), ["input-grab"])
+        XCTAssertEqual(KanataEventListener.normalizedCapabilities(["INPUT-GRAB"]), ["input-grab"])
+    }
 }
 
 /// Tests for KeyboardVisualizationViewModel TCP input handling with capitalized actions


### PR DESCRIPTION
## Summary

Closes the **no-replay gap** from #630/#635: kanata emits `InputGrab` only on grab-state *transitions* and doesn't replay on connect, so a fresh KeyPath connection never learned the **startup** grab result — the most important health signal (and the exact case the original karabiner crash hit). The bundled fork now answers a `RequestInputGrab` query with the current status; this PR asks for it on connect.

This makes the authoritative grab signal actually *primary* (not just a mid-session safety net), and is the foundation for #624 (honest status) and #625 (auto-recovery).

## Two parts

- **Fork** (`malpern/kanata`, landed on `keypath/bundled` @ `3d715e4`): adds `ClientMessage::RequestInputGrab`, caches the last grab status on the `Kanata` struct (updated inside `emit_input_grab`), and replies to the requesting client with the current `InputGrab` — identical shape to the transition-emitted message, so KeyPath's existing parser handles it. Stays silent if the grab hasn't resolved yet. Adds an `input-grab` HelloOk capability.
- **KeyPath**: sends `{"RequestInputGrab":{}}` after `HelloOk`, **gated on the `input-grab` capability**. The reply flows through the existing `handleLine` → `KanataGrabStatusStore` path (no consumer changes). Bumps the submodule pin to `3d715e4`.

## Review gate — one real finding, fixed

The adversarial review caught a genuine robustness bug in my first cut: sending `RequestInputGrab` *eagerly* (before `HelloOk`, ungated) would make an **older bundled kanata disconnect on the unknown message**, throwing the listener into a 1s reconnect loop that breaks **all** event listening (layers, hold/tap/chord) — not just the grab feature — in the post-app-update window before kanata is redeployed.

Fixed by sending it **after `HelloOk` and gating on `capabilities.contains("input-grab")`**, mirroring the existing `subscribeToHrmTraceIfSupported` pattern. An old kanata never advertises the capability, so it's never sent the message.

Other review angles (Rust `&mut self` borrow at all call sites, lock-drop-before-write in the handler, unicast-not-broadcast, cache-before-send ordering, cfg gating) all checked out clean.

## Testing

- Existing `KanataInputGrabConsumerTests` + `KanataEventListenerTests` green (the reply path is already covered by the InputGrab parser tests).
- Fork: protocol round-trip + extended cache test pass; zero new clippy warnings.
- The send itself (network I/O in `connectAndStream`) follows the untested-by-convention pattern of the adjacent `Hello`/`RequestCurrentLayerName`/HRM sends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)