### PR TITLE
Constrain overlay layer picker width

### DIFF
--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayDragHeader+LayerPicker.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayDragHeader+LayerPicker.swift
@@ -50,7 +50,7 @@ extension OverlayDragHeader {
             .accessibilityIdentifier("layer-picker-new")
         }
         .padding(.vertical, 6)
-        .frame(minWidth: 200)
+        .frame(width: 280)
         .pickerPopoverChrome()
     }
 


### PR DESCRIPTION
## Summary

- constrain the overlay layer picker popover to a fixed 280pt menu width
- prevents row `Spacer()` content from expanding the window-anchored popover across the overlay

## Verification

- `swiftformat --lint Sources/KeyPathAppKit/UI/Overlay/OverlayDragHeader+LayerPicker.swift`
- `python3 Scripts/check-accessibility.py`
- `swift build`
- `./Scripts/quick-deploy.sh`
- `codesign --verify --strict --verbose=2 /Applications/KeyPath.app`
