### PR TITLE
refactor: centralize app-navigation Notification.Name definitions (#489)

### DIFF
--- a/Sources/KeyPathAppKit/App.swift
+++ b/Sources/KeyPathAppKit/App.swift
@@ -620,7 +620,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             if !helperFunctional {
                 AppLogger.shared.info("🆕 [AppDelegate] Helper not functional - auto-launching wizard")
                 try? await Task.sleep(for: .seconds(1))
-                NotificationCenter.default.post(name: NSNotification.Name("ShowWizard"), object: nil)
+                NotificationCenter.default.post(name: .showWizard, object: nil)
             }
         }
     }
@@ -657,7 +657,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             },
             showWizardHandler: { targetPage in
                 NotificationCenter.default.post(
-                    name: NSNotification.Name("ShowWizard"),
+                    name: .showWizard,
                     object: nil,
                     userInfo: targetPage.map { ["targetPage": $0] }
                 )
@@ -825,7 +825,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 if NSApp.isActive, !NSApp.isHidden {
                     self.showMainWindow()
                     NotificationCenter.default.post(
-                        name: NSNotification.Name("ShowEmergencyStop"),
+                        name: .showEmergencyStop,
                         object: nil
                     )
                 }

--- a/Sources/KeyPathAppKit/Core/AppMenuCommands.swift
+++ b/Sources/KeyPathAppKit/Core/AppMenuCommands.swift
@@ -76,7 +76,7 @@ struct AppMenuCommands: Commands {
             Divider()
 
             Button("Install wizard...") {
-                NotificationCenter.default.post(name: NSNotification.Name("ShowWizard"), object: nil)
+                NotificationCenter.default.post(name: .showWizard, object: nil)
             }
             .keyboardShortcut("n", modifiers: [.command, .shift])
 
@@ -94,7 +94,7 @@ struct AppMenuCommands: Commands {
 
             Button("Simple Key Mappings\u{2026}") {
                 appDelegate.showMainWindow()
-                NotificationCenter.default.post(name: NSNotification.Name("ShowSimpleMods"), object: nil)
+                NotificationCenter.default.post(name: .showSimpleMods, object: nil)
             }
 
             Divider()
@@ -158,7 +158,7 @@ struct AppMenuCommands: Commands {
                 role: .destructive,
                 action: {
                     appDelegate.showMainWindow()
-                    NotificationCenter.default.post(name: NSNotification.Name("ShowUninstall"), object: nil)
+                    NotificationCenter.default.post(name: .showUninstall, object: nil)
                 },
                 label: {
                     Label("Uninstall KeyPath\u{2026}", systemImage: "trash")

--- a/Sources/KeyPathAppKit/Core/AppNotificationWiring.swift
+++ b/Sources/KeyPathAppKit/Core/AppNotificationWiring.swift
@@ -57,7 +57,7 @@ enum AppNotificationWiring {
     private static func registerFeedbackNotifications() {
         // Settings/permission flows sometimes post a "toast" message; show as a user notification.
         NotificationCenter.default.addObserver(
-            forName: NSNotification.Name("ShowUserFeedback"), object: nil, queue: NotificationObserverManager.mainOperationQueue
+            forName: .showUserFeedback, object: nil, queue: NotificationObserverManager.mainOperationQueue
         ) { notification in
             if let message = notification.userInfo?["message"] as? String {
                 Task { @MainActor in

--- a/Sources/KeyPathAppKit/Services/UserFeedbackService.swift
+++ b/Sources/KeyPathAppKit/Services/UserFeedbackService.swift
@@ -3,7 +3,7 @@ import Foundation
 enum UserFeedbackService {
     static func show(message: String) {
         NotificationCenter.default.post(
-            name: NSNotification.Name("ShowUserFeedback"),
+            name: .showUserFeedback,
             object: nil,
             userInfo: ["message": message]
         )

--- a/Sources/KeyPathAppKit/UI/CommandPalette/CommandPaletteWindowController.swift
+++ b/Sources/KeyPathAppKit/UI/CommandPalette/CommandPaletteWindowController.swift
@@ -393,7 +393,7 @@ final class CommandPaletteWindowController {
                 group: "Settings"
             ) {
                 DispatchQueue.main.async {
-                    NotificationCenter.default.post(name: NSNotification.Name("ShowWizard"), object: nil)
+                    NotificationCenter.default.post(name: .showWizard, object: nil)
                 }
             },
         ]

--- a/Sources/KeyPathAppKit/UI/RootView.swift
+++ b/Sources/KeyPathAppKit/UI/RootView.swift
@@ -28,13 +28,13 @@ struct RootView: View {
                 SimpleModsView(configPath: kanataVM.configPath)
                     .environment(kanataVM)
             }
-            .onReceive(NotificationCenter.default.publisher(for: NSNotification.Name("ShowEmergencyStop"))) { _ in
+            .onReceive(NotificationCenter.default.publisher(for: .showEmergencyStop)) { _ in
                 showingEmergencyStopDialog = true
             }
-            .onReceive(NotificationCenter.default.publisher(for: NSNotification.Name("ShowUninstall"))) { _ in
+            .onReceive(NotificationCenter.default.publisher(for: .showUninstall)) { _ in
                 showingUninstallDialog = true
             }
-            .onReceive(NotificationCenter.default.publisher(for: NSNotification.Name("ShowSimpleMods"))) { _ in
+            .onReceive(NotificationCenter.default.publisher(for: .showSimpleMods)) { _ in
                 showingSimpleModsDialog = true
             }
             .task {

--- a/Sources/KeyPathAppKit/Utilities/Notifications.swift
+++ b/Sources/KeyPathAppKit/Utilities/Notifications.swift
@@ -8,8 +8,12 @@ extension Notification.Name {
     static let kp_startupEmergencyMonitor = Notification.Name("KeyPath.Startup.EmergencyMonitor")
     static let kp_startupRevalidate = Notification.Name("KeyPath.Startup.Revalidate")
 
-    // Wizard events
+    // App navigation
     static let showWizard = Notification.Name("ShowWizard")
+    static let showEmergencyStop = Notification.Name("ShowEmergencyStop")
+    static let showUninstall = Notification.Name("ShowUninstall")
+    static let showSimpleMods = Notification.Name("ShowSimpleMods")
+    static let showUserFeedback = Notification.Name("ShowUserFeedback")
     static let wizardOpened = Notification.Name("KeyPath.Wizard.Opened")
     static let wizardClosed = Notification.Name("KeyPath.Wizard.Closed")
 


### PR DESCRIPTION
## Summary
- Replaced 12 inline `NSNotification.Name("Show*")` string literals across 6 files with typed constants
- Added `showEmergencyStop`, `showUninstall`, `showSimpleMods`, `showUserFeedback` to `Notifications.swift`
- Existing `showWizard` was already centralized; no duplication

## Test plan
- [x] `swift build` passes
- [x] All tests pass
- [ ] CI green

Closes #489