### PR TITLE
[codex] Prevent cross-worktree deploy races

### DIFF
--- a/Scripts/README.md
+++ b/Scripts/README.md
@@ -22,6 +22,7 @@
 - `uninstall.sh` - Uninstaller script
 - `archive/` - Deprecated or historical scripts
 - `lib/signing.sh` - Thin wrappers around codesign/notarytool/stapler with `KP_SIGN_DRY_RUN=1` for safe local runs; CI overrides hook into this.
+- `lib/deploy-lock.sh` - Shared cross-worktree lock for scripts that mutate `/Applications/KeyPath.app`.
 - `test-installer-device.sh` - Opt-in device smoke for InstallerEngine (requires `KEYPATH_E2E_DEVICE=1`; non-destructive).
 
 ## Testing

--- a/Scripts/build-and-sign.sh
+++ b/Scripts/build-and-sign.sh
@@ -7,6 +7,9 @@ set -euo pipefail
 
 SCRIPT_DIR=$(cd "$(dirname "$0")" >/dev/null && pwd)
 source "$SCRIPT_DIR/lib/signing.sh"
+source "$SCRIPT_DIR/lib/deploy-lock.sh"
+keypath_acquire_deploy_lock "build-and-sign ($SCRIPT_DIR/..)" "${KEYPATH_RELEASE_DEPLOY_LOCK_TIMEOUT_SECONDS:-600}"
+trap keypath_release_deploy_lock EXIT
 
 # Function to create Sparkle update archive with EdDSA signature.
 #

--- a/Scripts/lib/deploy-lock.sh
+++ b/Scripts/lib/deploy-lock.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+
+# Cross-worktree lock for scripts that mutate /Applications/KeyPath.app.
+# A worktree-local build lock is not enough: another checkout can still replace
+# mapped app binaries and trigger macOS CODESIGNING / Invalid Page kills.
+
+KEYPATH_DEPLOY_LOCK_DIR="${KEYPATH_DEPLOY_LOCK_DIR:-/tmp/keypath-deploy.lock}"
+KEYPATH_DEPLOY_LOCK_ACQUIRED=0
+
+keypath_deploy_lock_pid() {
+    local owner_file="$KEYPATH_DEPLOY_LOCK_DIR/owner"
+    [[ -f "$owner_file" ]] || return 1
+    awk -F= '/^pid=/ { print $2; exit }' "$owner_file" 2>/dev/null
+}
+
+keypath_deploy_lock_is_stale() {
+    local lock_pid
+    lock_pid="$(keypath_deploy_lock_pid || true)"
+    [[ -n "$lock_pid" ]] || return 0
+    ! kill -0 "$lock_pid" 2>/dev/null
+}
+
+keypath_acquire_deploy_lock() {
+    local label="${1:-KeyPath deploy}"
+    local timeout_seconds="${2:-0}"
+    local start_seconds
+    start_seconds="$(date +%s)"
+
+    while ! mkdir "$KEYPATH_DEPLOY_LOCK_DIR" 2>/dev/null; do
+        if keypath_deploy_lock_is_stale; then
+            echo "Removing stale KeyPath deploy lock: $KEYPATH_DEPLOY_LOCK_DIR"
+            rm -rf "$KEYPATH_DEPLOY_LOCK_DIR"
+            continue
+        fi
+
+        local owner=""
+        if [[ -f "$KEYPATH_DEPLOY_LOCK_DIR/owner" ]]; then
+            owner="$(tr '\n' ' ' < "$KEYPATH_DEPLOY_LOCK_DIR/owner")"
+        fi
+
+        if [[ "$timeout_seconds" == "0" ]]; then
+            echo "Another KeyPath deploy is already in progress. Skipping this deploy."
+            [[ -n "$owner" ]] && echo "Lock owner: $owner"
+            return 1
+        fi
+
+        local now_seconds
+        now_seconds="$(date +%s)"
+        if (( now_seconds - start_seconds >= timeout_seconds )); then
+            echo "Timed out waiting for KeyPath deploy lock: $KEYPATH_DEPLOY_LOCK_DIR" >&2
+            [[ -n "$owner" ]] && echo "Lock owner: $owner" >&2
+            return 1
+        fi
+
+        sleep 1
+    done
+
+    {
+        echo "pid=$$"
+        echo "label=$label"
+        echo "cwd=$(pwd)"
+        echo "started=$(date '+%Y-%m-%d %H:%M:%S')"
+    } > "$KEYPATH_DEPLOY_LOCK_DIR/owner"
+    KEYPATH_DEPLOY_LOCK_ACQUIRED=1
+    return 0
+}
+
+keypath_release_deploy_lock() {
+    [[ "$KEYPATH_DEPLOY_LOCK_ACQUIRED" == "1" ]] || return 0
+    local lock_pid
+    lock_pid="$(keypath_deploy_lock_pid || true)"
+    if [[ "$lock_pid" == "$$" ]]; then
+        rm -rf "$KEYPATH_DEPLOY_LOCK_DIR"
+    fi
+    KEYPATH_DEPLOY_LOCK_ACQUIRED=0
+}

--- a/Scripts/quick-deploy.sh
+++ b/Scripts/quick-deploy.sh
@@ -13,6 +13,7 @@ set -euo pipefail
 
 SCRIPT_DIR=$(cd "$(dirname "$0")" >/dev/null && pwd)
 PROJECT_DIR="$SCRIPT_DIR/.."
+source "$SCRIPT_DIR/lib/deploy-lock.sh"
 APP_NAME="KeyPath"
 APP_BUNDLE="/Applications/${APP_NAME}.app"
 MACOS_DIR="$APP_BUNDLE/Contents/MacOS"
