### PR TITLE
[codex] Fix raw simulate dry-run preview

### DIFF
--- a/Sources/KeyPathCLI/Commands/SimulateCommand.swift
+++ b/Sources/KeyPathCLI/Commands/SimulateCommand.swift
@@ -56,15 +56,16 @@ struct Simulate: AsyncParsableCommand {
             let simContent = rawContent ?? taps.map { tap in
                 "d:\(tap.key) t:\(tap.delayMs) u:\(tap.key)"
             }.joined(separator: " ")
+            let keyCount = rawContent.map(Self.rawEventCount) ?? taps.count
 
             let preview = CLISimulateDryRun(
-                keyCount: taps.count,
+                keyCount: keyCount,
                 simContent: simContent,
                 configPath: configPath ?? "(active config)"
             )
 
             CLIOutput.write(preview, context: ctx) {
-                "Would simulate \(taps.count) key(s): \(simContent)"
+                Self.dryRunDescription(rawContent: rawContent, keyCount: keyCount, simContent: simContent)
             }
             return
         }
@@ -119,14 +120,35 @@ struct Simulate: AsyncParsableCommand {
 
     private func loadRawSimulationContent() throws -> String? {
         if let rawSimulation {
-            return rawSimulation
+            return Self.normalizedRawSimulationContent(rawSimulation)
         }
         guard let simulationFile else { return nil }
         do {
-            return try String(contentsOfFile: simulationFile, encoding: .utf8)
+            let content = try String(contentsOfFile: simulationFile, encoding: .utf8)
+            return Self.normalizedRawSimulationContent(content)
         } catch {
             throw ValidationError("Could not read --sim-file '\(simulationFile)': \(error.localizedDescription)")
         }
+    }
+
+    static func dryRunDescription(rawContent: String?, keyCount: Int, simContent: String) -> String {
+        if rawContent != nil {
+            return "Would simulate raw timeline (\(keyCount) event(s)): \(simContent)"
+        }
+        return "Would simulate \(keyCount) key(s): \(simContent)"
+    }
+
+    static func rawEventCount(in simContent: String) -> Int {
+        simContent
+            .split(whereSeparator: \.isWhitespace)
+            .filter { token in
+                token.hasPrefix("d:") || token.hasPrefix("u:")
+            }
+            .count
+    }
+
+    static func normalizedRawSimulationContent(_ content: String) -> String {
+        content.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 }
 

--- a/Tests/KeyPathTests/CLI/CLICommandValidationTests.swift
+++ b/Tests/KeyPathTests/CLI/CLICommandValidationTests.swift
@@ -177,6 +177,22 @@ final class CLICommandValidationTests: XCTestCase {
         )
     }
 
+    func testSimulateRawDryRunPreviewCountsPressReleaseEvents() {
+        let raw = "d:f t:100 d:j t:50 u:j t:50 u:f"
+        let keyCount = Simulate.rawEventCount(in: raw)
+        let message = Simulate.dryRunDescription(rawContent: raw, keyCount: keyCount, simContent: raw)
+
+        XCTAssertEqual(keyCount, 4)
+        XCTAssertEqual(message, "Would simulate raw timeline (4 event(s)): d:f t:100 d:j t:50 u:j t:50 u:f")
+    }
+
+    func testSimulateNormalizesRawTimelineWhitespace() {
+        XCTAssertEqual(
+            Simulate.normalizedRawSimulationContent("d:f t:100 u:f\n"),
+            "d:f t:100 u:f"
+        )
+    }
+
     // MARK: - System command parsing
 
     func testSystemRepairAcceptsOpenPermissions() throws {


### PR DESCRIPTION
## Summary
- Report raw simulate dry-run event counts instead of `0` key taps.
- Use raw-specific human dry-run text.
- Trim trailing whitespace/newlines from `--raw` and `--sim-file` content.
- Add focused tests for the raw dry-run preview and raw content normalization.

## Validation
- `swiftformat --lint Sources/KeyPathCLI/Commands/SimulateCommand.swift Tests/KeyPathTests/CLI/CLICommandValidationTests.swift`
- `swift test --filter 'CLISimulate|CLICommandValidationTests.testSimulate'`
- `swift build`
- `.build/debug/keypath-cli simulate --raw 'd:f t:100 d:j t:50 u:j t:50 u:f' --dry-run --json`
- `.build/debug/keypath-cli simulate --raw 'd:f t:100 d:j t:50 u:j t:50 u:f' --dry-run --no-json`