### PR TITLE
Fix stale helper SMAppService recovery

### DIFF
--- a/Sources/KeyPathAppKit/Core/HelperManager+Installation.swift
+++ b/Sources/KeyPathAppKit/Core/HelperManager+Installation.swift
@@ -45,20 +45,36 @@ extension HelperManager {
         case .enabled:
             // Enabled means the app has background-item approval, not necessarily that
             // the daemon is registered. Attempt an idempotent register to ensure the
-            // system copies are installed. Treat enabled-after-call as success.
+            // system copies are installed. Then verify XPC actually responds: launchd
+            // can retain stale SMAppService state after app replacement.
+            var registerError: Error?
             do {
                 try svc.register()
-                AppLogger.shared.info("✅ [HelperManager] Helper registered (was Enabled prior)")
-                return
             } catch {
+                registerError = error
                 if svc.status == .enabled {
-                    AppLogger.shared.log("ℹ️ [HelperManager] Helper already Enabled; proceeding")
-                    return
+                    AppLogger.shared.log("ℹ️ [HelperManager] Helper already Enabled after register error; verifying XPC")
+                } else {
+                    throw HelperManagerError.installationFailed(
+                        "SMAppService register (enabled path) failed: \(error.localizedDescription)"
+                    )
                 }
-                throw HelperManagerError.installationFailed(
-                    "SMAppService register (enabled path) failed: \(error.localizedDescription)"
+            }
+
+            if await waitForHelperFunctionality(context: "enabled helper refresh", attempts: 2) {
+                AppLogger.shared.info("✅ [HelperManager] Helper registered and responding (was Enabled prior)")
+                return
+            }
+
+            AppLogger.shared.log(
+                "⚠️ [HelperManager] Helper SMAppService is enabled but XPC is unresponsive; clearing stale registration"
+            )
+            if let registerError {
+                AppLogger.shared.log(
+                    "ℹ️ [HelperManager] Enabled-path register error before stale recovery: \(registerError.localizedDescription)"
                 )
             }
+            try await recoverStaleEnabledHelper(svc)
         case .requiresApproval:
             throw HelperManagerError.installationFailed(
                 "Approval required in System Settings → Login Items."
@@ -143,6 +159,101 @@ extension HelperManager {
             parts.append("underlying=\(underlying.domain):\(underlying.code) \(underlying.localizedDescription)")
         }
         return parts.joined(separator: " ")
+    }
+
+    static func staleHelperSMAppServiceBootoutCommands() -> [String] {
+        [
+            "/bin/launchctl bootout system/\(helperBundleIdentifier) 2>/dev/null || true"
+        ]
+    }
+
+    private func recoverStaleEnabledHelper(_ svc: SMAppServiceProtocol) async throws {
+        await clearConnection()
+
+        do {
+            try await svc.unregister()
+            AppLogger.shared.log("✅ [HelperManager] Stale helper SMAppService unregister succeeded")
+        } catch {
+            AppLogger.shared.log(
+                "⚠️ [HelperManager] Stale helper SMAppService unregister failed: \(error.localizedDescription)"
+            )
+        }
+
+        let bootedOut = await bootOutStaleHelperSMAppServiceJob()
+        guard bootedOut else {
+            throw HelperManagerError.installationFailed(
+                "Unable to clear stale helper launchd job. Try again and approve the administrator prompt."
+            )
+        }
+
+        do {
+            try svc.register()
+            AppLogger.shared.log("✅ [HelperManager] Re-registered helper after stale SMAppService cleanup")
+        } catch {
+            if svc.status == .requiresApproval {
+                throw HelperManagerError.installationFailed(
+                    "Approval required in System Settings → Login Items."
+                )
+            }
+            throw HelperManagerError.installationFailed(
+                "SMAppService register after stale cleanup failed: \(error.localizedDescription)"
+            )
+        }
+
+        guard await waitForHelperFunctionality(context: "stale helper recovery", attempts: 6) else {
+            throw HelperManagerError.installationFailed(
+                "Helper registered after stale cleanup but did not respond via XPC."
+            )
+        }
+    }
+
+    private func bootOutStaleHelperSMAppServiceJob() async -> Bool {
+        AppLogger.shared.log("🔄 [HelperManager] Booting out stale helper launchd job")
+
+        #if DEBUG
+            if let override = Self.staleHelperSMAppServiceBootoutOverride {
+                let result = await override()
+                if !result.success {
+                    AppLogger.shared.log("❌ [HelperManager] Stale helper bootout override failed: \(result.output)")
+                }
+                return result.success
+            }
+        #endif
+
+        let command = Self.staleHelperSMAppServiceBootoutCommands().joined(separator: "\n")
+        let executor = await MainActor.run { AdminCommandExecutorHolder.shared }
+        do {
+            let result = try await executor.execute(
+                command: command,
+                description: "Clear stale KeyPath helper registration"
+            )
+            if result.exitCode == 0 {
+                AppLogger.shared.log("✅ [HelperManager] Stale helper launchd job cleared")
+                return true
+            }
+            AppLogger.shared.log(
+                "❌ [HelperManager] Stale helper launchd clear failed (\(result.exitCode)): \(result.output)"
+            )
+            return false
+        } catch {
+            AppLogger.shared.log("❌ [HelperManager] Stale helper launchd clear error: \(error.localizedDescription)")
+            return false
+        }
+    }
+
+    private func waitForHelperFunctionality(context: String, attempts: Int) async -> Bool {
+        for attempt in 1 ... attempts {
+            if await testHelperFunctionality() {
+                return true
+            }
+            if attempt < attempts {
+                AppLogger.shared.log(
+                    "⏳ [HelperManager] Helper not responding during \(context) (attempt \(attempt)/\(attempts)); waiting"
+                )
+                try? await Task.sleep(for: .milliseconds(500))
+            }
+        }
+        return false
     }
 
     private nonisolated func signingPreflightFailure() async -> String? {

--- a/Sources/KeyPathAppKit/Core/HelperManager.swift
+++ b/Sources/KeyPathAppKit/Core/HelperManager.swift
@@ -27,6 +27,8 @@ public actor HelperManager {
 
         nonisolated(unsafe) static var testHelperFunctionalityOverride: (() async -> Bool)?
         nonisolated(unsafe) static var testInstallHelperOverride: (() async throws -> Void)?
+        nonisolated(unsafe) static var staleHelperSMAppServiceBootoutOverride:
+            (() async -> (success: Bool, output: String))?
         nonisolated(unsafe) static var subprocessRunnerFactory: () -> SubprocessRunning = {
             SubprocessRunner.shared
         }

--- a/Tests/KeyPathTests/Core/HelperManagerTests.swift
+++ b/Tests/KeyPathTests/Core/HelperManagerTests.swift
@@ -12,6 +12,8 @@ final class HelperManagerTests: XCTestCase {
 
     override func tearDown() {
         HelperManager.smServiceFactory = originalFactory
+        HelperManager.testHelperFunctionalityOverride = nil
+        HelperManager.staleHelperSMAppServiceBootoutOverride = nil
         super.tearDown()
     }
 
@@ -39,16 +41,57 @@ final class HelperManagerTests: XCTestCase {
             XCTAssertTrue(msg.contains(expectedDescription), "missing detailed SM error: \(msg)")
         }
     }
+
+    func testStaleHelperSMAppServiceBootoutCommandsTargetSystemDomain() {
+        XCTAssertEqual(
+            HelperManager.staleHelperSMAppServiceBootoutCommands(),
+            ["/bin/launchctl bootout system/com.keypath.helper 2>/dev/null || true"]
+        )
+    }
+
+    func testInstallHelperRecoversEnabledButUnresponsiveRegistration() async throws {
+        let service = FakeSMAppService(status: .enabled)
+        HelperManager.smServiceFactory = { _ in service }
+
+        var bootoutCalls = 0
+        HelperManager.staleHelperSMAppServiceBootoutOverride = {
+            bootoutCalls += 1
+            return (true, "booted out")
+        }
+
+        HelperManager.testHelperFunctionalityOverride = {
+            service.unregisterCalls > 0
+        }
+
+        try await HelperManager.shared.installHelper()
+
+        XCTAssertEqual(service.registerCalls, 2)
+        XCTAssertEqual(service.unregisterCalls, 1)
+        XCTAssertEqual(bootoutCalls, 1)
+    }
 }
 
 // MARK: - Test Doubles
 
-private struct FakeSMAppService: SMAppServiceProtocol, @unchecked Sendable {
-    let status: SMAppService.Status
-    let registerError: Error
-    func register() throws {
-        throw registerError
+private final class FakeSMAppService: SMAppServiceProtocol, @unchecked Sendable {
+    var status: SMAppService.Status
+    var registerError: Error?
+    var registerCalls = 0
+    var unregisterCalls = 0
+
+    init(status: SMAppService.Status, registerError: Error? = nil) {
+        self.status = status
+        self.registerError = registerError
     }
 
-    func unregister() async throws {}
+    func register() throws {
+        registerCalls += 1
+        if let registerError {
+            throw registerError
+        }
+    }
+
+    func unregister() async throws {
+        unregisterCalls += 1
+    }
 }


### PR DESCRIPTION
## Summary
- verify an enabled privileged helper actually responds over XPC before treating SMAppService registration as healthy
- recover enabled-but-unresponsive helper registrations by unregistering, clearing stale launchd state with admin authorization, re-registering, and polling XPC readiness
- add regression coverage for the stale helper bootout command and enabled-but-unresponsive recovery path

## Validation
- python3 Scripts/check-accessibility.py
- swiftformat --lint Sources/KeyPathAppKit/Core/HelperManager.swift Sources/KeyPathAppKit/Core/HelperManager+Installation.swift Tests/KeyPathTests/Core/HelperManagerTests.swift
- swift test --filter HelperManagerTests
- swift test --filter HelperMaintenanceTests --filter InstallerEngineTests --filter InstallerEngineFailurePathTests
- swift build