### PR TITLE
test(lint): tighten seam regex + drop reference-only suites (#698)

### DIFF
--- a/Tests/KeyPathTests/Lint/TestSeamLintTests.swift
+++ b/Tests/KeyPathTests/Lint/TestSeamLintTests.swift
@@ -17,22 +17,23 @@ final class TestSeamLintTests: XCTestCase {
     /// Pre-existing suites that use a hazard type but still extend XCTestCase directly.
     /// Migrate these to KeyPathTestCase and remove them here. Never add new entries.
     private static let allowList: Set<String> = [
+        // Real-I/O suites: the seam fixes their pgrep hang but they also do real
+        // saveConfiguration/updateStatus/resetToDefaultConfig that needs deeper mocking.
         "ErrorHandlingTests.swift",
-        "FacadeLintTests.swift",
         "KeyPathTests.swift",
-        "PrivilegedOperationsCoordinatorTests.swift",
         "RuntimeCoordinatorResetTests.swift",
-        "SystemRequirementsTests.swift",
-        "VHIDDeviceManagerTests.swift",
-        "WizardPureLogicTests.swift"
+        // The seam's own test (sets testPIDProvider per test, asserts real-pgrep fallthrough).
+        "VHIDDeviceManagerTests.swift"
     ]
 
     func testCoordinatorSuitesUseKeyPathTestCase() throws {
         let testsDir = repositoryRoot().appendingPathComponent("Tests/KeyPathTests")
 
-        // Type used as a constructor `Type(` or as a type annotation `: Type`.
+        // Type used as a constructor `Type(` or as a type annotation `: Type`. The
+        // leading \b avoids matching a method name that merely ends in the type, e.g.
+        // `testDoNotBypassInstallerEngine()`.
         let hazard = try NSRegularExpression(
-            pattern: #"(RuntimeCoordinator|InstallerEngine|SystemValidator|VHIDDeviceManager)\s*\(|:\s*(RuntimeCoordinator|InstallerEngine|SystemValidator|VHIDDeviceManager)\b"#
+            pattern: #"\b(RuntimeCoordinator|InstallerEngine|SystemValidator|VHIDDeviceManager)\s*\(|:\s*(RuntimeCoordinator|InstallerEngine|SystemValidator|VHIDDeviceManager)\b"#
         )
 
         guard let enumerator = FileManager.default.enumerator(at: testsDir, includingPropertiesForKeys: nil) else {


### PR DESCRIPTION
Part of #698 — shrinks the test-seam allowlist 8 → 4.

1. **Tighten the regex** with a leading word boundary (`\b`) so it stops matching a *method name* ending in a type (e.g. `testDoNotBypassInstallerEngine()` was a false positive flagging FacadeLintTests).
2. **Drop 4 reference-only suites** that only name the types but never construct them: `FacadeLintTests`, `PrivilegedOperationsCoordinatorTests`, `SystemRequirementsTests`, `WizardPureLogicTests`.

Remaining allowlist (4) is the genuinely-hard set: `ErrorHandlingTests`, `KeyPathTests`, `RuntimeCoordinatorResetTests` (real config-regeneration I/O) + `VHIDDeviceManagerTests` (the seam's own test).

Verified `swift test --filter TestSeamLintTests` passes in 0.08s.