### PR TITLE
fix: detect alias-name collisions from key sanitization (#462)

### DIFF
--- a/Sources/KeyPathAppKit/Infrastructure/Config/KanataConfiguration+BlockBuilders.swift
+++ b/Sources/KeyPathAppKit/Infrastructure/Config/KanataConfiguration+BlockBuilders.swift
@@ -690,6 +690,29 @@ extension KanataConfiguration {
         return "beh_\(layer.kanataName)_\(sanitized)"
     }
 
+    /// The alias names `buildCollectionBlocks` would emit for a regular (non-chord)
+    /// mapping on the given layer, mirroring its path selection. Used by conflict
+    /// detection to catch alias-name collisions from key sanitization (#462) — e.g.
+    /// `caps-lock` and `caps_lock` both producing `beh_base_caps_lock`. Returns
+    /// empty for simple key outputs, which emit no alias.
+    static func generatedAliasNames(for mapping: KeyMapping, layer: RuleCollectionLayer) -> [String] {
+        var names: [String] = []
+        let trimmedOutput = mapping.action.kanataOutput.trimmingCharacters(in: .whitespacesAndNewlines)
+        if mapping.behavior != nil {
+            names.append(behaviorAliasName(for: mapping, layer: layer))
+        } else if mapping.requiresFork {
+            names.append(forkAliasName(for: mapping, layer: layer))
+        } else if trimmedOutput.hasPrefix("("), trimmedOutput.count > 1 {
+            names.append(actionAliasName(for: mapping, layer: layer))
+        }
+        // A per-device override wraps the output in an additional `dev_` alias,
+        // emitted regardless of which (if any) base alias was chosen above.
+        if let overrides = mapping.deviceOverrides, !overrides.isEmpty {
+            names.append(deviceSwitchAliasName(for: mapping, layer: layer))
+        }
+        return names
+    }
+
     /// Generate alias name for complex actions (push-msg, multi, etc.)
     static func actionAliasName(for mapping: KeyMapping, layer: RuleCollectionLayer) -> String {
         let sanitized =

--- a/Sources/KeyPathAppKit/Models/RuleCollectionDeduplicator.swift
+++ b/Sources/KeyPathAppKit/Models/RuleCollectionDeduplicator.swift
@@ -177,7 +177,54 @@ enum RuleCollectionDeduplicator {
             }
         }
 
-        return conflicts.sorted { $0.inputKey < $1.inputKey }
+        // Alias-name collisions (#462): generated alias names are
+        // `{prefix}_{layer}_{sanitized-input}`, and sanitization maps `-`/space (and,
+        // for device switches, any non-alphanumeric) to `_`. Two distinct input keys
+        // can therefore collapse to the same alias name (e.g. `caps-lock` and
+        // `caps_lock` → `beh_base_caps_lock`), which kanata rejects. These keys don't
+        // collide as defsrc inputs, so the key-overlap pass above misses them.
+        struct AliasOrigin {
+            let collectionName: String
+            let rawInput: String
+            let layer: String
+        }
+        var aliasOrigins: [String: [AliasOrigin]] = [:]
+        for collection in collections where collection.isEnabled {
+            for mapping in KanataConfiguration.effectiveMappings(for: collection) {
+                // Chord inputs (space-separated) render to defchordsv2, not aliases.
+                guard !mapping.input.contains(" ") else { continue }
+                for aliasName in KanataConfiguration.generatedAliasNames(
+                    for: mapping, layer: collection.targetLayer
+                ) {
+                    aliasOrigins[aliasName, default: []].append(AliasOrigin(
+                        collectionName: collection.name,
+                        rawInput: mapping.input,
+                        layer: collection.targetLayer.displayName
+                    ))
+                }
+            }
+        }
+        for (aliasName, origins) in aliasOrigins {
+            // Only a collision when *different* input keys produce the same alias.
+            // Same input across collections is already a key-overlap conflict above.
+            let distinctInputs = Set(origins.map(\.rawInput))
+            guard distinctInputs.count > 1 else { continue }
+            conflicts.append(KeyPathError.MappingConflictInfo(
+                inputKey: distinctInputs.sorted().joined(separator: " / "),
+                layer: origins.first?.layer ?? RuleCollectionLayer.base.displayName,
+                conflictingCollections: Array(Set(origins.map(\.collectionName))).sorted(),
+                holdDescriptions: ["keys \(distinctInputs.sorted().joined(separator: ", ")) all generate the alias '\(aliasName)'"]
+            ))
+        }
+
+        // Total ordering (inputKey, then layer, then explanation) so output is
+        // deterministic even when two conflicts share an inputKey — e.g. the same
+        // pair of keys colliding on two different alias prefixes at once.
+        return conflicts.sorted { lhs, rhs in
+            if lhs.inputKey != rhs.inputKey { return lhs.inputKey < rhs.inputKey }
+            if lhs.layer != rhs.layer { return lhs.layer < rhs.layer }
+            return lhs.holdDescriptions.joined() < rhs.holdDescriptions.joined()
+        }
     }
 
     /// Deduplicates collections by removing duplicate input keys.

