### PR TITLE
chore(format): establish swiftformat 0.61.1 fixed-point + pin version (#634)

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -1,8 +1,21 @@
 # SwiftFormat Configuration
-# Match SwiftLint rules to avoid conflicts
+# Match SwiftLint rules to avoid conflicts.
+#
+# Pinned tool version: swiftformat 0.61.1 (see mise.toml). master is kept as a
+# fixed-point for this version + this config, so a local run produces no churn.
+# Run: `swiftformat Sources Tests` (swiftversion is set below, so no CLI flag needed).
 
-# Disable trailing commas (SwiftLint doesn't allow them in collection literals)
---disable trailingCommas
+# Target Swift version — set here so CI's `swiftformat --lint` and local runs agree
+# (CI previously omitted it, which let version-dependent rules drift).
+--swiftversion 5.9
+
+# Disabled rules:
+# - trailingCommas: SwiftLint doesn't allow them in collection literals.
+# - redundantSendable: keep explicit `Sendable` as intent documentation; we don't
+#   want a formatter silently dropping conformances (even where implicit).
+# - noForceUnwrapInTests: this is a semantic rewrite (force-unwrap → `try #require`,
+#   adds `throws`), not formatting — out of scope for a mechanical format pass.
+--disable trailingCommas,redundantSendable,noForceUnwrapInTests
 
 # Match SwiftLint preferences
 --indent 4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,9 +80,15 @@ Two doc systems: `guides/` (user-facing, published to gh-pages) and `docs/` (dev
 ./build.sh                        # Canonical build (SKIP_NOTARIZE=1 for local dev)
 ./Scripts/quick-deploy.sh         # Fast debug deploy
 swift test                        # All tests (~532 tests, <5s)
-swiftformat Sources/ Tests/ --swiftversion 5.9
+swiftformat Sources Tests         # Uses pinned rules + swiftversion from .swiftformat
 swiftlint --fix --quiet
 ```
+
+**SwiftFormat is pinned to 0.61.1** (`mise.toml`); `master` is a formatted fixed-point
+for that version + `.swiftformat` config, so a run produces **no churn**. A different
+version reformats unrelated code (see #634) — match the pin (`mise install` or
+`brew install swiftformat` at 0.61.1) before formatting, and never bulk-reformat with
+an unpinned version.
 
 **"dd"** → Run `SKIP_NOTARIZE=1 ./build.sh`, respond **"Eye eye Captain!"**
 **"df"** → Run `./Scripts/quick-deploy.sh`, respond **"Eye eye Cap, fast deploying!"**

--- a/Sources/KeyPathAppKit/App.swift
+++ b/Sources/KeyPathAppKit/App.swift
@@ -93,7 +93,8 @@ func openPreferencesTab(_ notification: Notification.Name) {
         for item in appMenu.items {
             // Look for the "Settings..." menu item (standard name on macOS)
             if item.title.contains("Settings") || item.title.contains("Preferences"),
-               let action = item.action {
+               let action = item.action
+            {
                 AppLogger.shared.log("✅ [App] Found Settings menu item, triggering it")
                 NSApp.activate(ignoringOtherApps: true)
                 NSApp.sendAction(action, to: item.target, from: item)
@@ -118,7 +119,8 @@ func openPreferencesTab(_ notification: Notification.Name) {
 @MainActor
 class AppDelegate: NSObject, NSApplicationDelegate {
     static func isOneShotProbeEnvironment(_ environment: [String: String] = ProcessInfo.processInfo.environment)
-        -> Bool {
+        -> Bool
+    {
         OneShotProbeEnvironment.isActive(environment)
     }
 
@@ -202,7 +204,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
            let bundleIdentifier = Bundle.main.bundleIdentifier,
            SingleInstanceCoordinator.activateExistingAndTerminateIfNeeded(
                bundleIdentifier: bundleIdentifier
-           ) {
+           )
+        {
             AppLogger.shared.info("🪟 [AppDelegate] Duplicate normal app launch detected; exiting early")
             return
         }
@@ -435,7 +438,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     private func handleSubsequentActivation() {
         if !LiveKeyboardOverlayController.shared.isVisible,
-           LiveKeyboardOverlayController.shared.canAutoShow {
+           LiveKeyboardOverlayController.shared.canAutoShow
+        {
             LiveKeyboardOverlayController.shared.showForStartup()
             AppLogger.shared.debug("🪟 [AppDelegate] Subsequent activation - showing overlay")
         } else if !LiveKeyboardOverlayController.shared.isVisible {

--- a/Sources/KeyPathAppKit/CLI/CLIActionDescription.swift
+++ b/Sources/KeyPathAppKit/CLI/CLIActionDescription.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 // MARK: - CLI–GUI Parity Guard
+
 // Exhaustive switches on KeyAction and MappingBehavior ensure the CLI won't
 // compile if a new case is added without CLI support.
 

--- a/Sources/KeyPathAppKit/CLI/PacksFacade.swift
+++ b/Sources/KeyPathAppKit/CLI/PacksFacade.swift
@@ -64,7 +64,7 @@ public struct PacksFacade: Sendable {
 
         if dryRun {
             var warnings: [String] = []
-            let installedIDs = Set(await InstalledPackTracker.shared.allInstalled().map(\.packID))
+            let installedIDs = await Set(InstalledPackTracker.shared.allInstalled().map(\.packID))
             let suggestions = PackDependencyChecker.suggestions(for: pack.id, installedPackIDs: installedIDs)
             for dep in suggestions {
                 let depName = PackRegistry.pack(id: dep.packID)?.name ?? dep.packID
@@ -87,7 +87,7 @@ public struct PacksFacade: Sendable {
         )
 
         var warnings: [String] = []
-        let installedIDs = Set(await InstalledPackTracker.shared.allInstalled().map(\.packID))
+        let installedIDs = await Set(InstalledPackTracker.shared.allInstalled().map(\.packID))
         let suggestions = PackDependencyChecker.suggestions(for: pack.id, installedPackIDs: installedIDs)
         for dep in suggestions {
             let depName = PackRegistry.pack(id: dep.packID)?.name ?? dep.packID
@@ -187,7 +187,9 @@ public struct PacksFacade: Sendable {
         if dryRun {
             let current = await PackInstaller.shared.quickSettings(for: pack.id)
             var merged = current
-            for (k, v) in settingValues { merged[k] = v }
+            for (k, v) in settingValues {
+                merged[k] = v
+            }
             return CLIPackInstallResult(
                 packID: pack.id,
                 packName: pack.name,
@@ -404,7 +406,9 @@ public struct AmbiguousPackMatch: Error, CustomStringConvertible {
 
 public struct CLIPackNotFound: Error, CustomStringConvertible {
     public let query: String
-    public var description: String { "No pack found matching \"\(query)\"" }
+    public var description: String {
+        "No pack found matching \"\(query)\""
+    }
 }
 
 public struct CLIPackSettingError: Error, CustomStringConvertible {

--- a/Sources/KeyPathAppKit/CLI/RulesFacade.swift
+++ b/Sources/KeyPathAppKit/CLI/RulesFacade.swift
@@ -161,7 +161,7 @@ public struct RulesFacade: Sendable {
         let existingIsSimple = existing.behavior == nil
         let newIsSimple = newBehavior == nil
 
-        if existingIsSimple && newIsSimple {
+        if existingIsSimple, newIsSimple {
             throw CLIMergeError(
                 input: existing.input,
                 reason: "both rules are simple remaps with different outputs — ambiguous"
@@ -182,7 +182,7 @@ public struct RulesFacade: Sendable {
             return merged
         }
 
-        if case .dualRole(var existingDual) = existing.behavior, newIsSimple {
+        if case var .dualRole(existingDual) = existing.behavior, newIsSimple {
             existingDual.tapAction = newAction
             merged.behavior = .dualRole(existingDual)
             merged.action = newAction
@@ -319,11 +319,11 @@ public enum RuleAddResult: Codable, Sendable {
         let status = try container.decode(String.self, forKey: .status)
         switch status {
         case "created":
-            self = .created(try container.decode(CLIRuleDetail.self, forKey: .rule))
+            self = try .created(container.decode(CLIRuleDetail.self, forKey: .rule))
         case "replaced":
-            self = .replaced(try container.decode(CLIRuleDetail.self, forKey: .rule))
+            self = try .replaced(container.decode(CLIRuleDetail.self, forKey: .rule))
         case "merged":
-            self = .merged(try container.decode(CLIRuleDetail.self, forKey: .rule))
+            self = try .merged(container.decode(CLIRuleDetail.self, forKey: .rule))
         case "skipped":
             self = .skipped
         default:
@@ -359,10 +359,14 @@ public enum CLIConflictStrategy: String, Sendable {
 public struct CLIMergeError: Error, CustomStringConvertible {
     public let input: String
     public let reason: String
-    public var description: String { "Cannot merge rules for '\(input)': \(reason)" }
+    public var description: String {
+        "Cannot merge rules for '\(input)': \(reason)"
+    }
 }
 
 public struct CLIConflictError: Error, CustomStringConvertible {
     public let input: String
-    public var description: String { "Rule already exists for '\(input)'" }
+    public var description: String {
+        "Rule already exists for '\(input)'"
+    }
 }

--- a/Sources/KeyPathAppKit/CLI/SimulatorFacade.swift
+++ b/Sources/KeyPathAppKit/CLI/SimulatorFacade.swift
@@ -9,11 +9,10 @@ public struct SimulatorFacade: Sendable {
         configPath: String?,
         simulatorProvider: CLISimulatorProvider? = nil
     ) async throws -> CLISimulationResult {
-        let config: String
-        if let configPath {
-            config = configPath
+        let config: String = if let configPath {
+            configPath
         } else {
-            config = await MainActor.run { ConfigurationService().configurationPath }
+            await MainActor.run { ConfigurationService().configurationPath }
         }
 
         let provider = simulatorProvider ?? RealSimulatorProvider()

--- a/Sources/KeyPathAppKit/Core/AppNotificationWiring.swift
+++ b/Sources/KeyPathAppKit/Core/AppNotificationWiring.swift
@@ -145,5 +145,4 @@ enum AppNotificationWiring {
             }
         }
     }
-
 }

--- a/Sources/KeyPathAppKit/Core/OneShotProbeHandler.swift
+++ b/Sources/KeyPathAppKit/Core/OneShotProbeHandler.swift
@@ -55,5 +55,4 @@ enum OneShotProbeHandler {
         }
         return true
     }
-
 }

--- a/Sources/KeyPathAppKit/Core/PrivilegedOperationsRouter.swift
+++ b/Sources/KeyPathAppKit/Core/PrivilegedOperationsRouter.swift
@@ -162,7 +162,7 @@ public final class PrivilegedOperationsRouter {
             return false
         case .throttled:
             return false
-        case let .run(_, _):
+        case .run:
             break
         }
 
@@ -275,9 +275,9 @@ public final class PrivilegedOperationsRouter {
     public func restartKarabinerDaemonVerified() async throws -> Bool {
         switch Self.operationMode {
         case .privilegedHelper:
-            return try await helperRestartKarabinerDaemonVerified()
+            try await helperRestartKarabinerDaemonVerified()
         case .directSudo:
-            return try await sudoRestartKarabinerDaemonVerified()
+            try await sudoRestartKarabinerDaemonVerified()
         }
     }
 
@@ -337,21 +337,21 @@ public final class PrivilegedOperationsRouter {
 
     private func sudoActivateVHID() async throws {
         let vhidManager = VHIDDeviceManager()
-        if !(await vhidManager.activateManager()) {
+        if await !(vhidManager.activateManager()) {
             throw PrivilegedOperationError.operationFailed("VirtualHID activation failed")
         }
     }
 
     private func sudoUninstallDrivers() async throws {
         let vhidManager = VHIDDeviceManager()
-        if !(await vhidManager.uninstallAllDriverVersions()) {
+        if await !(vhidManager.uninstallAllDriverVersions()) {
             throw PrivilegedOperationError.operationFailed("Driver uninstallation failed")
         }
     }
 
     private func sudoInstallCorrectDriver() async throws {
         let vhidManager = VHIDDeviceManager()
-        if !(await vhidManager.downloadAndInstallCorrectVersion()) {
+        if await !(vhidManager.downloadAndInstallCorrectVersion()) {
             throw PrivilegedOperationError.operationFailed("Driver installation failed")
         }
     }
@@ -506,7 +506,7 @@ public final class PrivilegedOperationsRouter {
         return output.contains("kanata")
     }
 
-    private func removeLegacyKanataPlist(reason: String) async {
+    private func removeLegacyKanataPlist(reason _: String) async {
         let path = KanataDaemonManager.legacyPlistPath
         guard Foundation.FileManager().fileExists(atPath: path) else { return }
         guard path.hasPrefix("/Library/LaunchDaemons/"),

--- a/Sources/KeyPathAppKit/Infrastructure/Config/ConfigurationService.swift
+++ b/Sources/KeyPathAppKit/Infrastructure/Config/ConfigurationService.swift
@@ -827,7 +827,7 @@ public enum KanataKeyConverter {
         }
 
         // Known valid kanata key names that need no conversion (pass-through is safe)
-        let validKanataPassthrough: Set<String> = [
+        let validKanataPassthrough: Set = [
             // Arrow keys
             "up", "down", "left", "right",
             // Navigation
@@ -915,7 +915,7 @@ public enum KanataKeyConverter {
         }
 
         // Known key names that shouldn't be split into macros
-        let keyNames: Set<String> = [
+        let keyNames: Set = [
             "escape", "esc", "return", "ret", "enter",
             "backspace", "bspc", "delete", "del",
             "tab", "space", "spc",

--- a/Sources/KeyPathAppKit/Infrastructure/Config/KanataConfigurationGenerator.swift
+++ b/Sources/KeyPathAppKit/Infrastructure/Config/KanataConfigurationGenerator.swift
@@ -88,7 +88,10 @@ public struct KanataConfiguration: Sendable {
             globalRequirePriorIdleMs: requirePriorIdleMs
         )
         let mergedAliasDefinitions = deduplicateAliases(aliasDefinitions)
-        AppLogger.shared.log("📚 [KanataConfig] Total alias definitions: \(mergedAliasDefinitions.count) (before dedup: \(aliasDefinitions.count)), first 5: \(mergedAliasDefinitions.prefix(5).map(\.aliasName).joined(separator: ", "))")
+        AppLogger.shared
+            .log(
+                "📚 [KanataConfig] Total alias definitions: \(mergedAliasDefinitions.count) (before dedup: \(aliasDefinitions.count)), first 5: \(mergedAliasDefinitions.prefix(5).map(\.aliasName).joined(separator: ", "))"
+            )
         let blocks = deduplicateBlocks(rawBlocks)
         let enabledNames = enabledCollections.map(\.name).joined(separator: ", ")
 

--- a/Sources/KeyPathAppKit/InstallationWizard/WizardCommunicationPage.swift
+++ b/Sources/KeyPathAppKit/InstallationWizard/WizardCommunicationPage.swift
@@ -16,8 +16,13 @@ struct WizardCommunicationPage: View {
     @Environment(KanataViewModel.self) var kanataViewModel
     @Environment(\.preferencesService) private var preferences: PreferencesService
 
-    private var systemState: WizardSystemState { stateMachine.wizardState }
-    private var issues: [WizardIssue] { stateMachine.wizardIssues }
+    private var systemState: WizardSystemState {
+        stateMachine.wizardState
+    }
+
+    private var issues: [WizardIssue] {
+        stateMachine.wizardIssues
+    }
 
     /// Access underlying RuntimeCoordinator for business logic
     private var kanataManager: RuntimeCoordinator {

--- a/Sources/KeyPathAppKit/InstallationWizard/WizardWindowController.swift
+++ b/Sources/KeyPathAppKit/InstallationWizard/WizardWindowController.swift
@@ -56,18 +56,15 @@ final class WizardWindowController {
             .frame(width: 700)
             .fixedSize(horizontal: false, vertical: true)
 
-        let hosting: NSView
-        if let viewModel = kanataViewModel {
-            hosting = NSHostingView(rootView:
+        let hosting: NSView = if let viewModel = kanataViewModel {
+            NSHostingView(rootView:
                 styledView
                     .environment(viewModel)
-                    .environment(\.runtimeCoordinator, WizardDependencies.runtimeCoordinator)
-            )
+                    .environment(\.runtimeCoordinator, WizardDependencies.runtimeCoordinator))
         } else {
-            hosting = NSHostingView(rootView:
+            NSHostingView(rootView:
                 styledView
-                    .environment(\.runtimeCoordinator, WizardDependencies.runtimeCoordinator)
-            )
+                    .environment(\.runtimeCoordinator, WizardDependencies.runtimeCoordinator))
         }
 
         let window = NSWindow(

--- a/Sources/KeyPathAppKit/Intents/LayerEntity.swift
+++ b/Sources/KeyPathAppKit/Intents/LayerEntity.swift
@@ -15,12 +15,12 @@ struct LayerEntity: AppEntity {
 
 struct LayerEntityQuery: EntityQuery {
     func entities(for identifiers: [String]) async throws -> [LayerEntity] {
-        let allLayers = (try? await fetchLayers()) ?? []
+        let allLayers = await (try? fetchLayers()) ?? []
         return allLayers.filter { identifiers.contains($0.id) }
     }
 
     func suggestedEntities() async throws -> [LayerEntity] {
-        (try? await fetchLayers()) ?? []
+        await (try? fetchLayers()) ?? []
     }
 
     private func fetchLayers() async throws -> [LayerEntity] {

--- a/Sources/KeyPathAppKit/Intents/ServiceControlIntent.swift
+++ b/Sources/KeyPathAppKit/Intents/ServiceControlIntent.swift
@@ -22,9 +22,9 @@ struct ServiceControlIntent: AppIntent {
     @Parameter(title: "Action")
     var action: ServiceAction
 
-    // RuntimeCoordinator.startKanata/stopKanata/restartKanata delegate
-    // to ServiceLifecycleCoordinator internally — the CLAUDE.md anti-pattern
-    // is about calling launchctl or KanataDaemonManager directly.
+    /// RuntimeCoordinator.startKanata/stopKanata/restartKanata delegate
+    /// to ServiceLifecycleCoordinator internally — the CLAUDE.md anti-pattern
+    /// is about calling launchctl or KanataDaemonManager directly.
     @MainActor
     func perform() async throws -> some IntentResult & ReturnsValue<String> {
         guard let delegate = NSApp.delegate as? AppDelegate,
@@ -33,14 +33,13 @@ struct ServiceControlIntent: AppIntent {
             throw ServiceError.appNotRunning
         }
 
-        let success: Bool
-        switch action {
+        let success: Bool = switch action {
         case .start:
-            success = await manager.startKanata(reason: "Siri / App Intent")
+            await manager.startKanata(reason: "Siri / App Intent")
         case .stop:
-            success = await manager.stopKanata(reason: "Siri / App Intent")
+            await manager.stopKanata(reason: "Siri / App Intent")
         case .restart:
-            success = await manager.restartKanata(reason: "Siri / App Intent")
+            await manager.restartKanata(reason: "Siri / App Intent")
         }
 
         if success {

--- a/Sources/KeyPathAppKit/Managers/ConfigReloadCoordinator.swift
+++ b/Sources/KeyPathAppKit/Managers/ConfigReloadCoordinator.swift
@@ -157,8 +157,8 @@ final class ConfigReloadCoordinator {
             try? await Task.sleep(nanoseconds: 3_200_000_000)
             guard let self, !Task.isCancelled else { return }
             AppLogger.shared.log("🔁 [Reload] Firing deferred reload after cooldown expiry")
-            await self.triggerReload()
-            self.deferredReloadTask = nil
+            await triggerReload()
+            deferredReloadTask = nil
         }
     }
 

--- a/Sources/KeyPathAppKit/Managers/KanataDaemonManager.swift
+++ b/Sources/KeyPathAppKit/Managers/KanataDaemonManager.swift
@@ -334,7 +334,7 @@ public class KanataDaemonManager {
         }
     }
 
-    nonisolated private func readLaunchctlOutputs(for managementState: ServiceManagementState)
+    private nonisolated func readLaunchctlOutputs(for managementState: ServiceManagementState)
         async -> [(target: String, output: String, exitCode: Int32?)]
     {
         var outputs: [(target: String, output: String, exitCode: Int32?)] = []

--- a/Sources/KeyPathAppKit/Managers/RuntimeCoordinator.swift
+++ b/Sources/KeyPathAppKit/Managers/RuntimeCoordinator.swift
@@ -479,11 +479,10 @@ public class RuntimeCoordinator: SaveCoordinatorDelegate {
                 Task { @MainActor in
                     AppLogger.shared.log("🔌 [RuntimeCoordinator] Device selection changed, regenerating config and restarting Kanata...")
                     let regenerated = await self.ruleCollectionsManager.regenerateConfigFromCollections(skipReload: true)
-                    let success: Bool
-                    if regenerated {
-                        success = await self.restartKanata(reason: "Device selection changed")
+                    let success: Bool = if regenerated {
+                        await self.restartKanata(reason: "Device selection changed")
                     } else {
-                        success = false
+                        false
                     }
                     NotificationCenter.default.post(
                         name: .deviceSelectionApplyCompleted,
@@ -510,7 +509,6 @@ public class RuntimeCoordinator: SaveCoordinatorDelegate {
                     await self.handleGrabStatusChanged(active: active, reason: reason)
                 }
             })
-
         }
 
         AppLogger.shared.log("🏗️ [RuntimeCoordinator] init() completed")
@@ -727,7 +725,6 @@ public class RuntimeCoordinator: SaveCoordinatorDelegate {
     public func isKarabinerElementsRunning() async -> Bool {
         await systemRequirementsChecker.isKarabinerElementsRunning()
     }
-
 
     func killKarabinerGrabber() async -> Bool {
         await systemRequirementsChecker.killKarabinerGrabber()

--- a/Sources/KeyPathAppKit/Managers/ServiceLifecycleCoordinator.swift
+++ b/Sources/KeyPathAppKit/Managers/ServiceLifecycleCoordinator.swift
@@ -181,7 +181,7 @@ final class ServiceLifecycleCoordinator {
             // If the daemon registered but isn't running (e.g., it exited cleanly
             // after max retries), kickstart it to force a restart.
             try? await Task.sleep(for: .milliseconds(500))
-            if !(await kanataDaemonService.isDaemonRunning()) {
+            if await !(kanataDaemonService.isDaemonRunning()) {
                 AppLogger.shared.log("🔄 [Service] Daemon registered but not running — kickstarting")
                 _ = try? await SubprocessRunner.shared.launchctl("kickstart", ["system/com.keypath.kanata"])
             }
@@ -267,8 +267,8 @@ final class ServiceLifecycleCoordinator {
         if smAppServiceRefreshTask != nil { return }
         smAppServiceRefreshTask = Task { [weak self] in
             guard let self else { return false }
-            let value = await self.performSMAppServiceRefresh()
-            self.smAppServiceRefreshTask = nil
+            let value = await performSMAppServiceRefresh()
+            smAppServiceRefreshTask = nil
             return value
         }
     }

--- a/Sources/KeyPathAppKit/MenuBar/MenuBarController.swift
+++ b/Sources/KeyPathAppKit/MenuBar/MenuBarController.swift
@@ -92,7 +92,7 @@ final class MenuBarController: NSObject, NSMenuDelegate {
         keymapObservationTask = Task { @MainActor [weak self] in
             for await _ in NotificationCenter.default.notifications(named: .appKeymapsDidChange) {
                 guard let self, !Task.isCancelled else { break }
-                self.refreshAppKeymapCache()
+                refreshAppKeymapCache()
             }
         }
 

--- a/Sources/KeyPathAppKit/Models/HomeRowModsConfig.swift
+++ b/Sources/KeyPathAppKit/Models/HomeRowModsConfig.swift
@@ -17,7 +17,9 @@ public enum OppositeHandMode: String, Codable, Sendable {
         }
     }
 
-    public var isEnabled: Bool { self != .off }
+    public var isEnabled: Bool {
+        self != .off
+    }
 }
 
 /// Timing UI complexity level for home row mods

--- a/Sources/KeyPathAppKit/Models/JISPositionTable.swift
+++ b/Sources/KeyPathAppKit/Models/JISPositionTable.swift
@@ -117,5 +117,4 @@ enum JISPositionTable {
             nil
         }
     }
-
 }

--- a/Sources/KeyPathAppKit/Models/KeyAction.swift
+++ b/Sources/KeyPathAppKit/Models/KeyAction.swift
@@ -101,31 +101,31 @@ public extension KeyAction {
     var displayName: String {
         switch self {
         case let .keystroke(key):
-            return key
+            key
         case .hyper:
-            return "Hyper"
+            "Hyper"
         case .meh:
-            return "Meh"
+            "Meh"
         case let .launchApp(name, _):
-            return name
+            name
         case let .openURL(urlString):
-            return URLMappingFormatter.displayDomain(for: urlString)
+            URLMappingFormatter.displayDomain(for: urlString)
         case let .openFolder(_, name):
-            return name ?? "Folder"
+            name ?? "Folder"
         case let .runScript(path, name):
-            return name ?? URL(fileURLWithPath: path).deletingPathExtension().lastPathComponent
+            name ?? URL(fileURLWithPath: path).deletingPathExtension().lastPathComponent
         case let .systemAction(id):
-            return id
+            id
         case let .notify(title, _, _):
-            return title
+            title
         case let .windowAction(position):
-            return position
+            position
         case let .fakeKey(name, _):
-            return name
+            name
         case let .activateLayer(name):
-            return name
+            name
         case let .rawKanata(expr):
-            return expr
+            expr
         }
     }
 
@@ -133,31 +133,31 @@ public extension KeyAction {
     var autoDescription: String {
         switch self {
         case let .keystroke(key):
-            return "Remap to \(key)"
+            "Remap to \(key)"
         case .hyper:
-            return "Hyper (Cmd+Ctrl+Alt+Shift)"
+            "Hyper (Cmd+Ctrl+Alt+Shift)"
         case .meh:
-            return "Meh (Ctrl+Alt+Shift)"
+            "Meh (Ctrl+Alt+Shift)"
         case let .launchApp(name, _):
-            return "Open \(name)"
+            "Open \(name)"
         case let .openURL(urlString):
-            return "Open \(URLMappingFormatter.displayDomain(for: urlString))"
+            "Open \(URLMappingFormatter.displayDomain(for: urlString))"
         case let .openFolder(_, name):
-            return "Open \(name ?? "folder")"
+            "Open \(name ?? "folder")"
         case let .runScript(_, name):
-            return "Run \(name ?? "script")"
+            "Run \(name ?? "script")"
         case let .systemAction(id):
-            return "System: \(id)"
+            "System: \(id)"
         case let .notify(title, _, _):
-            return "Notify: \(title)"
+            "Notify: \(title)"
         case let .windowAction(position):
-            return "Window: \(position)"
+            "Window: \(position)"
         case let .fakeKey(name, action):
-            return "FakeKey: \(name) (\(action.rawValue))"
+            "FakeKey: \(name) (\(action.rawValue))"
         case let .activateLayer(name):
-            return "Activate \(name) layer"
+            "Activate \(name) layer"
         case let .rawKanata(expr):
-            return expr
+            expr
         }
     }
 }
@@ -206,20 +206,20 @@ public extension KeyAction {
 
     private static func resolveKeystroke(_ key: String) -> DisplayInfo? {
         switch key.lowercased() {
-        case "esc": return DisplayInfo(label: "Esc", icon: "escape")
-        case "enter", "ret": return DisplayInfo(label: "Return", icon: "return")
-        case "bspc": return DisplayInfo(label: "Backspace", icon: "delete.backward")
-        case "del": return DisplayInfo(label: "Delete", icon: "delete.forward")
-        case "tab": return DisplayInfo(label: "Tab", icon: "arrow.right.to.line")
-        case "spc": return DisplayInfo(label: "Space", icon: nil)
-        case "up": return DisplayInfo(label: "Up", icon: "arrow.up")
-        case "down": return DisplayInfo(label: "Down", icon: "arrow.down")
-        case "left": return DisplayInfo(label: "Left", icon: "arrow.left")
-        case "right": return DisplayInfo(label: "Right", icon: "arrow.right")
-        case "pp": return DisplayInfo(label: "Play/Pause", icon: "playpause")
-        case "next": return DisplayInfo(label: "Next", icon: "forward")
-        case "prev": return DisplayInfo(label: "Previous", icon: "backward")
-        default: return nil
+        case "esc": DisplayInfo(label: "Esc", icon: "escape")
+        case "enter", "ret": DisplayInfo(label: "Return", icon: "return")
+        case "bspc": DisplayInfo(label: "Backspace", icon: "delete.backward")
+        case "del": DisplayInfo(label: "Delete", icon: "delete.forward")
+        case "tab": DisplayInfo(label: "Tab", icon: "arrow.right.to.line")
+        case "spc": DisplayInfo(label: "Space", icon: nil)
+        case "up": DisplayInfo(label: "Up", icon: "arrow.up")
+        case "down": DisplayInfo(label: "Down", icon: "arrow.down")
+        case "left": DisplayInfo(label: "Left", icon: "arrow.left")
+        case "right": DisplayInfo(label: "Right", icon: "arrow.right")
+        case "pp": DisplayInfo(label: "Play/Pause", icon: "playpause")
+        case "next": DisplayInfo(label: "Next", icon: "forward")
+        case "prev": DisplayInfo(label: "Previous", icon: "backward")
+        default: nil
         }
     }
 
@@ -352,13 +352,13 @@ public extension KeyAction {
     var outputString: String {
         switch self {
         case let .keystroke(key):
-            return key
+            key
         case .hyper:
-            return "hyper"
+            "hyper"
         case .meh:
-            return "meh"
+            "meh"
         default:
-            return kanataOutput
+            kanataOutput
         }
     }
 }

--- a/Sources/KeyPathAppKit/Models/PhysicalLayout+Builtins.swift
+++ b/Sources/KeyPathAppKit/Models/PhysicalLayout+Builtins.swift
@@ -10,7 +10,7 @@ extension PhysicalLayout {
             return layout
         }
         #if DEBUG
-        print("PhysicalLayout: Failed to load MacBook US from JSON, using fallback")
+            print("PhysicalLayout: Failed to load MacBook US from JSON, using fallback")
         #endif
         return PhysicalLayout(id: "macbook-us", name: "MacBook US", keys: [], totalWidth: 15.54, totalHeight: 6.05)
     }()
@@ -25,7 +25,7 @@ extension PhysicalLayout {
             return layout
         }
         #if DEBUG
-        print("PhysicalLayout: Failed to load MacBook JIS from JSON, using fallback")
+            print("PhysicalLayout: Failed to load MacBook JIS from JSON, using fallback")
         #endif
         return PhysicalLayout(id: "macbook-jis", name: "MacBook JIS", keys: [], totalWidth: 15.54, totalHeight: 6.05)
     }()
@@ -41,7 +41,7 @@ extension PhysicalLayout {
             return layout
         }
         #if DEBUG
-        print("PhysicalLayout: Failed to load MacBook ISO from JSON, using fallback")
+            print("PhysicalLayout: Failed to load MacBook ISO from JSON, using fallback")
         #endif
         return PhysicalLayout(id: "macbook-iso", name: "MacBook ISO", keys: [], totalWidth: 15.54, totalHeight: 6.05)
     }()
@@ -59,7 +59,7 @@ extension PhysicalLayout {
             return layout
         }
         #if DEBUG
-        print("PhysicalLayout: Failed to load MacBook ABNT2 from JSON, using fallback")
+            print("PhysicalLayout: Failed to load MacBook ABNT2 from JSON, using fallback")
         #endif
         return PhysicalLayout(id: "macbook-abnt2", name: "MacBook ABNT2", keys: [], totalWidth: 15.54, totalHeight: 6.05)
     }()
@@ -74,52 +74,44 @@ extension PhysicalLayout {
             return layout
         }
         #if DEBUG
-        print("PhysicalLayout: Failed to load MacBook Korean from JSON, using fallback")
+            print("PhysicalLayout: Failed to load MacBook Korean from JSON, using fallback")
         #endif
         return PhysicalLayout(id: "macbook-korean", name: "MacBook Korean", keys: [], totalWidth: 15.54, totalHeight: 6.05)
     }()
 
     // MARK: - Apple Magic Keyboard Family
 
-    static let magicKeyboardCompact: PhysicalLayout = {
-        PhysicalLayout(
-            id: "magic-keyboard-compact",
-            name: "Magic Keyboard",
-            keys: macBookUS.keys,
-            totalWidth: macBookUS.totalWidth,
-            totalHeight: macBookUS.totalHeight
-        )
-    }()
+    static let magicKeyboardCompact: PhysicalLayout = .init(
+        id: "magic-keyboard-compact",
+        name: "Magic Keyboard",
+        keys: macBookUS.keys,
+        totalWidth: macBookUS.totalWidth,
+        totalHeight: macBookUS.totalHeight
+    )
 
-    static let magicKeyboardTouchID: PhysicalLayout = {
-        PhysicalLayout(
-            id: "magic-keyboard-touchid",
-            name: "Magic Keyboard with Touch ID",
-            keys: macBookUS.keys,
-            totalWidth: macBookUS.totalWidth,
-            totalHeight: macBookUS.totalHeight
-        )
-    }()
+    static let magicKeyboardTouchID: PhysicalLayout = .init(
+        id: "magic-keyboard-touchid",
+        name: "Magic Keyboard with Touch ID",
+        keys: macBookUS.keys,
+        totalWidth: macBookUS.totalWidth,
+        totalHeight: macBookUS.totalHeight
+    )
 
-    static let magicKeyboardNumpad: PhysicalLayout = {
-        PhysicalLayout(
-            id: "magic-keyboard-numpad",
-            name: "Magic Keyboard with Numeric Keypad",
-            keys: ansi100Percent.keys,
-            totalWidth: ansi100Percent.totalWidth,
-            totalHeight: ansi100Percent.totalHeight
-        )
-    }()
+    static let magicKeyboardNumpad: PhysicalLayout = .init(
+        id: "magic-keyboard-numpad",
+        name: "Magic Keyboard with Numeric Keypad",
+        keys: ansi100Percent.keys,
+        totalWidth: ansi100Percent.totalWidth,
+        totalHeight: ansi100Percent.totalHeight
+    )
 
-    static let magicKeyboardTouchIDNumpad: PhysicalLayout = {
-        PhysicalLayout(
-            id: "magic-keyboard-touchid-numpad",
-            name: "Magic Keyboard with Touch ID and Numeric Keypad",
-            keys: ansi100Percent.keys,
-            totalWidth: ansi100Percent.totalWidth,
-            totalHeight: ansi100Percent.totalHeight
-        )
-    }()
+    static let magicKeyboardTouchIDNumpad: PhysicalLayout = .init(
+        id: "magic-keyboard-touchid-numpad",
+        name: "Magic Keyboard with Touch ID and Numeric Keypad",
+        keys: ansi100Percent.keys,
+        totalWidth: ansi100Percent.totalWidth,
+        totalHeight: ansi100Percent.totalHeight
+    )
 
     // MARK: - Kinesis Advantage 360
 
@@ -143,7 +135,7 @@ extension PhysicalLayout {
         // Fallback to a minimal layout if JSON parsing fails
         // This should never happen in production, but provides graceful degradation
         #if DEBUG
-        print("PhysicalLayout: Failed to load Kinesis 360 from JSON, using fallback")
+            print("PhysicalLayout: Failed to load Kinesis 360 from JSON, using fallback")
         #endif
         return PhysicalLayout(
             id: "kinesis-360",
@@ -166,7 +158,7 @@ extension PhysicalLayout {
         }
 
         #if DEBUG
-        print("PhysicalLayout: Failed to load Kinesis mWave from JSON, using fallback")
+            print("PhysicalLayout: Failed to load Kinesis mWave from JSON, using fallback")
         #endif
         return PhysicalLayout(
             id: "kinesis-mwave",
@@ -191,7 +183,7 @@ extension PhysicalLayout {
             return layout
         }
         #if DEBUG
-        print("PhysicalLayout: Failed to load 40% ANSI from JSON, using fallback")
+            print("PhysicalLayout: Failed to load 40% ANSI from JSON, using fallback")
         #endif
         return PhysicalLayout(
             id: "ansi-40",
@@ -214,7 +206,7 @@ extension PhysicalLayout {
             return layout
         }
         #if DEBUG
-        print("PhysicalLayout: Failed to load 60% ANSI from JSON, using fallback")
+            print("PhysicalLayout: Failed to load 60% ANSI from JSON, using fallback")
         #endif
         return PhysicalLayout(
             id: "ansi-60",
@@ -237,7 +229,7 @@ extension PhysicalLayout {
             return layout
         }
         #if DEBUG
-        print("PhysicalLayout: Failed to load 65% ANSI from JSON, using fallback")
+            print("PhysicalLayout: Failed to load 65% ANSI from JSON, using fallback")
         #endif
         return PhysicalLayout(
             id: "ansi-65",
@@ -260,7 +252,7 @@ extension PhysicalLayout {
             return layout
         }
         #if DEBUG
-        print("PhysicalLayout: Failed to load 75% ANSI from JSON, using fallback")
+            print("PhysicalLayout: Failed to load 75% ANSI from JSON, using fallback")
         #endif
         return PhysicalLayout(
             id: "ansi-75",
@@ -283,7 +275,7 @@ extension PhysicalLayout {
             return layout
         }
         #if DEBUG
-        print("PhysicalLayout: Failed to load 80% ANSI from JSON, using fallback")
+            print("PhysicalLayout: Failed to load 80% ANSI from JSON, using fallback")
         #endif
         return PhysicalLayout(
             id: "ansi-80",
@@ -306,7 +298,7 @@ extension PhysicalLayout {
             return layout
         }
         #if DEBUG
-        print("PhysicalLayout: Failed to load 100% ANSI from JSON, using fallback")
+            print("PhysicalLayout: Failed to load 100% ANSI from JSON, using fallback")
         #endif
         return PhysicalLayout(
             id: "ansi-100",
@@ -331,7 +323,7 @@ extension PhysicalLayout {
             return layout
         }
         #if DEBUG
-        print("PhysicalLayout: Failed to load HHKB from JSON, using fallback")
+            print("PhysicalLayout: Failed to load HHKB from JSON, using fallback")
         #endif
         return PhysicalLayout(
             id: "hhkb",
@@ -355,7 +347,7 @@ extension PhysicalLayout {
             return layout
         }
         #if DEBUG
-        print("PhysicalLayout: Failed to load Corne from JSON, using fallback")
+            print("PhysicalLayout: Failed to load Corne from JSON, using fallback")
         #endif
         return PhysicalLayout(
             id: "corne",
@@ -379,7 +371,7 @@ extension PhysicalLayout {
             return layout
         }
         #if DEBUG
-        print("PhysicalLayout: Failed to load Sofle from JSON, using fallback")
+            print("PhysicalLayout: Failed to load Sofle from JSON, using fallback")
         #endif
         return PhysicalLayout(
             id: "sofle",
@@ -403,7 +395,7 @@ extension PhysicalLayout {
             return layout
         }
         #if DEBUG
-        print("PhysicalLayout: Failed to load Ferris Sweep from JSON, using fallback")
+            print("PhysicalLayout: Failed to load Ferris Sweep from JSON, using fallback")
         #endif
         return PhysicalLayout(
             id: "ferris-sweep",
@@ -427,7 +419,7 @@ extension PhysicalLayout {
             return layout
         }
         #if DEBUG
-        print("PhysicalLayout: Failed to load Cornix from JSON, using fallback")
+            print("PhysicalLayout: Failed to load Cornix from JSON, using fallback")
         #endif
         return PhysicalLayout(
             id: "cornix",

--- a/Sources/KeyPathAppKit/Models/PhysicalLayoutLoader.swift
+++ b/Sources/KeyPathAppKit/Models/PhysicalLayoutLoader.swift
@@ -87,13 +87,13 @@ enum PhysicalLayoutLoader {
     ) -> PhysicalLayout? {
         guard let url = KeyPathAppKitResources.url(forResource: filename, withExtension: "json") else {
             #if DEBUG
-            print("PhysicalLayoutLoader: Could not find \(filename).json in bundle")
+                print("PhysicalLayoutLoader: Could not find \(filename).json in bundle")
             #endif
             return nil
         }
         guard let data = try? Data(contentsOf: url) else {
             #if DEBUG
-            print("PhysicalLayoutLoader: Could not read data from \(filename).json")
+                print("PhysicalLayoutLoader: Could not read data from \(filename).json")
             #endif
             return nil
         }
@@ -114,7 +114,7 @@ enum PhysicalLayoutLoader {
     ) -> PhysicalLayout? {
         guard let dto = try? JSONDecoder().decode(PhysicalLayoutDTO.self, from: data) else {
             #if DEBUG
-            print("PhysicalLayoutLoader: Failed to decode layout JSON")
+                print("PhysicalLayoutLoader: Failed to decode layout JSON")
             #endif
             return nil
         }
@@ -139,4 +139,3 @@ enum PhysicalLayoutLoader {
         return layout
     }
 }
-

--- a/Sources/KeyPathAppKit/Models/RuleCollectionConfiguration.swift
+++ b/Sources/KeyPathAppKit/Models/RuleCollectionConfiguration.swift
@@ -937,4 +937,3 @@ public enum WindowSnappingActivationMode: String, Codable, Equatable, Sendable {
         }
     }
 }
-

--- a/Sources/KeyPathAppKit/Models/VallackZoneMap.swift
+++ b/Sources/KeyPathAppKit/Models/VallackZoneMap.swift
@@ -1,9 +1,9 @@
 import Foundation
 
 enum VallackZoneMap {
-    // Q=12, W=13, E=14, U=32, I=34, O=31
+    /// Q=12, W=13, E=14, U=32, I=34, O=31
     static let modifierKeyCodes: Set<UInt16> = [12, 13, 14, 32, 34, 31]
-    // F=3, J=38
+    /// F=3, J=38
     static let activatorKeyCodes: Set<UInt16> = [3, 38]
 
     static let navMappingKeyCodes: Set<UInt16> = [
@@ -26,14 +26,20 @@ enum VallackZoneMap {
 
     static func homeZones() -> [UInt16: KeyboardZone] {
         var zones: [UInt16: KeyboardZone] = [:]
-        for code in modifierKeyCodes { zones[code] = .modifier }
-        for code in activatorKeyCodes { zones[code] = .activator }
+        for code in modifierKeyCodes {
+            zones[code] = .modifier
+        }
+        for code in activatorKeyCodes {
+            zones[code] = .activator
+        }
         return zones
     }
 
     static func navZones() -> [UInt16: KeyboardZone] {
         var zones: [UInt16: KeyboardZone] = [:]
-        for code in navMappingKeyCodes { zones[code] = .navMapping }
+        for code in navMappingKeyCodes {
+            zones[code] = .navMapping
+        }
         return zones
     }
 

--- a/Sources/KeyPathAppKit/Services/Audio/TypingSoundsManager.swift
+++ b/Sources/KeyPathAppKit/Services/Audio/TypingSoundsManager.swift
@@ -140,9 +140,9 @@ final class TypingSoundsManager {
                 guard let self else { return }
                 switch action {
                 case "press", "repeat":
-                    self.playKeydown()
+                    playKeydown()
                 case "release":
-                    self.playKeyup()
+                    playKeyup()
                 default:
                     break
                 }

--- a/Sources/KeyPathAppKit/Services/Configuration/PreferencesService.swift
+++ b/Sources/KeyPathAppKit/Services/Configuration/PreferencesService.swift
@@ -441,9 +441,9 @@ final class PreferencesService: @unchecked Sendable {
         static let kindaVimLeaderHUDMode = KindaVimLeaderHUDMode.off
         static let neovimReferenceTopics = NeovimTerminalCategory.defaultRawValues
         static let neovimReferenceTopicsVersion = 2
-        // Figma uses hold-Space for pan/navigate; the overlay's hold-Space
-        // leader interferes. Ship disabled there by default — user can
-        // add more apps in Settings → Experimental.
+        /// Figma uses hold-Space for pan/navigate; the overlay's hold-Space
+        /// leader interferes. Ship disabled there by default — user can
+        /// add more apps in Settings → Experimental.
         static let overlaySuppressedBundleIDs: Set<String> = [
             "com.figma.Desktop",
             "com.figma.agent"

--- a/Sources/KeyPathAppKit/Services/Devices/AppleKeyboardRecognizer.swift
+++ b/Sources/KeyPathAppKit/Services/Devices/AppleKeyboardRecognizer.swift
@@ -38,10 +38,10 @@ enum AppleKeyboardRecognizer {
     ) -> DeviceRecognitionService.RecognitionResult? {
         let productID = event.productID
 
-        let compactProductIDs: Set<Int> = [0x0267, 0x029C]
-        let compactTouchIDProductIDs: Set<Int> = [0x029A]
-        let numpadProductIDs: Set<Int> = [0x026C]
-        let numpadTouchIDProductIDs: Set<Int> = [0x029F]
+        let compactProductIDs: Set = [0x0267, 0x029C]
+        let compactTouchIDProductIDs: Set = [0x029A]
+        let numpadProductIDs: Set = [0x026C]
+        let numpadTouchIDProductIDs: Set = [0x029F]
 
         let hasTouchID = lowerName.contains("touch id") || compactTouchIDProductIDs.contains(productID) || numpadTouchIDProductIDs.contains(productID)
         let hasNumericKeypad = lowerName.contains("numeric keypad") || numpadProductIDs.contains(productID) || numpadTouchIDProductIDs.contains(productID)

--- a/Sources/KeyPathAppKit/Services/Devices/AutoDetectKeyboardController.swift
+++ b/Sources/KeyPathAppKit/Services/Devices/AutoDetectKeyboardController.swift
@@ -39,8 +39,14 @@ final class AutoDetectKeyboardController {
         var confidence: KeyboardDetectionIndex.Confidence?
         var status: Status
 
-        var id: String { event.id }
-        var vidPidKey: String { event.vidPidKey }
+        var id: String {
+            event.id
+        }
+
+        var vidPidKey: String {
+            event.vidPidKey
+        }
+
         var canActivateOverlay: Bool {
             layoutId != nil && status != .possibleMatch
         }
@@ -116,7 +122,7 @@ final class AutoDetectKeyboardController {
         }
     ) {
         let defaults = UserDefaults.standard
-        self.baselineDisplayContext = BaselineDisplayContext(
+        baselineDisplayContext = BaselineDisplayContext(
             layoutId: defaults.string(forKey: Self.baselineLayoutDefaultsKey)
                 ?? defaults.string(forKey: LayoutPreferences.layoutIdKey)
                 ?? LayoutPreferences.defaultLayoutId,
@@ -235,13 +241,12 @@ final class AutoDetectKeyboardController {
             "🔌 [AutoDetect] Recognized \(result.keyboardName) (built-in: \(result.isBuiltIn), path: \(result.qmkPath ?? "none"), source: \(result.source.rawValue), match: \(result.matchType.rawValue))"
         )
 
-        let keyboardStatus: ConnectedKeyboard.Status
-        if result.confidence == .low {
-            keyboardStatus = .possibleMatch
+        let keyboardStatus: ConnectedKeyboard.Status = if result.confidence == .low {
+            .possibleMatch
         } else if result.isBuiltIn {
-            keyboardStatus = .suggested
+            .suggested
         } else {
-            keyboardStatus = .importRequired
+            .importRequired
         }
 
         upsertConnectedKeyboard(

--- a/Sources/KeyPathAppKit/Services/Devices/DeviceEnumerationService.swift
+++ b/Sources/KeyPathAppKit/Services/Devices/DeviceEnumerationService.swift
@@ -50,6 +50,7 @@ enum DeviceEnumerationService {
     }
 
     #if DEBUG
+
         // MARK: - Dev Fake Devices
 
         // DEV FALLBACK: macOS multi-device is blocked upstream (psych3r/driverkit#15).

--- a/Sources/KeyPathAppKit/Services/Devices/KeyboardDetectionIndex.swift
+++ b/Sources/KeyPathAppKit/Services/Devices/KeyboardDetectionIndex.swift
@@ -61,11 +61,11 @@ enum KeyboardDetectionIndex {
     }
 
     private static let cacheLock = NSLock()
-    nonisolated(unsafe) private static var cached: Cache?
+    private nonisolated(unsafe) static var cached: Cache?
 
     #if DEBUG
-        nonisolated(unsafe) private static var seededExactEntries: [Record]?
-        nonisolated(unsafe) private static var seededVendorFallbackEntries: [Record]?
+        private nonisolated(unsafe) static var seededExactEntries: [Record]?
+        private nonisolated(unsafe) static var seededVendorFallbackEntries: [Record]?
 
         static func seedIndex(exactEntries: [Record], vendorFallbackEntries: [Record] = []) {
             cacheLock.lock()

--- a/Sources/KeyPathAppKit/Services/Icons/AppIconResolver.swift
+++ b/Sources/KeyPathAppKit/Services/Icons/AppIconResolver.swift
@@ -60,7 +60,8 @@ enum AppIconResolver {
     private static func appIcon(name: String, bundleId: String?) -> NSImage? {
         // Try bundle ID first (most reliable)
         if let bundleId,
-           let appURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleId) {
+           let appURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleId)
+        {
             return NSWorkspace.shared.icon(forFile: appURL.path)
         }
 

--- a/Sources/KeyPathAppKit/Services/Import/QMKKeycodeMapping+LocaleAliases.swift
+++ b/Sources/KeyPathAppKit/Services/Import/QMKKeycodeMapping+LocaleAliases.swift
@@ -27,6 +27,7 @@ extension QMKKeycodeMapping {
         }
 
         // MARK: - Japanese (JP)
+
         alias("JP",
               ("ZKHK", "KC_GRV"), ("1", "KC_1"), ("2", "KC_2"), ("3", "KC_3"),
               ("4", "KC_4"), ("5", "KC_5"), ("6", "KC_6"), ("7", "KC_7"),
@@ -45,6 +46,7 @@ extension QMKKeycodeMapping {
               ("BSLS", "KC_INT1"), ("MHEN", "KC_INT5"), ("HENK", "KC_INT4"), ("KANA", "KC_INT2"))
 
         // MARK: - German (DE)
+
         alias("DE",
               ("CIRC", "KC_GRV"), ("1", "KC_1"), ("2", "KC_2"), ("3", "KC_3"),
               ("4", "KC_4"), ("5", "KC_5"), ("6", "KC_6"), ("7", "KC_7"),
@@ -62,6 +64,7 @@ extension QMKKeycodeMapping {
               ("COMM", "KC_COMM"), ("DOT", "KC_DOT"), ("MINS", "KC_SLSH"))
 
         // MARK: - French (FR)
+
         alias("FR",
               ("SUP2", "KC_GRV"), ("AMPR", "KC_1"), ("EACU", "KC_2"), ("DQUO", "KC_3"),
               ("QUOT", "KC_4"), ("LPRN", "KC_5"), ("MINS", "KC_6"), ("EGRV", "KC_7"),
@@ -79,6 +82,7 @@ extension QMKKeycodeMapping {
               ("SCLN", "KC_COMM"), ("COLN", "KC_DOT"), ("EXLM", "KC_SLSH"))
 
         // MARK: - UK (UK)
+
         alias("UK",
               ("GRV", "KC_GRV"), ("1", "KC_1"), ("2", "KC_2"), ("3", "KC_3"),
               ("4", "KC_4"), ("5", "KC_5"), ("6", "KC_6"), ("7", "KC_7"),
@@ -96,6 +100,7 @@ extension QMKKeycodeMapping {
               ("COMM", "KC_COMM"), ("DOT", "KC_DOT"), ("SLSH", "KC_SLSH"))
 
         // MARK: - Korean (KR)
+
         alias("KR",
               ("GRV", "KC_GRV"), ("1", "KC_1"), ("2", "KC_2"), ("3", "KC_3"),
               ("4", "KC_4"), ("5", "KC_5"), ("6", "KC_6"), ("7", "KC_7"),
@@ -114,6 +119,7 @@ extension QMKKeycodeMapping {
               ("HANJ", "KC_LNG2"), ("HAEN", "KC_LNG1"))
 
         // MARK: - Spanish (ES)
+
         alias("ES",
               ("MORD", "KC_GRV"), ("1", "KC_1"), ("2", "KC_2"), ("3", "KC_3"),
               ("4", "KC_4"), ("5", "KC_5"), ("6", "KC_6"), ("7", "KC_7"),
@@ -131,6 +137,7 @@ extension QMKKeycodeMapping {
               ("COMM", "KC_COMM"), ("DOT", "KC_DOT"), ("MINS", "KC_SLSH"))
 
         // MARK: - Italian (IT)
+
         alias("IT",
               ("BSLS", "KC_GRV"), ("1", "KC_1"), ("2", "KC_2"), ("3", "KC_3"),
               ("4", "KC_4"), ("5", "KC_5"), ("6", "KC_6"), ("7", "KC_7"),
@@ -148,6 +155,7 @@ extension QMKKeycodeMapping {
               ("COMM", "KC_COMM"), ("DOT", "KC_DOT"), ("MINS", "KC_SLSH"))
 
         // MARK: - Brazilian ABNT2 (BR)
+
         alias("BR",
               ("QUOT", "KC_GRV"), ("1", "KC_1"), ("2", "KC_2"), ("3", "KC_3"),
               ("4", "KC_4"), ("5", "KC_5"), ("6", "KC_6"), ("7", "KC_7"),
@@ -166,6 +174,7 @@ extension QMKKeycodeMapping {
               ("SLSH", "KC_INT1"), ("PDOT", "KC_PCMM"), ("PCMM", "KC_PDOT"))
 
         // MARK: - Nordic/Scandinavian (NO, SE, DK, FI)
+
         for prefix in ["NO", "SE", "DK", "FI"] {
             // These four locales share the same QWERTY alpha layout
             alias(prefix,
@@ -202,6 +211,7 @@ extension QMKKeycodeMapping {
         map["FI_ODIA"] = "KC_SCLN"; map["FI_ADIA"] = "KC_QUOT"; map["FI_QUOT"] = "KC_NUHS"
 
         // MARK: - Swiss (CH) — shared by Swiss German and Swiss French
+
         alias("CH",
               ("SECT", "KC_GRV"), ("1", "KC_1"), ("2", "KC_2"), ("3", "KC_3"),
               ("4", "KC_4"), ("5", "KC_5"), ("6", "KC_6"), ("7", "KC_7"),
@@ -221,6 +231,7 @@ extension QMKKeycodeMapping {
         map["CH_EGRV"] = "KC_LBRC"; map["CH_EACU"] = "KC_SCLN"; map["CH_AGRV"] = "KC_QUOT"
 
         // MARK: - Portuguese (PT)
+
         alias("PT",
               ("BSLS", "KC_GRV"), ("1", "KC_1"), ("2", "KC_2"), ("3", "KC_3"),
               ("4", "KC_4"), ("5", "KC_5"), ("6", "KC_6"), ("7", "KC_7"),
@@ -238,6 +249,7 @@ extension QMKKeycodeMapping {
               ("COMM", "KC_COMM"), ("DOT", "KC_DOT"), ("MINS", "KC_SLSH"))
 
         // MARK: - Turkish Q (TR)
+
         alias("TR",
               ("DQUO", "KC_GRV"), ("1", "KC_1"), ("2", "KC_2"), ("3", "KC_3"),
               ("4", "KC_4"), ("5", "KC_5"), ("6", "KC_6"), ("7", "KC_7"),
@@ -255,6 +267,7 @@ extension QMKKeycodeMapping {
               ("ODIA", "KC_COMM"), ("CCED", "KC_DOT"), ("DOT", "KC_SLSH"))
 
         // MARK: - Central/Eastern European (CZ, HU, HR, SI, RO, PL)
+
         // Czech — QWERTZ with diacritics on number row
         alias("CZ",
               ("SCLN", "KC_GRV"), ("PLUS", "KC_1"), ("ECAR", "KC_2"), ("SCAR", "KC_3"),
@@ -343,6 +356,7 @@ extension QMKKeycodeMapping {
               ("COMM", "KC_COMM"), ("DOT", "KC_DOT"), ("SLSH", "KC_SLSH"))
 
         // MARK: - Belgian (BE) — AZERTY variant
+
         alias("BE",
               ("SUP2", "KC_GRV"), ("AMPR", "KC_1"), ("EACU", "KC_2"), ("DQUO", "KC_3"),
               ("QUOT", "KC_4"), ("LPRN", "KC_5"), ("SECT", "KC_6"), ("EGRV", "KC_7"),
@@ -360,6 +374,7 @@ extension QMKKeycodeMapping {
               ("SCLN", "KC_COMM"), ("COLN", "KC_DOT"), ("EQL", "KC_SLSH"))
 
         // MARK: - Baltic (EE, LV, LT)
+
         // Estonian — QWERTY
         alias("EE",
               ("CARN", "KC_GRV"), ("1", "KC_1"), ("2", "KC_2"), ("3", "KC_3"),
@@ -412,6 +427,7 @@ extension QMKKeycodeMapping {
               ("COMM", "KC_COMM"), ("DOT", "KC_DOT"), ("SLSH", "KC_SLSH"))
 
         // MARK: - Icelandic (IS)
+
         alias("IS",
               ("RNGA", "KC_GRV"), ("1", "KC_1"), ("2", "KC_2"), ("3", "KC_3"),
               ("4", "KC_4"), ("5", "KC_5"), ("6", "KC_6"), ("7", "KC_7"),
@@ -429,6 +445,7 @@ extension QMKKeycodeMapping {
               ("COMM", "KC_COMM"), ("DOT", "KC_DOT"), ("THRN", "KC_SLSH"))
 
         // MARK: - Cyrillic (RU, UA, RS)
+
         // Russian
         alias("RU",
               ("YO", "KC_GRV"), ("1", "KC_1"), ("2", "KC_2"), ("3", "KC_3"),
@@ -481,6 +498,7 @@ extension QMKKeycodeMapping {
               ("COMM", "KC_COMM"), ("DOT", "KC_DOT"), ("MINS", "KC_SLSH"))
 
         // MARK: - Greek (GR)
+
         alias("GR",
               ("GRV", "KC_GRV"), ("1", "KC_1"), ("2", "KC_2"), ("3", "KC_3"),
               ("4", "KC_4"), ("5", "KC_5"), ("6", "KC_6"), ("7", "KC_7"),
@@ -497,6 +515,7 @@ extension QMKKeycodeMapping {
               ("COMM", "KC_COMM"), ("DOT", "KC_DOT"), ("SLSH", "KC_SLSH"))
 
         // MARK: - Hebrew (IL)
+
         alias("IL",
               ("SCLN", "KC_GRV"), ("1", "KC_1"), ("2", "KC_2"), ("3", "KC_3"),
               ("4", "KC_4"), ("5", "KC_5"), ("6", "KC_6"), ("7", "KC_7"),
@@ -513,6 +532,7 @@ extension QMKKeycodeMapping {
               ("TAV", "KC_COMM"), ("FTSD", "KC_DOT"), ("DOT", "KC_SLSH"))
 
         // MARK: - Alternative Layouts (DV, CM, BP, NE)
+
         // Dvorak
         alias("DV",
               ("GRV", "KC_GRV"), ("1", "KC_1"), ("2", "KC_2"), ("3", "KC_3"),
@@ -583,6 +603,7 @@ extension QMKKeycodeMapping {
               ("COMM", "KC_COMM"), ("DOT", "KC_DOT"), ("J", "KC_SLSH"))
 
         // MARK: - US International (US)
+
         alias("US",
               ("DGRV", "KC_GRV"), ("1", "KC_1"), ("2", "KC_2"), ("3", "KC_3"),
               ("4", "KC_4"), ("5", "KC_5"), ("6", "KC_6"), ("7", "KC_7"),
@@ -600,6 +621,7 @@ extension QMKKeycodeMapping {
               ("COMM", "KC_COMM"), ("DOT", "KC_DOT"), ("SLSH", "KC_SLSH"))
 
         // MARK: - Canadian Multilingual (CA)
+
         alias("CA",
               ("SLSH", "KC_GRV"), ("1", "KC_1"), ("2", "KC_2"), ("3", "KC_3"),
               ("4", "KC_4"), ("5", "KC_5"), ("6", "KC_6"), ("7", "KC_7"),
@@ -620,4 +642,5 @@ extension QMKKeycodeMapping {
     }()
     // swiftlint:enable function_body_length
 }
+
 // swiftlint:enable file_length

--- a/Sources/KeyPathAppKit/Services/KindaVim/KindaVimStrategyMonitor.swift
+++ b/Sources/KeyPathAppKit/Services/KindaVim/KindaVimStrategyMonitor.swift
@@ -71,9 +71,9 @@ final class KindaVimStrategyMonitor {
         // frontmost and the real user app hasn't re-activated yet.
         Task { @MainActor [weak self] in
             try? await Task.sleep(for: .seconds(1))
-            guard let self, self.monitoringCount > 0 else { return }
+            guard let self, monitoringCount > 0 else { return }
             let current = NSWorkspace.shared.frontmostApplication?.bundleIdentifier
-            self.handleFrontmostAppChanged(bundleID: current)
+            handleFrontmostAppChanged(bundleID: current)
         }
     }
 

--- a/Sources/KeyPathAppKit/Services/KindaVim/KindaVimStrategyResolver.swift
+++ b/Sources/KeyPathAppKit/Services/KindaVim/KindaVimStrategyResolver.swift
@@ -23,7 +23,7 @@ struct KindaVimStrategyResolver: Sendable {
         static let empty = PreferenceLists(ignored: [], keyboardEnforced: [], hybrid: [])
     }
 
-    static let defaultPreferencesURL: URL = URL(fileURLWithPath: NSHomeDirectory())
+    static let defaultPreferencesURL: URL = .init(fileURLWithPath: NSHomeDirectory())
         .appendingPathComponent("Library")
         .appendingPathComponent("Preferences")
         .appendingPathComponent("mo.com.sleeplessmind.kindaVim.plist")

--- a/Sources/KeyPathAppKit/Services/KindaVim/KindaVimTelemetryStore.swift
+++ b/Sources/KeyPathAppKit/Services/KindaVim/KindaVimTelemetryStore.swift
@@ -311,12 +311,12 @@ final class KindaVimTelemetryStore {
     }
 
     private func scheduleDebouncedFlush() {
-        guard flushTask == nil else { return }  // already armed
+        guard flushTask == nil else { return } // already armed
         let delay = flushInterval
         flushTask = Task { @MainActor [weak self] in
             try? await Task.sleep(for: .seconds(delay))
             guard let self, !Task.isCancelled else { return }
-            self.flushNow()
+            flushNow()
         }
     }
 

--- a/Sources/KeyPathAppKit/Services/KindaVim/VimBindings.swift
+++ b/Sources/KeyPathAppKit/Services/KindaVim/VimBindings.swift
@@ -15,7 +15,9 @@ import Foundation
 /// One Vim command, with enough metadata to render it in either the
 /// overlay (per-key) or the HUD list (grouped).
 struct VimHint: Identifiable, Equatable, Sendable {
-    var id: String { key + "|" + displayLabel }
+    var id: String {
+        key + "|" + displayLabel
+    }
 
     /// Physical key, lowercase, in kanata convention (e.g. "h", "0", "/").
     /// Multi-key sequences like `gg` use the leading key (the second is
@@ -49,7 +51,9 @@ struct VimHint: Identifiable, Equatable, Sendable {
         case secondary = 1
         case advanced = 2
 
-        static func < (lhs: Tier, rhs: Tier) -> Bool { lhs.rawValue < rhs.rawValue }
+        static func < (lhs: Tier, rhs: Tier) -> Bool {
+            lhs.rawValue < rhs.rawValue
+        }
     }
 
     enum Group: Int, CaseIterable, Sendable {
@@ -81,7 +85,9 @@ struct VimHint: Identifiable, Equatable, Sendable {
             }
         }
 
-        var sortOrder: Int { rawValue }
+        var sortOrder: Int {
+            rawValue
+        }
     }
 }
 
@@ -89,7 +95,9 @@ struct VimHintGroup: Equatable, Sendable {
     let group: VimHint.Group
     let entries: [VimHint]
 
-    var displayName: String { group.displayName }
+    var displayName: String {
+        group.displayName
+    }
 }
 
 enum VimBindings {
@@ -98,6 +106,7 @@ enum VimBindings {
     /// within each group is the order we want them to appear in lists.
     static let all: [VimHint] = [
         // MARK: Movement (core, hjkl)
+
         .init(key: "h", displayLabel: "←", actionLabel: "left",
               tier: .core, group: .movement,
               strategies: allStrategies, modes: motionModes),
@@ -112,6 +121,7 @@ enum VimBindings {
               strategies: allStrategies, modes: motionModes),
 
         // MARK: Word motion (core)
+
         .init(key: "w", displayLabel: "w", actionLabel: "word forward",
               tier: .core, group: .wordMotion,
               strategies: allStrategies, modes: motionModes),
@@ -123,6 +133,7 @@ enum VimBindings {
               strategies: allStrategies, modes: motionModes),
 
         // MARK: Line motion (core)
+
         .init(key: "0", displayLabel: "0", actionLabel: "line start",
               tier: .core, group: .lineMotion,
               strategies: allStrategies, modes: motionModes),
@@ -131,6 +142,7 @@ enum VimBindings {
               strategies: allStrategies, modes: motionModes),
 
         // MARK: Enter Insert (core: i/a/o; secondary: capitals)
+
         .init(key: "i", displayLabel: "i", actionLabel: "insert before cursor",
               tier: .core, group: .enterInsert,
               strategies: allStrategies, modes: [.normal, .visual]),
@@ -151,6 +163,7 @@ enum VimBindings {
               strategies: allStrategies, modes: [.normal, .visual]),
 
         // MARK: Edit (core: x; secondary: r/u/redo)
+
         .init(key: "x", displayLabel: "x", actionLabel: "delete char",
               tier: .core, group: .edit,
               strategies: allStrategies, modes: [.normal, .visual]),
@@ -165,6 +178,7 @@ enum VimBindings {
               strategies: allStrategies, modes: [.normal]),
 
         // MARK: Operators (secondary). In op-pending we still surface
+
         // these so the user can see "press the same one twice = whole line".
         .init(key: "d", displayLabel: "d", actionLabel: "delete (motion / dd line)",
               tier: .secondary, group: .operators,
@@ -177,6 +191,7 @@ enum VimBindings {
               strategies: allStrategies, modes: [.normal, .visual, .operatorPending]),
 
         // MARK: Find char (secondary)
+
         .init(key: "f", displayLabel: "f", actionLabel: "find char forward",
               tier: .secondary, group: .findChar,
               strategies: allStrategies, modes: [.normal, .visual]),
@@ -191,6 +206,7 @@ enum VimBindings {
               strategies: allStrategies, modes: [.normal, .visual]),
 
         // MARK: Top / Bottom (secondary; Accessibility-only)
+
         .init(key: "g", displayLabel: "gg", actionLabel: "doc top",
               tier: .secondary, group: .doc,
               strategies: [.accessibility, .hybrid], modes: motionModes),
@@ -199,6 +215,7 @@ enum VimBindings {
               strategies: [.accessibility, .hybrid], modes: motionModes),
 
         // MARK: Page (advanced — only shown with "Show all" toggle)
+
         .init(key: "ctrl-d", displayLabel: "⌃D", actionLabel: "half page down",
               tier: .advanced, group: .page,
               strategies: [.accessibility, .hybrid], modes: motionModes),
@@ -213,11 +230,13 @@ enum VimBindings {
               strategies: [.accessibility, .hybrid], modes: motionModes),
 
         // MARK: Match (advanced, Accessibility-only)
+
         .init(key: "%", displayLabel: "%", actionLabel: "match bracket",
               tier: .advanced, group: .match,
               strategies: [.accessibility, .hybrid], modes: motionModes),
 
         // MARK: Search (advanced)
+
         .init(key: "/", displayLabel: "/", actionLabel: "search forward",
               tier: .advanced, group: .search,
               strategies: [.accessibility, .hybrid], modes: [.normal, .visual]),

--- a/Sources/KeyPathAppKit/Services/KindaVim/VimInsightsEngine.swift
+++ b/Sources/KeyPathAppKit/Services/KindaVim/VimInsightsEngine.swift
@@ -28,10 +28,13 @@ struct VimInsight: Identifiable, Equatable, Sendable {
         case beginner
         case intermediate
         case advanced
-        case unknown  // not enough data
+        case unknown // not enough data
     }
 
-    var id: String { title }
+    var id: String {
+        title
+    }
+
     let glyph: Glyph
     let title: String
     let body: String
@@ -66,7 +69,6 @@ enum VimInsightsEngine {
                 priority: 100
             ))
             return candidates
-
         case .beginner:
             candidates.append(contentsOf: beginnerInsights(snapshot))
         case .intermediate:

--- a/Sources/KeyPathAppKit/Services/KindaVim/VimSequenceObserver.swift
+++ b/Sources/KeyPathAppKit/Services/KindaVim/VimSequenceObserver.swift
@@ -125,15 +125,15 @@ final class VimSequenceObserver {
     /// signal.
     private static func nonVimNavigationName(for keyCode: UInt16) -> String? {
         switch keyCode {
-        case 123: return "left"
-        case 124: return "right"
-        case 125: return "down"
-        case 126: return "up"
-        case 116: return "pageup"
-        case 121: return "pagedown"
-        case 115: return "home"
-        case 119: return "end"
-        default: return nil
+        case 123: "left"
+        case 124: "right"
+        case 125: "down"
+        case 126: "up"
+        case 116: "pageup"
+        case 121: "pagedown"
+        case 115: "home"
+        case 119: "end"
+        default: nil
         }
     }
 
@@ -222,7 +222,7 @@ final class VimSequenceObserver {
             // No bookkeeping — user is typing or kindaVim isn't reporting.
             currentOperator = nil
             countBuffer = ""
-            return  // skip telemetry recording
+            return // skip telemetry recording
         }
 
         if !character.isEmpty, !Self.isApplePrivateUse(character) {

--- a/Sources/KeyPathAppKit/Services/LayerMapping/LayerKeyMapper+Simulation.swift
+++ b/Sources/KeyPathAppKit/Services/LayerMapping/LayerKeyMapper+Simulation.swift
@@ -446,12 +446,12 @@ extension LayerKeyMapper {
         })
 
         // Hyper detection (Ctrl+Cmd+Alt+Shift)
-        let hyperSet: Set<String> = ["lctl", "lmet", "lalt", "lsft"]
+        let hyperSet: Set = ["lctl", "lmet", "lalt", "lsft"]
         if normalizedSet.isSuperset(of: hyperSet) || normalizedSet.isSuperset(of: Set(["lctl", "lmet", "lalt", "lshift"])) {
             return "✦"
         }
         // Meh detection (Ctrl+Alt+Shift)
-        let mehSet: Set<String> = ["lctl", "lalt", "lsft"]
+        let mehSet: Set = ["lctl", "lalt", "lsft"]
         if normalizedSet.isSuperset(of: mehSet) {
             return "◆"
         }

--- a/Sources/KeyPathAppKit/Services/LayerMapping/LayerKeyMapper.swift
+++ b/Sources/KeyPathAppKit/Services/LayerMapping/LayerKeyMapper.swift
@@ -181,8 +181,13 @@ struct SimulationReport: Sendable {
         let kanataName: String
     }
 
-    var failureCount: Int { failedKeys.count }
-    var hasSignificantFailures: Bool { failedKeys.count > 5 }
+    var failureCount: Int {
+        failedKeys.count
+    }
+
+    var hasSignificantFailures: Bool {
+        failedKeys.count > 5
+    }
 
     func copyableText() -> String {
         var lines: [String] = []

--- a/Sources/KeyPathAppKit/Services/LayerMapping/LayerMappingBuilder.swift
+++ b/Sources/KeyPathAppKit/Services/LayerMapping/LayerMappingBuilder.swift
@@ -29,7 +29,8 @@ enum LayerMappingBuilder {
                 } else {
                     let outputKey = keyMapping.action.outputString.lowercased()
                     if let description = keyMapping.description,
-                       let outputKeyCode = KeyboardVisualizationViewModel.kanataNameToKeyCode(outputKey) {
+                       let outputKeyCode = KeyboardVisualizationViewModel.kanataNameToKeyCode(outputKey)
+                    {
                         actionByInput[input] = .mapped(
                             displayLabel: description,
                             outputKey: outputKey,

--- a/Sources/KeyPathAppKit/Services/MainAppStateController.swift
+++ b/Sources/KeyPathAppKit/Services/MainAppStateController.swift
@@ -167,7 +167,7 @@ class MainAppStateController {
                         AppLogger.shared.error(
                             "🚨 [MainAppStateController] Critical error detected - triggering immediate revalidation"
                         )
-                        await self.revalidate()
+                        await revalidate()
                     }
                 }
             }

--- a/Sources/KeyPathAppKit/Services/Monitoring/OrphanDetector.swift
+++ b/Sources/KeyPathAppKit/Services/Monitoring/OrphanDetector.swift
@@ -183,7 +183,10 @@ final class OrphanDetector {
 
         let hasRealFailures = !userFilesFailed.isEmpty || daemonsError != nil
         if hasRealFailures {
-            AppLogger.shared.warn("🧹 [OrphanDetector] Cleanup partially complete: \(userFilesCleaned) files removed, \(userFilesFailed.count) failed, daemons: \(daemonsCleaned), daemonsError: \(daemonsError ?? "none")")
+            AppLogger.shared
+                .warn(
+                    "🧹 [OrphanDetector] Cleanup partially complete: \(userFilesCleaned) files removed, \(userFilesFailed.count) failed, daemons: \(daemonsCleaned), daemonsError: \(daemonsError ?? "none")"
+                )
         } else {
             AppLogger.shared.info("🧹 [OrphanDetector] Cleanup complete: \(userFilesCleaned) user files, daemons: \(daemonsCleaned), deferred: \(deferredForNextUninstall)")
         }

--- a/Sources/KeyPathAppKit/Services/Monitoring/StuckKeyRecoveryService.swift
+++ b/Sources/KeyPathAppKit/Services/Monitoring/StuckKeyRecoveryService.swift
@@ -40,7 +40,8 @@ final class StuckKeyRecoveryService {
         guard !isRecovering else { return }
 
         if let lastRecovery = lastRecoveryAt,
-           Date().timeIntervalSince(lastRecovery) < Self.recoveryCooldownSeconds {
+           Date().timeIntervalSince(lastRecovery) < Self.recoveryCooldownSeconds
+        {
             return
         }
 
@@ -126,7 +127,8 @@ final class StuckKeyRecoveryService {
 
         lines.append("=== Kanata Stderr (last 50 lines) ===")
         if let data = FileManager.default.contents(atPath: "/var/log/com.keypath.kanata.stderr.log"),
-           let content = String(data: data, encoding: .utf8) {
+           let content = String(data: data, encoding: .utf8)
+        {
             lines.append(contentsOf: content.components(separatedBy: .newlines).suffix(50))
         } else {
             lines.append("(file not readable)")

--- a/Sources/KeyPathAppKit/Services/Networking/KanataTCPClient+Parsing.swift
+++ b/Sources/KeyPathAppKit/Services/Networking/KanataTCPClient+Parsing.swift
@@ -16,7 +16,7 @@ extension KanataTCPClient {
         if json["status"] != nil { return true }
 
         // Named command response objects
-        let responseKeys: Set<String> = [
+        let responseKeys: Set = [
             "HelloOk", "StatusInfo", "ReloadResult",
             "LayerNames", "FakeKeyNames",
             "CurrentLayerName", "CurrentLayerInfo",

--- a/Sources/KeyPathAppKit/Services/Packs/PackDependencyChecker.swift
+++ b/Sources/KeyPathAppKit/Services/Packs/PackDependencyChecker.swift
@@ -6,7 +6,6 @@ import Foundation
 /// if they're met. No graph traversal needed for ~15 packs with 1-2 depth chains.
 @MainActor
 enum PackDependencyChecker {
-
     /// Returns unmet hard requirements for a specific pack.
     static func unmetRequirements(
         for packID: String,
@@ -106,13 +105,12 @@ enum PackDependencyChecker {
         guard let targetPack = PackRegistry.pack(id: dep.packID) else { return nil }
 
         // Check if the target pack is enabled
-        let isTargetEnabled: Bool
-        if targetPack.visualOnly {
-            isTargetEnabled = installedPackIDs.contains(targetPack.id)
+        let isTargetEnabled: Bool = if targetPack.visualOnly {
+            installedPackIDs.contains(targetPack.id)
         } else if let collectionID = targetPack.associatedCollectionID {
-            isTargetEnabled = enabledIDs.contains(collectionID)
+            enabledIDs.contains(collectionID)
         } else {
-            isTargetEnabled = false
+            false
         }
 
         guard isTargetEnabled else {

--- a/Sources/KeyPathAppKit/Services/Packs/PackZoneResolver.swift
+++ b/Sources/KeyPathAppKit/Services/Packs/PackZoneResolver.swift
@@ -17,7 +17,9 @@ enum PackZoneResolver {
         /// Per-key target layers: keyCode -> layer name to preview when that key is held
         let targets: [UInt16: String]
 
-        var activatorKeyCodes: Set<UInt16> { Set(targets.keys) }
+        var activatorKeyCodes: Set<UInt16> {
+            Set(targets.keys)
+        }
     }
 
     static func layerPreviewConfig(
@@ -65,9 +67,9 @@ enum PackZoneResolver {
     ) -> [UInt16: Color]? {
         switch packID {
         case PackRegistry.vallackSystem.id:
-            return VallackZoneMap.zones(forLayer: layerName)?.mapValues(\.color)
+            VallackZoneMap.zones(forLayer: layerName)?.mapValues(\.color)
         default:
-            return nil
+            nil
         }
     }
 

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionCatalog.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionCatalog.swift
@@ -31,15 +31,18 @@ struct RuleCollectionCatalog {
             // For tapHoldPicker: preserve user's selections but use catalog's options
             // This ensures removed options (like "None") don't persist
             if case let .tapHoldPicker(existingConfig) = existing.configuration,
-               case let .tapHoldPicker(catalogConfig) = updated.configuration {
+               case let .tapHoldPicker(catalogConfig) = updated.configuration
+            {
                 var mergedConfig = catalogConfig
                 // Preserve user's selection only if it's still a valid option
                 if let selectedTap = existingConfig.selectedTapOutput,
-                   catalogConfig.tapOptions.contains(where: { $0.output == selectedTap }) {
+                   catalogConfig.tapOptions.contains(where: { $0.output == selectedTap })
+                {
                     mergedConfig.selectedTapOutput = selectedTap
                 }
                 if let selectedHold = existingConfig.selectedHoldOutput,
-                   catalogConfig.holdOptions.contains(where: { $0.output == selectedHold }) {
+                   catalogConfig.holdOptions.contains(where: { $0.output == selectedHold })
+                {
                     mergedConfig.selectedHoldOutput = selectedHold
                 }
                 merged.configuration = .tapHoldPicker(mergedConfig)

--- a/Sources/KeyPathAppKit/Services/SimpleMods/SimpleModsParser.swift
+++ b/Sources/KeyPathAppKit/Services/SimpleMods/SimpleModsParser.swift
@@ -220,7 +220,7 @@ public final class SimpleModsParser: Sendable {
         }
 
         // Known valid keys (non-exhaustive but covers common cases)
-        let validKeys: Set<String> = [
+        let validKeys: Set = [
             "caps", "esc", "lctl", "rctl", "lsft", "rsft",
             "lalt", "ralt", "lmet", "rmet", "spc", "ret",
             "tab", "bspc", "del", "f1", "f2", "f3", "f4",

--- a/Sources/KeyPathAppKit/Services/System/VHIDSafetyCheck.swift
+++ b/Sources/KeyPathAppKit/Services/System/VHIDSafetyCheck.swift
@@ -6,7 +6,7 @@ import Foundation
 ///
 /// Extracted as a value type so the decision logic is unit-testable without
 /// instantiating singletons or hitting real system services.
-struct VHIDSafetyCheck {
+enum VHIDSafetyCheck {
     /// Returns `true` when kanata is running but the VirtualHID daemon is not healthy.
     /// Callers should emergency-stop kanata when this returns `true`.
     static func shouldEmergencyStop(kanataRunning: Bool, vhidDaemonHealthy: Bool) -> Bool {

--- a/Sources/KeyPathAppKit/Services/System/WindowManager.swift
+++ b/Sources/KeyPathAppKit/Services/System/WindowManager.swift
@@ -476,11 +476,10 @@ public final class WindowManager {
         let frontApp = NSWorkspace.shared.frontmostApplication
         let ownBundleId = Bundle.main.bundleIdentifier
 
-        let targetApp: NSRunningApplication?
-        if frontApp?.bundleIdentifier == ownBundleId {
-            targetApp = lastNonKeyPathApp
+        let targetApp: NSRunningApplication? = if frontApp?.bundleIdentifier == ownBundleId {
+            lastNonKeyPathApp
         } else {
-            targetApp = frontApp
+            frontApp
         }
 
         guard let app = targetApp else { return nil }

--- a/Sources/KeyPathAppKit/UI/CommandPalette/CommandPaletteWindowController.swift
+++ b/Sources/KeyPathAppKit/UI/CommandPalette/CommandPaletteWindowController.swift
@@ -401,7 +401,7 @@ final class CommandPaletteWindowController {
 }
 
 private class PanelDelegate: NSObject, NSWindowDelegate {
-    func windowDidResignKey(_ notification: Notification) {
+    func windowDidResignKey(_: Notification) {
         Task { @MainActor in
             CommandPaletteWindowController.shared.dismiss()
         }

--- a/Sources/KeyPathAppKit/UI/Components/OutputActionTypes.swift
+++ b/Sources/KeyPathAppKit/UI/Components/OutputActionTypes.swift
@@ -3,7 +3,9 @@ import Foundation
 struct OutputActionGroup: Identifiable {
     let title: String
     let actions: [SystemActionInfo]
-    var id: String { title }
+    var id: String {
+        title
+    }
 }
 
 private let clipboardIDs: Set<String> = ["cut", "copy", "paste", "undo", "redo", "select-all", "save", "find"]

--- a/Sources/KeyPathAppKit/UI/ContextHUD/ContextHUDController+ShowForLayer.swift
+++ b/Sources/KeyPathAppKit/UI/ContextHUD/ContextHUDController+ShowForLayer.swift
@@ -7,7 +7,8 @@ import SwiftUI
 extension ContextHUDController {
     func showForLayer(_ layerName: String) {
         if let frontBundle = NSWorkspace.shared.frontmostApplication?.bundleIdentifier,
-           PreferencesService.shared.overlaySuppressedBundleIDs.contains(frontBundle) {
+           PreferencesService.shared.overlaySuppressedBundleIDs.contains(frontBundle)
+        {
             dismiss()
             return
         }

--- a/Sources/KeyPathAppKit/UI/ContextHUD/ContextHUDViewModel.swift
+++ b/Sources/KeyPathAppKit/UI/ContextHUD/ContextHUDViewModel.swift
@@ -183,7 +183,7 @@ final class ContextHUDViewModel {
         // visual-only pack); the .kindaVimLearning style is its own view and
         // doesn't read `groups[]`. Nothing to do for KindaVim in this pass.
 
-// Split Vallack Navigation entries into hand sub-groups using sectionBreak/sectionLabel
+        // Split Vallack Navigation entries into hand sub-groups using sectionBreak/sectionLabel
         if let vallackGroup = groupMap[RuleCollectionIdentifier.vallackNavigation],
            let vallackCollection = collectionLookup[RuleCollectionIdentifier.vallackNavigation]
         {
@@ -202,7 +202,9 @@ final class ContextHUDViewModel {
             // Classify HUD entries into sections, override action with description
             var sectionEntries: [Int: [HUDKeyEntry]] = [:]
             var mappingsByInput: [String: KeyMapping] = [:]
-            for m in vallackCollection.mappings { mappingsByInput[m.input.lowercased()] = m }
+            for m in vallackCollection.mappings {
+                mappingsByInput[m.input.lowercased()] = m
+            }
 
             for entry in vallackGroup.entries {
                 let kanataName = OverlayKeyboardView.keyCodeToKanataName(entry.keyCode).lowercased()
@@ -333,7 +335,7 @@ final class ContextHUDViewModel {
         "find": ("Search", 2), "next": ("Search", 2),
     ]
 
-/// Neovim Terminal subcategory mapping: vimLabel → (subcategory name, sort order)
+    /// Neovim Terminal subcategory mapping: vimLabel → (subcategory name, sort order)
     static let neovimSubcategories: [String: (name: String, order: Int)] = [
         // Movement
         "←": ("Movement", 0), "↓": ("Movement", 0),

--- a/Sources/KeyPathAppKit/UI/Experimental/Mapper/MapperActionTypes.swift
+++ b/Sources/KeyPathAppKit/UI/Experimental/Mapper/MapperActionTypes.swift
@@ -30,7 +30,9 @@ public struct DeviceConditionInfo: Equatable, Identifiable {
     public let deviceHash: String
     public let displayName: String
     public let sfSymbolName: String
-    public var id: String { deviceHash }
+    public var id: String {
+        deviceHash
+    }
 
     public init(deviceHash: String, displayName: String, sfSymbolName: String) {
         self.deviceHash = deviceHash
@@ -98,11 +100,11 @@ public struct SystemActionInfo: Equatable, Hashable, Identifiable, Sendable {
     public var kanataOutput: String {
         switch output {
         case .pushMessage:
-            return "(push-msg \"system:\(id)\")"
-        case .hidKeycode(let keycode, _):
-            return keycode
-        case .modifierCombo(let combo):
-            return combo
+            "(push-msg \"system:\(id)\")"
+        case let .hidKeycode(keycode, _):
+            keycode
+        case let .modifierCombo(combo):
+            combo
         }
     }
 
@@ -126,13 +128,13 @@ public struct SystemActionInfo: Equatable, Hashable, Identifiable, Sendable {
 
     /// The HID keycode for media-key actions (e.g., `pp`, `mute`). Nil otherwise.
     public var kanataKeycode: String? {
-        if case .hidKeycode(let keycode, _) = output { return keycode }
+        if case let .hidKeycode(keycode, _) = output { return keycode }
         return nil
     }
 
     /// Canonical simulator name for media keys (e.g., `MediaPlayPause`). Nil otherwise.
     public var simulatorName: String? {
-        if case .hidKeycode(_, let name) = output { return name }
+        if case let .hidKeycode(_, name) = output { return name }
         return nil
     }
 
@@ -254,11 +256,11 @@ public struct SystemActionInfo: Equatable, Hashable, Identifiable, Sendable {
         if let action = allActions.first(where: { action in
             switch action.output {
             case .pushMessage:
-                return false
-            case .hidKeycode(let keycode, let simulator):
-                return keycode.lowercased() == lower || simulator?.lowercased() == lower
-            case .modifierCombo(let combo):
-                return combo.lowercased() == lower
+                false
+            case let .hidKeycode(keycode, simulator):
+                keycode.lowercased() == lower || simulator?.lowercased() == lower
+            case let .modifierCombo(combo):
+                combo.lowercased() == lower
             }
         }) {
             return action

--- a/Sources/KeyPathAppKit/UI/Experimental/MapperView+Inspector.swift
+++ b/Sources/KeyPathAppKit/UI/Experimental/MapperView+Inspector.swift
@@ -75,7 +75,6 @@ struct MapperInspectorPanel: View {
         viewModel.inputSequence?.keys.first?.baseKey.lowercased()
     }
 
-    @ViewBuilder
     private var packSuggestionsSection: some View {
         VStack(alignment: .leading, spacing: 2) {
             ForEach(packSuggestions) { pack in

--- a/Sources/KeyPathAppKit/UI/Experimental/MapperViewModel+CaptureManagement.swift
+++ b/Sources/KeyPathAppKit/UI/Experimental/MapperViewModel+CaptureManagement.swift
@@ -299,7 +299,8 @@ extension MapperViewModel {
                     // Guard against negative keyCodes (e.g., -1 for modifier-only keys or unknown keys)
                     if let firstKey = sequence.keys.first,
                        firstKey.keyCode >= 0,
-                       firstKey.keyCode <= Int64(UInt16.max) {
+                       firstKey.keyCode <= Int64(UInt16.max)
+                    {
                         let keyCode = UInt16(firstKey.keyCode)
                         self.inputKeyCode = keyCode
 
@@ -343,7 +344,8 @@ extension MapperViewModel {
             let info = mapping.info
 
             if let appIdentifier = info.appLaunchIdentifier,
-               let appInfo = appLaunchInfo(for: appIdentifier) {
+               let appInfo = appLaunchInfo(for: appIdentifier)
+            {
                 selectedApp = appInfo
                 outputLabel = appInfo.name
                 outputSequence = nil
@@ -362,7 +364,8 @@ extension MapperViewModel {
                 originalShiftedOutputKey = nil
                 AppLogger.shared.log("🔍 [MapperViewModel] Key \(keyCode) is URL: \(url)")
             } else if let systemId = info.systemActionIdentifier,
-                      let systemAction = SystemActionInfo.find(byOutput: systemId) ?? SystemActionInfo.find(byOutput: info.displayLabel) {
+                      let systemAction = SystemActionInfo.find(byOutput: systemId) ?? SystemActionInfo.find(byOutput: info.displayLabel)
+            {
                 selectedSystemAction = systemAction
                 outputLabel = systemAction.name
                 outputSequence = nil

--- a/Sources/KeyPathAppKit/UI/Experimental/MapperViewModel+RuleManagement.swift
+++ b/Sources/KeyPathAppKit/UI/Experimental/MapperViewModel+RuleManagement.swift
@@ -30,7 +30,8 @@ extension MapperViewModel {
            selectedURL == nil,
            !hasAdvancedBehavior,
            !hasShiftedOutput,
-           !hasDeviceCondition {
+           !hasDeviceCondition
+        {
             statusMessage = "Nothing to save - input and output are the same"
             statusIsError = true
             return
@@ -222,7 +223,8 @@ extension MapperViewModel {
             )
 
             if let appIdentifier = originalAppIdentifier,
-               let appInfo = appLaunchInfo(for: appIdentifier) {
+               let appInfo = appLaunchInfo(for: appIdentifier)
+            {
                 selectedApp = appInfo
                 outputLabel = appInfo.name
                 outputSequence = nil
@@ -231,7 +233,8 @@ extension MapperViewModel {
                 outputLabel = extractDomain(from: url)
                 outputSequence = nil
             } else if let systemActionId = originalSystemActionIdentifier,
-                      let systemAction = SystemActionInfo.find(byOutput: systemActionId) {
+                      let systemAction = SystemActionInfo.find(byOutput: systemActionId)
+            {
                 selectedSystemAction = systemAction
                 outputLabel = systemAction.name
                 outputSequence = nil

--- a/Sources/KeyPathAppKit/UI/Gallery/ChordGroupsPackContent.swift
+++ b/Sources/KeyPathAppKit/UI/Gallery/ChordGroupsPackContent.swift
@@ -196,78 +196,78 @@ private struct ChordRuleRow: View {
 
             // Rest of the row — tapping opens editor
             Button(action: onEdit) {
-            ZStack(alignment: .trailing) {
-                HStack {
-                    // Input keys — left aligned
-                    HStack(spacing: 3) {
-                        ForEach(chord.keys, id: \.self) { key in
-                            Text(key.uppercased())
-                                .font(.body.monospaced().weight(.semibold))
-                                .foregroundStyle(chord.isEnabled ? Self.keycapTextColor : Self.keycapTextColor.opacity(0.4))
-                                .padding(.horizontal, 10)
-                                .padding(.vertical, 6)
-                                .background(
-                                    RoundedRectangle(cornerRadius: 6)
-                                        .fill(chord.isEnabled ? Self.keycapBgColor : Self.keycapBgColor.opacity(0.4))
-                                )
-                                .overlay(
-                                    RoundedRectangle(cornerRadius: 6)
-                                        .strokeBorder(Color.secondary.opacity(0.15), lineWidth: 0.5)
-                                )
+                ZStack(alignment: .trailing) {
+                    HStack {
+                        // Input keys — left aligned
+                        HStack(spacing: 3) {
+                            ForEach(chord.keys, id: \.self) { key in
+                                Text(key.uppercased())
+                                    .font(.body.monospaced().weight(.semibold))
+                                    .foregroundStyle(chord.isEnabled ? Self.keycapTextColor : Self.keycapTextColor.opacity(0.4))
+                                    .padding(.horizontal, 10)
+                                    .padding(.vertical, 6)
+                                    .background(
+                                        RoundedRectangle(cornerRadius: 6)
+                                            .fill(chord.isEnabled ? Self.keycapBgColor : Self.keycapBgColor.opacity(0.4))
+                                    )
+                                    .overlay(
+                                        RoundedRectangle(cornerRadius: 6)
+                                            .strokeBorder(Color.secondary.opacity(0.15), lineWidth: 0.5)
+                                    )
+                            }
                         }
+
+                        Spacer()
+
+                        // Arrow — centered
+                        Image(systemName: "arrow.right")
+                            .font(.body.weight(.medium))
+                            .foregroundStyle(.secondary)
+
+                        Spacer()
+
+                        // Output — right aligned
+                        outputKeycap(for: chord.action, enabled: chord.isEnabled)
                     }
 
-                    Spacer()
+                    // Hover action buttons
+                    if isHovered {
+                        HStack(spacing: 2) {
+                            Button(action: onEdit) {
+                                Image(systemName: "pencil")
+                                    .font(.caption.weight(.semibold))
+                                    .foregroundStyle(.white)
+                                    .frame(width: 24, height: 24)
+                                    .background(Circle().fill(Color.accentColor))
+                            }
+                            .buttonStyle(.plain)
+                            .accessibilityLabel("Edit chord")
 
-                    // Arrow — centered
-                    Image(systemName: "arrow.right")
-                        .font(.body.weight(.medium))
-                        .foregroundStyle(.secondary)
-
-                    Spacer()
-
-                    // Output — right aligned
-                    outputKeycap(for: chord.action, enabled: chord.isEnabled)
-                }
-
-                // Hover action buttons
-                if isHovered {
-                    HStack(spacing: 2) {
-                        Button(action: onEdit) {
-                            Image(systemName: "pencil")
-                                .font(.caption.weight(.semibold))
-                                .foregroundStyle(.white)
-                                .frame(width: 24, height: 24)
-                                .background(Circle().fill(Color.accentColor))
+                            Button(action: onDelete) {
+                                Image(systemName: "trash")
+                                    .font(.caption.weight(.semibold))
+                                    .foregroundStyle(.white)
+                                    .frame(width: 24, height: 24)
+                                    .background(Circle().fill(Color.red.opacity(0.85)))
+                            }
+                            .buttonStyle(.plain)
+                            .accessibilityLabel("Delete chord")
                         }
-                        .buttonStyle(.plain)
-                        .accessibilityLabel("Edit chord")
-
-                        Button(action: onDelete) {
-                            Image(systemName: "trash")
-                                .font(.caption.weight(.semibold))
-                                .foregroundStyle(.white)
-                                .frame(width: 24, height: 24)
-                                .background(Circle().fill(Color.red.opacity(0.85)))
-                        }
-                        .buttonStyle(.plain)
-                        .accessibilityLabel("Delete chord")
+                        .padding(.trailing, 4)
+                        .transition(.opacity.combined(with: .scale(scale: 0.8)))
                     }
-                    .padding(.trailing, 4)
-                    .transition(.opacity.combined(with: .scale(scale: 0.8)))
                 }
+                .padding(.vertical, 6)
+                .padding(.horizontal, 8)
+                .background(isHovered ? Color.accentColor.opacity(0.15) : Color.clear)
+                .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8, style: .continuous)
+                        .stroke(Color.accentColor.opacity(isHovered ? 0.4 : 0), lineWidth: 1)
+                )
+                .contentShape(Rectangle())
             }
-            .padding(.vertical, 6)
-            .padding(.horizontal, 8)
-            .background(isHovered ? Color.accentColor.opacity(0.15) : Color.clear)
-            .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
-            .overlay(
-                RoundedRectangle(cornerRadius: 8, style: .continuous)
-                    .stroke(Color.accentColor.opacity(isHovered ? 0.4 : 0), lineWidth: 1)
-            )
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
+            .buttonStyle(.plain)
         }
         .onHover { hovering in
             withAnimation(.easeInOut(duration: 0.15)) {
@@ -309,10 +309,14 @@ private struct ChordEditItem: Identifiable {
     let groupIndex: Int
     let chordIndex: Int
     let chord: ChordDefinition
-    var id: UUID { chord.id }
+    var id: UUID {
+        chord.id
+    }
 }
 
 private struct ChordAddItem: Identifiable {
     let groupIndex: Int
-    var id: Int { groupIndex }
+    var id: Int {
+        groupIndex
+    }
 }

--- a/Sources/KeyPathAppKit/UI/Gallery/KindaVimInsightsView.swift
+++ b/Sources/KeyPathAppKit/UI/Gallery/KindaVimInsightsView.swift
@@ -145,7 +145,7 @@ struct KindaVimInsightsView: View {
         Chart {
             chartMarks(series)
         }
-        .chartYScale(domain: 0...100)
+        .chartYScale(domain: 0 ... 100)
         .chartYAxis {
             // Just 0 and 100 — anything else clutters this size.
             AxisMarks(position: .leading, values: [0, 100]) { value in
@@ -186,7 +186,9 @@ struct KindaVimInsightsView: View {
     private struct ChartPoint: Identifiable, Equatable {
         let date: Date
         let percent: Double
-        var id: Date { date }
+        var id: Date {
+            date
+        }
     }
 
     private static let chartDateFormatter: DateFormatter = {
@@ -273,17 +275,17 @@ struct KindaVimInsightsView: View {
 
     private static func tier(for count: Int) -> MasteryTier {
         switch count {
-        case 0: return .untried
-        case 1...9: return .learning
-        case 10...99: return .comfortable
-        default: return .fluent
+        case 0: .untried
+        case 1 ... 9: .learning
+        case 10 ... 99: .comfortable
+        default: .fluent
         }
     }
 
     private var topCommands: [UsageEntry] {
         snapshot.commandFrequency
             .filter { !$0.key.isEmpty }
-            .map { (key, count) in
+            .map { key, count in
                 UsageEntry(
                     key: key,
                     count: count,
@@ -306,7 +308,7 @@ struct KindaVimInsightsView: View {
         case "\u{F701}": return "↓"
         case "\u{F702}": return "←"
         case "\u{F703}": return "→"
-        case "\u{F704}"..."\u{F70F}":
+        case "\u{F704}" ... "\u{F70F}":
             guard let scalar = key.unicodeScalars.first else { return "?" }
             return "F\(scalar.value - 0xF704 + 1)"
         case "\u{F72C}": return "PgUp"
@@ -373,19 +375,19 @@ struct KindaVimInsightsView: View {
     /// to blue, Fluent to green. Same semantic palette as `tierColor`.
     private func barGradient(for tier: MasteryTier) -> [Color] {
         switch tier {
-        case .untried: return [Color.secondary.opacity(0.3), Color.secondary.opacity(0.15)]
-        case .learning: return [Color.orange.opacity(0.85), Color.orange.opacity(0.45)]
-        case .comfortable: return [Color.blue.opacity(0.85), Color.blue.opacity(0.45)]
-        case .fluent: return [Color.green.opacity(0.85), Color.green.opacity(0.45)]
+        case .untried: [Color.secondary.opacity(0.3), Color.secondary.opacity(0.15)]
+        case .learning: [Color.orange.opacity(0.85), Color.orange.opacity(0.45)]
+        case .comfortable: [Color.blue.opacity(0.85), Color.blue.opacity(0.45)]
+        case .fluent: [Color.green.opacity(0.85), Color.green.opacity(0.45)]
         }
     }
 
     private func tierColor(_ tier: MasteryTier) -> Color {
         switch tier {
-        case .untried: return .secondary
-        case .learning: return .orange
-        case .comfortable: return .blue
-        case .fluent: return .green
+        case .untried: .secondary
+        case .learning: .orange
+        case .comfortable: .blue
+        case .fluent: .green
         }
     }
 

--- a/Sources/KeyPathAppKit/UI/Gallery/KindaVimStatusBlock.swift
+++ b/Sources/KeyPathAppKit/UI/Gallery/KindaVimStatusBlock.swift
@@ -84,12 +84,14 @@ struct KindaVimStatusBlock: View {
             .accessibilityIdentifier("kindavim-status-terminal-info")
 
             if showTerminalInfo {
-                Text("Terminal apps are usually in KindaVim's ignore list. To practice vim motions there, add `bindkey -v` to your ~/.zshrc to enable zsh's built-in vi mode, then turn on \"Show vim hints in terminal apps\" above.")
-                    .font(.subheadline)
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
-                    .padding(.leading, 15)
-                    .transition(.opacity.combined(with: .move(edge: .top)))
+                Text(
+                    "Terminal apps are usually in KindaVim's ignore list. To practice vim motions there, add `bindkey -v` to your ~/.zshrc to enable zsh's built-in vi mode, then turn on \"Show vim hints in terminal apps\" above."
+                )
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+                .padding(.leading, 15)
+                .transition(.opacity.combined(with: .move(edge: .top)))
             }
 
             Divider()
@@ -115,9 +117,9 @@ struct KindaVimStatusBlock: View {
         } message: {
             Text(
                 "This permanently deletes all locally-recorded command counts, " +
-                "mode dwell time, and other usage statistics. KeyPath has no " +
-                "copies of this data — it stays on your Mac and is never sent " +
-                "anywhere."
+                    "mode dwell time, and other usage statistics. KeyPath has no " +
+                    "copies of this data — it stays on your Mac and is never sent " +
+                    "anywhere."
             )
         }
     }
@@ -169,7 +171,6 @@ struct KindaVimStatusBlock: View {
         .accessibilityIdentifier(id)
     }
 
-    @ViewBuilder
     private func row(label: String, value: String, tint: Color) -> some View {
         HStack {
             Text(label)
@@ -190,20 +191,20 @@ struct KindaVimStatusBlock: View {
 
     private var modeTint: Color {
         switch adapter.state.mode {
-        case .normal: return .green
-        case .insert: return .blue
-        case .visual: return .orange
-        case .operatorPending: return .purple
-        case .unknown: return .secondary
+        case .normal: .green
+        case .insert: .blue
+        case .visual: .orange
+        case .operatorPending: .purple
+        case .unknown: .secondary
         }
     }
 
     private var strategyTint: Color {
         switch strategyMonitor.currentStrategy {
-        case .accessibility: return .green
-        case .hybrid: return .blue
-        case .keyboard: return .orange
-        case .ignored: return .secondary
+        case .accessibility: .green
+        case .hybrid: .blue
+        case .keyboard: .orange
+        case .ignored: .secondary
         }
     }
 }

--- a/Sources/KeyPathAppKit/UI/Gallery/PackDetailView+Helpers.swift
+++ b/Sources/KeyPathAppKit/UI/Gallery/PackDetailView+Helpers.swift
@@ -63,9 +63,9 @@ extension PackDetailView {
 
     var holdTimingQuickSettingRange: ClosedRange<Double> {
         if case let .slider(_, min: lo, max: hi, step: _, unitSuffix: _) = holdTimingQuickSetting?.kind {
-            return Double(lo)...Double(hi)
+            return Double(lo) ... Double(hi)
         }
-        return 120...300
+        return 120 ... 300
     }
 
     var holdTimingQuickSettingStep: Double {

--- a/Sources/KeyPathAppKit/UI/Gallery/PackDetailView+PackActions.swift
+++ b/Sources/KeyPathAppKit/UI/Gallery/PackDetailView+PackActions.swift
@@ -118,7 +118,8 @@ extension PackDetailView {
     /// packs creates tagged CustomRules). Install's reload is suppressed
     /// so the follow-up tap/hold update fires exactly one reload.
     func applyPickerEdit(tap: String?, hold: String?) async {
-        AppLogger.shared.log("📦 [PackDetail] applyPickerEdit called: tap=\(tap ?? "nil"), hold=\(hold ?? "nil"), isInstalled=\(isInstalled), collectionID=\(pack.associatedCollectionID?.uuidString ?? "nil")")
+        AppLogger.shared
+            .log("📦 [PackDetail] applyPickerEdit called: tap=\(tap ?? "nil"), hold=\(hold ?? "nil"), isInstalled=\(isInstalled), collectionID=\(pack.associatedCollectionID?.uuidString ?? "nil")")
         if !isInstalled {
             await install(skipFinalReload: true)
         }

--- a/Sources/KeyPathAppKit/UI/Gallery/PackDetailView.swift
+++ b/Sources/KeyPathAppKit/UI/Gallery/PackDetailView.swift
@@ -473,7 +473,7 @@ struct PackDetailView: View {
     /// interactive keyboard + modifier controls instead of the generic
     /// tap-hold picker.
     var isHomeRowModsPack: Bool {
-        let homeRowKeys: Set<String> = ["a", "s", "d", "f", "j", "k", "l", "scln", ";"]
+        let homeRowKeys: Set = ["a", "s", "d", "f", "j", "k", "l", "scln", ";"]
         let inputs = Set(pack.bindings.map { $0.input.lowercased() })
         // Consider it a home-row pack if at least 4 of its bindings are on
         // the home row — covers light and full variants without listing
@@ -492,7 +492,7 @@ struct PackDetailView: View {
     var associatedPickerConfig: TapHoldPickerConfig? {
         guard let firstInput = pack.bindings.first?.input.lowercased() else { return nil }
         let base = RuleCollectionCatalog().defaultCollections().lazy
-            .compactMap { $0.configuration.tapHoldPickerConfig }
+            .compactMap(\.configuration.tapHoldPickerConfig)
             .first(where: { $0.inputKey.lowercased() == firstInput })
         guard var config = base else { return nil }
         if let liveTap = pickerTapSelection {
@@ -645,9 +645,9 @@ struct PackDetailView: View {
 
     private func settingRange(_ s: PackQuickSetting) -> ClosedRange<Double> {
         if case let .slider(_, min: lo, max: hi, step: _, unitSuffix: _) = s.kind {
-            return Double(lo)...Double(hi)
+            return Double(lo) ... Double(hi)
         }
-        return 0...100
+        return 0 ... 100
     }
 
     private func settingStep(_ s: PackQuickSetting) -> Double {

--- a/Sources/KeyPathAppKit/UI/Gallery/PackDetailWindowController.swift
+++ b/Sources/KeyPathAppKit/UI/Gallery/PackDetailWindowController.swift
@@ -18,7 +18,7 @@ final class PackDetailWindowController: NSObject {
                 return
             }
             // Different pack — replace content in the same window
-            self.openedFromOverlay = fromOverlay
+            openedFromOverlay = fromOverlay
             let content = PackDetailView(pack: pack, showBackToRules: fromOverlay)
                 .environment(kanataManager)
             existingWindow.contentView = NSHostingView(rootView: content)
@@ -54,7 +54,7 @@ final class PackDetailWindowController: NSObject {
         // Pack Detail is opened from the Rules tab (inside Settings), so the
         // overlay is already hidden and should stay hidden until Settings closes.
 
-        self.openedFromOverlay = fromOverlay
+        openedFromOverlay = fromOverlay
 
         willCloseObserver = NotificationCenter.default.addObserver(
             forName: NSWindow.willCloseNotification,
@@ -78,11 +78,13 @@ final class PackDetailWindowController: NSObject {
         }
 
         newWindow.makeKeyAndOrderFront(nil)
-        self.window = newWindow
-        self.currentPackID = pack.id
+        window = newWindow
+        currentPackID = pack.id
     }
 
-    var hasWindow: Bool { window != nil }
+    var hasWindow: Bool {
+        window != nil
+    }
 
     func closeWindow() {
         let wasFromOverlay = openedFromOverlay

--- a/Sources/KeyPathAppKit/UI/Gallery/SystemPackComponentsView.swift
+++ b/Sources/KeyPathAppKit/UI/Gallery/SystemPackComponentsView.swift
@@ -301,7 +301,6 @@ struct VallackSystemPackContent: View {
 
     // MARK: - Card Content
 
-    @ViewBuilder
     private var modsCardContent: some View {
         VStack(alignment: .leading, spacing: 8) {
             Text("Modifiers move to the top row so the home row is free for layer toggles. Tap for the letter, hold for the modifier.")
@@ -320,7 +319,6 @@ struct VallackSystemPackContent: View {
         }
     }
 
-    @ViewBuilder
     private var activatorCardContent: some View {
         VStack(alignment: .leading, spacing: 10) {
             Text("Hold either index finger to activate the navigation layer. Release to return to normal typing. Both activate the same layer — use whichever hand is free.")

--- a/Sources/KeyPathAppKit/UI/Gallery/ZonedKeyboardDiagram.swift
+++ b/Sources/KeyPathAppKit/UI/Gallery/ZonedKeyboardDiagram.swift
@@ -81,7 +81,9 @@ struct ZonedKeyboardDiagram: View {
         let label: String
         let x: Double
         let y: Double
-        var id: UInt16 { keyCode }
+        var id: UInt16 {
+            keyCode
+        }
     }
 
     private var activeKeymap: LogicalKeymap {

--- a/Sources/KeyPathAppKit/UI/Help/MarkdownHelpSheet.swift
+++ b/Sources/KeyPathAppKit/UI/Help/MarkdownHelpSheet.swift
@@ -37,4 +37,3 @@ struct MarkdownHelpSheet: View {
         .background(Color(NSColor.windowBackgroundColor))
     }
 }
-

--- a/Sources/KeyPathAppKit/UI/Help/WebHelpView.swift
+++ b/Sources/KeyPathAppKit/UI/Help/WebHelpView.swift
@@ -39,7 +39,7 @@ struct WebHelpView: NSViewRepresentable {
         }
 
         func webView(
-            _ webView: WKWebView,
+            _: WKWebView,
             decidePolicyFor navigationAction: WKNavigationAction,
             decisionHandler: @escaping @MainActor @Sendable (WKNavigationActionPolicy) -> Void
         ) {
@@ -59,7 +59,8 @@ struct WebHelpView: NSViewRepresentable {
 
             if let host = url.host,
                host.contains("malpern.github.io"),
-               url.path.hasPrefix("/KeyPath/guides/") {
+               url.path.hasPrefix("/KeyPath/guides/")
+            {
                 let resource = url.path
                     .replacingOccurrences(of: "/KeyPath/guides/", with: "")
                     .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
@@ -75,4 +76,3 @@ struct WebHelpView: NSViewRepresentable {
         }
     }
 }
-

--- a/Sources/KeyPathAppKit/UI/KeyboardTransforms/AnimatedKeyboardTransformGrid.swift
+++ b/Sources/KeyPathAppKit/UI/KeyboardTransforms/AnimatedKeyboardTransformGrid.swift
@@ -48,7 +48,7 @@ struct AnimatedKeyboardTransformGrid: View {
     }
 
     private var keyboardRows: [TransformRowModel] {
-        let desiredKeys: Set<String> = [
+        let desiredKeys: Set = [
             "1", "2", "3", "4", "5", "6", "7", "8", "9", "0",
             "q", "w", "e", "r", "t", "y", "u", "i", "o", "p",
             "a", "s", "d", "f", "g", "h", "j", "k", "l", "semicolon",

--- a/Sources/KeyPathAppKit/UI/KeyboardTransforms/KeyboardTransformGrid.swift
+++ b/Sources/KeyPathAppKit/UI/KeyboardTransforms/KeyboardTransformGrid.swift
@@ -43,7 +43,7 @@ struct KeyboardTransformGrid: View {
     }
 
     private var keyboardRows: [RowModel] {
-        let desiredKeys: Set<String> = [
+        let desiredKeys: Set = [
             "q", "w", "e", "r", "t", "y", "u", "i", "o", "p",
             "a", "s", "d", "f", "g", "h", "j", "k", "l", "semicolon",
             "z", "x", "c", "v", "b", "n", "m", "comma", "dot", "slash"

--- a/Sources/KeyPathAppKit/UI/KeyboardVisualization/KeyboardVisualizationViewModel+Fade.swift
+++ b/Sources/KeyPathAppKit/UI/KeyboardVisualization/KeyboardVisualizationViewModel+Fade.swift
@@ -9,10 +9,14 @@ extension KeyboardVisualizationViewModel {
     enum OverlayTiming {
         /// Grace period to wait for a quick re-press before clearing hold state (seconds).
         /// Trade-off: higher = less flicker, lower = less linger.
-        static var holdReleaseGrace: TimeInterval { 0 }
+        static var holdReleaseGrace: TimeInterval {
+            0
+        }
 
         /// Duration of fade-out animation when key is released (seconds).
-        static var keyReleaseFadeDuration: TimeInterval { 0 }
+        static var keyReleaseFadeDuration: TimeInterval {
+            0
+        }
     }
 
     /// Start fade-out animation for a released key

--- a/Sources/KeyPathAppKit/UI/KeyboardVisualization/KeyboardVisualizationViewModel+TCP.swift
+++ b/Sources/KeyPathAppKit/UI/KeyboardVisualization/KeyboardVisualizationViewModel+TCP.swift
@@ -648,11 +648,11 @@ extension KeyboardVisualizationViewModel {
         layerPreviewTask = Task { @MainActor [weak self] in
             try? await Task.sleep(for: .milliseconds(50))
             guard let self, !Task.isCancelled else { return }
-            guard self.pressedKeyCodes.contains(keyCode) else { return }
-            self.prePreviewLayerName = self.currentLayerName
-            self.isShowingLayerPreview = true
-            self.currentPreviewTargetLayer = targetLayer
-            self.updateLayer(targetLayer)
+            guard pressedKeyCodes.contains(keyCode) else { return }
+            prePreviewLayerName = currentLayerName
+            isShowingLayerPreview = true
+            currentPreviewTargetLayer = targetLayer
+            updateLayer(targetLayer)
         }
     }
 

--- a/Sources/KeyPathAppKit/UI/KeyboardVisualization/KeyboardVisualizationViewModel+TestHooks.swift
+++ b/Sources/KeyPathAppKit/UI/KeyboardVisualization/KeyboardVisualizationViewModel+TestHooks.swift
@@ -5,19 +5,19 @@ import KeyPathCore
 import SwiftUI
 
 #if DEBUG
-extension KeyboardVisualizationViewModel {
-    func simulateHoldActivated(key: String, action: String) {
-        handleHoldActivated(key: key, action: action)
-    }
+    extension KeyboardVisualizationViewModel {
+        func simulateHoldActivated(key: String, action: String) {
+            handleHoldActivated(key: key, action: action)
+        }
 
-    func simulateTapActivated(key: String, action: String) {
-        handleTapActivated(key: key, action: action)
-    }
+        func simulateTapActivated(key: String, action: String) {
+            handleTapActivated(key: key, action: action)
+        }
 
-    func simulateTcpKeyInput(key: String, action: String) {
-        handleTcpKeyInput(key: key, action: action)
+        func simulateTcpKeyInput(key: String, action: String) {
+            handleTcpKeyInput(key: key, action: action)
+        }
     }
-}
 #endif
 
 extension KeyboardVisualizationViewModel {

--- a/Sources/KeyPathAppKit/UI/Overlay/BaseKeycap+Labels.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/BaseKeycap+Labels.swift
@@ -39,7 +39,8 @@ extension BaseKeycap {
         if info.isTransparent { return true }
         if info.isLayerSwitch { return false }
         if info.appLaunchIdentifier != nil || info.systemActionIdentifier != nil
-            || info.urlIdentifier != nil {
+            || info.urlIdentifier != nil
+        {
             return false
         }
         if !info.displayLabel.isEmpty, info.displayLabel.lowercased() != inputKeyName {

--- a/Sources/KeyPathAppKit/UI/Overlay/BaseKeycap+LayoutContent.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/BaseKeycap+LayoutContent.swift
@@ -226,7 +226,8 @@ extension BaseKeycap {
         } else {
             let sfSymbol: String? = {
                 if let info = layerKeyInfo,
-                   let outputSymbol = LabelMetadata.sfSymbol(forOutputLabel: info.displayLabel) {
+                   let outputSymbol = LabelMetadata.sfSymbol(forOutputLabel: info.displayLabel)
+                {
                     return outputSymbol
                 }
                 return LabelMetadata.sfSymbol(forKeyCode: key.keyCode)

--- a/Sources/KeyPathAppKit/UI/Overlay/BehaviorStatePicker.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/BehaviorStatePicker.swift
@@ -134,8 +134,8 @@ private struct BehaviorSegment: View {
                 Circle()
                     .fill(
                         isConfigured
-                        ? Color.accentColor.opacity(isDefault ? 0.35 : 1.0)
-                        : Color.clear
+                            ? Color.accentColor.opacity(isDefault ? 0.35 : 1.0)
+                            : Color.clear
                     )
                     .frame(width: 4, height: 4)
 

--- a/Sources/KeyPathAppKit/UI/Overlay/HoverDropdownButton.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/HoverDropdownButton.swift
@@ -3,8 +3,8 @@ import SwiftUI
 
 struct HoverDropdownButton: View {
     let text: String
-    var sfSymbol: String? = nil
-    var icon: (name: String, image: NSImage?)? = nil
+    var sfSymbol: String?
+    var icon: (name: String, image: NSImage?)?
     let action: () -> Void
 
     @State private var isHovering = false

--- a/Sources/KeyPathAppKit/UI/Overlay/KeyboardIllustrationCard.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/KeyboardIllustrationCard.swift
@@ -171,7 +171,8 @@ struct KeyboardIllustrationCard: View {
         )
 
         if let url = imageURL,
-           let image = NSImage(contentsOf: url) {
+           let image = NSImage(contentsOf: url)
+        {
             Image(nsImage: image)
                 .resizable()
                 .interpolation(.high)

--- a/Sources/KeyPathAppKit/UI/Overlay/KeycapLayoutRole.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/KeycapLayoutRole.swift
@@ -190,11 +190,10 @@ struct LabelMetadata {
         // For labels like "⇥ tab" (symbol + space + text), extract just the symbol.
         // For multi-word text labels like "Caps Lock", keep the full string and lowercase.
         let firstWord = label.contains(" ") ? String(label.split(separator: " ").first ?? "") : label
-        let cleanLabel: String
-        if firstWord.count == 1, firstWord.first?.isLetter == false {
-            cleanLabel = firstWord
+        let cleanLabel: String = if firstWord.count == 1, firstWord.first?.isLetter == false {
+            firstWord
         } else {
-            cleanLabel = label.count > 1 ? label.lowercased() : label
+            label.count > 1 ? label.lowercased() : label
         }
 
         switch cleanLabel {

--- a/Sources/KeyPathAppKit/UI/Overlay/LauncherStore.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/LauncherStore.swift
@@ -36,11 +36,11 @@ final class LauncherStore {
             let filteredMappings: [LauncherMapping] = config.mappings.filter { mapping in
                 switch mapping.action {
                 case let .launchApp(name, bundleId):
-                    return Self.isAppInstalled(name: name, bundleId: bundleId)
+                    Self.isAppInstalled(name: name, bundleId: bundleId)
                 case .openURL, .openFolder, .runScript:
-                    return true
+                    true
                 default:
-                    return true
+                    true
                 }
             }
 

--- a/Sources/KeyPathAppKit/UI/Overlay/LiveKeyboardOverlayController+KeyClickHandling.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/LiveKeyboardOverlayController+KeyClickHandling.swift
@@ -114,7 +114,7 @@ extension LiveKeyboardOverlayController {
         )
     }
 
-    func handleKeyDoubleClick(key: PhysicalKey, layerInfo: LayerKeyInfo?) {
+    func handleKeyDoubleClick(key: PhysicalKey, layerInfo _: LayerKeyInfo?) {
         guard viewModel.isLauncherModeActive else { return }
         let inputKey = OverlayKeyboardView.keyCodeToKanataName(key.keyCode)
         let normalizedKey = inputKey.lowercased()

--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayInspectorPanel+CustomRules.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayInspectorPanel+CustomRules.swift
@@ -113,7 +113,7 @@ extension OverlayInspectorPanel {
             guard !pack.visualOnly else { return false }
             return enabledIDs.contains(collectionID)
         }.filter { pack in
-            let systemIDs: Set<String> = ["com.keypath.pack.leader-key"]
+            let systemIDs: Set = ["com.keypath.pack.leader-key"]
             return !systemIDs.contains(pack.id)
         }
     }

--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView+LabelClassification.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView+LabelClassification.swift
@@ -5,7 +5,7 @@ extension OverlayKeycapView {
     /// Whether this key has a special label that should always be rendered in the keycap
     /// (not handled by floating labels). Includes navigation keys, system keys, number row, etc.
     var hasSpecialLabel: Bool {
-        let specialLabels: Set<String> = [
+        let specialLabels: Set = [
             "Home", "End", "PgUp", "PgDn", "Del", "Lyr", "Fn", "Mod", "✦", "◆",
             "↩", "⌫", "⇥", "⇪", "esc", "⎋",
             "◀", "▶", "▲", "▼", "←", "→", "↑", "↓",

--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayMapperSection+AppMappingIndicators.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayMapperSection+AppMappingIndicators.swift
@@ -372,7 +372,10 @@ extension OverlayMapperSection {
 
     /// Clear the action for the currently selected behavior slot
     func clearCurrentSlot() {
-        AppLogger.shared.log("🧹 [OverlayMapper] clearCurrentSlot: slot=\(selectedBehaviorSlot), tapCount=\(selectedTapCount), tapMode=\(selectedTapOutputMode), input=\(viewModel.inputLabel), hasManager=\(viewModel.kanataManager != nil)")
+        AppLogger.shared
+            .log(
+                "🧹 [OverlayMapper] clearCurrentSlot: slot=\(selectedBehaviorSlot), tapCount=\(selectedTapCount), tapMode=\(selectedTapOutputMode), input=\(viewModel.inputLabel), hasManager=\(viewModel.kanataManager != nil)"
+            )
         switch selectedBehaviorSlot {
         case .tap:
             if selectedTapCount > 1 {

--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayMapperSection+Layers.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayMapperSection+Layers.swift
@@ -181,7 +181,6 @@ extension OverlayMapperSection {
         }
     }
 
-
     var shouldShowHealthGate: Bool {
         if healthIndicatorState == .checking { return true }
         if case .unhealthy = healthIndicatorState { return true }

--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayMapperSection+ShiftOutput.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayMapperSection+ShiftOutput.swift
@@ -136,12 +136,12 @@ extension OverlayMapperSection {
             .accessibilityHidden(true)
     }
 
-    private func tapOutputModeRow<TrailingAction: View>(
+    private func tapOutputModeRow(
         title: String,
         subtitle: String,
         mode: TapOutputMode,
         accessibilityIdentifier: String,
-        @ViewBuilder trailingAction: () -> TrailingAction = { EmptyView() }
+        @ViewBuilder trailingAction: () -> some View = { EmptyView() }
     ) -> some View {
         let isSelected = selectedTapOutputMode == mode
         return Button {

--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayMapperSection+Styles.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayMapperSection+Styles.swift
@@ -41,9 +41,9 @@ extension View {
     /// Drop-in replacement for `.popover()` that renders content as an inline overlay
     /// instead of using NSPopover. Avoids a crash on borderless overlay windows where
     /// NSPopover's animated resize triggers a null function pointer callback.
-    func inlinePopover<Content: View>(
+    func inlinePopover(
         isPresented: Binding<Bool>,
-        @ViewBuilder content: @escaping () -> Content
+        @ViewBuilder content: @escaping () -> some View
     ) -> some View {
         overlay(alignment: .top) {
             if isPresented.wrappedValue {

--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayMapperSection+SystemActionGroups.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayMapperSection+SystemActionGroups.swift
@@ -10,7 +10,6 @@ private struct SystemActionPopoverContentHeightKey: PreferenceKey {
 }
 
 extension OverlayMapperSection {
-
     /// Keep the picker compact by default, then grow it to a larger scrollable surface
     /// whenever any section expands. Using an explicit height lets the popover resize
     /// with the presented SwiftUI view instead of relying on a maxHeight that never
@@ -36,7 +35,8 @@ extension OverlayMapperSection {
 
     /// Popover content for output type picker with collapsible sections
     var systemActionPopover: some View {
-        let isKeystrokeSelected = viewModel.selectedSystemAction == nil && viewModel.selectedApp == nil && selectedLayerOutput == nil && viewModel.selectedURL == nil && viewModel.selectedFolder == nil && viewModel.selectedScript == nil
+        let isKeystrokeSelected = viewModel.selectedSystemAction == nil && viewModel.selectedApp == nil && selectedLayerOutput == nil && viewModel.selectedURL == nil && viewModel
+            .selectedFolder == nil && viewModel.selectedScript == nil
         let isSystemActionSelected = viewModel.selectedSystemAction != nil
         let isAppSelected = viewModel.selectedApp != nil
         let isLayerSelected = selectedLayerOutput != nil
@@ -396,11 +396,10 @@ extension OverlayMapperSection {
 
         guard panel.runModal() == .OK, let url = panel.url else { return }
 
-        let path: String
-        if url.path.hasPrefix(NSHomeDirectory()) {
-            path = url.path.replacingOccurrences(of: NSHomeDirectory(), with: "~")
+        let path: String = if url.path.hasPrefix(NSHomeDirectory()) {
+            url.path.replacingOccurrences(of: NSHomeDirectory(), with: "~")
         } else {
-            path = url.path
+            url.path
         }
 
         viewModel.selectFolder(path: path, name: url.lastPathComponent)
@@ -418,11 +417,10 @@ extension OverlayMapperSection {
 
         guard panel.runModal() == .OK, let url = panel.url else { return }
 
-        let path: String
-        if url.path.hasPrefix(NSHomeDirectory()) {
-            path = url.path.replacingOccurrences(of: NSHomeDirectory(), with: "~")
+        let path: String = if url.path.hasPrefix(NSHomeDirectory()) {
+            url.path.replacingOccurrences(of: NSHomeDirectory(), with: "~")
         } else {
-            path = url.path
+            url.path
         }
 
         let name = url.deletingPathExtension().lastPathComponent

--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayMapperSection.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayMapperSection.swift
@@ -489,146 +489,146 @@ struct OverlayMapperSection: View {
 
     private var mapperMainContent: some View {
         GeometryReader { scrollProxy in
-        ScrollView {
-        VStack(spacing: 0) {
-            Spacer(minLength: 20)
+            ScrollView {
+                VStack(spacing: 0) {
+                    Spacer(minLength: 20)
 
-            // Custom keycap layout with labels on top
-            GeometryReader { proxy in
-                let availableWidth = max(1, proxy.size.width - 8)
-                let keycapWidth: CGFloat = 100
-                let arrowWidth: CGFloat = 20
-                let spacing: CGFloat = 16
-                let baseWidth = keycapWidth * 2 + spacing * 2 + arrowWidth
-                let scale = min(1, availableWidth / baseWidth)
+                    // Custom keycap layout with labels on top
+                    GeometryReader { proxy in
+                        let availableWidth = max(1, proxy.size.width - 8)
+                        let keycapWidth: CGFloat = 100
+                        let arrowWidth: CGFloat = 20
+                        let spacing: CGFloat = 16
+                        let baseWidth = keycapWidth * 2 + spacing * 2 + arrowWidth
+                        let scale = min(1, availableWidth / baseWidth)
 
-                VStack(spacing: 8) {
-                    // Keycap row — vertically centered, fixed height
-                    HStack(alignment: .center, spacing: spacing) {
-                        // Input keycap
-                        ZStack(alignment: .top) {
-                            MapperInputKeycap(
-                                label: viewModel.inputLabel,
-                                keyCode: viewModel.inputKeyCode,
-                                isRecording: viewModel.isRecordingInput,
-                                fadeAmount: fadeAmount,
-                                customShiftSymbol: viewModel.isShiftedOutputDefault ? nil : viewModel.shiftedOutputLabel,
-                                onTap: { viewModel.toggleInputRecording() }
-                            )
-                            .scaleEffect(inputKeycapBounce ? 1.05 : 1.0)
-                            .scaleEffect(inputKeycapScale)
+                        VStack(spacing: 8) {
+                            // Keycap row — vertically centered, fixed height
+                            HStack(alignment: .center, spacing: spacing) {
+                                // Input keycap
+                                ZStack(alignment: .top) {
+                                    MapperInputKeycap(
+                                        label: viewModel.inputLabel,
+                                        keyCode: viewModel.inputKeyCode,
+                                        isRecording: viewModel.isRecordingInput,
+                                        fadeAmount: fadeAmount,
+                                        customShiftSymbol: viewModel.isShiftedOutputDefault ? nil : viewModel.shiftedOutputLabel,
+                                        onTap: { viewModel.toggleInputRecording() }
+                                    )
+                                    .scaleEffect(inputKeycapBounce ? 1.05 : 1.0)
+                                    .scaleEffect(inputKeycapScale)
 
-                            if let inputModifierLabel {
-                                Text(inputModifierLabel)
-                                    .font(.caption.weight(.medium))
-                                    .foregroundStyle(Color.accentColor)
-                                    .offset(y: -18)
-                                    .opacity(showBehaviorLabel ? 1 : 0)
-                                    .scaleEffect(showBehaviorLabel ? 1 : 0.8)
-                            }
-                        }
-                        .frame(width: keycapWidth)
+                                    if let inputModifierLabel {
+                                        Text(inputModifierLabel)
+                                            .font(.caption.weight(.medium))
+                                            .foregroundStyle(Color.accentColor)
+                                            .offset(y: -18)
+                                            .opacity(showBehaviorLabel ? 1 : 0)
+                                            .scaleEffect(showBehaviorLabel ? 1 : 0.8)
+                                    }
+                                }
+                                .frame(width: keycapWidth)
 
-                        // Arrow
-                        Image(systemName: "arrow.right")
-                            .font(.title3)
-                            .foregroundColor(.secondary)
-                            .modifier(TextGlowModifier(fadeAmount: fadeAmount))
-                            .frame(width: arrowWidth)
-
-                        // Output keycap
-                        ZStack(alignment: .top) {
-                            if selectedBehaviorSlot == .tap, selectedTapCount == 1 {
-                                MapperKeycapView(
-                                    label: activeTapOutputLabel,
-                                    isRecording: activeTapIsRecording,
-                                    maxWidth: keycapWidth,
-                                    appInfo: selectedTapOutputMode == .default ? viewModel.selectedApp : nil,
-                                    systemActionInfo: selectedTapOutputMode == .default ? viewModel.selectedSystemAction : nil,
-                                    urlFavicon: selectedTapOutputMode == .default ? viewModel.selectedURLFavicon : nil,
-                                    folderInfo: selectedTapOutputMode == .default ? viewModel.selectedFolder : nil,
-                                    scriptInfo: selectedTapOutputMode == .default ? viewModel.selectedScript : nil,
-                                    fadeAmount: fadeAmount,
-                                    onTap: { toggleRecordingForCurrentSlot() }
-                                )
-                            } else {
-                                let slotName = selectedTapCount > 1
-                                    ? "\(selectedTapCount)× Tap"
-                                    : selectedBehaviorSlot.label
-                                BehaviorSlotKeycap(
-                                    label: currentSlotOutputLabel,
-                                    isConfigured: currentSlotIsConfigured,
-                                    isRecording: isRecordingForCurrentSlot,
-                                    slotName: slotName,
-                                    fadeAmount: fadeAmount,
-                                    onTap: { toggleRecordingForCurrentSlot() },
-                                    onClear: { clearCurrentSlot() }
-                                )
-                            }
-                        }
-                        .frame(width: keycapWidth)
-                    }
-
-                    // Controls row — centered under keycaps
-                    HStack(spacing: spacing) {
-                        appConditionDropdown
-                            .frame(width: keycapWidth, alignment: .center)
-
-                        if tapHasNonIdentityMapping || currentSlotIsConfigured {
-                            Button {
-                                showingResetDialog = true
-                            } label: {
-                                Image(systemName: "arrow.counterclockwise")
-                                    .font(.caption)
+                                // Arrow
+                                Image(systemName: "arrow.right")
+                                    .font(.title3)
                                     .foregroundColor(.secondary)
+                                    .modifier(TextGlowModifier(fadeAmount: fadeAmount))
+                                    .frame(width: arrowWidth)
+
+                                // Output keycap
+                                ZStack(alignment: .top) {
+                                    if selectedBehaviorSlot == .tap, selectedTapCount == 1 {
+                                        MapperKeycapView(
+                                            label: activeTapOutputLabel,
+                                            isRecording: activeTapIsRecording,
+                                            maxWidth: keycapWidth,
+                                            appInfo: selectedTapOutputMode == .default ? viewModel.selectedApp : nil,
+                                            systemActionInfo: selectedTapOutputMode == .default ? viewModel.selectedSystemAction : nil,
+                                            urlFavicon: selectedTapOutputMode == .default ? viewModel.selectedURLFavicon : nil,
+                                            folderInfo: selectedTapOutputMode == .default ? viewModel.selectedFolder : nil,
+                                            scriptInfo: selectedTapOutputMode == .default ? viewModel.selectedScript : nil,
+                                            fadeAmount: fadeAmount,
+                                            onTap: { toggleRecordingForCurrentSlot() }
+                                        )
+                                    } else {
+                                        let slotName = selectedTapCount > 1
+                                            ? "\(selectedTapCount)× Tap"
+                                            : selectedBehaviorSlot.label
+                                        BehaviorSlotKeycap(
+                                            label: currentSlotOutputLabel,
+                                            isConfigured: currentSlotIsConfigured,
+                                            isRecording: isRecordingForCurrentSlot,
+                                            slotName: slotName,
+                                            fadeAmount: fadeAmount,
+                                            onTap: { toggleRecordingForCurrentSlot() },
+                                            onClear: { clearCurrentSlot() }
+                                        )
+                                    }
+                                }
+                                .frame(width: keycapWidth)
                             }
-                            .buttonStyle(.plain)
-                            .help("Clear mapping")
-                            .accessibilityIdentifier("overlay-mapper-reset-trigger")
-                            .frame(width: arrowWidth)
-                        } else {
-                            Color.clear
-                                .frame(width: arrowWidth, height: 1)
+
+                            // Controls row — centered under keycaps
+                            HStack(spacing: spacing) {
+                                appConditionDropdown
+                                    .frame(width: keycapWidth, alignment: .center)
+
+                                if tapHasNonIdentityMapping || currentSlotIsConfigured {
+                                    Button {
+                                        showingResetDialog = true
+                                    } label: {
+                                        Image(systemName: "arrow.counterclockwise")
+                                            .font(.caption)
+                                            .foregroundColor(.secondary)
+                                    }
+                                    .buttonStyle(.plain)
+                                    .help("Clear mapping")
+                                    .accessibilityIdentifier("overlay-mapper-reset-trigger")
+                                    .frame(width: arrowWidth)
+                                } else {
+                                    Color.clear
+                                        .frame(width: arrowWidth, height: 1)
+                                }
+
+                                outputTypeDropdown
+                                    .frame(width: keycapWidth, alignment: .center)
+                            }
+                            .saturation(Double(1 - fadeAmount))
+                            .opacity(Double(1 - fadeAmount * 0.5))
                         }
-
-                        outputTypeDropdown
-                            .frame(width: keycapWidth, alignment: .center)
+                        .border(showDebugBorders ? Color.blue : Color.clear, width: 1)
+                        .frame(width: baseWidth, height: proxy.size.height, alignment: .center)
+                        .scaleEffect(scale, anchor: .center)
+                        .frame(width: availableWidth, height: proxy.size.height, alignment: .center)
                     }
-                    .saturation(Double(1 - fadeAmount))
-                    .opacity(Double(1 - fadeAmount * 0.5))
+                    .frame(height: 132)
+
+                    appMappingIndicators
+                        .saturation(Double(1 - fadeAmount))
+                        .opacity(Double(1 - fadeAmount * 0.5))
+
+                    packSuggestionsForSelectedKey
+                        .saturation(Double(1 - fadeAmount))
+                        .opacity(Double(1 - fadeAmount * 0.5))
+
+                    if selectedBehaviorSlot == .hold, !viewModel.holdAction.isEmpty {
+                        holdVariantButton
+                            .saturation(Double(1 - fadeAmount))
+                            .opacity(Double(1 - fadeAmount * 0.5))
+                    }
+
+                    if viewModel.showAdvanced {
+                        AdvancedBehaviorContent(viewModel: viewModel)
+                            .transition(.opacity.combined(with: .move(edge: .top)))
+                            .saturation(Double(1 - fadeAmount))
+                            .opacity(Double(1 - fadeAmount * 0.5))
+                    }
+
+                    Spacer(minLength: 0)
                 }
-                .border(showDebugBorders ? Color.blue : Color.clear, width: 1)
-                .frame(width: baseWidth, height: proxy.size.height, alignment: .center)
-                .scaleEffect(scale, anchor: .center)
-                .frame(width: availableWidth, height: proxy.size.height, alignment: .center)
+                .frame(maxWidth: .infinity, minHeight: scrollProxy.size.height, alignment: .leading)
             }
-            .frame(height: 132)
-
-            appMappingIndicators
-                .saturation(Double(1 - fadeAmount))
-                .opacity(Double(1 - fadeAmount * 0.5))
-
-            packSuggestionsForSelectedKey
-                .saturation(Double(1 - fadeAmount))
-                .opacity(Double(1 - fadeAmount * 0.5))
-
-            if selectedBehaviorSlot == .hold, !viewModel.holdAction.isEmpty {
-                holdVariantButton
-                    .saturation(Double(1 - fadeAmount))
-                    .opacity(Double(1 - fadeAmount * 0.5))
-            }
-
-            if viewModel.showAdvanced {
-                AdvancedBehaviorContent(viewModel: viewModel)
-                    .transition(.opacity.combined(with: .move(edge: .top)))
-                    .saturation(Double(1 - fadeAmount))
-                    .opacity(Double(1 - fadeAmount * 0.5))
-            }
-
-            Spacer(minLength: 0)
-        }
-        .frame(maxWidth: .infinity, minHeight: scrollProxy.size.height, alignment: .leading)
-        }
         }
     }
 
@@ -734,8 +734,8 @@ struct OverlayMapperSection: View {
         var packs = PackRegistry.packsTargeting(kanataKey: kanataKey)
         if !packs.contains(where: { $0.id == PackRegistry.launcher.id }),
            let launcherConfig = kanataViewModel?.ruleCollections
-               .first(where: { $0.id == RuleCollectionIdentifier.launcher })?
-               .configuration.launcherGridConfig,
+           .first(where: { $0.id == RuleCollectionIdentifier.launcher })?
+           .configuration.launcherGridConfig,
            launcherConfig.mappings.contains(where: {
                LauncherGridConfig.normalizeKey($0.key) == LauncherGridConfig.normalizeKey(kanataKey)
            })

--- a/Sources/KeyPathAppKit/UI/Overlay/Popover/WindowAnchoredPopover.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/Popover/WindowAnchoredPopover.swift
@@ -30,11 +30,11 @@ public extension View {
     ///   - content: The popover content. Built once when `isPresented`
     ///     becomes `true` and cached until dismissal, so heavier content
     ///     doesn't pay a rebuild cost on every layout pass.
-    func windowAnchoredPopover<PopoverContent: View>(
+    func windowAnchoredPopover(
         isPresented: Binding<Bool>,
         edge: WindowAnchoredPopoverEdge = .leading,
         gap: CGFloat = 8,
-        @ViewBuilder content: @escaping () -> PopoverContent
+        @ViewBuilder content: @escaping () -> some View
     ) -> some View {
         modifier(
             WindowAnchoredPopoverModifier(
@@ -169,7 +169,9 @@ private struct WindowAnchoredPopoverHostModifier: ViewModifier {
                     Color.black.opacity(0.001)
                         .contentShape(Rectangle())
                         .onTapGesture {
-                            for entry in entries { entry.dismiss() }
+                            for entry in entries {
+                                entry.dismiss()
+                            }
                         }
                         .accessibilityIdentifier("window-anchored-popover-dismiss-backdrop")
                         .accessibilityLabel("Dismiss popover")
@@ -191,11 +193,15 @@ private struct WindowAnchoredPopoverHostModifier: ViewModifier {
                 if newEntries.isEmpty {
                     removeEscMonitor()
                 } else {
-                    installEscMonitor(dismissAll: { for entry in newEntries { entry.dismiss() } })
+                    installEscMonitor(dismissAll: { for entry in newEntries {
+                        entry.dismiss()
+                    } })
                 }
             }
             .onAppear {
-                installEscMonitor(dismissAll: { for entry in entries { entry.dismiss() } })
+                installEscMonitor(dismissAll: { for entry in entries {
+                    entry.dismiss()
+                } })
             }
             .onDisappear { removeEscMonitor() }
         }
@@ -286,22 +292,22 @@ private struct WindowAnchoredPopoverContent: View {
     private func position(for edge: WindowAnchoredPopoverEdge, size: CGSize) -> CGPoint {
         switch edge {
         case .leading:
-            return CGPoint(
+            CGPoint(
                 x: triggerFrame.minX - entry.gap - size.width / 2,
                 y: clampVertical(centerY: triggerFrame.midY, size: size)
             )
         case .trailing:
-            return CGPoint(
+            CGPoint(
                 x: triggerFrame.maxX + entry.gap + size.width / 2,
                 y: clampVertical(centerY: triggerFrame.midY, size: size)
             )
         case .top:
-            return CGPoint(
+            CGPoint(
                 x: clampHorizontal(centerX: triggerFrame.midX, size: size),
                 y: triggerFrame.minY - entry.gap - size.height / 2
             )
         case .bottom:
-            return CGPoint(
+            CGPoint(
                 x: clampHorizontal(centerX: triggerFrame.midX, size: size),
                 y: triggerFrame.maxY + entry.gap + size.height / 2
             )

--- a/Sources/KeyPathAppKit/UI/Overlay/VimHintLayer.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/VimHintLayer.swift
@@ -145,7 +145,7 @@ struct VimHintLayer: View {
         return !motionGroups.contains(hint.group)
     }
 
-    nonisolated private static let terminalBundleIDs: Set<String> = [
+    private nonisolated static let terminalBundleIDs: Set<String> = [
         "net.kovidgoyal.kitty",
         "com.mitchellh.ghostty",
         "com.apple.Terminal",
@@ -182,44 +182,44 @@ private func groupColor(for group: VimHint.Group) -> Color {
 
 private func shortActionLabel(for hint: VimHint) -> String {
     switch hint.actionLabel {
-    case "left": return "left"
-    case "down": return "down"
-    case "up": return "up"
-    case "right": return "right"
-    case "word forward": return "word →"
-    case "word back": return "← word"
-    case "end of word": return "end"
-    case "line start": return "start"
-    case "line end": return "end"
-    case "insert before cursor": return "insert"
-    case "append after cursor": return "append"
-    case "open line below": return "open ↓"
-    case "insert at line start": return "Insert"
-    case "append at line end": return "Append"
-    case "open line above": return "open ↑"
-    case "delete char": return "del chr"
-    case "replace char": return "replace"
-    case "undo": return "undo"
-    case "redo": return "redo"
-    case "delete (motion / dd line)": return "delete"
-    case "change (motion / cc line)": return "change"
-    case "yank (motion / yy line)": return "yank"
-    case "find char forward": return "find →"
-    case "find char backward": return "← find"
-    case "to char forward": return "to →"
-    case "to char backward": return "← to"
-    case "doc top": return "top"
-    case "doc bottom": return "bottom"
-    case "half page down": return "½ pg ↓"
-    case "half page up": return "½ pg ↑"
-    case "page down": return "pg ↓"
-    case "page up": return "pg ↑"
-    case "match bracket": return "match"
-    case "search forward": return "search"
-    case "search backward": return "search"
-    case "next match": return "next"
-    case "previous match": return "prev"
-    default: return String(hint.actionLabel.prefix(6))
+    case "left": "left"
+    case "down": "down"
+    case "up": "up"
+    case "right": "right"
+    case "word forward": "word →"
+    case "word back": "← word"
+    case "end of word": "end"
+    case "line start": "start"
+    case "line end": "end"
+    case "insert before cursor": "insert"
+    case "append after cursor": "append"
+    case "open line below": "open ↓"
+    case "insert at line start": "Insert"
+    case "append at line end": "Append"
+    case "open line above": "open ↑"
+    case "delete char": "del chr"
+    case "replace char": "replace"
+    case "undo": "undo"
+    case "redo": "redo"
+    case "delete (motion / dd line)": "delete"
+    case "change (motion / cc line)": "change"
+    case "yank (motion / yy line)": "yank"
+    case "find char forward": "find →"
+    case "find char backward": "← find"
+    case "to char forward": "to →"
+    case "to char backward": "← to"
+    case "doc top": "top"
+    case "doc bottom": "bottom"
+    case "half page down": "½ pg ↓"
+    case "half page up": "½ pg ↑"
+    case "page down": "pg ↓"
+    case "page up": "pg ↑"
+    case "match bracket": "match"
+    case "search forward": "search"
+    case "search backward": "search"
+    case "next match": "next"
+    case "previous match": "prev"
+    default: String(hint.actionLabel.prefix(6))
     }
 }
 
@@ -275,25 +275,25 @@ private struct VimHintLabel: View {
 
     private var fillOpacity: Double {
         switch hint.tier {
-        case .core: return 0.2
-        case .secondary: return 0.1
-        case .advanced: return 0.05
+        case .core: 0.2
+        case .secondary: 0.1
+        case .advanced: 0.05
         }
     }
 
     private var borderOpacity: Double {
         switch hint.tier {
-        case .core: return 0.6
-        case .secondary: return 0.35
-        case .advanced: return 0.2
+        case .core: 0.6
+        case .secondary: 0.35
+        case .advanced: 0.2
         }
     }
 
     private var labelOpacity: Double {
         switch hint.tier {
-        case .core: return 1.0
-        case .secondary: return 0.8
-        case .advanced: return 0.55
+        case .core: 1.0
+        case .secondary: 0.8
+        case .advanced: 0.55
         }
     }
 }

--- a/Sources/KeyPathAppKit/UI/Previews/PreviewFixtures.swift
+++ b/Sources/KeyPathAppKit/UI/Previews/PreviewFixtures.swift
@@ -53,6 +53,7 @@
         ]
 
         // MARK: - Connected Devices (fake data for UI development)
+
         // TODO: Remove once macOS multi-device support lands upstream:
         //   - psych3r/driverkit#15 (macOS multi-device DriverKit support)
         //   - jtroo/kanata#1974 (Kanata device-switch support)

--- a/Sources/KeyPathAppKit/UI/Rules/CustomRulesView+Subviews.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/CustomRulesView+Subviews.swift
@@ -263,7 +263,10 @@ struct DeviceRulesSectionHeader: View {
     let device: ConnectedDevice?
     let deviceHash: String
 
-    private var isConnected: Bool { device != nil }
+    private var isConnected: Bool {
+        device != nil
+    }
+
     private var displayName: String {
         device?.displayName ?? "Device \(deviceHash.suffix(8))"
     }

--- a/Sources/KeyPathAppKit/UI/Rules/ExpandableKindaVimRow.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/ExpandableKindaVimRow.swift
@@ -21,7 +21,7 @@ struct ExpandableKindaVimRow: View {
         .background(
             RoundedRectangle(cornerRadius: 10)
                 .fill(isHovered ? Color(NSColor.controlBackgroundColor).opacity(0.5)
-                                : Color(NSColor.windowBackgroundColor))
+                    : Color(NSColor.windowBackgroundColor))
                 .allowsHitTesting(false)
         )
         .overlay(
@@ -135,7 +135,6 @@ struct ExpandableKindaVimRow: View {
 
     // MARK: - Static Mode Badge
 
-    @ViewBuilder
     private func staticModeBadge(_ label: String, tint: Color) -> some View {
         HStack(spacing: 4) {
             Text("VIM")

--- a/Sources/KeyPathAppKit/UI/Rules/HomeRowKeyboardView.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/HomeRowKeyboardView.swift
@@ -109,8 +109,6 @@ struct HomeRowKeyboardView<PopoverContent: View>: View {
                             .popover(isPresented: popoverBinding(for: key), arrowEdge: .top) {
                                 if let keyPopoverContent {
                                     keyPopoverContent(key)
-                                } else {
-                                    EmptyView()
                                 }
                             }
                         }
@@ -148,8 +146,6 @@ struct HomeRowKeyboardView<PopoverContent: View>: View {
                             .popover(isPresented: popoverBinding(for: key), arrowEdge: .top) {
                                 if let keyPopoverContent {
                                     keyPopoverContent(key)
-                                } else {
-                                    EmptyView()
                                 }
                             }
                         }
@@ -229,7 +225,7 @@ extension HomeRowKeyboardView where PopoverContent == EmptyView {
         self.timingPreviewPhase = timingPreviewPhase
         self.leftHandKeys = leftHandKeys
         self.rightHandKeys = rightHandKeys
-        self.keyPopoverContent = nil
+        keyPopoverContent = nil
         self.onPopoverDismiss = onPopoverDismiss
         self.onKeySelected = onKeySelected
     }

--- a/Sources/KeyPathAppKit/UI/Rules/HomeRowLayerTogglesModalView.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/HomeRowLayerTogglesModalView.swift
@@ -205,8 +205,8 @@ struct HomeRowLayerTogglesModalView: View {
                                 get: { Double(localConfig.timing.quickTapTermMs) },
                                 set: { localConfig.timing.quickTapTermMs = Int($0) }
                             ), in: 0 ... 80, step: 5)
-                            .accessibilityLabel("Quick tap term")
-                            .accessibilityValue("\(localConfig.timing.quickTapTermMs) ms")
+                                .accessibilityLabel("Quick tap term")
+                                .accessibilityValue("\(localConfig.timing.quickTapTermMs) ms")
                             Text(String(localized: "\(localConfig.timing.quickTapTermMs) ms"))
                                 .font(.caption)
                                 .foregroundColor(.secondary)

--- a/Sources/KeyPathAppKit/UI/Rules/HomeRowTimingSection.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/HomeRowTimingSection.swift
@@ -111,6 +111,7 @@ struct HomeRowTimingSection: View {
             }
 
             // MARK: - Composite Timing Slider
+
             HStack(spacing: 8) {
                 Label("Prefer letters", systemImage: "character.cursor.ibeam")
                     .font(.caption2)
@@ -159,6 +160,7 @@ struct HomeRowTimingSection: View {
             .animation(.easeInOut(duration: 0.15), value: isEditingHoldDuration)
 
             // MARK: - Advanced: Independent Sliders
+
             DisclosureGroup("Adjust independently") {
                 VStack(alignment: .leading, spacing: 12) {
                     // Hold duration
@@ -178,8 +180,8 @@ struct HomeRowTimingSection: View {
                                             get: { config.timing.tapWindow },
                                             set: { config.timing.tapWindow = $0; updateConfig() }
                                         ), format: .number)
-                                        .textFieldStyle(.roundedBorder).frame(width: 70)
-                                        .accessibilityIdentifier("home-row-mods-tap-window-field")
+                                            .textFieldStyle(.roundedBorder).frame(width: 70)
+                                            .accessibilityIdentifier("home-row-mods-tap-window-field")
                                         Text("ms").font(.caption).foregroundColor(.secondary)
                                     }
                                 }
@@ -190,8 +192,8 @@ struct HomeRowTimingSection: View {
                                             get: { config.timing.holdDelay },
                                             set: { config.timing.holdDelay = $0; updateConfig() }
                                         ), format: .number)
-                                        .textFieldStyle(.roundedBorder).frame(width: 70)
-                                        .accessibilityIdentifier("home-row-mods-hold-delay-field")
+                                            .textFieldStyle(.roundedBorder).frame(width: 70)
+                                            .accessibilityIdentifier("home-row-mods-hold-delay-field")
                                         Text("ms").font(.caption).foregroundColor(.secondary)
                                     }
                                 }
@@ -201,9 +203,12 @@ struct HomeRowTimingSection: View {
                                 Text("Letters feel snappy").font(.caption2).foregroundStyle(.secondary)
                                 Slider(value: Binding(
                                     get: { 1.0 - effectiveSliderPosition },
-                                    set: { let v = TypingFeelMapping.timingValues(forSliderPosition: 1.0 - $0); config.timing.tapWindow = v.tapWindow; config.timing.holdDelay = v.holdDelay; debouncedUpdateConfig() }
-                                ), in: 0...1, step: 0.05)
-                                .accessibilityIdentifier("home-row-mods-hold-duration-advanced")
+                                    set: {
+                                        let v = TypingFeelMapping.timingValues(forSliderPosition: 1.0 - $0); config.timing.tapWindow = v.tapWindow; config.timing.holdDelay = v
+                                            .holdDelay; debouncedUpdateConfig()
+                                    }
+                                ), in: 0 ... 1, step: 0.05)
+                                    .accessibilityIdentifier("home-row-mods-hold-duration-advanced")
                                 Text("Modifiers feel snappy").font(.caption2).foregroundStyle(.secondary)
                             }
                         }
@@ -221,31 +226,31 @@ struct HomeRowTimingSection: View {
                             InfoTip("How long you must pause after typing before holds are allowed. Prevents accidental modifiers mid-word.")
                         }
                         if config.timing.requirePriorIdleMs > 0 {
-                        HStack(spacing: 8) {
-                            Text("Modifiers work mid-typing").font(.caption2).foregroundStyle(.secondary)
-                            Slider(value: Binding(
-                                get: { 350.0 - Double(max(config.timing.requirePriorIdleMs, 50)) },
-                                set: { config.timing.requirePriorIdleMs = Int(350.0 - $0); debouncedUpdateConfig() }
-                            ), in: 50...300, step: 10) { editing in
-                                isEditingIdleWindow = editing
-                            }
-                            .accessibilityIdentifier("home-row-mods-prior-idle-advanced")
-                            .overlay(alignment: .top) {
-                                if isEditingIdleWindow {
-                                    Text("\(config.timing.requirePriorIdleMs)ms")
-                                        .font(.caption.weight(.semibold).width(.condensed))
-                                        .foregroundStyle(.white)
-                                        .padding(.horizontal, 6)
-                                        .padding(.vertical, 2)
-                                        .background(Capsule().fill(Color.accentColor))
-                                        .offset(y: -18)
-                                        .allowsHitTesting(false)
-                                        .transition(.opacity)
+                            HStack(spacing: 8) {
+                                Text("Modifiers work mid-typing").font(.caption2).foregroundStyle(.secondary)
+                                Slider(value: Binding(
+                                    get: { 350.0 - Double(max(config.timing.requirePriorIdleMs, 50)) },
+                                    set: { config.timing.requirePriorIdleMs = Int(350.0 - $0); debouncedUpdateConfig() }
+                                ), in: 50 ... 300, step: 10) { editing in
+                                    isEditingIdleWindow = editing
                                 }
+                                .accessibilityIdentifier("home-row-mods-prior-idle-advanced")
+                                .overlay(alignment: .top) {
+                                    if isEditingIdleWindow {
+                                        Text("\(config.timing.requirePriorIdleMs)ms")
+                                            .font(.caption.weight(.semibold).width(.condensed))
+                                            .foregroundStyle(.white)
+                                            .padding(.horizontal, 6)
+                                            .padding(.vertical, 2)
+                                            .background(Capsule().fill(Color.accentColor))
+                                            .offset(y: -18)
+                                            .allowsHitTesting(false)
+                                            .transition(.opacity)
+                                    }
+                                }
+                                Text("No misfires while typing").font(.caption2).foregroundStyle(.secondary)
                             }
-                            Text("No misfires while typing").font(.caption2).foregroundStyle(.secondary)
-                        }
-                        .animation(.easeInOut(duration: 0.15), value: isEditingIdleWindow)
+                            .animation(.easeInOut(duration: 0.15), value: isEditingIdleWindow)
                         } // requirePriorIdleMs > 0
                     }
                 }
@@ -279,8 +284,6 @@ struct HomeRowTimingSection: View {
                     "Hold actions (modifiers or layers) only activate when you press a key with the other hand. Same-hand typing always produces letters — no accidental modifiers during fast rolls.\n\nOn Press: Faster response, may misfire on fast same-hand rolls.\nOn Release: More forgiving — waits for the other-hand key to be released before committing."
                 )
             }
-
-
 
             // MARK: - Quick Tap
 

--- a/Sources/KeyPathAppKit/UI/Rules/KeyRepeatControlView.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/KeyRepeatControlView.swift
@@ -238,8 +238,8 @@ struct KeyRepeatControlView: View {
                     .font(.caption.monospaced())
                     .foregroundStyle(.tertiary)
             }
-            cleanSlider(label: "Delay", value: $globalDelayMs, range: 50...2000, snap: 10, id: "global-delay")
-            cleanSlider(label: "Speed", value: $globalIntervalMs, range: 5...200, snap: 5, id: "global-speed")
+            cleanSlider(label: "Delay", value: $globalDelayMs, range: 50 ... 2000, snap: 10, id: "global-delay")
+            cleanSlider(label: "Speed", value: $globalIntervalMs, range: 5 ... 200, snap: 5, id: "global-speed")
         }
     }
 
@@ -258,8 +258,8 @@ struct KeyRepeatControlView: View {
                 }
             }
             if arrowEnabled {
-                cleanSlider(label: "Delay", value: $arrowDelayMs, range: 50...1000, snap: 10, id: "arrow-delay")
-                cleanSlider(label: "Speed", value: $arrowIntervalMs, range: 5...100, snap: 5, id: "arrow-speed")
+                cleanSlider(label: "Delay", value: $arrowDelayMs, range: 50 ... 1000, snap: 10, id: "arrow-delay")
+                cleanSlider(label: "Speed", value: $arrowIntervalMs, range: 5 ... 100, snap: 5, id: "arrow-speed")
             }
         }
     }
@@ -271,8 +271,8 @@ struct KeyRepeatControlView: View {
                 .toggleStyle(.checkbox)
                 .accessibilityIdentifier("key-repeat-delete-toggle")
             if deleteEnabled {
-                cleanSlider(label: "Delay", value: $deleteDelayMs, range: 50...1000, snap: 10, id: "delete-delay")
-                cleanSlider(label: "Speed", value: $deleteIntervalMs, range: 5...100, snap: 5, id: "delete-speed")
+                cleanSlider(label: "Delay", value: $deleteDelayMs, range: 50 ... 1000, snap: 10, id: "delete-delay")
+                cleanSlider(label: "Speed", value: $deleteIntervalMs, range: 5 ... 100, snap: 5, id: "delete-speed")
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -285,8 +285,8 @@ struct KeyRepeatControlView: View {
                 .toggleStyle(.checkbox)
                 .accessibilityIdentifier("key-repeat-fwd-delete-toggle")
             if fwdDeleteEnabled {
-                cleanSlider(label: "Delay", value: $fwdDeleteDelayMs, range: 50...1000, snap: 10, id: "fwd-delete-delay")
-                cleanSlider(label: "Speed", value: $fwdDeleteIntervalMs, range: 5...100, snap: 5, id: "fwd-delete-speed")
+                cleanSlider(label: "Delay", value: $fwdDeleteDelayMs, range: 50 ... 1000, snap: 10, id: "fwd-delete-delay")
+                cleanSlider(label: "Speed", value: $fwdDeleteIntervalMs, range: 5 ... 100, snap: 5, id: "fwd-delete-speed")
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -308,17 +308,17 @@ struct KeyRepeatControlView: View {
                         cleanSlider(label: "Delay", value: Binding(
                             get: { customOverrides.indices.contains(index) ? customOverrides[index].delayMs : entry.delayMs },
                             set: { if customOverrides.indices.contains(index) { customOverrides[index].delayMs = $0 } }
-                        ), range: 50...2000, snap: 10)
+                        ), range: 50 ... 2000, snap: 10)
                         cleanSlider(label: "Speed", value: Binding(
                             get: { customOverrides.indices.contains(index) ? customOverrides[index].intervalMs : entry.intervalMs },
                             set: { if customOverrides.indices.contains(index) { customOverrides[index].intervalMs = $0 } }
-                        ), range: 5...200, snap: 5)
+                        ), range: 5 ... 200, snap: 5)
                     }
 
                     Button { customOverrides.remove(at: index) } label: {
                         Image(systemName: "xmark.circle.fill").font(.subheadline).foregroundStyle(.tertiary)
                     }.buttonStyle(.plain)
-                    .accessibilityIdentifier("key-repeat-remove-custom-\(entry.key)")
+                        .accessibilityIdentifier("key-repeat-remove-custom-\(entry.key)")
                 }
             }
         }
@@ -343,7 +343,7 @@ struct KeyRepeatControlView: View {
                     Label("Add custom key", systemImage: "plus.circle")
                         .font(.subheadline.weight(.medium))
                 }.buttonStyle(.plain).foregroundStyle(Color.accentColor)
-                .accessibilityIdentifier("key-repeat-add-custom-key-button")
+                    .accessibilityIdentifier("key-repeat-add-custom-key-button")
             }
         }
     }
@@ -390,10 +390,10 @@ struct KeyRepeatControlView: View {
             Slider(value: Binding(
                 get: { Double(value.wrappedValue) },
                 set: { value.wrappedValue = Int(($0 / Double(snap)).rounded() * Double(snap)) }
-            ), in: Double(range.lowerBound)...Double(range.upperBound))
-            .controlSize(.small)
-            .accessibilityIdentifier(id.isEmpty ? "key-repeat-slider-\(label.lowercased())" : "key-repeat-slider-\(id)")
-            .accessibilityValue(displayValue)
+            ), in: Double(range.lowerBound) ... Double(range.upperBound))
+                .controlSize(.small)
+                .accessibilityIdentifier(id.isEmpty ? "key-repeat-slider-\(label.lowercased())" : "key-repeat-slider-\(id)")
+                .accessibilityValue(displayValue)
         }
     }
 
@@ -421,7 +421,9 @@ struct KeyRepeatControlView: View {
         emitConfig()
     }
 
-    private func emitConfig() { onConfigChanged(buildConfig()) }
+    private func emitConfig() {
+        onConfigChanged(buildConfig())
+    }
 
     private func buildConfig() -> KeyRepeatControlConfig {
         var overrides: [KeyRepeatOverride] = []

--- a/Sources/KeyPathAppKit/UI/Rules/LauncherMappingEditor.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/LauncherMappingEditor.swift
@@ -532,7 +532,8 @@ struct LauncherMappingEditor: View {
         formRow("Icon") {
             HStack(spacing: 8) {
                 if !customIconPath.isEmpty,
-                   let img = NSImage(contentsOfFile: (customIconPath as NSString).expandingTildeInPath) {
+                   let img = NSImage(contentsOfFile: (customIconPath as NSString).expandingTildeInPath)
+                {
                     Image(nsImage: img)
                         .resizable()
                         .aspectRatio(contentMode: .fit)

--- a/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView+MappingRow.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView+MappingRow.swift
@@ -8,7 +8,18 @@ import SwiftUI
 // MARK: - Mapping Row View
 
 struct MappingRowView: View {
-    let mapping: (input: String, output: String, shiftedOutput: String?, ctrlOutput: String?, description: String?, sectionBreak: Bool, sectionLabel: String?, enabled: Bool, id: UUID, behavior: MappingBehavior?)
+    let mapping: (
+        input: String,
+        output: String,
+        shiftedOutput: String?,
+        ctrlOutput: String?,
+        description: String?,
+        sectionBreak: Bool,
+        sectionLabel: String?,
+        enabled: Bool,
+        id: UUID,
+        behavior: MappingBehavior?
+    )
     let layerActivator: MomentaryActivator?
     var leaderKeyDisplay: String = "␣ Space"
     let onEditMapping: ((UUID) -> Void)?
@@ -173,5 +184,4 @@ struct MappingRowView: View {
             }
         }
     }
-
 }

--- a/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView+MappingTable.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView+MappingTable.swift
@@ -8,7 +8,18 @@ import SwiftUI
 // MARK: - Mapping Table Content
 
 struct MappingTableContent: View {
-    let mappings: [(input: String, output: String, shiftedOutput: String?, ctrlOutput: String?, description: String?, sectionBreak: Bool, sectionLabel: String?, enabled: Bool, id: UUID, behavior: MappingBehavior?)]
+    let mappings: [(
+        input: String,
+        output: String,
+        shiftedOutput: String?,
+        ctrlOutput: String?,
+        description: String?,
+        sectionBreak: Bool,
+        sectionLabel: String?,
+        enabled: Bool,
+        id: UUID,
+        behavior: MappingBehavior?
+    )]
 
     private var hasShiftVariants: Bool {
         mappings.contains { $0.shiftedOutput != nil }

--- a/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView+Packs.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView+Packs.swift
@@ -14,7 +14,8 @@ extension RulesTabView {
     var kindaVimRow: some View {
         let pack = PackRegistry.kindaVim
         if !isSearching || pack.name.localizedCaseInsensitiveContains(trimmedSearchQuery)
-            || "kindavim".contains(trimmedSearchQuery.lowercased()) {
+            || "kindavim".contains(trimmedSearchQuery.lowercased())
+        {
             ExpandableKindaVimRow(
                 isPackEnabled: isKindaVimInstalled,
                 onToggle: { newValue in
@@ -51,7 +52,8 @@ extension RulesTabView {
         let pack = PackRegistry.keystrokeHistory
         if !isSearching || pack.name.localizedCaseInsensitiveContains(trimmedSearchQuery)
             || "keystroke history".contains(trimmedSearchQuery.lowercased())
-            || "debug".contains(trimmedSearchQuery.lowercased()) {
+            || "debug".contains(trimmedSearchQuery.lowercased())
+        {
             ExpandableKeystrokeHistoryRow(
                 isPackEnabled: isKeystrokeHistoryInstalled,
                 onToggle: { newValue in

--- a/Sources/KeyPathAppKit/UI/Settings/SettingsView+ScriptExecution.swift
+++ b/Sources/KeyPathAppKit/UI/Settings/SettingsView+ScriptExecution.swift
@@ -40,8 +40,8 @@ struct ScriptExecutionSettingsSection: View {
                         }
                     }
                 ))
-                    .toggleStyle(.switch)
-                    .labelsHidden()
+                .toggleStyle(.switch)
+                .labelsHidden()
             }
             .accessibilityIdentifier("settings-script-execution-toggle")
             .accessibilityLabel("Allow script execution")

--- a/Sources/KeyPathAppKit/UI/Settings/SettingsView.swift
+++ b/Sources/KeyPathAppKit/UI/Settings/SettingsView.swift
@@ -68,225 +68,225 @@ struct StatusSettingsTabView: View {
 
     var body: some View {
         ScrollView {
-        VStack(alignment: .leading, spacing: 0) {
-            if FeatureFlags.allowOptionalWizard, showSetupBanner {
-                SetupBanner {
-                    wizardInitialPage = .summary
+            VStack(alignment: .leading, spacing: 0) {
+                if FeatureFlags.allowOptionalWizard, showSetupBanner {
+                    SetupBanner {
+                        wizardInitialPage = .summary
+                    }
+                    .padding(.horizontal, 20)
+                    .padding(.top, 20)
                 }
-                .padding(.horizontal, 20)
-                .padding(.top, 20)
-            }
 
-            // System Status Hero Section
-            HStack(alignment: .top, spacing: 40) {
-                // Large status indicator with centered toggle
-                VStack(spacing: 16) {
-                    VStack(spacing: 12) {
-                        ZStack {
-                            Circle()
-                                .fill(systemHealthTint.opacity(0.15))
-                                .frame(width: 80, height: 80)
+                // System Status Hero Section
+                HStack(alignment: .top, spacing: 40) {
+                    // Large status indicator with centered toggle
+                    VStack(spacing: 16) {
+                        VStack(spacing: 12) {
+                            ZStack {
+                                Circle()
+                                    .fill(systemHealthTint.opacity(0.15))
+                                    .frame(width: 80, height: 80)
 
-                            Button(action: { wizardInitialPage = .summary }) {
-                                Image(systemName: systemHealthIcon)
-                                    .font(.largeTitle)
-                                    .foregroundColor(systemHealthTint)
-                            }
-                            .buttonStyle(.plain)
-                            .accessibilityIdentifier("status-system-health-button")
-                            .accessibilityLabel("System status: \(systemHealthMessage)")
-                        }
-
-                        VStack(spacing: 4) {
-                            Text(systemHealthMessage)
-                                .font(.title3.weight(.semibold))
-                                .multilineTextAlignment(.center)
-
-                            if let issue = primaryIssueDetail {
-                                Text(issue.message)
-                                    .font(.footnote)
-                                    .foregroundColor(issue.level.tintColor)
-                                    .multilineTextAlignment(.center)
-                                    .fixedSize(horizontal: false, vertical: true)
-                            }
-
-                            Button(action: {
-                                NotificationCenter.default.post(name: .openSettingsRules, object: nil)
-                            }) {
-                                let enabledCollections = kanataManager.ruleCollections.filter(\.isEnabled).count
-                                let enabledCustomRules = kanataManager.customRules.filter(\.isEnabled).count
-                                let activeCount = enabledCollections + enabledCustomRules
-                                Text(activeRulesText(count: activeCount))
-                                    .font(.body)
-                                    .foregroundColor(.secondary)
-                            }
-                            .buttonStyle(.plain)
-                            .accessibilityIdentifier("status-active-rules-button")
-                            .accessibilityLabel("View active rules")
-                        }
-                    }
-
-                    // Action button when there are problems. Suppressed when the
-                    // user has intentionally turned the service off — nothing is
-                    // broken, so there's nothing to fix.
-                    if !isSystemHealthy, !isIntentionallyDisabled {
-                        if isOnlyKanataUnverified {
-                            // Only issue is unverified kanata — lead with FDA
-                            Button(action: { SystemDiagnostics.open(.fullDiskAccess) }) {
-                                Label("Enable Enhanced Diagnostics", systemImage: "checkmark.shield")
-                                    .font(.body.weight(.semibold))
-                            }
-                            .buttonStyle(.borderedProminent)
-                            .controlSize(.large)
-                            .tint(.blue)
-                            .accessibilityIdentifier("status-enable-fda-button")
-                        } else {
-                            Button(action: { wizardInitialPage = .summary }) {
-                                Label("Fix it", systemImage: "wand.and.stars")
-                                    .font(.body.weight(.semibold))
-                            }
-                            .buttonStyle(.borderedProminent)
-                            .controlSize(.large)
-                            .tint(overallHealthLevel == .critical ? .red : .orange)
-                            .accessibilityIdentifier("status-fix-it-button")
-                            .accessibilityLabel("Fix system issues")
-                        }
-                    }
-
-                    // Centered toggle
-                    HStack(spacing: 12) {
-                        Toggle(
-                            "",
-                            isOn: Binding(
-                                get: { effectiveServiceRunning },
-                                set: { newValue in
-                                    // Optimistic update: change UI immediately
-                                    localServiceRunning = newValue
-                                    // Record explicit user intent (persists across
-                                    // relaunch and the isServiceRunning onChange reset).
-                                    userDisabledService = !newValue
-                                    // Then trigger async operation
-                                    Task {
-                                        if newValue {
-                                            await startViaInstallerEngine()
-                                        } else {
-                                            await stopViaInstallerEngine()
-                                        }
-                                        await refreshStatus()
-                                    }
+                                Button(action: { wizardInitialPage = .summary }) {
+                                    Image(systemName: systemHealthIcon)
+                                        .font(.largeTitle)
+                                        .foregroundColor(systemHealthTint)
                                 }
-                            )
-                        )
-                        .toggleStyle(.switch)
-                        .controlSize(.large)
-                        .accessibilityIdentifier("status-service-toggle")
-                        .accessibilityLabel("KeyPath Runtime")
+                                .buttonStyle(.plain)
+                                .accessibilityIdentifier("status-system-health-button")
+                                .accessibilityLabel("System status: \(systemHealthMessage)")
+                            }
 
-                        Text(effectiveServiceRunning ? "ON" : "OFF")
-                            .font(.body.weight(.medium))
-                            .foregroundColor(effectiveServiceRunning ? .green : .secondary)
-                    }
-
-                    if let runtimePathTitle = kanataManager.activeRuntimePathTitle {
-                        VStack(spacing: 4) {
-                            Text(runtimePathTitle)
-                                .font(.footnote.weight(.semibold))
-                                .foregroundColor(.secondary)
-
-                            if let runtimePathDetail = kanataManager.activeRuntimePathDetail {
-                                Text(runtimePathDetail)
-                                    .font(.caption)
-                                    .foregroundColor(.secondary)
+                            VStack(spacing: 4) {
+                                Text(systemHealthMessage)
+                                    .font(.title3.weight(.semibold))
                                     .multilineTextAlignment(.center)
-                                    .fixedSize(horizontal: false, vertical: true)
+
+                                if let issue = primaryIssueDetail {
+                                    Text(issue.message)
+                                        .font(.footnote)
+                                        .foregroundColor(issue.level.tintColor)
+                                        .multilineTextAlignment(.center)
+                                        .fixedSize(horizontal: false, vertical: true)
+                                }
+
+                                Button(action: {
+                                    NotificationCenter.default.post(name: .openSettingsRules, object: nil)
+                                }) {
+                                    let enabledCollections = kanataManager.ruleCollections.filter(\.isEnabled).count
+                                    let enabledCustomRules = kanataManager.customRules.filter(\.isEnabled).count
+                                    let activeCount = enabledCollections + enabledCustomRules
+                                    Text(activeRulesText(count: activeCount))
+                                        .font(.body)
+                                        .foregroundColor(.secondary)
+                                }
+                                .buttonStyle(.plain)
+                                .accessibilityIdentifier("status-active-rules-button")
+                                .accessibilityLabel("View active rules")
                             }
                         }
-                        .frame(maxWidth: 220)
-                        .accessibilityIdentifier("status-runtime-path")
-                        .accessibilityLabel(
-                            "Active runtime path: \(runtimePathTitle)\(kanataManager.activeRuntimePathDetail.map { ", \($0)" } ?? "")"
-                        )
+
+                        // Action button when there are problems. Suppressed when the
+                        // user has intentionally turned the service off — nothing is
+                        // broken, so there's nothing to fix.
+                        if !isSystemHealthy, !isIntentionallyDisabled {
+                            if isOnlyKanataUnverified {
+                                // Only issue is unverified kanata — lead with FDA
+                                Button(action: { SystemDiagnostics.open(.fullDiskAccess) }) {
+                                    Label("Enable Enhanced Diagnostics", systemImage: "checkmark.shield")
+                                        .font(.body.weight(.semibold))
+                                }
+                                .buttonStyle(.borderedProminent)
+                                .controlSize(.large)
+                                .tint(.blue)
+                                .accessibilityIdentifier("status-enable-fda-button")
+                            } else {
+                                Button(action: { wizardInitialPage = .summary }) {
+                                    Label("Fix it", systemImage: "wand.and.stars")
+                                        .font(.body.weight(.semibold))
+                                }
+                                .buttonStyle(.borderedProminent)
+                                .controlSize(.large)
+                                .tint(overallHealthLevel == .critical ? .red : .orange)
+                                .accessibilityIdentifier("status-fix-it-button")
+                                .accessibilityLabel("Fix system issues")
+                            }
+                        }
+
+                        // Centered toggle
+                        HStack(spacing: 12) {
+                            Toggle(
+                                "",
+                                isOn: Binding(
+                                    get: { effectiveServiceRunning },
+                                    set: { newValue in
+                                        // Optimistic update: change UI immediately
+                                        localServiceRunning = newValue
+                                        // Record explicit user intent (persists across
+                                        // relaunch and the isServiceRunning onChange reset).
+                                        userDisabledService = !newValue
+                                        // Then trigger async operation
+                                        Task {
+                                            if newValue {
+                                                await startViaInstallerEngine()
+                                            } else {
+                                                await stopViaInstallerEngine()
+                                            }
+                                            await refreshStatus()
+                                        }
+                                    }
+                                )
+                            )
+                            .toggleStyle(.switch)
+                            .controlSize(.large)
+                            .accessibilityIdentifier("status-service-toggle")
+                            .accessibilityLabel("KeyPath Runtime")
+
+                            Text(effectiveServiceRunning ? "ON" : "OFF")
+                                .font(.body.weight(.medium))
+                                .foregroundColor(effectiveServiceRunning ? .green : .secondary)
+                        }
+
+                        if let runtimePathTitle = kanataManager.activeRuntimePathTitle {
+                            VStack(spacing: 4) {
+                                Text(runtimePathTitle)
+                                    .font(.footnote.weight(.semibold))
+                                    .foregroundColor(.secondary)
+
+                                if let runtimePathDetail = kanataManager.activeRuntimePathDetail {
+                                    Text(runtimePathDetail)
+                                        .font(.caption)
+                                        .foregroundColor(.secondary)
+                                        .multilineTextAlignment(.center)
+                                        .fixedSize(horizontal: false, vertical: true)
+                                }
+                            }
+                            .frame(maxWidth: 220)
+                            .accessibilityIdentifier("status-runtime-path")
+                            .accessibilityLabel(
+                                "Active runtime path: \(runtimePathTitle)\(kanataManager.activeRuntimePathDetail.map { ", \($0)" } ?? "")"
+                            )
+                        }
                     }
-                }
-                .frame(minWidth: 220)
+                    .frame(minWidth: 220)
 
-                // Permissions grid
-                VStack(alignment: .leading, spacing: 12) {
-                    Text("Permissions")
-                        .font(.headline)
-                        .foregroundColor(.secondary)
-
-                    VStack(alignment: .leading, spacing: 8) {
-                        PermissionStatusRow(
-                            title: "KeyPath Accessibility",
-                            icon: "checkmark.shield",
-                            status: permissionSnapshot?.keyPath.accessibility,
-                            isKanata: false,
-                            hasFullDiskAccess: hasFullDiskAccess,
-                            onTap: { wizardInitialPage = .accessibility }
-                        )
-
-                        PermissionStatusRow(
-                            title: "KeyPath Input Monitoring",
-                            icon: "keyboard",
-                            // No Apple API to query KeyPath IM — always .unknown.
-                            // Kanata's IM grant is what matters. Show green to avoid
-                            // a permanent unresolvable "?" in Settings.
-                            status: .granted,
-                            isKanata: false,
-                            hasFullDiskAccess: hasFullDiskAccess,
-                            onTap: { wizardInitialPage = .inputMonitoring }
-                        )
-
-                        PermissionStatusRow(
-                            title: "Kanata Accessibility",
-                            icon: "checkmark.shield",
-                            status: permissionSnapshot?.kanata.accessibility,
-                            isKanata: true,
-                            hasFullDiskAccess: hasFullDiskAccess,
-                            onTap: { wizardInitialPage = .accessibility }
-                        )
-
-                        PermissionStatusRow(
-                            title: "Kanata Input Monitoring",
-                            icon: "keyboard",
-                            status: permissionSnapshot?.kanata.inputMonitoring,
-                            isKanata: true,
-                            hasFullDiskAccess: hasFullDiskAccess,
-                            onTap: { wizardInitialPage = .inputMonitoring }
-                        )
-                    }
-
-                    VStack(alignment: .leading, spacing: 8) {
-                        Text("System Status")
+                    // Permissions grid
+                    VStack(alignment: .leading, spacing: 12) {
+                        Text("Permissions")
                             .font(.headline)
                             .foregroundColor(.secondary)
-                            .padding(.top, 10)
 
-                        ForEach(systemStatusRows) { row in
-                            SettingsSystemStatusRow(
-                                title: row.title,
-                                icon: row.icon,
-                                status: row.status,
-                                message: row.message,
-                                onTap: row.targetPage.map { page in
-                                    { wizardInitialPage = page }
-                                }
+                        VStack(alignment: .leading, spacing: 8) {
+                            PermissionStatusRow(
+                                title: "KeyPath Accessibility",
+                                icon: "checkmark.shield",
+                                status: permissionSnapshot?.keyPath.accessibility,
+                                isKanata: false,
+                                hasFullDiskAccess: hasFullDiskAccess,
+                                onTap: { wizardInitialPage = .accessibility }
+                            )
+
+                            PermissionStatusRow(
+                                title: "KeyPath Input Monitoring",
+                                icon: "keyboard",
+                                // No Apple API to query KeyPath IM — always .unknown.
+                                // Kanata's IM grant is what matters. Show green to avoid
+                                // a permanent unresolvable "?" in Settings.
+                                status: .granted,
+                                isKanata: false,
+                                hasFullDiskAccess: hasFullDiskAccess,
+                                onTap: { wizardInitialPage = .inputMonitoring }
+                            )
+
+                            PermissionStatusRow(
+                                title: "Kanata Accessibility",
+                                icon: "checkmark.shield",
+                                status: permissionSnapshot?.kanata.accessibility,
+                                isKanata: true,
+                                hasFullDiskAccess: hasFullDiskAccess,
+                                onTap: { wizardInitialPage = .accessibility }
+                            )
+
+                            PermissionStatusRow(
+                                title: "Kanata Input Monitoring",
+                                icon: "keyboard",
+                                status: permissionSnapshot?.kanata.inputMonitoring,
+                                isKanata: true,
+                                hasFullDiskAccess: hasFullDiskAccess,
+                                onTap: { wizardInitialPage = .inputMonitoring }
                             )
                         }
+
+                        VStack(alignment: .leading, spacing: 8) {
+                            Text("System Status")
+                                .font(.headline)
+                                .foregroundColor(.secondary)
+                                .padding(.top, 10)
+
+                            ForEach(systemStatusRows) { row in
+                                SettingsSystemStatusRow(
+                                    title: row.title,
+                                    icon: row.icon,
+                                    status: row.status,
+                                    message: row.message,
+                                    onTap: row.targetPage.map { page in
+                                        { wizardInitialPage = page }
+                                    }
+                                )
+                            }
+                        }
                     }
+
+                    Spacer()
                 }
-
-                Spacer()
-            }
-            .padding(.horizontal, 20)
-            .padding(.top, 24)
-
-            keyboardDetailsSection
                 .padding(.horizontal, 20)
                 .padding(.top, 24)
-                .padding(.bottom, 20)
-        }
+
+                keyboardDetailsSection
+                    .padding(.horizontal, 20)
+                    .padding(.top, 24)
+                    .padding(.bottom, 20)
+            }
         }
         .settingsBackground()
         .withToasts(settingsToastManager)
@@ -336,7 +336,6 @@ struct StatusSettingsTabView: View {
 
     @State private var showKeyboardDetails = false
 
-    @ViewBuilder
     private var keyboardDetailsSection: some View {
         VStack(alignment: .leading, spacing: 14) {
             Text("Connected Keyboard")
@@ -461,7 +460,6 @@ struct StatusSettingsTabView: View {
         }
     }
 
-    @ViewBuilder
     private func keyboardInfoRow(title: String, value: String) -> some View {
         GridRow {
             Text(title)

--- a/Sources/KeyPathAppKit/Utilities/AppRestarter.swift
+++ b/Sources/KeyPathAppKit/Utilities/AppRestarter.swift
@@ -11,7 +11,7 @@ enum AppRestarter {
             userDefaults = defaults
         }
     #else
-        nonisolated(unsafe) private static let userDefaults: UserDefaults = .standard
+        private nonisolated(unsafe) static let userDefaults: UserDefaults = .standard
     #endif
     /// Restarts the application after a brief delay
     /// - Parameter afterDelay: Delay in seconds before restarting (default: 0.5)

--- a/Sources/KeyPathAppKit/Utilities/DependencyInjection.swift
+++ b/Sources/KeyPathAppKit/Utilities/DependencyInjection.swift
@@ -48,7 +48,6 @@ extension EnvironmentValues {
     }
 }
 
-
 // MARK: - Service Container DI
 
 /// EnvironmentKey for the central ServiceContainer

--- a/Sources/KeyPathAppKit/Utilities/KeyDisplayFormatter.swift
+++ b/Sources/KeyPathAppKit/Utilities/KeyDisplayFormatter.swift
@@ -183,8 +183,8 @@ public enum KeyDisplayFormatter {
         if parts.count > 1 {
             // Check for Hyper (Ctrl+Cmd+Alt+Shift)
             let partSet = Set(parts)
-            let hyperSet: Set<String> = ["lctl", "lmet", "lalt", "lsft"]
-            let mehSet: Set<String> = ["lctl", "lalt", "lsft"]
+            let hyperSet: Set = ["lctl", "lmet", "lalt", "lsft"]
+            let mehSet: Set = ["lctl", "lalt", "lsft"]
 
             if partSet.isSuperset(of: hyperSet) { return "✦" }
             if partSet.isSuperset(of: mehSet) { return "◆" }

--- a/Sources/KeyPathAppKit/Utilities/NotificationObserverManager.swift
+++ b/Sources/KeyPathAppKit/Utilities/NotificationObserverManager.swift
@@ -28,10 +28,14 @@ import Foundation
 /// For `@MainActor` types, use the `@MainActor` variant methods.
 public final class NotificationObserverManager: @unchecked Sendable {
     public static let mainOperationQueue: OperationQueue? = nil
+    // swiftformat:disable redundantClosure — collapsing this IIFE lets `.perform` lose its
+    // explicit `NotificationCenter` base, which breaks type inference (won't compile).
     public static let defaultCenter: NotificationCenter = {
         NotificationCenter.perform(NSSelectorFromString("defaultCenter"))?
             .takeUnretainedValue() as? NotificationCenter ?? NotificationCenter()
     }()
+
+    // swiftformat:enable redundantClosure
 
     /// Stored observer with its associated notification center
     private struct StoredObserver {

--- a/Sources/KeyPathAppKit/WizardProtocolConformances.swift
+++ b/Sources/KeyPathAppKit/WizardProtocolConformances.swift
@@ -25,12 +25,12 @@ extension WizardServiceManagementState {
     var asInternal: KanataDaemonManager.ServiceManagementState {
         // EXHAUSTIVE: must mirror KanataDaemonManager.ServiceManagementState exactly — do not add a default case
         switch self {
-        case .legacyActive: return .legacyActive
-        case .smappserviceActive: return .smappserviceActive
-        case .smappservicePending: return .smappservicePending
-        case .uninstalled: return .uninstalled
-        case .conflicted: return .conflicted
-        case .unknown: return .unknown
+        case .legacyActive: .legacyActive
+        case .smappserviceActive: .smappserviceActive
+        case .smappservicePending: .smappservicePending
+        case .uninstalled: .uninstalled
+        case .conflicted: .conflicted
+        case .unknown: .unknown
         }
     }
 }
@@ -53,7 +53,7 @@ extension RuntimeCoordinator: RuntimeCoordinating {
         await serviceLifecycleCoordinator.isInTransientRuntimeStartupWindow()
     }
 
-    public func runFullRepair(reason: String) async -> WizardRepairReport {
+    public func runFullRepair(reason _: String) async -> WizardRepairReport {
         let report = await installerEngine.run(intent: .repair, using: privilegeBroker)
         return WizardRepairReport(
             success: report.success,
@@ -72,7 +72,7 @@ extension HelperManager: WizardHelperManaging {}
 
 extension KanataDaemonManager: WizardDaemonManaging {
     public func refreshManagementState() async -> WizardServiceManagementState {
-        WizardServiceManagementState(await refreshManagementStateInternal())
+        await WizardServiceManagementState(refreshManagementStateInternal())
     }
 
     public nonisolated var kanataServiceID: String {

--- a/Sources/KeyPathCLI/Commands/Help/HelpExamplesCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Help/HelpExamplesCommand.swift
@@ -88,7 +88,9 @@ struct HelpExamples: AsyncParsableCommand {
         ),
         ExampleEntry(
             description: "Create a tap-dance (single=Esc, double=Caps Lock)",
-            commands: [#"keypath rule add caps --behavior '{"tapOrTapDance":{"tapDance":{"windowMs":200,"steps":[{"label":"Esc","action":{"keystroke":{"key":"esc"}}},{"label":"Caps","action":{"keystroke":{"key":"caps"}}}]}}}' --apply"#]
+            commands: [
+                #"keypath rule add caps --behavior '{"tapOrTapDance":{"tapDance":{"windowMs":200,"steps":[{"label":"Esc","action":{"keystroke":{"key":"esc"}}},{"label":"Caps","action":{"keystroke":{"key":"caps"}}}]}}}' --apply"#
+            ]
         ),
         ExampleEntry(
             description: "Preview a rule without saving",

--- a/Sources/KeyPathCLI/Commands/Pack/PackInstallCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Pack/PackInstallCommand.swift
@@ -112,20 +112,19 @@ struct PackInstall: AsyncParsableCommand {
             throw error.code.exitCode
         } catch let installErr as PackInstaller.InstallError {
             spinner.fail("Install failed")
-            let error: CLIError
-            switch installErr {
+            let error = switch installErr {
             case .mutuallyExclusive:
-                error = CLIError.conflict(
+                CLIError.conflict(
                     installErr.errorDescription ?? installErr.localizedDescription,
                     hint: "Uninstall the conflicting pack first"
                 )
             case let .dependencyMissing(name, _):
-                error = CLIError.validation(
+                CLIError.validation(
                     installErr.errorDescription ?? installErr.localizedDescription,
                     hint: "Install \(name) first"
                 )
             default:
-                error = CLIError.validation(installErr.errorDescription ?? installErr.localizedDescription)
+                CLIError.validation(installErr.errorDescription ?? installErr.localizedDescription)
             }
             CLIOutput.writeError(error, context: ctx)
             throw error.code.exitCode

--- a/Sources/KeyPathCLI/Commands/Pack/PackShowCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Pack/PackShowCommand.swift
@@ -86,7 +86,10 @@ struct PackShow: AsyncParsableCommand {
                 lines.append("Quick Settings:")
                 for setting in detail.quickSettings {
                     let current = detail.quickSettingValues[setting.id] ?? setting.defaultValue
-                    lines.append("  \(setting.label): \(current)\(setting.unitSuffix) (range: \(setting.min)-\(setting.max)\(setting.unitSuffix), default: \(setting.defaultValue)\(setting.unitSuffix))")
+                    lines
+                        .append(
+                            "  \(setting.label): \(current)\(setting.unitSuffix) (range: \(setting.min)-\(setting.max)\(setting.unitSuffix), default: \(setting.defaultValue)\(setting.unitSuffix))"
+                        )
                 }
             }
 

--- a/Sources/KeyPathCLI/Commands/Pack/PackUninstallCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Pack/PackUninstallCommand.swift
@@ -44,11 +44,11 @@ struct PackUninstall: AsyncParsableCommand {
             CLIOutput.write(result, context: ctx) {
                 switch result.action {
                 case "not-installed":
-                    return "Pack '\(result.packName)' is not installed."
+                    "Pack '\(result.packName)' is not installed."
                 case "would-uninstall":
-                    return "Would uninstall '\(result.packName)'"
+                    "Would uninstall '\(result.packName)'"
                 default:
-                    return ""
+                    ""
                 }
             }
 

--- a/Sources/KeyPathCLI/Commands/Rule/RuleAddCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Rule/RuleAddCommand.swift
@@ -54,7 +54,7 @@ struct RuleAdd: AsyncParsableCommand {
         if modeCount > 1 {
             throw ValidationError("Specify only one of: <output>, --action, or --tap/--hold")
         }
-        if modeCount == 0 && behavior == nil {
+        if modeCount == 0, behavior == nil {
             throw ValidationError("Specify an output key, --action, --tap/--hold, or --behavior")
         }
     }

--- a/Sources/KeyPathCLI/Commands/Rule/RuleEnsureCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Rule/RuleEnsureCommand.swift
@@ -128,21 +128,20 @@ struct RuleEnsure: AsyncParsableCommand {
     private func ensureOne(spec: EnsureSpec, facade: RulesFacade, dryRun: Bool) async throws -> CLIEnsureResult {
         let existing = await facade.showRule(input: spec.input)
 
-        let matchesDesired: Bool
-        if let existing {
+        let matchesDesired: Bool = if let existing {
             if let hold = spec.hold {
                 if case let .dualRole(dr) = existing.behavior {
-                    matchesDesired = existing.action.outputString == spec.output
+                    existing.action.outputString == spec.output
                         && dr.holdActionString == hold
                         && dr.tapTimeout == spec.timeout
                 } else {
-                    matchesDesired = false
+                    false
                 }
             } else {
-                matchesDesired = existing.action.outputString == spec.output && existing.behavior == nil
+                existing.action.outputString == spec.output && existing.behavior == nil
             }
         } else {
-            matchesDesired = false
+            false
         }
 
         if matchesDesired {

--- a/Sources/KeyPathCLI/Commands/Service/ServiceStatusCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Service/ServiceStatusCommand.swift
@@ -56,7 +56,9 @@ private func formatHumanReadable(_ status: CLIStatusResult, noColor: Bool) -> St
     let ok = ANSIColor.green("✓", noColor: noColor)
     let fail = ANSIColor.red("✗", noColor: noColor)
 
-    func check(_ value: Bool) -> String { value ? ok : fail }
+    func check(_ value: Bool) -> String {
+        value ? ok : fail
+    }
 
     var lines: [String] = []
     lines.append(ANSIColor.bold("=== System Status ===", noColor: noColor))

--- a/Sources/KeyPathCLI/Utilities/Output.swift
+++ b/Sources/KeyPathCLI/Utilities/Output.swift
@@ -8,7 +8,9 @@ public struct OutputContext: Sendable {
     public let noColor: Bool
     public let quiet: Bool
 
-    public var shouldOutputJSON: Bool { forceJSON || (!forceHuman && !isInteractive) }
+    public var shouldOutputJSON: Bool {
+        forceJSON || (!forceHuman && !isInteractive)
+    }
 
     public init(isInteractive: Bool, forceJSON: Bool, forceHuman: Bool, noColor: Bool, quiet: Bool = false) {
         self.isInteractive = isInteractive
@@ -30,7 +32,7 @@ public struct OutputContext: Sendable {
 }
 
 enum CLIOutput {
-    static func write<T: Encodable>(_ value: T, context: OutputContext, humanRender: () -> String) {
+    static func write(_ value: some Encodable, context: OutputContext, humanRender: () -> String) {
         if context.shouldOutputJSON {
             writeJSON(value)
         } else {
@@ -44,7 +46,7 @@ enum CLIOutput {
         let data: T
     }
 
-    static func writeJSON<T: Encodable>(_ value: T) {
+    static func writeJSON(_ value: some Encodable) {
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
         encoder.dateEncodingStrategy = .iso8601

--- a/Sources/KeyPathCLI/Utilities/Spinner.swift
+++ b/Sources/KeyPathCLI/Utilities/Spinner.swift
@@ -11,9 +11,9 @@ final class CLISpinner: @unchecked Sendable {
     private var frameIndex = 0
 
     init(context: OutputContext) {
-        self.noColor = context.noColor
-        self.isInteractive = context.isInteractive && !context.quiet
-        self.message = ""
+        noColor = context.noColor
+        isInteractive = context.isInteractive && !context.quiet
+        message = ""
     }
 
     func start(_ message: String) {

--- a/Sources/KeyPathHelper/HelperService.swift
+++ b/Sources/KeyPathHelper/HelperService.swift
@@ -14,7 +14,7 @@ class HelperService: NSObject, HelperProtocol {
     /// Helper version (must match app version for compatibility)
     private static let version = "1.1.0"
     private static let vhidRootOnlyDirectory = "/Library/Application Support/org.pqrs/tmp/rootonly"
-private let logger = Logger(subsystem: "com.keypath.helper", category: "service")
+    private let logger = Logger(subsystem: "com.keypath.helper", category: "service")
 
     // MARK: - Version Management
 
@@ -226,6 +226,7 @@ private let logger = Logger(subsystem: "com.keypath.helper", category: "service"
             reply: reply
         )
     }
+
     func installBundledVHIDDriver(pkgPath: String, reply: @escaping (Bool, String?) -> Void) {
         NSLog("[KeyPathHelper] installBundledVHIDDriver requested: %@", pkgPath)
         executePrivilegedOperation(
@@ -298,6 +299,7 @@ private let logger = Logger(subsystem: "com.keypath.helper", category: "service"
         _ = run("/bin/launchctl", ["kickstart", "-k", "system/\(vhidDaemonServiceID)"])
         _ = run("/bin/launchctl", ["kickstart", "-k", "system/\(vhidManagerServiceID)"])
     }
+
     // MARK: - Process Management
 
     func terminateProcess(_ pid: Int32, reply: @escaping (Bool, String?) -> Void) {

--- a/Sources/KeyPathInsights/ActivityLogging/UI/ActivityLoggingSettingsSection.swift
+++ b/Sources/KeyPathInsights/ActivityLogging/UI/ActivityLoggingSettingsSection.swift
@@ -128,7 +128,7 @@ struct ActivityLoggingSettingsSection: View {
                 eventCount = 0
             } catch {
                 #if DEBUG
-                print("❌ [ActivityLogging] Reset failed: \(error.localizedDescription)")
+                    print("❌ [ActivityLogging] Reset failed: \(error.localizedDescription)")
                 #endif
             }
             isResetting = false

--- a/Sources/KeyPathInsights/InsightsPreferences.swift
+++ b/Sources/KeyPathInsights/InsightsPreferences.swift
@@ -12,9 +12,9 @@ enum InsightsPreferences {
         get {
             if UserDefaults.standard.object(forKey: Keys.activityLoggingEnabled) == nil {
                 #if DEBUG
-                return true
+                    return true
                 #else
-                return false
+                    return false
                 #endif
             }
             return UserDefaults.standard.bool(forKey: Keys.activityLoggingEnabled)

--- a/Sources/KeyPathInstallationWizard/Core/InstallerEngine+Recipes.swift
+++ b/Sources/KeyPathInstallationWizard/Core/InstallerEngine+Recipes.swift
@@ -6,11 +6,11 @@ import KeyPathWizardCore
 
 // MARK: - Recipe Generation Extension
 
-extension InstallerEngine {
+public extension InstallerEngine {
     // MARK: - Action Determination
 
     /// Determine which actions are needed based on intent and context
-    public func determineActions(for intent: InstallIntent, context: SystemContext)
+    func determineActions(for intent: InstallIntent, context: SystemContext)
         -> [AutoFixAction]
     {
         // Use shared ActionDeterminer to avoid duplication
@@ -20,7 +20,7 @@ extension InstallerEngine {
     // MARK: - Recipe Generation
 
     /// Generate ServiceRecipes from AutoFixActions
-    public func generateRecipes(from actions: [AutoFixAction], context: SystemContext)
+    func generateRecipes(from actions: [AutoFixAction], context: SystemContext)
         -> [ServiceRecipe]
     {
         var recipes: [ServiceRecipe] = []
@@ -35,7 +35,7 @@ extension InstallerEngine {
     }
 
     /// Convert an AutoFixAction to a ServiceRecipe
-    public func recipeForAction(_ action: AutoFixAction, context _: SystemContext) -> ServiceRecipe? {
+    func recipeForAction(_ action: AutoFixAction, context _: SystemContext) -> ServiceRecipe? {
         switch action {
         case .installRequiredRuntimeServices:
             ServiceRecipe(
@@ -198,7 +198,7 @@ extension InstallerEngine {
     /// If complex dependencies emerge, implement topological sort here.
     ///
     /// Related: Linear MAL-35, MAL-16 (duplicate issues resolved by documenting design)
-    public func orderRecipes(_ recipes: [ServiceRecipe]) -> [ServiceRecipe] {
+    func orderRecipes(_ recipes: [ServiceRecipe]) -> [ServiceRecipe] {
         // Validate design assumption: no recipe should currently declare dependencies
         assert(
             recipes.allSatisfy(\.dependencies.isEmpty),
@@ -211,7 +211,7 @@ extension InstallerEngine {
     }
 
     /// Map AutoFixAction to recipe ID
-    public func recipeIDForAction(_ action: AutoFixAction) -> String {
+    func recipeIDForAction(_ action: AutoFixAction) -> String {
         switch action {
         case .installRequiredRuntimeServices:
             InstallerRecipeID.installRequiredRuntimeServices

--- a/Sources/KeyPathInstallationWizard/Core/InstallerEngine.swift
+++ b/Sources/KeyPathInstallationWizard/Core/InstallerEngine.swift
@@ -34,9 +34,9 @@ public final class InstallerEngine {
 
     /// Internal designated initializer to share construction logic
     public init(
-        processLifecycleManager: ProcessLifecycleManager,
+        processLifecycleManager _: ProcessLifecycleManager,
         systemValidator injectedValidator: (any WizardSystemValidating)? = nil,
-        kanataManager: (any RuntimeCoordinating)? = nil
+        kanataManager _: (any RuntimeCoordinating)? = nil
     ) {
         self.injectedValidator = injectedValidator
 

--- a/Sources/KeyPathInstallationWizard/Core/KanataBinaryDetector.swift
+++ b/Sources/KeyPathInstallationWizard/Core/KanataBinaryDetector.swift
@@ -168,5 +168,4 @@ public final class KanataBinaryDetector: Sendable {
             return [.bundledKanataMissing] // CRITICAL: App bundle corrupted
         }
     }
-
 }

--- a/Sources/KeyPathInstallationWizard/Core/PackageManager.swift
+++ b/Sources/KeyPathInstallationWizard/Core/PackageManager.swift
@@ -7,6 +7,7 @@ import Security
 /// Implements the package management integration identified in the installer improvement analysis
 public class PackageManager {
     public init() {}
+
     // MARK: - Code Signing Cache
 
     /// Cache for code signing status to avoid expensive Security framework calls

--- a/Sources/KeyPathInstallationWizard/Core/PrivilegedExecutor.swift
+++ b/Sources/KeyPathInstallationWizard/Core/PrivilegedExecutor.swift
@@ -225,7 +225,7 @@ public final class PrivilegedExecutor: @unchecked Sendable {
 
 // MARK: - Convenience Extensions
 
-extension PrivilegedExecutor {
+public extension PrivilegedExecutor {
     /// Execute multiple commands in sequence with administrator privileges.
     /// All commands are joined with && and executed in a single privileged session.
     ///
@@ -233,7 +233,7 @@ extension PrivilegedExecutor {
     ///   - commands: Array of shell commands to execute
     ///   - prompt: The prompt to show in the admin dialog
     /// - Returns: Tuple of (success, output)
-    public func executeWithPrivileges(commands: [String], prompt: String) -> (success: Bool, output: String) {
+    func executeWithPrivileges(commands: [String], prompt: String) -> (success: Bool, output: String) {
         let combinedCommand = commands.joined(separator: " && ")
         return executeWithPrivileges(command: combinedCommand, prompt: prompt)
     }
@@ -245,7 +245,7 @@ extension PrivilegedExecutor {
     ///   - service: The service identifier or path
     ///   - prompt: The prompt to show in the admin dialog
     /// - Returns: Tuple of (success, output)
-    public func launchctl(_ subcommand: String, service: String, prompt: String) -> (
+    func launchctl(_ subcommand: String, service: String, prompt: String) -> (
         success: Bool, output: String
     ) {
         let command = "/bin/launchctl \(subcommand) \(service)"
@@ -259,7 +259,7 @@ extension PrivilegedExecutor {
     ///   - destination: Destination file path
     ///   - prompt: The prompt to show in the admin dialog
     /// - Returns: Tuple of (success, output)
-    public func copyFile(from source: String, to destination: String, prompt: String) -> (
+    func copyFile(from source: String, to destination: String, prompt: String) -> (
         success: Bool, output: String
     ) {
         let command = "/bin/cp '\(source)' '\(destination)'"
@@ -272,7 +272,7 @@ extension PrivilegedExecutor {
     ///   - path: Path to the file to remove
     ///   - prompt: The prompt to show in the admin dialog
     /// - Returns: Tuple of (success, output)
-    public func removeFile(at path: String, prompt: String) -> (success: Bool, output: String) {
+    func removeFile(at path: String, prompt: String) -> (success: Bool, output: String) {
         let command = "/bin/rm -f '\(path)'"
         return executeWithPrivileges(command: command, prompt: prompt)
     }
@@ -283,7 +283,7 @@ extension PrivilegedExecutor {
     ///   - path: Path to the directory to create
     ///   - prompt: The prompt to show in the admin dialog
     /// - Returns: Tuple of (success, output)
-    public func createDirectory(at path: String, prompt: String) -> (success: Bool, output: String) {
+    func createDirectory(at path: String, prompt: String) -> (success: Bool, output: String) {
         let command = "/bin/mkdir -p '\(path)'"
         return executeWithPrivileges(command: command, prompt: prompt)
     }
@@ -295,7 +295,7 @@ extension PrivilegedExecutor {
     ///   - signal: Signal to send (default: 15 / SIGTERM)
     ///   - prompt: The prompt to show in the admin dialog
     /// - Returns: Tuple of (success, output)
-    public func killProcess(pid: Int32, signal: Int32 = 15, prompt: String) -> (
+    func killProcess(pid: Int32, signal: Int32 = 15, prompt: String) -> (
         success: Bool, output: String
     ) {
         let command = "/bin/kill -\(signal) \(pid)"

--- a/Sources/KeyPathInstallationWizard/Core/ServiceBootstrapper.swift
+++ b/Sources/KeyPathInstallationWizard/Core/ServiceBootstrapper.swift
@@ -499,7 +499,7 @@ public final class ServiceBootstrapper {
     /// - Conditional installation and restart
     ///
     /// - Returns: `true` if all services are healthy after the operation
-@MainActor
+    @MainActor
     public func recoverRequiredRuntimeServices() async -> Bool {
         AppLogger.shared.log("🔧 [ServiceBootstrapper] Starting comprehensive service health fix")
 
@@ -661,7 +661,7 @@ public final class ServiceBootstrapper {
     }
 
     /// Resolve legacy/conflicted SMAppService state
-@MainActor
+    @MainActor
     private func resolveLegacyConflict() async {
         AppLogger.shared.log("🔄 [ServiceBootstrapper] Resolving legacy/conflicted state")
         guard let daemonManager else {
@@ -688,7 +688,7 @@ public final class ServiceBootstrapper {
     /// Fix broken SMAppService state with retry logic
     ///
     /// - Returns: `true` if the broken state was resolved, `false` if all retries failed
-@MainActor
+    @MainActor
     private func fixBrokenSMAppServiceState() async -> Bool {
         AppLogger.shared.log("🔄 [ServiceBootstrapper] Fixing broken SMAppService state")
         AppLogger.shared.log("🐛 Known macOS bug: BundleProgram path caching after uninstall/reinstall")
@@ -827,11 +827,11 @@ public final class ServiceBootstrapper {
         // launchctl bootstrap is async — services may take 1-3 seconds to start.
         var daemonLoaded = false
         var managerLoaded = false
-        for _ in 0..<10 {
+        for _ in 0 ..< 10 {
             ServiceHealthChecker.shared.invalidateHealthCache()
             daemonLoaded = await ServiceHealthChecker.shared.isServiceLoaded(serviceID: Self.vhidDaemonServiceID)
             managerLoaded = await ServiceHealthChecker.shared.isServiceLoaded(serviceID: Self.vhidManagerServiceID)
-            if daemonLoaded && managerLoaded { break }
+            if daemonLoaded, managerLoaded { break }
             _ = await WizardSleep.ms(500)
         }
         let configured = ServiceHealthChecker.shared.isVHIDDaemonConfiguredCorrectly()
@@ -889,7 +889,7 @@ public final class ServiceBootstrapper {
     /// 2. Kanata daemon registration via SMAppService
     ///
     /// - Returns: `true` if all services were installed successfully
-@MainActor
+    @MainActor
     public func installAllServices() async -> Bool {
         AppLogger.shared.log("🔧 [ServiceBootstrapper] Installing all services (VHID + Kanata)")
 
@@ -937,7 +937,7 @@ public final class ServiceBootstrapper {
     /// Handles state checking, conflict resolution, and SMAppService registration.
     ///
     /// - Returns: `true` if registration succeeded or already registered
-@MainActor
+    @MainActor
     private func registerKanataWithSMAppService() async -> Bool {
         AppLogger.shared.log("📱 [ServiceBootstrapper] Registering Kanata daemon via SMAppService")
 

--- a/Sources/KeyPathInstallationWizard/Core/ServiceHealthChecker.swift
+++ b/Sources/KeyPathInstallationWizard/Core/ServiceHealthChecker.swift
@@ -4,7 +4,6 @@ import KeyPathCore
 import KeyPathWizardCore
 import Network
 import os.lock
-import os.lock
 
 /// Handles health checking and status reporting for LaunchDaemon services.
 ///
@@ -539,7 +538,7 @@ public final class ServiceHealthChecker: @unchecked Sendable {
     }
 
     private nonisolated func evaluateKanataLaunchctlRunningState(
-        managementState: WizardServiceManagementState,
+        managementState _: WizardServiceManagementState,
         launchctlTargets: [String]
     ) async
         -> (isRunning: Bool, exitCode: Int32?)
@@ -662,11 +661,10 @@ public final class ServiceHealthChecker: @unchecked Sendable {
         // Only examine errors from the most recent kanata launch.
         // The stderr log accumulates across restarts; stale errors from previous
         // runs (before permissions were granted) cause false positives.
-        let logChunk: String
-        if let lastLaunchRange = fullLog.range(of: "[kanata-launcher] Launching Kanata", options: .backwards) {
-            logChunk = String(fullLog[lastLaunchRange.lowerBound...])
+        let logChunk: String = if let lastLaunchRange = fullLog.range(of: "[kanata-launcher] Launching Kanata", options: .backwards) {
+            String(fullLog[lastLaunchRange.lowerBound...])
         } else {
-            logChunk = fullLog
+            fullLog
         }
 
         var permissionRejected = false

--- a/Sources/KeyPathInstallationWizard/Core/VHIDDeviceManager.swift
+++ b/Sources/KeyPathInstallationWizard/Core/VHIDDeviceManager.swift
@@ -205,7 +205,6 @@ public final class VHIDDeviceManager: @unchecked Sendable {
         return String(compact.prefix(160)) + "…"
     }
 
-
     private func evaluateDaemonProcess() async -> DaemonHealthState {
         // During startup mode, use fast non-blocking check to avoid false negatives
         // while still preventing UI freezes from Process() execution

--- a/Sources/KeyPathInstallationWizard/Core/WizardStateMachine.swift
+++ b/Sources/KeyPathInstallationWizard/Core/WizardStateMachine.swift
@@ -117,10 +117,10 @@ public class WizardStateMachine {
     public func autoNavigateIfNeeded(for state: WizardSystemState, issues: [WizardIssue]) async {
         guard !userInteractionMode else { return }
 
-        let recommended = WizardRouter.route(
+        let recommended = await WizardRouter.route(
             state: state,
             issues: issues,
-            helperInstalled: await WizardDependencies.helperManager?.isHelperInstalled() ?? false,
+            helperInstalled: WizardDependencies.helperManager?.isHelperInstalled() ?? false,
             helperNeedsApproval: WizardDependencies.helperManager?.helperNeedsLoginItemsApproval() ?? false
         )
 
@@ -153,9 +153,17 @@ public class WizardStateMachine {
         return curIdx >= lastIdx
     }
 
-    public func isCurrentPage(_ page: WizardPage) -> Bool { currentPage == page }
-    public var canNavigateBack: Bool { currentPage != .summary }
-    public var canNavigateForward: Bool { true }
+    public func isCurrentPage(_ page: WizardPage) -> Bool {
+        currentPage == page
+    }
+
+    public var canNavigateBack: Bool {
+        currentPage != .summary
+    }
+
+    public var canNavigateForward: Bool {
+        true
+    }
 
     public var previousPageInSequence: WizardPage? {
         let order = customSequence ?? WizardPage.orderedPages

--- a/Sources/KeyPathInstallationWizard/UI/Components/SheetWindowModifier.swift
+++ b/Sources/KeyPathInstallationWizard/UI/Components/SheetWindowModifier.swift
@@ -97,10 +97,10 @@ public class SheetWindowResizeDelegate: NSObject, NSWindowDelegate {
     }
 }
 
-extension View {
+public extension View {
     /// Customizes sheet window appearance (removes border, sets dark mode-aware background)
     /// Also ensures window resizes from bottom (top-left corner stays stable)
-    public func customizeSheetWindow() -> some View {
+    func customizeSheetWindow() -> some View {
         modifier(SheetWindowModifier())
     }
 }

--- a/Sources/KeyPathInstallationWizard/UI/Components/WizardActionSection.swift
+++ b/Sources/KeyPathInstallationWizard/UI/Components/WizardActionSection.swift
@@ -62,8 +62,6 @@ public struct WizardActionSection: View {
             WizardButton("Start KeyPath Runtime", style: .primary, isDefaultAction: true) {
                 onStartService()
             }
-        } else {
-            EmptyView()
         }
     }
 

--- a/Sources/KeyPathInstallationWizard/UI/Components/WizardButtonBar.swift
+++ b/Sources/KeyPathInstallationWizard/UI/Components/WizardButtonBar.swift
@@ -122,9 +122,9 @@ public struct WizardButtonBar: View {
 
 // MARK: - Convenience Initializers
 
-extension WizardButtonBar {
+public extension WizardButtonBar {
     /// Single primary button (most common case)
-    public static func primaryOnly(title: String, action: @escaping () -> Void, isLoading: Bool = false)
+    static func primaryOnly(title: String, action: @escaping () -> Void, isLoading: Bool = false)
         -> WizardButtonBar
     {
         WizardButtonBar(
@@ -133,7 +133,7 @@ extension WizardButtonBar {
     }
 
     /// Primary + Cancel (common case)
-    public static func primaryAndCancel(
+    static func primaryAndCancel(
         primaryTitle: String, primaryAction: @escaping () -> Void, cancelTitle: String = "Cancel",
         cancelAction: @escaping () -> Void,
         isLoading: Bool = false
@@ -145,7 +145,7 @@ extension WizardButtonBar {
     }
 
     /// Primary + Secondary + Cancel (full set)
-    public static func full(
+    static func full(
         primaryTitle: String,
         primaryAction: @escaping () -> Void,
         secondaryTitle: String,

--- a/Sources/KeyPathInstallationWizard/UI/Components/WizardHeroSection.swift
+++ b/Sources/KeyPathInstallationWizard/UI/Components/WizardHeroSection.swift
@@ -151,9 +151,9 @@ public struct WizardHeroSection: View {
 
 // MARK: - Convenience Initializers
 
-extension WizardHeroSection {
+public extension WizardHeroSection {
     /// Convenience initializer for success state with large checkmark overlay
-    public static func success(
+    static func success(
         icon: String,
         title: String,
         subtitle: String,
@@ -178,7 +178,7 @@ extension WizardHeroSection {
     }
 
     /// Convenience initializer for warning state with small warning overlay
-    public static func warning(
+    static func warning(
         icon: String,
         title: String,
         subtitle: String,
@@ -203,7 +203,7 @@ extension WizardHeroSection {
     }
 
     /// Convenience initializer for info state with question mark overlay
-    public static func info(
+    static func info(
         icon: String,
         title: String,
         subtitle: String,
@@ -228,7 +228,7 @@ extension WizardHeroSection {
     }
 
     /// Convenience initializer for error state with small error overlay
-    public static func error(
+    static func error(
         icon: String,
         title: String,
         subtitle: String,

--- a/Sources/KeyPathInstallationWizard/UI/Components/WizardNavigationControl.swift
+++ b/Sources/KeyPathInstallationWizard/UI/Components/WizardNavigationControl.swift
@@ -90,9 +90,9 @@ public struct WizardDetailPageModifier: ViewModifier {
     }
 }
 
-extension View {
+public extension View {
     /// Adds the standard navigation control overlay to wizard detail pages
-    public func wizardDetailPage() -> some View {
+    func wizardDetailPage() -> some View {
         modifier(WizardDetailPageModifier())
     }
 }

--- a/Sources/KeyPathInstallationWizard/UI/Components/WizardProgressSuppression.swift
+++ b/Sources/KeyPathInstallationWizard/UI/Components/WizardProgressSuppression.swift
@@ -13,10 +13,10 @@ public struct WizardInlineProgressVisiblePreferenceKey: PreferenceKey {
     }
 }
 
-extension View {
+public extension View {
     /// Marks that this view subtree contains an inline progress indicator that is currently visible.
     /// The wizard root uses this to hide the global operation overlay.
-    public func wizardInlineProgressVisible(_ isVisible: Bool = true) -> some View {
+    func wizardInlineProgressVisible(_ isVisible: Bool = true) -> some View {
         preference(key: WizardInlineProgressVisiblePreferenceKey.self, value: isVisible)
     }
 }

--- a/Sources/KeyPathInstallationWizard/UI/Helpers/DragToAuthorize/DragToAuthorizeController.swift
+++ b/Sources/KeyPathInstallationWizard/UI/Helpers/DragToAuthorize/DragToAuthorizeController.swift
@@ -263,15 +263,14 @@ public final class DragToAuthorizeController: ObservableObject {
     private func checkPermission(for target: PermissionTarget) async {
         let snapshot = await PermissionOracle.shared.forceRefresh()
 
-        let granted: Bool
-        switch target {
+        let granted: Bool = switch target {
         case .accessibility:
-            granted = snapshot.kanata.accessibility == .granted
+            snapshot.kanata.accessibility == .granted
         case .inputMonitoring:
-            granted = snapshot.kanata.inputMonitoring == .granted
+            snapshot.kanata.inputMonitoring == .granted
         case .fullDiskAccess:
             // FDA doesn't exist in PermissionSet — skip polling for it
-            granted = false
+            false
         }
 
         if granted {

--- a/Sources/KeyPathInstallationWizard/UI/Helpers/DragToAuthorize/DragToAuthorizePanel.swift
+++ b/Sources/KeyPathInstallationWizard/UI/Helpers/DragToAuthorize/DragToAuthorizePanel.swift
@@ -20,6 +20,11 @@ final class DragToAuthorizePanel: NSPanel {
         hasShadow = true
     }
 
-    override var canBecomeKey: Bool { false }
-    override var canBecomeMain: Bool { false }
+    override var canBecomeKey: Bool {
+        false
+    }
+
+    override var canBecomeMain: Bool {
+        false
+    }
 }

--- a/Sources/KeyPathInstallationWizard/UI/InstallationWizardView+Actions.swift
+++ b/Sources/KeyPathInstallationWizard/UI/InstallationWizardView+Actions.swift
@@ -3,11 +3,11 @@ import KeyPathCore
 import KeyPathWizardCore
 import SwiftUI
 
-extension InstallationWizardView {
+public extension InstallationWizardView {
     // MARK: - Actions
 
     /// Main "Fix All" handler - delegates to InstallerEngine which handles all repair logic
-    public func performAutoFix() {
+    func performAutoFix() {
         AppLogger.shared.log("🔧 [Wizard] Fix button clicked - delegating to InstallerEngine")
 
         Task {
@@ -78,7 +78,7 @@ extension InstallationWizardView {
     }
 
     /// Single-action fix handler for individual "Fix" buttons on pages
-    public func performAutoFix(_ action: AutoFixAction, suppressToast: Bool = false) async -> Bool {
+    func performAutoFix(_ action: AutoFixAction, suppressToast: Bool = false) async -> Bool {
         // Single-flight guard for Fix buttons
         if inFlightFixActions.contains(action) {
             if !suppressToast {
@@ -191,12 +191,12 @@ extension InstallationWizardView {
     }
 
     /// UI-only descriptions for auto-fix actions (delegated to AutoFixActionDescriptions)
-    public func describeAutoFixActionForUI(_ action: AutoFixAction) -> String {
+    func describeAutoFixActionForUI(_ action: AutoFixAction) -> String {
         AutoFixActionDescriptions.describe(action)
     }
 
     /// Get user-friendly description for auto-fix actions
-    public func getAutoFixActionDescription(_ action: AutoFixAction) -> String {
+    func getAutoFixActionDescription(_ action: AutoFixAction) -> String {
         AppLogger.shared.log("🔍 [ActionDescription] getAutoFixActionDescription called for: \(action)")
         let description = AutoFixActionDescriptions.describe(action)
         AppLogger.shared.log("🔍 [ActionDescription] Returning description: \(description)")

--- a/Sources/KeyPathInstallationWizard/UI/InstallationWizardView+Computed.swift
+++ b/Sources/KeyPathInstallationWizard/UI/InstallationWizardView+Computed.swift
@@ -3,10 +3,10 @@ import KeyPathCore
 import KeyPathWizardCore
 import SwiftUI
 
-extension InstallationWizardView {
+public extension InstallationWizardView {
     // MARK: - Computed Properties
 
-    public func getBuildTimestamp() -> String {
+    func getBuildTimestamp() -> String {
         let formatter = DateFormatter()
         formatter.dateFormat = "MM/dd HH:mm"
         // Use compile time if available, otherwise current time
@@ -14,7 +14,7 @@ extension InstallationWizardView {
     }
 
     /// Quick summary to surface state when a fix times out
-    public func describeServiceState() async -> String {
+    func describeServiceState() async -> String {
         guard let daemonManager = WizardDependencies.daemonManager else {
             AppLogger.shared.log("⚠️ [Wizard] daemonManager not configured")
             return "daemonManager not configured"
@@ -23,7 +23,8 @@ extension InstallationWizardView {
         let vhidRunning = await VHIDDeviceManager().detectRunning()
         return "VHID running=\(vhidRunning ? "yes" : "no"); services=\(state.description)"
     }
-    public func handlePageChange(from oldPage: WizardPage, to newPage: WizardPage) {
+
+    func handlePageChange(from oldPage: WizardPage, to newPage: WizardPage) {
         AppLogger.shared.log("🧭 [Wizard] View detected page change: \(oldPage) → \(newPage)")
         if newPage == .summary, !isValidating {
             refreshSystemState(showSpinner: true, previousPage: oldPage)
@@ -39,9 +40,9 @@ extension InstallationWizardView {
 
 // MARK: - Focus Ring Suppression Helper
 
-extension InstallationWizardView {
+public extension InstallationWizardView {
     /// Recursively disable focus rings in all subviews
-    public func disableFocusRings(in view: NSView) {
+    func disableFocusRings(in view: NSView) {
         view.focusRingType = .none
         for subview in view.subviews {
             disableFocusRings(in: subview)

--- a/Sources/KeyPathInstallationWizard/UI/InstallationWizardView+Dismissal.swift
+++ b/Sources/KeyPathInstallationWizard/UI/InstallationWizardView+Dismissal.swift
@@ -2,8 +2,8 @@ import KeyPathCore
 import KeyPathWizardCore
 import SwiftUI
 
-extension InstallationWizardView {
-    public func handleCloseButtonTapped() {
+public extension InstallationWizardView {
+    func handleCloseButtonTapped() {
         let criticalIssues = stateMachine.wizardIssues.filter { $0.severity == .critical }
 
         if criticalIssues.isEmpty {
@@ -13,11 +13,11 @@ extension InstallationWizardView {
         }
     }
 
-    public func forceInstantClose() {
+    func forceInstantClose() {
         dismissAndRefreshMainScreen()
     }
 
-    public func dismissAndRefreshMainScreen() {
+    func dismissAndRefreshMainScreen() {
         stopLoginItemsApprovalPolling()
 
         Task { @MainActor in
@@ -26,9 +26,9 @@ extension InstallationWizardView {
         }
     }
 
-    public func performBackgroundCleanup() {}
+    func performBackgroundCleanup() {}
 
-    public func forciblyCloseWizard() {
+    func forciblyCloseWizard() {
         isForceClosing = true
 
         Task { @MainActor in

--- a/Sources/KeyPathInstallationWizard/UI/InstallationWizardView+Freshness.swift
+++ b/Sources/KeyPathInstallationWizard/UI/InstallationWizardView+Freshness.swift
@@ -3,14 +3,14 @@ import KeyPathCore
 import KeyPathWizardCore
 import SwiftUI
 
-extension InstallationWizardView {
+public extension InstallationWizardView {
     // MARK: - Freshness Guard
 
-    public func isFresh(_ result: SystemStateResult) -> Bool {
+    func isFresh(_ result: SystemStateResult) -> Bool {
         snapshotAge(result) <= 3.0
     }
 
-    public func snapshotAge(_ result: SystemStateResult) -> TimeInterval {
+    func snapshotAge(_ result: SystemStateResult) -> TimeInterval {
         Date().timeIntervalSince(result.detectionTimestamp)
     }
 }

--- a/Sources/KeyPathInstallationWizard/UI/InstallationWizardView+KeyboardNavigation.swift
+++ b/Sources/KeyPathInstallationWizard/UI/InstallationWizardView+KeyboardNavigation.swift
@@ -3,11 +3,11 @@ import KeyPathCore
 import KeyPathWizardCore
 import SwiftUI
 
-extension InstallationWizardView {
+public extension InstallationWizardView {
     // MARK: - Keyboard Navigation
 
     /// Navigate to the previous page using keyboard left arrow
-    public func navigateToPreviousPage() {
+    func navigateToPreviousPage() {
         guard stateMachine.currentPage != .summary else { return }
         let defaultSequence: [WizardPage] = [
             .fullDiskAccess, .conflicts, .inputMonitoring, .accessibility,
@@ -23,7 +23,7 @@ extension InstallationWizardView {
     }
 
     /// Navigate to the next page using keyboard right arrow, respecting prerequisites
-    public func navigateToNextPage() {
+    func navigateToNextPage() {
         guard stateMachine.currentPage != .summary else { return }
         Task { @MainActor in
             if let next = await stateMachine.getNextPage(

--- a/Sources/KeyPathInstallationWizard/UI/InstallationWizardView+LoginItemsPolling.swift
+++ b/Sources/KeyPathInstallationWizard/UI/InstallationWizardView+LoginItemsPolling.swift
@@ -3,8 +3,8 @@ import KeyPathCore
 import KeyPathWizardCore
 import SwiftUI
 
-extension InstallationWizardView {
-    public func openLoginItemsSettings() {
+public extension InstallationWizardView {
+    func openLoginItemsSettings() {
         if let url = URL(string: "x-apple.systempreferences:com.apple.LoginItems-Settings.extension") {
             NSWorkspace.shared.open(url)
         } else {
@@ -16,7 +16,7 @@ extension InstallationWizardView {
     }
 
     /// Start polling for Login Items approval status change
-    public func startLoginItemsApprovalPolling() {
+    func startLoginItemsApprovalPolling() {
         stopLoginItemsApprovalPolling()
 
         AppLogger.shared.log("🔍 [LoginItems] Starting approval polling (3 min timeout)...")
@@ -55,7 +55,7 @@ extension InstallationWizardView {
     }
 
     /// Stop polling for Login Items approval
-    public func stopLoginItemsApprovalPolling() {
+    func stopLoginItemsApprovalPolling() {
         loginItemsPollingTask?.cancel()
         loginItemsPollingTask = nil
     }

--- a/Sources/KeyPathInstallationWizard/UI/InstallationWizardView+OperationProgress.swift
+++ b/Sources/KeyPathInstallationWizard/UI/InstallationWizardView+OperationProgress.swift
@@ -3,17 +3,22 @@ import KeyPathCore
 import KeyPathWizardCore
 import SwiftUI
 
-extension InstallationWizardView {
-    public func getCurrentOperationName() -> String {
+public extension InstallationWizardView {
+    func getCurrentOperationName() -> String {
         if fixInFlight { return "Applying Fix..." }
         if isValidating { return "Detecting System State" }
         return "Processing..."
     }
 
-    public func getCurrentOperationProgress() -> Double { 0.0 }
-    public func isCurrentOperationIndeterminate() -> Bool { true }
+    func getCurrentOperationProgress() -> Double {
+        0.0
+    }
 
-    public func getDetailedErrorMessage(for action: AutoFixAction, actionDescription _: String)
+    func isCurrentOperationIndeterminate() -> Bool {
+        true
+    }
+
+    func getDetailedErrorMessage(for action: AutoFixAction, actionDescription _: String)
         async -> String
     {
         var message = AutoFixActionDescriptions.errorMessage(for: action)

--- a/Sources/KeyPathInstallationWizard/UI/InstallationWizardView+StateManagement.swift
+++ b/Sources/KeyPathInstallationWizard/UI/InstallationWizardView+StateManagement.swift
@@ -4,10 +4,10 @@ import KeyPathPermissions
 import KeyPathWizardCore
 import SwiftUI
 
-extension InstallationWizardView {
+public extension InstallationWizardView {
     // MARK: - State Management
 
-    public func setupWizard() async {
+    func setupWizard() async {
         AppLogger.shared.log("🔍 [Wizard] Setting up wizard with new architecture")
 
         // Always reset navigation state for fresh run
@@ -56,7 +56,7 @@ extension InstallationWizardView {
         }
     }
 
-    public func performInitialStateCheck(retryAllowed: Bool = true) async {
+    func performInitialStateCheck(retryAllowed: Bool = true) async {
         // Check if user has already closed wizard
         guard !Task.isCancelled else {
             AppLogger.shared.log("🔍 [Wizard] Initial state check cancelled - wizard closing")
@@ -133,7 +133,7 @@ extension InstallationWizardView {
             let permSnapshot = await PermissionOracle.shared.forceRefresh()
             let permissionsStillUnknown =
                 permSnapshot.kanata.accessibility == .unknown
-                || permSnapshot.kanata.inputMonitoring == .unknown
+                    || permSnapshot.kanata.inputMonitoring == .unknown
             if permissionsStillUnknown {
                 AppLogger.shared.log("🔍 [Wizard] Permissions still unverified — staying on summary to avoid skipping permission pages")
                 Task { @MainActor in
@@ -167,7 +167,7 @@ extension InstallationWizardView {
         }
     }
 
-    public func monitorSystemState() async {
+    func monitorSystemState() async {
         AppLogger.shared.log("🟡 [MONITOR] System state monitoring started with 60s interval")
 
         // Smart monitoring: Only poll when needed, much less frequently
@@ -193,13 +193,13 @@ extension InstallationWizardView {
     }
 
     /// Determine if background polling is needed
-    public func shouldPerformBackgroundPolling() -> Bool {
+    func shouldPerformBackgroundPolling() -> Bool {
         // Only poll on summary page where overview is shown
         stateMachine.currentPage == .summary
     }
 
     /// Perform targeted state check based on current page
-    public func performSmartStateCheck(retryAllowed: Bool = true) async {
+    func performSmartStateCheck(retryAllowed: Bool = true) async {
         // Check if force closing is in progress
         guard !isForceClosing else {
             AppLogger.shared.log("🔍 [Wizard] Smart state check blocked - force closing in progress")

--- a/Sources/KeyPathInstallationWizard/UI/InstallationWizardView+UIComponents.swift
+++ b/Sources/KeyPathInstallationWizard/UI/InstallationWizardView+UIComponents.swift
@@ -108,8 +108,6 @@ extension InstallationWizardView {
                         stateMachine.navigateToPage(.summary)
                     }
                 )
-            } else {
-                EmptyView()
             }
         case .stopExternalKanata:
             WizardStopKanataPage(
@@ -135,8 +133,6 @@ extension InstallationWizardView {
                         stateMachine.nextPage()
                     }
                 )
-            } else {
-                EmptyView()
             }
         case .helper:
             if let coordinator = kanataManager {
@@ -155,8 +151,6 @@ extension InstallationWizardView {
                 factory(
                     performAutoFix
                 )
-            } else {
-                EmptyView()
             }
         case .service:
             WizardKanataServicePage(
@@ -165,7 +159,6 @@ extension InstallationWizardView {
         }
     }
 
-    @ViewBuilder
     private func unconfiguredView(page: String) -> some View {
         VStack(spacing: 8) {
             Text("Wizard not fully configured")

--- a/Sources/KeyPathInstallationWizard/UI/InstallationWizardView+UnifiedRefresh.swift
+++ b/Sources/KeyPathInstallationWizard/UI/InstallationWizardView+UnifiedRefresh.swift
@@ -3,14 +3,14 @@ import KeyPathCore
 import KeyPathWizardCore
 import SwiftUI
 
-extension InstallationWizardView {
+public extension InstallationWizardView {
     // MARK: - Unified State Refresh
 
     /// Consolidated refresh method that handles all refresh scenarios
     /// - Parameters:
     ///   - showSpinner: Whether to show summary validating activity state
     ///   - previousPage: The page we're coming from (enables special handling for communication page)
-    public func refreshSystemState(showSpinner: Bool = false, previousPage: WizardPage? = nil) {
+    func refreshSystemState(showSpinner: Bool = false, previousPage: WizardPage? = nil) {
         guard !isForceClosing else {
             AppLogger.shared.log("🔍 [Wizard] Refresh blocked - force closing in progress")
             return
@@ -68,7 +68,7 @@ extension InstallationWizardView {
 
     /// Internal: Performs state detection with retry logic for communication page
     @MainActor
-    public func performStateDetection(previousPage: WizardPage?, attempt: Int, showSpinner: Bool) {
+    func performStateDetection(previousPage: WizardPage?, attempt: Int, showSpinner: Bool) {
         guard !isForceClosing else { return }
 
         let operation = WizardOperations.stateDetection(
@@ -100,7 +100,7 @@ extension InstallationWizardView {
     }
 
     /// Check if we should retry due to transient communication issues
-    public func shouldRetryForCommunication(result: SystemStateResult) -> Bool {
+    func shouldRetryForCommunication(result: SystemStateResult) -> Bool {
         // Retry if service appears not running
         switch result.state {
         case .serviceNotRunning, .daemonNotRunning:
@@ -125,7 +125,7 @@ extension InstallationWizardView {
         }
     }
 
-    public func cachedPreferredPage() async -> WizardPage? {
+    func cachedPreferredPage() async -> WizardPage? {
         guard let cachedState = stateMachine.lastWizardSnapshot else { return nil }
         let helperInstalled = await WizardDependencies.helperManager?.isHelperInstalled() ?? false
         let helperNeedsApproval = WizardDependencies.helperManager?.helperNeedsLoginItemsApproval() ?? false
@@ -138,7 +138,7 @@ extension InstallationWizardView {
         return page != .summary ? page : nil
     }
 
-    public func sanitizedIssues(from issues: [WizardIssue], for state: WizardSystemState)
+    func sanitizedIssues(from issues: [WizardIssue], for state: WizardSystemState)
         -> [WizardIssue]
     {
         guard shouldSuppressCommunicationIssues(for: state) else {
@@ -155,7 +155,7 @@ extension InstallationWizardView {
     }
 
     @MainActor
-    public func applySystemStateResult(_ result: SystemStateResult) -> [WizardIssue] {
+    func applySystemStateResult(_ result: SystemStateResult) -> [WizardIssue] {
         let filteredIssues = sanitizedIssues(from: result.issues, for: result.state)
         stateMachine.updateWizardState(result.state, issues: filteredIssues)
 
@@ -201,14 +201,14 @@ extension InstallationWizardView {
         return filteredIssues
     }
 
-    public func shouldSuppressCommunicationIssues(for state: WizardSystemState) -> Bool {
+    func shouldSuppressCommunicationIssues(for state: WizardSystemState) -> Bool {
         if case .active = state {
             return false
         }
         return true
     }
 
-    public func isCommunicationIssue(_ issue: WizardIssue) -> Bool {
+    func isCommunicationIssue(_ issue: WizardIssue) -> Bool {
         guard case let .component(component) = issue.identifier else {
             return false
         }
@@ -225,7 +225,7 @@ extension InstallationWizardView {
         }
     }
 
-    public func startKeyPathRuntime() {
+    func startKeyPathRuntime() {
         Task {
             if stateMachine.wizardState != .active {
                 guard let kanataManager else {
@@ -258,5 +258,4 @@ extension InstallationWizardView {
             }
         }
     }
-
 }

--- a/Sources/KeyPathInstallationWizard/UI/InstallationWizardView.swift
+++ b/Sources/KeyPathInstallationWizard/UI/InstallationWizardView.swift
@@ -38,7 +38,10 @@ public struct InstallationWizardView: View {
     // New architecture components
     @State public var stateMachine = WizardStateMachine()
     @State public var asyncOperationManager = WizardAsyncOperationManager()
-    public var isOperationRunning: Bool { asyncOperationManager.hasRunningOperations }
+    public var isOperationRunning: Bool {
+        asyncOperationManager.hasRunningOperations
+    }
+
     @State public var toastManager = WizardToastManager()
 
     // UI state

--- a/Sources/KeyPathInstallationWizard/UI/Pages/WizardAccessibilityPage.swift
+++ b/Sources/KeyPathInstallationWizard/UI/Pages/WizardAccessibilityPage.swift
@@ -16,9 +16,17 @@ public struct WizardAccessibilityPage: View {
 
     @Environment(WizardStateMachine.self) private var stateMachine
 
-    private var systemState: WizardSystemState { stateMachine.wizardState }
-    private var issues: [WizardIssue] { stateMachine.wizardIssues.filter { $0.category == .permissions } }
-    private var allIssues: [WizardIssue] { stateMachine.wizardIssues }
+    private var systemState: WizardSystemState {
+        stateMachine.wizardState
+    }
+
+    private var issues: [WizardIssue] {
+        stateMachine.wizardIssues.filter { $0.category == .permissions }
+    }
+
+    private var allIssues: [WizardIssue] {
+        stateMachine.wizardIssues
+    }
 
     private func statusIcon(for status: InstallationStatus) -> (name: String, color: Color) {
         switch status {

--- a/Sources/KeyPathInstallationWizard/UI/Pages/WizardConflictsPage.swift
+++ b/Sources/KeyPathInstallationWizard/UI/Pages/WizardConflictsPage.swift
@@ -12,9 +12,17 @@ public struct WizardConflictsPage: View {
     @State private var actionStatus: WizardDesign.ActionStatus = .idle
     @Environment(WizardStateMachine.self) private var stateMachine
 
-    private var systemState: WizardSystemState { stateMachine.wizardState }
-    private var issues: [WizardIssue] { stateMachine.wizardIssues.filter { $0.category == .conflicts } }
-    private var allIssues: [WizardIssue] { stateMachine.wizardIssues }
+    private var systemState: WizardSystemState {
+        stateMachine.wizardState
+    }
+
+    private var issues: [WizardIssue] {
+        stateMachine.wizardIssues.filter { $0.category == .conflicts }
+    }
+
+    private var allIssues: [WizardIssue] {
+        stateMachine.wizardIssues
+    }
 
     public init(
         isFixing: Bool,

--- a/Sources/KeyPathInstallationWizard/UI/Pages/WizardFullDiskAccessPage.swift
+++ b/Sources/KeyPathInstallationWizard/UI/Pages/WizardFullDiskAccessPage.swift
@@ -19,8 +19,13 @@ public struct WizardFullDiskAccessPage: View {
 
     @Environment(WizardStateMachine.self) private var stateMachine
 
-    private var systemState: WizardSystemState { stateMachine.wizardState }
-    private var issues: [WizardIssue] { stateMachine.wizardIssues }
+    private var systemState: WizardSystemState {
+        stateMachine.wizardState
+    }
+
+    private var issues: [WizardIssue] {
+        stateMachine.wizardIssues
+    }
 
     public init() {}
 

--- a/Sources/KeyPathInstallationWizard/UI/Pages/WizardHelperPage.swift
+++ b/Sources/KeyPathInstallationWizard/UI/Pages/WizardHelperPage.swift
@@ -25,8 +25,13 @@ public struct WizardHelperPage: View {
     @State private var approvalPollingTimer: Timer?
     @Environment(WizardStateMachine.self) private var stateMachine
 
-    private var systemState: WizardSystemState { stateMachine.wizardState }
-    private var issues: [WizardIssue] { stateMachine.wizardIssues }
+    private var systemState: WizardSystemState {
+        stateMachine.wizardState
+    }
+
+    private var issues: [WizardIssue] {
+        stateMachine.wizardIssues
+    }
 
     public init(
         isFixing: Bool,

--- a/Sources/KeyPathInstallationWizard/UI/Pages/WizardInputMonitoringPage.swift
+++ b/Sources/KeyPathInstallationWizard/UI/Pages/WizardInputMonitoringPage.swift
@@ -19,9 +19,17 @@ public struct WizardInputMonitoringPage: View {
 
     @Environment(WizardStateMachine.self) private var stateMachine
 
-    private var systemState: WizardSystemState { stateMachine.wizardState }
-    private var issues: [WizardIssue] { stateMachine.wizardIssues.filter { $0.category == .permissions } }
-    private var allIssues: [WizardIssue] { stateMachine.wizardIssues }
+    private var systemState: WizardSystemState {
+        stateMachine.wizardState
+    }
+
+    private var issues: [WizardIssue] {
+        stateMachine.wizardIssues.filter { $0.category == .permissions }
+    }
+
+    private var allIssues: [WizardIssue] {
+        stateMachine.wizardIssues
+    }
 
     public init(
         onRefresh: @escaping () async -> Void,

--- a/Sources/KeyPathInstallationWizard/UI/Pages/WizardKanataServicePage.swift
+++ b/Sources/KeyPathInstallationWizard/UI/Pages/WizardKanataServicePage.swift
@@ -15,8 +15,13 @@ public struct WizardKanataServicePage: View {
     /// Integration with RuntimeCoordinator for better error context
     @Environment(WizardStateMachine.self) private var stateMachine
 
-    private var systemState: WizardSystemState { stateMachine.wizardState }
-    private var issues: [WizardIssue] { stateMachine.wizardIssues }
+    private var systemState: WizardSystemState {
+        stateMachine.wizardState
+    }
+
+    private var issues: [WizardIssue] {
+        stateMachine.wizardIssues
+    }
 
     public init(onRefresh: @escaping () -> Void) {
         self.onRefresh = onRefresh

--- a/Sources/KeyPathInstallationWizard/UI/Pages/WizardKarabinerComponentsPage.swift
+++ b/Sources/KeyPathInstallationWizard/UI/Pages/WizardKarabinerComponentsPage.swift
@@ -26,8 +26,13 @@ public struct WizardKarabinerComponentsPage: View {
     @State private var stepProgressCancellable: AnyCancellable?
     @Environment(WizardStateMachine.self) private var stateMachine
 
-    private var systemState: WizardSystemState { stateMachine.wizardState }
-    private var issues: [WizardIssue] { stateMachine.wizardIssues }
+    private var systemState: WizardSystemState {
+        stateMachine.wizardState
+    }
+
+    private var issues: [WizardIssue] {
+        stateMachine.wizardIssues
+    }
 
     public init(
         isFixing: Bool,

--- a/Sources/KeyPathInstallationWizard/UI/Pages/WizardSummaryPage.swift
+++ b/Sources/KeyPathInstallationWizard/UI/Pages/WizardSummaryPage.swift
@@ -14,8 +14,13 @@ public struct WizardSummaryPage: View {
 
     @Environment(WizardStateMachine.self) private var stateMachine
 
-    private var systemState: WizardSystemState { stateMachine.wizardState }
-    private var issues: [WizardIssue] { stateMachine.wizardIssues }
+    private var systemState: WizardSystemState {
+        stateMachine.wizardState
+    }
+
+    private var issues: [WizardIssue] {
+        stateMachine.wizardIssues
+    }
 
     // MARK: - Header State
 

--- a/Sources/KeyPathInstallationWizard/UI/WizardDesignSystem.swift
+++ b/Sources/KeyPathInstallationWizard/UI/WizardDesignSystem.swift
@@ -255,25 +255,25 @@ public enum WizardDesign {
 
     @MainActor enum Transition {
         /// Card appearance from top
-        public static let cardAppear: AnyTransition = .opacity.combined(with: .move(edge: .top))
+        static let cardAppear: AnyTransition = .opacity.combined(with: .move(edge: .top))
 
         /// Overlay icon changes
-        public static let overlayChange: AnyTransition = .opacity.combined(with: .scale(scale: 0.8))
+        static let overlayChange: AnyTransition = .opacity.combined(with: .scale(scale: 0.8))
 
         /// Technical details expansion
-        public static let detailsExpand: AnyTransition = .asymmetric(
+        static let detailsExpand: AnyTransition = .asymmetric(
             insertion: .move(edge: .top).combined(with: .opacity),
             removal: .opacity
         )
 
         /// Page slide forward (next page)
-        public static let pageSlideForward: AnyTransition = .asymmetric(
+        static let pageSlideForward: AnyTransition = .asymmetric(
             insertion: .move(edge: .trailing).combined(with: .opacity),
             removal: .move(edge: .leading).combined(with: .opacity)
         )
 
         /// Page slide backward (previous page)
-        public static let pageSlideBackward: AnyTransition = .asymmetric(
+        static let pageSlideBackward: AnyTransition = .asymmetric(
             insertion: .move(edge: .leading).combined(with: .opacity),
             removal: .move(edge: .trailing).combined(with: .opacity)
         )
@@ -556,7 +556,6 @@ public enum WizardDesign {
                             }
                             .padding(.top, WizardDesign.Spacing.elementGap)
                         }
-
                     }
                     .padding(.vertical, WizardDesign.Spacing.pageVertical)
 
@@ -672,30 +671,30 @@ public enum WizardDesign {
 
 // MARK: - View Extensions
 
-extension View {
+public extension View {
     /// Apply wizard card styling
-    public func wizardCard() -> some View {
+    func wizardCard() -> some View {
         modifier(WizardDesign.Component.Card())
     }
 
     /// Apply status indicator styling
-    public func wizardStatusIndicator(_ status: InstallationStatus) -> some View {
+    func wizardStatusIndicator(_ status: InstallationStatus) -> some View {
         modifier(WizardDesign.Component.StatusIndicator(status: status))
     }
 
     /// Apply standard wizard page padding
-    public func wizardPagePadding() -> some View {
+    func wizardPagePadding() -> some View {
         padding(.horizontal, WizardDesign.Spacing.pageVertical)
             .padding(.vertical, WizardDesign.Spacing.sectionGap)
     }
 
     /// Apply standard wizard content spacing
-    public func wizardContentSpacing() -> some View {
+    func wizardContentSpacing() -> some View {
         frame(maxWidth: WizardDesign.Layout.maxContentWidth)
     }
 
     /// Apply toast card styling
-    public func wizardToastCard() -> some View {
+    func wizardToastCard() -> some View {
         modifier(WizardDesign.Component.ToastCard())
     }
 }
@@ -1208,8 +1207,8 @@ public struct WizardPageHeader: View {
 // MARK: - Tap Gesture Modifier
 
 private struct TapGestureModifier: ViewModifier {
-    public let isNavigable: Bool
-    public let action: (() -> Void)?
+    let isNavigable: Bool
+    let action: (() -> Void)?
 
     func body(content: Content) -> some View {
         if isNavigable, let action {
@@ -1224,15 +1223,15 @@ private struct TapGestureModifier: ViewModifier {
 
 // MARK: - View Extension
 
-extension View {
+public extension View {
     /// Wraps content in a standardized hero section container with Spacer() and padding
-    public func heroSectionContainer() -> some View {
+    func heroSectionContainer() -> some View {
         modifier(WizardDesign.HeroSectionContainer())
     }
 
     /// Conditionally apply a modifier
     @ViewBuilder
-    public func `if`(_ condition: Bool, transform: (Self) -> some View) -> some View {
+    func `if`(_ condition: Bool, transform: (Self) -> some View) -> some View {
         if condition {
             transform(self)
         } else {

--- a/Sources/KeyPathInstallationWizard/UI/WizardToastManager.swift
+++ b/Sources/KeyPathInstallationWizard/UI/WizardToastManager.swift
@@ -253,9 +253,9 @@ public struct ToastModifier: ViewModifier {
     }
 }
 
-extension View {
+public extension View {
     /// Add toast notification support to a view
-    public func withToasts(_ toastManager: WizardToastManager, onToastAction: (() -> Void)? = nil)
+    func withToasts(_ toastManager: WizardToastManager, onToastAction: (() -> Void)? = nil)
         -> some View
     {
         modifier(ToastModifier(toastManager: toastManager, onToastAction: onToastAction))

--- a/Sources/KeyPathKanataLauncher/LauncherService.swift
+++ b/Sources/KeyPathKanataLauncher/LauncherService.swift
@@ -242,7 +242,6 @@ struct LauncherService {
 
     // MARK: - Environment Helpers
 
-
     func environmentFlag(_ key: String) -> Bool {
         let value = ProcessInfo.processInfo.environment[key]?
             .trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Sources/KeyPathLayoutTracerKit/ComboBoxFields.swift
+++ b/Sources/KeyPathLayoutTracerKit/ComboBoxFields.swift
@@ -35,7 +35,7 @@ struct LabelComboBoxField: NSViewRepresentable {
         return stack
     }
 
-    func updateNSView(_ nsView: NSStackView, context: Context) {
+    func updateNSView(_: NSStackView, context: Context) {
         context.coordinator.text = $text
         context.coordinator.suggestions = suggestions
         if let comboBox = context.coordinator.comboBox {
@@ -112,7 +112,7 @@ struct KeyCodeComboBoxField: NSViewRepresentable {
         return stack
     }
 
-    func updateNSView(_ nsView: NSStackView, context: Context) {
+    func updateNSView(_: NSStackView, context: Context) {
         context.coordinator.value = $value
         context.coordinator.suggestions = suggestions
         if let comboBox = context.coordinator.comboBox {
@@ -163,7 +163,7 @@ struct KeyCodeComboBoxField: NSViewRepresentable {
                 value.wrappedValue = numericPrefix
             } else if let match = suggestions.first(where: { suggestion in
                 suggestion.searchTokens.contains { $0.localizedCaseInsensitiveContains(trimmed) } ||
-                suggestion.displayText.localizedCaseInsensitiveContains(trimmed)
+                    suggestion.displayText.localizedCaseInsensitiveContains(trimmed)
             }) {
                 value.wrappedValue = match.keyCode
             }

--- a/Sources/KeyPathLayoutTracerKit/KeySuggestionCatalog.swift
+++ b/Sources/KeyPathLayoutTracerKit/KeySuggestionCatalog.swift
@@ -5,7 +5,9 @@ struct KeyCodeSuggestion: Identifiable, Hashable {
     let canonicalName: String
     let preferredLabel: String
 
-    var id: UInt16 { keyCode }
+    var id: UInt16 {
+        keyCode
+    }
 
     var displayText: String {
         "\(keyCode)  \(preferredLabel)  \(canonicalName)"
@@ -109,7 +111,7 @@ enum KeySuggestionCatalog {
         }
     }
 
-    // Sourced from KeyPath's canonical macOS keycode mapping used by the overlay/simulator.
+    /// Sourced from KeyPath's canonical macOS keycode mapping used by the overlay/simulator.
     private static let macOSKeycodes: [(UInt16, String)] = [
         (0, "a"), (1, "s"), (2, "d"), (3, "f"), (4, "h"), (5, "g"),
         (6, "z"), (7, "x"), (8, "c"), (9, "v"), (10, "intlbackslash"), (11, "b"),

--- a/Sources/KeyPathLayoutTracerKit/LabeledDoubleField.swift
+++ b/Sources/KeyPathLayoutTracerKit/LabeledDoubleField.swift
@@ -7,7 +7,7 @@ struct LabeledDoubleField: View {
 
     var body: some View {
         LabeledContent(title) {
-            TextField(title, value: $value, format: .number.precision(.fractionLength(0...2)))
+            TextField(title, value: $value, format: .number.precision(.fractionLength(0 ... 2)))
                 .textFieldStyle(.roundedBorder)
                 .frame(width: 140)
                 .accessibilityIdentifier(accessibilityID)

--- a/Sources/KeyPathLayoutTracerKit/LayoutCatalog.swift
+++ b/Sources/KeyPathLayoutTracerKit/LayoutCatalog.swift
@@ -1,7 +1,10 @@
 import Foundation
 
 struct LayoutCatalogEntry: Identifiable, Equatable {
-    var id: String { fileURL.path }
+    var id: String {
+        fileURL.path
+    }
+
     let fileURL: URL
     let filename: String
     let layoutID: String
@@ -13,9 +16,9 @@ enum LayoutCatalog {
         let manager = FileManager.default
         guard let resourcesURL = bundledLayoutsDirectoryURL(),
               let files = try? manager.contentsOfDirectory(
-                at: resourcesURL,
-                includingPropertiesForKeys: nil,
-                options: [.skipsHiddenFiles]
+                  at: resourcesURL,
+                  includingPropertiesForKeys: nil,
+                  options: [.skipsHiddenFiles]
               )
         else {
             return []

--- a/Sources/KeyPathLayoutTracerKit/LayoutTracerCanvasView.swift
+++ b/Sources/KeyPathLayoutTracerKit/LayoutTracerCanvasView.swift
@@ -155,17 +155,17 @@ struct LayoutTracerCanvasView: View {
         // #available check alone isn't enough because the compiler can't
         // type-check the call on older SDKs even inside the guarded branch.
         #if compiler(>=6.2)
-        if #available(macOS 26, *) {
-            RoundedRectangle(cornerRadius: 22, style: .continuous)
-                .fill(.clear)
-                .glassEffect(.regular.tint(.white.opacity(0.02)), in: .rect(cornerRadius: 22))
-        } else {
+            if #available(macOS 26, *) {
+                RoundedRectangle(cornerRadius: 22, style: .continuous)
+                    .fill(.clear)
+                    .glassEffect(.regular.tint(.white.opacity(0.02)), in: .rect(cornerRadius: 22))
+            } else {
+                RoundedRectangle(cornerRadius: 22, style: .continuous)
+                    .fill(Color.black.opacity(0.12))
+            }
+        #else
             RoundedRectangle(cornerRadius: 22, style: .continuous)
                 .fill(Color.black.opacity(0.12))
-        }
-        #else
-        RoundedRectangle(cornerRadius: 22, style: .continuous)
-            .fill(Color.black.opacity(0.12))
         #endif
     }
 
@@ -269,12 +269,11 @@ struct LayoutTracerCanvasView: View {
             document.beginInteractiveChange()
         }
         guard let origin = draggingGuideOrigin else { return }
-        let delta: Double
-        switch guide.axis {
+        let delta: Double = switch guide.axis {
         case .horizontal:
-            delta = translation.height / (document.zoom * document.coordinateScale)
+            translation.height / (document.zoom * document.coordinateScale)
         case .vertical:
-            delta = translation.width / (document.zoom * document.coordinateScale)
+            translation.width / (document.zoom * document.coordinateScale)
         }
         let proposedPosition = origin + delta
         if final, proposedPosition <= guideRemovalThreshold {

--- a/Sources/KeyPathLayoutTracerKit/LayoutTracerImporter.swift
+++ b/Sources/KeyPathLayoutTracerKit/LayoutTracerImporter.swift
@@ -15,11 +15,10 @@ enum LayoutTracerImporter {
         let decoder = JSONDecoder()
         let layout = try decoder.decode(LayoutTracerPhysicalLayoutDTO.self, from: data)
         let derivedMaxX = layout.keys.map { $0.x + $0.width }.max() ?? 0
-        let recommendedCoordinateScale: Double
-        if layout.totalWidth == nil, derivedMaxX < 100 {
-            recommendedCoordinateScale = 64
+        let recommendedCoordinateScale: Double = if layout.totalWidth == nil, derivedMaxX < 100 {
+            64
         } else {
-            recommendedCoordinateScale = 1
+            1
         }
         return ImportedTracingLayout(
             id: layout.id,

--- a/Sources/KeyPathLayoutTracerKit/LayoutTracerInspectorView.swift
+++ b/Sources/KeyPathLayoutTracerKit/LayoutTracerInspectorView.swift
@@ -26,8 +26,8 @@ struct LayoutTracerInspectorView: View {
         let matches = availableLayouts
             .filter {
                 $0.displayName.localizedCaseInsensitiveContains(query) ||
-                $0.layoutID.localizedCaseInsensitiveContains(query) ||
-                $0.filename.localizedCaseInsensitiveContains(query)
+                    $0.layoutID.localizedCaseInsensitiveContains(query) ||
+                    $0.filename.localizedCaseInsensitiveContains(query)
             }
             .prefix(6)
             .map { $0 }
@@ -131,7 +131,7 @@ struct LayoutTracerInspectorView: View {
                             }
                             .buttonStyle(.plain)
                             .background(
-                                (highlightedLayoutID == layout.id ? Color.accentColor.opacity(0.22) : Color.white.opacity(0.03))
+                                highlightedLayoutID == layout.id ? Color.accentColor.opacity(0.22) : Color.white.opacity(0.03)
                             )
                             .clipShape(RoundedRectangle(cornerRadius: 8))
                             .accessibilityIdentifier("layoutTracer.search.result.\(layout.layoutID)")
@@ -146,7 +146,7 @@ struct LayoutTracerInspectorView: View {
                     .foregroundStyle(.secondary)
             }
 
-            if document.backgroundImageURL != nil, (document.hasLayoutOverlay || document.hasAnalysisProposals) {
+            if document.backgroundImageURL != nil, document.hasLayoutOverlay || document.hasAnalysisProposals {
                 VStack(alignment: .leading, spacing: 10) {
                     HStack(spacing: 8) {
                         if document.hasLayoutOverlay {
@@ -240,7 +240,7 @@ struct LayoutTracerInspectorView: View {
             HStack(spacing: 8) {
                 Image(systemName: "plus.magnifyingglass")
                     .foregroundStyle(.secondary)
-                Slider(value: $document.zoom, in: 0.03...2.0)
+                Slider(value: $document.zoom, in: 0.03 ... 2.0)
                     .frame(width: 140)
                     .accessibilityIdentifier("layoutTracer.zoom")
                 Button("Fit") {
@@ -253,7 +253,7 @@ struct LayoutTracerInspectorView: View {
             HStack(spacing: 8) {
                 Image(systemName: "photo")
                     .foregroundStyle(.secondary)
-                Slider(value: $document.imageOpacity, in: 0.1...1.0)
+                Slider(value: $document.imageOpacity, in: 0.1 ... 1.0)
                     .frame(width: 200)
                     .accessibilityIdentifier("layoutTracer.imageOpacity")
             }
@@ -261,14 +261,13 @@ struct LayoutTracerInspectorView: View {
             HStack(spacing: 8) {
                 Image(systemName: "roundedcorner")
                     .foregroundStyle(.secondary)
-                Slider(value: $document.keyCornerRadius, in: 0...24)
+                Slider(value: $document.keyCornerRadius, in: 0 ... 24)
                     .frame(width: 140)
                     .accessibilityIdentifier("layoutTracer.keyCornerRadius")
                 Text("\(Int(document.keyCornerRadius.rounded()))")
                     .font(.body.monospacedDigit())
                     .frame(minWidth: 24, alignment: .trailing)
             }
-
         }
         .tracerGlassCard()
     }
@@ -280,61 +279,61 @@ struct LayoutTracerInspectorView: View {
                     Text("Selected Key")
                         .font(.headline)
 
-                LabelComboBoxField(
-                    title: "Label",
-                    text: binding(for: \.label),
-                    suggestions: KeySuggestionCatalog.commonLabelSuggestions,
-                    accessibilityID: "layoutTracer.selected.label"
-                )
-                KeyCodeComboBoxField(
-                    title: "Key Code",
-                    value: bindingUInt16(for: \.keyCode),
-                    suggestions: KeySuggestionCatalog.keyCodeSuggestions,
-                    accessibilityID: "layoutTracer.selected.keyCode"
-                )
-                LabeledDoubleField(title: "X", value: bindingDouble(for: \.x), accessibilityID: "layoutTracer.selected.x")
-                LabeledDoubleField(title: "Y", value: bindingDouble(for: \.y), accessibilityID: "layoutTracer.selected.y")
-                LabeledDoubleField(title: "Width", value: bindingDouble(for: \.width), accessibilityID: "layoutTracer.selected.width")
-                LabeledDoubleField(title: "Height", value: bindingDouble(for: \.height), accessibilityID: "layoutTracer.selected.height")
+                    LabelComboBoxField(
+                        title: "Label",
+                        text: binding(for: \.label),
+                        suggestions: KeySuggestionCatalog.commonLabelSuggestions,
+                        accessibilityID: "layoutTracer.selected.label"
+                    )
+                    KeyCodeComboBoxField(
+                        title: "Key Code",
+                        value: bindingUInt16(for: \.keyCode),
+                        suggestions: KeySuggestionCatalog.keyCodeSuggestions,
+                        accessibilityID: "layoutTracer.selected.keyCode"
+                    )
+                    LabeledDoubleField(title: "X", value: bindingDouble(for: \.x), accessibilityID: "layoutTracer.selected.x")
+                    LabeledDoubleField(title: "Y", value: bindingDouble(for: \.y), accessibilityID: "layoutTracer.selected.y")
+                    LabeledDoubleField(title: "Width", value: bindingDouble(for: \.width), accessibilityID: "layoutTracer.selected.width")
+                    LabeledDoubleField(title: "Height", value: bindingDouble(for: \.height), accessibilityID: "layoutTracer.selected.height")
 
-                HStack(spacing: 8) {
-                    Text("Rotation")
-                        .frame(width: 70, alignment: .leading)
-                    Button {
-                        document.rotateSelectedKey(by: -5)
-                    } label: {
-                        Image(systemName: "rotate.left")
+                    HStack(spacing: 8) {
+                        Text("Rotation")
+                            .frame(width: 70, alignment: .leading)
+                        Button {
+                            document.rotateSelectedKey(by: -5)
+                        } label: {
+                            Image(systemName: "rotate.left")
+                        }
+                        .help("Rotate Counterclockwise")
+                        .accessibilityIdentifier("layoutTracer.rotate.left")
+
+                        Text("\(Int((selected.rotation ?? 0).rounded()))°")
+                            .font(.body.monospacedDigit())
+                            .frame(minWidth: 44)
+
+                        Button {
+                            document.rotateSelectedKey(by: 5)
+                        } label: {
+                            Image(systemName: "rotate.right")
+                        }
+                        .help("Rotate Clockwise")
+                        .accessibilityIdentifier("layoutTracer.rotate.right")
                     }
-                    .help("Rotate Counterclockwise")
-                    .accessibilityIdentifier("layoutTracer.rotate.left")
 
-                    Text("\(Int((selected.rotation ?? 0).rounded()))°")
-                        .font(.body.monospacedDigit())
-                        .frame(minWidth: 44)
-
-                    Button {
-                        document.rotateSelectedKey(by: 5)
-                    } label: {
-                        Image(systemName: "rotate.right")
+                    HStack {
+                        Button("←") { document.nudgeSelectedKey(dx: -1, dy: 0) }
+                            .accessibilityIdentifier("layoutTracer.nudge.left")
+                        Button("→") { document.nudgeSelectedKey(dx: 1, dy: 0) }
+                            .accessibilityIdentifier("layoutTracer.nudge.right")
+                        Button("↑") { document.nudgeSelectedKey(dx: 0, dy: -1) }
+                            .accessibilityIdentifier("layoutTracer.nudge.up")
+                        Button("↓") { document.nudgeSelectedKey(dx: 0, dy: 1) }
+                            .accessibilityIdentifier("layoutTracer.nudge.down")
                     }
-                    .help("Rotate Clockwise")
-                    .accessibilityIdentifier("layoutTracer.rotate.right")
-                }
 
-                HStack {
-                    Button("←") { document.nudgeSelectedKey(dx: -1, dy: 0) }
-                        .accessibilityIdentifier("layoutTracer.nudge.left")
-                    Button("→") { document.nudgeSelectedKey(dx: 1, dy: 0) }
-                        .accessibilityIdentifier("layoutTracer.nudge.right")
-                    Button("↑") { document.nudgeSelectedKey(dx: 0, dy: -1) }
-                        .accessibilityIdentifier("layoutTracer.nudge.up")
-                    Button("↓") { document.nudgeSelectedKey(dx: 0, dy: 1) }
-                        .accessibilityIdentifier("layoutTracer.nudge.down")
-                }
-
-                Text("Current frame: \(Int(selected.width))×\(Int(selected.height)) at (\(Int(selected.x)), \(Int(selected.y)))")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+                    Text("Current frame: \(Int(selected.width))×\(Int(selected.height)) at (\(Int(selected.x)), \(Int(selected.y)))")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
                 }
                 .tracerGlassCard()
             }

--- a/Sources/KeyPathLayoutTracerKit/LiquidGlassSupport.swift
+++ b/Sources/KeyPathLayoutTracerKit/LiquidGlassSupport.swift
@@ -5,19 +5,19 @@ struct LiquidGlassCardModifier: ViewModifier {
         // See note on LayoutTracerCanvasView.canvasBackground — need a
         // compile-time gate, not just a runtime #available check.
         #if compiler(>=6.2)
-        if #available(macOS 26, *) {
-            content
-                .padding(14)
-                .glassEffect(.regular, in: .rect(cornerRadius: 18))
-        } else {
+            if #available(macOS 26, *) {
+                content
+                    .padding(14)
+                    .glassEffect(.regular, in: .rect(cornerRadius: 18))
+            } else {
+                content
+                    .padding(14)
+                    .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+            }
+        #else
             content
                 .padding(14)
                 .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
-        }
-        #else
-        content
-            .padding(14)
-            .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
         #endif
     }
 }
@@ -30,13 +30,13 @@ extension View {
     @ViewBuilder
     func tracerGlassButtonStyle() -> some View {
         #if compiler(>=6.2)
-        if #available(macOS 26, *) {
-            self.buttonStyle(.glass)
-        } else {
-            self.buttonStyle(.bordered)
-        }
+            if #available(macOS 26, *) {
+                buttonStyle(.glass)
+            } else {
+                buttonStyle(.bordered)
+            }
         #else
-        self.buttonStyle(.bordered)
+            buttonStyle(.bordered)
         #endif
     }
 }

--- a/Sources/KeyPathLayoutTracerKit/TracingDocument.swift
+++ b/Sources/KeyPathLayoutTracerKit/TracingDocument.swift
@@ -551,12 +551,11 @@ final class TracingDocument {
     }
 
     private func clampedGuidePosition(_ position: Double, axis: TracingGuide.Axis) -> Double {
-        let maxPosition: Double
-        switch axis {
+        let maxPosition: Double = switch axis {
         case .horizontal:
-            maxPosition = max(editorTotalHeight / coordinateScale, 0)
+            max(editorTotalHeight / coordinateScale, 0)
         case .vertical:
-            maxPosition = max(editorTotalWidth / coordinateScale, 0)
+            max(editorTotalWidth / coordinateScale, 0)
         }
         return max(0, min(position, maxPosition))
     }

--- a/Sources/KeyPathWizardCore/WizardDependencies.swift
+++ b/Sources/KeyPathWizardCore/WizardDependencies.swift
@@ -22,7 +22,7 @@ public enum WizardDependencies {
     public static var runtimeCoordinator: (any RuntimeCoordinating)?
 
     /// HelperManager instance
-    nonisolated(unsafe) public static var helperManager: (any WizardHelperManaging)?
+    public nonisolated(unsafe) static var helperManager: (any WizardHelperManaging)?
 
     /// KanataDaemonManager instance
     public static var daemonManager: (any WizardDaemonManaging)?
@@ -36,10 +36,10 @@ public enum WizardDependencies {
     public static var helperMaintenance: (any WizardHelperMaintaining)?
 
     /// FullDiskAccessChecker instance
-    nonisolated(unsafe) public static var fullDiskAccessChecker: (any WizardFullDiskAccessChecking)?
+    public nonisolated(unsafe) static var fullDiskAccessChecker: (any WizardFullDiskAccessChecking)?
 
     /// PermissionRequestService instance
-    nonisolated(unsafe) public static var permissionRequestService: (any WizardPermissionRequesting)?
+    public nonisolated(unsafe) static var permissionRequestService: (any WizardPermissionRequesting)?
 
     /// PrivilegedOperationsCoordinator instance
     public static var privilegedOperations: (any WizardPrivilegedOperating)?
@@ -61,47 +61,47 @@ public enum WizardDependencies {
     // MARK: - Type-Erased Closures
 
     /// SMAppService factory for helper plist (type-erased)
-    nonisolated(unsafe) public static var smServiceFactory: ((String) -> Any)?
+    public nonisolated(unsafe) static var smServiceFactory: ((String) -> Any)?
 
     /// Check if the helper needs Login Items approval in System Settings
-    nonisolated(unsafe) public static var helperNeedsApproval: (() -> Bool)?
+    public nonisolated(unsafe) static var helperNeedsApproval: (() -> Bool)?
 
     /// UninstallCoordinator factory (type-erased, creates new instance each call)
     public static var createUninstallCoordinator: (() -> any WizardUninstalling)?
 
     /// AdminCommandExecutor - execute(batch:) for privileged commands
-    nonisolated(unsafe) public static var executePrivilegedBatch: ((PrivilegedCommandRunner.Batch) async throws -> (exitCode: Int32, output: String))?
+    public nonisolated(unsafe) static var executePrivilegedBatch: ((PrivilegedCommandRunner.Batch) async throws -> (exitCode: Int32, output: String))?
 
     /// KeyPathAppKitResources bundle accessor
-    nonisolated(unsafe) public static var resourceBundle: Bundle?
+    public nonisolated(unsafe) static var resourceBundle: Bundle?
 
     // MARK: - ExternalKanataService (static methods)
 
     /// Get info about externally-running Kanata process
-    nonisolated(unsafe) public static var getExternalKanataInfo: (() -> WizardSystemPaths.RunningKanataInfo?)?
+    public nonisolated(unsafe) static var getExternalKanataInfo: (() -> WizardSystemPaths.RunningKanataInfo?)?
 
     /// Stop an externally-running Kanata process
-    nonisolated(unsafe) public static var stopExternalKanata: ((WizardSystemPaths.RunningKanataInfo) async -> Result<Void, Error>)?
+    public nonisolated(unsafe) static var stopExternalKanata: ((WizardSystemPaths.RunningKanataInfo) async -> Result<Void, Error>)?
 
     /// Check if external Kanata is running
-    nonisolated(unsafe) public static var hasExternalKanataRunning: (() -> Bool)?
+    public nonisolated(unsafe) static var hasExternalKanataRunning: (() -> Bool)?
 
     // MARK: - TCPProbe (static method)
 
     /// TCP connectivity probe
-    nonisolated(unsafe) public static var tcpProbe: ((Int, Int) -> Bool)?
+    public nonisolated(unsafe) static var tcpProbe: ((Int, Int) -> Bool)?
 
     // MARK: - NotificationObserverManager factory
 
     /// Factory to create notification observer managers
-    nonisolated(unsafe) public static var createNotificationObserverManager: (() -> Any)?
+    public nonisolated(unsafe) static var createNotificationObserverManager: (() -> Any)?
 
     // MARK: - Ad-hoc Signature Cache
 
     /// Whether the app is running ad-hoc signed (not notarized).
     /// Cached at startup by KeyPathAppKit to avoid blocking the main thread
     /// with a synchronous codesign subprocess call from SwiftUI views.
-    nonisolated(unsafe) public static var isRunningAdHoc: Bool = false
+    public nonisolated(unsafe) static var isRunningAdHoc: Bool = false
 
     // MARK: - Test Support
 

--- a/Tests/KeyPathLayoutTracerTests/LayoutAnalysisImporterTests.swift
+++ b/Tests/KeyPathLayoutTracerTests/LayoutAnalysisImporterTests.swift
@@ -1,6 +1,6 @@
 import Foundation
-import Testing
 @testable import KeyPathLayoutTracerKit
+import Testing
 
 struct LayoutAnalysisImporterTests {
     @Test

--- a/Tests/KeyPathLayoutTracerTests/LayoutTracerExporterTests.swift
+++ b/Tests/KeyPathLayoutTracerTests/LayoutTracerExporterTests.swift
@@ -1,6 +1,6 @@
 import Foundation
-import Testing
 @testable import KeyPathLayoutTracerKit
+import Testing
 
 struct LayoutTracerExporterTests {
     @Test

--- a/Tests/KeyPathLayoutTracerTests/LayoutTracerSnapEngineTests.swift
+++ b/Tests/KeyPathLayoutTracerTests/LayoutTracerSnapEngineTests.swift
@@ -1,5 +1,5 @@
-import Testing
 @testable import KeyPathLayoutTracerKit
+import Testing
 
 struct LayoutTracerSnapEngineTests {
     @Test

--- a/Tests/KeyPathLayoutTracerTests/TracingDocumentUndoTests.swift
+++ b/Tests/KeyPathLayoutTracerTests/TracingDocumentUndoTests.swift
@@ -1,6 +1,6 @@
 import Foundation
-import Testing
 @testable import KeyPathLayoutTracerKit
+import Testing
 
 struct TracingDocumentUndoTests {
     @Test

--- a/Tests/KeyPathSnapshotTests/Support/SnapshotHelpers.swift
+++ b/Tests/KeyPathSnapshotTests/Support/SnapshotHelpers.swift
@@ -30,7 +30,10 @@ enum DocSize {
     /// Taller subpanel (per-finger sliders, expanded settings) — 650×500
     static let subpanelTall = CGSize(width: 650, height: 500)
     /// Pack detail dialog — use pack.preferredDetailWidth × 800
-    static func packDetail(width: CGFloat) -> CGSize { CGSize(width: width, height: 800) }
+    static func packDetail(width: CGFloat) -> CGSize {
+        CGSize(width: width, height: 800)
+    }
+
     /// Settings tab (Rules, General, etc.) — 680×700
     static let settingsTab = CGSize(width: 680, height: 700)
     /// Full overlay + inspector composite — 1400×800

--- a/Tests/KeyPathTests/CLI/CLIKarabinerImportTests.swift
+++ b/Tests/KeyPathTests/CLI/CLIKarabinerImportTests.swift
@@ -195,7 +195,7 @@ final class CLIKarabinerImportTests: XCTestCase {
         """
         let result = try facade.importFromKarabiner(data: Data(json.utf8), collectionName: nil, profileIndex: nil)
 
-        XCTAssertTrue(result.collections.isEmpty || result.collections.allSatisfy { $0.mappings.isEmpty })
+        XCTAssertTrue(result.collections.isEmpty || result.collections.allSatisfy(\.mappings.isEmpty))
         XCTAssertFalse(result.skippedRules.isEmpty)
         XCTAssertTrue(result.skippedRules.first?.reason.contains("Mouse") == true
             || result.skippedRules.first?.reason.contains("mouse") == true)

--- a/Tests/KeyPathTests/CLI/CLIOutputSnapshotTests.swift
+++ b/Tests/KeyPathTests/CLI/CLIOutputSnapshotTests.swift
@@ -1,6 +1,6 @@
+import Foundation
 @testable import KeyPathAppKit
 @testable import KeyPathCLI
-import Foundation
 import XCTest
 
 final class CLIOutputSnapshotTests: XCTestCase {
@@ -244,7 +244,7 @@ final class CLIOutputSnapshotTests: XCTestCase {
         )
         let json = try encode(value)
         let dict = try JSONSerialization.jsonObject(with: Data(json.utf8)) as! [String: Any]
-        let expectedKeys: Set<String> = [
+        let expectedKeys: Set = [
             "isOperational", "helperInstalled", "helperWorking", "helperVersion",
             "keyPathAccessibility", "keyPathInputMonitoring",
             "kanataAccessibility", "kanataInputMonitoring",
@@ -291,7 +291,7 @@ final class CLIOutputSnapshotTests: XCTestCase {
         let detail = CLIRuleDetail(from: rule)
         let json = try encode(detail)
         let dict = try JSONSerialization.jsonObject(with: Data(json.utf8)) as! [String: Any]
-        let expectedKeys: Set<String> = [
+        let expectedKeys: Set = [
             "input", "action", "shiftedOutput", "title", "notes",
             "targetLayer", "isEnabled", "createdAt",
         ]
@@ -406,13 +406,13 @@ final class CLIOutputSnapshotTests: XCTestCase {
 
     // MARK: - Helpers
 
-    private func encode<T: Encodable>(_ value: T) throws -> String {
+    private func encode(_ value: some Encodable) throws -> String {
         let data = try encoder.encode(value)
         return String(data: data, encoding: .utf8)!
     }
 
-    private func assertSnapshot<T: Encodable>(
-        _ value: T,
+    private func assertSnapshot(
+        _ value: some Encodable,
         expected: String,
         file: StaticString = #filePath,
         line: UInt = #line

--- a/Tests/KeyPathTests/CLI/CLIPackCRUDTests.swift
+++ b/Tests/KeyPathTests/CLI/CLIPackCRUDTests.swift
@@ -24,7 +24,7 @@ final class CLIPackCRUDTests: XCTestCase {
             }
         }
         for record in originalInstalledPacks {
-            if !(await InstalledPackTracker.shared.isInstalled(packID: record.packID)) {
+            if await !(InstalledPackTracker.shared.isInstalled(packID: record.packID)) {
                 try await InstalledPackTracker.shared.upsert(record)
             }
         }

--- a/Tests/KeyPathTests/CLI/CLIRuleAddIntegrationTests.swift
+++ b/Tests/KeyPathTests/CLI/CLIRuleAddIntegrationTests.swift
@@ -17,79 +17,79 @@ final class CLIRuleAddIntegrationTests: XCTestCase {
 
     // MARK: - KeyAction JSON decoding (all 13 variants)
 
-    func testDecodeKeystrokeAction() async throws {
+    func testDecodeKeystrokeAction() throws {
         let json = #"{"keystroke":{"key":"esc"}}"#
         let action = try decode(KeyAction.self, from: json)
         XCTAssertEqual(action, .keystroke(key: "esc"))
     }
 
-    func testDecodeHyperAction() async throws {
+    func testDecodeHyperAction() throws {
         let json = #"{"hyper":{}}"#
         let action = try decode(KeyAction.self, from: json)
         XCTAssertEqual(action, .hyper)
     }
 
-    func testDecodeMehAction() async throws {
+    func testDecodeMehAction() throws {
         let json = #"{"meh":{}}"#
         let action = try decode(KeyAction.self, from: json)
         XCTAssertEqual(action, .meh)
     }
 
-    func testDecodeLaunchAppAction() async throws {
+    func testDecodeLaunchAppAction() throws {
         let json = #"{"launchApp":{"name":"Safari","bundleId":"com.apple.Safari"}}"#
         let action = try decode(KeyAction.self, from: json)
         XCTAssertEqual(action, .launchApp(name: "Safari", bundleId: "com.apple.Safari"))
     }
 
-    func testDecodeOpenURLAction() async throws {
+    func testDecodeOpenURLAction() throws {
         let json = #"{"openURL":{"_0":"https://example.com"}}"#
         let action = try decode(KeyAction.self, from: json)
         XCTAssertEqual(action, .openURL("https://example.com"))
     }
 
-    func testDecodeOpenFolderAction() async throws {
+    func testDecodeOpenFolderAction() throws {
         let json = #"{"openFolder":{"path":"~/Documents","name":"Docs"}}"#
         let action = try decode(KeyAction.self, from: json)
         XCTAssertEqual(action, .openFolder(path: "~/Documents", name: "Docs"))
     }
 
-    func testDecodeRunScriptAction() async throws {
+    func testDecodeRunScriptAction() throws {
         let json = #"{"runScript":{"path":"~/.scripts/foo.sh","name":"Foo"}}"#
         let action = try decode(KeyAction.self, from: json)
         XCTAssertEqual(action, .runScript(path: "~/.scripts/foo.sh", name: "Foo"))
     }
 
-    func testDecodeSystemActionAction() async throws {
+    func testDecodeSystemActionAction() throws {
         let json = #"{"systemAction":{"id":"volume-up"}}"#
         let action = try decode(KeyAction.self, from: json)
         XCTAssertEqual(action, .systemAction(id: "volume-up"))
     }
 
-    func testDecodeNotifyAction() async throws {
+    func testDecodeNotifyAction() throws {
         let json = #"{"notify":{"title":"Done","body":"Build succeeded","sound":true}}"#
         let action = try decode(KeyAction.self, from: json)
         XCTAssertEqual(action, .notify(title: "Done", body: "Build succeeded", sound: true))
     }
 
-    func testDecodeWindowActionAction() async throws {
+    func testDecodeWindowActionAction() throws {
         let json = #"{"windowAction":{"position":"left-half"}}"#
         let action = try decode(KeyAction.self, from: json)
         XCTAssertEqual(action, .windowAction(position: "left-half"))
     }
 
-    func testDecodeFakeKeyAction() async throws {
+    func testDecodeFakeKeyAction() throws {
         let json = #"{"fakeKey":{"name":"vk1","action":"tap"}}"#
         let action = try decode(KeyAction.self, from: json)
         XCTAssertEqual(action, .fakeKey(name: "vk1", action: .tap))
     }
 
-    func testDecodeActivateLayerAction() async throws {
+    func testDecodeActivateLayerAction() throws {
         let json = #"{"activateLayer":{"name":"nav"}}"#
         let action = try decode(KeyAction.self, from: json)
         XCTAssertEqual(action, .activateLayer(name: "nav"))
     }
 
-    func testDecodeRawKanataAction() async throws {
+    func testDecodeRawKanataAction() throws {
         let json = #"{"rawKanata":{"_0":"(multi lctl c)"}}"#
         let action = try decode(KeyAction.self, from: json)
         XCTAssertEqual(action, .rawKanata("(multi lctl c)"))
@@ -97,7 +97,7 @@ final class CLIRuleAddIntegrationTests: XCTestCase {
 
     // MARK: - MappingBehavior JSON decoding
 
-    func testDecodeDualRoleBehavior() async throws {
+    func testDecodeDualRoleBehavior() throws {
         let json = #"{"dualRole":{"tapAction":{"keystroke":{"key":"a"}},"holdAction":{"keystroke":{"key":"lctl"}},"tapTimeout":200,"holdTimeout":200,"activateHoldOnOtherKey":true}}"#
         let behavior = try decode(MappingBehavior.self, from: json)
         if case let .dualRole(d) = behavior {
@@ -110,7 +110,7 @@ final class CLIRuleAddIntegrationTests: XCTestCase {
         }
     }
 
-    func testDecodeMacroBehavior() async throws {
+    func testDecodeMacroBehavior() throws {
         let json = #"{"macro":{"text":"hello world","outputs":[],"source":"text"}}"#
         let behavior = try decode(MappingBehavior.self, from: json)
         if case let .macro(m) = behavior {
@@ -121,7 +121,7 @@ final class CLIRuleAddIntegrationTests: XCTestCase {
         }
     }
 
-    func testDecodeChordBehavior() async throws {
+    func testDecodeChordBehavior() throws {
         let json = #"{"chord":{"keys":["j","k"],"output":{"keystroke":{"key":"esc"}},"timeout":200}}"#
         let behavior = try decode(MappingBehavior.self, from: json)
         if case let .chord(c) = behavior {
@@ -133,7 +133,7 @@ final class CLIRuleAddIntegrationTests: XCTestCase {
         }
     }
 
-    func testDecodeTapDanceBehavior() async throws {
+    func testDecodeTapDanceBehavior() throws {
         let json = #"{"tapOrTapDance":{"tapDance":{"_0":{"windowMs":200,"steps":[{"label":"Single","action":{"keystroke":{"key":"esc"}}},{"label":"Double","action":{"keystroke":{"key":"caps"}}}]}}}}"#
         let behavior = try decode(MappingBehavior.self, from: json)
         if case let .tapOrTapDance(.tapDance(td)) = behavior {

--- a/Tests/KeyPathTests/CLI/CLIRuleCRUDTests.swift
+++ b/Tests/KeyPathTests/CLI/CLIRuleCRUDTests.swift
@@ -217,7 +217,7 @@ final class CLIRuleCRUDTests: XCTestCase {
         XCTAssertEqual(detail?.notes, "Makes caps into hyper")
     }
 
-    func testRuleShowNotFoundReturnsNil() async throws {
+    func testRuleShowNotFoundReturnsNil() async {
         let detail = await facade.showRule(input: "nonexistent")
         XCTAssertNil(detail)
     }

--- a/Tests/KeyPathTests/CLI/CollectionsFacadeResolutionTests.swift
+++ b/Tests/KeyPathTests/CLI/CollectionsFacadeResolutionTests.swift
@@ -2,7 +2,6 @@
 import XCTest
 
 final class CollectionsFacadeResolutionTests: XCTestCase {
-
     private let facade = CollectionsFacade()
 
     private func testCollections() -> [RuleCollection] {

--- a/Tests/KeyPathTests/CLI/OutputContractTests.swift
+++ b/Tests/KeyPathTests/CLI/OutputContractTests.swift
@@ -103,7 +103,7 @@ final class OutputContractTests: XCTestCase {
 
     // MARK: - Helpers
 
-    private func jsonKeys<T: Encodable>(_ value: T) throws -> Set<String> {
+    private func jsonKeys(_ value: some Encodable) throws -> Set<String> {
         let data = try encoder.encode(value)
         let dict = try JSONSerialization.jsonObject(with: data) as! [String: Any]
         return Set(dict.keys)

--- a/Tests/KeyPathTests/CLI/PacksFacadeTests.swift
+++ b/Tests/KeyPathTests/CLI/PacksFacadeTests.swift
@@ -2,7 +2,6 @@
 import XCTest
 
 final class PacksFacadeTests: XCTestCase {
-
     // MARK: - resolvePack: by full ID
 
     func testResolvePack_FullID_ReturnsExactMatch() throws {
@@ -76,7 +75,7 @@ final class PacksFacadeTests: XCTestCase {
             category: "Test",
             tagline: "A test pack",
             isInstalled: true,
-            installedAt: Date(timeIntervalSince1970: 1700000000)
+            installedAt: Date(timeIntervalSince1970: 1_700_000_000)
         )
         let data = try JSONEncoder().encode(pack)
         let decoded = try JSONDecoder().decode(CLIPack.self, from: data)

--- a/Tests/KeyPathTests/Config/PackRuntimeBehaviorTests.swift
+++ b/Tests/KeyPathTests/Config/PackRuntimeBehaviorTests.swift
@@ -1,5 +1,5 @@
-@testable import KeyPathAppKit
 import Foundation
+@testable import KeyPathAppKit
 import XCTest
 
 /// Runtime behavior guard for starter-kit packs. For each pack, we enable
@@ -14,7 +14,9 @@ import XCTest
 ///
 /// Skips gracefully if the simulator binary isn't available.
 final class PackRuntimeBehaviorTests: XCTestCase {
-    private var simulatorURL: URL? { findBinary("kanata_simulated_input") }
+    private var simulatorURL: URL? {
+        findBinary("kanata_simulated_input")
+    }
 
     // MARK: - Starter-kit headline behaviors
 

--- a/Tests/KeyPathTests/Config/RuleCollectionKanataValidationTests.swift
+++ b/Tests/KeyPathTests/Config/RuleCollectionKanataValidationTests.swift
@@ -131,14 +131,14 @@ final class RuleCollectionKanataValidationTests: XCTestCase {
             let err = String(data: errData, encoding: .utf8) ?? ""
             let out = String(data: outData, encoding: .utf8) ?? ""
             XCTFail("""
-                kanata --check rejected config for \(label) (exit \(process.terminationStatus)).
-                --- stderr ---
-                \(err)
-                --- stdout ---
-                \(out)
-                --- config (first 800 chars) ---
-                \(String(config.prefix(800)))
-                """)
+            kanata --check rejected config for \(label) (exit \(process.terminationStatus)).
+            --- stderr ---
+            \(err)
+            --- stdout ---
+            \(out)
+            --- config (first 800 chars) ---
+            \(String(config.prefix(800)))
+            """)
         }
     }
 }

--- a/Tests/KeyPathTests/ConfigApplyTypesExtendedTests.swift
+++ b/Tests/KeyPathTests/ConfigApplyTypesExtendedTests.swift
@@ -2,7 +2,6 @@
 import XCTest
 
 final class ConfigApplyTypesExtendedTests: XCTestCase {
-
     // MARK: - ApplyResult
 
     func testApplyResult_SuccessDefaults() {
@@ -87,7 +86,7 @@ final class ConfigApplyTypesExtendedTests: XCTestCase {
     }
 
     func testConfigDiagnostics_Equality() {
-        let date = Date(timeIntervalSince1970: 1700000000)
+        let date = Date(timeIntervalSince1970: 1_700_000_000)
         let a = ConfigDiagnostics(mappingCountBefore: 3, timestamp: date)
         let b = ConfigDiagnostics(mappingCountBefore: 3, timestamp: date)
         XCTAssertEqual(a, b)

--- a/Tests/KeyPathTests/Core/KanataHostBridgeTests.swift
+++ b/Tests/KeyPathTests/Core/KanataHostBridgeTests.swift
@@ -48,7 +48,7 @@ final class KanataHostBridgeTests: XCTestCase {
         let result = KanataHostBridge.createPassthruRuntime(
             runtimeHost: runtimeHost,
             configPath: "/tmp/keypath.kbd",
-            tcpPort: 37_001
+            tcpPort: 37001
         )
 
         XCTAssertEqual(

--- a/Tests/KeyPathTests/Core/PrivilegedOperationsCoordinatorTests.swift
+++ b/Tests/KeyPathTests/Core/PrivilegedOperationsCoordinatorTests.swift
@@ -1,7 +1,7 @@
 import Foundation
 @testable import KeyPathAppKit
-@testable import KeyPathInstallationWizard
 @testable import KeyPathCore
+@testable import KeyPathInstallationWizard
 @preconcurrency import XCTest
 
 /// Tests for PrivilegedOperationsRouter

--- a/Tests/KeyPathTests/Core/PrivilegedOperationsGoldenTests.swift
+++ b/Tests/KeyPathTests/Core/PrivilegedOperationsGoldenTests.swift
@@ -257,7 +257,7 @@ final class PrivilegedOperationsGoldenTests: XCTestCase {
             lastAttempt: nil
         )
         XCTAssertEqual(decision, .skipPendingApproval,
-                        "Pending approval takes priority even with stale registration")
+                       "Pending approval takes priority even with stale registration")
     }
 
     // MARK: - KanataReadinessResult: Semantics

--- a/Tests/KeyPathTests/Core/ServiceContainerTests.swift
+++ b/Tests/KeyPathTests/Core/ServiceContainerTests.swift
@@ -7,7 +7,6 @@ import Testing
 @Suite("ServiceContainer Tests")
 @MainActor
 struct ServiceContainerTests {
-
     @Test("default init creates container with shared instances")
     func defaultInitCreatesContainer() {
         let container = ServiceContainer()
@@ -37,7 +36,7 @@ struct ServiceContainerTests {
         // the macro expansion compiles and runs correctly.
         let container = ServiceContainer()
         // Access a property to exercise the @Observable getter path
-        let _ = container.preferences
+        _ = container.preferences
     }
 
     @Test("multiple containers are independent instances")
@@ -54,7 +53,6 @@ struct ServiceContainerTests {
 
 @Suite("BuildInfo Tests")
 struct BuildInfoTests {
-
     @Test("current returns non-empty version")
     func currentReturnsNonEmptyVersion() {
         let info = BuildInfo.current()
@@ -105,7 +103,7 @@ struct BuildInfoTests {
     func kanataVersionCachedIsAccessible() {
         // In a test environment, kanata may not be installed, so the cached version
         // may be nil. We just verify accessing it does not crash.
-        let _ = BuildInfo.kanataVersionCached
+        _ = BuildInfo.kanataVersionCached
     }
 
     @Test("current returns fallback values in test environment")

--- a/Tests/KeyPathTests/ErrorRecoveryTests.swift
+++ b/Tests/KeyPathTests/ErrorRecoveryTests.swift
@@ -7,7 +7,6 @@ import XCTest
 /// Verifies that crash detection, config backup, and validation
 /// failure handling work correctly.
 final class ErrorRecoveryTests: XCTestCase {
-
     // MARK: - Config Backup
 
     @MainActor

--- a/Tests/KeyPathTests/Infrastructure/AliasDeduplicationTests.swift
+++ b/Tests/KeyPathTests/Infrastructure/AliasDeduplicationTests.swift
@@ -1,7 +1,7 @@
 @testable import KeyPathAppKit
+import KeyPathCore
 @testable import KeyPathInstallationWizard
 @testable import KeyPathWizardCore
-import KeyPathCore
 import XCTest
 
 final class AliasDeduplicationTests: XCTestCase {
@@ -147,7 +147,7 @@ final class AliasDeduplicationTests: XCTestCase {
 
     // MARK: - Integration: config gen safety net still works
 
-    func testConfigGenSafetyNetProducesValidConfig() throws {
+    func testConfigGenSafetyNetProducesValidConfig() {
         let hrmCollection = makeCollection(
             name: "Home Row Mods",
             configuration: .homeRowMods(HomeRowModsConfig(

--- a/Tests/KeyPathTests/Infrastructure/BehaviorRenderingGoldenTests.swift
+++ b/Tests/KeyPathTests/Infrastructure/BehaviorRenderingGoldenTests.swift
@@ -306,6 +306,7 @@ struct BehaviorRenderingGoldenTests {
         )
         let layerInfos = [HyperLinkedLayerInfo(layerName: "nav", triggerMode: .hold)]
         let result = KanataBehaviorRenderer.render(mapping, hyperLinkedLayerInfos: layerInfos)
-        #expect(result == "(tap-hold $tap-timeout $hold-timeout esc (multi lctl lmet lalt lsft (layer-while-held nav) (on-press-fakekey kp-layer-nav-enter tap) (on-release-fakekey kp-layer-nav-exit tap)))")
+        #expect(result ==
+            "(tap-hold $tap-timeout $hold-timeout esc (multi lctl lmet lalt lsft (layer-while-held nav) (on-press-fakekey kp-layer-nav-enter tap) (on-release-fakekey kp-layer-nav-exit tap)))")
     }
 }

--- a/Tests/KeyPathTests/Infrastructure/DeviceSwitchConfigTests.swift
+++ b/Tests/KeyPathTests/Infrastructure/DeviceSwitchConfigTests.swift
@@ -80,7 +80,7 @@ final class DeviceSwitchConfigTests: XCTestCase {
 
         // Override for device hash "0xBBBB1111" (index 1) comes first in the overrides array
         XCTAssertTrue(device1Pos!.lowerBound < device0Pos!.lowerBound,
-                       "Overrides should appear in input order")
+                      "Overrides should appear in input order")
     }
 
     func testDefaultFallthroughAlwaysPresent() {

--- a/Tests/KeyPathTests/Infrastructure/KanataBehaviorRendererChordTests.swift
+++ b/Tests/KeyPathTests/Infrastructure/KanataBehaviorRendererChordTests.swift
@@ -3,7 +3,6 @@ import XCTest
 
 /// Tests for KanataBehaviorRenderer's chord rendering and advanced action conversion.
 final class KanataBehaviorRendererChordTests: XCTestCase {
-
     // MARK: - Chord rendering
 
     func testRenderChord_ReturnsAliasReference() {

--- a/Tests/KeyPathTests/Infrastructure/KanataConfigMappingGeneratorTests.swift
+++ b/Tests/KeyPathTests/Infrastructure/KanataConfigMappingGeneratorTests.swift
@@ -6,7 +6,6 @@ import XCTest
 /// that turn collection configs (HRM, layer toggles, chords, auto-shift, tap-hold pickers)
 /// into concrete KeyMapping arrays consumed by the config renderer.
 final class KanataConfigMappingGeneratorTests: XCTestCase {
-
     // MARK: - generateHomeRowModsMappings
 
     func testHRM_DefaultConfig_ProducesMappingsForAllEnabledKeys() {

--- a/Tests/KeyPathTests/InstallationEngine/InstallerEngineFailurePathTests.swift
+++ b/Tests/KeyPathTests/InstallationEngine/InstallerEngineFailurePathTests.swift
@@ -1,6 +1,6 @@
 @testable import KeyPathAppKit
-@testable import KeyPathInstallationWizard
 import KeyPathCore
+@testable import KeyPathInstallationWizard
 import KeyPathPermissions
 @testable import KeyPathWizardCore
 @preconcurrency import XCTest

--- a/Tests/KeyPathTests/InstallationEngine/InstallerEnginePlanTests.swift
+++ b/Tests/KeyPathTests/InstallationEngine/InstallerEnginePlanTests.swift
@@ -1,6 +1,6 @@
 @testable import KeyPathAppKit
-@testable import KeyPathInstallationWizard
 import KeyPathCore
+@testable import KeyPathInstallationWizard
 @testable import KeyPathWizardCore
 @preconcurrency import XCTest
 

--- a/Tests/KeyPathTests/InstallationEngine/InstallerEngineTests.swift
+++ b/Tests/KeyPathTests/InstallationEngine/InstallerEngineTests.swift
@@ -1,6 +1,6 @@
 @testable import KeyPathAppKit
-@testable import KeyPathInstallationWizard
 import KeyPathCore
+@testable import KeyPathInstallationWizard
 @testable import KeyPathWizardCore
 @preconcurrency import XCTest
 

--- a/Tests/KeyPathTests/InstallationWizard/KarabinerComponentsStatusEvaluatorTests.swift
+++ b/Tests/KeyPathTests/InstallationWizard/KarabinerComponentsStatusEvaluatorTests.swift
@@ -1,6 +1,6 @@
 @testable import KeyPathAppKit
-@testable import KeyPathInstallationWizard
 import KeyPathCore
+@testable import KeyPathInstallationWizard
 import KeyPathPermissions
 import KeyPathWizardCore
 @preconcurrency import XCTest

--- a/Tests/KeyPathTests/InstallationWizard/SystemContextAdapterPermissionSeverityTests.swift
+++ b/Tests/KeyPathTests/InstallationWizard/SystemContextAdapterPermissionSeverityTests.swift
@@ -1,6 +1,6 @@
 @testable import KeyPathAppKit
-@testable import KeyPathInstallationWizard
 @testable import KeyPathDaemonLifecycle
+@testable import KeyPathInstallationWizard
 @testable import KeyPathPermissions
 import KeyPathWizardCore
 @preconcurrency import XCTest

--- a/Tests/KeyPathTests/InstallationWizard/WizardRecipeParityTests.swift
+++ b/Tests/KeyPathTests/InstallationWizard/WizardRecipeParityTests.swift
@@ -1,6 +1,6 @@
 @testable import KeyPathAppKit
-@testable import KeyPathInstallationWizard
 import KeyPathCore
+@testable import KeyPathInstallationWizard
 import KeyPathPermissions
 import KeyPathWizardCore
 @preconcurrency import XCTest

--- a/Tests/KeyPathTests/InstallationWizard/WizardStateRegressionTests.swift
+++ b/Tests/KeyPathTests/InstallationWizard/WizardStateRegressionTests.swift
@@ -1,6 +1,6 @@
 @testable import KeyPathAppKit
-@testable import KeyPathInstallationWizard
 import KeyPathCore
+@testable import KeyPathInstallationWizard
 import KeyPathPermissions
 import KeyPathWizardCore
 @preconcurrency import XCTest

--- a/Tests/KeyPathTests/InstalledPackTrackerTests.swift
+++ b/Tests/KeyPathTests/InstalledPackTrackerTests.swift
@@ -2,7 +2,6 @@
 import XCTest
 
 final class InstalledPackTrackerTests: XCTestCase {
-
     private var tempDir: URL!
 
     override func setUp() {
@@ -172,7 +171,7 @@ final class InstalledPackTrackerTests: XCTestCase {
         let original = InstalledPackRecord(
             packID: "com.keypath.pack.test",
             version: "1.0.0",
-            installedAt: Date(timeIntervalSince1970: 1700000000),
+            installedAt: Date(timeIntervalSince1970: 1_700_000_000),
             quickSettingValues: ["holdTimeout": 200, "speed": 5]
         )
         let encoder = JSONEncoder()
@@ -189,7 +188,7 @@ final class InstalledPackTrackerTests: XCTestCase {
     }
 
     func testInstalledPackRecordEquality() {
-        let date = Date(timeIntervalSince1970: 1700000000)
+        let date = Date(timeIntervalSince1970: 1_700_000_000)
         let a = InstalledPackRecord(packID: "x", version: "1", installedAt: date, quickSettingValues: ["k": 1])
         let b = InstalledPackRecord(packID: "x", version: "1", installedAt: date, quickSettingValues: ["k": 1])
         let c = InstalledPackRecord(packID: "x", version: "2", installedAt: date, quickSettingValues: ["k": 1])

--- a/Tests/KeyPathTests/Integration/ConfigGenerationEndToEndTests.swift
+++ b/Tests/KeyPathTests/Integration/ConfigGenerationEndToEndTests.swift
@@ -7,7 +7,6 @@ import XCTest
 /// verifying that critical kanata blocks appear correctly in generated configs.
 @MainActor
 final class ConfigGenerationEndToEndTests: XCTestCase {
-
     private func generateConfig(
         collections: [RuleCollection],
         customRules: [CustomRule] = []

--- a/Tests/KeyPathTests/Integration/ConfigRoundTripTests.swift
+++ b/Tests/KeyPathTests/Integration/ConfigRoundTripTests.swift
@@ -5,7 +5,6 @@ import XCTest
 /// Round-trip tests: save collections → load → regenerate config → compare.
 /// Detects serialization bugs where data is lost or mutated during persistence.
 final class ConfigRoundTripTests: XCTestCase {
-
     @MainActor
     func testRuleCollections_SaveLoadRoundTrip_ProducesIdenticalConfig() async throws {
         TestEnvironment.forceTestMode = true

--- a/Tests/KeyPathTests/Integration/ConfigValidationTests.swift
+++ b/Tests/KeyPathTests/Integration/ConfigValidationTests.swift
@@ -11,7 +11,6 @@ import XCTest
 ///
 /// Requires: kanata binary at /usr/local/bin/kanata or the bundled app path.
 final class ConfigValidationTests: XCTestCase {
-
     private func findKanataBinary() -> String? {
         // Only use the bundled binary — it matches the version KeyPath ships.
         // System-installed kanata (e.g., homebrew v1.10) may be too old and

--- a/Tests/KeyPathTests/Integration/MapperSaveIntegrationTests.swift
+++ b/Tests/KeyPathTests/Integration/MapperSaveIntegrationTests.swift
@@ -8,7 +8,6 @@ import XCTest
 /// These exercise the path from MapperViewModel.save() through RuleCollectionsManager
 /// to ConfigurationService, verifying the full chain that breaks most often.
 final class MapperSaveIntegrationTests: XCTestCase {
-
     @MainActor
     private func createTestEnvironment() async throws -> (RuleCollectionsManager, URL) {
         TestEnvironment.forceTestMode = true

--- a/Tests/KeyPathTests/Integration/PackInstallIntegrationTests.swift
+++ b/Tests/KeyPathTests/Integration/PackInstallIntegrationTests.swift
@@ -11,7 +11,6 @@ import XCTest
 /// 2. A valid .kbd config file is generated with the expected content
 /// 3. The KeyboardVisualizationViewModel picks up the change and updates its label map
 final class PackInstallIntegrationTests: XCTestCase {
-
     @MainActor
     func testCapsLockPackInstall_GeneratesConfigAndUpdatesLabels() async throws {
         TestEnvironment.forceTestMode = true
@@ -74,7 +73,7 @@ final class PackInstallIntegrationTests: XCTestCase {
         vm.updateTapHoldIdleLabels(from: collections)
 
         let capsKeyCode: UInt16 = 57
-        if case .tapHoldPicker(let config) = capsCollection?.configuration {
+        if case let .tapHoldPicker(config) = capsCollection?.configuration {
             let expectedOutput = config.selectedTapOutput ?? config.tapOptions.first?.output
             if let expectedOutput {
                 let label = vm.tapHoldIdleLabels[capsKeyCode]
@@ -166,7 +165,7 @@ final class PackInstallIntegrationTests: XCTestCase {
         // Vim nav maps h→left, j→down, k→up, l→right on a nav layer
         XCTAssertTrue(
             configContent.contains("left") && configContent.contains("down") &&
-            configContent.contains("up") && configContent.contains("right"),
+                configContent.contains("up") && configContent.contains("right"),
             "Config should contain arrow key mappings from vim navigation"
         )
         XCTAssertTrue(

--- a/Tests/KeyPathTests/KindaVimTelemetryStoreTests.swift
+++ b/Tests/KeyPathTests/KindaVimTelemetryStoreTests.swift
@@ -66,7 +66,7 @@ final class KindaVimTelemetryStoreTests: XCTestCase {
 
         store.recordCommand("h")
         store.recordCommand("h")
-        store.recordCommand("J")  // case-insensitive
+        store.recordCommand("J") // case-insensitive
         store.recordCommand("k")
 
         let snapshot = store.loadSnapshot()
@@ -134,7 +134,7 @@ final class KindaVimTelemetryStoreTests: XCTestCase {
             let storeA = makeStore()
             storeA.recordCommand("h")
             storeA.recordModeDwell("normal", duration: 12)
-            storeA.flushNow()  // force the debounced write before storeA goes away
+            storeA.flushNow() // force the debounced write before storeA goes away
         }
 
         // New store instance reading the same file should see the data.
@@ -152,7 +152,7 @@ final class KindaVimTelemetryStoreTests: XCTestCase {
         defaults.set(true, forKey: KindaVimTelemetryStore.optInKey)
         let store = makeStore()
         store.recordCommand("h")
-        store.flushNow()  // force the debounced write
+        store.flushNow() // force the debounced write
         XCTAssertTrue(FileManager.default.fileExists(atPath: tempFileURL.path))
 
         store.clearAll()
@@ -170,7 +170,7 @@ final class KindaVimTelemetryStoreTests: XCTestCase {
         defaults.set(true, forKey: KindaVimTelemetryStore.optInKey)
         let store = makeStore()
         store.recordNonVimNavigation("left")
-        store.recordNonVimNavigation("LEFT")  // case-insensitive
+        store.recordNonVimNavigation("LEFT") // case-insensitive
         store.recordNonVimNavigation("right")
         let snap = store.loadSnapshot()
         XCTAssertEqual(snap.nonVimNavigationFrequency["left"], 2)
@@ -183,7 +183,7 @@ final class KindaVimTelemetryStoreTests: XCTestCase {
         store.recordCommand("h")
         store.recordCommand("h")
         store.recordCommand("j")
-        store.recordCommand("w")  // not hjkl, doesn't count toward daily hjkl
+        store.recordCommand("w") // not hjkl, doesn't count toward daily hjkl
         let snap = store.loadSnapshot()
         XCTAssertEqual(snap.dailySnapshots.count, 1)
         XCTAssertEqual(snap.dailySnapshots.last?.hjklCount, 3)
@@ -203,7 +203,9 @@ final class KindaVimTelemetryStoreTests: XCTestCase {
         defaults.set(true, forKey: KindaVimTelemetryStore.optInKey)
         let store = makeStore()
         // 9 presses of `h` — not yet fluent
-        for _ in 0..<9 { store.recordCommand("h") }
+        for _ in 0 ..< 9 {
+            store.recordCommand("h")
+        }
         XCTAssertEqual(store.loadSnapshot().dailySnapshots.last?.vocabularySize, 0)
 
         // 10th press crosses the threshold
@@ -252,7 +254,7 @@ final class KindaVimTelemetryStoreTests: XCTestCase {
         let store = KindaVimTelemetryStore(
             fileURL: tempFileURL,
             userDefaults: defaults,
-            flushInterval: 60  // long enough that the debounce won't fire
+            flushInterval: 60 // long enough that the debounce won't fire
         )
         store.recordCommand("h")
         XCTAssertFalse(FileManager.default.fileExists(atPath: tempFileURL.path),

--- a/Tests/KeyPathTests/LabelMetadataExhaustiveTests.swift
+++ b/Tests/KeyPathTests/LabelMetadataExhaustiveTests.swift
@@ -4,7 +4,6 @@ import XCTest
 /// Exhaustive data-driven tests for LabelMetadata.forLabel().
 /// Covers all ~31 known mappings to catch regressions when entries are added/changed.
 final class LabelMetadataExhaustiveTests: XCTestCase {
-
     // MARK: - Wide Modifier Word Labels
 
     func testAllWideModifierSymbolsProduceWordLabels() {
@@ -110,15 +109,15 @@ final class LabelMetadataExhaustiveTests: XCTestCase {
 
     func testAllFunctionKeySFSymbols() {
         let expected: [(UInt16, String)] = [
-            (122, "sun.min"),     // F1
-            (120, "sun.max"),     // F2
+            (122, "sun.min"), // F1
+            (120, "sun.max"), // F2
             (99, "rectangle.3.group"), // F3
-            (118, "magnifyingglass"),  // F4
-            (96, "mic"),          // F5
-            (97, "moon"),         // F6
-            (98, "backward"),     // F7
-            (100, "playpause"),   // F8
-            (101, "forward"),     // F9
+            (118, "magnifyingglass"), // F4
+            (96, "mic"), // F5
+            (97, "moon"), // F6
+            (98, "backward"), // F7
+            (100, "playpause"), // F8
+            (101, "forward"), // F9
             (109, "speaker.slash"), // F10
         ]
         for (keyCode, symbol) in expected {

--- a/Tests/KeyPathTests/MapperConflictAndSaveTests.swift
+++ b/Tests/KeyPathTests/MapperConflictAndSaveTests.swift
@@ -5,7 +5,6 @@ import XCTest
 /// Tests for MapperViewModel canSave logic, identity mapping detection,
 /// shifted output blocking, and conflict state management.
 final class MapperConflictAndSaveTests: XCTestCase {
-
     // MARK: - canSave
 
     @MainActor

--- a/Tests/KeyPathTests/MapperKanataFormatTests.swift
+++ b/Tests/KeyPathTests/MapperKanataFormatTests.swift
@@ -4,7 +4,6 @@ import XCTest
 
 /// Tests for KeyMappingFormatter: KeySequence → kanata format conversion.
 final class MapperKanataFormatTests: XCTestCase {
-
     // MARK: - Single Key Formatting
 
     func testSingleLetterKey() {

--- a/Tests/KeyPathTests/MapperMultiTapTests.swift
+++ b/Tests/KeyPathTests/MapperMultiTapTests.swift
@@ -3,7 +3,6 @@ import XCTest
 
 /// Tests for multi-tap index mapping and tap-dance step management.
 final class MapperMultiTapTests: XCTestCase {
-
     // MARK: - multiTapAction Index Mapping
 
     @MainActor

--- a/Tests/KeyPathTests/ModeARevertTests.swift
+++ b/Tests/KeyPathTests/ModeARevertTests.swift
@@ -111,7 +111,7 @@ final class ModeARevertTests: XCTestCase {
         let snapshot = makeSnapshot(kanataRunning: false, kanataPermissionRejected: true)
 
         let permIssues = snapshot.blockingIssues.filter {
-            if case .permissionMissing(let app, let perm, _) = $0 {
+            if case let .permissionMissing(app, perm, _) = $0 {
                 return app == "Kanata" && perm == "Accessibility"
             }
             return false
@@ -119,7 +119,7 @@ final class ModeARevertTests: XCTestCase {
         XCTAssertFalse(permIssues.isEmpty, "blockingIssues must contain Kanata Accessibility permission issue")
 
         let serviceIssues = snapshot.blockingIssues.filter {
-            if case .serviceNotRunning(let name, _) = $0 {
+            if case let .serviceNotRunning(name, _) = $0 {
                 return name == "Kanata Service"
             }
             return false
@@ -131,7 +131,7 @@ final class ModeARevertTests: XCTestCase {
         let snapshot = makeSnapshot(kanataRunning: false, kanataPermissionRejected: false)
 
         let serviceIssues = snapshot.blockingIssues.filter {
-            if case .serviceNotRunning(let name, _) = $0 {
+            if case let .serviceNotRunning(name, _) = $0 {
                 return name == "Kanata Service"
             }
             return false

--- a/Tests/KeyPathTests/Models/ChordGroupsConfigTests.swift
+++ b/Tests/KeyPathTests/Models/ChordGroupsConfigTests.swift
@@ -78,7 +78,7 @@ final class ChordGroupsConfigTests: XCTestCase {
             ]
         )
 
-        let expected: Set<String> = ["s", "d", "f", "j", "k"]
+        let expected: Set = ["s", "d", "f", "j", "k"]
         XCTAssertEqual(group.participatingKeys, expected)
     }
 

--- a/Tests/KeyPathTests/Models/CustomRuleDeviceOverrideTests.swift
+++ b/Tests/KeyPathTests/Models/CustomRuleDeviceOverrideTests.swift
@@ -42,7 +42,7 @@ final class CustomRuleDeviceOverrideTests: XCTestCase {
         let mapping = rule.asKeyMapping()
 
         XCTAssertNotNil(mapping.deviceOverrides?.first?.behavior)
-        if case .dualRole(let loaded) = mapping.deviceOverrides?.first?.behavior {
+        if case let .dualRole(loaded) = mapping.deviceOverrides?.first?.behavior {
             XCTAssertEqual(loaded.holdAction, .keystroke(key: "lctl"))
         } else {
             XCTFail("Expected dualRole behavior")
@@ -123,7 +123,7 @@ final class CustomRuleDeviceOverrideTests: XCTestCase {
 
         XCTAssertEqual(decoded, original)
         XCTAssertEqual(decoded.deviceOverrides?.count, 1)
-        if case .dualRole(let loaded) = decoded.deviceOverrides?.first?.behavior {
+        if case let .dualRole(loaded) = decoded.deviceOverrides?.first?.behavior {
             XCTAssertEqual(loaded.holdAction, .keystroke(key: "lctl"))
         } else {
             XCTFail("Expected dualRole behavior after round-trip")

--- a/Tests/KeyPathTests/Models/CustomRuleModelTests.swift
+++ b/Tests/KeyPathTests/Models/CustomRuleModelTests.swift
@@ -2,7 +2,6 @@
 import XCTest
 
 final class CustomRuleModelTests: XCTestCase {
-
     // MARK: - displayTitle
 
     func testDisplayTitle_WithTitle_ReturnsTitle() {
@@ -192,7 +191,7 @@ final class CustomRuleModelTests: XCTestCase {
 
     func testEquality_SameID_SameDate_Equal() {
         let id = UUID()
-        let date = Date(timeIntervalSince1970: 1700000000)
+        let date = Date(timeIntervalSince1970: 1_700_000_000)
         let a = CustomRule(id: id, input: "a", action: .keystroke(key: "b"), createdAt: date)
         let b = CustomRule(id: id, input: "a", action: .keystroke(key: "b"), createdAt: date)
         XCTAssertEqual(a, b)

--- a/Tests/KeyPathTests/Models/PhysicalLayoutDrawerInjectionTests.swift
+++ b/Tests/KeyPathTests/Models/PhysicalLayoutDrawerInjectionTests.swift
@@ -1,7 +1,6 @@
 import Foundation
-import Testing
-
 @testable import KeyPathAppKit
+import Testing
 
 @Suite("PhysicalLayout Drawer Key Injection")
 struct PhysicalLayoutDrawerInjectionTests {

--- a/Tests/KeyPathTests/PackCollectionIntegrationTests.swift
+++ b/Tests/KeyPathTests/PackCollectionIntegrationTests.swift
@@ -5,7 +5,6 @@ import XCTest
 /// Verifies that packs correctly reference their backing collections
 /// and that config generation produces valid kanata config.
 final class PackCollectionIntegrationTests: XCTestCase {
-
     // MARK: - Pack-to-Collection Mapping
 
     func testAllNonVisualPacksHaveAssociatedCollections() {
@@ -19,7 +18,7 @@ final class PackCollectionIntegrationTests: XCTestCase {
 
     func testAssociatedCollectionsExistInCatalog() {
         let catalog = RuleCollectionCatalog().defaultCollections()
-        let catalogIDs = Set(catalog.map { $0.id })
+        let catalogIDs = Set(catalog.map(\.id))
 
         for pack in PackRegistry.starterKit {
             guard let collectionID = pack.associatedCollectionID else { continue }
@@ -90,7 +89,7 @@ final class PackCollectionIntegrationTests: XCTestCase {
             return XCTFail("Collection not found in catalog")
         }
 
-        if case .tapHoldPicker(let config) = collection.configuration {
+        if case let .tapHoldPicker(config) = collection.configuration {
             XCTAssertEqual(config.inputKey.lowercased(), "caps", "Should target caps key")
             XCTAssertFalse(config.tapOptions.isEmpty, "Should have tap options")
             XCTAssertFalse(config.holdOptions.isEmpty, "Should have hold options")

--- a/Tests/KeyPathTests/PackConfigPipelineTests.swift
+++ b/Tests/KeyPathTests/PackConfigPipelineTests.swift
@@ -6,7 +6,6 @@ import XCTest
 /// Tests the path from user interaction (slider, picker, toggle) through
 /// config generation to verify the correct kanata syntax is produced.
 final class PackConfigPipelineTests: XCTestCase {
-
     // MARK: - Home Row Mods
 
     @MainActor

--- a/Tests/KeyPathTests/PackDependencyExtendedTests.swift
+++ b/Tests/KeyPathTests/PackDependencyExtendedTests.swift
@@ -5,13 +5,14 @@ import XCTest
 /// Extended dependency system tests covering allUnmetRequirements,
 /// dependents, config predicates, and suggestions.
 final class PackDependencyExtendedTests: XCTestCase {
-
     // MARK: - allUnmetRequirements
 
     @MainActor
     func testAllUnmetRequirements_EmptyWhenNoRequiredDeps() {
         var collections = RuleCollectionCatalog().defaultCollections()
-        for i in collections.indices { collections[i].isEnabled = false }
+        for i in collections.indices {
+            collections[i].isEnabled = false
+        }
         // Enable layer packs WITHOUT Vim Nav — they only have enhancedBy, not requires
         for i in collections.indices {
             if collections[i].id == RuleCollectionIdentifier.windowSnapping
@@ -33,7 +34,9 @@ final class PackDependencyExtendedTests: XCTestCase {
     @MainActor
     func testAllUnmetRequirements_EmptyWhenDepsAreMet() {
         var collections = RuleCollectionCatalog().defaultCollections()
-        for i in collections.indices { collections[i].isEnabled = false }
+        for i in collections.indices {
+            collections[i].isEnabled = false
+        }
         // Enable Vim Nav AND Window Snapping
         for i in collections.indices {
             if collections[i].id == RuleCollectionIdentifier.vimNavigation
@@ -58,7 +61,9 @@ final class PackDependencyExtendedTests: XCTestCase {
     func testDependents_FindsAllVimNavDependents() {
         var collections = RuleCollectionCatalog().defaultCollections()
         // Enable everything
-        for i in collections.indices { collections[i].isEnabled = true }
+        for i in collections.indices {
+            collections[i].isEnabled = true
+        }
 
         let dependents = PackDependencyChecker.dependents(
             of: "com.keypath.pack.vim-navigation",
@@ -80,7 +85,9 @@ final class PackDependencyExtendedTests: XCTestCase {
     @MainActor
     func testDependents_OnlyReturnsEnabledPacks() {
         var collections = RuleCollectionCatalog().defaultCollections()
-        for i in collections.indices { collections[i].isEnabled = false }
+        for i in collections.indices {
+            collections[i].isEnabled = false
+        }
         // Only Vim Nav enabled, nothing depends on it that's also enabled
         if let idx = collections.firstIndex(where: { $0.id == RuleCollectionIdentifier.vimNavigation }) {
             collections[idx].isEnabled = true
@@ -100,7 +107,9 @@ final class PackDependencyExtendedTests: XCTestCase {
     @MainActor
     func testConfigPredicate_HoldOutputMatch() {
         var collections = RuleCollectionCatalog().defaultCollections()
-        for i in collections.indices { collections[i].isEnabled = true }
+        for i in collections.indices {
+            collections[i].isEnabled = true
+        }
         // Caps Lock Remap defaults to hold=Hyper (C-S-M-A-)
 
         let unmet = PackDependencyChecker.unmetRequirements(

--- a/Tests/KeyPathTests/PackDependencyTests.swift
+++ b/Tests/KeyPathTests/PackDependencyTests.swift
@@ -2,7 +2,6 @@
 import XCTest
 
 final class PackDependencyTests: XCTestCase {
-
     func testNoCyclicDependencies() {
         // Verify no pack A requires B which requires A
         var visited = Set<String>()
@@ -41,7 +40,7 @@ final class PackDependencyTests: XCTestCase {
     }
 
     func testPacksWithNoDependencies() {
-        let noDeps = PackRegistry.starterKit.filter { $0.dependencies.isEmpty }
+        let noDeps = PackRegistry.starterKit.filter(\.dependencies.isEmpty)
         XCTAssertTrue(noDeps.contains { $0.id == "com.keypath.pack.caps-lock-to-escape" })
         XCTAssertTrue(noDeps.contains { $0.id == "com.keypath.pack.vim-navigation" })
         XCTAssertTrue(noDeps.contains { $0.id == "com.keypath.pack.home-row-mods" })
@@ -67,7 +66,9 @@ final class PackDependencyTests: XCTestCase {
     @MainActor
     func testNoRequiredDeps_UnmetRequirementsEmpty() {
         var collections = RuleCollectionCatalog().defaultCollections()
-        for i in collections.indices { collections[i].isEnabled = false }
+        for i in collections.indices {
+            collections[i].isEnabled = false
+        }
         if let idx = collections.firstIndex(where: { $0.id == RuleCollectionIdentifier.windowSnapping }) {
             collections[idx].isEnabled = true
         }
@@ -84,7 +85,9 @@ final class PackDependencyTests: XCTestCase {
     @MainActor
     func testEnhancedByDeps_NotReportedAsUnmet() {
         var collections = RuleCollectionCatalog().defaultCollections()
-        for i in collections.indices { collections[i].isEnabled = false }
+        for i in collections.indices {
+            collections[i].isEnabled = false
+        }
 
         // Window Snapping is enhancedBy Vim Nav, not requires
         let unmet = PackDependencyChecker.unmetRequirements(

--- a/Tests/KeyPathTests/PackDetailWindowTests.swift
+++ b/Tests/KeyPathTests/PackDetailWindowTests.swift
@@ -3,7 +3,6 @@ import XCTest
 
 /// Tests for Pack Detail window sizing and pack metadata.
 final class PackDetailWindowTests: XCTestCase {
-
     func testNarrowPacksGetNarrowWindow() {
         let narrowPacks = [
             "com.keypath.pack.caps-lock-to-escape",
@@ -21,7 +20,7 @@ final class PackDetailWindowTests: XCTestCase {
             }
             // Verify these are NOT in the wide or medium lists
             // (they should get 560px default)
-            let wideIDs: Set<String> = [
+            let wideIDs: Set = [
                 "com.keypath.pack.vim-navigation",
                 "com.keypath.pack.window-snapping",
                 "com.keypath.pack.mission-control",

--- a/Tests/KeyPathTests/PackInstallerRenderTests.swift
+++ b/Tests/KeyPathTests/PackInstallerRenderTests.swift
@@ -5,7 +5,6 @@ import XCTest
 /// Pack model computed properties. These don't require RuleCollectionsManager.
 @MainActor
 final class PackInstallerRenderTests: XCTestCase {
-
     // MARK: - renderBindings: simple remap (no holdOutput)
 
     func testRenderBindings_SimpleRemap_ProducesKeystrokeAction() {

--- a/Tests/KeyPathTests/PackZoneResolverTests.swift
+++ b/Tests/KeyPathTests/PackZoneResolverTests.swift
@@ -2,7 +2,6 @@
 import XCTest
 
 final class PackZoneResolverTests: XCTestCase {
-
     // MARK: - activeZoneColors
 
     func testActiveZoneColors_NoInstalledPacks_ReturnsEmpty() {

--- a/Tests/KeyPathTests/PermissionOracleFastModeTests.swift
+++ b/Tests/KeyPathTests/PermissionOracleFastModeTests.swift
@@ -6,7 +6,6 @@ import Testing
 
 @Suite("PermissionOracle Fast/Test Mode")
 struct PermissionOracleFastModeTests {
-
     @Test("Snapshot in test mode completes under 1 second")
     @MainActor
     func snapshotIsFastInTestMode() async {

--- a/Tests/KeyPathTests/PreferencesServiceTests.swift
+++ b/Tests/KeyPathTests/PreferencesServiceTests.swift
@@ -3,7 +3,6 @@ import XCTest
 
 @MainActor
 final class PreferencesServiceTests: XCTestCase {
-
     // MARK: - Port Validation
 
     func testIsValidPort_AcceptsUserPorts() {

--- a/Tests/KeyPathTests/RecommendationEngineTests.swift
+++ b/Tests/KeyPathTests/RecommendationEngineTests.swift
@@ -3,10 +3,11 @@ import XCTest
 
 /// Tests for the contextual recommendation engine.
 final class RecommendationEngineTests: XCTestCase {
-
     func testAlwaysRecommendsCorePacksWhenDisabled() {
         var collections = RuleCollectionCatalog().defaultCollections()
-        for i in collections.indices { collections[i].isEnabled = false }
+        for i in collections.indices {
+            collections[i].isEnabled = false
+        }
 
         let recs = RulesRecommendationEngine.recommendations(from: collections)
         let ids = Set(recs.map(\.collectionId))
@@ -19,7 +20,9 @@ final class RecommendationEngineTests: XCTestCase {
 
     func testEnabledPacksExcludedFromRecommendations() {
         var collections = RuleCollectionCatalog().defaultCollections()
-        for i in collections.indices { collections[i].isEnabled = false }
+        for i in collections.indices {
+            collections[i].isEnabled = false
+        }
         if let idx = collections.firstIndex(where: { $0.id == RuleCollectionIdentifier.capsLockRemap }) {
             collections[idx].isEnabled = true
         }
@@ -33,7 +36,9 @@ final class RecommendationEngineTests: XCTestCase {
 
     func testVimEnabled_RecommendsMissionControl() {
         var collections = RuleCollectionCatalog().defaultCollections()
-        for i in collections.indices { collections[i].isEnabled = false }
+        for i in collections.indices {
+            collections[i].isEnabled = false
+        }
         if let idx = collections.firstIndex(where: { $0.id == RuleCollectionIdentifier.vimNavigation }) {
             collections[idx].isEnabled = true
         }
@@ -47,7 +52,9 @@ final class RecommendationEngineTests: XCTestCase {
 
     func testCapsLockEnabled_RecommendsBackupCapsLock() {
         var collections = RuleCollectionCatalog().defaultCollections()
-        for i in collections.indices { collections[i].isEnabled = false }
+        for i in collections.indices {
+            collections[i].isEnabled = false
+        }
         if let idx = collections.firstIndex(where: { $0.id == RuleCollectionIdentifier.capsLockRemap }) {
             collections[idx].isEnabled = true
         }
@@ -61,7 +68,9 @@ final class RecommendationEngineTests: XCTestCase {
 
     func testHRMEnabled_RecommendsVimNav() {
         var collections = RuleCollectionCatalog().defaultCollections()
-        for i in collections.indices { collections[i].isEnabled = false }
+        for i in collections.indices {
+            collections[i].isEnabled = false
+        }
         if let idx = collections.firstIndex(where: { $0.id == RuleCollectionIdentifier.homeRowMods }) {
             collections[idx].isEnabled = true
         }
@@ -75,7 +84,9 @@ final class RecommendationEngineTests: XCTestCase {
 
     func testPowerUser_RecommendsLeaderKey() {
         var collections = RuleCollectionCatalog().defaultCollections()
-        for i in collections.indices { collections[i].isEnabled = false }
+        for i in collections.indices {
+            collections[i].isEnabled = false
+        }
         // Enable 3+ productivity packs
         var enabledCount = 0
         for i in collections.indices where collections[i].category == .productivity {
@@ -94,7 +105,9 @@ final class RecommendationEngineTests: XCTestCase {
 
     func testAllEnabled_NoRecommendations() {
         var collections = RuleCollectionCatalog().defaultCollections()
-        for i in collections.indices { collections[i].isEnabled = true }
+        for i in collections.indices {
+            collections[i].isEnabled = true
+        }
 
         let recs = RulesRecommendationEngine.recommendations(from: collections)
 

--- a/Tests/KeyPathTests/RuleCollections/DeduplicatorEdgeCaseTests.swift
+++ b/Tests/KeyPathTests/RuleCollections/DeduplicatorEdgeCaseTests.swift
@@ -4,7 +4,6 @@ import XCTest
 /// Edge case tests for RuleCollectionDeduplicator.
 /// Verifies merge logic when multiple collections map the same key.
 final class DeduplicatorEdgeCaseTests: XCTestCase {
-
     // MARK: - Same Key, Different Collections
 
     func testFirstCollectionWins_SameKeyOnSameLayer() {
@@ -109,9 +108,9 @@ final class DeduplicatorEdgeCaseTests: XCTestCase {
         let allMappings = deduped.flatMap(\.mappings)
 
         XCTAssertTrue(allMappings.contains { $0.input == "s" && $0.action.outputString == "d" },
-                       "Non-conflicting key 's' from first collection should survive")
+                      "Non-conflicting key 's' from first collection should survive")
         XCTAssertTrue(allMappings.contains { $0.input == "f" && $0.action.outputString == "g" },
-                       "Non-conflicting key 'f' from second collection should survive")
+                      "Non-conflicting key 'f' from second collection should survive")
     }
 
     // MARK: - Empty Collections

--- a/Tests/KeyPathTests/RuleCollections/RuleCollectionCatalogTests.swift
+++ b/Tests/KeyPathTests/RuleCollections/RuleCollectionCatalogTests.swift
@@ -2,7 +2,6 @@
 import XCTest
 
 final class RuleCollectionCatalogTests: XCTestCase {
-
     // MARK: - Default Collections
 
     func testDefaultCollections_IsNonEmpty() {

--- a/Tests/KeyPathTests/RuleCollections/RuleCollectionConflictDetectionTests.swift
+++ b/Tests/KeyPathTests/RuleCollections/RuleCollectionConflictDetectionTests.swift
@@ -4,7 +4,6 @@ import XCTest
 
 @MainActor
 final class RuleCollectionConflictDetectionTests: XCTestCase {
-
     private func makeManager() -> RuleCollectionsManager {
         RuleCollectionsManager(
             ruleCollectionStore: .shared,

--- a/Tests/KeyPathTests/RuleCollections/RuleCollectionStorePersistenceTests.swift
+++ b/Tests/KeyPathTests/RuleCollections/RuleCollectionStorePersistenceTests.swift
@@ -2,7 +2,6 @@
 import XCTest
 
 final class RuleCollectionStorePersistenceTests: XCTestCase {
-
     private var tempDir: URL!
 
     override func setUp() {

--- a/Tests/KeyPathTests/RuleCollections/RuleCollectionsManagerAPITests.swift
+++ b/Tests/KeyPathTests/RuleCollections/RuleCollectionsManagerAPITests.swift
@@ -4,7 +4,6 @@ import XCTest
 
 @MainActor
 final class RuleCollectionsManagerAPITests: XCTestCase {
-
     private func makeManager() -> RuleCollectionsManager {
         RuleCollectionsManager(
             ruleCollectionStore: .shared,

--- a/Tests/KeyPathTests/RuleCollections/RuleCollectionsManagerTests.swift
+++ b/Tests/KeyPathTests/RuleCollections/RuleCollectionsManagerTests.swift
@@ -454,7 +454,7 @@ final class RuleCollectionsManagerTests: XCTestCase {
     // the KindaVim rule collection was retired from the catalog; KindaVim now
     // ships as a visual-only pack and the mutex is enforced by PackInstaller.
 
-@MainActor
+    @MainActor
     func testNeovimReferenceCoexistsWithVimNavigationWithoutConflictDialog() async throws {
         let (manager, _) = try await createTestManager()
         defer { TestEnvironment.forceTestMode = false }

--- a/Tests/KeyPathTests/Services/ActionDispatcherTests.swift
+++ b/Tests/KeyPathTests/Services/ActionDispatcherTests.swift
@@ -430,7 +430,6 @@ struct ActionDispatcherSystemWindowTests {
         }
     }
 
-
     @Test("Dispatches repair helper action")
     @MainActor
     func dispatchesRepairHelperAction() throws {

--- a/Tests/KeyPathTests/Services/ConfigBackupManagerTests.swift
+++ b/Tests/KeyPathTests/Services/ConfigBackupManagerTests.swift
@@ -2,7 +2,6 @@
 import XCTest
 
 final class ConfigBackupManagerTests: XCTestCase {
-
     private var tempDir: String!
 
     override func setUp() {
@@ -19,7 +18,9 @@ final class ConfigBackupManagerTests: XCTestCase {
         super.tearDown()
     }
 
-    private var configPath: String { "\(tempDir!)/keypath.kbd" }
+    private var configPath: String {
+        "\(tempDir!)/keypath.kbd"
+    }
 
     private func writeValidConfig(_ content: String? = nil) throws {
         let validConfig = content ?? """

--- a/Tests/KeyPathTests/Services/ConfigReloadCoordinatorTests.swift
+++ b/Tests/KeyPathTests/Services/ConfigReloadCoordinatorTests.swift
@@ -112,7 +112,6 @@ private final class NotificationMessage: @unchecked Sendable {
 @Suite("ConfigReloadCoordinator Tests")
 @MainActor
 struct ConfigReloadCoordinatorTests {
-
     // MARK: - Factory
 
     /// Creates a ConfigReloadCoordinator with the given mock dependencies.
@@ -189,7 +188,7 @@ struct ConfigReloadCoordinatorTests {
             // In test environment triggerTCPReload returns networkError,
             // so the callback is not expected to fire.
             #expect(callbackCalled == false,
-                "onReloadSuccess should not fire when TCP is disabled in test env")
+                    "onReloadSuccess should not fire when TCP is disabled in test env")
         }
     }
 
@@ -220,7 +219,7 @@ struct ConfigReloadCoordinatorTests {
         // If TCP is disabled, we verify no false positive notification fires.
         if !result.isSuccess {
             #expect(received.value == false,
-                "Should not post recovered notification when reload failed")
+                    "Should not post recovered notification when reload failed")
         }
     }
 
@@ -251,10 +250,10 @@ struct ConfigReloadCoordinatorTests {
         // That is NOT a cooldown message, so configReloadFailed should be posted.
         if !result.isSuccess {
             #expect(received.value == true,
-                "Should post configReloadFailed for non-cooldown errors")
+                    "Should post configReloadFailed for non-cooldown errors")
             if let msg = message.value {
                 #expect(!msg.contains("cooldown"),
-                    "Error message should not be a cooldown block")
+                        "Error message should not be a cooldown block")
             }
         }
     }
@@ -295,10 +294,12 @@ struct ConfigReloadCoordinatorTests {
         let partialB = "In cooldown period"
         #expect(
             !(partialA.contains("Reload blocked") && partialA.contains("cooldown")),
-            "Partial match without 'cooldown' should not be detected")
+            "Partial match without 'cooldown' should not be detected"
+        )
         #expect(
             !(partialB.contains("Reload blocked") && partialB.contains("cooldown")),
-            "Partial match without 'Reload blocked' should not be detected")
+            "Partial match without 'Reload blocked' should not be detected"
+        )
 
         // Confirm the coordinator itself can be called without crashing
         _ = await coordinator.triggerConfigReload()
@@ -313,9 +314,9 @@ struct ConfigReloadCoordinatorTests {
         let tcpResult = await coordinator.triggerTCPReload()
 
         #expect(tcpResult.isSuccess == false,
-            "TCP reload should not succeed in test environment")
+                "TCP reload should not succeed in test environment")
         #expect(tcpResult.errorMessage?.contains("Test environment") == true,
-            "Error should mention test environment, got: \(tcpResult.errorMessage ?? "nil")")
+                "Error should mention test environment, got: \(tcpResult.errorMessage ?? "nil")")
     }
 
     // MARK: - ReloadResult properties
@@ -368,7 +369,7 @@ struct ConfigReloadCoordinatorTests {
         // Verify the coordinator is still functional after the failure path.
         let result = await coordinator.triggerConfigReload()
         #expect(result.isSuccess == false,
-            "Should still return failure on subsequent calls with unhealthy service")
+                "Should still return failure on subsequent calls with unhealthy service")
     }
 
     // MARK: - TCPReloadResult properties
@@ -432,7 +433,7 @@ struct ConfigReloadCoordinatorTests {
         if let err1 = result1.errorMessage, let err2 = result2.errorMessage {
             // err1 is a health-related message, err2 is a TCP/test-environment message
             #expect(err1 != err2 || result2.isSuccess,
-                "Second call should get past the health check gate")
+                    "Second call should get past the health check gate")
         }
     }
 

--- a/Tests/KeyPathTests/Services/ConfigurationServiceTests.swift
+++ b/Tests/KeyPathTests/Services/ConfigurationServiceTests.swift
@@ -1238,7 +1238,7 @@ class ConfigurationServiceTests: XCTestCase {
         let allKeyCodes: [UInt16] = Array(0 ... 126) + [200, 255]
 
         // Valid kanata key names (single chars, function keys, and known abbreviations)
-        let validKanataKeys: Set<String> = [
+        let validKanataKeys: Set = [
             // Single character keys (a-z, 0-9, punctuation)
             "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m",
             "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z",

--- a/Tests/KeyPathTests/Services/CustomRulesStorePersistenceTests.swift
+++ b/Tests/KeyPathTests/Services/CustomRulesStorePersistenceTests.swift
@@ -2,7 +2,6 @@
 import XCTest
 
 final class CustomRulesStorePersistenceTests: XCTestCase {
-
     private var tempDir: URL!
 
     override func setUp() {
@@ -67,7 +66,7 @@ final class CustomRulesStorePersistenceTests: XCTestCase {
     func testSaveAndLoad_PreservesAllFields() async throws {
         let store = makeStore()
         let id = UUID()
-        let date = Date(timeIntervalSince1970: 1700000000)
+        let date = Date(timeIntervalSince1970: 1_700_000_000)
         var rule = CustomRule(
             id: id,
             title: "Test Rule",

--- a/Tests/KeyPathTests/Services/DiagnosticsServiceTests.swift
+++ b/Tests/KeyPathTests/Services/DiagnosticsServiceTests.swift
@@ -256,5 +256,4 @@ final class DiagnosticsServiceTests: XCTestCase {
         XCTAssertEqual(DiagnosticCategory.system.rawValue, "System")
         XCTAssertEqual(DiagnosticCategory.conflict.rawValue, "Conflict")
     }
-
 }

--- a/Tests/KeyPathTests/Services/LayerKeyMapperLabelTests.swift
+++ b/Tests/KeyPathTests/Services/LayerKeyMapperLabelTests.swift
@@ -3,31 +3,31 @@ import XCTest
 
 final class LayerKeyMapperLabelTests: XCTestCase {
     func testHyperDetectionWithRightSideAliases() {
-        let outputs: Set<String> = ["rctl", "rmet", "ralt", "rsft"]
+        let outputs: Set = ["rctl", "rmet", "ralt", "rsft"]
         let label = LayerKeyMapper.labelForOutputKeys(outputs) { key in key }
         XCTAssertEqual(label, "✦")
     }
 
     func testHyperDetectionWithPlainModifierNames() {
-        let outputs: Set<String> = ["lctl", "lmet", "lalt", "lsft"]
+        let outputs: Set = ["lctl", "lmet", "lalt", "lsft"]
         let label = LayerKeyMapper.labelForOutputKeys(outputs) { key in key }
         XCTAssertEqual(label, "✦")
     }
 
     func testMehDetectionWithMixedAliases() {
-        let outputs: Set<String> = ["control", "lalt", "shift"]
+        let outputs: Set = ["control", "lalt", "shift"]
         let label = LayerKeyMapper.labelForOutputKeys(outputs) { key in key }
         XCTAssertEqual(label, "◆")
     }
 
     func testSingleKeyFallback() {
-        let outputs: Set<String> = ["escape"]
+        let outputs: Set = ["escape"]
         let label = LayerKeyMapper.labelForOutputKeys(outputs) { _ in "⎋" }
         XCTAssertEqual(label, "⎋")
     }
 
     func testComboFallbackJoinsLabels() {
-        let outputs: Set<String> = ["lmet", "left"]
+        let outputs: Set = ["lmet", "left"]
         let label = LayerKeyMapper.labelForOutputKeys(outputs) { key in
             switch key {
             case "lmet": "⌘"

--- a/Tests/KeyPathTests/Services/PlistGeneratorTests.swift
+++ b/Tests/KeyPathTests/Services/PlistGeneratorTests.swift
@@ -1,6 +1,6 @@
 @testable import KeyPathAppKit
-@testable import KeyPathInstallationWizard
 @testable import KeyPathCore
+@testable import KeyPathInstallationWizard
 @preconcurrency import XCTest
 
 /// Unit tests for PlistGenerator service.

--- a/Tests/KeyPathTests/Services/RuleCollectionsCoordinatorTests.swift
+++ b/Tests/KeyPathTests/Services/RuleCollectionsCoordinatorTests.swift
@@ -39,7 +39,6 @@ private func cleanUp(_ url: URL) {
 @Suite("RuleCollectionsCoordinator — Configuration")
 @MainActor
 struct RuleCollectionsCoordinatorConfigTests {
-
     @Test("unconfigured coordinator has no-op callbacks")
     func unconfiguredCoordinatorHasNoOpCallbacks() async throws {
         let (manager, tempDir) = try makeTestManager()
@@ -88,7 +87,6 @@ struct RuleCollectionsCoordinatorConfigTests {
 @Suite("RuleCollectionsCoordinator — Toggle Operations")
 @MainActor
 struct RuleCollectionsCoordinatorToggleTests {
-
     @Test("toggleRuleCollection enables a disabled collection")
     func toggleEnablesDisabled() async throws {
         let (manager, tempDir) = try makeTestManager()
@@ -172,7 +170,6 @@ struct RuleCollectionsCoordinatorToggleTests {
 @Suite("RuleCollectionsCoordinator — Batch Operations")
 @MainActor
 struct RuleCollectionsCoordinatorBatchTests {
-
     @Test("batchEnableCollections enables multiple collections")
     func batchEnablesMultiple() async throws {
         let (manager, tempDir) = try makeTestManager()
@@ -230,7 +227,6 @@ struct RuleCollectionsCoordinatorBatchTests {
 @Suite("RuleCollectionsCoordinator — Custom Rules")
 @MainActor
 struct RuleCollectionsCoordinatorCustomRuleTests {
-
     @Test("makeCustomRule creates rule with correct input and output")
     func makeCustomRuleCorrectFields() throws {
         let (manager, tempDir) = try makeTestManager()
@@ -318,7 +314,6 @@ struct RuleCollectionsCoordinatorCustomRuleTests {
 @Suite("RuleCollectionsCoordinator — Read-Only Access")
 @MainActor
 struct RuleCollectionsCoordinatorReadOnlyTests {
-
     @Test("ruleCollections returns manager's collections matching catalog count")
     func ruleCollectionsMatchesCatalog() throws {
         let (manager, tempDir) = try makeTestManager()

--- a/Tests/KeyPathTests/Services/VHIDDeviceManagerTests.swift
+++ b/Tests/KeyPathTests/Services/VHIDDeviceManagerTests.swift
@@ -1,6 +1,6 @@
 @testable import KeyPathAppKit
-@testable import KeyPathInstallationWizard
 @testable import KeyPathCore
+@testable import KeyPathInstallationWizard
 @preconcurrency import XCTest
 
 final class VHIDDeviceManagerTests: XCTestCase {

--- a/Tests/KeyPathTests/Services/VHIDSafetyInvariantTests.swift
+++ b/Tests/KeyPathTests/Services/VHIDSafetyInvariantTests.swift
@@ -8,7 +8,6 @@
 /// system services are needed.
 @MainActor
 final class VHIDSafetyInvariantTests: KeyPathTestCase {
-
     // MARK: - Emergency Stop Decision
 
     func test_emergencyStop_triggeredWhenKanataRunningWithoutVHID() {

--- a/Tests/KeyPathTests/TCPClientRobustnessTests.swift
+++ b/Tests/KeyPathTests/TCPClientRobustnessTests.swift
@@ -37,7 +37,7 @@ final class TCPClientRobustnessTests: XCTestCase {
 
     func testExtractFirstLine_LargePayload() {
         let client = KanataTCPClient(port: port)
-        let largeValue = String(repeating: "x", count: 50_000)
+        let largeValue = String(repeating: "x", count: 50000)
         let json = "{\"data\":\"\(largeValue)\"}\n"
         let data = Data(json.utf8)
 
@@ -176,7 +176,7 @@ final class TCPClientRobustnessTests: XCTestCase {
         let client = KanataTCPClient(port: port)
         var ids: [UInt64] = []
         for _ in 0 ..< 100 {
-            ids.append(await client.generateRequestId())
+            await ids.append(client.generateRequestId())
         }
         for i in 1 ..< ids.count {
             XCTAssertGreaterThan(ids[i], ids[i - 1], "IDs must be strictly monotonic")
@@ -295,7 +295,7 @@ final class TCPClientRobustnessTests: XCTestCase {
         XCTAssertEqual(hello.capabilities, ["reload"])
     }
 
-    func testHelloOk_HasCapabilities() throws {
+    func testHelloOk_HasCapabilities() {
         let hello = KanataTCPClient.TcpHelloOk(
             version: "1.10.0",
             protocolVersion: 1,
@@ -497,8 +497,13 @@ final class TCPClientRobustnessTests: XCTestCase {
 
         actor Counter {
             var count = 0
-            func increment() { count += 1 }
-            func get() -> Int { count }
+            func increment() {
+                count += 1
+            }
+
+            func get() -> Int {
+                count
+            }
         }
         let counter = Counter()
 

--- a/Tests/KeyPathTests/TestEnvironmentDetectionTests.swift
+++ b/Tests/KeyPathTests/TestEnvironmentDetectionTests.swift
@@ -5,7 +5,6 @@ import XCTest
 /// Verifies that test mode is correctly detected when running tests,
 /// and documents the detection mechanism to prevent regressions.
 final class TestEnvironmentDetectionTests: XCTestCase {
-
     func testIsRunningTests_TrueInTestContext() {
         XCTAssertTrue(
             TestEnvironment.isRunningTests,

--- a/Tests/KeyPathTests/UI/MapperNotificationPayloadTests.swift
+++ b/Tests/KeyPathTests/UI/MapperNotificationPayloadTests.swift
@@ -5,7 +5,6 @@ import XCTest
 /// Tests for the outputKey vs displayLabel distinction in mapper notification payloads.
 /// This is a critical data flow boundary — mixing these up causes config validation errors.
 final class MapperNotificationPayloadTests: XCTestCase {
-
     // MARK: - outputKey Resolution
 
     func testOutputKeyPrefersLayerInfoOutputKey() {
@@ -104,11 +103,11 @@ final class MapperNotificationPayloadTests: XCTestCase {
     /// Mirrors the outputKey resolution logic from LiveKeyboardOverlayController+KeyClickHandling
     private func resolveOutputKey(inputKey: String, layerInfo: LayerKeyInfo?) -> String {
         if let simpleOutput = layerInfo?.outputKey {
-            return simpleOutput
+            simpleOutput
         } else if let displayLabel = layerInfo?.displayLabel, !displayLabel.isEmpty {
-            return displayLabel
+            displayLabel
         } else {
-            return inputKey
+            inputKey
         }
     }
 

--- a/Tests/KeyPathTests/UI/OutputActionGroupingTests.swift
+++ b/Tests/KeyPathTests/UI/OutputActionGroupingTests.swift
@@ -1,9 +1,8 @@
-import Testing
 @testable import KeyPathAppKit
+import Testing
 
 @Suite("OutputActionGrouping")
 struct OutputActionGroupingTests {
-
     // MARK: - Detailed grouping (overlay mapper)
 
     @Test("detailed produces 9 groups in expected order")
@@ -167,7 +166,7 @@ struct OutputActionGroupingTests {
     @Test("detailed media key IDs all exist in SystemActionInfo.allActions")
     func detailedMediaKeyIDsExist() {
         let allIDs = Set(SystemActionInfo.allActions.map(\.id))
-        let hardcodedIDs: Set<String> = [
+        let hardcodedIDs: Set = [
             "play-pause", "next-track", "prev-track",
             "mute", "volume-up", "volume-down",
             "brightness-up", "brightness-down",
@@ -224,7 +223,6 @@ struct OutputActionGroupingTests {
 
 @Suite("KeystrokePresetGridView")
 struct KeystrokePresetGridViewTests {
-
     @Test("presets have unique keys")
     func presetsUnique() {
         let keys = KeystrokePresetGridView.presets.map(\.key)
@@ -249,7 +247,7 @@ struct KeystrokePresetGridViewTests {
     @Test("presets include expected common keys")
     func presetsIncludeCommonKeys() {
         let keys = Set(KeystrokePresetGridView.presets.map(\.key))
-        let expected: Set<String> = ["esc", "enter", "bspc", "del", "tab", "spc", "up", "down", "left", "right"]
+        let expected: Set = ["esc", "enter", "bspc", "del", "tab", "spc", "up", "down", "left", "right"]
         #expect(keys == expected)
     }
 

--- a/Tests/KeyPathTests/UI/OverlayEffectiveLabelTests.swift
+++ b/Tests/KeyPathTests/UI/OverlayEffectiveLabelTests.swift
@@ -3,7 +3,6 @@ import KeyPathCore
 import XCTest
 
 final class OverlayEffectiveLabelTests: XCTestCase {
-
     // MARK: - effectiveLabel Priority Chain
 
     func testHoldLabelTakesPriorityWhenPressed() {

--- a/Tests/KeyPathTests/UI/OverlayHJKLRegressionTests.swift
+++ b/Tests/KeyPathTests/UI/OverlayHJKLRegressionTests.swift
@@ -3,21 +3,20 @@ import Foundation
 import KeyPathCore
 import Testing
 
-/// Regression tests for HJKL arrow rendering across overlay layers.
-///
-/// These tests protect against three bugs that occurred in the same session:
-/// 1. Nav layer HJKL showed text ("H — Left") instead of arrow symbols
-///    because augmentation dropped vimLabels
-/// 2. KindaVim HJKL showed letter + arrow overlap because floating labels
-///    weren't hidden when vim hints rendered
-/// 3. Base layer HJKL went blank because floating labels were hidden whenever
-///    the KindaVim pack was installed, not just when hints actually rendered
+// Regression tests for HJKL arrow rendering across overlay layers.
+//
+// These tests protect against three bugs that occurred in the same session:
+// 1. Nav layer HJKL showed text ("H — Left") instead of arrow symbols
+//    because augmentation dropped vimLabels
+// 2. KindaVim HJKL showed letter + arrow overlap because floating labels
+//    weren't hidden when vim hints rendered
+// 3. Base layer HJKL went blank because floating labels were hidden whenever
+//    the KindaVim pack was installed, not just when hints actually rendered
 
 // MARK: - Augmentation preserves vimLabels
 
 @Suite("mergeAugmentation preserves vimLabels")
 struct MergeAugmentationTests {
-
     @Test("vimLabel from original is preserved when augmentation has none")
     func preservesOriginalVimLabel() {
         let original = LayerKeyInfo.mapped(
@@ -138,7 +137,6 @@ struct MergeAugmentationTests {
 
 @Suite("Floating label HJKL visibility logic")
 struct FloatingLabelHJKLTests {
-
     @Test("HJKL floating labels hidden when vim hints render")
     func hjklHiddenDuringVimHints() {
         let vimHintsActive = true
@@ -177,7 +175,6 @@ struct FloatingLabelHJKLTests {
 
 @Suite("mergeAugmentation edge cases")
 struct MergeAugmentationEdgeCaseTests {
-
     @Test("transparent augmented key preserves original displayLabel")
     func transparentPreservesOriginalLabel() {
         let original = LayerKeyInfo.mapped(
@@ -336,7 +333,6 @@ struct MergeAugmentationEdgeCaseTests {
 
 @Suite("VimBindings HJKL display labels are arrow-only")
 struct VimBindingsArrowLabelTests {
-
     @Test("HJKL hints have pure arrow displayLabels")
     func hjklDisplayLabelsAreArrows() {
         let hints = VimBindings.hints(strategy: .accessibility, mode: .normal, showAdvanced: false)

--- a/Tests/KeyPathTests/UI/OverlayKeyboardLayoutTests.swift
+++ b/Tests/KeyPathTests/UI/OverlayKeyboardLayoutTests.swift
@@ -3,7 +3,6 @@ import Testing
 
 @Suite("OverlayKeyboardView.escLeftInset")
 struct OverlayKeyboardLayoutTests {
-
     @Test("returns keyGap at scale 1 for macBookUS")
     func escLeftInsetAtScaleOne() {
         let inset = OverlayKeyboardView.escLeftInset(

--- a/Tests/KeyPathTests/UI/TCPEventParsingTests.swift
+++ b/Tests/KeyPathTests/UI/TCPEventParsingTests.swift
@@ -6,7 +6,6 @@ import XCTest
 /// Verifies that key input, hold, tap, and message events are correctly
 /// parsed and update the view model state.
 final class TCPEventParsingTests: XCTestCase {
-
     // MARK: - Key Input Events
 
     @MainActor
@@ -137,7 +136,7 @@ final class TCPEventParsingTests: XCTestCase {
     func testRapidPressRelease_DoesNotLeakState() {
         let vm = KeyboardVisualizationViewModel()
 
-        for _ in 0..<100 {
+        for _ in 0 ..< 100 {
             vm.simulateTcpKeyInput(key: "a", action: "press")
             vm.simulateTcpKeyInput(key: "a", action: "release")
         }

--- a/Tests/KeyPathTests/UI/TapHoldIdleLabelTests.swift
+++ b/Tests/KeyPathTests/UI/TapHoldIdleLabelTests.swift
@@ -3,7 +3,6 @@ import KeyPathCore
 import XCTest
 
 final class TapHoldIdleLabelTests: XCTestCase {
-
     @MainActor
     func testUpdateTapHoldIdleLabelsFromEnabledCollection() {
         let vm = KeyboardVisualizationViewModel()

--- a/Tests/KeyPathTests/Utilities/NotificationObserverManagerTests.swift
+++ b/Tests/KeyPathTests/Utilities/NotificationObserverManagerTests.swift
@@ -53,7 +53,6 @@ private final class SendableBox<T>: @unchecked Sendable {
 
 @Suite("NotificationObserverManager Tests")
 struct NotificationObserverManagerTests {
-
     // MARK: - Observer Count
 
     @Test("initial observerCount is zero")

--- a/Tests/KeyPathTests/VallackOverlayZoneTests.swift
+++ b/Tests/KeyPathTests/VallackOverlayZoneTests.swift
@@ -369,9 +369,9 @@ final class VallackOverlayZoneTests: XCTestCase {
         let hidden = catalog.filter { $0.owningPackID != nil }
 
         XCTAssertTrue(visible.contains { $0.id == RuleCollectionIdentifier.vallackNavigation },
-                       "Vallack pack row should be visible")
+                      "Vallack pack row should be visible")
         XCTAssertFalse(visible.contains { $0.id == RuleCollectionIdentifier.homeRowLayerToggles },
-                        "Layer Toggles should be hidden")
+                       "Layer Toggles should be hidden")
         XCTAssertTrue(hidden.contains { $0.id == RuleCollectionIdentifier.homeRowLayerToggles })
     }
 
@@ -451,23 +451,23 @@ final class VallackOverlayZoneTests: XCTestCase {
 
     func testNavSubtitlesMatchDesign() {
         let subs = VallackZoneMap.navSubtitles
-        XCTAssertEqual(subs[12], "tab")     // Q
-        XCTAssertEqual(subs[13], "esc")     // W
-        XCTAssertEqual(subs[14], "◀tab")    // E
-        XCTAssertEqual(subs[15], "tab▶")    // R
-        XCTAssertEqual(subs[17], "⌘[")      // T
-        XCTAssertEqual(subs[16], "⌘C")      // Y
-        XCTAssertEqual(subs[32], "⌫")       // U
-        XCTAssertEqual(subs[34], "↵")       // I
-        XCTAssertEqual(subs[0], "⌘tab")     // A
-        XCTAssertEqual(subs[1], "home")     // S
-        XCTAssertEqual(subs[2], "end")      // D
-        XCTAssertEqual(subs[41], "⌘V")      // ;
-        XCTAssertEqual(subs[9], "⌘]")       // V
-        XCTAssertEqual(subs[4], "←")        // H
-        XCTAssertEqual(subs[38], "↓")       // J
-        XCTAssertEqual(subs[40], "↑")       // K
-        XCTAssertEqual(subs[37], "→")       // L
+        XCTAssertEqual(subs[12], "tab") // Q
+        XCTAssertEqual(subs[13], "esc") // W
+        XCTAssertEqual(subs[14], "◀tab") // E
+        XCTAssertEqual(subs[15], "tab▶") // R
+        XCTAssertEqual(subs[17], "⌘[") // T
+        XCTAssertEqual(subs[16], "⌘C") // Y
+        XCTAssertEqual(subs[32], "⌫") // U
+        XCTAssertEqual(subs[34], "↵") // I
+        XCTAssertEqual(subs[0], "⌘tab") // A
+        XCTAssertEqual(subs[1], "home") // S
+        XCTAssertEqual(subs[2], "end") // D
+        XCTAssertEqual(subs[41], "⌘V") // ;
+        XCTAssertEqual(subs[9], "⌘]") // V
+        XCTAssertEqual(subs[4], "←") // H
+        XCTAssertEqual(subs[38], "↓") // J
+        XCTAssertEqual(subs[40], "↑") // K
+        XCTAssertEqual(subs[37], "→") // L
     }
 
     func testVallackNavDescriptionsAvoidVerboseLabels() {

--- a/Tests/KeyPathTests/ViewModelSyncTests.swift
+++ b/Tests/KeyPathTests/ViewModelSyncTests.swift
@@ -6,7 +6,6 @@ import Testing
 @MainActor
 @Suite("Window Snapping Activation Mode Tests")
 struct WindowSnappingActivationModeTests {
-
     private func createManagerWithWindowSnapping() async -> RuleCollectionsManager {
         TestEnvironment.forceTestMode = true
 

--- a/Tests/KeyPathTests/VimInsightsEngineTests.swift
+++ b/Tests/KeyPathTests/VimInsightsEngineTests.swift
@@ -9,7 +9,7 @@ final class VimInsightsEngineTests: XCTestCase {
 
     func testStageIsUnknownBelowSampleFloor() {
         var snap = KindaVimTelemetrySnapshot()
-        snap.commandFrequency = ["h": 5, "j": 5]  // total 10 → below floor of 50
+        snap.commandFrequency = ["h": 5, "j": 5] // total 10 → below floor of 50
         XCTAssertEqual(VimInsightsEngine.stage(for: snap), .unknown)
     }
 
@@ -23,7 +23,7 @@ final class VimInsightsEngineTests: XCTestCase {
 
     func testStageIsIntermediateInTheMiddle() {
         var snap = KindaVimTelemetrySnapshot()
-        snap.commandFrequency = ["h": 30, "j": 30, "k": 20, "l": 20]  // 100 hjkl
+        snap.commandFrequency = ["h": 30, "j": 30, "k": 20, "l": 20] // 100 hjkl
         snap.nonVimNavigationFrequency = ["left": 25]
         // 25 / 125 = 20% → intermediate
         XCTAssertEqual(VimInsightsEngine.stage(for: snap), .intermediate)
@@ -65,8 +65,8 @@ final class VimInsightsEngineTests: XCTestCase {
 
     func testIntermediateSurfacesFoundationGapForB() {
         var snap = KindaVimTelemetrySnapshot()
-        snap.commandFrequency = ["h": 30, "j": 30, "w": 20]  // w fluent, b absent
-        snap.nonVimNavigationFrequency = ["left": 15]  // ~16% reliance
+        snap.commandFrequency = ["h": 30, "j": 30, "w": 20] // w fluent, b absent
+        snap.nonVimNavigationFrequency = ["left": 15] // ~16% reliance
         let insights = VimInsightsEngine.insights(for: snap)
         XCTAssertTrue(insights.contains { $0.title.contains("`b`") })
     }
@@ -106,7 +106,7 @@ final class VimInsightsEngineTests: XCTestCase {
     func testInsightsOrderedByPriority() {
         var snap = KindaVimTelemetrySnapshot()
         snap.commandFrequency = ["h": 30, "j": 30, "i": 30, "w": 30]
-        snap.nonVimNavigationFrequency = ["left": 30]  // intermediate
+        snap.nonVimNavigationFrequency = ["left": 30] // intermediate
         let insights = VimInsightsEngine.insights(for: snap, maxInsights: 5)
         let priorities = insights.map(\.priority)
         XCTAssertEqual(priorities, priorities.sorted(by: >))

--- a/Tests/KeyPathTests/VimSequenceObserverTests.swift
+++ b/Tests/KeyPathTests/VimSequenceObserverTests.swift
@@ -44,7 +44,7 @@ final class VimSequenceObserverTests: XCTestCase {
         mode = .normal
         observer.ingest(character: "5")
         XCTAssertEqual(observer.countBuffer, "5")
-        observer.ingest(character: "0")  // not a leading zero — ok mid-buffer
+        observer.ingest(character: "0") // not a leading zero — ok mid-buffer
         XCTAssertEqual(observer.countBuffer, "50")
     }
 
@@ -61,7 +61,7 @@ final class VimSequenceObserverTests: XCTestCase {
         mode = .normal
         observer.ingest(character: "5")
         XCTAssertEqual(observer.countBuffer, "5")
-        observer.ingest(character: "j")  // motion consumes the count
+        observer.ingest(character: "j") // motion consumes the count
         XCTAssertEqual(observer.countBuffer, "")
     }
 
@@ -77,7 +77,7 @@ final class VimSequenceObserverTests: XCTestCase {
 
         // kindaVim flips to insert (e.g. user pressed Esc, then `i`).
         mode = .insert
-        observer.ingest(character: "x")  // insert mode keystroke
+        observer.ingest(character: "x") // insert mode keystroke
         XCTAssertNil(observer.currentOperator)
         XCTAssertEqual(observer.countBuffer, "")
     }
@@ -98,7 +98,7 @@ final class VimSequenceObserverTests: XCTestCase {
         XCTAssertEqual(observer.currentOperator, "d")
 
         // Sequence completes: kindaVim flips back to normal. No new key.
-        mode = .normal  // (still normal — but pretend we transitioned through op-pending)
+        mode = .normal // (still normal — but pretend we transitioned through op-pending)
         observer.syncWithMode()
         // Mode didn't actually change, so state should remain.
         XCTAssertEqual(observer.currentOperator, "d")

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,6 @@
+# Pinned developer tool versions (https://mise.jdx.dev).
+# swiftformat is version-sensitive: a different version reformats unrelated code
+# (see issue #634). Pinning keeps master a fixed-point so format runs don't churn.
+# Install with: `mise install` (or `brew install swiftformat` at this exact version).
+[tools]
+swiftformat = "0.61.1"


### PR DESCRIPTION
Fixes #634.

## Problem
Running `swiftformat` locally reformatted ~300 unrelated files: master was never a fixed-point for the installed version, and the tool version was unpinned (CI's lint is advisory/non-gating and didn't even pass `--swiftversion`). Every Swift edit risked spurious churn that had to be hand-reverted — it bit this session repeatedly.

## Fix
Make master a clean fixed-point so a format run produces **zero churn**:
- **Pin swiftformat `0.61.1`** via `mise.toml`; document it in `CLAUDE.md`.
- **Set `--swiftversion 5.9` in `.swiftformat`** so CI's lint and local runs finally agree (CI previously omitted it, letting version-dependent rules drift).
- **One-time reformat** of `Sources` + `Tests` to the pinned ruleset (264 files).

## Curated to keep the pass purely cosmetic (no behavior change)
- **Disabled `redundantSendable`** — keep explicit `Sendable` as intent documentation; don't let a formatter silently drop conformances (it's what stripped `Sendable` from `RuntimeStatus` earlier).
- **Disabled `noForceUnwrapInTests`** — it's a *semantic* rewrite (force-unwrap → `try #require(...)`, adds `throws` to test funcs), not formatting. Out of scope for a mechanical pass; can be a deliberate change later if wanted.
- **Exempted one declaration** in `NotificationObserverManager` from `redundantClosure` via a `// swiftformat:disable` directive — collapsing that IIFE made `.perform` lose its `NotificationCenter` base and broke type inference (wouldn't compile). Documented inline.

The remaining changes are mechanical: indentation, redundant `return`/`async`/`self`/type, import sorting, brace/wrapping, blank-line and spacing normalization.

## Verification
- `swiftformat Sources Tests --lint` → **0/1174 require formatting** (true fixed-point).
- `swift build` clean; full `swift test` suite **green, 0 failures**.

## Note
This is a large but purely-mechanical diff. After merge, anyone formatting at the pinned version gets no churn. Reviewers can spot-check; the build + full test suite passing is the behavior-preservation guarantee.