### PR TITLE
Clean up Swift build warnings

### DIFF
--- a/Sources/KeyPathAppKit/Core/DistributedNotificationBridge.swift
+++ b/Sources/KeyPathAppKit/Core/DistributedNotificationBridge.swift
@@ -21,21 +21,23 @@ enum DistributedNotificationBridge {
             queue: .main
         ) { notification in
             guard let layerName = notification.userInfo?["layerName"] as? String else { return }
-            guard layerName != previousLayer else { return }
+            MainActor.assumeIsolated {
+                guard layerName != previousLayer else { return }
 
-            let previous = previousLayer
-            previousLayer = layerName
-            currentLayer = layerName
+                let previous = previousLayer
+                previousLayer = layerName
+                currentLayer = layerName
 
-            DistributedNotificationCenter.default().postNotificationName(
-                layerChangedName,
-                object: "com.keypath.app",
-                userInfo: [
-                    "layer": layerName,
-                    "previous": previous,
-                ],
-                deliverImmediately: true
-            )
+                DistributedNotificationCenter.default().postNotificationName(
+                    layerChangedName,
+                    object: "com.keypath.app",
+                    userInfo: [
+                        "layer": layerName,
+                        "previous": previous,
+                    ],
+                    deliverImmediately: true
+                )
+            }
         }
     }
 

