### PR TITLE
fix(vim-insights): track shift state and re-enable 0/$ suggestions (#691)

### DIFF
--- a/Sources/KeyPathAppKit/Services/KindaVim/VimInsightsEngine.swift
+++ b/Sources/KeyPathAppKit/Services/KindaVim/VimInsightsEngine.swift
@@ -168,15 +168,26 @@ enum VimInsightsEngine {
                 priority: 75
             ))
         }
-        // NOTE: we used to suggest learning `0` / `$` here, gated on
-        // `commandFrequency["0"]` / `["4"]` being low. That's unsafe:
-        // VimSequenceObserver records every typed character — including
-        // count prefixes (`4j`, `14w`) — into `commandFrequency`. So a
-        // user heavily relying on counts accumulates `"4"` presses
-        // without ever using `$`, suppressing the suggestion. We can't
-        // distinguish raw digits from shifted symbols without tracking
-        // shift state, which we don't. Drop the rule rather than ship
-        // false negatives.
+        if (snapshot.commandFrequency["w"] ?? 0) >= fluencyThreshold,
+           (snapshot.commandFrequency["0"] ?? 0) < 5
+        {
+            out.append(.init(
+                glyph: .learn,
+                title: "Try `0` (start of line)",
+                body: "Jumps to the first column instantly. Pairs with `$` (end of line) to replace Home/End.",
+                priority: 70
+            ))
+        }
+        if (snapshot.commandFrequency["w"] ?? 0) >= fluencyThreshold,
+           (snapshot.commandFrequency["$"] ?? 0) < 5
+        {
+            out.append(.init(
+                glyph: .learn,
+                title: "Try `$` (end of line)",
+                body: "Jumps to the last character on the line. Pairs with `0` (start of line) to replace Home/End.",
+                priority: 70
+            ))
+        }
         if (snapshot.commandFrequency["i"] ?? 0) >= fluencyThreshold,
            (snapshot.commandFrequency["a"] ?? 0) < 5
         {

--- a/Sources/KeyPathAppKit/Services/KindaVim/VimSequenceObserver.swift
+++ b/Sources/KeyPathAppKit/Services/KindaVim/VimSequenceObserver.swift
@@ -114,7 +114,9 @@ final class VimSequenceObserver {
             KindaVimTelemetryStore.shared.recordNonVimNavigation(navName)
         }
 
-        guard let chars = event.charactersIgnoringModifiers, !chars.isEmpty else { return }
+        let isShifted = event.modifierFlags.contains(.shift)
+        guard let chars = (isShifted ? event.characters : event.charactersIgnoringModifiers),
+              !chars.isEmpty else { return }
         ingestCore(character: chars)
     }
 


### PR DESCRIPTION
## Summary
- VimSequenceObserver now uses `event.characters` when shift is held, correctly recording `$` instead of `4`
- Re-enabled the `0` (start of line) and `$` (end of line) insight rules that were suppressed due to this blind spot

## Test plan
- [x] `swift build` passes
- [x] All tests pass
- [ ] CI green

Closes #691