### PR TITLE
refactor: remove unused deprecated shims (#651)

### DIFF
--- a/Sources/KeyPathAppKit/Services/Monitoring/KanataEventListener.swift
+++ b/Sources/KeyPathAppKit/Services/Monitoring/KanataEventListener.swift
@@ -1004,9 +1004,3 @@ actor KanataEventListener {
         case connectionClosed
     }
 }
-
-// MARK: - Backward Compatibility
-
-/// Deprecated: Use KanataEventListener instead
-@available(*, deprecated, renamed: "KanataEventListener")
-typealias LayerChangeListener = KanataEventListener

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+EventMonitoring.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+EventMonitoring.swift
@@ -265,10 +265,4 @@ extension RuleCollectionsManager {
         await eventListener.stop()
         AppLogger.shared.log("🌐 [RuleCollectionsManager] Stopped event monitoring")
     }
-
-    /// Deprecated: Use startEventMonitoring instead
-    @available(*, deprecated, renamed: "startEventMonitoring")
-    func startLayerMonitoring(port: Int) {
-        startEventMonitoring(port: port)
-    }
 }


### PR DESCRIPTION
Part of #651 (dead-code sweep). Removes the two `@available(*, deprecated, renamed:)` shims that have **zero callers**:

- `LayerChangeListener` typealias → `KanataEventListener`
- `RuleCollectionsManager.startLayerMonitoring(port:)` → `startEventMonitoring(port:)`

Verified no static / dynamic / test references before removing.

**Deliberately kept:**
- `fallbackTapHoldOutputMap` — also named in #651 as a phase-out candidate, but it's **live** (used by `KeyboardVisualizationViewModel+Suppression` and `+TCP`). "Will be phased out" ≠ dead today.
- The "moved to X.swift" comments point at files that **exist** (`BaseKeycap.swift`, `KanataConfigurationGenerator.swift`) and whose extension files still hold real code — accurate breadcrumbs, not the #633-style broken references.

## Verification
`swift build` clean, full `swift test` green.

## Remaining in #651 (not this PR)
The **`periphery` scanner integration** is the other half of #651. It's an open-ended tooling + triage effort (config tuning to suppress false positives, deciding local-script vs scheduled-CI vs gating, then working the backlog) and a full scan adds another build — risky to bolt onto the 5-min `code-quality` job. Recommend handling it deliberately as its own task; leaving #651 open for it.