### PR TITLE
refactor: centralize operational timing constants (#492)

### DIFF
--- a/Sources/KeyPathAppKit/Core/HelperManager+RequestHandlers.swift
+++ b/Sources/KeyPathAppKit/Core/HelperManager+RequestHandlers.swift
@@ -63,7 +63,7 @@ extension HelperManager {
     /// - Throws: HelperError if the operation fails
     private func executeXPCCall(
         _ name: String,
-        timeout: TimeInterval = 30.0,
+        timeout: TimeInterval = KeyPathConstants.Timing.helperRequestTimeout,
         _ call: @escaping @Sendable (HelperProtocol, @escaping (Bool, String?) -> Void) -> Void
     ) async throws {
         // Detect concurrent XPC calls (indicates a bug in caller logic)
@@ -113,7 +113,7 @@ extension HelperManager {
     /// used by the void-returning helper operations.
     private func executeValueXPCCall<T: Sendable>(
         _ name: String,
-        timeout: TimeInterval = 30.0,
+        timeout: TimeInterval = KeyPathConstants.Timing.helperRequestTimeout,
         _ call: @escaping @Sendable (
             HelperProtocol,
             @escaping @Sendable (Result<T, Error>) -> Void

--- a/Sources/KeyPathAppKit/Core/PrivilegedOperationsRouter.swift
+++ b/Sources/KeyPathAppKit/Core/PrivilegedOperationsRouter.swift
@@ -20,10 +20,10 @@ public final class PrivilegedOperationsRouter {
 
     private static var lastServiceInstallAttempt: Date?
     private static var lastSMAppApprovalNotice: Date?
-    private static let smAppApprovalNoticeThrottle: TimeInterval = 5
+    private static let smAppApprovalNoticeThrottle: TimeInterval = KeyPathConstants.Timing.smAppApprovalThrottle
 
-    private static let kanataReadinessTimeout: TimeInterval = 20
-    private static let kanataReadinessPollIntervalSeconds: TimeInterval = 0.5
+    private static let kanataReadinessTimeout: TimeInterval = KeyPathConstants.Timing.kanataReadinessTimeout
+    private static let kanataReadinessPollIntervalSeconds: TimeInterval = KeyPathConstants.Timing.kanataReadinessPollInterval
     private static let kanataLaunchctlNotFoundExitCode: Int32 = 113
     private static let persistentLaunchctlNotFoundThreshold = 3
 

--- a/Sources/KeyPathAppKit/UI/KeyboardVisualization/KeyboardVisualizationViewModel.swift
+++ b/Sources/KeyPathAppKit/UI/KeyboardVisualization/KeyboardVisualizationViewModel.swift
@@ -98,7 +98,7 @@ class KeyboardVisualizationViewModel {
     @ObservationIgnored var lastTcpEventTime: Date?
 
     /// How long without events before we consider disconnected (seconds)
-    @ObservationIgnored let tcpConnectionTimeout: TimeInterval = 3.0
+    @ObservationIgnored let tcpConnectionTimeout: TimeInterval = KeyPathConstants.Timing.tcpConnectionTimeout
 
     // MARK: - One-Shot Modifier State
 
@@ -111,7 +111,7 @@ class KeyboardVisualizationViewModel {
     /// Short-lived cache of resolved hold labels to avoid repeated simulator runs (keyCode -> (label, timestamp))
     @ObservationIgnored var holdLabelCache: [UInt16: (label: String, timestamp: Date)] = [:]
     /// Cache time-to-live in seconds
-    @ObservationIgnored let holdLabelCacheTTL: TimeInterval = 5
+    @ObservationIgnored let holdLabelCacheTTL: TimeInterval = KeyPathConstants.Timing.holdLabelCacheTTL
     /// Pending delayed clears for hold-active keys to tolerate tap-hold-press jitter
     @ObservationIgnored var holdClearWorkItems: [UInt16: DispatchWorkItem] = [:]
 

--- a/Sources/KeyPathCore/KeyPathConstants.swift
+++ b/Sources/KeyPathCore/KeyPathConstants.swift
@@ -94,4 +94,14 @@ public enum KeyPathConstants {
         public static let inputMonitoringPrivacy = "x-apple.systempreferences:com.apple.preference.security?Privacy_ListenEvent"
         public static let accessibilityPrivacy = "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility"
     }
+
+    public enum Timing {
+        public static let tcpConnectionTimeout: TimeInterval = 3.0
+        public static let toastDuration: TimeInterval = 3.0
+        public static let holdLabelCacheTTL: TimeInterval = 5
+        public static let helperRequestTimeout: TimeInterval = 30.0
+        public static let kanataReadinessTimeout: TimeInterval = 20
+        public static let kanataReadinessPollInterval: TimeInterval = 0.5
+        public static let smAppApprovalThrottle: TimeInterval = 5
+    }
 }


### PR DESCRIPTION
## Summary
- Added `KeyPathConstants.Timing` namespace with 7 operational timeout constants
- Replaced inline magic values in KeyboardVisualizationViewModel, PrivilegedOperationsRouter, HelperManager+RequestHandlers
- UI-local animation durations left in place (context-specific)

## Test plan
- [x] `swift build` passes
- [x] All tests pass
- [ ] CI green

Closes #492