### PR TITLE
Fix HRM layer assignment and Vallack pack apply

### DIFF
--- a/Sources/KeyPathAppKit/Services/LayerMapping/LayerMappingBuilder.swift
+++ b/Sources/KeyPathAppKit/Services/LayerMapping/LayerMappingBuilder.swift
@@ -78,6 +78,29 @@ enum LayerMappingBuilder {
                         actionByInput[overlayInput] = info
                     }
                 }
+            } else if case let .homeRowMods(config) = collection.configuration,
+                      config.holdMode == .layers
+            {
+                for key in config.enabledKeys {
+                    guard let layerName = config.layerAssignments[key]?.trimmingCharacters(in: .whitespacesAndNewlines),
+                          !layerName.isEmpty
+                    else { continue }
+                    let input = KanataKeyConverter.convertToKanataKey(key).lowercased()
+                    let info = LayerKeyInfo.mapped(
+                        displayLabel: LayerInfo.displayName(for: layerName),
+                        outputKey: layerName,
+                        outputKeyCode: nil,
+                        collectionId: collection.id
+                    )
+                    actionByInput[input] = info
+                    // Overlay key names are not always the same canonical strings used in
+                    // saved HRM config (for example ";" vs "semicolon"). Register both
+                    // forms so physical keycode lookup still resolves the layer label.
+                    if let keyCode = KanataKeyCodeMap.keyCode(for: key) {
+                        let overlayInput = KanataKeyCodeMap.overlayName(for: keyCode).lowercased()
+                        actionByInput[overlayInput] = info
+                    }
+                }
             }
         }
 

