### PR TITLE
[codex] Fix CLI helper trust repair diagnostics

### DIFF
--- a/Scripts/build-and-sign.sh
+++ b/Scripts/build-and-sign.sh
@@ -458,8 +458,12 @@ else
     # Sign bundled kanata simulator binary
     kp_sign "$CONTENTS/Library/KeyPath/kanata-simulator" --force --options=runtime --sign "$SIGNING_IDENTITY"
 
-    # Sign command-line tool embedded in the app bundle.
-    kp_sign "$MACOS/keypath-cli" --force --options=runtime --sign "$SIGNING_IDENTITY"
+    # Sign command-line tool embedded in the app bundle with a stable identifier
+    # trusted by the privileged helper for CLI system diagnostics and repair.
+    kp_sign "$MACOS/keypath-cli" \
+        --force --options=runtime \
+        --identifier "com.keypath.KeyPath.CLI" \
+        --sign "$SIGNING_IDENTITY"
 
     # Sign Insights plugin bundle
     kp_sign "$INSIGHTS_BUNDLE" --force --options=runtime --deep --sign "$SIGNING_IDENTITY"

--- a/Scripts/quick-deploy.sh
+++ b/Scripts/quick-deploy.sh
@@ -356,6 +356,7 @@ echo "✍️  Signing..."
 SIGNING_IDENTITY="${CODESIGN_IDENTITY:-Developer ID Application: Micah Alpern (X2RKZ5TG99)}"
 HELPER_EXEC="$APP_BUNDLE/Contents/Library/HelperTools/KeyPathHelper"
 HELPER_ENTITLEMENTS="$PROJECT_DIR/Sources/KeyPathHelper/KeyPathHelper.entitlements"
+CLI_EXEC="$APP_BUNDLE/Contents/MacOS/keypath-cli"
 
 # Re-sign the embedded privileged helper with its REQUIRED signing identifier and
 # re-seal the app afterwards. `codesign --deep` on the app re-signs nested
@@ -363,16 +364,23 @@ HELPER_ENTITLEMENTS="$PROJECT_DIR/Sources/KeyPathHelper/KeyPathHelper.entitlemen
 # SMPrivilegedExecutables entry requires identifier "com.keypath.helper". A mismatch
 # makes the helper fail validation — the setup wizard reports a privileged-helper
 # error it "can't fix". So after the --deep pass we re-sign the helper with the
