### PR TITLE
feat(lifecycle): detect stale running kanata and notify user to restart (#638)

### DIFF
--- a/Sources/KeyPathAppKit/Core/AppNotificationWiring.swift
+++ b/Sources/KeyPathAppKit/Core/AppNotificationWiring.swift
@@ -101,6 +101,23 @@ enum AppNotificationWiring {
             }
         }
 
+        // Restart kanata to adopt a newer bundled binary (#638, user-triggered)
+        NotificationCenter.default.addObserver(
+            forName: .restartKanataForUpdate, object: nil, queue: NotificationObserverManager.mainOperationQueue
+        ) { [weak delegate] _ in
+            Task { @MainActor in
+                AppLogger.shared.log("🔄 [App] Restart-to-adopt requested via notification")
+                guard let manager = delegate?.kanataManager else {
+                    AppLogger.shared.error("❌ [App] Restart-to-adopt requested but RuntimeCoordinator unavailable")
+                    return
+                }
+                let success = await manager.restartKanata(reason: "Adopt updated kanata binary")
+                if !success {
+                    AppLogger.shared.error("❌ [App] Restart-to-adopt failed")
+                }
+            }
+        }
+
         // Open Input Monitoring settings
         NotificationCenter.default.addObserver(
             forName: .openInputMonitoringSettings, object: nil, queue: NotificationObserverManager.mainOperationQueue

--- a/Sources/KeyPathAppKit/Managers/RuntimeCoordinator.swift
+++ b/Sources/KeyPathAppKit/Managers/RuntimeCoordinator.swift
@@ -1187,6 +1187,9 @@ public class RuntimeCoordinator: SaveCoordinatorDelegate {
 
         if context.services.kanataRunning {
             AppLogger.shared.info("✅ [Init] Kanata is already running - skipping initialization")
+            // A daemon can outlive a KeyPath upgrade/redeploy and keep running
+            // stale kanata code; adopt the bundled binary if so (#638).
+            await serviceLifecycleCoordinator.adoptBundledKanataIfStale()
             return
         }
 

--- a/Sources/KeyPathAppKit/Managers/RuntimeCoordinator.swift
+++ b/Sources/KeyPathAppKit/Managers/RuntimeCoordinator.swift
@@ -1188,8 +1188,11 @@ public class RuntimeCoordinator: SaveCoordinatorDelegate {
         if context.services.kanataRunning {
             AppLogger.shared.info("✅ [Init] Kanata is already running - skipping initialization")
             // A daemon can outlive a KeyPath upgrade/redeploy and keep running
-            // stale kanata code; adopt the bundled binary if so (#638).
-            await serviceLifecycleCoordinator.adoptBundledKanataIfStale()
+            // stale kanata code. Notify the user to restart and adopt the bundled
+            // binary — never auto-restart a working keyboard (#638).
+            if await serviceLifecycleCoordinator.isRunningKanataStale() {
+                await UserNotificationService.shared.notifyKanataUpdateReady()
+            }
             return
         }
 

--- a/Sources/KeyPathAppKit/Managers/ServiceLifecycleCoordinator.swift
+++ b/Sources/KeyPathAppKit/Managers/ServiceLifecycleCoordinator.swift
@@ -117,6 +117,11 @@ final class ServiceLifecycleCoordinator {
             }
 
             await AppContextService.shared.start()
+            // Record that the running daemon now matches the binary we bundle, so
+            // a later launch can detect when an upgrade left it stale (#638).
+            if let bundled = KanataBinaryIdentity.bundledCodeHash() {
+                await MainActor.run { PreferencesService.shared.adoptedKanataCodeHash = bundled }
+            }
             onError?(nil)
             onWarning?(nil)
             onStateChanged?()
@@ -156,6 +161,62 @@ final class ServiceLifecycleCoordinator {
         let stopped = await stopKanata(reason: "\(reason) (stop for restart)")
         guard stopped else { return false }
         return await startKanata(reason: "\(reason) (restart)")
+    }
+
+    /// Ensure a running kanata daemon is the binary KeyPath currently bundles.
+    ///
+    /// A daemon can outlive a KeyPath upgrade/redeploy and keep running stale
+    /// kanata code (health checks only see it alive). When the bundled cdhash
+    /// differs from what we last adopted — including the first run with no record,
+    /// which covers an already-running older daemon — restart it so it adopts the
+    /// new binary. The cdhash is stable across the deploy's re-sign step, so a
+    /// Swift-only redeploy doesn't bounce kanata. Call only when kanata is already
+    /// running; `startKanata` records adoption on every KeyPath-initiated start.
+    ///
+    /// Adopting a newer binary is an optimization — it must NEVER sacrifice a
+    /// working keyboard. `restartKanata` stops before it starts, so we only act
+    /// when we're confident the start will succeed: the running daemon is our own
+    /// SMAppService daemon (don't fight an external/homebrew kanata), and the
+    /// VirtualHID daemon (the main reason `startKanata` fails) is healthy.
+    /// Otherwise we leave the working-but-stale daemon alone and retry on a later
+    /// launch — a stale daemon is harmless (features capability-gate gracefully).
+    @discardableResult
+    func adoptBundledKanataIfStale() async -> Bool {
+        guard !TestEnvironment.isRunningTests else { return false }
+        guard let bundled = KanataBinaryIdentity.bundledCodeHash() else {
+            AppLogger.shared.log("⚠️ [Service] Bundled kanata cdhash unavailable — skipping binary adopt check (#638)")
+            return false
+        }
+        let adopted = await MainActor.run { PreferencesService.shared.adoptedKanataCodeHash }
+        guard KanataBinaryIdentity.shouldAdoptBundled(adopted: adopted, bundled: bundled) else {
+            return false
+        }
+
+        // Only adopt our own SMAppService daemon — restarting won't kill an
+        // external kanata, so we'd just spawn a second process contending for the
+        // keyboard.
+        let managementState = await KanataDaemonManager.shared.refreshManagementStateInternal()
+        guard managementState == .smappserviceActive else {
+            AppLogger.shared.log("⏭️ [Service] Skipping kanata adopt — not our SMAppService daemon (state=\(managementState)) (#638)")
+            return false
+        }
+        // Don't stop a working kanata unless the restart's main precondition holds.
+        let vhidHealthy = await ServiceHealthChecker.shared.isServiceHealthy(
+            serviceID: ServiceHealthChecker.vhidDaemonServiceID
+        )
+        guard vhidHealthy else {
+            AppLogger.shared.log("⏭️ [Service] Skipping kanata adopt — VirtualHID not healthy; won't risk a working keyboard (#638)")
+            return false
+        }
+
+        AppLogger.shared.log(
+            "🔁 [Service] Running kanata predates bundled binary (adopted=\(adopted ?? "none") bundled=\(bundled)) — restarting to adopt"
+        )
+        let ok = await restartKanata(reason: "adopt updated kanata binary")
+        if !ok {
+            AppLogger.shared.error("❌ [Service] kanata adopt restart failed — will retry on next start/launch")
+        }
+        return ok
     }
 
     func isInTransientRuntimeStartupWindow() async -> Bool {

--- a/Sources/KeyPathAppKit/Managers/ServiceLifecycleCoordinator.swift
+++ b/Sources/KeyPathAppKit/Managers/ServiceLifecycleCoordinator.swift
@@ -163,60 +163,39 @@ final class ServiceLifecycleCoordinator {
         return await startKanata(reason: "\(reason) (restart)")
     }
 
-    /// Ensure a running kanata daemon is the binary KeyPath currently bundles.
+    /// Whether the running kanata daemon predates the binary KeyPath bundles, so
+    /// a restart would adopt newer code (#638).
     ///
     /// A daemon can outlive a KeyPath upgrade/redeploy and keep running stale
-    /// kanata code (health checks only see it alive). When the bundled cdhash
-    /// differs from what we last adopted — including the first run with no record,
-    /// which covers an already-running older daemon — restart it so it adopts the
-    /// new binary. The cdhash is stable across the deploy's re-sign step, so a
-    /// Swift-only redeploy doesn't bounce kanata. Call only when kanata is already
-    /// running; `startKanata` records adoption on every KeyPath-initiated start.
-    ///
-    /// Adopting a newer binary is an optimization — it must NEVER sacrifice a
-    /// working keyboard. `restartKanata` stops before it starts, so we only act
-    /// when we're confident the start will succeed: the running daemon is our own
-    /// SMAppService daemon (don't fight an external/homebrew kanata), and the
-    /// VirtualHID daemon (the main reason `startKanata` fails) is healthy.
-    /// Otherwise we leave the working-but-stale daemon alone and retry on a later
-    /// launch — a stale daemon is harmless (features capability-gate gracefully).
-    @discardableResult
-    func adoptBundledKanataIfStale() async -> Bool {
+    /// kanata code — health checks only see it alive (PID + TCP). When the
+    /// bundled cdhash differs from what we last adopted (including the first run
+    /// with no record, which covers an already-running older daemon) the user is
+    /// notified to restart and adopt it. **Detection only — KeyPath never
+    /// auto-restarts a working keyboard.** True only for our own SMAppService
+    /// daemon, since restarting wouldn't adopt an external/homebrew kanata. The
+    /// cdhash is stable across the deploy's re-sign step, so a Swift-only
+    /// redeploy isn't flagged. `startKanata` records adoption on every
+    /// KeyPath-initiated start, so a user-triggered restart clears the flag.
+    func isRunningKanataStale() async -> Bool {
         guard !TestEnvironment.isRunningTests else { return false }
         guard let bundled = KanataBinaryIdentity.bundledCodeHash() else {
-            AppLogger.shared.log("⚠️ [Service] Bundled kanata cdhash unavailable — skipping binary adopt check (#638)")
+            AppLogger.shared.log("⚠️ [Service] Bundled kanata cdhash unavailable — skipping staleness check (#638)")
             return false
         }
         let adopted = await MainActor.run { PreferencesService.shared.adoptedKanataCodeHash }
         guard KanataBinaryIdentity.shouldAdoptBundled(adopted: adopted, bundled: bundled) else {
             return false
         }
-
-        // Only adopt our own SMAppService daemon — restarting won't kill an
-        // external kanata, so we'd just spawn a second process contending for the
-        // keyboard.
+        // Only our own SMAppService daemon can be adopted by a restart.
         let managementState = await KanataDaemonManager.shared.refreshManagementStateInternal()
         guard managementState == .smappserviceActive else {
-            AppLogger.shared.log("⏭️ [Service] Skipping kanata adopt — not our SMAppService daemon (state=\(managementState)) (#638)")
+            AppLogger.shared.log("⏭️ [Service] Stale binary but not our SMAppService daemon (state=\(managementState)) — not flagging (#638)")
             return false
         }
-        // Don't stop a working kanata unless the restart's main precondition holds.
-        let vhidHealthy = await ServiceHealthChecker.shared.isServiceHealthy(
-            serviceID: ServiceHealthChecker.vhidDaemonServiceID
-        )
-        guard vhidHealthy else {
-            AppLogger.shared.log("⏭️ [Service] Skipping kanata adopt — VirtualHID not healthy; won't risk a working keyboard (#638)")
-            return false
-        }
-
         AppLogger.shared.log(
-            "🔁 [Service] Running kanata predates bundled binary (adopted=\(adopted ?? "none") bundled=\(bundled)) — restarting to adopt"
+            "🔁 [Service] Running kanata predates bundled binary (adopted=\(adopted ?? "none") bundled=\(bundled)) — will notify user to restart"
         )
-        let ok = await restartKanata(reason: "adopt updated kanata binary")
-        if !ok {
-            AppLogger.shared.error("❌ [Service] kanata adopt restart failed — will retry on next start/launch")
-        }
-        return ok
+        return true
     }
 
     func isInTransientRuntimeStartupWindow() async -> Bool {

--- a/Sources/KeyPathAppKit/Services/Configuration/PreferencesService.swift
+++ b/Sources/KeyPathAppKit/Services/Configuration/PreferencesService.swift
@@ -264,6 +264,15 @@ final class PreferencesService: @unchecked Sendable {
         }
     }
 
+    /// cdhash of the bundled kanata binary KeyPath last (re)started the daemon
+    /// with. Compared to the current bundled cdhash to detect a stale running
+    /// daemon after an upgrade/redeploy (#638). nil until first recorded.
+    var adoptedKanataCodeHash: String? {
+        didSet {
+            UserDefaults.standard.set(adoptedKanataCodeHash, forKey: Keys.adoptedKanataCodeHash)
+        }
+    }
+
     // MARK: - Leader Key Configuration
 
     /// Primary leader key preference (Space → Nav by default)
@@ -413,6 +422,7 @@ final class PreferencesService: @unchecked Sendable {
         static let neovimReferenceTopicsVersion = "KeyPath.Neovim.ReferenceTopicsVersion"
         static let keyLabelStyle = "KeyPath.Display.KeyLabelStyle"
         static let unmappedLayerKeyStyle = "KeyPath.Overlay.UnmappedLayerKeyStyle"
+        static let adoptedKanataCodeHash = "KeyPath.Kanata.AdoptedCodeHash"
         static let overlayHiddenHintShowCount = "KeyPath.Education.OverlayHiddenHintShowCount"
         static let overlaySuppressedBundleIDs = "KeyPath.Overlay.SuppressedBundleIDs"
     }
@@ -503,6 +513,9 @@ final class PreferencesService: @unchecked Sendable {
         let unmappedLayerKeyStyleString = UserDefaults.standard.string(forKey: Keys.unmappedLayerKeyStyle)
             ?? Defaults.unmappedLayerKeyStyle.rawValue
         unmappedLayerKeyStyle = UnmappedLayerKeyStyle(rawValue: unmappedLayerKeyStyleString) ?? Defaults.unmappedLayerKeyStyle
+
+        // Adopted kanata binary identity (#638)
+        adoptedKanataCodeHash = UserDefaults.standard.string(forKey: Keys.adoptedKanataCodeHash)
 
         // Testing preferences
         accessibilityTestMode =

--- a/Sources/KeyPathAppKit/Services/UserNotificationService.swift
+++ b/Sources/KeyPathAppKit/Services/UserNotificationService.swift
@@ -23,6 +23,7 @@ final class UserNotificationService: NSObject, UNUserNotificationCenterDelegate 
         case recovery = "KP_RECOVERY"
         case permission = "KP_PERMISSION"
         case info = "KP_INFO"
+        case update = "KP_UPDATE"
     }
 
     /// Action identifiers
@@ -32,6 +33,7 @@ final class UserNotificationService: NSObject, UNUserNotificationCenterDelegate 
         case openInputMonitoring = "KP_ACTION_OPEN_INPUT_MONITORING"
         case openAccessibility = "KP_ACTION_OPEN_ACCESSIBILITY"
         case openApp = "KP_ACTION_OPEN_APP"
+        case restartToAdopt = "KP_ACTION_RESTART_ADOPT"
     }
 
     private init(preferences: PreferencesService = .shared) {
@@ -90,6 +92,9 @@ final class UserNotificationService: NSObject, UNUserNotificationCenterDelegate 
         let openApp = UNNotificationAction(
             identifier: Action.openApp.rawValue, title: "Open KeyPath", options: [.foreground]
         )
+        let restartToAdopt = UNNotificationAction(
+            identifier: Action.restartToAdopt.rawValue, title: "Restart Now", options: []
+        )
 
         let serviceFailure = UNNotificationCategory(
             identifier: Category.serviceFailure.rawValue,
@@ -107,8 +112,12 @@ final class UserNotificationService: NSObject, UNUserNotificationCenterDelegate 
             identifier: Category.info.rawValue,
             actions: [openApp], intentIdentifiers: [], options: []
         )
+        let update = UNNotificationCategory(
+            identifier: Category.update.rawValue,
+            actions: [restartToAdopt, openApp], intentIdentifiers: [], options: []
+        )
 
-        center.setNotificationCategories([serviceFailure, recovery, permission, info])
+        center.setNotificationCategories([serviceFailure, recovery, permission, info, update])
     }
 
     // MARK: - Dedupe / Rate limiting
@@ -205,6 +214,22 @@ final class UserNotificationService: NSObject, UNUserNotificationCenterDelegate 
         )
     }
 
+    /// Notify the user that the running kanata daemon predates the bundled
+    /// binary (e.g. after a KeyPath upgrade) and a restart will apply the update
+    /// (#638). Detection-only by design — the user chooses when to restart via
+    /// the "Restart Now" action; KeyPath never auto-restarts a working keyboard.
+    /// Rate-limited to at most once a day; shown even when frontmost.
+    func notifyKanataUpdateReady() {
+        sendNotification(
+            title: "Keyboard engine update ready",
+            body: "Restart the keyboard service to apply the latest KeyPath update.",
+            category: .update,
+            key: "kanata.update.ready",
+            ttl: 86400,
+            allowWhenFrontmost: true
+        )
+    }
+
     func notifyRecoverySucceeded(_ message: String = "All set") {
         sendNotification(
             title: "KeyPath Ready",
@@ -250,6 +275,8 @@ final class UserNotificationService: NSObject, UNUserNotificationCenterDelegate 
             NotificationCenter.default.post(name: .openInstallationWizard, object: nil)
         case Action.retryStart.rawValue:
             NotificationCenter.default.post(name: .retryStartService, object: nil)
+        case Action.restartToAdopt.rawValue:
+            NotificationCenter.default.post(name: .restartKanataForUpdate, object: nil)
         case Action.openInputMonitoring.rawValue:
             NotificationCenter.default.post(name: .openInputMonitoringSettings, object: nil)
         case Action.openAccessibility.rawValue:

--- a/Sources/KeyPathAppKit/Services/UserNotificationService.swift
+++ b/Sources/KeyPathAppKit/Services/UserNotificationService.swift
@@ -218,14 +218,25 @@ final class UserNotificationService: NSObject, UNUserNotificationCenterDelegate 
     /// binary (e.g. after a KeyPath upgrade) and a restart will apply the update
     /// (#638). Detection-only by design — the user chooses when to restart via
     /// the "Restart Now" action; KeyPath never auto-restarts a working keyboard.
-    /// Rate-limited to at most once a day; shown even when frontmost.
+    ///
+    /// Short dedup window (30 min) on purpose: this fires once per app launch
+    /// (from init), so a 30-min window suppresses only rapid relaunches while
+    /// letting a notification that was dropped — e.g. sent in the startup race
+    /// before notification authorization resolved — retry on the next launch,
+    /// instead of being lost for a day. Shown even when frontmost.
+    ///
+    /// Known limitation: if the user has notifications disabled there is no
+    /// in-app fallback yet, so the nudge is silently skipped (the stale daemon
+    /// is harmless — it just misses new features). An in-app banner is a
+    /// follow-up.
     func notifyKanataUpdateReady() {
+        requestAuthorizationIfNeeded()
         sendNotification(
             title: "Keyboard engine update ready",
             body: "Restart the keyboard service to apply the latest KeyPath update.",
             category: .update,
             key: "kanata.update.ready",
-            ttl: 86400,
+            ttl: 1800,
             allowWhenFrontmost: true
         )
     }

--- a/Sources/KeyPathAppKit/Utilities/Notifications.swift
+++ b/Sources/KeyPathAppKit/Utilities/Notifications.swift
@@ -25,6 +25,7 @@ extension Notification.Name {
     // User notification actions
     static let openInstallationWizard = Notification.Name("KeyPath.Action.OpenWizard")
     static let retryStartService = Notification.Name("KeyPath.Action.RetryStart")
+    static let restartKanataForUpdate = Notification.Name("KeyPath.Action.RestartKanataForUpdate")
     static let openInputMonitoringSettings = Notification.Name("KeyPath.Action.OpenInputMonitoring")
     static let openAccessibilitySettings = Notification.Name("KeyPath.Action.OpenAccessibility")
     static let openApp = Notification.Name("KeyPath.Action.OpenApp")

--- a/Sources/KeyPathCore/KanataBinaryIdentity.swift
+++ b/Sources/KeyPathCore/KanataBinaryIdentity.swift
@@ -1,0 +1,45 @@
+import Foundation
+import Security
+
+/// Identity of the bundled kanata binary, used to detect when a running kanata
+/// daemon predates the binary KeyPath now ships (e.g. after a KeyPath upgrade or
+/// redeploy) so KeyPath can restart it to adopt the new binary.
+///
+/// Uses the code-signing **cdhash** (`kSecCodeInfoUnique`), not a file hash or
+/// mtime: a deploy re-signs the kanata binary in place, which changes the file
+/// bytes/mtime even when the code is identical — a file-based signal would bounce
+/// kanata on every Swift-only redeploy. The cdhash is stable across re-signs of
+/// identical code and changes only when the code changes.
+public enum KanataBinaryIdentity {
+    /// cdhash (lowercase hex) of the signed binary at `path`, or nil if it can't
+    /// be read (unsigned, missing, or query failure — caller should no-op).
+    public static func codeHash(atPath path: String) -> String? {
+        let url = URL(fileURLWithPath: path)
+        var staticCode: SecStaticCode?
+        guard SecStaticCodeCreateWithPath(url as CFURL, [], &staticCode) == errSecSuccess,
+              let staticCode
+        else { return nil }
+        var info: CFDictionary?
+        // SecCSFlags(2) == kSecCSSigningInformation, which includes the cdhash.
+        guard SecCodeCopySigningInformation(staticCode, SecCSFlags(rawValue: 2), &info) == errSecSuccess,
+              let dict = info as? [String: Any],
+              let cdhash = dict[kSecCodeInfoUnique as String] as? Data
+        else { return nil }
+        return cdhash.map { String(format: "%02x", $0) }.joined()
+    }
+
+    /// cdhash of the kanata binary KeyPath currently bundles, or nil if unavailable.
+    public static func bundledCodeHash() -> String? {
+        codeHash(atPath: WizardSystemPaths.bundledKanataPath)
+    }
+
+    /// Whether the running kanata should be restarted to adopt the bundled
+    /// binary. True when the bundled identity is known and differs from what
+    /// KeyPath last adopted — including the first run with no record yet, which
+    /// covers a daemon that was already running an older binary. False when the
+    /// bundled identity can't be determined (don't act on uncertainty).
+    public static func shouldAdoptBundled(adopted: String?, bundled: String?) -> Bool {
+        guard let bundled else { return false }
+        return adopted != bundled
+    }
+}

--- a/Tests/KeyPathTests/Services/KanataBinaryIdentityTests.swift
+++ b/Tests/KeyPathTests/Services/KanataBinaryIdentityTests.swift
@@ -1,0 +1,51 @@
+@testable import KeyPathAppKit
+import KeyPathCore
+@preconcurrency import XCTest
+
+/// Tests for stale-kanata-binary detection (#638): the pure adopt decision,
+/// cdhash extraction guards, and persistence of the adopted identity.
+final class KanataBinaryIdentityTests: XCTestCase {
+    // MARK: - shouldAdoptBundled decision
+
+    func testShouldAdopt_firstRun_noRecord_adopts() {
+        // No record yet (first run, or a daemon already running an older binary).
+        XCTAssertTrue(KanataBinaryIdentity.shouldAdoptBundled(adopted: nil, bundled: "abc123"))
+    }
+
+    func testShouldAdopt_alreadyCurrent_doesNotAdopt() {
+        XCTAssertFalse(KanataBinaryIdentity.shouldAdoptBundled(adopted: "abc123", bundled: "abc123"))
+    }
+
+    func testShouldAdopt_upgrade_differentHash_adopts() {
+        XCTAssertTrue(KanataBinaryIdentity.shouldAdoptBundled(adopted: "oldhash", bundled: "newhash"))
+    }
+
+    func testShouldAdopt_bundledUnknown_doesNotAdopt() {
+        // Can't read the bundled cdhash → don't act on uncertainty (never restart).
+        XCTAssertFalse(KanataBinaryIdentity.shouldAdoptBundled(adopted: "abc123", bundled: nil))
+        XCTAssertFalse(KanataBinaryIdentity.shouldAdoptBundled(adopted: nil, bundled: nil))
+    }
+
+    // MARK: - codeHash extraction
+
+    func testCodeHash_missingPath_returnsNil() {
+        XCTAssertNil(KanataBinaryIdentity.codeHash(atPath: "/nonexistent/path/to/kanata"))
+    }
+
+    // MARK: - Persistence round-trip
+
+    func testAdoptedCodeHash_persistsAcrossReload() {
+        let key = "KeyPath.Kanata.AdoptedCodeHash"
+        let original = UserDefaults.standard.string(forKey: key)
+        defer { UserDefaults.standard.set(original, forKey: key) }
+
+        let writer = PreferencesService()
+        writer.adoptedKanataCodeHash = "deadbeef"
+        let reloaded = PreferencesService()
+        XCTAssertEqual(reloaded.adoptedKanataCodeHash, "deadbeef")
+
+        writer.adoptedKanataCodeHash = nil
+        let cleared = PreferencesService()
+        XCTAssertNil(cleared.adoptedKanataCodeHash)
+    }
+}


### PR DESCRIPTION
Closes #638.

## Problem
A kanata daemon can outlive a KeyPath upgrade/redeploy and keep running the **old** binary. Health checks are liveness-only (PID + TCP), so a stale daemon looks healthy and KeyPath reuses it indefinitely. New bundled features (e.g. this session's InputGrab / RequestInputGrab work) stay silently **inert** until a manual daemon restart.

## Approach: detect, then NOTIFY (not auto-restart)

The first cut auto-restarted the daemon at startup. Review (and a step-back with the maintainer) concluded that's **too aggressive for the value**: a stale-but-working kanata still remaps fine — it just misses new features — while a failed auto-restart could leave the keyboard down with no in-session recovery. Trading startup-path risk on a *keyboard tool* for "adopt new features promptly" is the wrong asymmetry.

So this **detects** staleness and **notifies** the user; the user chooses when to restart. KeyPath never auto-restarts a working keyboard.

- **`KanataBinaryIdentity`** (KeyPathCore): code-signing **cdhash** (`kSecCodeInfoUnique`) of the bundled binary + a pure `shouldAdoptBundled` decision. cdhash, not file-hash/mtime — a deploy re-signs kanata in place, so a file signal would false-trigger on every Swift-only `df`; cdhash is stable across re-signs.
- **`PreferencesService.adoptedKanataCodeHash`**: persisted record; `startKanata` records it on every KeyPath-initiated start (so a restart clears the flag).
- **`ServiceLifecycleCoordinator.isRunningKanataStale()`**: detection only — bundled cdhash differs from the record AND it's our own SMAppService daemon (restarting wouldn't adopt an external kanata).
- On startup (already-running path), if stale → `UserNotificationService.notifyKanataUpdateReady()`: a rate-limited notification with a **"Restart Now"** action that routes through the normal **user-initiated** `restartKanata` (failures surface — no silent dead keyboard).

First run has no record → notifies once (covers the currently-stale daemon); thereafter only on a real binary change. The launcher always re-execs the fresh binary, so a restart adopts it.

## Review findings addressed
- **Auto-restart danger (round 1):** removed entirely — pivoted to notify.
- **Dropped-first-notify race:** the once/day dedup key was burned even when the first-launch notification was dropped (sent before notification auth resolved). Shortened the dedup to 30 min (fires once per launch anyway) + request auth before sending, so a dropped prompt retries next launch.
- **Known limitation (documented):** if the user has notifications disabled there's no in-app fallback yet — the nudge is skipped (harmless; stale daemon just misses new features). In-app banner is a follow-up.

## Testing
- `KanataBinaryIdentityTests`: the `shouldAdoptBundled` decision (first-run / current / upgrade / unknown), cdhash nil on missing path, persistence round-trip.
- The notify wiring mirrors the existing `retryStart` action (tested-by-convention). Risk surface is small (worst case = a spurious or missing notification).
- Existing lifecycle/coordinator/prefs suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)