### PR TITLE
[codex] Refine release process workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,7 +67,7 @@ Use opt-ins only when needed:
 Use the public release script only when producing public distribution artifacts:
 ```bash
 ./Scripts/release-doctor.sh --ship
-./Scripts/release.sh 1.0.0
+./Scripts/release.sh <version>
 ```
 
 This path may bump versions, regenerate screenshots, create Sparkle artifacts,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,17 +31,24 @@ Notes:
   restarts KeyPath only if it was running.
 - It intentionally does **not** redeploy the privileged helper unless
   `KEYPATH_DEPLOY_HELPER=1` is set. Avoid helper redeploys during UI work.
-- Use Poltergeist when you want continuous rebuild/deploy:
-  `poltergeist start`, edit, then `poltergeist wait keypath`.
+- Use Poltergeist only for focused single-agent Swift/UI iteration:
+  `poltergeist start`, edit, then `poltergeist wait keypath`. Stop it before
+  release work, helper/service work, broad tests, or parallel agents.
 
 ### 2. Release Candidate: signed local testing
 Use after a PR is merged when `/Applications/KeyPath.app` should match a real
 Developer ID/notarized build for manual testing:
 ```bash
+git fetch --prune origin
+git pull --ff-only origin master
 ./Scripts/release-candidate.sh
 ```
 
+Run this from the intended `master` worktree. If another worktree owns `master`,
+pull and deploy there instead of from the feature worktree.
+
 Defaults:
+- runs `./Scripts/release-doctor.sh --release-candidate` before the expensive build
 - skips screenshot regeneration (`SKIP_SNAPSHOTS=1`)
 - skips Peekaboo screenshot generation (`SKIP_PEEKABOO=1`)
 - skips Sparkle archive/appcast generation (`SKIP_SPARKLE=1`)
@@ -57,14 +64,17 @@ Use opt-ins only when needed:
 ```
 
 ### 3. Ship: public release artifacts
-Use the full script only when producing public distribution artifacts:
+Use the public release script only when producing public distribution artifacts:
 ```bash
-./Scripts/build-and-sign.sh
+./Scripts/release-doctor.sh --ship
+./Scripts/release.sh 1.0.0
 ```
 
-This path may regenerate screenshots, create Sparkle artifacts, notarize, staple,
-deploy, and publish website help content depending on environment flags. It is
-intentionally slower than the release-candidate path.
+This path may bump versions, regenerate screenshots, create Sparkle artifacts,
+notarize, staple, deploy, tag, create a GitHub release, and publish website help
+content depending on environment flags. It is intentionally slower than the
+release-candidate path. `Scripts/build-and-sign.sh` is the lower-level artifact
+builder used by the release scripts.
 
 ### 4. Installed app verification
 After any signed/notarized deploy, or when diagnosing a local install:
@@ -151,7 +161,7 @@ Watches source files, auto-builds, deploys to /Applications, and restarts. Insta
 | `poltergeist stop` | Stop watching |
 | `poltergeist wait keypath` | Block until build completes |
 
-**Workflow tip:** Run `poltergeist start` at session start. After any Swift file edit, the app automatically runs `./Scripts/quick-deploy.sh`, deploys to /Applications, and restarts. No manual steps needed.
+**Workflow tip:** Use `poltergeist start` only during focused single-agent app/UI iteration. After any watched Swift file edit, it runs `./Scripts/quick-deploy.sh`, deploys to `/Applications`, and restarts. Stop it before release builds, helper/service work, broad tests, or parallel agents.
 
 ### Peekaboo (UI Automation)
 macOS screenshots and GUI automation. Install: `brew install steipete/tap/peekaboo`
@@ -178,7 +188,7 @@ open "keypath://fakekey/nav-mode/tap" # Trigger virtual key
 ### Composing Tools
 ```bash
 # Example: AI-driven development workflow
-poltergeist start                    # Ensure auto-rebuild is running
+poltergeist start                    # Optional for focused single-agent UI iteration
 # ... make code changes ...
 poltergeist wait keypath             # Wait for build to complete
 peekaboo see "Is the KeyPath app running?" # Check UI state
@@ -187,11 +197,12 @@ peekaboo type "Hello world"          # Type into focused app
 peekaboo hotkey "cmd+s"              # Save
 ```
 
-**Recommended agent workflow:**
-1. `poltergeist start` at session start (runs `./Scripts/quick-deploy.sh` for incremental builds)
-2. Make code edits
-3. `poltergeist wait keypath` before testing
-4. Use Peekaboo for UI verification
-5. Use KeyPath URL scheme for keyboard actions
+**Recommended agent workflow when Poltergeist is useful:**
+1. Confirm no other agents/worktrees are doing builds.
+2. `poltergeist start` for focused Swift/UI iteration.
+3. Make code edits.
+4. `poltergeist wait keypath` before testing.
+5. Use Peekaboo for UI verification.
+6. `poltergeist stop` before release work, helper/service work, broad tests, or handing off.
 
 See `docs/LLM_VISION_UI_AUTOMATION.md` for detailed architecture.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,7 @@ Two doc systems: `guides/` (user-facing, published to gh-pages) and `docs/` (dev
 ```bash
 ./build.sh                        # Canonical build (SKIP_NOTARIZE=1 for local dev)
 ./Scripts/quick-deploy.sh         # Fast debug deploy
