### PR TITLE
[codex] Show home row mods as overlay subtitles

### DIFF
--- a/Sources/KeyPathAppKit/UI/Overlay/BaseKeycap+CenteredContent.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/BaseKeycap+CenteredContent.swift
@@ -24,6 +24,8 @@ extension BaseKeycap {
                 fnKeyContent
             } else if let navSymbol = navOverlaySymbol {
                 navOverlayContent(arrow: navSymbol, letter: baseLabel)
+            } else if let subtitle = zoneSubtitle, !isLayerMode, !isLauncherMode, zoneSubtitleRenderedInline {
+                inlineSubtitleContent(primary: effectiveLabel, subtitle: subtitle)
             } else if let shiftSymbol = metadata.shiftSymbol, !isNumpadKey {
                 dualSymbolContent(main: effectiveLabel, shift: shiftSymbol)
             } else if let sfSymbol = LabelMetadata.sfSymbol(forOutputLabel: effectiveLabel) {
@@ -35,29 +37,30 @@ extension BaseKeycap {
                 layerKeyContent(label: key.label)
             } else {
                 let displayText = effectiveLabel.isEmpty ? key.label : effectiveLabel
-                if let subtitle = zoneSubtitle, !isLayerMode, !isLauncherMode {
-                    let adj = OpticalAdjustments.forLabel(displayText)
-                    VStack(spacing: dualSymbolSpacing(for: displayText)) {
-                        Text(displayText.uppercased())
-                            .font(.system(
-                                size: 12.5 * scale * adj.fontScale,
-                                weight: adj.fontWeight ?? .medium
-                            ))
-                            .offset(y: adj.verticalOffset * scale)
-                            .foregroundStyle(foregroundColor)
-                        Text(subtitle)
-                            .font(.system(size: 8.5 * scale, weight: .light))
-                            .foregroundStyle(foregroundColor.opacity(isSmallSize ? 0 : 0.65))
-                    }
+                Text(isNumpadKey ? displayText : displayText.uppercased())
+                    .font(.system(size: isNumpadKey ? 14 * scale : 12 * scale, weight: .medium))
+                    .foregroundStyle(foregroundColor)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
-                } else {
-                    Text(isNumpadKey ? displayText : displayText.uppercased())
-                        .font(.system(size: isNumpadKey ? 14 * scale : 12 * scale, weight: .medium))
-                        .foregroundStyle(foregroundColor)
-                        .frame(maxWidth: .infinity, maxHeight: .infinity)
-                }
             }
         }
