### PR TITLE
Compact General settings option cards

### DIFF
--- a/Sources/KeyPathAppKit/UI/ContextHUD/ContextHUDSettingsSection.swift
+++ b/Sources/KeyPathAppKit/UI/ContextHUD/ContextHUDSettingsSection.swift
@@ -57,7 +57,8 @@ struct ContextHUDSettingsSection: View {
                         icon: "hand.tap",
                         title: "Hold",
                         subtitle: "Show while held",
-                        isSelected: triggerMode == .holdToShow
+                        isSelected: triggerMode == .holdToShow,
+                        cardWidth: SettingsOptionCard.settingsRowWidth
                     ) {
                         triggerMode = .holdToShow
                         services.preferences.contextHUDTriggerMode = .holdToShow
@@ -69,7 +70,8 @@ struct ContextHUDSettingsSection: View {
                         icon: "hand.point.up",
                         title: "Tap",
                         subtitle: "Toggle on/off",
-                        isSelected: triggerMode == .tapToToggle
+                        isSelected: triggerMode == .tapToToggle,
+                        cardWidth: SettingsOptionCard.settingsRowWidth
                     ) {
                         triggerMode = .tapToToggle
                         services.preferences.contextHUDTriggerMode = .tapToToggle

--- a/Sources/KeyPathAppKit/UI/Settings/SettingsOptionCard.swift
+++ b/Sources/KeyPathAppKit/UI/Settings/SettingsOptionCard.swift
@@ -3,10 +3,13 @@ import SwiftUI
 /// Reusable horizontal option card for settings selections.
 /// Displays an icon + title/subtitle with accent-colored selected state.
 struct SettingsOptionCard: View {
+    static let settingsRowWidth: CGFloat = 240
+
     let icon: String
     let title: String
     let subtitle: String
     let isSelected: Bool
+    var cardWidth: CGFloat?
     var onHoverChanged: ((Bool) -> Void)?
     let action: () -> Void
     @State private var isHovered = false
@@ -27,14 +30,18 @@ struct SettingsOptionCard: View {
                     Text(title)
                         .font(.subheadline.weight(isSelected ? .semibold : .regular))
                         .foregroundStyle(isSelected ? .primary : .secondary)
+                        .lineLimit(1)
                     Text(subtitle)
                         .font(.caption2)
                         .foregroundStyle(.tertiary)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
                 }
             }
-            .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.vertical, 10)
             .padding(.horizontal, 12)
+            .frame(width: cardWidth, alignment: .leading)
+            .frame(maxWidth: cardWidth == nil ? .infinity : nil, alignment: .leading)
             .contentShape(Rectangle())
             .background(
                 RoundedRectangle(cornerRadius: 8, style: .continuous)
@@ -51,6 +58,8 @@ struct SettingsOptionCard: View {
             )
         }
         .buttonStyle(.plain)
+        .frame(width: cardWidth, alignment: .leading)
+        .fixedSize(horizontal: cardWidth != nil, vertical: false)
         .onHover { hovering in
             isHovered = hovering
             onHoverChanged?(hovering)

--- a/Sources/KeyPathAppKit/UI/Settings/SettingsView+General.swift
+++ b/Sources/KeyPathAppKit/UI/Settings/SettingsView+General.swift
@@ -38,7 +38,8 @@ struct GeneralSettingsTabView: View {
                             icon: "textformat.123",
                             title: "Symbols",
                             subtitle: "⌫ ⇥ ⇪ ⇧ ↩",
-                            isSelected: services.preferences.keyLabelStyle == .symbols
+                            isSelected: services.preferences.keyLabelStyle == .symbols,
+                            cardWidth: SettingsOptionCard.settingsRowWidth
                         ) {
                             services.preferences.keyLabelStyle = .symbols
                         }
@@ -49,7 +50,8 @@ struct GeneralSettingsTabView: View {
                             icon: "textformat.abc",
                             title: "Text",
                             subtitle: "delete tab caps shift",
-                            isSelected: services.preferences.keyLabelStyle == .text
+                            isSelected: services.preferences.keyLabelStyle == .text,
+                            cardWidth: SettingsOptionCard.settingsRowWidth
                         ) {
                             services.preferences.keyLabelStyle = .text
                         }
@@ -70,7 +72,8 @@ struct GeneralSettingsTabView: View {
                             icon: "keyboard",
                             title: "Base layer",
                             subtitle: "Look like the base layer",
-                            isSelected: services.preferences.unmappedLayerKeyStyle == .baseLayer
+                            isSelected: services.preferences.unmappedLayerKeyStyle == .baseLayer,
+                            cardWidth: SettingsOptionCard.settingsRowWidth
                         ) {
                             services.preferences.unmappedLayerKeyStyle = .baseLayer
                         }
@@ -81,7 +84,8 @@ struct GeneralSettingsTabView: View {
                             icon: "eye.slash",
                             title: "Dimmed",
                             subtitle: "Dim so mappings stand out",
-                            isSelected: services.preferences.unmappedLayerKeyStyle == .dimmed
+                            isSelected: services.preferences.unmappedLayerKeyStyle == .dimmed,
+                            cardWidth: SettingsOptionCard.settingsRowWidth
                         ) {
                             services.preferences.unmappedLayerKeyStyle = .dimmed
                         }
@@ -102,7 +106,8 @@ struct GeneralSettingsTabView: View {
                             icon: "arrow.right",
                             title: "Sequences",
                             subtitle: "Keys one after another",
-                            isSelected: services.preferences.isSequenceMode
+                            isSelected: services.preferences.isSequenceMode,
+                            cardWidth: SettingsOptionCard.settingsRowWidth
                         ) {
                             services.preferences.isSequenceMode = true
                         }
@@ -112,7 +117,8 @@ struct GeneralSettingsTabView: View {
                             icon: "command",
                             title: "Combos",
                             subtitle: "Keys pressed together",
-                            isSelected: !services.preferences.isSequenceMode
+                            isSelected: !services.preferences.isSequenceMode,
+                            cardWidth: SettingsOptionCard.settingsRowWidth
                         ) {
                             services.preferences.isSequenceMode = false
                         }
@@ -132,7 +138,8 @@ struct GeneralSettingsTabView: View {
                             icon: "keyboard",
                             title: "Physical Keys",
                             subtitle: "Pause mappings",
-                            isSelected: !services.preferences.applyMappingsDuringRecording
+                            isSelected: !services.preferences.applyMappingsDuringRecording,
+                            cardWidth: SettingsOptionCard.settingsRowWidth
                         ) {
                             services.preferences.applyMappingsDuringRecording = false
                         }
@@ -142,7 +149,8 @@ struct GeneralSettingsTabView: View {
                             icon: "wand.and.stars",
                             title: "With Mappings",
                             subtitle: "Include KeyPath",
-                            isSelected: services.preferences.applyMappingsDuringRecording
+                            isSelected: services.preferences.applyMappingsDuringRecording,
+                            cardWidth: SettingsOptionCard.settingsRowWidth
                         ) {
                             services.preferences.applyMappingsDuringRecording = true
                         }


### PR DESCRIPTION
## Summary
- Add an explicit fixed-width mode to `SettingsOptionCard`
- Apply compact fixed-width cards to the General settings two-option rows
- Keep card text single-line with tail truncation so compact rows do not overlap

## Root cause
The shared settings option card used `maxWidth: .infinity`, which let the two-option rows expand back across the Settings window.

## Validation
- `swift build`
- `python3 Scripts/check-accessibility.py`
- `./Scripts/quick-deploy.sh`
- Computer-use visual check of Settings > General
