### PR TITLE
[codex] Fix notarytool wrapper with default keychain

### DIFF
--- a/Scripts/lib/signing.sh
+++ b/Scripts/lib/signing.sh
@@ -35,18 +35,20 @@ kp_notarize_zip() {
     local zip_path=$1
     local profile=$2
     shift 2
-    # Optionally read the notary profile from a specific keychain (KP_NOTARY_KEYCHAIN).
-    # Without it, notarytool uses the default (login) keychain, exactly as before.
-    local keychain_args=()
-    if [ -n "${KP_NOTARY_KEYCHAIN:-}" ]; then
-        keychain_args=(--keychain "$KP_NOTARY_KEYCHAIN")
-    fi
     if [ "$KP_SIGN_DRY_RUN" = "1" ]; then
-        echo "[DRY RUN] $KP_NOTARY_CMD submit $zip_path --keychain-profile $profile ${keychain_args[*]} --wait $*"
+        if [ -n "${KP_NOTARY_KEYCHAIN:-}" ]; then
+            echo "[DRY RUN] $KP_NOTARY_CMD submit $zip_path --keychain-profile $profile --keychain $KP_NOTARY_KEYCHAIN --wait $*"
+        else
+            echo "[DRY RUN] $KP_NOTARY_CMD submit $zip_path --keychain-profile $profile --wait $*"
+        fi
         return 0
     fi
     # Use word-splitting for multi-word command (xcrun notarytool)
-    $KP_NOTARY_CMD submit "$zip_path" --keychain-profile "$profile" "${keychain_args[@]}" --wait "$@"
+    if [ -n "${KP_NOTARY_KEYCHAIN:-}" ]; then
+        $KP_NOTARY_CMD submit "$zip_path" --keychain-profile "$profile" --keychain "$KP_NOTARY_KEYCHAIN" --wait "$@"
+    else
+        $KP_NOTARY_CMD submit "$zip_path" --keychain-profile "$profile" --wait "$@"
+    fi
 }
 
 kp_staple() {


### PR DESCRIPTION
## Summary

The notarized build reached the `kp_notarize_zip` helper and failed before Apple submission because `Scripts/lib/signing.sh` expanded an empty `keychain_args` array under `set -u` when `KP_NOTARY_KEYCHAIN` was unset.

The wrapper now conditionally includes the `--keychain` argument only when `KP_NOTARY_KEYCHAIN` is set, preserving the default login-keychain behavior for the normal `KeyPath-Profile` path.

## Validation

- `bash -n Scripts/lib/signing.sh`
- dry-run `kp_notarize_zip` with default keychain profile
- dry-run `kp_notarize_zip` with explicit `KP_NOTARY_KEYCHAIN`
- `swift test --filter SigningPipelineTests`
- pre-push build hook
