### PR TITLE
feat: inline resolution dialog for save-time mapping conflicts (#460)

### DIFF
--- a/Sources/KeyPathAppKit/Managers/RuntimeCoordinator.swift
+++ b/Sources/KeyPathAppKit/Managers/RuntimeCoordinator.swift
@@ -111,6 +111,10 @@ public class RuntimeCoordinator: SaveCoordinatorDelegate {
     var pendingRuleConflict: RuleConflictContext?
     var conflictResolutionContinuation: CheckedContinuation<RuleConflictChoice?, Never>?
 
+    // Save-time mapping conflict resolution state (#460)
+    var pendingMappingConflict: MappingConflictContext?
+    var mappingConflictContinuation: CheckedContinuation<UUID?, Never>?
+
     /// Rule collections are now managed by RuleCollectionsCoordinator
     var ruleCollections: [RuleCollection] {
         get { ruleCollectionsCoordinator.ruleCollections }
@@ -434,6 +438,9 @@ public class RuntimeCoordinator: SaveCoordinatorDelegate {
         }
         ruleCollectionsManager.onConflictResolution = { [weak self] context in
             await self?.promptForConflictResolution(context)
+        }
+        ruleCollectionsManager.onMappingConflictResolution = { [weak self] context in
+            await self?.promptForMappingConflict(context)
         }
         // Note: onActionURI callback not needed - RuleCollectionsManager.handleActionURI()
         // already dispatches to ActionDispatcher. Setting this would cause double dispatch.
@@ -1090,7 +1097,8 @@ public class RuntimeCoordinator: SaveCoordinatorDelegate {
             saveStatus: saveStatus,
 
             // Rule conflict resolution
-            pendingRuleConflict: pendingRuleConflict
+            pendingRuleConflict: pendingRuleConflict,
+            pendingMappingConflict: pendingMappingConflict
         )
     }
 
@@ -1508,6 +1516,39 @@ public class RuntimeCoordinator: SaveCoordinatorDelegate {
         pendingRuleConflict = nil
         conflictResolutionContinuation?.resume(returning: choice)
         conflictResolutionContinuation = nil
+        notifyStateChanged()
+    }
+
+    /// Prompt the user to resolve a save-time mapping conflict by disabling a
+    /// collection (#460). Returns the collection id to disable, or nil to cancel.
+    @MainActor
+    func promptForMappingConflict(_ context: MappingConflictContext) async -> UUID? {
+        // Cancel any pending resolution to avoid continuation leak
+        mappingConflictContinuation?.resume(returning: nil)
+        mappingConflictContinuation = nil
+
+        pendingMappingConflict = context
+        notifyStateChanged()
+
+        return await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                mappingConflictContinuation = continuation
+            }
+        } onCancel: {
+            Task { @MainActor in
+                self.mappingConflictContinuation?.resume(returning: nil)
+                self.mappingConflictContinuation = nil
+                self.pendingMappingConflict = nil
+                self.notifyStateChanged()
+            }
+        }
+    }
+
+    /// Called by ViewModel when the user resolves (or dismisses) a mapping conflict.
+    func resolveMappingConflict(disabling collectionID: UUID?) {
+        pendingMappingConflict = nil
+        mappingConflictContinuation?.resume(returning: collectionID)
+        mappingConflictContinuation = nil
         notifyStateChanged()
     }
 

