### PR TITLE
[codex] Add app-bundled CLI repair workflow

### DIFF
--- a/Scripts/build-and-sign.sh
+++ b/Scripts/build-and-sign.sh
@@ -230,10 +230,15 @@ MACOS="${CONTENTS}/MacOS"
 	# Copy main executable
 	ditto "$BUILD_DIR/KeyPath" "$MACOS/KeyPath"
 
+	# Copy command-line tool. Keep the filename distinct from KeyPath on
+	# case-insensitive filesystems; users can opt into a shell shim from the app.
+	ditto "$BUILD_DIR/keypath-cli" "$MACOS/keypath-cli"
+
 	# Ensure app-bundle rpath can locate embedded frameworks
 	# SwiftPM-built executables usually have LC_RPATH=@loader_path, which points to Contents/MacOS.
 	# For an app bundle, frameworks live at Contents/Frameworks, so add that search path.
 	install_name_tool -add_rpath "@executable_path/../Frameworks" "$MACOS/KeyPath" 2>/dev/null || true
+	install_name_tool -add_rpath "@executable_path/../Frameworks" "$MACOS/keypath-cli" 2>/dev/null || true
 
 	# Create "Kanata Engine.app" bundle wrapping the kanata binary.
 	# This gives kanata a CFBundleIdentifier so macOS TCC tracks it by bundle ID
@@ -324,6 +329,7 @@ ditto "Sources/KeyPathApp/com.keypath.kanata.plist" "$LAUNCH_DAEMONS/com.keypath
 	    local missing=0
 	    for path in \
 	        "$HELPER_TOOLS/KeyPathHelper" \
+	        "$MACOS/keypath-cli" \
 	        "$LAUNCH_DAEMONS/com.keypath.helper.plist" \
 	        "$LAUNCH_DAEMONS/com.keypath.kanata.plist" \
 	        "$FRAMEWORKS/Sparkle.framework" \
@@ -440,6 +446,9 @@ else
 
     # Sign bundled kanata simulator binary
     kp_sign "$CONTENTS/Library/KeyPath/kanata-simulator" --force --options=runtime --sign "$SIGNING_IDENTITY"
+
+    # Sign command-line tool embedded in the app bundle.
+    kp_sign "$MACOS/keypath-cli" --force --options=runtime --sign "$SIGNING_IDENTITY"
 
     # Sign Insights plugin bundle
     kp_sign "$INSIGHTS_BUNDLE" --force --options=runtime --deep --sign "$SIGNING_IDENTITY"

--- a/Scripts/quick-deploy.sh
+++ b/Scripts/quick-deploy.sh
@@ -202,16 +202,23 @@ rm -f "$BUILD_LOG"
 
 # Get the built binary
 DEBUG_BIN="$BIN_DIR/KeyPath"
+CLI_BIN="$BIN_DIR/keypath-cli"
 
 if [[ ! -f "$DEBUG_BIN" ]]; then
     echo "❌ Build failed - binary not found"
     log_build_event "FAILED_NO_BINARY"
     exit 1
 fi
+if [[ ! -f "$CLI_BIN" ]]; then
+    echo "❌ Build failed - CLI binary not found"
+    log_build_event "FAILED_NO_CLI_BINARY"
+    exit 1
+fi
 
 # Copy binary to app bundle
 echo "📦 Deploying..."
 cp "$DEBUG_BIN" "$MACOS_DIR/$APP_NAME"
+cp "$CLI_BIN" "$MACOS_DIR/keypath-cli"
 
 # Do not hot-swap the embedded privileged helper by default.
 #
@@ -315,6 +322,9 @@ done
 if ! otool -l "$MACOS_DIR/$APP_NAME" | grep -q "@executable_path/../Frameworks"; then
     install_name_tool -add_rpath "@executable_path/../Frameworks" "$MACOS_DIR/$APP_NAME" 2>/dev/null || true
 fi
+if ! otool -l "$MACOS_DIR/keypath-cli" | grep -q "@executable_path/../Frameworks"; then
+    install_name_tool -add_rpath "@executable_path/../Frameworks" "$MACOS_DIR/keypath-cli" 2>/dev/null || true
+fi
 
 # Assemble and sync Insights.bundle to PlugIns
 INSIGHTS_DYLIB="$BIN_DIR/libKeyPathInsights.dylib"
@@ -368,6 +378,9 @@ if security find-identity -v -p codesigning | grep -Fq "$SIGNING_IDENTITY"; then
     fi
     if [[ -f "$APP_BUNDLE/Contents/Library/KeyPath/libkeypath_kanata_host_bridge.dylib" ]]; then
         codesign --force --options=runtime --sign "$SIGNING_IDENTITY" "$APP_BUNDLE/Contents/Library/KeyPath/libkeypath_kanata_host_bridge.dylib" 2>/dev/null || true
+    fi
+    if [[ -f "$APP_BUNDLE/Contents/MacOS/keypath-cli" ]]; then
+        codesign --force --options=runtime --sign "$SIGNING_IDENTITY" "$APP_BUNDLE/Contents/MacOS/keypath-cli" 2>/dev/null || true
     fi
     codesign --force --options=runtime --sign "$SIGNING_IDENTITY" --entitlements "$ENTITLEMENTS" --deep "$APP_BUNDLE"
     resign_helper_identifier "$SIGNING_IDENTITY"

--- a/Scripts/verify-installed-app.sh
+++ b/Scripts/verify-installed-app.sh
@@ -27,6 +27,12 @@ if [[ ! -d "$APP_PATH" ]]; then
     exit 1
 fi
 
+CLI_PATH="$APP_PATH/Contents/MacOS/keypath-cli"
+if [[ ! -x "$CLI_PATH" ]]; then
+    echo "❌ Bundled CLI is missing or not executable: $CLI_PATH" >&2
+    exit 1
+fi
+
 print_section "Trust Policy"
 codesign --verify --strict --verbose=2 "$APP_PATH"
 if [[ "$REQUIRE_NOTARIZED" == "1" ]]; then
@@ -53,6 +59,9 @@ if ! pgrep -x "KeyPath" >/dev/null; then
     exit 1
 fi
 pgrep -fl 'KeyPath|KeyPathHelper|kanata|kanata-launcher' || true
+
+print_section "Bundled CLI"
+"$CLI_PATH" --version
 
 print_section "Kanata Launchd"
 if ! launchctl print "$KANATA_LABEL" >"$KANATA_LAUNCHCTL_OUTPUT" 2>&1; then

