### PR TITLE
Fix HRM stability validation and add release QA harness

### DIFF
--- a/Scripts/qa-hrm-settings-smoke.sh
+++ b/Scripts/qa-hrm-settings-smoke.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CLI="${KEYPATH_CLI:-/Applications/KeyPath.app/Contents/MacOS/keypath-cli}"
+CONFIG_DIR="${KEYPATH_CONFIG_DIR:-$HOME/.config/keypath}"
+COLLECTIONS_JSON="$CONFIG_DIR/RuleCollections.json"
+TMP_DIR="$(mktemp -d)"
+BACKUP_PATH=""
+
+cleanup() {
+  local status=$?
+  if [[ -n "$BACKUP_PATH" ]]; then
+    "$CLI" config restore --json --quiet "$BACKUP_PATH" --reload >/dev/null || {
+      echo "warning: failed to restore KeyPath config from $BACKUP_PATH" >&2
+    }
+  fi
+  rm -rf "$TMP_DIR"
+  exit "$status"
+}
+trap cleanup EXIT
+
+require_file() {
+  if [[ ! -e "$1" ]]; then
+    echo "error: required file not found: $1" >&2
+    exit 1
+  fi
+}
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local label="$3"
+  if [[ "$haystack" != *"$needle"* ]]; then
+    echo "error: $label did not contain expected snippet:" >&2
+    echo "  $needle" >&2
+    exit 1
+  fi
+}
+
+assert_not_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local label="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    echo "error: $label unexpectedly contained snippet:" >&2
+    echo "  $needle" >&2
+    exit 1
+  fi
+}
+
+apply_hrm_case() {
+  local hold_mode="$1"
+  local opposite_hand_mode="$2"
+  local layer_toggle_mode="$3"
+  local enabled_keys_json="$4"
+  local timing_json="$5"
+
+  python3 - "$COLLECTIONS_JSON" "$hold_mode" "$opposite_hand_mode" "$layer_toggle_mode" "$enabled_keys_json" "$timing_json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+hold_mode = sys.argv[2]
+opposite_hand_mode = sys.argv[3]
+layer_toggle_mode = sys.argv[4]
+enabled_keys = json.loads(sys.argv[5])
+timing = json.loads(sys.argv[6])
+
+payload = json.loads(path.read_text())
+collections = payload.get("collections")
+if not isinstance(collections, list):
+    raise SystemExit("RuleCollections.json does not contain a collections array")
+
+for collection in collections:
+    configuration = collection.get("configuration") or {}
+    if collection.get("name") == "Home Row Mods" or configuration.get("type") == "homeRowMods":
+        collection["isEnabled"] = True
+        configuration.update({
+            "type": "homeRowMods",
+            "enabledKeys": enabled_keys,
+            "modifierAssignments": {
+                "a": "lsft", "s": "lctl", "d": "lalt", "f": "lmet",
+                "j": "rmet", "k": "ralt", "l": "rctl", ";": "rsft",
+            },
+            "layerAssignments": {
+                "a": "fun", "s": "num", "d": "sym", "f": "nav",
+                "j": "nav", "k": "sym", "l": "num", ";": "fun",
+            },
+            "holdMode": hold_mode,
+            "hasUserSelectedHoldMode": True,
+            "layerToggleMode": layer_toggle_mode,
+            "timing": timing,
+            "keySelection": "custom",
+            "showAdvanced": True,
+            "timingMode": "precision",
+            "showExpertTiming": True,
+            "oppositeHandMode": opposite_hand_mode,
+        })
+        collection["configuration"] = configuration
+        path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+        break
+else:
+    raise SystemExit("Home Row Mods collection not found")
+PY
+
+  "$CLI" config apply --json --quiet >/dev/null
+}
+
+show_config() {
+  "$CLI" config show --no-json --quiet
+}
+
+require_file "$CLI"
+require_file "$COLLECTIONS_JSON"
+
+backup_json="$("$CLI" config backup --json --quiet --output "$TMP_DIR/keypath-config-backup")"
+BACKUP_PATH="$(python3 -c 'import json, sys; print(json.load(sys.stdin)["data"]["backupPath"])' <<< "$backup_json")"
+
+default_timing='{"tapWindow":200,"holdDelay":150,"quickTapEnabled":false,"quickTapTermMs":0,"tapOffsets":{},"holdOffsets":{},"requirePriorIdleMs":150}'
+
+echo "==> modifiers with opposite-hand press"
+apply_hrm_case "modifiers" "press" "whileHeld" '["a","s","d","f","j","k","l",";"]' "$default_timing"
+config="$(show_config)"
+assert_contains "$config" "(defhands" "opposite-hand press config"
+assert_contains "$config" "beh_base_a (tap-hold-opposite-hand 150 a lsft)" "opposite-hand press config"
+
+echo "==> modifiers with opposite-hand release"
+apply_hrm_case "modifiers" "release" "whileHeld" '["a"]' "$default_timing"
+config="$(show_config)"
+assert_contains "$config" "beh_base_a (tap-hold-opposite-hand-release 150 a lsft)" "opposite-hand release config"
+
+echo "==> opposite-hand off with quick tap and per-key timing"
+timing='{"tapWindow":230,"holdDelay":180,"quickTapEnabled":true,"quickTapTermMs":25,"tapOffsets":{"a":40},"holdOffsets":{"a":30},"requirePriorIdleMs":220}'
+apply_hrm_case "modifiers" "off" "whileHeld" '["a"]' "$timing"
+config="$(show_config)"
+assert_not_contains "$config" "(defhands" "opposite-hand off config"
+assert_contains "$config" "tap-hold-require-prior-idle 220" "opposite-hand off config"
+assert_contains "$config" "beh_base_a (tap-hold-press 295 210 a lsft)" "opposite-hand off config"
+
+echo "==> layer hold while held"
+apply_hrm_case "layers" "off" "whileHeld" '["f"]' "$default_timing"
+config="$(show_config)"
+assert_contains "$config" 'beh_base_f (tap-hold-press $tap-timeout 150 f (layer-while-held nav))' "layer while-held config"
+
+echo "==> layer hold toggle"
+apply_hrm_case "layers" "off" "toggle" '["f"]' "$default_timing"
+config="$(show_config)"
+assert_contains "$config" 'beh_base_f (tap-hold-press $tap-timeout 150 f (layer-toggle nav))' "layer toggle config"
+
+echo "==> disabled key omitted"
+apply_hrm_case "modifiers" "off" "whileHeld" '["s"]' "$default_timing"
+config="$(show_config)"
+assert_contains "$config" 'beh_base_s (tap-hold-press $tap-timeout 150 s lctl)' "disabled-key config"
+assert_not_contains "$config" "beh_base_a" "disabled-key config"
+
+echo "HRM settings smoke passed. Restoring original KeyPath config."

