### PR TITLE
refactor: remove dead VirtualHID log-recovery path (#633)

### DIFF
--- a/Sources/KeyPathAppKit/Managers/RecoveryCoordinator.swift
+++ b/Sources/KeyPathAppKit/Managers/RecoveryCoordinator.swift
@@ -110,39 +110,6 @@ final class RecoveryCoordinator {
         }
     }
 
-    /// Trigger VirtualHID recovery when connection failures are detected
-    ///
-    /// - Parameters:
-    ///   - addDiagnostic: Handler to add diagnostic to system
-    ///   - attemptRecovery: Handler to perform recovery
-    func triggerVirtualHIDRecovery(
-        addDiagnostic: (KanataDiagnostic) -> Void,
-        attemptRecovery: () async -> Void
-    ) async {
-        let diagnostic = createVirtualHIDFailureDiagnostic()
-        addDiagnostic(diagnostic)
-        await attemptRecovery()
-    }
-
-    /// Create a VirtualHID failure diagnostic
-    func createVirtualHIDFailureDiagnostic() -> KanataDiagnostic {
-        AppLogger.shared.log("🚨 [RecoveryCoordinator] VirtualHID connection failure detected in real-time")
-
-        return KanataDiagnostic(
-            timestamp: Date(),
-            severity: .error,
-            category: .conflict,
-            title: "VirtualHID Connection Failed",
-            description:
-            "Real-time monitoring detected repeated VirtualHID connection failures. Keyboard remapping is not functioning.",
-            technicalDetails:
-            "Detected multiple consecutive asio.system connection failures",
-            suggestedAction:
-            "KeyPath will attempt automatic recovery. If issues persist, restart the application.",
-            canAutoFix: true
-        )
-    }
-
     // MARK: - Auto-Fix Logic
 
     /// Determine if a diagnostic can be auto-fixed

--- a/Sources/KeyPathAppKit/Managers/RuntimeCoordinator.swift
+++ b/Sources/KeyPathAppKit/Managers/RuntimeCoordinator.swift
@@ -962,29 +962,6 @@ public class RuntimeCoordinator: SaveCoordinatorDelegate {
         KanataKeyConverter.convertToKanataSequence(sequence)
     }
 
-    // MARK: - Real-Time VirtualHID Connection Monitoring
-
-    // startLogMonitoring/stopLogMonitoring moved to RuntimeCoordinator+Output.swif
-
-    /// Analyze new log content for VirtualHID connection issues (delegates parsing to DiagnosticsService)
-    func analyzeLogContent(_ content: String) async {
-        let events = diagnosticsService.analyzeKanataLogChunk(content)
-        for event in events {
-            switch event {
-            case .virtualHIDConnectionFailed:
-                let shouldTriggerRecovery = await diagnosticsManager.recordConnectionFailure()
-                if shouldTriggerRecovery {
-                    AppLogger.shared.log(
-                        "🚨 [LogMonitor] Maximum connection failures reached - triggering recovery"
-                    )
-                    await triggerVirtualHIDRecovery()
-                }
-            case .virtualHIDConnected:
-                await diagnosticsManager.recordConnectionSuccess()
-            }
-        }
-    }
-
     // MARK: - One-click Service Regeneration
 
     /// Regenerate LaunchDaemon services (rewrite plists, bootstrap, kickstart) using current settings.
@@ -1004,18 +981,6 @@ public class RuntimeCoordinator: SaveCoordinatorDelegate {
         AppLogger.shared.error("❌ [Services] Regenerate services failed: \(failureReason)")
         lastError = "Regenerate services failed: \(failureReason)"
         return false
-    }
-
-    /// Trigger VirtualHID recovery when connection failures are detected
-    private func triggerVirtualHIDRecovery() async {
-        await recoveryCoordinator.triggerVirtualHIDRecovery(
-            addDiagnostic: { [weak self] diagnostic in
-                self?.addDiagnostic(diagnostic)
-            },
-            attemptRecovery: { [weak self] in
-                await self?.attemptKeyboardRecovery()
-            }
-        )
     }
 
     // MARK: - Enhanced Config Validation and Recovery

--- a/Sources/KeyPathAppKit/Services/Monitoring/DiagnosticsService.swift
+++ b/Sources/KeyPathAppKit/Services/Monitoring/DiagnosticsService.swift
@@ -52,11 +52,6 @@ struct VirtualHIDDaemonStatus: Sendable {
     let serviceHealthy: Bool?
 }
 
-enum DiagnosticsLogEvent: Sendable {
-    case virtualHIDConnectionFailed
-    case virtualHIDConnected
-}
-
 // MARK: - Protocol
 
 /// Service responsible for generating and analyzing system diagnostics
@@ -76,8 +71,6 @@ protocol DiagnosticsServiceProtocol: Sendable {
     func analyzeLogFile(path: String) async -> [KanataDiagnostic]
     /// VirtualHID daemon low-level status (used for summaries)
     func virtualHIDDaemonStatus() async -> VirtualHIDDaemonStatus
-    /// Parse a log chunk into high-level events
-    func analyzeKanataLogChunk(_ chunk: String) -> [DiagnosticsLogEvent]
 }
 
 // MARK: - Implementation
