### PR TITLE
Improve test hygiene guardrails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,8 @@ jobs:
         # SwiftPM can wrap XCTest post-run SIGABRT as exit 1 on the self-hosted runner;
         # run-tests-safe.sh still fails if it parses any test failures and emits a warning when this path is used.
         KEYPATH_ALLOW_TEST_RUNNER_CRASH_SUCCESS: "1"
+        KEYPATH_TEST_ENFORCE_CLEAN_SUMMARY: "1"
+        KEYPATH_TEST_RESET_MODULE_CACHE: "0"
       run: |
         echo "Running full named test lane..."
         export CI_ENVIRONMENT=true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,6 +140,15 @@ jobs:
         fi
 
         echo "" >> $GITHUB_STEP_SUMMARY
+        echo "### Fast Smoke Lane" >> $GITHUB_STEP_SUMMARY
+        if [ "${SMOKE_STATUS:-unknown}" = "failed" ]; then
+          echo "- \`smoke-isolated\`: failed" >> $GITHUB_STEP_SUMMARY
+        elif [ "${SMOKE_STATUS:-unknown}" = "passed" ]; then
+          echo "- \`smoke-isolated\`: passed" >> $GITHUB_STEP_SUMMARY
+        else
+          echo "- \`smoke-isolated\`: status unknown" >> $GITHUB_STEP_SUMMARY
+        fi
+        echo "" >> $GITHUB_STEP_SUMMARY
         echo "### Installer Reliability Matrix" >> $GITHUB_STEP_SUMMARY
         if [ -f "test-results/installer-reliability/latest/matrix-summary.md" ]; then
           cat test-results/installer-reliability/latest/matrix-summary.md >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,11 +142,11 @@ jobs:
         echo "" >> $GITHUB_STEP_SUMMARY
         echo "### Fast Smoke Lane" >> $GITHUB_STEP_SUMMARY
         if [ "${SMOKE_STATUS:-unknown}" = "failed" ]; then
-          echo "- \`smoke-isolated\`: failed" >> $GITHUB_STEP_SUMMARY
+          echo "- \`smoke\`: failed" >> $GITHUB_STEP_SUMMARY
         elif [ "${SMOKE_STATUS:-unknown}" = "passed" ]; then
-          echo "- \`smoke-isolated\`: passed" >> $GITHUB_STEP_SUMMARY
+          echo "- \`smoke\`: passed" >> $GITHUB_STEP_SUMMARY
         else
-          echo "- \`smoke-isolated\`: status unknown" >> $GITHUB_STEP_SUMMARY
+          echo "- \`smoke\`: status unknown" >> $GITHUB_STEP_SUMMARY
         fi
         echo "" >> $GITHUB_STEP_SUMMARY
         echo "### Installer Reliability Matrix" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
         chmod +x ./Scripts/lint-no-subprocess-in-autofixer.sh
         ./Scripts/lint-no-subprocess-in-autofixer.sh
 
-    - name: Build and Run All Tests
+    - name: Run Test Lane - full
       env:
         KP_SIGN_DRY_RUN: "1"
         KEYPATH_BUNDLED_SIMULATOR_OVERRIDE: /opt/homebrew/bin/kanata-simulator
@@ -90,12 +90,13 @@ jobs:
         # run-tests-safe.sh still fails if it parses any test failures and emits a warning when this path is used.
         KEYPATH_ALLOW_TEST_RUNNER_CRASH_SUCCESS: "1"
       run: |
-        echo "Building and running full test suite..."
+        echo "Running full named test lane..."
         export CI_ENVIRONMENT=true
         export SKIP_EVENT_TAP_TESTS=1
         export TIMEOUT_SECONDS=300
+        chmod +x ./Scripts/test-lane.sh
         chmod +x ./Scripts/run-tests-safe.sh
-        if ./Scripts/run-tests-safe.sh; then
+        if ./Scripts/test-lane.sh full; then
           echo "TEST_STATUS=passed" >> $GITHUB_ENV
         else
           echo "TEST_STATUS=failed" >> $GITHUB_ENV

--- a/.github/workflows/test-ci-locally.sh
+++ b/.github/workflows/test-ci-locally.sh
@@ -23,13 +23,13 @@ else
     brew install kanata
 fi
 
-# Test 2: Run isolated smoke lane
-echo "🧪 Running isolated smoke lane..."
+# Test 2: Run smoke lane
+echo "🧪 Running smoke lane..."
 chmod +x ./Scripts/test-lane.sh
-if KEYPATH_ISOLATED_SMOKE_CLEAN=1 ./Scripts/test-lane.sh smoke-isolated 2>&1 | tee local_test_output.log; then
-    echo "✅ Isolated smoke lane completed"
+if KEYPATH_ISOLATED_SMOKE_CLEAN=1 ./Scripts/test-lane.sh smoke 2>&1 | tee local_test_output.log; then
+    echo "✅ Smoke lane completed"
 else
-    echo "❌ Isolated smoke lane failed"
+    echo "❌ Smoke lane failed"
     cat local_test_output.log
     exit 1
 fi

--- a/.github/workflows/test-ci-locally.sh
+++ b/.github/workflows/test-ci-locally.sh
@@ -10,6 +10,8 @@ echo "🧪 Testing CI workflow locally..."
 # Set CI environment variables
 export CI_ENVIRONMENT=true
 export KEYPATH_TESTING=false
+export SKIP_EVENT_TAP_TESTS=1
+export KP_SIGN_DRY_RUN=1
 
 # Test 1: Check if kanata is available
 echo "📦 Checking kanata availability..."
@@ -21,17 +23,29 @@ else
     brew install kanata
 fi
 
-# Test 2: Run unit tests
-echo "🧪 Running unit tests..."
-if swift test --filter ".*Tests" 2>&1 | tee local_test_output.log; then
-    echo "✅ Unit tests completed"
+# Test 2: Run isolated smoke lane
+echo "🧪 Running isolated smoke lane..."
+chmod +x ./Scripts/test-lane.sh
+if KEYPATH_ISOLATED_SMOKE_CLEAN=1 ./Scripts/test-lane.sh smoke-isolated 2>&1 | tee local_test_output.log; then
+    echo "✅ Isolated smoke lane completed"
 else
-    echo "❌ Unit tests failed"
+    echo "❌ Isolated smoke lane failed"
     cat local_test_output.log
     exit 1
 fi
 
-# Test 3: Build release
+# Test 3: Run full named lane
+echo "🧪 Running full test lane..."
+chmod +x ./Scripts/run-tests-safe.sh
+if ./Scripts/test-lane.sh full 2>&1 | tee local_test_output.log; then
+    echo "✅ Full test lane completed"
+else
+    echo "❌ Full test lane failed"
+    cat local_test_output.log
+    exit 1
+fi
+
+# Test 4: Build release
 echo "🔨 Testing release build..."
 if swift build -c release; then
     echo "✅ Release build successful"
@@ -40,7 +54,7 @@ else
     exit 1
 fi
 
-# Test 4: Verify artifacts
+# Test 5: Verify artifacts
 echo "🔍 Verifying build artifacts..."
 if [ -f ".build/release/KeyPath" ]; then
     echo "✅ KeyPath binary created successfully"

--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,7 @@ peekaboo/
 *.tmp
 temp_*
 test_output.safe.txt
+test_output.smoke.txt
 test_output.smoke-isolated.txt
 
 # Local-only test security setup (DO NOT COMMIT)

--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,8 @@ temp_*
 test_output.safe.txt
 test_output.smoke.txt
 test_output.smoke-isolated.txt
+test_output.*.txt
+test_output.*.txt.build
 
 # Local-only test security setup (DO NOT COMMIT)
 Scripts/setup-test-sudoers.sh

--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,7 @@ peekaboo/
 *.tmp
 temp_*
 test_output.safe.txt
+test_output.smoke-isolated.txt
 
 # Local-only test security setup (DO NOT COMMIT)
 Scripts/setup-test-sudoers.sh

--- a/Package.swift
+++ b/Package.swift
@@ -280,6 +280,17 @@ let package = Package(
         ),
         // Tests
         .testTarget(
+            name: "KeyPathSmokeTests",
+            dependencies: [
+                "KeyPathCore",
+                "KeyPathPermissions"
+            ],
+            path: "Tests/KeyPathSmokeTests",
+            swiftSettings: [
+                .swiftLanguageMode(.v6)
+            ]
+        ),
+        .testTarget(
             name: "KeyPathTests",
             dependencies: [
                 "KeyPathAppKit",

--- a/Scripts/README.md
+++ b/Scripts/README.md
@@ -12,6 +12,8 @@
 - `./test.sh` — Run the full test suite (root)
 - `./Scripts/test-lane.sh <lane>` — Run a named SwiftPM test lane (`smoke`,
   `smoke-root`, `unit`, `appkit`, `installer`, `snapshot`, `device`, or `full`).
+- `./Scripts/measure-local-loop.sh` — Measure local feedback lanes and write a
+  Markdown report under `.build/local-loop-measurements/`.
 - `./Scripts/run-installer-reliability-matrix.sh` — Automated installer reliability matrix + diagnostic artifact bundle (`test-results/installer-reliability/latest`).
 - `./Scripts/repro-duplicate-keys.sh` — CPU-load repro harness for duplicate keypress detection (filters navigation keys by default). Supports `--auto-type osascript` or `--auto-type peekaboo` for deterministic automated keystroke generation, and continuously samples Kanata process metrics (CPU%, memory, threads, priority).
 
@@ -49,8 +51,14 @@
 - `./Scripts/run-tests-safe.sh` - CI-style safe test runner. Defaults to quiet
   app logs (`KEYPATH_LOG_LEVEL=3`) and prints build/test timing plus log size.
   Set `KEYPATH_TEST_VERBOSE_LOGS=1` for debug-level app diagnostics during a
-  noisy test investigation. Set `KEYPATH_TEST_RESET_MODULE_CACHE=0` when a
-  narrow local lane should reuse the Swift module cache.
+  noisy test investigation. Local named lanes reuse the normalized Swift module
+  cache by default; set `KEYPATH_TEST_RESET_MODULE_CACHE=1` when a narrow local
+  lane should intentionally reset it.
+- `./Scripts/measure-local-loop.sh --preset baseline` - Measure the standard
+  MacBook Air local baseline (`smoke`, `unit`, `appkit`) and write
+  `.build/local-loop-measurements/latest.md`.
+- See `docs/MACBOOK_AIR_LOCAL_LOOP.md` for the recommended command by change
+  type.
 - CI also runs:
   - `./Scripts/test-lane.sh smoke` as the early fail-fast lane.
   - `./Scripts/run-installer-reliability-matrix.sh` (pre/during/post install lanes + inspect snapshot artifact)

--- a/Scripts/README.md
+++ b/Scripts/README.md
@@ -11,7 +11,7 @@
 - `./Scripts/cleanup-local-build-artifacts.sh` — Dry-run cleanup of generated `.build`/`dist`/test artifacts across local worktrees. Add `--apply` to delete.
 - `./test.sh` — Run the full test suite (root)
 - `./Scripts/test-lane.sh <lane>` — Run a named SwiftPM test lane (`smoke`,
-  `unit`, `appkit`, `installer`, `snapshot`, `device`, or `full`).
+  `smoke-root`, `unit`, `appkit`, `installer`, `snapshot`, `device`, or `full`).
 - `./Scripts/run-installer-reliability-matrix.sh` — Automated installer reliability matrix + diagnostic artifact bundle (`test-results/installer-reliability/latest`).
 - `./Scripts/repro-duplicate-keys.sh` — CPU-load repro harness for duplicate keypress detection (filters navigation keys by default). Supports `--auto-type osascript` or `--auto-type peekaboo` for deterministic automated keystroke generation, and continuously samples Kanata process metrics (CPU%, memory, threads, priority).
 
@@ -32,8 +32,9 @@
 ## Testing
 - `test.sh` (in root) - All tests
 - `test-*.sh` (in Scripts/) - Individual test suites
-- `./Scripts/test-lane.sh smoke` - Fast sanity lane from the narrow
-  `KeyPathSmokeTests` target.
+- `./Scripts/test-lane.sh smoke` - Fast isolated product-level sanity lane.
+- `./Scripts/test-lane.sh smoke-root` - Root-package smoke target; useful for
+  diagnostics, but not the fast path.
 - `./Scripts/test-lane.sh unit` - Pure or mostly pure model/parser/renderer
   tests.
 - `./Scripts/test-lane.sh appkit` - UI-adjacent app logic, services, packs,
@@ -51,8 +52,7 @@
   noisy test investigation. Set `KEYPATH_TEST_RESET_MODULE_CACHE=0` when a
   narrow local lane should reuse the Swift module cache.
 - CI also runs:
-  - `swift test --filter SigningPipelineTests` (verifies signing/notary wrappers surface failures and honor dry-run)
-  - `swift test --filter InstallerEngineEndToEndTests` (ensures InstallerEngine executes plans and stops on broker failures)
+  - `./Scripts/test-lane.sh smoke` as the early fail-fast lane.
   - `./Scripts/run-installer-reliability-matrix.sh` (pre/during/post install lanes + inspect snapshot artifact)
   - Optional/local: `KEYPATH_E2E_DEVICE=1 swift test --filter InstallerDeviceTests` or `./Scripts/test-installer-device.sh` for real-surface installer smoke
 

--- a/Scripts/README.md
+++ b/Scripts/README.md
@@ -30,6 +30,10 @@
 ## Testing
 - `test.sh` (in root) - All tests
 - `test-*.sh` (in Scripts/) - Individual test suites
+- `./Scripts/run-tests-safe.sh` - CI-style safe test runner. Defaults to quiet
+  app logs (`KEYPATH_LOG_LEVEL=3`) and prints build/test timing plus log size.
+  Set `KEYPATH_TEST_VERBOSE_LOGS=1` for debug-level app diagnostics during a
+  noisy test investigation.
 - CI also runs:
   - `swift test --filter SigningPipelineTests` (verifies signing/notary wrappers surface failures and honor dry-run)
   - `swift test --filter InstallerEngineEndToEndTests` (ensures InstallerEngine executes plans and stops on broker failures)

--- a/Scripts/README.md
+++ b/Scripts/README.md
@@ -10,6 +10,8 @@
 - `./Scripts/release.sh <version>` — Public distribution release flow. Run `./Scripts/release-doctor.sh --ship` first.
 - `./Scripts/cleanup-local-build-artifacts.sh` — Dry-run cleanup of generated `.build`/`dist`/test artifacts across local worktrees. Add `--apply` to delete.
 - `./test.sh` — Run the full test suite (root)
+- `./Scripts/test-lane.sh <lane>` — Run a named SwiftPM test lane (`smoke`,
+  `unit`, `appkit`, `installer`, `snapshot`, `device`, or `full`).
 - `./Scripts/run-installer-reliability-matrix.sh` — Automated installer reliability matrix + diagnostic artifact bundle (`test-results/installer-reliability/latest`).
 - `./Scripts/repro-duplicate-keys.sh` — CPU-load repro harness for duplicate keypress detection (filters navigation keys by default). Supports `--auto-type osascript` or `--auto-type peekaboo` for deterministic automated keystroke generation, and continuously samples Kanata process metrics (CPU%, memory, threads, priority).
 
@@ -30,6 +32,19 @@
 ## Testing
 - `test.sh` (in root) - All tests
 - `test-*.sh` (in Scripts/) - Individual test suites
+- `./Scripts/test-lane.sh smoke` - Fast sanity lane across core parsing,
+  permissions, installer planning, CLI, and layout tracer tests.
+- `./Scripts/test-lane.sh unit` - Pure or mostly pure model/parser/renderer
+  tests.
+- `./Scripts/test-lane.sh appkit` - UI-adjacent app logic, services, packs,
+  config, mappers, and rule collection tests.
+- `./Scripts/test-lane.sh installer` - InstallerEngine, wizard, daemon/service
+  lifecycle, and health-check tests.
+- `./Scripts/test-lane.sh snapshot` - Visual snapshot tests; sets
+  `KEYPATH_SNAPSHOTS=1`.
+- `KEYPATH_E2E_DEVICE=1 ./Scripts/test-lane.sh device` - Opt-in real-system
+  installer smoke.
+- `./Scripts/test-lane.sh full` - Full safe SwiftPM test suite.
 - `./Scripts/run-tests-safe.sh` - CI-style safe test runner. Defaults to quiet
   app logs (`KEYPATH_LOG_LEVEL=3`) and prints build/test timing plus log size.
   Set `KEYPATH_TEST_VERBOSE_LOGS=1` for debug-level app diagnostics during a

--- a/Scripts/README.md
+++ b/Scripts/README.md
@@ -32,8 +32,8 @@
 ## Testing
 - `test.sh` (in root) - All tests
 - `test-*.sh` (in Scripts/) - Individual test suites
-- `./Scripts/test-lane.sh smoke` - Fast sanity lane across core parsing,
-  permissions, installer planning, CLI, and layout tracer tests.
+- `./Scripts/test-lane.sh smoke` - Fast sanity lane from the narrow
+  `KeyPathSmokeTests` target.
 - `./Scripts/test-lane.sh unit` - Pure or mostly pure model/parser/renderer
   tests.
 - `./Scripts/test-lane.sh appkit` - UI-adjacent app logic, services, packs,
@@ -48,7 +48,8 @@
 - `./Scripts/run-tests-safe.sh` - CI-style safe test runner. Defaults to quiet
   app logs (`KEYPATH_LOG_LEVEL=3`) and prints build/test timing plus log size.
   Set `KEYPATH_TEST_VERBOSE_LOGS=1` for debug-level app diagnostics during a
-  noisy test investigation.
+  noisy test investigation. Set `KEYPATH_TEST_RESET_MODULE_CACHE=0` when a
+  narrow local lane should reuse the Swift module cache.
 - CI also runs:
   - `swift test --filter SigningPipelineTests` (verifies signing/notary wrappers surface failures and honor dry-run)
   - `swift test --filter InstallerEngineEndToEndTests` (ensures InstallerEngine executes plans and stops on broker failures)

--- a/Scripts/measure-local-loop.sh
+++ b/Scripts/measure-local-loop.sh
@@ -1,0 +1,162 @@
+#!/bin/bash
+set -euo pipefail
+
+# Measure local developer feedback lanes and write a small Markdown report.
+# Outputs live under .build/ by default, so reports stay local-only.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd -P)"
+
+PRESET="quick"
+OUTPUT_DIR="${KEYPATH_LOCAL_LOOP_OUT:-$PROJECT_DIR/.build/local-loop-measurements}"
+CLEAN_SMOKE="${KEYPATH_LOCAL_LOOP_CLEAN_SMOKE:-0}"
+LANES=()
+
+usage() {
+  cat <<'USAGE'
+Usage: ./Scripts/measure-local-loop.sh [--preset quick|baseline|full] [--out DIR] [--clean-smoke] [lane ...]
+
+Presets:
+  quick     Run the fastest local sanity lane: smoke.
+  baseline  Run the usual MacBook Air development baseline: smoke, unit, appkit.
+  full      Run smoke, unit, appkit, and full.
+
+If explicit lanes are provided, they override the preset.
+
+Environment:
+  KEYPATH_LOCAL_LOOP_OUT          Output directory. Defaults to .build/local-loop-measurements.
+  KEYPATH_LOCAL_LOOP_CLEAN_SMOKE  Set to 1 to cold-build the isolated smoke lane.
+  TIMEOUT_SECONDS                 Passed through to safe-runner lanes.
+USAGE
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --preset)
+      PRESET="${2:-}"
+      shift 2
+      ;;
+    --preset=*)
+      PRESET="${1#--preset=}"
+      shift
+      ;;
+    --out)
+      OUTPUT_DIR="${2:-}"
+      shift 2
+      ;;
+    --out=*)
+      OUTPUT_DIR="${1#--out=}"
+      shift
+      ;;
+    --clean-smoke)
+      CLEAN_SMOKE=1
+      shift
+      ;;
+    -h|--help|help)
+      usage
+      exit 0
+      ;;
+    --*)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 64
+      ;;
+    *)
+      LANES+=("$1")
+      shift
+      ;;
+  esac
+done
+
+if [ "${#LANES[@]}" -eq 0 ]; then
+  case "$PRESET" in
+    quick)
+      LANES=(smoke)
+      ;;
+    baseline)
+      LANES=(smoke unit appkit)
+      ;;
+    full)
+      LANES=(smoke unit appkit full)
+      ;;
+    *)
+      echo "Unknown preset: $PRESET" >&2
+      usage >&2
+      exit 64
+      ;;
+  esac
+fi
+
+mkdir -p "$OUTPUT_DIR"
+STAMP="$(date +%Y%m%d-%H%M%S)"
+REPORT="$OUTPUT_DIR/$STAMP.md"
+
+{
+  echo "# Local Loop Measurement"
+  echo ""
+  echo "- Timestamp: \`$STAMP\`"
+  echo "- Preset: \`$PRESET\`"
+  echo "- Lanes: \`${LANES[*]}\`"
+  echo "- Output directory: \`$OUTPUT_DIR\`"
+  echo ""
+  echo "| Lane | Exit | Elapsed | Summary | Wrapper log | Test log |"
+  echo "| --- | ---: | ---: | --- | --- | --- |"
+} > "$REPORT"
+
+failed_lanes=0
+
+run_lane() {
+  local lane="$1"
+  local wrapper_log="$OUTPUT_DIR/$STAMP.$lane.wrapper.log"
+  local test_log="$OUTPUT_DIR/$STAMP.$lane.test.log"
+  local start_seconds
+  local elapsed_seconds
+  local exit_code
+  local summary_line
+
+  echo "==> Measuring lane: $lane"
+  start_seconds="$(date +%s)"
+
+  set +e
+  if [ "$lane" = "smoke" ] && [ "$CLEAN_SMOKE" = "1" ]; then
+    KEYPATH_ISOLATED_SMOKE_CLEAN=1 \
+      KEYPATH_TEST_LOG="$test_log" \
+      "$SCRIPT_DIR/test-lane.sh" "$lane" 2>&1 | tee "$wrapper_log"
+  else
+    KEYPATH_TEST_LOG="$test_log" \
+      "$SCRIPT_DIR/test-lane.sh" "$lane" 2>&1 | tee "$wrapper_log"
+  fi
+  exit_code="${PIPESTATUS[0]}"
+  set -e
+
+  elapsed_seconds="$(( $(date +%s) - start_seconds ))"
+  summary_line="$(awk '/Runner summary:|Isolated smoke summary:/ { line=$0 } END { print line }' "$wrapper_log")"
+  if [ -z "$summary_line" ]; then
+    summary_line="no summary line found"
+  fi
+
+  {
+    echo "| \`$lane\` | \`$exit_code\` | \`${elapsed_seconds}s\` | \`$summary_line\` | \`$wrapper_log\` | \`$test_log\` |"
+  } >> "$REPORT"
+
+  if [ "$exit_code" -ne 0 ]; then
+    failed_lanes=$((failed_lanes + 1))
+  fi
+}
+
+for lane in "${LANES[@]}"; do
+  run_lane "$lane"
+done
+
+ln -sfn "$REPORT" "$OUTPUT_DIR/latest.md"
+
+echo ""
+echo "Report: $REPORT"
+echo "Latest: $OUTPUT_DIR/latest.md"
+
+if [ "$failed_lanes" -ne 0 ]; then
+  echo "Local loop measurement completed with $failed_lanes failing lane(s)." >&2
+  exit 1
+fi
+
+echo "Local loop measurement completed successfully."

--- a/Scripts/measure-local-loop.sh
+++ b/Scripts/measure-local-loop.sh
@@ -90,6 +90,7 @@ fi
 mkdir -p "$OUTPUT_DIR"
 STAMP="$(date +%Y%m%d-%H%M%S)"
 REPORT="$OUTPUT_DIR/$STAMP.md"
+TSV_REPORT="$OUTPUT_DIR/$STAMP.tsv"
 
 {
   echo "# Local Loop Measurement"
@@ -102,6 +103,8 @@ REPORT="$OUTPUT_DIR/$STAMP.md"
   echo "| Lane | Exit | Elapsed | Summary | Wrapper log | Test log |"
   echo "| --- | ---: | ---: | --- | --- | --- |"
 } > "$REPORT"
+
+printf "timestamp\tpreset\tlane\texit\telapsed_seconds\tsummary\twrapper_log\ttest_log\n" > "$TSV_REPORT"
 
 failed_lanes=0
 
