### PR TITLE
Add isolated Core test harness

### DIFF
--- a/Scripts/README.md
+++ b/Scripts/README.md
@@ -11,7 +11,8 @@
 - `./Scripts/cleanup-local-build-artifacts.sh` — Dry-run cleanup of generated `.build`/`dist`/test artifacts across local worktrees. Add `--apply` to delete.
 - `./test.sh` — Run the full test suite (root)
 - `./Scripts/test-lane.sh <lane>` — Run a named SwiftPM test lane (`smoke`,
-  `smoke-root`, `unit`, `appkit`, `installer`, `snapshot`, `device`, or `full`).
+  `core-isolated`, `smoke-root`, `unit`, `appkit`, `installer`, `snapshot`,
+  `device`, or `full`).
 - `./Scripts/measure-local-loop.sh` — Measure local feedback lanes and write a
   Markdown report under `.build/local-loop-measurements/`.
 - `./Scripts/run-installer-reliability-matrix.sh` — Automated installer reliability matrix + diagnostic artifact bundle (`test-results/installer-reliability/latest`).
@@ -35,6 +36,8 @@
 - `test.sh` (in root) - All tests
 - `test-*.sh` (in Scripts/) - Individual test suites
 - `./Scripts/test-lane.sh smoke` - Fast isolated product-level sanity lane.
+- `./Scripts/test-lane.sh core-isolated` - Isolated Core harness that builds
+  only `KeyPathCore` and fails if `KeyPathAppKit` appears in the log.
 - `./Scripts/test-lane.sh smoke-root` - Root-package smoke target; useful for
   diagnostics, but not the fast path.
 - `./Scripts/test-lane.sh unit` - Pure or mostly pure model/parser/renderer
@@ -55,7 +58,7 @@
   cache by default; set `KEYPATH_TEST_RESET_MODULE_CACHE=1` when a narrow local
   lane should intentionally reset it.
 - `./Scripts/measure-local-loop.sh --preset baseline` - Measure the standard
-  MacBook Air local baseline (`smoke`, `unit`, `appkit`) and write
+  MacBook Air local baseline (`smoke`, `core-isolated`, `unit`, `appkit`) and write
   `.build/local-loop-measurements/latest.md`.
 - See `docs/MACBOOK_AIR_LOCAL_LOOP.md` for the recommended command by change
   type.

--- a/Scripts/measure-local-loop.sh
+++ b/Scripts/measure-local-loop.sh
@@ -10,22 +10,24 @@ PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd -P)"
 PRESET="quick"
 OUTPUT_DIR="${KEYPATH_LOCAL_LOOP_OUT:-$PROJECT_DIR/.build/local-loop-measurements}"
 CLEAN_SMOKE="${KEYPATH_LOCAL_LOOP_CLEAN_SMOKE:-0}"
+CLEAN_CORE="${KEYPATH_LOCAL_LOOP_CLEAN_CORE:-0}"
 LANES=()
 
 usage() {
   cat <<'USAGE'
-Usage: ./Scripts/measure-local-loop.sh [--preset quick|baseline|full] [--out DIR] [--clean-smoke] [lane ...]
+Usage: ./Scripts/measure-local-loop.sh [--preset quick|baseline|full] [--out DIR] [--clean-smoke] [--clean-core] [lane ...]
 
 Presets:
   quick     Run the fastest local sanity lane: smoke.
-  baseline  Run the usual MacBook Air development baseline: smoke, unit, appkit.
-  full      Run smoke, unit, appkit, and full.
+  baseline  Run the usual MacBook Air development baseline: smoke, core-isolated, unit, appkit.
+  full      Run smoke, core-isolated, unit, appkit, and full.
 
 If explicit lanes are provided, they override the preset.
 
 Environment:
   KEYPATH_LOCAL_LOOP_OUT          Output directory. Defaults to .build/local-loop-measurements.
   KEYPATH_LOCAL_LOOP_CLEAN_SMOKE  Set to 1 to cold-build the isolated smoke lane.
+  KEYPATH_LOCAL_LOOP_CLEAN_CORE   Set to 1 to cold-build the isolated Core lane.
   TIMEOUT_SECONDS                 Passed through to safe-runner lanes.
 USAGE
 }