--- a/Sources/KeyPathAppKit/Services/Networking/KanataTCPClient+Operations.swift
+++ b/Sources/KeyPathAppKit/Services/Networking/KanataTCPClient+Operations.swift
@@ -50,9 +50,7 @@ extension KanataTCPClient {
 
             while CFAbsoluteTimeGetCurrent() < deadline, attempts < 5 {
                 let remaining = max(0.1, deadline - CFAbsoluteTimeGetCurrent())
-                let nextLine = try await withTimeout(seconds: remaining) {
-                    try await self.readUntilNewline(on: connection)
-                }
+                let nextLine = try await readUntilNewline(on: connection, timeout: remaining)
                 attempts += 1
                 lastLine = nextLine
 
@@ -289,6 +287,7 @@ extension KanataTCPClient {
 
                 group.addTask {
                     try await Task.sleep(for: .milliseconds(timeoutMs + 1000))
+                    await self.closeConnection()
                     throw KeyPathError.communication(.timeout)
                 }
 
@@ -329,9 +328,7 @@ extension KanataTCPClient {
 
             while CFAbsoluteTimeGetCurrent() < deadline, attempts < 25 {
                 let remaining = max(0.1, deadline - CFAbsoluteTimeGetCurrent())
-                let nextLine = try await withTimeout(seconds: remaining) {
-                    try await self.readUntilNewline(on: connection)
-                }
+                let nextLine = try await readUntilNewline(on: connection, timeout: remaining)
                 attempts += 1
 
                 if !isCommandResponse(nextLine) {

--- a/Sources/KeyPathAppKit/Services/Networking/KanataTCPClient+Transport.swift
+++ b/Sources/KeyPathAppKit/Services/Networking/KanataTCPClient+Transport.swift
@@ -38,6 +38,7 @@ extension KanataTCPClient {
             // Timeout task
             group.addTask {
                 try await Task.sleep(for: .seconds(self.timeout))
+                await self.closeConnection()
                 throw KeyPathError.communication(.timeout)
             }
 
@@ -52,7 +53,7 @@ extension KanataTCPClient {
     /// Returns exactly ONE complete line (ending with \n) from the connection.
     /// Uses a persistent buffer to handle cases where Kanata sends multiple
     /// lines in a single TCP packet.
-    func readUntilNewline(on connection: NWConnection) async throws -> Data {
+    func readUntilNewline(on connection: NWConnection, timeout seconds: TimeInterval? = nil) async throws -> Data {
         // Validate connection is ready before attempting read
         guard connection.state == .ready else {
             AppLogger.shared.log("❌ [TCP] readUntilNewline called on non-ready connection (state=\(connection.state))")
@@ -78,46 +79,32 @@ extension KanataTCPClient {
 
         // Start with existing buffer contents
         let accumulator = Accumulator(initial: readBuffer)
+        let deadline = seconds.map { CFAbsoluteTimeGetCurrent() + $0 }
 
         // No complete line in buffer, need to read from connection
         while true {
-            try await withCheckedThrowingContinuation {
-                (continuation: CheckedContinuation<Void, Error>) in
-                connection.receive(minimumIncompleteLength: 1, maximumLength: maxLength) {
-                    content, _, isComplete, error in
-                    if let error {
-                        continuation.resume(
-                            throwing: KeyPathError.communication(
-                                .connectionFailed(reason: error.localizedDescription)
-                            )
-                        )
-                        return
-                    }
+            let remaining: TimeInterval?
+            if let deadline {
+                let timeLeft = deadline - CFAbsoluteTimeGetCurrent()
+                guard timeLeft > 0 else {
+                    closeConnection()
+                    throw TCPTimeoutError()
+                }
+                remaining = timeLeft
+            } else {
+                remaining = nil
+            }
 
-                    if let content {
-                        accumulator.data.append(content)
-                        // Check if we now have at least one complete line (ending with \n)
-                        if accumulator.data.contains(0x0A) {
-                            continuation.resume()
-                            return
-                        }
-                    }
+            let chunk = try await receiveChunk(on: connection, maxLength: maxLength, timeout: remaining)
 
-                    if isComplete {
-                        // Connection closed - return what we have if we have data, otherwise error
-                        if accumulator.data.isEmpty {
-                            continuation.resume(
-                                throwing: KeyPathError.communication(.connectionFailed(reason: "Connection closed"))
-                            )
-                        } else {
-                            // Return partial data if connection closed (may be valid for last line)
-                            continuation.resume()
-                        }
-                        return
-                    }
+            if let content = chunk.content {
+                accumulator.data.append(content)
+            }
 
-                    // No data yet, continue reading
-                    continuation.resume()
+            if chunk.isComplete {
+                // Connection closed - return what we have if we have data, otherwise error
+                if accumulator.data.isEmpty {
+                    throw KeyPathError.communication(.connectionFailed(reason: "Connection closed"))
                 }
             }
 
@@ -134,6 +121,56 @@ extension KanataTCPClient {
                 throw KeyPathError.communication(
                     .connectionFailed(reason: "Response too large or malformed")
                 )
+            }
+
+            if chunk.isComplete, !accumulator.data.isEmpty {
+                readBuffer.removeAll()
+                return accumulator.data
+            }
+        }
+    }
+
+    /// Receive one TCP chunk with an optional real-time deadline.
+    ///
+    /// `NWConnection.receive` is callback-based and does not observe Swift task
+    /// cancellation. The timeout path resumes the continuation itself and
+    /// tears down the underlying connection so callers cannot hang waiting for
+    /// a callback that may never arrive.
+    private func receiveChunk(
+        on connection: NWConnection,
+        maxLength: Int,
+        timeout seconds: TimeInterval?
+    ) async throws -> (content: Data?, isComplete: Bool) {
+        let completionFlag = CompletionFlag()
+
+        return try await withCheckedThrowingContinuation {
+            (continuation: CheckedContinuation<(content: Data?, isComplete: Bool), Error>) in
+            if let seconds {
+                DispatchQueue.global().asyncAfter(deadline: .now() + seconds) {
+                    if completionFlag.markCompleted() {
+                        connection.cancel()
+                        continuation.resume(throwing: TCPTimeoutError())
+                        Task {
+                            await self.closeConnection()
+                        }
+                    }
+                }
+            }
+
+            connection.receive(minimumIncompleteLength: 1, maximumLength: maxLength) {
+                content, _, isComplete, error in
+                guard completionFlag.markCompleted() else { return }
+
+                if let error {
+                    continuation.resume(
+                        throwing: KeyPathError.communication(
+                            .connectionFailed(reason: error.localizedDescription)
+                        )
+                    )
+                    return
+                }
+
+                continuation.resume(returning: (content, isComplete))
             }
         }
     }
@@ -195,9 +232,10 @@ extension KanataTCPClient {
                                     throw KeyPathError.communication(.timeout)
                                 }
                                 let remaining = max(0.05, deadline - now)
-                                responseData = try await withTimeout(seconds: remaining) {
-                                    try await self.readUntilNewline(on: connection)
-                                }
+                                responseData = try await self.readUntilNewline(
+                                    on: connection,
+                                    timeout: remaining
+                                )
 
                                 // First check: is this a command response?
                                 if !self.isCommandResponse(responseData) {

--- a/Sources/KeyPathAppKit/Services/Packs/Pack.swift
+++ b/Sources/KeyPathAppKit/Services/Packs/Pack.swift
@@ -11,6 +11,9 @@ public struct ManagedCollectionDefault: Equatable, Sendable {
     public let collectionID: UUID
     /// Whether to enable this collection on install
     public let enableOnInstall: Bool
+    /// Whether to disable this collection on install because it conflicts with
+    /// the managed pack. Its previous state is still snapshotted for uninstall.
+    public let disableOnInstall: Bool
     /// Configuration to apply on install (nil = just toggle, don't change config)
     public let defaultConfiguration: RuleCollectionConfiguration?
     /// Human-readable name for override/restore dialogs
@@ -19,11 +22,13 @@ public struct ManagedCollectionDefault: Equatable, Sendable {
     public init(
         collectionID: UUID,
         enableOnInstall: Bool = true,
+        disableOnInstall: Bool = false,
         defaultConfiguration: RuleCollectionConfiguration? = nil,
         displayName: String
     ) {
         self.collectionID = collectionID
         self.enableOnInstall = enableOnInstall
+        self.disableOnInstall = disableOnInstall
         self.defaultConfiguration = defaultConfiguration
         self.displayName = displayName
     }

--- a/Sources/KeyPathAppKit/Services/Packs/PackInstaller.swift
+++ b/Sources/KeyPathAppKit/Services/Packs/PackInstaller.swift
@@ -98,23 +98,19 @@ public final class PackInstaller {
 
         // System packs batch all collection changes into a single config regen.
         if pack.isSystemPack {
-            // Record the install BEFORE applying configs so that when
-            // regenerateConfigFromCollections posts .ruleCollectionsChanged,
-            // any listener querying packManagingCollection already finds
-            // the ownership record.
             let record = InstalledPackRecord(
                 packID: pack.id,
                 version: pack.version,
                 installedAt: Date(),
                 quickSettingValues: resolvedSettings
             )
-            try await InstalledPackTracker.shared.upsert(record)
             do {
                 try await applyManagedDefaults(pack: pack, manager: manager)
             } catch {
                 try? await InstalledPackTracker.shared.remove(packID: pack.id)
                 throw error
             }
+            try await InstalledPackTracker.shared.upsert(record)
             AppLogger.shared.log(
                 "✅ [PackInstaller] Installed system pack '\(pack.name)'"
             )
@@ -200,13 +196,27 @@ public final class PackInstaller {
 
         // System packs batch all collection changes into a single config regen.
         if let pack = PackRegistry.pack(id: packID), pack.isSystemPack {
+            let originalCollections = manager.ruleCollections
             let didRestore = await restoreOrKeepOnUninstall(pack: pack, manager: manager)
             if let collectionID = pack.associatedCollectionID,
                let i = manager.ruleCollections.firstIndex(where: { $0.id == collectionID })
             {
                 manager.ruleCollections[i].isEnabled = false
             }
-            await manager.regenerateConfigFromCollections()
+
+            var applied = await manager.regenerateConfigFromCollections()
+            if !applied, didRestore, disableRestoreConflictCollections(for: pack, manager: manager) {
+                AppLogger.shared.log(
+                    "⚠️ [PackInstaller] Retrying managed restore for '\(packID)' after disabling install-conflict collections"
+                )
+                applied = await manager.regenerateConfigFromCollections()
+            }
+
+            guard applied else {
+                manager.ruleCollections = originalCollections
+                throw InstallError.saveFailed("could not apply managed collection restore")
+            }
+            removeManagedSnapshot(for: pack)
             try await InstalledPackTracker.shared.remove(packID: packID)
             AppLogger.shared.log(
                 "✅ [PackInstaller] Uninstalled system pack '\(packID)' (restored=\(didRestore))"
@@ -556,6 +566,7 @@ public final class PackInstaller {
         manager: RuleCollectionsManager
     ) async throws {
         let snapshot = snapshotManagedCollections(pack: pack, manager: manager)
+        let originalCollections = manager.ruleCollections
 
         let catalog = RuleCollectionCatalog().defaultCollections()
 
@@ -585,14 +596,24 @@ public final class PackInstaller {
                 }
             }
 
-            if managed.enableOnInstall {
+            if managed.disableOnInstall {
+                manager.ruleCollections[i].isEnabled = false
+            } else if managed.enableOnInstall {
                 manager.ruleCollections[i].isEnabled = true
             }
         }
 
         try PackCollectionSnapshot.save(snapshot)
 
-        await manager.regenerateConfigFromCollections()
+        let applied = await manager.regenerateConfigFromCollections()
+        guard applied else {
+            manager.ruleCollections = originalCollections
+            PackCollectionSnapshot.remove(for: pack.id)
+            if pack.id == "com.keypath.pack.vallack-system" {
+                PackCollectionSnapshot.removeLegacyVallack()
+            }
+            throw InstallError.saveFailed("could not apply managed collection defaults")
+        }
         AppLogger.shared.log("📦 [PackInstaller] Applied managed defaults for '\(pack.name)'")
     }
 
@@ -749,13 +770,38 @@ public final class PackInstaller {
             }
         }
 
+        AppLogger.shared.log("📦 [PackInstaller] Uninstall restore for '\(pack.id)': restored=\(shouldRestore)")
+        return shouldRestore
+    }
+
+    private func removeManagedSnapshot(for pack: Pack) {
         PackCollectionSnapshot.remove(for: pack.id)
         if pack.id == "com.keypath.pack.vallack-system" {
             PackCollectionSnapshot.removeLegacyVallack()
         }
+    }
 
-        AppLogger.shared.log("📦 [PackInstaller] Uninstall restore for '\(pack.id)': restored=\(shouldRestore)")
-        return shouldRestore
+    private func disableRestoreConflictCollections(
+        for pack: Pack,
+        manager: RuleCollectionsManager
+    ) -> Bool {
+        var changed = false
+
+        for managed in pack.managedDefaults where managed.disableOnInstall {
+            guard let i = manager.ruleCollections.firstIndex(where: { $0.id == managed.collectionID }),
+                  manager.ruleCollections[i].isEnabled
+            else {
+                continue
+            }
+
+            manager.ruleCollections[i].isEnabled = false
+            changed = true
+            AppLogger.shared.log(
+                "⚠️ [PackInstaller] Leaving '\(managed.displayName)' disabled because restored settings conflicted during uninstall"
+            )
+        }
+
+        return changed
     }
 
     private static func buildComparisonView(

--- a/Sources/KeyPathAppKit/Services/Packs/PackRegistry.swift
+++ b/Sources/KeyPathAppKit/Services/Packs/PackRegistry.swift
@@ -687,6 +687,12 @@ public enum PackRegistry {
                 )),
                 displayName: "Vallack Layer Toggles"
             ),
+            ManagedCollectionDefault(
+                collectionID: RuleCollectionIdentifier.homeRowArrows,
+                enableOnInstall: false,
+                disableOnInstall: true,
+                displayName: "Home Row Arrows"
+            ),
         ]
     )
 

--- a/Sources/KeyPathAppKit/UI/Rules/HomeRowModsCollectionView+Configuration.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/HomeRowModsCollectionView+Configuration.swift
@@ -276,6 +276,7 @@ extension HomeRowModsCollectionView {
                 Spacer()
                 Button("Cancel") {
                     newLayerName = ""
+                    pendingNewLayerAssignmentKey = nil
                     showingNewLayerSheet = false
                 }
                 .keyboardShortcut(.cancelAction)
@@ -287,11 +288,12 @@ extension HomeRowModsCollectionView {
                         guard !raw.isEmpty else { return }
                         await onEnsureLayersExist([raw])
                         locallyCreatedLayers.insert(raw)
-                        if let selectedKey {
-                            config.layerAssignments[selectedKey] = raw
+                        if let assignmentKey = pendingNewLayerAssignmentKey ?? selectedKey {
+                            HomeRowModsNewLayerAssignment.assign(layerName: raw, to: assignmentKey, config: &config)
                             updateConfig()
                         }
                         newLayerName = ""
+                        pendingNewLayerAssignmentKey = nil
                         showingNewLayerSheet = false
                     }
                 }
@@ -305,5 +307,13 @@ extension HomeRowModsCollectionView {
         .frame(width: 360)
         .accessibilityIdentifier("home-row-mods-new-layer-sheet")
         .accessibilityLabel("Create new home row layer")
+    }
+}
+
+enum HomeRowModsNewLayerAssignment {
+    static func assign(layerName: String, to key: String, config: inout HomeRowModsConfig) {
+        let normalizedLayer = layerName.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !normalizedLayer.isEmpty else { return }
+        config.layerAssignments[key] = normalizedLayer
     }
 }

--- a/Sources/KeyPathAppKit/UI/Rules/HomeRowModsCollectionView+Popovers.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/HomeRowModsCollectionView+Popovers.swift
@@ -109,6 +109,7 @@ extension HomeRowModsCollectionView {
             PopoverListDivider()
 
             Button {
+                pendingNewLayerAssignmentKey = key
                 showingNewLayerSheet = true
             } label: {
                 HStack(spacing: 10) {

--- a/Sources/KeyPathAppKit/UI/Rules/HomeRowModsCollectionView.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/HomeRowModsCollectionView.swift
@@ -23,6 +23,7 @@ struct HomeRowModsCollectionView: View {
     @State var showingCustomizeWindow = false
     @State var selectedKey: String?
     @State var showingNewLayerSheet = false
+    @State var pendingNewLayerAssignmentKey: String?
     @State var newLayerName = ""
     @State var locallyCreatedLayers: Set<String> = []
     @State var hoveredHoldBehavior: HomeRowHoldMode?

--- a/Tests/KeyPathTests/HomeRowModsConfigTests.swift
+++ b/Tests/KeyPathTests/HomeRowModsConfigTests.swift
@@ -50,4 +50,21 @@ final class HomeRowModsConfigTests: XCTestCase {
         XCTAssertEqual(decoded.layerToggleMode, .whileHeld)
         XCTAssertEqual(decoded.layerAssignments, HomeRowModsConfig.defaultLayerAssignments)
     }
+
+    func testNewLayerAssignmentNormalizesAndAssignsPendingKey() {
+        var config = HomeRowModsConfig(holdMode: .layers)
+
+        HomeRowModsNewLayerAssignment.assign(layerName: " QA-Temp ", to: "a", config: &config)
+
+        XCTAssertEqual(config.layerAssignments["a"], "qa-temp")
+    }
+
+    func testNewLayerAssignmentIgnoresBlankLayerName() {
+        var config = HomeRowModsConfig(holdMode: .layers)
+        let original = config.layerAssignments["a"]
+
+        HomeRowModsNewLayerAssignment.assign(layerName: "   ", to: "a", config: &config)
+
+        XCTAssertEqual(config.layerAssignments["a"], original)
+    }
 }

--- a/Tests/KeyPathTests/PackInstallerRenderTests.swift
+++ b/Tests/KeyPathTests/PackInstallerRenderTests.swift
@@ -242,12 +242,13 @@ final class PackInstallerRenderTests: XCTestCase {
         XCTAssertEqual(pack.managedCollectionIDs, [RuleCollectionIdentifier.capsLockRemap])
     }
 
-    func testManagedCollectionIDs_VallackSystem_ReturnsThreeCollections() {
+    func testManagedCollectionIDs_VallackSystem_ReturnsManagedCollections() {
         let pack = PackRegistry.vallackSystem
-        XCTAssertEqual(pack.managedCollectionIDs.count, 3)
+        XCTAssertEqual(pack.managedCollectionIDs.count, 4)
         XCTAssertTrue(pack.managedCollectionIDs.contains(RuleCollectionIdentifier.vallackNavigation))
         XCTAssertTrue(pack.managedCollectionIDs.contains(RuleCollectionIdentifier.homeRowMods))
         XCTAssertTrue(pack.managedCollectionIDs.contains(RuleCollectionIdentifier.homeRowLayerToggles))
+        XCTAssertTrue(pack.managedCollectionIDs.contains(RuleCollectionIdentifier.homeRowArrows))
     }
 
     func testPreferredDetailWidth_WidePacksReturn760() {

--- a/Tests/KeyPathTests/PackOwnershipTests.swift
+++ b/Tests/KeyPathTests/PackOwnershipTests.swift
@@ -35,10 +35,11 @@ final class PackOwnershipTests: XCTestCase {
     func testManagedCollectionIDsVallack() throws {
         let pack = try XCTUnwrap(PackRegistry.pack(id: "com.keypath.pack.vallack-system"))
         let ids = Set(pack.managedCollectionIDs)
-        XCTAssertEqual(ids.count, 3)
+        XCTAssertEqual(ids.count, 4)
         XCTAssertTrue(ids.contains(RuleCollectionIdentifier.vallackNavigation))
         XCTAssertTrue(ids.contains(RuleCollectionIdentifier.homeRowMods))
         XCTAssertTrue(ids.contains(RuleCollectionIdentifier.homeRowLayerToggles))
+        XCTAssertTrue(ids.contains(RuleCollectionIdentifier.homeRowArrows))
     }
 
     func testManagedCollectionIDsVisualOnly() throws {
@@ -76,7 +77,7 @@ final class PackOwnershipTests: XCTestCase {
         XCTAssertNil(owner)
     }
 
-    func testVallackOwnsAllThreeCollections() async throws {
+    func testVallackOwnsManagedCollections() async throws {
         let record = InstalledPackRecord(
             packID: "com.keypath.pack.vallack-system",
             version: "1.0.0"
@@ -92,10 +93,14 @@ final class PackOwnershipTests: XCTestCase {
         let togglesOwner = await InstalledPackTracker.shared.packManagingCollection(
             RuleCollectionIdentifier.homeRowLayerToggles
         )
+        let arrowsOwner = await InstalledPackTracker.shared.packManagingCollection(
+            RuleCollectionIdentifier.homeRowArrows
+        )
 
         XCTAssertEqual(navOwner?.packName, "Ben Vallack Nav")
         XCTAssertEqual(hrmOwner?.packName, "Ben Vallack Nav")
         XCTAssertEqual(togglesOwner?.packName, "Ben Vallack Nav")
+        XCTAssertEqual(arrowsOwner?.packName, "Ben Vallack Nav")
     }
 
     // MARK: - Self-managed badge filtering

--- a/Tests/KeyPathTests/Services/LayerMappingBuilderTests.swift
+++ b/Tests/KeyPathTests/Services/LayerMappingBuilderTests.swift
@@ -272,8 +272,8 @@ struct LayerMappingBuilderTests {
         #expect(result[0]?.displayLabel == "←")
     }
 
-    @Test("home row mods layer hold mode does not inject modifier labels")
-    func homeRowModsLayerHoldModeDoesNotInjectModifierLabels() {
+    @Test("home row mods layer hold mode injects assigned layer labels")
+    func homeRowModsLayerHoldModeInjectsAssignedLayerLabels() {
         let mapping: [UInt16: LayerKeyInfo] = [
             0: LayerKeyInfo(
                 displayLabel: "A",
@@ -282,10 +282,18 @@ struct LayerMappingBuilderTests {
                 isTransparent: true,
                 isLayerSwitch: false
             ),
+            41: LayerKeyInfo(
+                displayLabel: ";",
+                outputKey: "semicolon",
+                outputKeyCode: 41,
+                isTransparent: true,
+                isLayerSwitch: false
+            ),
         ]
         let config = HomeRowModsConfig(
-            enabledKeys: ["a"],
+            enabledKeys: ["a", ";"],
             modifierAssignments: ["a": "lsft"],
+            layerAssignments: ["a": "nav", ";": "fun"],
             holdMode: .layers
         )
         let collection = RuleCollection(
@@ -306,7 +314,9 @@ struct LayerMappingBuilderTests {
             currentLayerName: "base"
         )
 
-        #expect(result[0]?.displayLabel == "A")
-        #expect(result[0]?.collectionId == nil)
+        #expect(result[0]?.displayLabel == "Nav")
+        #expect(result[41]?.displayLabel == "Fun")
+        #expect(result[0]?.collectionId == RuleCollectionIdentifier.homeRowMods)
+        #expect(result[0]?.isTransparent == false)
     }
 }

--- a/Tests/KeyPathTests/TCPClientRobustnessTests.swift
+++ b/Tests/KeyPathTests/TCPClientRobustnessTests.swift
@@ -1,5 +1,6 @@
 @testable import KeyPathAppKit
 @testable import KeyPathCore
+import Network
 @preconcurrency import XCTest
 
 /// Robustness tests for KanataTCPClient covering edge cases around
@@ -488,6 +489,52 @@ final class TCPClientRobustnessTests: XCTestCase {
         default:
             XCTFail("Expected networkError when server not running, got \(result)")
         }
+    }
+
+    func testReloadConfig_SilentServerReturnsWithoutHanging() async throws {
+        let (listener, assignedPort) = try makeSilentListener()
+        XCTAssertGreaterThan(assignedPort, 0)
+        defer { listener.cancel() }
+
+        let client = KanataTCPClient(port: assignedPort, timeout: 0.2)
+
+        let start = Date()
+        let result = await client.reloadConfig(timeoutMs: 100)
+        let elapsed = Date().timeIntervalSince(start)
+
+        XCTAssertLessThan(elapsed, 2.0, "Silent TCP server should not leave reload waiting indefinitely")
+        switch result {
+        case .failure, .networkError:
+            break
+        default:
+            XCTFail("Expected reload failure or networkError for silent server, got \(result)")
+        }
+    }
+
+    private func makeSilentListener() throws -> (listener: NWListener, port: Int) {
+        var lastError: Error?
+
+        for _ in 0 ..< 20 {
+            let candidate = UInt16.random(in: 38000 ... 49000)
+            guard let port = NWEndpoint.Port(rawValue: candidate) else { continue }
+
+            do {
+                let listener = try NWListener(using: .tcp, on: port)
+                listener.newConnectionHandler = { connection in
+                    connection.start(queue: .global())
+                }
+                listener.start(queue: .global())
+                return (listener, Int(candidate))
+            } catch {
+                lastError = error
+            }
+        }
+
+        throw lastError ?? NSError(
+            domain: "TCPClientRobustnessTests",
+            code: 1,
+            userInfo: [NSLocalizedDescriptionKey: "Could not allocate a random TCP listener port"]
+        )
     }
 
     // MARK: - EngineReloadSingleFlight Tests

--- a/Tests/KeyPathTests/VallackSystemPackTests.swift
+++ b/Tests/KeyPathTests/VallackSystemPackTests.swift
@@ -160,7 +160,7 @@ final class VallackSystemPackTests: XCTestCase {
 
     func testVallackSystemPackIsSystemPack() {
         XCTAssertTrue(PackRegistry.vallackSystem.isSystemPack)
-        XCTAssertEqual(PackRegistry.vallackSystem.managedDefaults.count, 3)
+        XCTAssertEqual(PackRegistry.vallackSystem.managedDefaults.count, 4)
     }
 
     func testManagedCollectionIDsDerivedFromDefaults() {
@@ -168,6 +168,7 @@ final class VallackSystemPackTests: XCTestCase {
         XCTAssertTrue(ids.contains(RuleCollectionIdentifier.vallackNavigation))
         XCTAssertTrue(ids.contains(RuleCollectionIdentifier.homeRowMods))
         XCTAssertTrue(ids.contains(RuleCollectionIdentifier.homeRowLayerToggles))
+        XCTAssertTrue(ids.contains(RuleCollectionIdentifier.homeRowArrows))
     }
 
     func testNonSystemPackIsNotSystemPack() {
@@ -217,6 +218,45 @@ final class VallackSystemPackTests: XCTestCase {
         } else {
             XCTFail("Layer Toggles should have homeRowLayerTogglesConfig after Vallack install")
         }
+
+        let arrowsCollection = collections.first { $0.id == RuleCollectionIdentifier.homeRowArrows }
+        XCTAssertFalse(arrowsCollection?.isEnabled ?? true, "Vallack install should disable conflicting Home Row Arrows")
+
+        let persisted = await manager.ruleCollectionStore.loadCollections()
+        let persistedMods = persisted.first { $0.id == RuleCollectionIdentifier.homeRowMods }
+        XCTAssertTrue(persistedMods?.isEnabled ?? false, "Home Row Mods preset should be persisted")
+        XCTAssertEqual(
+            persistedMods?.configuration.homeRowModsConfig?.modifierAssignments,
+            HomeRowModsConfig.vallackTwoRowSplit,
+            "Persisted Home Row Mods config should use Vallack top-row modifiers"
+        )
+    }
+
+    @MainActor
+    func testVallackInstallFromDefaultCatalogAppliesWithoutHomeRowArrowConflict() async throws {
+        TestEnvironment.forceTestMode = true
+        defer { TestEnvironment.forceTestMode = false }
+
+        let (manager, tempDir) = try makeTestManager()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        manager.ruleCollections = RuleCollectionCatalog().defaultCollections()
+
+        _ = try await PackInstaller.shared.install(PackRegistry.vallackSystem, manager: manager)
+
+        XCTAssertFalse(
+            manager.ruleCollections.first { $0.id == RuleCollectionIdentifier.homeRowArrows }?.isEnabled ?? true,
+            "Full-catalog Vallack install should disable Home Row Arrows before regenerating"
+        )
+        XCTAssertTrue(
+            manager.ruleCollections.first { $0.id == RuleCollectionIdentifier.vallackNavigation }?.isEnabled ?? false,
+            "Full-catalog Vallack install should enable Vallack navigation"
+        )
+        XCTAssertEqual(
+            manager.ruleCollections
+                .first { $0.id == RuleCollectionIdentifier.homeRowMods }?
+                .configuration.homeRowModsConfig?.modifierAssignments,
+            HomeRowModsConfig.vallackTwoRowSplit
+        )
     }
 
     @MainActor
@@ -252,6 +292,7 @@ final class VallackSystemPackTests: XCTestCase {
 
         let (manager, tempDir) = try makeTestManager()
         defer { try? FileManager.default.removeItem(at: tempDir) }
+        manager.ruleCollections = RuleCollectionCatalog().defaultCollections()
 
         let snapshotURL = FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent(".config/keypath/pack-snapshots/com.keypath.pack.vallack-system.json")
@@ -262,6 +303,9 @@ final class VallackSystemPackTests: XCTestCase {
             .first { $0.id == RuleCollectionIdentifier.homeRowMods }?.isEnabled ?? false
         let preTogglesEnabled = manager.ruleCollections
             .first { $0.id == RuleCollectionIdentifier.homeRowLayerToggles }?.isEnabled ?? false
+        if let arrowsIndex = manager.ruleCollections.firstIndex(where: { $0.id == RuleCollectionIdentifier.homeRowArrows }) {
+            manager.ruleCollections[arrowsIndex].isEnabled = true
+        }
 
         // Install then uninstall
         _ = try await PackInstaller.shared.install(PackRegistry.vallackSystem, manager: manager)
@@ -289,10 +333,124 @@ final class VallackSystemPackTests: XCTestCase {
             "Layer Toggles enabled state should revert"
         )
 
+        let arrowsCollection = collections.first { $0.id == RuleCollectionIdentifier.homeRowArrows }
+        XCTAssertTrue(arrowsCollection?.isEnabled ?? false, "Home Row Arrows should restore after uninstall")
+
         // Snapshot file should be cleaned up
         XCTAssertFalse(
             FileManager.default.fileExists(atPath: snapshotURL.path),
             "Snapshot file should be removed after uninstall"
+        )
+
+        let persisted = await manager.ruleCollectionStore.loadCollections()
+        let persistedNav = persisted.first { $0.id == RuleCollectionIdentifier.vallackNavigation }
+        XCTAssertFalse(persistedNav?.isEnabled ?? true, "Persisted Vallack nav should be disabled after uninstall")
+    }
+
+    @MainActor
+    func testVallackUninstallRestoresHRMWhenPriorArrowStateWouldConflict() async throws {
+        TestEnvironment.forceTestMode = true
+        defer { TestEnvironment.forceTestMode = false }
+
+        let (manager, tempDir) = try makeTestManager()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        manager.ruleCollections = RuleCollectionCatalog().defaultCollections()
+
+        let snapshotURL = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".config/keypath/pack-snapshots/com.keypath.pack.vallack-system.json")
+        defer { try? FileManager.default.removeItem(at: snapshotURL) }
+
+        guard let modsIndex = manager.ruleCollections.firstIndex(where: { $0.id == RuleCollectionIdentifier.homeRowMods }),
+              let arrowsIndex = manager.ruleCollections.firstIndex(where: { $0.id == RuleCollectionIdentifier.homeRowArrows })
+        else {
+            XCTFail("Expected HRM and Home Row Arrows catalog collections")
+            return
+        }
+
+        var preInstallHRM = HomeRowModsConfig()
+        preInstallHRM.holdMode = HomeRowHoldMode.modifiers
+        preInstallHRM.enabledKeys = Set(["a", "s", "d", "f", "j", "k", "l", ";"])
+        manager.ruleCollections[modsIndex].configuration = .homeRowMods(preInstallHRM)
+        manager.ruleCollections[modsIndex].isEnabled = true
+        manager.ruleCollections[arrowsIndex].isEnabled = true
+
+        _ = try await PackInstaller.shared.install(PackRegistry.vallackSystem, manager: manager)
+        try await PackInstaller.shared.uninstall(packID: PackRegistry.vallackSystem.id, manager: manager)
+
+        let restoredMods = try XCTUnwrap(
+            manager.ruleCollections
+                .first { $0.id == RuleCollectionIdentifier.homeRowMods }?
+                .configuration.homeRowModsConfig
+        )
+        XCTAssertEqual(restoredMods.enabledKeys, preInstallHRM.enabledKeys)
+        XCTAssertEqual(restoredMods.modifierAssignments, preInstallHRM.modifierAssignments)
+
+        let arrowsCollection = manager.ruleCollections.first { $0.id == RuleCollectionIdentifier.homeRowArrows }
+        XCTAssertFalse(
+            arrowsCollection?.isEnabled ?? true,
+            "Home Row Arrows should stay disabled when restoring it would conflict with restored HRM"
+        )
+
+        let isInstalled = await InstalledPackTracker.shared.isInstalled(packID: PackRegistry.vallackSystem.id)
+        XCTAssertFalse(isInstalled, "Vallack install record should be removed after successful uninstall")
+        XCTAssertNil(PackCollectionSnapshot.load(for: PackRegistry.vallackSystem.id))
+    }
+
+    @MainActor
+    func testVallackInstallDoesNotRecordWhenManagedApplyFails() async throws {
+        TestEnvironment.forceTestMode = true
+        defer { TestEnvironment.forceTestMode = false }
+
+        try? await InstalledPackTracker.shared.remove(packID: PackRegistry.vallackSystem.id)
+        PackCollectionSnapshot.remove(for: PackRegistry.vallackSystem.id)
+
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("vallack-apply-fail-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer {
+            try? FileManager.default.removeItem(at: tempDir)
+            PackCollectionSnapshot.remove(for: PackRegistry.vallackSystem.id)
+        }
+
+        let blockedConfigDirectory = tempDir.appendingPathComponent("not-a-directory")
+        try "file blocks config directory".write(to: blockedConfigDirectory, atomically: true, encoding: .utf8)
+
+        let manager = RuleCollectionsManager(
+            ruleCollectionStore: RuleCollectionStore(
+                fileURL: tempDir.appendingPathComponent("RuleCollections.json")
+            ),
+            customRulesStore: CustomRulesStore(
+                fileURL: tempDir.appendingPathComponent("CustomRules.json")
+            ),
+            configurationService: ConfigurationService(configDirectory: blockedConfigDirectory.path),
+            eventListener: KanataEventListener()
+        )
+        manager.ruleCollections = RuleCollectionCatalog().defaultCollections()
+        let originalCollections = manager.ruleCollections
+
+        do {
+            _ = try await PackInstaller.shared.install(PackRegistry.vallackSystem, manager: manager)
+            XCTFail("Install should fail when managed defaults cannot be applied")
+        } catch let error as PackInstaller.InstallError {
+            guard case .saveFailed = error else {
+                XCTFail("Expected saveFailed, got \(error)")
+                return
+            }
+        }
+
+        let isInstalled = await InstalledPackTracker.shared.isInstalled(packID: PackRegistry.vallackSystem.id)
+        XCTAssertFalse(
+            isInstalled,
+            "Failed managed install must not record the pack as installed"
+        )
+        XCTAssertEqual(
+            manager.ruleCollections,
+            originalCollections,
+            "Failed managed install should restore in-memory collections"
+        )
+        XCTAssertNil(
+            PackCollectionSnapshot.load(for: PackRegistry.vallackSystem.id),
+            "Failed managed install should not leave an uninstall snapshot behind"
         )
     }
 


### PR DESCRIPTION
## Summary
- Fix HRM New Layer creation so the newly created layer is assigned to the key that launched the flow.
- Teach overlay label augmentation to show HRM layer hold labels in layer mode instead of alpha hold labels.
- Make Vallack system pack apply managed HRM/nav defaults atomically, disable conflicting Home Row Arrows during install, and make uninstall restore HRM snapshots without hanging even when the prior Home Row Arrows state would conflict.
- Bound TCP read waits for reload/hello paths so silent TCP reads cannot hang command/application flows.

Fixes #804
Fixes #810
Fixes #811

## Verification
- `swift test --jobs 4 --filter 'HomeRowModsConfigTests|LayerMappingBuilderTests|VallackSystemPackTests|PackOwnershipTests|PackInstallerRenderTests/testManagedCollectionIDs_VallackSystem_ReturnsManagedCollections|TCPClientRobustnessTests/testReloadConfig_SilentServerReturnsWithoutHanging'`
- `./Scripts/test-fast.sh --changed` passed before the final uninstall fallback change: 4,274 tests passed.
- After the final uninstall fallback change, `./Scripts/test-fast.sh --changed` rebuilt and then timed out in the broad suite inside an orphaned `xctest` waiter; focused issue coverage above was rerun and passed.
- `python3 Scripts/check-accessibility.py`
- `./Scripts/quick-deploy.sh`
- `REQUIRE_NOTARIZED=0 REQUIRE_STAPLED=0 ./Scripts/verify-installed-app.sh`
- Installed CLI QA with `/Applications/KeyPath.app/Contents/MacOS/keypath-cli`: enable Home Row Arrows precondition, Vallack install `--apply`, Vallack uninstall `--apply`, config restore/apply; all completed without hangs and reloaded over TCP.

## Computer Use
Computer Use was attempted against the installed app, but the app had no key window exposed in this run (`cgWindowNotFound`). Installed verification was completed through the installed CLI, persisted config, app logs, and `verify-installed-app.sh`.
