### PR TITLE
fix: Task race in RulesSummaryView + shared input-capture constants

### DIFF
--- a/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView.swift
@@ -33,6 +33,7 @@ struct RulesTabView: View {
     @State var unmetDependencyMap: [String: [UnmetDependency]] = [:]
     @State var collectionOwnershipMap: [UUID: (packID: String, packName: String)] = [:]
     @State var managedToggleCollection: RuleCollection?
+    @State private var onAppearTask: Task<Void, Never>?
     private let catalog = RuleCollectionCatalog()
 
     /// Total count of custom rules (everywhere + app-specific)
@@ -438,22 +439,25 @@ struct RulesTabView: View {
         }
         .animation(.spring(response: 0.3, dampingFraction: 0.8), value: kanataManager.toastMessage)
         .onAppear {
-            // Capture sort order once when view appears (enabled first, then disabled)
-            // This ensures stable layout - toggling a rule won't move it until window reopens
             if stableSortOrder.isEmpty {
                 stableSortOrder = computeSortOrder()
             }
-            // Load app-specific keymaps
             loadAppKeymaps()
-            Task {
+            onAppearTask?.cancel()
+            onAppearTask = Task {
                 isKindaVimInstalled = await InstalledPackTracker.shared.isInstalled(
                     packID: PackRegistry.kindaVim.id
                 )
                 isKeystrokeHistoryInstalled = await InstalledPackTracker.shared.isInstalled(
                     packID: PackRegistry.keystrokeHistory.id
                 )
+                guard !Task.isCancelled else { return }
                 await refreshCollectionOwnership()
             }
+        }
+        .onDisappear {
+            onAppearTask?.cancel()
+            onAppearTask = nil
         }
         .onReceive(NotificationCenter.default.publisher(for: .appKeymapsDidChange)) { _ in
             loadAppKeymaps()

--- a/Sources/KeyPathInstallationWizard/Core/ServiceHealthChecker.swift
+++ b/Sources/KeyPathInstallationWizard/Core/ServiceHealthChecker.swift
@@ -27,6 +27,10 @@ public final class ServiceHealthChecker: @unchecked Sendable {
     private nonisolated static let launchctlNotFoundExitCode: Int32 = 113
     private nonisolated static let kanataRestartGraceWindow: TimeInterval = 12.0
 
+    /// Reason codes for input-capture failures, shared with SystemInspector.
+    public nonisolated static let inputCaptureBuiltInKeyboardReason = "kanata-cannot-open-built-in-keyboard"
+    public nonisolated static let inputCaptureGrabFailureReason = "kanata-failed-to-grab-keyboard"
+
     // MARK: - Short-lived health cache
 
     private struct HealthCacheEntry {
@@ -594,7 +598,7 @@ public final class ServiceHealthChecker: @unchecked Sendable {
         }
         return KanataInputCaptureStatus(
             isReady: false,
-            issue: grab.reason ?? "kanata-failed-to-grab-keyboard"
+            issue: grab.reason ?? Self.inputCaptureGrabFailureReason
         )
     }
 
@@ -700,7 +704,7 @@ public final class ServiceHealthChecker: @unchecked Sendable {
                 else { continue }
                 inputCaptureIssue = KanataInputCaptureStatus(
                     isReady: false,
-                    issue: "kanata-cannot-open-built-in-keyboard"
+                    issue: Self.inputCaptureBuiltInKeyboardReason
                 )
                 break
             }
@@ -717,7 +721,7 @@ public final class ServiceHealthChecker: @unchecked Sendable {
         if inputCaptureIssue.isReady, !permissionRejected, Self.detectsInputGrabFailure(in: logChunk) {
             inputCaptureIssue = KanataInputCaptureStatus(
                 isReady: false,
-                issue: "kanata-failed-to-grab-keyboard"
+                issue: Self.inputCaptureGrabFailureReason
             )
         }
 

--- a/Sources/KeyPathInstallationWizard/Core/SystemInspector.swift
+++ b/Sources/KeyPathInstallationWizard/Core/SystemInspector.swift
@@ -361,13 +361,13 @@ public enum SystemInspector {
     /// permission problem (the built-in keyboard couldn't be opened) — vs. a
     /// grab failure that a restart, not a permission grant, fixes.
     static func isInputCapturePermissionReason(_ reason: String?) -> Bool {
-        reason == "kanata-cannot-open-built-in-keyboard"
+        reason == ServiceHealthChecker.inputCaptureBuiltInKeyboardReason
     }
 
     /// Human-readable detail for a non-permission input-capture failure, using
     /// kanata's authoritative reason (from the InputGrab signal) when present.
     static func inputCaptureFailureDetail(_ reason: String?) -> String {
-        guard let reason, reason != "kanata-failed-to-grab-keyboard" else {
+        guard let reason, reason != ServiceHealthChecker.inputCaptureGrabFailureReason else {
             return "The keyboard couldn't be captured — the input driver may have crashed, or another app may be holding the keyboard exclusively."
         }
         return "Reason: \(reason)."

--- a/Tests/KeyPathTests/InstallationWizard/SystemInspectorInputCaptureTests.swift
+++ b/Tests/KeyPathTests/InstallationWizard/SystemInspectorInputCaptureTests.swift
@@ -21,7 +21,7 @@ final class SystemInspectorInputCaptureTests: XCTestCase {
     // MARK: - State routing
 
     func testGrabFailure_routesToService_notPermissions() {
-        let state = SystemInspector.determineState(context(inputCaptureIssue: "kanata-failed-to-grab-keyboard"))
+        let state = SystemInspector.determineState(context(inputCaptureIssue: ServiceHealthChecker.inputCaptureGrabFailureReason))
         XCTAssertEqual(state, .serviceNotRunning, "A grab failure must not be misrouted to the permissions page")
     }
 
@@ -32,7 +32,7 @@ final class SystemInspectorInputCaptureTests: XCTestCase {
     }
 
     func testBuiltInKeyboardPermission_staysOnPermissions() {
-        let state = SystemInspector.determineState(context(inputCaptureIssue: "kanata-cannot-open-built-in-keyboard"))
+        let state = SystemInspector.determineState(context(inputCaptureIssue: ServiceHealthChecker.inputCaptureBuiltInKeyboardReason))
         XCTAssertEqual(state, .missingPermissions(missing: [.kanataInputMonitoring]))
     }
 
@@ -45,7 +45,7 @@ final class SystemInspectorInputCaptureTests: XCTestCase {
     // MARK: - Issue card
 
     func testGrabFailure_issueIsHonest_noFalseAutofix() {
-        let issues = SystemInspector.generateIssues(context(inputCaptureIssue: "kanata-failed-to-grab-keyboard"))
+        let issues = SystemInspector.generateIssues(context(inputCaptureIssue: ServiceHealthChecker.inputCaptureGrabFailureReason))
         guard let issue = issues.first(where: { $0.identifier == .daemon }) else {
             return XCTFail("Expected an honest daemon issue for a grab failure")
         }
@@ -66,7 +66,7 @@ final class SystemInspectorInputCaptureTests: XCTestCase {
         // The Service page must reflect the grab failure even though the process
         // is up + TCP-reachable (the #624 dishonesty — and the trap of routing
         // here without making the status honest).
-        let issues = SystemInspector.generateIssues(context(inputCaptureIssue: "kanata-failed-to-grab-keyboard"))
+        let issues = SystemInspector.generateIssues(context(inputCaptureIssue: ServiceHealthChecker.inputCaptureGrabFailureReason))
         let status = ServiceStatusEvaluator.evaluate(
             kanataIsRunning: true,
             systemState: .serviceNotRunning,
@@ -96,7 +96,7 @@ final class SystemInspectorInputCaptureTests: XCTestCase {
     }
 
     func testBuiltInKeyboard_keepsPermissionIssue() {
-        let issues = SystemInspector.generateIssues(context(inputCaptureIssue: "kanata-cannot-open-built-in-keyboard"))
+        let issues = SystemInspector.generateIssues(context(inputCaptureIssue: ServiceHealthChecker.inputCaptureBuiltInKeyboardReason))
         XCTAssertTrue(issues.contains { $0.identifier == .permission(.kanataInputMonitoring) })
         XCTAssertFalse(issues.contains { $0.identifier == .daemon && $0.title.contains("Capturing") })
     }
@@ -104,8 +104,8 @@ final class SystemInspectorInputCaptureTests: XCTestCase {
     // MARK: - Helpers
 
     func testIsInputCapturePermissionReason() {
-        XCTAssertTrue(SystemInspector.isInputCapturePermissionReason("kanata-cannot-open-built-in-keyboard"))
-        XCTAssertFalse(SystemInspector.isInputCapturePermissionReason("kanata-failed-to-grab-keyboard"))
+        XCTAssertTrue(SystemInspector.isInputCapturePermissionReason(ServiceHealthChecker.inputCaptureBuiltInKeyboardReason))
+        XCTAssertFalse(SystemInspector.isInputCapturePermissionReason(ServiceHealthChecker.inputCaptureGrabFailureReason))
         XCTAssertFalse(SystemInspector.isInputCapturePermissionReason("another process has exclusive grab"))
         XCTAssertFalse(SystemInspector.isInputCapturePermissionReason(nil))
     }

--- a/Tests/KeyPathTests/InstallationWizard/WizardPureLogicTests.swift
+++ b/Tests/KeyPathTests/InstallationWizard/WizardPureLogicTests.swift
@@ -345,7 +345,7 @@ final class WizardPureLogicTests: XCTestCase {
                 karabinerDaemonRunning: true,
                 vhidHealthy: true,
                 kanataInputCaptureReady: false,
-                kanataInputCaptureIssue: "kanata-cannot-open-built-in-keyboard"
+                kanataInputCaptureIssue: ServiceHealthChecker.inputCaptureBuiltInKeyboardReason
             )
         )
         let (state, issues) = SystemInspector.inspect(context: context)

--- a/Tests/KeyPathTests/InstallationWizard/WizardStateRegressionTests.swift
+++ b/Tests/KeyPathTests/InstallationWizard/WizardStateRegressionTests.swift
@@ -80,7 +80,7 @@ final class WizardStateRegressionTests: XCTestCase {
             karabinerDaemonRunning: true,
             vhidHealthy: true,
             kanataInputCaptureReady: false,
-            kanataInputCaptureIssue: "kanata-cannot-open-built-in-keyboard"
+            kanataInputCaptureIssue: ServiceHealthChecker.inputCaptureBuiltInKeyboardReason
         )
 
         let components = ComponentStatus(

--- a/Tests/KeyPathTests/Services/KanataInputGrabConsumerTests.swift
+++ b/Tests/KeyPathTests/Services/KanataInputGrabConsumerTests.swift
@@ -66,7 +66,7 @@ final class KanataInputGrabConsumerTests: KeyPathTestCase {
 
     func testResolve_noStore_usesStderrFallback() {
         // Store empty → fall back to the #632 stderr detector verbatim.
-        let failedFallback = ServiceHealthChecker.KanataInputCaptureStatus(isReady: false, issue: "kanata-failed-to-grab-keyboard")
+        let failedFallback = ServiceHealthChecker.KanataInputCaptureStatus(isReady: false, issue: ServiceHealthChecker.inputCaptureGrabFailureReason)
         XCTAssertEqual(
             ServiceHealthChecker.resolveInputCaptureStatus(stderrFallback: failedFallback),
             failedFallback
@@ -85,7 +85,7 @@ final class KanataInputGrabConsumerTests: KeyPathTestCase {
             KanataInputGrabStatus(active: true, devices: ["kbd"], reason: nil, observedAt: Date())
         )
         let stderrFailure = ServiceHealthChecker.KanataInputCaptureStatus(
-            isReady: false, issue: "kanata-cannot-open-built-in-keyboard"
+            isReady: false, issue: ServiceHealthChecker.inputCaptureBuiltInKeyboardReason
         )
         XCTAssertEqual(
             ServiceHealthChecker.resolveInputCaptureStatus(stderrFallback: stderrFailure),
@@ -132,7 +132,7 @@ final class KanataInputGrabConsumerTests: KeyPathTestCase {
         )
         let resolved = ServiceHealthChecker.resolveInputCaptureStatus(stderrFallback: .ready)
         XCTAssertFalse(resolved.isReady)
-        XCTAssertEqual(resolved.issue, "kanata-failed-to-grab-keyboard")
+        XCTAssertEqual(resolved.issue, ServiceHealthChecker.inputCaptureGrabFailureReason)
     }
 
     // MARK: - end-to-end decision

--- a/Tests/KeyPathTests/Services/ServiceHealthCheckerTests.swift
+++ b/Tests/KeyPathTests/Services/ServiceHealthCheckerTests.swift
@@ -204,7 +204,7 @@ final class ServiceHealthCheckerTests: XCTestCase {
         let diagnosis = await checker.diagnoseDaemonStderr()
         XCTAssertFalse(diagnosis.permissionRejected)
         XCTAssertFalse(diagnosis.inputCapture.isReady)
-        XCTAssertEqual(diagnosis.inputCapture.issue, "kanata-cannot-open-built-in-keyboard")
+        XCTAssertEqual(diagnosis.inputCapture.issue, ServiceHealthChecker.inputCaptureBuiltInKeyboardReason)
     }
 
     func testDiagnoseDaemonStderrDetectsAccessibilityRejection() async throws {
@@ -227,14 +227,14 @@ final class ServiceHealthCheckerTests: XCTestCase {
             isRunning: true,
             isResponding: true,
             inputCaptureReady: false,
-            inputCaptureIssue: "kanata-cannot-open-built-in-keyboard",
+            inputCaptureIssue: ServiceHealthChecker.inputCaptureBuiltInKeyboardReason,
             launchctlExitCode: 0,
             staleEnabledRegistration: false,
             recentlyRestarted: false
         )
 
         let decision = ServiceHealthChecker.decideKanataHealth(for: snapshot)
-        XCTAssertEqual(decision, .unhealthy(reason: "kanata-cannot-open-built-in-keyboard"))
+        XCTAssertEqual(decision, .unhealthy(reason: ServiceHealthChecker.inputCaptureBuiltInKeyboardReason))
         XCTAssertFalse(decision.isHealthy)
     }
 

--- a/Tests/KeyPathTests/TestSupport/SystemContextBuilder.swift
+++ b/Tests/KeyPathTests/TestSupport/SystemContextBuilder.swift
@@ -13,7 +13,7 @@ struct SystemContextBuilder {
     /// The input-capture failure reason surfaced when not ready (#624 attribution).
     /// Defaults to the built-in-keyboard permission reason; set to a grab-failure
     /// reason, or explicitly nil, to exercise the other branches.
-    var kanataInputCaptureIssue: String? = "kanata-cannot-open-built-in-keyboard"
+    var kanataInputCaptureIssue: String? = ServiceHealthChecker.inputCaptureBuiltInKeyboardReason
     var componentsInstalled: Bool = false
     var conflicts: [SystemConflict] = []
     var driverCompatible: Bool = true


### PR DESCRIPTION
## Summary
- **#481**: Fix `onAppear` Task race in `RulesSummaryView` — cancel previous Task on disappear, check cancellation before updating state. Prevents stale async updates when view is rapidly removed/re-added.
- **#643**: Extract `inputCaptureBuiltInKeyboardReason` / `inputCaptureGrabFailureReason` as shared constants on `ServiceHealthChecker`, replacing stringly-coupled raw literals in `SystemInspector` and 6 test files. A one-sided rename can no longer silently flip attribution.
- **#630**: Already fully implemented (kanata fork + Swift consumer). Closing separately.

## Test plan
- [x] Build passes
- [x] All test failures are pre-existing (same 8 failures on master)
- [ ] CI green

Closes #481, closes #643