### PR TITLE
Fix stale Kanata SMAppService recovery

### DIFF
--- a/Sources/KeyPathInstallationWizard/Core/ServiceBootstrapper.swift
+++ b/Sources/KeyPathInstallationWizard/Core/ServiceBootstrapper.swift
@@ -1,3 +1,4 @@
+import Darwin
 import Foundation
 import KeyPathCore
 import KeyPathWizardCore
@@ -23,6 +24,10 @@ public final class ServiceBootstrapper {
     private init() {}
 
     public private(set) var lastVHIDRepairOutput: String?
+
+    #if DEBUG
+        static var staleSMAppServiceBootoutOverride: (() async -> (success: Bool, output: String))?
+    #endif
 
     // MARK: - Service Identifiers
 
@@ -704,6 +709,12 @@ public final class ServiceBootstrapper {
                 AppLogger.shared.log("🔄 Attempt \(attempt)/\(maxRetries)")
 
                 try await daemonManager.unregister()
+                let bootedOut = await bootOutStaleKanataSMAppServiceJob(attempt: attempt)
+                if !bootedOut {
+                    AppLogger.shared.log("❌ Attempt \(attempt) failed: stale launchd job could not be booted out")
+                    continue
+                }
+                ServiceHealthChecker.shared.invalidateHealthCache()
                 for _ in 0 ..< 10 { // ~1s
                     if await !(ServiceHealthChecker.shared.isServiceHealthy(serviceID: Self.kanataServiceID)) {
                         break
@@ -736,6 +747,48 @@ public final class ServiceBootstrapper {
         AppLogger.shared.log("⚠️ [ServiceBootstrapper] Could not fix SMAppService state - user may need to reboot")
         return false
     }
+
+    static func staleKanataSMAppServiceBootoutCommands(userID: uid_t = getuid()) -> [String] {
+        [
+            "/bin/launchctl bootout gui/\(userID)/\(kanataServiceID) 2>/dev/null || true",
+            "/bin/launchctl bootout system/\(kanataServiceID) 2>/dev/null || true"
+        ]
+    }
+
+    @MainActor
+    private func bootOutStaleKanataSMAppServiceJob(attempt: Int) async -> Bool {
+        AppLogger.shared.log(
+            "🔄 [ServiceBootstrapper] Booting out stale Kanata launchd job before SMAppService re-register (attempt \(attempt))"
+        )
+
+        #if DEBUG
+            if let override = Self.staleSMAppServiceBootoutOverride {
+                let result = await override()
+                if !result.success {
+                    AppLogger.shared.log("❌ [ServiceBootstrapper] Test bootout override failed: \(result.output)")
+                }
+                return result.success
+            }
+        #endif
+
+        let result = await executePrivilegedBatch(
+            label: "clear stale Kanata service registration",
+            commands: Self.staleKanataSMAppServiceBootoutCommands(),
+            prompt: "KeyPath needs to clear a stale keyboard runtime registration."
+        )
+        if result.success {
+            AppLogger.shared.log("✅ [ServiceBootstrapper] Stale Kanata launchd job booted out")
+        } else {
+            AppLogger.shared.log("❌ [ServiceBootstrapper] Failed to boot out stale Kanata launchd job: \(result.output)")
+        }
+        return result.success
+    }
+
+    #if DEBUG
+        func _testBootOutStaleKanataSMAppServiceJob(attempt: Int = 1) async -> Bool {
+            await bootOutStaleKanataSMAppServiceJob(attempt: attempt)
+        }
+    #endif
 
     // MARK: - VHID Service Repair
 

--- a/Tests/KeyPathTests/Services/ServiceBootstrapperTests.swift
+++ b/Tests/KeyPathTests/Services/ServiceBootstrapperTests.swift
@@ -243,6 +243,31 @@ final class ServiceBootstrapperTests: XCTestCase {
         XCTAssertTrue(installResult)
     }
 
+    func testStaleSMAppServiceBootoutCommandsTargetGuiAndSystemDomains() {
+        let commands = ServiceBootstrapper.staleKanataSMAppServiceBootoutCommands(userID: 501)
+
+        XCTAssertEqual(commands, [
+            "/bin/launchctl bootout gui/501/com.keypath.kanata 2>/dev/null || true",
+            "/bin/launchctl bootout system/com.keypath.kanata 2>/dev/null || true"
+        ])
+    }
+
+    func testStaleSMAppServiceBootoutUsesOverrideResult() async {
+        let bootstrapper = ServiceBootstrapper.shared
+        var calls = 0
+
+        ServiceBootstrapper.staleSMAppServiceBootoutOverride = {
+            calls += 1
+            return (success: true, output: "booted")
+        }
+        defer { ServiceBootstrapper.staleSMAppServiceBootoutOverride = nil }
+
+        let result = await bootstrapper._testBootOutStaleKanataSMAppServiceJob()
+
+        XCTAssertTrue(result)
+        XCTAssertEqual(calls, 1)
+    }
+
     func testRepairVHIDDaemonServicesInTestModeSetsOutput() async {
         let bootstrapper = ServiceBootstrapper.shared
         let result = await bootstrapper.repairVHIDDaemonServices()


### PR DESCRIPTION
## Summary
- boot out stale Kanata launchd jobs during SMAppService broken-state recovery before re-registering
- target both gui/<uid> and system launchd domains so failed relative-path jobs do not survive app replacement
- add focused tests for the stale bootout command path

## Why
Release verification after PR #743 produced a signed/notarized app, but replacing /Applications/KeyPath.app left com.keypath.kanata in launchd spawn failed / EX_CONFIG with an unresolved Contents/Library/KeyPath/kanata-launcher path. The existing recovery loop only unregistered/re-registered SMAppService metadata; it did not clear the stale launchd job first.

## Validation
- python3 Scripts/check-accessibility.py
- swiftformat --lint Sources/KeyPathInstallationWizard/Core/ServiceBootstrapper.swift Tests/KeyPathTests/Services/ServiceBootstrapperTests.swift
- swift test --filter ServiceBootstrapperTests
- swift test --filter KanataDaemonManagerTests --filter ServiceHealthCheckerTests --filter ServiceInstallGuardTests
- swift build