@@ -109,20 +102,6 @@ final class DiagnosticsService: DiagnosticsServiceProtocol, @unchecked Sendable 
             serviceState: running ? "running" : "stopped",
             serviceHealthy: health
         )
-    }
-
-    nonisolated func analyzeKanataLogChunk(_ chunk: String) -> [DiagnosticsLogEvent] {
-        var events: [DiagnosticsLogEvent] = []
-        let lower = chunk.lowercased()
-        if lower.contains("connection established") || lower.contains("vhid connected") {
-            events.append(.virtualHIDConnected)
-        }
-        if lower.contains("asio.system") || lower.contains("connection failed")
-            || lower.contains("vhid error")
-        {
-            events.append(.virtualHIDConnectionFailed)
-        }
-        return events
     }
 
     func getSystemDiagnostics(engineClient _: EngineClient?) async -> [KanataDiagnostic] {

--- a/Tests/KeyPathTests/Services/RecoveryCoordinatorTests.swift
+++ b/Tests/KeyPathTests/Services/RecoveryCoordinatorTests.swift
@@ -100,38 +100,6 @@ struct RecoveryCoordinatorVirtualHIDValidationTests {
     }
 }
 
-// MARK: - VirtualHID Recovery
-
-@Suite("RecoveryCoordinator — VirtualHID Recovery")
-@MainActor
-struct RecoveryCoordinatorVirtualHIDRecoveryTests {
-    @Test("triggerVirtualHIDRecovery adds diagnostic and triggers recovery")
-    func addsDiagnosticAndTriggersRecovery() async {
-        let coordinator = RecoveryCoordinator()
-        var addedDiagnostic: KanataDiagnostic?
-        var recoveryCalled = false
-
-        await coordinator.triggerVirtualHIDRecovery(
-            addDiagnostic: { addedDiagnostic = $0 },
-            attemptRecovery: { recoveryCalled = true }
-        )
-
-        #expect(addedDiagnostic != nil, "addDiagnostic should have been called")
-        #expect(recoveryCalled, "attemptRecovery should have been called")
-    }
-
-    @Test("createVirtualHIDFailureDiagnostic has correct properties")
-    func diagnosticHasCorrectProperties() {
-        let coordinator = RecoveryCoordinator()
-        let diagnostic = coordinator.createVirtualHIDFailureDiagnostic()
-
-        #expect(diagnostic.severity == .error)
-        #expect(diagnostic.category == .conflict)
-        #expect(diagnostic.canAutoFix == true)
-        #expect(diagnostic.title == "VirtualHID Connection Failed")
-    }
-}
-
 // MARK: - Auto-Fix Logic
 
 @Suite("RecoveryCoordinator — Auto-Fix Logic")


### PR DESCRIPTION
Fixes #633.

## What
Removes the orphaned "VirtualHID-log-failure → recovery" mechanism that #625 superseded with authoritative **grab-signal** recovery (`RuntimeCoordinator.handleGrabStatusChanged` → `attemptKeyboardRecovery`).

`RuntimeCoordinator.analyzeLogContent` had **zero callers** (its comment even referenced a `RuntimeCoordinator+Output.swift` that doesn't exist); the live log loop is `DiagnosticsManager.analyzeLogContent`. The dead copy carried a whole recovery subtree that looked functional but never ran — exactly the "passes review-by-reading, never executes" hazard #633 calls out.

## Removed (verified only-self-referenced, whole subtree)
- `RuntimeCoordinator.analyzeLogContent` + `triggerVirtualHIDRecovery`
- `RecoveryCoordinator.triggerVirtualHIDRecovery` + `createVirtualHIDFailureDiagnostic`
- `DiagnosticsService.analyzeKanataLogChunk` (protocol decl + impl) + the `DiagnosticsLogEvent` enum
- `RecoveryCoordinatorVirtualHIDRecoveryTests` (only exercised the dead methods)

## Kept (live — confirmed independent)
- The grab-signal recovery path (#625) — the actual live recovery.
- `DiagnosticsManager.analyzeLogContent` (the live log loop).
- `DiagnosticsService`'s own live "VirtualHID Connection Failed" diagnostic + its test (`DiagnosticsServiceTests`).
- `RuntimeCoordinator.diagnosticsService` (still injected into other components).
- `recordConnectionFailure/Success`, `attemptKeyboardRecovery` (all still used).

Only one conformer of `DiagnosticsServiceProtocol` exists (`DiagnosticsService`), so dropping the protocol method breaks no mock.

## Verification
121 deletions, 0 insertions. `swift build` clean, full `swift test` green, `swiftformat --lint` 0/1174.

## Note (remaining #633 scope)
This clears the confirmed-dead subtree. The issue also mentions a broader sweep (periphery scan; `LayerChangeListener`/`startLayerMonitoring`/`fallbackTapHoldOutputMap` shims) — left as follow-up.