### PR TITLE
Fix HRM insights capability state

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,26 @@ Notes:
   `poltergeist start`, edit, then `poltergeist wait keypath`. Stop it before
   release work, helper/service work, broad tests, or parallel agents.
 
+### Swift Build/Test Performance
+
+- Prefer targeted tests while iterating:
+  `swift test --filter <TestClassOrMethod>`
+- Run full `swift test` before PR/merge, release-candidate work, or after
+  broad/shared changes.
+- Avoid running broad Swift builds/tests concurrently across worktrees. Before
+  full test, release-candidate, or expensive build work, check for active Swift
+  compiles:
+  `pgrep -fl 'swift-test|swift-build|swift-frontend|swift-driver'`
+- If another worktree/agent is compiling and you must continue, reduce local
+  parallelism:
+  `swift test --jobs 4`
+  `swift build --jobs 4`
+- Do not delete `.build` or run clean builds unless diagnosing cache/build-state
+  problems; preserving incremental build products is usually faster.
+- If a full suite stalls after compilation, triage it as a test failure/hang,
+  not compile slowness. Capture the failing test name and log path in the
+  handoff.
+
 ### 2. Release Candidate: signed local testing
 Use after a PR is merged when `/Applications/KeyPath.app` should match a real
 Developer ID/notarized build for manual testing:
@@ -150,6 +170,11 @@ under test.
 ### Testing
 - **Mock Time**: Do not use `Thread.sleep`. Use `Date` overrides or mock clocks.
 - **Environment**: Use `KEYPATH_USE_INSTALLER_ENGINE=1` (default now) for tests.
+- Use the narrowest meaningful test command during iteration; prefer
+  `swift test --filter <TestClassOrMethod>` for focused changes.
+- Run full `swift test` before PR/merge when practical, but do not leave hung
+  suites running. If a full run times out or stalls in an unrelated test, report
+  the failing test and keep targeted validation for the current change.
 
 ### Accessibility (CRITICAL)
 - **ALL interactive UI elements MUST have `.accessibilityIdentifier()`**
@@ -157,7 +182,7 @@ under test.
 - **Enforcement:** Pre-commit hook + CI check (currently warning only)
 - **Verification:** Run `python3 Scripts/check-accessibility.py` before committing
 - **See:** `ACCESSIBILITY_COVERAGE.md` for complete reference
-- **Rationale:** Enables automation (Peekaboo, XCUITest) and ensures testability
+- **Rationale:** Enables automation (Computer Use, XCUITest, legacy Peekaboo) and ensures testability
 
 ## Available External Tools
 
@@ -175,6 +200,13 @@ Watches source files, auto-builds, deploys to /Applications, and restarts. Insta
 | `poltergeist wait keypath` | Block until build completes |
 
 **Workflow tip:** Use `poltergeist start` only during focused single-agent app/UI iteration. After any watched Swift file edit, it runs `./Scripts/quick-deploy.sh`, deploys to `/Applications`, and restarts. Stop it before release builds, helper/service work, broad tests, or parallel agents.
+
+### Computer Use (Preferred UI QA)
+
+Use Computer Use for agent-driven UI testing and release QA. It reads the
+macOS accessibility tree, can click accessible controls, and validates the same
+automation hooks we need for 1.0 QA. Prefer Computer Use over Peekaboo unless
+the user explicitly asks for Peekaboo or Computer Use is unavailable.
 
 ### Peekaboo (UI Automation)
 macOS screenshots and GUI automation. Install: `brew install steipete/tap/peekaboo`
@@ -215,7 +247,7 @@ peekaboo hotkey "cmd+s"              # Save
 2. `poltergeist start` for focused Swift/UI iteration.
 3. Make code edits.
 4. `poltergeist wait keypath` before testing.
