### PR TITLE
fix: detect duplicate keys within a single app's keymap (#465)

### DIFF
--- a/Sources/KeyPathAppKit/Services/Configuration/AppConfigGenerator.swift
+++ b/Sources/KeyPathAppKit/Services/Configuration/AppConfigGenerator.swift
@@ -11,6 +11,8 @@ public enum AppConfigError: LocalizedError, Equatable {
     case writeFailed(path: String, underlying: String)
     /// No ConfigurationService available for validation
     case validationUnavailable
+    /// One or more apps map the same input key more than once (#465)
+    case duplicateKeys(duplicates: [AppKeymapDuplicate])
 
     public var errorDescription: String? {
         switch self {
@@ -20,6 +22,10 @@ public enum AppConfigError: LocalizedError, Equatable {
             "Failed to write app config to \(path): \(underlying)"
         case .validationUnavailable:
             "Config validation service unavailable"
+        case let .duplicateKeys(duplicates):
+            "Duplicate keys in app keymap(s): "
+                + duplicates.map { "\($0.app) maps \($0.keys.joined(separator: ", ")) more than once" }
+                .joined(separator: "; ")
         }
     }
 
@@ -35,7 +41,21 @@ public enum AppConfigError: LocalizedError, Equatable {
             return "Could not save config to \(path)"
         case .validationUnavailable:
             return "Validation service unavailable"
+        case let .duplicateKeys(duplicates):
+            guard let first = duplicates.first else { return "Duplicate keys in an app keymap" }
+            return "\(first.app) maps \(first.keys.joined(separator: ", ")) more than once — each key can have only one action per app."
         }
+    }
+}
+
+/// Describes input keys that an app's keymap maps more than once.
+public struct AppKeymapDuplicate: Equatable, Sendable {
+    public let app: String
+    public let keys: [String]
+
+    public init(app: String, keys: [String]) {
+        self.app = app
+        self.keys = keys
     }
 }
 
