### PR TITLE
fix(overlay): decouple hold-label rendering from simulator flag (#689)

### DIFF
--- a/Sources/KeyPathAppKit/UI/ContextHUD/ContextHUDController+ShowForLayer.swift
+++ b/Sources/KeyPathAppKit/UI/ContextHUD/ContextHUDController+ShowForLayer.swift
@@ -112,7 +112,7 @@ extension ContextHUDController {
 
                 var holdLabels = holdLabelCache[normalizedLayerName] ?? [:]
 
-                if holdLabels.isEmpty, FeatureFlags.simulatorAndVirtualKeysEnabled {
+                if holdLabels.isEmpty {
                     holdLabels = await resolveHoldLabels(
                         keyMap: effectiveKeyMap,
                         configPath: configPath,
@@ -215,16 +215,14 @@ extension ContextHUDController {
                         )
                         guard !Task.isCancelled else { return }
 
-                        if FeatureFlags.simulatorAndVirtualKeysEnabled {
-                            let holdLabels = await resolveHoldLabels(
-                                keyMap: keyMap,
-                                configPath: configPath,
-                                layerName: layerName
-                            )
-                            guard !Task.isCancelled else { return }
-                            if !holdLabels.isEmpty {
-                                holdLabelCache[layerName] = holdLabels
-                            }
+                        let holdLabels = await resolveHoldLabels(
+                            keyMap: keyMap,
+                            configPath: configPath,
+                            layerName: layerName
+                        )
+                        guard !Task.isCancelled else { return }
+                        if !holdLabels.isEmpty {
+                            holdLabelCache[layerName] = holdLabels
                         }
                         AppLogger.shared.info("🎯 [ContextHUD] Precomputed layer '\(layerName)'")
                     }

--- a/Sources/KeyPathAppKit/UI/KeyboardVisualization/KeyboardVisualizationViewModel+TCP.swift
+++ b/Sources/KeyPathAppKit/UI/KeyboardVisualization/KeyboardVisualizationViewModel+TCP.swift
@@ -352,10 +352,6 @@ extension KeyboardVisualizationViewModel {
 
         // If Kanata omitted the action string, try to resolve the hold label via simulator
         if action.isEmpty {
-            guard FeatureFlags.simulatorAndVirtualKeysEnabled else {
-                AppLogger.shared.debug("🔒 [KeyboardViz] Simulator disabled; skipping hold label resolution for \(key)")
-                return
-            }
             // Check short-lived cache first
             if let cached = holdLabelCache[keyCode], Date().timeIntervalSince(cached.timestamp) < holdLabelCacheTTL {
                 holdLabels[keyCode] = cached.label


### PR DESCRIPTION
## Summary
- Hold labels were gated behind `FeatureFlags.simulatorAndVirtualKeysEnabled` in 3 places
- Toggling the simulator off silently killed hold-label rendering with no indication
- Removed the guard from KeyboardVisualizationViewModel+TCP and ContextHUDController+ShowForLayer (both resolution and precomputation)

## Test plan
- [x] `swift build` passes
- [x] All tests pass
- [ ] CI green

Closes #689