--- a/Sources/KeyPathAppKit/CLI/CLIRuntimeBootstrap.swift
+++ b/Sources/KeyPathAppKit/CLI/CLIRuntimeBootstrap.swift
@@ -1,0 +1,27 @@
+import Foundation
+import KeyPathCore
+import KeyPathDaemonLifecycle
+import KeyPathInstallationWizard
+import KeyPathWizardCore
+
+@MainActor
+enum CLIRuntimeBootstrap {
+    private static var isConfigured = false
+
+    static func ensureConfigured() {
+        guard !isConfigured else { return }
+
+        // The CLI owns stdout/stderr. Keep app-internal logs in the log file so
+        // JSON output remains machine-parseable in debug builds.
+        AppLogger.shared.setConsoleLoggingEnabled(false)
+
+        let processLifecycleManager = ProcessLifecycleManager()
+        let validator = SystemValidator(
+            processLifecycleManager: processLifecycleManager,
+            kanataManager: nil
+        )
+
+        configureCLIWizardDependencies(systemValidator: validator)
+        isConfigured = true
+    }
+}

--- a/Sources/KeyPathAppKit/CLI/SystemFacade.swift
+++ b/Sources/KeyPathAppKit/CLI/SystemFacade.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 import KeyPathCore
 import KeyPathDaemonLifecycle
