### PR TITLE
Harden settings and preferences test coverage

### DIFF
--- a/Sources/KeyPathAppKit/Services/Configuration/PreferencesService.swift
+++ b/Sources/KeyPathAppKit/Services/Configuration/PreferencesService.swift
@@ -181,7 +181,7 @@ final class PreferencesService: @unchecked Sendable {
     var tcpServerPort: Int {
         didSet {
             // Validate port range and revert if invalid
-            if !isValidPort(tcpServerPort) {
+            if !Self.isValidPort(tcpServerPort) {
                 AppLogger.shared.log(
                     "❌ [PreferencesService] Invalid TCP port \(tcpServerPort), reverting to \(oldValue)"
                 )
@@ -330,7 +330,7 @@ final class PreferencesService: @unchecked Sendable {
     /// Auto-dismiss timeout for the Context HUD (seconds, 1-10)
     var contextHUDTimeout: TimeInterval {
         didSet {
-            let clamped = min(max(contextHUDTimeout, 1), 10)
+            let clamped = Self.clampedContextHUDTimeout(contextHUDTimeout)
             if clamped != contextHUDTimeout {
                 contextHUDTimeout = clamped
             } else {
@@ -352,7 +352,7 @@ final class PreferencesService: @unchecked Sendable {
     /// Custom hold duration in milliseconds (used when preset is `.custom`).
     var contextHUDHoldDelayCustomMs: Int {
         didSet {
-            let clamped = min(max(contextHUDHoldDelayCustomMs, 100), 2000)
+            let clamped = Self.clampedContextHUDHoldDelayCustomMs(contextHUDHoldDelayCustomMs)
             if clamped != contextHUDHoldDelayCustomMs {
                 contextHUDHoldDelayCustomMs = clamped
             } else {
@@ -473,6 +473,12 @@ final class PreferencesService: @unchecked Sendable {
             AppLogger.shared.log(
                 "🔧 [PreferencesService] Migrated legacy TCP port \(storedTCPPort) → \(Defaults.tcpServerPort)"
             )
+        } else if let storedTCPPort, !Self.isValidPort(storedTCPPort) {
+            UserDefaults.standard.removeObject(forKey: Keys.tcpServerPort)
+            tcpServerPort = Defaults.tcpServerPort
+            AppLogger.shared.log(
+                "🔧 [PreferencesService] Removed invalid TCP port \(storedTCPPort); using \(Defaults.tcpServerPort)"
+            )
         } else {
             tcpServerPort = storedTCPPort ?? Defaults.tcpServerPort
         }
@@ -541,17 +547,26 @@ final class PreferencesService: @unchecked Sendable {
         contextHUDTriggerMode = ContextHUDTriggerMode(rawValue: triggerModeString)
             ?? Defaults.contextHUDTriggerMode
 
-        contextHUDTimeout = UserDefaults.standard.object(forKey: Keys.contextHUDTimeout) as? TimeInterval
-            ?? Defaults.contextHUDTimeout
+        let storedTimeout = UserDefaults.standard.object(forKey: Keys.contextHUDTimeout) as? TimeInterval
+        let rawTimeout = storedTimeout ?? Defaults.contextHUDTimeout
+        let sanitizedTimeout = Self.clampedContextHUDTimeout(rawTimeout)
+        contextHUDTimeout = sanitizedTimeout
+        if storedTimeout != nil, sanitizedTimeout != rawTimeout {
+            UserDefaults.standard.set(sanitizedTimeout, forKey: Keys.contextHUDTimeout)
+        }
 
         let holdDelayPresetString = UserDefaults.standard.string(forKey: Keys.contextHUDHoldDelayPreset)
             ?? Defaults.contextHUDHoldDelayPreset.rawValue
         contextHUDHoldDelayPreset = ContextHUDHoldDelayPreset(rawValue: holdDelayPresetString)
             ?? Defaults.contextHUDHoldDelayPreset
 
-        contextHUDHoldDelayCustomMs =
-            UserDefaults.standard.object(forKey: Keys.contextHUDHoldDelayCustomMs) as? Int
-                ?? Defaults.contextHUDHoldDelayCustomMs
+        let storedCustomDelay = UserDefaults.standard.object(forKey: Keys.contextHUDHoldDelayCustomMs) as? Int
+        let rawCustomDelay = storedCustomDelay ?? Defaults.contextHUDHoldDelayCustomMs
+        let sanitizedCustomDelay = Self.clampedContextHUDHoldDelayCustomMs(rawCustomDelay)
+        contextHUDHoldDelayCustomMs = sanitizedCustomDelay
+        if storedCustomDelay != nil, sanitizedCustomDelay != rawCustomDelay {
+            UserDefaults.standard.set(sanitizedCustomDelay, forKey: Keys.contextHUDHoldDelayCustomMs)
+        }
 
         let kindaVimHUDModeString = UserDefaults.standard.string(forKey: Keys.kindaVimLeaderHUDMode)
             ?? Defaults.kindaVimLeaderHUDMode.rawValue
@@ -589,12 +604,26 @@ final class PreferencesService: @unchecked Sendable {
 
     /// Validate port is in acceptable range
     func isValidPort(_ port: Int) -> Bool {
-        port >= 1024 && port <= 65535
+        Self.isValidPort(port)
     }
 
     /// Get current communication configuration as string for logging
     var communicationConfigDescription: String {
         "TCP on port \(tcpServerPort) (no authentication required)"
+    }
+}
+
+private extension PreferencesService {
+    static func isValidPort(_ port: Int) -> Bool {
+        port >= 1024 && port <= 65535
+    }
+
+    static func clampedContextHUDTimeout(_ timeout: TimeInterval) -> TimeInterval {
+        min(max(timeout, 1), 10)
+    }
+
+    static func clampedContextHUDHoldDelayCustomMs(_ delay: Int) -> Int {
+        min(max(delay, 100), 2000)
     }
 }
 

--- a/Tests/KeyPathTests/Services/KeyboardDisplayContextStoreTests.swift
+++ b/Tests/KeyPathTests/Services/KeyboardDisplayContextStoreTests.swift
@@ -2,10 +2,23 @@
 import XCTest
 
 final class KeyboardDisplayContextStoreTests: KeyPathTestCase {
+    private var tempDir: URL!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("KeyboardDisplayContextStoreTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() async throws {
+        try? FileManager.default.removeItem(at: tempDir)
+        tempDir = nil
+        try await super.tearDown()
+    }
+
     func testSaveLoadAndRemoveContext() async throws {
-        let tempURL = FileManager.default.temporaryDirectory
-            .appendingPathComponent(UUID().uuidString)
-            .appendingPathComponent("KeyboardDisplayContexts.json")
+        let tempURL = tempDir.appendingPathComponent("KeyboardDisplayContexts.json")
         let store = KeyboardDisplayContextStore.testStore(at: tempURL)
 
         let context = KeyboardDisplayContextStore.Context(
@@ -27,5 +40,45 @@ final class KeyboardDisplayContextStoreTests: KeyPathTestCase {
         try await store.removeContext(vendorProductKey: "29EA:1001")
         let removed = await store.context(vendorProductKey: "29EA:1001")
         XCTAssertNil(removed)
+    }
+
+    func testSavingContextReplacesSameDeviceLayoutAndKeymap() async throws {
+        let tempURL = tempDir.appendingPathComponent("KeyboardDisplayContexts.json")
+        let store = KeyboardDisplayContextStore.testStore(at: tempURL)
+
+        try await store.saveContext(KeyboardDisplayContextStore.Context(
+            vendorProductKey: "05AC:0341",
+            layoutId: "macbook-us",
+            keymapId: "qwerty",
+            includePunctuationStore: "{\"qwerty\":true}",
+            keyboardName: "Apple Internal Keyboard",
+            updatedAt: Date(timeIntervalSince1970: 1)
+        ))
+        try await store.saveContext(KeyboardDisplayContextStore.Context(
+            vendorProductKey: "05AC:0341",
+            layoutId: "macbook-jis",
+            keymapId: "dvorak",
+            includePunctuationStore: "{\"dvorak\":false}",
+            keyboardName: "Apple Internal Keyboard",
+            updatedAt: Date(timeIntervalSince1970: 2)
+        ))
+
+        let contexts = await store.allContexts()
+        XCTAssertEqual(contexts.count, 1)
+        XCTAssertEqual(contexts.first?.layoutId, "macbook-jis")
+        XCTAssertEqual(contexts.first?.keymapId, "dvorak")
+        XCTAssertEqual(contexts.first?.includePunctuationStore, "{\"dvorak\":false}")
+    }
+
+    func testMalformedContextFileLoadsEmpty() async throws {
+        let tempURL = tempDir.appendingPathComponent("KeyboardDisplayContexts.json")
+        try "not-json".write(to: tempURL, atomically: true, encoding: .utf8)
+        let store = KeyboardDisplayContextStore.testStore(at: tempURL)
+
+        let contexts = await store.allContexts()
+        let missingContext = await store.context(vendorProductKey: "05AC:0341")
+
+        XCTAssertTrue(contexts.isEmpty)
+        XCTAssertNil(missingContext)
     }
 }

--- a/Tests/KeyPathTests/Services/PreferencesServicePersistenceTests.swift
+++ b/Tests/KeyPathTests/Services/PreferencesServicePersistenceTests.swift
@@ -3,6 +3,233 @@
 
 @MainActor
 final class PreferencesServicePersistenceTests: XCTestCase {
+    private static let preferenceKeys = [
+        "KeyPath.Communication.Protocol",
+        "KeyPath.TCP.ServerPort",
+        "KeyPath.Notifications.Enabled",
+        "KeyPath.Recording.ApplyMappingsDuringRecording",
+        "KeyPath.Recording.IsSequenceMode",
+        "KeyPath.Diagnostics.VerboseKanataLogging",
+        "KeyPath.Testing.AccessibilityTestMode",
+        "KeyPath.LeaderKey.Preference",
+        "KeyPath.ContextHUD.DisplayMode",
+        "KeyPath.ContextHUD.TriggerMode",
+        "KeyPath.ContextHUD.Timeout",
+        "KeyPath.ContextHUD.HoldDelayPreset",
+        "KeyPath.ContextHUD.HoldDelayCustomMs",
+        "KeyPath.KindaVim.LeaderHUDMode",
+        "KeyPath.Neovim.ReferenceTopics",
+        "KeyPath.Neovim.ReferenceTopicsVersion",
+        "KeyPath.Display.KeyLabelStyle",
+        "KeyPath.Overlay.UnmappedLayerKeyStyle",
+        "KeyPath.Education.OverlayHiddenHintShowCount",
+        "KeyPath.Overlay.SuppressedBundleIDs",
+    ]
+
+    private func withPreservedDefaults<T>(
+        keys: [String] = PreferencesServicePersistenceTests.preferenceKeys,
+        _ body: () throws -> T
+    ) rethrows -> T {
+        let savedValues = Dictionary(uniqueKeysWithValues: keys.map { ($0, UserDefaults.standard.object(forKey: $0)) })
+        defer {
+            for key in keys {
+                if let value = savedValues[key] {
+                    UserDefaults.standard.set(value, forKey: key)
+                } else {
+                    UserDefaults.standard.removeObject(forKey: key)
+                }
+            }
+        }
+        return try body()
+    }
+
+    // MARK: - Critical Preference Round Trips
+
+    func testCriticalSettings_RoundTripThroughUserDefaults() {
+        withPreservedDefaults {
+            for key in Self.preferenceKeys {
+                UserDefaults.standard.removeObject(forKey: key)
+            }
+
+            let leader = LeaderKeyPreference(
+                key: "tab",
+                targetLayer: .custom("window"),
+                enabled: false
+            )
+            let writer = PreferencesService()
+            writer.tcpServerPort = 45678
+            writer.notificationsEnabled = false
+            writer.applyMappingsDuringRecording = false
+            writer.isSequenceMode = false
+            writer.verboseKanataLogging = false
+            writer.accessibilityTestMode = true
+            writer.keyLabelStyle = .text
+            writer.unmappedLayerKeyStyle = .dimmed
+            writer.leaderKeyPreference = leader
+            writer.overlayHiddenHintShowCount = 3
+            writer.overlaySuppressedBundleIDs = Set(["com.example.Editor", "com.example.Terminal"])
+            writer.contextHUDDisplayMode = .both
+            writer.contextHUDTriggerMode = .tapToToggle
+            writer.contextHUDTimeout = 6.5
+            writer.contextHUDHoldDelayPreset = .custom
+            writer.contextHUDHoldDelayCustomMs = 750
+            writer.kindaVimLeaderHUDMode = .cheatSheetOnly
+            writer.neovimReferenceTopics = Set([
+                NeovimTerminalCategory.basicMotions.rawValue,
+                NeovimTerminalCategory.search.rawValue,
+            ])
+
+            let loaded = PreferencesService()
+
+            XCTAssertEqual(loaded.tcpServerPort, 45678)
+            XCTAssertFalse(loaded.notificationsEnabled)
+            XCTAssertFalse(loaded.applyMappingsDuringRecording)
+            XCTAssertFalse(loaded.isSequenceMode)
+            XCTAssertFalse(loaded.verboseKanataLogging)
+            XCTAssertTrue(loaded.accessibilityTestMode)
+            XCTAssertEqual(loaded.keyLabelStyle, .text)
+            XCTAssertEqual(loaded.unmappedLayerKeyStyle, .dimmed)
+            XCTAssertEqual(loaded.leaderKeyPreference, leader)
+            XCTAssertEqual(loaded.overlayHiddenHintShowCount, 3)
+            XCTAssertEqual(loaded.overlaySuppressedBundleIDs, Set(["com.example.Editor", "com.example.Terminal"]))
+            XCTAssertEqual(loaded.contextHUDDisplayMode, .both)
+            XCTAssertEqual(loaded.contextHUDTriggerMode, .tapToToggle)
+            XCTAssertEqual(loaded.contextHUDTimeout, 6.5)
+            XCTAssertEqual(loaded.contextHUDHoldDelayPreset, .custom)
+            XCTAssertEqual(loaded.contextHUDHoldDelayCustomMs, 750)
+            XCTAssertEqual(loaded.contextHUDHoldDelayMs, 750)
+            XCTAssertEqual(loaded.kindaVimLeaderHUDMode, .cheatSheetOnly)
+            XCTAssertEqual(
+                loaded.neovimReferenceTopics,
+                Set([
+                    NeovimTerminalCategory.basicMotions.rawValue,
+                    NeovimTerminalCategory.search.rawValue,
+                ])
+            )
+        }
+    }
+
+    func testLoadClampsInvalidPersistedRuntimeAndHUDValues() {
+        withPreservedDefaults {
+            UserDefaults.standard.set(80, forKey: "KeyPath.TCP.ServerPort")
+            UserDefaults.standard.set(99.0, forKey: "KeyPath.ContextHUD.Timeout")
+            UserDefaults.standard.set(-25, forKey: "KeyPath.ContextHUD.HoldDelayCustomMs")
+
+            let prefs = PreferencesService()
+
+            XCTAssertEqual(prefs.tcpServerPort, 37001)
+            XCTAssertNil(UserDefaults.standard.object(forKey: "KeyPath.TCP.ServerPort"))
+            XCTAssertEqual(prefs.contextHUDTimeout, 10.0)
+            XCTAssertEqual(UserDefaults.standard.double(forKey: "KeyPath.ContextHUD.Timeout"), 10.0)
+            XCTAssertEqual(prefs.contextHUDHoldDelayCustomMs, 100)
+            XCTAssertEqual(UserDefaults.standard.integer(forKey: "KeyPath.ContextHUD.HoldDelayCustomMs"), 100)
+        }
+    }
+
+    func testLoadFallsBackForInvalidStoredEnumsAndLeaderPreference() {
+        withPreservedDefaults {
+            UserDefaults.standard.set("udp", forKey: "KeyPath.Communication.Protocol")
+            UserDefaults.standard.set("emoji", forKey: "KeyPath.Display.KeyLabelStyle")
+            UserDefaults.standard.set("invisible", forKey: "KeyPath.Overlay.UnmappedLayerKeyStyle")
+            UserDefaults.standard.set("drawer", forKey: "KeyPath.ContextHUD.DisplayMode")
+            UserDefaults.standard.set("doubleTap", forKey: "KeyPath.ContextHUD.TriggerMode")
+            UserDefaults.standard.set("instant", forKey: "KeyPath.ContextHUD.HoldDelayPreset")
+            UserDefaults.standard.set("coach", forKey: "KeyPath.KindaVim.LeaderHUDMode")
+            UserDefaults.standard.set(Data("not-json".utf8), forKey: "KeyPath.LeaderKey.Preference")
+            UserDefaults.standard.set(["search", "bogus-topic"], forKey: "KeyPath.Neovim.ReferenceTopics")
+            UserDefaults.standard.set(2, forKey: "KeyPath.Neovim.ReferenceTopicsVersion")
+
+            let prefs = PreferencesService()
+
+            XCTAssertEqual(prefs.communicationProtocol, .tcp)
+            XCTAssertEqual(prefs.keyLabelStyle, .symbols)
+            XCTAssertEqual(prefs.unmappedLayerKeyStyle, .baseLayer)
+            XCTAssertEqual(prefs.contextHUDDisplayMode, .overlayOnly)
+            XCTAssertEqual(prefs.contextHUDTriggerMode, .holdToShow)
+            XCTAssertEqual(prefs.contextHUDHoldDelayPreset, .long)
+            XCTAssertEqual(prefs.kindaVimLeaderHUDMode, .off)
+            XCTAssertEqual(prefs.leaderKeyPreference, .default)
+            XCTAssertEqual(prefs.neovimReferenceTopics, Set([NeovimTerminalCategory.search.rawValue]))
+        }
+    }
+
+    func testRuntimeAffectingPreferenceChangesPostNotifications() {
+        withPreservedDefaults {
+            let prefs = PreferencesService()
+            let recorder = NotificationRecorder()
+            let center = NotificationCenter.default
+            let observedNames: [Notification.Name] = [
+                .verboseLoggingChanged,
+                .accessibilityTestModeChanged,
+                .overlaySuppressedBundleIDsChanged,
+                .configAffectingPreferenceChanged,
+            ]
+            let observers = observedNames.map { name in
+                center.addObserver(forName: name, object: nil, queue: nil) { notification in
+                    recorder.record(notification.name)
+                }
+            }
+            defer {
+                for observer in observers {
+                    center.removeObserver(observer)
+                }
+            }
+
+            prefs.verboseKanataLogging.toggle()
+            prefs.accessibilityTestMode.toggle()
+            prefs.overlaySuppressedBundleIDs = Set(["com.example.SuppressMe"])
+            prefs.contextHUDTriggerMode = prefs.contextHUDTriggerMode == .holdToShow ? .tapToToggle : .holdToShow
+            prefs.contextHUDHoldDelayPreset = .custom
+            prefs.contextHUDHoldDelayCustomMs = 444
+
+            let postedNames = recorder.names
+            XCTAssertTrue(postedNames.contains(.verboseLoggingChanged))
+            XCTAssertTrue(postedNames.contains(.accessibilityTestModeChanged))
+            XCTAssertTrue(postedNames.contains(.overlaySuppressedBundleIDsChanged))
+            XCTAssertGreaterThanOrEqual(
+                postedNames.filter { $0 == .configAffectingPreferenceChanged }.count,
+                3
+            )
+        }
+    }
+
+    func testRuntimePreferencesAffectKanataLaunchArguments() {
+        withPreservedDefaults {
+            let tempDir = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+                .appendingPathComponent("PreferencesServiceConfigArgs-\(UUID().uuidString)", isDirectory: true)
+            defer { try? FileManager.default.removeItem(at: tempDir) }
+
+            let configService = ConfigurationService(configDirectory: tempDir.path)
+            let manager = ConfigurationManager(
+                configurationService: configService,
+                configBackupManager: ConfigBackupManager(configPath: configService.configurationPath),
+                configFileWatcher: nil
+            )
+
+            let prefs = PreferencesService.shared
+            let originalPort = prefs.tcpServerPort
+            let originalVerboseLogging = prefs.verboseKanataLogging
+            defer {
+                prefs.tcpServerPort = originalPort
+                prefs.verboseKanataLogging = originalVerboseLogging
+            }
+
+            prefs.tcpServerPort = 45678
+            prefs.verboseKanataLogging = true
+
+            let verboseArgs = manager.buildKanataArguments(checkOnly: false)
+            XCTAssertEqual(verboseArgs.portArgumentValue, "45678")
+            XCTAssertTrue(verboseArgs.contains("--trace"))
+            XCTAssertTrue(verboseArgs.contains("--log-layer-changes"))
+
+            prefs.verboseKanataLogging = false
+            let normalArgs = manager.buildKanataArguments(checkOnly: false)
+            XCTAssertEqual(normalArgs.portArgumentValue, "45678")
+            XCTAssertFalse(normalArgs.contains("--trace"))
+            XCTAssertTrue(normalArgs.contains("--log-layer-changes"))
+        }
+    }
+
     // MARK: - Value Clamping Tests
 
     func testContextHUDTimeout_ClampedToMinimum() {
@@ -438,5 +665,29 @@ final class PreferencesServicePersistenceTests: XCTestCase {
 
     func testNeovimTerminalCategory_InvalidRawValue() {
         XCTAssertNil(NeovimTerminalCategory(rawValue: "nonexistent"))
+    }
+}
+
+private extension [String] {
+    var portArgumentValue: String? {
+        guard let index = firstIndex(of: "--port"), index + 1 < count else { return nil }
+        return self[index + 1]
+    }
+}
+
+private final class NotificationRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var recordedNames: [Notification.Name] = []
+
+    var names: [Notification.Name] {
+        lock.lock()
+        defer { lock.unlock() }
+        return recordedNames
+    }
+
+    func record(_ name: Notification.Name) {
+        lock.lock()
+        recordedNames.append(name)
+        lock.unlock()
     }
 }


### PR DESCRIPTION
Closes #816

## Summary
- add critical PreferencesService UserDefaults round-trip, invalid-load fallback, clamping, notification, and Kanata launch-argument coverage
- sanitize invalid persisted TCP ports and stale Context HUD timeout/hold-delay values at load time
- expand keyboard display context persistence coverage for replacement and malformed-store recovery

## Validation
- `swift build`
- `swift test --filter PreferencesServicePersistenceTests`
- `swift test --filter KeyboardDisplayContextStoreTests`
- `./Scripts/test-fast.sh config`
- `python3 Scripts/check-accessibility.py`
- `swift test --filter "RecordingCoordinatorTests/testOutputRecordingFailsWhenAccessibilityDenied|HardViewSnapshotTests/testPackDetailCapsLockRemap"`

## Notes
- `./Scripts/test-fast.sh --changed` fell back to the full safe/snapshot suite and surfaced a pre-existing snapshot drift in `HardViewSnapshotTests.testPackDetailCapsLockRemap`: the reference image includes the “Part of Quick Launcher” badge while the isolated generated image does not. This PR does not touch pack detail rendering or snapshot baselines.
