### PR TITLE
Use explicit managed repeat allowlist

### DIFF
--- a/Sources/KeyPathAppKit/Infrastructure/Config/KanataConfigurationGenerator.swift
+++ b/Sources/KeyPathAppKit/Infrastructure/Config/KanataConfigurationGenerator.swift
@@ -104,6 +104,7 @@ public struct KanataConfiguration: Sendable {
             "  process-unmapped-keys yes",
             "  danger-enable-cmd yes",
             "  managed-repeat yes",
+            "  managed-repeat-unlisted no",
         ]
         if let krc = keyRepeatConfig, krc.isEnabled {
             defcfgLines.append("  managed-repeat-delay \(krc.globalDelayMs)")

--- a/Tests/KeyPathTests/Infrastructure/KanataConfigurationGeneratorSnapshotTests.swift
+++ b/Tests/KeyPathTests/Infrastructure/KanataConfigurationGeneratorSnapshotTests.swift
@@ -9,6 +9,29 @@ final class KanataConfigurationGeneratorSnapshotTests: XCTestCase {
         assertContains(config, "volu")
     }
 
+    func testManagedRepeatUsesExplicitDefrepeatAllowlist() throws {
+        let repeatCollection = try makeCollection(
+            id: XCTUnwrap(UUID(uuidString: "44444444-4444-4444-4444-444444444444")),
+            name: "Key Repeat Control",
+            summary: "Repeat",
+            category: .custom,
+            mappings: [],
+            targetLayer: .base,
+            momentaryActivator: nil,
+            configuration: .keyRepeatControl(KeyRepeatControlConfig())
+        )
+        let config = KanataConfiguration.generateFromCollections([repeatCollection])
+
+        assertContains(config, "managed-repeat yes")
+        assertContains(config, "managed-repeat-unlisted no")
+        assertContains(config, "(defrepeat")
+        assertContains(config, "(left  150 20)")
+        XCTAssertFalse(
+            config.contains("(e "),
+            "Alpha keys should not be implicitly enrolled in managed repeat\n\nActual output:\n\(config)"
+        )
+    }
+
     func testNavigationActivatorUsesOneShotAndWrapsMappings() throws {
         let navCollection = try makeCollection(
             id: XCTUnwrap(UUID(uuidString: "11111111-1111-1111-1111-111111111111")),

--- a/Tests/KeyPathTests/Integration/ConfigValidationTests.swift
+++ b/Tests/KeyPathTests/Integration/ConfigValidationTests.swift
@@ -9,17 +9,24 @@ import XCTest
 /// undefined aliases, invalid S-expression nesting, unsupported key names,
 /// missing deflayer entries, etc.
 ///
-/// Requires: kanata binary at /usr/local/bin/kanata or the bundled app path.
+/// Requires: a current KeyPath kanata binary, preferably via
+/// KEYPATH_KANATA_PATH or the repo-built External/kanata release binary.
 final class ConfigValidationTests: XCTestCase {
     private func findKanataBinary() -> String? {
-        // Only use the bundled binary — it matches the version KeyPath ships.
-        // System-installed kanata (e.g., homebrew v1.10) may be too old and
-        // reject features like defhands or tap-hold-require-prior-idle.
-        let bundled = "/Applications/KeyPath.app/Contents/Library/KeyPath/Kanata Engine.app/Contents/MacOS/kanata"
-        if FileManager.default.isExecutableFile(atPath: bundled) {
-            return bundled
-        }
-        return nil
+        let candidates: [String] = [
+            ProcessInfo.processInfo.environment["KEYPATH_KANATA_PATH"],
+            URL(fileURLWithPath: #filePath)
+                .deletingLastPathComponent() // Integration
+                .deletingLastPathComponent() // KeyPathTests
+                .deletingLastPathComponent() // Tests
+                .deletingLastPathComponent() // repo root
+                .appendingPathComponent("External/kanata/target/aarch64-apple-darwin/release/kanata")
+                .path,
+            "/opt/homebrew/bin/kanata",
+            "/Applications/KeyPath.app/Contents/Library/KeyPath/Kanata Engine.app/Contents/MacOS/kanata"
+        ].compactMap { $0 }
+
+        return candidates.first { FileManager.default.isExecutableFile(atPath: $0) }
     }
 
     @MainActor

--- a/Tests/KeyPathTests/Integration/GoldenConfigs/caps-escape-hyper.actual.kbd
+++ b/Tests/KeyPathTests/Integration/GoldenConfigs/caps-escape-hyper.actual.kbd
@@ -5,6 +5,7 @@
   process-unmapped-keys yes
   danger-enable-cmd yes
   managed-repeat yes
+  managed-repeat-unlisted no
   managed-repeat-delay 500
   managed-repeat-interval 30
 )

--- a/Tests/KeyPathTests/Integration/GoldenConfigs/caps-escape-hyper.kbd
+++ b/Tests/KeyPathTests/Integration/GoldenConfigs/caps-escape-hyper.kbd
@@ -5,6 +5,7 @@
   process-unmapped-keys yes
   danger-enable-cmd yes
   managed-repeat yes
+  managed-repeat-unlisted no
   managed-repeat-delay 500
   managed-repeat-interval 30
 )

--- a/Tests/KeyPathTests/Integration/GoldenConfigs/default.actual.kbd
+++ b/Tests/KeyPathTests/Integration/GoldenConfigs/default.actual.kbd
@@ -5,6 +5,7 @@
   process-unmapped-keys yes
   danger-enable-cmd yes
   managed-repeat yes
+  managed-repeat-unlisted no
   managed-repeat-delay 500
   managed-repeat-interval 30
 )

--- a/Tests/KeyPathTests/Integration/GoldenConfigs/default.kbd
+++ b/Tests/KeyPathTests/Integration/GoldenConfigs/default.kbd
@@ -5,6 +5,7 @@
   process-unmapped-keys yes
   danger-enable-cmd yes
   managed-repeat yes
+  managed-repeat-unlisted no
   managed-repeat-delay 500
   managed-repeat-interval 30
 )

--- a/Tests/KeyPathTests/Integration/GoldenConfigs/home-row-mods.actual.kbd
+++ b/Tests/KeyPathTests/Integration/GoldenConfigs/home-row-mods.actual.kbd
@@ -5,6 +5,7 @@
   process-unmapped-keys yes
   danger-enable-cmd yes
   managed-repeat yes
+  managed-repeat-unlisted no
   managed-repeat-delay 500
   managed-repeat-interval 30
   tap-hold-require-prior-idle 150

--- a/Tests/KeyPathTests/Integration/GoldenConfigs/home-row-mods.kbd
+++ b/Tests/KeyPathTests/Integration/GoldenConfigs/home-row-mods.kbd
@@ -5,6 +5,7 @@
   process-unmapped-keys yes
   danger-enable-cmd yes
   managed-repeat yes
+  managed-repeat-unlisted no
   managed-repeat-delay 500
   managed-repeat-interval 30
   tap-hold-require-prior-idle 150

--- a/Tests/KeyPathTests/Integration/GoldenConfigs/remap-with-shifted-output.actual.kbd
+++ b/Tests/KeyPathTests/Integration/GoldenConfigs/remap-with-shifted-output.actual.kbd
@@ -5,6 +5,7 @@
   process-unmapped-keys yes
   danger-enable-cmd yes
   managed-repeat yes
+  managed-repeat-unlisted no
   managed-repeat-delay 500
   managed-repeat-interval 30
 )

