### PR TITLE
fix: detect leader-key vs collection-activator conflicts (#463)

### DIFF
--- a/Sources/KeyPathAppKit/Infrastructure/Config/ConfigurationService.swift
+++ b/Sources/KeyPathAppKit/Infrastructure/Config/ConfigurationService.swift
@@ -241,9 +241,21 @@ public final class ConfigurationService: FileConfigurationProviding {
             )
         }
 
+        // Get leader key preference and trigger mode from PreferencesService on MainActor.
+        // Fetched before conflict detection so the leader key participates in it (#463).
+        let (leaderKeyPref, triggerMode, holdDelayMs) = await MainActor.run {
+            (PreferencesService.shared.leaderKeyPreference,
+             PreferencesService.shared.contextHUDTriggerMode,
+             PreferencesService.shared.contextHUDHoldDelayMs)
+        }
+
         // DETECT CONFLICTS BEFORE DEDUPLICATION
-        // This catches cases where multiple collections map the same key
-        let conflicts = RuleCollectionDeduplicator.detectConflicts(in: collectionsForConfig)
+        // This catches cases where multiple collections map the same key, and where
+        // a collection activator collides with the system leader key (#463).
+        let conflicts = RuleCollectionDeduplicator.detectConflicts(
+            in: collectionsForConfig,
+            leaderKey: leaderKeyPref
+        )
         if !conflicts.isEmpty {
             AppLogger.shared.log(
                 "⚠️ [ConfigService] Mapping conflicts detected: \(conflicts.map(\.description).joined(separator: "; "))"
@@ -256,13 +268,6 @@ public final class ConfigurationService: FileConfigurationProviding {
         let mappings = combinedCollections.enabledMappings()
         let preservedChordGroups = loadPreservedChordGroups()
         let preservedSequences = loadPreservedSequences()
-
-        // Get leader key preference and trigger mode from PreferencesService on MainActor
-        let (leaderKeyPref, triggerMode, holdDelayMs) = await MainActor.run {
-            (PreferencesService.shared.leaderKeyPreference,
-             PreferencesService.shared.contextHUDTriggerMode,
-             PreferencesService.shared.contextHUDHoldDelayMs)
-        }
 
         let configContent = KanataConfiguration.generateFromCollections(
             combinedCollections,

--- a/Sources/KeyPathAppKit/Models/RuleCollectionDeduplicator.swift
+++ b/Sources/KeyPathAppKit/Models/RuleCollectionDeduplicator.swift
@@ -44,6 +44,22 @@ enum RuleCollectionDeduplicator {
             }
         }
 
+        // The leader key (#463) also consumes its physical key's BASE-layer slot:
+        // buildCollectionBlocks emits the leader as a base entry (tap = key, hold =
+        // layer) before any collection, and deduplicateBlocks keeps it over a later
+        // base mapping — so a base-layer collection or custom rule that maps the same
+        // key is silently dropped. Claim that base slot so the collision surfaces.
+        if let leaderKey, leaderKey.enabled {
+            let normalizedInput = KanataKeyConverter.convertToKanataKey(leaderKey.key)
+            let inputKey = InputKey(input: normalizedInput, layer: .base)
+            claimedKeys[inputKey, default: []].append(
+                ClaimInfo(
+                    collectionName: "Leader Key",
+                    holdDescription: "\(leaderKey.targetLayer.displayName) layer"
+                )
+            )
+        }
+
         var conflicts: [KeyPathError.MappingConflictInfo] = []
         for (inputKey, claims) in claimedKeys where claims.count > 1 {
             let collectionNames = claims.map(\.collectionName)

--- a/Sources/KeyPathAppKit/Models/RuleCollectionDeduplicator.swift
+++ b/Sources/KeyPathAppKit/Models/RuleCollectionDeduplicator.swift
@@ -10,7 +10,10 @@ enum RuleCollectionDeduplicator {
     ///
     /// Uses `effectiveMappings(for:)` to include config-generated mappings (Home Row Mods,
     /// Layer Toggles, etc.) — not just the raw `.mappings` array.
-    static func detectConflicts(in collections: [RuleCollection]) -> [KeyPathError.MappingConflictInfo] {
+    static func detectConflicts(
+        in collections: [RuleCollection],
+        leaderKey: LeaderKeyPreference? = nil
+    ) -> [KeyPathError.MappingConflictInfo] {
         struct ClaimInfo {
             let collectionName: String
             let holdDescription: String?
@@ -78,6 +81,20 @@ enum RuleCollectionDeduplicator {
             let targetLayer: RuleCollectionLayer
         }
         var activatorClaims: [ActivatorSlot: [ActivatorClaim]] = [:]
+        // The system leader key (#463) is an activator too: pressing it from the
+        // base layer activates its target layer. buildCollectionBlocks seeds it into
+        // seenActivators before any collection, so a collection activator on the
+        // same base-layer key is silently dropped — include it as a claim so the
+        // collision is surfaced instead.
+        if let leaderKey, leaderKey.enabled {
+            let slot = ActivatorSlot(
+                sourceLayer: .base,
+                input: KanataKeyConverter.convertToKanataKey(leaderKey.key)
+            )
+            activatorClaims[slot, default: []].append(
+                ActivatorClaim(collectionName: "Leader Key", targetLayer: leaderKey.targetLayer)
+            )
+        }
         for collection in collections where collection.isEnabled {
             guard let activator = collection.momentaryActivator else { continue }
             // "hyper" activators are folded into the hyper hold action, not emitted

--- a/Tests/KeyPathTests/RuleCollections/RuleCollectionDeduplicatorTests.swift
+++ b/Tests/KeyPathTests/RuleCollections/RuleCollectionDeduplicatorTests.swift
@@ -282,6 +282,127 @@ final class RuleCollectionDeduplicatorTests: XCTestCase {
         )
     }
 
+    // MARK: - Leader Key vs Activator Conflict Detection (#463)
+
+    func testDetectsConflictBetweenLeaderKeyAndCollectionActivator() {
+        // The system leader key (space → nav, from base) and a collection that
+        // claims the same physical key from base but routes it to a different layer
+        // collide. buildCollectionBlocks inserts the leader alias into seenActivators
+        // first, so the collection's activator is silently dropped — surface it.
+        let leader = LeaderKeyPreference(key: "space", targetLayer: .navigation, enabled: true)
+
+        let windowCollection = RuleCollection(
+            name: "Window Mgmt",
+            summary: "Window",
+            category: .productivity,
+            mappings: [KeyMapping(input: "y", action: .keystroke(key: "left"))],
+            isEnabled: true,
+            targetLayer: .custom("window"),
+            momentaryActivator: MomentaryActivator(input: "space", targetLayer: .custom("window"))
+        )
+
+        let conflicts = RuleCollectionDeduplicator.detectConflicts(
+            in: [windowCollection],
+            leaderKey: leader
+        )
+
+        let conflict = conflicts.first { $0.inputKey == "spc" }
+        XCTAssertNotNil(conflict, "Leader key colliding with a collection activator should be surfaced")
+        XCTAssertTrue(conflict?.conflictingCollections.contains("Window Mgmt") ?? false)
+    }
+
+    func testNoConflictWhenLeaderKeyMatchesCollectionActivatorExactly() {
+        // The leader key (space → nav) and a nav collection's own space → nav
+        // activator describe the same activation — redundant, not a conflict.
+        let leader = LeaderKeyPreference(key: "space", targetLayer: .navigation, enabled: true)
+
+        let navCollection = RuleCollection(
+            name: "Vim Nav",
+            summary: "Nav",
+            category: .navigation,
+            mappings: [KeyMapping(input: "h", action: .keystroke(key: "left"))],
+            isEnabled: true,
+            targetLayer: .navigation,
+            momentaryActivator: MomentaryActivator(input: "space", targetLayer: .navigation)
+        )
+
+        let conflicts = RuleCollectionDeduplicator.detectConflicts(
+            in: [navCollection],
+            leaderKey: leader
+        )
+
+        XCTAssertFalse(
+            conflicts.contains { $0.inputKey == "spc" },
+            "Leader key matching a collection activator exactly is redundant, not a conflict"
+        )
+    }
+
+    func testNoConflictWhenLeaderKeyDisabled() {
+        let leader = LeaderKeyPreference(key: "space", targetLayer: .navigation, enabled: false)
+
+        let windowCollection = RuleCollection(
+            name: "Window Mgmt",
+            summary: "Window",
+            category: .productivity,
+            mappings: [KeyMapping(input: "y", action: .keystroke(key: "left"))],
+            isEnabled: true,
+            targetLayer: .custom("window"),
+            momentaryActivator: MomentaryActivator(input: "space", targetLayer: .custom("window"))
+        )
+
+        let conflicts = RuleCollectionDeduplicator.detectConflicts(
+            in: [windowCollection],
+            leaderKey: leader
+        )
+
+        XCTAssertTrue(conflicts.isEmpty, "A disabled leader key must not produce conflicts")
+    }
+
+    func testNoConflictWhenLeaderKeyDifferentKey() {
+        let leader = LeaderKeyPreference(key: "caps", targetLayer: .navigation, enabled: true)
+
+        let windowCollection = RuleCollection(
+            name: "Window Mgmt",
+            summary: "Window",
+            category: .productivity,
+            mappings: [KeyMapping(input: "y", action: .keystroke(key: "left"))],
+            isEnabled: true,
+            targetLayer: .custom("window"),
+            momentaryActivator: MomentaryActivator(input: "space", targetLayer: .custom("window"))
+        )
+
+        let conflicts = RuleCollectionDeduplicator.detectConflicts(
+            in: [windowCollection],
+            leaderKey: leader
+        )
+
+        XCTAssertTrue(conflicts.isEmpty, "Leader key on a different physical key does not conflict")
+    }
+
+    func testNoConflictWhenLeaderKeyCollidesWithChainedActivator() {
+        // Leader key activates nav from base; a collection reaches another layer
+        // using the same key but FROM the nav layer (chained). Different source
+        // layers — valid, not a conflict.
+        let leader = LeaderKeyPreference(key: "f", targetLayer: .navigation, enabled: true)
+
+        let chained = RuleCollection(
+            name: "Function Layer",
+            summary: "Function",
+            category: .productivity,
+            mappings: [KeyMapping(input: "j", action: .keystroke(key: "f5"))],
+            isEnabled: true,
+            targetLayer: .custom("function"),
+            momentaryActivator: MomentaryActivator(input: "f", targetLayer: .custom("function"), sourceLayer: .navigation)
+        )
+
+        let conflicts = RuleCollectionDeduplicator.detectConflicts(
+            in: [chained],
+            leaderKey: leader
+        )
+
+        XCTAssertTrue(conflicts.isEmpty, "Leader (base) vs chained activator (nav) on the same key is valid")
+    }
+
     // MARK: - Deduplication Tests
 
     func testDisabledCollectionDoesNotClaimKeysInDedupe() {

--- a/Tests/KeyPathTests/RuleCollections/RuleCollectionDeduplicatorTests.swift
+++ b/Tests/KeyPathTests/RuleCollections/RuleCollectionDeduplicatorTests.swift
@@ -403,6 +403,52 @@ final class RuleCollectionDeduplicatorTests: XCTestCase {
         XCTAssertTrue(conflicts.isEmpty, "Leader (base) vs chained activator (nav) on the same key is valid")
     }
 
+    func testDetectsConflictWhenBaseMappingShadowsLeaderKey() {
+        // A base-layer collection that maps the leader's physical key collides:
+        // buildCollectionBlocks emits the leader's base entry and deduplicateBlocks
+        // keeps it, silently dropping the user's base mapping.
+        let leader = LeaderKeyPreference(key: "space", targetLayer: .navigation, enabled: true)
+
+        let baseCollection = RuleCollection(
+            name: "Custom Base",
+            summary: "Base",
+            category: .custom,
+            mappings: [KeyMapping(input: "space", action: .keystroke(key: "backspace"))],
+            isEnabled: true,
+            targetLayer: .base
+        )
+
+        let conflicts = RuleCollectionDeduplicator.detectConflicts(
+            in: [baseCollection],
+            leaderKey: leader
+        )
+
+        let conflict = conflicts.first { $0.inputKey == "spc" }
+        XCTAssertNotNil(conflict, "A base mapping of the leader key should be surfaced as a conflict")
+        XCTAssertTrue(conflict?.conflictingCollections.contains("Leader Key") ?? false)
+        XCTAssertTrue(conflict?.conflictingCollections.contains("Custom Base") ?? false)
+    }
+
+    func testNoConflictWhenBaseMappingDiffersFromLeaderKey() {
+        let leader = LeaderKeyPreference(key: "space", targetLayer: .navigation, enabled: true)
+
+        let baseCollection = RuleCollection(
+            name: "Custom Base",
+            summary: "Base",
+            category: .custom,
+            mappings: [KeyMapping(input: "caps", action: .keystroke(key: "escape"))],
+            isEnabled: true,
+            targetLayer: .base
+        )
+
+        let conflicts = RuleCollectionDeduplicator.detectConflicts(
+            in: [baseCollection],
+            leaderKey: leader
+        )
+
+        XCTAssertTrue(conflicts.isEmpty, "A base mapping on a different key does not conflict with the leader")
+    }
+
     // MARK: - Deduplication Tests
 
     func testDisabledCollectionDoesNotClaimKeysInDedupe() {


### PR DESCRIPTION
## Summary

Part of the ADR-039 conflict-detection cluster; builds directly on #466.

The system leader key generates a **base-layer** activation independently of collections, and `buildCollectionBlocks` seeds it into `seenActivators` *before* any collection (KanataConfiguration+BlockBuilders.swift:63–117). So a collection whose momentary activator claims the same base-layer key but routes it to a **different** layer was silently dropped — the user saw the leader's activation work and the collection's vanish, with no explanation ([ADR-039](docs/adr/adr-039-key-conflict-resolution-principles.md) §1).

This threads `leaderKeyPreference` into `RuleCollectionDeduplicator.detectConflicts()` as a synthetic activator claim (slot = `base` + leader key, target = leader's target layer). It then flows through the same `(sourceLayer, input)`-slot logic added in #466.

## Behavior

- **Conflict** — a collection activator on the same base slot as the leader, routing to a *different* layer (e.g. leader `space → nav` + collection `space → window` from base). Surfaced as a "Leader Key" vs collection conflict.
- **Not a conflict** — exact match (default `space → nav` leader vs a nav collection's own `space → nav` activator) is redundant; a same-key chained activator from a *different* source layer (`f → nav` from base vs `f → function` from nav) is a valid chained setup.
- Disabled leader key contributes no claim.

`ConfigurationService` now fetches the leader preference *before* conflict detection so it participates in the gate.

## Regression check

Verified against all 22 seeded collections: only Vim ships a base-layer `space` activator, and it targets `nav` — redundant with the default `space → nav` leader, so it's correctly skipped. No default-enabled collection routes base-`space` to a non-nav layer, so default configs do not begin throwing.

## Tests

Added to `RuleCollectionDeduplicatorTests`: leader-vs-activator conflict surfaced; exact-match redundancy; disabled leader; different key; cross-source-layer chained activator. Full suite green; SwiftFormat 0.61.1 clean on changed files.

Fixes #463

🤖 Generated with [Claude Code](https://claude.com/claude-code)