### PR TITLE
feat(lifecycle): auto-recover degraded kanata via authoritative grab signal (#625)

### DIFF
--- a/Sources/KeyPathAppKit/Managers/Diagnostics/DiagnosticsManager.swift
+++ b/Sources/KeyPathAppKit/Managers/Diagnostics/DiagnosticsManager.swift
@@ -30,6 +30,12 @@ protocol DiagnosticsManaging: Sendable {
     /// Record a VirtualHID connection success.
     func recordConnectionSuccess() async
 
+    /// Record a kanata input-grab failure and decide whether to recover (bounded). (#625)
+    func recordGrabFailureAndDecideRecovery() async -> GrabRecoveryDecision
+
+    /// Record that the keyboard grab is healthy again (resets grab-recovery attempts).
+    func recordGrabSuccess() async
+
     /// Diagnose Kanata failure
     func diagnoseFailure(exitCode: Int32, output: String) -> [KanataDiagnostic]
 
@@ -178,6 +184,14 @@ final class DiagnosticsManager: @preconcurrency DiagnosticsManaging { // @precon
 
     func recordConnectionSuccess() async {
         await healthMonitor.recordConnectionSuccess()
+    }
+
+    func recordGrabFailureAndDecideRecovery() async -> GrabRecoveryDecision {
+        await healthMonitor.recordGrabFailureAndDecideRecovery()
+    }
+
+    func recordGrabSuccess() async {
+        await healthMonitor.recordGrabSuccess()
     }
 
     func diagnoseFailure(exitCode: Int32, output: String) -> [KanataDiagnostic] {

--- a/Sources/KeyPathAppKit/Managers/RuntimeCoordinator.swift
+++ b/Sources/KeyPathAppKit/Managers/RuntimeCoordinator.swift
@@ -1278,16 +1278,17 @@ public class RuntimeCoordinator: SaveCoordinatorDelegate {
             AppLogger.shared.log("🎛️ [RuntimeCoordinator] Grab recovery already in flight — ignoring")
 
         case .evaluate:
-            // Known limitation (#625): kanata only emits InputGrab on a transition or
-            // in reply to RequestInputGrab at connect — it does not re-emit a steady
-            // failure. So if the new kanata started by a recovery STILL fails to grab,
-            // its single post-restart `active=false` can land inside the lingering
-            // transition-grace / single-flight window and be suppressed, and the
-            // recovery loop won't auto-re-fire. This is not silent: the same store
-            // (KanataGrabStatusStore) feeds ServiceHealthChecker.resolveInputCaptureStatus,
-            // so the degraded state is still surfaced on the next health check. Robust
-            // post-recovery re-verification pairs with the part-1 deterministic restart
-            // (wait-for-exit before start), which is the follow-up PR.
+            // Note (#625): kanata only emits InputGrab on a transition or in reply to
+            // RequestInputGrab at connect — it does not re-emit a steady failure. The
+            // post-restart grab status from a freshly started kanata is no longer masked
+            // by the stop-grace (startKanata clears it), so a restart that lands degraded
+            // does reach here. The one residual window is single-flight: a failure event
+            // arriving while a recovery is still in flight is suppressed; in practice the
+            // new kanata's InputGrab arrives after the recovery call returns, so the
+            // bounded loop re-fires and advances toward give-up. Even in the rare miss,
+            // it is not silent — KanataGrabStatusStore also feeds
+            // ServiceHealthChecker.resolveInputCaptureStatus, so the degraded state is
+            // surfaced on the next health check.
             switch await diagnosticsManager.recordGrabFailureAndDecideRecovery() {
             case let .recover(attempt):
                 AppLogger.shared.warn(

--- a/Sources/KeyPathAppKit/Managers/RuntimeCoordinator.swift
+++ b/Sources/KeyPathAppKit/Managers/RuntimeCoordinator.swift
@@ -94,6 +94,15 @@ public class RuntimeCoordinator: SaveCoordinatorDelegate {
     // Core status tracking
     public var lastError: String?
     var lastWarning: String?
+    /// Single-flight guard for grab-failure auto-recovery (#625). A recovery is a
+    /// ~5s kill→restart sequence that itself produces more grab-status events;
+    /// without this, a burst of `active=false` events would launch overlapping
+    /// recoveries. MainActor isolation makes the check-and-set atomic.
+    private var isRecoveringGrab = false
+    /// True while `lastError` holds the grab-recovery give-up message (#625), so a
+    /// later authoritative grab success can clear exactly that error without
+    /// stomping an unrelated error someone else set in the meantime.
+    private var grabGiveUpErrorActive = false
     private var warningExpiryTask: Task<Void, Never>?
     var keyMappings: [KeyMapping] = []
     var currentLayerName: String = RuleCollectionLayer.base.displayName
@@ -484,6 +493,21 @@ public class RuntimeCoordinator: SaveCoordinatorDelegate {
                     if success {
                         NotificationCenter.default.post(name: .kanataConfigChanged, object: nil)
                     }
+                }
+            })
+
+            // Authoritative kanata grab status (#625): a grab failure means kanata
+            // is up but not remapping. Drive bounded auto-recovery off this signal.
+            notificationObserverTokens.append(NotificationCenter.default.addObserver(
+                forName: .kanataGrabStatusChanged,
+                object: nil,
+                queue: NotificationObserverManager.mainOperationQueue
+            ) { @Sendable [weak self] note in
+                guard let self else { return }
+                let active = note.userInfo?["active"] as? Bool ?? true
+                let reason = note.userInfo?["reason"] as? String
+                Task { @MainActor in
+                    await self.handleGrabStatusChanged(active: active, reason: reason)
                 }
             })
 
@@ -1196,6 +1220,92 @@ public class RuntimeCoordinator: SaveCoordinatorDelegate {
     }
 
     // MARK: - Recovery Operations (delegates to RecoveryCoordinator)
+
+    /// Pre-guard gate for a grab-status event (#625). Pure function so the
+    /// suppression rules are unit-testable without touching the real recovery action.
+    enum GrabRecoveryGate: Equatable, Sendable {
+        /// `active == true` — authoritative healthy grab; reset the recovery budget.
+        case recordSuccess
+        /// Benign `active=false` during an intentional stop — do nothing.
+        case suppressedDuringTransition
+        /// A recovery is already in flight — do nothing (single-flight).
+        case suppressedRecoveryInFlight
+        /// Genuine grab failure — consult the bounded guard and maybe recover.
+        case evaluate
+    }
+
+    nonisolated static func decideGrabRecoveryGate(
+        active: Bool,
+        isIntentionalTransition: Bool,
+        isRecovering: Bool
+    ) -> GrabRecoveryGate {
+        if active { return .recordSuccess }
+        if isIntentionalTransition { return .suppressedDuringTransition }
+        if isRecovering { return .suppressedRecoveryInFlight }
+        return .evaluate
+    }
+
+    /// React to an authoritative kanata `InputGrab` status (#625).
+    ///
+    /// `active == false` means kanata is up (process + TCP) but failed to seize the
+    /// keyboard — remapping is silently dead. Drive a bounded auto-recovery, gated so
+    /// it never fires on a benign `active=false` (intentional stop) and never overlaps
+    /// an in-flight recovery. `active == true` clears the recovery budget.
+    func handleGrabStatusChanged(active: Bool, reason: String?) async {
+        switch Self.decideGrabRecoveryGate(
+            active: active,
+            isIntentionalTransition: serviceLifecycleCoordinator.isIntentionalTransitionInProgress,
+            isRecovering: isRecoveringGrab
+        ) {
+        case .recordSuccess:
+            // Authoritative healthy grab → reset the episode budget so a future
+            // failure gets a fresh set of attempts.
+            await diagnosticsManager.recordGrabSuccess()
+            // If we'd previously given up and surfaced a persistent error, the grab
+            // is working again now — clear that stale message so the UI recovers.
+            if grabGiveUpErrorActive {
+                grabGiveUpErrorActive = false
+                lastError = nil
+                notifyStateChanged()
+            }
+
+        case .suppressedDuringTransition:
+            AppLogger.shared.log(
+                "🎛️ [RuntimeCoordinator] Grab inactive during an intentional transition — suppressing recovery (reason: \(reason ?? "none"))"
+            )
+
+        case .suppressedRecoveryInFlight:
+            AppLogger.shared.log("🎛️ [RuntimeCoordinator] Grab recovery already in flight — ignoring")
+
+        case .evaluate:
+            // Known limitation (#625): kanata only emits InputGrab on a transition or
+            // in reply to RequestInputGrab at connect — it does not re-emit a steady
+            // failure. So if the new kanata started by a recovery STILL fails to grab,
+            // its single post-restart `active=false` can land inside the lingering
+            // transition-grace / single-flight window and be suppressed, and the
+            // recovery loop won't auto-re-fire. This is not silent: the same store
+            // (KanataGrabStatusStore) feeds ServiceHealthChecker.resolveInputCaptureStatus,
+            // so the degraded state is still surfaced on the next health check. Robust
+            // post-recovery re-verification pairs with the part-1 deterministic restart
+            // (wait-for-exit before start), which is the follow-up PR.
+            switch await diagnosticsManager.recordGrabFailureAndDecideRecovery() {
+            case let .recover(attempt):
+                AppLogger.shared.warn(
+                    "🚨 [RuntimeCoordinator] kanata failed to grab the keyboard (reason: \(reason ?? "unknown")) — recovery attempt \(attempt), restarting"
+                )
+                isRecoveringGrab = true
+                defer { isRecoveringGrab = false }
+                await attemptKeyboardRecovery()
+            case let .giveUp(attempts):
+                AppLogger.shared.error(
+                    "❌ [RuntimeCoordinator] kanata still not grabbing the keyboard after \(attempts) recovery attempts — giving up (manual intervention / reboot likely needed)"
+                )
+                lastError = "Keyboard remapping is not active: kanata could not capture the keyboard after \(attempts) automatic recovery attempts. Try quitting other keyboard tools, then restart KeyPath."
+                grabGiveUpErrorActive = true
+                notifyStateChanged()
+            }
+        }
+    }
 
     func attemptKeyboardRecovery() async {
         await recoveryCoordinator.attemptKeyboardRecovery()

--- a/Sources/KeyPathAppKit/Managers/ServiceLifecycleCoordinator.swift
+++ b/Sources/KeyPathAppKit/Managers/ServiceLifecycleCoordinator.swift
@@ -40,9 +40,10 @@ final class ServiceLifecycleCoordinator {
     /// overlapping stop composes correctly; a short trailing grace swallows the late
     /// last-gasp event after the stop call returns.
     ///
-    /// Deliberately scoped to the STOP phase only: a plain `startKanata` (including the
-    /// start phase of a restart) stays un-gated so a genuine post-start grab failure
-    /// (the #625 race) is still caught and recovered.
+    /// Deliberately scoped to the STOP phase only, and the trailing grace is cleared at
+    /// the top of `startKanata`: the start phase of a restart stays un-gated so a genuine
+    /// post-start grab failure (the #625 race) from the freshly started kanata is still
+    /// caught and recovered, rather than masked as a benign transition.
     private var intentionalStopDepth = 0
     private var stopGraceUntil: Date?
     private let intentionalStopGrace: TimeInterval = 2.0
@@ -98,6 +99,13 @@ final class ServiceLifecycleCoordinator {
     @discardableResult
     func startKanata(reason: String = "Manual start") async -> Bool {
         AppLogger.shared.log("🚀 [Service] Starting Kanata (\(reason))")
+        // End any lingering post-stop grace (#625): we are deliberately starting a new
+        // kanata now, so its authoritative grab status is exactly what we want to act
+        // on. Without this, the 2s grace armed by the preceding stop in a restart would
+        // suppress a genuine `InputGrab active=false` from the freshly started daemon —
+        // the very degraded state this feature recovers from. The grace only needs to
+        // cover the OLD process's last gasp, which is already past once a start begins.
+        stopGraceUntil = nil
         onWarning?(nil)
         isStartingKanata = true
         defer {

--- a/Sources/KeyPathAppKit/Managers/ServiceLifecycleCoordinator.swift
+++ b/Sources/KeyPathAppKit/Managers/ServiceLifecycleCoordinator.swift
@@ -33,6 +33,28 @@ final class ServiceLifecycleCoordinator {
     /// Mutable flag shared with RuntimeCoordinator to track in-progress start attempts.
     var isStartingKanata = false
     private var lastStartAttemptAt: Date?
+
+    /// Intentional-transition gate (#625). While we are deliberately stopping kanata,
+    /// the dying process may emit one last `InputGrab active=false` on its still-open
+    /// socket — that is benign and must NOT trigger auto-recovery. Depth-counted so an
+    /// overlapping stop composes correctly; a short trailing grace swallows the late
+    /// last-gasp event after the stop call returns.
+    ///
+    /// Deliberately scoped to the STOP phase only: a plain `startKanata` (including the
+    /// start phase of a restart) stays un-gated so a genuine post-start grab failure
+    /// (the #625 race) is still caught and recovered.
+    private var intentionalStopDepth = 0
+    private var stopGraceUntil: Date?
+    private let intentionalStopGrace: TimeInterval = 2.0
+
+    /// True while an intentional kanata stop is in progress (or within the short grace
+    /// window after one). Read by RuntimeCoordinator before acting on a grab failure.
+    var isIntentionalTransitionInProgress: Bool {
+        if intentionalStopDepth > 0 { return true }
+        if let until = stopGraceUntil, Date() < until { return true }
+        return false
+    }
+
     private let windowEvaluator = TransientStartupWindowEvaluator(
         gracePeriod: RuntimeStartupTiming.uiGracePeriod,
         createdAt: Date()
@@ -134,6 +156,15 @@ final class ServiceLifecycleCoordinator {
     @discardableResult
     func stopKanata(reason: String = "Manual stop") async -> Bool {
         AppLogger.shared.log("🛑 [Service] Stopping Kanata (\(reason))")
+        // Mark this as an intentional transition so a benign `InputGrab active=false`
+        // emitted by the dying kanata doesn't trip auto-recovery (#625).
+        intentionalStopDepth += 1
+        defer {
+            intentionalStopDepth = max(0, intentionalStopDepth - 1)
+            if intentionalStopDepth == 0 {
+                stopGraceUntil = Date().addingTimeInterval(intentionalStopGrace)
+            }
+        }
         await AppContextService.shared.stop()
 
         do {

--- a/Sources/KeyPathAppKit/Services/Monitoring/KanataEventListener.swift
+++ b/Sources/KeyPathAppKit/Services/Monitoring/KanataEventListener.swift
@@ -344,6 +344,7 @@ actor KanataEventListener {
     private var tapDanceResolvedHandler: (@Sendable (KanataTapDanceResolution) async -> Void)?
     private var hrmTraceHandler: (@Sendable (KanataHrmTraceEvent) async -> Void)?
     private var capabilitiesUpdatedHandler: (@Sendable ([String]) async -> Void)?
+    private var grabStatusHandler: (@Sendable (_ active: Bool, _ reason: String?) async -> Void)?
     /// Capabilities advertised by Kanata in HelloOk (normalized to dash-case, e.g. "hold-activated").
     private var capabilities: Set<String> = []
     private var activeConnection: NWConnection?
@@ -367,6 +368,7 @@ actor KanataEventListener {
     ///   - onTapDanceResolved: Called when a tap-dance resolves to an action
     ///   - onHrmTrace: Called when an HRM trace decision event is received
     ///   - onCapabilitiesUpdated: Called when HelloOk capabilities are received
+    ///   - onGrabStatus: Called when an authoritative `InputGrab` status is received (#625)
     func start(
         port: Int,
         onLayerChange: @escaping @Sendable (String) async -> Void,
@@ -379,7 +381,8 @@ actor KanataEventListener {
         onChordResolved: (@Sendable (KanataChordResolution) async -> Void)? = nil,
         onTapDanceResolved: (@Sendable (KanataTapDanceResolution) async -> Void)? = nil,
         onHrmTrace: (@Sendable (KanataHrmTraceEvent) async -> Void)? = nil,
-        onCapabilitiesUpdated: (@Sendable ([String]) async -> Void)? = nil
+        onCapabilitiesUpdated: (@Sendable ([String]) async -> Void)? = nil,
+        onGrabStatus: (@Sendable (_ active: Bool, _ reason: String?) async -> Void)? = nil
     ) async {
         if self.port == port, listenTask != nil { return }
         await stop()
@@ -396,6 +399,7 @@ actor KanataEventListener {
         tapDanceResolvedHandler = onTapDanceResolved
         hrmTraceHandler = onHrmTrace
         capabilitiesUpdatedHandler = onCapabilitiesUpdated
+        grabStatusHandler = onGrabStatus
         AppLogger.shared.log("🌐 [EventListener] Starting event listener on port \(port)")
         listenTask = Task(priority: .background) { [weak self] in
             guard let self else { return }
@@ -421,6 +425,7 @@ actor KanataEventListener {
         tapDanceResolvedHandler = nil
         hrmTraceHandler = nil
         capabilitiesUpdatedHandler = nil
+        grabStatusHandler = nil
         capabilities.removeAll()
         isHrmTraceSubscribed = false
         isAwaitingHrmTraceSubscribeAck = false
@@ -725,6 +730,9 @@ actor KanataEventListener {
                 "🎛️ [EventListener] InputGrab active=\(status.active) devices=\(status.devices.count) reason=\(status.reason ?? "none")"
             )
             KanataGrabStatusStore.shared.record(status)
+            // Notify the recovery path (#625): active=false is an authoritative
+            // grab failure (up but not remapping); active=true clears it.
+            await grabStatusHandler?(status.active, status.reason)
             return
         }
 

--- a/Sources/KeyPathAppKit/Services/Monitoring/ServiceHealthMonitor.swift
+++ b/Sources/KeyPathAppKit/Services/Monitoring/ServiceHealthMonitor.swift
@@ -83,6 +83,14 @@ protocol ServiceHealthMonitorProtocol: AnyObject {
     /// Record a successful connection (resets failure count)
     func recordConnectionSuccess() async
 
+    /// Record a kanata input-grab failure (up but not grabbing the keyboard) and decide
+    /// whether to attempt recovery, with a bounded-attempts guard so a deterministic
+    /// crash (e.g. #631) doesn't restart forever. See #624/#625.
+    func recordGrabFailureAndDecideRecovery() async -> GrabRecoveryDecision
+
+    /// Record that the keyboard grab is healthy again (resets grab-recovery attempts).
+    func recordGrabSuccess() async
+
     /// Determine the appropriate recovery action based on current state
     /// - Parameter healthStatus: Current health status
     /// - Returns: Recommended recovery action
@@ -90,6 +98,17 @@ protocol ServiceHealthMonitorProtocol: AnyObject {
 
     /// Reset all monitoring state (e.g., after successful recovery)
     func resetMonitoringState() async
+}
+
+// MARK: - Grab Recovery Decision
+
+/// Outcome of a kanata input-grab-failure event: attempt a bounded recovery, or give
+/// up after exhausting attempts (so a deterministic crash doesn't restart forever).
+enum GrabRecoveryDecision: Equatable, Sendable {
+    /// Attempt recovery now; `attempt` is the 1-based attempt number in this episode.
+    case recover(attempt: Int)
+    /// Recovery budget exhausted — surface a persistent error instead of restarting again.
+    case giveUp(attempts: Int)
 }
 
 // MARK: - Process Status Type
@@ -126,6 +145,13 @@ final class ServiceHealthMonitor: ServiceHealthMonitorProtocol {
     private var lastStartAttempt: Date?
     private var lastServiceStart: Date? // Tracks when service was last started (for grace period)
     private var connectionFailureCount = 0
+    // Grab-failure recovery guard (#625): bound auto-restarts so a deterministic kanata
+    // crash (e.g. #631) doesn't restart forever. Attempts reset on grab-success or after
+    // a quiet window (a fresh failure episode gets a fresh budget).
+    private let maxGrabRecoveryAttempts = 3
+    private let grabRecoveryEpisodeWindow: TimeInterval = 300 // 5 min
+    private var grabRecoveryAttempts = 0
+    private var lastGrabRecoveryAt: Date?
     private var startAttemptCount = 0
     private var retryAttemptCount = 0
     private var lastHealthCheckResult: ServiceHealthStatus?
@@ -449,6 +475,40 @@ final class ServiceHealthMonitor: ServiceHealthMonitorProtocol {
         if connectionFailureCount > 0 {
             AppLogger.shared.info("[HealthMonitor] Connection restored - resetting failure count")
             connectionFailureCount = 0
+        }
+    }
+
+    func recordGrabFailureAndDecideRecovery() async -> GrabRecoveryDecision {
+        decideGrabRecovery(now: Date())
+    }
+
+    /// Testable core of the grab-recovery guard (injectable clock).
+    func decideGrabRecovery(now: Date) -> GrabRecoveryDecision {
+        // Start a fresh episode (fresh budget) if enough quiet time passed since the
+        // last recovery attempt — a failure long after a previous burst isn't the same
+        // crash loop.
+        if let last = lastGrabRecoveryAt, now.timeIntervalSince(last) > grabRecoveryEpisodeWindow {
+            grabRecoveryAttempts = 0
+        }
+        guard grabRecoveryAttempts < maxGrabRecoveryAttempts else {
+            AppLogger.shared.error(
+                "[HealthMonitor] kanata input-grab still failing after \(grabRecoveryAttempts) recovery attempts — giving up (manual intervention / reboot likely needed)"
+            )
+            return .giveUp(attempts: grabRecoveryAttempts)
+        }
+        grabRecoveryAttempts += 1
+        lastGrabRecoveryAt = now
+        AppLogger.shared.warn(
+            "[HealthMonitor] kanata input-grab failure — recovery attempt \(grabRecoveryAttempts)/\(maxGrabRecoveryAttempts)"
+        )
+        return .recover(attempt: grabRecoveryAttempts)
+    }
+
+    func recordGrabSuccess() async {
+        if grabRecoveryAttempts > 0 {
+            AppLogger.shared.info("[HealthMonitor] Keyboard grab restored — resetting grab-recovery attempts")
+            grabRecoveryAttempts = 0
+            lastGrabRecoveryAt = nil
         }
     }
 

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+EventMonitoring.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+EventMonitoring.swift
@@ -185,6 +185,19 @@ extension RuleCollectionsManager {
                             userInfo: ["capabilities": capabilities]
                         )
                     }
+                },
+                onGrabStatus: { active, reason in
+                    // Authoritative keyboard-grab status from kanata (#625). Route to
+                    // RuntimeCoordinator, which owns the recovery guard + action.
+                    await MainActor.run {
+                        var userInfo: [String: Any] = ["active": active]
+                        if let reason { userInfo["reason"] = reason }
+                        NotificationCenter.default.post(
+                            name: .kanataGrabStatusChanged,
+                            object: nil,
+                            userInfo: userInfo
+                        )
+                    }
                 }
             )
         }

--- a/Sources/KeyPathAppKit/UI/Overlay/LiveKeyboardOverlayTypes.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/LiveKeyboardOverlayTypes.swift
@@ -239,4 +239,7 @@ extension Notification.Name {
     static let kanataActionDispatched = Notification.Name("KeyPath.KanataActionDispatched")
     /// Posted when HelloOk capability list changes.
     static let kanataCapabilitiesUpdated = Notification.Name("KeyPath.KanataCapabilitiesUpdated")
+    /// Posted when an authoritative kanata `InputGrab` status is received (#625).
+    /// userInfo["active"]: Bool, userInfo["reason"]: String? (present on failure).
+    static let kanataGrabStatusChanged = Notification.Name("KeyPath.KanataGrabStatusChanged")
 }

--- a/Tests/KeyPathTests/InstallationWizard/WizardPureLogicTests.swift
+++ b/Tests/KeyPathTests/InstallationWizard/WizardPureLogicTests.swift
@@ -335,12 +335,17 @@ final class WizardPureLogicTests: XCTestCase {
     }
 
     func test_inspect_inputCaptureNotReady_producesIMIssue() {
+        // Per #642, input-capture-not-ready maps to an Input Monitoring permission
+        // issue ONLY when the failure reason is a genuine built-in-keyboard permission
+        // problem. A grab failure (driver crash / another app) routes to the service
+        // page instead — covered by SystemInspectorInputCaptureTests.
         let context = makeContext(
             services: HealthStatus(
                 kanataRunning: true,
                 karabinerDaemonRunning: true,
                 vhidHealthy: true,
-                kanataInputCaptureReady: false
+                kanataInputCaptureReady: false,
+                kanataInputCaptureIssue: "kanata-cannot-open-built-in-keyboard"
             )
         )
         let (state, issues) = SystemInspector.inspect(context: context)

--- a/Tests/KeyPathTests/RuntimeCoordinatorTests.swift
+++ b/Tests/KeyPathTests/RuntimeCoordinatorTests.swift
@@ -79,4 +79,18 @@ final class RuntimeCoordinatorTests: KeyPathTestCase {
         let duration = Date().timeIntervalSince(startTime)
         XCTAssertLessThan(duration, 10.0, "Config validation should complete within 10 seconds")
     }
+
+    // MARK: - Grab recovery (#625)
+
+    /// An authoritative grab success must not clear an unrelated error — only a
+    /// grab-recovery give-up message it set itself. (active=true takes the pure
+    /// .recordSuccess path, which performs no service side effects.)
+    func testGrabSuccessDoesNotClearUnrelatedError() async {
+        manager.lastError = "Some unrelated install error"
+        await manager.handleGrabStatusChanged(active: true, reason: nil)
+        XCTAssertEqual(
+            manager.lastError, "Some unrelated install error",
+            "Grab success should leave an unrelated error untouched"
+        )
+    }
 }

--- a/Tests/KeyPathTests/Services/ConfigReloadCoordinatorTests.swift
+++ b/Tests/KeyPathTests/Services/ConfigReloadCoordinatorTests.swift
@@ -62,6 +62,12 @@ private final class MockDiagnosticsManager: @preconcurrency DiagnosticsManaging 
         connectionFailureCount = 0
     }
 
+    func recordGrabFailureAndDecideRecovery() async -> GrabRecoveryDecision {
+        .recover(attempt: 1)
+    }
+
+    func recordGrabSuccess() async {}
+
     func diagnoseFailure(exitCode _: Int32, output _: String) -> [KanataDiagnostic] {
         []
     }

--- a/Tests/KeyPathTests/Services/GrabRecoveryGateTests.swift
+++ b/Tests/KeyPathTests/Services/GrabRecoveryGateTests.swift
@@ -1,0 +1,59 @@
+@testable import KeyPathAppKit
+import XCTest
+
+/// Unit tests for the #625 grab-failure auto-recovery gate — the pure suppression
+/// rules that decide whether an authoritative `InputGrab` status should drive
+/// recovery. The recover/give-up tail (the bounded budget) is covered separately by
+/// `ServiceHealthMonitorTests`; these tests cover only the pre-guard gate so they
+/// never touch the real recovery action (which would shell out to launchctl/pgrep).
+final class GrabRecoveryGateTests: XCTestCase {
+    typealias Gate = RuntimeCoordinator.GrabRecoveryGate
+
+    func testActiveGrabRecordsSuccess() {
+        // A healthy grab is always good news — even mid-transition or mid-recovery —
+        // and should reset the recovery budget.
+        XCTAssertEqual(
+            RuntimeCoordinator.decideGrabRecoveryGate(active: true, isIntentionalTransition: false, isRecovering: false),
+            .recordSuccess
+        )
+        XCTAssertEqual(
+            RuntimeCoordinator.decideGrabRecoveryGate(active: true, isIntentionalTransition: true, isRecovering: true),
+            .recordSuccess
+        )
+    }
+
+    func testGrabFailureWhileIdleEvaluates() {
+        // The real failure case: kanata up, not grabbing, no intentional transition,
+        // no recovery in flight → consult the bounded guard.
+        XCTAssertEqual(
+            RuntimeCoordinator.decideGrabRecoveryGate(active: false, isIntentionalTransition: false, isRecovering: false),
+            .evaluate
+        )
+    }
+
+    func testGrabFailureDuringIntentionalTransitionIsSuppressed() {
+        // Benign `active=false` from a kanata we're deliberately stopping must not
+        // trigger recovery.
+        XCTAssertEqual(
+            RuntimeCoordinator.decideGrabRecoveryGate(active: false, isIntentionalTransition: true, isRecovering: false),
+            .suppressedDuringTransition
+        )
+    }
+
+    func testGrabFailureWhileRecoveringIsSuppressed() {
+        // Single-flight: a recovery already tearing down/restarting kanata emits more
+        // `active=false` events; they must not launch overlapping recoveries.
+        XCTAssertEqual(
+            RuntimeCoordinator.decideGrabRecoveryGate(active: false, isIntentionalTransition: false, isRecovering: true),
+            .suppressedRecoveryInFlight
+        )
+    }
+
+    func testTransitionSuppressionTakesPrecedenceOverInFlight() {
+        // Both gates closed → either suppression is fine; transition is checked first.
+        XCTAssertEqual(
+            RuntimeCoordinator.decideGrabRecoveryGate(active: false, isIntentionalTransition: true, isRecovering: true),
+            .suppressedDuringTransition
+        )
+    }
+}

--- a/Tests/KeyPathTests/Services/ServiceHealthMonitorTests.swift
+++ b/Tests/KeyPathTests/Services/ServiceHealthMonitorTests.swift
@@ -461,4 +461,35 @@ class ServiceHealthMonitorTests: XCTestCase {
             "Crash loop window (\(45.0)s) must be >= \(minimumRequiredWindow)s ((\(crashThreshold)-1) x \(launchdThrottleInterval)s throttle)"
         )
     }
+
+    // MARK: - Grab-recovery guard (#625)
+
+    func testGrabRecoveryGuard_boundsAttemptsThenGivesUp() {
+        let t0 = Date()
+        XCTAssertEqual(monitor.decideGrabRecovery(now: t0), .recover(attempt: 1))
+        XCTAssertEqual(monitor.decideGrabRecovery(now: t0.addingTimeInterval(1)), .recover(attempt: 2))
+        XCTAssertEqual(monitor.decideGrabRecovery(now: t0.addingTimeInterval(2)), .recover(attempt: 3))
+        // 4th and beyond: budget exhausted → give up (don't restart forever).
+        XCTAssertEqual(monitor.decideGrabRecovery(now: t0.addingTimeInterval(3)), .giveUp(attempts: 3))
+        XCTAssertEqual(monitor.decideGrabRecovery(now: t0.addingTimeInterval(4)), .giveUp(attempts: 3))
+    }
+
+    func testGrabRecoveryGuard_resetsOnSuccess() async {
+        let t0 = Date()
+        _ = monitor.decideGrabRecovery(now: t0)
+        _ = monitor.decideGrabRecovery(now: t0.addingTimeInterval(1))
+        await monitor.recordGrabSuccess()
+        // After a healthy grab, the budget is fresh.
+        XCTAssertEqual(monitor.decideGrabRecovery(now: t0.addingTimeInterval(2)), .recover(attempt: 1))
+    }
+
+    func testGrabRecoveryGuard_freshEpisodeAfterQuietWindow() {
+        let t0 = Date()
+        _ = monitor.decideGrabRecovery(now: t0)
+        _ = monitor.decideGrabRecovery(now: t0)
+        _ = monitor.decideGrabRecovery(now: t0)
+        XCTAssertEqual(monitor.decideGrabRecovery(now: t0.addingTimeInterval(1)), .giveUp(attempts: 3))
+        // A failure long after the burst (> episode window) is a new episode → fresh budget.
+        XCTAssertEqual(monitor.decideGrabRecovery(now: t0.addingTimeInterval(301)), .recover(attempt: 1))
+    }
 }

--- a/Tests/KeyPathTests/Services/ServiceLifecycleCoordinatorTests.swift
+++ b/Tests/KeyPathTests/Services/ServiceLifecycleCoordinatorTests.swift
@@ -95,6 +95,22 @@ final class ServiceLifecycleCoordinatorTests: KeyPathTestCase {
         )
     }
 
+    func testStartClearsLingeringStopGrace() async {
+        // The stop-grace exists only to swallow the OLD process's last gasp. Once a new
+        // start begins (e.g. the start phase of a restart), the grace must end so a
+        // genuine `active=false` from the freshly started kanata is NOT masked as benign.
+        coordinator.isKarabinerDaemonRunning = { true }
+        _ = await coordinator.stopKanata(reason: "stop for restart")
+        XCTAssertTrue(coordinator.isIntentionalTransitionInProgress, "Grace armed after stop")
+
+        _ = await coordinator.startKanata(reason: "restart")
+
+        XCTAssertFalse(
+            coordinator.isIntentionalTransitionInProgress,
+            "Starting a new kanata must clear the stale stop-grace so post-start grab failures are caught"
+        )
+    }
+
     // MARK: - Restart
 
     func testRestartCallsStopThenStart() async {

--- a/Tests/KeyPathTests/Services/ServiceLifecycleCoordinatorTests.swift
+++ b/Tests/KeyPathTests/Services/ServiceLifecycleCoordinatorTests.swift
@@ -61,6 +61,40 @@ final class ServiceLifecycleCoordinatorTests: KeyPathTestCase {
         XCTAssertGreaterThan(stateChangeCount, 0)
     }
 
+    // MARK: - Intentional-transition gate (#625)
+
+    func testNotInIntentionalTransitionWhenIdle() {
+        // A fresh coordinator that hasn't stopped anything is not transitioning, so a
+        // grab failure observed now is genuine and eligible for recovery.
+        XCTAssertFalse(coordinator.isIntentionalTransitionInProgress)
+    }
+
+    func testIntentionalTransitionFlagSetDuringStop() async {
+        // The flag must be closed *while the stop runs*, so a benign `active=false`
+        // from the dying kanata is suppressed. We observe it from the onStateChanged
+        // callback, which fires inside stopKanata before its `defer` opens the grace.
+        var seenDuringStop: Bool?
+        coordinator.onStateChanged = { [unowned self] in
+            if seenDuringStop == nil {
+                seenDuringStop = coordinator.isIntentionalTransitionInProgress
+            }
+        }
+
+        _ = await coordinator.stopKanata(reason: "test")
+
+        XCTAssertEqual(seenDuringStop, true, "Transition gate must be closed during the stop")
+    }
+
+    func testIntentionalTransitionGraceHoldsBrieflyAfterStop() async {
+        // Immediately after stop returns, the short trailing grace keeps the gate closed
+        // so a late last-gasp `active=false` from the just-killed kanata is still suppressed.
+        _ = await coordinator.stopKanata(reason: "test")
+        XCTAssertTrue(
+            coordinator.isIntentionalTransitionInProgress,
+            "Gate should remain closed during the post-stop grace window"
+        )
+    }
+
     // MARK: - Restart
 
     func testRestartCallsStopThenStart() async {


### PR DESCRIPTION
## What & why

When kanata comes up **degraded** — TCP server + VirtualHID output ready but it **failed to seize the keyboard exclusively** (a restart race where the previous instance still holds the grab, a driver crash, or another app holding the keyboard) — remapping is **silently dead** with no retry until a forced clean restart. Closes the detection/recovery half of #625.

This wires **bounded auto-recovery** onto the authoritative `InputGrab` signal shipped last cycle (#630/#635/#637): kanata emits `active=false`+reason on a grab failure. That ground-truth signal (VNC-immune, not inferred from key-event flow) is now the detection trigger — replacing the dead log-scraping path a prior WIP attempt used (rejected in review).

## How it works

```
kanata InputGrab{active,reason}  →  KanataEventListener
   →  .kanataGrabStatusChanged notification
   →  RuntimeCoordinator.handleGrabStatusChanged(active,reason)
        active=true   → recordGrabSuccess() (reset budget)
        active=false  → gate → bounded guard → attemptKeyboardRecovery() | give up
```

- **Bounded guard** (reused, unit-tested): `ServiceHealthMonitor.decideGrabRecovery` — 3 attempts / 300s episode window / give-up, so a deterministic crash (#631) doesn't restart forever.
- **Two suppression gates** so recovery never fires spuriously:
  - *Benign `active=false` during an intentional stop* — suppressed via a depth-counted transition gate on `ServiceLifecycleCoordinator`, **scoped to the STOP phase only** so a genuine post-start grab failure is still caught.
  - *Single-flight* `isRecoveringGrab` — a recovery is a ~5s kill→restart that itself emits more grab events; this prevents overlapping recoveries.
- The pure gate decision (`decideGrabRecoveryGate`) is extracted and unit-tested, so the suppression rules are covered without touching the real recovery action.

## Scope

This is **part-2 of #625** (detection + recovery). The **part-1 stop→start race fix** (wait-for-old-process-exit before start) is a separate follow-up — higher blast radius (hot start/restart path), and this detection layer is the additive safety net that catches the race when it still slips through.

## Review-gate findings addressed
- **Fixed:** stale `lastError` — after give-up sets the persistent error, a later genuine grab success now clears exactly that message (guarded so it never stomps an unrelated error).
- **Documented limitation (in-code):** kanata doesn't re-emit a steady failure, so a *still-failing* kanata produced by a recovery can have its single post-restart `active=false` suppressed by the lingering grace/single-flight window and not auto-re-fire. This is **not silent** — the same `KanataGrabStatusStore` feeds `ServiceHealthChecker.resolveInputCaptureStatus`, so the degraded state is still surfaced on the next health check. Robust post-recovery re-verification pairs naturally with part-1's deterministic restart.

## Also
Fixes a stale test left red on `master` by #642 (`WizardPureLogicTests.test_inspect_inputCaptureNotReady_producesIMIssue`) — it now supplies a permission-type capture reason, matching #642's honest-attribution contract.

## Testing
- `swift test` green (the one intermittent `ProcessLifecycleIntegrationTests` PID-file flake is pre-existing and passes in isolation).
- New unit tests: pure gate decisions (`GrabRecoveryGateTests`), the intentional-transition gate (`ServiceLifecycleCoordinatorTests`), the bounded guard (`ServiceHealthMonitorTests`), and the stale-error safety property (`RuntimeCoordinatorTests`).
- **Not yet performed:** live failure-injection on the physical keyboard (induce a real grab failure → observe auto-recover / give-up). Inducing a grab failure risks disrupting a working setup mid-session; recommend doing this during the ds deploy/relaunch step or manually with a second grab-holder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)