### PR TITLE
fix(build): honor KP_SIGN_CMD when signing the privileged helper

### DIFF
--- a/Scripts/build-helper.sh
+++ b/Scripts/build-helper.sh
@@ -60,7 +60,9 @@ else
     HELPER_ENTITLEMENTS="Sources/KeyPathHelper/KeyPathHelper.entitlements"
 
     if [ -f "$HELPER_ENTITLEMENTS" ]; then
-        codesign --force --options=runtime \
+        # Honor KP_SIGN_CMD so the helper signs through the same path as the rest
+        # of the build (e.g. an unattended GUI-session codesign wrapper).
+        ${KP_SIGN_CMD:-codesign} --force --options=runtime \
             --identifier "com.keypath.helper" \
             --entitlements "$HELPER_ENTITLEMENTS" \
             --sign "$SIGNING_IDENTITY" \


### PR DESCRIPTION
## What

`Scripts/build-helper.sh` signed the privileged helper with a hard-coded `codesign` call, while the rest of the build signs through `kp_sign` → `KP_SIGN_CMD` (`Scripts/lib/signing.sh`).

## Why

That inconsistency meant any `KP_SIGN_CMD` override — an unattended signing wrapper, or the test stubs the signing lib is designed around (`KP_SIGN_DRY_RUN`, `KP_SIGN_CMD`) — was bypassed for the helper. A build that signed every other component would still fail at the helper step.

## Change

Route the helper signing through `${KP_SIGN_CMD:-codesign}`. Behavior is identical by default (`codesign`); it just becomes overridable like the rest of the build.

## Test

- `SKIP_NOTARIZE=1 ./build.sh` with `KP_SIGN_CMD` pointing at a Developer ID wrapper: signs the helper (`Identifier=com.keypath.helper`, `Authority=Developer ID Application`) and the full app; `codesign --verify --deep --strict` passes and the app satisfies its Designated Requirement.
- Default path (no `KP_SIGN_CMD`) unchanged.