### PR TITLE
Fix overlay alpha label suppression

### DIFF
--- a/Sources/KeyPathAppKit/UI/Overlay/FloatingLabelVisibility.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/FloatingLabelVisibility.swift
@@ -9,6 +9,11 @@ struct FloatingLabelVisibility {
     let zoneSubtitleLabels: Set<String>
 
     func isVisible(_ label: String) -> Bool {
+        suppressesKeycapContent(label)
+            && !(vimHintsActive && Self.isLoudVimHintLabel(label.uppercased()))
+    }
+
+    func suppressesKeycapContent(_ label: String) -> Bool {
         let normalized = label.uppercased()
         return labelToKeyCode[normalized] != nil
             && !Self.isSpecialLabel(label)
@@ -16,7 +21,6 @@ struct FloatingLabelVisibility {
             && !isLayerMode
             && !remappedLabels.contains(normalized)
             && !zoneSubtitleLabels.contains(normalized)
-            && !(vimHintsActive && Self.isLoudVimHintLabel(normalized))
     }
 
     private static func isLoudVimHintLabel(_ label: String) -> Bool {

--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayKeyboardView.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayKeyboardView.swift
@@ -450,6 +450,10 @@ struct OverlayKeyboardView: View {
             nil
         }
 
+        let floatingLabelsEnabled = !reduceMotion && activeColorway.legendStyle == .standard
+        let shouldSuppressKeycapLabel = floatingLabelsEnabled
+            && floatingLabelVisibility.suppressesKeycapContent(baseLabel)
+
         return OverlayKeycapView(
             key: key,
             baseLabel: baseLabel,
@@ -471,10 +475,10 @@ struct OverlayKeyboardView: View {
             colorway: activeColorway,
             // Pass layout width for rainbow gradient calculation
             layoutTotalWidth: layout.totalWidth,
-            // Hide keycap alpha labels when floating labels are rendered
-            // (floating labels handle animation, keycaps just show backgrounds)
+            // Hide a keycap alpha label only when the floating/hint overlay owns
+            // that label. Layer, launcher, remapped, and zone labels render inline.
             // Disable floating labels for non-standard legend styles (dots, blank, etc.)
-            useFloatingLabels: !reduceMotion && activeColorway.legendStyle == .standard,
+            useFloatingLabels: shouldSuppressKeycapLabel,
             // Kinesis keyboards have scooped/dished home row keys
             showScoopedHomeRow: layout.id == "kinesis-360",
             // Selection highlight for mapper drawer

--- a/Tests/KeyPathTests/UI/FloatingLabelVisibilityTests.swift
+++ b/Tests/KeyPathTests/UI/FloatingLabelVisibilityTests.swift
@@ -37,6 +37,13 @@ struct FloatingLabelVisibilityTests {
         #expect(vis.isVisible("F"))
     }
 
+    @Test("normal letter suppresses keycap content on base layer")
+    func normalLetterSuppressesKeycapContent() {
+        let vis = Self.base()
+        #expect(vis.suppressesKeycapContent("A"))
+        #expect(vis.suppressesKeycapContent("Q"))
+    }
+
     @Test("lowercase input still matches uppercase keyCode map")
     func lowercaseInput() {
         let vis = Self.base()
@@ -79,6 +86,7 @@ struct FloatingLabelVisibilityTests {
         #expect(!vis.isVisible("A"))
         #expect(!vis.isVisible("H"))
         #expect(!vis.isVisible("Q"))
+        #expect(!vis.suppressesKeycapContent("A"))
     }
 
     // MARK: - Layer mode
@@ -88,6 +96,7 @@ struct FloatingLabelVisibilityTests {
         let vis = Self.base(isLayerMode: true)
         #expect(!vis.isVisible("A"))
         #expect(!vis.isVisible("H"))
+        #expect(!vis.suppressesKeycapContent("A"))
     }
 
     // MARK: - Remapped labels
@@ -98,6 +107,7 @@ struct FloatingLabelVisibilityTests {
         #expect(!vis.isVisible("A"))
         #expect(!vis.isVisible("S"))
         #expect(vis.isVisible("D"))
+        #expect(!vis.suppressesKeycapContent("A"))
     }
 
     @Test("transparent layer entries do not suppress base floating labels")
@@ -147,6 +157,7 @@ struct FloatingLabelVisibilityTests {
         #expect(!vis.isVisible("A"))
         #expect(!vis.isVisible("F"))
         #expect(vis.isVisible("G"))
+        #expect(!vis.suppressesKeycapContent("A"))
     }
 
     // MARK: - Vim hints (HJKL regression)
@@ -158,6 +169,7 @@ struct FloatingLabelVisibilityTests {
         #expect(!vis.isVisible("J"))
         #expect(!vis.isVisible("K"))
         #expect(!vis.isVisible("L"))
+        #expect(vis.suppressesKeycapContent("H"))
     }
 
     @Test("HJKL visible when vim hints inactive")


### PR DESCRIPTION
## Summary
- split floating-label visibility from keycap-content suppression
- pass per-key alpha suppression into overlay keycaps instead of the old global floating-label flag
- add regression coverage for base alpha labels, layer/launcher/remapped/zone cases, and Vim hint-owned labels

## Validation
- swift test --filter FloatingLabelVisibilityTests
- swift test --filter UnmappedLayerKeyStyleTests
- swift build
- python3 Scripts/check-accessibility.py
- ./Scripts/quick-deploy.sh
- REQUIRE_NOTARIZED=0 REQUIRE_STAPLED=0 ./Scripts/verify-installed-app.sh
- pre-push swift build