### PR TITLE
ci: report required checks as success on docs-only PRs (#650)

### DIFF
--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -1,0 +1,40 @@
+name: KeyPath CI (docs)
+
+# Companion to ci.yml. ci.yml uses `paths-ignore` (docs/**, *.md, resources, …) so it
+# does NOT run on docs-only PRs — which leaves the *required* `build-and-test` (and, per
+# #652, `code-quality`) checks unreported, so the PR is permanently BLOCKED and can only
+# be admin-merged (#650). This workflow triggers on exactly those ignored paths and
+# reports the same check-run names as success, so docs-only PRs satisfy branch protection
+# without an admin override. The `paths` list MUST mirror ci.yml's `paths-ignore`.
+#
+# Mixed PRs (docs + code) trigger both workflows; ci.yml's real result governs pass/fail
+# (a real failure still blocks), and this stub's success is harmless/redundant.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches: [main, master]
+    paths:
+      - 'docs/**'
+      - '*.md'
+      - '.github/workflows/claude.yml'
+      - '.github/workflows/claude-code-review.yml'
+      - 'Sources/KeyPathAppKit/Resources/*.md'
+      - 'Sources/KeyPathAppKit/Resources/*.css'
+      - 'Sources/KeyPathAppKit/Resources/*.png'
+
+concurrency:
+  group: ci-docs-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # Job names MUST match ci.yml's required check contexts exactly.
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Docs-only change — no Swift build/test applicable; reporting success (#650)."
+
+  code-quality:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Docs-only change — no Swift code-quality applicable; reporting success (#650)."


### PR DESCRIPTION
Fixes #650.

## Problem
`ci.yml` uses `paths-ignore` (`docs/**`, `*.md`, resources, …), so a **docs-only PR never triggers it** → the required `build-and-test` check is never reported → the PR is permanently `BLOCKED` and can only land via `gh pr merge --admin`. We hit this on #646, #653, #654 this session.

## Fix
Add a companion **`ci-docs.yml`** that triggers on exactly the paths `ci.yml` ignores and reports the same check-run names — `build-and-test` **and** `code-quality` — as instant success. Docs-only PRs then satisfy branch protection normally.

- The `paths:` list mirrors `ci.yml`'s `paths-ignore` (keep them in sync).
- Reports `code-quality` too, so this also unblocks making it required (#652).
- **Mixed PRs** (docs + code) trigger both workflows; `ci.yml`'s real result governs pass/fail (a real failure still blocks), the stub's success is redundant/harmless.
- Stub runs on `ubuntu-latest` (free on this public repo; doesn't tie up the self-hosted mac runner).

## Verification
YAML validated. This PR touches `.github/workflows/` (not an ignored path), so `ci.yml`'s real `build-and-test` runs here as usual — no admin merge needed. The stub itself proves out on the next docs-only PR.