### PR TITLE
fix(wizard): progress indicator instead of disabled button while checking (#680)

### DIFF
--- a/Sources/KeyPathAppKit/InstallationWizard/WizardCommunicationPage.swift
+++ b/Sources/KeyPathAppKit/InstallationWizard/WizardCommunicationPage.swift
@@ -116,11 +116,17 @@ struct WizardCommunicationPage: View {
                         .buttonStyle(WizardDesign.Component.SecondaryButton())
                         .disabled(isFixing)
                     } else if commStatus == .checking || isAuthTesting {
-                        Button("Checking...") {}
-                            .buttonStyle(WizardDesign.Component.PrimaryButton(isLoading: true))
-                            .disabled(true)
-                            .frame(minHeight: 44)
-                            .padding(.top, WizardDesign.Spacing.itemGap)
+                        // Show an honest progress indicator rather than a disabled
+                        // button, which reads as a frozen/unresponsive control (#680).
+                        HStack(spacing: WizardDesign.Spacing.labelGap) {
+                            ProgressView()
+                                .controlSize(.small)
+                            Text("Checking…")
+                                .foregroundStyle(.secondary)
+                        }
+                        .frame(minHeight: 44)
+                        .padding(.top, WizardDesign.Spacing.itemGap)
+                        .accessibilityIdentifier("wizard-comm-checking-indicator")
                     } else {
                         Button("Re-check Status") {
                             Task { await checkCommunicationStatus() }


### PR DESCRIPTION
Closes #680.

The wizard communication page rendered a **disabled `Checking...` button** during the TCP check (empty action + `.disabled(true)`), which reads as a frozen/unresponsive control. Replaced with a plain `ProgressView` spinner + "Checking…" label so the in-progress state is unambiguous.