### PR TITLE
fix: detect duplicate chord group names (#464)

### DIFF
--- a/Sources/KeyPathAppKit/Models/ChordGroupsConfig.swift
+++ b/Sources/KeyPathAppKit/Models/ChordGroupsConfig.swift
@@ -67,11 +67,15 @@ public struct ChordGroupsConfig: Codable, Equatable, Sendable {
     /// two groups with the same name produce duplicate blocks that kanata rejects.
     /// Names are compared exactly (kanata identifiers are case-sensitive).
     ///
+    /// Only groups that actually render are counted: a group with no enabled
+    /// chords is skipped by the renderer, so it cannot collide — counting it would
+    /// flag a false conflict for draft/empty groups.
+    ///
     /// - Returns: One entry per duplicated name, with the number of groups using it,
     ///   sorted by name for stable output.
     public func detectDuplicateGroupNames() -> [(name: String, count: Int)] {
         var counts: [String: Int] = [:]
-        for group in groups {
+        for group in groups where group.chords.contains(where: \.isEnabled) {
             counts[group.name, default: 0] += 1
         }
         return counts

--- a/Sources/KeyPathAppKit/Models/ChordGroupsConfig.swift
+++ b/Sources/KeyPathAppKit/Models/ChordGroupsConfig.swift
@@ -61,6 +61,25 @@ public struct ChordGroupsConfig: Codable, Equatable, Sendable {
         !detectCrossGroupConflicts().isEmpty
     }
 
+    /// Detect chord groups that share the same name.
+    ///
+    /// Each group renders to a `(defchords <name> …)` block keyed by its name;
+    /// two groups with the same name produce duplicate blocks that kanata rejects.
+    /// Names are compared exactly (kanata identifiers are case-sensitive).
+    ///
+    /// - Returns: One entry per duplicated name, with the number of groups using it,
+    ///   sorted by name for stable output.
+    public func detectDuplicateGroupNames() -> [(name: String, count: Int)] {
+        var counts: [String: Int] = [:]
+        for group in groups {
+            counts[group.name, default: 0] += 1
+        }
+        return counts
+            .filter { $0.value > 1 }
+            .map { (name: $0.key, count: $0.value) }
+            .sorted { $0.name < $1.name }
+    }
+
     /// Get groups that conflict with a specific group.
     /// Returns groups that share keys with the specified group.
     public func conflictingGroups(for groupID: UUID) -> [ChordGroup] {

--- a/Sources/KeyPathAppKit/Models/RuleCollectionDeduplicator.swift
+++ b/Sources/KeyPathAppKit/Models/RuleCollectionDeduplicator.swift
@@ -140,6 +140,23 @@ enum RuleCollectionDeduplicator {
         // produces duplicate aliases that kanata rejects.
         for collection in collections where collection.isEnabled {
             if case let .chordGroups(config) = collection.configuration {
+                // Duplicate group names (#464): each group renders to a
+                // `(defchords <name> …)` block keyed by its name, so two groups
+                // sharing a name produce duplicate blocks that kanata rejects.
+                for duplicate in config.detectDuplicateGroupNames() {
+                    conflicts.append(KeyPathError.MappingConflictInfo(
+                        inputKey: duplicate.name,
+                        layer: collection.targetLayer.displayName,
+                        conflictingCollections: Array(
+                            repeating: "chord group '\(duplicate.name)'",
+                            count: duplicate.count
+                        ),
+                        holdDescriptions: [
+                            "\(duplicate.count) chord groups share the name '\(duplicate.name)' — chord group names must be unique"
+                        ]
+                    ))
+                }
+
                 let chordConflicts = config.detectCrossGroupConflicts()
                 for conflict in chordConflicts {
                     let groupNames = conflict.groups.map(\.name)

--- a/Tests/KeyPathTests/Models/ChordGroupsConfigTests.swift
+++ b/Tests/KeyPathTests/Models/ChordGroupsConfigTests.swift
@@ -187,6 +187,22 @@ final class ChordGroupsConfigTests: XCTestCase {
         XCTAssertTrue(config.detectDuplicateGroupNames().isEmpty)
     }
 
+    func testNoDuplicateWhenOneGroupHasNoEnabledChords() {
+        // The renderer skips groups with no enabled chords, so they never emit a
+        // (defchords …) block and cannot collide — don't flag them as duplicates.
+        let disabledChord = ChordDefinition(id: UUID(), keys: ["j", "k"], action: .keystroke(key: "up"), isEnabled: false)
+        let config = ChordGroupsConfig(groups: [
+            ChordGroup(id: UUID(), name: "Navigation", timeout: 250,
+                       chords: [ChordDefinition(id: UUID(), keys: ["s", "d"], action: .keystroke(key: "esc"))]),
+            ChordGroup(id: UUID(), name: "Navigation", timeout: 300, chords: [disabledChord])
+        ])
+
+        XCTAssertTrue(
+            config.detectDuplicateGroupNames().isEmpty,
+            "A same-named group with no enabled chords doesn't render, so it isn't a conflict"
+        )
+    }
+
     func testDuplicateGroupNamesCaseSensitive() {
         // Kanata identifiers are case-sensitive, so "Nav" and "nav" do not collide.
         let config = ChordGroupsConfig(groups: [

--- a/Tests/KeyPathTests/Models/ChordGroupsConfigTests.swift
+++ b/Tests/KeyPathTests/Models/ChordGroupsConfigTests.swift
@@ -160,6 +160,45 @@ final class ChordGroupsConfigTests: XCTestCase {
         XCTAssertEqual(conflicts.count, 0, "Should not detect conflicts for different key combinations")
     }
 
+    // MARK: - Duplicate Group Names (#464)
+
+    func testDetectsDuplicateGroupNames() {
+        let config = ChordGroupsConfig(groups: [
+            ChordGroup(id: UUID(), name: "Navigation", timeout: 250,
+                       chords: [ChordDefinition(id: UUID(), keys: ["s", "d"], action: .keystroke(key: "esc"))]),
+            ChordGroup(id: UUID(), name: "Navigation", timeout: 300,
+                       chords: [ChordDefinition(id: UUID(), keys: ["j", "k"], action: .keystroke(key: "up"))])
+        ])
+
+        let duplicates = config.detectDuplicateGroupNames()
+        XCTAssertEqual(duplicates.count, 1)
+        XCTAssertEqual(duplicates.first?.name, "Navigation")
+        XCTAssertEqual(duplicates.first?.count, 2)
+    }
+
+    func testNoDuplicateGroupNamesWhenUnique() {
+        let config = ChordGroupsConfig(groups: [
+            ChordGroup(id: UUID(), name: "Navigation", timeout: 250,
+                       chords: [ChordDefinition(id: UUID(), keys: ["s", "d"], action: .keystroke(key: "esc"))]),
+            ChordGroup(id: UUID(), name: "Editing", timeout: 300,
+                       chords: [ChordDefinition(id: UUID(), keys: ["j", "k"], action: .keystroke(key: "up"))])
+        ])
+
+        XCTAssertTrue(config.detectDuplicateGroupNames().isEmpty)
+    }
+
+    func testDuplicateGroupNamesCaseSensitive() {
+        // Kanata identifiers are case-sensitive, so "Nav" and "nav" do not collide.
+        let config = ChordGroupsConfig(groups: [
+            ChordGroup(id: UUID(), name: "Nav", timeout: 250,
+                       chords: [ChordDefinition(id: UUID(), keys: ["s", "d"], action: .keystroke(key: "esc"))]),
+            ChordGroup(id: UUID(), name: "nav", timeout: 300,
+                       chords: [ChordDefinition(id: UUID(), keys: ["j", "k"], action: .keystroke(key: "up"))])
+        ])
+
+        XCTAssertTrue(config.detectDuplicateGroupNames().isEmpty)
+    }
+
     // MARK: - Chord Definition
 
     func testChordDefinitionRecommendedCombo() {

--- a/Tests/KeyPathTests/RuleCollections/RuleCollectionDeduplicatorTests.swift
+++ b/Tests/KeyPathTests/RuleCollections/RuleCollectionDeduplicatorTests.swift
@@ -449,6 +449,54 @@ final class RuleCollectionDeduplicatorTests: XCTestCase {
         XCTAssertTrue(conflicts.isEmpty, "A base mapping on a different key does not conflict with the leader")
     }
 
+    // MARK: - Duplicate Chord Group Name Detection (#464)
+
+    func testDetectsDuplicateChordGroupNames() {
+        let config = ChordGroupsConfig(groups: [
+            ChordGroup(id: UUID(), name: "Navigation", timeout: 250,
+                       chords: [ChordDefinition(id: UUID(), keys: ["s", "d"], action: .keystroke(key: "esc"))]),
+            ChordGroup(id: UUID(), name: "Navigation", timeout: 300,
+                       chords: [ChordDefinition(id: UUID(), keys: ["j", "k"], action: .keystroke(key: "up"))])
+        ])
+        let collection = RuleCollection(
+            id: RuleCollectionIdentifier.chordGroups,
+            name: "Chord Groups",
+            summary: "Test",
+            category: .productivity,
+            mappings: [],
+            isEnabled: true,
+            configuration: .chordGroups(config)
+        )
+
+        let conflicts = RuleCollectionDeduplicator.detectConflicts(in: [collection])
+
+        let conflict = conflicts.first { $0.inputKey == "Navigation" }
+        XCTAssertNotNil(conflict, "Duplicate chord group names should be surfaced")
+        XCTAssertEqual(conflict?.conflictingCollections.count, 2)
+    }
+
+    func testNoConflictWhenChordGroupNamesUnique() {
+        let config = ChordGroupsConfig(groups: [
+            ChordGroup(id: UUID(), name: "Navigation", timeout: 250,
+                       chords: [ChordDefinition(id: UUID(), keys: ["s", "d"], action: .keystroke(key: "esc"))]),
+            ChordGroup(id: UUID(), name: "Editing", timeout: 300,
+                       chords: [ChordDefinition(id: UUID(), keys: ["j", "k"], action: .keystroke(key: "up"))])
+        ])
+        let collection = RuleCollection(
+            id: RuleCollectionIdentifier.chordGroups,
+            name: "Chord Groups",
+            summary: "Test",
+            category: .productivity,
+            mappings: [],
+            isEnabled: true,
+            configuration: .chordGroups(config)
+        )
+
+        let conflicts = RuleCollectionDeduplicator.detectConflicts(in: [collection])
+
+        XCTAssertTrue(conflicts.isEmpty, "Unique chord group names do not conflict")
+    }
+
     // MARK: - Deduplication Tests
 
     func testDisabledCollectionDoesNotClaimKeysInDedupe() {


### PR DESCRIPTION
## Summary

Part of the ADR-039 conflict-detection cluster.

Each chord group renders to a `(defchords <name> …)` block keyed by its name (KanataConfiguration+Rendering.swift:376/:325). Two groups sharing a name emit duplicate blocks that kanata rejects — previously caught only by `kanata --check`, never surfaced in KeyPath's own pre-flight detection (`detectCrossGroupConflicts()` checks shared *keys*, not names).

This adds `ChordGroupsConfig.detectDuplicateGroupNames()` and surfaces it through the existing chord-group branch of `RuleCollectionDeduplicator.detectConflicts()`, so it flows through the same `MappingConflictInfo` → thrown-error gate as every other conflict, before config generation (ADR-039 §2).

## Behavior

- **Conflict** — two groups in the same `ChordGroupsConfig` with the same exact name.
- Names compared **case-sensitively** (kanata identifiers are case-sensitive; `Nav` and `nav` are distinct).
- Unique names do not conflict. Verified the seeded `benVallackPreset` (groups "Navigation" + "Editing") is unaffected.

## Scope / follow-up

Scoped to within a single `ChordGroupsConfig` (the issue's case). A UI-authored group name colliding with a **preserved hand-written** `(defchords …)` block is a separate, pre-existing gap (different type and rendering source — `ChordGroupConfig` parsed from manual config) and is worth a follow-up; it's not introduced by this change.

## Tests

- `ChordGroupsConfigTests`: detects duplicate names, ignores unique names, case-sensitivity.
- `RuleCollectionDeduplicatorTests`: duplicate names surface via `detectConflicts`; unique names don't.

Full suite green; SwiftFormat 0.61.1 clean on changed files.

Fixes #464

🤖 Generated with [Claude Code](https://claude.com/claude-code)