### PR TITLE
Fix config QA blockers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,6 +100,19 @@ For trust-only diagnostics where KeyPath is not running yet:
 CHECK_RUNTIME=0 ./Scripts/verify-installed-app.sh
 ```
 
+### 5. Release QA CLI
+For release-candidate and installed-app QA, use the CLI inside the installed app:
+```bash
+/Applications/KeyPath.app/Contents/MacOS/keypath-cli
+```
+
+Do **not** use `.build/debug/keypath-cli` for release QA that validates or
+applies config. The debug CLI resolves bundled Kanata relative to `.build/debug`
+and expects `.build/debug/Contents/Library/KeyPath/Kanata Engine.app/...`, which
+does not exist in a normal SwiftPM debug build. The installed CLI resolves the
+bundled engine from `/Applications/KeyPath.app` and matches the deployed app
+under test.
+
 ## Architecture & Patterns
 
 ### InstallerEngine Façade

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,6 +154,20 @@ For trust-only diagnostics where KeyPath is not running yet:
 CHECK_RUNTIME=0 ./Scripts/verify-installed-app.sh
 ```
 
+**Release QA CLI:** For release-candidate and installed-app QA, use the CLI
+inside the installed app:
+
+```bash
+/Applications/KeyPath.app/Contents/MacOS/keypath-cli
+```
+
+Do **not** use `.build/debug/keypath-cli` for release QA that validates or
+applies config. The debug CLI resolves bundled Kanata relative to `.build/debug`
+and expects `.build/debug/Contents/Library/KeyPath/Kanata Engine.app/...`, which
+does not exist in a normal SwiftPM debug build. The installed CLI resolves the
+bundled engine from `/Applications/KeyPath.app` and matches the deployed app
+under test.
+
 **SwiftFormat is pinned to 0.61.1** (`mise.toml`); `master` is a formatted fixed-point
 for that version + `.swiftformat` config, so a run produces **no churn**. A different
 version reformats unrelated code (see #634) — match the pin (`mise install` or

--- a/Sources/KeyPathAppKit/CLI/ConfigFacade.swift
+++ b/Sources/KeyPathAppKit/CLI/ConfigFacade.swift
@@ -2,25 +2,47 @@ import Foundation
 import KeyPathCore
 
 public struct ConfigFacade: Sendable {
-    public init() {}
+    private let configDirectory: String
+    private let ruleCollectionLoader: @Sendable () async -> [RuleCollection]
+    private let customRuleLoader: @Sendable () async -> [CustomRule]
+    private let reloadHandler: (@Sendable () async -> Bool)?
+
+    public init(configDirectory: String = KeyPathConstants.Config.directory) {
+        self.configDirectory = configDirectory
+        ruleCollectionLoader = { await RuleCollectionStore.shared.loadCollections() }
+        customRuleLoader = { await CustomRulesStore.shared.loadRules() }
+        reloadHandler = nil
+    }
+
+    init(
+        configDirectory: String,
+        ruleCollectionLoader: @escaping @Sendable () async -> [RuleCollection],
+        customRuleLoader: @escaping @Sendable () async -> [CustomRule],
+        reloadHandler: (@Sendable () async -> Bool)? = nil
+    ) {
+        self.configDirectory = configDirectory
+        self.ruleCollectionLoader = ruleCollectionLoader
+        self.customRuleLoader = customRuleLoader
+        self.reloadHandler = reloadHandler
+    }
 
     // MARK: - Configuration
 
     @MainActor
     public func currentConfig() async -> String {
-        let service = ConfigurationService()
+        let service = ConfigurationService(configDirectory: configDirectory)
         let config = await service.current()
         return config.content
     }
 
     @MainActor
     public func configPath() -> String {
-        ConfigurationService().configurationPath
+        ConfigurationService(configDirectory: configDirectory).configurationPath
     }
 
     @MainActor
     public func validateConfig() async -> CLIValidationResult {
-        let service = ConfigurationService()
+        let service = ConfigurationService(configDirectory: configDirectory)
         let config = await service.current()
         if config.content.isEmpty {
             return CLIValidationResult(isValid: false, errors: ["No configuration generated yet. Run 'keypath apply' first."])
@@ -31,38 +53,47 @@ public struct ConfigFacade: Sendable {
 
     // MARK: - Apply
 
-    public func applyConfiguration() async throws -> CLIApplyResult {
-        let collections = await RuleCollectionStore.shared.loadCollections()
-        let customRules = await CustomRulesStore.shared.loadRules()
+    public func applyConfiguration(dryRun: Bool = false) async throws -> CLIApplyResult {
+        let collections = await ruleCollectionLoader()
+        let customRules = await customRuleLoader()
         let enabledCount = collections.filter(\.isEnabled).count
 
-        let service = await MainActor.run { ConfigurationService() }
+        let service = await MainActor.run { ConfigurationService(configDirectory: configDirectory) }
+
+        if dryRun {
+            let previewConfig = try await service.generateConfiguration(
+                ruleCollections: collections,
+                customRules: customRules
+            )
+            try await validateDryRunConfig(previewConfig.content)
+
+            return CLIApplyResult(
+                collectionsCount: collections.count,
+                enabledCount: enabledCount,
+                customRulesCount: customRules.count,
+                reloadSuccess: false,
+                changeset: changeset(collections: collections, customRules: customRules),
+                dryRun: true
+            )
+        }
+
         try await service.saveConfiguration(
             ruleCollections: collections,
             customRules: customRules
         )
 
-        let port = await MainActor.run { PreferencesService.shared.tcpServerPort }
-        let client = KanataTCPClient(port: port)
-        let result = await client.reloadConfig()
-        let reloadSuccess = if case .success = result {
-            true
+        let reloadSuccess = if let reloadHandler {
+            await reloadHandler()
         } else {
-            false
+            await tcpReload()
         }
-
-        let changeset = CLIApplyChangeset(
-            enabledCollections: collections.filter(\.isEnabled).map(\.name),
-            disabledCollections: collections.filter { !$0.isEnabled }.map(\.name),
-            customRules: customRules.filter(\.isEnabled).map { "\($0.input) → \($0.action.outputString)" }
-        )
 
         return CLIApplyResult(
             collectionsCount: collections.count,
             enabledCount: enabledCount,
             customRulesCount: customRules.count,
             reloadSuccess: reloadSuccess,
-            changeset: changeset
+            changeset: changeset(collections: collections, customRules: customRules)
         )
     }
 
@@ -70,8 +101,9 @@ public struct ConfigFacade: Sendable {
 
     public func backupConfig(outputPath: String? = nil) throws -> CLIConfigBackupResult {
         let fileManager = FileManager.default
-        let sourceURL = URL(fileURLWithPath: KeyPathConstants.Config.directory, isDirectory: true)
-        guard fileManager.fileExists(atPath: sourceURL.path) else {
+        let sourceURL = URL(fileURLWithPath: configDirectory, isDirectory: true)
+        let sourceCopyURL = try resolvedExistingDirectory(sourceURL, fileManager: fileManager)
+        guard fileManager.fileExists(atPath: sourceCopyURL.path) else {
             throw Self.error("Config directory does not exist: \(sourceURL.path)")
         }
 
@@ -87,7 +119,8 @@ public struct ConfigFacade: Sendable {
             at: destinationURL.deletingLastPathComponent(),
             withIntermediateDirectories: true
         )
-        try fileManager.copyItem(at: sourceURL, to: destinationURL)
+        try fileManager.createDirectory(at: destinationURL, withIntermediateDirectories: true)
+        try copyDirectoryContents(from: sourceCopyURL, to: destinationURL, fileManager: fileManager)
 
         return try CLIConfigBackupResult(
             sourcePath: sourceURL.path,
@@ -104,21 +137,33 @@ public struct ConfigFacade: Sendable {
             throw Self.error("Backup directory does not exist: \(sourceURL.path)")
         }
 
-        let destinationURL = URL(fileURLWithPath: KeyPathConstants.Config.directory, isDirectory: true)
+        let resolvedSourceURL = try resolvedExistingDirectory(sourceURL, fileManager: fileManager)
+        let destinationURL = URL(fileURLWithPath: configDirectory, isDirectory: true)
         try fileManager.createDirectory(
             at: destinationURL.deletingLastPathComponent(),
             withIntermediateDirectories: true
         )
+
+        let restoreTargetURL: URL
         if fileManager.fileExists(atPath: destinationURL.path) {
-            try fileManager.removeItem(at: destinationURL)
+            restoreTargetURL = try resolvedExistingDirectory(destinationURL, fileManager: fileManager)
+        } else {
+            restoreTargetURL = destinationURL
+            try fileManager.createDirectory(at: restoreTargetURL, withIntermediateDirectories: true)
         }
-        try fileManager.copyItem(at: sourceURL, to: destinationURL)
+
+        if sameResolvedPath(resolvedSourceURL, restoreTargetURL) {
+            throw Self.error("Backup path resolves to the active config directory: \(sourceURL.path)")
+        }
+
+        try removeDirectoryContents(at: restoreTargetURL, fileManager: fileManager)
+        try copyDirectoryContents(from: resolvedSourceURL, to: restoreTargetURL, fileManager: fileManager)
 
         let reloadSuccess = reload ? await tcpReload() : nil
         return try CLIConfigRestoreResult(
             sourcePath: sourceURL.path,
             restoredPath: destinationURL.path,
-            restoredItems: copiedItemNames(in: destinationURL),
+            restoredItems: copiedItemNames(in: restoreTargetURL),
             reloadRequested: reload,
             reloadSuccess: reloadSuccess
         )
@@ -192,6 +237,66 @@ public struct ConfigFacade: Sendable {
             .appendingPathComponent(name, isDirectory: true)
     }
 
+    private func validateDryRunConfig(_ content: String) async throws {
+        let tempDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("keypath-cli-dry-run-\(UUID().uuidString)", isDirectory: true)
+        defer {
+            try? FileManager.default.removeItem(at: tempDirectory)
+        }
+        let service = await MainActor.run { ConfigurationService(configDirectory: tempDirectory.path) }
+        let validation = await service.validateConfiguration(content)
+        guard validation.isValid else {
+            throw KeyPathError.configuration(.validationFailed(errors: validation.errors))
+        }
+    }
+
+    private func changeset(
+        collections: [RuleCollection],
+        customRules: [CustomRule]
+    ) -> CLIApplyChangeset {
+        CLIApplyChangeset(
+            enabledCollections: collections.filter(\.isEnabled).map(\.name),
+            disabledCollections: collections.filter { !$0.isEnabled }.map(\.name),
+            customRules: customRules.filter(\.isEnabled).map { "\($0.input) → \($0.action.outputString)" }
+        )
+    }
+
+    private func resolvedExistingDirectory(_ url: URL, fileManager: FileManager) throws -> URL {
+        var isDirectory: ObjCBool = false
+        guard fileManager.fileExists(atPath: url.path, isDirectory: &isDirectory), isDirectory.boolValue else {
+            throw Self.error("Directory does not exist: \(url.path)")
+        }
+        return url.resolvingSymlinksInPath()
+    }
+
+    private func copyDirectoryContents(from source: URL, to destination: URL, fileManager: FileManager) throws {
+        let contents = try fileManager.contentsOfDirectory(
+            at: source,
+            includingPropertiesForKeys: nil
+        )
+        for item in contents {
+            try fileManager.copyItem(
+                at: item,
+                to: destination.appendingPathComponent(item.lastPathComponent)
+            )
+        }
+    }
+
+    private func removeDirectoryContents(at directory: URL, fileManager: FileManager) throws {
+        let contents = try fileManager.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: nil
+        )
+        for item in contents {
+            try fileManager.removeItem(at: item)
+        }
+    }
+
+    private func sameResolvedPath(_ lhs: URL, _ rhs: URL) -> Bool {
+        lhs.resolvingSymlinksInPath().standardizedFileURL.path ==
+            rhs.resolvingSymlinksInPath().standardizedFileURL.path
+    }
+
     private func copiedItemNames(in directory: URL) throws -> [String] {
         try FileManager.default.contentsOfDirectory(atPath: directory.path).sorted()
     }
@@ -209,6 +314,23 @@ public struct CLIApplyResult: Codable, Sendable {
     public let customRulesCount: Int
     public let reloadSuccess: Bool
     public let changeset: CLIApplyChangeset?
+    public let dryRun: Bool?
+
+    public init(
+        collectionsCount: Int,
+        enabledCount: Int,
+        customRulesCount: Int,
+        reloadSuccess: Bool,
+        changeset: CLIApplyChangeset?,
+        dryRun: Bool? = nil
+    ) {
+        self.collectionsCount = collectionsCount
+        self.enabledCount = enabledCount
+        self.customRulesCount = customRulesCount
+        self.reloadSuccess = reloadSuccess
+        self.changeset = changeset
+        self.dryRun = dryRun
+    }
 }
 
 public struct CLIApplyChangeset: Codable, Sendable {

--- a/Sources/KeyPathAppKit/Infrastructure/Config/ConfigurationService.swift
+++ b/Sources/KeyPathAppKit/Infrastructure/Config/ConfigurationService.swift
@@ -233,6 +233,45 @@ public final class ConfigurationService: FileConfigurationProviding {
         ruleCollections: [RuleCollection],
         customRules: [CustomRule] = []
     ) async throws {
+        let newConfig = try await generateConfiguration(
+            ruleCollections: ruleCollections,
+            customRules: customRules
+        )
+
+        // VALIDATE BEFORE SAVING - prevent writing broken configs
+        AppLogger.shared.log("🔍 [ConfigService] Validating config before save...")
+        let validation = await validateConfiguration(newConfig.content)
+
+        if !validation.isValid {
+            AppLogger.shared.log(
+                "❌ [ConfigService] Config validation failed: \(validation.errors.joined(separator: ", "))"
+            )
+            throw KeyPathError.configuration(.validationFailed(errors: validation.errors))
+        }
+
+        AppLogger.shared.log("✅ [ConfigService] Config validation passed")
+
+        try await writeFileAsync(string: newConfig.content, to: configurationPath)
+
+        setCurrentConfiguration(newConfig)
+
+        // Notify observers on main actor
+        let snapshot = observersSnapshot()
+        let tasks = snapshot.map { observer in
+            Task { @MainActor in await observer(newConfig) }
+        }
+        for t in tasks {
+            await t.value
+        }
+
+        AppLogger.shared.log("✅ [ConfigService] Configuration saved with \(newConfig.keyMappings.count) mappings")
+    }
+
+    /// Generate a Kanata configuration from rule stores without writing it.
+    public func generateConfiguration(
+        ruleCollections: [RuleCollection],
+        customRules: [CustomRule] = []
+    ) async throws -> KanataConfiguration {
         // Custom rules come first so they take priority over preset collections
         let customRuleCollections = customRules.asRuleCollections()
         AppLogger.shared.log("🔧 [ConfigService] Converting \(customRules.count) custom rules to \(customRuleCollections.count) collections")
@@ -289,23 +328,7 @@ public final class ConfigurationService: FileConfigurationProviding {
             sequences: preservedSequences
         )
 
-        // VALIDATE BEFORE SAVING - prevent writing broken configs
-        AppLogger.shared.log("🔍 [ConfigService] Validating config before save...")
-        let validation = await validateConfiguration(configContent)
-
-        if !validation.isValid {
-            AppLogger.shared.log(
-                "❌ [ConfigService] Config validation failed: \(validation.errors.joined(separator: ", "))"
-            )
-            throw KeyPathError.configuration(.validationFailed(errors: validation.errors))
-        }
-
-        AppLogger.shared.log("✅ [ConfigService] Config validation passed")
-
-        try await writeFileAsync(string: configContent, to: configurationPath)
-
-        // Update current configuration
-        let newConfig = KanataConfiguration(
+        return KanataConfiguration(
             content: configContent,
             keyMappings: mappings,
             lastModified: Date(),
@@ -313,18 +336,6 @@ public final class ConfigurationService: FileConfigurationProviding {
             chordGroups: preservedChordGroups,
             sequences: preservedSequences
         )
-        setCurrentConfiguration(newConfig)
-
-        // Notify observers on main actor
-        let snapshot = observersSnapshot()
-        let tasks = snapshot.map { observer in
-            Task { @MainActor in await observer(newConfig) }
-        }
-        for t in tasks {
-            await t.value
-        }
-
-        AppLogger.shared.log("✅ [ConfigService] Configuration saved with \(mappings.count) mappings")
     }
 
     /// Strip managed-repeat directives that the runtime supports but `kanata --check` doesn't.

--- a/Sources/KeyPathCLI/Commands/Config/ConfigApplyCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Config/ConfigApplyCommand.swift
@@ -12,13 +12,16 @@ struct ConfigApply: AsyncParsableCommand {
 
     mutating func run() async throws {
         let ctx = globals.outputContext
+        let dryRun = globals.dryRun
         let spinner = CLISpinner(context: ctx)
-        spinner.start("Applying configuration...")
+        spinner.start(dryRun ? "Previewing configuration..." : "Applying configuration...")
 
         let facade = ConfigFacade()
-        let result = try await facade.applyConfiguration()
+        let result = try await facade.applyConfiguration(dryRun: dryRun)
 
-        if result.reloadSuccess {
+        if result.dryRun == true {
+            spinner.succeed("Configuration previewed")
+        } else if result.reloadSuccess {
             spinner.succeed("Configuration applied")
         } else {
             spinner.fail("Config written but Kanata reload failed")
@@ -38,7 +41,9 @@ struct ConfigApply: AsyncParsableCommand {
                     lines.append(ANSIColor.dim("  Rules: \(changeset.customRules.joined(separator: ", "))", noColor: nc))
                 }
             }
-            if result.reloadSuccess {
+            if result.dryRun == true {
+                lines.append(ANSIColor.yellow("Dry run: config validated; no files written and Kanata was not reloaded.", noColor: nc))
+            } else if result.reloadSuccess {
                 lines.append(ANSIColor.green("Kanata reloaded successfully.", noColor: nc))
             } else {
                 lines.append(ANSIColor.red("Config was written but Kanata reload failed.", noColor: nc))
@@ -47,7 +52,7 @@ struct ConfigApply: AsyncParsableCommand {
             return lines.joined(separator: "\n")
         }
 
-        if !result.reloadSuccess {
+        if result.dryRun != true, !result.reloadSuccess {
             throw CLIExitCode.serviceUnreachable.exitCode
         }
     }

--- a/Tests/KeyPathTests/CLI/ConfigFacadeTests.swift
+++ b/Tests/KeyPathTests/CLI/ConfigFacadeTests.swift
@@ -1,0 +1,131 @@
+@testable import KeyPathAppKit
+import XCTest
+
+final class ConfigFacadeTests: XCTestCase {
+    private var tempRoot: URL!
+
+    override func setUpWithError() throws {
+        tempRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ConfigFacadeTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        if let tempRoot {
+            try? FileManager.default.removeItem(at: tempRoot)
+        }
+        tempRoot = nil
+    }
+
+    func testBackupConfigSnapshotsResolvedSymlinkDirectory() throws {
+        let liveTarget = tempRoot.appendingPathComponent("dotfiles-keypath", isDirectory: true)
+        let configLink = tempRoot.appendingPathComponent(".config/keypath", isDirectory: true)
+        let backup = tempRoot.appendingPathComponent("backup", isDirectory: true)
+
+        try createSymlinkedConfig(link: configLink, target: liveTarget)
+        try "original".write(to: liveTarget.appendingPathComponent("RuleCollections.json"), atomically: true, encoding: .utf8)
+
+        let facade = ConfigFacade(configDirectory: configLink.path)
+        let result = try facade.backupConfig(outputPath: backup.path)
+
+        XCTAssertEqual(result.sourcePath, configLink.path)
+        XCTAssertEqual(result.backupPath, backup.path)
+        XCTAssertEqual(result.copiedItems, ["RuleCollections.json"])
+        XCTAssertFalse(isSymbolicLink(backup), "Backup must be an immutable directory snapshot, not a symlink.")
+
+        try "mutated".write(to: liveTarget.appendingPathComponent("RuleCollections.json"), atomically: true, encoding: .utf8)
+        let restored = try String(contentsOf: backup.appendingPathComponent("RuleCollections.json"), encoding: .utf8)
+        XCTAssertEqual(restored, "original")
+    }
+
+    func testRestoreConfigPreservesDestinationSymlinkAndRestoresSnapshotContents() async throws {
+        let liveTarget = tempRoot.appendingPathComponent("dotfiles-keypath", isDirectory: true)
+        let configLink = tempRoot.appendingPathComponent(".config/keypath", isDirectory: true)
+        let backup = tempRoot.appendingPathComponent("backup", isDirectory: true)
+
+        try createSymlinkedConfig(link: configLink, target: liveTarget)
+        try "original".write(to: liveTarget.appendingPathComponent("RuleCollections.json"), atomically: true, encoding: .utf8)
+
+        let facade = ConfigFacade(configDirectory: configLink.path)
+        _ = try facade.backupConfig(outputPath: backup.path)
+
+        try "mutated".write(to: liveTarget.appendingPathComponent("RuleCollections.json"), atomically: true, encoding: .utf8)
+        _ = try await facade.restoreConfig(from: backup.path, reload: false)
+
+        let restored = try String(contentsOf: liveTarget.appendingPathComponent("RuleCollections.json"), encoding: .utf8)
+        XCTAssertEqual(restored, "original")
+        XCTAssertTrue(isSymbolicLink(configLink), "Restore should preserve the configured ~/.config/keypath symlink.")
+    }
+
+    func testRestoreConfigRejectsBackupPathThatResolvesToActiveConfigDirectory() async throws {
+        let liveTarget = tempRoot.appendingPathComponent("dotfiles-keypath", isDirectory: true)
+        let configLink = tempRoot.appendingPathComponent(".config/keypath", isDirectory: true)
+
+        try createSymlinkedConfig(link: configLink, target: liveTarget)
+
+        let facade = ConfigFacade(configDirectory: configLink.path)
+        do {
+            _ = try await facade.restoreConfig(from: liveTarget.path, reload: false)
+            XCTFail("Expected restore to reject backup paths that resolve to the active config directory.")
+        } catch {
+            XCTAssertTrue(error.localizedDescription.contains("active config directory"))
+        }
+    }
+
+    func testApplyConfigurationDryRunDoesNotWriteActiveConfigOrReload() async throws {
+        let configDirectory = tempRoot.appendingPathComponent("config", isDirectory: true)
+        try FileManager.default.createDirectory(at: configDirectory, withIntermediateDirectories: true)
+        let configFile = configDirectory.appendingPathComponent("keypath.kbd")
+        try "original config".write(to: configFile, atomically: true, encoding: .utf8)
+
+        let reloadProbe = ReloadProbe()
+        let facade = ConfigFacade(
+            configDirectory: configDirectory.path,
+            ruleCollectionLoader: { [] },
+            customRuleLoader: { [] },
+            reloadHandler: { await reloadProbe.reload() }
+        )
+
+        let result = try await facade.applyConfiguration(dryRun: true)
+        let reloadCount = await reloadProbe.count
+
+        XCTAssertEqual(result.dryRun, true)
+        XCTAssertFalse(result.reloadSuccess)
+        XCTAssertEqual(reloadCount, 0)
+        XCTAssertEqual(try String(contentsOf: configFile, encoding: .utf8), "original config")
+
+        let activeItems = try FileManager.default.contentsOfDirectory(atPath: configDirectory.path)
+        XCTAssertEqual(activeItems, ["keypath.kbd"])
+    }
+
+    private func createSymlinkedConfig(link: URL, target: URL) throws {
+        try FileManager.default.createDirectory(at: target, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(
+            at: link.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.createSymbolicLink(at: link, withDestinationURL: target)
+    }
+
+    private func isSymbolicLink(_ url: URL) -> Bool {
+        guard let attributes = try? FileManager.default.attributesOfItem(atPath: url.path),
+              let type = attributes[.type] as? FileAttributeType
+        else {
+            return false
+        }
+        return type == .typeSymbolicLink
+    }
+}
+
+private actor ReloadProbe {
+    private var reloadCount = 0
+
+    var count: Int {
+        reloadCount
+    }
+
+    func reload() async -> Bool {
+        reloadCount += 1
+        return true
+    }
+}

--- a/Tests/KeyPathTests/Config/RuleCollectionKanataValidationTests.swift
+++ b/Tests/KeyPathTests/Config/RuleCollectionKanataValidationTests.swift
@@ -15,7 +15,7 @@ import XCTest
 /// need this coverage should build kanata first.
 final class RuleCollectionKanataValidationTests: XCTestCase {
     /// Resolve the kanata binary. CI should set `KEYPATH_KANATA_PATH` to an
-    /// explicit location; locally we fall back to the repo's debug build.
+    /// explicit location; locally we prefer the repo or app-bundled fork.
     private var kanataURL: URL? {
         let candidates: [String] = [
             ProcessInfo.processInfo.environment["KEYPATH_KANATA_PATH"],
@@ -26,7 +26,9 @@ final class RuleCollectionKanataValidationTests: XCTestCase {
                 .deletingLastPathComponent() // Tests
                 .deletingLastPathComponent() // repo root
                 .appendingPathComponent("External/kanata/target/aarch64-apple-darwin/release/kanata")
-                .path
+                .path,
+            "/Applications/KeyPath.app/Contents/Library/KeyPath/Kanata Engine.app/Contents/MacOS/kanata",
+            "/opt/homebrew/bin/kanata"
         ].compactMap { $0 }
 
         return candidates

--- a/Tests/KeyPathTests/Integration/ConfigValidationTests.swift
+++ b/Tests/KeyPathTests/Integration/ConfigValidationTests.swift
@@ -10,7 +10,7 @@ import XCTest
 /// missing deflayer entries, etc.
 ///
 /// Requires: a current KeyPath kanata binary, preferably via
-/// KEYPATH_KANATA_PATH or the repo-built External/kanata release binary.
+/// KEYPATH_KANATA_PATH, the repo-built fork, or the app-bundled fork.
 final class ConfigValidationTests: XCTestCase {
     private func findKanataBinary() -> String? {
         let candidates: [String] = [
@@ -22,8 +22,8 @@ final class ConfigValidationTests: XCTestCase {
                 .deletingLastPathComponent() // repo root
                 .appendingPathComponent("External/kanata/target/aarch64-apple-darwin/release/kanata")
                 .path,
-            "/opt/homebrew/bin/kanata",
-            "/Applications/KeyPath.app/Contents/Library/KeyPath/Kanata Engine.app/Contents/MacOS/kanata"
+            "/Applications/KeyPath.app/Contents/Library/KeyPath/Kanata Engine.app/Contents/MacOS/kanata",
+            "/opt/homebrew/bin/kanata"
         ].compactMap { $0 }
 
         return candidates.first { FileManager.default.isExecutableFile(atPath: $0) }

--- a/Tests/KeyPathTests/Services/ConfigurationServiceTests.swift
+++ b/Tests/KeyPathTests/Services/ConfigurationServiceTests.swift
@@ -1290,30 +1290,22 @@ class ConfigurationServiceTests: XCTestCase {
         try await validateCatalogConfig(withBinary: kanataBinary)
     }
 
-    /// Find the kanata binary, checking multiple locations
+    /// Find the kanata binary, checking fork-aware locations before PATH.
     private func findKanataBinary() throws -> String {
-        // Use Process to find kanata in PATH (includes /opt/homebrew/bin where CI installs the fork)
-        let which = Process()
-        which.executableURL = URL(fileURLWithPath: "/usr/bin/which")
-        which.arguments = ["kanata"]
-        let pipe = Pipe()
-        which.standardOutput = pipe
-        try? which.run()
-        which.waitUntilExit()
-        if which.terminationStatus == 0 {
-            let path = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
-                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-            if !path.isEmpty {
-                return path
-            }
-        }
-
-        // Fallback to well-known locations
         let candidates = [
-            "/opt/homebrew/bin/kanata",
+            ProcessInfo.processInfo.environment["KEYPATH_KANATA_PATH"],
+            URL(fileURLWithPath: #filePath)
+                .deletingLastPathComponent() // Services
+                .deletingLastPathComponent() // KeyPathTests
+                .deletingLastPathComponent() // Tests
+                .deletingLastPathComponent() // repo root
+                .appendingPathComponent("External/kanata/target/aarch64-apple-darwin/release/kanata")
+                .path,
             "/Applications/KeyPath.app/Contents/Library/KeyPath/Kanata Engine.app/Contents/MacOS/kanata",
             "/Applications/KeyPath.app/Contents/Library/KeyPath/kanata",
-        ]
+            "/opt/homebrew/bin/kanata",
+            findPathKanata()
+        ].compactMap { $0 }
 
         for candidate in candidates {
             if FileManager.default.isExecutableFile(atPath: candidate) {
@@ -1322,6 +1314,21 @@ class ConfigurationServiceTests: XCTestCase {
         }
 
         throw XCTSkip("Kanata binary not found in PATH or known locations")
+    }
+
+    private func findPathKanata() -> String? {
+        let which = Process()
+        which.executableURL = URL(fileURLWithPath: "/usr/bin/which")
+        which.arguments = ["kanata"]
+        let pipe = Pipe()
+        which.standardOutput = pipe
+        try? which.run()
+        which.waitUntilExit()
+        guard which.terminationStatus == 0 else { return nil }
+
+        let path = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return path.isEmpty ? nil : path
     }
 
     private func validateCatalogConfig(withBinary kanataBinary: String) async throws {


### PR DESCRIPTION
## Summary

- Fix config backup/restore so symlinked config directories are snapshotted and restored safely.
- Fix `config apply --dry-run` so it validates without writing config or reloading Kanata.
- Make Kanata validation tests prefer the repo/app bundled fork before stale PATH binaries.
- Document that release QA should use the installed app CLI.

Fixes #769
Fixes #770
Fixes #771

## Validation

- `swift test --filter ConfigFacadeTests`
- `swift test --filter CLIOutputSnapshotTests --filter OutputContractTests --filter PacksFacadeTests/testCLIApplyResult_CodableRoundTrip`
- `swift test --filter ConfigurationServiceTests/testDefaultCatalogGeneratesValidKanataConfig`
- `swift test --filter RuleCollectionKanataValidationTests`
- `swift test --filter ConfigValidationTests`
- `swift test`
- `swift build`
- `python3 Scripts/check-accessibility.py`
- `./Scripts/quick-deploy.sh`
- `/Applications/KeyPath.app/Contents/MacOS/keypath-cli config apply --dry-run --no-json --quiet` with active config hash unchanged before/after
