### PR TITLE
[codex] Fix release blocker stabilization issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,10 +232,7 @@ jobs:
 
     - name: Accessibility Check
       run: |
-        python3 Scripts/check-accessibility.py || {
-          echo "Some UI elements are missing accessibility identifiers"
-          exit 0
-        }
+        python3 Scripts/check-accessibility.py
 
     - name: Critical Pattern Analysis
       run: |
@@ -252,9 +249,26 @@ jobs:
         FORCE_UNWRAPS=0
         PRINT_STATEMENTS=0
 
-        if grep -r "!" Sources/KeyPath/Managers/ --include="*.swift" | grep -v "!=" | grep -v "// swiftlint:disable" >/dev/null 2>&1; then
+        python3 - <<'PY' > /tmp/keypath-force-unwraps.txt
+        from pathlib import Path
+        import re
+
+        pattern = re.compile(r"(?:\btry\s*!|(?:[\w\)\]\}\"'`])\s*!(?=\s*(?:[\)\]\}\.,;:]|$)))")
+        for path in Path("Sources/KeyPathAppKit/Managers").rglob("*.swift"):
+            try:
+                lines = path.read_text(encoding="utf-8").splitlines()
+            except UnicodeDecodeError:
+                continue
+            for idx, line in enumerate(lines, start=1):
+                stripped = line.strip()
+                if stripped.startswith("//") or "// swiftlint:disable" in line:
+                    continue
+                if pattern.search(line):
+                    print(f"{path}:{idx}: {stripped}")
+        PY
+        if [ -s /tmp/keypath-force-unwraps.txt ]; then
           echo "Force unwraps found in manager files:"
-          grep -r "!" Sources/KeyPath/Managers/ --include="*.swift" | grep -v "!=" | grep -v "// swiftlint:disable" | head -10
+          head -10 /tmp/keypath-force-unwraps.txt
           FORCE_UNWRAPS=1
         fi
 

--- a/Scripts/check-accessibility.py
+++ b/Scripts/check-accessibility.py
@@ -19,9 +19,9 @@ NC = "\033[0m"  # No Color
 
 # Patterns for interactive UI elements
 INTERACTIVE_PATTERNS = [
-    (r"Button\s*\(", "Button"),
-    (r"Toggle\s*\(", "Toggle"),
-    (r"Picker\s*\(", "Picker"),
+    (r"(?<![A-Za-z0-9_])Button\s*\(", "Button"),
+    (r"(?<![A-Za-z0-9_])Toggle\s*\(", "Toggle"),
+    (r"(?<![A-Za-z0-9_])Picker\s*\(", "Picker"),
 ]
 
 # Files/directories to exclude

--- a/Sources/KeyPathAppKit/Managers/ConfigReloadCoordinator.swift
+++ b/Sources/KeyPathAppKit/Managers/ConfigReloadCoordinator.swift
@@ -40,10 +40,6 @@ final class ConfigReloadCoordinator {
     /// Main reload method using TCP protocol.
     /// Checks service health, permission gates, and delegates to TCP reload.
     func triggerConfigReload() async -> ReloadResult {
-        if TestEnvironment.isRunningTests {
-            return ReloadResult(success: true, response: "Test environment", errorMessage: nil, protocol: nil)
-        }
-
         // Use cached state to avoid synchronous IPC to SMAppService in hot path
         let smState: KanataDaemonManager.ServiceManagementState
         let cached = await MainActor.run { KanataDaemonManager.shared.currentManagementState }
@@ -60,7 +56,8 @@ final class ConfigReloadCoordinator {
                 success: false,
                 response: nil,
                 errorMessage: "Approve KeyPath in Login Items before reloading config",
-                protocol: nil
+                protocol: nil,
+                disposition: .pending
             )
         }
 
@@ -76,7 +73,8 @@ final class ConfigReloadCoordinator {
                 success: false,
                 response: nil,
                 errorMessage: healthStatus.reason ?? "Kanata service is starting; retry shortly",
-                protocol: nil
+                protocol: nil,
+                disposition: .pending
             )
         }
 
@@ -91,7 +89,7 @@ final class ConfigReloadCoordinator {
             if !allowed {
                 AppLogger.shared.warn("⚠️ [Reload] Blocked by missing permission (JIT gate)")
                 return ReloadResult(
-                    success: false, response: nil, errorMessage: "Permission required", protocol: nil
+                    success: false, response: nil, errorMessage: "Permission required", protocol: nil, disposition: .rejected
                 )
             }
         }
@@ -108,7 +106,8 @@ final class ConfigReloadCoordinator {
                 success: true,
                 response: tcpResult.response ?? "",
                 errorMessage: nil,
-                protocol: .tcp
+                protocol: .tcp,
+                disposition: .applied
             )
         } else {
             AppLogger.shared.debug(
@@ -137,8 +136,24 @@ final class ConfigReloadCoordinator {
                 success: false,
                 response: tcpResult.response,
                 errorMessage: errorMessage,
-                protocol: .tcp
+                protocol: .tcp,
+                disposition: disposition(for: tcpResult, message: errorMessage)
             )
+        }
+    }
+
+    private func disposition(for tcpResult: TCPReloadResult, message: String) -> ReloadDisposition {
+        if isCooldownBlockMessage(message) {
+            return .pending
+        }
+
+        switch tcpResult {
+        case .failure:
+            return .rejected
+        case .networkError:
+            return .failed
+        case .success:
+            return .applied
         }
     }
 