--- a/Sources/KeyPathAppKit/Core/HelperManager+Installation.swift
+++ b/Sources/KeyPathAppKit/Core/HelperManager+Installation.swift
@@ -168,7 +168,7 @@ extension HelperManager {
     }
 
     private func recoverStaleEnabledHelper(_ svc: SMAppServiceProtocol) async throws {
-        await clearConnection()
+        clearConnection()
 
         do {
             try await svc.unregister()

--- a/Sources/KeyPathAppKit/Services/Devices/HIDDeviceMonitor.swift
+++ b/Sources/KeyPathAppKit/Services/Devices/HIDDeviceMonitor.swift
@@ -57,6 +57,7 @@ final class HIDDeviceMonitor {
     private let runLoopLock = NSLock()
     /// The IOKit thread's CFRunLoop. Written by the IOKit thread in setupHIDManager,
     /// read by MainActor in stopMonitoring. All access is under `runLoopLock`.
+    @ObservationIgnored
     private nonisolated(unsafe) var _monitorRunLoop: CFRunLoop?
 
     private var trackedDeviceIDs: [UInt: HIDKeyboardEvent] = [:]

--- a/Sources/KeyPathAppKit/Services/Packs/PackDependencyChecker.swift
+++ b/Sources/KeyPathAppKit/Services/Packs/PackDependencyChecker.swift
@@ -71,7 +71,6 @@ enum PackDependencyChecker {
         enabledCollections: [RuleCollection],
         installedPackIDs: Set<String>
     ) -> [Pack] {
-        let targetCollectionID = PackRegistry.pack(id: packID)?.associatedCollectionID
         let enabledIDs = Set(enabledCollections.filter(\.isEnabled).map(\.id))
 
         return PackRegistry.starterKit.filter { pack in

--- a/Sources/KeyPathAppKit/Services/System/SystemRequirementsChecker.swift
+++ b/Sources/KeyPathAppKit/Services/System/SystemRequirementsChecker.swift
@@ -83,7 +83,7 @@ final class SystemRequirementsChecker {
         let snapshot = await PermissionOracle.shared.currentSnapshot()
 
         let keyPathPath = Bundle.main.bundlePath
-        let kanataPath = WizardSystemPaths.kanataSystemInstallPath
+        let kanataPath = WizardSystemPaths.bundledKanataPath
 
         let keyPathHasInputMonitoring = snapshot.keyPath.inputMonitoring.isReady
         let keyPathHasAccessibility = snapshot.keyPath.accessibility.isReady
@@ -158,7 +158,7 @@ final class SystemRequirementsChecker {
 
     /// Reveal the canonical kanata binary in Finder to assist drag-and-drop into permissions
     func revealKanataInFinder(onRevealed: (() -> Void)? = nil) {
-        let kanataPath = WizardSystemPaths.kanataSystemInstallPath
+        let kanataPath = WizardSystemPaths.bundledKanataPath
         let folderPath = (kanataPath as NSString).deletingLastPathComponent
 
         let script = """

--- a/Sources/KeyPathAppKit/Services/System/WindowManager.swift
+++ b/Sources/KeyPathAppKit/Services/System/WindowManager.swift
@@ -99,7 +99,9 @@ public final class WindowManager {
             guard let app = notification.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication,
                   app.bundleIdentifier != ownBundleId
             else { return }
-            self?.lastNonKeyPathApp = app
+            MainActor.assumeIsolated {
+                self?.lastNonKeyPathApp = app
+            }
         }
     }
 

--- a/Sources/KeyPathAppKit/UI/ContextHUD/ContextHUDController+ShowForLayer.swift
+++ b/Sources/KeyPathAppKit/UI/ContextHUD/ContextHUDController+ShowForLayer.swift
@@ -88,21 +88,12 @@ extension ContextHUDController {
                     collections: scopedEnabledCollections
                 )
 
-                let shouldUseKindaVimLearningStyle = false
-
                 let hasNeovimEntries = effectiveKeyMap.values.contains { $0.collectionId == RuleCollectionIdentifier.neovimTerminal }
                 let shouldUseNeovimStyle = normalizedLayerName == "nav" &&
                     hasNeovimEntries &&
                     isApprovedNeovimTerminal
 
-                if shouldUseKindaVimLearningStyle, !hasStartedKindaVimStateMonitoring {
-                    kindaVimStateAdapter.startMonitoring()
-                    hasStartedKindaVimStateMonitoring = true
-                }
-
-                let style: HUDContentStyle = if shouldUseKindaVimLearningStyle {
-                    .kindaVimLearning
-                } else if shouldUseNeovimStyle {
+                let style: HUDContentStyle = if shouldUseNeovimStyle {
                     .neovimTerminal
                 } else {
                     resolvedStyle

--- a/Sources/KeyPathAppKit/UI/Gallery/PackDetailView+LiveState.swift
+++ b/Sources/KeyPathAppKit/UI/Gallery/PackDetailView+LiveState.swift
@@ -9,7 +9,7 @@ extension PackDetailView {
 
         // Resilience: if collection is enabled but tracker has no record, backfill
         if !installed, let collectionID = pack.associatedCollectionID {
-            let collections = await kanataManager.underlyingManager
+            let collections = kanataManager.underlyingManager
                 .ruleCollectionsManager.ruleCollections
             if let match = collections.first(where: { $0.id == collectionID }), match.isEnabled {
                 let record = InstalledPackRecord(
@@ -115,7 +115,7 @@ extension PackDetailView {
 
     func liveSingleKeySelection() async -> String? {
         guard let collectionID = pack.associatedCollectionID else { return nil }
-        let collections = await kanataManager.underlyingManager
+        let collections = kanataManager.underlyingManager
             .ruleCollectionsManager.ruleCollections
         if let match = collections.first(where: { $0.id == collectionID }),
            let cfg = match.configuration.singleKeyPickerConfig
@@ -129,7 +129,7 @@ extension PackDetailView {
         // Collection-backed pack: read live selection from the associated
         // collection's TapHoldPickerConfig (this is what Rules persists to).
         if let collectionID = pack.associatedCollectionID {
-            let collections = await kanataManager.underlyingManager
+            let collections = kanataManager.underlyingManager
                 .ruleCollectionsManager.ruleCollections
             if let match = collections.first(where: { $0.id == collectionID }),
                let cfg = match.configuration.tapHoldPickerConfig
@@ -160,7 +160,7 @@ extension PackDetailView {
         guard isHomeRowModsPack, let collectionID = pack.associatedCollectionID else {
             return nil
         }
-        let collections = await kanataManager.underlyingManager
+        let collections = kanataManager.underlyingManager
             .ruleCollectionsManager.ruleCollections
         if let match = collections.first(where: { $0.id == collectionID }),
            case let .homeRowMods(config) = match.configuration

--- a/Sources/KeyPathCLI/Commands/Import/ImportCollectionCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Import/ImportCollectionCommand.swift
@@ -61,7 +61,7 @@ struct ImportCollection: AsyncParsableCommand {
             CLIOutput.write(result, context: ctx) {
                 "Imported collection: \(result.name) (\(result.mappingCount) mappings)"
             }
-        } catch let error as AmbiguousCollectionMatch {
+        } catch is AmbiguousCollectionMatch {
             let cliError = CLIError.conflict(
                 "Collection '\(exported.name)' already exists",
                 hint: "Use --on-conflict=replace to overwrite, or --on-conflict=skip to no-op"

--- a/Sources/KeyPathCore/WizardSystemPaths.swift
+++ b/Sources/KeyPathCore/WizardSystemPaths.swift
@@ -430,8 +430,8 @@ public enum WizardSystemPaths {
 
         // Known KeyPath-managed binary paths
         let keyPathManagedPaths = [
-            kanataSystemInstallPath,
-            bundledKanataPath
+            bundledKanataPath,
+            legacySystemBinaryPath
         ]
 
         var externalProcess: RunningKanataInfo?

--- a/Sources/KeyPathInstallationWizard/Core/PackageManager.swift
+++ b/Sources/KeyPathInstallationWizard/Core/PackageManager.swift
@@ -130,8 +130,8 @@ public class PackageManager {
     /// Checks if Kanata is installed via any method
     public func detectKanataInstallation() async -> KanataInstallationInfo {
         let possiblePaths = [
-            WizardSystemPaths.kanataSystemInstallPath, // System-installed kanata (highest priority)
             WizardSystemPaths.bundledKanataPath, // Bundled kanata (preferred for detection)
+            WizardSystemPaths.legacySystemBinaryPath, // Pre-bundled KeyPath installs
             "/opt/homebrew/bin/kanata", // ARM Homebrew
             "/usr/local/bin/kanata", // Intel Homebrew
             "\(NSHomeDirectory())/.cargo/bin/kanata" // Rust cargo installation
@@ -164,9 +164,7 @@ public class PackageManager {
     }
 
     private func determineInstallationType(path: String) -> KanataInstallationType {
-        if path == WizardSystemPaths.kanataSystemInstallPath {
-            .bundled // System-installed kanata is treated as bundled (installed by KeyPath)
-        } else if path == WizardSystemPaths.bundledKanataPath {
+        if path == WizardSystemPaths.bundledKanataPath || path == WizardSystemPaths.legacySystemBinaryPath {
             .bundled
         } else if path.contains("/opt/homebrew/bin") || path.contains("/usr/local/bin") {
             .homebrew

--- a/Sources/KeyPathInstallationWizard/UI/Helpers/DragToAuthorize/DragToAuthorizeController.swift
+++ b/Sources/KeyPathInstallationWizard/UI/Helpers/DragToAuthorize/DragToAuthorizeController.swift
@@ -224,8 +224,9 @@ public final class DragToAuthorizeController {
                 panel.animator().setFrameOrigin(finalFrame.origin)
                 panel.animator().alphaValue = 1.0
             } completionHandler: { [weak self] in
-                self?.state = .visible
-                self?.stateModel?.transitionTo(.visible)
+                Task { @MainActor [weak self] in
+                    self?.transitionToVisible()
+                }
             }
         } else {
             // Simple fade + slide up
@@ -238,10 +239,16 @@ public final class DragToAuthorizeController {
                 panel.animator().setFrameOrigin(finalOrigin)
                 panel.animator().alphaValue = 1.0
             } completionHandler: { [weak self] in
-                self?.state = .visible
-                self?.stateModel?.transitionTo(.visible)
+                Task { @MainActor [weak self] in
+                    self?.transitionToVisible()
+                }
             }
         }
+    }
+
+    private func transitionToVisible() {
+        state = .visible
+        stateModel?.transitionTo(.visible)
     }
 
     private func transitionToSuccess() {

--- a/Tests/KeyPathTests/Core/KanataRuntimeHostTests.swift
+++ b/Tests/KeyPathTests/Core/KanataRuntimeHostTests.swift
@@ -33,18 +33,6 @@ final class KanataRuntimeHostTests: XCTestCase {
         XCTAssertEqual(host.preferredCoreBinaryPath(), host.bundledCorePath)
     }
 
-    func testDeprecatedSystemCorePathReturnsBundledCorePath() {
-        let host = KanataRuntimeHost(
-            launcherPath: "/tmp/kanata-launcher",
-            bridgeLibraryPath: "/tmp/libkeypath_kanata_host_bridge.dylib",
-            bundledCorePath: "/Applications/KeyPath.app/Contents/Library/KeyPath/Kanata Engine.app/Contents/MacOS/kanata",
-            kanataEngineBundlePath: "/Applications/KeyPath.app/Contents/Library/KeyPath/Kanata Engine.app"
-        )
-
-        // systemCorePath is a deprecated alias — must always equal bundledCorePath
-        XCTAssertEqual(host.systemCorePath, host.bundledCorePath)
-    }
-
     func testKanataEngineBundleIDIsCorrect() {
         XCTAssertEqual(KeyPathConstants.Bundle.kanataEngineBundleID, "com.keypath.kanata-engine")
     }

--- a/Tests/KeyPathTests/Services/UnmappedLayerKeyStyleTests.swift
+++ b/Tests/KeyPathTests/Services/UnmappedLayerKeyStyleTests.swift
@@ -6,6 +6,7 @@ import XCTest
 /// Tests for the "unmapped keys on layers" overlay setting: a transparent
 /// (unmapped) key leaves layer mode — rendering base-style — when the user
 /// prefers `.baseLayer`, while mapped keys keep full layer styling.
+@MainActor
 final class UnmappedLayerKeyStyleTests: KeyPathTestCase {
     private var savedStyle: UnmappedLayerKeyStyle!
 

--- a/Tests/KeyPathTests/TCPClientRobustnessTests.swift
+++ b/Tests/KeyPathTests/TCPClientRobustnessTests.swift
@@ -57,7 +57,7 @@ final class TCPClientRobustnessTests: XCTestCase {
 
     func testExtractFirstLine_BinaryFollowedByNewline() {
         let client = KanataTCPClient(port: port)
-        var data = Data([0xFF, 0xFE, 0x00, 0x0A])
+        let data = Data([0xFF, 0xFE, 0x00, 0x0A])
         let result = client.extractFirstLine(from: data)
         XCTAssertNotNil(result, "Should find newline byte even in non-UTF8 data")
     }


### PR DESCRIPTION
## Summary
- Clean up Swift concurrency, deprecation, and unused-code warnings across the app, CLI, installation wizard, and tests.
- Move wizard animation completion state updates back onto the main actor.
- Replace deprecated Kanata system-path references with bundled/legacy path handling.

## Validation
- swift build
- swift test --filter 'KanataRuntimeHostTests|UnmappedLayerKeyStyleTests|TCPClientRobustnessTests'\n- python3 Scripts/check-accessibility.py\n\n## Notes\n- ./Scripts/test-fast.sh --changed fell back to the full safe suite and surfaced separate snapshot/service failures. Targeted service tests pass in isolation; snapshot diffs are being tracked separately.