### PR TITLE
refactor: migrate last 3 ObservableObject types to @Observable (#491)

### DIFF
--- a/Sources/KeyPathAppKit/Services/Devices/HIDDeviceMonitor.swift
+++ b/Sources/KeyPathAppKit/Services/Devices/HIDDeviceMonitor.swift
@@ -2,6 +2,7 @@ import Foundation
 import IOKit
 import IOKit.hid
 import KeyPathCore
+import Observation
 
 /// Monitors USB HID keyboard connect/disconnect events via IOKit.
 ///
@@ -23,8 +24,9 @@ import KeyPathCore
 ///   alive while `CFRunLoopRun()` blocks.
 /// - `handleDeviceConnected`/`handleDeviceRemoved` run on the IOKit thread, extract
 ///   Sendable data, then hop to MainActor via `Task { @MainActor }`.
+@Observable
 @MainActor
-final class HIDDeviceMonitor: ObservableObject {
+final class HIDDeviceMonitor {
     static let shared = HIDDeviceMonitor()
 
     struct HIDKeyboardEvent: Sendable, Equatable, Identifiable {
@@ -42,9 +44,9 @@ final class HIDDeviceMonitor: ObservableObject {
         }
     }
 
-    @Published private(set) var connectedKeyboards: [HIDKeyboardEvent] = []
+    private(set) var connectedKeyboards: [HIDKeyboardEvent] = []
 
-    @Published private(set) var lastConnectedKeyboard: HIDKeyboardEvent?
+    private(set) var lastConnectedKeyboard: HIDKeyboardEvent?
 
     /// Dedicated thread for the IOKit run loop. Non-nil means monitoring is active.
     /// Only accessed from MainActor (startMonitoring/stopMonitoring).

--- a/Sources/KeyPathInstallationWizard/UI/Helpers/DragToAuthorize/DragToAuthorizeController.swift
+++ b/Sources/KeyPathInstallationWizard/UI/Helpers/DragToAuthorize/DragToAuthorizeController.swift
@@ -2,13 +2,15 @@ import AppKit
 import KeyPathCore
 import KeyPathPermissions
 import KeyPathWizardCore
+import Observation
 import SwiftUI
 
 /// Orchestrates the drag-to-authorize overlay lifecycle.
 /// Manages panel presentation, Settings window tracking, permission polling,
 /// and state transitions with animations.
+@Observable
 @MainActor
-public final class DragToAuthorizeController: ObservableObject {
+public final class DragToAuthorizeController {
     public static let shared = DragToAuthorizeController()
 
     // MARK: - Public Types
@@ -48,10 +50,10 @@ public final class DragToAuthorizeController: ObservableObject {
         case dismissing
     }
 
-    // MARK: - Published State
+    // MARK: - Observable State
 
-    @Published public private(set) var state: OverlayState = .idle
-    @Published public private(set) var currentTarget: PermissionTarget?
+    public private(set) var state: OverlayState = .idle
+    public private(set) var currentTarget: PermissionTarget?
 
     // MARK: - Private Properties
 

--- a/Sources/KeyPathLayoutTracerKit/LayoutTracerApp.swift
+++ b/Sources/KeyPathLayoutTracerKit/LayoutTracerApp.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 public struct LayoutTracerApp: App {
-    @StateObject private var menuState = LayoutTracerMenuState.shared
+    @State private var menuState = LayoutTracerMenuState.shared
 
     public init() {
         NSApplication.shared.setActivationPolicy(.regular)

--- a/Sources/KeyPathLayoutTracerKit/LayoutTracerMenuCommands.swift
+++ b/Sources/KeyPathLayoutTracerKit/LayoutTracerMenuCommands.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct LayoutTracerMenuCommands: Commands {
-    @ObservedObject var menuState: LayoutTracerMenuState
+    @Bindable var menuState: LayoutTracerMenuState
 
     var body: some Commands {
         CommandGroup(replacing: .newItem) {}

--- a/Sources/KeyPathLayoutTracerKit/LayoutTracerMenuState.swift
+++ b/Sources/KeyPathLayoutTracerKit/LayoutTracerMenuState.swift
@@ -1,15 +1,17 @@
 import Foundation
+import Observation
 
+@Observable
 @MainActor
-final class LayoutTracerMenuState: ObservableObject {
+final class LayoutTracerMenuState {
     static let shared = LayoutTracerMenuState()
 
-    @Published var canSave = false
-    @Published var canUndo = false
-    @Published var canRedo = false
-    @Published var canClearGuides = false
-    @Published var snapEnabled = true
-    @Published var showsSnapGuides = true
+    var canSave = false
+    var canUndo = false
+    var canRedo = false
+    var canClearGuides = false
+    var snapEnabled = true
+    var showsSnapGuides = true
 
     var save: (() -> Void)?
     var saveAs: (() -> Void)?

--- a/Sources/KeyPathLayoutTracerKit/LayoutTracerRootView.swift
+++ b/Sources/KeyPathLayoutTracerKit/LayoutTracerRootView.swift
@@ -4,7 +4,7 @@ import SwiftUI
 struct LayoutTracerRootView: View {
     @State private var document = TracingDocument()
     @State private var documentError: String?
-    @StateObject private var menuState = LayoutTracerMenuState.shared
+    @State private var menuState = LayoutTracerMenuState.shared
     @State private var saveSheetMode: SaveSheetMode?
     private let availableLayouts = LayoutCatalog.builtInLayouts()
 


### PR DESCRIPTION
## Summary
- **HIDDeviceMonitor**: `ObservableObject` → `@Observable`, removed `@Published`
- **LayoutTracerMenuState**: `ObservableObject` → `@Observable`, removed `@Published`; updated consumers (`@StateObject` → `@State`, `@ObservedObject` → `@Bindable`)
- **DragToAuthorizeController**: `ObservableObject` → `@Observable`, removed `@Published`

No remaining `ObservableObject` conformances in production code.

## Test plan
- [x] `swift build` passes
- [x] All tests pass
- [x] swiftformat clean
- [ ] CI green

Closes #491