### PR TITLE
feat(wizard): honest status attribution for kanata grab failures (#624)

### DIFF
--- a/Sources/KeyPathInstallationWizard/Core/ServiceStatusEvaluator.swift
+++ b/Sources/KeyPathInstallationWizard/Core/ServiceStatusEvaluator.swift
@@ -82,6 +82,13 @@ public enum ServiceStatusEvaluator {
                     continue
                 }
             }
+            // A grab failure (kanata running but not capturing input, #624) is a
+            // true failure — the service must not render "running" green. The
+            // error/critical filter above means the warning-level timeout daemon
+            // issue is unaffected.
+            if case .daemon = issue.identifier {
+                return issue.title
+            }
         }
         return nil
     }

--- a/Sources/KeyPathInstallationWizard/Core/ServiceStatusEvaluator.swift
+++ b/Sources/KeyPathInstallationWizard/Core/ServiceStatusEvaluator.swift
@@ -82,10 +82,11 @@ public enum ServiceStatusEvaluator {
                     continue
                 }
             }
-            // A grab failure (kanata running but not capturing input, #624) is a
-            // true failure — the service must not render "running" green. The
-            // error/critical filter above means the warning-level timeout daemon
-            // issue is unaffected.
+            // Any error/critical daemon issue is a true service failure (e.g. the
+            // #624 grab failure: kanata running but not capturing input) — the
+            // service must not render "running" green over it. The severity filter
+            // above keeps warning-level daemon issues (e.g. status-check timeout)
+            // from blocking.
             if case .daemon = issue.identifier {
                 return issue.title
             }

--- a/Sources/KeyPathInstallationWizard/Core/SystemInspector.swift
+++ b/Sources/KeyPathInstallationWizard/Core/SystemInspector.swift
@@ -35,7 +35,16 @@ public enum SystemInspector {
         }
 
         if !context.services.kanataInputCaptureReady {
-            return .missingPermissions(missing: [.kanataInputMonitoring])
+            // Be honest about WHY input capture failed (#624). Only a genuine
+            // built-in-keyboard permission problem belongs on the permissions
+            // page; a grab failure (driver crash, another app holding the
+            // keyboard, not root) is not fixed by regranting a permission —
+            // route to the service page so the remedy is "restart", not
+            // "regrant Input Monitoring".
+            if Self.isInputCapturePermissionReason(context.services.kanataInputCaptureIssue) {
+                return .missingPermissions(missing: [.kanataInputMonitoring])
+            }
+            return .serviceNotRunning
         }
 
         if context.services.kanataPermissionRejected {
@@ -122,15 +131,36 @@ public enum SystemInspector {
         if !context.services.kanataInputCaptureReady,
            !issues.contains(where: { $0.identifier == .permission(.kanataInputMonitoring) })
         {
-            issues.append(WizardIssue(
-                identifier: .permission(.kanataInputMonitoring),
-                severity: .error,
-                category: .permissions,
-                title: "KeyPath Runtime Cannot Open Built-In Keyboard",
-                description: "KeyPath Runtime is running but cannot open the built-in keyboard device, so remapping will not work on this laptop.",
-                autoFixAction: nil,
-                userAction: "Regrant Input Monitoring for the KeyPath runtime binary and restart KeyPath"
-            ))
+            if isInputCapturePermissionReason(context.services.kanataInputCaptureIssue) {
+                issues.append(WizardIssue(
+                    identifier: .permission(.kanataInputMonitoring),
+                    severity: .error,
+                    category: .permissions,
+                    title: "KeyPath Runtime Cannot Open Built-In Keyboard",
+                    description: "KeyPath Runtime is running but cannot open the built-in keyboard device, so remapping will not work on this laptop.",
+                    autoFixAction: nil,
+                    userAction: "Regrant Input Monitoring for the KeyPath runtime binary and restart KeyPath"
+                ))
+            } else {
+                // Grab failure (driver crash / another app holding the keyboard /
+                // not root) — honest attribution + a one-click restart, not a
+                // permission misdiagnosis (#624).
+                issues.append(WizardIssue(
+                    identifier: .daemon,
+                    severity: .error,
+                    category: .daemon,
+                    title: "Kanata Isn't Capturing Keyboard Input",
+                    description: "KeyPath's keyboard engine is running but isn't capturing input, so remapping won't work. "
+                        + inputCaptureFailureDetail(context.services.kanataInputCaptureIssue),
+                    // No one-click auto-fix yet: the existing recipes don't actually
+                    // bounce the wedged kanata process (they find SMAppService
+                    // "already healthy" and no-op), so a Restart button here would
+                    // be a false remedy. Point to the real restart instead; a
+                    // proper one-click kanata kickstart is a follow-up.
+                    autoFixAction: nil,
+                    userAction: "Restart the keyboard service from Settings → Status (or quit and reopen KeyPath)"
+                ))
+            }
         }
     }
 
@@ -323,5 +353,23 @@ public enum SystemInspector {
         if context.components.vhidVersionMismatch { missing.append(.vhidDriverVersionMismatch) }
         if !context.components.vhidDeviceHealthy { missing.append(.vhidDeviceRunning) }
         return missing
+    }
+
+    // MARK: - Input-capture failure attribution (#624)
+
+    /// Whether an input-capture failure reason is a genuine Input Monitoring
+    /// permission problem (the built-in keyboard couldn't be opened) — vs. a
+    /// grab failure that a restart, not a permission grant, fixes.
+    static func isInputCapturePermissionReason(_ reason: String?) -> Bool {
+        reason == "kanata-cannot-open-built-in-keyboard"
+    }
+
+    /// Human-readable detail for a non-permission input-capture failure, using
+    /// kanata's authoritative reason (from the InputGrab signal) when present.
+    static func inputCaptureFailureDetail(_ reason: String?) -> String {
+        guard let reason, reason != "kanata-failed-to-grab-keyboard" else {
+            return "The keyboard couldn't be captured — the input driver may have crashed, or another app may be holding the keyboard exclusively."
+        }
+        return "Reason: \(reason)."
     }
 }

