### PR TITLE
feat(build): let notarytool read its profile from a specific keychain (KP_NOTARY_KEYCHAIN)

### DIFF
--- a/Scripts/lib/signing.sh
+++ b/Scripts/lib/signing.sh
@@ -35,12 +35,18 @@ kp_notarize_zip() {
     local zip_path=$1
     local profile=$2
     shift 2
+    # Optionally read the notary profile from a specific keychain (KP_NOTARY_KEYCHAIN).
+    # Without it, notarytool uses the default (login) keychain, exactly as before.
+    local keychain_args=()
+    if [ -n "${KP_NOTARY_KEYCHAIN:-}" ]; then
+        keychain_args=(--keychain "$KP_NOTARY_KEYCHAIN")
+    fi
     if [ "$KP_SIGN_DRY_RUN" = "1" ]; then
-        echo "[DRY RUN] $KP_NOTARY_CMD submit $zip_path --keychain-profile $profile --wait $*"
+        echo "[DRY RUN] $KP_NOTARY_CMD submit $zip_path --keychain-profile $profile ${keychain_args[*]} --wait $*"
         return 0
     fi
     # Use word-splitting for multi-word command (xcrun notarytool)
-    $KP_NOTARY_CMD submit "$zip_path" --keychain-profile "$profile" --wait "$@"
+    $KP_NOTARY_CMD submit "$zip_path" --keychain-profile "$profile" "${keychain_args[@]}" --wait "$@"
 }
 
 kp_staple() {


### PR DESCRIPTION
## What
`kp_notarize_zip` invoked `notarytool submit --keychain-profile <profile>` with no `--keychain`, so notarytool only looked in the **default (login)** keychain.

## Why
That blocks unattended / non-interactive builds whose session can't unlock the login keychain — notarytool fails with `keychainLocked(keychainName: "default")`. Storing the notary profile in an isolated signing keychain is the standard headless pattern, but the build had no way to point at it.

## Change
Optional `KP_NOTARY_KEYCHAIN` env var. When set, `--keychain "$KP_NOTARY_KEYCHAIN"` is appended; unset preserves the exact prior behavior. Mirrors the existing `KP_SIGN_CMD` / `KP_SIGN_DRY_RUN` override pattern in the same file.

## Test
- Full `./build.sh` (no `SKIP_NOTARIZE`) with `KP_NOTARY_KEYCHAIN` pointing at an isolated keychain holding the `KeyPath-Profile` credential: notarization **Accepted**, staple + validate worked, `spctl` reports **"Notarized Developer ID"** offline.
- Unset: dry-run shows the command unchanged from before.