@@ -52,6 +54,10 @@ while [ "$#" -gt 0 ]; do
       CLEAN_SMOKE=1
       shift
       ;;
+    --clean-core)
+      CLEAN_CORE=1
+      shift
+      ;;
     -h|--help|help)
       usage
       exit 0
@@ -74,10 +80,10 @@ if [ "${#LANES[@]}" -eq 0 ]; then
       LANES=(smoke)
       ;;
     baseline)
-      LANES=(smoke unit appkit)
+      LANES=(smoke core-isolated unit appkit)
       ;;
     full)
-      LANES=(smoke unit appkit full)
+      LANES=(smoke core-isolated unit appkit full)
       ;;
     *)
       echo "Unknown preset: $PRESET" >&2
@@ -125,6 +131,10 @@ run_lane() {
     KEYPATH_ISOLATED_SMOKE_CLEAN=1 \
       KEYPATH_TEST_LOG="$test_log" \
       "$SCRIPT_DIR/test-lane.sh" "$lane" 2>&1 | tee "$wrapper_log"
+  elif [ "$lane" = "core-isolated" ] && [ "$CLEAN_CORE" = "1" ]; then
+    KEYPATH_ISOLATED_CORE_CLEAN=1 \
+      KEYPATH_TEST_LOG="$test_log" \
+      "$SCRIPT_DIR/test-lane.sh" "$lane" 2>&1 | tee "$wrapper_log"
   else
     KEYPATH_TEST_LOG="$test_log" \
       "$SCRIPT_DIR/test-lane.sh" "$lane" 2>&1 | tee "$wrapper_log"
@@ -133,7 +143,7 @@ run_lane() {
   set -e
 
   elapsed_seconds="$(( $(date +%s) - start_seconds ))"
-  summary_line="$(awk '/Runner summary:|Isolated smoke summary:/ { line=$0 } END { print line }' "$wrapper_log")"
+  summary_line="$(awk '/Runner summary:|Isolated smoke summary:|Isolated Core summary:/ { line=$0 } END { print line }' "$wrapper_log")"
   if [ -z "$summary_line" ]; then
     summary_line="no summary line found"
   fi

--- a/Scripts/test-lane.sh
+++ b/Scripts/test-lane.sh
@@ -18,6 +18,8 @@ Usage: ./Scripts/test-lane.sh <lane>
 Lanes:
   smoke      Fast isolated sanity checks against core products.
   smoke-root Root-package smoke target; useful for diagnostics, not the fast path.
+  core-isolated
+             Experimental isolated Core harness; must avoid the KeyPathAppKit graph.
   unit       Pure or mostly pure model/parser/renderer logic.
   appkit     UI-adjacent app logic, services, packs, config, mappers, and rule collections.
   installer  InstallerEngine, wizard, daemon/service lifecycle, and health-check tests.
@@ -37,6 +39,10 @@ Environment:
                              Set to 1 to remove the isolated harness build dir first.
   KEYPATH_ISOLATED_SMOKE_ALLOW_APPKIT
                              Set to 1 to allow KeyPathAppKit mentions in the isolated lane log.
+  KEYPATH_ISOLATED_CORE_CLEAN
+                             Set to 1 to remove the isolated Core harness build dir first.
+  KEYPATH_ISOLATED_CORE_ALLOW_APPKIT
+                             Set to 1 to allow KeyPathAppKit mentions in the isolated Core log.
 USAGE
 }
 
@@ -115,9 +121,62 @@ run_isolated_smoke_lane() {
   return "$exit_code"
 }
 
+run_isolated_core_lane() {
+  local lane="${1:-core-isolated}"
+  local harness_dir="$PROJECT_DIR/dev-tools/core-harness"
+  local log_path="${KEYPATH_TEST_LOG:-$PROJECT_DIR/test_output.${lane}.txt}"
+  local build_path="${KEYPATH_ISOLATED_CORE_BUILD_PATH:-$harness_dir/.build}"
+
+  if [ "${KEYPATH_ISOLATED_CORE_CLEAN:-0}" = "1" ]; then
+    rm -rf "$build_path"
+  fi
+
+  mkdir -p "$(dirname "$log_path")"
+
+  echo "🛣️  Running KeyPath test lane: $lane"
+  echo "📦 Harness: $harness_dir"
+  echo "🧱 Build path: $build_path"
+  echo "📄 Log: $log_path"
+
+  local start elapsed exit_code
+  start="$(date +%s)"
+  set +e
+  (
+    cd "$harness_dir"
+    SWIFT_TEST=1 \
+      SKIP_EVENT_TAP_TESTS=1 \
+      KEYPATH_LOG_LEVEL="${KEYPATH_LOG_LEVEL:-3}" \
+      swift test \
+        --scratch-path "$build_path" \
+        --disable-xctest
+  ) 2>&1 | tee "$log_path"
+  exit_code="${PIPESTATUS[0]}"
+  set -e
+  elapsed="$(( $(date +%s) - start ))"
+
+  local appkit_compiles=0
+  if grep -q "KeyPathAppKit" "$log_path"; then
+    appkit_compiles=1
+  fi
+
+  echo "📊 Isolated Core summary: exit=$exit_code total=${elapsed}s appkit_in_log=$appkit_compiles log=$(wc -c < "$log_path") bytes"
+
+  if [ "$appkit_compiles" = "1" ]; then
+    echo "⚠️  Isolated Core log mentioned KeyPathAppKit; cold-build isolation was not proven."
+    if [ "${KEYPATH_ISOLATED_CORE_ALLOW_APPKIT:-0}" != "1" ]; then
+      return 1
+    fi
+  fi
+
+  return "$exit_code"
+}
+
 case "$LANE" in
   smoke)
     run_isolated_smoke_lane "$LANE"