--- a/Tests/KeyPathTests/Integration/GoldenConfigs/remap-with-shifted-output.kbd
+++ b/Tests/KeyPathTests/Integration/GoldenConfigs/remap-with-shifted-output.kbd
@@ -5,6 +5,7 @@
   process-unmapped-keys yes
   danger-enable-cmd yes
   managed-repeat yes
+  managed-repeat-unlisted no
   managed-repeat-delay 500
   managed-repeat-interval 30
 )

--- a/Tests/KeyPathTests/Integration/GoldenConfigs/simple-remap-a-to-b.actual.kbd
+++ b/Tests/KeyPathTests/Integration/GoldenConfigs/simple-remap-a-to-b.actual.kbd
@@ -5,6 +5,7 @@
   process-unmapped-keys yes
   danger-enable-cmd yes
   managed-repeat yes
+  managed-repeat-unlisted no
   managed-repeat-delay 500
   managed-repeat-interval 30
 )

--- a/Tests/KeyPathTests/Integration/GoldenConfigs/simple-remap-a-to-b.kbd
+++ b/Tests/KeyPathTests/Integration/GoldenConfigs/simple-remap-a-to-b.kbd
@@ -5,6 +5,7 @@
   process-unmapped-keys yes
   danger-enable-cmd yes
   managed-repeat yes
+  managed-repeat-unlisted no
   managed-repeat-delay 500
   managed-repeat-interval 30
 )

--- a/Tests/KeyPathTests/Integration/GoldenConfigs/vim-navigation.actual.kbd
+++ b/Tests/KeyPathTests/Integration/GoldenConfigs/vim-navigation.actual.kbd
@@ -5,6 +5,7 @@
   process-unmapped-keys yes
   danger-enable-cmd yes
   managed-repeat yes
+  managed-repeat-unlisted no
   managed-repeat-delay 500
   managed-repeat-interval 30
 )

--- a/Tests/KeyPathTests/Integration/GoldenConfigs/vim-navigation.kbd
+++ b/Tests/KeyPathTests/Integration/GoldenConfigs/vim-navigation.kbd
@@ -5,6 +5,7 @@
   process-unmapped-keys yes
   danger-enable-cmd yes
   managed-repeat yes
+  managed-repeat-unlisted no
   managed-repeat-delay 500
   managed-repeat-interval 30
 )


### PR DESCRIPTION
## Summary
- update bundled Kanata to malpern/kanata#25
- emit managed-repeat-unlisted no so KeyPath repeats only explicit defrepeat keys
- add generator coverage and update golden configs

## Tests
- cargo test --manifest-path External/kanata/Cargo.toml --features simulated_output managed_repeat -- --nocapture
- cargo test -p kanata-parser --manifest-path External/kanata/Cargo.toml managed_repeat -- --nocapture
- swift test --filter KanataConfigurationGeneratorSnapshotTests
- swift test --filter ConfigGoldenFileTests
- swift test --filter ConfigurationServiceSavePipelineTests
- python3 Scripts/check-accessibility.py