@@ -46,6 +47,7 @@ public struct SystemFacade: Sendable {
 
     @MainActor
     public func runStatus() async -> CLIStatusResult {
+        CLIRuntimeBootstrap.ensureConfigured()
         let engine = InstallerEngine()
         let context = await engine.inspectSystem()
 
@@ -78,23 +80,82 @@ public struct SystemFacade: Sendable {
     // MARK: - Installer
 
     @MainActor
-    public func runInstall() async -> CLIInstallerReport {
+    public func runInstall(dryRun: Bool = false) async -> CLIInstallerReport {
+        CLIRuntimeBootstrap.ensureConfigured()
+        if let bundleIssue = Self.systemRepairBundleIssue() {
+            return CLIInstallerReport(bundleIssue: bundleIssue, dryRun: dryRun, title: "Installation")
+        }
         let engine = InstallerEngine()
+        let context = await engine.inspectSystem()
+        let plan = await engine.makePlan(for: .install, context: context)
+        if dryRun {
+            return CLIInstallerReport(
+                dryRunPlan: plan,
+                context: context,
+                title: "Installation"
+            )
+        }
         let broker = PrivilegeBroker()
-        let report = await engine.run(intent: .install, using: broker)
-        return CLIInstallerReport(from: report)
+        let report = await engine.execute(plan: plan, using: broker)
+        let finalContext = report.success ? await engine.inspectSystem() : nil
+        return CLIInstallerReport(
+            from: report,
+            initialContext: context,
+            finalContext: finalContext,
+            plan: plan,
+            title: "Installation"
+        )
     }
 
     @MainActor
-    public func runRepair() async -> CLIInstallerReport {
+    public func runRepair(dryRun: Bool = false) async -> CLIInstallerReport {
+        CLIRuntimeBootstrap.ensureConfigured()
+        if let bundleIssue = Self.systemRepairBundleIssue() {
+            return CLIInstallerReport(bundleIssue: bundleIssue, dryRun: dryRun, title: "Repair")
+        }
         let engine = InstallerEngine()
+        let context = await engine.inspectSystem()
+        let plan = await engine.makePlan(for: .repair, context: context)
+        if dryRun {
+            return CLIInstallerReport(
+                dryRunPlan: plan,
+                context: context,
+                title: "Repair"
+            )
+        }
+
+        let initialIssues = Self.issues(from: context)
+        let initialUserActionIssues = initialIssues.filter { !$0.canAutoFix }
+        if !initialUserActionIssues.isEmpty, plan.recipes.isEmpty {
+            return CLIInstallerReport(
+                success: false,
+                failureReason: Self.userActionFailureReason(initialUserActionIssues, prefix: "Repair requires user action"),
+                steps: [],
+                fastRepair: false,
+                dryRun: false,
+                userActionRequired: true,
+                issues: initialIssues,
+                plannedRecipes: [],
+                unmetRequirements: plan.blockedBy.map { [$0.name] } ?? [],
+                logs: []
+            )
+        }
+
         let broker = PrivilegeBroker()
-        let report = await engine.run(intent: .repair, using: broker)
-        return CLIInstallerReport(from: report)
+        let report = await engine.execute(plan: plan, using: broker)
+        let finalContext = report.success ? await engine.inspectSystem() : nil
+        return CLIInstallerReport(
+            from: report,
+            initialContext: context,
+            finalContext: finalContext,
+            plan: plan,
+            title: "Repair"
+        )
     }
 
     @MainActor
     public func runUninstall(deleteConfig: Bool) async -> CLIInstallerReport {
+        CLIRuntimeBootstrap.ensureConfigured()
         let engine = InstallerEngine()
         let broker = PrivilegeBroker()
         let report = await engine.uninstall(deleteConfig: deleteConfig, using: broker)
@@ -102,10 +163,25 @@ public struct SystemFacade: Sendable {
     }
 
     @MainActor
-    public func runInspect() async -> CLIInspectResult {
+    public func runInspect(planIntent: InstallIntent = .repair) async -> CLIInspectResult {
+        CLIRuntimeBootstrap.ensureConfigured()
+        if let bundleIssue = Self.systemRepairBundleIssue() {
+            return CLIInspectResult(
+                macOSVersion: ProcessInfo.processInfo.operatingSystemVersionString,
+                driverCompatible: false,
+                planStatus: "blocked",
+                blockedBy: "Valid KeyPath.app bundle",
+                plannedRecipes: [],
+                planIntent: "\(planIntent)",
+                isOperational: false,
+                userActionRequired: true,
+                promptsNeeded: false,
+                issues: [bundleIssue]
+            )
+        }
         let engine = InstallerEngine()
         let context = await engine.inspectSystem()
-        let plan = await engine.makePlan(for: .inspectOnly, context: context)
+        let plan = await engine.makePlan(for: planIntent, context: context)
 
         let planStatus: String
         var blockedBy: String?
@@ -122,8 +198,220 @@ public struct SystemFacade: Sendable {
             driverCompatible: context.system.driverCompatible,
             planStatus: planStatus,
             blockedBy: blockedBy,
-            plannedRecipes: plan.recipes.map { "\($0.id) (\($0.type))" }
+            plannedRecipes: plan.recipes.map { "\($0.id) (\($0.type))" },
+            planIntent: "\(planIntent)",
+            isOperational: Self.isOperational(context),
+            userActionRequired: Self.issues(from: context).contains { !$0.canAutoFix },
+            promptsNeeded: plan.metadata.promptsNeeded,
+            issues: Self.issues(from: context)
         )
+    }
+
+    @MainActor
+    public func openFirstRemediationURL(in issues: [CLISystemIssue]) -> Bool {
+        guard let rawURL = issues.compactMap(\.remediationURL).first,
+              let url = URL(string: rawURL)
+        else {
+            return false
+        }
+        return NSWorkspace.shared.open(url)
+    }
+
+    fileprivate static func isOperational(_ context: SystemContext) -> Bool {
+        context.permissions.isSystemReady
+            && context.helper.isReady
+            && context.components.hasAllRequired
+            && context.services.isHealthy
+            && !context.conflicts.hasConflicts
+    }
+
+    fileprivate static func systemRepairBundleIssue() -> CLISystemIssue? {
+        let bundlePath = Bundle.main.bundlePath
+        let requiredPaths = [
+            "\(bundlePath)/Contents/MacOS/keypath-cli",
+            "\(bundlePath)/Contents/Library/LaunchDaemons/com.keypath.kanata.plist",
+            "\(bundlePath)/Contents/Library/HelperTools/KeyPathHelper",
+            WizardSystemPaths.bundledKanataPath,
+            WizardSystemPaths.bundledKanataLauncherPath,
+        ]
+        if requiredPaths.allSatisfy({ FileManager.default.fileExists(atPath: $0) }) {
+            return nil
+        }
+
+        return CLISystemIssue(
+            title: "System repair requires the app-bundled CLI",
+            category: "bundle",
+            action: "Open KeyPath and choose File > Install Command Line Tool, or run /Applications/KeyPath.app/Contents/MacOS/keypath-cli",
+            canAutoFix: false
+        )
+    }
+
+    fileprivate static func issues(from context: SystemContext) -> [CLISystemIssue] {
+        var issues: [CLISystemIssue] = []
+
+        if !context.helper.isInstalled {
+            issues.append(.init(
+                title: "Privileged Helper not installed",
+                category: "helper",
+                action: "Install or repair KeyPath services",
+                canAutoFix: true
+            ))
+        } else if !context.helper.isWorking {
+            issues.append(.init(
+                title: "Privileged Helper unhealthy",
+                category: "helper",
+                action: "Reinstall the privileged helper",
+                canAutoFix: true
+            ))
+        }
+
+        appendPermissionIssues(from: context, to: &issues)
+
+        for conflict in context.conflicts.conflicts {
+            issues.append(.init(
+                title: Self.conflictTitle(conflict),
+                category: "conflict",
+                action: "Terminate conflicting process",
+                canAutoFix: context.conflicts.canAutoResolve
+            ))
+        }
+
+        if !context.components.kanataBinaryInstalled {
+            issues.append(.init(
+                title: "Kanata binary not installed",
+                category: "component",
+                action: "Reinstall KeyPath; the bundled Kanata engine is missing",
+                canAutoFix: false
+            ))
+        }
+        if !context.components.karabinerDriverInstalled {
+            issues.append(.init(
+                title: "Karabiner VirtualHID driver not installed",
+                category: "component",
+                action: "Install the bundled VirtualHID driver",
+                canAutoFix: true
+            ))
+        }
+        if context.components.vhidVersionMismatch {
+            issues.append(.init(
+                title: "Karabiner VirtualHID driver version incompatible",
+                category: "component",
+                action: "Install the compatible bundled VirtualHID driver",
+                canAutoFix: true
+            ))
+        }
+        if !context.components.vhidDeviceHealthy {
+            issues.append(.init(
+                title: "VirtualHID device unhealthy",
+                category: "component",
+                action: "Repair VirtualHID services",
+                canAutoFix: true
+            ))
+        }
+
+        if !context.services.isHealthy {
+            if !context.services.kanataRunning, let configError = context.services.configParseError {
+                issues.append(.init(
+                    title: "Configuration error prevents remapping",
+                    category: "configuration",
+                    action: configError,
+                    canAutoFix: false
+                ))
+            } else if !context.services.kanataRunning, context.services.kanataPermissionRejected {
+                issues.append(.init(
+                    title: "Kanata needs Accessibility permission",
+                    category: "permissions",
+                    action: "Re-grant Accessibility for Kanata Engine in System Settings",
+                    canAutoFix: false
+                ))
+            } else if !context.services.kanataRunning {
+                issues.append(.init(
+                    title: "Kanata service not running",
+                    category: "service",
+                    action: "Start or reinstall the Kanata service",
+                    canAutoFix: true
+                ))
+            }
+            if !context.services.karabinerDaemonRunning {
+                issues.append(.init(
+                    title: "Karabiner VirtualHID daemon not running",
+                    category: "service",
+                    action: "Start or repair the VirtualHID daemon",
+                    canAutoFix: true
+                ))
+            }
+        }
+
+        return issues
+    }
+
+    private static func appendPermissionIssues(from context: SystemContext, to issues: inout [CLISystemIssue]) {
+        if !context.permissions.keyPath.accessibility.isReady {
+            issues.append(.init(
+                title: "KeyPath needs Accessibility permission",
+                category: "permissions",
+                action: "Open KeyPath.app and grant Accessibility in System Settings > Privacy & Security > Accessibility",
+                canAutoFix: false,
+                remediationURL: WizardSystemPaths.accessibilitySettings
+            ))
+        }
+        if !context.permissions.keyPath.inputMonitoring.isReady {
+            issues.append(.init(
+                title: "KeyPath needs Input Monitoring permission",
+                category: "permissions",
+                action: "Open KeyPath.app and grant Input Monitoring in System Settings > Privacy & Security > Input Monitoring",
+                canAutoFix: false,
+                remediationURL: WizardSystemPaths.inputMonitoringSettings
+            ))
+        }
+        if !context.permissions.kanata.accessibility.isReady {
+            issues.append(.init(
+                title: "Kanata needs Accessibility permission",
+                category: "permissions",
+                action: "Open the KeyPath Installation Wizard to grant Kanata Engine Accessibility",
+                canAutoFix: false,
+                remediationURL: WizardSystemPaths.accessibilitySettings
+            ))
+        }
+        if !context.permissions.kanata.inputMonitoring.isReady {
+            issues.append(.init(
+                title: "Kanata needs Input Monitoring permission",
+                category: "permissions",
+                action: "Open the KeyPath Installation Wizard to grant Kanata Engine Input Monitoring",
+                canAutoFix: false,
+                remediationURL: WizardSystemPaths.inputMonitoringSettings
+            ))
+        }
+        if !context.services.kanataInputCaptureReady {
+            issues.append(.init(
+                title: "Kanata cannot capture keyboard input",
+                category: "permissions",
+                action: context.services.kanataInputCaptureIssue
+                    ?? "Re-grant Input Monitoring for Kanata Engine in System Settings",
+                canAutoFix: false,
+                remediationURL: WizardSystemPaths.inputMonitoringSettings
+            ))
+        }
+    }
+
+    private static func conflictTitle(_ conflict: SystemConflict) -> String {
+        switch conflict {
+        case let .kanataProcessRunning(pid, _):
+            "Conflicting Kanata process running (PID \(pid))"
+        case let .karabinerGrabberRunning(pid):
+            "Karabiner Grabber running (PID \(pid))"
+        case let .karabinerVirtualHIDDeviceRunning(pid, _):
+            "Karabiner VirtualHID process running (PID \(pid))"
+        case let .karabinerVirtualHIDDaemonRunning(pid):
+            "Karabiner VirtualHID daemon running (PID \(pid))"
+        case let .exclusiveDeviceAccess(device):
+            "Device in exclusive use: \(device)"
+        }
+    }
+
+    fileprivate static func userActionFailureReason(_ issues: [CLISystemIssue], prefix: String) -> String {
+        guard let first = issues.first else { return prefix }
+        return "\(prefix): \(first.title). \(first.action)"
     }
 }
 
@@ -155,6 +443,12 @@ public struct CLIInstallerReport: Codable, Sendable {
     public let failureReason: String?
     public let steps: [CLIInstallerStep]
     public let fastRepair: Bool
+    public let dryRun: Bool?
+    public let userActionRequired: Bool?
+    public let issues: [CLISystemIssue]?
+    public let plannedRecipes: [String]?
+    public let unmetRequirements: [String]?
+    public let logs: [String]?
 
     init(from report: InstallerReport) {
         success = report.success
@@ -163,6 +457,75 @@ public struct CLIInstallerReport: Codable, Sendable {
             CLIInstallerStep(name: $0.recipeID, success: $0.success, error: $0.error)
         }
         fastRepair = false
+        dryRun = nil
+        userActionRequired = nil
+        issues = nil
+        plannedRecipes = nil
+        unmetRequirements = nil
+        logs = nil
+    }
+
+    init(
+        from report: InstallerReport,
+        initialContext: SystemContext,
+        finalContext: SystemContext?,
+        plan: InstallPlan,
+        title: String
+    ) {
+        let finalIssues = SystemFacade.issues(from: finalContext ?? initialContext)
+        let finalUserActionIssues = finalIssues.filter { !$0.canAutoFix }
+        let finalOperational = finalContext.map(SystemFacade.isOperational) ?? false
+        let completedButStillBlocked = report.success && !finalOperational && !finalIssues.isEmpty
+
+        success = report.success && !completedButStillBlocked
+        if let reportFailure = report.failureReason {
+            failureReason = reportFailure
+        } else if !finalUserActionIssues.isEmpty {
+            failureReason = SystemFacade.userActionFailureReason(
+                finalUserActionIssues,
+                prefix: "\(title) requires user action"
+            )
+        } else if completedButStillBlocked {
+            failureReason = "Repair completed but system still has blocking issue(s)"
+        } else {
+            failureReason = nil
+        }
+        steps = report.executedRecipes.map {
+            CLIInstallerStep(name: $0.recipeID, success: $0.success, error: $0.error)
+        }
+        fastRepair = false
+        dryRun = false
+        userActionRequired = !finalUserActionIssues.isEmpty || plan.metadata.promptsNeeded
+        issues = finalIssues
+        plannedRecipes = plan.recipes.map { "\($0.id) (\($0.type))" }
+        unmetRequirements = report.unmetRequirements.map(\.name)
+        logs = report.logs
+    }
+
+    init(dryRunPlan plan: InstallPlan, context: SystemContext, title: String) {
+        let contextIssues = SystemFacade.issues(from: context)
+        let userActionIssues = contextIssues.filter { !$0.canAutoFix }
+        let blockedBy = plan.blockedBy.map { [$0.name] } ?? []
+
+        success = blockedBy.isEmpty && userActionIssues.isEmpty
+        if !blockedBy.isEmpty {
+            failureReason = "Plan blocked by requirement: \(blockedBy.joined(separator: ", "))"
+        } else if !userActionIssues.isEmpty {
+            failureReason = SystemFacade.userActionFailureReason(
+                userActionIssues,
+                prefix: "\(title) requires user action"
+            )
+        } else {
+            failureReason = nil
+        }
+        steps = []
+        fastRepair = false
+        dryRun = true
+        userActionRequired = !userActionIssues.isEmpty || plan.metadata.promptsNeeded
+        issues = contextIssues
+        plannedRecipes = plan.recipes.map { "\($0.id) (\($0.type))" }
+        unmetRequirements = blockedBy
+        logs = nil
     }
 
     init(success: Bool, failureReason: String?, steps: [CLIInstallerStep], fastRepair: Bool) {
@@ -170,6 +533,49 @@ public struct CLIInstallerReport: Codable, Sendable {
         self.failureReason = failureReason
         self.steps = steps
         self.fastRepair = fastRepair
+        dryRun = nil
+        userActionRequired = nil
+        issues = nil
+        plannedRecipes = nil
+        unmetRequirements = nil
+        logs = nil
+    }
+
+    init(bundleIssue: CLISystemIssue, dryRun: Bool, title: String) {
+        success = false
+        failureReason = "\(title) requires the signed KeyPath.app bundle. \(bundleIssue.action)"
+        steps = []
+        fastRepair = false
+        self.dryRun = dryRun
+        userActionRequired = true
+        issues = [bundleIssue]
+        plannedRecipes = []
+        unmetRequirements = ["Valid KeyPath.app bundle"]
+        logs = nil
+    }
+
+    init(
+        success: Bool,
+        failureReason: String?,
+        steps: [CLIInstallerStep],
+        fastRepair: Bool,
+        dryRun: Bool?,
+        userActionRequired: Bool?,
+        issues: [CLISystemIssue]?,
+        plannedRecipes: [String]?,
+        unmetRequirements: [String]?,
+        logs: [String]?
+    ) {
+        self.success = success
+        self.failureReason = failureReason
+        self.steps = steps
+        self.fastRepair = fastRepair
+        self.dryRun = dryRun
+        self.userActionRequired = userActionRequired
+        self.issues = issues
+        self.plannedRecipes = plannedRecipes
+        self.unmetRequirements = unmetRequirements
+        self.logs = logs
     }
 }
 
@@ -185,4 +591,31 @@ public struct CLIInspectResult: Codable, Sendable {
     public let planStatus: String
     public let blockedBy: String?
     public let plannedRecipes: [String]
+    public let planIntent: String?
+    public let isOperational: Bool?
+    public let userActionRequired: Bool?
+    public let promptsNeeded: Bool?
+    public let issues: [CLISystemIssue]?
+}
+
+public struct CLISystemIssue: Codable, Sendable {
+    public let title: String
+    public let category: String
+    public let action: String
+    public let canAutoFix: Bool
+    public let remediationURL: String?
+
+    public init(
+        title: String,
+        category: String,
+        action: String,
+        canAutoFix: Bool,
+        remediationURL: String? = nil
+    ) {
+        self.title = title
+        self.category = category
+        self.action = action
+        self.canAutoFix = canAutoFix
+        self.remediationURL = remediationURL
+    }
 }

--- a/Sources/KeyPathAppKit/Core/AppMenuCommands.swift
+++ b/Sources/KeyPathAppKit/Core/AppMenuCommands.swift
@@ -80,6 +80,10 @@ struct AppMenuCommands: Commands {
             }
             .keyboardShortcut("n", modifiers: [.command, .shift])
 
+            Button("Install Command Line Tool...") {
+                installCommandLineTool()
+            }
+
             Divider()
 
             Button(
@@ -241,6 +245,56 @@ struct AppMenuCommands: Commands {
                 NSApplication.AboutPanelOptionKey.version: "Build \(info.build)"
             ]
         )
+    }
+
+    private func installCommandLineTool() {
+        if !CommandLineToolInstaller.canReplaceExistingDestination() {
+            let alert = NSAlert()
+            alert.messageText = "Command Line Tool Already Exists"
+            alert.informativeText = """
+            \(CommandLineToolInstaller.linkPath) already exists and is not a KeyPath command-line tool link.
+
+            Remove or rename the existing file before installing KeyPath's command-line tool.
+            """
+            alert.alertStyle = .warning
+            alert.runModal()
+            return
+        }
+
+        let alert = NSAlert()
+        alert.messageText = "Install Command Line Tool?"
+        alert.informativeText = """
+        This installs a terminal command at:
+        \(CommandLineToolInstaller.linkPath)
+
+        The command points to the signed CLI inside KeyPath.app. Opening KeyPath.app remains the primary way to launch KeyPath.
+        """
+        alert.alertStyle = .informational
+        alert.addButton(withTitle: "Install")
+        alert.addButton(withTitle: "Cancel")
+        guard alert.runModal() == .alertFirstButtonReturn else { return }
+
+        Task { @MainActor in
+            do {
+                try await CommandLineToolInstaller.install()
+                let success = NSAlert()
+                success.messageText = "Command Line Tool Installed"
+                success.informativeText = """
+                You can now run:
+                keypath-cli system inspect
+
+                The command points to the CLI inside KeyPath.app.
+                """
+                success.alertStyle = .informational
+                success.runModal()
+            } catch {
+                let failure = NSAlert()
+                failure.messageText = "Command Line Tool Install Failed"
+                failure.informativeText = error.localizedDescription
+                failure.alertStyle = .critical
+                failure.runModal()
+            }
+        }
     }
 }
 

--- a/Sources/KeyPathAppKit/Utilities/CommandLineToolInstaller.swift
+++ b/Sources/KeyPathAppKit/Utilities/CommandLineToolInstaller.swift
@@ -1,0 +1,75 @@
+import Foundation
+import KeyPathCore
+
+enum CommandLineToolInstaller {
+    static let linkPath = "/usr/local/bin/keypath-cli"
+
+    enum InstallError: LocalizedError {
+        case bundledToolMissing(String)
+        case destinationConflict(String)
+        case privilegedCommandFailed(String)
+
+        var errorDescription: String? {
+            switch self {
+            case let .bundledToolMissing(path):
+                "The bundled command-line tool was not found at \(path)."
+            case let .destinationConflict(path):
+                "\(path) already exists and is not a KeyPath command-line tool link."
+            case let .privilegedCommandFailed(output):
+                output.isEmpty ? "The command-line tool could not be installed." : output
+            }
+        }
+    }
+
+    static var bundledToolPath: String {
+        "\(Bundle.main.bundlePath)/Contents/MacOS/keypath-cli"
+    }
+
+    static func status() -> String {
+        if isInstalled {
+            return "Installed at \(linkPath)"
+        }
+        return "Not installed"
+    }
+
+    static var isInstalled: Bool {
+        existingLinkDestination() == bundledToolPath
+    }
+
+    static func canReplaceExistingDestination() -> Bool {
+        let manager = FileManager.default
+        guard manager.fileExists(atPath: linkPath) else { return true }
+        guard let destination = existingLinkDestination() else { return false }
+        return destination.contains("/KeyPath.app/Contents/MacOS/keypath-cli")
+    }
+
+    static func install() async throws {
+        let toolPath = bundledToolPath
+        guard FileManager.default.isExecutableFile(atPath: toolPath) else {
+            throw InstallError.bundledToolMissing(toolPath)
+        }
+        guard canReplaceExistingDestination() else {
+            throw InstallError.destinationConflict(linkPath)
+        }
+
+        let command = """
+        mkdir -p /usr/local/bin
+        ln -sfn \(shellSingleQuoted(toolPath)) \(shellSingleQuoted(linkPath))
+        """
+        let result = PrivilegedCommandRunner.execute(
+            command: command,
+            prompt: "KeyPath needs to install the keypath-cli command-line tool."
+        )
+        guard result.success else {
+            throw InstallError.privilegedCommandFailed(result.output)
+        }
+    }
+
+    private static func existingLinkDestination() -> String? {
+        try? FileManager.default.destinationOfSymbolicLink(atPath: linkPath)
+    }
+
+    private static func shellSingleQuoted(_ value: String) -> String {
+        "'" + value.replacingOccurrences(of: "'", with: "'\\''") + "'"
+    }
+}

--- a/Sources/KeyPathAppKit/WizardProtocolConformances.swift
+++ b/Sources/KeyPathAppKit/WizardProtocolConformances.swift
@@ -199,3 +199,62 @@ public func configureWizardDependencies(runtimeCoordinator: RuntimeCoordinator) 
         ))
     }
 }
+
+/// Configure WizardDependencies for app-bundled CLI repair/inspect entry points.
+@MainActor
+func configureCLIWizardDependencies(systemValidator: SystemValidator) {
+    WizardDependencies.runtimeCoordinator = nil
+    WizardDependencies.helperManager = HelperManager.shared
+    WizardDependencies.daemonManager = KanataDaemonManager.shared
+    WizardDependencies.systemValidator = systemValidator
+
+    MainAppStateController.shared.setValidator(systemValidator)
+    WizardDependencies.helperMaintenance = HelperMaintenance.shared
+    WizardDependencies.fullDiskAccessChecker = FullDiskAccessChecker.shared
+    WizardDependencies.permissionRequestService = PermissionRequestService.shared
+    WizardDependencies.privilegedOperations = PrivilegedOperationsRouter.shared
+
+    WizardDependencies.smServiceFactory = { plistName in
+        HelperManager.smServiceFactory(plistName)
+    }
+    WizardDependencies.helperNeedsApproval = {
+        HelperManager.smServiceFactory(HelperManager.helperPlistName).status == .requiresApproval
+    }
+    WizardDependencies.createUninstallCoordinator = {
+        UninstallCoordinator()
+    }
+    WizardDependencies.executePrivilegedBatch = { batch in
+        let result = try await AdminCommandExecutorHolder.shared.execute(batch: batch)
+        return (exitCode: result.exitCode, output: result.output)
+    }
+    WizardDependencies.resourceBundle = KeyPathAppKitResources.bundle
+
+    WizardDependencies.getExternalKanataInfo = {
+        ExternalKanataService.getExternalKanataInfo()
+    }
+    WizardDependencies.stopExternalKanata = { info in
+        let result = await ExternalKanataService.stopExternalKanata(info)
+        switch result {
+        case .success, .processNotFound:
+            return .success(())
+        case let .killFailed(reason):
+            return .failure(NSError(
+                domain: "ExternalKanata",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: reason]
+            ))
+        case let .launchAgentDisableFailed(reason):
+            return .failure(NSError(
+                domain: "ExternalKanata",
+                code: 2,
+                userInfo: [NSLocalizedDescriptionKey: reason]
+            ))
+        }
+    }
+    WizardDependencies.hasExternalKanataRunning = {
+        ExternalKanataService.hasExternalKanataRunning()
+    }
+    WizardDependencies.tcpProbe = { port, timeoutMs in
+        TCPProbe.probe(port: port, timeoutMs: timeoutMs)
+    }
+}

