### PR TITLE
Improve Computer Use QA hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Versioning once public release tags are established.
 
 - Release-governance docs: `SECURITY.md`, `CODE_OF_CONDUCT.md`, and this
   changelog.
-- CI/release-readiness tracking issues labeled as `release-blocker` in Linear.
+- CI/release-readiness tracking issues labeled as `release-blocker` in GitHub.
 - Mapper/overlay support for optional per-key shifted output customization:
   `Shift + key` can now send a separate output from tap/default output for
   global keystroke mappings.

--- a/Scripts/check-computer-use-readiness.py
+++ b/Scripts/check-computer-use-readiness.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""
+Source-level contract check for Computer Use reliability.
+
+This complements Scripts/check-accessibility.py. The generic checker verifies
+interactive controls have identifiers; this script tracks the high-value IDs,
+labels, and values that Computer Use depends on for stable automation.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+REQUIRED_SNIPPETS: dict[str, list[str]] = {
+    "Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView+ContentAndStyling.swift": [
+        '"keycap-code-\\(key.keyCode)"',
+        ".accessibilityAction",
+        "isAutomationClickable",
+    ],
+    "Sources/KeyPathAppKit/UI/Overlay/LiveKeyboardOverlayView.swift": [
+        '"keyboard-overlay"',
+    ],
+    "Sources/KeyPathAppKit/UI/Overlay/LiveKeyboardOverlayView+Header.swift": [
+        '"overlay-layer-indicator"',
+        ".accessibilityValue(layerDisplayName)",
+    ],
+    "Sources/KeyPathAppKit/UI/Settings/SettingsContainerView.swift": [
+        '"settings-window"',
+        '"settings-shortcut-status-button"',
+        ".openSettingsSystemStatus",
+        ".openSettingsLogs",
+    ],
+    "Sources/KeyPathAppKit/UI/Settings/SettingsView.swift": [
+        '"status-system-health-button"',
+        ".accessibilityValue(overallHealthLevel.accessibilityValue)",
+        '"status-active-rules-button"',
+        '"status-service-toggle"',
+    ],
+    "Sources/KeyPathAppKit/UI/Status/SettingsSystemStatusRows.swift": [
+        '"settings-status-row-button-\\(id)"',
+        ".accessibilityValue(accessibilityValue)",
+    ],
+    "Sources/KeyPathAppKit/Services/ActionDispatcher.swift": [
+        '"settings"',
+        "handleSettings",
+        "onSettingsAction",
+        "onSettingsNavigationAction",
+        "SettingsNavigationUserInfo.ruleCollectionTarget",
+        "openPreferencesTab(notification, userInfo: userInfo)",
+    ],
+    "Sources/KeyPathAppKit/Utilities/Notifications.swift": [
+        "SettingsNavigationCoordinator",
+        "ruleCollectionTarget",
+    ],
+    "Sources/KeyPathAppKit/UI/Rules/RulesSummaryView+CollectionRow.swift": [
+        '"rules-summary-icon-button-\\(collectionId)"',
+        '"rules-summary-expand-button-\\(collectionId)"',
+        ".accessibilityValue(effectiveEnabled ? \"on\" : \"off\")",
+        '"rules-summary-add-rule-\\(collectionId)"',
+    ],
+    "Sources/KeyPathAppKit/UI/Rules/RulesSummaryView+MappingRow.swift": [
+        '"rules-summary-mapping-row-button-\\(mapping.id)"',
+        '"rules-summary-mapping-edit-\\(mapping.id)"',
+        '"rules-summary-mapping-delete-\\(mapping.id)"',
+        ".accessibilityValue(\"\\(prettyKeyName(mapping.input)) to \\(prettyKeyName(mapping.output))\")",
+    ],
+    "Sources/KeyPathAppKit/UI/Rules/RulesSummaryView+MappingTable.swift": [
+        '"rules-mapping-table-row-\\(mapping.id)"',
+        "mappingAccessibilityValue",
+    ],
+    "Sources/KeyPathAppKit/UI/Rules/RulesSummaryView.swift": [
+        "focusRuleCollection(from:",
+        "collectionMatchesNavigationTarget",
+    ],
+    "Sources/KeyPathAppKit/UI/Rules/HomeRowModsCollectionView.swift": [
+        '"home-row-mods-config-panel"',
+        "homeRowModsAccessibilityValue",
+        '"🧪 [QA] Home Row Mods config changed:',
+    ],
+    "Sources/KeyPathAppKit/UI/Rules/HomeRowModsCollectionView+Configuration.swift": [
+        '"home-row-mods-preferences-panel"',
+        '"home-row-mods-hold-mode-picker"',
+        '"home-row-mods-new-layer-sheet"',
+    ],
+    "Sources/KeyPathAppKit/UI/Rules/HomeRowKeyboardView.swift": [
+        '"home-row-key-chip-\\(key)"',
+        ".accessibilityValue(accessibilityValue)",
+    ],
+    "Sources/KeyPathAppKit/UI/Rules/HomeRowTimingSection.swift": [
+        '"home-row-mods-feel-slider"',
+        '"home-row-mods-fast-typing-protection-toggle"',
+        '"home-row-mods-tap-offset-\\(key)-field"',
+        '"home-row-mods-hold-offset-\\(key)-field"',
+    ],
+    "Sources/KeyPathCLI/Commands/Config/ConfigCommand.swift": [
+        "ConfigBackup.self",
+        "ConfigRestore.self",
+    ],
+    "Sources/KeyPathCLI/Commands/Collection/CollectionShowCommand.swift": [
+        "var full: Bool",
+        "showCollectionDetail",
+    ],
+}
+
+FORBIDDEN_SNIPPETS: dict[str, list[str]] = {
+    "Sources/KeyPathAppKit/UI/Overlay/OverlayKeyboardView.swift": [
+        '"overlay-keyboard"',
+    ],
+}
+
+
+def main() -> int:
+    failures: list[str] = []
+
+    for relative_path, snippets in REQUIRED_SNIPPETS.items():
+        path = ROOT / relative_path
+        if not path.exists():
+            failures.append(f"Missing file: {relative_path}")
+            continue
+
+        contents = path.read_text()
+        for snippet in snippets:
+            if snippet not in contents:
+                failures.append(f"{relative_path}: missing required snippet {snippet!r}")
+
+    for relative_path, snippets in FORBIDDEN_SNIPPETS.items():
+        path = ROOT / relative_path
+        if not path.exists():
+            continue
+
+        contents = path.read_text()
+        for snippet in snippets:
+            if snippet in contents:
+                failures.append(f"{relative_path}: forbidden snippet still present {snippet!r}")
+
+    if failures:
+        print("Computer Use readiness check failed:")
+        for failure in failures:
+            print(f"  - {failure}")
+        return 1
+
+    print("Computer Use readiness source contracts passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Sources/KeyPathAppKit/App.swift
+++ b/Sources/KeyPathAppKit/App.swift
@@ -81,11 +81,12 @@ func openFileInPreferredEditor(_ url: URL) {
 }
 
 @MainActor
-func openPreferencesTab(_ notification: Notification.Name) {
+func openPreferencesTab(_ notification: Notification.Name, userInfo: [AnyHashable: Any]? = nil) {
     AppLogger.shared.log("🎯 [App] Opening preferences tab: \(notification.rawValue)")
+    SettingsNavigationCoordinator.shared.store(notification: notification, userInfo: userInfo)
 
     // Post notification first to ensure tab switches when window opens
-    NotificationCenter.default.post(name: notification, object: nil)
+    NotificationCenter.default.post(name: notification, object: nil, userInfo: userInfo)
 
     // macOS 14+: The Settings menu item is automatically created by SwiftUI
     // Find it in the app menu and trigger it programmatically

--- a/Sources/KeyPathAppKit/CLI/CollectionsFacade.swift
+++ b/Sources/KeyPathAppKit/CLI/CollectionsFacade.swift
@@ -53,6 +53,14 @@ public struct CollectionsFacade: Sendable {
         return CLIRuleCollection(from: collections[index])
     }
 
+    public func showCollectionDetail(nameOrId: String) async throws -> CLIRuleCollectionDetail? {
+        let collections = await RuleCollectionStore.shared.loadCollections()
+        guard let index = try resolveCollectionIndex(nameOrId: nameOrId, in: collections) else {
+            return nil
+        }
+        return CLIRuleCollectionDetail(from: collections[index])
+    }
+
     public func createCollection(name: String, category: String?, summary: String?) async throws -> CLIRuleCollection {
         var collections = await RuleCollectionStore.shared.loadCollections()
         let cat: RuleCollectionCategory = if let category {
@@ -365,6 +373,48 @@ public struct CLIRuleCollection: Codable, Sendable {
         isEnabled = collection.isEnabled
         mappingCount = collection.mappings.count
         summary = collection.summary
+    }
+}
+
+public struct CLIRuleCollectionDetail: Codable, Sendable {
+    public let id: String
+    public let name: String
+    public let summary: String
+    public let category: String
+    public let displayStyle: String
+    public let isEnabled: Bool
+    public let isSystemDefault: Bool
+    public let owningPackID: String?
+    public let icon: String?
+    public let tags: [String]
+    public let targetLayer: String
+    public let activationHint: String?
+    public let mappingCount: Int
+    public let mappings: [KeyMapping]
+    public let configuration: RuleCollectionConfiguration
+    public let windowKeyConvention: String?
+    public let windowSnappingActivationMode: String?
+    public let functionKeyMode: String?
+
+    public init(from collection: RuleCollection) {
+        id = collection.id.uuidString
+        name = collection.name
+        summary = collection.summary
+        category = collection.category.rawValue
+        displayStyle = collection.displayStyle.rawValue
+        isEnabled = collection.isEnabled
+        isSystemDefault = collection.isSystemDefault
+        owningPackID = collection.owningPackID
+        icon = collection.icon
+        tags = collection.tags
+        targetLayer = collection.targetLayer.kanataName
+        activationHint = collection.activationHint
+        mappingCount = collection.mappings.count
+        mappings = collection.mappings
+        configuration = collection.configuration
+        windowKeyConvention = collection.windowKeyConvention?.rawValue
+        windowSnappingActivationMode = collection.windowSnappingActivationMode?.rawValue
+        functionKeyMode = collection.functionKeyMode?.rawValue
     }
 }
 

--- a/Sources/KeyPathAppKit/CLI/ConfigFacade.swift
+++ b/Sources/KeyPathAppKit/CLI/ConfigFacade.swift
@@ -66,6 +66,64 @@ public struct ConfigFacade: Sendable {
         )
     }
 
+    // MARK: - Backup / Restore
+
+    public func backupConfig(outputPath: String? = nil) throws -> CLIConfigBackupResult {
+        let fileManager = FileManager.default
+        let sourceURL = URL(fileURLWithPath: KeyPathConstants.Config.directory, isDirectory: true)
+        guard fileManager.fileExists(atPath: sourceURL.path) else {
+            throw Self.error("Config directory does not exist: \(sourceURL.path)")
+        }
+
+        let destinationURL = try outputPath.map {
+            URL(fileURLWithPath: ($0 as NSString).expandingTildeInPath, isDirectory: true)
+        } ?? defaultBackupURL()
+
+        if fileManager.fileExists(atPath: destinationURL.path) {
+            throw Self.error("Backup destination already exists: \(destinationURL.path)")
+        }
+
+        try fileManager.createDirectory(
+            at: destinationURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try fileManager.copyItem(at: sourceURL, to: destinationURL)
+
+        return try CLIConfigBackupResult(
+            sourcePath: sourceURL.path,
+            backupPath: destinationURL.path,
+            copiedItems: copiedItemNames(in: destinationURL)
+        )
+    }
+
+    public func restoreConfig(from backupPath: String, reload: Bool) async throws -> CLIConfigRestoreResult {
+        let fileManager = FileManager.default
+        let sourceURL = URL(fileURLWithPath: (backupPath as NSString).expandingTildeInPath, isDirectory: true)
+        var isDirectory: ObjCBool = false
+        guard fileManager.fileExists(atPath: sourceURL.path, isDirectory: &isDirectory), isDirectory.boolValue else {
+            throw Self.error("Backup directory does not exist: \(sourceURL.path)")
+        }
+
+        let destinationURL = URL(fileURLWithPath: KeyPathConstants.Config.directory, isDirectory: true)
+        try fileManager.createDirectory(
+            at: destinationURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        if fileManager.fileExists(atPath: destinationURL.path) {
+            try fileManager.removeItem(at: destinationURL)
+        }
+        try fileManager.copyItem(at: sourceURL, to: destinationURL)
+
+        let reloadSuccess = reload ? await tcpReload() : nil
+        return try CLIConfigRestoreResult(
+            sourcePath: sourceURL.path,
+            restoredPath: destinationURL.path,
+            restoredItems: copiedItemNames(in: destinationURL),
+            reloadRequested: reload,
+            reloadSuccess: reloadSuccess
+        )
+    }
+
     // MARK: - TCP
 
     func tcpClient() async -> KanataTCPClient {
@@ -116,6 +174,31 @@ public struct ConfigFacade: Sendable {
         if case .success = result { return true }
         return false
     }
+
+    private func defaultBackupURL() throws -> URL {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyyMMdd-HHmmss"
+        let name = "keypath-config-\(formatter.string(from: Date()))"
+        let supportDirectory = try FileManager.default.url(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: true
+        )
+        return supportDirectory
+            .appendingPathComponent("KeyPath", isDirectory: true)
+            .appendingPathComponent("QA Backups", isDirectory: true)
+            .appendingPathComponent(name, isDirectory: true)
+    }
+
+    private func copiedItemNames(in directory: URL) throws -> [String] {
+        try FileManager.default.contentsOfDirectory(atPath: directory.path).sorted()
+    }
+
+    private static func error(_ message: String) -> NSError {
+        NSError(domain: "KeyPath.ConfigFacade", code: 1, userInfo: [NSLocalizedDescriptionKey: message])
+    }
 }
 
 // MARK: - Config Types
@@ -132,6 +215,20 @@ public struct CLIApplyChangeset: Codable, Sendable {
     public let enabledCollections: [String]
     public let disabledCollections: [String]
     public let customRules: [String]
+}
+
+public struct CLIConfigBackupResult: Codable, Sendable {
+    public let sourcePath: String
+    public let backupPath: String
+    public let copiedItems: [String]
+}
+
+public struct CLIConfigRestoreResult: Codable, Sendable {
+    public let sourcePath: String
+    public let restoredPath: String
+    public let restoredItems: [String]
+    public let reloadRequested: Bool
+    public let reloadSuccess: Bool?
 }
 
 public struct CLIValidationResult: Codable, Sendable {

--- a/Sources/KeyPathAppKit/Services/ActionDispatcher.swift
+++ b/Sources/KeyPathAppKit/Services/ActionDispatcher.swift
@@ -27,6 +27,7 @@ public enum ActionDispatchResult: Sendable {
 /// - `keypath://fakekey/{name}/{action}` - Trigger Kanata virtual key (tap/press/release/toggle)
 /// - `keypath://system/{action}` - Trigger macOS system actions (mission-control, spotlight, dictation, dnd, launchpad, siri)
 /// - `keypath://window/{action}` - Window management (left, right, maximize, center, top-left, top-right, bottom-left, bottom-right, next-display, previous-display, undo)
+/// - `keypath://settings/{tab}` - Open Settings to a tab (status, rules, general, advanced, repair, logs)
 /// - `keypath://folder/{path}` - Open a folder in Finder
 /// - `keypath://script/{path}` - Execute a script (requires security approval)
 @MainActor
@@ -57,6 +58,12 @@ public final class ActionDispatcher {
 
     /// Called when a rule-related action is received
     public var onRuleAction: ((String, [String]) -> Void)?
+
+    /// Called when a settings tab action is received.
+    public var onSettingsAction: ((Notification.Name) -> Void)?
+
+    /// Called when a settings navigation action carries additional target details.
+    public var onSettingsNavigationAction: ((Notification.Name, [AnyHashable: Any]?) -> Void)?
 
     /// Called when script execution needs user confirmation
     /// Parameters: script path, confirm callback, cancel callback
@@ -108,6 +115,8 @@ public final class ActionDispatcher {
             return handleSystem(uri)
         case "window":
             return handleWindow(uri)
+        case "settings":
+            return handleSettings(uri)
         case "folder":
             return handleFolder(uri)
         case "script":
@@ -134,6 +143,55 @@ public final class ActionDispatcher {
     }
 
     // MARK: - Action Handlers
+
+    /// Open Settings to a stable automation-friendly tab.
+    /// Format: keypath://settings/status, keypath://settings/rules/home-row-mods
+    private func handleSettings(_ uri: KeyPathActionURI) -> ActionDispatchResult {
+        guard let rawTab = uri.target?.lowercased() else {
+            return .missingTarget("settings")
+        }
+
+        let notification: Notification.Name
+        switch rawTab {
+        case "status", "system", "system-status", "health":
+            notification = .openSettingsStatus
+        case "rules":
+            notification = .openSettingsRules
+        case "general", "logs":
+            notification = .openSettingsGeneral
+        case "advanced", "repair", "remove", "repair-remove":
+            notification = .openSettingsAdvanced
+        default:
+            let message = "Unknown settings tab: \(rawTab)"
+            AppLogger.shared.log("⚠️ [ActionDispatcher] \(message)")
+            onError?(message)
+            return .unknownAction("settings/\(rawTab)")
+        }
+
+        var userInfo: [AnyHashable: Any]?
+        if notification == .openSettingsRules {
+            let pathTarget = uri.pathComponents.dropFirst().joined(separator: "/")
+            let ruleTarget = uri.queryItems["collection"]
+                ?? uri.queryItems["rule"]
+                ?? (pathTarget.isEmpty ? nil : pathTarget)
+            if let ruleTarget {
+                userInfo = [SettingsNavigationUserInfo.ruleCollectionTarget: ruleTarget]
+            }
+        }
+
+        AppLogger.shared.log(
+            "🎯 [ActionDispatcher] Opening settings tab=\(rawTab) target=\(userInfo?[SettingsNavigationUserInfo.ruleCollectionTarget] as? String ?? "none")"
+        )
+
+        if let onSettingsNavigationAction {
+            onSettingsNavigationAction(notification, userInfo)
+        } else if let onSettingsAction {
+            onSettingsAction(notification)
+        } else {
+            openPreferencesTab(notification, userInfo: userInfo)
+        }
+        return .success
+    }
 
     /// Launch an application by name or bundle ID
     /// Format: keypath://launch/{app-name-or-bundle-id}

--- a/Sources/KeyPathAppKit/UI/MainWindowController.swift
+++ b/Sources/KeyPathAppKit/UI/MainWindowController.swift
@@ -32,6 +32,8 @@ final class MainWindowController: NSWindowController {
 
         // Configure window properties
         window.title = ""
+        window.setAccessibilityIdentifier("keypath-main-window")
+        window.setAccessibilityLabel("KeyPath")
         window.isOpaque = false
         window.backgroundColor = .clear
         window.isMovableByWindowBackground = false

--- a/Sources/KeyPathAppKit/UI/Overlay/FloatingKeymapLabel.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/FloatingKeymapLabel.swift
@@ -132,6 +132,7 @@ struct FloatingKeymapLabel: View, Equatable {
         .opacity(isVisible ? 1.0 : 0.0)
         .position(x: targetFrame.midX, y: targetFrame.midY)
         .allowsHitTesting(false)
+        .accessibilityHidden(true)
         // Only animate position during layout changes, not resize
         .animation(isLayoutChange() ? positionAnimation : nil, value: targetFrame)
         // Animate visibility changes unless disabled (e.g., launcher mode toggle)

--- a/Sources/KeyPathAppKit/UI/Overlay/LiveKeyboardOverlayView+Header.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/LiveKeyboardOverlayView+Header.swift
@@ -268,6 +268,7 @@ struct OverlayDragHeader: View {
 
     var body: some View {
         let buttonSize = max(10, height * 0.9)
+        let automationHitSize: CGFloat = 32
         let indicatorCornerRadius: CGFloat = 4
 
         HStack(spacing: 0) {
@@ -298,7 +299,7 @@ struct OverlayDragHeader: View {
                         Image(systemName: isInspectorOpen ? "xmark.circle" : "sidebar.right")
                             .font(.system(size: buttonSize * 0.72, weight: .semibold))
                             .foregroundStyle(drawerButtonHighlighted ? Color.accentColor : headerIconColor)
-                            .frame(width: buttonSize, height: buttonSize)
+                            .frame(width: automationHitSize, height: automationHitSize)
                             .scaleEffect(drawerButtonHighlighted ? 1.2 : 1.0)
                             .animation(.easeInOut(duration: 0.1), value: drawerButtonHighlighted)
                     }
@@ -477,6 +478,7 @@ struct OverlayDragHeader: View {
     @ViewBuilder
     private func layerPill(layerDisplayName: String, indicatorCornerRadius: CGFloat, buttonSize: CGFloat) -> some View {
         let iconName = LayerInfo.iconName(for: layerDisplayName)
+        let automationHitSize: CGFloat = 32
 
         Group {
             if shouldShowLayerName {
@@ -494,6 +496,7 @@ struct OverlayDragHeader: View {
                             .opacity(0.7)
                     }
                     .foregroundStyle(headerIconColor)
+                    .frame(minWidth: automationHitSize, minHeight: automationHitSize)
                     .padding(.horizontal, 8)
                     .padding(.vertical, 3)
                     .modifier(OverlayGlassEffectModifier(
@@ -512,7 +515,7 @@ struct OverlayDragHeader: View {
                     Image(systemName: iconName)
                         .font(.system(size: buttonSize * 0.72, weight: .semibold))
                         .foregroundStyle(headerIconColor)
-                        .frame(width: buttonSize, height: buttonSize)
+                        .frame(width: automationHitSize, height: automationHitSize)
                 }
                 .modifier(OverlayGlassButtonStyleModifier(reduceTransparency: reduceTransparency))
                 .accessibilityIdentifier("overlay-layer-picker-toggle")
@@ -556,6 +559,7 @@ struct OverlayDragHeader: View {
         .help("Current layer: \(layerDisplayName). Click to see available layers.")
         .accessibilityIdentifier("overlay-layer-indicator")
         .accessibilityLabel("Current layer: \(layerDisplayName). Click to see available layers.")
+        .accessibilityValue(layerDisplayName)
     }
 
     /// Handle hover state changes with grace period

--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayKeyboardView.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayKeyboardView.swift
@@ -318,8 +318,6 @@ struct OverlayKeyboardView: View {
             .animation(nil, value: isLauncherMode)
         }
         .aspectRatio(layout.totalWidth / layout.totalHeight, contentMode: .fit)
-        .accessibilityIdentifier("overlay-keyboard")
-        .accessibilityLabel(keyboardAccessibilityLabel)
         // Also disable at container level for any inherited animations
         .animation(nil, value: isLauncherMode)
         .onChange(of: effectivePressedKeyCodes) { _, _ in

--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView+ContentAndStyling.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView+ContentAndStyling.swift
@@ -107,7 +107,7 @@ extension OverlayKeycapView {
             iconVisible = isLauncherMode
         }
         .animation(nil, value: currentLayerName)
-        .allowsHitTesting(isInspectorVisible || isLauncherMode || key.layoutRole == .touchId)
+        .allowsHitTesting(isAutomationClickable)
         // Hover detection (must be before contentShape for hit testing)
         .contentShape(Rectangle())
         .onHover { hovering in
@@ -189,12 +189,20 @@ extension OverlayKeycapView {
         .accessibilityIdentifier(keycapAccessibilityId)
         .accessibilityLabel(keycapAccessibilityLabel)
         .accessibilityValue(keycapAccessibilityValue)
-        .accessibilityAddTraits(isInspectorVisible ? .isButton : [])
+        .accessibilityAddTraits(isAutomationClickable ? .isButton : [])
+        .accessibilityAction {
+            guard isAutomationClickable, let onKeyClick else { return }
+            onKeyClick(key, layerKeyInfo)
+        }
+    }
+
+    var isAutomationClickable: Bool {
+        isInspectorVisible || isLauncherMode || key.layoutRole == .touchId
     }
 
     /// Accessibility identifier for this keycap
     var keycapAccessibilityId: String {
-        "keycap-\(key.label.lowercased().replacingOccurrences(of: " ", with: "-"))"
+        "keycap-code-\(key.keyCode)"
     }
 
     /// Accessibility label describing the key and its current mapping

--- a/Sources/KeyPathAppKit/UI/Rules/HomeRowKeyboardView.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/HomeRowKeyboardView.swift
@@ -320,6 +320,7 @@ struct HomeRowKeyChip: View {
         .buttonStyle(.plain)
         .accessibilityIdentifier("home-row-key-chip-\(key)")
         .accessibilityLabel("Configure home row key \(keyDisplayLabel)")
+        .accessibilityValue(accessibilityValue)
         .onHover { hovering in
             onHover(hovering)
             #if os(macOS)
@@ -342,6 +343,15 @@ struct HomeRowKeyChip: View {
         } else {
             Color(NSColor.controlBackgroundColor).opacity(0.3)
         }
+    }
+
+    private var accessibilityValue: String {
+        let state = isEnabled ? "enabled" : "disabled"
+        let assignment = holdAssignment.map {
+            holdMode == .layers ? "layer \($0)" : "modifier \(modifierDisplay(for: $0))"
+        } ?? "no hold assignment"
+        let selection = isSelected ? ", selected" : ""
+        return "\(state), \(assignment)\(selection)"
     }
 
     private var textColor: Color {

--- a/Sources/KeyPathAppKit/UI/Rules/HomeRowModsCollectionView+Configuration.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/HomeRowModsCollectionView+Configuration.swift
@@ -8,6 +8,13 @@ import SwiftUI
 extension HomeRowModsCollectionView {
     var customizeWindowContent: some View {
         VStack(alignment: .leading, spacing: 0) {
+            Text("Home row preferences")
+                .frame(width: 0, height: 0)
+                .opacity(0.01)
+                .accessibilityIdentifier("home-row-mods-preferences-panel")
+                .accessibilityLabel("Home row preferences")
+                .accessibilityValue(homeRowModsAccessibilityValue)
+
             HStack {
                 Text("Home Row Preferences")
                     .font(.title3.weight(.semibold))
@@ -27,6 +34,7 @@ extension HomeRowModsCollectionView {
                 }
                 .keyboardShortcut(.defaultAction)
                 .accessibilityIdentifier("home-row-mods-done-button")
+                .accessibilityLabel("Done editing home row preferences")
             }
             .padding(.horizontal, 20)
             .padding(.top, 16)
@@ -63,6 +71,13 @@ extension HomeRowModsCollectionView {
                     .font(.headline)
                     .foregroundStyle(.secondary)
 
+                Text("Hold action mode")
+                    .frame(width: 0, height: 0)
+                    .opacity(0.01)
+                    .accessibilityIdentifier("home-row-mods-hold-mode-picker")
+                    .accessibilityLabel("Hold action mode")
+                    .accessibilityValue(config.holdMode.displayName)
+
                 HStack(spacing: 10) {
                     holdBehaviorOptionCard(
                         mode: .modifiers,
@@ -78,8 +93,6 @@ extension HomeRowModsCollectionView {
                         subtitle: "Advanced"
                     )
                 }
-                .accessibilityIdentifier("home-row-mods-hold-mode-picker")
-                .accessibilityLabel("Hold action mode")
 
                 Text(holdBehaviorExplanationText)
                     .font(.caption)
@@ -93,6 +106,13 @@ extension HomeRowModsCollectionView {
                     Text("Layer Activation")
                         .font(.headline)
                         .foregroundStyle(.secondary)
+
+                    Text("Layer activation mode")
+                        .frame(width: 0, height: 0)
+                        .opacity(0.01)
+                        .accessibilityIdentifier("home-row-mods-layer-toggle-mode-picker")
+                        .accessibilityLabel("Layer activation mode")
+                        .accessibilityValue(config.layerToggleMode.displayName)
 
                     HStack(spacing: 10) {
                         SettingsOptionCard(
@@ -108,6 +128,8 @@ extension HomeRowModsCollectionView {
                             updateConfig()
                         }
                         .accessibilityIdentifier("home-row-mods-layer-toggle-while-held")
+                        .accessibilityLabel("Layer activation while held")
+                        .accessibilityValue(config.layerToggleMode == .whileHeld ? "selected" : "not selected")
 
                         SettingsOptionCard(
                             icon: "switch.2",
@@ -122,10 +144,9 @@ extension HomeRowModsCollectionView {
                             updateConfig()
                         }
                         .accessibilityIdentifier("home-row-mods-layer-toggle-mode")
+                        .accessibilityLabel("Layer activation toggle")
+                        .accessibilityValue(config.layerToggleMode == .toggle ? "selected" : "not selected")
                     }
-                    .accessibilityElement(children: .contain)
-                    .accessibilityIdentifier("home-row-mods-layer-toggle-mode-picker")
-                    .accessibilityLabel("Layer activation mode")
 
                     Text(layerActivationExplanationText)
                         .font(.caption)
@@ -212,6 +233,8 @@ extension HomeRowModsCollectionView {
         .accessibilityIdentifier(
             mode == .modifiers ? "home-row-mods-hold-mode-modifiers" : "home-row-mods-hold-mode-layers"
         )
+        .accessibilityLabel("Use \(title) for home row holds")
+        .accessibilityValue(isSelected ? "selected" : "not selected")
     }
 
     func applyHoldMode(_ mode: HomeRowHoldMode) {
@@ -280,5 +303,7 @@ extension HomeRowModsCollectionView {
         }
         .padding(20)
         .frame(width: 360)
+        .accessibilityIdentifier("home-row-mods-new-layer-sheet")
+        .accessibilityLabel("Create new home row layer")
     }
 }

--- a/Sources/KeyPathAppKit/UI/Rules/HomeRowModsCollectionView+Popovers.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/HomeRowModsCollectionView+Popovers.swift
@@ -47,6 +47,7 @@ extension HomeRowModsCollectionView {
                 .focusable(false)
                 .accessibilityIdentifier("home-row-mods-modifier-option-\(option.kind)")
                 .accessibilityLabel("Set \(displayLabel(forCanonicalKey: key)) to \(option.symbol) \(option.label)")
+                .accessibilityValue(isModifierOptionSelected(option.kind, for: key) ? "selected" : "not selected")
 
                 if index < modifierOptions.count - 1 {
                     PopoverListDivider()
@@ -94,6 +95,7 @@ extension HomeRowModsCollectionView {
                 .focusable(false)
                 .accessibilityIdentifier("home-row-mods-layer-option-\(option.key)")
                 .accessibilityLabel("Set \(displayLabel(forCanonicalKey: key)) to \(option.label) layer")
+                .accessibilityValue(config.layerAssignments[key] == option.key ? "selected" : "not selected")
 
                 if index < layerOptions.count - 1 {
                     PopoverListDivider()
@@ -165,6 +167,7 @@ extension HomeRowModsCollectionView {
             .focusable(false)
             .accessibilityIdentifier("home-row-mods-enable-key-\(key)")
             .accessibilityLabel("Enable \(displayLabel(forCanonicalKey: key))")
+            .accessibilityValue(config.enabledKeys.contains(key) ? "enabled" : "disabled")
         }
         .padding(.vertical, 6)
         .frame(minWidth: 210)
@@ -196,6 +199,7 @@ extension HomeRowModsCollectionView {
         .focusable(false)
         .accessibilityIdentifier("home-row-mods-disable-key-\(key)")
         .accessibilityLabel("Disable \(displayLabel(forCanonicalKey: key))")
+        .accessibilityValue(config.enabledKeys.contains(key) ? "enabled" : "disabled")
     }
 
     func isModifierOptionSelected(_ kind: String, for key: String) -> Bool {

--- a/Sources/KeyPathAppKit/UI/Rules/HomeRowModsCollectionView.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/HomeRowModsCollectionView.swift
@@ -1,3 +1,4 @@
+import KeyPathCore
 import SwiftUI
 #if os(macOS)
     import AppKit
@@ -50,6 +51,13 @@ struct HomeRowModsCollectionView: View {
 
     var body: some View {
         VStack(spacing: 0) {
+            Text("Home row mods configuration")
+                .frame(width: 0, height: 0)
+                .opacity(0.01)
+                .accessibilityIdentifier("home-row-mods-config-panel")
+                .accessibilityLabel("Home row mods configuration")
+                .accessibilityValue(homeRowModsAccessibilityValue)
+
             // Visual keyboard (always visible when expanded)
             ViewThatFits(in: .horizontal) {
                 homeRowKeyboard(size: 72)
@@ -96,6 +104,8 @@ struct HomeRowModsCollectionView: View {
                     .controlSize(.small)
                     .disabled(!isCollectionEnabled)
                     .accessibilityIdentifier("home-row-mods-reset-defaults")
+                    .accessibilityLabel("Reset home row mods to defaults")
+                    .accessibilityValue(homeRowModsAccessibilityValue)
                 }
 
                 Button("Settings...") {
@@ -106,6 +116,7 @@ struct HomeRowModsCollectionView: View {
                 .disabled(!isCollectionEnabled)
                 .accessibilityIdentifier("home-row-mods-customize-button")
                 .accessibilityLabel("Home row mods settings")
+                .accessibilityValue(homeRowModsAccessibilityValue)
             }
             .padding(.horizontal, 10)
         }
@@ -170,6 +181,7 @@ struct HomeRowModsCollectionView: View {
     // MARK: - Helpers
 
     func updateConfig() {
+        AppLogger.shared.log("🧪 [QA] Home Row Mods config changed: \(homeRowModsAccessibilityValue)")
         onConfigChanged(config)
     }
 
@@ -266,6 +278,11 @@ struct HomeRowModsCollectionView: View {
         if config.modifierAssignments != baseline.modifierAssignments { return true }
         if holdTimingBinding != nil, holdTimingValue != holdTimingDefault { return true }
         return false
+    }
+
+    var homeRowModsAccessibilityValue: String {
+        let enabledKeys = config.enabledKeys.sorted().joined(separator: ",")
+        return "mode \(config.holdMode.displayName), layer activation \(config.layerToggleMode.displayName), enabled keys \(enabledKeys), tap window \(config.timing.tapWindow) ms, hold delay \(config.timing.holdDelay) ms, opposite hand \(config.oppositeHandMode.displayName)"
     }
 
     /// Reset assignments to the default for the current hold mode

--- a/Sources/KeyPathAppKit/UI/Rules/HomeRowModsModalView.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/HomeRowModsModalView.swift
@@ -1,3 +1,4 @@
+import KeyPathCore
 import SwiftUI
 #if os(macOS)
     import AppKit
@@ -23,6 +24,13 @@ struct HomeRowModsModalView: View {
 
     var body: some View {
         VStack(spacing: 0) {
+            Text("Customize home row mods")
+                .frame(width: 0, height: 0)
+                .opacity(0.01)
+                .accessibilityIdentifier("home-row-mods-modal")
+                .accessibilityLabel("Customize home row mods")
+                .accessibilityValue(homeRowModsAccessibilityValue)
+
             // Header
             HStack {
                 Text("Customize Home Row Mods")
@@ -71,6 +79,7 @@ struct HomeRowModsModalView: View {
                     .accessibilityIdentifier("home-row-mods-modal-cancel-button")
                     .accessibilityLabel("Cancel")
                 Button("Save", action: {
+                    AppLogger.shared.log("🧪 [QA] Home Row Mods modal saved: \(homeRowModsAccessibilityValue)")
                     onSave(localConfig)
                 })
                 .keyboardShortcut(.defaultAction)
@@ -114,6 +123,7 @@ struct HomeRowModsModalView: View {
             .pickerStyle(.segmented)
             .accessibilityIdentifier("home-row-mods-modal-hold-mode-picker")
             .accessibilityLabel("Hold action mode")
+            .accessibilityValue(localConfig.holdMode.displayName)
         }
         .padding(.horizontal)
     }
@@ -144,6 +154,7 @@ struct HomeRowModsModalView: View {
                 .pickerStyle(.segmented)
                 .accessibilityIdentifier("home-row-mods-modal-preset-picker")
                 .accessibilityLabel("Modifier preset selection")
+                .accessibilityValue(modifierPresetAccessibilityValue)
             } else {
                 Picker("Layer Preset", selection: Binding(
                     get: { layerPresetSelection(from: localConfig.layerAssignments) },
@@ -162,6 +173,7 @@ struct HomeRowModsModalView: View {
                 .pickerStyle(.segmented)
                 .accessibilityIdentifier("home-row-mods-modal-layer-preset-picker")
                 .accessibilityLabel("Layer preset selection")
+                .accessibilityValue(layerPresetAccessibilityValue)
 
                 Picker("Layer Mode", selection: Binding(
                     get: { localConfig.layerToggleMode },
@@ -174,6 +186,7 @@ struct HomeRowModsModalView: View {
                 .horizontalRadioGroupLayout()
                 .accessibilityIdentifier("home-row-mods-modal-layer-toggle-mode-picker")
                 .accessibilityLabel("Layer activation mode")
+                .accessibilityValue(localConfig.layerToggleMode.displayName)
             }
         }
         .padding(.horizontal)
@@ -184,6 +197,26 @@ struct HomeRowModsModalView: View {
             localConfig = newConfig
         }
         .padding(.horizontal)
+    }
+
+    private var homeRowModsAccessibilityValue: String {
+        let enabledKeys = localConfig.enabledKeys.sorted().joined(separator: ",")
+        return "mode \(localConfig.holdMode.displayName), layer activation \(localConfig.layerToggleMode.displayName), enabled keys \(enabledKeys), tap window \(localConfig.timing.tapWindow) ms, hold delay \(localConfig.timing.holdDelay) ms, opposite hand \(localConfig.oppositeHandMode.displayName)"
+    }
+
+    private var modifierPresetAccessibilityValue: String {
+        switch modifierPresetSelection(from: localConfig.modifierAssignments) {
+        case .macCAGS: "Mac CAGS"
+        case .winGACS: "Windows Linux GACS"
+        case .custom: "Custom"
+        }
+    }
+
+    private var layerPresetAccessibilityValue: String {
+        switch layerPresetSelection(from: localConfig.layerAssignments) {
+        case .default: "Default"
+        case .custom: "Custom"
+        }
     }
 }
 

--- a/Sources/KeyPathAppKit/UI/Rules/HomeRowTimingSection.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/HomeRowTimingSection.swift
@@ -92,6 +92,7 @@ struct HomeRowTimingSection: View {
                 )
                 .accessibilityIdentifier("home-row-mods-raw-values-toggle")
                 .accessibilityLabel("Raw values mode")
+                .accessibilityValue(config.showExpertTiming ? "on" : "off")
                 .accessibilityAddTraits(config.showExpertTiming ? .isSelected : [])
 
                 if hasNonDefaultTiming {
@@ -138,6 +139,8 @@ struct HomeRowTimingSection: View {
                 }
                 .frame(maxWidth: 250)
                 .accessibilityIdentifier("home-row-mods-feel-slider")
+                .accessibilityLabel("Home row typing feel")
+                .accessibilityValue("tap window \(config.timing.tapWindow) ms, hold delay \(config.timing.holdDelay) ms")
                 .overlay(alignment: .top) {
                     if isEditingHoldDuration {
                         Text("\(config.timing.holdDelay)ms")
@@ -182,6 +185,8 @@ struct HomeRowTimingSection: View {
                                         ), format: .number)
                                             .textFieldStyle(.roundedBorder).frame(width: 70)
                                             .accessibilityIdentifier("home-row-mods-tap-window-field")
+                                            .accessibilityLabel("Tap window")
+                                            .accessibilityValue("\(config.timing.tapWindow) ms")
                                         Text("ms").font(.caption).foregroundColor(.secondary)
                                     }
                                 }
@@ -194,6 +199,8 @@ struct HomeRowTimingSection: View {
                                         ), format: .number)
                                             .textFieldStyle(.roundedBorder).frame(width: 70)
                                             .accessibilityIdentifier("home-row-mods-hold-delay-field")
+                                            .accessibilityLabel("Hold delay")
+                                            .accessibilityValue("\(config.timing.holdDelay) ms")
                                         Text("ms").font(.caption).foregroundColor(.secondary)
                                     }
                                 }
@@ -209,6 +216,8 @@ struct HomeRowTimingSection: View {
                                     }
                                 ), in: 0 ... 1, step: 0.05)
                                     .accessibilityIdentifier("home-row-mods-hold-duration-advanced")
+                                    .accessibilityLabel("Advanced hold duration")
+                                    .accessibilityValue("tap window \(config.timing.tapWindow) ms, hold delay \(config.timing.holdDelay) ms")
                                 Text("Modifiers feel snappy").font(.caption2).foregroundStyle(.secondary)
                             }
                         }
@@ -223,6 +232,9 @@ struct HomeRowTimingSection: View {
                             ))
                             .toggleStyle(.checkbox)
                             .font(.subheadline)
+                            .accessibilityIdentifier("home-row-mods-fast-typing-protection-toggle")
+                            .accessibilityLabel("Fast typing protection")
+                            .accessibilityValue(config.timing.requirePriorIdleMs > 0 ? "on" : "off")
                             InfoTip("How long you must pause after typing before holds are allowed. Prevents accidental modifiers mid-word.")
                         }
                         if config.timing.requirePriorIdleMs > 0 {
@@ -235,6 +247,8 @@ struct HomeRowTimingSection: View {
                                     isEditingIdleWindow = editing
                                 }
                                 .accessibilityIdentifier("home-row-mods-prior-idle-advanced")
+                                .accessibilityLabel("Fast typing protection idle window")
+                                .accessibilityValue("\(config.timing.requirePriorIdleMs) ms")
                                 .overlay(alignment: .top) {
                                     if isEditingIdleWindow {
                                         Text("\(config.timing.requirePriorIdleMs)ms")
@@ -258,6 +272,7 @@ struct HomeRowTimingSection: View {
             }
             .font(.subheadline)
             .foregroundStyle(.secondary)
+            .accessibilityIdentifier("home-row-mods-adjust-independently-disclosure")
 
             // MARK: - Opposite-Hand Activation
 
@@ -279,6 +294,7 @@ struct HomeRowTimingSection: View {
                 .frame(maxWidth: 220)
                 .accessibilityIdentifier("home-row-mods-opposite-hand-picker")
                 .accessibilityLabel("Opposite-hand activation mode")
+                .accessibilityValue(config.oppositeHandMode.displayName)
 
                 InfoTip(
                     "Hold actions (modifiers or layers) only activate when you press a key with the other hand. Same-hand typing always produces letters — no accidental modifiers during fast rolls.\n\nOn Press: Faster response, may misfire on fast same-hand rolls.\nOn Release: More forgiving — waits for the other-hand key to be released before committing."
@@ -297,6 +313,7 @@ struct HomeRowTimingSection: View {
             .toggleStyle(.checkbox)
             .accessibilityIdentifier("home-row-mods-quick-tap-toggle")
             .accessibilityLabel("Favor tap when another key is pressed (quick tap)")
+            .accessibilityValue(config.timing.quickTapEnabled ? "on" : "off")
 
             if config.timing.quickTapEnabled {
                 HStack(spacing: 8) {
@@ -450,6 +467,9 @@ struct HomeRowTimingSection: View {
                             ), format: .number)
                                 .textFieldStyle(.roundedBorder)
                                 .frame(width: 70)
+                                .accessibilityIdentifier("home-row-mods-tap-offset-\(key)-field")
+                                .accessibilityLabel("\(key.uppercased()) tap offset")
+                                .accessibilityValue("\(config.timing.tapOffsets[key] ?? 0) ms")
                         }
                     }
                     Spacer()
@@ -482,6 +502,9 @@ struct HomeRowTimingSection: View {
                             ), format: .number)
                                 .textFieldStyle(.roundedBorder)
                                 .frame(width: 70)
+                                .accessibilityIdentifier("home-row-mods-hold-offset-\(key)-field")
+                                .accessibilityLabel("\(key.uppercased()) hold offset")
+                                .accessibilityValue("\(config.timing.holdOffsets[key] ?? 0) ms")
                         }
                     }
                     Spacer()
@@ -509,6 +532,8 @@ struct HomeRowTimingSection: View {
                     .background(hrmAvailabilityColor.opacity(0.12))
                     .clipShape(Capsule())
                     .accessibilityIdentifier("home-row-mods-hrm-availability-badge")
+                    .accessibilityLabel("Home row mods telemetry availability")
+                    .accessibilityValue(hrmObservability.availability.displayName)
             }
 
             Text("Live observability for home-row tap/hold decisions. Use calibration to preview conservative timing suggestions before applying.")

--- a/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView+CollectionRow.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView+CollectionRow.swift
@@ -243,6 +243,9 @@ struct ExpandableCollectionRow: View {
                     .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
+            .accessibilityIdentifier("rules-summary-icon-button-\(collectionId)")
+            .accessibilityLabel(isExpanded ? "Collapse \(name)" : "Expand \(name)")
+            .accessibilityValue(effectiveEnabled ? "on" : "off")
 
             // Rest of row → opens detail window (or expands if no pack)
             Button {
@@ -293,6 +296,7 @@ struct ExpandableCollectionRow: View {
             .frame(maxWidth: .infinity, alignment: .leading)
             .accessibilityIdentifier("rules-summary-expand-button-\(collectionId)")
             .accessibilityLabel(isExpanded ? "Collapse \(name)" : "Expand \(name)")
+            .accessibilityValue(effectiveEnabled ? "on" : "off")
 
             // Help button (only for collections that provide one)
             if let onHelpTapped {
@@ -391,6 +395,7 @@ struct ExpandableCollectionRow: View {
                     }
                     .buttonStyle(.plain)
                     .accessibilityIdentifier("rules-summary-add-rule-\(collectionId)")
+                    .accessibilityLabel("Add rule to \(name)")
                 } else if displayStyle == .singleKeyPicker, let coll = collection {
                     // Segmented picker for single-key remapping
                     SingleKeyPickerContent(

--- a/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView+MappingRow.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView+MappingRow.swift
@@ -134,6 +134,8 @@ struct MappingRowView: View {
                                         .contentShape(Rectangle())
                                 }
                                 .buttonStyle(.plain)
+                                .accessibilityIdentifier("rules-summary-mapping-edit-\(mapping.id)")
+                                .accessibilityLabel("Edit mapping for \(prettyKeyName(mapping.input))")
                             }
 
                             if let onDelete = onDeleteMapping {
@@ -147,6 +149,8 @@ struct MappingRowView: View {
                                         .contentShape(Rectangle())
                                 }
                                 .buttonStyle(.plain)
+                                .accessibilityIdentifier("rules-summary-mapping-delete-\(mapping.id)")
+                                .accessibilityLabel("Delete mapping for \(prettyKeyName(mapping.input))")
                             }
 
                             // Spacer for alignment
@@ -173,6 +177,7 @@ struct MappingRowView: View {
         .buttonStyle(.plain)
         .accessibilityIdentifier("rules-summary-mapping-row-button-\(mapping.id)")
         .accessibilityLabel("Edit mapping for \(prettyKeyName(mapping.input))")
+        .accessibilityValue("\(prettyKeyName(mapping.input)) to \(prettyKeyName(mapping.output))")
         .onHover { hovering in
             isHovered = hovering
             if isEditable {

--- a/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView+MappingTable.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView+MappingTable.swift
@@ -102,6 +102,10 @@ struct MappingTableContent: View {
                 }
                 .padding(.horizontal, 12)
                 .padding(.vertical, 5)
+                .accessibilityElement(children: .combine)
+                .accessibilityIdentifier("rules-mapping-table-row-\(mapping.id)")
+                .accessibilityLabel(mapping.description ?? "Mapping")
+                .accessibilityValue(mappingAccessibilityValue(mapping))
             }
             .padding(.vertical, 4)
         }
@@ -158,6 +162,30 @@ struct MappingTableContent: View {
         raw.replacingOccurrences(of: "_", with: " ")
             .trimmingCharacters(in: .whitespaces)
             .capitalized
+    }
+
+    private func mappingAccessibilityValue(_ mapping: (
+        input: String,
+        output: String,
+        shiftedOutput: String?,
+        ctrlOutput: String?,
+        description: String?,
+        sectionBreak: Bool,
+        sectionLabel: String?,
+        enabled: Bool,
+        id: UUID,
+        behavior: MappingBehavior?
+    )) -> String {
+        var parts = [
+            "\(prettyKeyName(mapping.input)) to \(formatOutput(mapping.output))"
+        ]
+        if let shiftedOutput = mapping.shiftedOutput {
+            parts.append("shift to \(formatOutput(shiftedOutput))")
+        }
+        if let ctrlOutput = mapping.ctrlOutput {
+            parts.append("control to \(formatOutput(ctrlOutput))")
+        }
+        return parts.joined(separator: ", ")
     }
 
     /// Format key name for display in Key column (show Mac modifier names & symbols)

--- a/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView.swift
@@ -1,3 +1,4 @@
+import Foundation
 import KeyPathCore
 import KeyPathInstallationWizard
 import SwiftUI
@@ -422,6 +423,9 @@ struct RulesTabView: View {
                     .padding(.vertical, 12)
                     .padding(.horizontal, 12)
                 }
+                .onReceive(NotificationCenter.default.publisher(for: .openSettingsRules)) { notification in
+                    focusRuleCollection(from: notification.userInfo, scrollProxy: scrollProxy)
+                }
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
@@ -678,4 +682,87 @@ struct RulesTabView: View {
 
     // collectionMatchesSearch, openConfigInEditor, openBackupsFolder, resetToDefaultConfig → RulesSummaryView+Packs.swift
     // kindaVimRow, keystrokeHistoryRow, loadAppKeymaps, deleteAppRule → RulesSummaryView+Packs.swift
+
+    private func focusRuleCollection(from userInfo: [AnyHashable: Any]?, scrollProxy: ScrollViewProxy) {
+        guard let rawTarget = userInfo?[SettingsNavigationUserInfo.ruleCollectionTarget] as? String else {
+            return
+        }
+
+        let target = rawTarget.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !target.isEmpty else { return }
+
+        searchQuery = ""
+
+        if isCustomRulesTarget(target) {
+            AppLogger.shared.log("🎯 [Rules] Focusing custom rules from settings navigation")
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                withAnimation(.easeInOut(duration: 0.25)) {
+                    scrollProxy.scrollTo("custom-rules", anchor: .top)
+                }
+            }
+            return
+        }
+
+        guard let collection = allCollections.first(where: { collectionMatchesNavigationTarget($0, target: target) }) else {
+            AppLogger.shared.log("⚠️ [Rules] Could not find collection for settings target: \(target)")
+            return
+        }
+
+        recommendationFocusCollectionId = collection.id
+        AppLogger.shared.log("🎯 [Rules] Focusing collection \(collection.name) from settings target: \(target)")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
+            withAnimation(.easeInOut(duration: 0.25)) {
+                scrollProxy.scrollTo("collection-\(collection.id.uuidString)", anchor: .top)
+            }
+        }
+    }
+
+    private func collectionMatchesNavigationTarget(_ collection: RuleCollection, target: String) -> Bool {
+        let normalized = normalizeNavigationTarget(target)
+        guard !normalized.isEmpty else { return false }
+
+        if collection.id.uuidString.lowercased() == target.lowercased() {
+            return true
+        }
+
+        let candidates = [
+            collection.name,
+            dynamicCollectionName(for: collection),
+            collection.summary,
+        ].map(normalizeNavigationTarget)
+
+        if candidates.contains(normalized) {
+            return true
+        }
+
+        if collection.id == RuleCollectionIdentifier.homeRowMods,
+           ["home-row", "home-row-mod", "home-row-mods", "hrm", "top-row", "top-row-mods"].contains(normalized)
+        {
+            return true
+        }
+
+        return false
+    }
+
+    private func isCustomRulesTarget(_ target: String) -> Bool {
+        ["custom", "custom-rule", "custom-rules"].contains(normalizeNavigationTarget(target))
+    }
+
+    private func normalizeNavigationTarget(_ value: String) -> String {
+        let lowercased = value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        var result = ""
+        var previousWasSeparator = false
+
+        for scalar in lowercased.unicodeScalars {
+            if CharacterSet.alphanumerics.contains(scalar) {
+                result.unicodeScalars.append(scalar)
+                previousWasSeparator = false
+            } else if !previousWasSeparator {
+                result.append("-")
+                previousWasSeparator = true
+            }
+        }
+
+        return result.trimmingCharacters(in: CharacterSet(charactersIn: "-"))
+    }
 }

--- a/Sources/KeyPathAppKit/UI/Settings/SettingsContainerView.swift
+++ b/Sources/KeyPathAppKit/UI/Settings/SettingsContainerView.swift
@@ -41,7 +41,10 @@ struct SettingsContainerView: View {
     var body: some View {
         TabView(selection: $selection) {
             StatusSettingsTabView()
-                .tabItem { Label("Status", systemImage: "gauge.with.dots.needle.bottom.50percent") }
+                .tabItem {
+                    Label("Status", systemImage: "gauge.with.dots.needle.bottom.50percent")
+                        .accessibilityIdentifier("settings-tab-status")
+                }
                 .tag(SettingsTab.status)
 
             Group {
@@ -51,17 +54,27 @@ struct SettingsContainerView: View {
                     RulesDisabledView(onOpenStatus: { selection = .status })
                 }
             }
-            .tabItem { Label("Rules", systemImage: "list.bullet") }
+            .tabItem {
+                Label("Rules", systemImage: "list.bullet")
+                    .accessibilityIdentifier("settings-tab-rules")
+            }
             .tag(SettingsTab.rules)
 
             GeneralSettingsTabView()
-                .tabItem { Label("General", systemImage: "gearshape") }
+                .tabItem {
+                    Label("General", systemImage: "gearshape")
+                        .accessibilityIdentifier("settings-tab-general")
+                }
                 .tag(SettingsTab.general)
 
             AdvancedSettingsTabView()
-                .tabItem { Label("Repair/Remove", systemImage: "wrench.and.screwdriver") }
+                .tabItem {
+                    Label("Repair/Remove", systemImage: "wrench.and.screwdriver")
+                        .accessibilityIdentifier("settings-tab-repair")
+                }
                 .tag(SettingsTab.advanced)
         }
+        .accessibilityIdentifier("settings-window")
         .background(tabShortcutHandlers)
         .frame(
             minWidth: 680,
@@ -73,15 +86,26 @@ struct SettingsContainerView: View {
         .task { await refreshCanManageRules() }
         .onAppear {
             LiveKeyboardOverlayController.shared.autoHideOnceForSettings()
+            applyPendingSettingsNavigationIfNeeded()
         }
         .onDisappear {
             LiveKeyboardOverlayController.shared.resetSettingsAutoHideGuard()
         }
         .onReceive(NotificationCenter.default.publisher(for: .openSettingsGeneral)) { _ in
             selection = .general
+            SettingsNavigationCoordinator.shared.clearIfMatches(.openSettingsGeneral)
         }
         .onReceive(NotificationCenter.default.publisher(for: .openSettingsStatus)) { _ in
             selection = .status
+            SettingsNavigationCoordinator.shared.clearIfMatches(.openSettingsStatus)
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .openSettingsSystemStatus)) { _ in
+            selection = .status
+            SettingsNavigationCoordinator.shared.clearIfMatches(.openSettingsSystemStatus)
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .openSettingsLogs)) { _ in
+            selection = .general
+            SettingsNavigationCoordinator.shared.clearIfMatches(.openSettingsLogs)
         }
         .onReceive(NotificationCenter.default.publisher(for: .showDiagnostics)) { _ in
             selection = .advanced
@@ -89,17 +113,21 @@ struct SettingsContainerView: View {
                 NotificationCenter.default.post(name: .showErrorsTab, object: nil)
             }
         }
-        .onReceive(NotificationCenter.default.publisher(for: .openSettingsRules)) { _ in
+        .onReceive(NotificationCenter.default.publisher(for: .openSettingsRules)) { notification in
             selection = canManageRules ? .rules : .status
+            SettingsNavigationCoordinator.shared.clearIfMatches(.openSettingsRules)
+            AppLogger.shared.log("🎯 [Settings] Selected Rules tab target=\(notification.userInfo?[SettingsNavigationUserInfo.ruleCollectionTarget] as? String ?? "none")")
         }
         .onReceive(NotificationCenter.default.publisher(for: .openSettingsSimulator)) { _ in
             selection = .advanced
+            SettingsNavigationCoordinator.shared.clearIfMatches(.openSettingsSimulator)
         }
         .onReceive(NotificationCenter.default.publisher(for: .wizardClosed)) { _ in
             Task { await refreshCanManageRules() }
         }
         .onReceive(NotificationCenter.default.publisher(for: .openSettingsAdvanced)) { _ in
             selection = .advanced
+            SettingsNavigationCoordinator.shared.clearIfMatches(.openSettingsAdvanced)
         }
     }
 
@@ -107,12 +135,16 @@ struct SettingsContainerView: View {
         VStack {
             Button("") { selection = .status }
                 .keyboardShortcut("1", modifiers: .command)
+                .accessibilityIdentifier("settings-shortcut-status-button")
             Button("") { selection = canManageRules ? .rules : selection }
                 .keyboardShortcut("2", modifiers: .command)
+                .accessibilityIdentifier("settings-shortcut-rules-button")
             Button("") { selection = .general }
                 .keyboardShortcut("3", modifiers: .command)
+                .accessibilityIdentifier("settings-shortcut-general-button")
             Button("") { selection = .advanced }
                 .keyboardShortcut("4", modifiers: .command)
+                .accessibilityIdentifier("settings-shortcut-repair-button")
         }
         .frame(width: 0, height: 0)
         .opacity(0)
@@ -127,6 +159,24 @@ struct SettingsContainerView: View {
             if !canManageRules, selection == .rules {
                 selection = .status
             }
+        }
+    }
+
+    private func applyPendingSettingsNavigationIfNeeded() {
+        guard let request = SettingsNavigationCoordinator.shared.consumePendingRequest() else { return }
+        switch request.notification {
+        case .openSettingsGeneral, .openSettingsLogs:
+            selection = .general
+        case .openSettingsRules:
+            selection = canManageRules ? .rules : .status
+            AppLogger.shared.log("🎯 [Settings] Applied pending Rules navigation target=\(request.userInfo?[SettingsNavigationUserInfo.ruleCollectionTarget] as? String ?? "none")")
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
+                NotificationCenter.default.post(name: .openSettingsRules, object: nil, userInfo: request.userInfo)
+            }
+        case .openSettingsAdvanced, .openSettingsSimulator:
+            selection = .advanced
+        default:
+            selection = .status
         }
     }
 }

--- a/Sources/KeyPathAppKit/UI/Settings/SettingsView+StatusDetails.swift
+++ b/Sources/KeyPathAppKit/UI/Settings/SettingsView+StatusDetails.swift
@@ -13,6 +13,16 @@ extension StatusSettingsTabView {
         case critical = 2
         case checking = 3
         case disabled = 4
+
+        var accessibilityValue: String {
+            switch self {
+            case .success: "success"
+            case .warning: "warning"
+            case .critical: "critical"
+            case .checking: "checking"
+            case .disabled: "disabled"
+            }
+        }
     }
 
     var overallHealthLevel: OverallHealthLevel {

--- a/Sources/KeyPathAppKit/UI/Settings/SettingsView+StatusSupportingViews.swift
+++ b/Sources/KeyPathAppKit/UI/Settings/SettingsView+StatusSupportingViews.swift
@@ -36,6 +36,24 @@ struct PermissionStatusRow: View {
         .disabled(onTap == nil)
         .accessibilityIdentifier("settings-status-action-button-\(title.lowercased().replacingOccurrences(of: " ", with: "-"))")
         .accessibilityLabel(title)
+        .accessibilityValue(accessibilityValue)
+    }
+
+    private var accessibilityValue: String {
+        guard let status else { return "checking" }
+        switch status {
+        case .granted:
+            return "granted"
+        case .denied:
+            return "denied"
+        case let .error(message):
+            return message.isEmpty ? "error" : "error: \(message)"
+        case .unknown:
+            if isKanata, !hasFullDiskAccess {
+                return "unknown: full disk access required to verify"
+            }
+            return "unknown"
+        }
     }
 
     private var statusColor: Color {
@@ -177,6 +195,7 @@ struct StatusDetailRow: View {
                         .controlSize(.small)
                         .accessibilityIdentifier("status-action-\(action.title.lowercased().replacingOccurrences(of: " ", with: "-"))")
                         .accessibilityLabel(action.title)
+                        .accessibilityValue(detail.message)
                     }
                 }
             }

--- a/Sources/KeyPathAppKit/UI/Settings/SettingsView.swift
+++ b/Sources/KeyPathAppKit/UI/Settings/SettingsView.swift
@@ -40,6 +40,11 @@ struct StatusSettingsTabView: View {
         localServiceRunning ?? isServiceRunning
     }
 
+    private var activeRulesCount: Int {
+        kanataManager.ruleCollections.filter(\.isEnabled).count
+            + kanataManager.customRules.filter(\.isEnabled).count
+    }
+
     var hasFullDiskAccess: Bool {
         FullDiskAccessChecker.shared.hasFullDiskAccess()
     }
@@ -95,6 +100,7 @@ struct StatusSettingsTabView: View {
                                 .buttonStyle(.plain)
                                 .accessibilityIdentifier("status-system-health-button")
                                 .accessibilityLabel("System status: \(systemHealthMessage)")
+                                .accessibilityValue(overallHealthLevel.accessibilityValue)
                             }
 
                             VStack(spacing: 4) {
@@ -113,16 +119,14 @@ struct StatusSettingsTabView: View {
                                 Button(action: {
                                     NotificationCenter.default.post(name: .openSettingsRules, object: nil)
                                 }) {
-                                    let enabledCollections = kanataManager.ruleCollections.filter(\.isEnabled).count
-                                    let enabledCustomRules = kanataManager.customRules.filter(\.isEnabled).count
-                                    let activeCount = enabledCollections + enabledCustomRules
-                                    Text(activeRulesText(count: activeCount))
+                                    Text(activeRulesText(count: activeRulesCount))
                                         .font(.body)
                                         .foregroundColor(.secondary)
                                 }
                                 .buttonStyle(.plain)
                                 .accessibilityIdentifier("status-active-rules-button")
                                 .accessibilityLabel("View active rules")
+                                .accessibilityValue(activeRulesText(count: activeRulesCount))
                             }
                         }
 
@@ -181,6 +185,7 @@ struct StatusSettingsTabView: View {
                             .controlSize(.large)
                             .accessibilityIdentifier("status-service-toggle")
                             .accessibilityLabel("KeyPath Runtime")
+                            .accessibilityValue(effectiveServiceRunning ? "on" : "off")
 
                             Text(effectiveServiceRunning ? "ON" : "OFF")
                                 .font(.body.weight(.medium))
@@ -265,6 +270,7 @@ struct StatusSettingsTabView: View {
 
                             ForEach(systemStatusRows) { row in
                                 SettingsSystemStatusRow(
+                                    id: row.id,
                                     title: row.title,
                                     icon: row.icon,
                                     status: row.status,

--- a/Sources/KeyPathAppKit/UI/Status/SettingsSystemStatusRows.swift
+++ b/Sources/KeyPathAppKit/UI/Status/SettingsSystemStatusRows.swift
@@ -170,6 +170,7 @@ private extension SettingsSystemStatusRowsBuilder {
 }
 
 struct SettingsSystemStatusRow: View {
+    let id: String
     let title: String
     let icon: String
     let status: InstallationStatus
@@ -196,8 +197,9 @@ struct SettingsSystemStatusRow: View {
             }
             .buttonStyle(.plain)
             .disabled(onTap == nil)
-            .accessibilityIdentifier("settings-status-row-button-\(title.lowercased().replacingOccurrences(of: " ", with: "-"))")
+            .accessibilityIdentifier("settings-status-row-button-\(id)")
             .accessibilityLabel(title)
+            .accessibilityValue(accessibilityValue)
 
             if let message, status != .completed {
                 Text(message)
@@ -221,6 +223,12 @@ struct SettingsSystemStatusRow: View {
         }
     }
 
+    private var accessibilityValue: String {
+        let value = status.accessibilityValue
+        guard let message, !message.isEmpty else { return value }
+        return "\(value): \(message)"
+    }
+
     private var statusIcon: String {
         switch status {
         case .completed:
@@ -235,6 +243,19 @@ struct SettingsSystemStatusRow: View {
             "circle"
         case .unverified:
             "questionmark.circle"
+        }
+    }
+}
+
+private extension InstallationStatus {
+    var accessibilityValue: String {
+        switch self {
+        case .notStarted: "not started"
+        case .inProgress: "in progress"
+        case .completed: "completed"
+        case .warning: "warning"
+        case .failed: "failed"
+        case .unverified: "unverified"
         }
     }
 }

--- a/Sources/KeyPathAppKit/UI/ViewModels/KanataViewModel.swift
+++ b/Sources/KeyPathAppKit/UI/ViewModels/KanataViewModel.swift
@@ -359,6 +359,9 @@ class KanataViewModel {
     func updateHomeRowModsConfig(collectionId: UUID, config: HomeRowModsConfig) async {
         let wasNewlyEnabled = await manager.updateHomeRowModsConfig(collectionId: collectionId, config: config)
         ruleCollections = manager.rulesManager.ruleCollections
+        AppLogger.shared.log(
+            "🧪 [QA] Persisted Home Row Mods config collection=\(collectionId.uuidString) mode=\(config.holdMode.rawValue) keys=\(config.enabledKeys.sorted().joined(separator: ",")) tapWindow=\(config.timing.tapWindow) holdDelay=\(config.timing.holdDelay)"
+        )
         if wasNewlyEnabled {
             let name = ruleCollections.first(where: { $0.id == collectionId })?.name ?? "Collection"
             showToast("Turned on \(name)", type: .success)

--- a/Sources/KeyPathAppKit/Utilities/Notifications.swift
+++ b/Sources/KeyPathAppKit/Utilities/Notifications.swift
@@ -90,3 +90,35 @@ extension Notification.Name {
     /// userInfo["section"] = InspectorSection.rawValue (String)
     static let commandPaletteSelectInspectorSection = Notification.Name("KeyPath.CommandPalette.SelectInspectorSection")
 }
+
+enum SettingsNavigationUserInfo {
+    static let ruleCollectionTarget = "ruleCollectionTarget"
+}
+
+struct SettingsNavigationRequest {
+    let notification: Notification.Name
+    let userInfo: [AnyHashable: Any]?
+}
+
+@MainActor
+final class SettingsNavigationCoordinator {
+    static let shared = SettingsNavigationCoordinator()
+
+    private var pendingRequest: SettingsNavigationRequest?
+
+    private init() {}
+
+    func store(notification: Notification.Name, userInfo: [AnyHashable: Any]? = nil) {
+        pendingRequest = SettingsNavigationRequest(notification: notification, userInfo: userInfo)
+    }
+
+    func consumePendingRequest() -> SettingsNavigationRequest? {
+        defer { pendingRequest = nil }
+        return pendingRequest
+    }
+
+    func clearIfMatches(_ notification: Notification.Name) {
+        guard pendingRequest?.notification == notification else { return }
+        pendingRequest = nil
+    }
+}

--- a/Sources/KeyPathCLI/Commands/Collection/CollectionShowCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Collection/CollectionShowCommand.swift
@@ -13,9 +13,17 @@ struct CollectionShow: AsyncParsableCommand {
     @Argument(help: "Collection name or ID")
     var nameOrId: String
 
+    @Flag(name: .customLong("full"), help: "Show full collection model including display configuration")
+    var full: Bool = false
+
     mutating func run() async throws {
         let ctx = globals.outputContext
         let facade = CollectionsFacade()
+
+        if full {
+            try await showFullCollection(ctx: ctx, facade: facade)
+            return
+        }
 
         let collection: CLIRuleCollection
         do {
@@ -42,6 +50,40 @@ struct CollectionShow: AsyncParsableCommand {
             ID: \(collection.id)
             Enabled: \(collection.isEnabled)
             Mappings: \(collection.mappingCount)
+            Summary: \(collection.summary)
+            """
+        }
+    }
+
+    private func showFullCollection(ctx: OutputContext, facade: CollectionsFacade) async throws {
+        let collection: CLIRuleCollectionDetail
+        do {
+            guard let found = try await facade.showCollectionDetail(nameOrId: nameOrId) else {
+                let candidates = await facade.loadRuleCollections().map(\.name)
+                let suggestions = FuzzyMatch.suggestions(for: nameOrId, from: candidates)
+                let error = CLIError.notFound("Collection", query: nameOrId, listCommand: "keypath collection list", suggestions: suggestions)
+                CLIOutput.writeError(error, context: ctx)
+                throw error.code.exitCode
+            }
+            collection = found
+        } catch let ambiguous as AmbiguousCollectionMatch {
+            let error = CLIError.ambiguous(
+                ambiguous.description,
+                matches: ambiguous.matches.map { "\($0.name) (id: \($0.id))" }
+            )
+            CLIOutput.writeError(error, context: ctx)
+            throw error.code.exitCode
+        }
+
+        CLIOutput.write(collection, context: ctx) {
+            """
+            Name: \(collection.name)
+            ID: \(collection.id)
+            Enabled: \(collection.isEnabled)
+            Style: \(collection.displayStyle)
+            Mappings: \(collection.mappingCount)
+            Target layer: \(collection.targetLayer)
+            Configuration: \(collection.displayStyle)
             Summary: \(collection.summary)
             """
         }

--- a/Sources/KeyPathCLI/Commands/Config/ConfigBackupCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Config/ConfigBackupCommand.swift
@@ -1,0 +1,39 @@
+import ArgumentParser
+import Foundation
+import KeyPathAppKit
+
+struct ConfigBackup: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "backup",
+        abstract: "Copy the KeyPath config directory for QA-safe restore"
+    )
+
+    @OptionGroup var globals: GlobalOptions
+
+    @Option(name: .customLong("output"), help: "Backup directory to create. Defaults to ~/Library/Application Support/KeyPath/QA Backups/keypath-config-<timestamp>.")
+    var outputPath: String?
+
+    mutating func run() async throws {
+        let ctx = globals.outputContext
+        let facade = ConfigFacade()
+
+        do {
+            let result = try facade.backupConfig(outputPath: outputPath)
+            CLIOutput.write(result, context: ctx) {
+                """
+                Backup created: \(result.backupPath)
+                Source: \(result.sourcePath)
+                Items: \(result.copiedItems.isEmpty ? "none" : result.copiedItems.joined(separator: ", "))
+                """
+            }
+        } catch {
+            let cliError = CLIError.validation(
+                "Config backup failed",
+                hint: "Check that ~/.config/keypath exists and the destination does not already exist.",
+                details: [error.localizedDescription]
+            )
+            CLIOutput.writeError(cliError, context: ctx)
+            throw cliError.code.exitCode
+        }
+    }
+}

--- a/Sources/KeyPathCLI/Commands/Config/ConfigCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Config/ConfigCommand.swift
@@ -9,6 +9,8 @@ struct Config: AsyncParsableCommand {
             ConfigPath.self,
             ConfigCheck.self,
             ConfigApply.self,
+            ConfigBackup.self,
+            ConfigRestore.self,
         ]
     )
 }

--- a/Sources/KeyPathCLI/Commands/Config/ConfigRestoreCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Config/ConfigRestoreCommand.swift
@@ -1,0 +1,52 @@
+import ArgumentParser
+import Foundation
+import KeyPathAppKit
+
+struct ConfigRestore: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "restore",
+        abstract: "Restore the KeyPath config directory from a backup"
+    )
+
+    @OptionGroup var globals: GlobalOptions
+
+    @Argument(help: "Backup directory previously created by 'keypath config backup'")
+    var backupPath: String
+
+    @Flag(name: .customLong("reload"), help: "Ask the running Kanata service to reload after restore")
+    var reload: Bool = false
+
+    mutating func run() async throws {
+        let ctx = globals.outputContext
+        let facade = ConfigFacade()
+
+        do {
+            let result = try await facade.restoreConfig(from: backupPath, reload: reload)
+            CLIOutput.write(result, context: ctx) {
+                var lines = [
+                    "Config restored: \(result.restoredPath)",
+                    "Source: \(result.sourcePath)",
+                    "Items: \(result.restoredItems.isEmpty ? "none" : result.restoredItems.joined(separator: ", "))",
+                ]
+                if result.reloadRequested {
+                    lines.append(result.reloadSuccess == true ? "Kanata reload requested successfully." : "Kanata reload failed.")
+                }
+                return lines.joined(separator: "\n")
+            }
+
+            if result.reloadRequested, result.reloadSuccess != true {
+                throw CLIExitCode.serviceUnreachable.exitCode
+            }
+        } catch let exitCode as ExitCode {
+            throw exitCode
+        } catch {
+            let cliError = CLIError.validation(
+                "Config restore failed",
+                hint: "Pass a backup directory created by 'keypath config backup'.",
+                details: [error.localizedDescription]
+            )
+            CLIOutput.writeError(cliError, context: ctx)
+            throw cliError.code.exitCode
+        }
+    }
+}

--- a/Tests/KeyPathTests/CLI/CommandStructureTests.swift
+++ b/Tests/KeyPathTests/CLI/CommandStructureTests.swift
@@ -52,7 +52,7 @@ final class CommandStructureTests: XCTestCase {
 
     func testConfigHasExpectedVerbs() {
         let names = subcommandNames(of: Config.self)
-        XCTAssertEqual(Set(names), ["show", "path", "check", "apply"])
+        XCTAssertEqual(Set(names), ["show", "path", "check", "apply", "backup", "restore"])
     }
 
     func testSystemHasExpectedVerbs() {

--- a/Tests/KeyPathTests/Services/ActionDispatcherTests.swift
+++ b/Tests/KeyPathTests/Services/ActionDispatcherTests.swift
@@ -229,6 +229,58 @@ struct ActionDispatcherRoutingTests {
         #expect(receivedLayer == "editing")
     }
 
+    @Test("Dispatches settings action")
+    @MainActor
+    func dispatchesSettingsAction() throws {
+        var receivedNotification: Notification.Name?
+        ActionDispatcher.shared.onSettingsAction = { notification in
+            receivedNotification = notification
+        }
+        defer {
+            ActionDispatcher.shared.onSettingsAction = nil
+        }
+
+        let uri = try #require(KeyPathActionURI(string: "keypath://settings/status"))
+        let result = ActionDispatcher.shared.dispatch(uri)
+
+        #expect(result == .success)
+        #expect(receivedNotification == .openSettingsStatus)
+    }
+
+    @Test("Dispatches settings rule target action")
+    @MainActor
+    func dispatchesSettingsRuleTargetAction() throws {
+        var receivedNotification: Notification.Name?
+        var receivedUserInfo: [AnyHashable: Any]?
+        ActionDispatcher.shared.onSettingsNavigationAction = { notification, userInfo in
+            receivedNotification = notification
+            receivedUserInfo = userInfo
+        }
+        defer {
+            ActionDispatcher.shared.onSettingsNavigationAction = nil
+        }
+
+        let uri = try #require(KeyPathActionURI(string: "keypath://settings/rules/home-row-mods"))
+        let result = ActionDispatcher.shared.dispatch(uri)
+
+        #expect(result == .success)
+        #expect(receivedNotification == .openSettingsRules)
+        #expect(receivedUserInfo?[SettingsNavigationUserInfo.ruleCollectionTarget] as? String == "home-row-mods")
+    }
+
+    @Test("Returns unknownAction for unknown settings tab")
+    @MainActor
+    func returnsUnknownActionForUnknownSettingsTab() throws {
+        let uri = try #require(KeyPathActionURI(string: "keypath://settings/unknown"))
+        let result = ActionDispatcher.shared.dispatch(uri)
+
+        if case let .unknownAction(action) = result {
+            #expect(action == "settings/unknown")
+        } else {
+            Issue.record("Expected unknownAction for unknown settings tab")
+        }
+    }
+
     @Test("Dispatch message API returns unknownAction for invalid URI string")
     @MainActor
     func dispatchMessageInvalidString() {


### PR DESCRIPTION
## Summary
- add rule-targeted Settings deep links, including `keypath://settings/rules/home-row-mods`
- add CLI backup/restore helpers and full collection JSON output for QA setup/verification
- add Computer Use-friendly accessibility markers, labels, values, readiness checks, and routing coverage

## Validation
- `swift build`
- `./Scripts/quick-deploy.sh`
- `python3 Scripts/check-accessibility.py`
- `python3 Scripts/check-computer-use-readiness.py`
- `swift test --filter ActionDispatcherRoutingTests`
- CLI smoke: `keypath-cli config backup --json`
- CLI smoke: `keypath-cli collection show "Home Row Mods" --full --json`
- Computer Use smoke: opened `keypath://settings/rules/home-row-mods` and verified Home Row Mods summary/detail control IDs