### PR TITLE
[codex] Improve release workflow scripts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,6 +85,11 @@ For non-notarized local debug builds, skip distribution trust checks:
 REQUIRE_NOTARIZED=0 REQUIRE_STAPLED=0 ./Scripts/verify-installed-app.sh
 ```
 
+For trust-only diagnostics where KeyPath is not running yet:
+```bash
+CHECK_RUNTIME=0 ./Scripts/verify-installed-app.sh
+```
+
 ## Architecture & Patterns
 
 ### InstallerEngine Façade

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,78 @@ Rationale: older CLI/tooling may still expose `tools.web_search`, which prints a
 - Keep diffs minimal and focused. Preserve directory layout and script entry points.
 - Update docs/tests when behavior or commands change.
 
+## Build, Deploy, and Release Workflow
+
+Use the narrowest workflow that matches the task. Do not run the full notarized
+release path for ordinary UI/code iteration.
+
+### 1. Inner Loop: local development
+Use for Swift/UI changes while iterating:
+```bash
+swift build
+./Scripts/quick-deploy.sh
+python3 Scripts/check-accessibility.py
+```
+
+Notes:
+- `quick-deploy.sh` updates `/Applications/KeyPath.app`, re-signs locally, and
+  restarts KeyPath only if it was running.
+- It intentionally does **not** redeploy the privileged helper unless
+  `KEYPATH_DEPLOY_HELPER=1` is set. Avoid helper redeploys during UI work.
+- Use Poltergeist when you want continuous rebuild/deploy:
+  `poltergeist start`, edit, then `poltergeist wait keypath`.
+
+### 2. Release Candidate: signed local testing
+Use after a PR is merged when `/Applications/KeyPath.app` should match a real
+Developer ID/notarized build for manual testing:
+```bash
+./Scripts/release-candidate.sh
+```
+
+Defaults:
+- skips screenshot regeneration (`SKIP_SNAPSHOTS=1`)
+- skips Peekaboo screenshot generation (`SKIP_PEEKABOO=1`)
+- skips Sparkle archive/appcast generation (`SKIP_SPARKLE=1`)
+- skips website publishing (`SKIP_WEBSITE=1`)
+- deploys to `/Applications/KeyPath.app`
+- runs installed-app verification
+
+Use opt-ins only when needed:
+```bash
+./Scripts/release-candidate.sh --with-snapshots
+./Scripts/release-candidate.sh --with-sparkle
+./Scripts/release-candidate.sh --with-website
+```
+
+### 3. Ship: public release artifacts
+Use the full script only when producing public distribution artifacts:
+```bash
+./Scripts/build-and-sign.sh
+```
+
+This path may regenerate screenshots, create Sparkle artifacts, notarize, staple,
+deploy, and publish website help content depending on environment flags. It is
+intentionally slower than the release-candidate path.
+
+### 4. Installed app verification
+After any signed/notarized deploy, or when diagnosing a local install:
+```bash
+./Scripts/verify-installed-app.sh
+```
+
+It verifies:
+- code signature
+- Gatekeeper assessment
+- stapled notarization ticket
+- KeyPath process
+- `system/com.keypath.kanata` launchd job
+- TCP readiness on `127.0.0.1:37001`
+
+For non-notarized local debug builds, skip distribution trust checks:
+```bash
+REQUIRE_NOTARIZED=0 REQUIRE_STAPLED=0 ./Scripts/verify-installed-app.sh
+```
+
 ## Architecture & Patterns
 
 ### InstallerEngine Façade

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,10 +79,13 @@ Two doc systems: `guides/` (user-facing, published to gh-pages) and `docs/` (dev
 ```bash
 ./build.sh                        # Canonical build (SKIP_NOTARIZE=1 for local dev)
 ./Scripts/quick-deploy.sh         # Fast debug deploy