@@ -138,6 +141,15 @@ run_lane() {
   {
     echo "| \`$lane\` | \`$exit_code\` | \`${elapsed_seconds}s\` | \`$summary_line\` | \`$wrapper_log\` | \`$test_log\` |"
   } >> "$REPORT"
+  printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n" \
+    "$STAMP" \
+    "$PRESET" \
+    "$lane" \
+    "$exit_code" \
+    "$elapsed_seconds" \
+    "$summary_line" \
+    "$wrapper_log" \
+    "$test_log" >> "$TSV_REPORT"
 
   if [ "$exit_code" -ne 0 ]; then
     failed_lanes=$((failed_lanes + 1))
@@ -149,10 +161,13 @@ for lane in "${LANES[@]}"; do
 done
 
 ln -sfn "$REPORT" "$OUTPUT_DIR/latest.md"
+ln -sfn "$TSV_REPORT" "$OUTPUT_DIR/latest.tsv"
 
 echo ""
 echo "Report: $REPORT"
+echo "TSV: $TSV_REPORT"
 echo "Latest: $OUTPUT_DIR/latest.md"
+echo "Latest TSV: $OUTPUT_DIR/latest.tsv"
 
 if [ "$failed_lanes" -ne 0 ]; then
   echo "Local loop measurement completed with $failed_lanes failing lane(s)." >&2

--- a/Scripts/run-tests-safe.sh
+++ b/Scripts/run-tests-safe.sh
@@ -60,8 +60,10 @@ print_run_summary() {
   local now_seconds
   local total_duration
   local log_size
+  local build_log_size
   local build_duration
   local test_duration
+  local build_log_swift_warning_count
   local test_log_swift_warning_count
   local test_log_app_warning_count
   local test_log_app_error_count
@@ -75,15 +77,17 @@ print_run_summary() {
   now_seconds="$(date +%s)"
   total_duration=$((now_seconds - RUNNER_START_SECONDS))
   log_size="$(log_size_bytes "${LOG:-}")"
+  build_log_size="$(log_size_bytes "${BUILD_LOG:-}")"
   build_duration="$(format_duration "$BUILD_DURATION_SECONDS")"
   test_duration="$(format_duration "$TEST_DURATION_SECONDS")"
+  build_log_swift_warning_count="$(count_log_pattern "warning:" "${BUILD_LOG:-}")"
   test_log_swift_warning_count="$(count_log_pattern "warning:" "${LOG:-}")"
   test_log_app_warning_count="$(count_log_pattern "\\[WARN\\]" "${LOG:-}")"
   test_log_app_error_count="$(count_log_pattern "\\[ERROR\\]" "${LOG:-}")"
   filter_value="${TEST_FILTER:-none}"
   skip_value="${TEST_SKIP:-none}"
 
-  echo "📊 Runner summary: lane=${TEST_LANE} exit=${exit_code} prebuild=${TEST_PREBUILD} disable_xctest=${TEST_DISABLE_XCTEST} reset_module_cache=${TEST_RESET_MODULE_CACHE} build=${build_duration} test=${test_duration} total=${total_duration}s log=${log_size} bytes test_log_swift_warnings=${test_log_swift_warning_count} test_log_app_warnings=${test_log_app_warning_count} test_log_app_errors=${test_log_app_error_count}"
+  echo "📊 Runner summary: lane=${TEST_LANE} exit=${exit_code} prebuild=${TEST_PREBUILD} disable_xctest=${TEST_DISABLE_XCTEST} reset_module_cache=${TEST_RESET_MODULE_CACHE} build=${build_duration} test=${test_duration} total=${total_duration}s build_log=${build_log_size} bytes build_log_swift_warnings=${build_log_swift_warning_count} log=${log_size} bytes test_log_swift_warnings=${test_log_swift_warning_count} test_log_app_warnings=${test_log_app_warning_count} test_log_app_errors=${test_log_app_error_count}"
 
   if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
     {
@@ -101,10 +105,15 @@ print_run_summary() {
       echo "| Build duration | \`${build_duration}\` |"
       echo "| Test duration | \`${test_duration}\` |"
       echo "| Total duration | \`${total_duration}s\` |"
+      echo "| Build log size | \`${build_log_size} bytes\` |"
+      echo "| Build log Swift warnings | \`${build_log_swift_warning_count}\` |"
       echo "| Log size | \`${log_size} bytes\` |"
       echo "| Test log Swift warnings | \`${test_log_swift_warning_count}\` |"
       echo "| Test log app warnings | \`${test_log_app_warning_count}\` |"
       echo "| Test log app errors | \`${test_log_app_error_count}\` |"
+      if [ -n "${BUILD_LOG:-}" ]; then
+        echo "| Build log path | \`${BUILD_LOG}\` |"
+      fi
       if [ -n "${LOG:-}" ]; then
         echo "| Log path | \`${LOG}\` |"
       fi
@@ -315,6 +324,8 @@ if [ "$TEST_DISABLE_XCTEST" = "1" ]; then
 fi
 echo "📦 Scratch: $SCRATCH_PATH | HOME=$HOME"
 echo "🗂️  Module cache: $MODULE_CACHE"
+mkdir -p "$(dirname "$LOG")" "$(dirname "$BUILD_LOG")"
+rm -f "$LOG" "$BUILD_LOG"
 
 # 1) Build tests first (doesn't count against watchdog timeout)
 echo "🔨 Building tests..."
@@ -324,8 +335,8 @@ if [ "$TEST_PREBUILD" = "0" ]; then
   echo "⏭️  Skipping separate swift build --build-tests step"
   BUILD_EXIT_CODE=0
 else
-  swift build --build-tests --scratch-path "$SCRATCH_PATH" "${MODULE_CACHE_FLAGS[@]}"
-  BUILD_EXIT_CODE=$?
+  swift build --build-tests --scratch-path "$SCRATCH_PATH" "${MODULE_CACHE_FLAGS[@]}" 2>&1 | tee "$BUILD_LOG"
+  BUILD_EXIT_CODE="${PIPESTATUS[0]}"
 fi
 set -e
 BUILD_DURATION_SECONDS=$(($(date +%s) - BUILD_START_SECONDS))
@@ -336,11 +347,8 @@ if [ "$BUILD_EXIT_CODE" != "0" ]; then
 fi
 
 # 2) Run with watchdog
-LOG="${KEYPATH_TEST_LOG:-$PROJECT_DIR/test_output.safe.txt}"
 EXIT_FILE="$PROJECT_DIR/.xctest.exit.$$"
 TIMEOUT_FILE="$PROJECT_DIR/.xctest.timeout.$$"
-mkdir -p "$(dirname "$LOG")"
-rm -f "$LOG"
 
 echo "🚀 Launching swift test..."
 TEST_START_SECONDS="$(date +%s)"

--- a/Scripts/run-tests-safe.sh
+++ b/Scripts/run-tests-safe.sh
@@ -6,6 +6,8 @@ set -euo pipefail
 # - Skips CGEvent taps in code under test to prevent hangs
 # - Adds a watchdog timeout so CI never freezes
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd -P)"
 TIMEOUT_SECONDS=${TIMEOUT_SECONDS:-240}
 ALLOW_RUNNER_CRASH_SUCCESS=${KEYPATH_ALLOW_TEST_RUNNER_CRASH_SUCCESS:-0}
 ALLOW_NONZERO_TEST_SUCCESS=${KEYPATH_ALLOW_NONZERO_TEST_SUCCESS:-0}
@@ -15,11 +17,163 @@ SWIFT_TEST_ARGS=${SWIFT_TEST_ARGS:-}
 
 echo "🧪 Running tests via swift test with safety guards..."
 
+absolute_dir() {
+  local path="$1"
+  case "$path" in
+    /*) ;;
+    *) path="$PROJECT_DIR/$path" ;;
+  esac
+  mkdir -p "$path"
+  (cd "$path" && pwd -P)
+}
+
+log_size_bytes() {
+  local path="${1:-}"
+  if [ -n "$path" ] && [ -f "$path" ]; then
+    wc -c < "$path" | tr -d '[:space:]'
+  else
+    echo "0"
+  fi
+}
+
+format_duration() {
+  local value="${1:-not-run}"
+  if [ "$value" = "not-run" ]; then
+    echo "not-run"
+  else
+    echo "${value}s"
+  fi
+}
+
+print_run_summary() {
+  local exit_code="${1:-unknown}"
+  local now_seconds
+  local total_duration
+  local log_size
+  local build_duration
+  local test_duration
+
+  if [ "$SUMMARY_PRINTED" = "1" ]; then
+    return 0
+  fi
+
+  now_seconds="$(date +%s)"
+  total_duration=$((now_seconds - RUNNER_START_SECONDS))
+  log_size="$(log_size_bytes "${LOG:-}")"
+  build_duration="$(format_duration "$BUILD_DURATION_SECONDS")"
+  test_duration="$(format_duration "$TEST_DURATION_SECONDS")"
+
+  echo "📊 Runner summary: exit=${exit_code} build=${build_duration} test=${test_duration} total=${total_duration}s log=${log_size} bytes"
+
+  if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+    {
+      echo "### KeyPath Safe Test Runner"
+      echo ""
+      echo "| Metric | Value |"
+      echo "| --- | --- |"
+      echo "| Exit code | \`${exit_code}\` |"
+      echo "| Build duration | \`${build_duration}\` |"
+      echo "| Test duration | \`${test_duration}\` |"
+      echo "| Total duration | \`${total_duration}s\` |"
+      echo "| Log size | \`${log_size} bytes\` |"
+      if [ -n "${LOG:-}" ]; then
+        echo "| Log path | \`${LOG}\` |"
+      fi
+      echo ""
+    } >> "$GITHUB_STEP_SUMMARY"
+  fi
+
+  SUMMARY_PRINTED=1
+}
+
+kill_process_tree() {
+  local pid="${1:-}"
+  local child
+
+  if [ -z "$pid" ] || ! kill -0 "$pid" 2>/dev/null; then
+    return 0
+  fi
+
+  while read -r child; do
+    [ -z "$child" ] && continue
+    kill_process_tree "$child"
+  done < <(pgrep -P "$pid" 2>/dev/null || true)
+
+  kill -TERM "$pid" 2>/dev/null || true
+  sleep 0.2
+  kill -KILL "$pid" 2>/dev/null || true
+}
+
+terminate_process_tree() {
+  local pid="${1:-}"
+  kill_process_tree "$pid"
+  if [ -n "$pid" ]; then
+    wait "$pid" 2>/dev/null || true
+  fi
+}
+
+cleanup_orphaned_xctest() {
+  [ -z "${SCRATCH_PATH:-}" ] && return 0
+
+  while read -r pid; do
+    [ -z "$pid" ] && continue
+    local command_line
+    command_line="$(ps -p "$pid" -o command= 2>/dev/null || true)"
+    case "$command_line" in
+      *"$SCRATCH_PATH"*) ;;
+      *) continue ;;
+    esac
+    echo "🧹 Cleaning up orphaned KeyPathPackageTests.xctest process (pid=$pid)"
+    terminate_process_tree "$pid"
+  done < <(pgrep -f "KeyPathPackageTests\\.xctest" 2>/dev/null || true)
+}
+
+cleanup() {
+  local exit_code=$?
+
+  [ "${CLEANUP_ARMED:-1}" = "1" ] || return "$exit_code"
+
+  if [ -n "${WATCHDOG_PID:-}" ] && kill -0 "$WATCHDOG_PID" 2>/dev/null; then
+    terminate_process_tree "$WATCHDOG_PID"
+  fi
+
+  if [ -n "${TEST_PID:-}" ] && kill -0 "$TEST_PID" 2>/dev/null; then
+    terminate_process_tree "$TEST_PID"
+  fi
+
+  cleanup_orphaned_xctest
+  [ -n "${EXIT_FILE:-}" ] && rm -f "$EXIT_FILE"
+  [ -n "${TIMEOUT_FILE:-}" ] && rm -f "$TIMEOUT_FILE"
+
+  return "$exit_code"
+}
+
+on_signal() {
+  local signal="$1"
+  echo "⚠️  Received $signal; cleaning up test processes..."
+  cleanup
+  print_run_summary 130
+  exit 130
+}
+
+trap cleanup EXIT
+trap 'on_signal INT' INT
+trap 'on_signal TERM' TERM
+trap 'on_signal HUP' HUP
+
 # 1) Environment for test-safe code paths
 export SWIFT_TEST=1
 export SKIP_EVENT_TAP_TESTS=1
 export CI_ENVIRONMENT=${CI_ENVIRONMENT:-false}
 export NSUnbufferedIO=YES
+
+# Keep default test output focused. AppLogger uses numeric levels:
+# trace=0, debug=1, info=2, warn=3, error=4.
+if [ "${KEYPATH_TEST_VERBOSE_LOGS:-0}" = "1" ]; then
+    export KEYPATH_LOG_LEVEL=${KEYPATH_LOG_LEVEL:-1}
+else
+    export KEYPATH_LOG_LEVEL=${KEYPATH_LOG_LEVEL:-3}
+fi
 
 # Optional: Enable sudo mode for fully autonomous privileged operations
 # Set KEYPATH_USE_SUDO=1 to use sudo instead of osascript admin prompts
@@ -94,13 +248,19 @@ append_runner_crash_summary() {
 # (keypath depends on KeyPathAppKit → SwiftUI, which can fail to link from a
 # fresh scratch path on Xcode 16.4 due to SwiftUICore client restrictions).
 if [ "${CI_ENVIRONMENT}" = "true" ] || [ -n "${GITHUB_ACTIONS:-}" ]; then
-    SCRATCH_PATH=${SCRATCH_PATH:-.build}
+    SCRATCH_PATH=${SCRATCH_PATH:-"$PROJECT_DIR/.build"}
 else
-    SCRATCH_PATH=${SCRATCH_PATH:-.build-ci}
+    SCRATCH_PATH=${SCRATCH_PATH:-"$PROJECT_DIR/.build-ci"}
 fi
 export HOME=${TEST_HOME:-$(mktemp -d 2>/dev/null || mktemp -d -t keypath-tests)}
+SCRATCH_PATH="$(absolute_dir "$SCRATCH_PATH")"
 MODULE_CACHE="$SCRATCH_PATH/ModuleCache.noindex"
-mkdir -p "$SCRATCH_PATH" "$MODULE_CACHE"
+if [ -d "$MODULE_CACHE" ]; then
+  echo "🧹 Resetting generated module cache: $MODULE_CACHE"
+  rm -rf "$MODULE_CACHE"
+fi
+MODULE_CACHE="$(absolute_dir "$MODULE_CACHE")"
+HOME="$(absolute_dir "$HOME")"
 export CLANG_MODULECACHE_PATH="$MODULE_CACHE"
 export SWIFT_MODULECACHE_PATH="$MODULE_CACHE"
 MODULE_CACHE_FLAGS=(-Xcc "-fmodules-cache-path=$MODULE_CACHE")
@@ -109,13 +269,26 @@ echo "🗂️  Module cache: $MODULE_CACHE"
 
 # 1) Build tests first (doesn't count against watchdog timeout)
 echo "🔨 Building tests..."
+BUILD_START_SECONDS="$(date +%s)"
+set +e
 swift build --build-tests --scratch-path "$SCRATCH_PATH" "${MODULE_CACHE_FLAGS[@]}"
+BUILD_EXIT_CODE=$?
+set -e
+BUILD_DURATION_SECONDS=$(($(date +%s) - BUILD_START_SECONDS))
+if [ "$BUILD_EXIT_CODE" != "0" ]; then
+  echo "❌ Test build failed (exit $BUILD_EXIT_CODE)"
+  print_run_summary "$BUILD_EXIT_CODE"
+  exit "$BUILD_EXIT_CODE"
+fi
 
 # 2) Run with watchdog
-LOG=./test_output.safe.txt
+LOG="$PROJECT_DIR/test_output.safe.txt"
+EXIT_FILE="$PROJECT_DIR/.xctest.exit.$$"
+TIMEOUT_FILE="$PROJECT_DIR/.xctest.timeout.$$"
 rm -f "$LOG"
 
 echo "🚀 Launching swift test..."
+TEST_START_SECONDS="$(date +%s)"
 
 (
   set +e
@@ -141,8 +314,10 @@ TEST_PID=$!
     SECS=$((SECS+1))
     if [ $SECS -ge $TIMEOUT_SECONDS ]; then
       echo "⏰ Timeout after ${TIMEOUT_SECONDS}s. Killing tests (pid=$TEST_PID)."
-      kill -9 $TEST_PID 2>/dev/null || true
-      echo "124" > .xctest.exit
+      echo "1" > "$TIMEOUT_FILE"
+      kill_process_tree "$TEST_PID"
+      cleanup_orphaned_xctest
+      echo "124" > "$EXIT_FILE"
       break
     fi
   done
@@ -172,11 +347,13 @@ fi
 
 if [ "$EXIT_CODE" = "0" ]; then
   echo "✅ All tests passed ($PASS_COUNT passed)"
+  print_run_summary "$EXIT_CODE"
   exit 0
 fi
 
 if [ "$EXIT_CODE" = "124" ]; then
   echo "⚠️  Tests timed out; see $LOG"
+  print_run_summary "$EXIT_CODE"
   exit 124
 fi
 
@@ -222,6 +399,7 @@ fi
 if [ "$FAIL_COUNT" -gt 0 ]; then
   echo "❌ $FAIL_COUNT test(s) failed ($PASS_COUNT passed)"
   grep -E "Test Case '.*' failed|Test .* failed after" "$LOG" || true
+  print_run_summary "$EXIT_CODE"
   exit 1
 fi
 

--- a/Scripts/run-tests-safe.sh
+++ b/Scripts/run-tests-safe.sh
@@ -83,7 +83,7 @@ print_run_summary() {
   filter_value="${TEST_FILTER:-none}"
   skip_value="${TEST_SKIP:-none}"
 
-  echo "📊 Runner summary: lane=${TEST_LANE} exit=${exit_code} build=${build_duration} test=${test_duration} total=${total_duration}s log=${log_size} bytes test_log_swift_warnings=${test_log_swift_warning_count} test_log_app_warnings=${test_log_app_warning_count} test_log_app_errors=${test_log_app_error_count}"
+  echo "📊 Runner summary: lane=${TEST_LANE} exit=${exit_code} prebuild=${TEST_PREBUILD} disable_xctest=${TEST_DISABLE_XCTEST} reset_module_cache=${TEST_RESET_MODULE_CACHE} build=${build_duration} test=${test_duration} total=${total_duration}s log=${log_size} bytes test_log_swift_warnings=${test_log_swift_warning_count} test_log_app_warnings=${test_log_app_warning_count} test_log_app_errors=${test_log_app_error_count}"
 
   if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
     {
@@ -94,6 +94,9 @@ print_run_summary() {
       echo "| Lane | \`${TEST_LANE}\` |"
       echo "| Filter | \`${filter_value}\` |"
       echo "| Skip | \`${skip_value}\` |"
+      echo "| Prebuild | \`${TEST_PREBUILD}\` |"
+      echo "| Disable XCTest | \`${TEST_DISABLE_XCTEST}\` |"
+      echo "| Reset module cache | \`${TEST_RESET_MODULE_CACHE}\` |"
       echo "| Exit code | \`${exit_code}\` |"
       echo "| Build duration | \`${build_duration}\` |"
       echo "| Test duration | \`${test_duration}\` |"
@@ -231,6 +234,7 @@ fi
 if [ -n "$TEST_SKIP" ]; then
     echo "⏭️  Test skip: $TEST_SKIP"
 fi
+echo "🏗️  Test prebuild: $TEST_PREBUILD | disable XCTest: $TEST_DISABLE_XCTEST | reset module cache: $TEST_RESET_MODULE_CACHE"
 echo "🧪 SWIFT_TEST=$SWIFT_TEST | SKIP_EVENT_TAP_TESTS=$SKIP_EVENT_TAP_TESTS"
 declare -a TEST_SELECTOR_ARGS=()
 if [ -n "$TEST_FILTER" ]; then
@@ -288,9 +292,11 @@ fi
 export HOME=${TEST_HOME:-$(mktemp -d 2>/dev/null || mktemp -d -t keypath-tests)}
 SCRATCH_PATH="$(absolute_dir "$SCRATCH_PATH")"
 MODULE_CACHE="$SCRATCH_PATH/ModuleCache.noindex"
-if [ -d "$MODULE_CACHE" ]; then
+if [ "$TEST_RESET_MODULE_CACHE" = "1" ] && [ -d "$MODULE_CACHE" ]; then
   echo "🧹 Resetting generated module cache: $MODULE_CACHE"
   rm -rf "$MODULE_CACHE"
+elif [ "$TEST_RESET_MODULE_CACHE" != "1" ]; then
+  echo "♻️  Reusing generated module cache: $MODULE_CACHE"
 fi
 MODULE_CACHE="$(absolute_dir "$MODULE_CACHE")"
 HOME="$(absolute_dir "$HOME")"
@@ -304,6 +310,9 @@ fi
 if [ -n "$TEST_SKIP" ]; then
   SWIFT_TEST_ARGS+=(--skip "$TEST_SKIP")
 fi
+if [ "$TEST_DISABLE_XCTEST" = "1" ]; then
+  SWIFT_TEST_ARGS+=(--disable-xctest)
+fi
 echo "📦 Scratch: $SCRATCH_PATH | HOME=$HOME"
 echo "🗂️  Module cache: $MODULE_CACHE"
 
@@ -311,8 +320,13 @@ echo "🗂️  Module cache: $MODULE_CACHE"
 echo "🔨 Building tests..."
 BUILD_START_SECONDS="$(date +%s)"
 set +e
-swift build --build-tests --scratch-path "$SCRATCH_PATH" "${MODULE_CACHE_FLAGS[@]}"
-BUILD_EXIT_CODE=$?
+if [ "$TEST_PREBUILD" = "0" ]; then
+  echo "⏭️  Skipping separate swift build --build-tests step"
+  BUILD_EXIT_CODE=0
+else
+  swift build --build-tests --scratch-path "$SCRATCH_PATH" "${MODULE_CACHE_FLAGS[@]}"
+  BUILD_EXIT_CODE=$?
+fi
 set -e
 BUILD_DURATION_SECONDS=$(($(date +%s) - BUILD_START_SECONDS))
 if [ "$BUILD_EXIT_CODE" != "0" ]; then

--- a/Scripts/run-tests-safe.sh
+++ b/Scripts/run-tests-safe.sh
@@ -11,9 +11,24 @@ PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd -P)"
 TIMEOUT_SECONDS=${TIMEOUT_SECONDS:-240}
 ALLOW_RUNNER_CRASH_SUCCESS=${KEYPATH_ALLOW_TEST_RUNNER_CRASH_SUCCESS:-0}
 ALLOW_NONZERO_TEST_SUCCESS=${KEYPATH_ALLOW_NONZERO_TEST_SUCCESS:-0}
-TEST_FILTER=${TEST_FILTER:-}
-TEST_SKIP=${TEST_SKIP:-}
-SWIFT_TEST_ARGS=${SWIFT_TEST_ARGS:-}
+RUNNER_START_SECONDS="$(date +%s)"
+BUILD_DURATION_SECONDS="not-run"
+TEST_DURATION_SECONDS="not-run"
+SUMMARY_PRINTED=0
+TEST_PID=""
+WATCHDOG_PID=""
+EXIT_FILE=""
+TIMEOUT_FILE=""
+CLEANUP_ARMED=1
+TEST_LANE="${KEYPATH_TEST_LANE:-full}"
+TEST_FILTER="${KEYPATH_TEST_FILTER:-${TEST_FILTER:-}}"
+TEST_SKIP="${KEYPATH_TEST_SKIP:-${TEST_SKIP:-}}"
+TEST_PREBUILD="${KEYPATH_TEST_PREBUILD:-1}"
+TEST_DISABLE_XCTEST="${KEYPATH_TEST_DISABLE_XCTEST:-0}"
+TEST_RESET_MODULE_CACHE="${KEYPATH_TEST_RESET_MODULE_CACHE:-1}"
+LOG="${KEYPATH_TEST_LOG:-$PROJECT_DIR/test_output.safe.txt}"
+BUILD_LOG="${KEYPATH_TEST_BUILD_LOG:-$LOG.build}"
+EXTRA_SWIFT_TEST_ARGS="${SWIFT_TEST_ARGS:-}"
 
 echo "🧪 Running tests via swift test with safety guards..."
 
@@ -328,24 +343,7 @@ if [ -n "$TEST_SKIP" ]; then
 fi
 echo "🏗️  Test prebuild: $TEST_PREBUILD | disable XCTest: $TEST_DISABLE_XCTEST | reset module cache: $TEST_RESET_MODULE_CACHE"
 echo "🧪 SWIFT_TEST=$SWIFT_TEST | SKIP_EVENT_TAP_TESTS=$SKIP_EVENT_TAP_TESTS"
-declare -a TEST_SELECTOR_ARGS=()
-if [ -n "$TEST_FILTER" ]; then
-    TEST_SELECTOR_ARGS+=(--filter "$TEST_FILTER")
-fi
-if [ -n "$TEST_SKIP" ]; then
-    TEST_SELECTOR_ARGS+=(--skip "$TEST_SKIP")
-fi
-declare -a EXTRA_TEST_ARGS=()
-if [ -n "$SWIFT_TEST_ARGS" ]; then
-    # shellcheck disable=SC2206
-    EXTRA_TEST_ARGS=($SWIFT_TEST_ARGS)
-fi
-if [ "${#TEST_SELECTOR_ARGS[@]}" -gt 0 ] || [ "${#EXTRA_TEST_ARGS[@]}" -gt 0 ]; then
-    echo "🎯 Test selector args: ${TEST_SELECTOR_ARGS[*]:-(none)}"
-    echo "⚙️  Extra swift test args: ${EXTRA_TEST_ARGS[*]:-(none)}"
-else
-    echo "🎯 Test selector args: (full suite)"
-fi
+echo "🪵 KEYPATH_LOG_LEVEL=$KEYPATH_LOG_LEVEL | KEYPATH_TEST_VERBOSE_LOGS=${KEYPATH_TEST_VERBOSE_LOGS:-0}"
 if [ "$ALLOW_RUNNER_CRASH_SUCCESS" = "1" ]; then
     echo "⚠️  KEYPATH_ALLOW_TEST_RUNNER_CRASH_SUCCESS=1 (signal crashes can pass only with zero parsed failures)"
 fi
@@ -395,15 +393,25 @@ HOME="$(absolute_dir "$HOME")"
 export CLANG_MODULECACHE_PATH="$MODULE_CACHE"
 export SWIFT_MODULECACHE_PATH="$MODULE_CACHE"
 MODULE_CACHE_FLAGS=(-Xcc "-fmodules-cache-path=$MODULE_CACHE")
-SWIFT_TEST_ARGS=()
+SWIFT_TEST_COMMAND_ARGS=()
 if [ -n "$TEST_FILTER" ]; then
-  SWIFT_TEST_ARGS+=(--filter "$TEST_FILTER")
+  SWIFT_TEST_COMMAND_ARGS+=(--filter "$TEST_FILTER")
 fi
 if [ -n "$TEST_SKIP" ]; then
-  SWIFT_TEST_ARGS+=(--skip "$TEST_SKIP")
+  SWIFT_TEST_COMMAND_ARGS+=(--skip "$TEST_SKIP")
 fi
 if [ "$TEST_DISABLE_XCTEST" = "1" ]; then
-  SWIFT_TEST_ARGS+=(--disable-xctest)
+  SWIFT_TEST_COMMAND_ARGS+=(--disable-xctest)
+fi
+if [ -n "$EXTRA_SWIFT_TEST_ARGS" ]; then
+  # shellcheck disable=SC2206
+  EXTRA_TEST_ARGS=($EXTRA_SWIFT_TEST_ARGS)
+  SWIFT_TEST_COMMAND_ARGS+=("${EXTRA_TEST_ARGS[@]}")
+fi
+if [ "${#SWIFT_TEST_COMMAND_ARGS[@]}" -gt 0 ]; then
+  echo "🎯 Swift test args: ${SWIFT_TEST_COMMAND_ARGS[*]}"
+else
+  echo "🎯 Swift test args: (full suite)"
 fi
 echo "📦 Scratch: $SCRATCH_PATH | HOME=$HOME"
 echo "🗂️  Module cache: $MODULE_CACHE"
@@ -439,15 +447,19 @@ TEST_START_SECONDS="$(date +%s)"
 (
   set +e
   set -o pipefail
-  SWIFT_TEST_COMMAND=(swift test --skip-build --scratch-path "$SCRATCH_PATH" "${MODULE_CACHE_FLAGS[@]}")
-  if [ "${#TEST_SELECTOR_ARGS[@]}" -gt 0 ]; then
-    SWIFT_TEST_COMMAND+=("${TEST_SELECTOR_ARGS[@]}")
+  SWIFT_TEST_COMMAND=(swift test --scratch-path "$SCRATCH_PATH" "${MODULE_CACHE_FLAGS[@]}")
+  if [ "$TEST_PREBUILD" != "0" ]; then
+    SWIFT_TEST_COMMAND+=(--skip-build)
   fi
-  if [ "${#EXTRA_TEST_ARGS[@]}" -gt 0 ]; then
-    SWIFT_TEST_COMMAND+=("${EXTRA_TEST_ARGS[@]}")
+  if [ "${#SWIFT_TEST_COMMAND_ARGS[@]}" -gt 0 ]; then
+    "${SWIFT_TEST_COMMAND[@]}" "${SWIFT_TEST_COMMAND_ARGS[@]}" 2>&1 | tee "$LOG"
+  else
+    "${SWIFT_TEST_COMMAND[@]}" 2>&1 | tee "$LOG"
   fi
-  "${SWIFT_TEST_COMMAND[@]}" 2>&1 | tee "$LOG"
-  echo $? > .xctest.exit
+  TEST_EXIT_CODE=$?
+  if [ ! -f "$EXIT_FILE" ]; then
+    echo "$TEST_EXIT_CODE" > "$EXIT_FILE"
+  fi
 ) &
 
 TEST_PID=$!
@@ -470,10 +482,20 @@ TEST_PID=$!
 ) & WATCHDOG_PID=$!
 
 wait $TEST_PID || true
-EXIT_CODE=$(cat .xctest.exit 2>/dev/null || echo 1)
-rm -f .xctest.exit
-kill $WATCHDOG_PID 2>/dev/null || true
-wait $WATCHDOG_PID 2>/dev/null || true
+TEST_DURATION_SECONDS=$(($(date +%s) - TEST_START_SECONDS))
+if [ -f "$TIMEOUT_FILE" ]; then
+  EXIT_CODE=124
+else
+  EXIT_CODE=$(cat "$EXIT_FILE" 2>/dev/null || echo 1)
+fi
+rm -f "$EXIT_FILE"
+rm -f "$TIMEOUT_FILE"
+if [ -n "$WATCHDOG_PID" ]; then
+  wait "$WATCHDOG_PID" 2>/dev/null || true
+fi
+cleanup_orphaned_xctest
+TEST_PID=""
+WATCHDOG_PID=""
 
 # 2) Summarize
 # Count actual test failures vs passes (both XCTest and Swift Testing formats)
@@ -517,10 +539,13 @@ if [ "$IS_SIGNAL_CRASH" = true ]; then
     fi
     append_runner_crash_summary "Allowed Test Runner Signal Crash" "signal $SIGNAL_NUM"
     echo "✅ Tests passed (ignoring allowed runner crash — $PASS_COUNT passed, 0 parsed failures)"
+    print_run_summary "$EXIT_CODE"
+    enforce_clean_summary
     exit 0
   fi
 
   echo "❌ Treating test runner signal crash as failure"
+  print_run_summary "$EXIT_CODE"
   exit "$EXIT_CODE"
 fi
 
@@ -535,10 +560,13 @@ if [ "$LOG_SIGNAL_CRASH" = true ]; then
     fi
     append_runner_crash_summary "Allowed SwiftPM-Wrapped Test Runner Signal Crash" "$LOG_SIGNAL_CRASH_LINE"
     echo "✅ Tests passed (ignoring allowed runner crash — $PASS_COUNT passed, 0 parsed failures)"
+    print_run_summary "$EXIT_CODE"
+    enforce_clean_summary
     exit 0
   fi
 
   echo "❌ Treating test runner signal crash as failure"
+  print_run_summary "$EXIT_CODE"
   exit "$EXIT_CODE"
 fi
 
@@ -553,6 +581,8 @@ fi
 # Non-zero exit but no failures found — check for any passing output
 if [ "$ALLOW_NONZERO_TEST_SUCCESS" = "1" ] && [ "$PASS_COUNT" -gt 0 ]; then
   echo "✅ Tests passed (ignoring allowed runner exit code $EXIT_CODE — $PASS_COUNT passed)"
+  print_run_summary "$EXIT_CODE"
+  enforce_clean_summary
   exit 0
 fi
 
@@ -561,4 +591,5 @@ if [ "$PASS_COUNT" -gt 0 ]; then
 else
   echo "❌ Test run failed (exit $EXIT_CODE, no test output found)"
 fi
+print_run_summary "$EXIT_CODE"
 exit $EXIT_CODE

--- a/Scripts/run-tests-safe.sh
+++ b/Scripts/run-tests-safe.sh
@@ -237,9 +237,11 @@ else
     export KEYPATH_LOG_LEVEL=${KEYPATH_LOG_LEVEL:-3}
 fi
 
-# Optional: Enable sudo mode for fully autonomous privileged operations
-# Set KEYPATH_USE_SUDO=1 to use sudo instead of osascript admin prompts
-# Auto-detect if sudoers are configured and enable automatically
+# Optional: Enable sudo mode for fully autonomous privileged operations.
+# Ordinary local/CI test lanes stay hermetic by default: they skip admin
+# operations instead of probing or mutating the real machine. Set
+# KEYPATH_USE_SUDO=1 for an explicit sudo-backed run, or set
+# KEYPATH_TEST_AUTO_SUDO=1 to restore auto-detection for a manual experiment.
 #
 # IMPORTANT: In CI we must keep tests hermetic and avoid privileged system modifications.
 # CI-safe tests should exercise "test mode" code paths (TestEnvironment.shouldSkipAdminOperations == true).
@@ -247,11 +249,15 @@ if [ "${CI_ENVIRONMENT}" = "true" ] || [ -n "${GITHUB_ACTIONS:-}" ]; then
     export KEYPATH_USE_SUDO=${KEYPATH_USE_SUDO:-0}
     echo "🔒 CI mode - forcing KEYPATH_USE_SUDO=$KEYPATH_USE_SUDO"
 elif [ -z "${KEYPATH_USE_SUDO:-}" ]; then
-    # Check if sudo -n works (NOPASSWD configured)
-    if sudo -n launchctl list com.keypath.kanata >/dev/null 2>&1 || \
-       sudo -n true >/dev/null 2>&1; then
-        export KEYPATH_USE_SUDO=1
-        echo "🔐 Auto-detected sudoers config - enabling KEYPATH_USE_SUDO=1"
+    if [ "${KEYPATH_TEST_AUTO_SUDO:-0}" = "1" ]; then
+        # Check if sudo -n works (NOPASSWD configured)
+        if sudo -n launchctl list com.keypath.kanata >/dev/null 2>&1 || \
+           sudo -n true >/dev/null 2>&1; then
+            export KEYPATH_USE_SUDO=1
+            echo "🔐 Auto-detected sudoers config - enabling KEYPATH_USE_SUDO=1"
+        else
+            export KEYPATH_USE_SUDO=0
+        fi
     else
         export KEYPATH_USE_SUDO=0
     fi

--- a/Scripts/run-tests-safe.sh
+++ b/Scripts/run-tests-safe.sh
@@ -65,6 +65,8 @@ print_run_summary() {
   local test_log_swift_warning_count
   local test_log_app_warning_count
   local test_log_app_error_count
+  local filter_value
+  local skip_value
 
   if [ "$SUMMARY_PRINTED" = "1" ]; then
     return 0
@@ -78,8 +80,10 @@ print_run_summary() {
   test_log_swift_warning_count="$(count_log_pattern "warning:" "${LOG:-}")"
   test_log_app_warning_count="$(count_log_pattern "\\[WARN\\]" "${LOG:-}")"
   test_log_app_error_count="$(count_log_pattern "\\[ERROR\\]" "${LOG:-}")"
+  filter_value="${TEST_FILTER:-none}"
+  skip_value="${TEST_SKIP:-none}"
 
-  echo "📊 Runner summary: exit=${exit_code} build=${build_duration} test=${test_duration} total=${total_duration}s log=${log_size} bytes test_log_swift_warnings=${test_log_swift_warning_count} test_log_app_warnings=${test_log_app_warning_count} test_log_app_errors=${test_log_app_error_count}"
+  echo "📊 Runner summary: lane=${TEST_LANE} exit=${exit_code} build=${build_duration} test=${test_duration} total=${total_duration}s log=${log_size} bytes test_log_swift_warnings=${test_log_swift_warning_count} test_log_app_warnings=${test_log_app_warning_count} test_log_app_errors=${test_log_app_error_count}"
 
   if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
     {
@@ -87,6 +91,9 @@ print_run_summary() {
       echo ""
       echo "| Metric | Value |"
       echo "| --- | --- |"
+      echo "| Lane | \`${TEST_LANE}\` |"
+      echo "| Filter | \`${filter_value}\` |"
+      echo "| Skip | \`${skip_value}\` |"
       echo "| Exit code | \`${exit_code}\` |"
       echo "| Build duration | \`${build_duration}\` |"
       echo "| Test duration | \`${test_duration}\` |"
@@ -217,6 +224,13 @@ else
 fi
 
 echo "⏱️  Timeout: ${TIMEOUT_SECONDS}s"
+echo "🛣️  Test lane: $TEST_LANE"
+if [ -n "$TEST_FILTER" ]; then
+    echo "🔎 Test filter: $TEST_FILTER"
+fi
+if [ -n "$TEST_SKIP" ]; then
+    echo "⏭️  Test skip: $TEST_SKIP"
+fi
 echo "🧪 SWIFT_TEST=$SWIFT_TEST | SKIP_EVENT_TAP_TESTS=$SKIP_EVENT_TAP_TESTS"
 declare -a TEST_SELECTOR_ARGS=()
 if [ -n "$TEST_FILTER" ]; then
@@ -283,6 +297,13 @@ HOME="$(absolute_dir "$HOME")"
 export CLANG_MODULECACHE_PATH="$MODULE_CACHE"
 export SWIFT_MODULECACHE_PATH="$MODULE_CACHE"
 MODULE_CACHE_FLAGS=(-Xcc "-fmodules-cache-path=$MODULE_CACHE")
+SWIFT_TEST_ARGS=()
+if [ -n "$TEST_FILTER" ]; then
+  SWIFT_TEST_ARGS+=(--filter "$TEST_FILTER")
+fi
+if [ -n "$TEST_SKIP" ]; then
+  SWIFT_TEST_ARGS+=(--skip "$TEST_SKIP")
+fi
 echo "📦 Scratch: $SCRATCH_PATH | HOME=$HOME"
 echo "🗂️  Module cache: $MODULE_CACHE"
 
@@ -301,9 +322,10 @@ if [ "$BUILD_EXIT_CODE" != "0" ]; then
 fi
 
 # 2) Run with watchdog
-LOG="$PROJECT_DIR/test_output.safe.txt"
+LOG="${KEYPATH_TEST_LOG:-$PROJECT_DIR/test_output.safe.txt}"
 EXIT_FILE="$PROJECT_DIR/.xctest.exit.$$"
 TIMEOUT_FILE="$PROJECT_DIR/.xctest.timeout.$$"
+mkdir -p "$(dirname "$LOG")"
 rm -f "$LOG"
 
 echo "🚀 Launching swift test..."

--- a/Scripts/run-tests-safe.sh
+++ b/Scripts/run-tests-safe.sh
@@ -36,6 +36,16 @@ log_size_bytes() {
   fi
 }
 
+count_log_pattern() {
+  local pattern="$1"
+  local path="${2:-}"
+  if [ -n "$path" ] && [ -f "$path" ]; then
+    grep -cE "$pattern" "$path" 2>/dev/null || true
+  else
+    echo "0"
+  fi
+}
+
 format_duration() {
   local value="${1:-not-run}"
   if [ "$value" = "not-run" ]; then
@@ -52,6 +62,9 @@ print_run_summary() {
   local log_size
   local build_duration
   local test_duration
+  local test_log_swift_warning_count
+  local test_log_app_warning_count
+  local test_log_app_error_count
 
   if [ "$SUMMARY_PRINTED" = "1" ]; then
     return 0
@@ -62,8 +75,11 @@ print_run_summary() {
   log_size="$(log_size_bytes "${LOG:-}")"
   build_duration="$(format_duration "$BUILD_DURATION_SECONDS")"
   test_duration="$(format_duration "$TEST_DURATION_SECONDS")"
+  test_log_swift_warning_count="$(count_log_pattern "warning:" "${LOG:-}")"
+  test_log_app_warning_count="$(count_log_pattern "\\[WARN\\]" "${LOG:-}")"
+  test_log_app_error_count="$(count_log_pattern "\\[ERROR\\]" "${LOG:-}")"
 
-  echo "📊 Runner summary: exit=${exit_code} build=${build_duration} test=${test_duration} total=${total_duration}s log=${log_size} bytes"
+  echo "📊 Runner summary: exit=${exit_code} build=${build_duration} test=${test_duration} total=${total_duration}s log=${log_size} bytes test_log_swift_warnings=${test_log_swift_warning_count} test_log_app_warnings=${test_log_app_warning_count} test_log_app_errors=${test_log_app_error_count}"
 
   if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
     {
@@ -76,6 +92,9 @@ print_run_summary() {
       echo "| Test duration | \`${test_duration}\` |"
       echo "| Total duration | \`${total_duration}s\` |"
       echo "| Log size | \`${log_size} bytes\` |"
+      echo "| Test log Swift warnings | \`${test_log_swift_warning_count}\` |"
+      echo "| Test log app warnings | \`${test_log_app_warning_count}\` |"
+      echo "| Test log app errors | \`${test_log_app_error_count}\` |"
       if [ -n "${LOG:-}" ]; then
         echo "| Log path | \`${LOG}\` |"
       fi

--- a/Scripts/run-tests-safe.sh
+++ b/Scripts/run-tests-safe.sh
@@ -46,6 +46,24 @@ count_log_pattern() {
   fi
 }
 
+count_swift_warnings() {
+  local path="${1:-}"
+  if [ -n "$path" ] && [ -f "$path" ]; then
+    awk '/warning:/ && $0 !~ /\.pcm: No such file or directory/ { count++ } END { print count + 0 }' "$path"
+  else
+    echo "0"
+  fi
+}
+
+count_module_cache_warnings() {
+  local path="${1:-}"
+  if [ -n "$path" ] && [ -f "$path" ]; then
+    awk '/warning: .*\.pcm: No such file or directory/ { count++ } END { print count + 0 }' "$path"
+  else
+    echo "0"
+  fi
+}
+
 format_duration() {
   local value="${1:-not-run}"
   if [ "$value" = "not-run" ]; then
@@ -64,7 +82,9 @@ print_run_summary() {
   local build_duration
   local test_duration
   local build_log_swift_warning_count
+  local build_log_module_cache_warning_count
   local test_log_swift_warning_count
+  local test_log_module_cache_warning_count
   local test_log_app_warning_count
   local test_log_app_error_count
   local filter_value
@@ -80,14 +100,16 @@ print_run_summary() {
   build_log_size="$(log_size_bytes "${BUILD_LOG:-}")"
   build_duration="$(format_duration "$BUILD_DURATION_SECONDS")"
   test_duration="$(format_duration "$TEST_DURATION_SECONDS")"
-  build_log_swift_warning_count="$(count_log_pattern "warning:" "${BUILD_LOG:-}")"
-  test_log_swift_warning_count="$(count_log_pattern "warning:" "${LOG:-}")"
+  build_log_swift_warning_count="$(count_swift_warnings "${BUILD_LOG:-}")"
+  build_log_module_cache_warning_count="$(count_module_cache_warnings "${BUILD_LOG:-}")"
+  test_log_swift_warning_count="$(count_swift_warnings "${LOG:-}")"
+  test_log_module_cache_warning_count="$(count_module_cache_warnings "${LOG:-}")"
   test_log_app_warning_count="$(count_log_pattern "\\[WARN\\]" "${LOG:-}")"
   test_log_app_error_count="$(count_log_pattern "\\[ERROR\\]" "${LOG:-}")"
   filter_value="${TEST_FILTER:-none}"
   skip_value="${TEST_SKIP:-none}"
 
-  echo "📊 Runner summary: lane=${TEST_LANE} exit=${exit_code} prebuild=${TEST_PREBUILD} disable_xctest=${TEST_DISABLE_XCTEST} reset_module_cache=${TEST_RESET_MODULE_CACHE} build=${build_duration} test=${test_duration} total=${total_duration}s build_log=${build_log_size} bytes build_log_swift_warnings=${build_log_swift_warning_count} log=${log_size} bytes test_log_swift_warnings=${test_log_swift_warning_count} test_log_app_warnings=${test_log_app_warning_count} test_log_app_errors=${test_log_app_error_count}"
+  echo "📊 Runner summary: lane=${TEST_LANE} exit=${exit_code} prebuild=${TEST_PREBUILD} disable_xctest=${TEST_DISABLE_XCTEST} reset_module_cache=${TEST_RESET_MODULE_CACHE} build=${build_duration} test=${test_duration} total=${total_duration}s build_log=${build_log_size} bytes build_log_swift_warnings=${build_log_swift_warning_count} build_log_module_cache_warnings=${build_log_module_cache_warning_count} log=${log_size} bytes test_log_swift_warnings=${test_log_swift_warning_count} test_log_module_cache_warnings=${test_log_module_cache_warning_count} test_log_app_warnings=${test_log_app_warning_count} test_log_app_errors=${test_log_app_error_count}"
 
   if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
     {
@@ -107,8 +129,10 @@ print_run_summary() {
       echo "| Total duration | \`${total_duration}s\` |"
       echo "| Build log size | \`${build_log_size} bytes\` |"
       echo "| Build log Swift warnings | \`${build_log_swift_warning_count}\` |"
+      echo "| Build log module-cache warnings | \`${build_log_module_cache_warning_count}\` |"
       echo "| Log size | \`${log_size} bytes\` |"
       echo "| Test log Swift warnings | \`${test_log_swift_warning_count}\` |"
+      echo "| Test log module-cache warnings | \`${test_log_module_cache_warning_count}\` |"
       echo "| Test log app warnings | \`${test_log_app_warning_count}\` |"
       echo "| Test log app errors | \`${test_log_app_error_count}\` |"
       if [ -n "${BUILD_LOG:-}" ]; then

--- a/Scripts/run-tests-safe.sh
+++ b/Scripts/run-tests-safe.sh
@@ -64,6 +64,59 @@ count_module_cache_warnings() {
   fi
 }
 
+check_summary_metric() {
+  local label="$1"
+  local value="$2"
+  local maximum="$3"
+
+  if [ "$value" -gt "$maximum" ] 2>/dev/null; then
+    echo "❌ $label exceeded guardrail: $value > $maximum"
+    return 1
+  fi
+
+  echo "✅ $label within guardrail: $value <= $maximum"
+  return 0
+}
+
+enforce_clean_summary() {
+  local build_log_swift_warning_count
+  local build_log_module_cache_warning_count
+  local test_log_swift_warning_count
+  local test_log_module_cache_warning_count
+  local test_log_app_warning_count
+  local test_log_app_error_count
+  local failures=0
+
+  if [ "${KEYPATH_TEST_ENFORCE_CLEAN_SUMMARY:-0}" != "1" ]; then
+    return 0
+  fi
+
+  build_log_swift_warning_count="$(count_swift_warnings "${BUILD_LOG:-}")"
+  build_log_module_cache_warning_count="$(count_module_cache_warnings "${BUILD_LOG:-}")"
+  test_log_swift_warning_count="$(count_swift_warnings "${LOG:-}")"
+  test_log_module_cache_warning_count="$(count_module_cache_warnings "${LOG:-}")"
+  test_log_app_warning_count="$(count_log_pattern "\\[WARN\\]" "${LOG:-}")"
+  test_log_app_error_count="$(count_log_pattern "\\[ERROR\\]" "${LOG:-}")"
+
+  echo "🧯 Enforcing clean test summary guardrails..."
+  check_summary_metric "Build log Swift warnings" "$build_log_swift_warning_count" "${KEYPATH_TEST_MAX_BUILD_SWIFT_WARNINGS:-0}" || failures=$((failures + 1))
+  check_summary_metric "Build log module-cache warnings" "$build_log_module_cache_warning_count" "${KEYPATH_TEST_MAX_BUILD_MODULE_CACHE_WARNINGS:-0}" || failures=$((failures + 1))
+  check_summary_metric "Test log Swift warnings" "$test_log_swift_warning_count" "${KEYPATH_TEST_MAX_TEST_SWIFT_WARNINGS:-0}" || failures=$((failures + 1))
+  check_summary_metric "Test log module-cache warnings" "$test_log_module_cache_warning_count" "${KEYPATH_TEST_MAX_TEST_MODULE_CACHE_WARNINGS:-0}" || failures=$((failures + 1))
+  check_summary_metric "Test log app warnings" "$test_log_app_warning_count" "${KEYPATH_TEST_MAX_TEST_APP_WARNINGS:-0}" || failures=$((failures + 1))
+  check_summary_metric "Test log app errors" "$test_log_app_error_count" "${KEYPATH_TEST_MAX_TEST_APP_ERRORS:-0}" || failures=$((failures + 1))
+
+  if [ "$failures" -ne 0 ]; then
+    echo "❌ Clean test summary guardrail failed with $failures regression(s)."
+    echo "   Build log: ${BUILD_LOG:-none}"
+    echo "   Test log: ${LOG:-none}"
+    return 1
+  fi
+
+  echo "✅ Clean test summary guardrail passed."
+  return 0
+}
+
 format_duration() {
   local value="${1:-not-run}"
   if [ "$value" = "not-run" ]; then
@@ -441,6 +494,7 @@ fi
 if [ "$EXIT_CODE" = "0" ]; then
   echo "✅ All tests passed ($PASS_COUNT passed)"
   print_run_summary "$EXIT_CODE"
+  enforce_clean_summary
   exit 0
 fi
 

--- a/Scripts/test-lane.sh
+++ b/Scripts/test-lane.sh
@@ -44,6 +44,7 @@ run_safe_lane() {
   local lane="$1"
   local default_filter="${2:-}"
   local default_timeout="${3:-240}"
+  local default_reset_module_cache="${4:-1}"
   local default_log="$PROJECT_DIR/test_output.${lane}.txt"
 
   if [ "$lane" = "full" ]; then
@@ -53,6 +54,7 @@ run_safe_lane() {
   export KEYPATH_TEST_LANE="$lane"
   export KEYPATH_TEST_FILTER="${KEYPATH_TEST_FILTER:-$default_filter}"
   export KEYPATH_TEST_LOG="${KEYPATH_TEST_LOG:-$default_log}"
+  export KEYPATH_TEST_RESET_MODULE_CACHE="${KEYPATH_TEST_RESET_MODULE_CACHE:-$default_reset_module_cache}"
   export TIMEOUT_SECONDS="${TIMEOUT_SECONDS:-$default_timeout}"
 
   if [ -z "$KEYPATH_TEST_FILTER" ]; then
@@ -124,17 +126,17 @@ case "$LANE" in
     run_safe_lane "$LANE" "KeyPathSmokeTests" 120
     ;;
   unit)
-    run_safe_lane "$LANE" "KeyPathErrorTests|TextToKanataKeyMapperTests|KanataBehaviorParserTests|KanataBehaviorRendererTests|KanataDefseqParserTests|PhysicalLayoutTests|MappingBehaviorTests|LayerKeyMapperNormalizeTests|LayerKeyMapperLabelTests|LayerKeyInfoExtractionTests|LabelMetadataTests|ConfigApplyTypesTests|VirtualKeyParserTests|QMKLayoutParserTests|HandAssignmentTests|TypingFeelMappingTests|KindaVimTelemetryStoreTests|GlobalHotkeyMatcherTests|VimSequenceObserverTests" 180
+    run_safe_lane "$LANE" "KeyPathErrorTests|TextToKanataKeyMapperTests|KanataBehaviorParserTests|KanataBehaviorRendererTests|KanataDefseqParserTests|PhysicalLayoutTests|MappingBehaviorTests|LayerKeyMapperNormalizeTests|LayerKeyMapperLabelTests|LayerKeyInfoExtractionTests|LabelMetadataTests|ConfigApplyTypesTests|VirtualKeyParserTests|QMKLayoutParserTests|HandAssignmentTests|TypingFeelMappingTests|KindaVimTelemetryStoreTests|GlobalHotkeyMatcherTests|VimSequenceObserverTests" 180 0
     ;;
   appkit)
-    run_safe_lane "$LANE" "AppContext|Mapper|RuleCollections|Config|RuntimeCoordinator|Pack|Services|Preferences|Keyboard|MainAppState|ContentView|FDADetection|RecordingCoordinator|RecommendationEngine|Vallack|GenericPack" 240
+    run_safe_lane "$LANE" "AppContext|Mapper|RuleCollections|Config|RuntimeCoordinator|Pack|Services|Preferences|Keyboard|MainAppState|ContentView|FDADetection|RecordingCoordinator|RecommendationEngine|Vallack|GenericPack" 240 0
     ;;
   installer)
-    run_safe_lane "$LANE" "InstallerEngine|InstallationWizard|PackageManager|ServiceLifecycle|ServiceHealth|ConfigReloadCoordinator|KanataDaemon|PlistGenerator|PrivilegedExecutor|RecoveryCoordinator|ServiceInstallGuard" 240
+    run_safe_lane "$LANE" "InstallerEngine|InstallationWizard|PackageManager|ServiceLifecycle|ServiceHealth|ConfigReloadCoordinator|KanataDaemon|PlistGenerator|PrivilegedExecutor|RecoveryCoordinator|ServiceInstallGuard" 240 0
     ;;
   snapshot)
     export KEYPATH_SNAPSHOTS=1
-    run_safe_lane "$LANE" "KeyPathSnapshotTests" 240
+    run_safe_lane "$LANE" "KeyPathSnapshotTests" 240 0
     ;;
   device)
     if [ "${KEYPATH_E2E_DEVICE:-0}" != "1" ]; then

--- a/Scripts/test-lane.sh
+++ b/Scripts/test-lane.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+set -euo pipefail
+
+# KeyPath named test lanes.
+# These lanes intentionally start as filters over the existing safe runner.
+# Milestone 4 can narrow SwiftPM test target dependencies once timings show
+# which lanes justify package graph changes.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd -P)"
+
+LANE="${1:-${KEYPATH_TEST_LANE:-full}}"
+LANE="${LANE#--lane=}"
+
+usage() {
+  cat <<'USAGE'
+Usage: ./Scripts/test-lane.sh <lane>
+
+Lanes:
+  smoke      Fast sanity checks across core parsing, permissions, installer planning, CLI, and layout tracer.
+  unit       Pure or mostly pure model/parser/renderer logic.
+  appkit     UI-adjacent app logic, services, packs, config, mappers, and rule collections.
+  installer  InstallerEngine, wizard, daemon/service lifecycle, and health-check tests.
+  snapshot   Visual snapshot tests; sets KEYPATH_SNAPSHOTS=1.
+  device     Opt-in real-system installer smoke; requires KEYPATH_E2E_DEVICE=1.
+  full       Full safe SwiftPM test suite.
+
+Environment:
+  TIMEOUT_SECONDS            Watchdog timeout passed through to run-tests-safe.sh.
+  KEYPATH_TEST_VERBOSE_LOGS  Set to 1 for debug-level app diagnostics.
+  KEYPATH_TEST_FILTER        Overrides the lane's default Swift test filter.
+  KEYPATH_TEST_SKIP          Optional Swift test skip regex.
+USAGE
+}
+
+run_safe_lane() {
+  local lane="$1"
+  local default_filter="${2:-}"
+  local default_timeout="${3:-240}"
+  local default_log="$PROJECT_DIR/test_output.${lane}.txt"
+
+  if [ "$lane" = "full" ]; then
+    default_log="$PROJECT_DIR/test_output.safe.txt"
+  fi
+
+  export KEYPATH_TEST_LANE="$lane"
+  export KEYPATH_TEST_FILTER="${KEYPATH_TEST_FILTER:-$default_filter}"
+  export KEYPATH_TEST_LOG="${KEYPATH_TEST_LOG:-$default_log}"
+  export TIMEOUT_SECONDS="${TIMEOUT_SECONDS:-$default_timeout}"
+
+  if [ -z "$KEYPATH_TEST_FILTER" ]; then
+    unset KEYPATH_TEST_FILTER
+  fi
+
+  echo "🛣️  Running KeyPath test lane: $lane"
+  "$SCRIPT_DIR/run-tests-safe.sh"
+}
+
+case "$LANE" in
+  smoke)
+    run_safe_lane "$LANE" "KeyPathErrorTests|PermissionOracleFastModeTests|TextToKanataKeyMapperTests|KanataDefseqParserTests|RuleCollectionCatalogTests|InstallerEnginePlanTests|CLISmokeTests|LayoutTracerExporterTests" 120
+    ;;
+  unit)
+    run_safe_lane "$LANE" "KeyPathErrorTests|TextToKanataKeyMapperTests|KanataBehaviorParserTests|KanataBehaviorRendererTests|KanataDefseqParserTests|PhysicalLayoutTests|MappingBehaviorTests|LayerKeyMapperNormalizeTests|LayerKeyMapperLabelTests|LayerKeyInfoExtractionTests|LabelMetadataTests|ConfigApplyTypesTests|VirtualKeyParserTests|QMKLayoutParserTests|HandAssignmentTests|TypingFeelMappingTests|KindaVimTelemetryStoreTests|GlobalHotkeyMatcherTests|VimSequenceObserverTests" 180
+    ;;
+  appkit)
+    run_safe_lane "$LANE" "AppContext|Mapper|RuleCollections|Config|RuntimeCoordinator|Pack|Services|Preferences|Keyboard|MainAppState|ContentView|FDADetection|RecordingCoordinator|RecommendationEngine|Vallack|GenericPack" 240
+    ;;
+  installer)
+    run_safe_lane "$LANE" "InstallerEngine|InstallationWizard|PackageManager|ServiceLifecycle|ServiceHealth|ConfigReloadCoordinator|KanataDaemon|PlistGenerator|PrivilegedExecutor|RecoveryCoordinator|ServiceInstallGuard" 240
+    ;;
+  snapshot)
+    export KEYPATH_SNAPSHOTS=1
+    run_safe_lane "$LANE" "KeyPathSnapshotTests" 240
+    ;;
+  device)
+    if [ "${KEYPATH_E2E_DEVICE:-0}" != "1" ]; then
+      echo "❌ Device lane requires KEYPATH_E2E_DEVICE=1."
+      echo "   This lane can touch real system surfaces; run intentionally."
+      exit 2
+    fi
+    export KEYPATH_TEST_LANE="$LANE"
+    echo "🛣️  Running KeyPath test lane: $LANE"
+    "$SCRIPT_DIR/test-installer-device.sh"
+    ;;
+  full)
+    run_safe_lane "$LANE" "" "${TIMEOUT_SECONDS:-300}"
+    ;;
+  -h|--help|help)
+    usage
+    ;;
+  *)
+    echo "❌ Unknown test lane: $LANE"
+    echo ""
+    usage
+    exit 64
+    ;;
+esac

--- a/Scripts/test-lane.sh
+++ b/Scripts/test-lane.sh
@@ -149,7 +149,7 @@ case "$LANE" in
     "$SCRIPT_DIR/test-installer-device.sh"
     ;;
   full)
-    run_safe_lane "$LANE" "" "${TIMEOUT_SECONDS:-300}"
+    run_safe_lane "$LANE" "" "${TIMEOUT_SECONDS:-300}" 0
     ;;
   -h|--help|help)
     usage

--- a/Scripts/test-lane.sh
+++ b/Scripts/test-lane.sh
@@ -17,6 +17,8 @@ Usage: ./Scripts/test-lane.sh <lane>
 
 Lanes:
   smoke      Fast sanity checks from the narrow smoke test target.
+  smoke-isolated
+             Experimental smoke harness that depends only on core products.
   unit       Pure or mostly pure model/parser/renderer logic.
   appkit     UI-adjacent app logic, services, packs, config, mappers, and rule collections.
   installer  InstallerEngine, wizard, daemon/service lifecycle, and health-check tests.
@@ -32,6 +34,10 @@ Environment:
                              Set to 0 to reuse the Swift module cache.
   KEYPATH_TEST_FILTER        Overrides the lane's default Swift test filter.
   KEYPATH_TEST_SKIP          Optional Swift test skip regex.
+  KEYPATH_ISOLATED_SMOKE_CLEAN
+                             Set to 1 to remove the isolated harness build dir first.
+  KEYPATH_ISOLATED_SMOKE_ALLOW_APPKIT
+                             Set to 1 to allow KeyPathAppKit mentions in the isolated lane log.
 USAGE
 }
 
@@ -58,12 +64,64 @@ run_safe_lane() {
   "$SCRIPT_DIR/run-tests-safe.sh"
 }
 
+run_isolated_smoke_lane() {
+  local harness_dir="$PROJECT_DIR/dev-tools/smoke-harness"
+  local log_path="${KEYPATH_TEST_LOG:-$PROJECT_DIR/test_output.smoke-isolated.txt}"
+  local build_path="${KEYPATH_ISOLATED_SMOKE_BUILD_PATH:-$harness_dir/.build}"
+
+  if [ "${KEYPATH_ISOLATED_SMOKE_CLEAN:-0}" = "1" ]; then
+    rm -rf "$build_path"
+  fi
+
+  mkdir -p "$(dirname "$log_path")"
+
+  echo "🛣️  Running KeyPath test lane: smoke-isolated"
+  echo "📦 Harness: $harness_dir"
+  echo "🧱 Build path: $build_path"
+  echo "📄 Log: $log_path"
+
+  local start elapsed exit_code
+  start="$(date +%s)"
+  set +e
+  (
+    cd "$harness_dir"
+    SWIFT_TEST=1 \
+      SKIP_EVENT_TAP_TESTS=1 \
+      KEYPATH_LOG_LEVEL="${KEYPATH_LOG_LEVEL:-3}" \
+      swift test \
+        --scratch-path "$build_path" \
+        --disable-xctest
+  ) 2>&1 | tee "$log_path"
+  exit_code="${PIPESTATUS[0]}"
+  set -e
+  elapsed="$(( $(date +%s) - start ))"
+
+  local appkit_compiles=0
+  if grep -q "KeyPathAppKit" "$log_path"; then
+    appkit_compiles=1
+  fi
+
+  echo "📊 Isolated smoke summary: exit=$exit_code total=${elapsed}s appkit_in_log=$appkit_compiles log=$(wc -c < "$log_path") bytes"
+
+  if [ "$appkit_compiles" = "1" ]; then
+    echo "⚠️  Isolated smoke log mentioned KeyPathAppKit; cold-build isolation was not proven."
+    if [ "${KEYPATH_ISOLATED_SMOKE_ALLOW_APPKIT:-0}" != "1" ]; then
+      return 1
+    fi
+  fi
+
+  return "$exit_code"
+}
+
 case "$LANE" in
   smoke)
     export KEYPATH_TEST_PREBUILD="${KEYPATH_TEST_PREBUILD:-0}"
     export KEYPATH_TEST_DISABLE_XCTEST="${KEYPATH_TEST_DISABLE_XCTEST:-1}"
     export KEYPATH_TEST_RESET_MODULE_CACHE="${KEYPATH_TEST_RESET_MODULE_CACHE:-0}"
     run_safe_lane "$LANE" "KeyPathSmokeTests" 120
+    ;;
+  smoke-isolated)
+    run_isolated_smoke_lane
     ;;
   unit)
     run_safe_lane "$LANE" "KeyPathErrorTests|TextToKanataKeyMapperTests|KanataBehaviorParserTests|KanataBehaviorRendererTests|KanataDefseqParserTests|PhysicalLayoutTests|MappingBehaviorTests|LayerKeyMapperNormalizeTests|LayerKeyMapperLabelTests|LayerKeyInfoExtractionTests|LabelMetadataTests|ConfigApplyTypesTests|VirtualKeyParserTests|QMKLayoutParserTests|HandAssignmentTests|TypingFeelMappingTests|KindaVimTelemetryStoreTests|GlobalHotkeyMatcherTests|VimSequenceObserverTests" 180

--- a/Scripts/test-lane.sh
+++ b/Scripts/test-lane.sh
@@ -2,9 +2,8 @@
 set -euo pipefail
 
 # KeyPath named test lanes.
-# These lanes intentionally start as filters over the existing safe runner.
-# Milestone 4 can narrow SwiftPM test target dependencies once timings show
-# which lanes justify package graph changes.
+# Most lanes are filters over the existing safe runner. The smoke lane uses a
+# smaller SwiftPM test target so local sanity checks avoid the AppKit test graph.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd -P)"
@@ -17,7 +16,7 @@ usage() {
 Usage: ./Scripts/test-lane.sh <lane>
 
 Lanes:
-  smoke      Fast sanity checks across core parsing, permissions, installer planning, CLI, and layout tracer.
+  smoke      Fast sanity checks from the narrow smoke test target.
   unit       Pure or mostly pure model/parser/renderer logic.
   appkit     UI-adjacent app logic, services, packs, config, mappers, and rule collections.
   installer  InstallerEngine, wizard, daemon/service lifecycle, and health-check tests.
@@ -28,6 +27,9 @@ Lanes:
 Environment:
   TIMEOUT_SECONDS            Watchdog timeout passed through to run-tests-safe.sh.
   KEYPATH_TEST_VERBOSE_LOGS  Set to 1 for debug-level app diagnostics.
+  KEYPATH_TEST_PREBUILD      Set to 0 to let swift test handle the build.
+  KEYPATH_TEST_RESET_MODULE_CACHE
+                             Set to 0 to reuse the Swift module cache.
   KEYPATH_TEST_FILTER        Overrides the lane's default Swift test filter.
   KEYPATH_TEST_SKIP          Optional Swift test skip regex.
 USAGE
@@ -58,7 +60,10 @@ run_safe_lane() {
 
 case "$LANE" in
   smoke)
-    run_safe_lane "$LANE" "KeyPathErrorTests|PermissionOracleFastModeTests|TextToKanataKeyMapperTests|KanataDefseqParserTests|RuleCollectionCatalogTests|InstallerEnginePlanTests|CLISmokeTests|LayoutTracerExporterTests" 120
+    export KEYPATH_TEST_PREBUILD="${KEYPATH_TEST_PREBUILD:-0}"
+    export KEYPATH_TEST_DISABLE_XCTEST="${KEYPATH_TEST_DISABLE_XCTEST:-1}"
+    export KEYPATH_TEST_RESET_MODULE_CACHE="${KEYPATH_TEST_RESET_MODULE_CACHE:-0}"
+    run_safe_lane "$LANE" "KeyPathSmokeTests" 120
     ;;
   unit)
     run_safe_lane "$LANE" "KeyPathErrorTests|TextToKanataKeyMapperTests|KanataBehaviorParserTests|KanataBehaviorRendererTests|KanataDefseqParserTests|PhysicalLayoutTests|MappingBehaviorTests|LayerKeyMapperNormalizeTests|LayerKeyMapperLabelTests|LayerKeyInfoExtractionTests|LabelMetadataTests|ConfigApplyTypesTests|VirtualKeyParserTests|QMKLayoutParserTests|HandAssignmentTests|TypingFeelMappingTests|KindaVimTelemetryStoreTests|GlobalHotkeyMatcherTests|VimSequenceObserverTests" 180

--- a/Scripts/test-lane.sh
+++ b/Scripts/test-lane.sh
@@ -2,8 +2,8 @@
 set -euo pipefail
 
 # KeyPath named test lanes.
-# Most lanes are filters over the existing safe runner. The smoke lane uses a
-# smaller SwiftPM test target so local sanity checks avoid the AppKit test graph.
+# Most lanes are filters over the existing safe runner. The default smoke lane
+# uses an isolated SwiftPM harness so local sanity checks avoid the AppKit graph.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd -P)"
@@ -16,9 +16,8 @@ usage() {
 Usage: ./Scripts/test-lane.sh <lane>
 
 Lanes:
-  smoke      Fast sanity checks from the narrow smoke test target.
-  smoke-isolated
-             Experimental smoke harness that depends only on core products.
+  smoke      Fast isolated sanity checks against core products.
+  smoke-root Root-package smoke target; useful for diagnostics, not the fast path.
   unit       Pure or mostly pure model/parser/renderer logic.
   appkit     UI-adjacent app logic, services, packs, config, mappers, and rule collections.
   installer  InstallerEngine, wizard, daemon/service lifecycle, and health-check tests.
@@ -65,8 +64,9 @@ run_safe_lane() {
 }
 
 run_isolated_smoke_lane() {
+  local lane="${1:-smoke}"
   local harness_dir="$PROJECT_DIR/dev-tools/smoke-harness"
-  local log_path="${KEYPATH_TEST_LOG:-$PROJECT_DIR/test_output.smoke-isolated.txt}"
+  local log_path="${KEYPATH_TEST_LOG:-$PROJECT_DIR/test_output.${lane}.txt}"
   local build_path="${KEYPATH_ISOLATED_SMOKE_BUILD_PATH:-$harness_dir/.build}"
 
   if [ "${KEYPATH_ISOLATED_SMOKE_CLEAN:-0}" = "1" ]; then
@@ -75,7 +75,7 @@ run_isolated_smoke_lane() {
 
   mkdir -p "$(dirname "$log_path")"
 
-  echo "🛣️  Running KeyPath test lane: smoke-isolated"
+  echo "🛣️  Running KeyPath test lane: $lane"
   echo "📦 Harness: $harness_dir"
   echo "🧱 Build path: $build_path"
   echo "📄 Log: $log_path"
@@ -115,13 +115,13 @@ run_isolated_smoke_lane() {
 
 case "$LANE" in
   smoke)
+    run_isolated_smoke_lane "$LANE"
+    ;;
+  smoke-root)
     export KEYPATH_TEST_PREBUILD="${KEYPATH_TEST_PREBUILD:-0}"
     export KEYPATH_TEST_DISABLE_XCTEST="${KEYPATH_TEST_DISABLE_XCTEST:-1}"
     export KEYPATH_TEST_RESET_MODULE_CACHE="${KEYPATH_TEST_RESET_MODULE_CACHE:-0}"
     run_safe_lane "$LANE" "KeyPathSmokeTests" 120
-    ;;
-  smoke-isolated)
-    run_isolated_smoke_lane
     ;;
   unit)
     run_safe_lane "$LANE" "KeyPathErrorTests|TextToKanataKeyMapperTests|KanataBehaviorParserTests|KanataBehaviorRendererTests|KanataDefseqParserTests|PhysicalLayoutTests|MappingBehaviorTests|LayerKeyMapperNormalizeTests|LayerKeyMapperLabelTests|LayerKeyInfoExtractionTests|LabelMetadataTests|ConfigApplyTypesTests|VirtualKeyParserTests|QMKLayoutParserTests|HandAssignmentTests|TypingFeelMappingTests|KindaVimTelemetryStoreTests|GlobalHotkeyMatcherTests|VimSequenceObserverTests" 180

--- a/Sources/KeyPathAppKit/Core/DistributedNotificationBridge.swift
+++ b/Sources/KeyPathAppKit/Core/DistributedNotificationBridge.swift
@@ -41,6 +41,24 @@ enum DistributedNotificationBridge {
         }
     }
 
+    private static func postLayerChanged(_ layerName: String) {
+        guard layerName != previousLayer else { return }
+
+        let previous = previousLayer
+        previousLayer = layerName
+        currentLayer = layerName
+
+        DistributedNotificationCenter.default().postNotificationName(
+            layerChangedName,
+            object: "com.keypath.app",
+            userInfo: [
+                "layer": layerName,
+                "previous": previous,
+            ],
+            deliverImmediately: true
+        )
+    }
+
     static func postServiceState(_ state: String) {
         DistributedNotificationCenter.default().postNotificationName(
             serviceStateChangedName,

--- a/Sources/KeyPathAppKit/Infrastructure/Config/ConfigurationService.swift
+++ b/Sources/KeyPathAppKit/Infrastructure/Config/ConfigurationService.swift
@@ -880,9 +880,11 @@ public enum KanataKeyConverter {
 
         // Unknown key name - log warning and return as-is to avoid silent breakage.
         // The downstream CLI validation (kanata --check) will catch this before save.
-        AppLogger.shared.log(
+        AppLogger.shared.warnUnlessQuietTest(
             "⚠️ [KanataKeyConverter] Unknown key name '\(trimmed)' - may not be valid kanata key",
-            level: .warn
+            file: #file,
+            function: #function,
+            line: #line
         )
         return lowercased
     }

--- a/Sources/KeyPathAppKit/Infrastructure/Config/ConfigurationService.swift
+++ b/Sources/KeyPathAppKit/Infrastructure/Config/ConfigurationService.swift
@@ -634,14 +634,14 @@ extension ConfigurationService {
         // against bugs that could wipe the user's config
         let trimmed = string.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else {
-            AppLogger.shared.error("🛑 [ConfigService] BLOCKED: Attempted to write empty content to \(path)")
+            AppLogger.shared.errorUnlessQuietTest("🛑 [ConfigService] BLOCKED: Attempted to write empty content to \(path)")
             throw KeyPathError.configuration(.invalidFormat(reason: "Cannot write empty configuration"))
         }
 
         // Additional safety: config files must have minimum required structure
         if path.hasSuffix(".kbd") {
             guard trimmed.contains("defsrc") || trimmed.contains("deflayer") else {
-                AppLogger.shared.error("🛑 [ConfigService] BLOCKED: Config missing required defsrc/deflayer: \(path)")
+                AppLogger.shared.errorUnlessQuietTest("🛑 [ConfigService] BLOCKED: Config missing required defsrc/deflayer: \(path)")
                 throw KeyPathError.configuration(.invalidFormat(reason: "Configuration missing required defsrc or deflayer block"))
             }
         }

--- a/Sources/KeyPathAppKit/Infrastructure/Config/KanataConfiguration+BlockBuilders.swift
+++ b/Sources/KeyPathAppKit/Infrastructure/Config/KanataConfiguration+BlockBuilders.swift
@@ -526,7 +526,7 @@ extension KanataConfiguration {
         for alias in aliases {
             if let existingIndex = seen[alias.aliasName] {
                 AppLogger.shared
-                    .error(
+                    .errorUnlessQuietTest(
                         "🚨 [ConfigGen] Duplicate alias '\(alias.aliasName)' — this should have been caught by conflict detection. Keeping last definition as safety fallback. First: '\(result[existingIndex].definition.prefix(80))' → Replaced by: '\(alias.definition.prefix(80))'"
                     )
                 result[existingIndex] = alias
@@ -537,7 +537,7 @@ extension KanataConfiguration {
         }
 
         if result.count < aliases.count {
-            AppLogger.shared.error("🚨 [ConfigGen] Had to deduplicate \(aliases.count - result.count) alias(es) — investigate why conflict detection missed this")
+            AppLogger.shared.errorUnlessQuietTest("🚨 [ConfigGen] Had to deduplicate \(aliases.count - result.count) alias(es) — investigate why conflict detection missed this")
         }
 
         return result

--- a/Sources/KeyPathAppKit/Managers/ConfigReloadCoordinator.swift
+++ b/Sources/KeyPathAppKit/Managers/ConfigReloadCoordinator.swift
@@ -217,7 +217,7 @@ final class ConfigReloadCoordinator {
     func triggerReload() async {
         let result = await triggerConfigReload()
         if !result.isSuccess {
-            AppLogger.shared.warn(
+            AppLogger.shared.warnUnlessQuietTest(
                 "⚠️ [Reload] Reload failed (no automatic restart): \(result.errorMessage ?? "Unknown")"
             )
         }

--- a/Sources/KeyPathAppKit/Managers/ConfigReloadCoordinator.swift
+++ b/Sources/KeyPathAppKit/Managers/ConfigReloadCoordinator.swift
@@ -66,7 +66,7 @@ final class ConfigReloadCoordinator {
             tcpPort: PreferencesService.shared.tcpServerPort
         )
         if !healthStatus.isHealthy {
-            AppLogger.shared.warn(
+            AppLogger.shared.warnUnlessQuietTest(
                 "⚠️ [Reload] Skipping TCP reload because Kanata service is not healthy yet: \(healthStatus.reason ?? "unknown reason")"
             )
             return ReloadResult(

--- a/Sources/KeyPathAppKit/Managers/InstallationCoordinator.swift
+++ b/Sources/KeyPathAppKit/Managers/InstallationCoordinator.swift
@@ -94,7 +94,7 @@ final class InstallationCoordinator {
             AppLogger.shared.log("✅ [Installation] Step \(stepNumber) SUCCESS: User config available at \(configPath)")
             return StepResult(stepNumber: stepNumber, totalSteps: totalSteps, success: true, warning: false)
         } else {
-            AppLogger.shared.error("❌ [Installation] Step \(stepNumber) FAILED: User config missing at \(configPath)")
+            AppLogger.shared.errorUnlessQuietTest("❌ [Installation] Step \(stepNumber) FAILED: User config missing at \(configPath)")
             return StepResult(stepNumber: stepNumber, totalSteps: totalSteps, success: false, warning: false)
         }
     }

--- a/Sources/KeyPathAppKit/Managers/RecoveryCoordinator.swift
+++ b/Sources/KeyPathAppKit/Managers/RecoveryCoordinator.swift
@@ -98,7 +98,7 @@ final class RecoveryCoordinator {
     ) async {
         // Check if VirtualHID daemon is running first
         if await !isKarabinerDaemonRunning() {
-            AppLogger.shared.warn("⚠️ [Recovery] Karabiner daemon not running - recovery failed")
+            AppLogger.shared.warnUnlessQuietTest("⚠️ [Recovery] Karabiner daemon not running - recovery failed")
             onError("Recovery failed: Karabiner daemon not available")
             return
         }
@@ -106,7 +106,7 @@ final class RecoveryCoordinator {
         // Try starting the runtime normally via the runtime coordinator
         let started = await startKanata()
         if !started {
-            AppLogger.shared.error("❌ [Recovery] Failed to start Kanata during validation")
+            AppLogger.shared.errorUnlessQuietTest("❌ [Recovery] Failed to start Kanata during validation")
         }
     }
 
@@ -164,7 +164,7 @@ final class RecoveryCoordinator {
             AppLogger.shared.log("🛑 [Mappings] Paused by killing Kanata processes")
             return true
         } catch {
-            AppLogger.shared.warn("⚠️ [Mappings] Failed to pause mappings: \(error)")
+            AppLogger.shared.warnUnlessQuietTest("⚠️ [Mappings] Failed to pause mappings: \(error)")
             return false
         }
     }
@@ -179,7 +179,7 @@ final class RecoveryCoordinator {
             try? await Task.sleep(for: .milliseconds(200))
             AppLogger.shared.info("🚀 [Mappings] Resumed by restarting service")
         } else {
-            AppLogger.shared.warn("⚠️ [Mappings] Failed to resume mappings")
+            AppLogger.shared.warnUnlessQuietTest("⚠️ [Mappings] Failed to resume mappings")
         }
         return success
     }

--- a/Sources/KeyPathAppKit/Managers/SaveCoordinator.swift
+++ b/Sources/KeyPathAppKit/Managers/SaveCoordinator.swift
@@ -291,7 +291,7 @@ final class SaveCoordinator {
 
     func restoreLastGoodConfig() async throws {
         guard let backup = lastGoodConfig else {
-            AppLogger.shared.warn("⚠️ [SaveCoordinator] No backup available - writing minimal safe config")
+            AppLogger.shared.warnUnlessQuietTest("⚠️ [SaveCoordinator] No backup available - writing minimal safe config")
             try await writeMinimalSafeConfig()
             return
         }
@@ -320,7 +320,7 @@ final class SaveCoordinator {
         let configDir = URL(fileURLWithPath: configurationService.configDirectory)
         try Foundation.FileManager().createDirectory(at: configDir, withIntermediateDirectories: true)
         try safeConfig.write(to: configURL, atomically: true, encoding: .utf8)
-        AppLogger.shared.warn("🛡️ [SaveCoordinator] Wrote minimal safe config to \(configPath)")
+        AppLogger.shared.warnUnlessQuietTest("🛡️ [SaveCoordinator] Wrote minimal safe config to \(configPath)")
     }
 
     func hasBackup() -> Bool {

--- a/Sources/KeyPathAppKit/Managers/ServiceLifecycleCoordinator.swift
+++ b/Sources/KeyPathAppKit/Managers/ServiceLifecycleCoordinator.swift
@@ -291,7 +291,7 @@ final class ServiceLifecycleCoordinator {
             return false
         }
 
-        AppLogger.shared.warn(
+        AppLogger.shared.warnUnlessQuietTest(
             "⚠️ [Service] Running Kanata binary does not match bundled binary; " +
                 "forcing privileged runtime recovery. running(pid=\(runningIdentity.pid), " +
                 "path=\(runningIdentity.executablePath)) bundled=\(bundledPath)"

--- a/Sources/KeyPathAppKit/Managers/ServiceLifecycleCoordinator.swift
+++ b/Sources/KeyPathAppKit/Managers/ServiceLifecycleCoordinator.swift
@@ -207,7 +207,7 @@ final class ServiceLifecycleCoordinator {
         }
 
         if let checker = isKarabinerDaemonRunning, await !checker() {
-            AppLogger.shared.error("❌ [Service] Cannot start Kanata - VirtualHID daemon is not running")
+            AppLogger.shared.errorUnlessQuietTest("❌ [Service] Cannot start Kanata - VirtualHID daemon is not running")
             onError?("Cannot start: Karabiner VirtualHID daemon is not running. Please complete the setup wizard.")
             onStateChanged?()
             return false
@@ -219,7 +219,9 @@ final class ServiceLifecycleCoordinator {
             serviceID: ServiceHealthChecker.vhidDaemonServiceID
         )
         if !VHIDSafetyCheck.canStartKanata(vhidDaemonHealthy: vhidHealthy) {
-            AppLogger.shared.error("❌ [Service] Cannot start kanata — VirtualHID daemon not healthy (ServiceHealthChecker)")
+            AppLogger.shared.errorUnlessQuietTest(
+                "❌ [Service] Cannot start kanata — VirtualHID daemon not healthy (ServiceHealthChecker)"
+            )
             onError?("Cannot start: VirtualHID daemon health check failed. Please reinstall drivers.")
             onStateChanged?()
             return false
@@ -267,7 +269,7 @@ final class ServiceLifecycleCoordinator {
             return true
         } catch {
             let message = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
-            AppLogger.shared.error("❌ [Service] LaunchDaemon registration failed: \(message)")
+            AppLogger.shared.errorUnlessQuietTest("❌ [Service] LaunchDaemon registration failed: \(message)")
             onError?("Failed to start Kanata: \(message)")
             onStateChanged?()
             return false
@@ -518,13 +520,15 @@ final class ServiceLifecycleCoordinator {
             // Poll until the processes exit; escalate to SIGKILL past the grace window.
             let survivors = await waitForProcessesGone(pids, withinMs: WaitForExitTiming.processExitGraceMs)
             for pid in survivors {
-                AppLogger.shared.warn("⚠️ [Service] \(name) (PID \(pid)) did not exit within grace — SIGKILL")
+                AppLogger.shared.warnUnlessQuietTest("⚠️ [Service] \(name) (PID \(pid)) did not exit within grace — SIGKILL")
                 sendSignal(pid, SIGKILL)
             }
             if !survivors.isEmpty {
                 let stillAlive = await waitForProcessesGone(survivors, withinMs: WaitForExitTiming.postKillConfirmMs)
                 if !stillAlive.isEmpty {
-                    AppLogger.shared.warn("⚠️ [Service] \(name) PIDs \(stillAlive) still alive after SIGKILL — proceeding anyway")
+                    AppLogger.shared.warnUnlessQuietTest(
+                        "⚠️ [Service] \(name) PIDs \(stillAlive) still alive after SIGKILL — proceeding anyway"
+                    )
                 }
             }
         }
@@ -566,7 +570,7 @@ final class ServiceLifecycleCoordinator {
             if !listening { return true }
             if poll < maxPolls - 1 { await waitSleep(WaitForExitTiming.pollInterval) }
         }
-        AppLogger.shared.warn(
+        AppLogger.shared.warnUnlessQuietTest(
             "⚠️ [Service] TCP port \(port) still in use after wait-for-exit — proceeding anyway (grab auto-recovery is the backstop)"
         )
         return false

--- a/Sources/KeyPathAppKit/Models/QMKLayoutParser.swift
+++ b/Sources/KeyPathAppKit/Models/QMKLayoutParser.swift
@@ -258,7 +258,7 @@ enum QMKLayoutParser {
                 keys: keys
             )
         } catch {
-            AppLogger.shared.error("⚠️ [QMKLayoutParser] Failed to parse JSON: \(error)")
+            AppLogger.shared.errorUnlessQuietTest("⚠️ [QMKLayoutParser] Failed to parse JSON: \(error)")
             return nil
         }
     }

--- a/Sources/KeyPathAppKit/Services/Configuration/ConfigHotReloadService.swift
+++ b/Sources/KeyPathAppKit/Services/Configuration/ConfigHotReloadService.swift
@@ -144,7 +144,7 @@ final class ConfigHotReloadService {
 
         // Check file exists
         guard Foundation.FileManager().fileExists(atPath: configPath) else {
-            AppLogger.shared.error("❌ [ConfigHotReload] Config file no longer exists: \(configPath)")
+            AppLogger.shared.errorUnlessQuietTest("❌ [ConfigHotReload] Config file no longer exists: \(configPath)")
             let result = ReloadResult.failure("Config file was deleted")
             callbacks.onFailure?(result.message)
             scheduleStatusReset()
@@ -159,7 +159,7 @@ final class ConfigHotReloadService {
                 "📁 [ConfigHotReload] Read \(configContent.count) characters from external file"
             )
         } catch {
-            AppLogger.shared.error("❌ [ConfigHotReload] Failed to read external config: \(error)")
+            AppLogger.shared.errorUnlessQuietTest("❌ [ConfigHotReload] Failed to read external config: \(error)")
             let result = ReloadResult.failure("Failed to read config: \(error.localizedDescription)")
             callbacks.onFailure?(result.message)
             scheduleStatusReset()
@@ -168,7 +168,7 @@ final class ConfigHotReloadService {
 
         // Validate configuration
         guard let configService = configurationService else {
-            AppLogger.shared.error("❌ [ConfigHotReload] ConfigurationService not configured")
+            AppLogger.shared.errorUnlessQuietTest("❌ [ConfigHotReload] ConfigurationService not configured")
             let result = ReloadResult.failure("Service not configured")
             callbacks.onFailure?(result.message)
             scheduleStatusReset()
@@ -178,7 +178,7 @@ final class ConfigHotReloadService {
         let validationResult = await configService.validateConfiguration(configContent)
         if !validationResult.isValid {
             let errorMsg = validationResult.errors.first ?? "Unknown validation error"
-            AppLogger.shared.error(
+            AppLogger.shared.errorUnlessQuietTest(
                 "❌ [ConfigHotReload] Validation failed: \(validationResult.errors.joined(separator: ", "))"
             )
             let result = ReloadResult.failure("Invalid config: \(errorMsg)")
@@ -189,7 +189,7 @@ final class ConfigHotReloadService {
 
         // Trigger hot reload via TCP
         guard let handler = reloadHandler else {
-            AppLogger.shared.error("❌ [ConfigHotReload] Reload handler not configured")
+            AppLogger.shared.errorUnlessQuietTest("❌ [ConfigHotReload] Reload handler not configured")
             let result = ReloadResult.failure("Reload handler not configured")
             callbacks.onFailure?(result.message)
             scheduleStatusReset()

--- a/Sources/KeyPathAppKit/Services/Configuration/ConfigHotReloadService.swift
+++ b/Sources/KeyPathAppKit/Services/Configuration/ConfigHotReloadService.swift
@@ -261,7 +261,7 @@ final class ConfigHotReloadService {
         do {
             return try parser(configContent)
         } catch {
-            AppLogger.shared.warn("⚠️ [ConfigHotReload] Failed to parse config: \(error)")
+            AppLogger.shared.warnUnlessQuietTest("⚠️ [ConfigHotReload] Failed to parse config: \(error)")
             return nil
         }
     }

--- a/Sources/KeyPathAppKit/Services/Configuration/ConfigHotReloadService.swift
+++ b/Sources/KeyPathAppKit/Services/Configuration/ConfigHotReloadService.swift
@@ -232,7 +232,7 @@ final class ConfigHotReloadService {
             }
 
             let message = reloadOutcome.message ?? "Hot reload failed"
-            AppLogger.shared.error("❌ [ConfigHotReload] \(message)")
+            AppLogger.shared.errorUnlessQuietTest("❌ [ConfigHotReload] \(message)")
             let result = ReloadResult.failure(message)
             callbacks.onFailure?(result.message)
             scheduleStatusReset()

--- a/Sources/KeyPathAppKit/Services/Devices/KeyboardDisplayContextStore.swift
+++ b/Sources/KeyPathAppKit/Services/Devices/KeyboardDisplayContextStore.swift
@@ -75,7 +75,7 @@ actor KeyboardDisplayContextStore {
             let data = try Data(contentsOf: fileURL)
             return try decoder.decode([Context].self, from: data)
         } catch {
-            AppLogger.shared.warn("⚠️ [KeyboardDisplayContextStore] Failed to load contexts: \(error)")
+            AppLogger.shared.warnUnlessQuietTest("⚠️ [KeyboardDisplayContextStore] Failed to load contexts: \(error)")
             return []
         }
     }

--- a/Sources/KeyPathAppKit/Services/MainAppStateController.swift
+++ b/Sources/KeyPathAppKit/Services/MainAppStateController.swift
@@ -356,7 +356,7 @@ class MainAppStateController {
     /// Optimization: Skips validation if completed within cooldown period (30s) to avoid redundant work on rapid restarts
     func performInitialValidation() async {
         guard serviceLifecycle != nil else {
-            AppLogger.shared.warn("⚠️ [MainAppStateController] Cannot validate - not configured")
+            AppLogger.shared.warnUnlessQuietTest("⚠️ [MainAppStateController] Cannot validate - not configured")
             return
         }
 
@@ -468,7 +468,7 @@ class MainAppStateController {
 
     private func performValidation() async {
         guard let validator else {
-            AppLogger.shared.warn("⚠️ [MainAppStateController] Cannot validate - validator not configured")
+            AppLogger.shared.warnUnlessQuietTest("⚠️ [MainAppStateController] Cannot validate - validator not configured")
             validationState = .checking
             issues = []
             lastValidationDate = Date()

--- a/Sources/KeyPathAppKit/Services/Monitoring/ServiceHealthMonitor.swift
+++ b/Sources/KeyPathAppKit/Services/Monitoring/ServiceHealthMonitor.swift
@@ -203,7 +203,7 @@ final class ServiceHealthMonitor: ServiceHealthMonitorProtocol {
 
         // First check: Verify process is actually running
         guard processStatus.isRunning else {
-            AppLogger.shared.warn("[HealthMonitor] Process not running")
+            AppLogger.shared.warnUnlessQuietTest("[HealthMonitor] Process not running")
             return ServiceHealthStatus.unhealthy(reason: "Process not running", shouldRestart: true)
         }
 

--- a/Sources/KeyPathAppKit/Services/Monitoring/ServiceHealthMonitor.swift
+++ b/Sources/KeyPathAppKit/Services/Monitoring/ServiceHealthMonitor.swift
@@ -385,7 +385,7 @@ final class ServiceHealthMonitor: ServiceHealthMonitorProtocol {
 
     func recordStartFailure() async {
         let backoffInterval = calculateBackoffInterval(attemptCount: startAttemptCount)
-        AppLogger.shared.warn(
+        AppLogger.shared.warnUnlessQuietTest(
             "[HealthMonitor] Recorded start failure (attempt \(startAttemptCount), next backoff: \(String(format: "%.1f", backoffInterval))s)"
         )
     }
@@ -423,10 +423,10 @@ final class ServiceHealthMonitor: ServiceHealthMonitorProtocol {
         let isCrashLoop = uniquePIDs.count >= crashLoopThreshold
 
         if isCrashLoop {
-            AppLogger.shared.error(
+            AppLogger.shared.errorUnlessQuietTest(
                 "[HealthMonitor] CRASH LOOP DETECTED: \(uniquePIDs.count) different PIDs in \(crashLoopWindowSeconds)s window"
             )
-            AppLogger.shared.error(
+            AppLogger.shared.errorUnlessQuietTest(
                 "[HealthMonitor] PIDs observed: \(uniquePIDs.sorted())"
             )
 
@@ -465,7 +465,7 @@ final class ServiceHealthMonitor: ServiceHealthMonitorProtocol {
 
         let shouldTriggerRecovery = connectionFailureCount >= maxConnectionFailures
         if shouldTriggerRecovery {
-            AppLogger.shared.warn("[HealthMonitor] Max connection failures reached - recovery needed")
+            AppLogger.shared.warnUnlessQuietTest("[HealthMonitor] Max connection failures reached - recovery needed")
         }
 
         return shouldTriggerRecovery
@@ -491,14 +491,14 @@ final class ServiceHealthMonitor: ServiceHealthMonitorProtocol {
             grabRecoveryAttempts = 0
         }
         guard grabRecoveryAttempts < maxGrabRecoveryAttempts else {
-            AppLogger.shared.error(
+            AppLogger.shared.errorUnlessQuietTest(
                 "[HealthMonitor] kanata input-grab still failing after \(grabRecoveryAttempts) recovery attempts — giving up (manual intervention / reboot likely needed)"
             )
             return .giveUp(attempts: grabRecoveryAttempts)
         }
         grabRecoveryAttempts += 1
         lastGrabRecoveryAt = now
-        AppLogger.shared.warn(
+        AppLogger.shared.warnUnlessQuietTest(
             "[HealthMonitor] kanata input-grab failure — recovery attempt \(grabRecoveryAttempts)/\(maxGrabRecoveryAttempts)"
         )
         return .recover(attempt: grabRecoveryAttempts)
@@ -522,14 +522,14 @@ final class ServiceHealthMonitor: ServiceHealthMonitorProtocol {
 
         // Check if we've exceeded max attempts
         if startAttemptCount >= maxStartAttempts {
-            AppLogger.shared.error(
+            AppLogger.shared.errorUnlessQuietTest(
                 "[HealthMonitor] Max start attempts (\(maxStartAttempts)) reached - giving up"
             )
             return .giveUp(reason: "Failed to start after \(maxStartAttempts) attempts")
         }
 
         if retryAttemptCount >= maxRetryAttempts {
-            AppLogger.shared.error(
+            AppLogger.shared.errorUnlessQuietTest(
                 "[HealthMonitor] Max retry attempts (\(maxRetryAttempts)) reached - giving up"
             )
             return .giveUp(reason: "Failed to recover after \(maxRetryAttempts) retry attempts")
@@ -537,7 +537,7 @@ final class ServiceHealthMonitor: ServiceHealthMonitorProtocol {
 
         // Check if connection failures warrant full recovery
         if connectionFailureCount >= maxConnectionFailures {
-            AppLogger.shared.warn(
+            AppLogger.shared.warnUnlessQuietTest(
                 "[HealthMonitor] Connection failures detected - recommend full recovery"
             )
             return .fullRecovery

--- a/Sources/KeyPathAppKit/Services/Monitoring/StuckKeyRecoveryService.swift
+++ b/Sources/KeyPathAppKit/Services/Monitoring/StuckKeyRecoveryService.swift
@@ -47,7 +47,7 @@ final class StuckKeyRecoveryService {
 
         isRecovering = true
 
-        AppLogger.shared.error(
+        AppLogger.shared.errorUnlessQuietTest(
             "🚨 [StuckKeyRecovery] Stuck key detected: \(correlation.key) repeating with kanata unresponsive for \(msSinceKanata)ms — triggering automatic restart"
         )
 
@@ -63,10 +63,12 @@ final class StuckKeyRecoveryService {
                 if success {
                     AppLogger.shared.info("✅ [StuckKeyRecovery] Kanata restarted — stuck key should be cleared")
                 } else {
-                    AppLogger.shared.error("❌ [StuckKeyRecovery] Kanata restart failed — user may need to intervene")
+                    AppLogger.shared.errorUnlessQuietTest(
+                        "❌ [StuckKeyRecovery] Kanata restart failed — user may need to intervene"
+                    )
                 }
             } else {
-                AppLogger.shared.error("❌ [StuckKeyRecovery] No restart handler configured — cannot recover")
+                AppLogger.shared.errorUnlessQuietTest("❌ [StuckKeyRecovery] No restart handler configured — cannot recover")
             }
         }
     }

--- a/Sources/KeyPathAppKit/Services/Networking/KanataTCPClient+Operations.swift
+++ b/Sources/KeyPathAppKit/Services/Networking/KanataTCPClient+Operations.swift
@@ -247,7 +247,7 @@ extension KanataTCPClient {
 
             return false
         } catch {
-            AppLogger.shared.warn("❌ [TCP] Server check failed: \(error)")
+            AppLogger.shared.warnUnlessQuietTest("❌ [TCP] Server check failed: \(error)")
             // FIX #3: Close connection on error so next call gets fresh connection
             if shouldRetry(error) {
                 AppLogger.shared.debug("🌐 [TCP] Closing connection after server check failure")

--- a/Sources/KeyPathAppKit/Services/Packs/InstalledPackTracker.swift
+++ b/Sources/KeyPathAppKit/Services/Packs/InstalledPackTracker.swift
@@ -42,6 +42,10 @@ public actor InstalledPackTracker {
     public init(fileURL: URL? = nil) {
         if let fileURL {
             self.fileURL = fileURL
+        } else if TestEnvironment.isRunningTests {
+            self.fileURL = FileManager.default.temporaryDirectory
+                .appendingPathComponent("keypath-installed-packs-\(ProcessInfo.processInfo.processIdentifier)-\(UUID().uuidString)", isDirectory: true)
+                .appendingPathComponent("installed-packs.json")
         } else {
             // ~/.config/keypath/installed-packs.json
             let home = FileManager.default.homeDirectoryForCurrentUser

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+PublicAPI.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+PublicAPI.swift
@@ -752,7 +752,8 @@ extension RuleCollectionsManager {
             if let oldActivator = ruleCollections[index].momentaryActivator {
                 ruleCollections[index].momentaryActivator = MomentaryActivator(
                     input: newKey,
-                    targetLayer: oldActivator.targetLayer
+                    targetLayer: oldActivator.targetLayer,
+                    sourceLayer: oldActivator.sourceLayer
                 )
                 AppLogger.shared.log(
                     "🔑 [RuleCollections] Updated '\(ruleCollections[index].name)' activator to '\(newKey)'"

--- a/Sources/KeyPathAppKit/Services/SimpleMods/SimpleModsWriter.swift
+++ b/Sources/KeyPathAppKit/Services/SimpleMods/SimpleModsWriter.swift
@@ -68,7 +68,7 @@ public final class SimpleModsWriter: Sendable {
                 // SAFETY: Never write empty config - this would break kanata
                 let trimmed = newContent.trimmingCharacters(in: .whitespacesAndNewlines)
                 guard !trimmed.isEmpty, trimmed.contains("defsrc") || trimmed.contains("deflayer") else {
-                    AppLogger.shared.error("🛑 [SimpleModsWriter] BLOCKED: Would have written invalid config")
+                    AppLogger.shared.errorUnlessQuietTest("🛑 [SimpleModsWriter] BLOCKED: Would have written invalid config")
                     throw KeyPathError.configuration(.invalidFormat(reason: "Cannot write empty or invalid configuration"))
                 }
 

--- a/Sources/KeyPathAppKit/Services/StatePublisherService.swift
+++ b/Sources/KeyPathAppKit/Services/StatePublisherService.swift
@@ -67,7 +67,7 @@ final class StatePublisherService<State: Sendable> {
     /// The configured state provider will be invoked to create a new snapshot.
     func notifyStateChanged() {
         guard let provider = stateProvider else {
-            AppLogger.shared.warn("⚠️ [StatePublisher] notifyStateChanged called but no provider configured")
+            AppLogger.shared.warnUnlessQuietTest("⚠️ [StatePublisher] notifyStateChanged called but no provider configured")
             return
         }
         let state = provider()

--- a/Sources/KeyPathCore/Logger.swift
+++ b/Sources/KeyPathCore/Logger.swift
@@ -231,6 +231,15 @@ public final class AppLogger {
         log(message, level: .warn, file: file, function: function, line: line)
     }
 
+    /// Log an expected fixture/setup diagnostic as a warning in normal use, but
+    /// downgrade it to debug during quiet test runs.
+    public func warnUnlessQuietTest(
+        _ message: String, file: String = #file, function: String = #function, line: Int = #line
+    ) {
+        let level: AppLogLevel = TestEnvironment.shouldQuietExpectedTestDiagnostics ? .debug : .warn
+        log(message, level: level, file: file, function: function, line: line)
+    }
+
     public func error(
         _ message: String, file: String = #file, function: String = #function, line: Int = #line
     ) {

--- a/Sources/KeyPathCore/Logger.swift
+++ b/Sources/KeyPathCore/Logger.swift
@@ -240,6 +240,15 @@ public final class AppLogger {
         log(message, level: level, file: file, function: function, line: line)
     }
 
+    /// Log an expected failure-path diagnostic as an error in normal use, but
+    /// downgrade it to debug during quiet test runs.
+    public func errorUnlessQuietTest(
+        _ message: String, file: String = #file, function: String = #function, line: Int = #line
+    ) {
+        let level: AppLogLevel = TestEnvironment.shouldQuietExpectedTestDiagnostics ? .debug : .error
+        log(message, level: level, file: file, function: function, line: line)
+    }
+
     public func error(
         _ message: String, file: String = #file, function: String = #function, line: Int = #line
     ) {

--- a/Sources/KeyPathCore/SubprocessRunner.swift
+++ b/Sources/KeyPathCore/SubprocessRunner.swift
@@ -100,7 +100,7 @@ public actor SubprocessRunner: SubprocessRunning {
 
                     // Log completion
                     if duration > 5.0 {
-                        AppLogger.shared.warn(
+                        AppLogger.shared.warnUnlessQuietTest(
                             "⚠️ [SubprocessRunner] \(executable) took \(String(format: "%.2f", duration))s (>5s threshold)"
                         )
                     } else {
@@ -136,7 +136,7 @@ public actor SubprocessRunner: SubprocessRunning {
                     try task.run()
                 } catch {
                     runContext.timeoutTask?.cancel()
-                    AppLogger.shared.error("❌ [SubprocessRunner] Failed to launch \(executable): \(error)")
+                    AppLogger.shared.errorUnlessQuietTest("❌ [SubprocessRunner] Failed to launch \(executable): \(error)")
                     runContext.resume(
                         with: .failure(SubprocessError.launchFailed(executable: executable, error: error))
                     )

--- a/Sources/KeyPathCore/TestEnvironment.swift
+++ b/Sources/KeyPathCore/TestEnvironment.swift
@@ -121,6 +121,12 @@ public enum TestEnvironment {
         isRunningTests
     }
 
+    /// True when tests should keep expected fixture/setup diagnostics out of
+    /// default warning output. Set `KEYPATH_TEST_VERBOSE_LOGS=1` to show them.
+    public static var shouldQuietExpectedTestDiagnostics: Bool {
+        isRunningTests && ProcessInfo.processInfo.environment["KEYPATH_TEST_VERBOSE_LOGS"] != "1"
+    }
+
     /// Force test mode (for manual testing)
     /// Thread-safe: Uses atomic access pattern to avoid MainActor isolation issues
     private static let _forceTestModeLock = NSLock()

--- a/Sources/KeyPathInstallationWizard/Core/VHIDDeviceManager.swift
+++ b/Sources/KeyPathInstallationWizard/Core/VHIDDeviceManager.swift
@@ -611,7 +611,7 @@ public final class VHIDDeviceManager: @unchecked Sendable {
         // Step 2: Use bundled pkg (required - no download fallback)
         let bundledPkgPath = WizardSystemPaths.bundledVHIDDriverPkgPath
         guard WizardSystemPaths.bundledVHIDDriverPkgExists else {
-            AppLogger.shared.error(
+            AppLogger.shared.errorUnlessQuietTest(
                 "❌ [VHIDManager] Bundled VHID driver pkg not found at: \(bundledPkgPath). " +
                     "This indicates a corrupt KeyPath installation."
             )

--- a/Tests/KeyPathSmokeTests/KanataDefseqParserSmokeTests.swift
+++ b/Tests/KeyPathSmokeTests/KanataDefseqParserSmokeTests.swift
@@ -1,0 +1,90 @@
+@testable import KeyPathCore
+import Testing
+
+@Suite("KanataDefseqParser Smoke Tests")
+struct KanataDefseqParserSmokeTests {
+    @Test("Parses a single defseq")
+    func parsesSingleSequence() {
+        let config = """
+        (defseq window-leader
+          (space w))
+        """
+
+        let sequences = KanataDefseqParser.parseSequences(from: config)
+
+        #expect(sequences.count == 1)
+        #expect(sequences[0].name == "window-leader")
+        #expect(sequences[0].keys == ["space", "w"])
+    }
+
+    @Test("Parses multiple sequences")
+    func parsesMultipleSequences() {
+        let config = """
+        (defseq
+          window-leader (space w)
+          app-leader (space a))
+        """
+
+        let sequences = KanataDefseqParser.parseSequences(from: config)
+
+        #expect(sequences.count == 2)
+        #expect(sequences.first { $0.name == "window-leader" }?.keys == ["space", "w"])
+        #expect(sequences.first { $0.name == "app-leader" }?.keys == ["space", "a"])
+    }
+
+    @Test("Ignores comments")
+    func ignoresComments() {
+        let config = """
+        ;; Window management sequence
+        #| block comment |#
+        (defseq window-leader
+          (space w))  ;; Space followed by w
+        """
+
+        let sequences = KanataDefseqParser.parseSequences(from: config)
+
+        #expect(sequences.count == 1)
+        #expect(sequences[0].name == "window-leader")
+        #expect(sequences[0].keys == ["space", "w"])
+    }
+
+    @Test("Returns no sequences when absent")
+    func returnsNoSequencesWhenAbsent() {
+        let config = """
+        (defsrc
+          grv  1    2    3    4    5    6    7    8    9    0    -    =    bspc
+        )
+        """
+
+        let sequences = KanataDefseqParser.parseSequences(from: config)
+
+        #expect(sequences.isEmpty)
+    }
+
+    @Test("Extracts sequences from a real config shape")
+    func extractsSequencesFromRealConfigShape() {
+        let config = """
+        ;; Keyboard configuration
+        (defcfg
+          concurrent-tap-hold true
+        )
+
+        ;; Sequences for layer activation
+        (defseq
+          window-leader (space w)
+          app-leader (space a)
+          nav-leader (space n))
+
+        (defalias
+          spc (tap-hold-press 200 200 spc lmet)
+        )
+        """
+
+        let sequences = KanataDefseqParser.parseSequences(from: config)
+
+        #expect(sequences.count == 3)
+        #expect(sequences.contains { $0.name == "window-leader" })
+        #expect(sequences.contains { $0.name == "app-leader" })
+        #expect(sequences.contains { $0.name == "nav-leader" })
+    }
+}

--- a/Tests/KeyPathSmokeTests/KeyPathErrorTests.swift
+++ b/Tests/KeyPathSmokeTests/KeyPathErrorTests.swift
@@ -1,5 +1,4 @@
 import Foundation
-@testable import KeyPathAppKit
 import KeyPathCore
 import Testing
 

--- a/Tests/KeyPathSmokeTests/PermissionOracleFastModeTests.swift
+++ b/Tests/KeyPathSmokeTests/PermissionOracleFastModeTests.swift
@@ -1,5 +1,4 @@
 import Foundation
-@testable import KeyPathAppKit
 @testable import KeyPathCore
 @testable import KeyPathPermissions
 import Testing

--- a/Tests/KeyPathTests/Core/PrivilegedOperationsCoordinatorTests.swift
+++ b/Tests/KeyPathTests/Core/PrivilegedOperationsCoordinatorTests.swift
@@ -14,6 +14,8 @@ final class PrivilegedOperationsRouterTests: XCTestCase {
 
     override func setUp() async throws {
         try await super.setUp()
+        previousSudoEnv = ProcessInfo.processInfo.environment["KEYPATH_USE_SUDO"]
+        setenv("KEYPATH_USE_SUDO", "0", 1)
         await MainActor.run {
             originalExecutor = AdminCommandExecutorHolder.shared
             originalSudoEnv = ProcessInfo.processInfo.environment["KEYPATH_USE_SUDO"]
@@ -41,6 +43,12 @@ final class PrivilegedOperationsRouterTests: XCTestCase {
             originalSudoEnv = nil
             originalAllowAdminOperationsInTests = false
         }
+        if let previousSudoEnv {
+            setenv("KEYPATH_USE_SUDO", previousSudoEnv, 1)
+        } else {
+            unsetenv("KEYPATH_USE_SUDO")
+        }
+        previousSudoEnv = nil
         try await super.tearDown()
     }
 

--- a/Tests/KeyPathTests/Core/PrivilegedOperationsCoordinatorTests.swift
+++ b/Tests/KeyPathTests/Core/PrivilegedOperationsCoordinatorTests.swift
@@ -10,6 +10,7 @@ import Foundation
 final class PrivilegedOperationsRouterTests: XCTestCase {
     private nonisolated(unsafe) var originalExecutor: AdminCommandExecutor!
     private nonisolated(unsafe) var originalSudoEnv: String?
+    private var previousSudoEnv: String?
     private nonisolated(unsafe) var originalAllowAdminOperationsInTests = false
 
     override func setUp() async throws {

--- a/Tests/KeyPathTests/InstallationEngine/InstallerEngineFailurePathTests.swift
+++ b/Tests/KeyPathTests/InstallationEngine/InstallerEngineFailurePathTests.swift
@@ -63,7 +63,7 @@ final class InstallerEngineFailurePathTests: KeyPathAsyncTestCase {
 
     // MARK: - Recipe Execution Failure Tests
 
-    func testExecute_StopsOnFirstRecipeFailure() async {
+    func testExecute_StopsOnFirstRecipeFailure() async throws {
         let stub = StubPrivilegedOperationsCoordinator()
         stub.failOnCall = "installRequiredRuntimeServices"
         let broker = PrivilegeBroker(coordinator: stub)
@@ -72,8 +72,7 @@ final class InstallerEngineFailurePathTests: KeyPathAsyncTestCase {
         let plan = await engine.makePlan(for: .install, context: context)
 
         guard plan.status == .ready else {
-            XCTSkip("Plan is blocked — cannot test recipe execution")
-            return
+            throw XCTSkip("Plan is blocked — cannot test recipe execution")
         }
 
         let report = await engine.execute(plan: plan, using: broker)
@@ -86,7 +85,7 @@ final class InstallerEngineFailurePathTests: KeyPathAsyncTestCase {
         XCTAssertNotNil(failedRecipes.first?.error)
     }
 
-    func testExecute_SuccessfulRecipesBeforeFailureAreRecorded() async {
+    func testExecute_SuccessfulRecipesBeforeFailureAreRecorded() async throws {
         let stub = StubPrivilegedOperationsCoordinator()
         stub.failOnCall = "repairVHIDDaemonServices"
         let broker = PrivilegeBroker(coordinator: stub)
@@ -95,8 +94,7 @@ final class InstallerEngineFailurePathTests: KeyPathAsyncTestCase {
         let plan = await engine.makePlan(for: .repair, context: context)
 
         guard plan.status == .ready, plan.recipes.count > 1 else {
-            XCTSkip("Need multi-recipe plan for this test")
-            return
+            throw XCTSkip("Need multi-recipe plan for this test")
         }
 
         let report = await engine.execute(plan: plan, using: broker)
@@ -110,7 +108,7 @@ final class InstallerEngineFailurePathTests: KeyPathAsyncTestCase {
         }
     }
 
-    func testExecute_FailedRecipeIncludesErrorDescription() async {
+    func testExecute_FailedRecipeIncludesErrorDescription() async throws {
         let stub = StubPrivilegedOperationsCoordinator()
         stub.failOnCall = "installRequiredRuntimeServices"
         let broker = PrivilegeBroker(coordinator: stub)
@@ -119,8 +117,7 @@ final class InstallerEngineFailurePathTests: KeyPathAsyncTestCase {
         let plan = await engine.makePlan(for: .install, context: context)
 
         guard plan.status == .ready else {
-            XCTSkip("Plan is blocked")
-            return
+            throw XCTSkip("Plan is blocked")
         }
 
         let report = await engine.execute(plan: plan, using: broker)
@@ -237,7 +234,7 @@ final class InstallerEngineFailurePathTests: KeyPathAsyncTestCase {
 
     // MARK: - Report Structure Tests
 
-    func testReport_FailureReasonIncludesRecipeID() async {
+    func testReport_FailureReasonIncludesRecipeID() async throws {
         let stub = StubPrivilegedOperationsCoordinator()
         stub.failOnCall = "installRequiredRuntimeServices"
         let broker = PrivilegeBroker(coordinator: stub)
@@ -246,8 +243,7 @@ final class InstallerEngineFailurePathTests: KeyPathAsyncTestCase {
         let plan = await engine.makePlan(for: .install, context: context)
 
         guard plan.status == .ready else {
-            XCTSkip("Plan is blocked")
-            return
+            throw XCTSkip("Plan is blocked")
         }
 
         let report = await engine.execute(plan: plan, using: broker)
@@ -260,7 +256,7 @@ final class InstallerEngineFailurePathTests: KeyPathAsyncTestCase {
         }
     }
 
-    func testReport_RecipeDurationsAreNonNegative() async {
+    func testReport_RecipeDurationsAreNonNegative() async throws {
         let stub = StubPrivilegedOperationsCoordinator()
         let broker = PrivilegeBroker(coordinator: stub)
 
@@ -268,8 +264,7 @@ final class InstallerEngineFailurePathTests: KeyPathAsyncTestCase {
         let plan = await engine.makePlan(for: .install, context: context)
 
         guard plan.status == .ready else {
-            XCTSkip("Plan is blocked")
-            return
+            throw XCTSkip("Plan is blocked")
         }
 
         let report = await engine.execute(plan: plan, using: broker)
@@ -296,7 +291,7 @@ final class InstallerEngineFailurePathTests: KeyPathAsyncTestCase {
 
     // MARK: - Recipe Logs Tests
 
-    func testReport_FailedRecipeHasLogs() async {
+    func testReport_FailedRecipeHasLogs() async throws {
         let stub = StubPrivilegedOperationsCoordinator()
         stub.failOnCall = "installRequiredRuntimeServices"
         let broker = PrivilegeBroker(coordinator: stub)
@@ -305,8 +300,7 @@ final class InstallerEngineFailurePathTests: KeyPathAsyncTestCase {
         let plan = await engine.makePlan(for: .install, context: context)
 
         guard plan.status == .ready else {
-            XCTSkip("Plan is blocked")
-            return
+            throw XCTSkip("Plan is blocked")
         }
 
         let report = await engine.execute(plan: plan, using: broker)
@@ -320,7 +314,7 @@ final class InstallerEngineFailurePathTests: KeyPathAsyncTestCase {
         )
     }
 
-    func testReport_AggregatedLogsIncludeAllRecipes() async {
+    func testReport_AggregatedLogsIncludeAllRecipes() async throws {
         let stub = StubPrivilegedOperationsCoordinator()
         let broker = PrivilegeBroker(coordinator: stub)
 
@@ -328,8 +322,7 @@ final class InstallerEngineFailurePathTests: KeyPathAsyncTestCase {
         let plan = await engine.makePlan(for: .install, context: context)
 
         guard plan.status == .ready, !plan.recipes.isEmpty else {
-            XCTSkip("Need non-empty plan")
-            return
+            throw XCTSkip("Need non-empty plan")
         }
 
         let report = await engine.execute(plan: plan, using: broker)

--- a/Tests/KeyPathTests/PackConfigPipelineTests.swift
+++ b/Tests/KeyPathTests/PackConfigPipelineTests.swift
@@ -138,8 +138,8 @@ final class PackConfigPipelineTests: XCTestCase {
         let mappings = RuleCollectionCatalog.windowMappings(for: .standard)
         XCTAssertFalse(mappings.isEmpty, "Standard convention should produce mappings")
 
-        let hasLeft = mappings.contains { ($0.description ?? "").lowercased().contains("left") }
-        let hasRight = mappings.contains { ($0.description ?? "").lowercased().contains("right") }
+        let hasLeft = mappings.contains { $0.description.lowercased().contains("left") }
+        let hasRight = mappings.contains { $0.description.lowercased().contains("right") }
         XCTAssertTrue(hasLeft, "Should have left half mapping")
         XCTAssertTrue(hasRight, "Should have right half mapping")
     }

--- a/Tests/KeyPathTests/PermissionOracleFastModeTests.swift
+++ b/Tests/KeyPathTests/PermissionOracleFastModeTests.swift
@@ -4,7 +4,7 @@ import Foundation
 @testable import KeyPathPermissions
 import Testing
 
-@Suite("PermissionOracle Fast/Test Mode")
+@Suite("PermissionOracle Fast/Test Mode", .serialized)
 struct PermissionOracleFastModeTests {
     @Test("Snapshot in test mode completes under 1 second")
     @MainActor

--- a/Tests/KeyPathTests/RuleCollections/MultiCollectionConflictTests.swift
+++ b/Tests/KeyPathTests/RuleCollections/MultiCollectionConflictTests.swift
@@ -256,11 +256,11 @@ final class MultiCollectionConflictTests: XCTestCase {
     // MARK: - Deduplicator Activator Conflicts
 
     func testDeduplicator_DuplicateActivatorRemoved() {
-        var a = collection(
+        let a = collection(
             name: "A", mappings: [("h", "left")], layer: .navigation,
             activator: MomentaryActivator(input: "space", targetLayer: .navigation)
         )
-        var b = collection(
+        let b = collection(
             name: "B", mappings: [("j", "down")], layer: .navigation,
             activator: MomentaryActivator(input: "space", targetLayer: .navigation)
         )

--- a/Tests/KeyPathTests/RuleCollections/RuleCollectionStoreTests.swift
+++ b/Tests/KeyPathTests/RuleCollections/RuleCollectionStoreTests.swift
@@ -218,8 +218,8 @@ final class RuleCollectionStoreTests: XCTestCase {
         try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
         let fileURL = tempDir.appendingPathComponent("collections.json")
 
-        // Write garbage data
-        try try XCTUnwrap("this is not json at all".data(using: .utf8)?.write(to: fileURL))
+        let garbageData = try XCTUnwrap("this is not json at all".data(using: .utf8))
+        try garbageData.write(to: fileURL)
 
         let store = RuleCollectionStore.testStore(at: fileURL)
         let result = await store.loadCollectionsDetailed()

--- a/Tests/KeyPathTests/Services/ConfigurationServiceSavePipelineTests.swift
+++ b/Tests/KeyPathTests/Services/ConfigurationServiceSavePipelineTests.swift
@@ -14,9 +14,9 @@ final class ConfigurationServiceSavePipelineTests: KeyPathTestCase {
 
     private lazy var configService: ConfigurationService = .init(configDirectory: tempDirectory.path)
 
-    override func tearDown() {
+    override func tearDown() async throws {
         try? FileManager.default.removeItem(at: tempDirectory)
-        super.tearDown()
+        try await super.tearDown()
     }
 
     // MARK: - Conflict Rejection Tests

--- a/Tests/KeyPathTests/Services/ServiceBootstrapperTests.swift
+++ b/Tests/KeyPathTests/Services/ServiceBootstrapperTests.swift
@@ -12,6 +12,24 @@ import Foundation
 /// - Service identifier constants
 @MainActor
 final class ServiceBootstrapperTests: XCTestCase {
+    private var previousSudoEnv: String?
+
+    override func setUp() async throws {
+        try await super.setUp()
+        previousSudoEnv = ProcessInfo.processInfo.environment["KEYPATH_USE_SUDO"]
+        setenv("KEYPATH_USE_SUDO", "0", 1)
+    }
+
+    override func tearDown() async throws {
+        if let previousSudoEnv {
+            setenv("KEYPATH_USE_SUDO", previousSudoEnv, 1)
+        } else {
+            unsetenv("KEYPATH_USE_SUDO")
+        }
+        previousSudoEnv = nil
+        try await super.tearDown()
+    }
+
     // MARK: - Service Identifier Tests
 
     func testServiceIdentifiers() {

--- a/Tests/KeyPathTests/Services/UnmappedLayerKeyStyleTests.swift
+++ b/Tests/KeyPathTests/Services/UnmappedLayerKeyStyleTests.swift
@@ -1,7 +1,7 @@
 @testable import KeyPathAppKit
 import KeyPathCore
 import SwiftUI
-import XCTest
+@preconcurrency import XCTest
 
 /// Tests for the "unmapped keys on layers" overlay setting: a transparent
 /// (unmapped) key leaves layer mode — rendering base-style — when the user
@@ -10,8 +10,8 @@ import XCTest
 final class UnmappedLayerKeyStyleTests: KeyPathTestCase {
     private var savedStyle: UnmappedLayerKeyStyle!
 
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws {
+        try await super.setUp()
         // Tripwire: the isLayerMode tests drive the view through
         // PreferencesService.shared, which only works because the default
         // @Environment(\.services) ServiceContainer uses `.shared` for its
@@ -23,9 +23,9 @@ final class UnmappedLayerKeyStyleTests: KeyPathTestCase {
         savedStyle = PreferencesService.shared.unmappedLayerKeyStyle
     }
 
-    override func tearDown() {
+    override func tearDown() async throws {
         PreferencesService.shared.unmappedLayerKeyStyle = savedStyle
-        super.tearDown()
+        try await super.tearDown()
     }
 
     private func keycap(layer: String, info: LayerKeyInfo?, zoneSubtitle: String? = nil) -> OverlayKeycapView {

--- a/Tests/KeyPathTests/UI/OutputActionGroupingTests.swift
+++ b/Tests/KeyPathTests/UI/OutputActionGroupingTests.swift
@@ -221,6 +221,7 @@ struct OutputActionGroupingTests {
 
 // MARK: - KeystrokePresetGridView
 
+@MainActor
 @Suite("KeystrokePresetGridView")
 struct KeystrokePresetGridViewTests {
     @Test("presets have unique keys")

--- a/Tests/KeyPathTests/VallackOverlayZoneTests.swift
+++ b/Tests/KeyPathTests/VallackOverlayZoneTests.swift
@@ -1,8 +1,9 @@
 @testable import KeyPathAppKit
 import KeyPathCore
 import SwiftUI
-import XCTest
+@preconcurrency import XCTest
 
+@MainActor
 final class VallackOverlayZoneTests: XCTestCase {
     // MARK: - Home Layer Zone Mapping
 
@@ -256,12 +257,6 @@ final class VallackOverlayZoneTests: XCTestCase {
     // MARK: - Collection Color for Vallack Nav
 
     func testCollectionColorForVallackNavReturnsGreen() {
-        let keycapView = OverlayKeycapView(
-            key: PhysicalKey(keyCode: 4, label: "H", x: 5, y: 2, width: 1, height: 1),
-            baseLabel: "H",
-            isPressed: false,
-            scale: 1.0
-        )
         let color = KeycapSymbols.collectionColor(for: RuleCollectionIdentifier.vallackNavigation)
         let expected = Color(red: 0.2, green: 0.7, blue: 0.4)
         XCTAssertEqual(String(describing: color), String(describing: expected))
@@ -474,7 +469,7 @@ final class VallackOverlayZoneTests: XCTestCase {
         let catalog = RuleCollectionCatalog().defaultCollections()
         let collection = catalog.first { $0.id == RuleCollectionIdentifier.vallackNavigation }!
         for mapping in collection.mappings {
-            let desc = mapping.description ?? ""
+            let desc = mapping.description
             XCTAssertFalse(desc.contains("Backspace"), "'\(mapping.input)' should not use verbose 'Backspace': got '\(desc)'")
             XCTAssertFalse(desc.contains("Escape"), "'\(mapping.input)' should not use verbose 'Escape': got '\(desc)'")
             XCTAssertFalse(desc.contains("Previous Tab"), "'\(mapping.input)' should use '◀tab' not 'Previous Tab': got '\(desc)'")

--- a/dev-tools/smoke-harness/Package.swift
+++ b/dev-tools/smoke-harness/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
         .macOS(.v15)
     ],
     dependencies: [
-        .package(path: "../..")
+        .package(name: "KeyPath", path: "../..")
     ],
     targets: [
         .testTarget(

--- a/dev-tools/smoke-harness/Package.swift
+++ b/dev-tools/smoke-harness/Package.swift
@@ -1,0 +1,24 @@
+// swift-tools-version: 6.1
+import PackageDescription
+
+let package = Package(
+    name: "KeyPathSmokeHarness",
+    platforms: [
+        .macOS(.v15)
+    ],
+    dependencies: [
+        .package(path: "../..")
+    ],
+    targets: [
+        .testTarget(
+            name: "KeyPathIsolatedSmokeTests",
+            dependencies: [
+                .product(name: "KeyPathCore", package: "KeyPath"),
+                .product(name: "KeyPathPermissions", package: "KeyPath")
+            ],
+            swiftSettings: [
+                .swiftLanguageMode(.v6)
+            ]
+        )
+    ]
+)

--- a/dev-tools/smoke-harness/Tests/KeyPathIsolatedSmokeTests/KanataDefseqParserSmokeTests.swift
+++ b/dev-tools/smoke-harness/Tests/KeyPathIsolatedSmokeTests/KanataDefseqParserSmokeTests.swift
@@ -1,0 +1,90 @@
+import KeyPathCore
+import Testing
+
+@Suite("KanataDefseqParser Isolated Smoke Tests")
+struct KanataDefseqParserSmokeTests {
+    @Test("Parses a single defseq")
+    func parsesSingleSequence() {
+        let config = """
+        (defseq window-leader
+          (space w))
+        """
+
+        let sequences = KanataDefseqParser.parseSequences(from: config)
+
+        #expect(sequences.count == 1)
+        #expect(sequences[0].name == "window-leader")
+        #expect(sequences[0].keys == ["space", "w"])
+    }
+
+    @Test("Parses multiple sequences")
+    func parsesMultipleSequences() {
+        let config = """
+        (defseq
+          window-leader (space w)
+          app-leader (space a))
+        """
+
+        let sequences = KanataDefseqParser.parseSequences(from: config)
+
+        #expect(sequences.count == 2)
+        #expect(sequences.first { $0.name == "window-leader" }?.keys == ["space", "w"])
+        #expect(sequences.first { $0.name == "app-leader" }?.keys == ["space", "a"])
+    }
+
+    @Test("Ignores comments")
+    func ignoresComments() {
+        let config = """
+        ;; Window management sequence
+        #| block comment |#
+        (defseq window-leader
+          (space w))  ;; Space followed by w
+        """
+
+        let sequences = KanataDefseqParser.parseSequences(from: config)
+
+        #expect(sequences.count == 1)
+        #expect(sequences[0].name == "window-leader")
+        #expect(sequences[0].keys == ["space", "w"])
+    }
+
+    @Test("Returns no sequences when absent")
+    func returnsNoSequencesWhenAbsent() {
+        let config = """
+        (defsrc
+          grv  1    2    3    4    5    6    7    8    9    0    -    =    bspc
+        )
+        """
+
+        let sequences = KanataDefseqParser.parseSequences(from: config)
+
+        #expect(sequences.isEmpty)
+    }
+
+    @Test("Extracts sequences from a real config shape")
+    func extractsSequencesFromRealConfigShape() {
+        let config = """
+        ;; Keyboard configuration
+        (defcfg
+          concurrent-tap-hold true
+        )
+
+        ;; Sequences for layer activation
+        (defseq
+          window-leader (space w)
+          app-leader (space a)
+          nav-leader (space n))
+
+        (defalias
+          spc (tap-hold-press 200 200 spc lmet)
+        )
+        """
+
+        let sequences = KanataDefseqParser.parseSequences(from: config)
+
+        #expect(sequences.count == 3)
+        #expect(sequences.contains { $0.name == "window-leader" })
+        #expect(sequences.contains { $0.name == "app-leader" })
+        #expect(sequences.contains { $0.name == "nav-leader" })
+    }
+}

--- a/dev-tools/smoke-harness/Tests/KeyPathIsolatedSmokeTests/KeyPathErrorSmokeTests.swift
+++ b/dev-tools/smoke-harness/Tests/KeyPathIsolatedSmokeTests/KeyPathErrorSmokeTests.swift
@@ -1,0 +1,44 @@
+import KeyPathCore
+import Testing
+
+@Suite("KeyPathError Isolated Smoke Tests")
+struct KeyPathErrorSmokeTests {
+    @Test("Configuration errors expose stable user-facing text")
+    func configurationErrorText() {
+        let fileNotFound = KeyPathError.configuration(.fileNotFound(path: "/test/path"))
+        #expect(fileNotFound.errorDescription?.contains("/test/path") == true)
+        #expect(fileNotFound.failureReason == "Configuration operation failed")
+        #expect(fileNotFound.isRecoverable == true)
+
+        let parseError = KeyPathError.configuration(.parseError(line: 42, message: "invalid syntax"))
+        #expect(parseError.errorDescription?.contains("line 42") == true)
+        #expect(parseError.errorDescription?.contains("invalid syntax") == true)
+    }
+
+    @Test("Permission errors stay user-facing and non-recoverable")
+    func permissionErrorClassification() {
+        let accessibility = KeyPathError.permission(.accessibilityNotGranted)
+        #expect(accessibility.errorDescription == "Accessibility permission not granted")
+        #expect(accessibility.recoverySuggestion?.contains("System Settings") == true)
+        #expect(accessibility.shouldDisplayToUser == true)
+        #expect(accessibility.isRecoverable == false)
+    }
+
+    @Test("Communication errors remain recoverable")
+    func communicationErrorClassification() {
+        let timeout = KeyPathError.communication(.timeout)
+        #expect(timeout.errorDescription == "Communication timeout")
+        #expect(timeout.recoverySuggestion?.contains("restart") == true)
+        #expect(timeout.isRecoverable == true)
+    }
+
+    @Test("Equatable conformance works across common branches")
+    func equatableConformance() {
+        let left = KeyPathError.configuration(.fileNotFound(path: "/test"))
+        let right = KeyPathError.configuration(.fileNotFound(path: "/test"))
+        let other = KeyPathError.process(.notRunning)
+
+        #expect(left == right)
+        #expect(left != other)
+    }
+}

--- a/dev-tools/smoke-harness/Tests/KeyPathIsolatedSmokeTests/PermissionOracleFastModeSmokeTests.swift
+++ b/dev-tools/smoke-harness/Tests/KeyPathIsolatedSmokeTests/PermissionOracleFastModeSmokeTests.swift
@@ -1,0 +1,50 @@
+import Foundation
+import KeyPathCore
+import KeyPathPermissions
+import Testing
+
+@Suite("PermissionOracle Isolated Fast/Test Mode", .serialized)
+struct PermissionOracleFastModeSmokeTests {
+    @Test("Snapshot in test mode completes under 1 second")
+    @MainActor
+    func snapshotIsFastInTestMode() async {
+        TestEnvironment.forceTestMode = true
+        defer { TestEnvironment.forceTestMode = false }
+
+        let start = Date()
+        let snapshot = await PermissionOracle.shared.currentSnapshot()
+        let duration = Date().timeIntervalSince(start)
+
+        #expect(duration < 1.0)
+        #expect(snapshot.keyPath.confidence == .low)
+        #expect(snapshot.keyPath.source.contains("test"))
+    }
+
+    @Test("Cached snapshot has same timestamp on immediate re-read")
+    @MainActor
+    func snapshotCachingHonorsTTL() async {
+        TestEnvironment.forceTestMode = true
+        defer { TestEnvironment.forceTestMode = false }
+
+        let first = await PermissionOracle.shared.currentSnapshot()
+        let second = await PermissionOracle.shared.currentSnapshot()
+
+        #expect(first.timestamp.timeIntervalSince1970 == second.timestamp.timeIntervalSince1970)
+    }
+
+    @Test("forceRefresh returns a fresh snapshot in test mode")
+    @MainActor
+    func forceRefreshWorksInTestMode() async {
+        TestEnvironment.forceTestMode = true
+        defer { TestEnvironment.forceTestMode = false }
+
+        await PermissionOracle.shared.invalidateCache()
+        let start = Date()
+        let snapshot = await PermissionOracle.shared.forceRefresh()
+        let duration = Date().timeIntervalSince(start)
+
+        #expect(duration < 1.0)
+        #expect(snapshot.keyPath.confidence == .low)
+        #expect(!snapshot.diagnosticSummary.isEmpty)
+    }
+}

--- a/docs/MACBOOK_AIR_LOCAL_LOOP.md
+++ b/docs/MACBOOK_AIR_LOCAL_LOOP.md
@@ -50,10 +50,11 @@ feedback:
 ```
 
 Reports are written under `.build/local-loop-measurements/`, with the latest
-report linked at:
+Markdown and TSV reports linked at:
 
 ```bash
 .build/local-loop-measurements/latest.md
+.build/local-loop-measurements/latest.tsv
 ```
 
 Presets:

--- a/docs/MACBOOK_AIR_LOCAL_LOOP.md
+++ b/docs/MACBOOK_AIR_LOCAL_LOOP.md
@@ -63,6 +63,25 @@ Presets:
 - `baseline`: runs `smoke`, `unit`, and `appkit`.
 - `full`: runs `smoke`, `unit`, `appkit`, and `full`.
 
+## Clean Summary Guardrail
+
+The safe runner can fail a passing test lane when warning/error counts regress:
+
+```bash
+KEYPATH_TEST_ENFORCE_CLEAN_SUMMARY=1 ./Scripts/test-lane.sh full
+```
+
+This checks the summary counts for Swift warnings, module-cache warnings, app
+warnings, and app errors. Duration is intentionally not enforced because local
+timing varies with machine load. Override a threshold only for a deliberate
+temporary baseline:
+
+```bash
+KEYPATH_TEST_ENFORCE_CLEAN_SUMMARY=1 \
+KEYPATH_TEST_MAX_TEST_APP_WARNINGS=1 \
+./Scripts/test-lane.sh full
+```
+
 ## Debugging Noisy Failures
 
 Use the quiet defaults first. If the failure needs app diagnostics, opt into

--- a/docs/MACBOOK_AIR_LOCAL_LOOP.md
+++ b/docs/MACBOOK_AIR_LOCAL_LOOP.md
@@ -1,0 +1,88 @@
+# MacBook Air Local Test Loop
+
+This workflow optimizes for fast, reliable feedback on the primary development
+MacBook Air. Mac mini orchestration is intentionally deferred until local lane
+measurements show a capacity problem that remote execution would actually solve.
+
+## Default Loop
+
+Run the smallest lane that covers the files you changed:
+
+| Change type | Command |
+| --- | --- |
+| Core APIs, permissions, parser smoke coverage | `./Scripts/test-lane.sh smoke` |
+| Pure model/parser/renderer logic | `./Scripts/test-lane.sh unit` |
+| AppKit-adjacent logic, services, config, packs, mappers | `./Scripts/test-lane.sh appkit` |
+| InstallerEngine, wizard, daemon lifecycle, health checks | `./Scripts/test-lane.sh installer` |
+| Snapshot or visual output changes | `./Scripts/test-lane.sh snapshot` |
+| Device/system installer surface | `KEYPATH_E2E_DEVICE=1 ./Scripts/test-lane.sh device` |
+| Before a broad handoff or PR | `./Scripts/test-lane.sh full` |
+
+For very narrow debugging, override the lane filter:
+
+```bash
+KEYPATH_TEST_FILTER=SaveCoordinatorTests ./Scripts/test-lane.sh appkit
+```
+
+## Warm Cache Policy
+
+The local named lanes `unit`, `appkit`, `installer`, and `snapshot` reuse the
+normalized Swift module cache by default. This is the right default for the
+MacBook Air edit-test loop.
+
+The `full` lane keeps the stricter reset behavior by default. Override either
+mode explicitly when needed:
+
+```bash
+KEYPATH_TEST_RESET_MODULE_CACHE=1 ./Scripts/test-lane.sh appkit
+KEYPATH_TEST_RESET_MODULE_CACHE=0 ./Scripts/test-lane.sh full
+```
+
+## Measuring The Loop
+
+Use the measurement wrapper when changing lane behavior or comparing cold/warm
+feedback:
+
+```bash
+./Scripts/measure-local-loop.sh
+./Scripts/measure-local-loop.sh --preset baseline
+./Scripts/measure-local-loop.sh --clean-smoke smoke
+```
+
+Reports are written under `.build/local-loop-measurements/`, with the latest
+report linked at:
+
+```bash
+.build/local-loop-measurements/latest.md
+```
+
+Presets:
+
+- `quick`: runs `smoke`.
+- `baseline`: runs `smoke`, `unit`, and `appkit`.
+- `full`: runs `smoke`, `unit`, `appkit`, and `full`.
+
+## Debugging Noisy Failures
+
+Use the quiet defaults first. If the failure needs app diagnostics, opt into
+verbose logs for that run only:
+
+```bash
+KEYPATH_TEST_VERBOSE_LOGS=1 KEYPATH_TEST_FILTER=ConfigHotReloadServiceTests ./Scripts/test-lane.sh appkit
+```
+
+If a filtered lane passes but the full lane fails, treat that as either a broad
+build/test-runner interaction or cross-target coupling. Preserve the focused
+passing command in the issue or PR notes before escalating to broader runs.
+
+## Build And UI Iteration
+
+For app iteration rather than test verification, keep Poltergeist running:
+
+```bash
+poltergeist start
+poltergeist wait keypath
+```
+
+Use this for deploy/relaunch feedback. Use the lane commands above for test
+signal.

--- a/docs/MACBOOK_AIR_LOCAL_LOOP.md
+++ b/docs/MACBOOK_AIR_LOCAL_LOOP.md
@@ -76,6 +76,16 @@ If a filtered lane passes but the full lane fails, treat that as either a broad
 build/test-runner interaction or cross-target coupling. Preserve the focused
 passing command in the issue or PR notes before escalating to broader runs.
 
+Local lanes also default to hermetic test-mode behavior with
+`KEYPATH_USE_SUDO=0`, even if passwordless sudo is configured on the machine.
+This keeps the MacBook Air loop aligned with CI and prevents installer tests
+from probing real system services unless a run explicitly asks for it:
+
+```bash
+KEYPATH_USE_SUDO=1 ./Scripts/test-lane.sh installer
+KEYPATH_TEST_AUTO_SUDO=1 ./Scripts/test-lane.sh installer
+```
+
 ## Build And UI Iteration
 
 For app iteration rather than test verification, keep Poltergeist running:

--- a/docs/TEST_HYGIENE_PLAN.md
+++ b/docs/TEST_HYGIENE_PLAN.md
@@ -458,8 +458,14 @@ Milestone 6 is now started with the MacBook Air local loop as the target:
   measurable clarity or speed benefits.
 - Current warm MacBook Air baseline from
   `./Scripts/measure-local-loop.sh --preset baseline`: `smoke` 3s,
-  `unit` 6s, and `appkit` 22s. All three lanes reported zero Swift warnings,
+  `unit` 5s, and `appkit` 25s. All three lanes reported zero Swift warnings,
   module-cache warnings, app warnings, and app errors in their final summaries.
+- Current warm installer baseline from `./Scripts/measure-local-loop.sh
+  installer`: 11s total, 263 passed, and zero Swift warnings,
+  module-cache warnings, app warnings, or app errors. This required keeping
+  `run-tests-safe.sh` hermetic by default (`KEYPATH_USE_SUDO=0` unless
+  explicitly overridden) and downgrading expected installer failure-path
+  diagnostics to debug in quiet test runs.
 
 The Mac mini workflow is deferred. Revisit it only after the MacBook Air loop is
 fast and boring enough that remote execution would solve a measured capacity

--- a/docs/TEST_HYGIENE_PLAN.md
+++ b/docs/TEST_HYGIENE_PLAN.md
@@ -275,6 +275,9 @@ Status:
     an explicit main-actor helper.
 - After those fixes, `./Scripts/test-lane.sh smoke-root` passed in 28s with a
   6,647-byte log and `test_log_swift_warnings=0`.
+- Removed redundant `await` annotations from `PackDetailView+LiveState` live
+  rule-collection reads; local `swift build` recompiled the file without
+  re-emitting the warning.
 
 ### Milestone 6: Measurement And Regression Guardrails
 

--- a/docs/TEST_HYGIENE_PLAN.md
+++ b/docs/TEST_HYGIENE_PLAN.md
@@ -169,11 +169,13 @@ Status:
   `KeyPathCore` and `KeyPathPermissions`.
 - Moved `KeyPathErrorTests` and `PermissionOracleFastModeTests` into that
   target, removing their accidental `KeyPathAppKit` imports.
+- Added focused `KanataDefseqParser` coverage to the smoke target so core
+  parser regressions are still covered without importing `KeyPathAppKit`.
 - Updated `./Scripts/test-lane.sh smoke` to run `KeyPathSmokeTests` with
   XCTest disabled, no separate `swift build --build-tests` prebuild, and module
   cache reuse.
 
-Current Milestone 4 local smoke lane measurement:
+Current Milestone 4 local smoke lane measurements:
 
 - command: `CI_ENVIRONMENT=true KP_SIGN_DRY_RUN=1 KEYPATH_BUNDLED_SIMULATOR_OVERRIDE=/opt/homebrew/bin/kanata-simulator ./Scripts/test-lane.sh smoke`;
 - build: 0s separate prebuild, 6.49s SwiftPM incremental build inside
@@ -183,10 +185,23 @@ Current Milestone 4 local smoke lane measurement:
 - test log size: 4,941 bytes;
 - test log Swift warnings: 0;
 - result: 31 Swift Testing tests in 2 suites passed.
+- after adding parser smoke coverage, the same lane passed 36 Swift Testing
+  tests in 3 suites, but a later repeat run timed out at 120s while compiling
+  `KeyPathAppKit` before reaching test execution.
 - `swift test list --disable-xctest` still works and lists the
   `KeyPathSmokeTests.*` entries, but SwiftPM builds the package-wide test runner
   for that command; the local measurement was 231s and should not be used as
   the smoke lane fast-path benchmark.
+- `swift test --target KeyPathSmokeTests` is not available in SwiftPM, and
+  `swift test --specifier KeyPathSmokeTests --disable-xctest` still compiled
+  the broad package graph in local probing.
+
+Conclusion: this slice improves smoke lane selection, removes accidental AppKit
+imports from migrated tests, and keeps logs/test execution narrow once the
+runner reaches execution. It does not yet satisfy the cold-build isolation goal.
+True isolation will likely require a separate minimal package/test harness or a
+different runner strategy, not only more `swift test --filter` usage in the
+current package.
 
 ### Milestone 5: Warning And Failure Signal Cleanup
 

--- a/docs/TEST_HYGIENE_PLAN.md
+++ b/docs/TEST_HYGIENE_PLAN.md
@@ -327,6 +327,11 @@ Work:
 - Capture MacBook Air local and CI baseline numbers before major lane changes.
 - Track cold versus warm build behavior separately.
 - Document recommended MacBook Air commands for common development loops.
+- Keep existing lane names stable unless a measured usability problem justifies
+  a change.
+- Treat regex-based `swift test --filter` lanes as transitional; prefer smaller
+  test targets/packages and Swift Testing suites/tags where they reduce build
+  graph cost or improve clarity.
 - Keep Mac mini orchestration out of scope for this milestone except for
   preserving measurements that will help evaluate it later.
 
@@ -336,6 +341,9 @@ Acceptance criteria:
 - Full-suite log size and runtime are tracked before and after changes.
 - The recommended local workflow prioritizes the fastest reliable MacBook Air
   command for each common change type.
+- Future lane refinements remain aligned with Apple's test-pyramid guidance:
+  many fast isolated tests, fewer integration checks, and heavier UI/device
+  validation only where it provides distinct signal.
 - Later Mac mini orchestration decisions can use measured data instead of
   guesses, but do not drive the current milestone.
 
@@ -444,6 +452,10 @@ Milestone 6 is now started with the MacBook Air local loop as the target:
   without copying terminal output.
 - `docs/MACBOOK_AIR_LOCAL_LOOP.md` documents the recommended lane by change
   type, warm-cache policy, measurement presets, and when to use verbose logs.
+- Future milestone work should keep lane names stable, avoid treating filter
+  strings as the final architecture, and move toward Apple-aligned test
+  organization when target/package boundaries or Swift Testing suites/tags give
+  measurable clarity or speed benefits.
 
 The Mac mini workflow is deferred. Revisit it only after the MacBook Air loop is
 fast and boring enough that remote execution would solve a measured capacity

--- a/docs/TEST_HYGIENE_PLAN.md
+++ b/docs/TEST_HYGIENE_PLAN.md
@@ -289,6 +289,15 @@ Status:
 - Updated `run-tests-safe.sh` to capture the prebuild phase in a separate build
   log and report `build_log_swift_warnings` alongside test-log warning counts;
   the same focused appkit lane reported both warning counts as zero.
+- Isolated service/privileged tests from the local runner's sudo auto-detection
+  by forcing `KEYPATH_USE_SUDO=0` inside those test classes and restoring the
+  prior environment afterward.
+- After that isolation fix, the broad `appkit` lane reached the existing
+  pass condition: 1,338 XCTest tests passed, 18 skipped, no test failures,
+  `build_log_swift_warnings=0`, and `test_log_swift_warnings=0`. Remaining
+  signal issues are app-log noise (`test_log_app_errors=30`,
+  `test_log_app_warnings=2`) and SwiftPM's post-suite signal-5 helper exit,
+  which the runner already treats as pass when tests succeeded.
 
 ### Milestone 6: Measurement And Regression Guardrails
 

--- a/docs/TEST_HYGIENE_PLAN.md
+++ b/docs/TEST_HYGIENE_PLAN.md
@@ -448,14 +448,18 @@ Milestone 6 is now started with the MacBook Air local loop as the target:
   module cache by default for faster warm local feedback; `full` keeps the
   stricter reset default.
 - `Scripts/measure-local-loop.sh` records lane summaries into
-  `.build/local-loop-measurements/` so local timing changes can be compared
-  without copying terminal output.
+  `.build/local-loop-measurements/` as Markdown and TSV so local timing changes
+  can be compared without copying terminal output.
 - `docs/MACBOOK_AIR_LOCAL_LOOP.md` documents the recommended lane by change
   type, warm-cache policy, measurement presets, and when to use verbose logs.
 - Future milestone work should keep lane names stable, avoid treating filter
   strings as the final architecture, and move toward Apple-aligned test
   organization when target/package boundaries or Swift Testing suites/tags give
   measurable clarity or speed benefits.
+- Current warm MacBook Air baseline from
+  `./Scripts/measure-local-loop.sh --preset baseline`: `smoke` 3s,
+  `unit` 6s, and `appkit` 22s. All three lanes reported zero Swift warnings,
+  module-cache warnings, app warnings, and app errors in their final summaries.
 
 The Mac mini workflow is deferred. Revisit it only after the MacBook Air loop is
 fast and boring enough that remote execution would solve a measured capacity

--- a/docs/TEST_HYGIENE_PLAN.md
+++ b/docs/TEST_HYGIENE_PLAN.md
@@ -257,6 +257,39 @@ The remaining high-volume noise is mostly build-time Swift compiler warnings,
 not app diagnostics in the test log. The next cleanup pass should focus on the
 largest repeated warning families before changing runner behavior further.
 
+Milestone 3 is now started with named lane entry points in
+`Scripts/test-lane.sh`. The initial implementation deliberately uses SwiftPM
+filters over the existing safe runner:
+
+- `smoke` for fast sanity coverage across core parsing, permissions, installer
+  planning, CLI, and layout tracer tests;
+- `unit` for pure or mostly pure model/parser/renderer logic;
+- `appkit` for UI-adjacent app logic, services, packs, config, mappers, and rule
+  collections;
+- `installer` for InstallerEngine, wizard, daemon/service lifecycle, and
+  health-check tests;
+- `snapshot` for visual snapshot tests with `KEYPATH_SNAPSHOTS=1`;
+- `device` for opt-in real-system installer smoke under `KEYPATH_E2E_DEVICE=1`;
+- `full` for the existing full safe SwiftPM suite.
+
+CI now calls the named `full` lane instead of embedding the raw safe-runner
+command. This gives developers and CI a shared vocabulary before Milestone 4
+changes the SwiftPM test target graph.
+
+Latest local smoke lane measurement:
+
+- command: `CI_ENVIRONMENT=true ./Scripts/test-lane.sh smoke`;
+- build: 213s;
+- test: 3s;
+- total: 216s;
+- test log size: 18,939 bytes;
+- result: 102 passed, 0 failures.
+
+This confirms that filters make execution and logs small, but the current
+`KeyPathTests` target still forces a broad build. Milestone 4 should prioritize
+moving smoke/unit tests that only need `KeyPathCore`, `KeyPathPermissions`, or
+`KeyPathLayoutTracerKit` into narrower targets.
+
 The Mac mini workflow should be revisited after milestones 1-3, because those
 changes determine whether the Mini should mainly run full verification, focused
 remote lanes, UI/system tests, or all of the above.

--- a/docs/TEST_HYGIENE_PLAN.md
+++ b/docs/TEST_HYGIENE_PLAN.md
@@ -298,6 +298,14 @@ Status:
   signal issues are app-log noise (`test_log_app_errors=30`,
   `test_log_app_warnings=2`) and SwiftPM's post-suite signal-5 helper exit,
   which the runner already treats as pass when tests succeeded.
+- Added `AppLogger.errorUnlessQuietTest` for expected negative-path diagnostics
+  that should remain errors in normal app use but should not pollute quiet test
+  logs. Applied it to config write guards, duplicate alias fallback logging, hot
+  reload failure branches, and simple-mods invalid-config guards. The broad
+  `appkit` lane then passed with `test_log_app_errors=0`,
+  `test_log_app_warnings=2`, and `test_log_swift_warnings=0`. The remaining
+  reported `build_log_swift_warnings=35` were stale Clang PCM/module-cache
+  warnings during the reset/rebuild path, not Swift source diagnostics.
 
 ### Milestone 6: Measurement And Regression Guardrails
 

--- a/docs/TEST_HYGIENE_PLAN.md
+++ b/docs/TEST_HYGIENE_PLAN.md
@@ -161,6 +161,33 @@ Acceptance criteria:
   pressure.
 - `swift test --list-tests` and lane scripts still work locally and in CI.
 
+Status:
+
+- Started with the smoke lane because it is the fastest developer feedback
+  path.
+- Added a narrow `KeyPathSmokeTests` SwiftPM target that depends only on
+  `KeyPathCore` and `KeyPathPermissions`.
+- Moved `KeyPathErrorTests` and `PermissionOracleFastModeTests` into that
+  target, removing their accidental `KeyPathAppKit` imports.
+- Updated `./Scripts/test-lane.sh smoke` to run `KeyPathSmokeTests` with
+  XCTest disabled, no separate `swift build --build-tests` prebuild, and module
+  cache reuse.
+
+Current Milestone 4 local smoke lane measurement:
+
+- command: `CI_ENVIRONMENT=true KP_SIGN_DRY_RUN=1 KEYPATH_BUNDLED_SIMULATOR_OVERRIDE=/opt/homebrew/bin/kanata-simulator ./Scripts/test-lane.sh smoke`;
+- build: 0s separate prebuild, 6.49s SwiftPM incremental build inside
+  `swift test`;
+- test: 13s;
+- total: 13s;
+- test log size: 4,941 bytes;
+- test log Swift warnings: 0;
+- result: 31 Swift Testing tests in 2 suites passed.
+- `swift test list --disable-xctest` still works and lists the
+  `KeyPathSmokeTests.*` entries, but SwiftPM builds the package-wide test runner
+  for that command; the local measurement was 231s and should not be used as
+  the smoke lane fast-path benchmark.
+
 ### Milestone 5: Warning And Failure Signal Cleanup
 
 Goal: warnings and failure output should support triage instead of burying it.
@@ -289,6 +316,9 @@ This confirms that filters make execution and logs small, but the current
 `KeyPathTests` target still forces a broad build. Milestone 4 should prioritize
 moving smoke/unit tests that only need `KeyPathCore`, `KeyPathPermissions`, or
 `KeyPathLayoutTracerKit` into narrower targets.
+
+Milestone 4 started by moving the first smoke tests into `KeyPathSmokeTests`;
+see the Milestone 4 status section above for the current measurement.
 
 The Mac mini workflow should be revisited after milestones 1-3, because those
 changes determine whether the Mini should mainly run full verification, focused

--- a/docs/TEST_HYGIENE_PLAN.md
+++ b/docs/TEST_HYGIENE_PLAN.md
@@ -208,9 +208,9 @@ Milestone 4b isolated smoke harness:
 - Added `dev-tools/smoke-harness`, a separate SwiftPM package that depends on
   the root package by path but imports only the `KeyPathCore` and
   `KeyPathPermissions` products.
-- Added `./Scripts/test-lane.sh smoke-isolated` as an experimental lane that
-  runs the harness with its own build directory and reports whether
-  `KeyPathAppKit` appeared in the build log.
+- Added `./Scripts/test-lane.sh smoke-isolated` as a fast lane that runs the
+  harness with its own build directory and fails if `KeyPathAppKit` appears in
+  the build log, unless explicitly overridden.
 - Seeded the harness with public-API smoke coverage for `KeyPathError`,
   `KanataDefseqParser`, and `PermissionOracle` fast/test mode.
 
@@ -228,6 +228,10 @@ core/product-level smoke coverage. The next dependency-audit work should use
 this lane as the fast proof point and only extract additional non-UI targets
 from `KeyPathAppKit` when important smoke coverage cannot be expressed through
 existing public products.
+
+CI now runs `smoke-isolated` as an early fail-fast lane before building the
+kanata fork or running the full test lane. The full lane remains the broad
+verification gate.
 
 ### Milestone 5: Warning And Failure Signal Cleanup
 
@@ -340,9 +344,9 @@ filters over the existing safe runner:
 - `device` for opt-in real-system installer smoke under `KEYPATH_E2E_DEVICE=1`;
 - `full` for the existing full safe SwiftPM suite.
 
-CI now calls the named `full` lane instead of embedding the raw safe-runner
-command. This gives developers and CI a shared vocabulary before Milestone 4
-changes the SwiftPM test target graph.
+CI now calls the named `smoke-isolated` lane before the named `full` lane. This
+gives developers and CI a shared vocabulary for the fast product-level smoke
+check and the broad verification gate.
 
 Latest local smoke lane measurement:
 

--- a/docs/TEST_HYGIENE_PLAN.md
+++ b/docs/TEST_HYGIENE_PLAN.md
@@ -286,6 +286,9 @@ Status:
 - Focused appkit lane validation passed for
   `UnmappedLayerKeyStyleTests|VallackOverlayZoneTests` with 58 XCTest tests and
   `test_log_swift_warnings=0`.
+- Updated `run-tests-safe.sh` to capture the prebuild phase in a separate build
+  log and report `build_log_swift_warnings` alongside test-log warning counts;
+  the same focused appkit lane reported both warning counts as zero.
 
 ### Milestone 6: Measurement And Regression Guardrails
 

--- a/docs/TEST_HYGIENE_PLAN.md
+++ b/docs/TEST_HYGIENE_PLAN.md
@@ -387,7 +387,9 @@ quality, lane design, dependency narrowing, and measurement.
 As of 2026-06-08, Milestone 1 is implemented in `Scripts/run-tests-safe.sh`:
 
 - scratch, `HOME`, and module-cache paths are normalized to absolute paths;
-- generated module caches are reset before build to avoid stale PCM path aliases;
+- generated module caches live under the normalized scratch path and are reused
+  by default for warm local/CI lanes; set `KEYPATH_TEST_RESET_MODULE_CACHE=1`
+  for an intentional cache-reset diagnostic run.
 - the runner traps interruption/exit and cleans the SwiftPM test process tree;
 - full-run timing and log-size summaries are printed locally and in GitHub step
   summaries.
@@ -460,9 +462,8 @@ see the Milestone 4 status section above for the current measurement.
 
 Milestone 6 is now started with the MacBook Air local loop as the target:
 
-- `unit`, `appkit`, `installer`, and `snapshot` lanes reuse the normalized
-  module cache by default for faster warm local feedback; `full` keeps the
-  stricter reset default.
+- `unit`, `appkit`, `installer`, `snapshot`, and `full` lanes reuse the
+  normalized module cache by default for faster warm local feedback.
 - `Scripts/measure-local-loop.sh` records lane summaries into
   `.build/local-loop-measurements/` as Markdown and TSV so local timing changes
   can be compared without copying terminal output.

--- a/docs/TEST_HYGIENE_PLAN.md
+++ b/docs/TEST_HYGIENE_PLAN.md
@@ -240,6 +240,23 @@ SwiftPM still reports a post-suite `swiftpm-testing-helper` signal 5 exit after
 the test suite has passed. The runner currently treats that as a harness exit,
 not a test failure, when there are passing tests and no failed tests in the log.
 
+Milestone 2 is partially implemented. The runner now defaults expected fixture
+diagnostics to debug level in quiet test runs while preserving warning-level
+output in normal app usage and under `KEYPATH_TEST_VERBOSE_LOGS=1`. The latest
+local full safe-runner measurement after this change:
+
+- build: 139s;
+- test: 53s;
+- total: 193s;
+- test log size: 919,538 bytes;
+- test log app warnings: 28;
+- test log app errors: 63;
+- result: 3,477 executed, 100 skipped, 0 failures.
+
+The remaining high-volume noise is mostly build-time Swift compiler warnings,
+not app diagnostics in the test log. The next cleanup pass should focus on the
+largest repeated warning families before changing runner behavior further.
+
 The Mac mini workflow should be revisited after milestones 1-3, because those
 changes determine whether the Mini should mainly run full verification, focused
 remote lanes, UI/system tests, or all of the above.

--- a/docs/TEST_HYGIENE_PLAN.md
+++ b/docs/TEST_HYGIENE_PLAN.md
@@ -255,6 +255,17 @@ Acceptance criteria:
 - The runner reports warning counts or a stable summary.
 - Existing warning cleanup remains linked to #750 instead of duplicating scope.
 
+Status:
+
+- Started with two repeated AppKit warning families observed during root-package
+  smoke builds:
+  - removed the dead `shouldUseKindaVimLearningStyle = false` branch from
+    `ContextHUDController.showForLayer`;
+  - made the `WindowManager` frontmost-app observer's main-actor mutation
+    explicit.
+- Local `swift build` recompiled both touched AppKit files and completed without
+  re-emitting those warnings.
+
 ### Milestone 6: Measurement And Regression Guardrails
 
 Goal: we should know whether hygiene changes actually improve the loop.

--- a/docs/TEST_HYGIENE_PLAN.md
+++ b/docs/TEST_HYGIENE_PLAN.md
@@ -314,6 +314,22 @@ Status:
   warm `appkit` lane passed its existing condition with 1,338 XCTest tests
   passed, 18 skipped, `test_log_app_warnings=0`, `test_log_app_errors=0`,
   `test_log_swift_warnings=0`, and `build_log_swift_warnings=0`.
+- Fixed the unfiltered `full` lane invocation path in `run-tests-safe.sh` so
+  lanes with no filter/skip arguments do not trip `set -u` on an empty
+  `SWIFT_TEST_ARGS` array.
+- Quieted expected full-lane negative-path diagnostics from state publishing,
+  stuck-key recovery, TCP server probes, and subprocess launch failures while
+  preserving warning/error severity in normal app usage.
+- Made `PIDFileManager.removePID()` idempotent when another parallel test
+  removes the PID file between the existence check and `removeItem`.
+- Made the `OverlayHealthIndicatorObserverTests` async gate cancellation-aware
+  so the dismiss-cancellation test no longer leaks a checked continuation.
+- Current `./Scripts/measure-local-loop.sh full` baseline: build 4s, test 40s,
+  total 45s, test log 896,341 bytes, zero Swift warnings, zero module-cache
+  warnings, zero app warnings, and zero app errors. SwiftPM still emits the
+  known post-suite `swiftpm-testing-helper` signal 5 after tests pass; the safe
+  runner classifies that as a harness exit when the suite reports passing tests
+  and no failures.
 
 ### Milestone 6: Measurement And Regression Guardrails
 
@@ -466,6 +482,10 @@ Milestone 6 is now started with the MacBook Air local loop as the target:
   `run-tests-safe.sh` hermetic by default (`KEYPATH_USE_SUDO=0` unless
   explicitly overridden) and downgrading expected installer failure-path
   diagnostics to debug in quiet test runs.
+- Current warm full baseline from `./Scripts/measure-local-loop.sh full`: 45s
+  total, 4s build, 40s test execution, zero Swift warnings, zero module-cache
+  warnings, zero app warnings, and zero app errors. This is now suitable as the
+  broad local confidence check when the narrower lane for a change passes first.
 
 The Mac mini workflow is deferred. Revisit it only after the MacBook Air loop is
 fast and boring enough that remote execution would solve a measured capacity

--- a/docs/TEST_HYGIENE_PLAN.md
+++ b/docs/TEST_HYGIENE_PLAN.md
@@ -468,6 +468,10 @@ Milestone 6 is now started with the MacBook Air local loop as the target:
   can be compared without copying terminal output.
 - `docs/MACBOOK_AIR_LOCAL_LOOP.md` documents the recommended lane by change
   type, warm-cache policy, measurement presets, and when to use verbose logs.
+- `run-tests-safe.sh` now supports `KEYPATH_TEST_ENFORCE_CLEAN_SUMMARY=1` to
+  fail an otherwise passing lane when summary warning/error counts regress.
+  CI enables this guardrail for the full lane; elapsed time remains
+  informational rather than enforced.
 - Future milestone work should keep lane names stable, avoid treating filter
   strings as the final architecture, and move toward Apple-aligned test
   organization when target/package boundaries or Swift Testing suites/tags give

--- a/docs/TEST_HYGIENE_PLAN.md
+++ b/docs/TEST_HYGIENE_PLAN.md
@@ -278,6 +278,14 @@ Status:
 - Removed redundant `await` annotations from `PackDetailView+LiveState` live
   rule-collection reads; local `swift build` recompiled the file without
   re-emitting the warning.
+- Cleaned two repeated test warning families:
+  - made `UnmappedLayerKeyStyleTests` use the existing main-actor async XCTest
+    lifecycle pattern for shared preferences and `OverlayKeycapView` access;
+  - made `VallackOverlayZoneTests` main-actor aware, removed an unused keycap
+    construction, and removed a redundant nil-coalescing expression.
+- Focused appkit lane validation passed for
+  `UnmappedLayerKeyStyleTests|VallackOverlayZoneTests` with 58 XCTest tests and
+  `test_log_swift_warnings=0`.
 
 ### Milestone 6: Measurement And Regression Guardrails
 

--- a/docs/TEST_HYGIENE_PLAN.md
+++ b/docs/TEST_HYGIENE_PLAN.md
@@ -434,6 +434,17 @@ behavior.
 Milestone 4 started by moving the first smoke tests into `KeyPathSmokeTests`;
 see the Milestone 4 status section above for the current measurement.
 
+Milestone 6 is now started with the MacBook Air local loop as the target:
+
+- `unit`, `appkit`, `installer`, and `snapshot` lanes reuse the normalized
+  module cache by default for faster warm local feedback; `full` keeps the
+  stricter reset default.
+- `Scripts/measure-local-loop.sh` records lane summaries into
+  `.build/local-loop-measurements/` so local timing changes can be compared
+  without copying terminal output.
+- `docs/MACBOOK_AIR_LOCAL_LOOP.md` documents the recommended lane by change
+  type, warm-cache policy, measurement presets, and when to use verbose logs.
+
 The Mac mini workflow is deferred. Revisit it only after the MacBook Air loop is
 fast and boring enough that remote execution would solve a measured capacity
 problem instead of compensating for harness noise.

--- a/docs/TEST_HYGIENE_PLAN.md
+++ b/docs/TEST_HYGIENE_PLAN.md
@@ -203,6 +203,32 @@ True isolation will likely require a separate minimal package/test harness or a
 different runner strategy, not only more `swift test --filter` usage in the
 current package.
 
+Milestone 4b isolated smoke harness:
+
+- Added `dev-tools/smoke-harness`, a separate SwiftPM package that depends on
+  the root package by path but imports only the `KeyPathCore` and
+  `KeyPathPermissions` products.
+- Added `./Scripts/test-lane.sh smoke-isolated` as an experimental lane that
+  runs the harness with its own build directory and reports whether
+  `KeyPathAppKit` appeared in the build log.
+- Seeded the harness with public-API smoke coverage for `KeyPathError`,
+  `KanataDefseqParser`, and `PermissionOracle` fast/test mode.
+
+Current isolated smoke measurements:
+
+- clean command: `KEYPATH_ISOLATED_SMOKE_CLEAN=1 ./Scripts/test-lane.sh smoke-isolated`;
+- clean total: 10-14s;
+- warm command: `./Scripts/test-lane.sh smoke-isolated`;
+- warm total: 1-3s;
+- result: 12 Swift Testing tests in 3 suites passed;
+- `appkit_in_log=0` for both runs.
+
+Conclusion: the separate harness satisfies the cold-build isolation goal for
+core/product-level smoke coverage. The next dependency-audit work should use
+this lane as the fast proof point and only extract additional non-UI targets
+from `KeyPathAppKit` when important smoke coverage cannot be expressed through
+existing public products.
+
 ### Milestone 5: Warning And Failure Signal Cleanup
 
 Goal: warnings and failure output should support triage instead of burying it.

--- a/docs/TEST_HYGIENE_PLAN.md
+++ b/docs/TEST_HYGIENE_PLAN.md
@@ -265,6 +265,16 @@ Status:
     explicit.
 - Local `swift build` recompiled both touched AppKit files and completed without
   re-emitting those warnings.
+- A root-package `smoke-root` diagnostic then passed in 115s with
+  `test_log_swift_warnings=2498`, surfacing the next repeated production warning
+  families.
+- Cleaned the next two repeated production warning families:
+  - routed `DragToAuthorizeController` animation-completion state transitions
+    through an explicit main-actor helper;
+  - routed `DistributedNotificationBridge` layer-change observer work through
+    an explicit main-actor helper.
+- After those fixes, `./Scripts/test-lane.sh smoke-root` passed in 28s with a
+  6,647-byte log and `test_log_swift_warnings=0`.
 
 ### Milestone 6: Measurement And Regression Guardrails
 

--- a/docs/TEST_HYGIENE_PLAN.md
+++ b/docs/TEST_HYGIENE_PLAN.md
@@ -171,13 +171,13 @@ Status:
   target, removing their accidental `KeyPathAppKit` imports.
 - Added focused `KanataDefseqParser` coverage to the smoke target so core
   parser regressions are still covered without importing `KeyPathAppKit`.
-- Updated `./Scripts/test-lane.sh smoke` to run `KeyPathSmokeTests` with
+- Updated `./Scripts/test-lane.sh smoke-root` to run `KeyPathSmokeTests` with
   XCTest disabled, no separate `swift build --build-tests` prebuild, and module
   cache reuse.
 
 Current Milestone 4 local smoke lane measurements:
 
-- command: `CI_ENVIRONMENT=true KP_SIGN_DRY_RUN=1 KEYPATH_BUNDLED_SIMULATOR_OVERRIDE=/opt/homebrew/bin/kanata-simulator ./Scripts/test-lane.sh smoke`;
+- command: `CI_ENVIRONMENT=true KP_SIGN_DRY_RUN=1 KEYPATH_BUNDLED_SIMULATOR_OVERRIDE=/opt/homebrew/bin/kanata-simulator ./Scripts/test-lane.sh smoke-root`;
 - build: 0s separate prebuild, 6.49s SwiftPM incremental build inside
   `swift test`;
 - test: 13s;
@@ -208,17 +208,20 @@ Milestone 4b isolated smoke harness:
 - Added `dev-tools/smoke-harness`, a separate SwiftPM package that depends on
   the root package by path but imports only the `KeyPathCore` and
   `KeyPathPermissions` products.
-- Added `./Scripts/test-lane.sh smoke-isolated` as a fast lane that runs the
-  harness with its own build directory and fails if `KeyPathAppKit` appears in
-  the build log, unless explicitly overridden.
+- Replaced `./Scripts/test-lane.sh smoke` with the isolated harness. The old
+  root-package smoke target remains available as `./Scripts/test-lane.sh
+  smoke-root` for diagnostics.
+- The isolated smoke lane runs the harness with its own build directory and
+  fails if `KeyPathAppKit` appears in the build log, unless explicitly
+  overridden.
 - Seeded the harness with public-API smoke coverage for `KeyPathError`,
   `KanataDefseqParser`, and `PermissionOracle` fast/test mode.
 
 Current isolated smoke measurements:
 
-- clean command: `KEYPATH_ISOLATED_SMOKE_CLEAN=1 ./Scripts/test-lane.sh smoke-isolated`;
+- clean command: `KEYPATH_ISOLATED_SMOKE_CLEAN=1 ./Scripts/test-lane.sh smoke`;
 - clean total: 10-14s;
-- warm command: `./Scripts/test-lane.sh smoke-isolated`;
+- warm command: `./Scripts/test-lane.sh smoke`;
 - warm total: 1-3s;
 - result: 12 Swift Testing tests in 3 suites passed;
 - `appkit_in_log=0` for both runs.
@@ -229,9 +232,9 @@ this lane as the fast proof point and only extract additional non-UI targets
 from `KeyPathAppKit` when important smoke coverage cannot be expressed through
 existing public products.
 
-CI now runs `smoke-isolated` as an early fail-fast lane before building the
-kanata fork or running the full test lane. The full lane remains the broad
-verification gate.
+CI now runs `smoke` as an early fail-fast lane before building the kanata fork
+or running the full test lane. The full lane remains the broad verification
+gate.
 
 ### Milestone 5: Warning And Failure Signal Cleanup
 
@@ -330,11 +333,12 @@ not app diagnostics in the test log. The next cleanup pass should focus on the
 largest repeated warning families before changing runner behavior further.
 
 Milestone 3 is now started with named lane entry points in
-`Scripts/test-lane.sh`. The initial implementation deliberately uses SwiftPM
-filters over the existing safe runner:
+`Scripts/test-lane.sh`. Most lanes are SwiftPM filters over the existing safe
+runner; `smoke` now uses the isolated harness from Milestone 4b:
 
-- `smoke` for fast sanity coverage across core parsing, permissions, installer
-  planning, CLI, and layout tracer tests;
+- `smoke` for fast isolated product-level sanity coverage;
+- `smoke-root` for the root-package `KeyPathSmokeTests` target, retained as a
+  diagnostic lane rather than the fast path;
 - `unit` for pure or mostly pure model/parser/renderer logic;
 - `appkit` for UI-adjacent app logic, services, packs, config, mappers, and rule
   collections;
@@ -344,23 +348,23 @@ filters over the existing safe runner:
 - `device` for opt-in real-system installer smoke under `KEYPATH_E2E_DEVICE=1`;
 - `full` for the existing full safe SwiftPM suite.
 
-CI now calls the named `smoke-isolated` lane before the named `full` lane. This
-gives developers and CI a shared vocabulary for the fast product-level smoke
-check and the broad verification gate.
+CI now calls the named `smoke` lane before the named `full` lane. This gives
+developers and CI a shared vocabulary for the fast product-level smoke check
+and the broad verification gate.
 
-Latest local smoke lane measurement:
+Latest local root-package smoke lane measurement:
 
-- command: `CI_ENVIRONMENT=true ./Scripts/test-lane.sh smoke`;
+- command: `CI_ENVIRONMENT=true ./Scripts/test-lane.sh smoke-root`;
 - build: 213s;
 - test: 3s;
 - total: 216s;
 - test log size: 18,939 bytes;
 - result: 102 passed, 0 failures.
 
-This confirms that filters make execution and logs small, but the current
-`KeyPathTests` target still forces a broad build. Milestone 4 should prioritize
-moving smoke/unit tests that only need `KeyPathCore`, `KeyPathPermissions`, or
-`KeyPathLayoutTracerKit` into narrower targets.
+This confirms that filters make execution and logs small, but the root-package
+test runner can still force a broad build. The isolated `smoke` harness is now
+the fast path; `smoke-root` remains useful when validating root SwiftPM target
+behavior.
 
 Milestone 4 started by moving the first smoke tests into `KeyPathSmokeTests`;
 see the Milestone 4 status section above for the current measurement.

--- a/docs/TEST_HYGIENE_PLAN.md
+++ b/docs/TEST_HYGIENE_PLAN.md
@@ -306,6 +306,11 @@ Status:
   `test_log_app_warnings=2`, and `test_log_swift_warnings=0`. The remaining
   reported `build_log_swift_warnings=35` were stale Clang PCM/module-cache
   warnings during the reset/rebuild path, not Swift source diagnostics.
+- Quieted the last expected fallback warnings in `SaveCoordinator`; a focused
+  `SaveCoordinatorTests` run passed with zero app warnings/errors, and a broad
+  warm `appkit` lane passed its existing condition with 1,338 XCTest tests
+  passed, 18 skipped, `test_log_app_warnings=0`, `test_log_app_errors=0`,
+  `test_log_swift_warnings=0`, and `build_log_swift_warnings=0`.
 
 ### Milestone 6: Measurement And Regression Guardrails
 

--- a/docs/TEST_HYGIENE_PLAN.md
+++ b/docs/TEST_HYGIENE_PLAN.md
@@ -289,6 +289,9 @@ Status:
 - Updated `run-tests-safe.sh` to capture the prebuild phase in a separate build
   log and report `build_log_swift_warnings` alongside test-log warning counts;
   the same focused appkit lane reported both warning counts as zero.
+- Refined the warning summary so missing Clang PCM/module-cache rebuild
+  messages are reported as `*_module_cache_warnings` instead of inflating the
+  Swift source-warning counts.
 - Isolated service/privileged tests from the local runner's sudo auto-detection
   by forcing `KEYPATH_USE_SUDO=0` inside those test classes and restoring the
   prior environment afterward.

--- a/docs/TEST_HYGIENE_PLAN.md
+++ b/docs/TEST_HYGIENE_PLAN.md
@@ -3,16 +3,16 @@
 Created: 2026-06-08
 
 This plan is about making KeyPath's existing tests faster to run, easier to
-trust, and easier to debug before we add more remote-machine orchestration. It
-does not replace `docs/TEST-IMPROVEMENT-PLAN.md`, which focuses on coverage
-gaps. This document focuses on harness behavior, log quality, lane design, and
-build graph cost.
+trust, and easier to debug on the primary development machine. It does not
+replace `docs/TEST-IMPROVEMENT-PLAN.md`, which focuses on coverage gaps. This
+document focuses on harness behavior, log quality, lane design, and build graph
+cost.
 
 ## Why This Comes First
 
-Before splitting work between the MacBook Air and Mac mini, the test loop should
-be clean enough that a remote run gives concise signal. Otherwise a faster
-machine only hides:
+The immediate priority is the MacBook Air local loop. Remote Mac mini
+orchestration is intentionally deferred until the local lanes are already clean,
+predictable, and measured. Otherwise a faster machine only hides:
 
 - broad SwiftPM builds that compile most of the app graph for routine checks;
 - noisy logs that make failures hard to find;
@@ -317,23 +317,27 @@ Status:
 
 ### Milestone 6: Measurement And Regression Guardrails
 
-Goal: we should know whether hygiene changes actually improve the loop.
+Goal: we should know whether hygiene changes actually improve the MacBook Air
+local loop.
 
 Work:
 
 - Add a lightweight timing wrapper for build time, test execution time, log size,
   and exit status.
-- Capture local and CI baseline numbers before major lane changes.
+- Capture MacBook Air local and CI baseline numbers before major lane changes.
 - Track cold versus warm build behavior separately.
-- Document recommended local commands for MacBook Air and Mac mini workflows
-  after the hygiene work lands.
+- Document recommended MacBook Air commands for common development loops.
+- Keep Mac mini orchestration out of scope for this milestone except for
+  preserving measurements that will help evaluate it later.
 
 Acceptance criteria:
 
 - Each lane reports elapsed time.
 - Full-suite log size and runtime are tracked before and after changes.
+- The recommended local workflow prioritizes the fastest reliable MacBook Air
+  command for each common change type.
 - Later Mac mini orchestration decisions can use measured data instead of
-  guesses.
+  guesses, but do not drive the current milestone.
 
 ## Relationship To Existing Issues
 
@@ -351,7 +355,8 @@ quality, lane design, dependency narrowing, and measurement.
 2. Reduce test log noise enough that failures are readable.
 3. Add named lane scripts around the current suite.
 4. Audit and split test dependencies where the payoff is clear.
-5. Clean warning hotspots and add measurement guardrails.
+5. Clean warning hotspots.
+6. Add MacBook Air local-loop measurement guardrails and workflow docs.
 
 ## Current Status
 
@@ -429,6 +434,6 @@ behavior.
 Milestone 4 started by moving the first smoke tests into `KeyPathSmokeTests`;
 see the Milestone 4 status section above for the current measurement.
 
-The Mac mini workflow should be revisited after milestones 1-3, because those
-changes determine whether the Mini should mainly run full verification, focused
-remote lanes, UI/system tests, or all of the above.
+The Mac mini workflow is deferred. Revisit it only after the MacBook Air loop is
+fast and boring enough that remote execution would solve a measured capacity
+problem instead of compensating for harness noise.

--- a/docs/TEST_HYGIENE_PLAN.md
+++ b/docs/TEST_HYGIENE_PLAN.md
@@ -1,0 +1,245 @@
+# Test Hygiene Plan
+
+Created: 2026-06-08
+
+This plan is about making KeyPath's existing tests faster to run, easier to
+trust, and easier to debug before we add more remote-machine orchestration. It
+does not replace `docs/TEST-IMPROVEMENT-PLAN.md`, which focuses on coverage
+gaps. This document focuses on harness behavior, log quality, lane design, and
+build graph cost.
+
+## Why This Comes First
+
+Before splitting work between the MacBook Air and Mac mini, the test loop should
+be clean enough that a remote run gives concise signal. Otherwise a faster
+machine only hides:
+
+- broad SwiftPM builds that compile most of the app graph for routine checks;
+- noisy logs that make failures hard to find;
+- test harness failures that leave orphaned `xctest` processes behind;
+- local path/cache aliasing that can crash the Swift frontend;
+- warning noise that drowns out new diagnostics.
+
+## Observed Problems
+
+These observations came from running `Scripts/run-tests-safe.sh` locally in a
+CI-like environment.
+
+### Relative Scratch Path Can Poison Module Caches
+
+Running with the default CI scratch path hit a Swift frontend crash where the
+same Clang PCM module appeared through two paths:
+
+- `Scripts/../.build/ModuleCache.noindex/...`
+- `.build/ModuleCache.noindex/...`
+
+Using an absolute scratch path avoided that specific crash. The runner should
+normalize scratch and module-cache paths before invoking SwiftPM.
+
+### The Safe Runner Can Leave Orphaned Test Processes
+
+During measurement, the wrapper process disappeared while the generated
+`KeyPathPackageTests.xctest` process continued running. The harness should own
+the full process tree and clean it up on normal exit, timeout, signal, or
+wrapper failure.
+
+### Full Test Builds Are Too Broad For Routine Feedback
+
+`Scripts/run-tests-safe.sh` runs `swift build --build-tests`, which currently
+pulls in a very wide graph: KeyPathAppKit UI, CLI, layout tracer, snapshot test
+targets, resources, Sparkle artifacts, and SwiftPM dependencies. That is
+appropriate for a full verification lane, but too expensive for many local
+development checks.
+
+### Logs Are Too Noisy
+
+A partial run produced thousands of lines and multi-megabyte output before the
+suite finished. The most visible sources were repeated Swift warnings and
+runtime diagnostics from config generation, rule collection bootstrapping, and
+test-mode services. The suite even triggered log rotation during one run.
+
+### Compiler Warnings Reduce Signal
+
+The run repeatedly emitted Swift warnings for concurrency isolation, unused
+values, and always-false branches. Some of this overlaps existing issue #750,
+but the test runner should still make new warnings easier to spot.
+
+## Milestones
+
+### Milestone 1: Stabilize The Harness
+
+Goal: `Scripts/run-tests-safe.sh` should be predictable, reproducible, and
+cleanup-safe.
+
+Work:
+
+- Normalize `SCRATCH_PATH`, `CLANG_MODULECACHE_PATH`, and
+  `SWIFT_MODULECACHE_PATH` to absolute paths.
+- Remove mixed path forms such as `Scripts/../.build` from the SwiftPM command
+  environment.
+- Track and clean up the full child process tree, including generated
+  `.xctest` processes.
+- Add signal traps for `INT`, `TERM`, `HUP`, and wrapper exit.
+- Preserve the existing CI behavior of reusing `.build` when explicitly needed,
+  but use the normalized absolute version of that path.
+- Add a small harness self-test or shellcheck-style validation for cleanup
+  behavior where practical.
+
+Acceptance criteria:
+
+- `Scripts/run-tests-safe.sh` prints normalized scratch/module-cache paths.
+- If the wrapper is interrupted, no `KeyPathPackageTests.xctest` process remains.
+- A default local run does not produce duplicate PCM module path errors.
+- CI behavior remains compatible with the existing self-hosted runner.
+
+### Milestone 2: Reduce Test Log Noise
+
+Goal: full test logs should contain failure-relevant information by default.
+
+Work:
+
+- Add a test/CI log level that suppresses routine config-generation diagnostics.
+- Keep explicit diagnostics available behind an opt-in variable such as
+  `KEYPATH_TEST_VERBOSE_LOGS=1`.
+- Suppress repeated "expected in test mode" diagnostics such as missing
+  user-local AppKeymaps when tests intentionally isolate `HOME`.
+- Audit high-volume debug/info statements in config generation, rule collection
+  bootstrapping, runtime coordinator state publication, and event listeners.
+- Make `run-tests-safe.sh` print a concise summary with failed tests, timeout
+  reason, and the path to full logs.
+
+Acceptance criteria:
+
+- A normal full run log is small enough to scan without log rotation.
+- Failure summaries are visible in the last 100 lines.
+- Verbose diagnostics remain available for targeted debugging.
+
+### Milestone 3: Define Focused Test Lanes
+
+Goal: developers and agents should not need to run the full suite for every
+change.
+
+Work:
+
+- Define named lanes for common feedback needs:
+  - `smoke`: fastest sanity checks for core compile and critical unit tests.
+  - `unit`: pure logic and mocked tests.
+  - `appkit`: UI-adjacent logic that requires KeyPathAppKit.
+  - `snapshot`: visual snapshots, gated by `KEYPATH_SNAPSHOTS=1`.
+  - `installer`: mocked installer and service lifecycle tests.
+  - `device`: opt-in real-system tests gated by device/system variables.
+  - `full`: current broad suite.
+- Add stable script entry points under `Scripts/` or root-level wrappers.
+- Make `.github/workflows/ci.yml` call those named lanes instead of embedding
+  raw command fragments.
+- Document which lane to run for common change types.
+
+Acceptance criteria:
+
+- A developer can choose a lane without remembering filters.
+- CI summary identifies which lane failed.
+- Full suite remains available and is not weakened.
+
+### Milestone 4: Audit SwiftPM Test Target Dependencies
+
+Goal: narrow test lanes should avoid compiling unrelated product graphs.
+
+Work:
+
+- Review `Package.swift` test targets and dependencies.
+- Identify tests in `KeyPathTests` that only need `KeyPathCore`,
+  `KeyPathPermissions`, or another smaller module.
+- Move or split tests where that avoids importing `KeyPathAppKit`.
+- Keep snapshot and visual tests in their own target/lane.
+- Avoid broad source imports for CLI-only or pure parser tests.
+
+Acceptance criteria:
+
+- At least one narrow lane builds without compiling the full KeyPathAppKit UI
+  graph.
+- Test targets remain understandable and do not create circular dependency
+  pressure.
+- `swift test --list-tests` and lane scripts still work locally and in CI.
+
+### Milestone 5: Warning And Failure Signal Cleanup
+
+Goal: warnings and failure output should support triage instead of burying it.
+
+Work:
+
+- Coordinate with existing issue #750 for Swift 6 concurrency/compiler warnings.
+- Prioritize warnings that repeat across many files or indicate actor-isolation
+  mistakes in tests.
+- Fix low-risk unused-value warnings in tests.
+- Keep a warning baseline or summary so new warnings are visible.
+- Avoid making all warnings fatal until the baseline is meaningfully reduced.
+
+Acceptance criteria:
+
+- Repeated warnings are reduced enough that new diagnostics stand out.
+- The runner reports warning counts or a stable summary.
+- Existing warning cleanup remains linked to #750 instead of duplicating scope.
+
+### Milestone 6: Measurement And Regression Guardrails
+
+Goal: we should know whether hygiene changes actually improve the loop.
+
+Work:
+
+- Add a lightweight timing wrapper for build time, test execution time, log size,
+  and exit status.
+- Capture local and CI baseline numbers before major lane changes.
+- Track cold versus warm build behavior separately.
+- Document recommended local commands for MacBook Air and Mac mini workflows
+  after the hygiene work lands.
+
+Acceptance criteria:
+
+- Each lane reports elapsed time.
+- Full-suite log size and runtime are tracked before and after changes.
+- Later Mac mini orchestration decisions can use measured data instead of
+  guesses.
+
+## Relationship To Existing Issues
+
+- #604 covers the broad long-term test improvement plan.
+- #698 covers real `pgrep`/process-spawn deadlocks and tests bypassing the safe
+  base class.
+- #750 covers Swift 6 concurrency and compiler warning cleanup.
+
+The issues created from this plan should focus on harness stability, log
+quality, lane design, dependency narrowing, and measurement.
+
+## Recommended Order
+
+1. Stabilize `run-tests-safe.sh` path handling and cleanup.
+2. Reduce test log noise enough that failures are readable.
+3. Add named lane scripts around the current suite.
+4. Audit and split test dependencies where the payoff is clear.
+5. Clean warning hotspots and add measurement guardrails.
+
+## Current Status
+
+As of 2026-06-08, Milestone 1 is implemented in `Scripts/run-tests-safe.sh`:
+
+- scratch, `HOME`, and module-cache paths are normalized to absolute paths;
+- generated module caches are reset before build to avoid stale PCM path aliases;
+- the runner traps interruption/exit and cleans the SwiftPM test process tree;
+- full-run timing and log-size summaries are printed locally and in GitHub step
+  summaries.
+
+Latest local full safe-runner baseline:
+
+- build: 86s;
+- test: 48s;
+- total: 135s;
+- log size: 3,087,438 bytes;
+- result: 3,476 executed, 100 skipped, 0 failures.
+
+SwiftPM still reports a post-suite `swiftpm-testing-helper` signal 5 exit after
+the test suite has passed. The runner currently treats that as a harness exit,
+not a test failure, when there are passing tests and no failed tests in the log.
+
+The Mac mini workflow should be revisited after milestones 1-3, because those
+changes determine whether the Mini should mainly run full verification, focused
+remote lanes, UI/system tests, or all of the above.


### PR DESCRIPTION
## Summary
- Adds named local test lanes plus the isolated smoke harness for fast MacBook Air feedback.
- Stabilizes `run-tests-safe.sh` summaries, cleanup, warm module-cache behavior, and clean-summary enforcement.
- Quiets expected failure-path diagnostics in tests so CI can enforce zero Swift warnings, zero app warnings, and zero app errors.
- Updates the test hygiene docs for the current warm-cache full-lane policy.

## Validation
- `./Scripts/test-lane.sh smoke`
- `KEYPATH_TEST_FILTER=SubprocessRunnerTests KEYPATH_TEST_RESET_MODULE_CACHE=0 KEYPATH_TEST_ENFORCE_CLEAN_SUMMARY=1 ./Scripts/test-lane.sh unit`
- `CI_ENVIRONMENT=true SKIP_EVENT_TAP_TESTS=1 TIMEOUT_SECONDS=300 KEYPATH_ALLOW_TEST_RUNNER_CRASH_SUCCESS=1 KEYPATH_TEST_ENFORCE_CLEAN_SUMMARY=1 ./Scripts/test-lane.sh full`
- `python3 Scripts/check-accessibility.py`
- `git diff --check`
- pre-push build hook
