### PR TITLE
fix: Tier-3 minor fixes — dead stub removal + telemetry quit flush (#693, #690)

### DIFF
--- a/Sources/KeyPathAppKit/App.swift
+++ b/Sources/KeyPathAppKit/App.swift
@@ -309,6 +309,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // after the UI app quits. Only ServiceLifecycleCoordinator.stopKanata()
         // should broadcast service state changes.
         DistributedNotificationBridge.stop()
+        // Flush pending KindaVim telemetry so counters aren't lost on quit (up to one
+        // ~5s flush interval would otherwise be dropped — see #690). No-op when disabled.
+        KindaVimTelemetryStore.shared.flushNow()
         kanataManager?.cleanupSync()
         AppLogger.shared.info("✅ [AppDelegate] Cleanup complete, app terminating")
     }

--- a/Sources/KeyPathAppKit/Services/KindaVim/KindaVimTelemetryStore.swift
+++ b/Sources/KeyPathAppKit/Services/KindaVim/KindaVimTelemetryStore.swift
@@ -164,10 +164,9 @@ final class KindaVimTelemetryStore {
 
     deinit {
         flushTask?.cancel()
-        // No final flush from deinit — the @MainActor restriction makes
-        // it impractical, and the `flushNow()` API + app-deactivation
-        // hook (TODO in a follow-up) covers correctness for the cases
-        // that matter (Pack Detail viewing, app quit).
+        // No final flush from deinit — the @MainActor restriction makes it
+        // impractical. Correctness is covered by the `flushNow()` API: called
+        // when viewing Pack Detail and from applicationWillTerminate on app quit (#690).
     }
 
     // MARK: - Opt-in gate

--- a/Sources/KeyPathAppKit/UI/Gallery/PackDetailView+Helpers.swift
+++ b/Sources/KeyPathAppKit/UI/Gallery/PackDetailView+Helpers.swift
@@ -74,10 +74,6 @@ extension PackDetailView {
         }
         return 20
     }
-
-    func copyValidationErrorsToClipboard() {
-        // Placeholder for future implementation
-    }
 }
 
 // MARK: - Undo snapshot


### PR DESCRIPTION
Two small Tier-3 cleanups.

**#693** — `PackDetailView.copyValidationErrorsToClipboard()` was an empty placeholder, never called, with no validation-error state to copy (the real impl is in `LiveKeyboardOverlayView`). Deleted as dead code.

**#690** — KindaVim telemetry flushed on a ~5s timer with no final flush in deinit, losing up to one interval on quit. Now calls the existing MainActor-safe `flushNow()` from `applicationWillTerminate` (no-op when disabled).