@@ -101,6 +102,7 @@ cleanup() {
     local exit_code=$?
     # Always restore the agent, even on failure, so KeyPath is never left disabled.
     reload_agent
+    keypath_release_deploy_lock
     release_lock
 
     if [[ $exit_code -ne 0 ]] && [[ $exit_code -ne 130 ]]; then
@@ -117,6 +119,11 @@ trap cleanup EXIT
 # Try to acquire lock
 if ! acquire_lock; then
     exit 0  # Exit cleanly - not an error, just skipped
+fi
+
+if ! keypath_acquire_deploy_lock "quick-deploy ($PROJECT_DIR)" "${KEYPATH_QUICK_DEPLOY_LOCK_TIMEOUT_SECONDS:-0}"; then
+    log_build_event "SKIPPED_DEPLOY_LOCK"
+    exit 0
 fi
 
 BUILD_START_MS=$(get_time_ms)

--- a/Tests/KeyPathTests/Lint/DeploymentScriptContractTests.swift
+++ b/Tests/KeyPathTests/Lint/DeploymentScriptContractTests.swift
@@ -1,0 +1,54 @@
+import Foundation
+import XCTest
+
+final class DeploymentScriptContractTests: XCTestCase {
+    func testInstalledAppDeployScriptsUseCrossWorktreeLock() throws {
+        let root = repositoryRoot()
+        let lockScript = try contents(of: root.appendingPathComponent("Scripts/lib/deploy-lock.sh"))
+        let quickDeploy = try contents(of: root.appendingPathComponent("Scripts/quick-deploy.sh"))
+        let buildAndSign = try contents(of: root.appendingPathComponent("Scripts/build-and-sign.sh"))
+
+        XCTAssertTrue(
+            lockScript.contains("KEYPATH_DEPLOY_LOCK_DIR"),
+            "The deploy lock must be shared outside any single worktree."
+        )
+        XCTAssertTrue(
+            quickDeploy.contains(#"source "$SCRIPT_DIR/lib/deploy-lock.sh""#),
+            "quick-deploy must use the shared deploy lock before mutating /Applications/KeyPath.app."
+        )
+        XCTAssertTrue(
+            quickDeploy.contains("keypath_acquire_deploy_lock"),
+            "quick-deploy must acquire the shared deploy lock."
+        )
+        XCTAssertTrue(
+            quickDeploy.contains("keypath_release_deploy_lock"),
+            "quick-deploy must release the shared deploy lock during cleanup."
+        )
+        XCTAssertTrue(
+            buildAndSign.contains(#"source "$SCRIPT_DIR/lib/deploy-lock.sh""#),
+            "build-and-sign must use the shared deploy lock during release-candidate and release deploys."
+        )
+        XCTAssertTrue(
+            buildAndSign.contains("keypath_acquire_deploy_lock"),
+            "build-and-sign must acquire the shared deploy lock."
+        )
+        XCTAssertTrue(
+            buildAndSign.contains("trap keypath_release_deploy_lock EXIT"),
+            "build-and-sign must release the shared deploy lock on exit."
+        )
+    }
+}
+
+// MARK: - Helpers
+
+private func repositoryRoot(file: StaticString = #filePath) -> URL {
+    URL(fileURLWithPath: file.description)
+        .deletingLastPathComponent() // Lint
+        .deletingLastPathComponent() // KeyPathTests
+        .deletingLastPathComponent() // Tests
+        .deletingLastPathComponent() // repo root
+}
+
+private func contents(of url: URL) throws -> String {
+    try String(contentsOf: url, encoding: .utf8)
+}

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -16,6 +16,12 @@ swift build
 restarts KeyPath only if it was already running. It does not redeploy the
 privileged helper unless `KEYPATH_DEPLOY_HELPER=1` is set.
 
+Supported scripts that mutate `/Applications/KeyPath.app` use a shared
+machine-wide deploy lock at `/tmp/keypath-deploy.lock`. This is intentionally
+outside the worktree: replacing a signed app bundle from another checkout while
+KeyPath is running can produce macOS crash reports with `CODESIGNING`,
+`Invalid Page`, or `SIGKILL (Code Signature Invalid)`.
+
 Poltergeist is optional acceleration for focused single-agent UI/app iteration:
 
 ```bash
@@ -53,6 +59,11 @@ Then it delegates to `build-and-sign.sh` with fast release-candidate defaults:
 
 It deploys to `/Applications/KeyPath.app` and runs
 `./Scripts/verify-installed-app.sh` after the build.
+
+Release-candidate and public release builds hold the shared deploy lock for the
+whole build/sign/notarize/deploy flow. Update old worktrees before running
+`quick-deploy.sh`; older scripts that do not use this lock can still overwrite
+the installed app and invalidate the running process.
 
 Opt into slower work only when needed:
 


### PR DESCRIPTION
## Summary
- add a shared machine-wide deploy lock for scripts that mutate `/Applications/KeyPath.app`
- make `quick-deploy.sh` skip cleanly when another deploy owns the installed app
- make `build-and-sign.sh` hold the lock through build/sign/notarize/deploy so release-candidate installs cannot be clobbered by another worktree
- document the deploy race and add a script contract test

## Root cause
The attached crash report is `SIGKILL (Code Signature Invalid)` with `CODESIGNING / Invalid Page`. That happens when `/Applications/KeyPath.app` is replaced or re-signed while the running app still has mapped pages from the previous signed binary. The existing `quick-deploy.sh` lock was worktree-local, so another checkout could still deploy over a release-candidate app.

## Validation
- `bash -n Scripts/lib/deploy-lock.sh Scripts/quick-deploy.sh Scripts/build-and-sign.sh && git diff --check`
- deploy-lock positive acquire/release smoke
- deploy-lock negative smoke with a live owner PID
- `swift test --filter DeploymentScriptContractTests`
- pre-push `swift build` hook passed