### PR TITLE
Fix overlay layer picker popover

### DIFF
--- a/Sources/KeyPathAppKit/UI/Overlay/LiveKeyboardOverlayView+Header.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/LiveKeyboardOverlayView+Header.swift
@@ -178,8 +178,6 @@ struct OverlayDragHeader: View {
     @State var newLayerName = ""
     /// Layer being hovered for delete button
     @State var hoveredLayer: String?
-    /// Computed arrow edge for layer picker (up by default, down near screen top)
-    @State private var layerPickerArrowEdge: Edge = .top
     /// When the health indicator dismissed — used to suppress "No TCP" briefly at startup
     @State private var healthDismissedAt: Date?
 
@@ -529,7 +527,7 @@ struct OverlayDragHeader: View {
         .onHover { hovering in
             handleLayerPillHover(hovering)
         }
-        .inlinePopover(isPresented: $isLayerPickerOpen) {
+        .windowAnchoredPopover(isPresented: $isLayerPickerOpen, edge: .bottom, gap: 6) {
             layerPickerPopover
         }
         .sheet(isPresented: $showingNewLayerSheet) {
@@ -625,48 +623,9 @@ struct OverlayDragHeader: View {
         }
     }
 
-    /// Toggle layer picker with smart positioning (opens up by default, down near screen top)
+    /// Toggle the layer picker. The root popover host handles positioning and edge flipping.
     private func toggleLayerMenu() {
-        if isLayerPickerOpen {
-            // Closing - just toggle
-            isLayerPickerOpen = false
-        } else {
-            // Opening - compute arrow edge first
-            layerPickerArrowEdge = computeLayerPickerArrowEdge()
-            isLayerPickerOpen = true
-        }
-    }
-
-    /// Compute which edge the popover arrow should point from based on available screen space
-    private func computeLayerPickerArrowEdge() -> Edge {
-        guard let window = findOverlayWindow(),
-              let screen = window.screen ?? NSScreen.main
-        else {
-            return .top // Default to opening upward
-        }
-
-        let windowTop = window.frame.maxY
-        let screenTop = screen.visibleFrame.maxY
-        let spaceAbove = screenTop - windowTop
-
-        // Estimate popover height (layers + new layer option + padding)
-        // Each row is ~40pt, header/footer ~12pt
-        let estimatedRowHeight: CGFloat = 40
-        let estimatedPopoverHeight = CGFloat(availableLayers.count + 1) * estimatedRowHeight + 24
-
-        // If not enough space above, open downward (arrowEdge: .bottom)
-        // Add some margin (20pt) for safety
-        if spaceAbove < estimatedPopoverHeight + 20 {
-            return .bottom
-        }
-
-        return .top
-    }
-
-    private func findOverlayWindow() -> NSWindow? {
-        NSApplication.shared.windows.first {
-            $0.styleMask.contains(.borderless) && $0.level == .floating
-        }
+        isLayerPickerOpen.toggle()
     }
 }
 

--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayDragHeader+LayerPicker.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayDragHeader+LayerPicker.swift
@@ -170,6 +170,7 @@ extension OverlayDragHeader {
             }
             .buttonStyle(LayerPickerButtonStyle())
             .focusable(false)
+            .accessibilityIdentifier("layer-picker-\(layer)")
 
             // Delete button for user-created layers (hover only)
             if canDelete {

--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayMapperSection+Styles.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayMapperSection+Styles.swift
@@ -37,28 +37,4 @@ extension View {
             .clipShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
             .padding(outerPadding)
     }
-
-    /// Drop-in replacement for `.popover()` that renders content as an inline overlay
-    /// instead of using NSPopover. Avoids a crash on borderless overlay windows where
-    /// NSPopover's animated resize triggers a null function pointer callback.
-    func inlinePopover(
-        isPresented: Binding<Bool>,
-        @ViewBuilder content: @escaping () -> some View
-    ) -> some View {
-        overlay(alignment: .top) {
-            if isPresented.wrappedValue {
-                ZStack {
-                    Color.black.opacity(0.01)
-                        .frame(width: 2000, height: 2000)
-                        .onTapGesture { isPresented.wrappedValue = false }
-
-                    content()
-                        .shadow(color: .black.opacity(0.3), radius: 12, y: 4)
-                        .fixedSize(horizontal: false, vertical: true)
-                }
-                .transition(.opacity)
-                .zIndex(999)
-            }
-        }
-    }
 }


### PR DESCRIPTION
## Summary
- Move the overlay header layer picker from the old clipped inline overlay to the existing root-level `windowAnchoredPopover` host.
- Remove the now-unused `inlinePopover` helper and stale screen-space positioning code.
- Add accessibility identifiers for layer picker rows so UI automation can target them directly.

## Root Cause
The Base layer pill rendered its picker as a local overlay inside `OverlayDragHeader`, but the header is intentionally `.clipped()`. The picker content was therefore clipped/invisible even though the button toggled state. The old inline popover also centered content inside a large backdrop, which could place it off-screen.

## Validation
- `swift build`
- `python3 Scripts/check-accessibility.py`
- `swift test --filter LayerSelectorTests`
- Pre-push build hook
- Manual computer-use verification on `/Applications/KeyPath.app`: clicking `overlay-layer-indicator` shows `layer-picker-base`, `layer-picker-launcher`, `layer-picker-nav`, and `layer-picker-new`; selecting `layer-picker-nav` dismisses the picker.

Fixes #733
