### PR TITLE
Fix base overlay floating labels

### DIFF
--- a/Sources/KeyPathAppKit/Services/LayerMapping/LayerKeyMapper+KeyConversion.swift
+++ b/Sources/KeyPathAppKit/Services/LayerMapping/LayerKeyMapper+KeyConversion.swift
@@ -157,9 +157,9 @@ extension LayerKeyMapper {
         case "bksl", "backslash": "backslash"
         case "scln", "semicolon": "semicolon"
         case "apos", "apostrophe", "quote": "apostrophe"
-        case "comm", "comma": "comma"
-        case "dot", "period": "dot"
-        case "slash", "slsh": "slash"
+        case "comm", "comma", ",": "comma"
+        case "dot", "period", ".": "dot"
+        case "slash", "slsh", "/": "slash"
         default:
             key.lowercased()
         }

--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayKeyboardView.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayKeyboardView.swift
@@ -189,7 +189,10 @@ struct OverlayKeyboardView: View {
         var remapped = Set<String>()
         if !isKeymapTransitioning {
             for (label, keyCode) in ltk {
-                if layerKeyMap[keyCode] != nil {
+                let inputKeyName = Self.keyCodeToKanataName(keyCode).lowercased()
+                if let info = layerKeyMap[keyCode],
+                   Self.shouldHideFloatingLabel(for: info, baseLabel: label, inputKeyName: inputKeyName)
+                {
                     remapped.insert(label)
                 }
             }
@@ -216,6 +219,26 @@ struct OverlayKeyboardView: View {
             remappedLabels: remapped,
             zoneSubtitleLabels: zoneSubs
         )
+    }
+
+    nonisolated static func shouldHideFloatingLabel(
+        for info: LayerKeyInfo,
+        baseLabel: String,
+        inputKeyName: String
+    ) -> Bool {
+        if info.isTransparent {
+            return false
+        }
+        if info.isLayerSwitch {
+            return true
+        }
+        if info.appLaunchIdentifier != nil || info.systemActionIdentifier != nil || info.urlIdentifier != nil {
+            return true
+        }
+        if let outputKey = info.outputKey {
+            return outputKey.lowercased() != inputKeyName
+        }
+        return !info.displayLabel.isEmpty && info.displayLabel.uppercased() != baseLabel.uppercased()
     }
 
     var keyboardAccessibilityLabel: String {

--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView+VisualStyling.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView+VisualStyling.swift
@@ -136,6 +136,11 @@ extension OverlayKeycapView {
         // Inline layer: mapped keys get a subtle accent tint, unmapped keys stay normal
         else if isInlineLayer, hasLayerMapping {
             Color.accentColor.opacity(0.15)
+        } else if services.preferences.unmappedLayerKeyStyle == .baseLayer,
+                  currentLayerName.lowercased() != "base",
+                  isVisuallyUnmappedLayerKey
+        {
+            colorway.alphaBaseColor
         } else if isModifierKey {
             colorway.modBaseColor
         } else if isAccentKey {

--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView.swift
@@ -83,15 +83,29 @@ struct OverlayKeycapView: View {
         }
         // Under base-style, an unmapped key leaves layer mode so it renders
         // like the base/inline layer instead of dimming. Unmapped = transparent
-        // (production) or nil (hand-built maps). The zoneSubtitle guard keeps
-        // nav-hint keys in layer mode so their subtitle still renders.
+        // (production), explicit blockers, or nil (hand-built maps).
         if services.preferences.unmappedLayerKeyStyle == .baseLayer,
-           zoneSubtitle == nil,
-           layerKeyInfo == nil || layerKeyInfo?.isTransparent == true
+           isVisuallyUnmappedLayerKey
         {
             return false
         }
         return true
+    }
+
+    /// Whether this layer entry represents "nothing active here" for visual
+    /// styling. Kanata can express that as transparent passthrough, omitted
+    /// info, or an explicit `XX` blocker with no label/output.
+    var isVisuallyUnmappedLayerKey: Bool {
+        guard let info = layerKeyInfo else { return true }
+        if info.isTransparent { return true }
+        if info.isLayerSwitch { return false }
+        if info.appLaunchIdentifier != nil || info.systemActionIdentifier != nil || info.urlIdentifier != nil {
+            return false
+        }
+        if let outputKey = info.outputKey {
+            return LayerKeyMapper.normalizeKeyName(outputKey) == LayerKeyMapper.normalizeKeyName(inputKeyName)
+        }
+        return info.displayLabel.isEmpty || info.displayLabel.uppercased() == baseLabel.uppercased()
     }
 
     /// "Inline" layers render like the base layer — unmapped keys keep their

--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView.swift
@@ -102,6 +102,9 @@ struct OverlayKeycapView: View {
         if info.appLaunchIdentifier != nil || info.systemActionIdentifier != nil || info.urlIdentifier != nil {
             return false
         }
+        if key.layoutRole == .narrowModifier {
+            return true
+        }
         if let outputKey = info.outputKey {
             return LayerKeyMapper.normalizeKeyName(outputKey) == LayerKeyMapper.normalizeKeyName(inputKeyName)
         }

--- a/Tests/KeyPathTests/Services/UnmappedLayerKeyStyleTests.swift
+++ b/Tests/KeyPathTests/Services/UnmappedLayerKeyStyleTests.swift
@@ -39,6 +39,24 @@ final class UnmappedLayerKeyStyleTests: KeyPathTestCase {
         )
     }
 
+    private func keycap(
+        keyCode: UInt16,
+        label: String,
+        layer: String = "nav",
+        info: LayerKeyInfo?,
+        zoneSubtitle: String? = nil
+    ) -> OverlayKeycapView {
+        OverlayKeycapView(
+            key: PhysicalKey(keyCode: keyCode, label: label, x: 1, y: 2, width: 1, height: 1),
+            baseLabel: label,
+            isPressed: false,
+            scale: 1.0,
+            currentLayerName: layer,
+            layerKeyInfo: info,
+            zoneSubtitle: zoneSubtitle
+        )
+    }
+
     func testUnmappedKey_baseLayerPref_leavesLayerMode() {
         PreferencesService.shared.unmappedLayerKeyStyle = .baseLayer
         let view = keycap(layer: "nav", info: .transparent(fallbackLabel: "Q"))
@@ -56,12 +74,111 @@ final class UnmappedLayerKeyStyleTests: KeyPathTestCase {
         XCTAssertFalse(view.isLayerMode, "A nil-info (unmapped) key should also render base-style")
     }
 
-    func testUnmappedKey_withZoneSubtitle_staysInLayerMode() {
-        // A key carrying a nav-hint subtitle keeps layer styling so the subtitle
-        // still renders (avoids a stray subtitle on a base-styled keycap).
+    func testUnmappedKey_withZoneSubtitle_baseLayerPref_leavesLayerMode() {
+        // A subtitle should not force a transparent/pass-through key into layer
+        // styling. The subtitle can still render inline on the base-styled keycap.
         PreferencesService.shared.unmappedLayerKeyStyle = .baseLayer
         let view = keycap(layer: "nav", info: .transparent(fallbackLabel: "Q"), zoneSubtitle: "◀")
-        XCTAssertTrue(view.isLayerMode, "Keys with a zone subtitle keep layer styling even under base-style")
+        XCTAssertFalse(view.isLayerMode, "Transparent keys keep base styling even when a subtitle exists")
+    }
+
+    func testExplicitlyBlockedKey_baseLayerPref_leavesLayerMode() {
+        PreferencesService.shared.unmappedLayerKeyStyle = .baseLayer
+        let view = keycap(
+            keyCode: 47,
+            label: ".",
+            info: LayerKeyInfo(
+                displayLabel: "",
+                outputKey: nil,
+                outputKeyCode: nil,
+                isTransparent: false,
+                isLayerSwitch: false
+            )
+        )
+        XCTAssertTrue(view.isVisuallyUnmappedLayerKey)
+        XCTAssertFalse(view.isLayerMode, "XX-blocked punctuation should render base-style under the base-style preference")
+        XCTAssertEqual(
+            String(describing: view.backgroundColor),
+            String(describing: GMKColorway.default.alphaBaseColor)
+        )
+    }
+
+    func testFallbackSameLabelNoOutput_baseLayerPref_leavesLayerMode() {
+        PreferencesService.shared.unmappedLayerKeyStyle = .baseLayer
+        let view = keycap(
+            keyCode: 44,
+            label: "/",
+            info: LayerKeyInfo(
+                displayLabel: "/",
+                outputKey: nil,
+                outputKeyCode: nil,
+                isTransparent: false,
+                isLayerSwitch: false
+            )
+        )
+        XCTAssertTrue(view.isVisuallyUnmappedLayerKey)
+        XCTAssertFalse(view.isLayerMode, "Fallback punctuation with no output should render as visually unmapped")
+        XCTAssertEqual(
+            String(describing: view.backgroundColor),
+            String(describing: GMKColorway.default.alphaBaseColor)
+        )
+    }
+
+    func testLiteralPunctuationIdentity_baseLayerPref_leavesLayerMode() {
+        PreferencesService.shared.unmappedLayerKeyStyle = .baseLayer
+        let view = keycap(
+            keyCode: 44,
+            label: "/",
+            info: LayerKeyInfo(
+                displayLabel: "/",
+                outputKey: "/",
+                outputKeyCode: 44,
+                isTransparent: false,
+                isLayerSwitch: false
+            )
+        )
+        XCTAssertTrue(view.isVisuallyUnmappedLayerKey)
+        XCTAssertFalse(view.isLayerMode, "Literal slash output should normalize as identity/pass-through")
+        XCTAssertEqual(
+            String(describing: view.backgroundColor),
+            String(describing: GMKColorway.default.alphaBaseColor)
+        )
+    }
+
+    func testTransparentFn_baseLayerPref_leavesLayerMode() {
+        PreferencesService.shared.unmappedLayerKeyStyle = .baseLayer
+        let view = keycap(
+            keyCode: 63,
+            label: "fn",
+            info: .transparent(fallbackLabel: "fn")
+        )
+        XCTAssertTrue(view.isVisuallyUnmappedLayerKey)
+        XCTAssertFalse(view.isLayerMode, "Transparent fn should not pick up layer fallback coloring")
+        XCTAssertEqual(
+            String(describing: view.backgroundColor),
+            String(describing: GMKColorway.default.alphaBaseColor)
+        )
+    }
+
+    func testMappedSlashWithCollection_baseLayerPref_keepsCollectionLayerColor() {
+        PreferencesService.shared.unmappedLayerKeyStyle = .baseLayer
+        let view = keycap(
+            keyCode: 44,
+            label: "/",
+            info: .mapped(
+                displayLabel: "find",
+                outputKey: "f",
+                outputKeyCode: 3,
+                collectionId: RuleCollectionIdentifier.vimNavigation,
+                vimLabel: "find"
+            )
+        )
+        XCTAssertFalse(view.isVisuallyUnmappedLayerKey)
+        XCTAssertTrue(view.isLayerMode, "Mapped punctuation should still render as an active layer key")
+        XCTAssertEqual(
+            String(describing: view.backgroundColor),
+            String(describing: KeycapSymbols.collectionColor(for: RuleCollectionIdentifier.vimNavigation))
+        )
     }
 
     func testUnmappedKey_dimmedPref_staysInLayerMode() {

--- a/Tests/KeyPathTests/Services/UnmappedLayerKeyStyleTests.swift
+++ b/Tests/KeyPathTests/Services/UnmappedLayerKeyStyleTests.swift
@@ -160,6 +160,27 @@ final class UnmappedLayerKeyStyleTests: KeyPathTestCase {
         )
     }
 
+    func testFnModifierOutput_baseLayerPref_leavesLayerMode() {
+        PreferencesService.shared.unmappedLayerKeyStyle = .baseLayer
+        let view = keycap(
+            keyCode: 63,
+            label: "fn",
+            info: LayerKeyInfo(
+                displayLabel: "fn",
+                outputKey: "fn",
+                outputKeyCode: 63,
+                isTransparent: false,
+                isLayerSwitch: false
+            )
+        )
+        XCTAssertTrue(view.isVisuallyUnmappedLayerKey)
+        XCTAssertFalse(view.isLayerMode, "fn should not be treated as an active layer mapping")
+        XCTAssertEqual(
+            String(describing: view.backgroundColor),
+            String(describing: GMKColorway.default.alphaBaseColor)
+        )
+    }
+
     func testMappedSlashWithCollection_baseLayerPref_keepsCollectionLayerColor() {
         PreferencesService.shared.unmappedLayerKeyStyle = .baseLayer
         let view = keycap(

--- a/Tests/KeyPathTests/UI/FloatingLabelVisibilityTests.swift
+++ b/Tests/KeyPathTests/UI/FloatingLabelVisibilityTests.swift
@@ -100,6 +100,45 @@ struct FloatingLabelVisibilityTests {
         #expect(vis.isVisible("D"))
     }
 
+    @Test("transparent layer entries do not suppress base floating labels")
+    func transparentLayerEntriesDoNotSuppressBaseFloatingLabels() {
+        let info = LayerKeyInfo.transparent(fallbackLabel: "A")
+
+        #expect(!OverlayKeyboardView.shouldHideFloatingLabel(
+            for: info,
+            baseLabel: "A",
+            inputKeyName: "a"
+        ))
+    }
+
+    @Test("identity mappings do not suppress base floating labels")
+    func identityMappingsDoNotSuppressBaseFloatingLabels() {
+        let info = LayerKeyInfo.mapped(displayLabel: "A", outputKey: "a", outputKeyCode: 0)
+
+        #expect(!OverlayKeyboardView.shouldHideFloatingLabel(
+            for: info,
+            baseLabel: "A",
+            inputKeyName: "a"
+        ))
+    }
+
+    @Test("real remaps and actions suppress base floating labels")
+    func realRemapsAndActionsSuppressBaseFloatingLabels() {
+        let remap = LayerKeyInfo.mapped(displayLabel: "B", outputKey: "b", outputKeyCode: 11)
+        let action = LayerKeyInfo.systemAction(action: "spotlight", description: "Spotlight")
+
+        #expect(OverlayKeyboardView.shouldHideFloatingLabel(
+            for: remap,
+            baseLabel: "A",
+            inputKeyName: "a"
+        ))
+        #expect(OverlayKeyboardView.shouldHideFloatingLabel(
+            for: action,
+            baseLabel: "A",
+            inputKeyName: "a"
+        ))
+    }
+
     // MARK: - Zone subtitle labels
 
     @Test("labels with zone subtitles are hidden")


### PR DESCRIPTION
## Summary
- fix overlay floating-label suppression so transparent/pass-through layer entries do not hide base alpha labels
- keep real remaps, layer switches, app launches, system actions, and URLs suppressing the base floating label
- add regression coverage for transparent, identity, and real-remap/action label suppression

## Validation
- `swift test --filter FloatingLabelVisibilityTests`
- `KEYPATH_SNAPSHOTS=1 swift test --filter HardViewSnapshotTests.testLiveKeyboardOverlayBase`
- `swiftformat Sources/KeyPathAppKit/UI/Overlay/OverlayKeyboardView.swift Tests/KeyPathTests/UI/FloatingLabelVisibilityTests.swift`
- `git diff --check`
- `./Scripts/quick-deploy.sh`
- computer-use live UI inspection: base overlay shows QWERTY/home-row alpha labels and punctuation labels again
- pre-push `swift build`