+./Scripts/release-doctor.sh       # Read-only release preflight
 ./Scripts/release-candidate.sh    # Signed/notarized post-merge testing
 swift test                        # All tests (~532 tests, <5s)
 swiftformat Sources Tests         # Uses pinned rules + swiftversion from .swiftformat
@@ -90,22 +91,28 @@ swiftlint --fix --quiet
 Use the narrowest workflow that matches the task:
 
 **Inner loop:** For normal Swift/UI iteration, prefer `swift build` and
-`./Scripts/quick-deploy.sh`. Use Poltergeist for continuous rebuild/deploy:
-`poltergeist start`, edit, then `poltergeist wait keypath`. `quick-deploy.sh`
-updates `/Applications/KeyPath.app`, re-signs locally, and restarts KeyPath only
-if it was already running. It does not redeploy the privileged helper unless
-`KEYPATH_DEPLOY_HELPER=1` is set.
+`./Scripts/quick-deploy.sh`. Use Poltergeist only for focused single-agent
+Swift/UI iteration: `poltergeist start`, edit, then `poltergeist wait keypath`.
+`quick-deploy.sh` updates `/Applications/KeyPath.app`, re-signs locally, and
+restarts KeyPath only if it was already running. It does not redeploy the
+privileged helper unless `KEYPATH_DEPLOY_HELPER=1` is set.
 
 **Release candidate:** After a PR is merged and manual testing needs a real
 Developer ID/notarized app in `/Applications`, run:
 
 ```bash
+git fetch --prune origin
+git pull --ff-only origin master
 ./Scripts/release-candidate.sh
 ```
 
-This defaults to `SKIP_SNAPSHOTS=1`, `SKIP_PEEKABOO=1`, `SKIP_SPARKLE=1`, and
-`SKIP_WEBSITE=1`, then runs installed-app verification. Opt into slower release
-work only when needed:
+Run this from the intended `master` worktree. If another worktree owns `master`,
+pull and deploy there instead of from the feature worktree.
+
+This runs `./Scripts/release-doctor.sh --release-candidate`, defaults to
+`SKIP_SNAPSHOTS=1`, `SKIP_PEEKABOO=1`, `SKIP_SPARKLE=1`, and `SKIP_WEBSITE=1`,
+then runs installed-app verification. Opt into slower release work only when
+needed:
 
 ```bash
 ./Scripts/release-candidate.sh --with-snapshots
@@ -113,15 +120,18 @@ work only when needed:
 ./Scripts/release-candidate.sh --with-website
 ```
 
-**Public ship:** Use the full release script only when producing public
+**Public ship:** Use the public release script only when producing public
 distribution artifacts:
 
 ```bash
-./Scripts/build-and-sign.sh
+./Scripts/release-doctor.sh --ship
+./Scripts/release.sh 1.0.0
 ```
 
-That path may regenerate screenshots, create Sparkle artifacts, notarize,
-staple, deploy, and publish website help content depending on environment flags.
+That path may bump versions, regenerate screenshots, create Sparkle artifacts,
+notarize, staple, deploy, tag, create a GitHub release, and publish website help
+content depending on environment flags. `Scripts/build-and-sign.sh` is the
+lower-level artifact builder used by the release scripts.
 
 **Installed verification:** After signed/notarized deploys, or when diagnosing a
 local install, run:
@@ -152,13 +162,13 @@ an unpinned version.
 
 **"dd"** → Run `SKIP_NOTARIZE=1 ./build.sh`, respond **"Eye eye Captain!"**
 **"df"** → Run `./Scripts/quick-deploy.sh`, respond **"Eye eye Cap, fast deploying!"**
-**"ds"** → Full ship workflow for the current changes, end to end: branch off master → format/lint + commit → review gate → push + open PR → babysit CI → address feedback → merge → pull master → rebuild/deploy from master. Follow [`docs/agent-pr-workflow.md`](docs/agent-pr-workflow.md) and its invariants; risk-tier the babysit (auto-merge mechanical PRs, full babysit for logic/hot-path).
+**"ds"** → Development ship workflow for the current changes, end to end: branch off master → format/lint + commit → review gate → push + open PR → babysit CI → address feedback → merge → pull master → `./Scripts/release-candidate.sh` from master for signed/notarized manual testing. Follow [`docs/agent-pr-workflow.md`](docs/agent-pr-workflow.md) and its invariants; risk-tier the babysit (auto-merge mechanical PRs, full babysit for logic/hot-path). Public distribution is a separate explicit release: `./Scripts/release-doctor.sh --ship && ./Scripts/release.sh <version>`.
 
 Test targets: `Tests/KeyPathTests/` (target: `KeyPathTests`). Files in `Tests/KeyPathAppKitTests/` are NOT compiled. Snapshot tests in `Tests/KeyPathSnapshotTests/`.
 
 ## Poltergeist (Auto-Deploy)
 
-`poltergeist start` / `poltergeist stop`. **Stop before running parallel agents** — file change watchers cause SwiftPM lock contention.
+`poltergeist start` / `poltergeist stop`. Use it only for focused single-agent Swift/UI iteration. **Stop before running parallel agents, broad tests, helper/service work, or release builds** — file change watchers cause SwiftPM lock contention and surprise app restarts.
 
 ## Linear
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,7 +125,7 @@ distribution artifacts:
 
 ```bash
 ./Scripts/release-doctor.sh --ship
-./Scripts/release.sh 1.0.0
+./Scripts/release.sh <version>
 ```
 
 That path may bump versions, regenerate screenshots, create Sparkle artifacts,

