### PR TITLE
Tighten release workflow tooling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,6 +94,10 @@ Use opt-ins only when needed:
 ./Scripts/release-candidate.sh --with-website
 ```
 
+If local worktrees/builds are consuming disk, inspect generated artifacts with
+`./Scripts/cleanup-local-build-artifacts.sh` and delete them only with
+`./Scripts/cleanup-local-build-artifacts.sh --apply`.
+
 ### 3. Ship: public release artifacts
 Use the public release script only when producing public distribution artifacts:
 ```bash
@@ -104,8 +108,10 @@ Use the public release script only when producing public distribution artifacts:
 This path may bump versions, regenerate screenshots, create Sparkle artifacts,
 notarize, staple, deploy, tag, create a GitHub release, and publish website help
 content depending on environment flags. It is intentionally slower than the
-release-candidate path. `Scripts/build-and-sign.sh` is the lower-level artifact
-builder used by the release scripts.
+release-candidate path. `release.sh` runs `release-doctor.sh --ship`
+automatically unless explicitly skipped for script debugging. Do not use
+`--skip-notarize` for public releases. `Scripts/build-and-sign.sh` is the
+lower-level artifact builder used by the release scripts.
 
 ### 4. Installed app verification
 After any signed/notarized deploy, or when diagnosing a local install:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,6 +154,9 @@ needed:
 ./Scripts/release-candidate.sh --with-website
 ```
 
+For local disk cleanup, run `./Scripts/cleanup-local-build-artifacts.sh` first to
+inspect generated artifacts across worktrees, then add `--apply` to remove them.
+
 **Public ship:** Use the public release script only when producing public
 distribution artifacts:
 
@@ -164,7 +167,9 @@ distribution artifacts:
 
 That path may bump versions, regenerate screenshots, create Sparkle artifacts,
 notarize, staple, deploy, tag, create a GitHub release, and publish website help
-content depending on environment flags. `Scripts/build-and-sign.sh` is the
+content depending on environment flags. `release.sh` runs the ship preflight
+automatically unless explicitly skipped for script debugging. Do not use
+`--skip-notarize` for public releases. `Scripts/build-and-sign.sh` is the
 lower-level artifact builder used by the release scripts.
 
 **Installed verification:** After signed/notarized deploys, or when diagnosing a

--- a/Scripts/README.md
+++ b/Scripts/README.md
@@ -8,6 +8,7 @@
   - Release builds now fail if Sparkle EdDSA signing cannot be produced for the update archive.
   - For local-only testing, set `ALLOW_UNSIGNED_SPARKLE=1` to continue without an EdDSA signature.
 - `./Scripts/release.sh <version>` — Public distribution release flow. Run `./Scripts/release-doctor.sh --ship` first.
+- `./Scripts/cleanup-local-build-artifacts.sh` — Dry-run cleanup of generated `.build`/`dist`/test artifacts across local worktrees. Add `--apply` to delete.
 - `./test.sh` — Run the full test suite (root)
 - `./Scripts/run-installer-reliability-matrix.sh` — Automated installer reliability matrix + diagnostic artifact bundle (`test-results/installer-reliability/latest`).
 - `./Scripts/repro-duplicate-keys.sh` — CPU-load repro harness for duplicate keypress detection (filters navigation keys by default). Supports `--auto-type osascript` or `--auto-type peekaboo` for deterministic automated keystroke generation, and continuously samples Kanata process metrics (CPU%, memory, threads, priority).
@@ -17,6 +18,7 @@
 - `release-doctor.sh` - Read-only preflight for signing, notarization, Sparkle, website, watcher, and runtime state.
 - `release-candidate.sh` - Post-merge signed/notarized local build wrapper with fast defaults.
 - `release.sh` - Public release wrapper for versioned distribution artifacts.
+- `cleanup-local-build-artifacts.sh` - Safe local disk cleanup helper for generated build artifacts.
 - `run-tests-safe.sh` - The safe test runner implementation
 - `run-installer-reliability-matrix.sh` - Runs installer scenario lanes and writes `matrix-summary.md` + `matrix-results.json`
 - `uninstall.sh` - Uninstaller script

--- a/Scripts/cleanup-local-build-artifacts.sh
+++ b/Scripts/cleanup-local-build-artifacts.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" >/dev/null && pwd)
+PROJECT_DIR=$(cd "$SCRIPT_DIR/.." >/dev/null && pwd)
+
+APPLY=0
+INCLUDE_CURRENT=0
+INCLUDE_TMP=0
+
+usage() {
+    cat <<'EOF'
+Usage: Scripts/cleanup-local-build-artifacts.sh [--apply] [--include-current] [--include-tmp-keypath]
+
+Find generated build artifacts in local KeyPath worktrees. The default mode is
+read-only and prints what would be removed.
+
+Options:
+  --apply                Remove the generated artifact directories.
+  --include-current      Include the current worktree. Default: skip it.
+  --include-tmp-keypath  Also scan /tmp/keypath-* directories.
+  -h, --help            Show this help.
+
+Targets removed with --apply:
+  .build
+  .swiftpm
+  build
+  dist
+  test-results
+EOF
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --apply)
+            APPLY=1
+            ;;
+        --include-current)
+            INCLUDE_CURRENT=1
+            ;;
+        --include-tmp-keypath)
+            INCLUDE_TMP=1
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+    shift
+done
+
+cd "$PROJECT_DIR"
+
+current_path=$(pwd -P)
+candidates_file=$(mktemp)
+trap 'rm -f "$candidates_file"' EXIT
+
+git worktree list --porcelain | awk '/^worktree / { print substr($0, 10) }' > "$candidates_file"
+
+if [ "$INCLUDE_TMP" -eq 1 ]; then
+    find /tmp -maxdepth 1 -type d -name 'keypath-*' -print 2>/dev/null >> "$candidates_file" || true
+fi
+
+echo "KeyPath local build artifact cleanup"
+if [ "$APPLY" -eq 1 ]; then
+    echo "Mode: apply"
+else
+    echo "Mode: dry-run"
+fi
+echo
+
+found=0
+while IFS= read -r worktree; do
+    [ -n "$worktree" ] || continue
+    [ -d "$worktree" ] || continue
+
+    worktree_path=$(cd "$worktree" >/dev/null 2>&1 && pwd -P) || continue
+    if [ "$INCLUDE_CURRENT" -eq 0 ] && [ "$worktree_path" = "$current_path" ]; then
+        continue
+    fi
+
+    if ! git -C "$worktree_path" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+        continue
+    fi
+
+    for relative_path in .build .swiftpm build dist test-results; do
+        target="$worktree_path/$relative_path"
+        [ -d "$target" ] || continue
+
+        found=1
+        size=$(du -sh "$target" 2>/dev/null | awk '{print $1}')
+        echo "$target (${size:-unknown})"
+        if [ "$APPLY" -eq 1 ]; then
+            rm -rf "$target"
+            echo "  removed"
+        else
+            echo "  would remove"
+        fi
+    done
+done < "$candidates_file"
+
+if [ "$found" -eq 0 ]; then
+    echo "No generated artifact directories found."
+fi
+
+if [ "$APPLY" -eq 0 ]; then
+    echo
+    echo "Run with --apply to remove the listed directories."
+fi

--- a/Scripts/release-doctor.sh
+++ b/Scripts/release-doctor.sh
@@ -129,6 +129,19 @@ resolve_sign_update() {
     return 1
 }
 
+find_worktree_for_branch() {
+    local branch_name=$1
+    git worktree list --porcelain | awk -v target="refs/heads/${branch_name}" '
+        /^worktree / { path=substr($0, 10) }
+        /^branch / {
+            if ($2 == target) {
+                print path
+                exit
+            }
+        }
+    '
+}
+
 cd "$PROJECT_DIR"
 
 print_section "Release Doctor"
@@ -179,11 +192,8 @@ if [[ -n "$(git status --porcelain --untracked-files=normal)" ]]; then
     warn "Working tree has untracked files"
 fi
 
-if git worktree list --porcelain | grep -q '^branch refs/heads/master$'; then
-    master_worktree=$(git worktree list --porcelain | awk '
-        /^worktree / { path=substr($0, 10) }
-        /^branch refs\/heads\/master$/ { print path; exit }
-    ')
+master_worktree=$(find_worktree_for_branch master)
+if [[ -n "$master_worktree" ]]; then
     if [[ "$master_worktree" != "$PROJECT_DIR" ]]; then
         warn "master is checked out in another worktree: $master_worktree"
         echo "   Merge PRs through GitHub or from outside this repo, then fetch/prune before deploying."
@@ -246,8 +256,8 @@ fi
 if [[ "$effective_skip_website" == "1" ]]; then
     pass "Website publish checks skipped (SKIP_WEBSITE=1)"
 else
-    ghpages_dir="$PROJECT_DIR/.worktrees/gh-pages"
-    if [[ -d "$ghpages_dir/.git" || -f "$ghpages_dir/.git" ]]; then
+    ghpages_dir=$(find_worktree_for_branch gh-pages)
+    if [[ -n "$ghpages_dir" && ( -d "$ghpages_dir/.git" || -f "$ghpages_dir/.git" ) ]]; then
         pass "gh-pages worktree found: $ghpages_dir"
         if git -C "$ghpages_dir" diff --quiet && git -C "$ghpages_dir" diff --cached --quiet; then
             pass "gh-pages worktree has no tracked changes"
@@ -257,8 +267,10 @@ else
         if [[ -n "$(git -C "$ghpages_dir" status --porcelain --untracked-files=normal)" ]]; then
             warn "gh-pages worktree has untracked files"
         fi
+    elif git show-ref --verify --quiet refs/heads/gh-pages || git show-ref --verify --quiet refs/remotes/origin/gh-pages; then
+        pass "gh-pages branch found; release.sh can create a temporary worktree"
     else
-        fail "gh-pages worktree missing at $ghpages_dir"
+        fail "gh-pages branch not found; website download publishing would fail"
     fi
 fi
 

--- a/Scripts/release.sh
+++ b/Scripts/release.sh
@@ -10,7 +10,7 @@ set -euo pipefail
 #   ./Scripts/release.sh --dry-run          # Show what would happen without doing it
 #   ./Scripts/release.sh --dry-run 1.2.0    # Dry run with version bump
 #   ./Scripts/release.sh --refresh-keyboard-data
-#   ./Scripts/release.sh --skip-notarize    # Local release build without notarization
+#   ./Scripts/release.sh --no-doctor        # Skip release-doctor preflight
 
 SCRIPT_DIR=$(cd "$(dirname "$0")" >/dev/null && pwd)
 REPO_ROOT="${SCRIPT_DIR%/Scripts}"
@@ -19,7 +19,33 @@ INFO_PLIST="$REPO_ROOT/Sources/KeyPathApp/Info.plist"
 DRY_RUN=false
 SKIP_NOTARIZE=false
 REFRESH_KEYBOARD_DATA=false
+RUN_DOCTOR=true
 NEW_VERSION=""
+TEMP_GHPAGES_WORKTREE=""
+
+cleanup() {
+    if [ -n "$TEMP_GHPAGES_WORKTREE" ]; then
+        git worktree remove "$TEMP_GHPAGES_WORKTREE" 2>/dev/null || true
+    fi
+}
+trap cleanup EXIT
+
+find_worktree_for_branch() {
+    local branch_name=$1
+    git worktree list --porcelain | awk -v target="refs/heads/${branch_name}" '
+        /^worktree / { path=substr($0, 10) }
+        /^branch / {
+            if ($2 == target) {
+                print path
+                exit
+            }
+        }
+    '
+}
+
+usage() {
+    echo "Usage: $0 [--dry-run] [--no-doctor] [--refresh-keyboard-data] [--skip-notarize dry-run only] [X.Y.Z]"
+}
 
 # Parse arguments
 for arg in "$@"; do
@@ -30,6 +56,9 @@ for arg in "$@"; do
         --skip-notarize)
             SKIP_NOTARIZE=true
             ;;
+        --no-doctor)
+            RUN_DOCTOR=false
+            ;;
         --refresh-keyboard-data)
             REFRESH_KEYBOARD_DATA=true
             ;;
@@ -38,7 +67,7 @@ for arg in "$@"; do
                 NEW_VERSION="$arg"
             else
                 echo "❌ Invalid argument: $arg"
-                echo "Usage: $0 [--dry-run] [--skip-notarize] [--refresh-keyboard-data] [X.Y.Z]"
+                usage
                 exit 1
             fi
             ;;
@@ -50,6 +79,12 @@ cd "$REPO_ROOT"
 echo "🚀 KeyPath Release Script"
 echo "========================="
 echo ""
+
+if [ "$SKIP_NOTARIZE" = true ] && [ "$DRY_RUN" = false ]; then
+    echo "❌ ERROR: release.sh publishes public artifacts and must notarize them."
+    echo "   Use ./build.sh or ./Scripts/release-candidate.sh for local unnotarized testing."
+    exit 1
+fi
 
 # Get current version
 CURRENT_VERSION=$(defaults read "$INFO_PLIST" CFBundleShortVersionString 2>/dev/null || echo "0.0.0")
@@ -75,7 +110,7 @@ fi
 echo ""
 echo "🎯 Release version: $VERSION"
 if [ "$SKIP_NOTARIZE" = true ]; then
-    echo "⚠️  Notarization: skipped (--skip-notarize)"
+    echo "⚠️  Notarization: skipped (--skip-notarize dry-run only)"
 fi
 if [ "$REFRESH_KEYBOARD_DATA" = true ]; then
     echo "🗂️  Keyboard data: refresh before build"
@@ -100,33 +135,51 @@ fi
 if [ "$DRY_RUN" = true ]; then
     echo "🔍 [DRY RUN] Would perform the following steps:"
     echo ""
+    STEP=1
+    if [ "$RUN_DOCTOR" = true ]; then
+        echo "   ${STEP}. Run release-doctor ship preflight"
+        STEP=$((STEP + 1))
+    fi
     if [ "$REFRESH_KEYBOARD_DATA" = true ]; then
-        echo "   1. Refresh keyboard detection data"
-        echo "   2. Build and sign KeyPath"
-        echo "   3. Create Sparkle archive: dist/sparkle/KeyPath-${VERSION}.zip"
-        echo "   4. Sign with EdDSA"
-        echo "   5. Generate appcast entry"
+        echo "   ${STEP}. Refresh keyboard detection data"
+        STEP=$((STEP + 1))
+    fi
+    if [ "$SKIP_NOTARIZE" = true ]; then
+        echo "   ${STEP}. Build/sign KeyPath without notarization (dry-run only)"
     else
-        echo "   1. Build and sign KeyPath"
-        echo "   2. Create Sparkle archive: dist/sparkle/KeyPath-${VERSION}.zip"
-        echo "   3. Sign with EdDSA"
-        echo "   4. Generate appcast entry"
+        echo "   ${STEP}. Build, sign, notarize, and staple KeyPath"
     fi
-    NEXT_STEP=5
-    if [ "$REFRESH_KEYBOARD_DATA" = true ]; then
-        NEXT_STEP=6
-    fi
+    STEP=$((STEP + 1))
+    echo "   ${STEP}. Create Sparkle archive: dist/sparkle/KeyPath-${VERSION}.zip"
+    STEP=$((STEP + 1))
+    echo "   ${STEP}. Sign Sparkle archive with EdDSA"
+    STEP=$((STEP + 1))
+    echo "   ${STEP}. Create DMG: dist/sparkle/KeyPath-${VERSION}.dmg"
+    STEP=$((STEP + 1))
+    echo "   ${STEP}. Generate appcast entry"
+    STEP=$((STEP + 1))
     echo ""
     echo "   Then you would:"
-    echo "   ${NEXT_STEP}. git add -A && git commit -m 'chore: release v${VERSION}'"
-    echo "   $((NEXT_STEP + 1)). git tag v${VERSION}"
-    echo "   $((NEXT_STEP + 2)). git push origin main --tags"
-    echo "   $((NEXT_STEP + 3)). Create GitHub Release and upload ZIP"
-    echo "   $((NEXT_STEP + 4)). Update appcast.xml with generated entry"
-    echo "   $((NEXT_STEP + 5)). git add appcast.xml && git commit -m 'chore: update appcast for v${VERSION}'"
-    echo "   $((NEXT_STEP + 6)). git push"
+    echo "   ${STEP}. git tag v${VERSION}"
+    STEP=$((STEP + 1))
+    echo "   ${STEP}. Create GitHub Release and upload ZIP + DMG"
+    STEP=$((STEP + 1))
+    echo "   ${STEP}. Update appcast.xml with generated entry"
+    STEP=$((STEP + 1))
+    echo "   ${STEP}. git add appcast.xml && git commit -m 'chore: update appcast for v${VERSION}'"
+    STEP=$((STEP + 1))
+    echo "   ${STEP}. Update and push gh-pages download links"
+    STEP=$((STEP + 1))
+    echo "   ${STEP}. Update and push Homebrew cask if the local tap is installed"
+    STEP=$((STEP + 1))
+    echo "   ${STEP}. Push appcast commit and tag: git push origin master --tags"
     echo ""
     exit 0
+fi
+
+if [ "$RUN_DOCTOR" = true ] && [ "${SKIP_RELEASE_DOCTOR:-0}" != "1" ]; then
+    echo "🩺 Running release preflight..."
+    ./Scripts/release-doctor.sh --ship
 fi
 
 if [ "$REFRESH_KEYBOARD_DATA" = true ]; then
@@ -210,8 +263,19 @@ else
 fi
 
 echo "🌐 Updating gh-pages download link..."
-GHPAGES_WORKTREE=$(mktemp -d)
-git worktree add "$GHPAGES_WORKTREE" gh-pages 2>/dev/null
+GHPAGES_WORKTREE=$(find_worktree_for_branch gh-pages)
+if [ -n "$GHPAGES_WORKTREE" ]; then
+    echo "   Using existing gh-pages worktree: $GHPAGES_WORKTREE"
+else
+    TEMP_GHPAGES_WORKTREE=$(mktemp -d)
+    GHPAGES_WORKTREE="$TEMP_GHPAGES_WORKTREE"
+    git worktree add "$GHPAGES_WORKTREE" gh-pages
+fi
+
+if ! git -C "$GHPAGES_WORKTREE" diff --quiet || ! git -C "$GHPAGES_WORKTREE" diff --cached --quiet; then
+    echo "❌ gh-pages worktree has uncommitted tracked changes: $GHPAGES_WORKTREE" >&2
+    exit 1
+fi
 
 DMG_URL="https://github.com/malpern/KeyPath/releases/download/v${VERSION}/KeyPath-${VERSION}.dmg"
 if [ -f "$GHPAGES_WORKTREE/index.md" ]; then
@@ -230,7 +294,6 @@ if [ -f "$GHPAGES_WORKTREE/index.md" ]; then
 else
     echo "   ⚠️  index.md not found on gh-pages — update manually"
 fi
-git worktree remove "$GHPAGES_WORKTREE" 2>/dev/null || true
 
 echo "🍺 Updating Homebrew cask..."
 HOMEBREW_TAP="/opt/homebrew/Library/Taps/malpern/homebrew-tap"

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -142,6 +142,9 @@ release scripts. Prefer `release-candidate.sh` for post-merge manual testing and
 Releases must be notarized. Do not use `SKIP_NOTARIZE=1` or `--skip-notarize` for
 public distribution; unnotarized apps trigger Gatekeeper warnings.
 
+`release.sh` runs `release-doctor.sh --ship` automatically unless
+`--no-doctor` or `SKIP_RELEASE_DOCTOR=1` is used for script debugging.
+
 ## Preflight Details
 
 `release-doctor.sh` is read-only. It checks local prerequisites and state before
@@ -195,3 +198,31 @@ fail if `sign_update` cannot produce a signature, unless
 
 Existing users get update notifications from `appcast.xml`. Release notes linked
 from the appcast should remain readable in dark mode.
+
+## Local Artifact Cleanup
+
+Parallel worktrees and repeated SwiftPM builds can leave large generated
+directories behind. Inspect them first:
+
+```bash
+./Scripts/cleanup-local-build-artifacts.sh
+```
+
+Then remove only generated artifact directories:
+
+```bash
+./Scripts/cleanup-local-build-artifacts.sh --apply
+```
+
+The helper skips the current worktree by default. Use `--include-current` when
+you intentionally want to force the current checkout to rebuild from scratch, and
+`--include-tmp-keypath` to include `/tmp/keypath-*` worktrees.
+
+For stale worktree directories themselves, inspect first and remove only the
+specific worktree you are done with:
+
+```bash
+git worktree list
+git worktree remove <path>
+git worktree prune --dry-run
+```


### PR DESCRIPTION
## Summary
- make `release.sh` run `release-doctor --ship` by default and block non-dry-run public releases that skip notarization
- make release dry-runs reflect the real ZIP + DMG + appcast + gh-pages + Homebrew flow and use `master` in push guidance
- make release-doctor/release.sh discover an existing `gh-pages` worktree anywhere, not only `.worktrees/gh-pages`
- add `Scripts/cleanup-local-build-artifacts.sh` for dry-run-first cleanup of generated artifacts across local worktrees
- document the updated release and cleanup workflow in AGENTS, CLAUDE, Scripts README, and release-process docs

## Validation
- `bash -n Scripts/release.sh Scripts/release-doctor.sh Scripts/cleanup-local-build-artifacts.sh`
- `git diff --check`
- `./Scripts/release.sh --dry-run --refresh-keyboard-data 9.9.9`
- `./Scripts/release.sh --skip-notarize 9.9.9` exits before mutating files
- `./Scripts/cleanup-local-build-artifacts.sh`
- `./Scripts/release-doctor.sh --ship`
- pre-push `swift build`