+./Scripts/release-candidate.sh    # Signed/notarized post-merge testing
 swift test                        # All tests (~532 tests, <5s)
 swiftformat Sources Tests         # Uses pinned rules + swiftversion from .swiftformat
 swiftlint --fix --quiet
 ```
+
+### Workflow tiers
 
 Use the narrowest workflow that matches the task:
 
@@ -133,6 +136,12 @@ KeyPath process, `system/com.keypath.kanata`, and TCP readiness on
 
 ```bash
 REQUIRE_NOTARIZED=0 REQUIRE_STAPLED=0 ./Scripts/verify-installed-app.sh
+```
+
+For trust-only diagnostics where KeyPath is not running yet:
+
+```bash
+CHECK_RUNTIME=0 ./Scripts/verify-installed-app.sh
 ```
 
 **SwiftFormat is pinned to 0.61.1** (`mise.toml`); `master` is a formatted fixed-point

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,57 @@ swiftformat Sources Tests         # Uses pinned rules + swiftversion from .swift
 swiftlint --fix --quiet
 ```
 
+Use the narrowest workflow that matches the task:
+
+**Inner loop:** For normal Swift/UI iteration, prefer `swift build` and
+`./Scripts/quick-deploy.sh`. Use Poltergeist for continuous rebuild/deploy:
+`poltergeist start`, edit, then `poltergeist wait keypath`. `quick-deploy.sh`
+updates `/Applications/KeyPath.app`, re-signs locally, and restarts KeyPath only
+if it was already running. It does not redeploy the privileged helper unless
+`KEYPATH_DEPLOY_HELPER=1` is set.
+
+**Release candidate:** After a PR is merged and manual testing needs a real
+Developer ID/notarized app in `/Applications`, run:
+
+```bash
+./Scripts/release-candidate.sh
+```
+
+This defaults to `SKIP_SNAPSHOTS=1`, `SKIP_PEEKABOO=1`, `SKIP_SPARKLE=1`, and
+`SKIP_WEBSITE=1`, then runs installed-app verification. Opt into slower release
+work only when needed:
+
+```bash
+./Scripts/release-candidate.sh --with-snapshots
+./Scripts/release-candidate.sh --with-sparkle
+./Scripts/release-candidate.sh --with-website
+```
+
+**Public ship:** Use the full release script only when producing public
+distribution artifacts:
+
+```bash
+./Scripts/build-and-sign.sh
+```
+
+That path may regenerate screenshots, create Sparkle artifacts, notarize,
+staple, deploy, and publish website help content depending on environment flags.
+
+**Installed verification:** After signed/notarized deploys, or when diagnosing a
+local install, run:
+
+```bash
+./Scripts/verify-installed-app.sh
+```
+
+It checks code signature, Gatekeeper assessment, stapled notarization ticket,
+KeyPath process, `system/com.keypath.kanata`, and TCP readiness on
+`127.0.0.1:37001`. For non-notarized debug builds:
+
+```bash
+REQUIRE_NOTARIZED=0 REQUIRE_STAPLED=0 ./Scripts/verify-installed-app.sh
+```
+
 **SwiftFormat is pinned to 0.61.1** (`mise.toml`); `master` is a formatted fixed-point
 for that version + `.swiftformat` config, so a run produces **no churn**. A different
 version reformats unrelated code (see #634) — match the pin (`mise install` or

--- a/Scripts/build-and-sign.sh
+++ b/Scripts/build-and-sign.sh
@@ -197,9 +197,9 @@ echo "🔐 Building privileged helper..."
 # Screenshot regeneration is only needed for full public release builds or when
 # help/snapshot assets intentionally changed. Release-candidate builds should set
 # SKIP_SNAPSHOTS=1 to avoid spending time regenerating unrelated images.
-if [ "${SKIP_SNAPSHOTS:-0}" = "1" ]; then
+if [ "${SKIP_SNAPSHOTS:-}" = "1" ]; then
     echo "⏭️  Skipping screenshot regeneration (SKIP_SNAPSHOTS=1)"
-elif [ "${SKIP_NOTARIZE:-}" != "1" ]; then
+elif [ "${SKIP_SNAPSHOTS:-}" = "0" ] || [ "${SKIP_NOTARIZE:-}" != "1" ]; then
     echo "📸 Regenerating help screenshots..."
     SKIP_PEEKABOO="${SKIP_PEEKABOO:-1}" ./Scripts/regenerate-screenshots.sh
 else

--- a/Scripts/build-and-sign.sh
+++ b/Scripts/build-and-sign.sh
@@ -194,9 +194,12 @@ echo "🔐 Building privileged helper..."
 # Build and sign the helper tool
 ./Scripts/build-helper.sh
 
-# Screenshot regeneration + website publish only run for full release builds.
-# Skipped when SKIP_NOTARIZE=1 (dev builds via `dd`).
-if [ "${SKIP_NOTARIZE:-}" != "1" ]; then
+# Screenshot regeneration is only needed for full public release builds or when
+# help/snapshot assets intentionally changed. Release-candidate builds should set
+# SKIP_SNAPSHOTS=1 to avoid spending time regenerating unrelated images.
+if [ "${SKIP_SNAPSHOTS:-0}" = "1" ]; then
+    echo "⏭️  Skipping screenshot regeneration (SKIP_SNAPSHOTS=1)"
+elif [ "${SKIP_NOTARIZE:-}" != "1" ]; then
     echo "📸 Regenerating help screenshots..."
     SKIP_PEEKABOO="${SKIP_PEEKABOO:-1}" ./Scripts/regenerate-screenshots.sh
 else

--- a/Scripts/release-candidate.sh
+++ b/Scripts/release-candidate.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" >/dev/null && pwd)
+PROJECT_DIR="$SCRIPT_DIR/.."
+
+VERIFY=1
+
+usage() {
+    cat <<'EOF'
+Usage: Scripts/release-candidate.sh [options]
+
+Build a signed/notarized release-candidate app, deploy it to /Applications,
+and verify the installed runtime. This is the right path after a PR merge when
+you need a real Developer ID + notarized build for local manual testing.
+
+Defaults:
+  SKIP_SNAPSHOTS=1
+  SKIP_PEEKABOO=1
+  SKIP_SPARKLE=1
+  SKIP_WEBSITE=1
+
+Options:
+  --with-snapshots    Regenerate help/snapshot images.
+  --with-sparkle      Build Sparkle archive/appcast artifacts.
+  --with-website      Publish website help content when the release script allows it.
+  --with-peekaboo     Allow Peekaboo screenshot generation during snapshot regeneration.
+  --no-verify         Skip Scripts/verify-installed-app.sh after deploy.
+  -h, --help          Show this help.
+
+Environment:
+  CODESIGN_IDENTITY   Developer ID Application identity override.
+  NOTARY_PROFILE      notarytool keychain profile override.
+EOF
+}
+
+export SKIP_SNAPSHOTS="${SKIP_SNAPSHOTS:-1}"
+export SKIP_PEEKABOO="${SKIP_PEEKABOO:-1}"
+export SKIP_SPARKLE="${SKIP_SPARKLE:-1}"
+export SKIP_WEBSITE="${SKIP_WEBSITE:-1}"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --with-snapshots)
+            export SKIP_SNAPSHOTS=0
+            ;;
+        --with-sparkle)
+            export SKIP_SPARKLE=0
+            ;;
+        --with-website)
+            export SKIP_WEBSITE=0
+            ;;
+        --with-peekaboo)
+            export SKIP_PEEKABOO=0
+            ;;
+        --no-verify)
+            VERIFY=0
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+    shift
+done
+
+cd "$PROJECT_DIR"
+
+echo "🚢 Building release candidate"
+echo "   SKIP_SNAPSHOTS=$SKIP_SNAPSHOTS"
+echo "   SKIP_PEEKABOO=$SKIP_PEEKABOO"
+echo "   SKIP_SPARKLE=$SKIP_SPARKLE"
+echo "   SKIP_WEBSITE=$SKIP_WEBSITE"
+
+"$SCRIPT_DIR/build-and-sign.sh"
+
+if [[ "$VERIFY" == "1" ]]; then
+    "$SCRIPT_DIR/verify-installed-app.sh"
+else
+    echo "⏭️  Skipping installed-app verification (--no-verify)"
+fi

