### PR TITLE
[codex] Add raw CLI simulation timelines

### DIFF
--- a/Sources/KeyPathAppKit/CLI/SimulatorFacade.swift
+++ b/Sources/KeyPathAppKit/CLI/SimulatorFacade.swift
@@ -19,6 +19,21 @@ public struct SimulatorFacade: Sendable {
         return try await provider.simulate(taps: keys, configPath: config)
     }
 
+    public func simulateRaw(
+        simContent: String,
+        configPath: String?,
+        simulatorProvider: CLISimulatorProvider? = nil
+    ) async throws -> CLISimulationResult {
+        let config: String = if let configPath {
+            configPath
+        } else {
+            await MainActor.run { ConfigurationService().configurationPath }
+        }
+
+        let provider = simulatorProvider ?? RealSimulatorProvider()
+        return try await provider.simulateRaw(simContent: simContent, configPath: config)
+    }
+
     public func validateKey(_ key: String) -> String? {
         guard CustomRuleValidator.isValidKey(key) else { return nil }
         return CustomRuleValidator.normalizeKey(key)
@@ -61,6 +76,7 @@ public struct CLISimEvent: Codable, Sendable {
 
 public protocol CLISimulatorProvider: Sendable {
     func simulate(taps: [CLISimulatorKeyTap], configPath: String) async throws -> CLISimulationResult
+    func simulateRaw(simContent: String, configPath: String) async throws -> CLISimulationResult
 }
 
 struct RealSimulatorProvider: CLISimulatorProvider {
@@ -70,6 +86,16 @@ struct RealSimulatorProvider: CLISimulatorProvider {
             SimulatorKeyTap(kanataKey: $0.key, displayLabel: $0.key, delayAfterMs: $0.delayMs, isHold: $0.isHold)
         }
         let result = try await service.simulate(taps: internalTaps, configPath: configPath)
+        return cliSimulationResult(from: result)
+    }
+
+    func simulateRaw(simContent: String, configPath: String) async throws -> CLISimulationResult {
+        let service = SimulatorService()
+        let result = try await service.simulateRaw(simContent: simContent, configPath: configPath)
+        return cliSimulationResult(from: result)
+    }
+
+    private func cliSimulationResult(from result: SimulationResult) -> CLISimulationResult {
         let events = result.events.map { event -> CLISimEvent in
             switch event {
             case let .input(t, action, key):

--- a/Sources/KeyPathCLI/Commands/SimulateCommand.swift
+++ b/Sources/KeyPathCLI/Commands/SimulateCommand.swift
@@ -6,13 +6,13 @@ struct Simulate: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "simulate",
         abstract: "Simulate a key sequence and show what Kanata would output",
-        discussion: "Pass keys as space-separated arguments. Append ':hold' to simulate a long press."
+        discussion: "Pass keys as space-separated arguments. Append ':hold' to simulate a long press. Use --raw or --sim-file for overlapping press/release timelines."
     )
 
     @OptionGroup var globals: GlobalOptions
 
     @Argument(help: "Key sequence as space-separated keys (e.g., 'caps a' or 'caps:hold a')")
-    var keys: [String]
+    var keys: [String] = []
 
     @Option(name: .customLong("config"), help: "Path to kanata config file (default: active config)")
     var configPath: String?
@@ -20,10 +20,30 @@ struct Simulate: AsyncParsableCommand {
     @Option(name: .customLong("delay"), help: "Default delay between keys in ms (default: 200)")
     var delayMs: UInt64 = 200
 
+    @Option(name: .customLong("raw"), help: "Raw kanata simulator timeline, e.g. 'd:f t:100 d:j t:50 u:j t:50 u:f'")
+    var rawSimulation: String?
+
+    @Option(name: .customLong("sim-file"), help: "Path to a raw kanata simulator timeline file")
+    var simulationFile: String?
+
+    func validate() throws {
+        let rawModes = [rawSimulation != nil, simulationFile != nil].filter { $0 }.count
+        if rawModes > 1 {
+            throw ValidationError("Use only one of --raw or --sim-file")
+        }
+        if rawModes > 0, !keys.isEmpty {
+            throw ValidationError("Pass either key arguments or a raw simulation timeline, not both")
+        }
+        if rawModes == 0, keys.isEmpty {
+            throw ValidationError("Pass at least one key, --raw, or --sim-file")
+        }
+    }
+
     mutating func run() async throws {
         let ctx = globals.outputContext
         let facade = SimulatorFacade()
 
+        let rawContent = try loadRawSimulationContent()
         let taps = keys.map { key -> CLISimulatorKeyTap in
             let parts = key.split(separator: ":", maxSplits: 1)
             let keyName = String(parts[0])
@@ -33,7 +53,7 @@ struct Simulate: AsyncParsableCommand {
         }
 
         if globals.dryRun {
-            let simContent = taps.map { tap in
+            let simContent = rawContent ?? taps.map { tap in
                 "d:\(tap.key) t:\(tap.delayMs) u:\(tap.key)"
             }.joined(separator: " ")
 
@@ -50,10 +70,17 @@ struct Simulate: AsyncParsableCommand {
         }
 
         do {
-            let result = try await facade.simulate(
-                keys: taps,
-                configPath: configPath
-            )
+            let result = if let rawContent {
+                try await facade.simulateRaw(
+                    simContent: rawContent,
+                    configPath: configPath
+                )
+            } else {
+                try await facade.simulate(
+                    keys: taps,
+                    configPath: configPath
+                )
+            }
 
             CLIOutput.write(result, context: ctx) {
                 formatHumanOutput(result)
@@ -88,6 +115,18 @@ struct Simulate: AsyncParsableCommand {
         }
         lines.append("Final layer: \(result.finalLayer) | Duration: \(result.durationMs)ms")
         return lines.joined(separator: "\n")
+    }
+
+    private func loadRawSimulationContent() throws -> String? {
+        if let rawSimulation {
+            return rawSimulation
+        }
+        guard let simulationFile else { return nil }
+        do {
+            return try String(contentsOfFile: simulationFile, encoding: .utf8)
+        } catch {
+            throw ValidationError("Could not read --sim-file '\(simulationFile)': \(error.localizedDescription)")
+        }
     }
 }
 

--- a/Tests/KeyPathTests/CLI/CLICommandValidationTests.swift
+++ b/Tests/KeyPathTests/CLI/CLICommandValidationTests.swift
@@ -145,6 +145,38 @@ final class CLICommandValidationTests: XCTestCase {
         XCTAssertEqual(cmd.lines, 50)
     }
 
+    // MARK: - Simulate command parsing
+
+    func testSimulateAcceptsRawTimeline() throws {
+        let cmd = try Simulate.parse(["--raw", "d:f t:100 d:j t:50 u:j t:50 u:f"])
+        XCTAssertEqual(cmd.rawSimulation, "d:f t:100 d:j t:50 u:j t:50 u:f")
+        XCTAssertTrue(cmd.keys.isEmpty)
+    }
+
+    func testSimulateAcceptsSimFile() throws {
+        let cmd = try Simulate.parse(["--sim-file", "/tmp/keypath-sim.txt"])
+        XCTAssertEqual(cmd.simulationFile, "/tmp/keypath-sim.txt")
+        XCTAssertTrue(cmd.keys.isEmpty)
+    }
+
+    func testSimulateRejectsRawAndKeysTogether() {
+        XCTAssertThrowsError(
+            try Simulate.parse(["--raw", "d:f t:100 u:f", "f"])
+        )
+    }
+
+    func testSimulateRejectsRawAndSimFileTogether() {
+        XCTAssertThrowsError(
+            try Simulate.parse(["--raw", "d:f t:100 u:f", "--sim-file", "/tmp/keypath-sim.txt"])
+        )
+    }
+
+    func testSimulateRejectsNoInput() {
+        XCTAssertThrowsError(
+            try Simulate.parse([])
+        )
+    }
+
     // MARK: - System command parsing
 
     func testSystemRepairAcceptsOpenPermissions() throws {

--- a/Tests/KeyPathTests/CLI/CLISimulateTests.swift
+++ b/Tests/KeyPathTests/CLI/CLISimulateTests.swift
@@ -4,6 +4,7 @@
 final class MockSimulatorProvider: CLISimulatorProvider, @unchecked Sendable {
     var result: CLISimulationResult
     var lastTaps: [CLISimulatorKeyTap] = []
+    var lastRawContent: String?
     var lastConfigPath: String = ""
     var shouldThrow: Error?
 
@@ -13,6 +14,13 @@ final class MockSimulatorProvider: CLISimulatorProvider, @unchecked Sendable {
 
     func simulate(taps: [CLISimulatorKeyTap], configPath: String) async throws -> CLISimulationResult {
         lastTaps = taps
+        lastConfigPath = configPath
+        if let error = shouldThrow { throw error }
+        return result
+    }
+
+    func simulateRaw(simContent: String, configPath: String) async throws -> CLISimulationResult {
+        lastRawContent = simContent
         lastConfigPath = configPath
         if let error = shouldThrow { throw error }
         return result
@@ -139,6 +147,27 @@ final class CLISimulateTests: XCTestCase {
         XCTAssertEqual(mock.lastTaps[1].key, "a")
         XCTAssertEqual(mock.lastTaps[1].delayMs, 100)
         XCTAssertEqual(mock.lastConfigPath, "/my/config.kbd")
+    }
+
+    func testRawSimulationPassedToProvider() async throws {
+        let mock = MockSimulatorProvider(result: CLISimulationResult(
+            events: [
+                CLISimEvent(type: "output", timeMs: 100, action: "press", key: "lmet"),
+            ],
+            finalLayer: "base",
+            durationMs: 200
+        ))
+        let raw = "d:f t:100 d:j t:50 u:j t:50 u:f"
+
+        let result = try await facade.simulateRaw(
+            simContent: raw,
+            configPath: "/my/config.kbd",
+            simulatorProvider: mock
+        )
+
+        XCTAssertEqual(mock.lastRawContent, raw)
+        XCTAssertEqual(mock.lastConfigPath, "/my/config.kbd")
+        XCTAssertEqual(result.events.first?.key, "lmet")
     }
 
     // MARK: - Result Structure
@@ -332,6 +361,43 @@ final class CLISimulateIntegrationTests: XCTestCase {
         XCTAssertTrue(outputs.contains { $0.key == "2" }, "Key '1' should produce '2'")
         XCTAssertTrue(result.durationMs > 0)
     }
+
+    func testRealSimulateRawHomeRowModsOppositeHandChord() async throws {
+        let simulatorPath = try requireSimulatorPath()
+
+        let config = HomeRowModsConfig(
+            enabledKeys: ["f", "j"],
+            modifierAssignments: ["f": "lmet", "j": "rmet"],
+            holdMode: .modifiers,
+            timing: TimingConfig(tapWindow: 200, holdDelay: 150, requirePriorIdleMs: 0),
+            oppositeHandMode: .press
+        )
+        let collection = RuleCollection(
+            name: "Home Row Mods",
+            summary: "Tap for letters, hold for modifiers",
+            category: .productivity,
+            mappings: [],
+            isEnabled: true,
+            configuration: .homeRowMods(config)
+        )
+        let renderedConfig = KanataConfiguration.generateFromCollections([collection])
+        let configPath = try createTempConfig(renderedConfig)
+        defer { try? FileManager.default.removeItem(atPath: configPath) }
+
+        let provider = RealSimulatorTestProvider(simulatorPath: simulatorPath)
+        let result = try await runOrSkipOnVersionMismatch {
+            try await facade.simulateRaw(
+                simContent: "d:f t:100 d:j t:50 u:j t:50 u:f",
+                configPath: configPath,
+                simulatorProvider: provider
+            )
+        }
+
+        let activatedLeftCommand = result.events.contains { event in
+            event.type == "output" && event.action == "press" && event.key == "lmet"
+        }
+        XCTAssertTrue(activatedLeftCommand, "Overlapping f+j HRM simulation should activate f's left-command hold action")
+    }
 }
 
 /// Provider that uses the real SimulatorService with a specific binary path.
@@ -348,6 +414,16 @@ private final class RealSimulatorTestProvider: CLISimulatorProvider, @unchecked 
             SimulatorKeyTap(kanataKey: $0.key, displayLabel: $0.key, delayAfterMs: $0.delayMs, isHold: $0.isHold)
         }
         let result = try await service.simulate(taps: internalTaps, configPath: configPath)
+        return cliSimulationResult(from: result)
+    }
+
+    func simulateRaw(simContent: String, configPath: String) async throws -> CLISimulationResult {
+        let service = SimulatorService(simulatorPath: simulatorPath)
+        let result = try await service.simulateRaw(simContent: simContent, configPath: configPath)
+        return cliSimulationResult(from: result)
+    }
+
+    private func cliSimulationResult(from result: SimulationResult) -> CLISimulationResult {
         let events = result.events.map { event -> CLISimEvent in
             switch event {
             case let .input(t, action, key):

--- a/docs/keypath-cli-skill.md
+++ b/docs/keypath-cli-skill.md
@@ -173,4 +173,7 @@ When an error includes a `hint` field, it contains a runnable command to fix the
 - Use `--on-conflict replace` for idempotent updates
 - Never use `keypath service logs --follow` — it blocks indefinitely
 - Pack-managed collections cannot be toggled independently — uninstall the pack first
-- The `simulate` command requires Kanata binary — skip if not installed
+- The `simulate` command requires the bundled `kanata-simulator` binary — skip if not installed
+- Use `keypath simulate a b --json` for simple tap sequences
+- Use `keypath simulate --raw 'd:f t:100 d:j t:50 u:j t:50 u:f' --json` for overlapping press/release timelines such as Home Row Mods opposite-hand QA
+- Use `keypath simulate --sim-file ./scenario.sim --json` for reusable raw simulator scripts

--- a/docs/plans/cli-remaining-phases.md
+++ b/docs/plans/cli-remaining-phases.md
@@ -316,18 +316,20 @@ keypath keyboard forget <deviceHash>
 
 ```
 keypath simulate <key-sequence> [--config <path>]
-keypath simulate --file <sim-file>
+keypath simulate --raw <raw-sim-timeline> [--config <path>]
+keypath simulate --sim-file <sim-file> [--config <path>]
 ```
 
 #### Input format
 
 ```
-# Key sequence as space-separated keys with timing
-keypath simulate "a:press a:release"
-keypath simulate "caps:press caps:release"
+# Simple key taps
+keypath simulate a b
+keypath simulate caps:hold a
 
-# With custom timing (ms between events)
-keypath simulate "a:press 50 a:release 100 b:press 50 b:release"
+# Raw kanata simulator timelines for overlapping key events
+keypath simulate --raw 'd:f t:100 d:j t:50 u:j t:50 u:f'
+keypath simulate --sim-file ./home-row-mods.sim
 ```
 
 #### Output (structured JSON)
@@ -346,12 +348,15 @@ keypath simulate "a:press 50 a:release 100 b:press 50 b:release"
 
 #### Implementation
 
-Delegates to `SimulatorService.simulate(taps:configPath:)` which runs the bundled `kanata-simulator` binary.
+Delegates to `SimulatorService.simulate(taps:configPath:)` for simple tap sequences and
+`SimulatorService.simulateRaw(simContent:configPath:)` for raw overlapping timelines.
+Both run the bundled `kanata-simulator` binary.
 
 #### CLIFacade additions
 
 ```swift
 public func simulate(keys: [SimulatorKeyTap], configPath: String?) async throws -> CLISimulationResult
+public func simulateRaw(simContent: String, configPath: String?) async throws -> CLISimulationResult
 ```
 
 #### Tests (~4)
@@ -360,6 +365,7 @@ public func simulate(keys: [SimulatorKeyTap], configPath: String?) async throws 
 - `testSimulateLayerSwitch`
 - `testSimulateTapHold`
 - `testSimulateInvalidKeyReturnsError`
+- `testRealSimulateRawHomeRowModsOppositeHandChord`
 
 ---
 


### PR DESCRIPTION
## Summary
- Add `keypath-cli simulate --raw` and `--sim-file` for raw kanata simulator timelines with overlapping press/release events.
- Route raw simulations through `SimulatorFacade.simulateRaw` and the existing `SimulatorService.simulateRaw` path.
- Add CLI validation, facade/provider tests, and a real HRM opposite-hand chord regression test.
- Update CLI docs/planning docs with the raw timeline syntax.

Closes #788

## Validation
- `swift test --filter 'CLISimulate|CLICommandValidationTests.testSimulate'` passed: 17 tests, including `testRealSimulateRawHomeRowModsOppositeHandChord`.
- `swift build` passed.
- `.build/debug/keypath-cli simulate --raw 'd:f t:100 d:j t:50 u:j t:50 u:f' --dry-run --json` passed.
- `swiftformat --lint Sources/KeyPathAppKit/CLI/SimulatorFacade.swift Sources/KeyPathCLI/Commands/SimulateCommand.swift Tests/KeyPathTests/CLI/CLISimulateTests.swift Tests/KeyPathTests/CLI/CLICommandValidationTests.swift` passed.
- `python3 Scripts/check-accessibility.py` passed.

## Known unrelated gate noise
- `./Scripts/test-fast.sh --changed` fell back to the broad safe suite and failed 11 tests outside this change surface: snapshot tests, privileged operation router tests, and service health checker tests. The focused CLI/HRM regression tests are green.