### PR TITLE
fix: detect momentary-activator conflicts instead of silent dedup (#466)

### DIFF
--- a/Sources/KeyPathAppKit/Models/RuleCollectionDeduplicator.swift
+++ b/Sources/KeyPathAppKit/Models/RuleCollectionDeduplicator.swift
@@ -58,34 +58,46 @@ enum RuleCollectionDeduplicator {
         }
 
         // Momentary activator conflicts (#466): two collections claim the same
-        // physical activator key but route it to different layers. The silent
-        // `seenActivators` dedup in buildCollectionBlocks would drop one without
-        // notice — surface it via the same detect-and-explain path instead.
-        // Identical activators (same key + same target layer) are redundant, not
-        // conflicting, and are intentionally skipped (matching the toggle-time
-        // conflictInfo semantics).
+        // physical activator key from the same source layer but route it to
+        // different target layers. The silent `seenActivators` dedup in
+        // buildCollectionBlocks would drop one without notice — surface it via the
+        // same detect-and-explain path instead.
+        //
+        // The claim slot is (sourceLayer, input): a key can only carry one binding
+        // per layer. The same key activating different targets from *different*
+        // source layers is a valid chained-layer setup (e.g. `f` → arrows from base
+        // and `f` → function from nav), not a conflict. Identical activators (same
+        // slot + same target) are redundant, not conflicting. Both are skipped so
+        // the detection does not over-fire (matching the toggle-time conflictInfo).
+        struct ActivatorSlot: Hashable {
+            let sourceLayer: RuleCollectionLayer
+            let input: String
+        }
         struct ActivatorClaim {
             let collectionName: String
             let targetLayer: RuleCollectionLayer
         }
-        var activatorClaims: [String: [ActivatorClaim]] = [:]
+        var activatorClaims: [ActivatorSlot: [ActivatorClaim]] = [:]
         for collection in collections where collection.isEnabled {
             guard let activator = collection.momentaryActivator else { continue }
             // "hyper" activators are folded into the hyper hold action, not emitted
             // as standalone layer activators — they never collide in seenActivators.
             guard activator.input.lowercased() != "hyper" else { continue }
-            let normalizedInput = KanataKeyConverter.convertToKanataKey(activator.input)
-            activatorClaims[normalizedInput, default: []].append(
+            let slot = ActivatorSlot(
+                sourceLayer: activator.sourceLayer,
+                input: KanataKeyConverter.convertToKanataKey(activator.input)
+            )
+            activatorClaims[slot, default: []].append(
                 ActivatorClaim(collectionName: collection.name, targetLayer: activator.targetLayer)
             )
         }
-        for (input, claims) in activatorClaims where claims.count > 1 {
+        for (slot, claims) in activatorClaims where claims.count > 1 {
             // Only a conflict if the activators disagree on which layer to activate.
             let distinctTargets = Set(claims.map(\.targetLayer))
             guard distinctTargets.count > 1 else { continue }
             conflicts.append(KeyPathError.MappingConflictInfo(
-                inputKey: input,
-                layer: RuleCollectionLayer.base.displayName,
+                inputKey: slot.input,
+                layer: slot.sourceLayer.displayName,
                 conflictingCollections: claims.map(\.collectionName),
                 holdDescriptions: claims.map { "\($0.collectionName): activates \($0.targetLayer.displayName)" }
             ))

--- a/Sources/KeyPathAppKit/Models/RuleCollectionDeduplicator.swift
+++ b/Sources/KeyPathAppKit/Models/RuleCollectionDeduplicator.swift
@@ -57,6 +57,40 @@ enum RuleCollectionDeduplicator {
             ))
         }
 
+        // Momentary activator conflicts (#466): two collections claim the same
+        // physical activator key but route it to different layers. The silent
+        // `seenActivators` dedup in buildCollectionBlocks would drop one without
+        // notice — surface it via the same detect-and-explain path instead.
+        // Identical activators (same key + same target layer) are redundant, not
+        // conflicting, and are intentionally skipped (matching the toggle-time
+        // conflictInfo semantics).
+        struct ActivatorClaim {
+            let collectionName: String
+            let targetLayer: RuleCollectionLayer
+        }
+        var activatorClaims: [String: [ActivatorClaim]] = [:]
+        for collection in collections where collection.isEnabled {
+            guard let activator = collection.momentaryActivator else { continue }
+            // "hyper" activators are folded into the hyper hold action, not emitted
+            // as standalone layer activators — they never collide in seenActivators.
+            guard activator.input.lowercased() != "hyper" else { continue }
+            let normalizedInput = KanataKeyConverter.convertToKanataKey(activator.input)
+            activatorClaims[normalizedInput, default: []].append(
+                ActivatorClaim(collectionName: collection.name, targetLayer: activator.targetLayer)
+            )
+        }
+        for (input, claims) in activatorClaims where claims.count > 1 {
+            // Only a conflict if the activators disagree on which layer to activate.
+            let distinctTargets = Set(claims.map(\.targetLayer))
+            guard distinctTargets.count > 1 else { continue }
+            conflicts.append(KeyPathError.MappingConflictInfo(
+                inputKey: input,
+                layer: RuleCollectionLayer.base.displayName,
+                conflictingCollections: claims.map(\.collectionName),
+                holdDescriptions: claims.map { "\($0.collectionName): activates \($0.targetLayer.displayName)" }
+            ))
+        }
+
         // Within-collection chord group conflicts: two chord groups sharing keys
         // produces duplicate aliases that kanata rejects.
         for collection in collections where collection.isEnabled {

--- a/Tests/KeyPathTests/RuleCollections/RuleCollectionDeduplicatorTests.swift
+++ b/Tests/KeyPathTests/RuleCollections/RuleCollectionDeduplicatorTests.swift
@@ -128,6 +128,127 @@ final class RuleCollectionDeduplicatorTests: XCTestCase {
         XCTAssertEqual(conflictKeys, ["h", "j"])
     }
 
+    // MARK: - Momentary Activator Conflict Detection (#466)
+
+    func testDetectsConflictWhenTwoActivatorsTargetDifferentLayers() {
+        // Two collections claim the same physical activator key ("space") but route
+        // it to different layers. The silent `seenActivators` dedup in
+        // buildCollectionBlocks would drop one without explanation — surface it instead.
+        let navCollection = RuleCollection(
+            name: "Vim Nav",
+            summary: "Nav",
+            category: .navigation,
+            mappings: [KeyMapping(input: "h", action: .keystroke(key: "left"))],
+            isEnabled: true,
+            targetLayer: .navigation,
+            momentaryActivator: MomentaryActivator(input: "space", targetLayer: .navigation)
+        )
+
+        let windowCollection = RuleCollection(
+            name: "Window Mgmt",
+            summary: "Window",
+            category: .productivity,
+            mappings: [KeyMapping(input: "y", action: .keystroke(key: "left"))],
+            isEnabled: true,
+            targetLayer: .custom("window"),
+            momentaryActivator: MomentaryActivator(input: "space", targetLayer: .custom("window"))
+        )
+
+        let conflicts = RuleCollectionDeduplicator.detectConflicts(in: [navCollection, windowCollection])
+
+        // "space" normalizes to the kanata key "spc"
+        let activatorConflict = conflicts.first { $0.inputKey == "spc" }
+        XCTAssertNotNil(activatorConflict, "Activator key collision on different layers should be surfaced")
+        XCTAssertEqual(Set(activatorConflict?.conflictingCollections ?? []), ["Vim Nav", "Window Mgmt"])
+    }
+
+    func testNoActivatorConflictWhenSameTargetLayer() {
+        // Two navigation collections sharing the same activator (space → nav) are
+        // redundant, not conflicting — both want the same layer activated the same way.
+        let first = RuleCollection(
+            name: "Vim Nav",
+            summary: "Nav",
+            category: .navigation,
+            mappings: [KeyMapping(input: "h", action: .keystroke(key: "left"))],
+            isEnabled: true,
+            targetLayer: .navigation,
+            momentaryActivator: MomentaryActivator(input: "space", targetLayer: .navigation)
+        )
+
+        let second = RuleCollection(
+            name: "Nav Extras",
+            summary: "Nav",
+            category: .navigation,
+            mappings: [KeyMapping(input: "j", action: .keystroke(key: "down"))],
+            isEnabled: true,
+            targetLayer: .navigation,
+            momentaryActivator: MomentaryActivator(input: "space", targetLayer: .navigation)
+        )
+
+        let conflicts = RuleCollectionDeduplicator.detectConflicts(in: [first, second])
+
+        XCTAssertFalse(
+            conflicts.contains { $0.inputKey == "spc" },
+            "Identical activators targeting the same layer are redundant, not a conflict"
+        )
+    }
+
+    func testNoActivatorConflictWhenDifferentKeys() {
+        let first = RuleCollection(
+            name: "Vim Nav",
+            summary: "Nav",
+            category: .navigation,
+            mappings: [KeyMapping(input: "h", action: .keystroke(key: "left"))],
+            isEnabled: true,
+            targetLayer: .navigation,
+            momentaryActivator: MomentaryActivator(input: "space", targetLayer: .navigation)
+        )
+
+        let second = RuleCollection(
+            name: "Window Mgmt",
+            summary: "Window",
+            category: .productivity,
+            mappings: [KeyMapping(input: "y", action: .keystroke(key: "left"))],
+            isEnabled: true,
+            targetLayer: .custom("window"),
+            momentaryActivator: MomentaryActivator(input: "tab", targetLayer: .custom("window"))
+        )
+
+        let conflicts = RuleCollectionDeduplicator.detectConflicts(in: [first, second])
+
+        XCTAssertTrue(conflicts.isEmpty, "Distinct activator keys do not conflict")
+    }
+
+    func testDisabledCollectionActivatorIgnoredInConflictDetection() {
+        let enabled = RuleCollection(
+            name: "Vim Nav",
+            summary: "Nav",
+            category: .navigation,
+            mappings: [KeyMapping(input: "h", action: .keystroke(key: "left"))],
+            isEnabled: true,
+            targetLayer: .navigation,
+            momentaryActivator: MomentaryActivator(input: "space", targetLayer: .navigation)
+        )
+
+        var disabled = RuleCollection(
+            name: "Window Mgmt",
+            summary: "Window",
+            category: .productivity,
+            mappings: [KeyMapping(input: "y", action: .keystroke(key: "left"))],
+            isEnabled: false,
+            targetLayer: .custom("window"),
+            momentaryActivator: MomentaryActivator(input: "space", targetLayer: .custom("window"))
+        )
+        disabled.isEnabled = false
+
+        let conflicts = RuleCollectionDeduplicator.detectConflicts(in: [enabled, disabled])
+
+        XCTAssertFalse(
+            conflicts.contains { $0.inputKey == "spc" },
+            "A disabled collection's activator must not trigger a conflict"
+        )
+    }
+
     // MARK: - Deduplication Tests
 
     func testDisabledCollectionDoesNotClaimKeysInDedupe() {

--- a/Tests/KeyPathTests/RuleCollections/RuleCollectionDeduplicatorTests.swift
+++ b/Tests/KeyPathTests/RuleCollections/RuleCollectionDeduplicatorTests.swift
@@ -219,6 +219,39 @@ final class RuleCollectionDeduplicatorTests: XCTestCase {
         XCTAssertTrue(conflicts.isEmpty, "Distinct activator keys do not conflict")
     }
 
+    func testNoActivatorConflictWhenSameKeyDifferentSourceLayers() {
+        // A key can carry a different binding per source layer. `f` activating one
+        // layer from base and another from nav is a valid chained-layer setup
+        // (e.g. Home Row Arrows on base + Function layer reached from nav), not a
+        // conflict — the generator places them in separate layers.
+        let fromBase = RuleCollection(
+            name: "Home Row Arrows",
+            summary: "Arrows",
+            category: .navigation,
+            mappings: [KeyMapping(input: "h", action: .keystroke(key: "left"))],
+            isEnabled: true,
+            targetLayer: .navigation,
+            momentaryActivator: MomentaryActivator(input: "f", targetLayer: .navigation, sourceLayer: .base)
+        )
+
+        let fromNav = RuleCollection(
+            name: "Function Layer",
+            summary: "Function",
+            category: .productivity,
+            mappings: [KeyMapping(input: "j", action: .keystroke(key: "f5"))],
+            isEnabled: true,
+            targetLayer: .custom("function"),
+            momentaryActivator: MomentaryActivator(input: "f", targetLayer: .custom("function"), sourceLayer: .navigation)
+        )
+
+        let conflicts = RuleCollectionDeduplicator.detectConflicts(in: [fromBase, fromNav])
+
+        XCTAssertFalse(
+            conflicts.contains { $0.inputKey == "f" },
+            "Same activator key on different source layers is a valid chained setup, not a conflict"
+        )
+    }
+
     func testDisabledCollectionActivatorIgnoredInConflictDetection() {
         let enabled = RuleCollection(
             name: "Vim Nav",


### PR DESCRIPTION
## Summary

Closes the silent-dedup gap from issue #466 (part of the ADR-039 conflict-detection cluster).

When two enabled collections claim the **same physical activator key** but route it to **different layers**, `buildCollectionBlocks`'s `seenActivators` set silently dropped one. The user saw one collection's layer activation work and the other vanish, with no explanation — a violation of [ADR-039](docs/adr/adr-039-key-conflict-resolution-principles.md) §1 ("never silently discard a user's intent").

This moves the check into `RuleCollectionDeduplicator.detectConflicts()`, so the conflict surfaces through the existing `MappingConflictInfo → KeyPathError.mappingConflicts` thrown-error gate **before config generation** (ADR-039 §2, "detect at the earliest moment"), consistent with how cross-collection key overlaps and chord-group conflicts already surface.

## Behavior

- **Conflict** — two enabled collections whose normalized activator keys match but target **different** layers. Surfaced with the collection names and which layer each activates.
- **Not a conflict** — same key + **same** target layer. These are redundant (both want the same layer activated the same way); dedup harmlessly keeps one. This matches the existing toggle-time `conflictInfo` semantics, so detection doesn't over-fire.
- `hyper` activators and disabled collections are skipped, consistent with generation.

## Scope

Collection-vs-collection only. **Leader-key-vs-activator** collisions (the system leader key colliding with a collection activator) are deferred to **#463**, which threads `leaderKeyPreference` into `detectConflicts()`.

## Tests

Added to `RuleCollectionDeduplicatorTests`:
- conflict surfaced when two activators target different layers
- no conflict when they target the same layer (redundant)
- no conflict for distinct keys
- disabled-collection activators ignored

Full suite green (`swift test`), SwiftFormat 0.61.1 clean on changed files.

Fixes #466

🤖 Generated with [Claude Code](https://claude.com/claude-code)