### PR TITLE
test: migrate 9 coordinator suites to KeyPathTestCase (#698)

### DIFF
--- a/Tests/KeyPathTests/ContentViewDebounceTests.swift
+++ b/Tests/KeyPathTests/ContentViewDebounceTests.swift
@@ -6,7 +6,7 @@ import SwiftUI
 /// Phase 1 Unit Tests: ContentView Debouncing
 /// Tests the save operation debouncing added in Phase 1.3 to prevent rapid successive saves
 @MainActor
-class ContentViewDebounceTests: XCTestCase {
+class ContentViewDebounceTests: KeyPathTestCase {
     lazy var testManager: RuntimeCoordinator = .init()
 
     // MARK: - Debounce Logic Tests (Non-UI)

--- a/Tests/KeyPathTests/InstallationEngine/InstallerEngineBrokerForwardingTests.swift
+++ b/Tests/KeyPathTests/InstallationEngine/InstallerEngineBrokerForwardingTests.swift
@@ -3,7 +3,7 @@
 @preconcurrency import XCTest
 
 @MainActor
-final class InstallerEngineBrokerForwardingTests: XCTestCase {
+final class InstallerEngineBrokerForwardingTests: KeyPathTestCase {
     func testUninstallVirtualHIDDriversRoutesToBroker() async throws {
         let coordinator = PrivilegedCoordinatorStub()
         let broker = PrivilegeBroker(coordinator: coordinator)

--- a/Tests/KeyPathTests/InstallationWizard/WizardRecipeParityTests.swift
+++ b/Tests/KeyPathTests/InstallationWizard/WizardRecipeParityTests.swift
@@ -7,7 +7,7 @@ import KeyPathWizardCore
 
 /// Characterization tests to ensure auto-fix actions map to the same recipes the planner uses.
 @MainActor
-final class WizardRecipeParityTests: XCTestCase {
+final class WizardRecipeParityTests: KeyPathTestCase {
     func testRecipeIDsMatchForCommonActions() {
         let engine = InstallerEngine()
         let context = SystemContextBuilder(

--- a/Tests/KeyPathTests/KeyboardCaptureTests.swift
+++ b/Tests/KeyPathTests/KeyboardCaptureTests.swift
@@ -5,7 +5,7 @@ import KeyPathCore
 @preconcurrency import XCTest
 
 @MainActor
-final class KeyboardCaptureTests: XCTestCase {
+final class KeyboardCaptureTests: KeyPathTestCase {
     private let defaultNotificationCenter = NotificationCenter
         .perform(NSSelectorFromString("defaultCenter"))?
         .takeUnretainedValue() as? NotificationCenter

--- a/Tests/KeyPathTests/Lint/TestSeamLintTests.swift
+++ b/Tests/KeyPathTests/Lint/TestSeamLintTests.swift
@@ -17,23 +17,14 @@ final class TestSeamLintTests: XCTestCase {
     /// Pre-existing suites that use a hazard type but still extend XCTestCase directly.
     /// Migrate these to KeyPathTestCase and remove them here. Never add new entries.
     private static let allowList: Set<String> = [
-        "ContentViewDebounceTests.swift",
         "ErrorHandlingTests.swift",
         "FacadeLintTests.swift",
-        "GrabRecoveryGateTests.swift",
-        "InstallerEngineBrokerForwardingTests.swift",
-        "KanataViewModelTests.swift",
-        "KeyboardCaptureTests.swift",
         "KeyPathTests.swift",
-        "LayerSelectorTests.swift",
-        "OverlayHealthIndicatorObserverTests.swift",
         "PrivilegedOperationsCoordinatorTests.swift",
-        "RecordingCoordinatorTests.swift",
         "RuntimeCoordinatorResetTests.swift",
         "SystemRequirementsTests.swift",
         "VHIDDeviceManagerTests.swift",
-        "WizardPureLogicTests.swift",
-        "WizardRecipeParityTests.swift"
+        "WizardPureLogicTests.swift"
     ]
 
     func testCoordinatorSuitesUseKeyPathTestCase() throws {

--- a/Tests/KeyPathTests/RecordingCoordinatorTests.swift
+++ b/Tests/KeyPathTests/RecordingCoordinatorTests.swift
@@ -3,7 +3,7 @@ import KeyPathPermissions
 @preconcurrency import XCTest
 
 @MainActor
-final class RecordingCoordinatorTests: XCTestCase {
+final class RecordingCoordinatorTests: KeyPathTestCase {
     private var statusMessages: [String] = []
     private lazy var permissionProvider = StubPermissionProvider(
         snapshot: RecordingCoordinatorTests.snapshot(accessibility: .unknown)

--- a/Tests/KeyPathTests/Services/GrabRecoveryGateTests.swift
+++ b/Tests/KeyPathTests/Services/GrabRecoveryGateTests.swift
@@ -6,7 +6,7 @@ import XCTest
 /// recovery. The recover/give-up tail (the bounded budget) is covered separately by
 /// `ServiceHealthMonitorTests`; these tests cover only the pre-guard gate so they
 /// never touch the real recovery action (which would shell out to launchctl/pgrep).
-final class GrabRecoveryGateTests: XCTestCase {
+final class GrabRecoveryGateTests: KeyPathTestCase {
     typealias Gate = RuntimeCoordinator.GrabRecoveryGate
 
     func testActiveGrabRecordsSuccess() {

--- a/Tests/KeyPathTests/UI/KanataViewModelTests.swift
+++ b/Tests/KeyPathTests/UI/KanataViewModelTests.swift
@@ -8,7 +8,7 @@
 /// - ViewModel delegates actions to KanataManager
 /// - UI state updates correctly
 @MainActor
-final class KanataViewModelTests: XCTestCase {
+final class KanataViewModelTests: KeyPathTestCase {
     // Note: These tests are simple sanity checks to verify the MVVM architecture compiles and runs
     // Full integration testing is done at the UI level
 

--- a/Tests/KeyPathTests/UI/LayerSelectorTests.swift
+++ b/Tests/KeyPathTests/UI/LayerSelectorTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 /// Tests for layer selector functionality in MapperViewModel
 @MainActor
-final class LayerSelectorTests: XCTestCase {
+final class LayerSelectorTests: KeyPathTestCase {
     // MARK: - getAvailableLayers Tests
 
     func testGetAvailableLayers_defaultsToBaseAndNav() {

--- a/Tests/KeyPathTests/UI/OverlayHealthIndicatorObserverTests.swift
+++ b/Tests/KeyPathTests/UI/OverlayHealthIndicatorObserverTests.swift
@@ -4,7 +4,7 @@ import KeyPathInstallationWizard
 import KeyPathWizardCore
 import XCTest
 
-final class OverlayHealthIndicatorObserverTests: XCTestCase {
+final class OverlayHealthIndicatorObserverTests: KeyPathTestCase {
     @MainActor
     func testHealthyStateTriggersDismiss() async {
         var states: [HealthIndicatorState] = []


### PR DESCRIPTION
Part of #698 — shrinks the test-seam allowlist from 17 → 8 by migrating suites that construct coordinators onto `KeyPathTestCase` (installs the `testPIDProvider` seam, preventing the real-`pgrep` deadlock).

## Migrated (9) — each verified in isolation locally
`ContentViewDebounceTests`, `GrabRecoveryGateTests`, `InstallerEngineBrokerForwardingTests`, `KanataViewModelTests`, `KeyboardCaptureTests`, `LayerSelectorTests`, `OverlayHealthIndicatorObserverTests`, `RecordingCoordinatorTests`, `WizardRecipeParityTests`.
- Batch of 8: **47 tests / 0 failures / 4.3s**; `KeyboardCaptureTests`: **22 / 0 / 1.6s** — no deadlock, no behavior change.

## Deliberately still allowlisted
- **Real-I/O suites** (`ErrorHandlingTests`, `KeyPathTests`, `KanataManagerResetTests`): the seam fixes their pgrep hang (verified: `ErrorHandlingTests.testAsyncConfigurationErrors` went from *hangs forever* → 8ms) but they also do real `saveConfiguration`/`updateStatus` I/O that still hangs. Need deeper per-suite mocking — tracked in #698.
- **`VHIDDeviceManagerTests`**: the seam's *own* test suite (sets `testPIDProvider` per test, asserts the real-pgrep fallthrough). Must not be force-seamed.
- `FacadeLintTests`, `PrivilegedOperationsCoordinatorTests`, `SystemRequirementsTests`, `WizardPureLogicTests`: only reference the type names.

The `TestSeamLintTests` ratchet passes with the reduced allowlist (verified in isolation). CI `build-and-test` exercises the full suite as the backstop.