### PR TITLE
fix(mapper): add chord editing section, prevent silent dual-role fallback (#671)

### DIFF
--- a/Sources/KeyPathAppKit/UI/Experimental/AdvancedBehaviorContent.swift
+++ b/Sources/KeyPathAppKit/UI/Experimental/AdvancedBehaviorContent.swift
@@ -314,11 +314,72 @@ struct AdvancedBehaviorContent: View {
 
                 Spacer()
             }
+            // Chord row
+            VStack(alignment: .leading, spacing: 8) {
+                HStack(spacing: 16) {
+                    Text("Chord")
+                        .font(.subheadline)
+                        .foregroundColor(.secondary)
+                        .frame(width: 70, alignment: .trailing)
+
+                    HStack(spacing: 4) {
+                        ForEach(viewModel.comboKeys, id: \.self) { key in
+                            Text(key.uppercased())
+                                .font(.caption)
+                                .fontWeight(.medium)
+                                .padding(.horizontal, 6)
+                                .padding(.vertical, 3)
+                                .background(Color.accentColor.opacity(0.15))
+                                .cornerRadius(4)
+                        }
+                    }
+
+                    if viewModel.comboKeys.isEmpty {
+                        Text("No chord keys")
+                            .font(.caption)
+                            .foregroundColor(.secondary.opacity(0.5))
+                    }
+
+                    Spacer()
+                }
+                .accessibilityIdentifier("mapper-chord-keys-row")
+
+                if !viewModel.comboKeys.isEmpty {
+                    HStack(spacing: 16) {
+                        Text("Output")
+                            .font(.subheadline)
+                            .foregroundColor(.secondary)
+                            .frame(width: 70, alignment: .trailing)
+
+                        MiniActionKeycap(
+                            label: viewModel.comboOutput.isEmpty ? "" : formatKeyForDisplay(viewModel.comboOutput),
+                            isRecording: viewModel.isRecordingComboOutput,
+                            onTap: { viewModel.toggleComboOutputRecording() }
+                        )
+
+                        if !viewModel.comboOutput.isEmpty {
+                            Button {
+                                viewModel.comboOutput = ""
+                            } label: {
+                                Image(systemName: "xmark.circle.fill")
+                                    .foregroundColor(.secondary.opacity(0.6))
+                            }
+                            .buttonStyle(.plain)
+                            .help("Clear chord output")
+                            .accessibilityIdentifier("mapper-clear-combo-output-button")
+                        }
+
+                        Spacer()
+                    }
+                    .accessibilityIdentifier("mapper-chord-output-row")
+                }
+            }
         }
         .padding(.leading, 8)
         .animation(.easeInOut(duration: 0.2), value: viewModel.holdAction.isEmpty)
         .animation(.easeInOut(duration: 0.2), value: viewModel.tapDanceSteps.count)
         .animation(.easeInOut(duration: 0.2), value: viewModel.showTimingAdvanced)
+        .animation(.easeInOut(duration: 0.2), value: viewModel.comboKeys.isEmpty)
     }
 
     // MARK: - Hold Behavior Picker

--- a/Sources/KeyPathAppKit/UI/Experimental/Mapper/AdvancedBehaviorManager.swift
+++ b/Sources/KeyPathAppKit/UI/Experimental/Mapper/AdvancedBehaviorManager.swift
@@ -157,7 +157,8 @@ public final class AdvancedBehaviorManager {
     public func checkHoldConflict() -> Bool {
         !doubleTapAction.isEmpty ||
             tapDanceSteps.contains { !$0.action.isEmpty } ||
-            (macroBehavior?.isValid == true)
+            (macroBehavior?.isValid == true) ||
+            hasValidCombo
     }
 
     /// Check if setting tap-dance would conflict with existing hold

--- a/Sources/KeyPathAppKit/UI/Experimental/MapperViewModel+RuleManagement.swift
+++ b/Sources/KeyPathAppKit/UI/Experimental/MapperViewModel+RuleManagement.swift
@@ -82,11 +82,21 @@ extension MapperViewModel {
         customRule.shiftedOutput = shiftedOutputKanata
 
         // Add behavior based on configured actions
-        // Priority: macro → dualRole → tap-dance → chord
+        // Priority: macro → chord → dualRole → tap-dance
         // (UI should prevent conflicting behaviors from being set simultaneously)
         if let macroBehavior, macroBehavior.isValid {
             customRule.behavior = .macro(macroBehavior)
             AppLogger.shared.log("💾 [MapperViewModel] Adding macro behavior")
+        } else if advancedBehavior.hasValidCombo {
+            var allKeys = [inputKanata]
+            allKeys.append(contentsOf: advancedBehavior.comboKeys)
+            let chord = ChordBehavior(
+                keys: allKeys,
+                output: KanataBehaviorRenderer.parseActionString(advancedBehavior.comboOutput),
+                timeout: advancedBehavior.comboTimeout
+            )
+            customRule.behavior = .chord(chord)
+            AppLogger.shared.log("💾 [MapperViewModel] Adding chord behavior: keys=\(allKeys), output='\(chord.outputString)'")
         } else if !holdAction.isEmpty {
             let dualRole = DualRoleBehavior(
                 tapAction: KanataBehaviorRenderer.parseActionString(outputKanata),
@@ -110,16 +120,6 @@ extension MapperViewModel {
             let tapDance = TapDanceBehavior(windowMs: tapTimeout, steps: steps)
             customRule.behavior = .tapOrTapDance(.tapDance(tapDance))
             AppLogger.shared.log("💾 [MapperViewModel] Adding tapDance behavior: \(steps.count) steps")
-        } else if advancedBehavior.hasValidCombo {
-            var allKeys = [inputKanata]
-            allKeys.append(contentsOf: advancedBehavior.comboKeys)
-            let chord = ChordBehavior(
-                keys: allKeys,
-                output: KanataBehaviorRenderer.parseActionString(advancedBehavior.comboOutput),
-                timeout: advancedBehavior.comboTimeout
-            )
-            customRule.behavior = .chord(chord)
-            AppLogger.shared.log("💾 [MapperViewModel] Adding chord behavior: keys=\(allKeys), output='\(chord.outputString)'")
         }
 
         // Apply device condition: scoped output goes into deviceOverrides,


### PR DESCRIPTION
## Summary
- Added chord keys + output section to AdvancedBehaviorContent so loaded chord data is visible and editable
- Added chord to `checkHoldConflict()` so the conflict dialog fires when setting hold on a chord rule
- Moved chord above dualRole in save priority (macro → chord → dualRole → tapDance) to prevent silent conversion

## Test plan
- [x] `swift build` passes
- [x] All tests pass
- [x] swiftformat clean
- [ ] CI green

Closes #671