### PR TITLE
feat: add Norwegian and Russian logical keymaps (part of #289)

### DIFF
--- a/Sources/KeyPathAppKit/Models/LogicalKeymap.swift
+++ b/Sources/KeyPathAppKit/Models/LogicalKeymap.swift
@@ -41,7 +41,9 @@ struct LogicalKeymap: Identifiable {
         graphite,
         // International layouts
         azerty,
-        qwertz
+        qwertz,
+        norwegian,
+        russian
     ]
 
     /// Alternative/ergonomic layouts (excluding QWERTY)
@@ -56,7 +58,9 @@ struct LogicalKeymap: Identifiable {
     /// International layouts
     static let internationalLayouts: [LogicalKeymap] = [
         azerty,
-        qwertz
+        qwertz,
+        norwegian,
+        russian
     ]
 
     /// Look up a static keymap by ID. Returns nil for unknown IDs and for `systemId`.
@@ -141,6 +145,49 @@ struct LogicalKeymap: Identifiable {
             bottom: ["y", "x", "c", "v", "b", "n", "m", ",", ".", "-"]
         ),
         extraLabels: [:]
+    )
+
+    /// Norwegian - Nordic keyboard layout.
+    /// QWERTY letter arrangement plus the three Norwegian letters: Ø replaces `;`,
+    /// Æ replaces `'`, and Å replaces `[` (the key right of P). The key right of `.`
+    /// is `-` (US `/` position). Verified against kbdlayout.info/KBDNO.
+    static let norwegian: LogicalKeymap = .init(
+        id: "norwegian",
+        name: "Norwegian",
+        description: "The standard Norwegian (Nordic) layout — QWERTY with Æ, Ø, and Å.",
+        learnMoreURL: URL(string: "https://en.wikipedia.org/wiki/Keyboard_layout#Norwegian")!,
+        iconFilename: "Norwegian",
+        coreLabels: buildCoreMap(
+            top: ["q", "w", "e", "r", "t", "y", "u", "i", "o", "p"],
+            home: ["a", "s", "d", "f", "g", "h", "j", "k", "l", "ø"],
+            bottom: ["z", "x", "c", "v", "b", "n", "m", ",", ".", "-"]
+        ),
+        extraLabels: [
+            KeyCode.leftBracket: "å", // right of P
+            KeyCode.apostrophe: "æ" // right of Ø
+        ]
+    )
+
+    /// Russian - ЙЦУКЕН (JCUKEN) Cyrillic layout.
+    /// Standard Russian arrangement (by letter frequency, not a QWERTY remap).
+    /// Verified against en.wikipedia.org/wiki/JCUKEN.
+    static let russian: LogicalKeymap = .init(
+        id: "russian",
+        name: "Russian",
+        description: "The standard Russian ЙЦУКЕН (JCUKEN) Cyrillic layout.",
+        learnMoreURL: URL(string: "https://en.wikipedia.org/wiki/JCUKEN")!,
+        iconFilename: "Russian",
+        coreLabels: buildCoreMap(
+            top: ["й", "ц", "у", "к", "е", "н", "г", "ш", "щ", "з"],
+            home: ["ф", "ы", "в", "а", "п", "р", "о", "л", "д", "ж"],
+            bottom: ["я", "ч", "с", "м", "и", "т", "ь", "б", "ю", "."]
+        ),
+        extraLabels: [
+            KeyCode.leftBracket: "х", // right of З
+            KeyCode.rightBracket: "ъ",
+            KeyCode.apostrophe: "э", // right of Ж
+            KeyCode.grave: "ё"
+        ]
     )
 
     static let colemak: LogicalKeymap = .init(

--- a/Tests/KeyPathTests/Models/InternationalLogicalKeymapTests.swift
+++ b/Tests/KeyPathTests/Models/InternationalLogicalKeymapTests.swift
@@ -1,0 +1,72 @@
+@testable import KeyPathAppKit
+import XCTest
+
+/// Verifies the international LogicalKeymaps added in #289 are registered and
+/// produce the correct per-key labels. Layouts verified against kbdlayout.info
+/// (Norwegian) and en.wikipedia.org/wiki/JCUKEN (Russian).
+final class InternationalLogicalKeymapTests: XCTestCase {
+    // macOS virtual key codes for keys outside the QWERTY-label lookup table.
+    private let leftBracket: UInt16 = 33 // US `[`, right of P
+    private let rightBracket: UInt16 = 30 // US `]`
+    private let apostrophe: UInt16 = 39 // US `'`, right of `;`
+    private let grave: UInt16 = 50 // US backtick
+
+    private func keyCode(_ qwerty: String) -> UInt16 {
+        guard let code = LogicalKeymap.keyCode(forQwertyLabel: qwerty) else {
+            fatalError("no keycode for \(qwerty)")
+        }
+        return code
+    }
+
+    // MARK: - Registration
+
+    func testNewKeymapsAreRegistered() {
+        XCTAssertNotNil(LogicalKeymap.find(id: "norwegian"))
+        XCTAssertNotNil(LogicalKeymap.find(id: "russian"))
+        XCTAssertTrue(LogicalKeymap.internationalLayouts.contains { $0.id == "norwegian" })
+        XCTAssertTrue(LogicalKeymap.internationalLayouts.contains { $0.id == "russian" })
+        XCTAssertTrue(LogicalKeymap.all.contains { $0.id == "norwegian" })
+        XCTAssertTrue(LogicalKeymap.all.contains { $0.id == "russian" })
+    }
+
+    // MARK: - Norwegian
+
+    func testNorwegianCoreLabels() {
+        let nb = LogicalKeymap.norwegian
+        // Letters follow QWERTY...
+        XCTAssertEqual(nb.label(for: keyCode("q"), includeExtraKeys: false), "q")
+        XCTAssertEqual(nb.label(for: keyCode("a"), includeExtraKeys: false), "a")
+        XCTAssertEqual(nb.label(for: keyCode("z"), includeExtraKeys: false), "z")
+        // ...except Ø replaces the home-row `;`, and `-` sits in the US `/` slot.
+        XCTAssertEqual(nb.label(for: keyCode(";"), includeExtraKeys: false), "ø")
+        XCTAssertEqual(nb.label(for: keyCode("/"), includeExtraKeys: false), "-")
+    }
+
+    func testNorwegianExtraLetters() {
+        let nb = LogicalKeymap.norwegian
+        // Å (right of P) and Æ (right of Ø) are outside the 30-key block.
+        XCTAssertEqual(nb.label(for: leftBracket, includeExtraKeys: true), "å")
+        XCTAssertEqual(nb.label(for: apostrophe, includeExtraKeys: true), "æ")
+        // Not shown when extra keys are toggled off.
+        XCTAssertNil(nb.label(for: leftBracket, includeExtraKeys: false))
+    }
+
+    // MARK: - Russian (ЙЦУКЕН)
+
+    func testRussianCoreLabels() {
+        let ru = LogicalKeymap.russian
+        XCTAssertEqual(ru.label(for: keyCode("q"), includeExtraKeys: false), "й")
+        XCTAssertEqual(ru.label(for: keyCode("a"), includeExtraKeys: false), "ф")
+        XCTAssertEqual(ru.label(for: keyCode("z"), includeExtraKeys: false), "я")
+        XCTAssertEqual(ru.label(for: keyCode("p"), includeExtraKeys: false), "з")
+        XCTAssertEqual(ru.label(for: keyCode(";"), includeExtraKeys: false), "ж")
+    }
+
+    func testRussianExtraLetters() {
+        let ru = LogicalKeymap.russian
+        XCTAssertEqual(ru.label(for: leftBracket, includeExtraKeys: true), "х")
+        XCTAssertEqual(ru.label(for: rightBracket, includeExtraKeys: true), "ъ")
+        XCTAssertEqual(ru.label(for: apostrophe, includeExtraKeys: true), "э")
+        XCTAssertEqual(ru.label(for: grave, includeExtraKeys: true), "ё")
+    }
+}


### PR DESCRIPTION
## Summary

The overlay ships *physical* layouts for international keyboards (JIS, ISO, etc.) but had no matching *logical* keymaps — so users on those keyboards saw **US-QWERTY labels** on the overlay. This adds the first two international keymaps:

- **Norwegian (Nordic):** QWERTY letter arrangement with **Ø** on `;`, **Æ** on `'`, **Å** on `[` (right of P), and `-` in the US `/` slot. Verified against [kbdlayout.info/KBDNO](http://kbdlayout.info/KBDNO/).
- **Russian:** the standard **ЙЦУКЕН (JCUKEN)** Cyrillic layout, with х/ъ/э/ё on the bracket/apostrophe/grave keys. Verified against [JCUKEN (Wikipedia)](https://en.wikipedia.org/wiki/JCUKEN).

Both follow the existing 30-key-block + `extraLabels` model (same as AZERTY/QWERTZ) and are registered in `internationalLayouts`/`all`, so they appear in the overlay keymap picker's International section (`OverlayInspectorPanel+Keymaps.swift:162`).

## Scope

**Part of #289 — does not close it.** Norwegian + Russian are the clean, accurately-encodable wins (pure letter/positional layouts). The remaining listed locales — **Japanese JIS, Korean, Portuguese** — need symbol/kana/jamo label sets (a different kind of data) and are left for a follow-up.

Icons fall back to the placeholder keyboard glyph (no Norwegian/Russian SVG yet) — adding artwork is a follow-up; functionality (correct labels) is unaffected.

## Tests

`InternationalLogicalKeymapTests` (5 cases): registration in `find`/`internationalLayouts`/`all`, plus per-key label assertions for both layouts (core block + the extra Æ/Å/х/ъ/э/ё keys). Build green; SwiftFormat 0.61.1 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)