-# correct identifier, then re-seal the OUTER app WITHOUT --deep so the corrected
-# helper signature is preserved. $1 = signing identity ("-" for ad-hoc).
-resign_helper_identifier() {
+# correct identifiers, then re-seal the OUTER app WITHOUT --deep so the corrected
+# nested signatures are preserved. $1 = signing identity ("-" for ad-hoc).
+resign_nested_identifiers() {
     local sign_id="$1"
-    [[ -f "$HELPER_EXEC" && -f "$HELPER_ENTITLEMENTS" ]] || return 0
-    codesign --force --options=runtime \
-        --identifier "com.keypath.helper" \
-        --entitlements "$HELPER_ENTITLEMENTS" \
-        --sign "$sign_id" \
-        "$HELPER_EXEC" || echo "⚠️  Failed to re-sign helper with com.keypath.helper identifier"
+    if [[ -f "$HELPER_EXEC" && -f "$HELPER_ENTITLEMENTS" ]]; then
+        codesign --force --options=runtime \
+            --identifier "com.keypath.helper" \
+            --entitlements "$HELPER_ENTITLEMENTS" \
+            --sign "$sign_id" \
+            "$HELPER_EXEC" || echo "⚠️  Failed to re-sign helper with com.keypath.helper identifier"
+    fi
+    if [[ -f "$CLI_EXEC" ]]; then
+        codesign --force --options=runtime \
+            --identifier "com.keypath.KeyPath.CLI" \
+            --sign "$sign_id" \
+            "$CLI_EXEC" || echo "⚠️  Failed to re-sign keypath-cli with com.keypath.KeyPath.CLI identifier"
+    fi
     codesign --force --options=runtime --sign "$sign_id" --entitlements "$ENTITLEMENTS" "$APP_BUNDLE"
 }
 
@@ -391,14 +399,14 @@ if security find-identity -v -p codesigning | grep -Fq "$SIGNING_IDENTITY"; then
         codesign --force --options=runtime --sign "$SIGNING_IDENTITY" "$APP_BUNDLE/Contents/Library/KeyPath/libkeypath_kanata_host_bridge.dylib" 2>/dev/null || true
     fi
     if [[ -f "$APP_BUNDLE/Contents/MacOS/keypath-cli" ]]; then
-        codesign --force --options=runtime --sign "$SIGNING_IDENTITY" "$APP_BUNDLE/Contents/MacOS/keypath-cli" 2>/dev/null || true
+        codesign --force --options=runtime --identifier "com.keypath.KeyPath.CLI" --sign "$SIGNING_IDENTITY" "$APP_BUNDLE/Contents/MacOS/keypath-cli" 2>/dev/null || true
     fi
     codesign --force --options=runtime --sign "$SIGNING_IDENTITY" --entitlements "$ENTITLEMENTS" --deep "$APP_BUNDLE"
-    resign_helper_identifier "$SIGNING_IDENTITY"
+    resign_nested_identifiers "$SIGNING_IDENTITY"
 else
     echo "⚠️  Developer ID identity not found; using ad-hoc signing (helper may reject this build)."
     codesign --force --sign - --entitlements "$ENTITLEMENTS" --deep "$APP_BUNDLE"
-    resign_helper_identifier "-"
+    resign_nested_identifiers "-"
 fi
 
 # Verify signature is valid before restarting — catch any silent corruption.

--- a/Scripts/verify-installed-app.sh
+++ b/Scripts/verify-installed-app.sh
@@ -44,6 +44,12 @@ for executable in "$APP_PATH/Contents/MacOS/KeyPath" "$CLI_PATH"; do
         exit 1
     fi
 done
+cli_codesign_output="$(codesign -dv "$CLI_PATH" 2>&1)"
+if ! grep -q '^Identifier=com\.keypath\.KeyPath\.CLI$' <<<"$cli_codesign_output"; then
+    echo "❌ Bundled CLI is not signed with identifier com.keypath.KeyPath.CLI" >&2
+    echo "   The privileged helper will reject CLI XPC health checks without this identifier." >&2
+    exit 1
+fi
 
 print_section "Trust Policy"
 codesign --verify --strict --verbose=2 "$APP_PATH"

--- a/Sources/KeyPathHelper/main.swift
+++ b/Sources/KeyPathHelper/main.swift
@@ -9,7 +9,7 @@ import Security
 // as a LaunchDaemon Mach service.
 //
 // Security:
-// - Only accepts connections from KeyPath.app (com.keypath.KeyPath) in release builds
+// - Only accepts connections from KeyPath.app or its bundled CLI in release builds
 // - Validates code signature via audit token before accepting connections
 // - All operations are logged to system log for audit trail
 
@@ -74,7 +74,7 @@ func validateConnection(_ connection: NSXPCConnection, requirement requirementSt
             let teamID = info[kSecCodeInfoTeamIdentifier as String] as? String ?? "unknown"
             NSLog("[KeyPathHelper] Code signature validation failed for PID \(pid): \(status)")
             NSLog("[KeyPathHelper]   → Connecting process: identifier=\(identifier), team=\(teamID)")
-            NSLog("[KeyPathHelper]   → Expected: identifier=\"com.keypath.KeyPath\", team=\"X2RKZ5TG99\"")
+            NSLog("[KeyPathHelper]   → Expected: identifier=\"com.keypath.KeyPath\" or \"com.keypath.KeyPath.CLI\", team=\"X2RKZ5TG99\"")
             NSLog("[KeyPathHelper]   → This likely means app was updated but not restarted")
             logger.error(
                 """
@@ -103,13 +103,13 @@ class HelperDelegate: NSObject, NSXPCListenerDelegate {
     func listener(_: NSXPCListener, shouldAcceptNewConnection connection: NSXPCConnection) -> Bool {
         // Security requirement:
         // - DEBUG: allow any app from our Developer ID team for contributor convenience
-        // - RELEASE: require the exact app bundle identifier for strict production security
+        // - RELEASE: require the exact app or bundled CLI identifier for strict production security
         #if DEBUG
             let requirementString =
                 "anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] and certificate leaf[field.1.2.840.113635.100.6.1.13] and certificate leaf[subject.OU] = X2RKZ5TG99"
         #else
             // swiftlint:disable:next line_length
-            let requirementString = "identifier \"com.keypath.KeyPath\" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] and certificate leaf[field.1.2.840.113635.100.6.1.13] and certificate leaf[subject.OU] = X2RKZ5TG99"
+            let requirementString = "(identifier \"com.keypath.KeyPath\" or identifier \"com.keypath.KeyPath.CLI\") and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] and certificate leaf[field.1.2.840.113635.100.6.1.13] and certificate leaf[subject.OU] = X2RKZ5TG99"
         #endif
 
         // Validate the caller's code signature using audit token
@@ -118,7 +118,7 @@ class HelperDelegate: NSObject, NSXPCListenerDelegate {
             return false
         }
 
-        NSLog("[KeyPathHelper] ✅ Accepting connection from validated KeyPath.app")
+        NSLog("[KeyPathHelper] ✅ Accepting connection from validated KeyPath client")
 
         // Set up the XPC interface
         connection.exportedInterface = NSXPCInterface(with: HelperProtocol.self)

--- a/Sources/KeyPathInstallationWizard/Core/InstallerEngine+Recipes.swift
+++ b/Sources/KeyPathInstallationWizard/Core/InstallerEngine+Recipes.swift
@@ -61,14 +61,14 @@ public extension InstallerEngine {
         case .installPrivilegedHelper:
             ServiceRecipe(
                 id: InstallerRecipeID.installPrivilegedHelper,
-                type: .installService,
+                type: .repairPrivilegedHelper,
                 serviceID: KeyPathConstants.Bundle.helperID
             )
 
         case .reinstallPrivilegedHelper:
             ServiceRecipe(
                 id: InstallerRecipeID.reinstallPrivilegedHelper,
-                type: .installService,
+                type: .repairPrivilegedHelper,
                 serviceID: KeyPathConstants.Bundle.helperID
             )
 

--- a/Sources/KeyPathInstallationWizard/Core/InstallerEngine.swift
+++ b/Sources/KeyPathInstallationWizard/Core/InstallerEngine.swift
@@ -362,6 +362,11 @@ public final class InstallerEngine {
             try await executeInstallService(recipe, using: broker)
             logs.append("LaunchDaemon services installed")
 
+        case .repairPrivilegedHelper:
+            logs.append("Repairing privileged helper registration...")
+            try await executeRepairPrivilegedHelper()
+            logs.append("Privileged helper repair completed")
+
         case .restartService:
             logs.append("Checking VHID Manager activation status...")
             if let serviceID = recipe.serviceID {
@@ -391,6 +396,21 @@ public final class InstallerEngine {
     /// Execute a single recipe (legacy method for backward compatibility)
     private func executeRecipe(_ recipe: ServiceRecipe, using broker: PrivilegeBroker) async throws {
         _ = try await executeRecipeWithDetails(recipe, using: broker)
+    }
+
+    /// Execute privileged helper repair via the helper-maintenance workflow.
+    private func executeRepairPrivilegedHelper() async throws {
+        guard let helperMaintenance = WizardDependencies.helperMaintenance else {
+            throw InstallerError.healthCheckFailed("Helper maintenance is not configured")
+        }
+
+        let repaired = await helperMaintenance.runCleanupAndRepair(useAppleScriptFallback: true)
+        guard repaired else {
+            let failure = helperMaintenance.lastErrorLine
+                ?? helperMaintenance.logLines.last
+                ?? "Privileged helper repair failed"
+            throw InstallerError.healthCheckFailed(failure)
+        }
     }
 
     /// Execute installService recipe

--- a/Sources/KeyPathInstallationWizard/Core/InstallerEngineTypes.swift
+++ b/Sources/KeyPathInstallationWizard/Core/InstallerEngineTypes.swift
@@ -156,6 +156,8 @@ public struct EngineSystemInfo: Sendable, Equatable {
 public enum RecipeType: Sendable, Equatable {
     /// Install a LaunchDaemon service
     case installService
+    /// Repair or refresh the privileged helper registration
+    case repairPrivilegedHelper
     /// Restart an existing service
     case restartService
     /// Install a component (Kanata binary, driver, etc.)

--- a/Tests/KeyPathTests/InstallationEngine/InstallerEngineEndToEndTests.swift
+++ b/Tests/KeyPathTests/InstallationEngine/InstallerEngineEndToEndTests.swift
@@ -58,6 +58,36 @@ final class InstallerEngineEndToEndTests: KeyPathAsyncTestCase {
         )
     }
 
+    func testExecutePlanRunsHelperMaintenanceForPrivilegedHelperRepair() async {
+        let coordinator = StubPrivilegedOperationsCoordinator()
+        let broker = PrivilegeBroker(coordinator: coordinator)
+        let engine = InstallerEngine()
+        let helperMaintenance = StubHelperMaintenance()
+        WizardDependencies.helperMaintenance = helperMaintenance
+        defer { WizardDependencies.helperMaintenance = nil }
+
+        let plan = InstallPlan(
+            recipes: [
+                ServiceRecipe(
+                    id: InstallerRecipeID.reinstallPrivilegedHelper,
+                    type: .repairPrivilegedHelper,
+                    serviceID: "com.keypath.helper"
+                )
+            ],
+            status: .ready,
+            intent: .repair
+        )
+
+        let report = await engine.execute(plan: plan, using: broker)
+
+        XCTAssertTrue(report.success, "Helper maintenance success should mark the recipe successful")
+        XCTAssertEqual(helperMaintenance.repairCallCount, 1)
+        XCTAssertFalse(
+            coordinator.calls.contains("installRequiredRuntimeServices"),
+            "Privileged helper repair must not be routed to Kanata LaunchDaemon installation"
+        )
+    }
+
     func testExecutePlanTreatsPendingApprovalAsHealthyForKanataHealthCheck() async throws {
         #if DEBUG
             final class PendingApprovalSMAppService: SMAppServiceProtocol, @unchecked Sendable {
@@ -99,5 +129,22 @@ final class InstallerEngineEndToEndTests: KeyPathAsyncTestCase {
         #else
             throw XCTSkip("Uses DEBUG-only KanataDaemonManager.smServiceFactory override")
         #endif
+    }
+}
+
+@MainActor
+private final class StubHelperMaintenance: WizardHelperMaintaining {
+    private(set) var repairCallCount = 0
+    var logLines: [String] = []
+    var lastErrorLine: String?
+
+    func detectDuplicateAppCopies() -> [String] {
+        ["/Applications/KeyPath.app"]
+    }
+
+    func runCleanupAndRepair(useAppleScriptFallback _: Bool) async -> Bool {
+        repairCallCount += 1
+        logLines.append("helper repair invoked")
+        return true
     }
 }

--- a/Tests/KeyPathTests/InstallationEngine/InstallerEngineTests.swift
+++ b/Tests/KeyPathTests/InstallationEngine/InstallerEngineTests.swift
@@ -470,6 +470,14 @@ final class InstallerEngineTests: KeyPathAsyncTestCase {
         let runtimeServicesRecipe = engine.recipeForAction(.installRequiredRuntimeServices, context: context)
         XCTAssertEqual(runtimeServicesRecipe?.id, InstallerRecipeID.installRequiredRuntimeServices)
 
+        let installHelperRecipe = engine.recipeForAction(.installPrivilegedHelper, context: context)
+        XCTAssertEqual(installHelperRecipe?.id, InstallerRecipeID.installPrivilegedHelper)
+        XCTAssertEqual(installHelperRecipe?.type, .repairPrivilegedHelper)
+
+        let reinstallHelperRecipe = engine.recipeForAction(.reinstallPrivilegedHelper, context: context)
+        XCTAssertEqual(reinstallHelperRecipe?.id, InstallerRecipeID.reinstallPrivilegedHelper)
+        XCTAssertEqual(reinstallHelperRecipe?.type, .repairPrivilegedHelper)
+
         let karabinerStartRecipe = engine.recipeForAction(.startKarabinerDaemon, context: context)
         XCTAssertEqual(karabinerStartRecipe?.id, InstallerRecipeID.startKarabinerDaemon)
         XCTAssertEqual(karabinerStartRecipe?.serviceID, KeyPathConstants.Bundle.vhidDaemonID)

--- a/Tests/KeyPathTests/Lint/HelperTrustContractTests.swift
+++ b/Tests/KeyPathTests/Lint/HelperTrustContractTests.swift
@@ -1,0 +1,65 @@
+import Foundation
+import Security
+@preconcurrency import XCTest
+
+final class HelperTrustContractTests: XCTestCase {
+    func testBundledCLIIdentifierMatchesHelperTrustRequirement() throws {
+        let root = repositoryRoot()
+        let cliIdentifier = "com.keypath.KeyPath.CLI"
+
+        let helperMain = try contents(
+            of: root.appendingPathComponent("Sources/KeyPathHelper/main.swift")
+        )
+        let buildAndSign = try contents(
+            of: root.appendingPathComponent("Scripts/build-and-sign.sh")
+        )
+        let quickDeploy = try contents(
+            of: root.appendingPathComponent("Scripts/quick-deploy.sh")
+        )
+        let verifyInstalledApp = try contents(
+            of: root.appendingPathComponent("Scripts/verify-installed-app.sh")
+        )
+
+        XCTAssertTrue(
+            helperMain.contains(#"identifier \"\#(cliIdentifier)\""#),
+            "The helper release trust requirement must accept the app-bundled CLI identifier."
+        )
+        XCTAssertTrue(
+            buildAndSign.contains(#"--identifier "\#(cliIdentifier)""#),
+            "Release signing must stamp keypath-cli with the helper-trusted identifier."
+        )
+        XCTAssertTrue(
+            quickDeploy.contains(#"--identifier "\#(cliIdentifier)""#),
+            "Quick deploy signing must preserve the helper-trusted CLI identifier."
+        )
+        XCTAssertTrue(
+            verifyInstalledApp.contains(#"Identifier=com\.keypath\.KeyPath\.CLI"#),
+            "Installed-app verification must fail if keypath-cli is signed with the wrong identifier."
+        )
+    }
+
+    func testHelperReleaseTrustRequirementParses() {
+        let releaseRequirement =
+            #"(identifier "com.keypath.KeyPath" or identifier "com.keypath.KeyPath.CLI") and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] and certificate leaf[field.1.2.840.113635.100.6.1.13] and certificate leaf[subject.OU] = X2RKZ5TG99"#
+
+        var requirement: SecRequirement?
+        let status = SecRequirementCreateWithString(releaseRequirement as CFString, [], &requirement)
+
+        XCTAssertEqual(status, errSecSuccess)
+        XCTAssertNotNil(requirement)
+    }
+}
+
+// MARK: - Helpers
+
+private func repositoryRoot(file: StaticString = #filePath) -> URL {
+    URL(fileURLWithPath: file.description)
+        .deletingLastPathComponent() // Lint
+        .deletingLastPathComponent() // KeyPathTests
+        .deletingLastPathComponent() // Tests
+        .deletingLastPathComponent() // repo root
+}
+
+private func contents(of url: URL) throws -> String {
+    try String(contentsOf: url, encoding: .utf8)
+}

--- a/docs/troubleshooting-helper.md
+++ b/docs/troubleshooting-helper.md
@@ -13,6 +13,8 @@ What Changed
 Quick Validation Checklist
 - Helper binary exists in the app: `/Applications/KeyPath.app/Contents/Library/HelperTools/KeyPathHelper`
 - Helper plist exists in the app: `/Applications/KeyPath.app/Contents/Library/LaunchDaemons/com.keypath.helper.plist`
+- Bundled CLI is signed as `com.keypath.KeyPath.CLI`:
+  `codesign -dv /Applications/KeyPath.app/Contents/MacOS/keypath-cli 2>&1 | grep '^Identifier=com.keypath.KeyPath.CLI$'`
 - `Info.plist` contains `SMPrivilegedExecutables` for `com.keypath.helper` with the correct requirement.
 - Helper binary is signed and satisfies the requirement (see Diagnostic Script below).
 - App bundle is signed, notarized, and stapled.
@@ -43,6 +45,13 @@ Hypotheses To Investigate
 Development Caveat
 - `Scripts/quick-deploy.sh` should not hot-swap the embedded helper by default.
 - Replacing `/Applications/KeyPath.app/Contents/Library/HelperTools/KeyPathHelper` during fast iteration can leave the registered helper in a `spawn failed` state even when `codesign --verify --deep --strict /Applications/KeyPath.app` still passes.
+- `keypath-cli system inspect` uses helper XPC to check helper health. The helper
+  trusts `com.keypath.KeyPath` and the app-bundled CLI identifier
+  `com.keypath.KeyPath.CLI`, both signed by team `X2RKZ5TG99`.
+- If the CLI reports `Privileged Helper unhealthy` after a helper-signing or
+  helper-trust change, repair must refresh the SMAppService helper registration
+  through `HelperMaintenance.runCleanupAndRepair(...)`; reinstalling only
+  LaunchDaemon services will not replace a stale registered helper process.
 - Symptom:
   - `launchctl print system/com.keypath.helper` shows `job state = spawn failed`
   - `last exit code = 78: EX_CONFIG`


### PR DESCRIPTION
## Summary
- sign the app-bundled `keypath-cli` with the stable identifier `com.keypath.KeyPath.CLI` and trust that identifier in the privileged helper release requirement
- route privileged-helper install/reinstall recipes through `HelperMaintenance.runCleanupAndRepair(...)` instead of the Kanata LaunchDaemon installer
- add installed-app verifier coverage, helper trust contract tests, InstallerEngine regression tests, and troubleshooting docs

## Root cause
`keypath-cli system inspect` could report `Privileged Helper unhealthy` even when the installed runtime was TCP-ready because the helper only trusted the app bundle identifier in release builds. The CLI was also able to plan `reinstall-privileged-helper`, but that recipe was typed as a generic service install, so repair did not refresh the SMAppService helper registration.

## Validation
- `swift test --filter HelperTrustContractTests|InstallerEngineEndToEndTests/testExecutePlanRunsHelperMaintenanceForPrivilegedHelperRepair|InstallerEngineTests/testRecipeIDsAreCentralizedForRuntimeServicesAndKanata`
- `bash -n Scripts/build-and-sign.sh && bash -n Scripts/quick-deploy.sh && bash -n Scripts/verify-installed-app.sh && git diff --check`
- `python3 Scripts/check-accessibility.py`
- `KEYPATH_DEPLOY_HELPER=1 ./Scripts/quick-deploy.sh`
- `/Applications/KeyPath.app/Contents/MacOS/keypath-cli system repair --json --timeout 90 --quiet`
- `/Applications/KeyPath.app/Contents/MacOS/keypath-cli system inspect --json --timeout 20`
- `REQUIRE_NOTARIZED=0 REQUIRE_STAPLED=0 ./Scripts/verify-installed-app.sh`