@@ -92,6 +112,34 @@ public enum AppConfigGenerator {
 
     // MARK: - Generation
 
+    /// Detect input keys that an enabled app maps more than once (#465).
+    ///
+    /// Each `kp-<key>` alias is generated once per input key and dispatches per app
+    /// via a switch expression. Cross-app duplicates (the same key in different apps)
+    /// are valid — that's the whole point of the switch. But the same key appearing
+    /// twice *within one app* produces two switch cases with the same condition: the
+    /// second is unreachable, so the user's second mapping is silently dropped.
+    ///
+    /// Keys are compared lowercased, matching how `generateAliasBlock` keys them.
+    /// Only enabled apps are checked — disabled apps don't render.
+    ///
+    /// - Returns: One entry per app that has duplicates, with the duplicated keys
+    ///   sorted, in input order of `keymaps`.
+    public static func detectDuplicateKeys(in keymaps: [AppKeymap]) -> [AppKeymapDuplicate] {
+        var result: [AppKeymapDuplicate] = []
+        for keymap in keymaps where keymap.mapping.isEnabled {
+            var counts: [String: Int] = [:]
+            for override in keymap.overrides {
+                counts[override.inputKey.lowercased(), default: 0] += 1
+            }
+            let dups = counts.filter { $0.value > 1 }.keys.sorted()
+            if !dups.isEmpty {
+                result.append(AppKeymapDuplicate(app: keymap.mapping.displayName, keys: dups))
+            }
+        }
+        return result
+    }
+
     /// Generate the complete app-specific config file content.
     ///
     /// - Parameter keymaps: The app keymaps to generate config for.
@@ -129,6 +177,18 @@ public enum AppConfigGenerator {
         from keymaps: [AppKeymap],
         configService: ConfigurationService? = nil
     ) async throws {
+        // Detect within-app duplicate keys before generating — kanata accepts the
+        // resulting config (the duplicate switch case is just dead), so this would
+        // otherwise silently drop the user's second mapping (#465).
+        let duplicates = detectDuplicateKeys(in: keymaps)
+        if !duplicates.isEmpty {
+            AppLogger.shared.error(
+                "❌ [AppConfigGenerator] Duplicate keys within app keymap(s): "
+                    + duplicates.map { "\($0.app): \($0.keys.joined(separator: ", "))" }.joined(separator: "; ")
+            )
+            throw AppConfigError.duplicateKeys(duplicates: duplicates)
+        }
+
         let content = generate(from: keymaps)
         let path = appConfigPath
 

--- a/Sources/KeyPathAppKit/Services/Configuration/AppConfigGenerator.swift
+++ b/Sources/KeyPathAppKit/Services/Configuration/AppConfigGenerator.swift
@@ -114,27 +114,41 @@ public enum AppConfigGenerator {
 
     /// Detect input keys that an enabled app maps more than once (#465).
     ///
-    /// Each `kp-<key>` alias is generated once per input key and dispatches per app
-    /// via a switch expression. Cross-app duplicates (the same key in different apps)
-    /// are valid — that's the whole point of the switch. But the same key appearing
-    /// twice *within one app* produces two switch cases with the same condition: the
-    /// second is unreachable, so the user's second mapping is silently dropped.
+    /// Each `kp-<key>` alias dispatches per app via a switch expression. Cross-app
+    /// duplicates (the same key in different apps) are valid — that's the whole
+    /// point of the switch. But two switch cases with the *same* condition make the
+    /// second unreachable, so the user's second mapping is silently dropped. That
+    /// happens whenever the same input key is claimed twice for the same rendered
+    /// virtual key — either within one app entry, or across two entries for the
+    /// same app (a legacy/hand-edited store can hold duplicate app entries).
     ///
-    /// Keys are compared lowercased, matching how `generateAliasBlock` keys them.
-    /// Only enabled apps are checked — disabled apps don't render.
+    /// `generateAliasBlock` flattens overrides across all enabled keymaps and keys
+    /// switch cases by `virtualKeyName`, so detection groups the same way: by
+    /// virtual key, over all enabled keymaps, with keys compared lowercased.
     ///
-    /// - Returns: One entry per app that has duplicates, with the duplicated keys
-    ///   sorted, in input order of `keymaps`.
+    /// - Returns: One entry per app (virtual key) that has duplicates, with the
+    ///   duplicated keys sorted, in first-seen order of `keymaps`.
     public static func detectDuplicateKeys(in keymaps: [AppKeymap]) -> [AppKeymapDuplicate] {
-        var result: [AppKeymapDuplicate] = []
+        var order: [String] = [] // virtualKeyName, in first-seen order
+        var appName: [String: String] = [:] // virtualKeyName → display name
+        var counts: [String: [String: Int]] = [:] // virtualKeyName → (lowercased key → count)
+
         for keymap in keymaps where keymap.mapping.isEnabled {
-            var counts: [String: Int] = [:]
-            for override in keymap.overrides {
-                counts[override.inputKey.lowercased(), default: 0] += 1
+            let vkName = keymap.mapping.virtualKeyName
+            if counts[vkName] == nil {
+                order.append(vkName)
+                appName[vkName] = keymap.mapping.displayName
             }
-            let dups = counts.filter { $0.value > 1 }.keys.sorted()
+            for override in keymap.overrides {
+                counts[vkName, default: [:]][override.inputKey.lowercased(), default: 0] += 1
+            }
+        }
+
+        var result: [AppKeymapDuplicate] = []
+        for vkName in order {
+            let dups = (counts[vkName] ?? [:]).filter { $0.value > 1 }.keys.sorted()
             if !dups.isEmpty {
-                result.append(AppKeymapDuplicate(app: keymap.mapping.displayName, keys: dups))
+                result.append(AppKeymapDuplicate(app: appName[vkName] ?? vkName, keys: dups))
             }
         }
         return result

--- a/Tests/KeyPathTests/AppContext/AppConfigGeneratorTests.swift
+++ b/Tests/KeyPathTests/AppContext/AppConfigGeneratorTests.swift
@@ -130,6 +130,29 @@ final class AppConfigGeneratorTests: XCTestCase {
         XCTAssertEqual(AppConfigGenerator.detectDuplicateKeys(in: [keymap]).first?.keys, ["j"])
     }
 
+    func testDetectDuplicateKeys_SameKeyAcrossDuplicateAppEntries_Detected() {
+        // A legacy/hand-edited store can hold the same app as two entries. Both
+        // render to the same vk_safari switch, so the same key in each collides.
+        let keymaps = [
+            AppKeymap(
+                bundleIdentifier: "com.apple.Safari",
+                displayName: "Safari",
+                overrides: [AppKeyOverride(inputKey: "j", action: .keystroke(key: "down"))]
+            ),
+            AppKeymap(
+                bundleIdentifier: "com.apple.Safari",
+                displayName: "Safari",
+                overrides: [AppKeyOverride(inputKey: "j", action: .keystroke(key: "pgdn"))]
+            )
+        ]
+
+        let duplicates = AppConfigGenerator.detectDuplicateKeys(in: keymaps)
+
+        XCTAssertEqual(duplicates.count, 1)
+        XCTAssertEqual(duplicates.first?.app, "Safari")
+        XCTAssertEqual(duplicates.first?.keys, ["j"])
+    }
+
     func testDetectDuplicateKeys_DisabledAppIgnored() {
         let keymap = AppKeymap(
             mapping: AppKeyMapping(

--- a/Tests/KeyPathTests/AppContext/AppConfigGeneratorTests.swift
+++ b/Tests/KeyPathTests/AppContext/AppConfigGeneratorTests.swift
@@ -66,6 +66,89 @@ final class AppConfigGeneratorTests: XCTestCase {
         XCTAssertFalse(content.contains(" nop"), "Should NOT contain 'nop' - it's invalid Kanata")
     }
 
+    // MARK: - Duplicate Key Detection (#465)
+
+    func testDetectDuplicateKeys_SameKeyTwiceInOneApp_Detected() {
+        let keymap = AppKeymap(
+            bundleIdentifier: "com.apple.Safari",
+            displayName: "Safari",
+            overrides: [
+                AppKeyOverride(inputKey: "j", action: .keystroke(key: "down")),
+                AppKeyOverride(inputKey: "j", action: .keystroke(key: "pgdn"))
+            ]
+        )
+
+        let duplicates = AppConfigGenerator.detectDuplicateKeys(in: [keymap])
+
+        XCTAssertEqual(duplicates.count, 1)
+        XCTAssertEqual(duplicates.first?.app, "Safari")
+        XCTAssertEqual(duplicates.first?.keys, ["j"])
+    }
+
+    func testDetectDuplicateKeys_SameKeyDifferentApps_NotDetected() {
+        // Cross-app duplicates are valid — the switch expression dispatches per app.
+        let keymaps = [
+            AppKeymap(
+                bundleIdentifier: "com.apple.Safari",
+                displayName: "Safari",
+                overrides: [AppKeyOverride(inputKey: "j", action: .keystroke(key: "down"))]
+            ),
+            AppKeymap(
+                bundleIdentifier: "com.microsoft.VSCode",
+                displayName: "VS Code",
+                overrides: [AppKeyOverride(inputKey: "j", action: .keystroke(key: "pgdn"))]
+            )
+        ]
+
+        XCTAssertTrue(AppConfigGenerator.detectDuplicateKeys(in: keymaps).isEmpty)
+    }
+
+    func testDetectDuplicateKeys_UniqueKeys_NotDetected() {
+        let keymap = AppKeymap(
+            bundleIdentifier: "com.apple.Safari",
+            displayName: "Safari",
+            overrides: [
+                AppKeyOverride(inputKey: "j", action: .keystroke(key: "down")),
+                AppKeyOverride(inputKey: "k", action: .keystroke(key: "up"))
+            ]
+        )
+
+        XCTAssertTrue(AppConfigGenerator.detectDuplicateKeys(in: [keymap]).isEmpty)
+    }
+
+    func testDetectDuplicateKeys_CaseInsensitive() {
+        // Generation lowercases input keys, so "J" and "j" collide on the same alias.
+        let keymap = AppKeymap(
+            bundleIdentifier: "com.apple.Safari",
+            displayName: "Safari",
+            overrides: [
+                AppKeyOverride(inputKey: "J", action: .keystroke(key: "down")),
+                AppKeyOverride(inputKey: "j", action: .keystroke(key: "pgdn"))
+            ]
+        )
+
+        XCTAssertEqual(AppConfigGenerator.detectDuplicateKeys(in: [keymap]).first?.keys, ["j"])
+    }
+
+    func testDetectDuplicateKeys_DisabledAppIgnored() {
+        let keymap = AppKeymap(
+            mapping: AppKeyMapping(
+                bundleIdentifier: "com.apple.Safari",
+                displayName: "Safari",
+                isEnabled: false
+            ),
+            overrides: [
+                AppKeyOverride(inputKey: "j", action: .keystroke(key: "down")),
+                AppKeyOverride(inputKey: "j", action: .keystroke(key: "pgdn"))
+            ]
+        )
+
+        XCTAssertTrue(
+            AppConfigGenerator.detectDuplicateKeys(in: [keymap]).isEmpty,
+            "Disabled apps don't render, so their duplicates aren't conflicts"
+        )
+    }
+
     // MARK: - Kanata Keyword Safety
 
     func testGenerate_UsesKanataKeywordConstant() {


### PR DESCRIPTION
## Summary

Part of the ADR-039 conflict-detection cluster.

If the same input key appears twice in **one app's** keymap, `generateAliasBlock` emits two switch cases with the same `((input virtual vk_app))` condition in the `kp-<key>` alias. The second case is unreachable, so the user's second mapping is **silently dropped**. kanata accepts the config (a dead switch case is valid), so this slips past `kanata --check` entirely — it was never surfaced.

Cross-app duplicates (same key, different apps) remain valid — that's the whole point of the per-app switch dispatch.

## Change

- `AppConfigGenerator.detectDuplicateKeys(in:)` — returns per-app duplicated keys, compared **lowercased** and only for **enabled** apps, matching exactly what `generateAliasBlock` renders.
- New `AppConfigError.duplicateKeys` case + `AppKeymapDuplicate` struct.
- `generateAndSave` gates on it and throws before writing (detect-and-explain, ADR-039 §1).

## Why a backstop (and why throwing is safe here)

The UI save path already removes any existing override for the same key before appending (`MapperViewModel+AppKeymapIntegration.swift:51`), and Karabiner import replaces by bundle id — so **no normal flow produces a within-app duplicate**. This gate is a backstop for legacy / hand-edited `AppKeymaps.json`. The throw is consistent with the existing `validationFailed` throw in the same `generateAndSave` function (same blast radius / startup behavior).

## Follow-up (out of scope)

`regenerateFromStore()` regenerates **all** apps from the store, so a corrupt duplicate in one app would block regeneration of others (and leave a stale config at startup, logged not surfaced). This is a pre-existing property of the regenerate-all design (already true for `validationFailed`), not introduced here — worth a separate follow-up to isolate per-app failures / self-heal.

## Tests

`AppConfigGeneratorTests`: in-app duplicate detected; cross-app valid (not detected); unique keys; case-insensitive collision; disabled-app ignored.

Full suite green; SwiftFormat 0.61.1 clean on changed files.

Fixes #465

🤖 Generated with [Claude Code](https://claude.com/claude-code)