### PR TITLE
[codex] Fix home row mod overlay labels

### DIFF
--- a/Sources/KeyPathAppKit/Services/LayerMapping/LayerMappingBuilder.swift
+++ b/Sources/KeyPathAppKit/Services/LayerMapping/LayerMappingBuilder.swift
@@ -54,6 +54,31 @@ enum LayerMappingBuilder {
                     }
                 }
             }
+
+            if case let .homeRowMods(config) = collection.configuration,
+               config.holdMode == .modifiers
+            {
+                for key in config.enabledKeys {
+                    guard let modifier = config.modifierAssignments[key],
+                          let displayLabel = KeyDisplayFormatter.tapHoldLabel(for: modifier)
+                    else { continue }
+                    let input = KanataKeyConverter.convertToKanataKey(key).lowercased()
+                    let info = LayerKeyInfo.mapped(
+                        displayLabel: displayLabel,
+                        outputKey: modifier,
+                        outputKeyCode: nil,
+                        collectionId: collection.id
+                    )
+                    actionByInput[input] = info
+                    // Overlay key names are not always the same canonical strings used in
+                    // saved HRM config (for example ";" vs "semicolon"). Register both
+                    // forms so physical keycode lookup still resolves the modifier label.
+                    if let keyCode = KeyboardVisualizationViewModel.kanataNameToKeyCode(key) {
+                        let overlayInput = OverlayKeyboardView.keyCodeToKanataName(keyCode).lowercased()
+                        actionByInput[overlayInput] = info
+                    }
+                }
+            }
         }
 
         for rule in customRules where rule.isEnabled {

--- a/Sources/KeyPathAppKit/UI/KeyboardVisualization/KeyboardVisualizationViewModel+FeatureCollections.swift
+++ b/Sources/KeyPathAppKit/UI/KeyboardVisualization/KeyboardVisualizationViewModel+FeatureCollections.swift
@@ -17,12 +17,25 @@ extension KeyboardVisualizationViewModel {
     func updateTapHoldIdleLabels(from collections: [RuleCollection]) {
         var labels: [UInt16: String] = [:]
         for collection in collections where collection.isEnabled {
-            guard case let .tapHoldPicker(config) = collection.configuration else { continue }
-            let output = config.selectedTapOutput ?? config.tapOptions.first?.output
-            guard let output, let keyCode = Self.kanataNameToKeyCode(config.inputKey) else { continue }
-            if let label = Self.tapHoldOutputDisplayLabel(output) {
-                labels[keyCode] = label
-                AppLogger.shared.info("🏷️ [TapHoldIdle] keyCode=\(keyCode) input=\(config.inputKey) tapOutput=\(output) label=\(label)")
+            switch collection.configuration {
+            case let .tapHoldPicker(config):
+                let output = config.selectedTapOutput ?? config.tapOptions.first?.output
+                guard let output, let keyCode = Self.kanataNameToKeyCode(config.inputKey) else { continue }
+                if let label = Self.tapHoldOutputDisplayLabel(output) {
+                    labels[keyCode] = label
+                    AppLogger.shared.info("🏷️ [TapHoldIdle] keyCode=\(keyCode) input=\(config.inputKey) tapOutput=\(output) label=\(label)")
+                }
+            case let .homeRowMods(config):
+                // Visually suppressed when it echoes the base key, but still feeds "tap A, hold ⇧" accessibility labels.
+                for key in config.enabledKeys {
+                    guard let keyCode = Self.kanataNameToKeyCode(key),
+                          let label = Self.tapHoldOutputDisplayLabel(key)
+                    else { continue }
+                    labels[keyCode] = label
+                    AppLogger.shared.info("🏷️ [TapHoldIdle] keyCode=\(keyCode) input=\(key) tapOutput=(self) label=\(label)")
+                }
+            default:
+                continue
             }
         }
         AppLogger.shared.info("🏷️ [TapHoldIdle] Updated: \(labels.count) entries")

--- a/Sources/KeyPathAppKit/UI/KeyboardVisualization/KeyboardVisualizationViewModel+TestHooks.swift
+++ b/Sources/KeyPathAppKit/UI/KeyboardVisualization/KeyboardVisualizationViewModel+TestHooks.swift
@@ -39,7 +39,7 @@ extension KeyboardVisualizationViewModel {
             "rightbrace": 30, "o": 31, "u": 32, "leftbrace": 33, "i": 34, "p": 35,
             // Home row continued
             "enter": 36, "ret": 36, "return": 36,
-            "l": 37, "j": 38, "apostrophe": 39, "k": 40, "semicolon": 41, "backslash": 42,
+            "l": 37, "j": 38, "apostrophe": 39, "k": 40, "semicolon": 41, "scln": 41, ";": 41, "backslash": 42,
             // Bottom row continued
             "comma": 43, "slash": 44, "n": 45, "m": 46, "dot": 47,
             // Special keys

--- a/Sources/KeyPathAppKit/UI/Overlay/BaseKeycap+Labels.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/BaseKeycap+Labels.swift
@@ -7,7 +7,11 @@ extension BaseKeycap {
         if isPressed, let holdLabel {
             return holdLabel
         }
-        if !isPressed, let tapHoldIdleLabel, shouldShowTapHoldIdleLabel {
+        if !isPressed,
+           let tapHoldIdleLabel,
+           shouldShowTapHoldIdleLabel,
+           !TapHoldLabelPrecedence.idleLabelMatchesBase(tapHoldIdleLabel, baseLabel: baseLabel, keyLabel: key.label)
+        {
             return tapHoldIdleLabel
         }
         if isLayerMode, let subtitle = zoneSubtitle {

--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView.swift
@@ -225,7 +225,11 @@ struct OverlayKeycapView: View {
             return holdLabel
         }
 
-        if !isPressed, let tapHoldIdleLabel, shouldShowTapHoldIdleLabel {
+        if !isPressed,
+           let tapHoldIdleLabel,
+           shouldShowTapHoldIdleLabel,
+           !TapHoldLabelPrecedence.idleLabelMatchesBase(tapHoldIdleLabel, baseLabel: baseLabel, keyLabel: key.label)
+        {
             return tapHoldIdleLabel
         }
 

--- a/Sources/KeyPathAppKit/UI/Overlay/TapHoldLabelPrecedence.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/TapHoldLabelPrecedence.swift
@@ -1,0 +1,7 @@
+enum TapHoldLabelPrecedence {
+    /// Suppress idle tap labels that only echo the base key so HRM hold modifiers can take precedence.
+    static func idleLabelMatchesBase(_ tapHoldIdleLabel: String, baseLabel: String, keyLabel: String) -> Bool {
+        tapHoldIdleLabel.uppercased() == baseLabel.uppercased()
+            || tapHoldIdleLabel.uppercased() == keyLabel.uppercased()
+    }
+}

--- a/Tests/KeyPathTests/Services/LayerMappingBuilderTests.swift
+++ b/Tests/KeyPathTests/Services/LayerMappingBuilderTests.swift
@@ -184,4 +184,129 @@ struct LayerMappingBuilderTests {
     func nonMediaKeyReturnsNil() {
         #expect(LayerMappingBuilder.mediaKeyDisplayLabel("a") == nil)
     }
+
+    // MARK: - Home Row Mods augmentation
+
+    @Test("home row mods augment base layer with hold modifier labels")
+    func homeRowModsAugmentBaseLayerWithHoldModifierLabels() {
+        let mapping: [UInt16: LayerKeyInfo] = [
+            0: LayerKeyInfo(
+                displayLabel: "A",
+                outputKey: "a",
+                outputKeyCode: 0,
+                isTransparent: true,
+                isLayerSwitch: false
+            ),
+            1: LayerKeyInfo(
+                displayLabel: "S",
+                outputKey: "s",
+                outputKeyCode: 1,
+                isTransparent: true,
+                isLayerSwitch: false
+            ),
+            41: LayerKeyInfo(
+                displayLabel: ";",
+                outputKey: "semicolon",
+                outputKeyCode: 41,
+                isTransparent: true,
+                isLayerSwitch: false
+            ),
+        ]
+        let config = HomeRowModsConfig(
+            enabledKeys: ["a", "s", ";"],
+            modifierAssignments: ["a": "lsft", "s": "lctl", ";": "rsft"]
+        )
+        let collection = RuleCollection(
+            id: RuleCollectionIdentifier.homeRowMods,
+            name: "Home Row Mods",
+            summary: "",
+            category: .productivity,
+            mappings: [],
+            isEnabled: true,
+            isSystemDefault: true,
+            configuration: .homeRowMods(config)
+        )
+
+        let result = LayerMappingBuilder.augmentWithPushMsgActions(
+            mapping: mapping,
+            customRules: [],
+            ruleCollections: [collection],
+            currentLayerName: "base"
+        )
+
+        #expect(result[0]?.displayLabel == "⇧")
+        #expect(result[1]?.displayLabel == "⌃")
+        // Semicolon verifies the dual-registration path for config aliases like ";" vs overlay names.
+        #expect(result[41]?.displayLabel == "⇧")
+        #expect(result[0]?.collectionId == RuleCollectionIdentifier.homeRowMods)
+        #expect(result[0]?.isTransparent == false)
+    }
+
+    @Test("home row mods augmentation ignores non-base layer")
+    func homeRowModsAugmentationIgnoresNonBaseLayer() {
+        let mapping: [UInt16: LayerKeyInfo] = [
+            0: .mapped(displayLabel: "←", outputKey: "left", outputKeyCode: 123)
+        ]
+        let config = HomeRowModsConfig(
+            enabledKeys: ["a"],
+            modifierAssignments: ["a": "lsft"]
+        )
+        let collection = RuleCollection(
+            id: RuleCollectionIdentifier.homeRowMods,
+            name: "Home Row Mods",
+            summary: "",
+            category: .productivity,
+            mappings: [],
+            isEnabled: true,
+            isSystemDefault: true,
+            configuration: .homeRowMods(config)
+        )
+
+        let result = LayerMappingBuilder.augmentWithPushMsgActions(
+            mapping: mapping,
+            customRules: [],
+            ruleCollections: [collection],
+            currentLayerName: "nav"
+        )
+
+        #expect(result[0]?.displayLabel == "←")
+    }
+
+    @Test("home row mods layer hold mode does not inject modifier labels")
+    func homeRowModsLayerHoldModeDoesNotInjectModifierLabels() {
+        let mapping: [UInt16: LayerKeyInfo] = [
+            0: LayerKeyInfo(
+                displayLabel: "A",
+                outputKey: "a",
+                outputKeyCode: 0,
+                isTransparent: true,
+                isLayerSwitch: false
+            ),
+        ]
+        let config = HomeRowModsConfig(
+            enabledKeys: ["a"],
+            modifierAssignments: ["a": "lsft"],
+            holdMode: .layers
+        )
+        let collection = RuleCollection(
+            id: RuleCollectionIdentifier.homeRowMods,
+            name: "Home Row Mods",
+            summary: "",
+            category: .productivity,
+            mappings: [],
+            isEnabled: true,
+            isSystemDefault: true,
+            configuration: .homeRowMods(config)
+        )
+
+        let result = LayerMappingBuilder.augmentWithPushMsgActions(
+            mapping: mapping,
+            customRules: [],
+            ruleCollections: [collection],
+            currentLayerName: "base"
+        )
+
+        #expect(result[0]?.displayLabel == "A")
+        #expect(result[0]?.collectionId == nil)
+    }
 }

--- a/Tests/KeyPathTests/UI/HomeRowModsOverlayLabelTests.swift
+++ b/Tests/KeyPathTests/UI/HomeRowModsOverlayLabelTests.swift
@@ -1,0 +1,87 @@
+@testable import KeyPathAppKit
+import KeyPathCore
+import SwiftUI
+import XCTest
+
+@MainActor
+final class HomeRowModsOverlayLabelTests: XCTestCase {
+    func testHomeRowModShowsHoldModifierWhenTapMatchesBaseLabel() {
+        let key = PhysicalKey(keyCode: 0, label: "A", x: 0, y: 0, width: 1, height: 1)
+        let info = LayerKeyInfo.mapped(
+            displayLabel: "⇧",
+            outputKey: "lsft",
+            outputKeyCode: nil,
+            collectionId: RuleCollectionIdentifier.homeRowMods
+        )
+
+        let keycap = OverlayKeycapView(
+            key: key,
+            baseLabel: "A",
+            isPressed: false,
+            scale: 1.0,
+            layerKeyInfo: info,
+            tapHoldIdleLabel: "A"
+        )
+
+        XCTAssertEqual(keycap.effectiveLabel, "⇧")
+        XCTAssertEqual(keycap.keycapAccessibilityLabel, "A, tap A, hold ⇧")
+    }
+
+    func testTapHoldPickerStyleNonMatchingIdleLabelStillShowsIdleTapLabel() {
+        let key = PhysicalKey(keyCode: 57, label: "⇪", x: 0, y: 0, width: 1, height: 1)
+        let info = LayerKeyInfo.mapped(
+            displayLabel: "⌃",
+            outputKey: "lctl",
+            outputKeyCode: nil
+        )
+
+        let keycap = OverlayKeycapView(
+            key: key,
+            baseLabel: "⇪",
+            isPressed: false,
+            scale: 1.0,
+            layerKeyInfo: info,
+            tapHoldIdleLabel: "⎋"
+        )
+
+        XCTAssertEqual(keycap.effectiveLabel, "⎋")
+        XCTAssertEqual(keycap.keycapAccessibilityLabel, "⇪, tap ⎋, hold ⌃")
+    }
+
+    func testBaseKeycapMatchesHomeRowModPrecedence() {
+        let key = PhysicalKey(keyCode: 0, label: "A", x: 0, y: 0, width: 1, height: 1)
+        let info = LayerKeyInfo.mapped(
+            displayLabel: "⇧",
+            outputKey: "lsft",
+            outputKeyCode: nil,
+            collectionId: RuleCollectionIdentifier.homeRowMods
+        )
+        let keycap = BaseKeycap(
+            key: key,
+            baseLabel: "A",
+            scale: 1.0,
+            foregroundColor: .white,
+            colorway: .default,
+            layerKeyInfo: info,
+            holdLabel: nil,
+            tapHoldIdleLabel: "A",
+            useFloatingLabels: false,
+            shiftLabelOverride: nil,
+            isPressed: false,
+            currentLayerName: "base",
+            isLauncherMode: false,
+            isLayerMode: false,
+            isKeymapTransitioning: false,
+            appIcon: nil,
+            faviconImage: nil,
+            systemActionIcon: nil,
+            zoneSubtitle: nil,
+            isLoadingLayerMap: false,
+            isCapsLockOn: false,
+            isInlineLayer: false,
+            hasLayerMapping: true
+        )
+
+        XCTAssertEqual(keycap.effectiveLabel, "⇧")
+    }
+}

--- a/Tests/KeyPathTests/UI/TapHoldIdleLabelTests.swift
+++ b/Tests/KeyPathTests/UI/TapHoldIdleLabelTests.swift
@@ -132,6 +132,50 @@ final class TapHoldIdleLabelTests: XCTestCase {
         XCTAssertEqual(vm.tapHoldIdleLabels.count, 2, "Should have labels for both caps and tab")
     }
 
+    @MainActor
+    func testHomeRowModsPopulateIdleTapLabels() {
+        let vm = KeyboardVisualizationViewModel()
+        let config = HomeRowModsConfig(
+            enabledKeys: ["a", "s", ";"],
+            modifierAssignments: ["a": "lsft", "s": "lctl", ";": "rsft"]
+        )
+        let collection = RuleCollection(
+            id: RuleCollectionIdentifier.homeRowMods,
+            name: "Home Row Mods",
+            summary: "",
+            category: .productivity,
+            mappings: [],
+            isEnabled: true,
+            isSystemDefault: true,
+            configuration: .homeRowMods(config)
+        )
+
+        vm.updateTapHoldIdleLabels(from: [collection])
+
+        XCTAssertEqual(vm.tapHoldIdleLabels[0], "A")
+        XCTAssertEqual(vm.tapHoldIdleLabels[1], "S")
+        XCTAssertEqual(vm.tapHoldIdleLabels[41], ";")
+    }
+
+    @MainActor
+    func testDisabledHomeRowModsDoNotPopulateIdleTapLabels() {
+        let vm = KeyboardVisualizationViewModel()
+        let collection = RuleCollection(
+            id: RuleCollectionIdentifier.homeRowMods,
+            name: "Home Row Mods",
+            summary: "",
+            category: .productivity,
+            mappings: [],
+            isEnabled: false,
+            isSystemDefault: true,
+            configuration: .homeRowMods(HomeRowModsConfig())
+        )
+
+        vm.updateTapHoldIdleLabels(from: [collection])
+
+        XCTAssertTrue(vm.tapHoldIdleLabels.isEmpty)
+    }
+
     // MARK: - kanataNameToKeyCode mapping
 
     func testKanataNameToKeyCodeMapsCommonKeys() {
@@ -144,6 +188,8 @@ final class TapHoldIdleLabelTests: XCTestCase {
         XCTAssertEqual(KeyboardVisualizationViewModel.kanataNameToKeyCode("escape"), 53)
         XCTAssertEqual(KeyboardVisualizationViewModel.kanataNameToKeyCode("enter"), 36)
         XCTAssertEqual(KeyboardVisualizationViewModel.kanataNameToKeyCode("ret"), 36)
+        XCTAssertEqual(KeyboardVisualizationViewModel.kanataNameToKeyCode(";"), 41)
+        XCTAssertEqual(KeyboardVisualizationViewModel.kanataNameToKeyCode("scln"), 41)
     }
 
     func testKanataNameToKeyCodeIsCaseInsensitive() {


### PR DESCRIPTION
## Summary
- show Home Row Mods hold modifiers on the live overlay instead of plain base letters
- preserve alternate tap-hold idle labels, such as Caps tap-to-Esc
- add focused coverage for HRM layer-map augmentation, tap-hold idle labels, and overlay label precedence

## Root cause
Home Row Mods generated functional Kanata tap-hold behavior, but the overlay label pipeline only populated tap-hold idle labels for tap-hold picker collections. The base-layer mapping also did not augment HRM tap-hold keys with their hold modifier labels, so the overlay fell back to identity labels like A/S/D/F/J/K/L/;.

## Validation
- swift test --filter TapHoldIdleLabelTests
- swift test --filter HomeRowModsOverlayLabelTests
- swift test --filter LayerMappingBuilderTests
- swift build
- python3 Scripts/check-accessibility.py
- ./Scripts/quick-deploy.sh
- REQUIRE_NOTARIZED=0 REQUIRE_STAPLED=0 ./Scripts/verify-installed-app.sh
- Computer Use verified the installed live overlay shows tap/hold labels for A/S/D/F/J/K/L/;

## Notes
`./Scripts/test-fast.sh --changed` fell back to the broad safe suite and reported 10 unrelated snapshot/service-health/privileged-router failures after 4,242 passing tests.

Closes #795