### PR TITLE
refactor(overlay): unify key-active state model (#627)

### DIFF
--- a/Sources/KeyPathAppKit/UI/KeyboardVisualization/KeyboardVisualizationViewModel+Capture.swift
+++ b/Sources/KeyPathAppKit/UI/KeyboardVisualization/KeyboardVisualizationViewModel+Capture.swift
@@ -40,8 +40,7 @@ extension KeyboardVisualizationViewModel {
         guard isCapturing else { return }
 
         isCapturing = false
-        pressedKeyCodes.removeAll()
-        holdLabels.removeAll()
+        keyVisualStates.removeAll()
         holdLabelCache.removeAll()
         activeTapHoldSources.removeAll()
         dynamicTapHoldOutputMap.removeAll()
@@ -89,6 +88,6 @@ extension KeyboardVisualizationViewModel {
     }
 
     func isPressed(_ key: PhysicalKey) -> Bool {
-        pressedKeyCodes.contains(key.keyCode)
+        keyVisualStates[key.keyCode]?.isPressed ?? false
     }
 }

--- a/Sources/KeyPathAppKit/UI/KeyboardVisualization/KeyboardVisualizationViewModel+Computed.swift
+++ b/Sources/KeyPathAppKit/UI/KeyboardVisualization/KeyboardVisualizationViewModel+Computed.swift
@@ -65,7 +65,6 @@ extension KeyboardVisualizationViewModel {
     /// Uses only Kanata TCP KeyInput events to show the actual physical keys pressed,
     /// not the transformed output keys from CGEvent tap.
     var effectivePressedKeyCodes: Set<UInt16> {
-        // Use TCP physical keys and any keys currently in an active hold state.
-        pressedKeyCodes.union(holdActiveKeyCodes)
+        Set(keyVisualStates.filter(\.value.appearsPressed).map(\.key))
     }
 }

--- a/Sources/KeyPathAppKit/UI/KeyboardVisualization/KeyboardVisualizationViewModel+Fade.swift
+++ b/Sources/KeyPathAppKit/UI/KeyboardVisualization/KeyboardVisualizationViewModel+Fade.swift
@@ -45,7 +45,10 @@ extension KeyboardVisualizationViewModel {
             // Fade complete - clean up
             keyFadeAmounts.removeValue(forKey: keyCode)
             fadeOutTasks.removeValue(forKey: keyCode)
-            holdReleaseFadeKeyCodes.remove(keyCode)
+            if var state = keyVisualStates[keyCode] {
+                state.releasedFromHold = false
+                keyVisualStates[keyCode] = state.isIdle ? nil : state
+            }
         }
 
         fadeOutTasks[keyCode] = task
@@ -56,6 +59,9 @@ extension KeyboardVisualizationViewModel {
         fadeOutTasks[keyCode]?.cancel()
         fadeOutTasks.removeValue(forKey: keyCode)
         keyFadeAmounts.removeValue(forKey: keyCode)
-        holdReleaseFadeKeyCodes.remove(keyCode)
+        if var state = keyVisualStates[keyCode] {
+            state.releasedFromHold = false
+            keyVisualStates[keyCode] = state.isIdle ? nil : state
+        }
     }
 }

--- a/Sources/KeyPathAppKit/UI/KeyboardVisualization/KeyboardVisualizationViewModel+LayoutMapping.swift
+++ b/Sources/KeyPathAppKit/UI/KeyboardVisualization/KeyboardVisualizationViewModel+LayoutMapping.swift
@@ -42,9 +42,7 @@ extension KeyboardVisualizationViewModel {
                 holdClearWorkItems[keyCode]?.cancel()
                 holdClearWorkItems.removeValue(forKey: keyCode)
             }
-            holdActiveKeyCodes.removeAll()
-            holdLabels.removeAll()
-            pressedKeyCodes.removeAll()
+            keyVisualStates.removeAll()
         }
 
         // Check if we'll be entering/exiting launcher mode