--- a/Scripts/README.md
+++ b/Scripts/README.md
@@ -2,15 +2,21 @@
 
 ## Supported commands (recommended)
 - `./Scripts/quick-deploy.sh` — Incremental local dev (fast, deploys to /Applications; run `./build.sh` once first).
+- `./Scripts/release-doctor.sh` — Read-only preflight for signed/notarized release-candidate or public ship builds.
+- `./Scripts/release-candidate.sh` — Signed/notarized post-merge manual-testing build; skips snapshots, Sparkle, and website publishing by default.
 - `./build.sh` — Canonical build & sign entry (root). Use `SKIP_CODESIGN=1` to bypass signing for local dev.
   - Release builds now fail if Sparkle EdDSA signing cannot be produced for the update archive.
   - For local-only testing, set `ALLOW_UNSIGNED_SPARKLE=1` to continue without an EdDSA signature.
+- `./Scripts/release.sh <version>` — Public distribution release flow. Run `./Scripts/release-doctor.sh --ship` first.
 - `./test.sh` — Run the full test suite (root)
 - `./Scripts/run-installer-reliability-matrix.sh` — Automated installer reliability matrix + diagnostic artifact bundle (`test-results/installer-reliability/latest`).
 - `./Scripts/repro-duplicate-keys.sh` — CPU-load repro harness for duplicate keypress detection (filters navigation keys by default). Supports `--auto-type osascript` or `--auto-type peekaboo` for deterministic automated keystroke generation, and continuously samples Kanata process metrics (CPU%, memory, threads, priority).
 
 ## Scripts in this directory
 - `build-and-sign.sh` - The implementation of the build process
+- `release-doctor.sh` - Read-only preflight for signing, notarization, Sparkle, website, watcher, and runtime state.
+- `release-candidate.sh` - Post-merge signed/notarized local build wrapper with fast defaults.
+- `release.sh` - Public release wrapper for versioned distribution artifacts.
 - `run-tests-safe.sh` - The safe test runner implementation
 - `run-installer-reliability-matrix.sh` - Runs installer scenario lanes and writes `matrix-summary.md` + `matrix-results.json`
 - `uninstall.sh` - Uninstaller script

--- a/Scripts/release-candidate.sh
+++ b/Scripts/release-candidate.sh
@@ -5,6 +5,7 @@ SCRIPT_DIR=$(cd "$(dirname "$0")" >/dev/null && pwd)
 PROJECT_DIR="$SCRIPT_DIR/.."
 
 VERIFY=1
+DOCTOR=1
 
 usage() {
     cat <<'EOF'
@@ -15,6 +16,7 @@ and verify the installed runtime. This is the right path after a PR merge when
 you need a real Developer ID + notarized build for local manual testing.
 
 Defaults:
+  release-doctor preflight
   SKIP_SNAPSHOTS=1
   SKIP_PEEKABOO=1
   SKIP_SPARKLE=1
@@ -25,6 +27,7 @@ Options:
   --with-sparkle      Build Sparkle archive/appcast artifacts.
   --with-website      Publish website help content when the release script allows it.
   --with-peekaboo     Allow Peekaboo screenshot generation during snapshot regeneration.
+  --no-doctor         Skip Scripts/release-doctor.sh preflight.
   --no-verify         Skip Scripts/verify-installed-app.sh after deploy.
   -h, --help          Show this help.
 
@@ -53,6 +56,9 @@ while [[ $# -gt 0 ]]; do
         --with-peekaboo)
             export SKIP_PEEKABOO=0
             ;;
+        --no-doctor)
+            DOCTOR=0
+            ;;
         --no-verify)
             VERIFY=0
             ;;
@@ -76,6 +82,12 @@ echo "   SKIP_SNAPSHOTS=$SKIP_SNAPSHOTS"
 echo "   SKIP_PEEKABOO=$SKIP_PEEKABOO"
 echo "   SKIP_SPARKLE=$SKIP_SPARKLE"
 echo "   SKIP_WEBSITE=$SKIP_WEBSITE"
+
+if [[ "$DOCTOR" == "1" && "${SKIP_RELEASE_DOCTOR:-0}" != "1" ]]; then
+    "$SCRIPT_DIR/release-doctor.sh" --release-candidate
+else
+    echo "⏭️  Skipping release preflight (--no-doctor or SKIP_RELEASE_DOCTOR=1)"
+fi
 
 "$SCRIPT_DIR/build-and-sign.sh"
 

--- a/Scripts/release-doctor.sh
+++ b/Scripts/release-doctor.sh
@@ -148,6 +148,19 @@ else
 fi
 check_command nc
 
+print_section "Disk Space"
+available_kb=$(df -Pk "$PROJECT_DIR" 2>/dev/null | awk 'NR==2 {print $4}')
+if [[ -n "$available_kb" ]]; then
+    available_gb=$((available_kb / 1024 / 1024))
+    if (( available_gb < 5 )); then
+        warn "Low disk space: ${available_gb}GB available on project volume; SwiftPM builds and notarization artifacts can be large"
+    else
+        pass "Project volume has ${available_gb}GB available"
+    fi
+else
+    warn "Could not determine available disk space for $PROJECT_DIR"
+fi
+
 print_section "Git State"
 branch=$(git branch --show-current || true)
 if [[ -n "$branch" ]]; then