--- a/Tests/KeyPathTests/RuleCollections/RuleCollectionDeduplicatorTests.swift
+++ b/Tests/KeyPathTests/RuleCollections/RuleCollectionDeduplicatorTests.swift
@@ -497,6 +497,67 @@ final class RuleCollectionDeduplicatorTests: XCTestCase {
         XCTAssertTrue(conflicts.isEmpty, "Unique chord group names do not conflict")
     }
 
+    // MARK: - Alias Name Collision Detection (#462)
+
+    func testDetectsAliasNameCollisionFromSanitization() {
+        // "caps-lock" and "caps_lock" are different input keys, but both sanitize
+        // to the alias stem "caps_lock" — so a complex-action mapping for each
+        // produces the same `act_base_caps_lock` alias, which kanata rejects.
+        let collection = RuleCollection(
+            name: "Custom",
+            summary: "Custom",
+            category: .custom,
+            mappings: [
+                KeyMapping(input: "caps-lock", action: .rawKanata("(macro h)")),
+                KeyMapping(input: "caps_lock", action: .rawKanata("(macro j)"))
+            ],
+            isEnabled: true,
+            targetLayer: .base
+        )
+
+        let conflicts = RuleCollectionDeduplicator.detectConflicts(in: [collection])
+
+        let aliasConflict = conflicts.first { $0.inputKey.contains("caps-lock") && $0.inputKey.contains("caps_lock") }
+        XCTAssertNotNil(aliasConflict, "Two keys sanitizing to the same alias name should be surfaced")
+    }
+
+    func testNoAliasCollisionForSimpleMappings() {
+        // Simple key outputs generate no alias, so they can't collide on alias names.
+        let collection = RuleCollection(
+            name: "Custom",
+            summary: "Custom",
+            category: .custom,
+            mappings: [
+                KeyMapping(input: "caps-lock", action: .keystroke(key: "esc")),
+                KeyMapping(input: "caps_lock", action: .keystroke(key: "tab"))
+            ],
+            isEnabled: true,
+            targetLayer: .base
+        )
+
+        let conflicts = RuleCollectionDeduplicator.detectConflicts(in: [collection])
+
+        XCTAssertTrue(conflicts.isEmpty, "Simple mappings generate no alias, so no alias collision")
+    }
+
+    func testNoAliasCollisionForDistinctStems() {
+        let collection = RuleCollection(
+            name: "Custom",
+            summary: "Custom",
+            category: .custom,
+            mappings: [
+                KeyMapping(input: "caps-lock", action: .rawKanata("(macro h)")),
+                KeyMapping(input: "tab", action: .rawKanata("(macro j)"))
+            ],
+            isEnabled: true,
+            targetLayer: .base
+        )
+
+        let conflicts = RuleCollectionDeduplicator.detectConflicts(in: [collection])
+
+        XCTAssertTrue(conflicts.isEmpty, "Distinct sanitized stems don't collide")
+    }
+
     // MARK: - Deduplication Tests
 
     func testDisabledCollectionDoesNotClaimKeysInDedupe() {


### PR DESCRIPTION
## Summary

Part of the ADR-039 conflict-detection cluster.

Generated alias names are `{prefix}_{layer}_{sanitized-input}`, where sanitization maps `-`/space (and, for device switches, any non-alphanumeric) to `_`. Two **distinct** input keys can therefore collapse to the same alias name — e.g. `caps-lock` and `caps_lock` both → `beh_base_caps_lock` — which kanata rejects. These keys don't collide as `defsrc` inputs, so the key-overlap pass misses them; previously this was caught only by the `deduplicateAliases` safety net (logs + keeps last) or `kanata --check`.

## Change

- `KanataConfiguration.generatedAliasNames(for:layer:)` — returns the alias names `buildCollectionBlocks` would emit for a regular mapping, by **calling the real alias-name functions** (`behaviorAliasName`/`forkAliasName`/`actionAliasName`/`deviceSwitchAliasName`) and mirroring its exact path selection, so it can't drift from generation. Simple key outputs emit no alias.
- A pass in `RuleCollectionDeduplicator.detectConflicts()` that flags when **more than one distinct input key** produces the same alias name. Keying on distinct inputs avoids double-reporting the same-input key conflicts the `claimedKeys` pass already handles.
- Final conflict ordering made a **total order** (inputKey → layer → explanation) for deterministic output.

## Correctness / over-fire

- Skips chord inputs (`input.contains(" ")`), matching generation's `regularMappings` filter.
- No over-fire on seeded data: no catalog/Vim/Vallack collection input key contains `-`/`_`/space, so nothing collides. Full suite green.
- Verified against `buildCollectionBlocks` line-by-line: path order (behavior → fork → complex-action → simple) plus the independent `dev_` alias all match.

## Follow-up (out of scope)

The `layer_*` activator/leader alias family (`aliasSafeName`) isn't covered here — two activator/leader keys differing only by separator could still produce a duplicate `layer_*` alias. That's a separate pre-existing gap (the activator-slot pass keys on `convertToKanataKey`, not the sanitized alias); #462 is scoped to the four mapping-alias generators it enumerates.

## Tests

`RuleCollectionDeduplicatorTests`: collision from sanitization detected; simple mappings (no alias) don't collide; distinct stems don't collide.

Full suite green; SwiftFormat 0.61.1 clean on changed files.

Fixes #462

🤖 Generated with [Claude Code](https://claude.com/claude-code)