--- a/Sources/KeyPathAppKit/UI/KeyboardVisualization/KeyboardVisualizationViewModel+TCP.swift
+++ b/Sources/KeyPathAppKit/UI/KeyboardVisualization/KeyboardVisualizationViewModel+TCP.swift
@@ -345,16 +345,16 @@ extension KeyboardVisualizationViewModel {
         // Convert the action string to a display label; if empty, wait for simulator resolution.
         if !action.isEmpty {
             let displayLabel = Self.actionToDisplayLabel(action)
-            holdLabels[keyCode] = displayLabel
+            keyVisualStates[keyCode, default: .init()].holdLabel = displayLabel
         }
-        holdActiveKeyCodes.insert(keyCode)
-        AppLogger.shared.info("🔒 [KeyboardViz] Hold activated: \(key) -> '\(holdLabels[keyCode] ?? "pending")' (from '\(action)')")
+        keyVisualStates[keyCode, default: .init()].isHoldActive = true
+        AppLogger.shared.info("🔒 [KeyboardViz] Hold activated: \(key) -> '\(keyVisualStates[keyCode]?.holdLabel ?? "pending")' (from '\(action)')")
 
         // If Kanata omitted the action string, try to resolve the hold label via simulator
         if action.isEmpty {
             // Check short-lived cache first
             if let cached = holdLabelCache[keyCode], Date().timeIntervalSince(cached.timestamp) < holdLabelCacheTTL {
-                holdLabels[keyCode] = cached.label
+                keyVisualStates[keyCode, default: .init()].holdLabel = cached.label
                 AppLogger.shared.debug("🔒 [KeyboardViz] Hold label served from cache: \(key) -> '\(cached.label)'")
                 return
             }
@@ -377,7 +377,7 @@ extension KeyboardVisualizationViewModel {
                         startLayer: layer
                     ) {
                         await MainActor.run {
-                            self.holdLabels[keyCode] = resolved
+                            self.keyVisualStates[keyCode, default: .init()].holdLabel = resolved
                             self.holdLabelCache[keyCode] = (resolved, Date())
                             AppLogger.shared.info("🔒 [KeyboardViz] Hold label resolved via simulator: \(key) -> '\(resolved)'")
                             self.resolvingHoldLabels.remove(keyCode)
@@ -544,12 +544,12 @@ extension KeyboardVisualizationViewModel {
                 return
             }
             cancelKeyFadeOut(keyCode) // Cancel any ongoing fade-out
-            pressedKeyCodes.insert(keyCode)
+            keyVisualStates[keyCode, default: .init()].isPressed = true
             // Track most recently pressed key for icon association
             lastPressedKeyCode = keyCode
             startLayerPreviewIfActivator(keyCode)
             // If a hold is already active for this key, keep it active and cancel any pending clear.
-            if holdActiveKeyCodes.contains(keyCode) {
+            if keyVisualStates[keyCode]?.isHoldActive == true {
                 holdClearWorkItems[keyCode]?.cancel()
                 holdClearWorkItems.removeValue(forKey: keyCode)
             } else {
@@ -588,8 +588,11 @@ extension KeyboardVisualizationViewModel {
             // If this was a suppressed key, just ignore the release too
             // But still clear any lingering hold state to prevent visual artifacts
             if shouldSuppress {
-                holdActiveKeyCodes.remove(keyCode)
-                holdLabels.removeValue(forKey: keyCode)
+                if var state = keyVisualStates[keyCode] {
+                    state.isHoldActive = false
+                    state.holdLabel = nil
+                    keyVisualStates[keyCode] = state.isIdle ? nil : state
+                }
                 holdLabelCache.removeValue(forKey: keyCode)
                 holdClearWorkItems[keyCode]?.cancel()
                 holdClearWorkItems.removeValue(forKey: keyCode)
@@ -598,20 +601,24 @@ extension KeyboardVisualizationViewModel {
             }
 
             // Track if this key was hold-active for orange release fade
-            if holdActiveKeyCodes.contains(keyCode) {
-                holdReleaseFadeKeyCodes.insert(keyCode)
+            if keyVisualStates[keyCode]?.isHoldActive == true {
+                keyVisualStates[keyCode, default: .init()].releasedFromHold = true
             }
-            pressedKeyCodes.remove(keyCode)
+            keyVisualStates[keyCode]?.isPressed = false
             cancelLayerPreviewIfActivator(keyCode)
             startKeyFadeOut(keyCode) // Start fade-out animation
             // Defer clearing hold state briefly to tolerate tap-hold-press sequences that emit rapid releases.
             let work = DispatchWorkItem { [weak self] in
                 guard let self else { return }
-                holdActiveKeyCodes.remove(keyCode)
-                if holdLabels[keyCode] != nil {
-                    holdLabels.removeValue(forKey: keyCode)
-                    holdLabelCache.removeValue(forKey: keyCode)
-                    AppLogger.shared.debug("⌨️ [KeyboardViz] Cleared hold label (delayed) for \(key)")
+                if var state = keyVisualStates[keyCode] {
+                    let hadLabel = state.holdLabel != nil
+                    state.isHoldActive = false
+                    state.holdLabel = nil
+                    keyVisualStates[keyCode] = state.isIdle ? nil : state
+                    if hadLabel {
+                        holdLabelCache.removeValue(forKey: keyCode)
+                        AppLogger.shared.debug("⌨️ [KeyboardViz] Cleared hold label (delayed) for \(key)")
+                    }
                 }
                 holdClearWorkItems.removeValue(forKey: keyCode)
             }
@@ -624,8 +631,9 @@ extension KeyboardVisualizationViewModel {
         }
 
         if keyCode == 57 {
+            let state = keyVisualStates[57]
             AppLogger.shared.debug(
-                "🧪 [KeyboardViz] caps state: tcpPressed=\(pressedKeyCodes.contains(57)) holdActive=\(holdActiveKeyCodes.contains(57)) holdLabel=\(holdLabels[57] ?? "nil")"
+                "🧪 [KeyboardViz] caps state: tcpPressed=\(state?.isPressed ?? false) holdActive=\(state?.isHoldActive ?? false) holdLabel=\(state?.holdLabel ?? "nil")"
             )
         }
     }
@@ -644,7 +652,7 @@ extension KeyboardVisualizationViewModel {
         layerPreviewTask = Task { @MainActor [weak self] in
             try? await Task.sleep(for: .milliseconds(50))
             guard let self, !Task.isCancelled else { return }
-            guard pressedKeyCodes.contains(keyCode) else { return }
+            guard keyVisualStates[keyCode]?.isPressed == true else { return }
             prePreviewLayerName = currentLayerName
             isShowingLayerPreview = true
             currentPreviewTargetLayer = targetLayer

--- a/Sources/KeyPathAppKit/UI/KeyboardVisualization/KeyboardVisualizationViewModel.swift
+++ b/Sources/KeyPathAppKit/UI/KeyboardVisualization/KeyboardVisualizationViewModel.swift
@@ -5,14 +5,33 @@ import KeyPathCore
 import Observation
 import SwiftUI
 
+/// Unified visual state for a single key on the overlay.
+/// Replaces four separate collections (pressedKeyCodes, holdActiveKeyCodes,
+/// holdLabels, holdReleaseFadeKeyCodes) with one map entry per key.
+struct KeyVisualState: Equatable {
+    var isPressed: Bool = false
+    var isHoldActive: Bool = false
+    var holdLabel: String?
+    var releasedFromHold: Bool = false
+
+    var appearsPressed: Bool {
+        isPressed || isHoldActive
+    }
+
+    var isIdle: Bool {
+        !isPressed && !isHoldActive && holdLabel == nil && !releasedFromHold
+    }
+}
+
 /// ViewModel for keyboard visualization that tracks pressed keys
 @MainActor
 @Observable
 class KeyboardVisualizationViewModel {
     // MARK: - Key State
 
-    /// Key codes currently pressed (from Kanata TCP KeyInput events)
-    var pressedKeyCodes: Set<UInt16> = []
+    /// Unified per-key visual state map (source of truth for press/hold/fade state)
+    var keyVisualStates: [UInt16: KeyVisualState] = [:]
+
     var layout: PhysicalLayout = .macBookUS
     /// Fade level for outline state (0 = fully visible, 1 = outline-only faded)
     var fadeAmount: CGFloat = 0
@@ -22,6 +41,24 @@ class KeyboardVisualizationViewModel {
     var keyFadeAmounts: [UInt16: CGFloat] = [:]
     /// Active fade-out timers for released keys
     @ObservationIgnored var fadeOutTasks: [UInt16: Task<Void, Never>] = [:]
+
+    // MARK: - Computed Accessors (backward compatibility)
+
+    var pressedKeyCodes: Set<UInt16> {
+        Set(keyVisualStates.filter(\.value.isPressed).map(\.key))
+    }
+
+    var holdActiveKeyCodes: Set<UInt16> {
+        Set(keyVisualStates.filter(\.value.isHoldActive).map(\.key))
+    }
+
+    var holdLabels: [UInt16: String] {
+        keyVisualStates.compactMapValues(\.holdLabel)
+    }
+
+    var holdReleaseFadeKeyCodes: Set<UInt16> {
+        Set(keyVisualStates.filter(\.value.releasedFromHold).map(\.key))
+    }
 
     // MARK: - Layer State
 
@@ -36,17 +73,8 @@ class KeyboardVisualizationViewModel {
     var hoveredRuleKeyCode: UInt16?
     /// Key mapping for the current layer: keyCode -> LayerKeyInfo
     var layerKeyMap: [UInt16: LayerKeyInfo] = [:]
-    /// Hold labels for tap-hold keys that have transitioned to hold state
-    /// Maps keyCode -> hold display label (e.g., "*" for Hyper)
-    var holdLabels: [UInt16: String] = [:]
     /// Idle labels for tap-hold inputs (show tap output when not pressed)
     var tapHoldIdleLabels: [UInt16: String] = [:]
-    /// Keys currently in a hold-active state (set when HoldActivated fires).
-    /// Used to keep the key visually pressed even if tap-hold implementations
-    /// emit spurious release/press events while held.
-    @ObservationIgnored var holdActiveKeyCodes: Set<UInt16> = []
-    /// Keys that were hold-active when released (for orange fade-out color)
-    var holdReleaseFadeKeyCodes: Set<UInt16> = []
     /// Custom icons for keys set via push-msg (keyCode -> icon name)
     /// Example: "arrow-left", "safari", "home"
     var customIcons: [UInt16: String] = [:]

--- a/Sources/KeyPathAppKit/UI/Overlay/LiveKeyboardOverlayView+ContentBuilders.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/LiveKeyboardOverlayView+ContentBuilders.swift
@@ -168,6 +168,7 @@ extension LiveKeyboardOverlayView {
                     oneShotKeyCodes: viewModel.oneShotHighlightedKeyCodes,
                     holdLabels: viewModel.holdLabels,
                     tapHoldIdleLabels: viewModel.tapHoldIdleLabels,
+                    holdActiveKeyCodes: viewModel.holdActiveKeyCodes,
                     holdReleaseFadeKeyCodes: viewModel.holdReleaseFadeKeyCodes,
                     customIcons: viewModel.customIcons,
                     onKeyClick: onKeyClick,

--- a/Sources/KeyPathAppKit/UI/Overlay/LiveKeyboardOverlayView+Inspector.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/LiveKeyboardOverlayView+Inspector.swift
@@ -253,7 +253,9 @@ struct OverlayInspectorPanel: View {
     LiveKeyboardOverlayView(
         viewModel: {
             let vm = KeyboardVisualizationViewModel()
-            vm.pressedKeyCodes = [0, 56, 55] // a, leftshift, leftmeta
+            for keyCode: UInt16 in [0, 56, 55] { // a, leftshift, leftmeta
+                vm.keyVisualStates[keyCode, default: .init()].isPressed = true
+            }
             return vm
         }(),
         uiState: LiveKeyboardOverlayUIState(),

--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayKeyboardView.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayKeyboardView.swift
@@ -34,6 +34,8 @@ struct OverlayKeyboardView: View {
     var holdLabels: [UInt16: String] = [:]
     /// Idle labels for tap-hold inputs (show tap output when not pressed)
     var tapHoldIdleLabels: [UInt16: String] = [:]
+    /// Keys currently in hold-active state (for orange styling)
+    var holdActiveKeyCodes: Set<UInt16> = []
     /// Keys that were hold-active when released (for orange fade-out color)
     var holdReleaseFadeKeyCodes: Set<UInt16> = []
     /// Custom icons for keys set via push-msg: keyCode -> icon name
@@ -446,7 +448,7 @@ struct OverlayKeyboardView: View {
             isEmphasized: emphasizedKeyCodes.contains(key.keyCode),
             isOneShot: oneShotKeyCodes.contains(key.keyCode),
             holdLabel: holdLabels[key.keyCode],
-            isHoldActive: holdLabels[key.keyCode] != nil,
+            isHoldActive: holdActiveKeyCodes.contains(key.keyCode),
             releaseFadeFromColor: holdReleaseFadeKeyCodes.contains(key.keyCode)
                 ? KeyPathColors.layerOrange : .accentColor,
             tapHoldIdleLabel: tapHoldIdleLabels[key.keyCode],


### PR DESCRIPTION
## Summary
- Replaced four parallel key state collections (`pressedKeyCodes`, `holdActiveKeyCodes`, `holdLabels`, `holdReleaseFadeKeyCodes`) with a single `keyVisualStates: [UInt16: KeyVisualState]` map
- Fixed latent bug where `isHoldActive` was derived from `holdLabels` presence instead of `holdActiveKeyCodes` — the two collections could diverge when hold labels resolve asynchronously
- Added computed backward-compatible accessors so downstream code (views, suppression logic) continues to work without churn
- Auto-cleanup: idle entries are removed from the map when all fields return to default

## Test plan
- [x] All 530+ tests pass with 0 failures
- [x] Build succeeds
- [x] SwiftFormat clean
- [ ] Visual verification: press/release keys on overlay, hold a tap-hold key → hold label appears, release → clears, switch layers → state resets, TCP reconnect → no stranded pressed keys

Closes #627