--- a/Scripts/verify-installed-app.sh
+++ b/Scripts/verify-installed-app.sh
@@ -8,6 +8,7 @@ TCP_PORT="${KEYPATH_TCP_PORT:-37001}"
 TCP_TIMEOUT_SECONDS="${KEYPATH_TCP_TIMEOUT_SECONDS:-20}"
 REQUIRE_NOTARIZED="${REQUIRE_NOTARIZED:-1}"
 REQUIRE_STAPLED="${REQUIRE_STAPLED:-1}"
+CHECK_RUNTIME="${CHECK_RUNTIME:-1}"
 KANATA_LAUNCHCTL_OUTPUT=$(mktemp -t keypath-kanata-launchctl.XXXXXX)
 TCP_PROBE_OUTPUT=$(mktemp -t keypath-tcp-probe.XXXXXX)
 
@@ -27,7 +28,7 @@ if [[ ! -d "$APP_PATH" ]]; then
 fi
 
 print_section "Trust Policy"
-codesign --verify --strict --deep --verbose=2 "$APP_PATH"
+codesign --verify --strict --verbose=2 "$APP_PATH"
 if [[ "$REQUIRE_NOTARIZED" == "1" ]]; then
     spctl -a -vvv -t install "$APP_PATH"
 else
@@ -38,6 +39,12 @@ if [[ "$REQUIRE_STAPLED" == "1" ]]; then
     xcrun stapler validate "$APP_PATH"
 else
     echo "⏭️  Skipping stapler validation (REQUIRE_STAPLED=0)"