@@ -168,7 +181,7 @@ fi
 
 if git worktree list --porcelain | grep -q '^branch refs/heads/master$'; then
     master_worktree=$(git worktree list --porcelain | awk '
-        /^worktree / { path=$2 }
+        /^worktree / { path=substr($0, 10) }
         /^branch refs\/heads\/master$/ { print path; exit }
     ')
     if [[ "$master_worktree" != "$PROJECT_DIR" ]]; then
@@ -262,7 +275,7 @@ else
     warn "Kanata launchd job is not registered"
 fi
 
-if nc -vz -w 1 127.0.0.1 37001 >/dev/null 2>&1; then
+if nc -z -w 1 127.0.0.1 37001 >/dev/null 2>&1; then
     pass "Kanata TCP endpoint is responding on 127.0.0.1:37001"
 else
     warn "Kanata TCP endpoint is not responding on 127.0.0.1:37001"

--- a/Scripts/release-doctor.sh
+++ b/Scripts/release-doctor.sh
@@ -1,0 +1,290 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" >/dev/null && pwd)
+PROJECT_DIR=$(cd "$SCRIPT_DIR/.." >/dev/null && pwd)
+
+MODE="release-candidate"
+STRICT=0
+
+usage() {
+    cat <<'EOF'
+Usage: Scripts/release-doctor.sh [--release-candidate|--ship] [--strict]
+
+Preflight the local machine and repository before a signed/notarized KeyPath
+build. This script is read-only: it does not build, sign, notarize, publish,
+restart services, or modify git state.
+
+Modes:
+  --release-candidate  Check the default post-merge manual-test path.
+  --ship               Also check Sparkle and website publishing prerequisites.
+
+Options:
+  --strict             Treat warnings as failures.
+  -h, --help           Show this help.
+
+Environment checked:
+  CODESIGN_IDENTITY    Developer ID Application identity override.
+  NOTARY_PROFILE       notarytool keychain profile override.
+  KP_NOTARY_KEYCHAIN   Optional notarytool keychain override.
+  SKIP_SPARKLE         If 1, skip Sparkle checks.
+  SKIP_WEBSITE         If 1, skip gh-pages website checks.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --release-candidate)
+            MODE="release-candidate"
+            ;;
+        --ship)
+            MODE="ship"
+            ;;
+        --strict)
+            STRICT=1
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+    shift
+done
+
+failures=0
+warnings=0
+
+print_section() {
+    echo
+    echo "== $1 =="
+}
+
+pass() {
+    echo "✅ $1"
+}
+
+warn() {
+    warnings=$((warnings + 1))
+    echo "⚠️  $1"
+}
+
+fail() {
+    failures=$((failures + 1))
+    echo "❌ $1"
+}
+
+check_command() {
+    local command_name=$1
+    if command -v "$command_name" >/dev/null 2>&1; then
+        pass "$command_name available ($(command -v "$command_name"))"
+    else
+        fail "$command_name is missing"
+    fi
+}
+
+check_optional_command() {
+    local command_name=$1
+    if command -v "$command_name" >/dev/null 2>&1; then
+        pass "$command_name available ($(command -v "$command_name"))"
+    else
+        warn "$command_name is missing"
+    fi
+}
+
+notarytool() {
+    xcrun notarytool "$@"
+}
+
+resolve_sign_update() {
+    if [[ -n "${KP_SPARKLE_SIGN_CMD:-}" && -x "${KP_SPARKLE_SIGN_CMD:-}" ]]; then
+        echo "$KP_SPARKLE_SIGN_CMD"
+        return 0
+    fi
+
+    if command -v sign_update >/dev/null 2>&1; then
+        command -v sign_update
+        return 0
+    fi
+
+    local cask_version=""
+    cask_version="$(brew list --cask --versions sparkle 2>/dev/null | awk '{print $2}')" || cask_version=""
+    local cask_root candidate
+    for cask_root in /opt/homebrew/Caskroom/sparkle /usr/local/Caskroom/sparkle; do
+        if [[ -n "$cask_version" && -x "$cask_root/$cask_version/bin/sign_update" ]]; then
+            echo "$cask_root/$cask_version/bin/sign_update"
+            return 0
+        fi
+        candidate="$(ls -1dt "$cask_root"/*/bin/sign_update 2>/dev/null | head -n1 || true)"
+        if [[ -n "$candidate" && -x "$candidate" ]]; then
+            echo "$candidate"
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+cd "$PROJECT_DIR"
+
+print_section "Release Doctor"
+echo "Mode: $MODE"
+
+print_section "Required Tools"
+check_command swift
+check_command xcrun
+check_command codesign
+check_command security
+check_command ditto
+check_command git
+if [[ "$MODE" == "ship" ]]; then
+    check_command gh
+else
+    check_optional_command gh
+fi
+check_command nc
+
+print_section "Git State"
+branch=$(git branch --show-current || true)
+if [[ -n "$branch" ]]; then
+    pass "Current branch: $branch"
+else
+    warn "Detached HEAD"
+fi
+
+if git diff --quiet && git diff --cached --quiet; then
+    pass "Working tree has no tracked changes"
+else
+    warn "Working tree has tracked changes; release builds should normally run from clean master"
+fi
+
+if [[ -n "$(git status --porcelain --untracked-files=normal)" ]]; then
+    warn "Working tree has untracked files"
+fi
+
+if git worktree list --porcelain | grep -q '^branch refs/heads/master$'; then
+    master_worktree=$(git worktree list --porcelain | awk '
+        /^worktree / { path=$2 }
+        /^branch refs\/heads\/master$/ { print path; exit }
+    ')
+    if [[ "$master_worktree" != "$PROJECT_DIR" ]]; then
+        warn "master is checked out in another worktree: $master_worktree"
+        echo "   Merge PRs through GitHub or from outside this repo, then fetch/prune before deploying."
+    else
+        pass "This worktree owns master"
+    fi
+else
+    warn "No local worktree currently owns master"
+fi
+
+print_section "Signing and Notarization"
+signing_identity="${CODESIGN_IDENTITY:-Developer ID Application: Micah Alpern (X2RKZ5TG99)}"
+notary_profile="${NOTARY_PROFILE:-KeyPath-Profile}"
+
+if security find-identity -v -p codesigning 2>/dev/null | grep -F "$signing_identity" >/dev/null; then
+    pass "Codesign identity found: $signing_identity"
+else
+    fail "Codesign identity not found: $signing_identity"
+    echo "   Set CODESIGN_IDENTITY or install the Developer ID Application certificate."
+fi
+
+notary_args=(history --keychain-profile "$notary_profile" --output-format json)
+if [[ -n "${KP_NOTARY_KEYCHAIN:-}" ]]; then
+    notary_args+=(--keychain "$KP_NOTARY_KEYCHAIN")
+fi
+
+if notarytool "${notary_args[@]}" >/dev/null 2>&1; then
+    pass "notarytool profile validated: $notary_profile"
+else
+    fail "notarytool profile failed validation: $notary_profile"
+    echo "   Set NOTARY_PROFILE or run: xcrun notarytool store-credentials"
+fi
+
+print_section "Release Artifacts"
+effective_skip_sparkle="${SKIP_SPARKLE:-}"
+effective_skip_website="${SKIP_WEBSITE:-}"
+if [[ "$MODE" == "release-candidate" ]]; then
+    effective_skip_sparkle="${SKIP_SPARKLE:-1}"
+    effective_skip_website="${SKIP_WEBSITE:-1}"
+fi
+
+if [[ "$effective_skip_sparkle" == "1" ]]; then
+    pass "Sparkle archive checks skipped (SKIP_SPARKLE=1)"
+else
+    if sign_update_path=$(resolve_sign_update); then
+        pass "Sparkle sign_update found: $sign_update_path"
+    elif [[ "${ALLOW_UNSIGNED_SPARKLE:-0}" == "1" ]]; then
+        warn "Sparkle sign_update missing, but ALLOW_UNSIGNED_SPARKLE=1"
+    else
+        fail "Sparkle sign_update not found; public Sparkle archive signing would fail"
+    fi
+
+    if command -v create-dmg >/dev/null 2>&1; then
+        pass "create-dmg available"
+    else
+        warn "create-dmg missing; build-and-sign.sh will create a plain fallback DMG"
+    fi
+fi
+
+if [[ "$effective_skip_website" == "1" ]]; then
+    pass "Website publish checks skipped (SKIP_WEBSITE=1)"
+else
+    ghpages_dir="$PROJECT_DIR/.worktrees/gh-pages"
+    if [[ -d "$ghpages_dir/.git" || -f "$ghpages_dir/.git" ]]; then
+        pass "gh-pages worktree found: $ghpages_dir"
+        if git -C "$ghpages_dir" diff --quiet && git -C "$ghpages_dir" diff --cached --quiet; then
+            pass "gh-pages worktree has no tracked changes"
+        else
+            fail "gh-pages worktree has uncommitted tracked changes"
+        fi
+        if [[ -n "$(git -C "$ghpages_dir" status --porcelain --untracked-files=normal)" ]]; then
+            warn "gh-pages worktree has untracked files"
+        fi
+    else
+        fail "gh-pages worktree missing at $ghpages_dir"
+    fi
+fi
+
+print_section "Installed Runtime"
+if pgrep -x KeyPath >/dev/null; then
+    pass "KeyPath is currently running"
+else
+    warn "KeyPath is not currently running"
+fi
+
+if launchctl print system/com.keypath.kanata >/dev/null 2>&1; then
+    pass "Kanata launchd job is registered"
+else
+    warn "Kanata launchd job is not registered"
+fi
+
+if nc -vz -w 1 127.0.0.1 37001 >/dev/null 2>&1; then
+    pass "Kanata TCP endpoint is responding on 127.0.0.1:37001"
+else
+    warn "Kanata TCP endpoint is not responding on 127.0.0.1:37001"
+fi
+
+print_section "Background Watchers"
+if pgrep -fl 'poltergeist' >/dev/null 2>&1; then
+    warn "Poltergeist is running; stop it before release builds to avoid SwiftPM lock contention"
+    pgrep -fl 'poltergeist' || true
+else
+    pass "Poltergeist is not running"
+fi
+
+print_section "Summary"
+if (( failures > 0 )); then
+    echo "❌ release-doctor found $failures failure(s) and $warnings warning(s)."
+    exit 1
+fi
+
+if (( STRICT == 1 && warnings > 0 )); then
+    echo "❌ release-doctor found $warnings warning(s) in --strict mode."
+    exit 1
+fi
+
+echo "✅ release-doctor passed with $warnings warning(s)."

--- a/docs/agent-pr-invariants.md
+++ b/docs/agent-pr-invariants.md
@@ -49,7 +49,7 @@ All of these must be true before the agent reports "done." If any fails, fix it 
 ```
 PR state == MERGED
 local master SHA == origin/master SHA
-running app built from master (not worktree)
+running app built from master (not worktree; release-candidate build unless explicitly dev-only)
 linked issues state == CLOSED
 no worktrees left for this branch
 ```

--- a/docs/agent-pr-workflow.md
+++ b/docs/agent-pr-workflow.md
@@ -44,7 +44,7 @@ Most PR clock-time is latency, not rigor. Cut the latency without dropping any g
 ## Phase 5: Merge
 
 16. **Ask the user for permission to merge** — never merge without explicit approval.
-17. **Merge** — `gh pr merge <number> --merge --delete-branch` unless the PR explicitly needs another merge mode. If multiple worktrees are active, prefer `gh pr merge <number> --repo malpern/KeyPath --merge --delete-branch` from outside the repo so `gh` does not try to switch a local worktree to `master`. If a local worktree error appears, verify GitHub state before retrying; the PR may already be merged.
+17. **Merge** — `gh pr merge <number> --merge --delete-branch` unless the PR explicitly needs another merge mode. This matches the repo's recent merge-commit history and preserves individual commits when a PR intentionally has more than one. If multiple worktrees are active, prefer `gh pr merge <number> --repo malpern/KeyPath --merge --delete-branch` from outside the repo so `gh` does not try to switch a local worktree to `master`. If a local worktree error appears, verify GitHub state before retrying; the PR may already be merged.
 18. **Verify the merge** — `gh pr view <number> --json state` should show `"state": "MERGED"`.
 19. **Verify issues closed** — for each `Fixes #NNN` reference, confirm the issue is now closed: `gh issue view <number> --json state`.
 

--- a/docs/agent-pr-workflow.md
+++ b/docs/agent-pr-workflow.md
@@ -44,7 +44,7 @@ Most PR clock-time is latency, not rigor. Cut the latency without dropping any g
 ## Phase 5: Merge
 
 16. **Ask the user for permission to merge** — never merge without explicit approval.
-17. **Merge** — `gh pr merge <number> --squash --delete-branch`. If git complains about the local branch being in use (worktree), that's fine — the merge happens on GitHub. The error about local branch deletion is cosmetic.
+17. **Merge** — `gh pr merge <number> --merge --delete-branch` unless the PR explicitly needs another merge mode. If multiple worktrees are active, prefer `gh pr merge <number> --repo malpern/KeyPath --merge --delete-branch` from outside the repo so `gh` does not try to switch a local worktree to `master`. If a local worktree error appears, verify GitHub state before retrying; the PR may already be merged.
 18. **Verify the merge** — `gh pr view <number> --json state` should show `"state": "MERGED"`.
 19. **Verify issues closed** — for each `Fixes #NNN` reference, confirm the issue is now closed: `gh issue view <number> --json state`.
 
@@ -58,8 +58,8 @@ If the PR added or changed files in `guides/`:
 ## Phase 6: Cleanup
 
 20. **Exit the worktree** — `ExitWorktree` with `action: "remove"` and `discard_changes: true` (safe because all work is merged). This deletes the worktree directory and branch.
-21. **Pull master** — `git pull` from the main repo directory. Verify it fast-forwards to include your merged PR. If it doesn't fast-forward, something went wrong — investigate before proceeding.
-22. **Deploy from master** — run `SKIP_NOTARIZE=1 ./build.sh` (or `dd`) so the running app matches the merged code. This is critical — without this step, the user is running stale code and thinks the work is lost.
+21. **Pull master** — `git fetch --prune origin && git pull --ff-only origin master` from the intended master worktree. Verify it fast-forwards to include your merged PR. If another worktree owns `master`, do the pull and deploy from that worktree.
+22. **Deploy from master** — run `./Scripts/release-candidate.sh` so the running app matches merged master with a signed/notarized local build. For fast dev-only handoffs where notarization is explicitly unnecessary, use `./Scripts/quick-deploy.sh` and say that you did not produce a notarized build.
 23. **Confirm to the user** — state explicitly: PR merged, issues closed, master pulled, deployed, worktree cleaned up.
 
 ## What Can Go Wrong
@@ -67,6 +67,7 @@ If the PR added or changed files in `guides/`:
 | Symptom | Cause | Prevention |
 |---------|-------|------------|
 | Work "disappears" after merge | Merged to GitHub but never pulled to local master, or deployed from worktree not master | Always do Phase 6 steps 21-22 |
+| `gh pr merge` reports a local worktree error | The PR merged on GitHub, then `gh` tried to switch/delete a branch owned by another worktree | Verify `gh pr view <number> --json state,mergeCommit`, fetch/prune, then pull/deploy from the master worktree |
 | Issues stay open after merge | PR body didn't include `Fixes #NNN` keywords | Step 9: link issues before creating the PR |
 | PR shows conflicts after merge | Another PR merged first, moving master ahead | Resolve conflicts before merging (step 13) |
 | CI passes but app is broken | Tests don't cover the feature; only tested in worktree | Deploy from master (step 22) and have user verify |

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -105,7 +105,7 @@ Public releases are intentionally slower and should be explicit:
 
 ```bash
 ./Scripts/release-doctor.sh --ship
-./Scripts/release.sh 1.0.0
+./Scripts/release.sh <version>
 ```
 
 Use `--dry-run` before an unfamiliar release:

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -1,44 +1,186 @@
 # Release Process
 
-To publish a new release, run:
+Use the narrowest workflow that matches the job. Most post-merge testing should
+not run the full public distribution path.
+
+## Local Development
+
+For normal Swift/UI iteration:
 
 ```bash
-./Scripts/release.sh 1.0.0-beta4    # Specify the new version
-./Scripts/release.sh --dry-run 1.0.0-beta4  # Preview without doing anything
+swift build
+./Scripts/quick-deploy.sh
 ```
 
-**The script automates:**
-1. Version bump in Info.plist (CFBundleVersion + CFBundleShortVersionString)
-2. Full build, code sign, **notarize**, and Sparkle EdDSA signing
-3. Styled DMG creation (branded background, drag-to-Applications)
-4. Git tag creation
-5. GitHub Release with zip + DMG attached
-6. Appcast.xml update (Sparkle auto-update feed)
-7. gh-pages download link update (marketing site always points to latest DMG)
-8. Homebrew cask update (`malpern/tap/keypath` — version + SHA256)
+`quick-deploy.sh` deploys to `/Applications/KeyPath.app`, re-signs locally, and
+restarts KeyPath only if it was already running. It does not redeploy the
+privileged helper unless `KEYPATH_DEPLOY_HELPER=1` is set.
 
-**⚠️ Releases MUST be notarized.** Never use `SKIP_NOTARIZE=1` or `--skip-notarize` for release builds. Unnotarized apps trigger macOS Gatekeeper warnings that erode user trust. `SKIP_NOTARIZE` is only for local dev iteration (`dd`/`df` shortcuts).
+Poltergeist is optional acceleration for focused single-agent UI/app iteration:
 
-**After the script finishes, you must:**
-1. Write release notes on the GitHub Release page
-2. `git push` to push the appcast commit on master
-
-**Sparkle auto-update:** Existing users get notified within 24 hours. The appcast is served from `raw.githubusercontent.com/malpern/KeyPath/master/appcast.xml`. All releases currently omit `sparkle:channel` so all users see them (no stable/beta split yet).
-
-**Inline release notes & dark mode:** The generated appcast entry links to the GitHub release page (`<sparkle:releaseNotesLink>`), which handles dark mode on its own. If you instead hand-author rich inline notes in a `<description><![CDATA[…]]></description>` block, you **must** include dark-mode CSS — Sparkle's WebView follows the system appearance, and hardcoded light colors render as unreadable grey-on-black. Always add:
-
-```css
-:root { color-scheme: light dark; }
-@media (prefers-color-scheme: dark) {
-    body { color: #e8e8e8; }
-    .muted { color: #a0a0a0; }
-    .tag { background: #3a3a3a; color: #e8e8e8; }
-    a { color: #F59E0B; }
-}
+```bash
+poltergeist start
+# edit Swift files
+poltergeist wait keypath
+poltergeist stop
 ```
 
-(Mirror this for any other elements with hardcoded `color`/`background`.) See the v1.0.0-beta3 entry in `appcast.xml` for a complete example.
+Do not leave Poltergeist running during parallel agent work, broad tests,
+helper/service lifecycle work, or release builds. It can contend on SwiftPM locks
+and restart the app unexpectedly.
 
-**Marketing site:** The download button on keypath-app.com links to the DMG. The release script updates this automatically via a gh-pages worktree commit. Never hardcode a version-specific download URL in index.md manually.
+## Release Candidate For Manual Testing
 
-**Homebrew cask:** Users can install via `brew install --cask malpern/tap/keypath`. The cask lives in `github.com/malpern/homebrew-tap/Casks/keypath.rb`. The release script updates the version and SHA256 automatically.
+After a PR is merged and `/Applications/KeyPath.app` should match a real
+Developer ID/notarized build:
+
+```bash
+./Scripts/release-candidate.sh
+```
+
+The release-candidate wrapper first runs:
+
+```bash
+./Scripts/release-doctor.sh --release-candidate
+```
+
+Then it delegates to `build-and-sign.sh` with fast release-candidate defaults:
+
+- `SKIP_SNAPSHOTS=1`
+- `SKIP_PEEKABOO=1`
+- `SKIP_SPARKLE=1`
+- `SKIP_WEBSITE=1`
+
+It deploys to `/Applications/KeyPath.app` and runs
+`./Scripts/verify-installed-app.sh` after the build.
+
+Opt into slower work only when needed:
+
+```bash
+./Scripts/release-candidate.sh --with-snapshots
+./Scripts/release-candidate.sh --with-sparkle
+./Scripts/release-candidate.sh --with-website
+```
+
+Escape hatches for debugging the release scripts:
+
+```bash
+./Scripts/release-candidate.sh --no-doctor
+./Scripts/release-candidate.sh --no-verify
+SKIP_RELEASE_DOCTOR=1 ./Scripts/release-candidate.sh
+```
+
+## Installed App Verification
+
+After signed/notarized deploys:
+
+```bash
+./Scripts/verify-installed-app.sh
+```
+
+This checks:
+
+- code signature
+- Gatekeeper assessment
+- stapled notarization ticket
+- KeyPath process
+- `system/com.keypath.kanata` launchd job
+- TCP readiness on `127.0.0.1:37001`
+
+For non-notarized debug builds:
+
+```bash
+REQUIRE_NOTARIZED=0 REQUIRE_STAPLED=0 ./Scripts/verify-installed-app.sh
+```
+
+For trust-only diagnostics where KeyPath is not running yet:
+
+```bash
+CHECK_RUNTIME=0 ./Scripts/verify-installed-app.sh
+```
+
+## Public Distribution Release
+
+Public releases are intentionally slower and should be explicit:
+
+```bash
+./Scripts/release-doctor.sh --ship
+./Scripts/release.sh 1.0.0
+```
+
+Use `--dry-run` before an unfamiliar release:
+
+```bash
+./Scripts/release.sh --dry-run 1.0.0
+```
+
+The public release path may:
+
+1. bump `CFBundleVersion` and `CFBundleShortVersionString`
+2. build, sign, notarize, and staple the app
+3. regenerate screenshots when not skipped
+4. create Sparkle zip/appcast artifacts and a DMG
+5. create a git tag and GitHub release
+6. publish help content to the `gh-pages` worktree
+7. update appcast/Homebrew release assets when the release script handles them
+
+`Scripts/build-and-sign.sh` is the lower-level artifact builder used by the
+release scripts. Prefer `release-candidate.sh` for post-merge manual testing and
+`release.sh` for public distribution.
+
+Releases must be notarized. Do not use `SKIP_NOTARIZE=1` or `--skip-notarize` for
+public distribution; unnotarized apps trigger Gatekeeper warnings.
+
+## Preflight Details
+
+`release-doctor.sh` is read-only. It checks local prerequisites and state before
+the expensive build starts:
+
+- required tools (`swift`, `xcrun`, `codesign`, `security`, `git`, `gh`, `nc`)
+- current git branch, dirty state, and master worktree ownership
+- Developer ID signing identity
+- notarytool keychain profile
+- Sparkle `sign_update` when Sparkle artifacts are enabled
+- `gh-pages` worktree state when website publishing is enabled
+- currently installed KeyPath/Kanata runtime state
+- whether Poltergeist is running
+
+Warnings are informational by default. Use `--strict` when warnings should block:
+
+```bash
+./Scripts/release-doctor.sh --ship --strict
+```
+
+## Multi-Worktree Merge Safety
+
+When multiple worktrees exist, `gh pr merge` may merge the PR on GitHub and then
+fail locally while trying to switch to or delete a branch that another worktree
+owns. Treat the local error as a prompt to verify GitHub state, not as proof the
+merge failed.
+
+Safer pattern:
+
+```bash
+gh pr merge <number> --repo malpern/KeyPath --merge --delete-branch
+gh pr view <number> --repo malpern/KeyPath --json state,mergeCommit
+git fetch --prune origin
+```
+
+Then deploy from the intended master worktree:
+
+```bash
+git checkout master
+git pull --ff-only origin master
+./Scripts/release-candidate.sh
+```
+
+If another worktree owns `master`, do the pull and deploy from that worktree.
+
+## Sparkle Notes
+
+Sparkle auto-update artifacts require an EdDSA signature. Public release builds
+fail if `sign_update` cannot produce a signature, unless
+`ALLOW_UNSIGNED_SPARKLE=1` is set for local-only testing.
+
+Existing users get update notifications from `appcast.xml`. Release notes linked
+from the appcast should remain readable in dark mode.


### PR DESCRIPTION
## Summary
- demote Poltergeist from default workflow to optional focused single-agent UI iteration
- add `Scripts/release-doctor.sh`, a read-only release preflight for RC and public ship paths
- run release-doctor by default from `Scripts/release-candidate.sh`, with `--no-doctor` / `SKIP_RELEASE_DOCTOR=1` escape hatches
- update `CLAUDE.md`, `AGENTS.md`, script docs, release-process docs, and PR workflow docs for release-candidate-first post-merge testing
- document safer multi-worktree merge/pull/deploy handling

## Why
The release process was still too easy to over-escalate: agents could start Poltergeist by default, use full public release wording for normal post-merge testing, and discover signing/notary/gh-pages problems late in the build. This makes the fast path explicit and moves expensive-release failures earlier.

## Validation
- `bash -n Scripts/release-doctor.sh Scripts/release-candidate.sh Scripts/build-and-sign.sh Scripts/verify-installed-app.sh`
- `./Scripts/release-doctor.sh --help`
- `./Scripts/release-candidate.sh --help`
- `./Scripts/release-doctor.sh --release-candidate`
- `SKIP_WEBSITE=1 ./Scripts/release-doctor.sh --ship`
- `swift build`
- pre-push `swift build` hook passed

## Notes
- `./Scripts/release-doctor.sh --ship` correctly fails in this temp worktree unless `SKIP_WEBSITE=1` is set because `.worktrees/gh-pages` is not present here.
- Freed disk space by removing generated `.build`, `dist`, and `build` directories from old `/tmp/keypath-*` worktrees after the first push attempt exposed the disk was full.