+    ;;
+  core-isolated)
+    run_isolated_core_lane "$LANE"
     ;;
   smoke-root)
     export KEYPATH_TEST_PREBUILD="${KEYPATH_TEST_PREBUILD:-0}"

--- a/dev-tools/core-harness/Package.swift
+++ b/dev-tools/core-harness/Package.swift
@@ -1,0 +1,23 @@
+// swift-tools-version: 6.1
+import PackageDescription
+
+let package = Package(
+    name: "KeyPathCoreHarness",
+    platforms: [
+        .macOS(.v15)
+    ],
+    dependencies: [
+        .package(name: "KeyPath", path: "../..")
+    ],
+    targets: [
+        .testTarget(
+            name: "KeyPathIsolatedCoreTests",
+            dependencies: [
+                .product(name: "KeyPathCore", package: "KeyPath")
+            ],
+            swiftSettings: [
+                .swiftLanguageMode(.v6)
+            ]
+        )
+    ]
+)

--- a/dev-tools/core-harness/Tests/KeyPathIsolatedCoreTests/KanataDefseqParserCoreTests.swift
+++ b/dev-tools/core-harness/Tests/KeyPathIsolatedCoreTests/KanataDefseqParserCoreTests.swift
@@ -1,0 +1,65 @@
+import KeyPathCore
+import Testing
+
+@Suite("KanataDefseqParser Isolated Core Tests")
+struct KanataDefseqParserCoreTests {
+    @Test("Parses single-sequence defseq format")
+    func parsesSingleSequence() {
+        let config = """
+        (defseq window-leader
+          (space w))
+        """
+
+        let sequences = KanataDefseqParser.parseSequences(from: config)
+
+        #expect(sequences == [
+            .init(name: "window-leader", keys: ["space", "w"])
+        ])
+    }
+
+    @Test("Parses multi-sequence defseq format")
+    func parsesMultiSequence() {
+        let config = """
+        (defseq
+          window-leader (space w)
+          app-leader (space a)
+          nav-leader (space n))
+        """
+
+        let sequences = KanataDefseqParser.parseSequences(from: config)
+
+        #expect(sequences.count == 3)
+        #expect(sequences.first { $0.name == "window-leader" }?.keys == ["space", "w"])
+        #expect(sequences.first { $0.name == "app-leader" }?.keys == ["space", "a"])
+        #expect(sequences.first { $0.name == "nav-leader" }?.keys == ["space", "n"])
+    }
+
+    @Test("Ignores line and block comments")
+    func ignoresComments() {
+        let config = """
+        ;; Window management sequence
+        #|
+        ignored block
+        |#
+        (defseq window-leader
+          (space w)) ;; trailing comment
+        """
+
+        let sequences = KanataDefseqParser.parseSequences(from: config)
+
+        #expect(sequences == [
+            .init(name: "window-leader", keys: ["space", "w"])
+        ])
+    }
+
+    @Test("Returns no sequences when config has no defseq")
+    func returnsNoSequencesWhenAbsent() {
+        let config = """
+        (defsrc
+          grv 1 2 3 4 5 6 7 8 9 0 - = bspc
+        )
+        """
+
+        #expect(KanataDefseqParser.parseSequences(from: config).isEmpty)
+    }
+}