--- a/Sources/KeyPathCLI/Commands/System/SystemInspectCommand.swift
+++ b/Sources/KeyPathCLI/Commands/System/SystemInspectCommand.swift
@@ -30,16 +30,35 @@ struct SystemInspect: AsyncParsableCommand {
                 "macOS Version: \(result.macOSVersion)",
                 "Driver Compatible: \(result.driverCompatible ? "Yes" : "No")",
                 "",
+                "System Ready: \((result.isOperational ?? false) ? "Yes" : "No")",
                 "Plan Status: \(result.planStatus)",
             ]
+            if let intent = result.planIntent {
+                lines.append("Plan Intent: \(intent)")
+            }
             if let blockedBy = result.blockedBy {
                 lines.append("Blocked By: \(blockedBy)")
+            }
+            if result.promptsNeeded == true {
+                lines.append("Prompts Needed: Yes")
             }
             if !result.plannedRecipes.isEmpty {
                 lines.append("")
                 lines.append("Planned Recipes:")
                 for recipe in result.plannedRecipes {
                     lines.append("  - \(recipe)")
+                }
+            }
+            if let issues = result.issues, !issues.isEmpty {
+                lines.append("")
+                lines.append("Issues:")
+                for issue in issues {
+                    let fixability = issue.canAutoFix ? "auto-fixable" : "manual"
+                    lines.append("  - \(issue.title) [\(issue.category), \(fixability)]")
+                    lines.append("    Action: \(issue.action)")
+                    if let url = issue.remediationURL {
+                        lines.append("    Open: \(url)")
+                    }
                 }
             }
             lines.append("")

