### PR TITLE
fix(insights): graceful storage fallback + flush plugins on quit + Equatable label

### DIFF
--- a/Sources/KeyPathAppKit/App.swift
+++ b/Sources/KeyPathAppKit/App.swift
@@ -135,14 +135,44 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private var suppressLaunchSplashAutoHide = false
     private var keyboardCapture: KeyboardCapture?
 
-    func applicationShouldTerminate(_: NSApplication) -> NSApplication.TerminateReply {
+    func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
         AppLogger.shared.log("🔍 [AppDelegate] applicationShouldTerminate called")
         // Close wizard and all windows so nothing blocks the quit
         WizardWindowController.shared.closeWindow()
         for window in NSApp.windows {
             window.close()
         }
-        return .terminateNow
+
+        // Give loaded plugins (e.g. Insights) a chance to flush buffered state
+        // before the process exits. Plugin cleanup is async, so defer the quit
+        // and reply once it completes — bounded by a short timeout so a stuck
+        // flush can never block the user from quitting.
+        guard !PluginManager.shared.plugins.isEmpty else {
+            return .terminateNow
+        }
+
+        var didReply = false
+        let reply: @MainActor () -> Void = {
+            guard !didReply else { return }
+            didReply = true
+            sender.reply(toApplicationShouldTerminate: true)
+        }
+
+        PluginManager.shared.prepareForTerminationAll {
+            AppLogger.shared.info("🚪 [AppDelegate] Plugin termination flush complete")
+            reply()
+        }
+
+        // Safety timeout: never let a slow plugin hold up termination.
+        Task { @MainActor in
+            try? await Task.sleep(for: .seconds(2))
+            if !didReply {
+                AppLogger.shared.log("⚠️ [AppDelegate] Plugin termination flush timed out; quitting anyway")
+            }
+            reply()
+        }
+
+        return .terminateLater
     }
 
     func applicationShouldTerminateAfterLastWindowClosed(_: NSApplication) -> Bool {

--- a/Sources/KeyPathAppKit/Services/PluginManager.swift
+++ b/Sources/KeyPathAppKit/Services/PluginManager.swift
@@ -163,6 +163,31 @@ public final class PluginManager {
         }
     }
 