--- a/dev-tools/core-harness/Tests/KeyPathIsolatedCoreTests/KanataHostBridgeCoreTests.swift
+++ b/dev-tools/core-harness/Tests/KeyPathIsolatedCoreTests/KanataHostBridgeCoreTests.swift
@@ -1,0 +1,62 @@
+import KeyPathCore
+import Testing
+
+@Suite("KanataHostBridge Isolated Core Tests")
+struct KanataHostBridgeCoreTests {
+    @Test("Probe reports unavailable when bridge library is missing")
+    func probeReportsUnavailableWhenLibraryMissing() {
+        let runtimeHost = KanataRuntimeHost(
+            launcherPath: "/tmp/kanata-launcher",
+            bridgeLibraryPath: "/definitely/missing/libkeypath_kanata_host_bridge.dylib",
+            bundledCorePath: "/tmp/kanata",
+            kanataEngineBundlePath: "/tmp/Kanata Engine.app"
+        )
+
+        #expect(
+            KanataHostBridge.probe(runtimeHost: runtimeHost)
+                == .unavailable(reason: "library not found at /definitely/missing/libkeypath_kanata_host_bridge.dylib")
+        )
+    }
+
+    @Test("Bridge result summaries are stable")
+    func resultSummariesAreStable() {
+        #expect(
+            KanataHostBridgeProbeResult.loaded(version: "0.1.0", defaultConfigCount: 2).logSummary
+                == "Host bridge loaded: version=0.1.0 default_cfg_count=2"
+        )
+        #expect(
+            KanataHostBridgeRunResult.failed(reason: "permission denied").logSummary
+                == "Host bridge runtime failed: permission denied"
+        )
+        #expect(
+            KanataHostBridgeRunResult.unavailable(reason: "missing symbol").logSummary
+                == "Host bridge runtime unavailable: missing symbol"
+        )
+        #expect(
+            KanataHostBridgePassthruRuntimeResult.created(layerCount: 3).logSummary
+                == "Host bridge passthru runtime created successfully: layer_count=3"
+        )
+    }
+
+    @Test("Passthru runtime creation reports unavailable when bridge library is missing")
+    func passthruRuntimeReportsUnavailableWhenLibraryMissing() {
+        let runtimeHost = KanataRuntimeHost(
+            launcherPath: "/tmp/kanata-launcher",
+            bridgeLibraryPath: "/definitely/missing/libkeypath_kanata_host_bridge.dylib",
+            bundledCorePath: "/tmp/kanata",
+            kanataEngineBundlePath: "/tmp/Kanata Engine.app"
+        )
+
+        let result = KanataHostBridge.createPassthruRuntime(
+            runtimeHost: runtimeHost,
+            configPath: "/tmp/keypath.kbd",
+            tcpPort: 37001
+        )
+
+        #expect(
+            result.result
+                == .unavailable(reason: "library not found at /definitely/missing/libkeypath_kanata_host_bridge.dylib")
+        )
+        #expect(result.handle == nil)
+    }
+}