--- a/Sources/KeyPathAppKit/Managers/RuntimeCoordinator.swift
+++ b/Sources/KeyPathAppKit/Managers/RuntimeCoordinator.swift
@@ -923,12 +923,18 @@ public class RuntimeCoordinator: SaveCoordinatorDelegate {
             AppLogger.shared.info("🔄 [Reset] Triggering immediate config reload via TCP...")
             let reloadResult = await triggerConfigReload()
 
-            if reloadResult.isSuccess {
+            if reloadResult.disposition == .applied {
                 let response = reloadResult.response ?? "Success"
                 AppLogger.shared.info("✅ [Reset] Default config applied successfully via TCP: \(response)")
                 // Play happy chime on successful reset
                 await MainActor.run {
                     SoundManager.shared.playGlassSound()
+                    saveStatus = .success
+                }
+            } else if reloadResult.disposition == .pending {
+                let reason = reloadResult.errorMessage ?? "reload pending"
+                AppLogger.shared.info("ℹ️ [Reset] Default config saved; reload pending: \(reason)")
+                await MainActor.run {
                     saveStatus = .success
                 }
             } else {
@@ -1333,9 +1339,12 @@ public class RuntimeCoordinator: SaveCoordinatorDelegate {
         configHotReloadService.configure(
             configurationService: configurationService,
             reloadHandler: { [weak self] in
-                guard let self else { return false }
+                guard let self else { return .failed("Coordinator deallocated") }
                 let result = await triggerConfigReload()
-                return result.isSuccess
+                return ConfigHotReloadService.ReloadOutcome(
+                    disposition: result.disposition,
+                    message: result.errorMessage
+                )
             },
             configParser: { [weak self] content in
                 guard let self else { return [] }
@@ -1425,19 +1434,10 @@ public class RuntimeCoordinator: SaveCoordinatorDelegate {
         let result = await saveCoordinator.saveGeneratedConfig(
             content: configContent,
             reloadHandler: { [weak self] in
-                guard let self else { return (false, "Coordinator deallocated") }
-                let reloadResult = await triggerConfigReload()
-                // triggerConfigReload() already checks service health and returns failure
-                // when service is unavailable. Don't trigger rollback for that case -
-                // the config passed our validation, it just can't be applied yet.
-                if !reloadResult.isSuccess,
-                   let reason = reloadResult.errorMessage,
-                   reason.contains("not healthy") || reason.contains("requires approval") || reason.contains("starting")
-                {
-                    AppLogger.shared.info("ℹ️ [SaveCoordinator] Service unavailable - config saved but not validated by kanata")
-                    return (true, nil)
+                guard let self else {
+                    return ReloadResult(success: false, response: nil, errorMessage: "Coordinator deallocated", protocol: nil, disposition: .failed)
                 }
-                return (reloadResult.isSuccess, reloadResult.errorMessage)
+                return await triggerConfigReload()
             }
         )
 
@@ -1462,15 +1462,10 @@ public class RuntimeCoordinator: SaveCoordinatorDelegate {
             output: output,
             ruleCollectionsManager: ruleCollectionsManager,
             reloadHandler: { [weak self] in
-                guard let self else { return (false, "Coordinator deallocated") }
-                let tcpResult = await triggerTCPReload()
-                // Distinguish "TCP unreachable" (service down) from "kanata rejected config".
-                // Only trigger rollback for actual config rejections, not network errors.
-                if case .networkError = tcpResult {
-                    AppLogger.shared.info("ℹ️ [SaveCoordinator] TCP unreachable - config saved but not validated (service may be starting)")
-                    return (true, nil)
+                guard let self else {
+                    return ReloadResult(success: false, response: nil, errorMessage: "Coordinator deallocated", protocol: nil, disposition: .failed)
                 }
-                return (tcpResult.isSuccess, tcpResult.errorMessage)
+                return await triggerConfigReload()
             }
         )
 
@@ -1613,14 +1608,36 @@ public class RuntimeCoordinator: SaveCoordinatorDelegate {
 
 // MARK: - Result Types
 
+enum ReloadDisposition: Sendable, Equatable {
+    case applied
+    case pending
+    case rejected
+    case failed
+}
+
 /// TCP reload result
 struct ReloadResult {
     let success: Bool
     let response: String?
     let errorMessage: String?
     let `protocol`: CommunicationProtocol?
+    let disposition: ReloadDisposition
 
     var isSuccess: Bool {
-        success
+        disposition == .applied
+    }
+
+    init(
+        success: Bool,
+        response: String?,
+        errorMessage: String?,
+        protocol: CommunicationProtocol?,
+        disposition: ReloadDisposition? = nil
+    ) {
+        self.success = success
+        self.response = response
+        self.errorMessage = errorMessage
+        self.protocol = `protocol`
+        self.disposition = disposition ?? (success ? .applied : .failed)
     }
 }

--- a/Sources/KeyPathAppKit/Managers/SaveCoordinator.swift
+++ b/Sources/KeyPathAppKit/Managers/SaveCoordinator.swift
@@ -81,13 +81,13 @@ final class SaveCoordinator {
     ///   - input: The input key/sequence
     ///   - output: The output key/sequence
     ///   - ruleCollectionsManager: Manager to persist the custom rule
-    ///   - reloadHandler: Async handler to trigger config reload (returns success, error message)
+    ///   - reloadHandler: Async handler to trigger config reload and classify the result
     /// - Returns: SaveResult indicating success or failure with error details
     func saveMapping(
         input: String,
         output: String,
         ruleCollectionsManager: RuleCollectionsManager,
-        reloadHandler: @escaping () async -> (success: Bool, errorMessage: String?)
+        reloadHandler: @escaping () async -> ReloadResult
     ) async -> SaveResult {
         // Suppress file watcher to prevent double reload
         configFileWatcher?.suppressEvents(for: 1.0, reason: "Internal saveConfiguration")
@@ -122,9 +122,13 @@ final class SaveCoordinator {
             AppLogger.shared.debug("📡 [SaveCoordinator] Triggering TCP reload for validation")
             let reloadResult = await reloadHandler()
 
-            if reloadResult.success {
+            if reloadResult.disposition == .applied || reloadResult.disposition == .pending {
                 // Success!
-                AppLogger.shared.info("✅ [SaveCoordinator] Reload successful, config is valid")
+                if reloadResult.disposition == .applied {
+                    AppLogger.shared.info("✅ [SaveCoordinator] Reload successful, config is valid")
+                } else {
+                    AppLogger.shared.info("ℹ️ [SaveCoordinator] Config saved; reload pending: \(reloadResult.errorMessage ?? "service unavailable")")
+                }
                 playSuccessSound()
                 saveStatus = .success
                 scheduleStatusReset()
@@ -165,11 +169,11 @@ final class SaveCoordinator {
     ///
     /// - Parameters:
     ///   - content: The full Kanata configuration content
-    ///   - reloadHandler: Async handler to trigger config reload
+    ///   - reloadHandler: Async handler to trigger config reload and classify the result
     /// - Returns: SaveResult indicating success or failure
     func saveGeneratedConfig(
         content: String,
-        reloadHandler: @escaping () async -> (success: Bool, errorMessage: String?)
+        reloadHandler: @escaping () async -> ReloadResult
     ) async -> SaveResult {
         // Suppress file watcher to prevent double reload
         configFileWatcher?.suppressEvents(for: 1.0, reason: "Internal saveGeneratedConfiguration")
@@ -225,10 +229,16 @@ final class SaveCoordinator {
             // Step 6: Trigger reload for validation
             let reloadResult = await reloadHandler()
 
-            if reloadResult.success {
-                AppLogger.shared.info(
-                    "✅ [SaveCoordinator] TCP reload successful, config is active"
-                )
+            if reloadResult.disposition == .applied || reloadResult.disposition == .pending {
+                if reloadResult.disposition == .applied {
+                    AppLogger.shared.info(
+                        "✅ [SaveCoordinator] TCP reload successful, config is active"
+                    )
+                } else {
+                    AppLogger.shared.info(
+                        "ℹ️ [SaveCoordinator] Config saved; reload pending: \(reloadResult.errorMessage ?? "service unavailable")"
+                    )
+                }
                 playSuccessSound()
                 saveStatus = .success
                 scheduleStatusReset()

--- a/Sources/KeyPathAppKit/Managers/ServiceLifecycleCoordinator.swift
+++ b/Sources/KeyPathAppKit/Managers/ServiceLifecycleCoordinator.swift
@@ -3,6 +3,7 @@ import KeyPathCore
 import KeyPathDaemonLifecycle
 import KeyPathInstallationWizard
 import KeyPathPermissions
+import KeyPathWizardCore
 
 /// Manages the lifecycle of the Kanata runtime service (start, stop, restart, status).
 ///
@@ -68,6 +69,26 @@ final class ServiceLifecycleCoordinator {
         static func pollCount(forMs ms: Int) -> Int {
             max(1, ms / pollIntervalMs)
         }
+    }
+
+    enum RuntimeReadinessTiming {
+        static let pollIntervalMs = 250
+        static let timeoutMs = 5000
+        static let tcpProbeTimeoutMs = 300
+
+        static var pollInterval: Duration {
+            .milliseconds(pollIntervalMs)
+        }
+
+        static var pollCount: Int {
+            max(1, timeoutMs / pollIntervalMs)
+        }
+    }
+
+    private enum RuntimeReadinessVerification {
+        case ready
+        case pendingApproval(String)
+        case failed(String)
     }
 
     /// Mutable flag shared with RuntimeCoordinator to track in-progress start attempts.
@@ -186,6 +207,23 @@ final class ServiceLifecycleCoordinator {
                 _ = try? await SubprocessRunner.shared.launchctl("kickstart", ["system/com.keypath.kanata"])
             }
 
+            switch await verifyRuntimeReadinessAfterStart(reason: reason) {
+            case .ready:
+                break
+            case let .pendingApproval(message):
+                AppLogger.shared.warn("⚠️ [Service] \(message)")
+                onError?(nil)
+                onWarning?(message)
+                onStateChanged?()
+                DistributedNotificationBridge.postServiceState("pending-approval")
+                return true
+            case let .failed(message):
+                AppLogger.shared.error("❌ [Service] \(message)")
+                onError?(message)
+                onStateChanged?()
+                return false
+            }
+
             await AppContextService.shared.start()
             onError?(nil)
             onWarning?(nil)
@@ -278,6 +316,51 @@ final class ServiceLifecycleCoordinator {
         let isPending = managementState == .smappservicePending
         smAppServicePendingCache = (isPending, Date())
         return isPending
+    }
+
+    private func verifyRuntimeReadinessAfterStart(reason: String) async -> RuntimeReadinessVerification {
+        var lastSummary = "no runtime snapshot collected"
+
+        for attempt in 0 ..< RuntimeReadinessTiming.pollCount {
+            let managementState = await KanataDaemonManager.shared.refreshManagementStateInternal()
+            if managementState == .smappservicePending {
+                return .pendingApproval("Kanata is registered but pending approval in System Settings → Login Items.")
+            }
+
+            let staleRegistration = managementState == .smappserviceActive
+                ? await KanataDaemonManager.shared.isRegisteredButNotLoaded()
+                : false
+            let snapshot = await ServiceHealthChecker.shared.checkKanataServiceRuntimeSnapshot(
+                managementState: WizardServiceManagementState(managementState),
+                staleEnabledRegistration: staleRegistration,
+                tcpPort: PreferencesService.shared.tcpServerPort,
+                timeoutMs: RuntimeReadinessTiming.tcpProbeTimeoutMs
+            )
+            let decision = ServiceHealthChecker.decideKanataHealth(for: snapshot)
+            lastSummary =
+                "state=\(managementState.description), running=\(snapshot.isRunning), tcp=\(snapshot.isResponding), inputCapture=\(snapshot.inputCaptureReady), decision=\(decision)"
+
+            if snapshot.isRunning, snapshot.isResponding, snapshot.inputCaptureReady, !snapshot.staleEnabledRegistration {
+                AppLogger.shared.log("✅ [Service] Runtime readiness verified after start (\(reason)): \(lastSummary)")
+                return .ready
+            }
+
+            if attempt < RuntimeReadinessTiming.pollCount - 1 {
+                await sleepForReadinessPoll()
+            }
+        }
+
+        return .failed("Kanata start did not reach runtime readiness after \(RuntimeReadinessTiming.timeoutMs)ms (\(lastSummary))")
+    }
+
+    private func sleepForReadinessPoll() async {
+        #if DEBUG
+            if let testSleep = Self.testSleep {
+                await testSleep(RuntimeReadinessTiming.pollInterval)
+                return
+            }
+        #endif
+        try? await Task.sleep(for: RuntimeReadinessTiming.pollInterval)
     }
 
     // MARK: - Runtime Status

--- a/Sources/KeyPathAppKit/Services/Configuration/ConfigBackupManager.swift
+++ b/Sources/KeyPathAppKit/Services/Configuration/ConfigBackupManager.swift
@@ -13,12 +13,14 @@ public final class ConfigBackupManager {
 
     private let backupDirectory: String
     private let configPath: String
+    private let dateProvider: () -> Date
     private let maxBackups = 5
 
     // MARK: - Initialization
 
-    public init(configPath: String) {
+    public init(configPath: String, dateProvider: @escaping () -> Date = { Date() }) {
         self.configPath = configPath
+        self.dateProvider = dateProvider
         let configDir = (configPath as NSString).deletingLastPathComponent
         backupDirectory = "\(configDir)/.backups"
 
@@ -46,19 +48,12 @@ public final class ConfigBackupManager {
                 return false
             }
 
-            // Create timestamped backup filename
-            let timestamp = ISO8601DateFormatter().string(from: Date())
-                .replacingOccurrences(of: ":", with: "-")
-                .replacingOccurrences(of: "T", with: "_")
-                .replacingOccurrences(of: "Z", with: "")
-
-            let backupFileName = "keypath_\(timestamp).kbd"
-            let backupPath = "\(backupDirectory)/\(backupFileName)"
+            let backup = uniqueBackupPath(prefix: "keypath", date: dateProvider())
 
             // Write backup file
-            try content.write(toFile: backupPath, atomically: true, encoding: .utf8)
+            try content.write(toFile: backup.path, atomically: true, encoding: .utf8)
 
-            AppLogger.shared.log("✅ [BackupManager] Created pre-edit backup: \(backupFileName)")
+            AppLogger.shared.log("✅ [BackupManager] Created pre-edit backup: \(backup.fileName)")
 
             // Cleanup old backups
             cleanupOldBackups()
@@ -128,9 +123,8 @@ public final class ConfigBackupManager {
 
         // Create a backup of current config (if it exists) before restoring
         if Foundation.FileManager().fileExists(atPath: configPath) {
-            let currentBackupPath =
-                "\(backupDirectory)/before_restore_\(Date().timeIntervalSince1970).kbd"
-            try? Foundation.FileManager().copyItem(atPath: configPath, toPath: currentBackupPath)
+            let currentBackup = uniqueBackupPath(prefix: "before_restore", date: dateProvider())
+            try? Foundation.FileManager().copyItem(atPath: configPath, toPath: currentBackup.path)
         }
 
         // Restore the backup
@@ -180,6 +174,30 @@ public final class ConfigBackupManager {
         } catch {
             AppLogger.shared.log("❌ [BackupManager] Failed to create backup directory: \(error)")
         }
+    }
+
+    private func uniqueBackupPath(prefix: String, date: Date) -> (fileName: String, path: String) {
+        let baseName = "\(prefix)_\(timestampString(from: date))"
+        var fileName = "\(baseName).kbd"
+        var path = "\(backupDirectory)/\(fileName)"
+        var suffix = 1
+
+        while Foundation.FileManager().fileExists(atPath: path) {
+            fileName = "\(baseName)_\(suffix).kbd"
+            path = "\(backupDirectory)/\(fileName)"
+            suffix += 1
+        }
+
+        return (fileName, path)
+    }
+
+    private func timestampString(from date: Date) -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter.string(from: date)
+            .replacingOccurrences(of: ":", with: "-")
+            .replacingOccurrences(of: "T", with: "_")
+            .replacingOccurrences(of: "Z", with: "")
     }
 
     private func cleanupOldBackups() {

--- a/Sources/KeyPathAppKit/Services/Configuration/ConfigHotReloadService.swift
+++ b/Sources/KeyPathAppKit/Services/Configuration/ConfigHotReloadService.swift
@@ -35,6 +35,31 @@ final class ConfigHotReloadService {
         static func pendingReload(content: String) -> ReloadResult {
             ReloadResult(success: false, message: "Config saved, will apply when service starts", newContent: content, pendingReload: true)
         }
+
+        static func pendingReload(content: String, message: String) -> ReloadResult {
+            ReloadResult(success: false, message: message, newContent: content, pendingReload: true)
+        }
+    }
+
+    struct ReloadOutcome: Sendable {
+        let disposition: ReloadDisposition
+        let message: String?
+
+        static var applied: ReloadOutcome {
+            ReloadOutcome(disposition: .applied, message: nil)
+        }
+
+        static func pending(_ message: String?) -> ReloadOutcome {
+            ReloadOutcome(disposition: .pending, message: message)
+        }
+
+        static func rejected(_ message: String?) -> ReloadOutcome {
+            ReloadOutcome(disposition: .rejected, message: message)
+        }
+
+        static func failed(_ message: String?) -> ReloadOutcome {
+            ReloadOutcome(disposition: .failed, message: message)
+        }
     }
 
     /// Callbacks for UI feedback during reload
@@ -49,7 +74,7 @@ final class ConfigHotReloadService {
     // MARK: - Properties
 
     private var configurationService: ConfigurationService?
-    private var reloadHandler: (() async -> Bool)?
+    private var reloadHandler: (() async -> ReloadOutcome)?
     private var configParser: ((String) throws -> [KeyMapping])?
     private var serviceManagementStateProvider: (() async -> KanataDaemonManager.ServiceManagementState)?
     private var isKanataProcessRunningProvider: (() async -> Bool)?
@@ -83,11 +108,11 @@ final class ConfigHotReloadService {
     ///
     /// - Parameters:
     ///   - configurationService: Service for validating config content
-    ///   - reloadHandler: Async handler to trigger TCP reload (returns success)
+    ///   - reloadHandler: Async handler to trigger reload and classify the result
     ///   - configParser: Parser to extract key mappings from config content
     func configure(
         configurationService: ConfigurationService,
-        reloadHandler: @escaping () async -> Bool,
+        reloadHandler: @escaping () async -> ReloadOutcome,
         configParser: @escaping (String) throws -> [KeyMapping],
         serviceManagementStateProvider: (() async -> KanataDaemonManager.ServiceManagementState)? = nil,
         isKanataProcessRunningProvider: (() async -> Bool)? = nil
@@ -171,14 +196,22 @@ final class ConfigHotReloadService {
             return result
         }
 
-        let reloadSuccess = await handler()
+        let reloadOutcome = await handler()
 
-        if reloadSuccess {
+        switch reloadOutcome.disposition {
+        case .applied:
             AppLogger.shared.info("✅ [ConfigHotReload] External config successfully reloaded")
             callbacks.onSuccess?(configContent)
             scheduleStatusReset()
             return .success(content: configContent)
-        } else {
+
+        case .pending:
+            let message = reloadOutcome.message ?? "Config saved, will apply when service starts"
+            AppLogger.shared.info("ℹ️ [ConfigHotReload] Reload pending: \(message)")
+            callbacks.onReset?()
+            return .pendingReload(content: configContent, message: message)
+
+        case .failed:
             // Check if service is simply unavailable (SMAppService pending, service not running, or process not started)
             // In this case, don't show error to user - config is valid, just can't reload yet
             let smState = await currentServiceManagementState()
@@ -198,8 +231,17 @@ final class ConfigHotReloadService {
                 return .pendingReload(content: configContent)
             }
 
-            AppLogger.shared.error("❌ [ConfigHotReload] Hot reload failed")
-            let result = ReloadResult.failure("Hot reload failed")
+            let message = reloadOutcome.message ?? "Hot reload failed"
+            AppLogger.shared.error("❌ [ConfigHotReload] \(message)")
+            let result = ReloadResult.failure(message)
+            callbacks.onFailure?(result.message)
+            scheduleStatusReset()
+            return result
+
+        case .rejected:
+            let message = reloadOutcome.message ?? "Hot reload rejected"
+            AppLogger.shared.error("❌ [ConfigHotReload] \(message)")
+            let result = ReloadResult.failure(message)
             callbacks.onFailure?(result.message)
             scheduleStatusReset()
             return result

--- a/Sources/KeyPathAppKit/Services/KeyboardCapture/KeyboardCapture.swift
+++ b/Sources/KeyPathAppKit/Services/KeyboardCapture/KeyboardCapture.swift
@@ -2,6 +2,7 @@ import AppKit
 import Carbon
 import Foundation
 import KeyPathCore
+import KeyPathPermissions
 import Observation
 
 // Import the event processing infrastructure
@@ -784,8 +785,7 @@ public class KeyboardCapture {
 
     /// Check permissions without prompting - using synchronous method to avoid deadlocks
     func checkAccessibilityPermissionsSilently() -> Bool {
-        // Use direct API call instead of async PermissionOracle to avoid semaphore deadlock
-        AXIsProcessTrusted()
+        PermissionOracle.shared.keyPathAccessibilityStatus().isReady
     }
 
     /// Public method to explicitly request permissions (for use in wizard)

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+PublicAPI.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+PublicAPI.swift
@@ -34,6 +34,7 @@ extension RuleCollectionsManager {
         }
 
         let snapshot = snapshotRuleState()
+        let leaderPreferenceSnapshot = PreferencesService.shared.leaderKeyPreference
 
         let catalogMatch = RuleCollectionCatalog().defaultCollections().first { $0.id == id }
         AppLogger.shared.log("🔀 [RuleCollections] catalogMatch=\(catalogMatch?.name ?? "nil")")
@@ -101,14 +102,23 @@ extension RuleCollectionsManager {
         AppLogger.shared.log("🔀 [RuleCollections] After toggle - collections: \(ruleCollections.map { "\($0.name) (enabled: \($0.isEnabled))" }.joined(separator: ", "))")
 
         // Special handling: If Leader Key collection is toggled off, reset all momentary activators to default (space)
-        if id == RuleCollectionIdentifier.leaderKey, !isEnabled {
-            applyLeaderKeyToMomentaryActivators("space")
+        if id == RuleCollectionIdentifier.leaderKey {
+            if isEnabled {
+                let key = leaderKeyOutput(from: resolvedCandidate) ?? leaderPreferenceSnapshot.key
+                syncLeaderKeyPreference(key: key, enabled: true)
+            } else {
+                syncLeaderKeyPreference(enabled: false)
+                applyLeaderKeyToMomentaryActivators("space")
+            }
         }
 
         refreshLayerIndicatorState()
         AppLogger.shared.log("🔀 [RuleCollections] Calling regenerateConfigFromCollections...")
         let applied = await regenerateConfigFromCollections()
         guard applied else {
+            if id == RuleCollectionIdentifier.leaderKey {
+                PreferencesService.shared.leaderKeyPreference = leaderPreferenceSnapshot
+            }
             AppLogger.shared.log("↩️ [RuleCollections] Toggle apply failed; rolling back to previous state")
             await rollbackToSnapshot(snapshot, userMessage: "Could not apply this rule change. Your previous rule state was restored.")
             return false
@@ -721,10 +731,19 @@ extension RuleCollectionsManager {
     /// Update the leader key for all collections that use momentary activation
     func updateLeaderKey(_ newKey: String) async {
         AppLogger.shared.log("🔑 [RuleCollections] Updating leader key to '\(newKey)'")
+        let snapshot = snapshotRuleState()
+        let leaderPreferenceSnapshot = PreferencesService.shared.leaderKeyPreference
+
         applyLeaderKeyToMomentaryActivators(newKey)
+        syncLeaderKeyPreference(key: newKey, enabled: true)
         dedupeRuleCollectionsInPlace()
         refreshLayerIndicatorState()
-        await regenerateConfigFromCollections()
+        let applied = await regenerateConfigFromCollections()
+        guard applied else {
+            PreferencesService.shared.leaderKeyPreference = leaderPreferenceSnapshot
+            await rollbackToSnapshot(snapshot, userMessage: "Could not apply this leader key change. Your previous rule state was restored.")
+            return
+        }
     }
 
     private func applyLeaderKeyToMomentaryActivators(_ newKey: String) {
@@ -740,6 +759,20 @@ extension RuleCollectionsManager {
                 )
             }
         }
+    }
+
+    private func leaderKeyOutput(from collection: RuleCollection) -> String? {
+        guard let config = collection.configuration.singleKeyPickerConfig else { return nil }
+        return config.selectedOutput ?? config.presetOptions.first?.output
+    }
+
+    private func syncLeaderKeyPreference(key: String? = nil, enabled: Bool) {
+        var preference = PreferencesService.shared.leaderKeyPreference
+        if let key {
+            preference.key = key
+        }
+        preference.enabled = enabled
+        PreferencesService.shared.leaderKeyPreference = preference
     }
 
     /// Save or update a custom rule

--- a/Sources/KeyPathAppKit/Services/System/WindowManager.swift
+++ b/Sources/KeyPathAppKit/Services/System/WindowManager.swift
@@ -2,6 +2,7 @@ import AppKit
 import ApplicationServices
 import Foundation
 import KeyPathCore
+import KeyPathPermissions
 
 // MARK: - Window Position
 
@@ -107,7 +108,7 @@ public final class WindowManager {
     /// Whether Accessibility permission is granted.
     /// Window management requires this permission to control other app windows.
     public var hasAccessibilityPermission: Bool {
-        AXIsProcessTrusted()
+        PermissionOracle.shared.keyPathAccessibilityStatus().isReady
     }
 
     /// Whether Space movement features are available.

--- a/Sources/KeyPathAppKit/UI/CommandPalette/CommandPaletteView.swift
+++ b/Sources/KeyPathAppKit/UI/CommandPalette/CommandPaletteView.swift
@@ -268,6 +268,7 @@ private struct CommandPaletteRow: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        .accessibilityIdentifier("command-palette-row-\(item.id)")
     }
 }
 

--- a/Sources/KeyPathAppKit/UI/Gallery/ChordGroupsPackContent.swift
+++ b/Sources/KeyPathAppKit/UI/Gallery/ChordGroupsPackContent.swift
@@ -193,6 +193,7 @@ private struct ChordRuleRow: View {
                     .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
+            .accessibilityIdentifier("chord-pack-toggle-\(chord.id.uuidString)")
 
             // Rest of the row — tapping opens editor
             Button(action: onEdit) {
@@ -242,6 +243,7 @@ private struct ChordRuleRow: View {
                             }
                             .buttonStyle(.plain)
                             .accessibilityLabel("Edit chord")
+                            .accessibilityIdentifier("chord-pack-edit-\(chord.id.uuidString)")
 
                             Button(action: onDelete) {
                                 Image(systemName: "trash")
@@ -252,6 +254,7 @@ private struct ChordRuleRow: View {
                             }
                             .buttonStyle(.plain)
                             .accessibilityLabel("Delete chord")
+                            .accessibilityIdentifier("chord-pack-delete-\(chord.id.uuidString)")
                         }
                         .padding(.trailing, 4)
                         .transition(.opacity.combined(with: .scale(scale: 0.8)))
@@ -268,6 +271,7 @@ private struct ChordRuleRow: View {
                 .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
+            .accessibilityIdentifier("chord-pack-edit-row-\(chord.id.uuidString)")
         }
         .onHover { hovering in
             withAnimation(.easeInOut(duration: 0.15)) {

--- a/Sources/KeyPathAppKit/UI/Overlay/HoverDropdownButton.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/HoverDropdownButton.swift
@@ -5,6 +5,7 @@ struct HoverDropdownButton: View {
     let text: String
     var sfSymbol: String?
     var icon: (name: String, image: NSImage?)?
+    var accessibilityIdentifier: String = "hover-dropdown-button"
     let action: () -> Void
 
     @State private var isHovering = false
@@ -36,6 +37,7 @@ struct HoverDropdownButton: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        .accessibilityIdentifier(accessibilityIdentifier)
         .onHover { isHovering = $0 }
     }
 }

--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayKeyboardView.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayKeyboardView.swift
@@ -513,7 +513,7 @@ struct OverlayKeyboardView: View {
         return baseY + halfHeight + keyGap * scale
     }
 
-    static func escLeftInset(
+    nonisolated static func escLeftInset(
         for layout: PhysicalLayout,
         scale: CGFloat,
         keyUnitSize: CGFloat = 32,

--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayMapperSection+OutputTypeDropdown.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayMapperSection+OutputTypeDropdown.swift
@@ -9,9 +9,9 @@ extension OverlayMapperSection {
         return HoverDropdownButton(
             text: currentType.label,
             sfSymbol: currentType.icon,
+            accessibilityIdentifier: "overlay-mapper-output-type",
             action: { isSystemActionPickerOpen = true }
         )
-        .accessibilityIdentifier("overlay-mapper-output-type")
         .accessibilityLabel("Select output action type")
         .windowAnchoredPopover(isPresented: $isSystemActionPickerOpen) {
             systemActionPopover

--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayMapperSection.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayMapperSection.swift
@@ -643,9 +643,9 @@ struct OverlayMapperSection: View {
         return HoverDropdownButton(
             text: displayText,
             icon: appConditionIcon,
+            accessibilityIdentifier: "overlay-mapper-app-condition",
             action: { isAppConditionPickerOpen = true }
         )
-        .accessibilityIdentifier("overlay-mapper-app-condition")
         .windowAnchoredPopover(isPresented: $isAppConditionPickerOpen) {
             appConditionPopover
         }
@@ -657,6 +657,7 @@ struct OverlayMapperSection: View {
             Button("Triple Tap") { selectedTapCount = 3 }
                 .accessibilityIdentifier("overlay-mapper-triple-tap")
             Button("Cancel", role: .cancel) {}
+                .accessibilityIdentifier("overlay-mapper-tap-count-cancel")
         }
     }
 

--- a/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView+CollectionRow.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView+CollectionRow.swift
@@ -390,6 +390,7 @@ struct ExpandableCollectionRow: View {
                         .contentShape(Rectangle())
                     }
                     .buttonStyle(.plain)
+                    .accessibilityIdentifier("rules-summary-add-rule-\(collectionId)")
                 } else if displayStyle == .singleKeyPicker, let coll = collection {
                     // Segmented picker for single-key remapping
                     SingleKeyPickerContent(

--- a/Sources/KeyPathAppKit/UI/Settings/SettingsView+ScriptExecution.swift
+++ b/Sources/KeyPathAppKit/UI/Settings/SettingsView+ScriptExecution.swift
@@ -224,6 +224,7 @@ private struct ScriptExecutionLogView: View {
             }
             .accessibilityIdentifier("settings-script-clear-log-confirm")
             Button("Cancel", role: .cancel) {}
+                .accessibilityIdentifier("settings-script-clear-log-cancel")
         } message: {
             Text("This permanently deletes the audit history of scripts KeyPath has run. This can't be undone.")
         }

--- a/Sources/KeyPathDaemonLifecycle/PIDFileManager.swift
+++ b/Sources/KeyPathDaemonLifecycle/PIDFileManager.swift
@@ -84,7 +84,13 @@ public enum PIDFileManager {
             return
         }
 
-        try FileManager.default.removeItem(atPath: pidFilePath)
+        do {
+            try FileManager.default.removeItem(atPath: pidFilePath)
+        } catch let error as NSError
+            where error.domain == NSCocoaErrorDomain && error.code == NSFileNoSuchFileError
+        {
+            return
+        }
         AppLogger.shared.log("🗑️ [PIDFile] Removed PID file")
     }
 

--- a/Sources/KeyPathPermissions/PermissionOracle.swift
+++ b/Sources/KeyPathPermissions/PermissionOracle.swift
@@ -159,6 +159,12 @@ public actor PermissionOracle {
         lastSnapshotTime = nil
     }
 
+    /// Synchronous, non-prompting Accessibility status for call sites that cannot
+    /// await a full permission snapshot.
+    public nonisolated func keyPathAccessibilityStatus() -> Status {
+        Self.checkKeyPathAccessibilityStatus()
+    }
+
     /// Get current permission snapshot - THE authoritative permission state
     ///
     /// This is the ONLY method other components should call.
@@ -282,8 +288,7 @@ public actor PermissionOracle {
         let start = Date()
 
         // Accessibility check via official Apple API (no prompt)
-        let axGranted = AXIsProcessTrusted()
-        let accessibility: Status = axGranted ? .granted : .denied
+        let accessibility = Self.checkKeyPathAccessibilityStatus()
 
         // Input Monitoring: use TCC database reading (passive, no prompt).
         // IOHIDCheckAccess would trigger the system permission dialog on first call,
@@ -306,6 +311,10 @@ public actor PermissionOracle {
             confidence: confidence,
             timestamp: Date()
         )
+    }
+
+    private nonisolated static func checkKeyPathAccessibilityStatus() -> Status {
+        AXIsProcessTrusted() ? .granted : .denied
     }
 
     // MARK: - Kanata Permission Detection (ADR-016: TCC Database Reading)

--- a/Tests/KeyPathTests/Integration/MapperSaveIntegrationTests.swift
+++ b/Tests/KeyPathTests/Integration/MapperSaveIntegrationTests.swift
@@ -162,7 +162,8 @@ final class MapperSaveIntegrationTests: XCTestCase {
         let packSuccess = await manager.toggleCollection(
             id: capsCollectionID,
             isEnabled: true,
-            autoResolveConflicts: true
+            autoResolveConflicts: true,
+            bypassOwnershipCheck: true
         )
         XCTAssertTrue(packSuccess)
 

--- a/Tests/KeyPathTests/Integration/PackInstallIntegrationTests.swift
+++ b/Tests/KeyPathTests/Integration/PackInstallIntegrationTests.swift
@@ -41,7 +41,8 @@ final class PackInstallIntegrationTests: XCTestCase {
         let success = await manager.toggleCollection(
             id: capsCollectionID,
             isEnabled: true,
-            autoResolveConflicts: true
+            autoResolveConflicts: true,
+            bypassOwnershipCheck: true
         )
         XCTAssertTrue(success, "toggleCollection should succeed")
 
@@ -74,8 +75,7 @@ final class PackInstallIntegrationTests: XCTestCase {
 
         let capsKeyCode: UInt16 = 57
         if case let .tapHoldPicker(config) = capsCollection?.configuration {
-            let expectedOutput = config.selectedTapOutput ?? config.tapOptions.first?.output
-            if let expectedOutput {
+            if config.selectedTapOutput != nil || config.tapOptions.first?.output != nil {
                 let label = vm.tapHoldIdleLabels[capsKeyCode]
                 XCTAssertNotNil(label, "Should have tap-hold idle label for caps after pack install")
             }
@@ -113,7 +113,8 @@ final class PackInstallIntegrationTests: XCTestCase {
         let success = await manager.toggleCollection(
             id: capsCollectionID,
             isEnabled: true,
-            autoResolveConflicts: true
+            autoResolveConflicts: true,
+            bypassOwnershipCheck: true
         )
         XCTAssertTrue(success)
 
@@ -154,7 +155,8 @@ final class PackInstallIntegrationTests: XCTestCase {
         let success = await manager.toggleCollection(
             id: collectionID,
             isEnabled: true,
-            autoResolveConflicts: true
+            autoResolveConflicts: true,
+            bypassOwnershipCheck: true
         )
         XCTAssertTrue(success)
 
@@ -204,7 +206,8 @@ final class PackInstallIntegrationTests: XCTestCase {
         let installed = await manager.toggleCollection(
             id: capsCollectionID,
             isEnabled: true,
-            autoResolveConflicts: true
+            autoResolveConflicts: true,
+            bypassOwnershipCheck: true
         )
         XCTAssertTrue(installed)
 
@@ -212,7 +215,8 @@ final class PackInstallIntegrationTests: XCTestCase {
         let uninstalled = await manager.toggleCollection(
             id: capsCollectionID,
             isEnabled: false,
-            autoResolveConflicts: true
+            autoResolveConflicts: true,
+            bypassOwnershipCheck: true
         )
         XCTAssertTrue(uninstalled)
 

--- a/Tests/KeyPathTests/KeyPathTests.swift
+++ b/Tests/KeyPathTests/KeyPathTests.swift
@@ -1,5 +1,6 @@
 @testable import KeyPathAppKit
 @testable import KeyPathInstallationWizard
+@testable import KeyPathPermissions
 @preconcurrency import XCTest
 
 @MainActor
@@ -691,6 +692,6 @@ extension KeyboardCapture {
     }
 
     func hasAccessibilityPermissions() -> Bool {
-        AXIsProcessTrusted()
+        PermissionOracle.shared.keyPathAccessibilityStatus().isReady
     }
 }

--- a/Tests/KeyPathTests/Lint/FacadeLintTests.swift
+++ b/Tests/KeyPathTests/Lint/FacadeLintTests.swift
@@ -12,6 +12,7 @@ final class FacadeLintTests: XCTestCase {
             root.appendingPathComponent("Sources/KeyPathAppKit/Managers/RuntimeCoordinator.swift").path,
             root.appendingPathComponent("Sources/KeyPathAppKit/Managers/RuntimeCoordinator+Lifecycle.swift").path,
             root.appendingPathComponent("Sources/KeyPathAppKit/InstallationWizard/Core/PermissionGrantCoordinator.swift").path,
+            root.appendingPathComponent("Sources/KeyPathAppKit/WizardProtocolConformances.swift").path,
         ]
         let violations = findPattern("PrivilegedOperationsRouter\\.shared", in: appKitRoot, allowList: allow)
         if !violations.isEmpty {
@@ -21,10 +22,8 @@ final class FacadeLintTests: XCTestCase {
 
     func testDirectAXChecksAreLimitedToAllowlist() {
         let root = repositoryRoot()
-        let sourcesDir = root.appendingPathComponent("Sources/KeyPathAppKit")
+        let sourcesDir = root.appendingPathComponent("Sources")
         let allow = [
-            root.appendingPathComponent("Sources/KeyPathAppKit/Services/KeyboardCapture.swift").path,
-            root.appendingPathComponent("Sources/KeyPathAppKit/UI/KeyboardVisualization/KeyboardVisualizationViewModel.swift").path,
             root.appendingPathComponent("Sources/KeyPathPermissions/PermissionOracle.swift").path,
         ]
         let violations = findPattern("AXIsProcessTrusted\\(", in: sourcesDir, allowList: allow)
@@ -51,12 +50,15 @@ private func findPattern(_ pattern: String, in directory: URL, allowList: [Strin
     }
     var hits: [String] = []
     let allowed = Set(allowList)
+    let regex = try? NSRegularExpression(pattern: pattern)
     for case let fileURL as URL in enumerator {
         guard fileURL.pathExtension == "swift" else { continue }
         if allowed.contains(fileURL.path) { continue }
         guard let contents = try? String(contentsOf: fileURL, encoding: .utf8) else { continue }
         let lines = contents.components(separatedBy: .newlines)
-        for (idx, line) in lines.enumerated() where line.contains(pattern) {
+        for (idx, line) in lines.enumerated() {
+            let range = NSRange(line.startIndex ..< line.endIndex, in: line)
+            guard regex?.firstMatch(in: line, range: range) != nil else { continue }
             hits.append("\(fileURL.path):\(idx + 1): \(line.trimmingCharacters(in: .whitespaces))")
         }
     }

--- a/Tests/KeyPathTests/PermissionOracleFastModeTests.swift
+++ b/Tests/KeyPathTests/PermissionOracleFastModeTests.swift
@@ -12,8 +12,9 @@ struct PermissionOracleFastModeTests {
         TestEnvironment.forceTestMode = true
         defer { TestEnvironment.forceTestMode = false }
 
+        let oracle = PermissionOracle()
         let start = Date()
-        let snapshot = await PermissionOracle.shared.currentSnapshot()
+        let snapshot = await oracle.currentSnapshot()
         let duration = Date().timeIntervalSince(start)
 
         #expect(duration < 1.0)
@@ -27,8 +28,9 @@ struct PermissionOracleFastModeTests {
         TestEnvironment.forceTestMode = true
         defer { TestEnvironment.forceTestMode = false }
 
-        let first = await PermissionOracle.shared.currentSnapshot()
-        let second = await PermissionOracle.shared.currentSnapshot()
+        let oracle = PermissionOracle()
+        let first = await oracle.currentSnapshot()
+        let second = await oracle.currentSnapshot()
         #expect(first.timestamp.timeIntervalSince1970 == second.timestamp.timeIntervalSince1970)
     }
 
@@ -38,7 +40,8 @@ struct PermissionOracleFastModeTests {
         TestEnvironment.forceTestMode = true
         defer { TestEnvironment.forceTestMode = false }
 
-        let snapshot = await PermissionOracle.shared.currentSnapshot()
+        let oracle = PermissionOracle()
+        let snapshot = await oracle.currentSnapshot()
         #expect(snapshot.kanata.confidence == .low)
     }
 
@@ -48,8 +51,9 @@ struct PermissionOracleFastModeTests {
         TestEnvironment.forceTestMode = true
         defer { TestEnvironment.forceTestMode = false }
 
+        let oracle = PermissionOracle()
         let before = Date()
-        let snapshot = await PermissionOracle.shared.currentSnapshot()
+        let snapshot = await oracle.currentSnapshot()
         #expect(snapshot.timestamp >= before.addingTimeInterval(-1))
     }
 
@@ -59,9 +63,10 @@ struct PermissionOracleFastModeTests {
         TestEnvironment.forceTestMode = true
         defer { TestEnvironment.forceTestMode = false }
 
-        await PermissionOracle.shared.invalidateCache()
+        let oracle = PermissionOracle()
+        await oracle.invalidateCache()
         let start = Date()
-        let snapshot = await PermissionOracle.shared.forceRefresh()
+        let snapshot = await oracle.forceRefresh()
         let duration = Date().timeIntervalSince(start)
 
         #expect(duration < 1.0)
@@ -74,7 +79,8 @@ struct PermissionOracleFastModeTests {
         TestEnvironment.forceTestMode = true
         defer { TestEnvironment.forceTestMode = false }
 
-        let snapshot = await PermissionOracle.shared.currentSnapshot()
+        let oracle = PermissionOracle()
+        let snapshot = await oracle.currentSnapshot()
         #expect(!snapshot.diagnosticSummary.isEmpty)
         #expect(snapshot.diagnosticSummary.contains("Permission Oracle"))
     }

--- a/Tests/KeyPathTests/RuleCollections/RuleCollectionsManagerTests.swift
+++ b/Tests/KeyPathTests/RuleCollections/RuleCollectionsManagerTests.swift
@@ -253,7 +253,11 @@ final class RuleCollectionsManagerTests: XCTestCase {
         }
 
         // Enable Caps Lock remap collection (maps caps -> something)
-        await manager.toggleCollection(id: RuleCollectionIdentifier.capsLockRemap, isEnabled: true)
+        await manager.toggleCollection(
+            id: RuleCollectionIdentifier.capsLockRemap,
+            isEnabled: true,
+            bypassOwnershipCheck: true
+        )
         XCTAssertTrue(manager.ruleCollections.contains { $0.id == RuleCollectionIdentifier.capsLockRemap && $0.isEnabled })
 
         // Create custom rule with same input (caps)
@@ -542,7 +546,11 @@ final class RuleCollectionsManagerTests: XCTestCase {
         XCTAssertTrue(initialRuleSaved)
         conflictingCustomRule = try XCTUnwrap(manager.customRules.first { $0.input == "caps" && $0.action.outputString == "esc" })
 
-        await manager.toggleCollection(id: RuleCollectionIdentifier.capsLockRemap, isEnabled: true)
+        await manager.toggleCollection(
+            id: RuleCollectionIdentifier.capsLockRemap,
+            isEnabled: true,
+            bypassOwnershipCheck: true
+        )
 
         XCTAssertTrue(
             manager.ruleCollections.contains { $0.id == RuleCollectionIdentifier.capsLockRemap && $0.isEnabled },
@@ -559,7 +567,19 @@ final class RuleCollectionsManagerTests: XCTestCase {
         let (manager, _) = try await createTestManager()
         defer { TestEnvironment.forceTestMode = false }
 
-        await manager.replaceCollections(RuleCollectionCatalog().defaultCollections())
+        PreferencesService.shared.leaderKeyPreference = .default
+        defer { PreferencesService.shared.leaderKeyPreference = .default }
+
+        let collections = RuleCollectionCatalog().defaultCollections().map { collection in
+            var collection = collection
+            if collection.momentaryActivator != nil,
+               collection.id != RuleCollectionIdentifier.vimNavigation
+            {
+                collection.isEnabled = false
+            }
+            return collection
+        }
+        await manager.replaceCollections(collections)
         await manager.updateLeaderKey("tab")
 
         let beforeInputs = manager.ruleCollections.compactMap(\.momentaryActivator?.input)
@@ -580,7 +600,11 @@ final class RuleCollectionsManagerTests: XCTestCase {
 
         manager.onConflictResolution = { _ in .keepNew }
 
-        await manager.toggleCollection(id: RuleCollectionIdentifier.capsLockRemap, isEnabled: true)
+        await manager.toggleCollection(
+            id: RuleCollectionIdentifier.capsLockRemap,
+            isEnabled: true,
+            bypassOwnershipCheck: true
+        )
         XCTAssertTrue(
             manager.ruleCollections.contains { $0.id == RuleCollectionIdentifier.capsLockRemap && $0.isEnabled },
             "Collection should start enabled"

--- a/Tests/KeyPathTests/Services/ConfigBackupManagerTests.swift
+++ b/Tests/KeyPathTests/Services/ConfigBackupManagerTests.swift
@@ -89,11 +89,15 @@ final class ConfigBackupManagerTests: XCTestCase {
 
     func testCleanupOldBackups_KeepsOnlyMaxBackups() throws {
         try writeValidConfig()
-        let manager = ConfigBackupManager(configPath: configPath)
+        var dateOffset: TimeInterval = 0
+        let baseDate = Date(timeIntervalSince1970: 1_700_000_000)
+        let manager = ConfigBackupManager(configPath: configPath) {
+            defer { dateOffset += 1 }
+            return baseDate.addingTimeInterval(dateOffset)
+        }
 
         for _ in 0 ..< 8 {
             XCTAssertTrue(manager.createPreEditBackup())
-            Thread.sleep(forTimeInterval: 0.05)
         }
 
         let backups = manager.getAvailableBackups()

--- a/Tests/KeyPathTests/Services/ConfigHotReloadServiceTests.swift
+++ b/Tests/KeyPathTests/Services/ConfigHotReloadServiceTests.swift
@@ -30,7 +30,7 @@ final class ConfigHotReloadServiceTests: XCTestCase {
             configurationService: configService,
             reloadHandler: { [weak self] in
                 self?.reloadHandlerCalled = true
-                return self?.reloadHandlerResult ?? false
+                return (self?.reloadHandlerResult ?? false) ? .applied : .failed("Hot reload failed")
             },
             configParser: { _ in
                 // Simple parser - in real usage this would parse Kanata config
@@ -155,7 +155,7 @@ final class ConfigHotReloadServiceTests: XCTestCase {
             configurationService: configService,
             reloadHandler: { [weak self] in
                 self?.reloadHandlerCalled = true
-                return self?.reloadHandlerResult ?? false
+                return (self?.reloadHandlerResult ?? false) ? .applied : .failed("Hot reload failed")
             },
             configParser: { _ in [] },
             serviceManagementStateProvider: { .smappserviceActive },
@@ -239,7 +239,7 @@ final class ConfigHotReloadServiceTests: XCTestCase {
     func testParseKeyMappingsReturnsMappings() {
         service.configure(
             configurationService: configService,
-            reloadHandler: { true },
+            reloadHandler: { .applied },
             configParser: { _ in
                 [KeyMapping(input: "caps", action: .keystroke(key: "esc"))]
             }
@@ -254,7 +254,7 @@ final class ConfigHotReloadServiceTests: XCTestCase {
         // Configure parser to throw an error
         service.configure(
             configurationService: configService,
-            reloadHandler: { true },
+            reloadHandler: { .applied },
             configParser: { _ in
                 throw NSError(domain: "test", code: 1, userInfo: [NSLocalizedDescriptionKey: "Parser error"])
             }
@@ -267,7 +267,7 @@ final class ConfigHotReloadServiceTests: XCTestCase {
     func testParseKeyMappingsHandlesParserErrors() {
         service.configure(
             configurationService: configService,
-            reloadHandler: { true },
+            reloadHandler: { .applied },
             configParser: { _ in
                 throw NSError(domain: "test", code: 1)
             }

--- a/Tests/KeyPathTests/Services/PermissionOracleTests.swift
+++ b/Tests/KeyPathTests/Services/PermissionOracleTests.swift
@@ -270,7 +270,7 @@ struct PermissionOracleTests {
     @Test("Oracle returns placeholder snapshot in test mode")
     func modeSnapshot() async {
         // This test verifies the Oracle behaves correctly in test environment
-        let oracle = PermissionOracle.shared
+        let oracle = PermissionOracle()
         let snapshot = await oracle.currentSnapshot()
 
         // In test mode, should get placeholder with unknown status
@@ -284,7 +284,7 @@ struct PermissionOracleTests {
 
     @Test("Cache invalidation works")
     func cacheInvalidation() async {
-        let oracle = PermissionOracle.shared
+        let oracle = PermissionOracle()
 
         // Get first snapshot
         let snapshot1 = await oracle.currentSnapshot()
@@ -310,7 +310,7 @@ struct PermissionOracleTests {
 
     @Test("Force refresh bypasses cache")
     func forceRefresh() async {
-        let oracle = PermissionOracle.shared
+        let oracle = PermissionOracle()
 
         // Get first snapshot
         let snapshot1 = await oracle.currentSnapshot()

--- a/Tests/KeyPathTests/UI/OverlayHealthIndicatorObserverTests.swift
+++ b/Tests/KeyPathTests/UI/OverlayHealthIndicatorObserverTests.swift
@@ -199,17 +199,16 @@ final class OverlayHealthIndicatorObserverTests: KeyPathTestCase {
 
 @MainActor
 private final class AsyncGate {
-    private var continuation: CheckedContinuation<Void, Never>?
+    private var isOpen = false
 
     func wait() async {
-        await withCheckedContinuation { continuation in
-            self.continuation = continuation
+        while !isOpen, !Task.isCancelled {
+            await Task.yield()
         }
     }
 
     func open() {
-        continuation?.resume()
-        continuation = nil
+        isOpen = true
     }
 }
 


### PR DESCRIPTION
## Summary

Refs #731.

This fixes the release-blocking stabilization work from issue #731:

- enforce the accessibility checker in CI and add missing identifiers for the currently failing UI controls
- route remaining direct Accessibility checks through PermissionOracle and fix the lint so direct AX usage is actually detected outside the allowlist
- make Kanata startup success wait for runtime readiness, with Login Items pending approval reported explicitly
- classify config reload outcomes as applied, pending, rejected, or failed so save/hot-reload/reset callers handle rollback consistently
- remove the obvious Thread.sleep test flake and make backup naming deterministic
- clean up release-test failures around shared permission state, rule collection ownership paths, leader key preference sync, PID removal races, and async observer gating

## Validation

- python3 Scripts/check-accessibility.py
- ./Scripts/lint-no-sleep.sh
- git diff --check
- rg -n "AXIsProcessTrusted\(|IOHIDCheckAccess\(" Sources Tests/KeyPathTests
- rg -n "Thread\.sleep" Sources Tests/KeyPathTests
- CI_ENVIRONMENT=true SKIP_EVENT_TAP_TESTS=1 TIMEOUT_SECONDS=300 KP_SIGN_DRY_RUN=1 ./Scripts/run-tests-safe.sh
- pre-push build hook