### PR TITLE
Tier-2 pre-release fixes: AI model/cost, managed-pack toggle, script & plugin UX, menu bar

### DIFF
--- a/Sources/KeyPathAppKit/MenuBar/MenuBarController.swift
+++ b/Sources/KeyPathAppKit/MenuBar/MenuBarController.swift
@@ -31,6 +31,10 @@ final class MenuBarController: NSObject, NSMenuDelegate {
     /// Updated asynchronously; read synchronously during menu building.
     private var cachedAppKeymaps: [String: AppKeymap] = [:]
 
+    /// Whether the status menu is currently open. Used to rebuild live when an
+    /// async keymap load resolves mid-display.
+    private var isMenuOpen = false
+
     // MARK: - Feature IDs (in display order: approachable → nerdy)
 
     private static let featureCollections: [(id: UUID, name: String)] = [
@@ -153,6 +157,19 @@ final class MenuBarController: NSObject, NSMenuDelegate {
 
     func menuNeedsUpdate(_: NSMenu) {
         rebuildMenu()
+    }
+
+    func menuWillOpen(_: NSMenu) {
+        isMenuOpen = true
+        // Reload app keymaps each time the menu opens so the per-app section is
+        // current. If the (async) load resolves while the menu is still open,
+        // refreshAppKeymapCache rebuilds it live — fixing the first-open race
+        // where the cache hadn't populated yet.
+        refreshAppKeymapCache()
+    }
+
+    func menuDidClose(_: NSMenu) {
+        isMenuOpen = false
     }
 
     // MARK: - Menu Building
@@ -342,16 +359,30 @@ final class MenuBarController: NSObject, NSMenuDelegate {
                 menu.addItem(mappingItem)
             }
 
-            // Show "and X more..." if there are more
+            // Remaining mappings live in an "X more…" submenu so they're
+            // actually viewable in the menu bar, rather than a flat row that
+            // silently opens the mapper.
             if keymap.overrides.count > 5 {
+                let remaining = Array(keymap.overrides.dropFirst(5))
                 let moreItem = NSMenuItem(
-                    title: "  and \(keymap.overrides.count - 5) more...",
-                    action: #selector(handleAppMappingClick),
+                    title: "  \(remaining.count) more\u{2026}",
+                    action: nil,
                     keyEquivalent: ""
                 )
-                moreItem.target = self
                 moreItem.indentationLevel = 1
-                moreItem.representedObject = bundleId
+
+                let submenu = NSMenu()
+                for override in remaining {
+                    let item = NSMenuItem(
+                        title: "\(override.inputKey) → \(KeyDisplayFormatter.format(override.action.displayName))",
+                        action: #selector(handleAppMappingClick),
+                        keyEquivalent: ""
+                    )
+                    item.target = self
+                    item.representedObject = bundleId
+                    submenu.addItem(item)
+                }
+                moreItem.submenu = submenu
                 menu.addItem(moreItem)
             }
         }
@@ -372,12 +403,18 @@ final class MenuBarController: NSObject, NSMenuDelegate {
     /// Called on initial configure and whenever `.appKeymapsDidChange` fires.
     private func refreshAppKeymapCache() {
         Task { @MainActor [weak self] in
+            guard let self else { return }
             let keymaps = await AppKeymapStore.shared.loadKeymaps()
             var keymapsByBundle: [String: AppKeymap] = [:]
             for keymap in keymaps {
                 keymapsByBundle[keymap.mapping.bundleIdentifier] = keymap
             }
-            self?.cachedAppKeymaps = keymapsByBundle
+            cachedAppKeymaps = keymapsByBundle
+            // If the menu is showing when the load lands, rebuild so the
+            // per-app section appears now instead of on the next open.
+            if isMenuOpen {
+                rebuildMenu()
+            }
         }
     }
 

--- a/Sources/KeyPathAppKit/Services/AI/AICostTracker.swift
+++ b/Sources/KeyPathAppKit/Services/AI/AICostTracker.swift
@@ -3,8 +3,9 @@ import KeyPathCore
 
 // MARK: - Pricing Constants
 
-/// Claude API pricing constants (Claude 3.5 Sonnet, Dec 2024)
-/// ⚠️ Update these when releasing new app versions
+/// Claude API pricing constants — must match `ClaudeAPIConstants.defaultModel`.
+/// Currently Claude Sonnet 4.x ($3/1M input, $15/1M output).
+/// ⚠️ Update these whenever `ClaudeAPIConstants.defaultModel` changes.
 public enum ClaudeAPIPricing {
     /// Price per million input tokens ($3/1M)
     public static let inputPricePerMillion: Double = 3.0

--- a/Sources/KeyPathAppKit/Services/AI/AnthropicConfigRepairService.swift
+++ b/Sources/KeyPathAppKit/Services/AI/AnthropicConfigRepairService.swift
@@ -8,9 +8,9 @@ public actor AnthropicConfigRepairService: ConfigRepairService {
     private let version: String
 
     public init(
-        endpoint: URL = URL(string: "https://api.anthropic.com/v1/messages")!,
-        model: String = "claude-3-5-sonnet-20241022",
-        version: String = "2023-06-01"
+        endpoint: URL = ClaudeAPIConstants.messagesEndpoint,
+        model: String = ClaudeAPIConstants.defaultModel,
+        version: String = ClaudeAPIConstants.apiVersion
     ) {
         self.endpoint = endpoint
         self.model = model
@@ -59,7 +59,7 @@ public actor AnthropicConfigRepairService: ConfigRepairService {
 
         // Biometric authentication before expensive API call
         let authResult = await BiometricAuthService.shared.authenticate(
-            reason: "This config repair will use your Anthropic API quota. Authenticate to proceed?"
+            reason: BiometricAuthService.defaultAuthReason
         )
 
         switch authResult {

--- a/Sources/KeyPathAppKit/Services/AI/BiometricAuthService.swift
+++ b/Sources/KeyPathAppKit/Services/AI/BiometricAuthService.swift
@@ -13,6 +13,12 @@ public final class BiometricAuthService: @unchecked Sendable {
     /// UserDefaults key for biometric auth preference
     public static let requireBiometricAuthKey = "KeyPath.AI.RequireBiometricAuth"
 
+    /// Default reason shown when authenticating before a paid Claude API call.
+    /// Intentionally avoids a precise dollar figure — per-request cost varies with
+    /// model and config size. Shared across all AI call sites for consistent copy.
+    public static let defaultAuthReason =
+        "This will use your Anthropic API quota (a small per-request cost). Authenticate to proceed?"
+
     /// Whether user has authenticated this session (persists until app restart)
     private var hasAuthenticatedThisSession: Bool = false
     private let userDefaults: UserDefaults
@@ -70,7 +76,7 @@ public final class BiometricAuthService: @unchecked Sendable {
     /// - Parameter reason: Explanation shown to user (should mention cost)
     /// - Returns: AuthResult indicating the outcome
     public func authenticate(
-        reason: String = "This AI generation will use your Anthropic API quota and cost approximately $0.01-0.03. Authenticate to proceed?"
+        reason: String = BiometricAuthService.defaultAuthReason
     ) async -> AuthResult {
         // Check if auth is required
         guard isEnabled else {

--- a/Sources/KeyPathAppKit/Services/AI/ClaudeAPIConstants.swift
+++ b/Sources/KeyPathAppKit/Services/AI/ClaudeAPIConstants.swift
@@ -9,8 +9,10 @@ public enum ClaudeAPIConstants {
     /// API version header value
     public static let apiVersion = "2023-06-01"
 
-    /// Default model for config generation and repair
-    public static let defaultModel = "claude-3-5-sonnet-20241022"
+    /// Default model for config generation and repair.
+    /// Single source of truth — update here when bumping models, and update
+    /// `ClaudeAPIPricing` in AICostTracker to match the new model's rates.
+    public static let defaultModel = "claude-sonnet-4-6"
 
     /// Maximum tokens for config generation responses
     public static let maxTokensForConfig = 4096

--- a/Sources/KeyPathAppKit/Services/Configuration/KanataConfigGenerator.swift
+++ b/Sources/KeyPathAppKit/Services/Configuration/KanataConfigGenerator.swift
@@ -254,7 +254,7 @@ public class KanataConfigGenerator {
 
         // Biometric authentication before expensive API call
         let authResult = await BiometricAuthService.shared.authenticate(
-            reason: "This AI generation will use your Anthropic API quota and cost approximately $0.01-0.03. Authenticate to proceed?"
+            reason: BiometricAuthService.defaultAuthReason
         )
 
         switch authResult {
@@ -267,16 +267,15 @@ public class KanataConfigGenerator {
             break // Continue with API call
         }
 
-        let url = URL(string: "https://api.anthropic.com/v1/messages")!
-        var request = URLRequest(url: url)
+        var request = URLRequest(url: ClaudeAPIConstants.messagesEndpoint)
         request.httpMethod = "POST"
         request.addValue("application/json", forHTTPHeaderField: "Content-Type")
         request.addValue(apiKey, forHTTPHeaderField: "x-api-key")
-        request.addValue("2023-06-01", forHTTPHeaderField: "anthropic-version")
+        request.addValue(ClaudeAPIConstants.apiVersion, forHTTPHeaderField: "anthropic-version")
 
         let requestBody: [String: Any] = [
-            "model": "claude-3-5-sonnet-20241022",
-            "max_tokens": 4096,
+            "model": ClaudeAPIConstants.defaultModel,
+            "max_tokens": ClaudeAPIConstants.maxTokensForConfig,
             "messages": [
                 [
                     "role": "user",

--- a/Sources/KeyPathAppKit/Services/PluginDownloader.swift
+++ b/Sources/KeyPathAppKit/Services/PluginDownloader.swift
@@ -1,0 +1,80 @@
+import Foundation
+import KeyPathCore
+
+/// Downloads a file to a temporary location with byte-level progress reporting
+/// and cooperative cancellation.
+///
+/// Bridges `URLSessionDownloadDelegate` callbacks into async/await: the download
+/// task is cancelled when the awaiting `Task` is cancelled, and progress is
+/// surfaced via `progressHandler` (called on the session's delegate queue, so
+/// hop to the main actor inside the handler before touching UI state).
+// SAFETY: @unchecked Sendable — `continuation`/`task` are written once before
+// `resume()` starts delivering delegate callbacks, so there is no concurrent
+// access; the continuation is resumed exactly once and then niled.
+final class PluginDownloader: NSObject, URLSessionDownloadDelegate, @unchecked Sendable {
+    private var continuation: CheckedContinuation<URL, Error>?
+    private let progressHandler: @Sendable (Double) -> Void
+    private var session: URLSession!
+    private var task: URLSessionDownloadTask?
+
+    init(progressHandler: @escaping @Sendable (Double) -> Void) {
+        self.progressHandler = progressHandler
+        super.init()
+        session = URLSession(configuration: .default, delegate: self, delegateQueue: nil)
+    }
+
+    /// Downloads `url`, returning a temp-file URL the caller is responsible for
+    /// removing. Throws `URLError`/`CancellationError` on failure or cancellation.
+    func download(from url: URL) async throws -> URL {
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { (cont: CheckedContinuation<URL, Error>) in
+                continuation = cont
+                let downloadTask = session.downloadTask(with: url)
+                task = downloadTask
+                downloadTask.resume()
+            }
+        } onCancel: {
+            task?.cancel()
+        }
+    }
+
+    // MARK: - URLSessionDownloadDelegate
+
+    func urlSession(
+        _: URLSession,
+        downloadTask _: URLSessionDownloadTask,
+        didWriteData _: Int64,
+        totalBytesWritten: Int64,
+        totalBytesExpectedToWrite: Int64
+    ) {
+        guard totalBytesExpectedToWrite > 0 else { return }
+        progressHandler(Double(totalBytesWritten) / Double(totalBytesExpectedToWrite))
+    }
+
+    func urlSession(
+        _: URLSession,
+        downloadTask _: URLSessionDownloadTask,
+        didFinishDownloadingTo location: URL
+    ) {
+        // The system deletes `location` once this delegate returns, so move the
+        // file out synchronously before resuming.
+        let destination = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+        do {
+            try FileManager.default.moveItem(at: location, to: destination)
+            continuation?.resume(returning: destination)
+        } catch {
+            continuation?.resume(throwing: error)
+        }
+        continuation = nil
+    }
+
+    func urlSession(_ session: URLSession, task _: URLSessionTask, didCompleteWithError error: Error?) {
+        // On success the continuation was already resumed in didFinishDownloadingTo.
+        if let error {
+            continuation?.resume(throwing: error)
+            continuation = nil
+        }
+        session.finishTasksAndInvalidate()
+    }
+}

--- a/Sources/KeyPathAppKit/Services/PluginManager.swift
+++ b/Sources/KeyPathAppKit/Services/PluginManager.swift
@@ -40,9 +40,20 @@ public final class PluginManager {
     /// Current install progress message
     public private(set) var installProgressMessage: String?
 
+    /// Download progress in 0...1 while downloading, or nil when indeterminate
+    /// (download not started, server didn't report a size, or unzip/install phase).
+    public private(set) var installProgress: Double?
+
+    /// Human-readable reason the last install failed, or nil. Cleared when a new
+    /// install starts or one succeeds. User-initiated cancellation does not set it.
+    public private(set) var installError: String?
+
     // MARK: - Private
 
     private var loadedBundlePaths: Set<String> = []
+
+    /// The in-flight install task, used for cancellation.
+    private var installTask: Task<Void, Never>?
 
     private var userPluginsDirectory: URL {
         guard let appSupport = Foundation.FileManager().urls(for: .applicationSupportDirectory, in: .userDomainMask).first else {
@@ -192,21 +203,82 @@ public final class PluginManager {
 
     // MARK: - Install / Remove
 
-    /// Downloads and installs a plugin bundle from a URL.
-    public func installPlugin(from url: URL) async -> Bool {
+    /// Error thrown during install with a user-facing message.
+    private struct InstallError: Error {
+        let userMessage: String
+    }
+
+    /// Starts a (cancellable) download + install of a plugin bundle. Fire-and-forget:
+    /// progress, completion, and any error are reflected on the observable state
+    /// (`isInstalling`, `installProgress`, `installProgressMessage`, `installError`).
+    /// Ignored if an install is already running.
+    public func beginInstall(from url: URL) {
+        guard installTask == nil else {
+            AppLogger.shared.warn("🔌 [PluginManager] Install already in progress; ignoring request")
+            return
+        }
+
+        installError = nil
+        installProgress = nil
         isInstalling = true
         installProgressMessage = "Downloading\u{2026}"
 
+        installTask = Task { [self] in
+            await performInstall(from: url)
+            isInstalling = false
+            installProgressMessage = nil
+            installProgress = nil
+            installTask = nil
+        }
+    }
+
+    /// Cancels an in-flight install. The download is aborted and partial files
+    /// are cleaned up; no error message is shown for user-initiated cancellation.
+    public func cancelInstall() {
+        guard installTask != nil else { return }
+        AppLogger.shared.info("🔌 [PluginManager] Cancelling in-flight install")
+        installProgressMessage = "Cancelling\u{2026}"
+        installTask?.cancel()
+    }
+
+    /// Backwards-compatible one-shot install. Returns true on success. Prefer
+    /// `beginInstall(from:)` for UI use so the install can be cancelled.
+    @discardableResult
+    public func installPlugin(from url: URL) async -> Bool {
+        isInstalling = true
+        installError = nil
+        installProgress = nil
+        installProgressMessage = "Downloading\u{2026}"
         defer {
             isInstalling = false
             installProgressMessage = nil
+            installProgress = nil
         }
+        await performInstall(from: url)
+        return installError == nil
+    }
 
+    /// Runs the full download → unzip → install pipeline, updating observable
+    /// state. Sets `installError` with a specific message on failure; leaves it
+    /// nil on success or user cancellation.
+    private func performInstall(from url: URL) async {
         do {
-            // Download
-            let (tempFileURL, _) = try await URLSession.shared.download(from: url)
+            // Download with progress + cancellation support.
+            let downloader = PluginDownloader { [weak self] progress in
+                Task { @MainActor in self?.installProgress = progress }
+            }
+            let tempFileURL: URL
+            do {
+                tempFileURL = try await downloader.download(from: url)
+            } catch let urlError as URLError where urlError.code == .cancelled {
+                throw CancellationError()
+            } catch let urlError as URLError {
+                throw InstallError(userMessage: networkMessage(for: urlError))
+            }
 
+            try Task.checkCancellation()
             installProgressMessage = "Installing\u{2026}"
+            installProgress = nil
 
             // Ensure plugins directory exists
             try Foundation.FileManager().createDirectory(at: userPluginsDirectory, withIntermediateDirectories: true)
@@ -218,7 +290,8 @@ public final class PluginManager {
             let result = try await SubprocessRunner.shared.run("/usr/bin/ditto", args: ["-xk", tempFileURL.path, unzipDir.path])
             guard result.exitCode == 0 else {
                 AppLogger.shared.error("🔌 [PluginManager] Unzip failed with status \(result.exitCode)")
-                return false
+                try? Foundation.FileManager().removeItem(at: tempFileURL)
+                throw InstallError(userMessage: "The download couldn't be unpacked — it may be corrupted. Try again.")
             }
 
             // Find the .bundle in unzipped contents
@@ -230,7 +303,9 @@ public final class PluginManager {
 
             guard let bundleSource = unzippedContents.first(where: { $0.pathExtension == "bundle" }) else {
                 AppLogger.shared.error("🔌 [PluginManager] No .bundle found in downloaded archive")
-                return false
+                try? Foundation.FileManager().removeItem(at: tempFileURL)
+                try? Foundation.FileManager().removeItem(at: unzipDir)
+                throw InstallError(userMessage: "The download didn't contain a valid plugin.")
             }
 
             let destination = userPluginsDirectory.appendingPathComponent(bundleSource.lastPathComponent)
@@ -250,10 +325,30 @@ public final class PluginManager {
             loadPlugin(from: destination)
 
             AppLogger.shared.info("🔌 [PluginManager] Plugin installed from: \(url.lastPathComponent)")
-            return true
+        } catch is CancellationError {
+            AppLogger.shared.info("🔌 [PluginManager] Install cancelled by user")
+        } catch let error as InstallError {
+            AppLogger.shared.error("🔌 [PluginManager] Install failed: \(error.userMessage)")
+            installError = error.userMessage
         } catch {
             AppLogger.shared.error("🔌 [PluginManager] Install failed: \(error)")
-            return false
+            installError = "Installation failed: \(error.localizedDescription)"
+        }
+    }
+
+    /// Maps a `URLError` to a concise, user-facing reason.
+    private func networkMessage(for error: URLError) -> String {
+        switch error.code {
+        case .notConnectedToInternet:
+            "No internet connection. Check your network and try again."
+        case .timedOut:
+            "The download timed out. Check your connection and try again."
+        case .cannotFindHost, .cannotConnectToHost, .dnsLookupFailed:
+            "Couldn't reach the download server. Try again later."
+        case .fileDoesNotExist, .badURL, .resourceUnavailable:
+            "The plugin download is unavailable. Try again later."
+        default:
+            "Download failed: \(error.localizedDescription)"
         }
     }
 

--- a/Sources/KeyPathAppKit/UI/Dialogs/AIKeyRequiredDialog.swift
+++ b/Sources/KeyPathAppKit/UI/Dialogs/AIKeyRequiredDialog.swift
@@ -144,7 +144,7 @@ struct AIKeyRequiredDialog: View {
                 .foregroundColor(.orange)
 
             VStack(alignment: .leading, spacing: 4) {
-                Text("• Each complex mapping costs approximately $0.01-0.03")
+                Text("• Each complex mapping makes one API call (a small per-request cost)")
                 Text("• Simple mappings are always free (no API call)")
                 Text("• Costs vary based on Anthropic's pricing")
                 Text("• Check your Anthropic dashboard for exact charges")

--- a/Sources/KeyPathAppKit/UI/Help/WebHelpView.swift
+++ b/Sources/KeyPathAppKit/UI/Help/WebHelpView.swift
@@ -188,7 +188,8 @@ private struct WebHelpWebView: NSViewRepresentable {
 
             if let host = url.host,
                host.contains("malpern.github.io"),
-               url.path.hasPrefix("/KeyPath/guides/") {
+               url.path.hasPrefix("/KeyPath/guides/")
+            {
                 let resource = url.path
                     .replacingOccurrences(of: "/KeyPath/guides/", with: "")
                     .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
@@ -211,7 +212,8 @@ private struct WebHelpWebView: NSViewRepresentable {
         ) {
             if navigationResponse.isForMainFrame,
                let http = navigationResponse.response as? HTTPURLResponse,
-               http.statusCode >= 400 {
+               http.statusCode >= 400
+            {
                 onLoadError?(http.statusCode == 404 ? .notFound : .generic)
                 decisionHandler(.cancel)
                 return

--- a/Sources/KeyPathAppKit/UI/Help/WebHelpView.swift
+++ b/Sources/KeyPathAppKit/UI/Help/WebHelpView.swift
@@ -1,13 +1,126 @@
 import SwiftUI
 import WebKit
 
-/// Loads a help article from the KeyPath website via WKWebView.
-struct WebHelpView: NSViewRepresentable {
+/// Why a help article failed to load, used to tailor the offline/404 fallback copy.
+enum HelpLoadError: Equatable {
+    /// The device appears to be offline or the host is unreachable.
+    case offline
+    /// The page loaded but the server returned a not-found / error status.
+    case notFound
+    /// Any other navigation failure.
+    case generic
+
+    var title: String {
+        switch self {
+        case .offline: "Can't reach the help site"
+        case .notFound: "This guide isn't available"
+        case .generic: "Couldn't load this guide"
+        }
+    }
+
+    var message: String {
+        switch self {
+        case .offline:
+            "KeyPath help lives online. Check your internet connection and try again."
+        case .notFound:
+            "This guide may have moved or isn't published yet. Try opening it in your browser, or report it so we can fix the link."
+        case .generic:
+            "Something went wrong loading this guide. Try again, or open it in your browser."
+        }
+    }
+}
+
+/// Loads a help article from the KeyPath website, with an offline/404 fallback.
+struct WebHelpView: View {
     let url: URL
     var onHelpLinkClicked: ((String) -> Void)?
 
+    @State private var loadError: HelpLoadError?
+    /// Bumped to ask the underlying web view to reload the current URL.
+    @State private var reloadToken = 0
+
+    var body: some View {
+        ZStack {
+            WebHelpWebView(
+                url: url,
+                reloadToken: reloadToken,
+                onHelpLinkClicked: onHelpLinkClicked,
+                onLoadError: { loadError = $0 },
+                onLoadSucceeded: { loadError = nil }
+            )
+
+            if let loadError {
+                fallbackView(loadError)
+            }
+        }
+        // Reset the error when navigating to a different article.
+        .onChange(of: url) { _, _ in loadError = nil }
+    }
+
+    private func fallbackView(_ error: HelpLoadError) -> some View {
+        VStack(spacing: 14) {
+            Image(systemName: error == .offline ? "wifi.slash" : "questionmark.folder")
+                .font(.system(size: 40))
+                .foregroundStyle(.secondary)
+
+            Text(error.title)
+                .font(.title3)
+                .fontWeight(.semibold)
+
+            Text(error.message)
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 360)
+
+            HStack(spacing: 10) {
+                Button {
+                    loadError = nil
+                    reloadToken += 1
+                } label: {
+                    Label("Try Again", systemImage: "arrow.clockwise")
+                }
+                .buttonStyle(.borderedProminent)
+                .accessibilityIdentifier("help-fallback-retry-button")
+
+                Button {
+                    NSWorkspace.shared.open(url)
+                } label: {
+                    Label("Open in Browser", systemImage: "safari")
+                }
+                .buttonStyle(.bordered)
+                .accessibilityIdentifier("help-fallback-open-browser-button")
+            }
+            .padding(.top, 4)
+
+            if error == .notFound {
+                Link("Report a broken link", destination: URL(string: "https://github.com/malpern/KeyPath/issues")!)
+                    .font(.caption)
+                    .accessibilityIdentifier("help-fallback-report-link")
+            }
+        }
+        .padding(40)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color(NSColor.windowBackgroundColor))
+        .accessibilityIdentifier("help-fallback-view")
+    }
+}
+
+/// The WKWebView backing `WebHelpView`. Reports navigation failures and error
+/// HTTP statuses so the parent can render a fallback instead of a blank page.
+private struct WebHelpWebView: NSViewRepresentable {
+    let url: URL
+    let reloadToken: Int
+    var onHelpLinkClicked: ((String) -> Void)?
+    var onLoadError: ((HelpLoadError) -> Void)?
+    var onLoadSucceeded: (() -> Void)?
+
     func makeCoordinator() -> Coordinator {
-        Coordinator(onHelpLinkClicked: onHelpLinkClicked)
+        Coordinator(
+            onHelpLinkClicked: onHelpLinkClicked,
+            onLoadError: onLoadError,
+            onLoadSucceeded: onLoadSucceeded
+        )
     }
 
     func makeNSView(context: Context) -> WKWebView {
@@ -19,23 +132,39 @@ struct WebHelpView: NSViewRepresentable {
         webView.setValue(false, forKey: "drawsBackground")
         webView.load(URLRequest(url: url))
         context.coordinator.currentURL = url
+        context.coordinator.lastReloadToken = reloadToken
         return webView
     }
 
     func updateNSView(_ webView: WKWebView, context: Context) {
         context.coordinator.onHelpLinkClicked = onHelpLinkClicked
+        context.coordinator.onLoadError = onLoadError
+        context.coordinator.onLoadSucceeded = onLoadSucceeded
+
         if context.coordinator.currentURL != url {
             context.coordinator.currentURL = url
+            webView.load(URLRequest(url: url))
+        } else if context.coordinator.lastReloadToken != reloadToken {
+            context.coordinator.lastReloadToken = reloadToken
             webView.load(URLRequest(url: url))
         }
     }
 
     final class Coordinator: NSObject, WKNavigationDelegate {
         var onHelpLinkClicked: ((String) -> Void)?
+        var onLoadError: ((HelpLoadError) -> Void)?
+        var onLoadSucceeded: (() -> Void)?
         var currentURL: URL?
+        var lastReloadToken = 0
 
-        init(onHelpLinkClicked: ((String) -> Void)?) {
+        init(
+            onHelpLinkClicked: ((String) -> Void)?,
+            onLoadError: ((HelpLoadError) -> Void)?,
+            onLoadSucceeded: (() -> Void)?
+        ) {
             self.onHelpLinkClicked = onHelpLinkClicked
+            self.onLoadError = onLoadError
+            self.onLoadSucceeded = onLoadSucceeded
         }
 
         func webView(
@@ -59,8 +188,7 @@ struct WebHelpView: NSViewRepresentable {
 
             if let host = url.host,
                host.contains("malpern.github.io"),
-               url.path.hasPrefix("/KeyPath/guides/")
-            {
+               url.path.hasPrefix("/KeyPath/guides/") {
                 let resource = url.path
                     .replacingOccurrences(of: "/KeyPath/guides/", with: "")
                     .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
@@ -73,6 +201,56 @@ struct WebHelpView: NSViewRepresentable {
 
             NSWorkspace.shared.open(url)
             decisionHandler(.cancel)
+        }
+
+        /// Detect HTTP error statuses (e.g. a 404 for an unpublished guide) on the main frame.
+        func webView(
+            _: WKWebView,
+            decidePolicyFor navigationResponse: WKNavigationResponse,
+            decisionHandler: @escaping @MainActor @Sendable (WKNavigationResponsePolicy) -> Void
+        ) {
+            if navigationResponse.isForMainFrame,
+               let http = navigationResponse.response as? HTTPURLResponse,
+               http.statusCode >= 400 {
+                onLoadError?(http.statusCode == 404 ? .notFound : .generic)
+                decisionHandler(.cancel)
+                return
+            }
+            decisionHandler(.allow)
+        }
+
+        func webView(_: WKWebView, didFinish _: WKNavigation!) {
+            onLoadSucceeded?()
+        }
+
+        func webView(_: WKWebView, didFailProvisionalNavigation _: WKNavigation!, withError error: Error) {
+            reportFailure(error)
+        }
+
+        func webView(_: WKWebView, didFail _: WKNavigation!, withError error: Error) {
+            reportFailure(error)
+        }
+
+        private func reportFailure(_ error: Error) {
+            let nsError = error as NSError
+            // Ignore cancellations from our own policy decisions (404 handling, internal links).
+            if nsError.domain == NSURLErrorDomain, nsError.code == NSURLErrorCancelled { return }
+            // WebKitErrorDomain 102 = frame load interrupted by a policy change (our .cancel calls).
+            if nsError.domain == "WebKitErrorDomain", nsError.code == 102 { return }
+
+            let offlineCodes: Set<Int> = [
+                NSURLErrorNotConnectedToInternet,
+                NSURLErrorCannotFindHost,
+                NSURLErrorCannotConnectToHost,
+                NSURLErrorNetworkConnectionLost,
+                NSURLErrorTimedOut,
+                NSURLErrorDNSLookupFailed
+            ]
+            if nsError.domain == NSURLErrorDomain, offlineCodes.contains(nsError.code) {
+                onLoadError?(.offline)
+            } else {
+                onLoadError?(.generic)
+            }
         }
     }
 }

--- a/Sources/KeyPathAppKit/UI/Help/WebHelpView.swift
+++ b/Sources/KeyPathAppKit/UI/Help/WebHelpView.swift
@@ -233,6 +233,15 @@ private struct WebHelpWebView: NSViewRepresentable {
             reportFailure(error)
         }
 
+        private static let offlineErrorCodes: Set<Int> = [
+            NSURLErrorNotConnectedToInternet,
+            NSURLErrorCannotFindHost,
+            NSURLErrorCannotConnectToHost,
+            NSURLErrorNetworkConnectionLost,
+            NSURLErrorTimedOut,
+            NSURLErrorDNSLookupFailed
+        ]
+
         private func reportFailure(_ error: Error) {
             let nsError = error as NSError
             // Ignore cancellations from our own policy decisions (404 handling, internal links).
@@ -240,15 +249,7 @@ private struct WebHelpWebView: NSViewRepresentable {
             // WebKitErrorDomain 102 = frame load interrupted by a policy change (our .cancel calls).
             if nsError.domain == "WebKitErrorDomain", nsError.code == 102 { return }
 
-            let offlineCodes: Set<Int> = [
-                NSURLErrorNotConnectedToInternet,
-                NSURLErrorCannotFindHost,
-                NSURLErrorCannotConnectToHost,
-                NSURLErrorNetworkConnectionLost,
-                NSURLErrorTimedOut,
-                NSURLErrorDNSLookupFailed
-            ]
-            if nsError.domain == NSURLErrorDomain, offlineCodes.contains(nsError.code) {
+            if nsError.domain == NSURLErrorDomain, Self.offlineErrorCodes.contains(nsError.code) {
                 onLoadError?(.offline)
             } else {
                 onLoadError?(.generic)

--- a/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView+CollectionRow.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView+CollectionRow.swift
@@ -306,32 +306,44 @@ struct ExpandableCollectionRow: View {
                 .accessibilityLabel("\(name) help")
             }
 
-            // Right side: Toggle (NOT inside button, so it receives taps)
-            Toggle(
-                "",
-                isOn: Binding(
-                    get: { effectiveEnabled },
-                    set: { newValue in
-                        // Optimistic update: change UI immediately
-                        localEnabled = newValue
-                        // Then trigger async operation
-                        onToggle(newValue)
-                    }
-                )
-            )
-            .labelsHidden()
-            .toggleStyle(.switch)
-            .tint(.blue)
-            .disabled(managingPackName != nil)
-            .overlay {
-                if managingPackName != nil {
-                    Color.clear
-                        .contentShape(Rectangle())
-                        .onTapGesture { onManagedToggleTapped?() }
+            // Right side: a managed-by-pack lock affordance, or the enable toggle.
+            if let managingPackName {
+                // This collection is owned by an installed pack — toggling it directly
+                // would be a dead control. Show an explicit, tappable lock that names
+                // the managing pack instead of a disabled switch with an invisible
+                // tap target (the former anti-pattern).
+                Button {
+                    onManagedToggleTapped?()
+                } label: {
+                    Image(systemName: "lock.fill")
+                        .foregroundColor(.secondary)
+                        .font(.body)
                 }
+                .buttonStyle(.plain)
+                .help("Managed by \(managingPackName). Tap to learn more.")
+                .accessibilityIdentifier("rules-summary-managed-\(collectionId)")
+                .accessibilityLabel("\(name) is managed by \(managingPackName)")
+                .accessibilityHint("Activate to learn how to change it")
+            } else {
+                // Toggle (NOT inside button, so it receives taps)
+                Toggle(
+                    "",
+                    isOn: Binding(
+                        get: { effectiveEnabled },
+                        set: { newValue in
+                            // Optimistic update: change UI immediately
+                            localEnabled = newValue
+                            // Then trigger async operation
+                            onToggle(newValue)
+                        }
+                    )
+                )
+                .labelsHidden()
+                .toggleStyle(.switch)
+                .tint(.blue)
+                .accessibilityIdentifier("rules-summary-toggle-\(collectionId)")
+                .accessibilityLabel("Toggle \(name)")
             }
-            .accessibilityIdentifier("rules-summary-toggle-\(collectionId)")
-            .accessibilityLabel("Toggle \(name)")
         }
         .padding(12)
     }

--- a/Sources/KeyPathAppKit/UI/Rules/ScriptSecurityWarningView.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/ScriptSecurityWarningView.swift
@@ -233,8 +233,87 @@ struct ScriptEnableConfirmationView: View {
     }
 }
 
+/// Confirmation dialog for enabling the "skip confirmation dialog" bypass.
+/// This is the riskier sub-toggle: with it on, scripts run with no per-run
+/// warning, so flipping it on warrants its own explicit confirmation.
+struct ScriptBypassConfirmationView: View {
+    let onAllow: () -> Void
+    let onCancel: () -> Void
+
+    var body: some View {
+        VStack(spacing: 20) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.largeTitle)
+                .foregroundColor(.orange)
+
+            Text("Skip the Per-Script Warning?")
+                .font(.title2.weight(.bold))
+
+            Text("With this on, scripts run the moment you press their shortcut — KeyPath will no longer show a warning before each one. Only do this if you fully trust every script you've added.")
+                .font(.body)
+                .foregroundColor(.secondary)
+                .multilineTextAlignment(.center)
+                .fixedSize(horizontal: false, vertical: true)
+
+            VStack(alignment: .leading, spacing: 10) {
+                warningPoint(
+                    icon: "bolt.fill",
+                    text: "Scripts run immediately, with no confirmation"
+                )
+                warningPoint(
+                    icon: "terminal.fill",
+                    text: "A mistaken or malicious script runs unchecked"
+                )
+            }
+            .padding(.horizontal, 8)
+
+            Text("You can turn this back on anytime in Settings.")
+                .font(.callout)
+                .foregroundColor(.secondary)
+                .multilineTextAlignment(.center)
+
+            Divider()
+
+            HStack(spacing: 16) {
+                Button("Cancel") {
+                    onCancel()
+                }
+                .keyboardShortcut(.cancelAction)
+                .accessibilityIdentifier("script-bypass-cancel-button")
+
+                Button("Skip Warnings") {
+                    ScriptSecurityService.shared.bypassFirstRunDialog = true
+                    onAllow()
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(.orange)
+                .accessibilityIdentifier("script-bypass-allow-button")
+            }
+        }
+        .padding(24)
+        .frame(width: 400)
+    }
+
+    private func warningPoint(icon: String, text: String) -> some View {
+        HStack(alignment: .top, spacing: 10) {
+            Image(systemName: icon)
+                .foregroundColor(.orange)
+                .frame(width: 20)
+            Text(text)
+                .font(.body)
+        }
+    }
+}
+
 #Preview("Enable Confirmation") {
     ScriptEnableConfirmationView(
+        onAllow: {},
+        onCancel: {}
+    )
+}
+
+#Preview("Bypass Confirmation") {
+    ScriptBypassConfirmationView(
         onAllow: {},
         onCancel: {}
     )

--- a/Sources/KeyPathAppKit/UI/Settings/PluginCatalogCard.swift
+++ b/Sources/KeyPathAppKit/UI/Settings/PluginCatalogCard.swift
@@ -9,7 +9,9 @@ import SwiftUI
 /// to let users discover and install optional add-ons like Activity Insights.
 struct PluginCatalogCard: View {
     let entry: PluginCatalogEntry
-    @State private var installFailed = false
+    private var pluginManager: PluginManager {
+        PluginManager.shared
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
@@ -46,22 +48,33 @@ struct PluginCatalogCard: View {
             }
             .padding(.vertical, 4)
 
-            // Install button
-            HStack {
-                if PluginManager.shared.isInstalling {
-                    ProgressView()
-                        .controlSize(.small)
-                    Text(PluginManager.shared.installProgressMessage ?? "Installing\u{2026}")
+            // Install button / progress
+            HStack(spacing: 10) {
+                if pluginManager.isInstalling {
+                    if let progress = pluginManager.installProgress {
+                        ProgressView(value: progress)
+                            .frame(maxWidth: 140)
+                        Text("\(Int(progress * 100))%")
+                            .font(.caption.monospacedDigit())
+                            .foregroundColor(.secondary)
+                    } else {
+                        ProgressView()
+                            .controlSize(.small)
+                    }
+                    Text(pluginManager.installProgressMessage ?? "Installing\u{2026}")
                         .font(.caption)
                         .foregroundColor(.secondary)
+
+                    Spacer()
+
+                    Button("Cancel") {
+                        pluginManager.cancelInstall()
+                    }
+                    .controlSize(.small)
+                    .accessibilityIdentifier("plugin-cancel-\(entry.id)")
                 } else {
                     Button {
-                        Task {
-                            let success = await PluginManager.shared.installPlugin(from: entry.downloadURL)
-                            if !success {
-                                installFailed = true
-                            }
-                        }
+                        pluginManager.beginInstall(from: entry.downloadURL)
                     } label: {
                         Text("Download & Install")
                     }
@@ -75,10 +88,12 @@ struct PluginCatalogCard: View {
                 }
             }
 
-            if installFailed {
-                Text("Installation failed. Check your internet connection and try again.")
+            if let installError = pluginManager.installError, !pluginManager.isInstalling {
+                Text(installError)
                     .font(.caption)
                     .foregroundColor(.red)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .accessibilityIdentifier("plugin-install-error-\(entry.id)")
             }
 
             // Learn more link

--- a/Sources/KeyPathAppKit/UI/Settings/SettingsView+AIConfig.swift
+++ b/Sources/KeyPathAppKit/UI/Settings/SettingsView+AIConfig.swift
@@ -12,6 +12,8 @@ struct AIConfigGenerationSettingsSection: View {
     @State private var isValidating: Bool = false
     @State private var validationError: String?
     @State private var isAddingKey: Bool = false
+    /// True when the last failure was a Keychain write (vs. validation), so we offer Retry + env-var guidance.
+    @State private var saveFailed: Bool = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
@@ -29,6 +31,11 @@ struct AIConfigGenerationSettingsSection: View {
                 statusButton
             }
             .accessibilityIdentifier("settings-ai-api-key-row")
+
+            // Environment-variable precedence explainer
+            if hasAPIKeyFromEnv {
+                envPrecedenceNote
+            }
 
             // API key input (shown when adding)
             if isAddingKey {
@@ -65,7 +72,9 @@ struct AIConfigGenerationSettingsSection: View {
 
     private var statusDescription: String {
         if hasAPIKeyFromEnv {
-            "Using environment variable"
+            hasAPIKeyInKeychain
+                ? "Using ANTHROPIC_API_KEY (overrides your saved key)"
+                : "Using ANTHROPIC_API_KEY environment variable"
         } else if hasAPIKeyInKeychain {
             "Stored in Keychain"
         } else {
@@ -73,12 +82,42 @@ struct AIConfigGenerationSettingsSection: View {
         }
     }
 
+    /// Explains that the environment variable always wins and how to switch to a Keychain key.
+    private var envPrecedenceNote: some View {
+        HStack(alignment: .top, spacing: 6) {
+            Image(systemName: "info.circle")
+                .foregroundColor(.secondary)
+                .font(.caption)
+            VStack(alignment: .leading, spacing: 2) {
+                Text("The ANTHROPIC_API_KEY environment variable always takes precedence over a key saved here.")
+                Text(hasAPIKeyInKeychain
+                    ? "Your saved Keychain key is kept but unused. To use it, unset the variable and relaunch KeyPath."
+                    : "To store a key in KeyPath instead, unset the variable and relaunch KeyPath.")
+            }
+            .font(.caption)
+            .foregroundColor(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(.leading, 16)
+        .accessibilityIdentifier("settings-ai-env-precedence-note")
+    }
+
     @ViewBuilder
     private var statusButton: some View {
         if hasAPIKeyFromEnv {
-            // Environment variable - just show indicator
-            Image(systemName: "checkmark.circle.fill")
-                .foregroundColor(.green)
+            if hasAPIKeyInKeychain {
+                // Env var wins, but a stale Keychain key exists — let the user clear it.
+                Button("Remove Saved Key") {
+                    removeAPIKey()
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+                .accessibilityIdentifier("settings-ai-remove-key-button")
+            } else {
+                // Environment variable - just show indicator
+                Image(systemName: "checkmark.circle.fill")
+                    .foregroundColor(.green)
+            }
         } else if hasAPIKeyInKeychain {
             // Has key - show remove button
             Button("Remove") {
@@ -93,6 +132,7 @@ struct AIConfigGenerationSettingsSection: View {
                 isAddingKey = false
                 apiKeyInput = ""
                 validationError = nil
+                saveFailed = false
             }
             .buttonStyle(.bordered)
             .controlSize(.small)
@@ -135,6 +175,23 @@ struct AIConfigGenerationSettingsSection: View {
                     .foregroundColor(.red)
             }
 
+            // On a Keychain write failure, offer a retry and an env-var fallback.
+            if saveFailed {
+                HStack(spacing: 8) {
+                    Button("Retry") {
+                        Task { await saveAPIKey() }
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                    .disabled(apiKeyInput.isEmpty || isValidating)
+                    .accessibilityIdentifier("settings-ai-retry-save-button")
+                }
+                Text("If saving keeps failing, set the ANTHROPIC_API_KEY environment variable instead, then relaunch KeyPath.")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
             Link("Get API Key from Anthropic →", destination: URL(string: "https://console.anthropic.com/settings/keys")!)
                 .font(.caption)
                 .accessibilityIdentifier("settings-ai-get-key-link")
@@ -153,6 +210,7 @@ struct AIConfigGenerationSettingsSection: View {
 
         isValidating = true
         validationError = nil
+        saveFailed = false
 
         let result = await APIKeyValidator.shared.validate(apiKeyInput)
 
@@ -163,12 +221,15 @@ struct AIConfigGenerationSettingsSection: View {
                 try KeychainService.shared.storeClaudeAPIKey(apiKeyInput)
                 apiKeyInput = ""
                 isAddingKey = false
+                saveFailed = false
                 refreshStatus()
             } catch {
-                validationError = "Failed to save: \(error.localizedDescription)"
+                validationError = "Couldn't save to Keychain: \(error.localizedDescription)"
+                saveFailed = true
             }
         } else {
             validationError = result.errorMessage ?? "Invalid API key"
+            saveFailed = false
         }
     }
 

--- a/Sources/KeyPathAppKit/UI/Settings/SettingsView+AIConfig.swift
+++ b/Sources/KeyPathAppKit/UI/Settings/SettingsView+AIConfig.swift
@@ -179,7 +179,7 @@ struct AIConfigGenerationSettingsSection: View {
             if saveFailed {
                 HStack(spacing: 8) {
                     Button("Retry") {
-                        Task { await saveAPIKey() }
+                        storeValidatedKey()
                     }
                     .buttonStyle(.bordered)
                     .controlSize(.small)
@@ -216,20 +216,27 @@ struct AIConfigGenerationSettingsSection: View {
 
         isValidating = false
 
-        if result.isValid {
-            do {
-                try KeychainService.shared.storeClaudeAPIKey(apiKeyInput)
-                apiKeyInput = ""
-                isAddingKey = false
-                saveFailed = false
-                refreshStatus()
-            } catch {
-                validationError = "Couldn't save to Keychain: \(error.localizedDescription)"
-                saveFailed = true
-            }
-        } else {
+        guard result.isValid else {
             validationError = result.errorMessage ?? "Invalid API key"
             saveFailed = false
+            return
+        }
+
+        storeValidatedKey()
+    }
+
+    /// Persists the already-validated `apiKeyInput` to the Keychain. Retry calls this
+    /// directly so a Keychain write failure doesn't trigger a redundant network re-validation.
+    private func storeValidatedKey() {
+        do {
+            try KeychainService.shared.storeClaudeAPIKey(apiKeyInput)
+            apiKeyInput = ""
+            isAddingKey = false
+            saveFailed = false
+            refreshStatus()
+        } catch {
+            validationError = "Couldn't save to Keychain: \(error.localizedDescription)"
+            saveFailed = true
         }
     }
 

--- a/Sources/KeyPathAppKit/UI/Settings/SettingsView+ScriptExecution.swift
+++ b/Sources/KeyPathAppKit/UI/Settings/SettingsView+ScriptExecution.swift
@@ -8,6 +8,7 @@ struct ScriptExecutionSettingsSection: View {
     @Bindable private var securityService = ScriptSecurityService.shared
     @State private var showingExecutionLog = false
     @State private var showingEnableConfirmation = false
+    @State private var showingBypassConfirmation = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
@@ -67,13 +68,29 @@ struct ScriptExecutionSettingsSection: View {
                             .foregroundColor(.orange)
                     }
                     Spacer()
-                    Toggle("", isOn: $securityService.bypassFirstRunDialog)
-                        .toggleStyle(.switch)
-                        .labelsHidden()
+                    Toggle("", isOn: Binding(
+                        get: { securityService.bypassFirstRunDialog },
+                        set: { newValue in
+                            if newValue {
+                                // Enabling the bypass is the risky direction — confirm it.
+                                showingBypassConfirmation = true
+                            } else {
+                                securityService.bypassFirstRunDialog = false
+                            }
+                        }
+                    ))
+                    .toggleStyle(.switch)
+                    .labelsHidden()
                 }
                 .padding(.leading, 24)
                 .accessibilityIdentifier("settings-script-bypass-dialog-toggle")
                 .accessibilityLabel("Skip script confirmation dialog")
+                .sheet(isPresented: $showingBypassConfirmation) {
+                    ScriptBypassConfirmationView(
+                        onAllow: { showingBypassConfirmation = false },
+                        onCancel: { showingBypassConfirmation = false }
+                    )
+                }
 
                 // Execution log button
                 HStack {
@@ -103,6 +120,7 @@ struct ScriptExecutionSettingsSection: View {
 private struct ScriptExecutionLogView: View {
     private var securityService = ScriptSecurityService.shared
     @Environment(\.dismiss) private var dismiss
+    @State private var showingClearConfirmation = false
 
     private var logEntries: [(id: Int, path: String, timestamp: String, success: Bool, error: String)] {
         securityService.executionLog.enumerated().reversed().map { index, entry in
@@ -187,7 +205,7 @@ private struct ScriptExecutionLogView: View {
                 Spacer()
 
                 Button("Clear Log") {
-                    clearLog()
+                    showingClearConfirmation = true
                 }
                 .buttonStyle(.bordered)
                 .disabled(logEntries.isEmpty)
@@ -196,6 +214,19 @@ private struct ScriptExecutionLogView: View {
             .padding()
         }
         .frame(width: 500, height: 400)
+        .confirmationDialog(
+            "Clear the script execution log?",
+            isPresented: $showingClearConfirmation,
+            titleVisibility: .visible
+        ) {
+            Button("Clear Log", role: .destructive) {
+                clearLog()
+            }
+            .accessibilityIdentifier("settings-script-clear-log-confirm")
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("This permanently deletes the audit history of scripts KeyPath has run. This can't be undone.")
+        }
     }
 
     private func formatTimestamp(_ iso8601: String) -> String {

--- a/Sources/KeyPathAppKit/UI/Settings/VirtualKeysInspectorView.swift
+++ b/Sources/KeyPathAppKit/UI/Settings/VirtualKeysInspectorView.swift
@@ -64,6 +64,7 @@ struct VirtualKeysInspectorView: View {
                     Image(systemName: "arrow.clockwise")
                 }
                 .buttonStyle(.borderless)
+                .disabled(isLoading) // avoid overlapping loads that could desync loadSource/virtualKeys
                 .help("Refresh")
                 .accessibilityIdentifier("virtual-keys-refresh-button")
                 .accessibilityLabel("Refresh virtual keys")

--- a/Sources/KeyPathAppKit/UI/Settings/VirtualKeysInspectorView.swift
+++ b/Sources/KeyPathAppKit/UI/Settings/VirtualKeysInspectorView.swift
@@ -10,10 +10,21 @@ struct VirtualKeysInspectorView: View {
     @State private var errorMessage: String?
     @State private var testingKey: String?
     @State private var testResult: TestResult?
+    @State private var loadSource: LoadSource?
 
     private enum TestResult {
         case success(String)
         case failure(String)
+    }
+
+    /// Which path produced the currently displayed keys.
+    ///
+    /// The live-TCP path can only return fake-key *names* — Kanata's TCP API doesn't
+    /// distinguish `defvirtualkeys` from `deffakekeys` — so those results can't be
+    /// grouped by source. The config-file parser labels sources accurately.
+    private enum LoadSource {
+        case liveTCP
+        case configFile
     }
 
     var body: some View {
@@ -45,6 +56,9 @@ struct VirtualKeysInspectorView: View {
                     .foregroundStyle(.secondary)
                 Text("Virtual Keys")
                     .font(.headline)
+                if !isLoading, let loadSource {
+                    sourceBadge(loadSource)
+                }
                 Spacer()
                 Button(action: { Task { await loadVirtualKeys() } }) {
                     Image(systemName: "arrow.clockwise")
@@ -59,6 +73,22 @@ struct VirtualKeysInspectorView: View {
                 .font(.caption)
                 .foregroundStyle(.secondary)
         }
+    }
+
+    /// Badge indicating whether keys came from the running service (live) or the config file.
+    private func sourceBadge(_ source: LoadSource) -> some View {
+        let isLive = source == .liveTCP
+        return Text(isLive ? "Live" : "From config file")
+            .font(.caption2.weight(.medium))
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background((isLive ? Color.green : Color.secondary).opacity(0.15))
+            .foregroundStyle(isLive ? Color.green : Color.secondary)
+            .clipShape(.rect(cornerRadius: 4))
+            .help(isLive
+                ? "Read live from the running Kanata service. Source type (virtual vs fake keys) isn't reported over the live connection."
+                : "Parsed from your config file. The service isn't reporting keys right now.")
+            .accessibilityIdentifier("virtual-keys-source-badge")
     }
 
     // MARK: - Loading
@@ -120,12 +150,20 @@ struct VirtualKeysInspectorView: View {
 
     private var keyListView: some View {
         VStack(alignment: .leading, spacing: 8) {
-            // Group by source
-            let grouped = Dictionary(grouping: virtualKeys, by: { $0.source })
+            // The live-TCP path can't report whether each key is a virtual or fake key,
+            // so group-by-source would be misleading there — show a flat list instead.
+            // Config-file parsing knows the source, so keep the labeled sections.
+            if loadSource == .liveTCP {
+                ForEach(virtualKeys) { key in
+                    keyRow(key)
+                }
+            } else {
+                let grouped = Dictionary(grouping: virtualKeys, by: { $0.source })
 
-            ForEach([VirtualKey.VirtualKeySource.virtualkeys, .fakekeys], id: \.self) { source in
-                if let keys = grouped[source], !keys.isEmpty {
-                    sourceSection(source: source, keys: keys)
+                ForEach([VirtualKey.VirtualKeySource.virtualkeys, .fakekeys], id: \.self) { source in
+                    if let keys = grouped[source], !keys.isEmpty {
+                        sourceSection(source: source, keys: keys)
+                    }
                 }
             }
 
@@ -225,22 +263,27 @@ struct VirtualKeysInspectorView: View {
         isLoading = true
         errorMessage = nil
 
-        // Try live TCP query first (returns keys from running kanata, including dynamic includes)
+        // Try live TCP query first (returns keys from running kanata, including dynamic includes).
+        // The TCP API can't distinguish virtual vs fake keys, so source is left as .fakekeys
+        // and the UI renders these as a flat (ungrouped) "Live" list.
         let liveNames = await loadVirtualKeysFromTCP()
         if let liveNames, !liveNames.isEmpty {
             virtualKeys = liveNames.map { VirtualKey(name: $0, action: "", source: .fakekeys) }
+            loadSource = .liveTCP
             isLoading = false
             return
         }
 
-        // Fall back to static config file parsing
+        // Fall back to static config file parsing (source labels are accurate here)
         do {
             let configPath = KeyPathConstants.Config.mainConfigPath
             let content = try String(contentsOfFile: configPath, encoding: .utf8)
             virtualKeys = VirtualKeyParser.parse(config: content)
+            loadSource = .configFile
         } catch {
             errorMessage = "Could not read config: \(error.localizedDescription)"
             virtualKeys = []
+            loadSource = nil
         }
 
         isLoading = false


### PR DESCRIPTION
Draft — opened for handoff/visibility. **Not ready to merge:** the mandatory `/thermo-nuclear-swift-review` gate (per CLAUDE.md) has not been run yet, and 3 Tier-2 issues plus 2 decision-required ones remain.

## What's here (5 commits, validated Tier-2 issues)

Each issue had a prior validation comment with corrected scope; these implement the corrected scope.

- **#675 + #677** — Centralized the Claude model id on `ClaudeAPIConstants.defaultModel` (bumped `claude-3-5-sonnet-20241022` → `claude-sonnet-4-6`) and routed all three call sites + pricing through it. Added shared `BiometricAuthService.defaultAuthReason` and softened the hardcoded "$0.01-0.03" cost copy (which read as a promise) across the biometric prompt, generator, repair service, and `AIKeyRequiredDialog`.
- **#682** — Replaced the pack-managed disabled-toggle-with-invisible-tap-overlay (the documented anti-pattern) with an explicit lock affordance ("Managed by X") that still calls `onManagedToggleTapped`.
- **#685** — Added `ScriptBypassConfirmationView` gating the riskier "Skip confirmation dialog" sub-toggle, and a destructive confirm before "Clear Log". (The main script-execution toggle already confirmed.)
- **#684** — New `PluginDownloader` (URLSession delegate → async bridge) with byte-level progress + cancellation. `PluginManager` gained observable `installProgress`/`installError` + `beginInstall`/`cancelInstall`; specific failure messages. `PluginCatalogCard` now shows a determinate progress bar + %, a Cancel button, and the specific error.
- **#683** — "and X more…" is now a submenu listing the remaining app mappings (each opens the mapper); fixed the `cachedAppKeymaps` first-open race by refreshing on `menuWillOpen` and rebuilding live when the async load resolves.

## Remaining Tier-2 work (not in this PR)
- **#678** — AI API key UX: env-var key is read-only with no manage/retry/fallback path.
- **#687** — Virtual Keys Inspector: surface live-TCP vs config source; the `.fakekeys` grouping is a TCP API limitation, not a mislabel.
- **#686** — In-app help offline/404 fallback (lowest priority).

## Decision-required (await user; recommendations to be posted on the issues)
- **#676** — Whether the biometric `.failed` branch should abort the paid API call (currently proceeds; `.cancelled` already aborts). Policy call.
- **#679** — Privileged uninstall (VHID/LaunchDaemon teardown) is a larger architectural task.

## Test status
Branch builds clean (`swift build`). `swift test` shows **18 pre-existing failures** (RuleCollectionsManagerTests / PackInstallIntegrationTests / MapperSaveIntegrationTests) that reproduce on master with these changes stashed — they are NOT introduced here and look environmental (a CustomRulesStore decode error + temp-dir write failures). These changes add no new failures.

## History note
The original branch `claude/keypath-feature-gaps-j0aVf` was the head of the now-merged (squash) PR #696 and was auto-deleted, so these commits were rebased onto current master onto this fresh branch.