--- a/dev-tools/core-harness/Tests/KeyPathIsolatedCoreTests/KanataRuntimeHostCoreTests.swift
+++ b/dev-tools/core-harness/Tests/KeyPathIsolatedCoreTests/KanataRuntimeHostCoreTests.swift
@@ -1,0 +1,65 @@
+import KeyPathCore
+import Testing
+
+@Suite("KanataRuntimeHost Isolated Core Tests")
+struct KanataRuntimeHostCoreTests {
+    @Test("Current host uses app-bundle-relative paths")
+    func currentUsesBundleRelativePaths() {
+        let host = KanataRuntimeHost.current(bundlePath: "/Applications/KeyPath.app")
+
+        #expect(host.launcherPath == "/Applications/KeyPath.app/Contents/Library/KeyPath/kanata-launcher")
+        #expect(host.bridgeLibraryPath == "/Applications/KeyPath.app/Contents/Library/KeyPath/libkeypath_kanata_host_bridge.dylib")
+        #expect(host.bundledCorePath == "/Applications/KeyPath.app/Contents/Library/KeyPath/Kanata Engine.app/Contents/MacOS/kanata")
+        #expect(host.kanataEngineBundlePath == "/Applications/KeyPath.app/Contents/Library/KeyPath/Kanata Engine.app")
+    }
+
+    @Test("Current host normalizes launcher directory to app bundle root")
+    func currentNormalizesLauncherDirectory() {
+        let host = KanataRuntimeHost.current(
+            bundlePath: "/Applications/KeyPath.app/Contents/Library/KeyPath"
+        )
+
+        #expect(host.launcherPath == "/Applications/KeyPath.app/Contents/Library/KeyPath/kanata-launcher")
+        #expect(host.bridgeLibraryPath == "/Applications/KeyPath.app/Contents/Library/KeyPath/libkeypath_kanata_host_bridge.dylib")
+        #expect(host.bundledCorePath == "/Applications/KeyPath.app/Contents/Library/KeyPath/Kanata Engine.app/Contents/MacOS/kanata")
+        #expect(host.kanataEngineBundlePath == "/Applications/KeyPath.app/Contents/Library/KeyPath/Kanata Engine.app")
+    }
+
+    @Test("Launch request builds command line and adds trace when needed")
+    func launchRequestBuildsCommandLine() {
+        let request = KanataRuntimeLaunchRequest(
+            configPath: "/Users/test/.config/keypath/keypath.kbd",
+            inheritedArguments: ["--port", "37001", "--log-layer-changes"],
+            addTraceLogging: true
+        )
+
+        #expect(
+            request.commandLine(binaryPath: "/Applications/KeyPath.app/Contents/Library/KeyPath/Kanata Engine.app/Contents/MacOS/kanata")
+                == [
+                    "/Applications/KeyPath.app/Contents/Library/KeyPath/Kanata Engine.app/Contents/MacOS/kanata",
+                    "--cfg", "/Users/test/.config/keypath/keypath.kbd",
+                    "--port", "37001",
+                    "--log-layer-changes",
+                    "--trace"
+                ]
+        )
+    }
+
+    @Test("Launch request does not duplicate trace when debug already exists")
+    func launchRequestDoesNotDuplicateTraceWhenDebugExists() {
+        let request = KanataRuntimeLaunchRequest(
+            configPath: "/Users/test/.config/keypath/keypath.kbd",
+            inheritedArguments: ["--debug"],
+            addTraceLogging: true
+        )
+
+        #expect(
+            request.commandLine(binaryPath: "/Applications/KeyPath.app/Contents/Library/KeyPath/Kanata Engine.app/Contents/MacOS/kanata")
+                == [
+                    "/Applications/KeyPath.app/Contents/Library/KeyPath/Kanata Engine.app/Contents/MacOS/kanata",
+                    "--cfg", "/Users/test/.config/keypath/keypath.kbd",
+                    "--debug"
+                ]
+        )
+    }
+}

