### PR TITLE
fix: detect collection-activator vs mapping key conflicts

### DIFF
--- a/Sources/KeyPathAppKit/Models/RuleCollectionDeduplicator.swift
+++ b/Sources/KeyPathAppKit/Models/RuleCollectionDeduplicator.swift
@@ -20,6 +20,10 @@ enum RuleCollectionDeduplicator {
         }
 
         var claimedKeys: [InputKey: [ClaimInfo]] = [:]
+        // Which collections place a regular mapping on each (input, layer) slot.
+        // Mappings only — NOT activators or the leader — so it can be cross-checked
+        // against activator placements without double-reporting.
+        var mappingOwners: [InputKey: Set<String>] = [:]
 
         for collection in collections where collection.isEnabled {
             let mappings = KanataConfiguration.effectiveMappings(for: collection)
@@ -30,6 +34,7 @@ enum RuleCollectionDeduplicator {
                 // sharing keys). Within-collection conflicts are detected separately.
                 guard seenKeysInCollection.insert(normalizedInput).inserted else { continue }
                 let inputKey = InputKey(input: normalizedInput, layer: collection.targetLayer)
+                mappingOwners[inputKey, default: []].insert(collection.name)
 
                 let holdDesc = mapping.behavior.flatMap { behavior -> String? in
                     if case let .dualRole(dr) = behavior {
@@ -116,13 +121,30 @@ enum RuleCollectionDeduplicator {
             // "hyper" activators are folded into the hyper hold action, not emitted
             // as standalone layer activators — they never collide in seenActivators.
             guard activator.input.lowercased() != "hyper" else { continue }
-            let slot = ActivatorSlot(
-                sourceLayer: activator.sourceLayer,
-                input: KanataKeyConverter.convertToKanataKey(activator.input)
-            )
+            let normalizedInput = KanataKeyConverter.convertToKanataKey(activator.input)
+            let slot = ActivatorSlot(sourceLayer: activator.sourceLayer, input: normalizedInput)
             activatorClaims[slot, default: []].append(
                 ActivatorClaim(collectionName: collection.name, targetLayer: activator.targetLayer)
             )
+
+            // Activator-vs-mapping conflict: this activator occupies its key's slot
+            // on its source layer (buildCollectionBlocks places the tap-hold there),
+            // but another collection maps the same key on that layer. The generator
+            // emits both and silently keeps one (e.g. Home Row Arrows' `f` activator
+            // shadowing Home Row Mods' hold-`f`). Surface it. Activator-vs-activator
+            // is handled by the redundant-aware pass below; leader collisions via the
+            // leader injection above — neither is in `mappingOwners`, so no double-report.
+            let mappingSlot = InputKey(input: normalizedInput, layer: activator.sourceLayer)
+            let otherMappers = (mappingOwners[mappingSlot] ?? []).subtracting([collection.name]).sorted()
+            if !otherMappers.isEmpty {
+                conflicts.append(KeyPathError.MappingConflictInfo(
+                    inputKey: normalizedInput,
+                    layer: activator.sourceLayer.displayName,
+                    conflictingCollections: [collection.name] + otherMappers,
+                    holdDescriptions: ["\(collection.name): activates \(activator.targetLayer.displayName)"]
+                        + otherMappers.map { "\($0): maps \(normalizedInput)" }
+                ))
+            }
         }
         for (slot, claims) in activatorClaims where claims.count > 1 {
             // Only a conflict if the activators disagree on which layer to activate.

--- a/Sources/KeyPathAppKit/Models/RuleCollectionDeduplicator.swift
+++ b/Sources/KeyPathAppKit/Models/RuleCollectionDeduplicator.swift
@@ -20,10 +20,13 @@ enum RuleCollectionDeduplicator {
         }
 
         var claimedKeys: [InputKey: [ClaimInfo]] = [:]
-        // Which collections place a regular mapping on each (input, layer) slot.
-        // Mappings only — NOT activators or the leader — so it can be cross-checked
-        // against activator placements without double-reporting.
-        var mappingOwners: [InputKey: Set<String>] = [:]
+        // Which collections place a regular mapping on each (input, layer) slot,
+        // keyed by collection id → name. Mappings only (NOT activators or the leader)
+        // so it can be cross-checked against activator placements without
+        // double-reporting. Keyed by id, not name: collection titles aren't unique
+        // (custom rules become collections titled by editable display text), so a
+        // name-based self-filter could cancel the real other owner.
+        var mappingOwners: [InputKey: [UUID: String]] = [:]
 
         for collection in collections where collection.isEnabled {
             let mappings = KanataConfiguration.effectiveMappings(for: collection)
@@ -34,7 +37,7 @@ enum RuleCollectionDeduplicator {
                 // sharing keys). Within-collection conflicts are detected separately.
                 guard seenKeysInCollection.insert(normalizedInput).inserted else { continue }
                 let inputKey = InputKey(input: normalizedInput, layer: collection.targetLayer)
-                mappingOwners[inputKey, default: []].insert(collection.name)
+                mappingOwners[inputKey, default: [:]][collection.id] = collection.name
 
                 let holdDesc = mapping.behavior.flatMap { behavior -> String? in
                     if case let .dualRole(dr) = behavior {
@@ -135,7 +138,10 @@ enum RuleCollectionDeduplicator {
             // is handled by the redundant-aware pass below; leader collisions via the
             // leader injection above — neither is in `mappingOwners`, so no double-report.
             let mappingSlot = InputKey(input: normalizedInput, layer: activator.sourceLayer)
-            let otherMappers = (mappingOwners[mappingSlot] ?? []).subtracting([collection.name]).sorted()
+            // Exclude the activator's own collection by id (names aren't unique).
+            let otherMappers = (mappingOwners[mappingSlot] ?? [:])
+                .filter { $0.key != collection.id }
+                .values.sorted()
             if !otherMappers.isEmpty {
                 conflicts.append(KeyPathError.MappingConflictInfo(
                     inputKey: normalizedInput,

--- a/Tests/KeyPathTests/RuleCollections/RuleCollectionDeduplicatorTests.swift
+++ b/Tests/KeyPathTests/RuleCollections/RuleCollectionDeduplicatorTests.swift
@@ -449,6 +449,106 @@ final class RuleCollectionDeduplicatorTests: XCTestCase {
         XCTAssertTrue(conflicts.isEmpty, "A base mapping on a different key does not conflict with the leader")
     }
 
+    // MARK: - Activator vs Mapping Conflict Detection
+
+    func testDetectsActivatorVsMappingConflict() {
+        // Mirrors Home Row Mods (maps `f` on base, e.g. hold = Cmd) + Home Row Arrows
+        // (momentary activator `f` from base → its own layer). Both claim `f` on the
+        // base layer; the generator silently keeps one. Surface it.
+        let homeRowMods = RuleCollection(
+            name: "Home Row Mods",
+            summary: "Mods",
+            category: .productivity,
+            mappings: [KeyMapping(input: "f", action: .keystroke(key: "f"))],
+            isEnabled: true,
+            targetLayer: .base
+        )
+
+        let homeRowArrows = RuleCollection(
+            name: "Home Row Arrows",
+            summary: "Arrows",
+            category: .navigation,
+            mappings: [KeyMapping(input: "j", action: .keystroke(key: "left"))],
+            isEnabled: true,
+            targetLayer: .custom("home-arrows"),
+            momentaryActivator: MomentaryActivator(input: "f", targetLayer: .custom("home-arrows"), sourceLayer: .base)
+        )
+
+        let conflicts = RuleCollectionDeduplicator.detectConflicts(in: [homeRowMods, homeRowArrows])
+
+        let conflict = conflicts.first { $0.inputKey == "f" }
+        XCTAssertNotNil(conflict, "An activator key colliding with another collection's base mapping should surface")
+        XCTAssertEqual(Set(conflict?.conflictingCollections ?? []), ["Home Row Arrows", "Home Row Mods"])
+    }
+
+    func testNoActivatorVsMappingConflictWhenDifferentKeys() {
+        let mapper = RuleCollection(
+            name: "Base Maps",
+            summary: "Base",
+            category: .productivity,
+            mappings: [KeyMapping(input: "f", action: .keystroke(key: "f"))],
+            isEnabled: true,
+            targetLayer: .base
+        )
+        let arrows = RuleCollection(
+            name: "Arrows",
+            summary: "Arrows",
+            category: .navigation,
+            mappings: [KeyMapping(input: "j", action: .keystroke(key: "left"))],
+            isEnabled: true,
+            targetLayer: .custom("arrows"),
+            momentaryActivator: MomentaryActivator(input: "g", targetLayer: .custom("arrows"), sourceLayer: .base)
+        )
+
+        let conflicts = RuleCollectionDeduplicator.detectConflicts(in: [mapper, arrows])
+        XCTAssertTrue(conflicts.isEmpty, "Activator and mapping on different keys do not conflict")
+    }
+
+    func testNoActivatorVsMappingConflictWhenDifferentSourceLayer() {
+        // Mapping on `f` base; activator `f` reached FROM the nav layer (chained).
+        // Different source layers — the generator places them separately. Valid.
+        let mapper = RuleCollection(
+            name: "Base Maps",
+            summary: "Base",
+            category: .productivity,
+            mappings: [KeyMapping(input: "f", action: .keystroke(key: "f"))],
+            isEnabled: true,
+            targetLayer: .base
+        )
+        let chained = RuleCollection(
+            name: "Chained",
+            summary: "Chained",
+            category: .navigation,
+            mappings: [KeyMapping(input: "j", action: .keystroke(key: "left"))],
+            isEnabled: true,
+            targetLayer: .custom("sym"),
+            momentaryActivator: MomentaryActivator(input: "f", targetLayer: .custom("sym"), sourceLayer: .navigation)
+        )
+
+        let conflicts = RuleCollectionDeduplicator.detectConflicts(in: [mapper, chained])
+        XCTAssertTrue(conflicts.isEmpty, "Activator from a different source layer than the mapping is valid")
+    }
+
+    func testNoActivatorVsMappingConflictWithinSameCollection() {
+        // A collection that both maps `f` on base and uses `f` as its own activator
+        // is a within-collection arrangement, not a cross-collection conflict.
+        let collection = RuleCollection(
+            name: "Solo",
+            summary: "Solo",
+            category: .navigation,
+            mappings: [KeyMapping(input: "f", action: .keystroke(key: "f"))],
+            isEnabled: true,
+            targetLayer: .base,
+            momentaryActivator: MomentaryActivator(input: "f", targetLayer: .custom("arrows"), sourceLayer: .base)
+        )
+
+        let conflicts = RuleCollectionDeduplicator.detectConflicts(in: [collection])
+        XCTAssertFalse(
+            conflicts.contains { $0.inputKey == "f" },
+            "Same-collection activator+mapping on a key is not a cross-collection conflict"
+        )
+    }
+
     // MARK: - Duplicate Chord Group Name Detection (#464)
 
     func testDetectsDuplicateChordGroupNames() {

--- a/Tests/KeyPathTests/RuleCollections/RuleCollectionDeduplicatorTests.swift
+++ b/Tests/KeyPathTests/RuleCollections/RuleCollectionDeduplicatorTests.swift
@@ -481,6 +481,35 @@ final class RuleCollectionDeduplicatorTests: XCTestCase {
         XCTAssertEqual(Set(conflict?.conflictingCollections ?? []), ["Home Row Arrows", "Home Row Mods"])
     }
 
+    func testActivatorVsMappingConflictDetectedWhenCollectionsShareName() {
+        // Collection titles aren't unique (custom rules use editable display text).
+        // Two distinct collections with the same name must still be detected by
+        // identity — a name-based self-filter would cancel the real other owner.
+        let mapper = RuleCollection(
+            name: "Shared Title",
+            summary: "Base",
+            category: .custom,
+            mappings: [KeyMapping(input: "f", action: .keystroke(key: "f"))],
+            isEnabled: true,
+            targetLayer: .base
+        )
+        let arrows = RuleCollection(
+            name: "Shared Title",
+            summary: "Arrows",
+            category: .navigation,
+            mappings: [KeyMapping(input: "j", action: .keystroke(key: "left"))],
+            isEnabled: true,
+            targetLayer: .custom("arrows"),
+            momentaryActivator: MomentaryActivator(input: "f", targetLayer: .custom("arrows"), sourceLayer: .base)
+        )
+
+        let conflicts = RuleCollectionDeduplicator.detectConflicts(in: [mapper, arrows])
+        XCTAssertTrue(
+            conflicts.contains { $0.inputKey == "f" },
+            "Activator-vs-mapping conflict must be detected by identity even when collections share a name"
+        )
+    }
+
     func testNoActivatorVsMappingConflictWhenDifferentKeys() {
         let mapper = RuleCollection(
             name: "Base Maps",


### PR DESCRIPTION
## Summary

Surfaced by real-app testing of the #460 dialog: enabling **Home Row Mods** + **Home Row Arrows** produced no warning, yet they genuinely conflict on `f`. The live config proved it — both `beh_base_f` (Home Row Mods: hold `f` = Cmd) and `layer_home-arrows_f` (Home Row Arrows' activator) were generated, but the base layer bound `f` to `@layer_home-arrows_f`, **silently dropping Home Row Mods' hold-`f`** (ADR-039 §1 violation).

## Root cause

A collection's **momentary activator** occupies its key's slot on its *source* layer, but the detection passes only cross-checked:
- mapping vs mapping (the `claimedKeys` pass)
- activator vs activator (#466)
- leader vs activator/mapping (#463)

**collection-activator vs another collection's mapping** was covered by none. Home Row Mods has no activator (its mods are dual-role mappings); Home Row Arrows' activator is `f` — so the activator pass (needs two activators) and the mapping pass (only sees mappings, not activators) both miss it.

## Fix

Track which collections map each `(input, layer)` slot (`mappingOwners`, mappings only), and in the activator pass flag when an activator's `(sourceLayer, key)` slot is also mapped by a **different** collection. Lives in the shared `RuleCollectionDeduplicator.detectConflicts`, so it flows through the `mappingConflicts` gate that **both** the GUI dialog (#460) and the CLI apply path use. Disjoint from the activator-vs-activator and leader passes (`mappingOwners` excludes activators and the leader), so no double-reporting.

## Tests

4 new cases in `RuleCollectionDeduplicatorTests` (31 total, green in 7ms): the Home-Row-Mods-shaped conflict + non-fire for different key, different source layer (valid chained), and same-collection.

**Note on local full suite:** the full `swift test` deadlocked locally (a system-probing integration test colliding with the live KeyPath/kanata on this machine — the pure-logic deduplicator tests run in milliseconds). Relying on CI `build-and-test` for the authoritative full-suite run in its clean environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)