-5. Use Peekaboo for UI verification.
+5. Use Computer Use for UI verification.
 6. `poltergeist stop` before release work, helper/service work, broad tests, or handing off.
 
 See `docs/LLM_VISION_UI_AUTOMATION.md` for detailed architecture.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,7 +81,8 @@ Two doc systems: `guides/` (user-facing, published to gh-pages) and `docs/` (dev
 ./Scripts/quick-deploy.sh         # Fast debug deploy
 ./Scripts/release-doctor.sh       # Read-only release preflight
 ./Scripts/release-candidate.sh    # Signed/notarized post-merge testing
-swift test                        # All tests (~532 tests, <5s)
+swift test --filter <TestName>     # Focused tests while iterating
+swift test                        # Full suite before PR/merge when practical
 swiftformat Sources Tests         # Uses pinned rules + swiftversion from .swiftformat
 swiftlint --fix --quiet
 ```
@@ -96,6 +97,29 @@ Swift/UI iteration: `poltergeist start`, edit, then `poltergeist wait keypath`.
 `quick-deploy.sh` updates `/Applications/KeyPath.app`, re-signs locally, and
 restarts KeyPath only if it was already running. It does not redeploy the
 privileged helper unless `KEYPATH_DEPLOY_HELPER=1` is set.
+
+### Swift build/test performance
+
+- Prefer targeted tests while iterating:
+  `swift test --filter <TestClassOrMethod>`
+- Run full `swift test` before PR/merge, release-candidate work, or after
+  broad/shared changes.
+- Avoid running broad Swift builds/tests concurrently across worktrees. Before
+  full test, release-candidate, or expensive build work, check for active Swift
+  compiles:
+  `pgrep -fl 'swift-test|swift-build|swift-frontend|swift-driver'`
+- If another worktree/agent is compiling and you must continue, reduce local
+  parallelism:
+  `swift test --jobs 4`
+  `swift build --jobs 4`
+- Do not delete `.build` or run clean builds unless diagnosing cache/build-state
+  problems; preserving incremental build products is usually faster.
+- If a full suite stalls after compilation, triage it as a test failure/hang,
+  not compile slowness. Capture the failing test name and log path in the
+  handoff.
+- Do not leave hung suites running. If a full run times out or stalls in an
+  unrelated test, report the failing test and keep targeted validation for the
+  current change.
 
 **Release candidate:** After a PR is merged and manual testing needs a real
 Developer ID/notarized app in `/Applications`, run:
@@ -184,9 +208,12 @@ Test targets: `Tests/KeyPathTests/` (target: `KeyPathTests`). Files in `Tests/Ke
 
 `poltergeist start` / `poltergeist stop`. Use it only for focused single-agent Swift/UI iteration. **Stop before running parallel agents, broad tests, helper/service work, or release builds** — file change watchers cause SwiftPM lock contention and surprise app restarts.
 
-## Linear
+## UI Automation
 
-Personal workspace (`malpern@gmail.com`) via `/linear-switch personal`. Smirkhealth (`micah@smirkhealth.com`) via `/linear-switch smirkhealth`. Restart Claude Code after switching.
+Use Computer Use for agent-driven UI testing and release QA. It reads the macOS
+accessibility tree, can click accessible controls, and validates the same
+automation hooks needed for 1.0 QA. Prefer Computer Use over Peekaboo unless the
+user explicitly asks for Peekaboo or Computer Use is unavailable.
 
 ## Deep-Dive References
 
@@ -198,7 +225,7 @@ Load these on demand — don't need them every session:
 | Help content writing | [`docs/help-content-philosophy.md`](docs/help-content-philosophy.md) |
 | Pack dependency system | [`docs/architecture/pack-dependency-system.md`](docs/architecture/pack-dependency-system.md) |
 | Overlay/mapper/gallery data flow | [`docs/architecture/overlay-data-flow.md`](docs/architecture/overlay-data-flow.md) |
-| Peekaboo UI automation | [`docs/LLM_VISION_UI_AUTOMATION.md`](docs/LLM_VISION_UI_AUTOMATION.md) |
+| UI automation | [`docs/LLM_VISION_UI_AUTOMATION.md`](docs/LLM_VISION_UI_AUTOMATION.md) |
 | All architecture guides | [`docs/architecture/`](docs/architecture/) |
 | All ADRs | [`docs/adr/README.md`](docs/adr/README.md) |
 | Feature docs | [`docs/features/`](docs/features/) |

--- a/Sources/KeyPathAppKit/Services/Monitoring/HrmObservabilityService.swift
+++ b/Sources/KeyPathAppKit/Services/Monitoring/HrmObservabilityService.swift
@@ -149,6 +149,10 @@ final class HrmObservabilityService {
         func _testSetRecommendations(_ values: [TimingRecommendation]) {
             recommendations = values
         }
+
+        func _testSetAvailability(_ value: AvailabilityState) {
+            availability = value
+        }
     #endif
 
     deinit {
@@ -335,14 +339,25 @@ final class HrmObservabilityService {
 
     private func handleCapabilities(_ rawCapabilities: [String]) {
         let normalized = Set(KanataEventListener.normalizedCapabilities(rawCapabilities))
-        advertisedCapabilities = normalized
+        var nextCapabilities = normalized
+        // Treat hrm-stats as sticky once observed; reconnect/reload capability
+        // events can be trace-only even though stats remain available.
+        if advertisedCapabilities.contains("hrm-stats"),
+           normalized.contains("hrm-trace"),
+           !normalized.contains("hrm-stats")
+        {
+            nextCapabilities.insert("hrm-stats")
+        }
+        advertisedCapabilities = nextCapabilities
 
-        if normalized.contains("hrm-stats") {
+        if nextCapabilities.contains("hrm-stats") {
             if availability == .unknown || availability == .unsupported || availability == .traceOnly {
                 availability = .supported
             }
-        } else if normalized.contains("hrm-trace") {
-            availability = .traceOnly
+        } else if nextCapabilities.contains("hrm-trace") {
+            if availability == .unknown || availability == .unsupported {
+                availability = .traceOnly
+            }
         } else {
             availability = .unsupported
             latestStats = nil

--- a/Sources/KeyPathAppKit/Services/Monitoring/HrmObservabilityService.swift
+++ b/Sources/KeyPathAppKit/Services/Monitoring/HrmObservabilityService.swift
@@ -359,11 +359,13 @@ final class HrmObservabilityService {
                 availability = .traceOnly
             }
         } else {
-            availability = .unsupported
-            latestStats = nil
-            topReasons = []
-            perKeyBreakdown = []
-            recommendations = []
+            if availability != .disabledInRuntimeConfig {
+                availability = .unsupported
+                latestStats = nil
+                topReasons = []
+                perKeyBreakdown = []
+                recommendations = []
+            }
         }
     }
 

--- a/Sources/KeyPathAppKit/Services/Monitoring/HrmObservabilityService.swift
+++ b/Sources/KeyPathAppKit/Services/Monitoring/HrmObservabilityService.swift
@@ -153,6 +153,10 @@ final class HrmObservabilityService {
         func _testSetAvailability(_ value: AvailabilityState) {
             availability = value
         }
+
+        func _testSetAdvertisedCapabilities(_ values: Set<String>) {
+            advertisedCapabilities = values
+        }
     #endif
 
     deinit {
@@ -405,7 +409,7 @@ final class HrmObservabilityService {
 
         // Receiving reason data proves the build supports HRM trace telemetry,
         // even if capabilities didn't advertise hrm-trace yet.
-        if availability == .unknown || availability == .unsupported {
+        if availability == .unknown || availability == .unsupported || availability == .traceOnly {
             availability = supportsHrmStats ? .supported : .traceOnly
         }
     }

--- a/Sources/KeyPathAppKit/Services/Monitoring/HrmObservabilityService.swift
+++ b/Sources/KeyPathAppKit/Services/Monitoring/HrmObservabilityService.swift
@@ -11,6 +11,7 @@ final class HrmObservabilityService {
     enum AvailabilityState: String, Sendable {
         case unknown
         case supported
+        case traceOnly
         case unsupported
         case disabledInRuntimeConfig
 
@@ -18,6 +19,7 @@ final class HrmObservabilityService {
             switch self {
             case .unknown: "Unknown"
             case .supported: "Supported"
+            case .traceOnly: "Trace only"
             case .unsupported: "Unsupported"
             case .disabledInRuntimeConfig: "Disabled in runtime config"
             }
@@ -335,10 +337,12 @@ final class HrmObservabilityService {
         let normalized = Set(KanataEventListener.normalizedCapabilities(rawCapabilities))
         advertisedCapabilities = normalized
 
-        if normalized.contains("hrm-stats") || normalized.contains("hrm-trace") {
-            if availability == .unknown || availability == .unsupported {
+        if normalized.contains("hrm-stats") {
+            if availability == .unknown || availability == .unsupported || availability == .traceOnly {
                 availability = .supported
             }
+        } else if normalized.contains("hrm-trace") {
+            availability = .traceOnly
         } else {
             availability = .unsupported
             latestStats = nil
@@ -382,10 +386,10 @@ final class HrmObservabilityService {
         }
         schedulePerKeyBreakdownRebuild()
 
-        // Receiving reason data proves the build supports HRM telemetry,
-        // even if capabilities didn't advertise hrm-stats/hrm-trace yet.
+        // Receiving reason data proves the build supports HRM trace telemetry,
+        // even if capabilities didn't advertise hrm-trace yet.
         if availability == .unknown || availability == .unsupported {
-            availability = .supported
+            availability = supportsHrmStats ? .supported : .traceOnly
         }
     }
 

--- a/Sources/KeyPathAppKit/UI/Rules/HomeRowTimingSection.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/HomeRowTimingSection.swift
@@ -547,6 +547,7 @@ struct HomeRowTimingSection: View {
                 .buttonStyle(.borderedProminent)
                 .disabled(!hrmObservability.supportsHrmStats || hrmObservability.calibrationState == .running)
                 .accessibilityIdentifier("home-row-mods-hrm-start-calibration-button")
+                .accessibilityHint(hrmCalibrationButtonAccessibilityHint)
 
                 Button("Refresh Stats") {
                     hrmObservability.refreshNow()
@@ -554,6 +555,14 @@ struct HomeRowTimingSection: View {
                 .buttonStyle(.bordered)
                 .disabled(!hrmObservability.supportsHrmStats)
                 .accessibilityIdentifier("home-row-mods-hrm-refresh-stats-button")
+                .accessibilityHint(hrmRefreshButtonAccessibilityHint)
+            }
+
+            if !hrmObservability.supportsHrmStats {
+                Text(hrmStatsUnavailableMessage)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .accessibilityIdentifier("home-row-mods-hrm-stats-unavailable")
             }
 
             if hrmObservability.calibrationState == .running {
@@ -723,6 +732,8 @@ struct HomeRowTimingSection: View {
         switch hrmObservability.availability {
         case .supported:
             .green
+        case .traceOnly:
+            .blue
         case .unsupported:
             .secondary
         case .disabledInRuntimeConfig:
@@ -730,6 +741,38 @@ struct HomeRowTimingSection: View {
         case .unknown:
             .secondary
         }
+    }
+
+    private var hrmStatsUnavailableMessage: String {
+        switch hrmObservability.availability {
+        case .traceOnly:
+            "Live decisions are available, but stats and calibration require Kanata's hrm-stats capability."
+        case .unsupported:
+            "Stats and calibration are unavailable because this Kanata build does not advertise HRM telemetry."
+        case .unknown:
+            "Stats and calibration are unavailable until Kanata reports HRM telemetry support."
+        case .disabledInRuntimeConfig:
+            "Stats and calibration are unavailable because HRM telemetry is disabled in the active runtime config."
+        case .supported:
+            ""
+        }
+    }
+
+    private var hrmCalibrationButtonAccessibilityHint: String {
+        if hrmObservability.calibrationState == .running {
+            return "Calibration is already running."
+        }
+        if !hrmObservability.supportsHrmStats {
+            return hrmStatsUnavailableMessage
+        }
+        return "Starts a 60 second home row mods calibration."
+    }
+
+    private var hrmRefreshButtonAccessibilityHint: String {
+        if !hrmObservability.supportsHrmStats {
+            return hrmStatsUnavailableMessage
+        }
+        return "Refreshes home row mods statistics from Kanata."
     }
 
     private func updateConfig() {

--- a/Tests/KeyPathTests/Services/HrmObservabilityServiceTests.swift
+++ b/Tests/KeyPathTests/Services/HrmObservabilityServiceTests.swift
@@ -20,6 +20,72 @@ final class HrmObservabilityServiceTests: XCTestCase {
         XCTAssertTrue(service.supportsHrmTrace)
     }
 
+    func testTraceOnlyCapabilitiesDoNotMarkStatsSupported() async {
+        let center = NotificationCenter()
+        let service = HrmObservabilityService.makeTestInstance(notificationCenter: center)
+
+        center.post(
+            name: .kanataCapabilitiesUpdated,
+            object: nil,
+            userInfo: ["capabilities": ["reload", "hrm-trace"]]
+        )
+        await Task.yield()
+        await Task.yield()
+
+        XCTAssertEqual(service.availability, .traceOnly)
+        XCTAssertEqual(service.availability.displayName, "Trace only")
+        XCTAssertFalse(service.supportsHrmStats)
+        XCTAssertTrue(service.supportsHrmTrace)
+    }
+
+    func testTraceEventWithoutStatsCapabilityKeepsTraceOnlyAvailability() async {
+        let center = NotificationCenter()
+        let service = HrmObservabilityService.makeTestInstance(notificationCenter: center)
+
+        center.post(
+            name: .kanataHrmTrace,
+            object: nil,
+            userInfo: [
+                "schemaVersion": 1,
+                "key": "f",
+                "decision": "hold",
+                "reason": "opposite-hand"
+            ]
+        )
+        await Task.yield()
+        await Task.yield()
+
+        XCTAssertEqual(service.availability, .traceOnly)
+        XCTAssertFalse(service.supportsHrmStats)
+        XCTAssertEqual(service.recentTraceEvents.count, 1)
+    }
+
+    func testTraceOnlyCapabilitiesUpgradeWhenStatsCapabilityArrives() async {
+        let center = NotificationCenter()
+        let service = HrmObservabilityService.makeTestInstance(notificationCenter: center)
+
+        center.post(
+            name: .kanataCapabilitiesUpdated,
+            object: nil,
+            userInfo: ["capabilities": ["hrm-trace"]]
+        )
+        await Task.yield()
+        await Task.yield()
+        XCTAssertEqual(service.availability, .traceOnly)
+
+        center.post(
+            name: .kanataCapabilitiesUpdated,
+            object: nil,
+            userInfo: ["capabilities": ["hrm-trace", "hrm-stats"]]
+        )
+        await Task.yield()
+        await Task.yield()
+
+        XCTAssertEqual(service.availability, .supported)
+        XCTAssertTrue(service.supportsHrmStats)
+        XCTAssertTrue(service.supportsHrmTrace)
+    }
+
     func testBuildRecommendationsReleaseBeforeTimeoutSuggestsLowerHoldDelay() {
         let service = HrmObservabilityService.makeTestInstance()
         service._testSetLatestStats(

--- a/Tests/KeyPathTests/Services/HrmObservabilityServiceTests.swift
+++ b/Tests/KeyPathTests/Services/HrmObservabilityServiceTests.swift
@@ -138,6 +138,24 @@ final class HrmObservabilityServiceTests: XCTestCase {
         XCTAssertTrue(service.supportsHrmTrace)
     }
 
+    func testNoHrmCapabilitiesDoNotOverwriteRuntimeDisabledState() async {
+        let center = NotificationCenter()
+        let service = HrmObservabilityService.makeTestInstance(notificationCenter: center)
+        service._testSetAvailability(.disabledInRuntimeConfig)
+
+        center.post(
+            name: .kanataCapabilitiesUpdated,
+            object: nil,
+            userInfo: ["capabilities": ["reload"]]
+        )
+        await Task.yield()
+        await Task.yield()
+
+        XCTAssertEqual(service.availability, .disabledInRuntimeConfig)
+        XCTAssertFalse(service.supportsHrmStats)
+        XCTAssertFalse(service.supportsHrmTrace)
+    }
+
     func testBuildRecommendationsReleaseBeforeTimeoutSuggestsLowerHoldDelay() {
         let service = HrmObservabilityService.makeTestInstance()
         service._testSetLatestStats(

--- a/Tests/KeyPathTests/Services/HrmObservabilityServiceTests.swift
+++ b/Tests/KeyPathTests/Services/HrmObservabilityServiceTests.swift
@@ -60,6 +60,30 @@ final class HrmObservabilityServiceTests: XCTestCase {
         XCTAssertEqual(service.recentTraceEvents.count, 1)
     }
 
+    func testTraceEventWithStickyStatsCapabilityUpgradesTraceOnlyAvailability() async {
+        let center = NotificationCenter()
+        let service = HrmObservabilityService.makeTestInstance(notificationCenter: center)
+        service._testSetAvailability(.traceOnly)
+        service._testSetAdvertisedCapabilities(["hrm-trace", "hrm-stats"])
+
+        center.post(
+            name: .kanataHrmTrace,
+            object: nil,
+            userInfo: [
+                "schemaVersion": 1,
+                "key": "f",
+                "decision": "hold",
+                "reason": "opposite-hand"
+            ]
+        )
+        await Task.yield()
+        await Task.yield()
+
+        XCTAssertEqual(service.availability, .supported)
+        XCTAssertTrue(service.supportsHrmStats)
+        XCTAssertEqual(service.recentTraceEvents.count, 1)
+    }
+
     func testTraceOnlyCapabilitiesUpgradeWhenStatsCapabilityArrives() async {
         let center = NotificationCenter()
         let service = HrmObservabilityService.makeTestInstance(notificationCenter: center)
@@ -152,6 +176,33 @@ final class HrmObservabilityServiceTests: XCTestCase {
         await Task.yield()
 
         XCTAssertEqual(service.availability, .disabledInRuntimeConfig)
+        XCTAssertFalse(service.supportsHrmStats)
+        XCTAssertFalse(service.supportsHrmTrace)
+    }
+
+    func testNoHrmCapabilitiesResetStickyStatsSupport() async {
+        let center = NotificationCenter()
+        let service = HrmObservabilityService.makeTestInstance(notificationCenter: center)
+
+        center.post(
+            name: .kanataCapabilitiesUpdated,
+            object: nil,
+            userInfo: ["capabilities": ["hrm-trace", "hrm-stats"]]
+        )
+        await Task.yield()
+        await Task.yield()
+        XCTAssertEqual(service.availability, .supported)
+        XCTAssertTrue(service.supportsHrmStats)
+
+        center.post(
+            name: .kanataCapabilitiesUpdated,
+            object: nil,
+            userInfo: ["capabilities": ["reload"]]
+        )
+        await Task.yield()
+        await Task.yield()
+
+        XCTAssertEqual(service.availability, .unsupported)
         XCTAssertFalse(service.supportsHrmStats)
         XCTAssertFalse(service.supportsHrmTrace)
     }

--- a/Tests/KeyPathTests/Services/HrmObservabilityServiceTests.swift
+++ b/Tests/KeyPathTests/Services/HrmObservabilityServiceTests.swift
@@ -86,6 +86,58 @@ final class HrmObservabilityServiceTests: XCTestCase {
         XCTAssertTrue(service.supportsHrmTrace)
     }
 
+    func testTraceOnlyCapabilitiesDoNotDowngradeStatsSupport() async {
+        let center = NotificationCenter()
+        let service = HrmObservabilityService.makeTestInstance(notificationCenter: center)
+
+        center.post(
+            name: .kanataCapabilitiesUpdated,
+            object: nil,
+            userInfo: ["capabilities": ["hrm-trace", "hrm-stats"]]
+        )
+        await Task.yield()
+        await Task.yield()
+        XCTAssertEqual(service.availability, .supported)
+
+        center.post(
+            name: .kanataCapabilitiesUpdated,
+            object: nil,
+            userInfo: ["capabilities": ["hrm-trace"]]
+        )
+        await Task.yield()
+        await Task.yield()
+
+        XCTAssertEqual(service.availability, .supported)
+        XCTAssertTrue(service.supportsHrmStats)
+        XCTAssertTrue(service.supportsHrmTrace)
+    }
+
+    func testTraceOnlyCapabilitiesDoNotOverwriteRuntimeDisabledState() async {
+        let center = NotificationCenter()
+        let service = HrmObservabilityService.makeTestInstance(notificationCenter: center)
+
+        center.post(
+            name: .kanataCapabilitiesUpdated,
+            object: nil,
+            userInfo: ["capabilities": ["hrm-trace", "hrm-stats"]]
+        )
+        await Task.yield()
+        await Task.yield()
+        service._testSetAvailability(.disabledInRuntimeConfig)
+
+        center.post(
+            name: .kanataCapabilitiesUpdated,
+            object: nil,
+            userInfo: ["capabilities": ["hrm-trace"]]
+        )
+        await Task.yield()
+        await Task.yield()
+
+        XCTAssertEqual(service.availability, .disabledInRuntimeConfig)
+        XCTAssertTrue(service.supportsHrmStats)
+        XCTAssertTrue(service.supportsHrmTrace)
+    }
+
     func testBuildRecommendationsReleaseBeforeTimeoutSuggestsLowerHoldDelay() {
         let service = HrmObservabilityService.makeTestInstance()
         service._testSetLatestStats(


### PR DESCRIPTION
## Summary
- distinguish HRM trace-only support from full stats/calibration support
- explain disabled HRM stats/calibration actions in the Home Row Mods UI and accessibility hints
- document local Swift build/test performance guidance and Computer Use as preferred UI QA in AGENTS.md and CLAUDE.md

Fixes #768

## Validation
- swift test --filter HrmObservabilityServiceTests
- python3 Scripts/check-accessibility.py
- git diff --check
- swift build via pre-push hook
- quick-deploy + Computer Use verification before commit

Note: a previous full swift test run hit an unrelated timeout/hang in ErrorHandlingTests.testConcurrentConfigurationOperations; targeted coverage for this change is green.