### PR TITLE
fix: bump stale Claude model, centralize AI constants, disable opening_brace lint

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -53,6 +53,7 @@ disabled_rules:
   - force_try           # Allow force try in tests
   - force_cast          # Allow force cast in tests
   - force_unwrapping    # Allow force unwrapping in tests
+  - opening_brace       # swiftformat owns brace style via wrapMultilineStatementBraces
 
 # Custom reporter for CI
 reporter: "github-actions-logging"

--- a/Scripts/build-and-sign.sh
+++ b/Scripts/build-and-sign.sh
@@ -561,7 +561,7 @@ GHPAGES_DIR="$SCRIPT_DIR/../.worktrees/gh-pages"
 if [ -d "$GHPAGES_DIR" ] && [ "${SKIP_WEBSITE:-0}" != "1" ] && [ "${SKIP_NOTARIZE:-}" != "1" ]; then
     echo ""
     echo "🌐 Publishing help content to website..."
-    "$SCRIPT_DIR/publish-help-to-web.sh"
+    "$SCRIPT_DIR/publish-guides.sh"
 
     echo ""
     echo "🌐 Committing and pushing gh-pages..."


### PR DESCRIPTION
## Summary
- **#675** — Update model from retired `claude-3-5-sonnet-20241022` to `claude-sonnet-4-6` and centralize all AI constants (`endpoint`, `model`, `apiVersion`) in `ClaudeAPIConstants` as a single source of truth
- **#677** — Update pricing comment to reference Sonnet 4.6, remove manual-update warning, and soften hardcoded "$0.01-0.03" cost copy to avoid implying a precise figure that goes stale
- **#708** — Disable swiftlint `opening_brace` rule that conflicts with swiftformat's `wrapMultilineStatementBraces`, letting swiftformat own brace style

## Test plan
- [x] `swift build` passes
- [x] All tests pass (0 failures)
- [x] `swiftformat` produces no changes on touched files
- [ ] CI green

Closes #675, closes #677, closes #708