+    }
+
+    func inlineSubtitleContent(primary: String, subtitle: String) -> some View {
+        let displayText = primary.isEmpty ? key.label : primary
+        let adj = OpticalAdjustments.forLabel(displayText)
+        return VStack(spacing: dualSymbolSpacing(for: displayText)) {
+            Text(displayText.uppercased())
+                .font(.system(
+                    size: 12.5 * scale * adj.fontScale,
+                    weight: adj.fontWeight ?? .medium
+                ))
+                .offset(y: adj.verticalOffset * scale)
+                .foregroundStyle(foregroundColor)
+            Text(subtitle)
+                .font(.system(size: 8.5 * scale, weight: .light))
+                .foregroundStyle(foregroundColor.opacity(isSmallSize ? 0 : 0.65))
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
     // MARK: - Navigation Word Content

--- a/Sources/KeyPathAppKit/UI/Overlay/BaseKeycap+Labels.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/BaseKeycap+Labels.swift
@@ -17,6 +17,9 @@ extension BaseKeycap {
         if isLayerMode, let subtitle = zoneSubtitle {
             return subtitle
         }
+        if rendersHomeRowModSubtitle {
+            return baseLabel.isEmpty ? key.label : baseLabel
+        }
         guard let info = layerKeyInfo else {
             return baseLabel
         }
@@ -196,6 +199,7 @@ extension BaseKeycap {
 
     var zoneSubtitleRenderedInline: Bool {
         guard zoneSubtitle != nil, !isLayerMode, !isLauncherMode else { return false }
+        if rendersHomeRowModSubtitle { return true }
         guard colorway.legendStyle == .standard else { return false }
         guard key.layoutRole == .centered else { return false }
         guard navigationSFSymbol == nil else { return false }

--- a/Sources/KeyPathAppKit/UI/Overlay/BaseKeycap+Labels.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/BaseKeycap+Labels.swift
@@ -199,6 +199,7 @@ extension BaseKeycap {
 
     var zoneSubtitleRenderedInline: Bool {
         guard zoneSubtitle != nil, !isLayerMode, !isLauncherMode else { return false }
+        if isResolvedHomeRowModHold { return false }
         if rendersHomeRowModSubtitle { return true }
         guard colorway.legendStyle == .standard else { return false }
         guard key.layoutRole == .centered else { return false }

--- a/Sources/KeyPathAppKit/UI/Overlay/BaseKeycap.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/BaseKeycap.swift
@@ -31,6 +31,20 @@ struct BaseKeycap: View {
     let isInlineLayer: Bool
     let hasLayerMapping: Bool
 
+    /// Home Row Mods render like the Vallack subtitle pattern: primary key
+    /// legend above, held modifier as the smaller subtitle below.
+    var rendersHomeRowModSubtitle: Bool {
+        guard currentLayerName.lowercased() == "base",
+              let info = layerKeyInfo,
+              info.collectionId == RuleCollectionIdentifier.homeRowMods,
+              let zoneSubtitle,
+              !zoneSubtitle.isEmpty
+        else {
+            return false
+        }
+        return zoneSubtitle == info.displayLabel
+    }
+
     // MARK: - Body (Content Routing)
 
     var body: some View {

--- a/Sources/KeyPathAppKit/UI/Overlay/BaseKeycap.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/BaseKeycap.swift
@@ -18,6 +18,7 @@ struct BaseKeycap: View {
     let useFloatingLabels: Bool
     let shiftLabelOverride: String?
     let isPressed: Bool
+    let isHoldActive: Bool
     let currentLayerName: String
     let isLauncherMode: Bool
     let isLayerMode: Bool
@@ -43,6 +44,12 @@ struct BaseKeycap: View {
             return false
         }
         return zoneSubtitle == info.displayLabel
+    }
+
+    /// Once the tap-hold ambiguity has resolved into hold state, show only the
+    /// resolved hold output.
+    var isResolvedHomeRowModHold: Bool {
+        rendersHomeRowModSubtitle && isPressed && isHoldActive && holdLabel != nil
     }
 
     // MARK: - Body (Content Routing)

--- a/Sources/KeyPathAppKit/UI/Overlay/KeycapRenderingUtilities.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/KeycapRenderingUtilities.swift
@@ -125,7 +125,7 @@ enum KeycapSymbols {
     /// rather than each color carrying an unrelated meaning. Collections without a
     /// vibrant category fall to the calm `keycapMapped` blue-gray — NOT orange — so
     /// simple remaps (function keys, caps/escape/delete remaps, leader, custom) don't
-    /// shout. Orange is reserved for the modifier-producing family.
+    /// shout. Modifier-producing keys use a quieter blue-gray.
     private enum LayerColors {
         static let navigation = KeyPathColors.layerGreen
         static let window = KeyPathColors.layerPurple
@@ -134,7 +134,7 @@ enum KeycapSymbols {
         /// Editor / terminal integration — shares the blue family with symbols
         /// (they don't appear together, so the shared hue is intentional).
         static let editor = KeyPathColors.layerBlue
-        static let modifier = KeyPathColors.layerOrange
+        static let modifier = KeyPathColors.layerModifier
         /// Calm default for everything without a vibrant category (simple remaps).
         static let mapped = KeyPathColors.keycapMapped
     }

--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayKeyboardView.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayKeyboardView.swift
@@ -76,6 +76,23 @@ struct OverlayKeyboardView: View {
         OverlayKeycapView.inlineLayerNames.contains(currentLayerName.lowercased())
     }
 
+    private func homeRowModSubtitle(for info: LayerKeyInfo?, key: PhysicalKey) -> String? {
+        guard currentLayerName.lowercased() == "base",
+              key.layoutRole == .centered,
+              let info,
+              info.collectionId == RuleCollectionIdentifier.homeRowMods,
+              !info.displayLabel.isEmpty,
+              !info.isTransparent,
+              !info.isLayerSwitch,
+              info.appLaunchIdentifier == nil,
+              info.systemActionIdentifier == nil,
+              info.urlIdentifier == nil
+        else {
+            return nil
+        }
+        return info.displayLabel
+    }
+
     /// Track caps lock state from system
     @State private var isCapsLockOn: Bool = NSEvent.modifierFlags.contains(.capsLock)
     /// Global monitor for flagsChanged events (detects caps lock toggled by kanata/IOKit)
@@ -434,6 +451,12 @@ struct OverlayKeyboardView: View {
             for: key,
             includeExtraKeys: includeKeymapPunctuation
         )
+        let layerInfo = layerKeyMap[key.keyCode]
+        let homeRowModSubtitle = homeRowModSubtitle(for: layerInfo, key: key)
+        let resolvedZoneColor = homeRowModSubtitle == nil
+            ? activeZoneColors[key.keyCode]
+            : KeycapSymbols.collectionColor(for: RuleCollectionIdentifier.homeRowMods)
+        let resolvedZoneSubtitle = homeRowModSubtitle ?? activeZoneSubtitles[key.keyCode]
 
         // Look up launcher mapping for this key by kanata name first (handles special keys
         // like enter/rightshift whose display labels differ from their mapping keys),
@@ -462,7 +485,7 @@ struct OverlayKeyboardView: View {
             fadeAmount: fadeAmount,
             currentLayerName: currentLayerName,
             isLoadingLayerMap: isLoadingLayerMap,
-            layerKeyInfo: layerKeyMap[key.keyCode],
+            layerKeyInfo: layerInfo,
             isEmphasized: emphasizedKeyCodes.contains(key.keyCode),
             isOneShot: oneShotKeyCodes.contains(key.keyCode),
             holdLabel: holdLabels[key.keyCode],
@@ -494,8 +517,8 @@ struct OverlayKeyboardView: View {
             launcherMapping: launcherMapping,
             // Keymap transition flag (bypasses remap gating for animation)
             isKeymapTransitioning: isKeymapTransitioning,
-            zoneColor: activeZoneColors[key.keyCode],
-            zoneSubtitle: activeZoneSubtitles[key.keyCode]
+            zoneColor: resolvedZoneColor,
+            zoneSubtitle: resolvedZoneSubtitle
         )
         .frame(
             width: keyWidth(for: key, scale: scale),

--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView+ContentAndStyling.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView+ContentAndStyling.swift
@@ -63,7 +63,8 @@ extension OverlayKeycapView {
             // Zone subtitle overlay (e.g., ⌃ under Q for hold modifier)
             // Skip when subtitle is rendered inline as a VStack in centeredContent
             if let subtitle = zoneSubtitle, !isLayerMode, !isLauncherMode,
-               !zoneSubtitleRenderedInline
+               !zoneSubtitleRenderedInline,
+               !isResolvedHomeRowModHold
             {
                 VStack(spacing: 0) {
                     Spacer()
@@ -388,6 +389,7 @@ extension OverlayKeycapView {
                 useFloatingLabels: useFloatingLabels,
                 shiftLabelOverride: shiftLabelOverride,
                 isPressed: isPressed,
+                isHoldActive: isHoldActive,
                 currentLayerName: currentLayerName,
                 isLauncherMode: isLauncherMode,
                 isLayerMode: isLayerMode,

--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView+LayoutContent.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView+LayoutContent.swift
@@ -12,6 +12,7 @@ extension OverlayKeycapView {
 
     var zoneSubtitleRenderedInline: Bool {
         guard zoneSubtitle != nil, !isLayerMode, !isLauncherMode else { return false }
+        if rendersHomeRowModSubtitle { return true }
         guard colorway.legendStyle == .standard else { return false }
         guard key.layoutRole == .centered else { return false }
         guard navigationSFSymbol == nil else { return false }

--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView+LayoutContent.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView+LayoutContent.swift
@@ -12,6 +12,7 @@ extension OverlayKeycapView {
 
     var zoneSubtitleRenderedInline: Bool {
         guard zoneSubtitle != nil, !isLayerMode, !isLauncherMode else { return false }
+        if isResolvedHomeRowModHold { return false }
         if rendersHomeRowModSubtitle { return true }
         guard colorway.legendStyle == .standard else { return false }
         guard key.layoutRole == .centered else { return false }

--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView+VisualStyling.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView+VisualStyling.swift
@@ -101,7 +101,7 @@ extension OverlayKeycapView {
 
     var backgroundColor: Color {
         if isPressed, isHoldActive {
-            KeyPathColors.layerOrange
+            KeyPathColors.layerModifier
         } else if isPressed, let zc = zoneColor {
             zc // Pressed activator/zone key stays in-palette
         } else if isPressed {

--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView.swift
@@ -83,6 +83,12 @@ struct OverlayKeycapView: View {
         return zoneSubtitle == info.displayLabel
     }
 
+    /// Once Kanata resolves a tap-hold key into hold state, render the single
+    /// resolved hold output instead of the idle alpha+modifier subtitle pair.
+    var isResolvedHomeRowModHold: Bool {
+        rendersHomeRowModSubtitle && isPressed && isHoldActive && holdLabel != nil
+    }
+
     /// Whether this key has a launcher mapping
     var hasLauncherMapping: Bool {
         launcherMapping != nil

--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayKeycapView.swift
@@ -69,6 +69,20 @@ struct OverlayKeycapView: View {
     /// Subtitle from active system pack (e.g., "⌃" under Q for hold modifier)
     var zoneSubtitle: String?
 
+    /// Home Row Mods use the same visual treatment as pack subtitles: keep the
+    /// alpha/punctuation key as the primary legend and show the held modifier below it.
+    var rendersHomeRowModSubtitle: Bool {
+        guard currentLayerName.lowercased() == "base",
+              let info = layerKeyInfo,
+              info.collectionId == RuleCollectionIdentifier.homeRowMods,
+              let zoneSubtitle,
+              !zoneSubtitle.isEmpty
+        else {
+            return false
+        }
+        return zoneSubtitle == info.displayLabel
+    }
+
     /// Whether this key has a launcher mapping
     var hasLauncherMapping: Bool {
         launcherMapping != nil
@@ -192,6 +206,10 @@ struct OverlayKeycapView: View {
         // If floating labels are disabled, always render content
         guard useFloatingLabels else { return true }
 
+        if rendersHomeRowModSubtitle {
+            return true
+        }
+
         // Special keys always render their own content
         if hasSpecialLabel { return true }
 
@@ -237,6 +255,10 @@ struct OverlayKeycapView: View {
         // In layer mode, zone subtitles become the primary label (e.g., nav icons)
         if isLayerMode, let subtitle = zoneSubtitle {
             return subtitle
+        }
+
+        if rendersHomeRowModSubtitle {
+            return baseLabel.isEmpty ? key.label : baseLabel
         }
 
         guard let info = layerKeyInfo else {

--- a/Sources/KeyPathAppKit/UI/Rules/HomeRowTimingSection.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/HomeRowTimingSection.swift
@@ -299,25 +299,14 @@ struct HomeRowTimingSection: View {
             HStack(spacing: 4) {
                 Text("Opposite-hand activation")
                 Spacer()
-                Picker("", selection: Binding(
-                    get: { config.oppositeHandMode },
-                    set: { newValue in
-                        config.oppositeHandMode = newValue
-                        updateConfig()
-                    }
-                )) {
-                    ForEach([OppositeHandMode.off, .press, .release], id: \.self) { mode in
-                        Text(mode.displayName).tag(mode)
-                    }
+                OppositeHandModeControl(selection: config.oppositeHandMode) { newValue in
+                    config.oppositeHandMode = newValue
+                    updateConfig()
                 }
-                .pickerStyle(.segmented)
                 .frame(maxWidth: 220)
-                .accessibilityIdentifier("home-row-mods-opposite-hand-picker")
-                .accessibilityLabel("Opposite-hand activation mode")
-                .accessibilityValue(config.oppositeHandMode.displayName)
 
                 InfoTip(
-                    "Hold actions (modifiers or layers) only activate when you press a key with the other hand. Same-hand typing always produces letters — no accidental modifiers during fast rolls.\n\nOn Press: Faster response, may misfire on fast same-hand rolls.\nOn Release: More forgiving — waits for the other-hand key to be released before committing."
+                    "Off: Hold resolves by timing, so holding a home-row key can become its modifier by itself.\n\nOn Press: Hold actions activate when you press a key with the other hand. Faster response, but more opinionated.\n\nOn Release: More forgiving — waits for the other-hand key to be released before committing."
                 )
             }
 
@@ -870,5 +859,46 @@ struct HomeRowTimingSection: View {
 private func chunks<T>(of array: [T], size: Int) -> [[T]] {
     stride(from: 0, to: array.count, by: size).map { start in
         Array(array[start ..< min(start + size, array.count)])
+    }
+}
+
+private struct OppositeHandModeControl: View {
+    let selection: OppositeHandMode
+    let onSelection: (OppositeHandMode) -> Void
+
+    private let modes: [OppositeHandMode] = [.off, .press, .release]
+
+    var body: some View {
+        HStack(spacing: 0) {
+            ForEach(modes, id: \.self) { mode in
+                Button {
+                    onSelection(mode)
+                } label: {
+                    Text(mode.displayName)
+                        .font(.subheadline.weight(selection == mode ? .semibold : .regular))
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.85)
+                        .frame(maxWidth: .infinity, minHeight: 26)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(selection == mode ? Color.white : Color.primary)
+                .background(
+                    RoundedRectangle(cornerRadius: 7, style: .continuous)
+                        .fill(selection == mode ? Color.accentColor : Color.clear)
+                )
+                .accessibilityIdentifier("home-row-mods-opposite-hand-\(mode.rawValue)")
+                .accessibilityLabel(mode.displayName)
+                .accessibilityValue(selection == mode ? "selected" : "not selected")
+                .accessibilityAddTraits(selection == mode ? .isSelected : [])
+            }
+        }
+        .padding(2)
+        .background(Color.primary.opacity(0.08))
+        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("home-row-mods-opposite-hand-picker")
+        .accessibilityLabel("Opposite-hand activation mode")
+        .accessibilityValue(selection.displayName)
     }
 }

--- a/Sources/KeyPathAppKit/UI/Style/KeyPathColors.swift
+++ b/Sources/KeyPathAppKit/UI/Style/KeyPathColors.swift
@@ -13,8 +13,11 @@ enum KeyPathColors {
 
     // MARK: - Layer State Colors (Overlay/HUD)
 
-    /// Orange — Vim layer, default layer mode, hold-active state
+    /// Orange — emphasis/default layer accents
     static let layerOrange = Color(red: 0.85, green: 0.45, blue: 0.15)
+
+    /// Muted blue-gray — modifier-producing keys and resolved hold state
+    static let layerModifier = Color(red: 0.34, green: 0.40, blue: 0.48)
 
     /// Green — Vallack navigation, "ready" state
     static let layerGreen = Color(red: 0.2, green: 0.7, blue: 0.4)

--- a/Tests/KeyPathTests/UI/HomeRowModsOverlayLabelTests.swift
+++ b/Tests/KeyPathTests/UI/HomeRowModsOverlayLabelTests.swift
@@ -29,9 +29,41 @@ final class HomeRowModsOverlayLabelTests: XCTestCase {
         XCTAssertTrue(keycap.zoneSubtitleRenderedInline)
         XCTAssertEqual(
             String(describing: keycap.backgroundColor),
-            String(describing: KeycapSymbols.collectionColor(for: RuleCollectionIdentifier.homeRowMods))
+            String(describing: KeyPathColors.layerModifier)
         )
         XCTAssertEqual(keycap.keycapAccessibilityLabel, "A, tap A, hold ⇧")
+    }
+
+    func testResolvedHomeRowModHoldShowsSingleHoldOutput() {
+        let key = PhysicalKey(keyCode: 0, label: "A", x: 0, y: 0, width: 1, height: 1)
+        let info = LayerKeyInfo.mapped(
+            displayLabel: "⇧",
+            outputKey: "lsft",
+            outputKeyCode: nil,
+            collectionId: RuleCollectionIdentifier.homeRowMods
+        )
+
+        let keycap = OverlayKeycapView(
+            key: key,
+            baseLabel: "A",
+            isPressed: true,
+            scale: 1.0,
+            layerKeyInfo: info,
+            holdLabel: "⇧",
+            isHoldActive: true,
+            tapHoldIdleLabel: "A",
+            zoneColor: KeycapSymbols.collectionColor(for: RuleCollectionIdentifier.homeRowMods),
+            zoneSubtitle: "⇧"
+        )
+
+        XCTAssertEqual(keycap.effectiveLabel, "⇧")
+        XCTAssertTrue(keycap.isResolvedHomeRowModHold)
+        XCTAssertFalse(keycap.zoneSubtitleRenderedInline)
+        XCTAssertEqual(
+            String(describing: keycap.backgroundColor),
+            String(describing: KeyPathColors.layerModifier)
+        )
+        XCTAssertEqual(keycap.keycapAccessibilityValue, "held")
     }
 
     func testHomeRowModSemicolonUsesModifierSubtitleInsteadOfShiftedPunctuation() {
@@ -98,6 +130,7 @@ final class HomeRowModsOverlayLabelTests: XCTestCase {
             useFloatingLabels: false,
             shiftLabelOverride: nil,
             isPressed: false,
+            isHoldActive: false,
             currentLayerName: "base",
             isLauncherMode: false,
             isLayerMode: false,
@@ -115,5 +148,45 @@ final class HomeRowModsOverlayLabelTests: XCTestCase {
         XCTAssertEqual(keycap.effectiveLabel, "A")
         XCTAssertTrue(keycap.rendersHomeRowModSubtitle)
         XCTAssertTrue(keycap.zoneSubtitleRenderedInline)
+    }
+
+    func testBaseKeycapResolvedHomeRowModHoldSuppressesSubtitle() {
+        let key = PhysicalKey(keyCode: 0, label: "A", x: 0, y: 0, width: 1, height: 1)
+        let info = LayerKeyInfo.mapped(
+            displayLabel: "⇧",
+            outputKey: "lsft",
+            outputKeyCode: nil,
+            collectionId: RuleCollectionIdentifier.homeRowMods
+        )
+        let keycap = BaseKeycap(
+            key: key,
+            baseLabel: "A",
+            scale: 1.0,
+            foregroundColor: .white,
+            colorway: .default,
+            layerKeyInfo: info,
+            holdLabel: "⇧",
+            tapHoldIdleLabel: "A",
+            useFloatingLabels: false,
+            shiftLabelOverride: nil,
+            isPressed: true,
+            isHoldActive: true,
+            currentLayerName: "base",
+            isLauncherMode: false,
+            isLayerMode: false,
+            isKeymapTransitioning: false,
+            appIcon: nil,
+            faviconImage: nil,
+            systemActionIcon: nil,
+            zoneSubtitle: "⇧",
+            isLoadingLayerMap: false,
+            isCapsLockOn: false,
+            isInlineLayer: false,
+            hasLayerMapping: true
+        )
+
+        XCTAssertEqual(keycap.effectiveLabel, "⇧")
+        XCTAssertTrue(keycap.isResolvedHomeRowModHold)
+        XCTAssertFalse(keycap.zoneSubtitleRenderedInline)
     }
 }

--- a/Tests/KeyPathTests/UI/HomeRowModsOverlayLabelTests.swift
+++ b/Tests/KeyPathTests/UI/HomeRowModsOverlayLabelTests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 @MainActor
 final class HomeRowModsOverlayLabelTests: XCTestCase {
-    func testHomeRowModShowsHoldModifierWhenTapMatchesBaseLabel() {
+    func testHomeRowModKeepsAlphaPrimaryAndShowsHoldModifierAsSubtitle() {
         let key = PhysicalKey(keyCode: 0, label: "A", x: 0, y: 0, width: 1, height: 1)
         let info = LayerKeyInfo.mapped(
             displayLabel: "⇧",
@@ -19,11 +19,42 @@ final class HomeRowModsOverlayLabelTests: XCTestCase {
             isPressed: false,
             scale: 1.0,
             layerKeyInfo: info,
-            tapHoldIdleLabel: "A"
+            tapHoldIdleLabel: "A",
+            zoneColor: KeycapSymbols.collectionColor(for: RuleCollectionIdentifier.homeRowMods),
+            zoneSubtitle: "⇧"
         )
 
-        XCTAssertEqual(keycap.effectiveLabel, "⇧")
+        XCTAssertEqual(keycap.effectiveLabel, "A")
+        XCTAssertTrue(keycap.rendersHomeRowModSubtitle)
+        XCTAssertTrue(keycap.zoneSubtitleRenderedInline)
+        XCTAssertEqual(
+            String(describing: keycap.backgroundColor),
+            String(describing: KeycapSymbols.collectionColor(for: RuleCollectionIdentifier.homeRowMods))
+        )
         XCTAssertEqual(keycap.keycapAccessibilityLabel, "A, tap A, hold ⇧")
+    }
+
+    func testHomeRowModSemicolonUsesModifierSubtitleInsteadOfShiftedPunctuation() {
+        let key = PhysicalKey(keyCode: 41, label: ";", x: 0, y: 0, width: 1, height: 1)
+        let info = LayerKeyInfo.mapped(
+            displayLabel: "⇧",
+            outputKey: "rsft",
+            outputKeyCode: nil,
+            collectionId: RuleCollectionIdentifier.homeRowMods
+        )
+
+        let keycap = OverlayKeycapView(
+            key: key,
+            baseLabel: ";",
+            isPressed: false,
+            scale: 1.0,
+            layerKeyInfo: info,
+            tapHoldIdleLabel: ";",
+            zoneSubtitle: "⇧"
+        )
+
+        XCTAssertEqual(keycap.effectiveLabel, ";")
+        XCTAssertTrue(keycap.zoneSubtitleRenderedInline)
     }
 
     func testTapHoldPickerStyleNonMatchingIdleLabelStillShowsIdleTapLabel() {
@@ -74,13 +105,15 @@ final class HomeRowModsOverlayLabelTests: XCTestCase {
             appIcon: nil,
             faviconImage: nil,
             systemActionIcon: nil,
-            zoneSubtitle: nil,
+            zoneSubtitle: "⇧",
             isLoadingLayerMap: false,
             isCapsLockOn: false,
             isInlineLayer: false,
             hasLayerMapping: true
         )
 
-        XCTAssertEqual(keycap.effectiveLabel, "⇧")
+        XCTAssertEqual(keycap.effectiveLabel, "A")
+        XCTAssertTrue(keycap.rendersHomeRowModSubtitle)
+        XCTAssertTrue(keycap.zoneSubtitleRenderedInline)
     }
 }

--- a/Tests/KeyPathTests/UI/OverlayKeycapViewColorTests.swift
+++ b/Tests/KeyPathTests/UI/OverlayKeycapViewColorTests.swift
@@ -6,7 +6,7 @@ import SwiftUI
 ///
 /// The taxonomy is semantic: keys are colored by *what their layer does*, grouped
 /// into families (navigation = green, window/spaces = purple, symbols = blue,
-/// launcher/apps = teal, editor = steel blue, modifier-producing = orange). Anything
+/// launcher/apps = teal, editor = steel blue, modifier-producing = muted blue-gray). Anything
 /// without a vibrant category falls to the calm `keycapMapped` blue-gray — NOT orange.
 @MainActor
 final class OverlayKeycapViewColorTests: XCTestCase {
@@ -49,13 +49,14 @@ final class OverlayKeycapViewColorTests: XCTestCase {
         }
     }
 
-    func testCollectionColor_ModifierFamilyIsOrange() {
+    func testCollectionColor_ModifierFamilyIsMutedModifierColor() {
         for id in [
             RuleCollectionIdentifier.homeRowMods,
             RuleCollectionIdentifier.homeRowLayerToggles,
             RuleCollectionIdentifier.capsLockHyperKey
         ] {
-            XCTAssertEqual(KeycapSymbols.collectionColor(for: id), KeyPathColors.layerOrange)
+            XCTAssertEqual(KeycapSymbols.collectionColor(for: id), KeyPathColors.layerModifier)
+            XCTAssertNotEqual(KeycapSymbols.collectionColor(for: id), KeyPathColors.layerOrange)
         }
     }
 


### PR DESCRIPTION
## Summary
- keep Home Row Mods primary key legends as the alpha/punctuation labels on the base overlay
- render the held modifier as the small inline subtitle using the existing Vallack-style subtitle treatment
- color active Home Row Mod keys with the Home Row Mods collection color and cover the semicolon/shifted-punctuation case

## Root Cause
The HRM layer mapping resolved its hold modifier display label as the keycap primary label. That made the live overlay replace A/S/D/F/J/K/L/; with modifier symbols instead of preserving the tap legend and showing the hold action as secondary information.

## Validation
- swift test --filter HomeRowModsOverlayLabelTests
- swift test --filter VallackOverlayZoneTests
- swift test --filter OverlayKeyboardViewTests
- swift test --filter OverlayEffectiveLabelTests
- swift test --filter FloatingLabelVisibilityTests
- swift build
- python3 Scripts/check-accessibility.py
- ./Scripts/test-fast.sh --changed
- ./Scripts/quick-deploy.sh
- REQUIRE_NOTARIZED=0 REQUIRE_STAPLED=0 ./Scripts/verify-installed-app.sh
- Computer Use installed-app inspection: overlay showed orange HRM keys with primary A/S/D/F/J/K/L/; labels and small modifier subtitles; accessibility labels remained tap/hold descriptive
