### PR TITLE
[codex] Delete dead ResizeHandle

### DIFF
--- a/Sources/KeyPathLayoutTracerKit/ResizeHandle.swift
+++ b/Sources/KeyPathLayoutTracerKit/ResizeHandle.swift
@@ -1,3 +1,0 @@
-enum ResizeHandle {
-    case bottomTrailing
-}


### PR DESCRIPTION
## Summary

Closes #738.

`ResizeHandle` had no live references outside its own declaration, so this removes the dead file.

## Validation

- `rg -n "\\bResizeHandle\\b" Sources Tests` returns no matches
- `swift build --target KeyPathLayoutTracerKit`
- pre-push build hook
