### PR TITLE
fix(devices): filter mice from keyboard picker (#304)

### DIFF
--- a/Sources/KeyPathAppKit/Models/ConnectedDevice.swift
+++ b/Sources/KeyPathAppKit/Models/ConnectedDevice.swift
@@ -47,6 +47,19 @@ struct ConnectedDevice: Codable, Identifiable, Hashable, Sendable {
         return lower.contains("trackpad") && !lower.contains("keyboard")
     }
 
+    /// True if this device is a known mouse that exposes a composite HID keyboard
+    /// endpoint (for programmable buttons/macros) but isn't an actual keyboard.
+    var isMouseOnly: Bool {
+        let lower = productKey.lowercased()
+        let mouseNames = ["x2a", "x2h", "x2v", "xlite", "x2 mini"]
+        return lower.contains("mouse") || mouseNames.contains(where: { lower == $0 })
+    }
+
+    /// True if this device should be excluded from the keyboard picker.
+    var isNonKeyboard: Bool {
+        isVirtualHID || isTrackpadOnly || isMouseOnly
+    }
+
     /// SF Symbol name for this device type.
     /// Apple internal keyboards (vendor 0x05AC) use `laptopcomputer`;
     /// all external keyboards use `keyboard`.

--- a/Sources/KeyPathAppKit/UI/Overlay/DeviceSelectionView.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/DeviceSelectionView.swift
@@ -11,9 +11,9 @@ struct DeviceSelectionView: View {
     @State private var needsRestart = false
     @State private var isRestarting = false
 
-    /// Physical (non-VirtualHID) devices currently connected.
+    /// Physical keyboard devices currently connected (excludes VirtualHID, trackpads, mice).
     private var physicalConnected: [ConnectedDevice] {
-        connectedDevices.filter { !$0.isVirtualHID }
+        connectedDevices.filter { !$0.isNonKeyboard }
     }
 
     /// Previously-seen devices that are no longer connected.
@@ -188,7 +188,7 @@ struct DeviceSelectionView: View {
 
         // Update lastSeen for connected devices
         let now = Date()
-        for device in connectedDevices where !device.isVirtualHID {
+        for device in connectedDevices where !device.isNonKeyboard {
             if selections[device.hash] == nil {
                 // New device — default to enabled, don't mark dirty
                 selections[device.hash] = DeviceSelection(

--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayMapperSection.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayMapperSection.swift
@@ -686,10 +686,10 @@ struct OverlayMapperSection: View {
         return parts.joined(separator: " · ")
     }
 
-    /// Physical keyboard devices currently connected (excludes VirtualHID and trackpad-only devices)
+    /// Physical keyboard devices currently connected (excludes VirtualHID, trackpads, mice)
     private var physicalDevices: [ConnectedDevice] {
         DeviceSelectionCache.shared.getConnectedDevices().filter { device in
-            !device.isVirtualHID && !device.isTrackpadOnly
+            !device.isNonKeyboard
         }
     }
 


### PR DESCRIPTION
## Summary
- Added `isMouseOnly` check for gaming mice that expose composite HID keyboard endpoints
- Added `isNonKeyboard` convenience combining VirtualHID, trackpad, and mouse filters
- Updated DeviceSelectionView and OverlayMapperSection to use unified filter

## Test plan
- [x] `swift build` passes
- [x] All tests pass
- [ ] CI green

Closes #304