### PR TITLE
feat(lifecycle): wait for kanata exit before start to fix stop→start race (#625 part-1)

### DIFF
--- a/Sources/KeyPathAppKit/Managers/ServiceLifecycleCoordinator.swift
+++ b/Sources/KeyPathAppKit/Managers/ServiceLifecycleCoordinator.swift
@@ -54,7 +54,7 @@ final class ServiceLifecycleCoordinator {
     /// Timing for the stop→start wait-for-exit (#625 part-1). Bounds are expressed in
     /// milliseconds so poll counts derive trivially and stay deterministic when the
     /// sleep seam is a no-op (a wall-clock deadline would never advance under that seam).
-    private enum WaitForExitTiming {
+    enum WaitForExitTiming {
         static let pollIntervalMs = 100
         static let processExitGraceMs = 2000 // SIGTERM → SIGKILL window
         static let portReleaseTimeoutMs = 2000 // after processes confirmed dead
@@ -344,6 +344,10 @@ final class ServiceLifecycleCoordinator {
     /// Bounded: on timeout we log a warning and proceed anyway rather than failing the
     /// start — leaving the user with no remapping would be worse, and the #625 grab
     /// auto-recovery is the backstop for any residual degraded case.
+    ///
+    /// `internal` (not `private`) so tests can drive it directly: `startKanata`'s VHID
+    /// gates short-circuit in the test environment, so the seam-injected polling logic
+    /// is exercised by calling this method rather than through `startKanata`.
     func waitForKanataExitBeforeStart() async {
         let processNames = ["kanata-launcher", "kanata"]
         var killedAny = false
@@ -374,9 +378,9 @@ final class ServiceLifecycleCoordinator {
 
         // Only wait on the TCP port if we actually killed something. A clean machine has
         // nothing of ours holding the port, so the common first-start path adds no latency.
-        if killedAny {
-            await waitForPortReleased()
-        }
+        guard killedAny else { return }
+        await waitForPortReleased()
+        AppLogger.shared.log("✅ [Service] wait-for-exit complete — old kanata gone, proceeding with start")
     }
 
     /// Poll the given PIDs until none are alive or the budget elapses.
@@ -384,12 +388,14 @@ final class ServiceLifecycleCoordinator {
     private func waitForProcessesGone(_ pids: [pid_t], withinMs budgetMs: Int) async -> [pid_t] {
         var remaining = pids
         let maxPolls = WaitForExitTiming.pollCount(forMs: budgetMs)
-        for _ in 0 ..< maxPolls {
+        for poll in 0 ..< maxPolls {
             remaining = remaining.filter { isProcessAlive($0) }
             if remaining.isEmpty { return [] }
-            await waitSleep(WaitForExitTiming.pollInterval)
+            // Skip the sleep after the final poll so the budget stays ~budgetMs, not
+            // budgetMs + one extra interval.
+            if poll < maxPolls - 1 { await waitSleep(WaitForExitTiming.pollInterval) }
         }
-        return remaining.filter { isProcessAlive($0) }
+        return remaining
     }
 
     /// Poll the kanata TCP port until nothing is listening (the old process released it)
@@ -424,7 +430,13 @@ final class ServiceLifecycleCoordinator {
         #if DEBUG
             if let probe = Self.testLivenessProbe { return probe(pid) }
         #endif
-        return kill(pid, 0) == 0
+        if kill(pid, 0) == 0 { return true }
+        // kanata runs as a root LaunchDaemon while this app is unprivileged, so
+        // `kill(pid, 0)` returns EPERM ("exists, but you may not signal it") — that
+        // is still ALIVE. Only ESRCH means the process is actually gone. Treating
+        // EPERM as dead would make the wait return immediately for the very process
+        // (the root kanata) this fix exists to wait out.
+        return errno == EPERM
     }
 
     private nonisolated func sendSignal(_ pid: pid_t, _ signal: Int32) {

--- a/Sources/KeyPathAppKit/Managers/ServiceLifecycleCoordinator.swift
+++ b/Sources/KeyPathAppKit/Managers/ServiceLifecycleCoordinator.swift
@@ -30,6 +30,46 @@ final class ServiceLifecycleCoordinator {
     private let kanataDaemonService: KanataDaemonService
     private let recoveryCoordinator: RecoveryCoordinator
 
+    // MARK: - Wait-for-exit test seams (#625 part-1)
+
+    // Test seams for the deterministic wait-for-exit routine. Without these, the
+    // polling loops would spawn real `pgrep` (which deadlocks under parallel test
+    // runs — see CLAUDE.md), probe a real TCP port, and sleep real time. Tests
+    // inject deterministic closures; production always uses the real subprocess /
+    // syscall / TCP probe. DEBUG-only and nil in production.
+    #if DEBUG
+        /// Replaces `SubprocessRunner.shared.pgrep`. Returns matching PIDs for a name.
+        nonisolated(unsafe) static var testPgrepProvider: ((String) -> [pid_t])?
+        /// Replaces `kill(pid, 0)`. Returns `true` when the process is still alive.
+        nonisolated(unsafe) static var testLivenessProbe: ((pid_t) -> Bool)?
+        /// Replaces `kill(pid, signal)` for SIGTERM/SIGKILL so tests with synthetic PIDs
+        /// never signal a real, unrelated process on the machine.
+        nonisolated(unsafe) static var testSignal: ((pid_t, Int32) -> Void)?
+        /// Replaces `TCPProbe.probe`. Returns `true` when something is listening.
+        nonisolated(unsafe) static var testTCPProbe: ((Int, Int) -> Bool)?
+        /// Replaces `Task.sleep` in the polling loops so tests never wait real time.
+        nonisolated(unsafe) static var testSleep: ((Duration) async -> Void)?
+    #endif
+
+    /// Timing for the stop→start wait-for-exit (#625 part-1). Bounds are expressed in
+    /// milliseconds so poll counts derive trivially and stay deterministic when the
+    /// sleep seam is a no-op (a wall-clock deadline would never advance under that seam).
+    private enum WaitForExitTiming {
+        static let pollIntervalMs = 100
+        static let processExitGraceMs = 2000 // SIGTERM → SIGKILL window
+        static let portReleaseTimeoutMs = 2000 // after processes confirmed dead
+        static let postKillConfirmMs = 500 // brief confirm-gone poll after SIGKILL
+        static let tcpProbeTimeoutMs = 150
+
+        static var pollInterval: Duration {
+            .milliseconds(pollIntervalMs)
+        }
+
+        static func pollCount(forMs ms: Int) -> Int {
+            max(1, ms / pollIntervalMs)
+        }
+    }
+
     /// Mutable flag shared with RuntimeCoordinator to track in-progress start attempts.
     var isStartingKanata = false
     private var lastStartAttemptAt: Date?
@@ -131,7 +171,7 @@ final class ServiceLifecycleCoordinator {
             return false
         }
 
-        await killOrphanedKanataProcesses()
+        await waitForKanataExitBeforeStart()
 
         do {
             lastStartAttemptAt = Date()
@@ -291,26 +331,128 @@ final class ServiceLifecycleCoordinator {
 
     // MARK: - Private
 
-    /// Kill orphaned kanata-launcher and kanata processes that aren't managed by
-    /// the current LaunchDaemon, so the new daemon can bind the TCP port.
-    private func killOrphanedKanataProcesses() async {
+    /// Terminate any orphaned `kanata-launcher` / `kanata` processes and wait until
+    /// they are fully gone AND the TCP port is released, BEFORE the new LaunchDaemon
+    /// registers (#625 part-1 — "wait-for-exit before start").
+    ///
+    /// The old kanata holds the exclusive keyboard grab and TCP port until it actually
+    /// exits, and `SMAppService.unregister()` returns before the OS finishes tearing the
+    /// process down. Registering a new kanata while the old one lingers is the stop→start
+    /// race that produces the silent "degraded" state (process up, but never grabbed the
+    /// keyboard). Waiting here makes the transition deterministic.
+    ///
+    /// Bounded: on timeout we log a warning and proceed anyway rather than failing the
+    /// start — leaving the user with no remapping would be worse, and the #625 grab
+    /// auto-recovery is the backstop for any residual degraded case.
+    func waitForKanataExitBeforeStart() async {
         let processNames = ["kanata-launcher", "kanata"]
+        var killedAny = false
+
         for name in processNames {
-            do {
-                let pids = await SubprocessRunner.shared.pgrep(name)
-                for pid in pids {
-                    AppLogger.shared.log("🧹 [Service] Killing orphaned \(name) (PID \(pid)) before LaunchDaemon start")
-                    kill(pid, SIGTERM)
+            let pids = await pgrepMatches(name)
+            guard !pids.isEmpty else { continue }
+            killedAny = true
+
+            for pid in pids {
+                AppLogger.shared.log("🧹 [Service] Terminating orphaned \(name) (PID \(pid)) before LaunchDaemon start")
+                sendSignal(pid, SIGTERM)
+            }
+
+            // Poll until the processes exit; escalate to SIGKILL past the grace window.
+            let survivors = await waitForProcessesGone(pids, withinMs: WaitForExitTiming.processExitGraceMs)
+            for pid in survivors {
+                AppLogger.shared.warn("⚠️ [Service] \(name) (PID \(pid)) did not exit within grace — SIGKILL")
+                sendSignal(pid, SIGKILL)
+            }
+            if !survivors.isEmpty {
+                let stillAlive = await waitForProcessesGone(survivors, withinMs: WaitForExitTiming.postKillConfirmMs)
+                if !stillAlive.isEmpty {
+                    AppLogger.shared.warn("⚠️ [Service] \(name) PIDs \(stillAlive) still alive after SIGKILL — proceeding anyway")
                 }
-                if !pids.isEmpty {
-                    try? await Task.sleep(for: .milliseconds(500))
-                    for pid in pids where kill(pid, 0) == 0 {
-                        kill(pid, SIGKILL)
-                    }
-                }
-            } catch {
-                // pgrep not finding matches is fine
             }
         }
+
+        // Only wait on the TCP port if we actually killed something. A clean machine has
+        // nothing of ours holding the port, so the common first-start path adds no latency.
+        if killedAny {
+            await waitForPortReleased()
+        }
+    }
+
+    /// Poll the given PIDs until none are alive or the budget elapses.
+    /// - Returns: PIDs still alive when the budget is exhausted (empty on success).
+    private func waitForProcessesGone(_ pids: [pid_t], withinMs budgetMs: Int) async -> [pid_t] {
+        var remaining = pids
+        let maxPolls = WaitForExitTiming.pollCount(forMs: budgetMs)
+        for _ in 0 ..< maxPolls {
+            remaining = remaining.filter { isProcessAlive($0) }
+            if remaining.isEmpty { return [] }
+            await waitSleep(WaitForExitTiming.pollInterval)
+        }
+        return remaining.filter { isProcessAlive($0) }
+    }
+
+    /// Poll the kanata TCP port until nothing is listening (the old process released it)
+    /// or the budget elapses. On timeout, warn and return — the caller proceeds anyway.
+    private func waitForPortReleased() async {
+        let port = PreferencesService.shared.tcpServerPort
+        let maxPolls = WaitForExitTiming.pollCount(forMs: WaitForExitTiming.portReleaseTimeoutMs)
+        for poll in 0 ..< maxPolls {
+            let listening = await probePort(port, timeoutMs: WaitForExitTiming.tcpProbeTimeoutMs)
+            if !listening { return }
+            if poll < maxPolls - 1 { await waitSleep(WaitForExitTiming.pollInterval) }
+        }
+        AppLogger.shared.warn(
+            "⚠️ [Service] TCP port \(port) still in use after wait-for-exit — proceeding anyway (grab auto-recovery is the backstop)"
+        )
+    }
+
+    // MARK: - Wait-for-exit primitives (test-seam aware)
+
+    private func pgrepMatches(_ name: String) async -> [pid_t] {
+        #if DEBUG
+            if let provider = Self.testPgrepProvider { return provider(name) }
+        #endif
+        // Never spawn a real `pgrep` under tests: it can deadlock under parallel runs
+        // (see CLAUDE.md) and would let synthetic PIDs reach a real `kill`. Tests that
+        // need orphan PIDs inject `testPgrepProvider`; everything else gets a clean slate.
+        if TestEnvironment.isRunningTests { return [] }
+        return await SubprocessRunner.shared.pgrep(name)
+    }
+
+    private nonisolated func isProcessAlive(_ pid: pid_t) -> Bool {
+        #if DEBUG
+            if let probe = Self.testLivenessProbe { return probe(pid) }
+        #endif
+        return kill(pid, 0) == 0
+    }
+
+    private nonisolated func sendSignal(_ pid: pid_t, _ signal: Int32) {
+        #if DEBUG
+            if let send = Self.testSignal {
+                send(pid, signal)
+                return
+            }
+        #endif
+        kill(pid, signal)
+    }
+
+    private func probePort(_ port: Int, timeoutMs: Int) async -> Bool {
+        #if DEBUG
+            if let probe = Self.testTCPProbe { return probe(port, timeoutMs) }
+        #endif
+        return await Task.detached(priority: .utility) {
+            TCPProbe.probe(port: port, timeoutMs: timeoutMs)
+        }.value
+    }
+
+    private func waitSleep(_ duration: Duration) async {
+        #if DEBUG
+            if let sleep = Self.testSleep {
+                await sleep(duration)
+                return
+            }
+        #endif
+        try? await Task.sleep(for: duration)
     }
 }

--- a/Sources/KeyPathAppKit/Managers/ServiceLifecycleCoordinator.swift
+++ b/Sources/KeyPathAppKit/Managers/ServiceLifecycleCoordinator.swift
@@ -379,8 +379,11 @@ final class ServiceLifecycleCoordinator {
         // Only wait on the TCP port if we actually killed something. A clean machine has
         // nothing of ours holding the port, so the common first-start path adds no latency.
         guard killedAny else { return }
-        await waitForPortReleased()
-        AppLogger.shared.log("✅ [Service] wait-for-exit complete — old kanata gone, proceeding with start")
+        if await waitForPortReleased() {
+            AppLogger.shared.log("✅ [Service] wait-for-exit complete — port released, proceeding with start")
+        }
+        // The timeout path already warned inside waitForPortReleased; no ✅ there so a
+        // `grep "✅"` of the log can't be fooled into thinking a stuck port was clean.
     }
 
     /// Poll the given PIDs until none are alive or the budget elapses.
@@ -399,18 +402,21 @@ final class ServiceLifecycleCoordinator {
     }
 
     /// Poll the kanata TCP port until nothing is listening (the old process released it)
-    /// or the budget elapses. On timeout, warn and return — the caller proceeds anyway.
-    private func waitForPortReleased() async {
+    /// or the budget elapses.
+    /// - Returns: `true` if the port was confirmed free, `false` on timeout (caller
+    ///   proceeds anyway; a warning is logged here).
+    private func waitForPortReleased() async -> Bool {
         let port = PreferencesService.shared.tcpServerPort
         let maxPolls = WaitForExitTiming.pollCount(forMs: WaitForExitTiming.portReleaseTimeoutMs)
         for poll in 0 ..< maxPolls {
             let listening = await probePort(port, timeoutMs: WaitForExitTiming.tcpProbeTimeoutMs)
-            if !listening { return }
+            if !listening { return true }
             if poll < maxPolls - 1 { await waitSleep(WaitForExitTiming.pollInterval) }
         }
         AppLogger.shared.warn(
             "⚠️ [Service] TCP port \(port) still in use after wait-for-exit — proceeding anyway (grab auto-recovery is the backstop)"
         )
+        return false
     }
 
     // MARK: - Wait-for-exit primitives (test-seam aware)

--- a/Tests/KeyPathTests/Services/ServiceLifecycleCoordinatorTests.swift
+++ b/Tests/KeyPathTests/Services/ServiceLifecycleCoordinatorTests.swift
@@ -266,7 +266,25 @@ final class ServiceLifecycleCoordinatorTests: KeyPathTestCase {
         // Must return despite the port never freeing.
         await coordinator.waitForKanataExitBeforeStart()
 
-        XCTAssertEqual(tcpProbes, 20, "Port poll bounded to portReleaseTimeout / pollInterval = 20 probes")
+        let expectedProbes = ServiceLifecycleCoordinator.WaitForExitTiming.pollCount(
+            forMs: ServiceLifecycleCoordinator.WaitForExitTiming.portReleaseTimeoutMs
+        )
+        XCTAssertEqual(tcpProbes, expectedProbes, "Port poll bounded to portReleaseTimeout / pollInterval")
+    }
+
+    func testWaitForExit_bothProcessNamesHaveOrphans() async {
+        // Both `kanata-launcher` and `kanata` can have live instances; each family must be
+        // terminated, not just the first one found.
+        var terminated: Set<pid_t> = []
+        ServiceLifecycleCoordinator.testPgrepProvider = { name in name == "kanata-launcher" ? [4242] : [5252] }
+        ServiceLifecycleCoordinator.testLivenessProbe = { _ in false } // exit immediately
+        ServiceLifecycleCoordinator.testSignal = { pid, sig in if sig == SIGTERM { terminated.insert(pid) } }
+        ServiceLifecycleCoordinator.testTCPProbe = { _, _ in false }
+        ServiceLifecycleCoordinator.testSleep = { _ in }
+
+        await coordinator.waitForKanataExitBeforeStart()
+
+        XCTAssertEqual(terminated, [4242, 5252], "Both process families are terminated")
     }
 
     func testWaitForExit_safeToCallRepeatedlyAcrossRestarts() async {

--- a/Tests/KeyPathTests/Services/ServiceLifecycleCoordinatorTests.swift
+++ b/Tests/KeyPathTests/Services/ServiceLifecycleCoordinatorTests.swift
@@ -233,8 +233,8 @@ final class ServiceLifecycleCoordinatorTests: KeyPathTestCase {
         // Must return (proceed), not hang, even though the process never dies.
         await coordinator.waitForKanataExitBeforeStart()
 
-        XCTAssertTrue(signals.contains(SIGTERM), "SIGTERM attempted first")
-        XCTAssertTrue(signals.contains(SIGKILL), "Surviving process SIGKILLed after the grace window")
+        XCTAssertEqual(signals.first, SIGTERM, "SIGTERM must precede SIGKILL")
+        XCTAssertEqual(signals.filter { $0 == SIGKILL }.count, 1, "Exactly one SIGKILL after the grace window")
     }
 
     func testWaitForExit_portBusyThenFrees() async {
@@ -285,6 +285,20 @@ final class ServiceLifecycleCoordinatorTests: KeyPathTestCase {
         await coordinator.waitForKanataExitBeforeStart()
 
         XCTAssertEqual(terminated, [4242, 5252], "Both process families are terminated")
+    }
+
+    func testWaitForExit_multiplePidsPerName() async {
+        // A single process family can have multiple orphans; every PID must be SIGTERMed.
+        var terminated: Set<pid_t> = []
+        ServiceLifecycleCoordinator.testPgrepProvider = { name in name == "kanata-launcher" ? [4242, 4243, 4244] : [] }
+        ServiceLifecycleCoordinator.testLivenessProbe = { _ in false } // all exit immediately
+        ServiceLifecycleCoordinator.testSignal = { pid, sig in if sig == SIGTERM { terminated.insert(pid) } }
+        ServiceLifecycleCoordinator.testTCPProbe = { _, _ in false }
+        ServiceLifecycleCoordinator.testSleep = { _ in }
+
+        await coordinator.waitForKanataExitBeforeStart()
+
+        XCTAssertEqual(terminated, [4242, 4243, 4244], "Every orphan PID for the name is terminated")
     }
 
     func testWaitForExit_safeToCallRepeatedlyAcrossRestarts() async {

--- a/Tests/KeyPathTests/Services/ServiceLifecycleCoordinatorTests.swift
+++ b/Tests/KeyPathTests/Services/ServiceLifecycleCoordinatorTests.swift
@@ -162,4 +162,131 @@ final class ServiceLifecycleCoordinatorTests: KeyPathTestCase {
         // but should not crash
         XCTAssertNotNil(inWindow)
     }
+
+    // MARK: - Wait-for-exit before start (#625 part-1)
+
+    //
+    // These drive `waitForKanataExitBeforeStart()` directly (it runs after the VHID
+    // gates in `startKanata`, which short-circuit in the test environment). All timing
+    // is deterministic: pgrep/liveness/signal/TCP/sleep are injected via DEBUG seams, so
+    // no real subprocess, signal, port, or wall-clock sleep is involved. Seams are reset
+    // to safe defaults in TestSingletonReset.resetAll() between tests.
+
+    func testWaitForExit_noOrphans_fastPath() async {
+        var sleeps = 0
+        var tcpProbes = 0
+        ServiceLifecycleCoordinator.testPgrepProvider = { _ in [] }
+        ServiceLifecycleCoordinator.testSleep = { _ in sleeps += 1 }
+        ServiceLifecycleCoordinator.testTCPProbe = { _, _ in tcpProbes += 1; return false }
+
+        await coordinator.waitForKanataExitBeforeStart()
+
+        XCTAssertEqual(sleeps, 0, "No orphans → no polling sleeps")
+        XCTAssertEqual(tcpProbes, 0, "No orphans → port-release poll is skipped (zero added latency)")
+    }
+
+    func testWaitForExit_processGoneImmediately() async {
+        var signals: [Int32] = []
+        var tcpProbes = 0
+        var sleeps = 0
+        ServiceLifecycleCoordinator.testPgrepProvider = { name in name == "kanata-launcher" ? [4242] : [] }
+        ServiceLifecycleCoordinator.testLivenessProbe = { _ in false } // already gone
+        ServiceLifecycleCoordinator.testSignal = { _, sig in signals.append(sig) }
+        ServiceLifecycleCoordinator.testTCPProbe = { _, _ in tcpProbes += 1; return false } // port free
+        ServiceLifecycleCoordinator.testSleep = { _ in sleeps += 1 }
+
+        await coordinator.waitForKanataExitBeforeStart()
+
+        XCTAssertEqual(signals, [SIGTERM], "Only SIGTERM; no SIGKILL escalation when the process exits immediately")
+        XCTAssertEqual(sleeps, 0, "Gone on first probe and port free on first probe → no sleeps")
+        XCTAssertEqual(tcpProbes, 1, "Port checked once and found free")
+    }
+
+    func testWaitForExit_processLingersThenExits() async {
+        var livenessProbes = 0
+        var signals: [Int32] = []
+        var sleeps = 0
+        ServiceLifecycleCoordinator.testPgrepProvider = { name in name == "kanata-launcher" ? [4242] : [] }
+        ServiceLifecycleCoordinator.testLivenessProbe = { _ in
+            livenessProbes += 1
+            return livenessProbes <= 2 // alive for two probes, then gone
+        }
+        ServiceLifecycleCoordinator.testSignal = { _, sig in signals.append(sig) }
+        ServiceLifecycleCoordinator.testTCPProbe = { _, _ in false } // port free immediately
+        ServiceLifecycleCoordinator.testSleep = { _ in sleeps += 1 }
+
+        await coordinator.waitForKanataExitBeforeStart()
+
+        XCTAssertEqual(signals, [SIGTERM], "Exited within the grace window → no SIGKILL")
+        XCTAssertEqual(livenessProbes, 3, "Polled liveness until the process disappeared")
+        XCTAssertEqual(sleeps, 2, "Two polling sleeps before exit; port was free immediately")
+    }
+
+    func testWaitForExit_processNeverExits_timeoutEscalatesToKillThenProceeds() async {
+        var signals: [Int32] = []
+        ServiceLifecycleCoordinator.testPgrepProvider = { name in name == "kanata-launcher" ? [4242] : [] }
+        ServiceLifecycleCoordinator.testLivenessProbe = { _ in true } // never exits
+        ServiceLifecycleCoordinator.testSignal = { _, sig in signals.append(sig) }
+        ServiceLifecycleCoordinator.testTCPProbe = { _, _ in false }
+        ServiceLifecycleCoordinator.testSleep = { _ in }
+
+        // Must return (proceed), not hang, even though the process never dies.
+        await coordinator.waitForKanataExitBeforeStart()
+
+        XCTAssertTrue(signals.contains(SIGTERM), "SIGTERM attempted first")
+        XCTAssertTrue(signals.contains(SIGKILL), "Surviving process SIGKILLed after the grace window")
+    }
+
+    func testWaitForExit_portBusyThenFrees() async {
+        var tcpProbes = 0
+        var sleeps = 0
+        ServiceLifecycleCoordinator.testPgrepProvider = { name in name == "kanata-launcher" ? [4242] : [] }
+        ServiceLifecycleCoordinator.testLivenessProbe = { _ in false } // process gone immediately
+        ServiceLifecycleCoordinator.testSignal = { _, _ in }
+        ServiceLifecycleCoordinator.testTCPProbe = { _, _ in
+            tcpProbes += 1
+            return tcpProbes <= 3 // busy for three probes, then released
+        }
+        ServiceLifecycleCoordinator.testSleep = { _ in sleeps += 1 }
+
+        await coordinator.waitForKanataExitBeforeStart()
+
+        XCTAssertEqual(tcpProbes, 4, "Polled the port until it was released")
+        XCTAssertEqual(sleeps, 3, "Slept between port probes while the port was busy")
+    }
+
+    func testWaitForExit_portNeverFrees_timeoutProceedsWithWarning() async {
+        var tcpProbes = 0
+        ServiceLifecycleCoordinator.testPgrepProvider = { name in name == "kanata-launcher" ? [4242] : [] }
+        ServiceLifecycleCoordinator.testLivenessProbe = { _ in false }
+        ServiceLifecycleCoordinator.testSignal = { _, _ in }
+        ServiceLifecycleCoordinator.testTCPProbe = { _, _ in tcpProbes += 1; return true } // always busy
+        ServiceLifecycleCoordinator.testSleep = { _ in }
+
+        // Must return despite the port never freeing.
+        await coordinator.waitForKanataExitBeforeStart()
+
+        XCTAssertEqual(tcpProbes, 20, "Port poll bounded to portReleaseTimeout / pollInterval = 20 probes")
+    }
+
+    func testWaitForExit_safeToCallRepeatedlyAcrossRestarts() async {
+        // A restart calls this on every start. Re-invoking after the orphan is gone must be
+        // a clean no-op (no signals, no port wait), not a crash or a redundant kill.
+        var pids: [pid_t] = [4242]
+        var signals: [Int32] = []
+        ServiceLifecycleCoordinator.testPgrepProvider = { name in name == "kanata-launcher" ? pids : [] }
+        ServiceLifecycleCoordinator.testLivenessProbe = { _ in false } // exits on first probe
+        ServiceLifecycleCoordinator.testSignal = { _, sig in signals.append(sig) }
+        ServiceLifecycleCoordinator.testTCPProbe = { _, _ in false }
+        ServiceLifecycleCoordinator.testSleep = { _ in }
+
+        await coordinator.waitForKanataExitBeforeStart()
+        XCTAssertEqual(signals, [SIGTERM], "First call terminates the orphan")
+
+        // Orphan is now gone — a second invocation must be a clean no-op.
+        pids = []
+        signals = []
+        await coordinator.waitForKanataExitBeforeStart()
+        XCTAssertEqual(signals, [], "Second call with no orphans signals nothing")
+    }
 }

--- a/Tests/KeyPathTests/Support/GlobalTestSetup.swift
+++ b/Tests/KeyPathTests/Support/GlobalTestSetup.swift
@@ -25,6 +25,19 @@ enum TestSingletonReset {
         // so a value left by one test must not bleed into another's health check.
         KanataGrabStatusStore.shared.reset()
 
+        // Wait-for-exit seams (#625 part-1): safe defaults so any test reaching
+        // ServiceLifecycleCoordinator.startKanata neither spawns real `pgrep`
+        // (parallel-run deadlock risk) nor waits real time. Tests that exercise the
+        // wait-for-exit logic override these explicitly and rely on this reset to
+        // avoid bleeding into the next test.
+        #if DEBUG
+            ServiceLifecycleCoordinator.testPgrepProvider = { _ in [] }
+            ServiceLifecycleCoordinator.testLivenessProbe = nil
+            ServiceLifecycleCoordinator.testSignal = nil
+            ServiceLifecycleCoordinator.testTCPProbe = nil
+            ServiceLifecycleCoordinator.testSleep = { _ in }
+        #endif
+
         // TestEnvironment flags
         TestEnvironment.forceTestMode = false
     }


### PR DESCRIPTION
## Summary

Fixes the **stop→start race** that lets kanata enter the silent **degraded state** (process up + TCP responding, but it never seized the keyboard, so remapping is dead). This is **part-1** of #625 — the race fix at the source. **Part-2** (auto-recovery safety net, #644) is already merged; this completes the issue.

**Root cause:** `restartKanata()` does stop-then-start. The old kanata's termination is asynchronous — `SMAppService.unregister()` returns before the OS finishes tearing the process down, and the old `killOrphanedKanataProcesses()` only slept a fixed 500ms. So when `startKanata()` → `register()` runs, the old kanata can still be alive holding the **exclusive keyboard grab** and **TCP port 37001**. The new kanata then can't grab → degraded.

**Fix:** Replace the fixed-sleep best-effort with a bounded, deterministic `waitForKanataExitBeforeStart()` that runs right before `register()`:

- `pgrep` orphans → `SIGTERM` → poll liveness (`kill(pid,0)`, 100ms interval) until gone → `SIGKILL` survivors past a 2s grace → brief confirm-gone poll.
- **Only if** something was killed, poll `TCPProbe` until port 37001 is released (2s budget). Clean machine (no orphans) = **zero added latency**.
- **On timeout: warn and proceed** rather than failing the start — leaving the user with no remapping would be worse, and part-2's grab auto-recovery is the backstop for any residual case.

**Why it's safe w.r.t. the part-2 machinery:**
- The part-2 gate (`stopGraceUntil` / `intentionalStopDepth`) is **untouched**.
- The wait sits entirely between `AppContextService.stop()` and `.start()`, so the TCP grab-event listener is down throughout — **no grab events are processed during the wait**, so the longer wait creates no new spurious-recovery window.

## Testing

- 7 new deterministic tests in `ServiceLifecycleCoordinatorTests` drive the polling logic via DEBUG seams (pgrep/liveness/signal/TCP/sleep) — **no real subprocess, signal, port, or wall-clock sleep**. Cover: no-orphans fast path, gone-immediately, linger-then-exit, never-exits→SIGKILL→proceed, port-busy-then-frees, port-never-frees→proceed, safe-to-call-repeatedly.
- `pgrepMatches` additionally hard-refuses real `pgrep` under `TestEnvironment.isRunningTests` (closes a latent parallel-run deadlock).
- Full `swift test` suite green; `SKIP_NOTARIZE=1 ./build.sh` produces a signed app.

**Manual verification (post-merge):** exercise a restart (toggle service / change a rule), confirm via `~/Library/Logs/KeyPath/keypath-debug.log` that the wait-for-exit log lines appear, the new kanata grabs the keyboard (no degraded state), and no spurious auto-recovery fires during a normal restart.

## Review

Ran `/code-review high` (7 finder angles) against the diff and addressed the actionable findings: removed two vacuous tests + replaced with an honest direct test; hardened the test-pgrep seam; dropped a wasted trailing sleep on the port-timeout path. Pre-existing items (pgrep `-f` breadth, PID-reuse window, overlapping-restart concurrency) noted as out of scope. The mandatory `/thermo-nuclear-swift-review` cloud gate was not run by the agent (user-triggered) — worth running on this PR.

Fixes #625

🤖 Generated with [Claude Code](https://claude.com/claude-code)