+fi
+
+if [[ "$CHECK_RUNTIME" != "1" ]]; then
+    echo "⏭️  Skipping runtime checks (CHECK_RUNTIME=0)"
+    echo "✅ Installed KeyPath passed requested trust checks."
+    exit 0
 fi
 
 print_section "Processes"
@@ -53,14 +60,18 @@ if ! launchctl print "$KANATA_LABEL" >"$KANATA_LAUNCHCTL_OUTPUT" 2>&1; then
     echo "❌ Kanata launchd job is not registered/running: $KANATA_LABEL" >&2
     exit 1
 fi
+line_count=$(wc -l <"$KANATA_LAUNCHCTL_OUTPUT" | tr -d ' ')
 sed -n '1,140p' "$KANATA_LAUNCHCTL_OUTPUT"
+if (( line_count > 140 )); then
+    echo "  ... (${line_count} total lines, truncated at 140)"
+fi
 
 print_section "TCP Readiness"
 deadline=$((SECONDS + TCP_TIMEOUT_SECONDS))
 while true; do
     if nc -vz -w 1 "$TCP_HOST" "$TCP_PORT" >"$TCP_PROBE_OUTPUT" 2>&1; then
         cat "$TCP_PROBE_OUTPUT"
-        echo "✅ Installed KeyPath is signed, notarized, running, and TCP-ready."
+        echo "✅ Installed KeyPath passed requested trust checks and is TCP-ready."
         exit 0
     fi
 

