### PR TITLE
fix(ai): fail-closed on unexpected biometric auth failure (#676)

### DIFF
--- a/Sources/KeyPathAppKit/Services/AI/AnthropicConfigRepairService.swift
+++ b/Sources/KeyPathAppKit/Services/AI/AnthropicConfigRepairService.swift
@@ -69,7 +69,13 @@ public actor AnthropicConfigRepairService: ConfigRepairService {
                 userInfo: [NSLocalizedDescriptionKey: "Authentication cancelled"]
             )
         case let .failed(errorMessage):
-            AppLogger.shared.log("⚠️ [ConfigRepair] Auth failed: \(errorMessage), proceeding anyway")
+            // Fail-closed: an unexpected auth error must not bypass the consent gate
+            // for a paid API call. Legit no-biometrics cases already route to password.
+            AppLogger.shared.log("⚠️ [ConfigRepair] Auth failed: \(errorMessage), aborting")
+            throw NSError(
+                domain: "ClaudeAPI", code: 5,
+                userInfo: [NSLocalizedDescriptionKey: "Authentication failed: \(errorMessage)"]
+            )
         case .authenticated, .notRequired:
             break
         }

--- a/Sources/KeyPathAppKit/Services/Configuration/KanataConfigGenerator.swift
+++ b/Sources/KeyPathAppKit/Services/Configuration/KanataConfigGenerator.swift
@@ -233,12 +233,15 @@ public class KanataConfigGenerator {
     /// Error thrown when user cancels biometric authentication
     public enum ConfigGeneratorError: Error, LocalizedError {
         case authenticationCancelled
+        case authenticationFailed(String)
         case noAPIKey
 
         public var errorDescription: String? {
             switch self {
             case .authenticationCancelled:
                 "Authentication was cancelled"
+            case let .authenticationFailed(message):
+                "Authentication failed: \(message)"
             case .noAPIKey:
                 "AI repair requires an API key. Add one in Settings → General → AI Configuration."
             }
@@ -261,8 +264,10 @@ public class KanataConfigGenerator {
         case .cancelled:
             throw ConfigGeneratorError.authenticationCancelled
         case let .failed(errorMessage):
-            AppLogger.shared.log("⚠️ [ConfigGenerator] Auth failed: \(errorMessage), proceeding anyway")
-        // Continue - biometric failure shouldn't block if user has API key
+            // Fail-closed: an unexpected auth error must not bypass the consent gate
+            // for a paid API call. Legit no-biometrics cases already route to password.
+            AppLogger.shared.log("⚠️ [ConfigGenerator] Auth failed: \(errorMessage), aborting")
+            throw ConfigGeneratorError.authenticationFailed(errorMessage)
         case .authenticated, .notRequired:
             break // Continue with API call
         }


### PR DESCRIPTION
Closes #676.

The biometric consent gate before a paid Claude API call aborted on `.cancelled` but **proceeded anyway** on `.failed` — logging the error and making the billable call without consent. That defeats the gate and makes *inducing* an auth error a reliable bypass.

`.failed` now throws at both call sites (`AnthropicConfigRepairService`, `KanataConfigGenerator`). Safe because the legitimate no-biometrics cases (userFallback / biometryNotAvailable / biometryNotEnrolled / biometryLockout) already fall back to password in `BiometricAuthService`, so `.failed` is genuinely an unexpected-error path. Per maintainer decision (fail-closed).

Adds `ConfigGeneratorError.authenticationFailed(String)`; AnthropicConfigRepairService throws an NSError mirroring its existing `.cancelled` path.