--- a/dev-tools/core-harness/Tests/KeyPathIsolatedCoreTests/TestEnvironmentCoreTests.swift
+++ b/dev-tools/core-harness/Tests/KeyPathIsolatedCoreTests/TestEnvironmentCoreTests.swift
@@ -1,0 +1,25 @@
+import Foundation
+import KeyPathCore
+import Testing
+
+@Suite("TestEnvironment Isolated Core Tests", .serialized)
+struct TestEnvironmentCoreTests {
+    @Test("Detects SwiftPM test execution")
+    func detectsSwiftPMTestExecution() {
+        #expect(TestEnvironment.isRunningTests)
+        #expect(TestEnvironment.isTestMode)
+    }
+
+    @Test("Force test mode can be toggled")
+    @MainActor
+    func forceTestModeCanBeToggled() {
+        let original = TestEnvironment.forceTestMode
+        defer { TestEnvironment.forceTestMode = original }
+
+        TestEnvironment.forceTestMode = true
+        #expect(TestEnvironment.isTestMode)
+
+        TestEnvironment.forceTestMode = false
+        #expect(TestEnvironment.isTestMode)
+    }
+}

--- a/docs/MACBOOK_AIR_LOCAL_LOOP.md
+++ b/docs/MACBOOK_AIR_LOCAL_LOOP.md
@@ -11,6 +11,7 @@ Run the smallest lane that covers the files you changed:
 | Change type | Command |
 | --- | --- |
 | Core APIs, permissions, parser smoke coverage | `./Scripts/test-lane.sh smoke` |
+| Core-only runtime, parser, and environment behavior | `./Scripts/test-lane.sh core-isolated` |
 | Pure model/parser/renderer logic | `./Scripts/test-lane.sh unit` |
 | AppKit-adjacent logic, services, config, packs, mappers | `./Scripts/test-lane.sh appkit` |
 | InstallerEngine, wizard, daemon lifecycle, health checks | `./Scripts/test-lane.sh installer` |
@@ -47,6 +48,7 @@ feedback:
 ./Scripts/measure-local-loop.sh
 ./Scripts/measure-local-loop.sh --preset baseline
 ./Scripts/measure-local-loop.sh --clean-smoke smoke
