### PR TITLE
[codex] Complete per-rule option coverage

### DIFF
--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionCatalog.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionCatalog.swift
@@ -50,6 +50,27 @@ struct RuleCollectionCatalog {
                 merged.configuration = existing.configuration
             }
         }
+
+        if existing.id == RuleCollectionIdentifier.windowSnapping {
+            if let convention = existing.windowKeyConvention {
+                merged.windowKeyConvention = convention
+                merged.mappings = Self.windowMappings(for: convention)
+            }
+
+            if let activationMode = existing.windowSnappingActivationMode {
+                merged.windowSnappingActivationMode = activationMode
+                merged.momentaryActivator = existing.momentaryActivator
+                merged.activationHint = existing.activationHint
+            }
+        }
+
+        if existing.id == RuleCollectionIdentifier.macFunctionKeys,
+           let mode = existing.functionKeyMode
+        {
+            merged.functionKeyMode = mode
+            merged.mappings = Self.functionKeyMappings(for: mode)
+        }
+
         return merged
     }
 

--- a/Tests/KeyPathTests/Integration/PerRuleOptionCoverageTests.swift
+++ b/Tests/KeyPathTests/Integration/PerRuleOptionCoverageTests.swift
@@ -1,0 +1,363 @@
+@testable import KeyPathAppKit
+import KeyPathCore
+import XCTest
+
+@MainActor
+final class PerRuleOptionCoverageTests: XCTestCase {
+    func testShippingRuleInventoryAccountsForEveryCatalogCollection() {
+        let expected: [UUID: (name: String, style: RuleCollectionDisplayStyle)] = [
+            RuleCollectionIdentifier.macFunctionKeys: ("macOS Function Keys", .table),
+            RuleCollectionIdentifier.leaderKey: ("Leader Key", .singleKeyPicker),
+            RuleCollectionIdentifier.vimNavigation: ("Vim - Apple Keyboard Shortcuts", .table),
+            RuleCollectionIdentifier.neovimTerminal: ("Neovim Terminal", .table),
+            RuleCollectionIdentifier.missionControl: ("Mission Control", .table),
+            RuleCollectionIdentifier.windowSnapping: ("Window Snapping", .table),
+            RuleCollectionIdentifier.capsLockRemap: ("Caps Lock Remap", .tapHoldPicker),
+            RuleCollectionIdentifier.backupCapsLock: ("Backup Caps Lock", .singleKeyPicker),
+            RuleCollectionIdentifier.escapeRemap: ("Escape", .singleKeyPicker),
+            RuleCollectionIdentifier.deleteRemap: ("Delete Enhancement", .singleKeyPicker),
+            RuleCollectionIdentifier.homeRowMods: ("Home Row Mods", .homeRowMods),
+            RuleCollectionIdentifier.homeRowLayerToggles: ("Home Row Layer Toggles", .homeRowLayerToggles),
+            RuleCollectionIdentifier.chordGroups: ("Chord Groups", .chordGroups),
+            RuleCollectionIdentifier.sequences: ("Sequences", .sequences),
+            RuleCollectionIdentifier.numpadLayer: ("Numpad", .table),
+            RuleCollectionIdentifier.symbolLayer: ("Symbol", .layerPresetPicker),
+            RuleCollectionIdentifier.funLayer: ("Function", .table),
+            RuleCollectionIdentifier.autoShiftSymbols: ("Auto Shift Symbols", .autoShiftSymbols),
+            RuleCollectionIdentifier.keyRepeatControl: ("Fast Navigation", .keyRepeatControl),
+            RuleCollectionIdentifier.homeRowArrows: ("Home Row Arrows", .layerPresetPicker),
+            RuleCollectionIdentifier.vallackNavigation: ("Ben Vallack Nav", .table),
+            RuleCollectionIdentifier.launcher: ("Quick Launcher", .launcherGrid)
+        ]
+
+        let collections = RuleCollectionCatalog().defaultCollections()
+        XCTAssertEqual(Set(collections.map(\.id)), Set(expected.keys))
+
+        for collection in collections {
+            let coverage = expected[collection.id]
+            XCTAssertEqual(collection.name, coverage?.name)
+            XCTAssertEqual(collection.displayStyle, coverage?.style, collection.name)
+        }
+    }
+
+    func testEveryEnabledTableCollectionEmitsDefaultConfigFragment() throws {
+        let tableIDs = [
+            RuleCollectionIdentifier.macFunctionKeys,
+            RuleCollectionIdentifier.vimNavigation,
+            RuleCollectionIdentifier.neovimTerminal,
+            RuleCollectionIdentifier.missionControl,
+            RuleCollectionIdentifier.windowSnapping,
+            RuleCollectionIdentifier.numpadLayer,
+            RuleCollectionIdentifier.funLayer,
+            RuleCollectionIdentifier.vallackNavigation
+        ]
+
+        for id in tableIDs {
+            var collection = try catalogCollection(id)
+            collection.isEnabled = true
+
+            let config = KanataConfiguration.generateFromCollections([collection])
+
+            assertContains(config, "(deflayer \(collection.targetLayer.kanataName)", collection.name)
+            let mapping = try XCTUnwrap(collection.mappings.first, collection.name)
+            assertContains(config, mapping.action.kanataOutput, collection.name)
+            assertBalanced(config, collection.name)
+        }
+    }
+
+    func testFunctionKeyModeVariantsEmitMediaAndStandardFunctionOutputs() throws {
+        var media = try catalogCollection(RuleCollectionIdentifier.macFunctionKeys)
+        media.isEnabled = true
+        media.functionKeyMode = .media
+        media.mappings = RuleCollectionCatalog.functionKeyMappings(for: .media)
+        let mediaConfig = KanataConfiguration.generateFromCollections([media])
+        assertContains(mediaConfig, "brdn", "media mode should emit brightness down")
+        assertContains(mediaConfig, "volu", "media mode should emit volume up")
+
+        var function = try catalogCollection(RuleCollectionIdentifier.macFunctionKeys)
+        function.isEnabled = true
+        function.functionKeyMode = .function
+        function.mappings = RuleCollectionCatalog.functionKeyMappings(for: .function)
+        let functionConfig = KanataConfiguration.generateFromCollections([function])
+        XCTAssertFalse(function.mappings.map(\.action.kanataOutput).contains("brdn"))
+        XCTAssertFalse(function.mappings.map(\.action.kanataOutput).contains("volu"))
+        assertContains(functionConfig, "(deflayer base", "function mode should still emit base layer")
+        assertBalanced(functionConfig, "function key mode")
+    }
+
+    func testWindowSnappingConventionVariantsEmitExpectedActionKeys() throws {
+        var standard = try catalogCollection(RuleCollectionIdentifier.windowSnapping)
+        standard.isEnabled = true
+        standard.windowKeyConvention = .standard
+        standard.mappings = RuleCollectionCatalog.windowMappings(for: .standard)
+        let standardConfig = KanataConfiguration.generateFromCollections([standard])
+        assertContains(standardConfig, #"act_window_l (push-msg "window:left")"#, "standard window left")
+        assertContains(standardConfig, #"act_window_r (push-msg "window:right")"#, "standard window right")
+
+        var vim = try catalogCollection(RuleCollectionIdentifier.windowSnapping)
+        vim.isEnabled = true
+        vim.windowKeyConvention = .vim
+        vim.mappings = RuleCollectionCatalog.windowMappings(for: .vim)
+        let vimConfig = KanataConfiguration.generateFromCollections([vim])
+        assertContains(vimConfig, #"act_window_h (push-msg "window:left")"#, "vim window left")
+        assertContains(vimConfig, #"act_window_l (push-msg "window:right")"#, "vim window right")
+    }
+
+    func testPickerAndGeneratedStyleOptionsEmitSpecificConfigFragments() throws {
+        var backupCaps = try catalogCollection(RuleCollectionIdentifier.backupCapsLock)
+        backupCaps.isEnabled = true
+        let backupConfig = KanataConfiguration.generateFromCollections([backupCaps])
+        assertContains(backupConfig, "(defchordsv2", "backup caps chord block")
+        assertContains(backupConfig, "(lsft rsft) caps $chord-timeout all-released ()", "backup caps chord")
+
+        var caps = try catalogCollection(RuleCollectionIdentifier.capsLockRemap)
+        caps.isEnabled = true
+        caps.configuration = .tapHoldPicker(TapHoldPickerConfig(
+            inputKey: "caps",
+            tapOptions: [SingleKeyPreset(output: "esc", label: "Escape", description: "")],
+            holdOptions: [SingleKeyPreset(output: "lctl", label: "Control", description: "")],
+            selectedTapOutput: "esc",
+            selectedHoldOutput: "lctl"
+        ))
+        let capsConfig = KanataConfiguration.generateFromCollections([caps])
+        assertContains(capsConfig, "beh_base_caps (tap-hold-press $tap-timeout $hold-timeout esc lctl)", "caps tap-hold picker")
+
+        var symbol = try catalogCollection(RuleCollectionIdentifier.symbolLayer)
+        symbol.isEnabled = true
+        symbol.configuration.updateSelectedPreset("paired")
+        let symbolConfig = KanataConfiguration.generateFromCollections([symbol])
+        assertContains(symbolConfig, "(deflayer sym", "symbol layer")
+        assertContains(symbolConfig, "(multi lsft grv)", "paired symbol preset")
+
+        var arrows = try catalogCollection(RuleCollectionIdentifier.homeRowArrows)
+        arrows.isEnabled = true
+        arrows.configuration.updateSelectedPreset("vim")
+        let arrowsConfig = KanataConfiguration.generateFromCollections([arrows])
+        assertContains(arrowsConfig, "(deflayer home-arrows", "home row arrows layer")
+        assertContains(arrowsConfig, "left", "vim arrow preset")
+    }
+
+    func testAdvancedGeneratedCollectionsEmitConfiguredFragments() {
+        let hrm = collection(
+            id: RuleCollectionIdentifier.homeRowMods,
+            name: "Home Row Mods",
+            configuration: .homeRowMods(HomeRowModsConfig(
+                enabledKeys: ["a"],
+                modifierAssignments: ["a": "lctl"],
+                holdMode: .modifiers,
+                oppositeHandMode: .off
+            ))
+        )
+        assertContains(
+            KanataConfiguration.generateFromCollections([hrm]),
+            "beh_base_a (tap-hold-press $tap-timeout 150 a lctl)",
+            "HRM modifier output"
+        )
+
+        let layerToggles = collection(
+            id: RuleCollectionIdentifier.homeRowLayerToggles,
+            name: "Home Row Layer Toggles",
+            configuration: .homeRowLayerToggles(HomeRowLayerTogglesConfig(
+                enabledKeys: ["f"],
+                layerAssignments: ["f": "nav"],
+                toggleMode: .toggle,
+                oppositeHandMode: .off
+            ))
+        )
+        assertContains(
+            KanataConfiguration.generateFromCollections([layerToggles]),
+            "beh_base_f (tap-hold-press $tap-timeout 150 f (layer-toggle nav))",
+            "home row layer toggle"
+        )
+
+        let chordGroup = ChordGroup(
+            id: UUID(uuidString: "11111111-1111-1111-1111-111111111111")!,
+            name: "kp-jk",
+            timeout: 175,
+            chords: [
+                ChordDefinition(
+                    id: UUID(uuidString: "22222222-2222-2222-2222-222222222222")!,
+                    keys: ["j", "k"],
+                    action: .keystroke(key: "esc")
+                )
+            ]
+        )
+        let chords = collection(
+            id: RuleCollectionIdentifier.chordGroups,
+            name: "Chord Groups",
+            configuration: .chordGroups(ChordGroupsConfig(groups: [chordGroup]))
+        )
+        let chordConfig = KanataConfiguration.generateFromCollections([chords])
+        assertContains(chordConfig, "(defchords kp-jk 175", "UI-authored chord group")
+        assertContains(chordConfig, "(j k) esc", "UI-authored chord output")
+
+        var autoShift = AutoShiftSymbolsConfig()
+        autoShift.enabledKeys = ["min"]
+        autoShift.timeoutMs = 175
+        autoShift.protectFastTyping = true
+        let autoShiftCollection = collection(
+            id: RuleCollectionIdentifier.autoShiftSymbols,
+            name: "Auto Shift Symbols",
+            configuration: .autoShiftSymbols(autoShift)
+        )
+        let autoShiftConfig = KanataConfiguration.generateFromCollections([autoShiftCollection])
+        assertContains(autoShiftConfig, "tap-hold-require-prior-idle 175", "auto-shift protect typing")
+        assertContains(autoShiftConfig, "beh_base_min (tap-hold 175 175 min S-min)", "auto-shift output")
+
+        var repeatConfig = KeyRepeatControlConfig()
+        repeatConfig.isEnabled = true
+        repeatConfig.globalDelayMs = 175
+        repeatConfig.globalIntervalMs = 30
+        repeatConfig.perKeyOverrides = [KeyRepeatOverride(key: "left", delayMs: 100, intervalMs: 15)]
+        let repeatCollection = collection(
+            id: RuleCollectionIdentifier.keyRepeatControl,
+            name: "Fast Navigation",
+            configuration: .keyRepeatControl(repeatConfig)
+        )
+        let repeatOutput = KanataConfiguration.generateFromCollections([repeatCollection])
+        assertContains(repeatOutput, "managed-repeat-delay 175", "repeat global delay")
+        assertContains(repeatOutput, "(left  100 15)", "repeat per-key override")
+    }
+
+    func testLauncherActionVariantsEmitPushMessages() {
+        var launcher = LauncherGridConfig()
+        launcher.hyperTriggerMode = .hold
+        launcher.mappings = [
+            LauncherMapping(key: "a", action: .launchApp(name: "Safari", bundleId: "com.apple.Safari")),
+            LauncherMapping(key: "u", action: .openURL("https://github.com")),
+            LauncherMapping(key: "f", action: .openFolder(path: "~/Downloads", name: "Downloads")),
+            LauncherMapping(key: "s", action: .runScript(path: "~/bin/demo.sh", name: "Demo")),
+            LauncherMapping(key: "m", action: .systemAction(id: "mission-control"))
+        ]
+        let launcherCollection = collection(
+            id: RuleCollectionIdentifier.launcher,
+            name: "Quick Launcher",
+            targetLayer: .custom("launcher"),
+            configuration: .launcherGrid(launcher)
+        )
+
+        let config = KanataConfiguration.generateFromCollections([launcherCollection])
+        assertContains(config, #"launch:com.apple.Safari"#, "launcher app action")
+        assertContains(config, #"open:https%3A%2F%2Fgithub.com"#, "launcher URL action")
+        assertContains(config, #"folder:~/Downloads"#, "launcher folder action")
+        assertContains(config, #"script:~/bin/demo.sh"#, "launcher script action")
+        assertContains(config, #"system:mission-control"#, "launcher system action")
+    }
+
+    func testCustomRuleFamiliesEmitConfigFragments() {
+        let collection = collection(
+            id: RuleCollectionIdentifier.customMappings,
+            name: "Custom Mappings",
+            mappings: [
+                KeyMapping(input: "caps", action: .keystroke(key: "esc")),
+                KeyMapping(input: "1", action: .keystroke(key: "1"), shiftedOutput: "S-1"),
+                KeyMapping(input: "a", action: .hyper),
+                KeyMapping(
+                    input: "s",
+                    action: .keystroke(key: "s"),
+                    behavior: .dualRole(DualRoleBehavior(
+                        tapAction: .keystroke(key: "s"),
+                        holdAction: .keystroke(key: "lalt"),
+                        activateHoldOnOtherKey: true
+                    ))
+                ),
+                KeyMapping(
+                    input: "d",
+                    action: .keystroke(key: "d"),
+                    behavior: .tapOrTapDance(.tapDance(TapDanceBehavior.twoStep(
+                        singleTap: .keystroke(key: "d"),
+                        doubleTap: .keystroke(key: "del"),
+                        windowMs: 175
+                    )))
+                ),
+                KeyMapping(
+                    input: "m",
+                    action: .keystroke(key: "m"),
+                    behavior: .macro(MacroBehavior(text: "ok"))
+                )
+            ]
+        )
+
+        let config = KanataConfiguration.generateFromCollections([collection])
+        assertContains(config, "esc", "simple remap")
+        assertContains(config, "fork 1 (multi lsft 1) (lsft rsft)", "shift-aware modifier variant")
+        assertContains(config, "act_base_a (multi lctl lmet lalt lsft)", "hyper modifier action")
+        assertContains(config, "tap-hold-press $tap-timeout $hold-timeout s lalt", "custom tap-hold")
+        assertContains(config, "tap-dance 175 (d del)", "tap dance")
+        assertContains(config, "(macro o k)", "text macro")
+    }
+
+    func testLeaderPreferenceAndPreservedSequencesEmitGeneratedConfigFragments() throws {
+        var nav = try catalogCollection(RuleCollectionIdentifier.vimNavigation)
+        nav.isEnabled = true
+
+        let leaderConfig = KanataConfiguration.generateFromCollections(
+            [nav],
+            leaderKeyPreference: LeaderKeyPreference(key: "space", targetLayer: .navigation, enabled: true),
+            navActivationMode: .tapToToggle
+        )
+        assertContains(leaderConfig, "layer_nav_spc", "leader preference alias")
+        assertContains(leaderConfig, "(one-shot-press 65000 (layer-while-held nav))", "leader one-shot nav")
+
+        let sequences = KanataDefseqParser.parseSequences(from: "(defseq window-leader (space w))")
+        let sequenceConfig = KanataConfiguration.generateFromCollections([nav], sequences: sequences)
+        assertContains(sequenceConfig, "(defseq", "preserved sequence block")
+        assertContains(sequenceConfig, "window-leader (space w)", "preserved sequence")
+    }
+
+    private func catalogCollection(_ id: UUID) throws -> RuleCollection {
+        try XCTUnwrap(
+            RuleCollectionCatalog().defaultCollections().first { $0.id == id },
+            "Missing catalog collection \(id)"
+        )
+    }
+
+    private func collection(
+        id: UUID,
+        name: String,
+        mappings: [KeyMapping] = [],
+        targetLayer: RuleCollectionLayer = .base,
+        configuration: RuleCollectionConfiguration = .list
+    ) -> RuleCollection {
+        RuleCollection(
+            id: id,
+            name: name,
+            summary: name,
+            category: .custom,
+            mappings: mappings,
+            isEnabled: true,
+            targetLayer: targetLayer,
+            configuration: configuration
+        )
+    }
+
+    private func assertContains(
+        _ config: String,
+        _ snippet: String,
+        _ context: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        XCTAssertTrue(
+            config.contains(snippet),
+            "Expected \(context) to contain:\n\(snippet)\n\nActual output:\n\(config)",
+            file: file,
+            line: line
+        )
+    }
+
+    private func assertBalanced(
+        _ config: String,
+        _ context: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        XCTAssertEqual(
+            config.filter { $0 == "(" }.count,
+            config.filter { $0 == ")" }.count,
+            "Unbalanced generated config for \(context)\n\nActual output:\n\(config)",
+            file: file,
+            line: line
+        )
+    }
+}

--- a/Tests/KeyPathTests/RuleCollections/RuleCollectionCatalogTests.swift
+++ b/Tests/KeyPathTests/RuleCollections/RuleCollectionCatalogTests.swift
@@ -96,6 +96,29 @@ final class RuleCollectionCatalogTests: XCTestCase {
         XCTAssertEqual(upgraded.name, "Unknown")
     }
 
+    func testUpgradedCollection_PreservesGeneratedOptionMappings() throws {
+        let catalog = RuleCollectionCatalog()
+
+        var windowSnapping = try XCTUnwrap(catalog.defaultCollections().first { $0.id == RuleCollectionIdentifier.windowSnapping })
+        windowSnapping.windowKeyConvention = .vim
+        windowSnapping.windowSnappingActivationMode = .quickLauncher
+        windowSnapping.mappings = RuleCollectionCatalog.windowMappings(for: .vim)
+
+        let upgradedWindowSnapping = catalog.upgradedCollection(from: windowSnapping)
+        XCTAssertEqual(upgradedWindowSnapping.windowKeyConvention, .vim)
+        XCTAssertEqual(upgradedWindowSnapping.windowSnappingActivationMode, .quickLauncher)
+        XCTAssertEqual(upgradedWindowSnapping.mappings.first?.input, "h")
+        XCTAssertEqual(upgradedWindowSnapping.mappings.first?.action, .rawKanata(#"(push-msg "window:left")"#))
+
+        var functionKeys = try XCTUnwrap(catalog.defaultCollections().first { $0.id == RuleCollectionIdentifier.macFunctionKeys })
+        functionKeys.functionKeyMode = .function
+        functionKeys.mappings = RuleCollectionCatalog.functionKeyMappings(for: .function)
+
+        let upgradedFunctionKeys = catalog.upgradedCollection(from: functionKeys)
+        XCTAssertEqual(upgradedFunctionKeys.functionKeyMode, .function)
+        XCTAssertEqual(upgradedFunctionKeys.mappings.first?.action, .keystroke(key: "f1"))
+    }
+
     // MARK: - Launcher Collection
 
     func testLauncherCollection_HasCorrectID() {

--- a/Tests/KeyPathTests/RuleCollections/RuleCollectionStorePersistenceTests.swift
+++ b/Tests/KeyPathTests/RuleCollections/RuleCollectionStorePersistenceTests.swift
@@ -56,6 +56,172 @@ final class RuleCollectionStorePersistenceTests: XCTestCase {
         XCTAssertFalse(hrmReloaded?.isEnabled ?? true)
     }
 
+    func testSaveAndLoad_PreservesPerRuleOptionConfigurations() async throws {
+        let store = makeStore()
+        var collections = await store.loadCollections()
+
+        if let idx = collections.firstIndex(where: { $0.id == RuleCollectionIdentifier.capsLockRemap }) {
+            collections[idx].isEnabled = true
+            collections[idx].configuration.updateSelectedTapOutput("esc")
+            collections[idx].configuration.updateSelectedHoldOutput("lctl")
+        }
+
+        if let idx = collections.firstIndex(where: { $0.id == RuleCollectionIdentifier.homeRowMods }) {
+            var timing = TimingConfig.default
+            timing.tapWindow = 210
+            timing.holdDelay = 170
+            timing.quickTapEnabled = true
+            timing.requirePriorIdleMs = 120
+            collections[idx].isEnabled = true
+            collections[idx].configuration = .homeRowMods(HomeRowModsConfig(
+                enabledKeys: ["a", "s"],
+                modifierAssignments: ["a": "lctl", "s": "lalt"],
+                holdMode: .modifiers,
+                timing: timing,
+                keySelection: .custom,
+                oppositeHandMode: .release
+            ))
+        }
+
+        if let idx = collections.firstIndex(where: { $0.id == RuleCollectionIdentifier.homeRowLayerToggles }) {
+            collections[idx].isEnabled = true
+            collections[idx].configuration = .homeRowLayerToggles(HomeRowLayerTogglesConfig(
+                enabledKeys: ["f"],
+                layerAssignments: ["f": "nav"],
+                keySelection: .custom,
+                toggleMode: .toggle,
+                showAdvanced: true,
+                oppositeHandMode: .off
+            ))
+        }
+
+        if let idx = collections.firstIndex(where: { $0.id == RuleCollectionIdentifier.chordGroups }) {
+            let chordGroup = ChordGroup(
+                id: UUID(uuidString: "11111111-1111-1111-1111-111111111111")!,
+                name: "persist-jk",
+                timeout: 180,
+                chords: [
+                    ChordDefinition(
+                        id: UUID(uuidString: "22222222-2222-2222-2222-222222222222")!,
+                        keys: ["j", "k"],
+                        action: .keystroke(key: "esc")
+                    )
+                ]
+            )
+            collections[idx].isEnabled = true
+            collections[idx].configuration = .chordGroups(ChordGroupsConfig(groups: [chordGroup], activeGroupID: chordGroup.id, showAdvanced: true))
+        }
+
+        if let idx = collections.firstIndex(where: { $0.id == RuleCollectionIdentifier.sequences }) {
+            let sequence = SequenceDefinition(
+                id: UUID(uuidString: "33333333-3333-3333-3333-333333333333")!,
+                name: "Window",
+                keys: ["space", "w"],
+                action: .activateLayer(.custom("window"))
+            )
+            collections[idx].isEnabled = true
+            collections[idx].configuration = .sequences(SequencesConfig(sequences: [sequence], activeSequenceID: sequence.id, globalTimeout: 750))
+        }
+
+        if let idx = collections.firstIndex(where: { $0.id == RuleCollectionIdentifier.symbolLayer }) {
+            collections[idx].isEnabled = true
+            collections[idx].configuration.updateSelectedPreset("programmer")
+        }
+
+        if let idx = collections.firstIndex(where: { $0.id == RuleCollectionIdentifier.launcher }) {
+            collections[idx].isEnabled = true
+            collections[idx].configuration = .launcherGrid(LauncherGridConfig(
+                activationMode: .holdHyper,
+                hyperTriggerMode: .tap,
+                mappings: [
+                    LauncherMapping(key: "a", action: .launchApp(name: "Safari", bundleId: "com.apple.Safari")),
+                    LauncherMapping(key: "u", action: .openURL("https://github.com")),
+                ],
+                hasSeenWelcome: true
+            ))
+        }
+
+        if let idx = collections.firstIndex(where: { $0.id == RuleCollectionIdentifier.autoShiftSymbols }) {
+            var config = AutoShiftSymbolsConfig()
+            config.enabledKeys = ["min", "eql"]
+            config.timeoutMs = 190
+            config.protectFastTyping = true
+            collections[idx].isEnabled = true
+            collections[idx].configuration = .autoShiftSymbols(config)
+        }
+
+        if let idx = collections.firstIndex(where: { $0.id == RuleCollectionIdentifier.keyRepeatControl }) {
+            collections[idx].isEnabled = true
+            collections[idx].configuration = .keyRepeatControl(KeyRepeatControlConfig(
+                isEnabled: true,
+                globalDelayMs: 175,
+                globalIntervalMs: 25,
+                perKeyOverrides: [KeyRepeatOverride(key: "left", delayMs: 100, intervalMs: 15)]
+            ))
+        }
+
+        if let idx = collections.firstIndex(where: { $0.id == RuleCollectionIdentifier.windowSnapping }) {
+            collections[idx].isEnabled = true
+            collections[idx].windowKeyConvention = .vim
+            collections[idx].windowSnappingActivationMode = .quickLauncher
+            collections[idx].mappings = RuleCollectionCatalog.windowMappings(for: .vim)
+        }
+
+        if let idx = collections.firstIndex(where: { $0.id == RuleCollectionIdentifier.macFunctionKeys }) {
+            collections[idx].functionKeyMode = .function
+            collections[idx].mappings = RuleCollectionCatalog.functionKeyMappings(for: .function)
+        }
+
+        try await store.saveCollections(collections)
+
+        let reloaded = await makeStore().loadCollections()
+
+        let caps = try XCTUnwrap(reloaded.first { $0.id == RuleCollectionIdentifier.capsLockRemap })
+        XCTAssertEqual(caps.configuration.tapHoldPickerConfig?.selectedTapOutput, "esc")
+        XCTAssertEqual(caps.configuration.tapHoldPickerConfig?.selectedHoldOutput, "lctl")
+
+        let hrm = try XCTUnwrap(reloaded.first { $0.id == RuleCollectionIdentifier.homeRowMods })
+        XCTAssertEqual(hrm.configuration.homeRowModsConfig?.enabledKeys, ["a", "s"])
+        XCTAssertEqual(hrm.configuration.homeRowModsConfig?.timing.requirePriorIdleMs, 120)
+        XCTAssertEqual(hrm.configuration.homeRowModsConfig?.oppositeHandMode, .release)
+
+        let toggles = try XCTUnwrap(reloaded.first { $0.id == RuleCollectionIdentifier.homeRowLayerToggles })
+        XCTAssertEqual(toggles.configuration.homeRowLayerTogglesConfig?.layerAssignments["f"], "nav")
+        XCTAssertEqual(toggles.configuration.homeRowLayerTogglesConfig?.toggleMode, .toggle)
+
+        let chords = try XCTUnwrap(reloaded.first { $0.id == RuleCollectionIdentifier.chordGroups })
+        XCTAssertEqual(chords.configuration.chordGroupsConfig?.groups.first?.name, "persist-jk")
+        XCTAssertEqual(chords.configuration.chordGroupsConfig?.showAdvanced, true)
+
+        let sequences = try XCTUnwrap(reloaded.first { $0.id == RuleCollectionIdentifier.sequences })
+        XCTAssertEqual(sequences.configuration.sequencesConfig?.sequences.first?.keys, ["space", "w"])
+        XCTAssertEqual(sequences.configuration.sequencesConfig?.globalTimeout, 750)
+
+        let symbol = try XCTUnwrap(reloaded.first { $0.id == RuleCollectionIdentifier.symbolLayer })
+        XCTAssertEqual(symbol.configuration.layerPresetPickerConfig?.selectedPresetId, "programmer")
+
+        let launcher = try XCTUnwrap(reloaded.first { $0.id == RuleCollectionIdentifier.launcher })
+        XCTAssertEqual(launcher.configuration.launcherGridConfig?.hyperTriggerMode, .tap)
+        XCTAssertEqual(launcher.configuration.launcherGridConfig?.mappings.count, 2)
+
+        let autoShift = try XCTUnwrap(reloaded.first { $0.id == RuleCollectionIdentifier.autoShiftSymbols })
+        XCTAssertEqual(autoShift.configuration.autoShiftSymbolsConfig?.enabledKeys, ["min", "eql"])
+        XCTAssertEqual(autoShift.configuration.autoShiftSymbolsConfig?.protectFastTyping, true)
+
+        let repeatControl = try XCTUnwrap(reloaded.first { $0.id == RuleCollectionIdentifier.keyRepeatControl })
+        XCTAssertEqual(repeatControl.configuration.keyRepeatControlConfig?.globalDelayMs, 175)
+        XCTAssertEqual(repeatControl.configuration.keyRepeatControlConfig?.perKeyOverrides.first?.intervalMs, 15)
+
+        let window = try XCTUnwrap(reloaded.first { $0.id == RuleCollectionIdentifier.windowSnapping })
+        XCTAssertEqual(window.windowKeyConvention, .vim)
+        XCTAssertEqual(window.windowSnappingActivationMode, .quickLauncher)
+        XCTAssertEqual(window.mappings.first?.input, "h")
+
+        let functionKeys = try XCTUnwrap(reloaded.first { $0.id == RuleCollectionIdentifier.macFunctionKeys })
+        XCTAssertEqual(functionKeys.functionKeyMode, .function)
+        XCTAssertEqual(functionKeys.mappings.first?.action, .keystroke(key: "f1"))
+    }
+
     // MARK: - Corrupt file → resilient recovery
 
     func testLoadCollections_CorruptFile_FallsBackToDefaults() async throws {

--- a/docs/testing/keypath-1.0-release-qa.md
+++ b/docs/testing/keypath-1.0-release-qa.md
@@ -130,15 +130,15 @@ current UI, `TODO` not yet assessed in the 1.0 matrix.
 
 | Area | Workflow | Expected release evidence | Status |
 | --- | --- | --- | --- |
-| Rules | Simple remap | UI creates rule, config maps source to target, reload clean | TODO #819 |
-| Rules | Modifier/hyper remap | Modifier options persist and render correct Kanata output | TODO #819 |
-| Rules | Tap-hold / dual-role | Timing/options persist; config emits correct dual-role behavior | TODO #819 |
+| Rules | Simple remap | UI creates rule, config maps source to target, reload clean | PASS #819 |
+| Rules | Modifier/hyper remap | Modifier options persist and render correct Kanata output | PASS #819 |
+| Rules | Tap-hold / dual-role | Timing/options persist; config emits correct dual-role behavior | PASS #819 |
 | Rules | Home Row Mods | See [hrm-settings-release-qa.md](hrm-settings-release-qa.md) | MANUAL #804 #810 #811 |
-| Rules | Layers and navigation | Layer controls update config, overlay labels, and runtime layer state | TODO #819 |
-| Rules | Launcher/app/system/URL actions | UI actions persist and generated behavior matches expected action type | TODO #819 |
-| Rules | Function/media keys | Pack/rule options emit correct media/function mappings | TODO #819 |
-| Rules | Chords/sequences/tap dance/macros/text | Shipping options have config and persistence assertions | TODO #819 |
-| Rules | App-specific mappings | App context persists and affects generated conditional config | TODO #819 |
+| Rules | Layers and navigation | Layer controls update config, overlay labels, and runtime layer state | PASS #819 |
+| Rules | Launcher/app/system/URL actions | UI actions persist and generated behavior matches expected action type | PASS #819 |
+| Rules | Function/media keys | Pack/rule options emit correct media/function mappings | PASS #819 |
+| Rules | Chords/sequences/tap dance/macros/text | Shipping options have config and persistence assertions | PASS #819 |
+| Rules | App-specific mappings | App context persists and affects generated conditional config | PASS #819 |
 | Packs | Install/uninstall common packs | Managed collections apply, snapshot, restore, and reload cleanly | TODO #815 |
 | Packs | Vallack system | Managed HRM/nav config applies and restores without hang | FAIL #811 |
 | Overlay | Base rendering | Geometry follows physical layout; labels follow logical keymap | TODO #818 |
@@ -155,6 +155,43 @@ current UI, `TODO` not yet assessed in the 1.0 matrix.
 | Settings | Advanced/runtime controls | Controls persist, route through helper/runtime, and log cleanly | TODO #816 #817 |
 | Runtime | Config validate/apply/reload | `qa-keypath-release-smoke.sh` applies representative fixtures, validates with bundled Kanata, reloads, checks TCP, and restores config | PASS #815 |
 | Runtime | Log review | `qa-keypath-log-gate.sh` captures recent app/CLI/Kanata/unified logs and fails on unclassified high-signal errors | PASS #817 |
+
+## Per-Rule Option Coverage Matrix
+
+Automated coverage is intentionally concentrated below the full UI. The current
+per-rule matrix is covered by:
+
+- `PerRuleOptionCoverageTests`: catalog inventory, representative generated
+  Kanata fragments for each shipping collection style, key option variants, and
+  custom behavior families.
+- `RuleCollectionStorePersistenceTests.testSaveAndLoad_PreservesPerRuleOptionConfigurations`:
+  persistence round-trip for editable per-rule options.
+- Existing focused suites for app-specific mappings, HRM timing, chord groups,
+  sequences parsing/preservation, launcher key validation, keymap mappings, and
+  UI snapshots.
+
+| Rule family / collection | Config evidence | Persistence/UI wiring evidence | Release QA row |
+| --- | --- | --- | --- |
+| Simple custom remap | `caps -> esc` generated fragment asserted | Custom rule model/store tests plus manual Rules editor row | Rules: Simple remap |
+| Modifier and Hyper/Meh remaps | Hyper action expands to Kanata `multi`; shift-aware fork output asserted | Mapping behavior and rule configuration helpers | Rules: Modifier/hyper remap |
+| Tap-hold / dual-role | Caps picker and custom dual-role emit `tap-hold-press`; HRM variants cover opposite-hand and timing | Tap/hold picker selections persist | Rules: Tap-hold / dual-role |
+| Home Row Mods | Modifier, layer, timing, quick-tap, require-prior-idle, and opposite-hand fragments asserted | HRM config persists; dedicated HRM manual QA remains for real UI/runtime | Rules: Home Row Mods |
+| Home Row Layer Toggles | `layer-while-held` and `layer-toggle` variants asserted with referenced layer generation | Layer assignment/toggle mode persists | Rules: Layers and navigation |
+| Navigation layers | Vim, Neovim, Mission Control, Numpad, Function, Home Row Arrows, and Vallack layer outputs asserted | Layer preset selections persist | Rules: Layers and navigation |
+| Leader key | Leader preference emits `layer_nav_spc` and one-shot nav activation | `LeaderKeyPreference` codable/persistence tests; UI row remains manual | Rules: Layers and navigation |
+| Window Snapping | Standard and Vim conventions assert action-key placement and `push-msg "window:*"` output | Convention and activation mode persist; dependency auto-enable covered by view-model sync tests | Rules: Layers and navigation |
+| Launcher actions | App, URL, folder, script, and system action push messages asserted | Launcher grid config and mappings persist | Rules: Launcher/app/system/URL actions |
+| Function/media keys | Media mode emits brightness/volume; F-key mode removes media outputs | Function key mode and generated mapping list persist | Rules: Function/media keys |
+| Chord groups | UI-authored `defchords` block and chord outputs asserted | Chord groups config persists; conflict tests cover validation | Rules: Chords/sequences/tap dance/macros/text |
+| Sequences | Existing tests preserve parsed manual `defseq` blocks through regeneration | `SequencesConfig` persists and UI model helpers round-trip; UI-authored runtime generation should be rechecked in installed QA | Rules: Chords/sequences/tap dance/macros/text |
+| Tap dance | Custom tap-dance generated fragment asserted | Mapping behavior codable tests | Rules: Chords/sequences/tap dance/macros/text |
+| Macro / text output | Text macro generated fragment asserted; text-to-Kanata mapper tests cover conversion breadth | Mapping behavior codable tests | Rules: Chords/sequences/tap dance/macros/text |
+| Auto Shift Symbols | Shifted tap-hold output and fast-typing protection asserted | Auto-shift config persists | Rules: Chords/sequences/tap dance/macros/text |
+| Fast Navigation / Key Repeat | `managed-repeat` defcfg and per-key `defrepeat` override asserted | Key repeat config persists | Rules: Function/media keys |
+| Backup Caps Lock | Both-shift chord emits `defchordsv2` | Single-key picker configuration persists through catalog store | Rules: Chords/sequences/tap dance/macros/text |
+| Escape / Delete single-key pickers | Catalog table/picker default outputs included in generated config | Picker config helpers and store persistence cover selected output | Rules: Simple remap |
+| App-specific mappings | `AppConfigGeneratorTests` assert virtual keys, switch aliases, duplicate handling, disabled apps, and sanitized keys | `AppKeymapStoreTests` and mapper app-specific tests cover storage/model wiring | Rules: App-specific mappings |
+| Disabled/enabled state and conflicts | Disabled collections excluded from config; conflict/deduplication suites cover overlapping keys and save-time behavior | Store persistence covers enabled state; manager tests cover API wiring | Rules: Simple remap |
 
 ## Stop Doing
 


### PR DESCRIPTION
## Summary
- add a per-rule option coverage suite that inventories all shipping rule collections and asserts representative Kanata output for default paths and key option variants
- preserve generated option mappings during catalog upgrades for window snapping conventions and function key modes
- extend persistence tests for editable per-rule options and update the 1.0 QA matrix with #819 evidence

## Root cause
Catalog upgrades started from fresh built-in definitions and only preserved `configuration`, so top-level generated option fields such as `windowKeyConvention` and `functionKeyMode` could be lost on reload.

## Validation
- `swift test --filter PerRuleOptionCoverageTests`
- `swift test --filter RuleCollectionStorePersistenceTests`
- `swift test --filter RuleCollectionCatalogTests`
- `swift build --jobs 4`
- `python3 Scripts/check-accessibility.py`
- `./Scripts/test-fast.sh rules`
- `./Scripts/test-fast.sh --changed` (full safe fallback; 4280 passed)

Closes #819