--- a/Sources/KeyPathAppKit/Services/MainAppStateController.swift
+++ b/Sources/KeyPathAppKit/Services/MainAppStateController.swift
@@ -436,6 +436,7 @@ class MainAppStateController {
         if force {
             // Force refresh: clear cooldown
             lastValidationTime = nil
+            validator?.invalidateCaches()
             AppLogger.shared.log("🔄 [MainAppStateController] Force refresh - cooldown cleared")
         }
         await performValidation()
@@ -445,6 +446,7 @@ class MainAppStateController {
     /// Called automatically when wizard closes to ensure fresh validation after setup changes
     func invalidateValidationCooldown() {
         lastValidationTime = nil
+        validator?.invalidateCaches()
         AppLogger.shared.log("🔄 [MainAppStateController] Validation cooldown invalidated")
     }
 
@@ -452,6 +454,7 @@ class MainAppStateController {
     func revalidate() async {
         AppLogger.shared.log("🔄 [MainAppStateController] Revalidate requested - clearing cooldown")
         lastValidationTime = nil
+        validator?.invalidateCaches()
         await performValidation()
     }
 
@@ -511,18 +514,15 @@ class MainAppStateController {
                 return first
             }
         } catch {
-            AppLogger.shared.error("⏱️ [MainAppStateController] Validation watchdog fired – routing through adapter with timedOut context")
-            let timedOutContext = SystemContext.timedOut
-            let adapted = SystemContextAdapter.adapt(timedOutContext)
-            lastValidatedSystemContext = timedOutContext
-            issues = adapted.issues
+            AppLogger.shared.error("⏱️ [MainAppStateController] Validation watchdog fired – preserving last state and surfacing timeout warning")
+            issues = [Self.validationTimeoutIssue()]
             lastValidationDate = Date()
             lastValidationTime = Date()
+            if let lastValidatedSystemContext {
+                lastAdaptedState = SystemContextAdapter.adapt(lastValidatedSystemContext).state
+            }
 
-            let blockingCount = issues.filter { $0.severity == .critical || $0.severity == .error }.count
-            validationState = blockingCount > 0
-                ? .failed(blockingCount: blockingCount, totalCount: issues.count)
-                : .failed(blockingCount: 0, totalCount: issues.count)
+            validationState = .failed(blockingCount: 0, totalCount: issues.count)
             return
         }
 
@@ -700,6 +700,18 @@ class MainAppStateController {
             )
             validationState = .checking
         }
+    }
+
+    static func validationTimeoutIssue() -> WizardIssue {
+        WizardIssue(
+            identifier: .validationTimeout,
+            severity: .warning,
+            category: .daemon,
+            title: "Status check timed out",
+            description: "System validation exceeded the 12s watchdog. This is usually transient; the next check should succeed.",
+            autoFixAction: nil,
+            userAction: "If this persists, try restarting KeyPath."
+        )
     }
 
     private func evaluateKanataStartupGate() async -> KanataStartupGateResult {

--- a/Sources/KeyPathAppKit/Services/System/SystemValidator.swift
+++ b/Sources/KeyPathAppKit/Services/System/SystemValidator.swift
@@ -40,6 +40,19 @@ public class SystemValidator {
     private let vhidDeviceManager: VHIDDeviceManager
     private let processLifecycleManager: ProcessLifecycleManager
     private weak var kanataManager: RuntimeCoordinator?
+    private var cachedComponentFacts: ComponentInstallationFacts?
+
+    private struct ComponentInstallationFacts: Sendable {
+        let kanataBinaryInstalled: Bool
+        let vhidInstalled: Bool
+        let vhidVersionMismatch: Bool
+        let karabinerDriverExtensionEnabled: Bool
+        let timestamp: Date
+
+        func isFresh(ttl: TimeInterval) -> Bool {
+            Date().timeIntervalSince(timestamp) < ttl
+        }
+    }
 
     init(
         vhidDeviceManager: VHIDDeviceManager = VHIDDeviceManager(),
@@ -99,6 +112,11 @@ public class SystemValidator {
         defer { inProgressValidation = nil }
 
         return await validationTask.value
+    }
+
+    func invalidateCaches() {
+        cachedComponentFacts = nil
+        ServiceHealthChecker.shared.invalidateHealthCache()
     }
 
     /// Perform the actual validation work
@@ -390,20 +408,16 @@ public class SystemValidator {
     private func checkComponents() async -> ComponentStatus {
         AppLogger.shared.log("🔍 [SystemValidator] Checking components")
 
-        // Check Kanata binary installation (canonical identity).
-        // The bundled binary at Contents/Library/KeyPath/kanata is the canonical path.
-        // TCC permissions survive app rebuilds at /Applications/KeyPath.app.
-        let kanataBinaryDetector = KanataBinaryDetector.shared
-        let kanataBinaryInstalled = kanataBinaryDetector.isInstalled()
-
-        // Check VirtualHID Device installation (fast sync check)
-        let vhidInstalled = vhidDeviceManager.detectInstallation()
-        let vhidVersionMismatch = vhidDeviceManager.hasVersionMismatch()
+        let facts = await componentInstallationFacts()
 
         // Check LaunchDaemon services via ServiceHealthChecker FIRST
         // This uses launchctl (fast) and provides VHID health, avoiding duplicate pgrep calls
         // that could contend with checkHealth()'s detectConnectionHealth() call
+        let daemonStatusStart = Date()
         let daemonStatus = await ServiceHealthChecker.shared.getServiceStatus()
+        AppLogger.shared.log(
+            "⏱️ [TIMING] SystemValidator.checkComponents daemon status completed in \(String(format: "%.3f", Date().timeIntervalSince(daemonStatusStart)))s"
+        )
         let vhidServicesHealthy = daemonStatus.vhidServicesHealthy
         // Use launchctl-based VHID daemon health instead of pgrep-based detectConnectionHealth
         // to avoid concurrent pgrep calls that can cause hangs (see checkHealth which also calls it)
@@ -413,27 +427,65 @@ public class SystemValidator {
         // Treat the driver as installed if either the extension is enabled or a VHID device is present.
         // This avoids false negatives when launchd state is stale but the driver is already active.
         let karabinerDriverInstalled =
-            await (kanataManager?.isKarabinerDriverExtensionEnabled() ?? false)
-                || vhidInstalled || vhidHealthy
-        // Use launchctl-based check instead of unreliable pgrep (same as checkHealth)
-        let karabinerDaemonRunning = await ServiceHealthChecker.shared.isServiceHealthy(
-            serviceID: "com.keypath.karabiner-vhiddaemon"
-        )
+            facts.karabinerDriverExtensionEnabled || facts.vhidInstalled || vhidHealthy
+        let karabinerDaemonRunning = daemonStatus.vhidDaemonServiceHealthy
 
         AppLogger.shared
             .log(
-                "🔍 [SystemValidator] Components: kanata=\(kanataBinaryInstalled), driver=\(karabinerDriverInstalled), daemon=\(karabinerDaemonRunning), vhid=\(vhidHealthy), vhidServices=\(vhidServicesHealthy), vhidVersionMismatch=\(vhidVersionMismatch)"
+                "🔍 [SystemValidator] Components: kanata=\(facts.kanataBinaryInstalled), driver=\(karabinerDriverInstalled), daemon=\(karabinerDaemonRunning), vhid=\(vhidHealthy), vhidServices=\(vhidServicesHealthy), vhidVersionMismatch=\(facts.vhidVersionMismatch)"
             )
 
         return ComponentStatus(
-            kanataBinaryInstalled: kanataBinaryInstalled,
+            kanataBinaryInstalled: facts.kanataBinaryInstalled,
             karabinerDriverInstalled: karabinerDriverInstalled,
             karabinerDaemonRunning: karabinerDaemonRunning,
-            vhidDeviceInstalled: vhidInstalled,
+            vhidDeviceInstalled: facts.vhidInstalled,
             vhidDeviceHealthy: vhidHealthy,
             vhidServicesHealthy: vhidServicesHealthy,
-            vhidVersionMismatch: vhidVersionMismatch
+            vhidVersionMismatch: facts.vhidVersionMismatch
         )
+    }
+
+    private func componentInstallationFacts() async -> ComponentInstallationFacts {
+        if let cachedComponentFacts, cachedComponentFacts.isFresh(ttl: 15.0) {
+            AppLogger.shared.log("🔍 [SystemValidator] Component installation facts CACHE HIT")
+            return cachedComponentFacts
+        }
+
+        let start = Date()
+
+        // Check Kanata binary installation (canonical identity).
+        // The bundled binary at Contents/Library/KeyPath/kanata is the canonical path.
+        // TCC permissions survive app rebuilds at /Applications/KeyPath.app.
+        let kanataBinaryDetector = KanataBinaryDetector.shared
+        let kanataBinaryInstalled = kanataBinaryDetector.isInstalled()
+
+        let vhidStart = Date()
+        let vhidInstalled = vhidDeviceManager.detectInstallation()
+        let vhidVersionMismatch = vhidDeviceManager.hasVersionMismatch()
+        AppLogger.shared.log(
+            "⏱️ [TIMING] SystemValidator.checkComponents VHID static facts completed in \(String(format: "%.3f", Date().timeIntervalSince(vhidStart)))s"
+        )
+
+        let karabinerStart = Date()
+        let karabinerDriverExtensionEnabled =
+            await (kanataManager?.isKarabinerDriverExtensionEnabled() ?? false)
+        AppLogger.shared.log(
+            "⏱️ [TIMING] SystemValidator.checkComponents Karabiner extension check completed in \(String(format: "%.3f", Date().timeIntervalSince(karabinerStart)))s"
+        )
+
+        let facts = ComponentInstallationFacts(
+            kanataBinaryInstalled: kanataBinaryInstalled,
+            vhidInstalled: vhidInstalled,
+            vhidVersionMismatch: vhidVersionMismatch,
+            karabinerDriverExtensionEnabled: karabinerDriverExtensionEnabled,
+            timestamp: Date()
+        )
+        cachedComponentFacts = facts
+        AppLogger.shared.log(
+            "⏱️ [TIMING] SystemValidator.checkComponents static facts completed in \(String(format: "%.3f", Date().timeIntervalSince(start)))s"
+        )
+        return facts
     }
 
     // MARK: - Conflict Detection
@@ -506,18 +558,19 @@ public class SystemValidator {
         // is running via pgrep.
         AppLogger.shared.log("🔍 [SystemValidator] checkHealth() - About to check Kanata service health...")
         let kanataStart = Date()
-        let kanataHealth = await ServiceHealthChecker.shared.checkKanataServiceHealth(
+        let kanataHealth = await ServiceHealthChecker.shared.checkKanataServiceRuntimeSnapshot(
             tcpPort: PreferencesService.shared.tcpServerPort
         )
         let kanataRunning = kanataHealth.isRunning
         let stderrDiagnosis = await ServiceHealthChecker.shared.diagnoseDaemonStderr()
-        // Layer kanata's authoritative InputGrab signal (#630) over the stderr
-        // detector, identical to checkKanataServiceRuntimeSnapshot, so both
-        // health pipelines agree on input-capture readiness.
-        let inputCapture = ServiceHealthChecker.resolveInputCaptureStatus(stderrFallback: stderrDiagnosis.inputCapture)
+        let configParseError = Self.effectiveConfigParseError(
+            stderrDiagnosis.configParseError,
+            kanataRunning: kanataHealth.isRunning,
+            tcpResponding: kanataHealth.isResponding
+        )
         let kanataDuration = Date().timeIntervalSince(kanataStart)
         AppLogger.shared.log(
-            "🔍 [SystemValidator] checkHealth() - Kanata service check complete: hostRunning=\(kanataHealth.isRunning), tcpResponding=\(kanataHealth.isResponding), healthy=\(kanataRunning), inputCaptureReady=\(inputCapture.isReady), permRejected=\(stderrDiagnosis.permissionRejected) (took \(String(format: "%.3f", kanataDuration))s)"
+            "🔍 [SystemValidator] checkHealth() - Kanata service check complete: hostRunning=\(kanataHealth.isRunning), tcpResponding=\(kanataHealth.isResponding), healthy=\(kanataRunning), inputCaptureReady=\(kanataHealth.inputCaptureReady), permRejected=\(stderrDiagnosis.permissionRejected) (took \(String(format: "%.3f", kanataDuration))s)"
         )
 
         // Use launchctl-based check instead of unreliable pgrep
@@ -546,7 +599,11 @@ public class SystemValidator {
             "🔍 [SystemValidator] checkHealth() EXIT - Health: kanata=\(kanataRunning), daemon=\(karabinerDaemonRunning) (launchctl), vhid=\(vhidHealthy), permRejected=\(stderrDiagnosis.permissionRejected) (total: \(String(format: "%.3f", totalDuration))s)"
         )
 
-        if let configError = stderrDiagnosis.configParseError {
+        if stderrDiagnosis.configParseError != nil, configParseError == nil {
+            AppLogger.shared.warn(
+                "🔍 [SystemValidator] checkHealth() - Ignoring stale stderr config parse error because Kanata is running and TCP-responsive"
+            )
+        } else if let configError = configParseError {
             AppLogger.shared.error("🔍 [SystemValidator] checkHealth() - Config parse error detected: \(configError)")
         }
 
@@ -554,11 +611,20 @@ public class SystemValidator {
             kanataRunning: kanataRunning,
             karabinerDaemonRunning: karabinerDaemonRunning,
             vhidHealthy: vhidHealthy,
-            kanataInputCaptureReady: inputCapture.isReady,
-            kanataInputCaptureIssue: inputCapture.issue,
+            kanataInputCaptureReady: kanataHealth.inputCaptureReady,
+            kanataInputCaptureIssue: kanataHealth.inputCaptureIssue,
             kanataPermissionRejected: stderrDiagnosis.permissionRejected,
-            configParseError: stderrDiagnosis.configParseError
+            configParseError: configParseError
         )
+    }
+
+    static func effectiveConfigParseError(
+        _ stderrConfigParseError: String?,
+        kanataRunning: Bool,
+        tcpResponding: Bool
+    ) -> String? {
+        guard let stderrConfigParseError else { return nil }
+        return kanataRunning && tcpResponding ? nil : stderrConfigParseError
     }
 
     // MARK: - Debug Support

--- a/Sources/KeyPathInstallationWizard/Core/ServiceHealthChecker.swift
+++ b/Sources/KeyPathInstallationWizard/Core/ServiceHealthChecker.swift
@@ -41,13 +41,41 @@ public final class ServiceHealthChecker: @unchecked Sendable {
         }
     }
 
+    private struct RuntimeCacheEntry {
+        let snapshot: KanataServiceRuntimeSnapshot
+        let timestamp: Date
+        func isValid(ttl: TimeInterval) -> Bool {
+            Date().timeIntervalSince(timestamp) < ttl
+        }
+    }
+
+    private struct RuntimeCacheState {
+        var entry: RuntimeCacheEntry?
+        var inFlight: Task<KanataServiceRuntimeSnapshot, Never>?
+    }
+
+    private struct ServiceStatusCacheEntry {
+        let status: LaunchDaemonStatus
+        let timestamp: Date
+        func isValid(ttl: TimeInterval) -> Bool {
+            Date().timeIntervalSince(timestamp) < ttl
+        }
+    }
+
     private nonisolated static let healthCacheTTL: TimeInterval = 2.0
 
     private let healthCache = OSAllocatedUnfairLock(initialState: [String: HealthCacheEntry]())
+    private let runtimeCache = OSAllocatedUnfairLock(initialState: RuntimeCacheState())
+    private let serviceStatusCache = OSAllocatedUnfairLock(initialState: ServiceStatusCacheEntry?.none)
 
     /// Clear cached health results. Useful in tests or after service state changes.
     public nonisolated func invalidateHealthCache() {
         healthCache.withLock { $0.removeAll() }
+        runtimeCache.withLock {
+            $0.entry = nil
+            $0.inFlight = nil
+        }
+        serviceStatusCache.withLock { $0 = nil }
     }
 
     // MARK: - Dependencies
@@ -394,6 +422,13 @@ public final class ServiceHealthChecker: @unchecked Sendable {
     ///
     /// - Returns: `LaunchDaemonStatus` with loaded and healthy status for all services
     public nonisolated func getServiceStatus() async -> LaunchDaemonStatus {
+        if let cached = serviceStatusCache.withLock({ $0 }),
+           cached.isValid(ttl: Self.healthCacheTTL)
+        {
+            AppLogger.shared.log("🔍 [ServiceHealthChecker] getServiceStatus() CACHE HIT")
+            return cached.status
+        }
+
         // Fast path: Check Kanata state first to avoid expensive checks if SMAppService is managing it
         let kanataState = await getDaemonManager()?.refreshManagementState() ?? Self.fallbackManagementState
         let kanataLoaded: Bool
@@ -414,12 +449,12 @@ public final class ServiceHealthChecker: @unchecked Sendable {
         }
 
         // VHID services always use launchctl (no SMAppService option)
-        let vhidDaemonLoaded = await isServiceLoaded(serviceID: Self.vhidDaemonServiceID)
-        let vhidManagerLoaded = await isServiceLoaded(serviceID: Self.vhidManagerServiceID)
-        let vhidDaemonHealthy = await isServiceHealthy(serviceID: Self.vhidDaemonServiceID)
-        let vhidManagerHealthy = await isServiceHealthy(serviceID: Self.vhidManagerServiceID)
+        async let vhidDaemonLoaded = isServiceLoaded(serviceID: Self.vhidDaemonServiceID)
+        async let vhidManagerLoaded = isServiceLoaded(serviceID: Self.vhidManagerServiceID)
+        async let vhidDaemonHealthy = isServiceHealthy(serviceID: Self.vhidDaemonServiceID)
+        async let vhidManagerHealthy = isServiceHealthy(serviceID: Self.vhidManagerServiceID)
 
-        return LaunchDaemonStatus(
+        let status = await LaunchDaemonStatus(
             kanataServiceLoaded: kanataLoaded,
             vhidDaemonServiceLoaded: vhidDaemonLoaded,
             vhidManagerServiceLoaded: vhidManagerLoaded,
@@ -427,6 +462,10 @@ public final class ServiceHealthChecker: @unchecked Sendable {
             vhidDaemonServiceHealthy: vhidDaemonHealthy,
             vhidManagerServiceHealthy: vhidManagerHealthy
         )
+        serviceStatusCache.withLock {
+            $0 = ServiceStatusCacheEntry(status: status, timestamp: Date())
+        }
+        return status
     }
 
     // MARK: - Kanata-Specific Health Check
@@ -483,6 +522,43 @@ public final class ServiceHealthChecker: @unchecked Sendable {
             }
         #endif
 
+        if tcpPort == KeyPathConstants.Networking.defaultTCPPort, timeoutMs == 300,
+           ProcessInfo.processInfo.environment["KEYPATH_TCP_PORT"] == nil
+        {
+            if let cached = runtimeCache.withLock({ $0.entry }),
+               cached.isValid(ttl: Self.healthCacheTTL)
+            {
+                AppLogger.shared.log("🔍 [ServiceHealthChecker] Kanata runtime snapshot CACHE HIT")
+                return cached.snapshot
+            }
+
+            if let inFlight = runtimeCache.withLock({ $0.inFlight }) {
+                AppLogger.shared.log("🔍 [ServiceHealthChecker] Kanata runtime snapshot IN-FLIGHT HIT")
+                return await inFlight.value
+            }
+
+            let task = Task<KanataServiceRuntimeSnapshot, Never> {
+                await self.checkKanataServiceRuntimeSnapshotUncached(
+                    tcpPort: tcpPort,
+                    timeoutMs: timeoutMs
+                )
+            }
+            runtimeCache.withLock { $0.inFlight = task }
+            let snapshot = await task.value
+            runtimeCache.withLock {
+                $0.entry = RuntimeCacheEntry(snapshot: snapshot, timestamp: Date())
+                $0.inFlight = nil
+            }
+            return snapshot
+        }
+
+        return await checkKanataServiceRuntimeSnapshotUncached(tcpPort: tcpPort, timeoutMs: timeoutMs)
+    }
+
+    private nonisolated func checkKanataServiceRuntimeSnapshotUncached(
+        tcpPort: Int,
+        timeoutMs: Int
+    ) async -> KanataServiceRuntimeSnapshot {
         let managementState = await getDaemonManager()?.refreshManagementState() ?? Self.fallbackManagementState
         let staleEnabledRegistration: Bool = if managementState == .smappserviceActive {
             await getDaemonManager()?.isRegisteredButNotLoaded() ?? false

--- a/Tests/KeyPathTests/Infrastructure/KanataConfigurationGeneratorSnapshotTests.swift
+++ b/Tests/KeyPathTests/Infrastructure/KanataConfigurationGeneratorSnapshotTests.swift
@@ -216,6 +216,19 @@ final class KanataConfigurationGeneratorSnapshotTests: XCTestCase {
         )
     }
 
+    private func makeHomeRowModsCollection(_ config: HomeRowModsConfig) throws -> RuleCollection {
+        try makeCollection(
+            id: XCTUnwrap(UUID(uuidString: "22222222-2222-2222-2222-222222222222")),
+            name: "Home Row Mods",
+            summary: "HRM",
+            category: .custom,
+            mappings: [],
+            targetLayer: .base,
+            momentaryActivator: nil,
+            configuration: .homeRowMods(config)
+        )
+    }
+
     // MARK: - defhands + require-prior-idle Integration
 
     func testOppositeHandActivation_EmitsDefhandsBlock() throws {
@@ -321,6 +334,77 @@ final class KanataConfigurationGeneratorSnapshotTests: XCTestCase {
         let config = KanataConfiguration.generateFromCollections([hrmCollection])
 
         XCTAssertFalse(config.contains("require-prior-idle"), "Should not contain require-prior-idle when 0")
+    }
+
+    func testHomeRowModsUiMatrix_OffModeTimingAndDisabledKeysRenderCorrectly() throws {
+        var timing = TimingConfig.default
+        timing.tapWindow = 230
+        timing.holdDelay = 180
+        timing.quickTapEnabled = true
+        timing.quickTapTermMs = 25
+        timing.tapOffsets = ["a": 40]
+        timing.holdOffsets = ["a": 30]
+        timing.requirePriorIdleMs = 220
+
+        let collection = try makeHomeRowModsCollection(HomeRowModsConfig(
+            enabledKeys: ["a"],
+            modifierAssignments: ["a": "lsft", "s": "lctl"],
+            holdMode: .modifiers,
+            timing: timing,
+            keySelection: .custom,
+            oppositeHandMode: .off
+        ))
+
+        let config = KanataConfiguration.generateFromCollections([collection])
+
+        assertContains(config, "tap-hold-require-prior-idle 220")
+        assertContains(config, "beh_base_a (tap-hold-press 295 210 a lsft)")
+        XCTAssertFalse(config.contains("defhands"), "Opposite-hand off should not emit defhands")
+        XCTAssertFalse(config.contains("beh_base_s"), "Disabled HRM keys should not emit aliases")
+    }
+
+    func testHomeRowModsUiMatrix_OppositeHandReleaseRendersReleaseVariant() throws {
+        let collection = try makeHomeRowModsCollection(HomeRowModsConfig(
+            enabledKeys: ["a"],
+            modifierAssignments: ["a": "lsft"],
+            holdMode: .modifiers,
+            oppositeHandMode: .release
+        ))
+
+        let config = KanataConfiguration.generateFromCollections([collection])
+
+        assertContains(config, "(defhands")
+        assertContains(config, "beh_base_a (tap-hold-opposite-hand-release 150 a lsft)")
+    }
+
+    func testHomeRowModsUiMatrix_LayerModeRendersBothActivationVariants() throws {
+        let whileHeldCollection = try makeHomeRowModsCollection(HomeRowModsConfig(
+            enabledKeys: ["f"],
+            layerAssignments: ["f": "nav"],
+            holdMode: .layers,
+            layerToggleMode: .whileHeld,
+            keySelection: .custom,
+            oppositeHandMode: .off
+        ))
+        let whileHeldConfig = KanataConfiguration.generateFromCollections([whileHeldCollection])
+        assertContains(
+            whileHeldConfig,
+            "beh_base_f (tap-hold-press $tap-timeout 150 f (layer-while-held nav))"
+        )
+
+        let toggleCollection = try makeHomeRowModsCollection(HomeRowModsConfig(
+            enabledKeys: ["f"],
+            layerAssignments: ["f": "nav"],
+            holdMode: .layers,
+            layerToggleMode: .toggle,
+            keySelection: .custom,
+            oppositeHandMode: .off
+        ))
+        let toggleConfig = KanataConfiguration.generateFromCollections([toggleCollection])
+        assertContains(
+            toggleConfig,
+            "beh_base_f (tap-hold-press $tap-timeout 150 f (layer-toggle nav))"
+        )
     }
 
     // MARK: - Layer Reference Completeness

--- a/Tests/KeyPathTests/MainAppStateControllerTests.swift
+++ b/Tests/KeyPathTests/MainAppStateControllerTests.swift
@@ -43,6 +43,19 @@ struct MainAppStateControllerTests {
         )
     }
 
+    @Test("Validation timeout issue is non-blocking")
+    func validationTimeoutIssueIsNonBlocking() {
+        let issue = MainAppStateController.validationTimeoutIssue()
+
+        #expect(issue.identifier == .validationTimeout)
+        #expect(issue.severity == .warning)
+        #expect(issue.autoFixAction == nil)
+        #expect(
+            MainAppStateController.ValidationState.failed(blockingCount: 0, totalCount: 1)
+                .hasCriticalIssues == false
+        )
+    }
+
     @Test("ValidationState equality works correctly")
     func validationStateEquality() {
         #expect(MainAppStateController.ValidationState.success == .success)

--- a/Tests/KeyPathTests/Services/SystemValidatorTests.swift
+++ b/Tests/KeyPathTests/Services/SystemValidatorTests.swift
@@ -143,4 +143,26 @@ struct SystemValidatorTests {
         // validate() should assert in debug builds
         // (We can't test this directly without crashing the test)
     }
+
+    @Test("Healthy TCP-responsive Kanata suppresses stale stderr config parse errors")
+    func staleConfigParseErrorSuppressedWhenRuntimeResponsive() {
+        let error = SystemValidator.effectiveConfigParseError(
+            "Duplicate alias: beh_base_a",
+            kanataRunning: true,
+            tcpResponding: true
+        )
+
+        #expect(error == nil)
+    }
+
+    @Test("Non-responsive Kanata keeps stderr config parse errors")
+    func configParseErrorKeptWhenRuntimeIsNotResponsive() {
+        let error = SystemValidator.effectiveConfigParseError(
+            "Duplicate alias: beh_base_a",
+            kanataRunning: true,
+            tcpResponding: false
+        )
+
+        #expect(error == "Duplicate alias: beh_base_a")
+    }
 }

--- a/docs/testing/hrm-settings-release-qa.md
+++ b/docs/testing/hrm-settings-release-qa.md
@@ -1,0 +1,96 @@
+# Home Row Mods Settings Release QA
+
+This plan codifies the deeper Home Row Mods settings pass without adding a nightly
+or weekly automation job. Run it on demand for release candidates, public release
+prep, or after changes to HRM settings, overlay labels, rule collections, pack
+install, config generation, or the installed CLI.
+
+## Cadence
+
+| When | Check | Owner | Status |
+| --- | --- | --- | --- |
+| Every PR touching HRM logic | Focused Swift tests for mapping generation, overlay label resolution, config rendering, and pack/config persistence. | Developer | ✅ Active |
+| Release candidate | `Scripts/qa-hrm-settings-smoke.sh` against `/Applications/KeyPath.app/Contents/MacOS/keypath-cli`, followed by installed-app verification. | Release driver | ✅ Active |
+| Public release prep | Manual Computer Use pass through the HRM settings UI using the matrix below, plus unified log review. | Release driver | ✅ Active |
+| Nightly/weekly automation | Schedule the same smoke plus a small Computer Use subset in a stable macOS runner. | Future | 🚧 Future enhancement |
+
+## On-Demand Installed-App Smoke
+
+```bash
+./Scripts/qa-hrm-settings-smoke.sh
+REQUIRE_NOTARIZED=0 REQUIRE_STAPLED=0 ./Scripts/verify-installed-app.sh
+```
+
+For release-candidate builds that are notarized/stapled, run the installed-app
+verification without the relaxed environment variables:
+
+```bash
+./Scripts/verify-installed-app.sh
+```
+
+The HRM smoke script intentionally uses the installed CLI, backs up
+`~/.config/keypath`, mutates only the Home Row Mods collection, applies/reloads
+through the app path under test, asserts generated Kanata output, and restores
+the original config in an exit trap.
+
+## Manual Computer Use Matrix
+
+Legend: ✅ passed, ❌ failed with issue, 🚧 blocked, future, not exposed, or needs
+retest after a fix. Current status reflects the deeper installed-app pass run on
+2026-06-07.
+
+| Area | Feature or combination | Expected behavior | State |
+| --- | --- | --- | --- |
+| Entry point | Open Home Row Preferences from pack detail and overlay settings | Sheet opens, focus lands in sheet, Done closes it | ✅ |
+| Hold behavior | Modifiers mode | Hold labels are modifier glyphs; config emits modifier HRM actions | ✅ |
+| Hold behavior | Layers mode | UI and generated config emit layer hold/toggle actions | ✅ |
+| Hold behavior | Switch modifiers -> layers -> modifiers | UI, pack detail, and generated config converge on the final selection | ✅ |
+| Timing | Shared timing slider | Slider changes tap/hold preference and generated timings | ✅ |
+| Timing | Raw values view | Numeric/raw timing values match slider state and remain editable if exposed | ✅ |
+| Timing | Adjust independently disclosure | Per-finger and per-key controls reveal/collapse without losing values | ✅ |
+| Timing | Pinky/ring/middle/index offsets | Offset changes affect corresponding keys only | ✅ |
+| Timing | Quick tap checkbox | Enables/disables quick-tap term and generated tap window addition | ✅ |
+| Timing | Fast typing protection | Enables/disables `tap-hold-require-prior-idle` in generated config | ✅ |
+| Opposite-hand activation | Off | UI selection sticks; config omits `defhands` and uses non-opposite-hand tap-hold | ✅ |
+| Opposite-hand activation | On Press | UI selection sticks; config uses `tap-hold-opposite-hand` and `defhands` | ✅ |
+| Opposite-hand activation | On Release | UI selection sticks; config uses `tap-hold-opposite-hand-release` and `defhands` | ✅ |
+| Key selection | Both hands | Not exposed in the current Home Row Mods pack-detail UI; represented by default `enabledKeys` plus individual key chips | 🚧 Not current UI |
+| Key selection | Left hand only | Not exposed in the current Home Row Mods pack-detail UI; use individual key chips to disable right-hand keys | 🚧 Not current UI |
+| Key selection | Right hand only | Not exposed in the current Home Row Mods pack-detail UI; use individual key chips to disable left-hand keys | 🚧 Not current UI |
+| Key selection | Custom individual keys | Toggle each key on/off; disabled keys are omitted from generated config | ✅ |
+| Key selection | Re-enable disabled key with custom assignment | Re-enabled key preserves the user's previous assignment | ❌ [#809](https://github.com/malpern/KeyPath/issues/809) |
+| Assignments | Modifier assignment popovers | Per-key modifier changes persist and update overlay labels | ✅ |
+| Assignments | Existing layer assignment popovers | Per-key layer changes persist in config and pack detail chips | ✅ |
+| Assignments | New Layer flow from key chip | Created layer is assigned to the selected key | ❌ [#804](https://github.com/malpern/KeyPath/issues/804) |
+| Pack detail | Layer-mode copy and relationship text | Copy reflects layer-mode behavior and does not describe F as Command | ❌ [#805](https://github.com/malpern/KeyPath/issues/805) |
+| Overlay | Idle overlay in modifiers mode | Primary alpha remains large; small modifier appears below; HRM keys use subtle tint | ✅ |
+| Overlay | Idle overlay in layers mode | Primary alpha remains large; small layer label appears below; HRM keys use subtle tint | ❌ [#810](https://github.com/malpern/KeyPath/issues/810) |
+| Overlay | Press/hold ambiguity | Simulator confirms resolved hold output after the ambiguity window; live overlay transient still needs physical keydown/manual automation coverage | 🚧 Manual overlay check |
+| Persistence | Close/reopen sheet | All HRM settings survive sheet close/reopen | ✅ |
+| Persistence | Relaunch KeyPath | All HRM settings survive app relaunch and overlay rebuild | ✅ |
+| Pack interop | Ben Vallack system enabled | Vallack top-row mods and nav layer coexist with HRM UI conventions | ❌ [#811](https://github.com/malpern/KeyPath/issues/811) |
+| Pack interop | Switch Vallack off | Previous HRM settings restore from snapshot | ❌ [#811](https://github.com/malpern/KeyPath/issues/811) |
+| Logs | Unified logs during every apply/reload | No errors from config apply, helper routing, overlay label resolution, or Kanata reload | ✅ |
+
+## Recent Findings To Keep In Scope
+
+| Issue | Severity label | Regression check |
+| --- | --- | --- |
+| [#804](https://github.com/malpern/KeyPath/issues/804) | `1.0 release` | In layer mode, creating a new layer from HRM must assign the selected key to that layer. |
+| [#805](https://github.com/malpern/KeyPath/issues/805) | `post-release` | HRM pack detail copy should reflect layer mode after switching from modifiers. |
+| [#806](https://github.com/malpern/KeyPath/issues/806) | `post-release` | Hold-timing slider accessibility increment/decrement should change the value or stop exposing invalid actions. |
+| [#809](https://github.com/malpern/KeyPath/issues/809) | `post-release` | Disabling and re-enabling an HRM key should preserve that key's custom assignment. |
+| [#810](https://github.com/malpern/KeyPath/issues/810) | `1.0 release` | HRM layer mode overlay should show assigned layer labels, not alpha hold labels. |
+| [#811](https://github.com/malpern/KeyPath/issues/811) | `1.0 release` | Installing Vallack system should apply managed HRM/nav config and uninstall should restore the prior HRM snapshot without hanging. |
+
+## Log Review
+
+During the public-release manual pass, capture the last few minutes of logs:
+
+```bash
+log show --last 10m --style compact --predicate 'process == "KeyPath" OR process == "keypath-cli" OR process == "kanata" OR subsystem CONTAINS "keypath"'
+```
+
+Treat errors or repeated warnings from HRM config generation, privileged helper
+routing, Kanata reload, overlay label resolution, or accessibility interactions
+as release-blocking until classified.

--- a/docs/testing/testing-strategy.md
+++ b/docs/testing/testing-strategy.md
@@ -81,6 +81,9 @@ For behaviors that can't be automated: real key events through the CGEvent tap, 
 
 Use Claude Code computer-use or Peekaboo for spot-checking specific bugs — not as a test harness.
 
+For Home Row Mods release QA, use the focused checklist and installed-app smoke
+script in [hrm-settings-release-qa.md](hrm-settings-release-qa.md).
+
 ## Anti-Patterns
 
 - **Don't use computer-use as a test harness.** It's for debugging and spot-checks, not reproducible test suites. It's non-deterministic, expensive, and can't run in CI.


### PR DESCRIPTION
## Summary

- Fix false HRM stability failures by reducing repeated service/component probes and caching short-lived validation facts.
- Suppress stale Kanata stderr config-parse errors when the current runtime is healthy and TCP-responsive.
- Preserve the last known validation state on watchdog timeout and show one non-blocking timeout warning instead of fabricated blocking issues.
- Add an installed-app HRM settings smoke script and release QA checklist.

Fixes #812.

## Verification

- `swift test --filter 'SystemValidatorTests|MainAppStateControllerTests'`
- `./Scripts/test-fast.sh --changed` (full safe suite fallback, 4269 tests passed)
- `python3 Scripts/check-accessibility.py`
- `./Scripts/quick-deploy.sh`
- `REQUIRE_NOTARIZED=0 REQUIRE_STAPLED=0 ./Scripts/verify-installed-app.sh`
- Installed config check passed
- Computer Use confirmed healthy installed overlay with HRM alpha labels and modifier subtitles
