### PR TITLE
refactor: replace inline config/log paths with KeyPathConstants (#497)

### DIFF
--- a/Sources/KeyPathAppKit/App.swift
+++ b/Sources/KeyPathAppKit/App.swift
@@ -340,7 +340,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         // On relaunch (not first-ever install), skip splash and go straight to overlay
         let hasExistingConfig = Foundation.FileManager.default.fileExists(
-            atPath: NSHomeDirectory() + "/.config/keypath/keypath.kbd"
+            atPath: KeyPathConstants.Config.mainConfigPath
         )
         if hasExistingConfig, !initialMainWindowShown {
             AppLogger.shared.info("🪟 [AppDelegate] Reopen on relaunch — skipping splash, showing overlay")
@@ -421,7 +421,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         suppressLaunchSplashAutoHide = false
 
         let hasExistingConfig = Foundation.FileManager.default.fileExists(
-            atPath: NSHomeDirectory() + "/.config/keypath/keypath.kbd"
+            atPath: KeyPathConstants.Config.mainConfigPath
         )
 
         if hasExistingConfig, !suppressAutoHideBecauseReopen {
@@ -546,7 +546,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             "🪟 [AppDelegate] Main window controller created (deferring show until activation)"
         )
         let hasExistingConfig = Foundation.FileManager.default.fileExists(
-            atPath: NSHomeDirectory() + "/.config/keypath/keypath.kbd"
+            atPath: KeyPathConstants.Config.mainConfigPath
         )
         if !hasExistingConfig {
             mainWindowController?.primeForActivation()

--- a/Sources/KeyPathAppKit/CLI/SystemFacade.swift
+++ b/Sources/KeyPathAppKit/CLI/SystemFacade.swift
@@ -34,7 +34,7 @@ public struct SystemFacade: Sendable {
     }
 
     public func serviceLogs(lines: Int = 50) -> [String] {
-        let logPath = NSString("~/Library/Logs/KeyPath/keypath-debug.log").expandingTildeInPath
+        let logPath = KeyPathConstants.Logs.userDebugLog
         guard let content = try? String(contentsOfFile: logPath, encoding: .utf8) else {
             return []
         }

--- a/Sources/KeyPathAppKit/Core/CompositionRoot.swift
+++ b/Sources/KeyPathAppKit/Core/CompositionRoot.swift
@@ -50,7 +50,7 @@ enum CompositionRoot {
 
         // Phase 4: MVVM - Initialize services and RuntimeCoordinator via composition root
         let configurationService = ConfigurationService(
-            configDirectory: "\(NSHomeDirectory())/.config/keypath"
+            configDirectory: KeyPathConstants.Config.directory
         )
         let manager = RuntimeCoordinator(injectedConfigurationService: configurationService)
         let viewModel = KanataViewModel(manager: manager)

--- a/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView+Packs.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView+Packs.swift
@@ -150,7 +150,7 @@ extension RulesTabView {
     }
 
     func openBackupsFolder() {
-        let backupsPath = "\(NSHomeDirectory())/.config/keypath/.backups"
+        let backupsPath = "\(KeyPathConstants.Config.directory)/.backups"
         NSWorkspace.shared.selectFile(nil, inFileViewerRootedAtPath: backupsPath)
     }
 

--- a/Sources/KeyPathAppKit/UI/Settings/SettingsView+General.swift
+++ b/Sources/KeyPathAppKit/UI/Settings/SettingsView+General.swift
@@ -161,7 +161,7 @@ struct GeneralSettingsTabView: View {
 
                     HStack(spacing: 12) {
                         Button {
-                            openLogFile(NSHomeDirectory() + "/Library/Logs/KeyPath/keypath-debug.log")
+                            openLogFile(KeyPathConstants.Logs.userDebugLog)
                         } label: {
                             Label("KeyPath Log", systemImage: "doc.text")
                         }

--- a/Sources/KeyPathCLI/Utilities/UpdateChecker.swift
+++ b/Sources/KeyPathCLI/Utilities/UpdateChecker.swift
@@ -1,10 +1,10 @@
 import Foundation
 import KeyPathAppKit
+import KeyPathCore
 
 enum UpdateChecker {
     private static let cacheFile: String = {
-        let home = FileManager.default.homeDirectoryForCurrentUser.path
-        return "\(home)/.config/keypath/.update-check"
+        "\(KeyPathConstants.Config.directory)/.update-check"
     }()
 
     private static let checkInterval: TimeInterval = 86400 // 24 hours

--- a/Sources/KeyPathCore/KeyPathConstants.swift
+++ b/Sources/KeyPathCore/KeyPathConstants.swift
@@ -45,6 +45,11 @@ public enum KeyPathConstants {
     }
 
     public enum Logs {
+        /// User-facing debug log: ~/Library/Logs/KeyPath/keypath-debug.log
+        public static var userDebugLog: String {
+            "\(NSHomeDirectory())/Library/Logs/KeyPath/keypath-debug.log"
+        }
+
         /// Standard output log for the kanata daemon
         public static let kanataStdout = "/var/log/com.keypath.kanata.stdout.log"
 

--- a/Sources/KeyPathDaemonLifecycle/ProcessLifecycleManager.swift
+++ b/Sources/KeyPathDaemonLifecycle/ProcessLifecycleManager.swift
@@ -288,7 +288,7 @@ public final class ProcessLifecycleManager {
     /// Uses cached PID lookups to prevent race conditions and improve performance
     private func isProcessManagedByLaunchDaemon(_ process: ProcessInfo) async -> Bool {
         // First check if the process uses our config path (necessary but not sufficient)
-        guard process.command.contains("/.config/keypath/keypath.kbd") else {
+        guard process.command.contains(KeyPathConstants.Config.fileName) else {
             AppLogger.shared.log(
                 "🔍 [ProcessLifecycleManager] PID \(process.pid): Wrong config path, not managed"
             )


### PR DESCRIPTION
## Summary
- Replaced 8 inline path constructions across 7 files with `KeyPathConstants.Config.*` and `KeyPathConstants.Logs.*`
- Added `Logs.userDebugLog` constant for the user-facing debug log path
- Skipped HelperService and LauncherService (parameterized with user's home dir for multi-user support)

## Test plan
- [x] `swift build` passes
- [x] All tests pass
- [ ] CI green

Closes #497