--- a/Sources/KeyPathCLI/Commands/System/SystemInstallCommand.swift
+++ b/Sources/KeyPathCLI/Commands/System/SystemInstallCommand.swift
@@ -12,6 +12,7 @@ struct SystemInstall: AsyncParsableCommand {
 
     mutating func run() async throws {
         let ctx = globals.outputContext
+        let dryRun = globals.dryRun
         let spinner = CLISpinner(context: ctx)
         spinner.start("Installing...")
 
@@ -19,18 +20,22 @@ struct SystemInstall: AsyncParsableCommand {
         let report: CLIInstallerReport
         do {
             report = try await withThrowingTimeout(seconds: globals.timeout) {
-                await facade.runInstall()
+                await facade.runInstall(dryRun: dryRun)
             }
         } catch is TimeoutError {
             spinner.fail("Installation timed out after \(globals.timeout)s")
             throw ExitCode.failure
         }
 
-        if report.success { spinner.succeed("Installation complete") }
+        if dryRun, report.success {
+            spinner.succeed("Installation plan ready")
+        } else if dryRun {
+            spinner.fail("Installation plan has blockers")
+        } else if report.success { spinner.succeed("Installation complete") }
         else { spinner.fail("Installation failed") }
 
         CLIOutput.write(report, context: ctx) {
-            formatInstallerReport(report, title: "Installation")
+            formatInstallerReport(report, title: dryRun ? "Installation Dry Run" : "Installation")
         }
 
         if !report.success {

--- a/Sources/KeyPathCLI/Commands/System/SystemRepairCommand.swift
+++ b/Sources/KeyPathCLI/Commands/System/SystemRepairCommand.swift
@@ -9,9 +9,12 @@ struct SystemRepair: AsyncParsableCommand {
     )
 
     @OptionGroup var globals: GlobalOptions
+    @Flag(name: .customLong("open-permissions"), help: "Open the relevant System Settings pane when permissions require manual repair")
+    var openPermissions: Bool = false
 
     mutating func run() async throws {
         let ctx = globals.outputContext
+        let dryRun = globals.dryRun
         let spinner = CLISpinner(context: ctx)
         spinner.start("Repairing...")
 
@@ -19,21 +22,32 @@ struct SystemRepair: AsyncParsableCommand {
         let report: CLIInstallerReport
         do {
             report = try await withThrowingTimeout(seconds: globals.timeout) {
-                await facade.runRepair()
+                await facade.runRepair(dryRun: dryRun)
             }
         } catch is TimeoutError {
             spinner.fail("Repair timed out after \(globals.timeout)s")
             throw ExitCode.failure
         }
 
-        if report.success { spinner.succeed("Repair complete") }
+        if dryRun, report.success {
+            spinner.succeed("Repair plan ready")
+        } else if dryRun {
+            spinner.fail("Repair plan has blockers")
+        } else if report.success { spinner.succeed("Repair complete") }
         else { spinner.fail("Repair failed") }
+
+        if openPermissions, let issues = report.issues {
+            let opened = await facade.openFirstRemediationURL(in: issues)
+            if !opened {
+                CLIOutput.progress("No permission remediation URL was available.", context: ctx)
+            }
+        }
 
         CLIOutput.write(report, context: ctx) {
             if report.fastRepair {
                 return "Repair completed via KanataService restart."
             }
-            return formatInstallerReport(report, title: "Repair")
+            return formatInstallerReport(report, title: dryRun ? "Repair Dry Run" : "Repair")
         }
 
         if !report.success {

--- a/Sources/KeyPathCLI/Utilities/ApplyHelper.swift
+++ b/Sources/KeyPathCLI/Utilities/ApplyHelper.swift
@@ -32,6 +32,42 @@ func formatInstallerReport(_ report: CLIInstallerReport, title: String, noColor:
         lines.append(ANSIColor.red("Failure Reason: \(reason)", noColor: noColor))
     }
 
+    if report.dryRun == true {
+        lines.append("Dry Run: Yes")
+    }
+    if report.userActionRequired == true {
+        lines.append("User Action Required: Yes")
+    }
+
+    if let plannedRecipes = report.plannedRecipes, !plannedRecipes.isEmpty {
+        lines.append("")
+        lines.append("Planned Recipes:")
+        for recipe in plannedRecipes {
+            lines.append("  - \(recipe)")
+        }
+    }
+
+    if let unmetRequirements = report.unmetRequirements, !unmetRequirements.isEmpty {
+        lines.append("")
+        lines.append("Unmet Requirements:")
+        for requirement in unmetRequirements {
+            lines.append("  - \(requirement)")
+        }
+    }
+
+    if let issues = report.issues, !issues.isEmpty {
+        lines.append("")
+        lines.append("Issues:")
+        for issue in issues {
+            let fixability = issue.canAutoFix ? "auto-fixable" : "manual"
+            lines.append("  - \(issue.title) [\(issue.category), \(fixability)]")
+            lines.append("    Action: \(issue.action)")
+            if let url = issue.remediationURL {
+                lines.append("    Open: \(url)")
+            }
+        }
+    }
+
     if !report.steps.isEmpty {
         lines.append("")
         lines.append("Steps:")

--- a/Sources/KeyPathCLI/Utilities/Spinner.swift
+++ b/Sources/KeyPathCLI/Utilities/Spinner.swift
@@ -5,22 +5,19 @@ final class CLISpinner: @unchecked Sendable {
     private static let asciiFrames = ["-", "\\", "|", "/"]
 
     private let noColor: Bool
-    private let isInteractive: Bool
+    private let isEnabled: Bool
     private var message: String
     private var timer: Timer?
     private var frameIndex = 0
 
     init(context: OutputContext) {
         noColor = context.noColor
-        isInteractive = context.isInteractive && !context.quiet
+        isEnabled = context.isInteractive && !context.quiet && !context.shouldOutputJSON
         message = ""
     }
 
     func start(_ message: String) {
-        guard isInteractive else {
-            FileHandle.standardError.write(Data("\(message)\n".utf8))
-            return
-        }
+        guard isEnabled else { return }
         self.message = message
         frameIndex = 0
         renderFrame()
@@ -34,12 +31,14 @@ final class CLISpinner: @unchecked Sendable {
     }
 
     func succeed(_ message: String) {
+        guard isEnabled else { return }
         stop()
         let marker = ANSIColor.green("✓", noColor: noColor)
         FileHandle.standardError.write(Data("\r\u{001b}[2K\(marker) \(message)\n".utf8))
     }
 
     func fail(_ message: String) {
+        guard isEnabled else { return }
         stop()
         let marker = ANSIColor.red("✗", noColor: noColor)
         FileHandle.standardError.write(Data("\r\u{001b}[2K\(marker) \(message)\n".utf8))
@@ -48,7 +47,7 @@ final class CLISpinner: @unchecked Sendable {
     func stop() {
         timer?.invalidate()
         timer = nil
-        if isInteractive {
+        if isEnabled {
             FileHandle.standardError.write(Data("\r\u{001b}[2K".utf8))
         }
     }

--- a/Sources/KeyPathCore/Logger.swift
+++ b/Sources/KeyPathCore/Logger.swift
@@ -50,7 +50,19 @@ public final class AppLogger {
     }
 
     /// Whether console logging is enabled (default: true in debug, false in release)
-    private let enableConsoleLogging: Bool
+    private var enableConsoleLogging: Bool
+
+    private func getConsoleLoggingEnabled() -> Bool {
+        levelLock.lock()
+        defer { levelLock.unlock() }
+        return enableConsoleLogging
+    }
+
+    public func setConsoleLoggingEnabled(_ enabled: Bool) {
+        levelLock.lock()
+        defer { levelLock.unlock() }
+        enableConsoleLogging = enabled
+    }
 
     // MARK: - State
 
@@ -184,7 +196,7 @@ public final class AppLogger {
         let logMessage = "[\(timestamp)] [\(levelPrefix)] [\(fileName):\(line) \(function)] \(message)"
 
         // Print to console if enabled
-        if enableConsoleLogging {
+        if getConsoleLoggingEnabled() {
             Swift.print(logMessage)
         }
 

--- a/Tests/KeyPathTests/CLI/CLICommandValidationTests.swift
+++ b/Tests/KeyPathTests/CLI/CLICommandValidationTests.swift
@@ -145,6 +145,14 @@ final class CLICommandValidationTests: XCTestCase {
         XCTAssertEqual(cmd.lines, 50)
     }
 
+    // MARK: - System command parsing
+
+    func testSystemRepairAcceptsOpenPermissions() throws {
+        let cmd = try SystemRepair.parse(["--dry-run", "--open-permissions"])
+        XCTAssertTrue(cmd.globals.dryRun)
+        XCTAssertTrue(cmd.openPermissions)
+    }
+
     // MARK: - Global options
 
     func testGlobalOptionsDryRun() throws {

--- a/Tests/KeyPathTests/CLI/OutputContractTests.swift
+++ b/Tests/KeyPathTests/CLI/OutputContractTests.swift
@@ -71,6 +71,43 @@ final class OutputContractTests: XCTestCase {
         XCTAssertTrue(required.isSubset(of: keys), "Missing required keys: \(required.subtracting(keys))")
     }
 
+    func testInstallerReportRepairMetadataJSONShape() throws {
+        let issue = CLISystemIssue(
+            title: "Kanata needs Input Monitoring permission",
+            category: "permissions",
+            action: "Open System Settings",
+            canAutoFix: false,
+            remediationURL: "x-apple.systempreferences:com.apple.preference.security?Privacy_ListenEvent"
+        )
+        let report = CLIInstallerReport(
+            success: false,
+            failureReason: "Repair requires user action",
+            steps: [],
+            fastRepair: false,
+            dryRun: true,
+            userActionRequired: true,
+            issues: [issue],
+            plannedRecipes: ["reinstall-privileged-helper (installService)"],
+            unmetRequirements: [],
+            logs: nil
+        )
+
+        let keys = try jsonKeys(report)
+        let required: Set = [
+            "dryRun", "failureReason", "fastRepair", "issues", "plannedRecipes",
+            "steps", "success", "unmetRequirements", "userActionRequired",
+        ]
+        XCTAssertTrue(required.isSubset(of: keys), "Missing required keys: \(required.subtracting(keys))")
+
+        let data = try encoder.encode(report)
+        let decoded = try decoder.decode(CLIInstallerReport.self, from: data)
+        XCTAssertEqual(decoded.issues?.first?.category, "permissions")
+        XCTAssertEqual(
+            decoded.issues?.first?.remediationURL,
+            "x-apple.systempreferences:com.apple.preference.security?Privacy_ListenEvent"
+        )
+    }
+
     func testValidationResultJSONShape() throws {
         let result = CLIValidationResult(isValid: true, errors: [])
         let keys = try jsonKeys(result)
@@ -85,6 +122,34 @@ final class OutputContractTests: XCTestCase {
         let result = try decoder.decode(CLIInspectResult.self, from: Data(json.utf8))
         let keys = try jsonKeys(result)
         let required: Set = ["driverCompatible", "macOSVersion", "planStatus", "plannedRecipes"]
+        XCTAssertTrue(required.isSubset(of: keys), "Missing required keys: \(required.subtracting(keys))")
+    }
+
+    func testInspectResultRepairMetadataJSONShape() throws {
+        let issue = CLISystemIssue(
+            title: "Privileged Helper unhealthy",
+            category: "helper",
+            action: "Reinstall the privileged helper",
+            canAutoFix: true
+        )
+        let result = CLIInspectResult(
+            macOSVersion: "26.5.0",
+            driverCompatible: true,
+            planStatus: "ready",
+            blockedBy: nil,
+            plannedRecipes: ["reinstall-privileged-helper (installService)"],
+            planIntent: "repair",
+            isOperational: false,
+            userActionRequired: false,
+            promptsNeeded: true,
+            issues: [issue]
+        )
+
+        let keys = try jsonKeys(result)
+        let required: Set = [
+            "driverCompatible", "issues", "isOperational", "macOSVersion", "planIntent",
+            "planStatus", "plannedRecipes", "promptsNeeded", "userActionRequired",
+        ]
         XCTAssertTrue(required.isSubset(of: keys), "Missing required keys: \(required.subtracting(keys))")
     }
 

--- a/docs/KEYPATH_GUIDE.adoc
+++ b/docs/KEYPATH_GUIDE.adoc
@@ -230,15 +230,16 @@ KeyPath includes a CLI for automation and system administration.
 [[cli-installation]]
 === CLI Installation
 
-The standalone CLI is exposed as `keypath`. To use it:
+The command-line tool is exposed as `keypath-cli`. Opening KeyPath.app remains
+the primary way to launch KeyPath; the CLI is a separate terminal entry point.
 
 [source,bash]
 ----
-# Add to PATH (add to ~/.zshrc or ~/.bash_profile)
-export PATH="$PATH:/Applications/KeyPath.app/Contents/MacOS"
+# Recommended: open KeyPath and choose File > Install Command Line Tool
+keypath-cli status
 
 # Or use full path
-/Applications/KeyPath.app/Contents/MacOS/keypath status
+/Applications/KeyPath.app/Contents/MacOS/keypath-cli status
 ----
 
 [[cli-commands]]

--- a/docs/keypath-cli-skill.md
+++ b/docs/keypath-cli-skill.md
@@ -21,6 +21,9 @@ editing config files directly.
 - When piped (non-TTY), output is JSON automatically
 - Use `--quiet` to suppress stderr decoration (spinners, progress)
 - Use `--dry-run` to preview any mutation before committing
+- For system install/repair, use the app-bundled CLI or the app-installed
+  `/usr/local/bin/keypath-cli` shim. Standalone debug/Homebrew formula binaries
+  are not authoritative for bundle-relative helper assets.
 
 ## Command Reference
 
@@ -107,11 +110,17 @@ keypath config apply --json         # Regenerate + reload (returns changeset wit
 
 ### System Management
 ```bash
-keypath system inspect --json       # Check system state and plan
-keypath system install              # Install services and components
-keypath system repair               # Fix broken services
-keypath system uninstall            # Remove all services
+keypath system inspect --json             # Check system state, repair plan, and issues
+keypath system install --dry-run --json   # Preview installation work and blockers
+keypath system repair --dry-run --json    # Preview repair work and manual permission actions
+keypath system repair --open-permissions  # Open System Settings for permission blockers
+keypath system repair                     # Fix auto-repairable services and components
+keypath system uninstall                  # Remove all services
 ```
+
+Permission repair boundary: the CLI can diagnose missing Accessibility/Input
+Monitoring grants and open the matching System Settings pane, but macOS still
+requires the user to approve those permissions manually.
 
 ### Import/Export
 ```bash

--- a/guides/cli.md
+++ b/guides/cli.md
@@ -8,15 +8,21 @@ permalink: /guides/cli/
 
 # Command Line
 
-KeyPath includes a CLI tool (`keypath`) for managing your keyboard from Terminal. Everything you can do in the app — remapping keys, managing layers, controlling the service — you can also do from the command line.
+KeyPath includes a CLI tool (`keypath-cli`) for managing your keyboard from Terminal. Opening KeyPath.app remains the primary way to launch KeyPath; the CLI is a separate terminal entry point.
 
-Install it with Homebrew:
+For DMG installs, open KeyPath and choose **File > Install Command Line Tool**. That installs:
 
 ```bash
-brew install keypath
+keypath-cli
 ```
 
-Or use the CLI bundled with the app at `/Applications/KeyPath.app/Contents/MacOS/keypath-cli`.
+The installed command points at the signed CLI inside `/Applications/KeyPath.app`, which is required for system install and repair commands that use bundled helper assets.
+
+You can also run the bundled CLI directly:
+
+```bash
+/Applications/KeyPath.app/Contents/MacOS/keypath-cli system inspect
+```
 
 All commands support `--json` for machine-readable output, making them easy to use in scripts, Shortcuts, and automation tools.
 
@@ -108,11 +114,18 @@ keypath export collection "My Rules"        # Export one collection
 ### System
 
 ```bash
-keypath system inspect            # Inspect system state
-keypath system install            # Install services
-keypath system repair             # Fix broken services
-keypath system uninstall          # Remove everything
+keypath system inspect                    # Inspect system state and repair plan
+keypath system install --dry-run          # Preview installation work and blockers
+keypath system repair --dry-run           # Preview repair work and manual permission actions
+keypath system repair --open-permissions  # Open System Settings for permission blockers
+keypath system repair                     # Fix auto-repairable services and components
+keypath system uninstall                  # Remove everything
 ```
+
+`system repair` can repair service/helper/component problems that KeyPath can
+control. macOS permissions such as Accessibility and Input Monitoring still
+require user approval; the CLI reports those as manual issues and can open the
+appropriate System Settings pane with `--open-permissions`.
 
 ### Simulation
 


### PR DESCRIPTION
## Summary
- Bundle `keypath-cli` inside `KeyPath.app`, sign it, verify it, and expose an explicit File > Install Command Line Tool... action that installs `/usr/local/bin/keypath-cli` as a symlink to the app-bundled binary.
- Make `keypath-cli system inspect/install/repair` use the app-bundled runtime for system repair, with clear diagnostics when run from a standalone debug/Homebrew-style context.
- Add repair/inspect metadata to human and JSON output, including permission remediation URLs and an `--open-permissions` repair option.
- Update CLI docs and focused CLI output/argument tests.

## Validation
- `swift build`
- `swift build --product keypath-cli`
- `swift test --filter FacadeLintTests/testAppKitSourcesDoNotBypassInstallerEngine`
- `swift test --filter OutputContractTests --filter CLICommandValidationTests`
- `python3 Scripts/check-accessibility.py`
- `bash -n Scripts/build-and-sign.sh && bash -n Scripts/quick-deploy.sh && bash -n Scripts/verify-installed-app.sh`
- `.build/debug/keypath-cli system inspect --json --timeout 10`
- `.build/debug/keypath-cli system repair --dry-run --json --timeout 10`
- `./Scripts/quick-deploy.sh`
- `open -a /Applications/KeyPath.app`
- `/Applications/KeyPath.app/Contents/MacOS/keypath-cli --version`
- `/Applications/KeyPath.app/Contents/MacOS/keypath-cli system inspect --json --timeout 20`
- `codesign --verify --strict --verbose=2 /Applications/KeyPath.app`
- `codesign --verify --strict --verbose=2 /Applications/KeyPath.app/Contents/MacOS/keypath-cli`

## Notes
- The installed app was rebuilt, quick-deployed to `/Applications/KeyPath.app`, and relaunched manually because it was not already running during quick deploy.
- Full installed-app runtime verification was not run as a pass condition because the local machine currently reports the privileged helper/service as unhealthy; the app-bundled CLI correctly diagnoses that as repair work instead of a bundle resolution failure.