+    /// Ask all loaded plugins to flush buffered state before app termination,
+    /// invoking `completion` once every plugin has finished (or immediately if
+    /// none implement the hook). Each plugin's cleanup is async; the caller is
+    /// responsible for bounding the overall wait with a timeout.
+    public func prepareForTerminationAll(completion: @escaping @MainActor () -> Void) {
+        let participating = plugins.filter { $0.responds(to: #selector(KeyPathPlugin.prepareForTermination(completion:))) }
+        guard !participating.isEmpty else {
+            completion()
+            return
+        }
+
+        var remaining = participating.count
+        AppLogger.shared.info("🔌 [PluginManager] Flushing \(remaining) plugin(s) for termination")
+        for plugin in participating {
+            plugin.prepareForTermination? {
+                MainActor.assumeIsolated {
+                    remaining -= 1
+                    if remaining == 0 {
+                        completion()
+                    }
+                }
+            }
+        }
+    }
+
     // MARK: - Install / Remove
 
     /// Downloads and installs a plugin bundle from a URL.

--- a/Sources/KeyPathAppKit/Services/PluginManager.swift
+++ b/Sources/KeyPathAppKit/Services/PluginManager.swift
@@ -178,7 +178,9 @@ public final class PluginManager {
         AppLogger.shared.info("🔌 [PluginManager] Flushing \(remaining) plugin(s) for termination")
         for plugin in participating {
             plugin.prepareForTermination? {
-                MainActor.assumeIsolated {
+                // Dispatch to MainActor rather than asserting — plugins may legally
+                // call their completion from any thread or actor context.
+                Task { @MainActor in
                     remaining -= 1
                     if remaining == 0 {
                         completion()

--- a/Sources/KeyPathInsights/ActivityLogging/Services/ActivityLogStorage.swift
+++ b/Sources/KeyPathInsights/ActivityLogging/Services/ActivityLogStorage.swift
@@ -51,10 +51,11 @@ public actor ActivityLogStorage {
         // Application Support directory must degrade gracefully rather than
         // crash the whole app, so fall back to the conventional home-relative
         // path if the API lookup ever fails.
-        let appSupport = FileManager.default.urls(
-            for: .applicationSupportDirectory,
-            in: .userDomainMask
-        ).first ?? URL(fileURLWithPath: NSHomeDirectory())
+        let appSupportResult = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)
+        if appSupportResult.isEmpty {
+            AppLogger.shared.warn("⚠️ [ActivityLogStorage] Application Support directory unavailable — using NSHomeDirectory fallback")
+        }
+        let appSupport = appSupportResult.first ?? URL(fileURLWithPath: NSHomeDirectory())
             .appendingPathComponent("Library")
             .appendingPathComponent("Application Support")
         baseDirectory = appSupport

--- a/Sources/KeyPathInsights/ActivityLogging/Services/ActivityLogStorage.swift
+++ b/Sources/KeyPathInsights/ActivityLogging/Services/ActivityLogStorage.swift
@@ -47,12 +47,16 @@ public actor ActivityLogStorage {
         encryption = ActivityLogEncryption.shared
 
         // Use ~/Library/Application Support/KeyPath/ActivityLog/
-        guard let appSupport = FileManager.default.urls(
+        // Activity logging is an optional, opt-in feature — a missing
+        // Application Support directory must degrade gracefully rather than
+        // crash the whole app, so fall back to the conventional home-relative
+        // path if the API lookup ever fails.
+        let appSupport = FileManager.default.urls(
             for: .applicationSupportDirectory,
             in: .userDomainMask
-        ).first else {
-            fatalError("Application Support directory unavailable")
-        }
+        ).first ?? URL(fileURLWithPath: NSHomeDirectory())
+            .appendingPathComponent("Library")
+            .appendingPathComponent("Application Support")
         baseDirectory = appSupport
             .appendingPathComponent("KeyPath")
             .appendingPathComponent(Self.directoryName)

--- a/Sources/KeyPathInsights/InsightsPlugin.swift
+++ b/Sources/KeyPathInsights/InsightsPlugin.swift
@@ -36,6 +36,14 @@ public class InsightsPlugin: NSObject, KeyPathPlugin {
         }
     }
 
+    public func prepareForTermination(completion: @escaping () -> Void) {
+        Task { @MainActor in
+            // Flush any buffered events to disk before the app exits.
+            await ActivityLogger.shared.prepareForTermination()
+            completion()
+        }
+    }
+
     public func didReceiveActionEvent(action: String, target: String?, uri: String) {
         Task { @MainActor in
             ActivityLogger.shared.recordKeyPathAction(action: action, target: target, uri: uri)

--- a/Sources/KeyPathInsights/InsightsPlugin.swift
+++ b/Sources/KeyPathInsights/InsightsPlugin.swift
@@ -37,10 +37,19 @@ public class InsightsPlugin: NSObject, KeyPathPlugin {
     }
 
     public func prepareForTermination(completion: @escaping () -> Void) {
+        // @escaping () -> Void is not Sendable; box it so it can cross into the
+        // @MainActor Task. Safe: PluginManager always calls this from @MainActor
+        // and guards the completion with MainActor.assumeIsolated.
+        final class Box: @unchecked Sendable {
+            let fn: () -> Void
+            init(_ fn: @escaping () -> Void) {
+                self.fn = fn
+            }
+        }
+        let box = Box(completion)
         Task { @MainActor in
-            // Flush any buffered events to disk before the app exits.
             await ActivityLogger.shared.prepareForTermination()
-            completion()
+            box.fn()
         }
     }
 

--- a/Sources/KeyPathPluginKit/KeyPathPlugin.swift
+++ b/Sources/KeyPathPluginKit/KeyPathPlugin.swift
@@ -28,6 +28,14 @@ import AppKit
     /// Called before the plugin is unloaded (optional, default no-op).
     @objc optional func deactivate()
 
+    /// Called when the host app is about to terminate, so the plugin can
+    /// flush any buffered state (e.g. analytics events) before the process
+    /// exits. The plugin performs its (possibly async) cleanup and **must**
+    /// invoke `completion` when finished; the host bounds the total wait with
+    /// a timeout so a stuck plugin can never block the user from quitting.
+    /// Optional — host skips plugins that don't implement it.
+    @objc optional func prepareForTermination(completion: @escaping () -> Void)
+
     /// Called when a `keypath://` action URI is dispatched.
     /// Plugins can use this to record analytics, trigger side effects, etc.
     @objc optional func didReceiveActionEvent(action: String, target: String?, uri: String)


### PR DESCRIPTION
## Summary

- **#673** — `ActivityLogStorage.init()`: replaced `fatalError` with a graceful `~/Library/Application Support` fallback so a missing directory can't crash the app on launch. Adds a warning log when the fallback fires.
- **#674** — On `applicationShouldTerminate`, loaded plugins now get a chance to flush buffered state before the process exits. Returns `.terminateLater`, calls `prepareForTerminationAll`, and replies after all plugins finish or a 2-second timeout fires — whichever comes first.
- **#485** — `FloatingKeymapLabel` conforms to `Equatable` and gains `.equatable()` in `OverlayKeyboardView`, so SwiftUI skips re-evaluating labels whose display inputs are unchanged when the parent re-renders for unrelated state.
- **Concurrency fix** (compile-time) — `InsightsPlugin.prepareForTermination(completion:)` wraps the non-`Sendable` `@escaping () -> Void` in a local `@unchecked Sendable` box so it can cross the Swift 6 actor boundary into `Task { @MainActor in }`.
- **Concurrency safety** (runtime) — `PluginManager.prepareForTerminationAll` changed from `MainActor.assumeIsolated` (runtime trap) to `Task { @MainActor in }` (guaranteed hop), protecting against future plugins that call their completion from a background thread.

## Test plan

- [ ] Build passes (`SKIP_NOTARIZE=1 ./build.sh`)
- [ ] `swift test` — all failures are pre-existing on `master` (verified)
- [ ] `swiftformat` — no churn at pinned 0.61.1
- [ ] Quit app with Activity Insights loaded — confirm clean quit (no hang, no crash)
- [ ] Check `~/Library/Application Support/KeyPath/ActivityLog/` for flushed events after quit/relaunch