--- a/Scripts/verify-installed-app.sh
+++ b/Scripts/verify-installed-app.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_PATH="${APP_PATH:-/Applications/KeyPath.app}"
+KANATA_LABEL="${KANATA_LABEL:-system/com.keypath.kanata}"
+TCP_HOST="${KEYPATH_TCP_HOST:-127.0.0.1}"
+TCP_PORT="${KEYPATH_TCP_PORT:-37001}"
+TCP_TIMEOUT_SECONDS="${KEYPATH_TCP_TIMEOUT_SECONDS:-20}"
+REQUIRE_NOTARIZED="${REQUIRE_NOTARIZED:-1}"
+REQUIRE_STAPLED="${REQUIRE_STAPLED:-1}"
+KANATA_LAUNCHCTL_OUTPUT=$(mktemp -t keypath-kanata-launchctl.XXXXXX)
+TCP_PROBE_OUTPUT=$(mktemp -t keypath-tcp-probe.XXXXXX)
+
+cleanup() {
+    rm -f "$KANATA_LAUNCHCTL_OUTPUT" "$TCP_PROBE_OUTPUT"
+}
+trap cleanup EXIT
+
+print_section() {
+    echo
+    echo "== $1 =="
+}
+
+if [[ ! -d "$APP_PATH" ]]; then
+    echo "❌ App not found: $APP_PATH" >&2
+    exit 1
+fi
+
+print_section "Trust Policy"
+codesign --verify --strict --deep --verbose=2 "$APP_PATH"
+if [[ "$REQUIRE_NOTARIZED" == "1" ]]; then
+    spctl -a -vvv -t install "$APP_PATH"
+else
+    echo "⏭️  Skipping Gatekeeper assessment (REQUIRE_NOTARIZED=0)"
+fi
+
+if [[ "$REQUIRE_STAPLED" == "1" ]]; then
+    xcrun stapler validate "$APP_PATH"
+else
+    echo "⏭️  Skipping stapler validation (REQUIRE_STAPLED=0)"
+fi
+
+print_section "Processes"
+if ! pgrep -x "KeyPath" >/dev/null; then
+    echo "❌ KeyPath process is not running" >&2
+    exit 1
+fi
+pgrep -fl 'KeyPath|KeyPathHelper|kanata|kanata-launcher' || true
+
+print_section "Kanata Launchd"
+if ! launchctl print "$KANATA_LABEL" >"$KANATA_LAUNCHCTL_OUTPUT" 2>&1; then
+    cat "$KANATA_LAUNCHCTL_OUTPUT" >&2
+    echo "❌ Kanata launchd job is not registered/running: $KANATA_LABEL" >&2
+    exit 1
+fi
+sed -n '1,140p' "$KANATA_LAUNCHCTL_OUTPUT"
+
+print_section "TCP Readiness"
+deadline=$((SECONDS + TCP_TIMEOUT_SECONDS))
+while true; do
+    if nc -vz -w 1 "$TCP_HOST" "$TCP_PORT" >"$TCP_PROBE_OUTPUT" 2>&1; then
+        cat "$TCP_PROBE_OUTPUT"
+        echo "✅ Installed KeyPath is signed, notarized, running, and TCP-ready."
+        exit 0
+    fi
+
+    if (( SECONDS >= deadline )); then
+        cat "$TCP_PROBE_OUTPUT" >&2 || true
+        echo "❌ TCP did not become ready at ${TCP_HOST}:${TCP_PORT}" >&2
+        exit 1
+    fi
+    sleep 1
+done


### PR DESCRIPTION
## Summary
- document the recommended inner-loop, release-candidate, ship, and installed-verification workflows in AGENTS.md and CLAUDE.md
- add Scripts/release-candidate.sh for signed/notarized local testing without screenshot, Sparkle, or website work by default
- add Scripts/verify-installed-app.sh to verify signature, Gatekeeper/stapler state, KeyPath process, launchd registration, and TCP readiness
- let build-and-sign skip screenshot regeneration explicitly via SKIP_SNAPSHOTS=1

## Why
The current release process is correct but too expensive for routine post-merge validation. This splits the process into a fast local development loop, a narrower release-candidate build for manual testing, and the full public shipping path. The same guidance now lives in both agent docs so Codex and Claude use the process consistently.

## Validation
- bash -n Scripts/build-and-sign.sh Scripts/release-candidate.sh Scripts/verify-installed-app.sh
- ./Scripts/release-candidate.sh --help
- ./Scripts/verify-installed-app.sh
- swift build
- pre-push swift build hook passed on push

## Notes
- The full notarized release-candidate build was not rerun in this PR because the wrapper delegates to the existing build-and-sign script and the live installed notarized app verification passed.