--- a/Tests/KeyPathTests/InstallationWizard/SystemInspectorInputCaptureTests.swift
+++ b/Tests/KeyPathTests/InstallationWizard/SystemInspectorInputCaptureTests.swift
@@ -36,6 +36,12 @@ final class SystemInspectorInputCaptureTests: XCTestCase {
         XCTAssertEqual(state, .missingPermissions(missing: [.kanataInputMonitoring]))
     }
 
+    func testNilReason_routesToService_notPermissions() {
+        // An unknown/unpopulated reason must never be blamed on permissions.
+        let state = SystemInspector.determineState(context(inputCaptureIssue: nil))
+        XCTAssertEqual(state, .serviceNotRunning)
+    }
+
     // MARK: - Issue card
 
     func testGrabFailure_issueIsHonest_noFalseAutofix() {

--- a/Tests/KeyPathTests/InstallationWizard/SystemInspectorInputCaptureTests.swift
+++ b/Tests/KeyPathTests/InstallationWizard/SystemInspectorInputCaptureTests.swift
@@ -1,0 +1,106 @@
+@testable import KeyPathInstallationWizard
+import KeyPathWizardCore
+import XCTest
+
+/// #624: when kanata is running but not capturing input, the wizard must
+/// attribute the failure honestly — a grab failure (driver crash, another app
+/// holding the keyboard, not root) is NOT a missing permission and is fixed by
+/// restarting, not by regranting Input Monitoring.
+final class SystemInspectorInputCaptureTests: XCTestCase {
+    private func context(inputCaptureIssue: String?) -> SystemContext {
+        SystemContextBuilder(
+            permissionsStatus: .granted,
+            helperReady: true,
+            servicesHealthy: true,
+            kanataInputCaptureReady: false,
+            kanataInputCaptureIssue: inputCaptureIssue,
+            componentsInstalled: true
+        ).build()
+    }
+
+    // MARK: - State routing
+
+    func testGrabFailure_routesToService_notPermissions() {
+        let state = SystemInspector.determineState(context(inputCaptureIssue: "kanata-failed-to-grab-keyboard"))
+        XCTAssertEqual(state, .serviceNotRunning, "A grab failure must not be misrouted to the permissions page")
+    }
+
+    func testAuthoritativeReason_routesToService() {
+        // A free-text InputGrab reason from kanata is also a grab failure.
+        let state = SystemInspector.determineState(context(inputCaptureIssue: "another process has exclusive grab"))
+        XCTAssertEqual(state, .serviceNotRunning)
+    }
+
+    func testBuiltInKeyboardPermission_staysOnPermissions() {
+        let state = SystemInspector.determineState(context(inputCaptureIssue: "kanata-cannot-open-built-in-keyboard"))
+        XCTAssertEqual(state, .missingPermissions(missing: [.kanataInputMonitoring]))
+    }
+
+    // MARK: - Issue card
+
+    func testGrabFailure_issueIsHonest_noFalseAutofix() {
+        let issues = SystemInspector.generateIssues(context(inputCaptureIssue: "kanata-failed-to-grab-keyboard"))
+        guard let issue = issues.first(where: { $0.identifier == .daemon }) else {
+            return XCTFail("Expected an honest daemon issue for a grab failure")
+        }
+        XCTAssertEqual(issue.title, "Kanata Isn't Capturing Keyboard Input")
+        // No auto-fix: the existing recipes don't actually bounce the wedged
+        // kanata process, so a one-click "Restart" here would be a false remedy.
+        XCTAssertNil(issue.autoFixAction)
+        XCTAssertEqual(issue.category, .daemon)
+        XCTAssertFalse(
+            issues.contains { $0.identifier == .permission(.kanataInputMonitoring) },
+            "A grab failure must not be surfaced as a missing Input Monitoring permission"
+        )
+    }
+
+    // MARK: - Service status must not lie green on a grab failure
+
+    func testGrabFailure_serviceStatusIsFailed_notRunning() {
+        // The Service page must reflect the grab failure even though the process
+        // is up + TCP-reachable (the #624 dishonesty — and the trap of routing
+        // here without making the status honest).
+        let issues = SystemInspector.generateIssues(context(inputCaptureIssue: "kanata-failed-to-grab-keyboard"))
+        let status = ServiceStatusEvaluator.evaluate(
+            kanataIsRunning: true,
+            systemState: .serviceNotRunning,
+            issues: issues
+        )
+        guard case let .failed(message) = status else {
+            return XCTFail("Grab failure should render the service as failed, not running")
+        }
+        XCTAssertEqual(message, "Kanata Isn't Capturing Keyboard Input")
+    }
+
+    func testTimeoutWarning_doesNotBlockServiceStatus() {
+        // A warning-severity daemon issue (status-check timeout) must NOT mark the
+        // service failed — only error/critical grab failures do.
+        let warning = WizardIssue(
+            identifier: .daemon, severity: .warning, category: .daemon,
+            title: "System check timed out", description: "", autoFixAction: nil, userAction: nil
+        )
+        XCTAssertNil(ServiceStatusEvaluator.blockingIssueMessage(from: [warning]))
+    }
+
+    func testAuthoritativeReason_surfacedInDescription() throws {
+        let issues = SystemInspector.generateIssues(context(inputCaptureIssue: "not running as root"))
+        let issue = issues.first { $0.identifier == .daemon }
+        XCTAssertNotNil(issue)
+        XCTAssertTrue(try XCTUnwrap(issue?.description.contains("not running as root")), "kanata's actual reason should be surfaced")
+    }
+
+    func testBuiltInKeyboard_keepsPermissionIssue() {
+        let issues = SystemInspector.generateIssues(context(inputCaptureIssue: "kanata-cannot-open-built-in-keyboard"))
+        XCTAssertTrue(issues.contains { $0.identifier == .permission(.kanataInputMonitoring) })
+        XCTAssertFalse(issues.contains { $0.identifier == .daemon && $0.title.contains("Capturing") })
+    }
+
+    // MARK: - Helpers
+
+    func testIsInputCapturePermissionReason() {
+        XCTAssertTrue(SystemInspector.isInputCapturePermissionReason("kanata-cannot-open-built-in-keyboard"))
+        XCTAssertFalse(SystemInspector.isInputCapturePermissionReason("kanata-failed-to-grab-keyboard"))
+        XCTAssertFalse(SystemInspector.isInputCapturePermissionReason("another process has exclusive grab"))
+        XCTAssertFalse(SystemInspector.isInputCapturePermissionReason(nil))
+    }
+}

--- a/Tests/KeyPathTests/TestSupport/SystemContextBuilder.swift
+++ b/Tests/KeyPathTests/TestSupport/SystemContextBuilder.swift
@@ -10,6 +10,9 @@ struct SystemContextBuilder {
     var helperReady: Bool = true
     var servicesHealthy: Bool = false
     var kanataInputCaptureReady: Bool = true
+    /// Overrides the input-capture failure reason when not ready (defaults to
+    /// the built-in-keyboard permission reason). Used to exercise #624 attribution.
+    var kanataInputCaptureIssue: String?
     var componentsInstalled: Bool = false
     var conflicts: [SystemConflict] = []
     var driverCompatible: Bool = true
@@ -51,7 +54,7 @@ struct SystemContextBuilder {
                 vhidHealthy: true,
                 kanataInputCaptureReady: kanataInputCaptureReady,
                 kanataInputCaptureIssue: kanataInputCaptureReady
-                    ? nil : "kanata-cannot-open-built-in-keyboard"
+                    ? nil : (kanataInputCaptureIssue ?? "kanata-cannot-open-built-in-keyboard")
             )
             : HealthStatus.empty
 

--- a/Tests/KeyPathTests/TestSupport/SystemContextBuilder.swift
+++ b/Tests/KeyPathTests/TestSupport/SystemContextBuilder.swift
@@ -10,9 +10,10 @@ struct SystemContextBuilder {
     var helperReady: Bool = true
     var servicesHealthy: Bool = false
     var kanataInputCaptureReady: Bool = true
-    /// Overrides the input-capture failure reason when not ready (defaults to
-    /// the built-in-keyboard permission reason). Used to exercise #624 attribution.
-    var kanataInputCaptureIssue: String?
+    /// The input-capture failure reason surfaced when not ready (#624 attribution).
+    /// Defaults to the built-in-keyboard permission reason; set to a grab-failure
+    /// reason, or explicitly nil, to exercise the other branches.
+    var kanataInputCaptureIssue: String? = "kanata-cannot-open-built-in-keyboard"
     var componentsInstalled: Bool = false
     var conflicts: [SystemConflict] = []
     var driverCompatible: Bool = true
@@ -53,8 +54,7 @@ struct SystemContextBuilder {
                 karabinerDaemonRunning: true,
                 vhidHealthy: true,
                 kanataInputCaptureReady: kanataInputCaptureReady,
-                kanataInputCaptureIssue: kanataInputCaptureReady
-                    ? nil : (kanataInputCaptureIssue ?? "kanata-cannot-open-built-in-keyboard")
+                kanataInputCaptureIssue: kanataInputCaptureReady ? nil : kanataInputCaptureIssue
             )
             : HealthStatus.empty
 


### PR DESCRIPTION
Closes #624 (the attribution half — detection already shipped via the authoritative InputGrab signal + #632).

## Problem
When kanata is running but failed to *grab* the keyboard, status was misdiagnosed as a **missing Input Monitoring permission** ("Cannot Open Built-In Keyboard → Regrant Input Monitoring") — the wrong remedy when the real cause was a driver crash or another app holding the keyboard exclusively (the original incident). Status had stopped lying *green* (the InputGrab signal drives `inputCaptureReady=false`), but it was still **dishonest about the cause**.

## Fix — honest attribution, keyed on the failure reason
`SystemInspector` (a pure function) now branches on `kanataInputCaptureIssue`:
- `kanata-cannot-open-built-in-keyboard` → genuine permission problem → permissions page + "regrant Input Monitoring" (unchanged).
- otherwise (driver crash / exclusive grab / not root / kanata's free-text InputGrab reason) → the **service** page + a **"Kanata Isn't Capturing Keyboard Input"** issue that carries kanata's actual reason.

## Review caught two ways the first cut still lied — both fixed
1. **Service page rendered green.** `ServiceStatusEvaluator` only treated `.permission` issues as blocking, so routing here showed "Service Running" over the grab failure. Now an **error-severity `.daemon` grab issue is blocking** → the page shows *failed*. The warning-level timeout daemon issue is unaffected (the existing severity filter).
2. **The auto-fix was a no-op.** `.restartCommServer` finds SMAppService "already healthy" and never bounces the wedged kanata process, so a one-click "Restart" would be a **false remedy**. Dropped it; the issue points to a restart that actually works.

## Explicitly NOT done
- The risky **functional KeyInput-liveness detector** (the issue's "do carefully" part) — obviated by the authoritative grab signal and false-positives on every VNC session. Noted on the issue.

## Testing
`SystemInspector` and `ServiceStatusEvaluator` are pure functions — fully unit-tested across both branches: state routing, the honest issue + reason surfacing, no-false-autofix, blocking service status, and that a warning timeout doesn't block. (Real flow coverage — the gap that bit #638.)

## Follow-ups
- A real one-click kanata-kickstart restart recipe (so the issue can offer a working "Restart" button).
- Share the reason-string constants between `ServiceHealthChecker` and `SystemInspector` (currently stringly-coupled — a one-sided rename would flip attribution).

🤖 Generated with [Claude Code](https://claude.com/claude-code)