### PR TITLE
fix(wizard): FDA drag-to-authorize polls actual permission (#681)

### DIFF
--- a/Sources/KeyPathInstallationWizard/UI/Helpers/DragToAuthorize/DragToAuthorizeController.swift
+++ b/Sources/KeyPathInstallationWizard/UI/Helpers/DragToAuthorize/DragToAuthorizeController.swift
@@ -1,6 +1,7 @@
 import AppKit
 import KeyPathCore
 import KeyPathPermissions
+import KeyPathWizardCore
 import SwiftUI
 
 /// Orchestrates the drag-to-authorize overlay lifecycle.
@@ -269,8 +270,7 @@ public final class DragToAuthorizeController: ObservableObject {
         case .inputMonitoring:
             snapshot.kanata.inputMonitoring == .granted
         case .fullDiskAccess:
-            // FDA doesn't exist in PermissionSet — skip polling for it
-            false
+            WizardDependencies.fullDiskAccessChecker?.hasFullDiskAccess() ?? false
         }
 
         if granted {


### PR DESCRIPTION
## Summary
- `checkPermission(for: .fullDiskAccess)` was hard-coding `false` because `PermissionSet` doesn't include FDA
- Now uses `WizardDependencies.fullDiskAccessChecker?.hasFullDiskAccess()` — same pattern as `WizardSystemStatusOverview` and `WizardSummaryPage`
- The drag-to-authorize overlay will now auto-dismiss when FDA is granted

## Test plan
- [x] `swift build` passes
- [x] All tests pass
- [ ] CI green

Closes #681