### PR TITLE
fix(tests): migrate remaining deadlocking suites to KeyPathTestCase (#698)

### DIFF
--- a/Sources/KeyPathAppKit/Managers/ConfigReloadCoordinator.swift
+++ b/Sources/KeyPathAppKit/Managers/ConfigReloadCoordinator.swift
@@ -40,6 +40,10 @@ final class ConfigReloadCoordinator {
     /// Main reload method using TCP protocol.
     /// Checks service health, permission gates, and delegates to TCP reload.
     func triggerConfigReload() async -> ReloadResult {
+        if TestEnvironment.isRunningTests {
+            return ReloadResult(success: true, response: "Test environment", errorMessage: nil, protocol: nil)
+        }
+
         // Use cached state to avoid synchronous IPC to SMAppService in hot path
         let smState: KanataDaemonManager.ServiceManagementState
         let cached = await MainActor.run { KanataDaemonManager.shared.currentManagementState }
@@ -125,7 +129,7 @@ final class ConfigReloadCoordinator {
                     object: nil,
                     userInfo: [
                         "message": errorMessage,
-                        "response": tcpResult.response ?? "",
+                        "response": tcpResult.response ?? ""
                     ]
                 )
             }

--- a/Tests/KeyPathTests/ErrorHandlingTests.swift
+++ b/Tests/KeyPathTests/ErrorHandlingTests.swift
@@ -3,7 +3,7 @@ import Foundation
 @preconcurrency import XCTest
 
 @MainActor
-final class ErrorHandlingTests: XCTestCase {
+final class ErrorHandlingTests: KeyPathTestCase {
     lazy var manager: RuntimeCoordinator = .init()
     lazy var capture: KeyboardCapture = .init()
 

--- a/Tests/KeyPathTests/KeyPathTests.swift
+++ b/Tests/KeyPathTests/KeyPathTests.swift
@@ -3,15 +3,7 @@
 @preconcurrency import XCTest
 
 @MainActor
-final class KeyPathTests: XCTestCase {
-    override func setUpWithError() throws {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
-    }
-
-    override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-    }
-
+final class KeyPathTests: KeyPathTestCase {
     // MARK: - KanataManager Tests
 
     func testKanataManagerInitialization() {

--- a/Tests/KeyPathTests/Lint/TestSeamLintTests.swift
+++ b/Tests/KeyPathTests/Lint/TestSeamLintTests.swift
@@ -17,11 +17,6 @@ final class TestSeamLintTests: XCTestCase {
     /// Pre-existing suites that use a hazard type but still extend XCTestCase directly.
     /// Migrate these to KeyPathTestCase and remove them here. Never add new entries.
     private static let allowList: Set<String> = [
-        // Real-I/O suites: the seam fixes their pgrep hang but they also do real
-        // saveConfiguration/updateStatus/resetToDefaultConfig that needs deeper mocking.
-        "ErrorHandlingTests.swift",
-        "KeyPathTests.swift",
-        "RuntimeCoordinatorResetTests.swift",
         // The seam's own test (sets testPIDProvider per test, asserts real-pgrep fallthrough).
         "VHIDDeviceManagerTests.swift"
     ]

--- a/Tests/KeyPathTests/RuntimeCoordinatorResetTests.swift
+++ b/Tests/KeyPathTests/RuntimeCoordinatorResetTests.swift
@@ -2,7 +2,7 @@
 @preconcurrency import XCTest
 
 @MainActor
-final class KanataManagerResetTests: XCTestCase {
+final class KanataManagerResetTests: KeyPathTestCase {
     func testResetWritesDefaultConfig() async throws {
         // Given a fresh manager
         let manager = RuntimeCoordinator()


### PR DESCRIPTION
## Summary

- Migrate 3 remaining deadlocking test suites (`ErrorHandlingTests`, `KeyPathTests`, `KanataManagerResetTests`) from `XCTestCase` to `KeyPathTestCase`, installing the pgrep seam that prevents subprocess deadlocks
- Add test-environment early return in `ConfigReloadCoordinator.triggerConfigReload()` — the pre-checks (SMAppService IPC, health check) blocked 10-30s before reaching the existing `triggerTCPReload()` test guard
- Shrink lint ratchet allowlist from 4 → 1 (only `VHIDDeviceManagerTests` remains, intentionally)

## Results

| Suite | Before | After |
|-------|--------|-------|
| `ErrorHandlingTests` (21 tests) | Deadlock (hangs forever) | 0.34s, 0 failures |
| `KeyPathTests` (35 tests) | Deadlock (hangs forever) | 3.8s, 0 failures |
| `KanataManagerResetTests` (1 test) | Deadlock (hangs forever) | 0.03s, 0 failures |
| Full suite (3,477 tests) | Hangs on these suites | 40s, 8 pre-existing env failures |

## Test plan

- [x] `swift test --filter ErrorHandlingTests` — 21 tests pass
- [x] `swift test --filter KeyPathTests.KeyPathTests` — 35 tests pass (1 skipped)
- [x] `swift test --filter KanataManagerResetTests` — 1 test passes
- [x] `swift test` full suite — 3,477 tests, 0 new failures
- [x] `TestSeamLintTests` passes with shrunk allowlist
- [x] Build passes