--- a/Sources/KeyPathAppKit/Models/KanataUIState.swift
+++ b/Sources/KeyPathAppKit/Models/KanataUIState.swift
@@ -50,6 +50,9 @@ struct KanataUIState: Sendable {
     /// Rule conflict resolution
     let pendingRuleConflict: RuleConflictContext?
 
+    /// Save-time mapping conflict resolution (#460)
+    let pendingMappingConflict: MappingConflictContext?
+
     /// Empty state for initialization fallback
     static let empty = KanataUIState(
         lastError: nil,
@@ -65,7 +68,8 @@ struct KanataUIState: Sendable {
         activeRuntimePathDetail: nil,
         validationError: nil,
         saveStatus: .idle,
-        pendingRuleConflict: nil
+        pendingRuleConflict: nil,
+        pendingMappingConflict: nil
     )
 }
 

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+ConflictResolution.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+ConflictResolution.swift
@@ -71,10 +71,19 @@ extension RuleCollectionsManager {
         AppLogger.shared.log(
             "🔧 [RuleCollections] Resolving mapping conflict by disabling '\(ruleCollections[index].name)' (#460)"
         )
-        // Disable in-memory and retry the full save (avoids a nested toggle save).
+        // Make the disable atomic: snapshot first, disable in-memory, retry the full
+        // save. If the retry still fails (another conflict, depth guard, validation),
+        // restore so in-memory state never diverges from what was actually persisted —
+        // callers that ignore the `false` return must not see an unsaved disable.
+        let snapshot = ruleCollections
         ruleCollections[index].isEnabled = false
         refreshLayerIndicatorState()
-        return await regenerateConfigFromCollections(skipReload: skipReload, conflictResolutionDepth: depth + 1)
+        let saved = await regenerateConfigFromCollections(skipReload: skipReload, conflictResolutionDepth: depth + 1)
+        if !saved {
+            ruleCollections = snapshot
+            refreshLayerIndicatorState()
+        }
+        return saved
     }
 
     // MARK: - Conflict Resolution

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+ConflictResolution.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+ConflictResolution.swift
@@ -3,6 +3,80 @@ import KeyPathCore
 import KeyPathPermissions
 
 extension RuleCollectionsManager {
+    // MARK: - Save-time mapping-conflict resolution (#460)
+
+    /// Determine whether a set of save-time mapping conflicts can be resolved by
+    /// disabling a collection — i.e. every named party of every conflict maps to a
+    /// real, enabled collection by exact name. Synthetic parties (chord group names,
+    /// alias key-pairs, the "Leader Key" preference) won't match a collection, so
+    /// those conflicts fall back to a plain explanation rather than offering an
+    /// action that wouldn't apply.
+    ///
+    /// - Returns: the distinct collections the user could disable (≥2), or nil when
+    ///   the conflicts aren't all collection-vs-collection.
+    nonisolated static func resolvableCollectionConflict(
+        conflicts: [KeyPathError.MappingConflictInfo],
+        collections: [RuleCollection]
+    ) -> [RuleCollection]? {
+        guard !conflicts.isEmpty else { return nil }
+
+        let byName = Dictionary(
+            collections.filter(\.isEnabled).map { ($0.name, $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+
+        var involved: [UUID: RuleCollection] = [:]
+        for conflict in conflicts {
+            // Every party must resolve to a real enabled collection; otherwise the
+            // whole set is treated as non-actionable (explanation fallback).
+            for name in conflict.conflictingCollections {
+                guard let collection = byName[name] else { return nil }
+                involved[collection.id] = collection
+            }
+        }
+
+        // Need at least two distinct collections for "disable one" to resolve anything.
+        guard involved.count >= 2 else { return nil }
+        return involved.values.sorted { $0.name < $1.name }
+    }
+
+    /// On a save-time mapping-conflict failure, if the conflicting parties are all
+    /// real collections, prompt the user to disable one and retry the save (#460).
+    /// - Returns: the retry result, or nil when the failure wasn't a resolvable
+    ///   mapping conflict or the user cancelled (caller falls back to its error path).
+    func tryResolveMappingConflict(_ error: Error, skipReload: Bool, depth: Int) async -> Bool? {
+        // Bound retries: each resolution disables one collection (strictly shrinking
+        // the enabled set), so this terminates, but the guard prevents pathological loops.
+        guard depth < 5,
+              let keyPathError = error as? KeyPathError,
+              case let .configuration(configError) = keyPathError,
+              case let .mappingConflicts(conflicts) = configError,
+              let callback = onMappingConflictResolution,
+              let resolvable = Self.resolvableCollectionConflict(
+                  conflicts: conflicts, collections: ruleCollections
+              )
+        else { return nil }
+
+        let context = MappingConflictContext(
+            explanation: conflicts.map(\.userExplanation).joined(separator: "\n\n"),
+            options: resolvable.map {
+                MappingConflictOption(id: $0.id, name: $0.name, icon: $0.icon ?? "square.stack.3d.up")
+            }
+        )
+
+        guard let chosenID = await callback(context),
+              let index = ruleCollections.firstIndex(where: { $0.id == chosenID })
+        else { return nil } // cancelled → fall back to explanation
+
+        AppLogger.shared.log(
+            "🔧 [RuleCollections] Resolving mapping conflict by disabling '\(ruleCollections[index].name)' (#460)"
+        )
+        // Disable in-memory and retry the full save (avoids a nested toggle save).
+        ruleCollections[index].isEnabled = false
+        refreshLayerIndicatorState()
+        return await regenerateConfigFromCollections(skipReload: skipReload, conflictResolutionDepth: depth + 1)
+    }
+
     // MARK: - Conflict Resolution
 
     typealias RuleStateSnapshot = (collections: [RuleCollection], customRules: [CustomRule])

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+Migrations.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+Migrations.swift
@@ -36,7 +36,7 @@ extension RuleCollectionsManager {
     /// Regenerates the Kanata configuration from collections and custom rules.
     /// Returns `true` on success, `false` if validation or saving fails.
     @discardableResult
-    func regenerateConfigFromCollections(skipReload: Bool = false) async -> Bool {
+    func regenerateConfigFromCollections(skipReload: Bool = false, conflictResolutionDepth: Int = 0) async -> Bool {
         dedupeRuleCollectionsInPlace()
 
         AppLogger.shared.log("🔄 [RuleCollections] regenerateConfigFromCollections: \(ruleCollections.count) collections, \(customRules.count) custom rules")
@@ -92,6 +92,14 @@ extension RuleCollectionsManager {
             AppLogger.shared.log("⚠️ [RuleCollections] Config save cancelled (task cancellation)")
             return false
         } catch {
+            // #460: if the failure is a mapping conflict between real collections,
+            // offer to disable one inline and retry, instead of just showing an error.
+            if let resolved = await tryResolveMappingConflict(
+                error, skipReload: skipReload, depth: conflictResolutionDepth
+            ) {
+                return resolved
+            }
+
             AppLogger.shared.log("❌ [RuleCollections] Failed to regenerate config: \(error)")
             AppLogger.shared.log("❌ [RuleCollections] Error details: \(String(describing: error))")
 
@@ -106,11 +114,17 @@ extension RuleCollectionsManager {
             }
 
             // Extract user-friendly error message
-            let userMessage = if let keyPathError = error as? KeyPathError,
-                                 case let .configuration(configError) = keyPathError,
-                                 case let .validationFailed(errors) = configError
+            let userMessage: String = if let keyPathError = error as? KeyPathError,
+                                         case let .configuration(configError) = keyPathError,
+                                         case let .validationFailed(errors) = configError
             {
                 "Configuration validation failed:\n\n" + errors.joined(separator: "\n")
+            } else if let keyPathError = error as? KeyPathError,
+                      case let .configuration(configError) = keyPathError,
+                      case let .mappingConflicts(conflicts) = configError
+            {
+                // Non-actionable (or cancelled) mapping conflict — explain it (#460).
+                conflicts.map(\.userExplanation).joined(separator: "\n\n")
             } else {
                 "Failed to save configuration: \(error.localizedDescription)"
             }

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager.swift
@@ -85,6 +85,10 @@ final class RuleCollectionsManager {
     /// Returns the user's choice, or nil if cancelled
     var onConflictResolution: ((RuleConflictContext) async -> RuleConflictChoice?)?
 
+    /// Callback for save-time mapping-conflict resolution (#460).
+    /// Returns the id of the collection to disable, or nil if cancelled.
+    var onMappingConflictResolution: ((MappingConflictContext) async -> UUID?)?
+
     /// Callback to suppress file watcher before internal saves (prevents double-reload beep)
     var onBeforeSave: (() -> Void)?
 

--- a/Sources/KeyPathAppKit/UI/Rules/ActiveRulesView.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/ActiveRulesView.swift
@@ -67,6 +67,20 @@ struct ActiveRulesView: View {
                     .interactiveDismissDisabled()
                 }
             }
+            .sheet(isPresented: $kanataManager.showMappingConflictDialog) {
+                if let context = kanataManager.pendingMappingConflict {
+                    MappingConflictResolutionDialog(
+                        context: context,
+                        onChoice: { collectionID in
+                            kanataManager.resolveMappingConflict(disabling: collectionID)
+                        },
+                        onCancel: {
+                            kanataManager.resolveMappingConflict(disabling: nil)
+                        }
+                    )
+                    .interactiveDismissDisabled()
+                }
+            }
         }
     }
 

--- a/Sources/KeyPathAppKit/UI/Rules/MappingConflictResolutionDialog.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/MappingConflictResolutionDialog.swift
@@ -1,0 +1,126 @@
+import Foundation
+import SwiftUI
+
+// MARK: - Mapping Conflict Types
+
+/// A collection the user can disable to resolve a save-time mapping conflict (#460).
+struct MappingConflictOption: Sendable, Equatable, Identifiable {
+    let id: UUID
+    let name: String
+    let icon: String
+}
+
+/// Context for a save-time mapping conflict that can be resolved by disabling a
+/// collection. Sendable so it can cross the actor boundary from the save task to
+/// the UI. Built only when every conflicting party is a real, toggleable collection
+/// (see `RuleCollectionsManager.resolvableCollectionConflict`).
+struct MappingConflictContext: Sendable, Equatable {
+    /// Plain-English explanation of the conflict(s).
+    let explanation: String
+    /// The collections involved — disabling one resolves the conflict.
+    let options: [MappingConflictOption]
+}
+
+// MARK: - Mapping Conflict Resolution Dialog
+
+/// Shown when saving a configuration fails because two enabled collections claim
+/// the same key. Lets the user disable one inline instead of hunting through the
+/// Rules tab.
+struct MappingConflictResolutionDialog: View {
+    let context: MappingConflictContext
+    /// Called with the collection id to disable, or invoked via `onCancel` to dismiss.
+    let onChoice: (UUID) -> Void
+    let onCancel: () -> Void
+
+    var body: some View {
+        VStack(spacing: 0) {
+            headerSection
+            Divider()
+            actionButtons
+        }
+        .frame(width: 420)
+        .background(Color(NSColor.windowBackgroundColor))
+    }
+
+    private var headerSection: some View {
+        ZStack(alignment: .topTrailing) {
+            VStack(spacing: 8) {
+                Text("Rule Conflict")
+                    .font(.title2.weight(.semibold))
+
+                Text(context.explanation)
+                    .font(.body)
+                    .foregroundColor(.secondary)
+                    .multilineTextAlignment(.center)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .padding(.horizontal, 20)
+
+                Text("Disable one to resolve. It can be re-enabled later.")
+                    .font(.caption)
+                    .foregroundColor(.secondary.opacity(0.6))
+            }
+
+            Button {
+                onCancel()
+            } label: {
+                Image(systemName: "xmark")
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundColor(.secondary)
+                    .frame(width: 22, height: 22)
+                    .background(Circle().fill(Color.secondary.opacity(0.16)))
+            }
+            .buttonStyle(.plain)
+            .keyboardShortcut(.cancelAction)
+            .accessibilityIdentifier("mapping-conflict-close-button")
+            .accessibilityLabel("Close")
+            .padding(.top, 2)
+            .padding(.trailing, 2)
+        }
+        .padding(.vertical, 20)
+        .padding(.horizontal, 20)
+    }
+
+    private var actionButtons: some View {
+        VStack(spacing: 10) {
+            ForEach(context.options) { option in
+                Button {
+                    onChoice(option.id)
+                } label: {
+                    HStack {
+                        Image(systemName: option.icon)
+                        Spacer()
+                        Text("Disable \(option.name)")
+                            .font(.body.weight(.medium))
+                        Spacer()
+                    }
+                    .padding(.vertical, 8)
+                    .padding(.horizontal, 12)
+                }
+                .buttonStyle(.bordered)
+                .accessibilityIdentifier("mapping-conflict-disable-\(option.id.uuidString)")
+                .accessibilityLabel("Disable \(option.name)")
+            }
+        }
+        .padding(20)
+    }
+}
+
+// MARK: - Preview
+
+#if DEBUG
+    struct MappingConflictResolutionDialog_Previews: PreviewProvider {
+        static var previews: some View {
+            MappingConflictResolutionDialog(
+                context: MappingConflictContext(
+                    explanation: "Home Row Mods and Home Row Layer Toggles both configure the \";\" key with different behaviors. A key can only have one action assigned.",
+                    options: [
+                        MappingConflictOption(id: UUID(), name: "Home Row Mods", icon: "keyboard"),
+                        MappingConflictOption(id: UUID(), name: "Home Row Layer Toggles", icon: "square.stack.3d.up")
+                    ]
+                ),
+                onChoice: { _ in },
+                onCancel: {}
+            )
+        }
+    }
+#endif

--- a/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView.swift
@@ -560,6 +560,20 @@ struct RulesTabView: View {
                 .interactiveDismissDisabled()
             }
         }
+        .sheet(isPresented: $kanataManager.showMappingConflictDialog) {
+            if let context = kanataManager.pendingMappingConflict {
+                MappingConflictResolutionDialog(
+                    context: context,
+                    onChoice: { collectionID in
+                        kanataManager.resolveMappingConflict(disabling: collectionID)
+                    },
+                    onCancel: {
+                        kanataManager.resolveMappingConflict(disabling: nil)
+                    }
+                )
+                .interactiveDismissDisabled()
+            }
+        }
         .alert("Reset Configuration?", isPresented: $showingResetConfirmation) {
             Button("Cancel", role: .cancel) {}
             Button("Open Backups Folder") {

--- a/Sources/KeyPathAppKit/UI/ViewModels/KanataViewModel.swift
+++ b/Sources/KeyPathAppKit/UI/ViewModels/KanataViewModel.swift
@@ -56,6 +56,10 @@ class KanataViewModel {
     var showRuleConflictDialog = false
     var pendingRuleConflict: RuleConflictContext?
 
+    // Save-time mapping conflict resolution (#460)
+    var showMappingConflictDialog = false
+    var pendingMappingConflict: MappingConflictContext?
+
     enum ToastType {
         case success
         case error
@@ -136,6 +140,10 @@ class KanataViewModel {
         // Handle rule conflict resolution dialog
         pendingRuleConflict = state.pendingRuleConflict
         showRuleConflictDialog = state.pendingRuleConflict != nil
+
+        // Handle save-time mapping conflict resolution dialog (#460)
+        pendingMappingConflict = state.pendingMappingConflict
+        showMappingConflictDialog = state.pendingMappingConflict != nil
 
         // Map validation error to alert properties
         if let error = state.validationError {
@@ -525,6 +533,13 @@ class KanataViewModel {
     func resolveRuleConflict(with choice: RuleConflictChoice?) {
         showRuleConflictDialog = false
         manager.resolveConflict(with: choice)
+    }
+
+    /// Called when the user resolves (or dismisses) a save-time mapping conflict (#460).
+    /// Pass the collection id to disable, or nil to cancel.
+    func resolveMappingConflict(disabling collectionID: UUID?) {
+        showMappingConflictDialog = false
+        manager.resolveMappingConflict(disabling: collectionID)
     }
 }
 

--- a/Tests/KeyPathTests/RuleCollections/SaveTimeConflictResolutionTests.swift
+++ b/Tests/KeyPathTests/RuleCollections/SaveTimeConflictResolutionTests.swift
@@ -1,0 +1,95 @@
+@testable import KeyPathAppKit
+import KeyPathCore
+import XCTest
+
+/// Tests for the save-time mapping-conflict resolvability core (#460):
+/// a conflict is resolvable-by-disable only when every named party maps to a
+/// real, enabled collection.
+final class SaveTimeConflictResolutionTests: XCTestCase {
+    private func collection(_ name: String, isEnabled: Bool = true) -> RuleCollection {
+        RuleCollection(
+            name: name,
+            summary: name,
+            category: .productivity,
+            mappings: [KeyMapping(input: "a", action: .keystroke(key: "b"))],
+            isEnabled: isEnabled
+        )
+    }
+
+    private func conflict(_ collections: [String], key: String = ";") -> KeyPathError.MappingConflictInfo {
+        KeyPathError.MappingConflictInfo(
+            inputKey: key,
+            layer: "Base",
+            conflictingCollections: collections
+        )
+    }
+
+    func testResolvableWhenAllPartiesAreRealCollections() {
+        let collections = [collection("Home Row Mods"), collection("Home Row Layer Toggles")]
+        let conflicts = [conflict(["Home Row Mods", "Home Row Layer Toggles"])]
+
+        let resolvable = RuleCollectionsManager.resolvableCollectionConflict(
+            conflicts: conflicts, collections: collections
+        )
+
+        XCTAssertEqual(resolvable?.map(\.name), ["Home Row Layer Toggles", "Home Row Mods"])
+    }
+
+    func testNotResolvableWhenAPartyIsSynthetic() {
+        // Chord-group-name conflicts name "chord group '...'", which is not a collection.
+        let collections = [collection("Chord Groups")]
+        let conflicts = [conflict(["chord group 'navigation'", "chord group 'navigation'"], key: "navigation")]
+
+        XCTAssertNil(RuleCollectionsManager.resolvableCollectionConflict(
+            conflicts: conflicts, collections: collections
+        ))
+    }
+
+    func testNotResolvableWhenLeaderKeyPartyHasNoCollection() {
+        // The leader conflict names "Leader Key" (a preference, not a collection).
+        let collections = [collection("Window Mgmt")]
+        let conflicts = [conflict(["Leader Key", "Window Mgmt"], key: "spc")]
+
+        XCTAssertNil(RuleCollectionsManager.resolvableCollectionConflict(
+            conflicts: conflicts, collections: collections
+        ))
+    }
+
+    func testNotResolvableWhenPartyCollectionIsDisabled() {
+        // A disabled collection isn't in the active set, so it can't be matched.
+        let collections = [collection("Home Row Mods"), collection("Home Row Layer Toggles", isEnabled: false)]
+        let conflicts = [conflict(["Home Row Mods", "Home Row Layer Toggles"])]
+
+        XCTAssertNil(RuleCollectionsManager.resolvableCollectionConflict(
+            conflicts: conflicts, collections: collections
+        ))
+    }
+
+    func testNotResolvableWhenOnlyOneDistinctCollection() {
+        let collections = [collection("Home Row Mods")]
+        let conflicts = [conflict(["Home Row Mods", "Home Row Mods"])]
+
+        XCTAssertNil(RuleCollectionsManager.resolvableCollectionConflict(
+            conflicts: conflicts, collections: collections
+        ))
+    }
+
+    func testMixedResolvableAndSyntheticFallsBack() {
+        // If any conflict in the set is non-actionable, the whole set falls back.
+        let collections = [collection("Home Row Mods"), collection("Home Row Layer Toggles")]
+        let conflicts = [
+            conflict(["Home Row Mods", "Home Row Layer Toggles"]),
+            conflict(["caps-lock / caps_lock"], key: "caps-lock / caps_lock")
+        ]
+
+        XCTAssertNil(RuleCollectionsManager.resolvableCollectionConflict(
+            conflicts: conflicts, collections: collections
+        ))
+    }
+
+    func testEmptyConflictsNotResolvable() {
+        XCTAssertNil(RuleCollectionsManager.resolvableCollectionConflict(
+            conflicts: [], collections: [collection("X")]
+        ))
+    }
+}


### PR DESCRIPTION
## Summary

Closes the loop on the ADR-039 detect-and-explain cluster (#462–#466). Those PRs made KeyPath **detect** save-time key conflicts and throw instead of silently dropping a mapping — but the user only saw an error and had to hand-navigate to the Rules tab to disable a collection and retry. This adds an **actionable resolution dialog**.

When a save fails with `mappingConflicts` and every conflicting party is a real, enabled collection (e.g. Home Row Mods vs Home Row Layer Toggles both claiming `;`), the user gets:

```
                    Rule Conflict
  Home Row Mods and Home Row Layer Toggles both configure
  the ";" key with different behaviors. A key can only have
  one action assigned.
      Disable one to resolve. (re-enableable later)

   [ Disable Home Row Mods ]   [ Disable Home Row Layer Toggles ]
```

Pick one → that collection is disabled → **the save automatically retries and succeeds**. No tab-hunting.

## Behavior / scope

- **Actionable only when both parties are real toggleable collections.** Synthetic conflicts — chord-group names (#464), alias key-pairs (#462), the `"Leader Key"` preference (#463) — aren't toggleable, so they fall back to a plain explanation (no misleading button). This is enforced by `resolvableCollectionConflict`, which requires every party to map by exact name to an enabled collection (≥2 distinct).
- **Central interception**, in `RuleCollectionsManager.regenerateConfigFromCollections`'s catch block, so every save path that funnels through regenerate is covered.
- **Disable-and-retry** is depth-guarded and terminates (disabling shrinks the enabled set, so conflicts monotonically decrease).
- The toggle-time rule-conflict dialog still fires first for collection-enable conflicts; this covers conflicts that bypass it (pack installs, restores, structural detections).

## Implementation

Mirrors the proven rule-conflict plumbing 1:1: `RuntimeCoordinator` pending state + `CheckedContinuation` (`promptForMappingConflict`/`resolveMappingConflict`), threaded through `KanataUIState` → `KanataViewModel`, presented as a new `MappingConflictResolutionDialog`.

## Verification

- **Unit-tested**: `SaveTimeConflictResolutionTests` (7 cases) covers the resolvability decision — real-collection vs synthetic/leader/disabled/single/mixed/empty. Full suite green; SwiftFormat 0.61.1 clean on changed files.
- **Needs real-app check** (can't be unit-tested): the sheet appearing, the choice resuming the save, and the retry completing in the running app.

## Follow-up (out of scope)

The inline disable bypasses the pack-ownership check — consistent with the existing toggle-time `.keepNew` path, but worth filtering pack-managed collections from the options later.

Fixes #460

🤖 Generated with [Claude Code](https://claude.com/claude-code)