### PR TITLE
[codex] Fix CLI control command reporting

### DIFF
--- a/Sources/KeyPathAppKit/CLI/SystemFacade.swift
+++ b/Sources/KeyPathAppKit/CLI/SystemFacade.swift
@@ -6,14 +6,46 @@ import KeyPathInstallationWizard
 import KeyPathWizardCore
 
 public struct SystemFacade: Sendable {
-    public init() {}
+    typealias RuntimeSnapshot = ServiceHealthChecker.KanataServiceRuntimeSnapshot
+
+    private let subprocessRunner: any SubprocessRunning
+    private let runtimeSnapshotProvider: @Sendable () async -> RuntimeSnapshot
+    private let runtimeTransitionTimeoutSeconds: TimeInterval
+    private let pollDelayNanoseconds: UInt64
+    private let restartDelayNanoseconds: UInt64
+
+    public init() {
+        self.init(
+            subprocessRunner: SubprocessRunner.shared,
+            runtimeSnapshotProvider: {
+                await ServiceHealthChecker.shared.checkKanataServiceRuntimeSnapshot()
+            }
+        )
+    }
+
+    init(
+        subprocessRunner: any SubprocessRunning,
+        runtimeSnapshotProvider: @escaping @Sendable () async -> RuntimeSnapshot,
+        runtimeTransitionTimeoutSeconds: TimeInterval = 5,
+        pollDelayNanoseconds: UInt64 = 200_000_000,
+        restartDelayNanoseconds: UInt64 = 500_000_000
+    ) {
+        self.subprocessRunner = subprocessRunner
+        self.runtimeSnapshotProvider = runtimeSnapshotProvider
+        self.runtimeTransitionTimeoutSeconds = runtimeTransitionTimeoutSeconds
+        self.pollDelayNanoseconds = pollDelayNanoseconds
+        self.restartDelayNanoseconds = restartDelayNanoseconds
+    }
 
     // MARK: - Service Lifecycle
 
     public func startService() async -> Bool {
         do {
-            try await SubprocessRunner.shared.launchctl("kickstart", ["system/com.keypath.kanata"])
-            return true
+            let result = try await subprocessRunner.launchctl("kickstart", ["system/com.keypath.kanata"])
+            guard result.exitCode == 0 else { return false }
+            return await waitForRuntime(timeoutSeconds: runtimeTransitionTimeoutSeconds) { snapshot in
+                snapshot.isRunning && snapshot.isResponding
+            }
         } catch {
             return false
         }
@@ -21,17 +53,40 @@ public struct SystemFacade: Sendable {
 
     public func stopService() async -> Bool {
         do {
-            try await SubprocessRunner.shared.launchctl("kill", ["SIGTERM", "system/com.keypath.kanata"])
-            return true
+            let result = try await subprocessRunner.launchctl("kill", ["SIGTERM", "system/com.keypath.kanata"])
+            guard result.exitCode == 0 else { return false }
+            return await waitForRuntime(timeoutSeconds: runtimeTransitionTimeoutSeconds) { snapshot in
+                !snapshot.isRunning && !snapshot.isResponding
+            }
         } catch {
             return false
         }
     }
 
     public func restartService() async -> Bool {
-        _ = await stopService()
-        try? await Task.sleep(nanoseconds: 500_000_000)
+        guard await stopService() else { return false }
+        if restartDelayNanoseconds > 0 {
+            try? await Task.sleep(nanoseconds: restartDelayNanoseconds)
+        }
         return await startService()
+    }
+
+    private func waitForRuntime(
+        timeoutSeconds: TimeInterval,
+        matches predicate: (RuntimeSnapshot) -> Bool
+    ) async -> Bool {
+        let deadline = Date().addingTimeInterval(timeoutSeconds)
+        repeat {
+            let snapshot = await runtimeSnapshotProvider()
+            if predicate(snapshot) {
+                return true
+            }
+            if pollDelayNanoseconds > 0 {
+                try? await Task.sleep(nanoseconds: pollDelayNanoseconds)
+            }
+        } while Date() < deadline
+
+        return false
     }
 
     public func serviceLogs(lines: Int = 50) -> [String] {

--- a/Sources/KeyPathCLI/Commands/Layer/LayerSwitchCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Layer/LayerSwitchCommand.swift
@@ -16,15 +16,67 @@ struct LayerSwitch: AsyncParsableCommand {
     mutating func run() async throws {
         let ctx = globals.outputContext
         let facade = ConfigFacade()
-        let success = await facade.tcpChangeLayer(name)
+
+        let layers: [String]
+        do {
+            layers = try await facade.tcpGetLayers()
+        } catch {
+            let cliError = CLIError.serviceUnreachable()
+            CLIOutput.writeError(cliError, context: ctx)
+            throw cliError.code.exitCode
+        }
+
+        guard layers.contains(name) else {
+            let error = CLIError.notFound("Layer", query: name, listCommand: "keypath layer list")
+            CLIOutput.writeError(error, context: ctx)
+            throw error.code.exitCode
+        }
+
+        let success = await switchLayerAndConfirm(name, facade: facade, timeoutSeconds: globals.timeout)
         if success {
             CLIOutput.write(["layer": name], context: ctx) {
                 "Switched to layer '\(name)'"
             }
         } else {
-            let error = CLIError.notFound("Layer", query: name, listCommand: "keypath layer list")
+            let error = CLIError.serviceUnreachable(
+                hint: "Layer switch was sent, but KeyPath could not confirm the active layer changed. Check with 'keypath layer current --json'."
+            )
             CLIOutput.writeError(error, context: ctx)
             throw error.code.exitCode
         }
+    }
+
+    private func switchLayerAndConfirm(
+        _ name: String,
+        facade: ConfigFacade,
+        timeoutSeconds: Int
+    ) async -> Bool {
+        let switchTask = Task {
+            await facade.tcpChangeLayer(name)
+        }
+        let observed = await waitForObservedLayer(name, facade: facade, timeoutSeconds: timeoutSeconds)
+        switchTask.cancel()
+        return observed
+    }
+
+    private func waitForObservedLayer(
+        _ name: String,
+        facade: ConfigFacade,
+        timeoutSeconds: Int
+    ) async -> Bool {
+        let deadline = Date().addingTimeInterval(TimeInterval(max(1, timeoutSeconds)))
+        repeat {
+            if Task.isCancelled {
+                return false
+            }
+            if let currentLayer = try? await facade.tcpGetCurrentLayer(),
+               currentLayer == name
+            {
+                return true
+            }
+            try? await Task.sleep(nanoseconds: 200_000_000)
+        } while Date() < deadline
+
+        return false
     }
 }

--- a/Sources/KeyPathCLI/Commands/Service/ServiceRestartCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Service/ServiceRestartCommand.swift
@@ -21,7 +21,10 @@ struct ServiceRestart: AsyncParsableCommand {
                 "Kanata service restarted."
             }
         } else {
-            let error = CLIError.serviceUnreachable(hint: "Failed to restart service. Check 'keypath service status' for details")
+            let error = CLIError.serviceControlFailed(
+                action: "restart",
+                hint: "macOS may require administrator authorization for system services. Check 'keypath service status --json' or use KeyPath's repair UI."
+            )
             CLIOutput.writeError(error, context: ctx)
             throw error.code.exitCode
         }

--- a/Sources/KeyPathCLI/Commands/Service/ServiceStartCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Service/ServiceStartCommand.swift
@@ -20,7 +20,10 @@ struct ServiceStart: AsyncParsableCommand {
                 "Kanata service started."
             }
         } else {
-            let error = CLIError.serviceUnreachable(hint: "Failed to start service. Is it installed? Run 'keypath system install'")
+            let error = CLIError.serviceControlFailed(
+                action: "start",
+                hint: "Run 'keypath service status --json' to inspect runtime health. If macOS blocks system service control, use KeyPath's repair UI."
+            )
             CLIOutput.writeError(error, context: ctx)
             throw error.code.exitCode
         }

--- a/Sources/KeyPathCLI/Commands/Service/ServiceStopCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Service/ServiceStopCommand.swift
@@ -20,7 +20,10 @@ struct ServiceStop: AsyncParsableCommand {
                 "Kanata service stopped."
             }
         } else {
-            let error = CLIError.serviceUnreachable(hint: "Failed to stop service. Is it running? Check with 'keypath service status'")
+            let error = CLIError.serviceControlFailed(
+                action: "stop",
+                hint: "macOS may require administrator authorization for system services. Check 'keypath service status --json' or use KeyPath's repair UI."
+            )
             CLIOutput.writeError(error, context: ctx)
             throw error.code.exitCode
         }

--- a/Sources/KeyPathCLI/Utilities/CLIError.swift
+++ b/Sources/KeyPathCLI/Utilities/CLIError.swift
@@ -71,6 +71,16 @@ public extension CLIError {
         )
     }
 
