### PR TITLE
fix: remove onChange that overwrites launcher mappings on restart

### DIFF
--- a/Sources/KeyPathAppKit/UI/Rules/LauncherCollectionView.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/LauncherCollectionView.swift
@@ -63,9 +63,6 @@ struct LauncherCollectionView: View {
                 onConfigChanged: onConfigChanged,
                 windowSnappingActive: windowSnappingActive
             )
-            .onChange(of: config) { _, newValue in
-                onConfigChanged(newValue)
-            }
         }
         .sheet(isPresented: $showBrowserHistory) {
             BrowserHistorySuggestionsView(existingDomains: existingDomains) { selectedSites in


### PR DESCRIPTION
## Summary
- Removes a redundant `onChange(of: config)` in `LauncherCollectionView` that fired on every binding update during app restart
- This overwrote user launcher mappings with stale in-memory state when `PackDetailView.refreshInstallState()` repopulated `launcherConfig`
- All user-initiated changes (drawer edits, activation mode, browser suggestions) already call `onConfigChanged` explicitly — the blanket `onChange` was redundant and harmful

## Test plan
- [x] Pre-push build passes
- [ ] CI green
- [ ] Verify launcher mappings persist across app restart