### PR TITLE
fix(overlay): skip redundant layer updates from kanata heartbeat (#622)

### DIFF
--- a/Sources/KeyPathAppKit/UI/KeyboardVisualization/KeyboardVisualizationViewModel+LayoutMapping.swift
+++ b/Sources/KeyPathAppKit/UI/KeyboardVisualization/KeyboardVisualizationViewModel+LayoutMapping.swift
@@ -20,8 +20,11 @@ extension KeyboardVisualizationViewModel {
 
     /// Update the current layer and rebuild key mapping
     func updateLayer(_ layerName: String) {
-        let wasLauncherMode = isLauncherModeActive
         let targetLayerName = layerName
+
+        guard currentLayerName != targetLayerName else { return }
+
+        let wasLauncherMode = isLauncherModeActive
 
         // Set layer name immediately so computed properties (isLauncherModeActive,
         // layer indicators) update without waiting for the async mapping rebuild.


### PR DESCRIPTION
## Summary
- Kanata emits `Current layer -> X` every ~500ms even when unchanged
- `updateLayer()` processed every message — clearing state, triggering async rebuilds, causing ~2Hz re-render churn
- Added early return when layer name hasn't changed (ContextHUDController already had this guard)

## Test plan
- [x] `swift build` passes
- [x] All tests pass
- [ ] CI green

Closes #622