+    static func serviceControlFailed(action: String, hint: String, details: [String]? = nil) -> CLIError {
+        CLIError(
+            code: .serviceUnreachable,
+            message: "Could not \(action) Kanata service",
+            hint: hint,
+            details: details,
+            docsUrl: CLIDocsURL.debugging
+        )
+    }
+
     static func validation(_ message: String, hint: String? = nil, details: [String]? = nil) -> CLIError {
         CLIError(
             code: .validation,

--- a/Tests/KeyPathTests/CLI/CLIErrorTests.swift
+++ b/Tests/KeyPathTests/CLI/CLIErrorTests.swift
@@ -50,6 +50,17 @@ final class CLIErrorTests: XCTestCase {
         XCTAssertFalse(error.hint!.isEmpty)
     }
 
+    func testServiceControlFailedDescribesAction() {
+        let error = CLIError.serviceControlFailed(
+            action: "restart",
+            hint: "macOS may require administrator authorization."
+        )
+
+        XCTAssertEqual(error.code, .serviceUnreachable)
+        XCTAssertEqual(error.message, "Could not restart Kanata service")
+        XCTAssertTrue(error.hint?.contains("authorization") ?? false)
+    }
+
     func testValidationErrorHasCode3() {
         let error = CLIError.validation("bad config")
         XCTAssertEqual(error.code, .validation)

--- a/Tests/KeyPathTests/CLI/CLIServiceTests.swift
+++ b/Tests/KeyPathTests/CLI/CLIServiceTests.swift
@@ -1,4 +1,6 @@
 @testable import KeyPathAppKit
+@testable import KeyPathCore
+@testable import KeyPathInstallationWizard
 @preconcurrency import XCTest
 
 @MainActor
@@ -22,5 +24,125 @@ final class CLIServiceTests: XCTestCase {
     func testServiceLogsDefaultsTo50Lines() {
         let lines = facade.serviceLogs()
         XCTAssertTrue(lines.count <= 50)
+    }
+
+    // MARK: - service lifecycle
+
+    func testStopServiceReturnsFalseWhenLaunchctlExitsNonZero() async {
+        let fakeRunner = SubprocessRunnerFake.shared
+        await fakeRunner.reset()
+        await fakeRunner.configureLaunchctlResult { _, _ in
+            ProcessResult(
+                exitCode: 112,
+                stdout: "",
+                stderr: "Not privileged to signal service.",
+                duration: 0.1
+            )
+        }
+
+        let facade = SystemFacade(
+            subprocessRunner: fakeRunner,
+            runtimeSnapshotProvider: { Self.runtimeSnapshot(running: true, responding: true) },
+            runtimeTransitionTimeoutSeconds: 0.05,
+            pollDelayNanoseconds: 0
+        )
+
+        let stopped = await facade.stopService()
+
+        XCTAssertFalse(stopped)
+    }
+
+    func testStopServiceWaitsForStoppedRuntimeAfterLaunchctlSuccess() async {
+        let fakeRunner = SubprocessRunnerFake.shared
+        await fakeRunner.reset()
+        let snapshots = RuntimeSnapshotSequence([
+            Self.runtimeSnapshot(running: true, responding: true),
+            Self.runtimeSnapshot(running: false, responding: false)
+        ])
+
+        let facade = SystemFacade(
+            subprocessRunner: fakeRunner,
+            runtimeSnapshotProvider: { await snapshots.next() },
+            runtimeTransitionTimeoutSeconds: 0.05,
+            pollDelayNanoseconds: 0
+        )
+
+        let stopped = await facade.stopService()
+
+        XCTAssertTrue(stopped)
+    }
+
+    func testRestartServiceDoesNotReportSuccessWhenStopFails() async {
+        let fakeRunner = SubprocessRunnerFake.shared
+        await fakeRunner.reset()
+        await fakeRunner.configureLaunchctlResult { subcommand, _ in
+            ProcessResult(
+                exitCode: subcommand == "kill" ? 112 : 0,
+                stdout: "",
+                stderr: subcommand == "kill" ? "Not privileged to signal service." : "",
+                duration: 0.1
+            )
+        }
+
+        let facade = SystemFacade(
+            subprocessRunner: fakeRunner,
+            runtimeSnapshotProvider: { Self.runtimeSnapshot(running: true, responding: true) },
+            runtimeTransitionTimeoutSeconds: 0.05,
+            pollDelayNanoseconds: 0,
+            restartDelayNanoseconds: 0
+        )
+
+        let restarted = await facade.restartService()
+        let commands = await fakeRunner.executedCommands
+
+        XCTAssertFalse(restarted)
+        XCTAssertEqual(commands.compactMap(\.args.first), ["kill"])
+    }
+
+    func testStartServiceReturnsFalseWhenRuntimeNeverBecomesHealthy() async {
+        let fakeRunner = SubprocessRunnerFake.shared
+        await fakeRunner.reset()
+
+        let facade = SystemFacade(
+            subprocessRunner: fakeRunner,
+            runtimeSnapshotProvider: { Self.runtimeSnapshot(running: true, responding: false) },
+            runtimeTransitionTimeoutSeconds: 0.05,
+            pollDelayNanoseconds: 0
+        )
+
+        let started = await facade.startService()
+
+        XCTAssertFalse(started)
+    }
+
+    private nonisolated static func runtimeSnapshot(
+        running: Bool,
+        responding: Bool
+    ) -> ServiceHealthChecker.KanataServiceRuntimeSnapshot {
+        ServiceHealthChecker.KanataServiceRuntimeSnapshot(
+            managementState: .smappserviceActive,
+            isRunning: running,
+            isResponding: responding,
+            inputCaptureReady: true,
+            inputCaptureIssue: nil,
+            launchctlExitCode: running ? 0 : nil,
+            staleEnabledRegistration: false,
+            recentlyRestarted: false
+        )
+    }
+}
+
+private actor RuntimeSnapshotSequence {
+    private var snapshots: [ServiceHealthChecker.KanataServiceRuntimeSnapshot]
+
+    init(_ snapshots: [ServiceHealthChecker.KanataServiceRuntimeSnapshot]) {
+        self.snapshots = snapshots
+    }
+
+    func next() -> ServiceHealthChecker.KanataServiceRuntimeSnapshot {
+        if snapshots.count > 1 {
+            return snapshots.removeFirst()
+        }
+        return snapshots[0]
     }
 }

--- a/Tests/KeyPathTests/TestHelpers/SubprocessRunnerFake.swift
+++ b/Tests/KeyPathTests/TestHelpers/SubprocessRunnerFake.swift
@@ -11,7 +11,7 @@ actor SubprocessRunnerFake: SubprocessRunning {
     // MARK: - Configuration
 
     /// Custom result provider for run() calls
-    var runResultProvider: ((String, [String]) -> ProcessResult)?
+    var runResultProvider: (@Sendable (String, [String]) -> ProcessResult)?
 
     /// Default result for run() calls
     var defaultRunResult = ProcessResult(
@@ -22,13 +22,13 @@ actor SubprocessRunnerFake: SubprocessRunning {
     )
 
     /// Custom result provider for pgrep() calls
-    var pgrepResultProvider: ((String) -> [pid_t])?
+    var pgrepResultProvider: (@Sendable (String) -> [pid_t])?
 
     /// Default PIDs for pgrep() calls
     var defaultPgrepResult: [pid_t] = []
 
     /// Custom result provider for launchctl() calls
-    var launchctlResultProvider: ((String, [String]) -> ProcessResult)?
+    var launchctlResultProvider: (@Sendable (String, [String]) -> ProcessResult)?
 
     /// Default result for launchctl() calls
     var defaultLaunchctlResult = ProcessResult(
@@ -67,15 +67,15 @@ actor SubprocessRunnerFake: SubprocessRunning {
 
     // MARK: - Test Configuration Helpers
 
-    func configureRunResult(_ provider: @escaping (String, [String]) -> ProcessResult) {
+    func configureRunResult(_ provider: @escaping @Sendable (String, [String]) -> ProcessResult) {
         runResultProvider = provider
     }
 
-    func configurePgrepResult(_ provider: @escaping (String) -> [pid_t]) {
+    func configurePgrepResult(_ provider: @escaping @Sendable (String) -> [pid_t]) {
         pgrepResultProvider = provider
     }
 
-    func configureLaunchctlResult(_ provider: @escaping (String, [String]) -> ProcessResult) {
+    func configureLaunchctlResult(_ provider: @escaping @Sendable (String, [String]) -> ProcessResult) {
         launchctlResultProvider = provider
     }
 

--- a/docs/keypath-cli-skill.md
+++ b/docs/keypath-cli-skill.md
@@ -30,9 +30,9 @@ editing config files directly.
 ### Status & Health
 ```bash
 keypath service status --json       # Full system health check
-keypath service start               # Start Kanata service
-keypath service stop                # Stop Kanata service
-keypath service restart             # Restart Kanata service
+keypath service start               # Start Kanata service and verify runtime health
+keypath service stop                # Stop Kanata service and verify it stopped
+keypath service restart             # Restart Kanata service; may fail if macOS requires authorization
 keypath service reload              # Reload config without restart
 ```
 

--- a/docs/plans/cli-remaining-phases.md
+++ b/docs/plans/cli-remaining-phases.md
@@ -243,9 +243,9 @@ Layers in KeyPath are defined by rule collections (`targetLayer` field). Creatin
 #### Commands
 
 ```
-keypath service start
-keypath service stop
-keypath service restart
+keypath service start               # verifies the service becomes healthy
+keypath service stop                # verifies the service stops
+keypath service restart             # fails instead of reporting success when authorization is required
 keypath service status           # (existing)
 keypath service reload           # (existing)
 keypath service logs [--lines <n>] [--follow]


### PR DESCRIPTION
## Summary
- make `keypath-cli layer switch` return promptly by confirming the observed active layer instead of waiting indefinitely for the `ChangeLayer` response
- make service start/stop/restart check `launchctl` exit codes and verify runtime postconditions before reporting success
- improve service-control error messages for macOS authorization failures and update CLI docs/tests

## Root Cause
Kanata applies `ChangeLayer`, but the CLI could keep waiting for a response path that does not complete. Service control commands also treated a spawned `launchctl` process as success even when `launchctl` exited nonzero, so nonprivileged stop/restart commands reported success while the daemon kept running.

## Validation
- `swift build`
- `swift test --filter CLI`
- `python3 Scripts/check-accessibility.py`
- live smoke: `.build/debug/keypath-cli layer switch nav --json --timeout 5` and back to `base` returned promptly and `layer current` confirmed both transitions
- live smoke: `.build/debug/keypath-cli service stop/restart --json` exited `6`, reported service-control failure with macOS authorization hint, and left the Kanata PID unchanged
- installed app-bundled CLI: `/Applications/KeyPath.app/Contents/MacOS/keypath-cli system inspect --json` reported `isOperational: true`

Closes #786
