### PR TITLE
test(lint): guard the KeyPathTestCase seam against new deadlocking suites (#698)

### DIFF
--- a/Tests/KeyPathTests/Lint/TestSeamLintTests.swift
+++ b/Tests/KeyPathTests/Lint/TestSeamLintTests.swift
@@ -1,0 +1,87 @@
+import Foundation
+@preconcurrency import XCTest
+
+/// Guards the test seam that keeps the suite from deadlocking (issue #698).
+///
+/// Suites that construct `RuntimeCoordinator` / `InstallerEngine` / `SystemValidator`
+/// / `VHIDDeviceManager` reach `VHIDDeviceManager.detectConnectionHealth()`, which
+/// spawns `pgrep` subprocesses with 3s timeouts. Under parallel execution those can
+/// deadlock and hang `swift test` indefinitely. `KeyPathTestCase` installs
+/// `VHIDDeviceManager.testPIDProvider = { [] }` so no real subprocess is ever spawned.
+///
+/// This test fails if a suite extends `XCTestCase` *directly* while using one of those
+/// types. To fix a new violation, change the base class to `KeyPathTestCase` (or
+/// `KeyPathAsyncTestCase`) — do **not** extend the allowlist. The allowlist is a
+/// ratchet of pre-existing suites still awaiting migration; it should only shrink.
+final class TestSeamLintTests: XCTestCase {
+    /// Pre-existing suites that use a hazard type but still extend XCTestCase directly.
+    /// Migrate these to KeyPathTestCase and remove them here. Never add new entries.
+    private static let allowList: Set<String> = [
+        "ContentViewDebounceTests.swift",
+        "ErrorHandlingTests.swift",
+        "FacadeLintTests.swift",
+        "GrabRecoveryGateTests.swift",
+        "InstallerEngineBrokerForwardingTests.swift",
+        "KanataViewModelTests.swift",
+        "KeyboardCaptureTests.swift",
+        "KeyPathTests.swift",
+        "LayerSelectorTests.swift",
+        "OverlayHealthIndicatorObserverTests.swift",
+        "PrivilegedOperationsCoordinatorTests.swift",
+        "RecordingCoordinatorTests.swift",
+        "RuntimeCoordinatorResetTests.swift",
+        "SystemRequirementsTests.swift",
+        "VHIDDeviceManagerTests.swift",
+        "WizardPureLogicTests.swift",
+        "WizardRecipeParityTests.swift"
+    ]
+
+    func testCoordinatorSuitesUseKeyPathTestCase() throws {
+        let testsDir = repositoryRoot().appendingPathComponent("Tests/KeyPathTests")
+
+        // Type used as a constructor `Type(` or as a type annotation `: Type`.
+        let hazard = try NSRegularExpression(
+            pattern: #"(RuntimeCoordinator|InstallerEngine|SystemValidator|VHIDDeviceManager)\s*\(|:\s*(RuntimeCoordinator|InstallerEngine|SystemValidator|VHIDDeviceManager)\b"#
+        )
+
+        guard let enumerator = FileManager.default.enumerator(at: testsDir, includingPropertiesForKeys: nil) else {
+            return XCTFail("Could not enumerate \(testsDir.path)")
+        }
+
+        var violations: [String] = []
+        for case let url as URL in enumerator where url.pathExtension == "swift" {
+            let name = url.lastPathComponent
+            if name == "TestSeamLintTests.swift" { continue }
+            if Self.allowList.contains(name) { continue }
+            guard let contents = try? String(contentsOf: url, encoding: .utf8) else { continue }
+            // Only suites that subclass XCTestCase directly are at risk; KeyPathTestCase
+            // (and its async variant) already install the seam.
+            guard contents.contains(": XCTestCase"),
+                  !contents.contains(": KeyPathTestCase"),
+                  !contents.contains(": KeyPathAsyncTestCase")
+            else { continue }
+            let range = NSRange(contents.startIndex..., in: contents)
+            if hazard.firstMatch(in: contents, range: range) != nil {
+                violations.append(name)
+            }
+        }
+
+        XCTAssertTrue(
+            violations.isEmpty,
+            """
+            These test suites construct deadlock-prone coordinators but extend XCTestCase \
+            directly. Use KeyPathTestCase / KeyPathAsyncTestCase (installs the pgrep seam — \
+            see issue #698) instead of adding to the allowlist:
+            \(violations.sorted().joined(separator: "\n"))
+            """
+        )
+    }
+}
+
+private func repositoryRoot(file: StaticString = #filePath) -> URL {
+    URL(fileURLWithPath: "\(file)")
+        .deletingLastPathComponent() // Lint
+        .deletingLastPathComponent() // KeyPathTests
+        .deletingLastPathComponent() // Tests
+        .deletingLastPathComponent() // repo root
+}


### PR DESCRIPTION
Part of #698.

## Problem
Suites that construct `RuntimeCoordinator` / `InstallerEngine` / `SystemValidator` / `VHIDDeviceManager` reach `VHIDDeviceManager.detectConnectionHealth()`, which spawns real `pgrep` subprocesses (3s timeout) that can deadlock `swift test` under parallel execution. `KeyPathTestCase` installs `VHIDDeviceManager.testPIDProvider = { [] }` to prevent this — but **17 suites bypass it** by extending `XCTestCase` directly.

## This PR — prevention (ratchet)
A source-scanning lint test (`TestSeamLintTests`, mirroring the existing `FacadeLintTests` pattern) fails when a suite extends `XCTestCase` directly while using a hazard type, unless it's on an allowlist of the current 17. **New offenders must use `KeyPathTestCase`; the allowlist should only shrink.**

Zero changes to existing test behavior. Verified in isolation: `swift test --filter TestSeamLintTests` passes in 0.08s.

## Why not migrate the 17 here
Migrating the base class is **necessary but not sufficient**. I verified it on `ErrorHandlingTests`: the seam fixed its pgrep deadlock (`testAsyncConfigurationErrors` went from *hangs forever* → passes in 8ms), but the suite **still hangs on a later method** that does real `saveConfiguration`/`updateStatus`/`cleanup` I/O. Those suites need deeper per-suite mocking, which can't be safely verified in this environment (the full suite deadlocks locally; CI is green). So migrations are tracked as incremental follow-up in #698, gated by this guard.

## Follow-ups (in #698)
- Migrate allowlisted suites to `KeyPathTestCase` + mock their real I/O, removing each from the allowlist.
- Add a per-test timeout in CI so a deadlock fails fast instead of hanging the runner.