+./Scripts/measure-local-loop.sh --clean-core core-isolated
 ```
 
 Reports are written under `.build/local-loop-measurements/`, with the latest
@@ -60,8 +62,8 @@ Markdown and TSV reports linked at:
 Presets:
 
 - `quick`: runs `smoke`.
-- `baseline`: runs `smoke`, `unit`, and `appkit`.
-- `full`: runs `smoke`, `unit`, `appkit`, and `full`.
+- `baseline`: runs `smoke`, `core-isolated`, `unit`, and `appkit`.
+- `full`: runs `smoke`, `core-isolated`, `unit`, `appkit`, and `full`.
 
 ## Clean Summary Guardrail
 

--- a/docs/TEST_HYGIENE_PLAN.md
+++ b/docs/TEST_HYGIENE_PLAN.md
@@ -363,6 +363,81 @@ Acceptance criteria:
 - Later Mac mini orchestration decisions can use measured data instead of
   guesses, but do not drive the current milestone.
 
+### Milestone 7: Bounded Core Harness Isolation
+
+Goal: stop treating root-package test-target splits as a speed strategy and
+prove whether a small isolated Core harness can provide a genuinely faster
+local confidence path.
+
+Context:
+
+- `KeyPathTests` is still one broad target. Even a narrow
+  `swift test --filter` against that target can force SwiftPM to compile the
+  broad app graph because the target depends on `KeyPathAppKit`, `KeyPathCLI`,
+  installer modules, and supporting packages.
+- Local measurement and SwiftPM research confirmed this is a tooling
+  limitation, not just a KeyPath package-shape problem: `swift test --filter`
+  filters test execution, but it does not reliably isolate the build graph
+  inside one root package.
+- Creating a root-package `KeyPathCoreTests` target improves organization and
+  log scope, but it does not meet the cold-build isolation goal because SwiftPM
+  still builds the generated package-wide test product.
+- The hidden `--test-product` workaround can target the generated
+  `KeyPathPackageTests` product in this toolchain, but that product is
+  package-wide. It does not create a per-target `KeyPathCoreTests` product.
+- `KeyPathInstallationWizard` is already a separate target that does not depend
+  on `KeyPathAppKit`, which is useful. Further installer/wizard splitting
+  should be measurement-driven.
+- `KeyPathCLI` is a separate target, but it currently depends on
+  `KeyPathAppKit`. Splitting CLI tests only helps if the CLI dependency graph is
+  narrowed or inverted so CLI-only tests no longer pull the app target.
+- The isolated `smoke` harness has already proven the pattern: true speed comes
+  from a smaller dependency graph, not just a smaller test filter.
+
+Work:
+
+- Treat the root-package `KeyPathCoreTests` experiment as a finding, not as the
+  milestone path. Do not check it in as a build-isolation success unless a later
+  toolchain proves it actually avoids the app graph.
+- Create a small `dev-tools/core-harness` SwiftPM package, modeled after the
+  isolated smoke harness, that depends only on `KeyPathCore`.
+- Copy or port only the highest-signal Core checks into the harness first:
+  `KanataRuntimeHostTests`, `KanataHostBridgeTests`,
+  `KanataDefseqParserTests`, and `TestEnvironmentDetectionTests`.
+  Add `SubprocessRunnerTests` only if the harness remains fast and stable.
+- Add a `core-isolated` lane only if the harness proves a real speed win. Keep
+  existing root lane names stable; do not replace `unit` with a harness command
+  until measurements justify it.
+- Measure cold and warm harness runs against the current `smoke` and `unit`
+  lanes, including whether `KeyPathAppKit` appears in the log.
+- Stop the harness effort if it does not materially outperform the root
+  filtered lane or if the copied-test maintenance burden starts to outweigh the
+  local-loop gain.
+- Audit `KeyPathCLI`'s dependency on `KeyPathAppKit`. If CLI tests remain a
+  meaningful local-loop cost, identify the smallest extraction that moves
+  CLI-facing models/facades/protocols into a non-AppKit target.
+- Revisit installer/wizard boundaries only after Core and CLI measurements. If
+  installer tests still dominate a lane we care about, split pure installer or
+  service lifecycle logic from SwiftUI wizard view code.
+- Keep the Mac mini/MacBook split deferred until local build graph isolation is
+  measured and no longer the main bottleneck.
+
+Acceptance criteria:
+
+- A cold isolated Core harness builds and runs without compiling
+  `KeyPathAppKit`.
+- The plan records before/after measurements for the current filtered unit lane,
+  the isolated smoke lane, and the isolated Core harness.
+- The harness either earns a permanent lane with clear speed evidence or is
+  explicitly retired so root-package organization work does not masquerade as
+  build-speed work.
+- The CLI/AppKit dependency audit produces either a scoped extraction plan or a
+  measured decision to defer it.
+- Installer/wizard follow-up is based on lane timing and dependency evidence,
+  not on target-count preferences.
+- Existing lane names remain stable unless a measured workflow problem justifies
+  a new name.
+
 ## Relationship To Existing Issues
 
 - #604 covers the broad long-term test improvement plan.
@@ -381,6 +456,9 @@ quality, lane design, dependency narrowing, and measurement.
 4. Audit and split test dependencies where the payoff is clear.
 5. Clean warning hotspots.
 6. Add MacBook Air local-loop measurement guardrails and workflow docs.
+7. Isolate the build graph for routine local checks with a bounded isolated
+   Core harness, then audit CLI/AppKit decoupling, then revisit
+   installer/wizard boundaries only if measurements justify it.
 
 ## Current Status
 
@@ -460,7 +538,7 @@ behavior.
 Milestone 4 started by moving the first smoke tests into `KeyPathSmokeTests`;
 see the Milestone 4 status section above for the current measurement.
 
-Milestone 6 is now started with the MacBook Air local loop as the target:
+Milestone 6 is implemented with the MacBook Air local loop as the target:
 
 - `unit`, `appkit`, `installer`, `snapshot`, and `full` lanes reuse the
   normalized module cache by default for faster warm local feedback.
@@ -469,6 +547,13 @@ Milestone 6 is now started with the MacBook Air local loop as the target:
   can be compared without copying terminal output.
 - `docs/MACBOOK_AIR_LOCAL_LOOP.md` documents the recommended lane by change
   type, warm-cache policy, measurement presets, and when to use verbose logs.
+- `core-isolated` now runs a separate `dev-tools/core-harness` package that
+  depends only on `KeyPathCore`; a clean run passed in 15s and a warm run passed
+  in 4s, both with `appkit_in_log=0`.
+- Follow-up measurements refined that baseline: `./Scripts/measure-local-loop.sh
+  --clean-core core-isolated` passed in 12s with `appkit_in_log=0`, and
+  `./Scripts/measure-local-loop.sh core-isolated` passed in 3s with
+  `appkit_in_log=0`.
 - `run-tests-safe.sh` now supports `KEYPATH_TEST_ENFORCE_CLEAN_SUMMARY=1` to
   fail an otherwise passing lane when summary warning/error counts regress.
   CI enables this guardrail for the full lane; elapsed time remains
@@ -478,9 +563,11 @@ Milestone 6 is now started with the MacBook Air local loop as the target:
   organization when target/package boundaries or Swift Testing suites/tags give
   measurable clarity or speed benefits.
 - Current warm MacBook Air baseline from
-  `./Scripts/measure-local-loop.sh --preset baseline`: `smoke` 3s,
-  `unit` 5s, and `appkit` 25s. All three lanes reported zero Swift warnings,
-  module-cache warnings, app warnings, and app errors in their final summaries.
+  `./Scripts/measure-local-loop.sh --preset baseline`: `smoke` 2s,
+  `core-isolated` 3s, `unit` 16s, and `appkit` 22s. The isolated lanes both
+  reported `appkit_in_log=0`; the root-package lanes reported zero Swift
+  warnings, module-cache warnings, app warnings, and app errors in their final
+  summaries.
 - Current warm installer baseline from `./Scripts/measure-local-loop.sh
   installer`: 11s total, 263 passed, and zero Swift warnings,
   module-cache warnings, app warnings, or app errors. This required keeping
@@ -495,3 +582,9 @@ Milestone 6 is now started with the MacBook Air local loop as the target:
 The Mac mini workflow is deferred. Revisit it only after the MacBook Air loop is
 fast and boring enough that remote execution would solve a measured capacity
 problem instead of compensating for harness noise.
+
+Next planned milestone: continue Milestone 7 by measuring the new
+`core-isolated` lane in the baseline preset and then auditing the remaining
+`unit` and `appkit` lanes. CLI and installer/wizard splits should follow only
+after the isolated Core harness earns its keep over repeated local runs and the
+remaining lane timings justify the extra dependency work.


### PR DESCRIPTION
## Summary

- add a separate `dev-tools/core-harness` SwiftPM package for Core-only checks
- add `./Scripts/test-lane.sh core-isolated` with an AppKit log guard
- add `core-isolated` to local-loop measurement presets and update the test hygiene plan

## Why

`swift test --filter` narrows test execution but not the root package build graph, so root-package test target splitting does not provide true cold-build isolation. The isolated harness follows the proven smoke-harness pattern and gives Core changes a smaller package universe.

## Validation

- `python3 Scripts/check-accessibility.py`
- `bash -n Scripts/test-lane.sh`
- `bash -n Scripts/measure-local-loop.sh`
- `git diff --check`
- `./Scripts/test-lane.sh core-isolated` passed in 3s with `appkit_in_log=0`
- `KEYPATH_ISOLATED_CORE_CLEAN=1 ./Scripts/test-lane.sh core-isolated` passed with `appkit_in_log=0`
- `./Scripts/measure-local-loop.sh --clean-core core-isolated` passed in 12s with `appkit_in_log=0`
- `./Scripts/measure-local-loop.sh --preset baseline` passed (`smoke`, `core-isolated`, `unit`, `appkit`)
