### PR TITLE
[codex] Guard Sparkle runtime rpath in deploy scripts

### DIFF
--- a/Scripts/build-and-sign.sh
+++ b/Scripts/build-and-sign.sh
@@ -285,6 +285,17 @@ MACOS="${CONTENTS}/MacOS"
 	    echo "   This usually indicates the Sparkle SPM dependency did not build." >&2
 	    exit 1
 	fi
+	if [ ! -f "$FRAMEWORKS/Sparkle.framework/Versions/B/Sparkle" ]; then
+	    echo "❌ ERROR: Embedded Sparkle binary is missing from $FRAMEWORKS/Sparkle.framework" >&2
+	    exit 1
+	fi
+	for executable in "$MACOS/KeyPath" "$MACOS/keypath-cli"; do
+	    if ! otool -l "$executable" | grep -q "@executable_path/../Frameworks"; then
+	        echo "❌ ERROR: $(basename "$executable") is missing @executable_path/../Frameworks rpath" >&2
+	        echo "   Without this, dyld cannot load the embedded Sparkle.framework at launch." >&2
+	        exit 1
+	    fi
+	done
 
 	# Assemble Insights plugin bundle
 	echo "🔌 Assembling Insights.bundle..."

--- a/Scripts/quick-deploy.sh
+++ b/Scripts/quick-deploy.sh
@@ -325,6 +325,17 @@ fi
 if ! otool -l "$MACOS_DIR/keypath-cli" | grep -q "@executable_path/../Frameworks"; then
     install_name_tool -add_rpath "@executable_path/../Frameworks" "$MACOS_DIR/keypath-cli" 2>/dev/null || true
 fi
+if [[ ! -f "$APP_BUNDLE/Contents/Frameworks/Sparkle.framework/Versions/B/Sparkle" ]]; then
+    echo "❌ Sparkle.framework is missing from the deployed app bundle" >&2
+    exit 1
+fi
+for executable in "$MACOS_DIR/$APP_NAME" "$MACOS_DIR/keypath-cli"; do
+    if ! otool -l "$executable" | grep -q "@executable_path/../Frameworks"; then
+        echo "❌ $(basename "$executable") is missing @executable_path/../Frameworks rpath" >&2
+        echo "   Without this, dyld cannot load the embedded Sparkle.framework at launch." >&2
+        exit 1
+    fi
+done
 
 # Assemble and sync Insights.bundle to PlugIns
 INSIGHTS_DYLIB="$BIN_DIR/libKeyPathInsights.dylib"

--- a/Scripts/verify-installed-app.sh
+++ b/Scripts/verify-installed-app.sh
@@ -32,6 +32,18 @@ if [[ ! -x "$CLI_PATH" ]]; then
     echo "❌ Bundled CLI is missing or not executable: $CLI_PATH" >&2
     exit 1
 fi
+SPARKLE_PATH="$APP_PATH/Contents/Frameworks/Sparkle.framework/Versions/B/Sparkle"
+if [[ ! -f "$SPARKLE_PATH" ]]; then
+    echo "❌ Sparkle.framework binary is missing: $SPARKLE_PATH" >&2
+    exit 1
+fi
+for executable in "$APP_PATH/Contents/MacOS/KeyPath" "$CLI_PATH"; do
+    if ! otool -l "$executable" | grep -q "@executable_path/../Frameworks"; then
+        echo "❌ $(basename "$executable") is missing @executable_path/../Frameworks rpath" >&2
+        echo "   Without this, dyld cannot load the embedded Sparkle.framework at launch." >&2
+        exit 1
+    fi
+done
 
 print_section "Trust Policy"
 codesign --verify --strict --verbose=2 "$APP_PATH"


### PR DESCRIPTION
## Summary
- Add explicit checks that `Sparkle.framework/Versions/B/Sparkle` is embedded before considering app assembly or deploy successful.
- Verify both `KeyPath` and `keypath-cli` include `@executable_path/../Frameworks` so dyld can resolve the embedded Sparkle framework at launch.
- Extend installed-app verification to catch this class of launch-time dyld failure directly.

## Crash Context
A crash report showed KeyPath aborting at launch because dyld could not resolve `@rpath/Sparkle.framework/Versions/B/Sparkle`. The currently deployed app already has the correct rpath and launches, but these guards prevent a future broken bundle from passing build/deploy verification.

## Validation
- `bash -n Scripts/build-and-sign.sh && bash -n Scripts/quick-deploy.sh && bash -n Scripts/verify-installed-app.sh`
- `CHECK_RUNTIME=0 ./Scripts/verify-installed-app.sh`
- `open -a /Applications/KeyPath.app && sleep 5 && ./Scripts/verify-installed-app.sh`
- pre-push `swift build`
