### PR TITLE
docs: add the "ds" full-ship shortcut to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,7 @@ an unpinned version.
 
 **"dd"** → Run `SKIP_NOTARIZE=1 ./build.sh`, respond **"Eye eye Captain!"**
 **"df"** → Run `./Scripts/quick-deploy.sh`, respond **"Eye eye Cap, fast deploying!"**
+**"ds"** → Full ship workflow for the current changes, end to end: branch off master → format/lint + commit → review gate → push + open PR → babysit CI → address feedback → merge → pull master → rebuild/deploy from master. Follow [`docs/agent-pr-workflow.md`](docs/agent-pr-workflow.md) and its invariants; risk-tier the babysit (auto-merge mechanical PRs, full babysit for logic/hot-path).
 
 Test targets: `Tests/KeyPathTests/` (target: `KeyPathTests`). Files in `Tests/KeyPathAppKitTests/` are NOT compiled. Snapshot tests in `Tests/KeyPathSnapshotTests/`.
 


### PR DESCRIPTION
The `ds` shortcut (full ship workflow) lived only as a machine-local agent memory, so it didn't carry to other computers. This promotes it into `CLAUDE.md` — which is in the repo and path-independent — so any machine's session picks it up.

Concise entry alongside `dd`/`df`, pointing at `docs/agent-pr-workflow.md` + invariants, and noting the risk-tiered babysit (auto-merge mechanical PRs, full babysit for logic/hot-path).

Docs-only; likely needs admin-merge per #650 if `build-and-test` is path-filtered for non-Swift changes.