### PR TITLE
ci: enforce the swiftformat version pin + make the format check gating

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,14 +200,29 @@ jobs:
         echo "Linting changed Swift files only..."
         echo "${{ steps.changed.outputs.swift_files }}" | xargs swiftlint --reporter github-actions-logging || true
 
+    - name: Verify SwiftFormat version matches pin
+      if: steps.changed.outputs.swift_files != ''
+      run: |
+        PINNED=$(sed -nE 's/^[[:space:]]*swiftformat[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/p' mise.toml)
+        ACTUAL=$(swiftformat --version | tr -d '[:space:]')
+        echo "SwiftFormat — pinned (mise.toml): '$PINNED', installed: '$ACTUAL'"
+        if [ -z "$PINNED" ]; then
+          echo "::error::Could not read the swiftformat pin from mise.toml"
+          exit 1
+        fi
+        if [ "$PINNED" != "$ACTUAL" ]; then
+          echo "::error::SwiftFormat version drift — runner has '$ACTUAL' but mise.toml pins '$PINNED'."
+          echo "::error::master is a formatted fixed-point for the pinned version; a different version produces spurious lint results. Install the pinned version on the runner (mise install / brew) or update mise.toml + reformat."
+          exit 1
+        fi
+
     - name: SwiftFormat Check
       if: steps.changed.outputs.swift_files != ''
       run: |
-        echo "Checking formatting of changed Swift files..."
+        echo "Checking formatting of changed Swift files (must match the pinned fixed-point)..."
         echo "${{ steps.changed.outputs.swift_files }}" | xargs swiftformat --lint || {
-          echo "SwiftFormat found formatting issues, but not failing CI"
-          echo "Run 'swiftformat Sources/ Tests/' locally to fix formatting"
-          exit 0
+          echo "::error::SwiftFormat found formatting issues. Run 'swiftformat Sources Tests' (at the pinned version) and commit."
+          exit 1
         }
 
     - name: Wizard Sleep Lint


### PR DESCRIPTION
Follow-up to #634/#647 (the swiftformat 0.61.1 fixed-point). Closes the gap noted in #647 review: CI passing only *proved* the runner happened to have 0.61.1 — nothing enforced it.

## Before
`code-quality` ran `swiftformat --lint` with `exit 0` on violations (advisory) against whatever swiftformat the self-hosted runner had on `PATH` (Homebrew). So:
- Runner version drift → spurious/meaningless lint results, silently.
- Misformatted PRs → passed with a green check.

## After
- **Verify SwiftFormat version matches pin** — reads the pin from `mise.toml`, compares to `swiftformat --version`, and **fails** `code-quality` on mismatch with an actionable message. Drift is now loud.
- **SwiftFormat Check is gating** — `swiftformat --lint` failures now fail the job (removed the `exit 0`). Safe because the version is asserted first, so a failure means a real formatting issue, not version drift, and master is already a 0/1174 fixed-point.

Both steps remain scoped to PRs that touch Swift files (no noise on docs-only PRs).

## Notes
- This PR only edits `ci.yml`, so the new steps (gated on changed Swift files) first execute on the next Swift PR; `build-and-test` runs here as usual. Version-parse logic validated locally on macOS (BSD sed), YAML validated.
- `code-quality` isn't a *required* status check, so today this surfaces problems as a red check rather than a hard block. To make it a hard gate, add `code-quality` to branch protection's required checks — left as the maintainer's call (a repo-settings change).