### PR TITLE
[codex] Polish HRM CLI export behavior

### DIFF
--- a/Sources/KeyPathAppKit/CLI/CollectionsFacade.swift
+++ b/Sources/KeyPathAppKit/CLI/CollectionsFacade.swift
@@ -333,6 +333,27 @@ public struct CollectionsFacade: Sendable {
             )
         }
 
+        let normalizedQuery = nameOrId.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let slugMatches = collections.enumerated().filter {
+            Self.slug(for: $0.element.name) == normalizedQuery
+        }
+        if slugMatches.count == 1 {
+            return slugMatches[0].offset
+        }
+        if slugMatches.count > 1 {
+            throw AmbiguousCollectionMatch(
+                query: nameOrId,
+                matches: slugMatches.map { .init(name: $0.element.name, id: $0.element.id.uuidString) },
+                hint: "Multiple collections match this slug. Use the ID to disambiguate."
+            )
+        }
+
+        if let aliasID = Self.collectionAliasIDs[normalizedQuery],
+           let index = collections.firstIndex(where: { $0.id == aliasID })
+        {
+            return index
+        }
+
         let substringMatches = collections.enumerated().filter {
             $0.element.name.localizedCaseInsensitiveContains(nameOrId)
         }
@@ -355,6 +376,27 @@ public struct CollectionsFacade: Sendable {
         case "nav", "navigation": .navigation
         default: .custom(name)
         }
+    }
+
+    private static let collectionAliasIDs: [String: UUID] = [
+        "home-row": RuleCollectionIdentifier.homeRowMods,
+        "home-row-mod": RuleCollectionIdentifier.homeRowMods,
+        "hrm": RuleCollectionIdentifier.homeRowMods,
+    ]
+
+    private static func slug(for name: String) -> String {
+        var result = ""
+        var previousWasSeparator = false
+        for scalar in name.lowercased().unicodeScalars {
+            if CharacterSet.alphanumerics.contains(scalar) {
+                result.unicodeScalars.append(scalar)
+                previousWasSeparator = false
+            } else if !previousWasSeparator {
+                result.append("-")
+                previousWasSeparator = true
+            }
+        }
+        return result.trimmingCharacters(in: CharacterSet(charactersIn: "-"))
     }
 }
 
@@ -426,6 +468,7 @@ public struct CLIExportedCollection: Codable, Sendable {
     public let category: String
     public let isEnabled: Bool
     public let targetLayer: String
+    public let configuration: RuleCollectionConfiguration?
     public let mappings: [CLIExportedMapping]
 
     public init(from collection: RuleCollection) {
@@ -434,6 +477,7 @@ public struct CLIExportedCollection: Codable, Sendable {
         category = collection.category.rawValue
         isEnabled = collection.isEnabled
         targetLayer = collection.targetLayer.kanataName
+        configuration = collection.configuration
         mappings = collection.mappings.map { CLIExportedMapping(from: $0) }
     }
 
@@ -450,7 +494,8 @@ public struct CLIExportedCollection: Codable, Sendable {
             category: cat,
             mappings: mappings.map { $0.toKeyMapping() },
             isEnabled: isEnabled,
-            targetLayer: layer
+            targetLayer: layer,
+            configuration: configuration ?? .list
         )
     }
 }

--- a/Sources/KeyPathAppKit/CLI/PacksFacade.swift
+++ b/Sources/KeyPathAppKit/CLI/PacksFacade.swift
@@ -52,15 +52,7 @@ public struct PacksFacade: Sendable {
             )
         }
 
-        for key in settingValues.keys {
-            guard pack.quickSettings.contains(where: { $0.id == key }) else {
-                throw CLIPackSettingError(
-                    packName: pack.name,
-                    settingKey: key,
-                    validKeys: pack.quickSettings.map(\.id)
-                )
-            }
-        }
+        try validateQuickSettings(settingValues, for: pack)
 
         if dryRun {
             var warnings: [String] = []
@@ -174,15 +166,7 @@ public struct PacksFacade: Sendable {
             )
         }
 
-        for key in settingValues.keys {
-            guard pack.quickSettings.contains(where: { $0.id == key }) else {
-                throw CLIPackSettingError(
-                    packName: pack.name,
-                    settingKey: key,
-                    validKeys: pack.quickSettings.map(\.id)
-                )
-            }
-        }
+        try validateQuickSettings(settingValues, for: pack)
 
         if dryRun {
             let current = await PackInstaller.shared.quickSettings(for: pack.id)
@@ -278,6 +262,34 @@ public struct PacksFacade: Sendable {
         manager.ruleCollections = RuleCollectionDeduplicator.dedupe(collections)
         manager.customRules = customRules
         return manager
+    }
+
+    private func validateQuickSettings(_ values: [String: Int], for pack: Pack) throws {
+        let settingsByID = Dictionary(uniqueKeysWithValues: pack.quickSettings.map { ($0.id, $0) })
+        for (key, value) in values {
+            guard let setting = settingsByID[key] else {
+                throw CLIPackSettingError(
+                    packName: pack.name,
+                    settingKey: key,
+                    validKeys: pack.quickSettings.map(\.id)
+                )
+            }
+            try validateQuickSettingValue(value, setting: setting, packName: pack.name)
+        }
+    }
+
+    private func validateQuickSettingValue(_ value: Int, setting: PackQuickSetting, packName: String) throws {
+        switch setting.kind {
+        case let .slider(_, min, max, _, unitSuffix):
+            guard value >= min, value <= max else {
+                throw CLIPackSettingValueError(
+                    packName: packName,
+                    settingKey: setting.id,
+                    value: value,
+                    reason: "must be between \(min)\(unitSuffix) and \(max)\(unitSuffix)"
+                )
+            }
+        }
     }
 }
 
@@ -420,6 +432,17 @@ public struct CLIPackSettingError: Error, CustomStringConvertible {
             return "Pack '\(packName)' has no quick settings, but --setting \(settingKey) was provided"
         }
         return "Unknown setting '\(settingKey)' for pack '\(packName)'. Valid keys: \(validKeys.joined(separator: ", "))"
+    }
+}
+
+public struct CLIPackSettingValueError: Error, CustomStringConvertible {
+    public let packName: String
+    public let settingKey: String
+    public let value: Int
+    public let reason: String
+
+    public var description: String {
+        "Invalid value \(value) for setting '\(settingKey)' on pack '\(packName)': \(reason)"
     }
 }
 

--- a/Sources/KeyPathAppKit/UI/Rules/HomeRowTimingSection.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/HomeRowTimingSection.swift
@@ -125,7 +125,9 @@ struct HomeRowTimingSection: View {
                         set: { inverted in
                             let pos = 1.0 - inverted
                             let values = TypingFeelMapping.timingValues(forSliderPosition: pos)
-                            config.timing.tapWindow = values.tapWindow
+                            if usesTimedTapWindow {
+                                config.timing.tapWindow = values.tapWindow
+                            }
                             config.timing.holdDelay = values.holdDelay
                             let idleFraction = 1.0 - pos
                             config.timing.requirePriorIdleMs = max(0, Int(50 + idleFraction * 200))
@@ -140,7 +142,7 @@ struct HomeRowTimingSection: View {
                 .frame(maxWidth: 250)
                 .accessibilityIdentifier("home-row-mods-feel-slider")
                 .accessibilityLabel("Home row typing feel")
-                .accessibilityValue("tap window \(config.timing.tapWindow) ms, hold delay \(config.timing.holdDelay) ms")
+                .accessibilityValue(timingSliderAccessibilityValue)
                 .overlay(alignment: .top) {
                     if isEditingHoldDuration {
                         Text("\(config.timing.holdDelay)ms")
@@ -176,20 +178,22 @@ struct HomeRowTimingSection: View {
                         }
                         if config.showExpertTiming {
                             HStack(spacing: 16) {
-                                VStack(alignment: .leading, spacing: 4) {
-                                    Text("Tap window").font(.caption).foregroundColor(.secondary)
-                                    HStack(spacing: 4) {
-                                        automationIntegerField(
-                                            placeholder: "",
-                                            value: Binding(
-                                                get: { config.timing.tapWindow },
-                                                set: { config.timing.tapWindow = $0 }
-                                            ),
-                                            range: 80 ... 350,
-                                            accessibilityIdentifier: "home-row-mods-tap-window-field",
-                                            accessibilityLabel: "Tap window"
-                                        )
-                                        Text("ms").font(.caption).foregroundColor(.secondary)
+                                if usesTimedTapWindow {
+                                    VStack(alignment: .leading, spacing: 4) {
+                                        Text("Tap window").font(.caption).foregroundColor(.secondary)
+                                        HStack(spacing: 4) {
+                                            automationIntegerField(
+                                                placeholder: "",
+                                                value: Binding(
+                                                    get: { config.timing.tapWindow },
+                                                    set: { config.timing.tapWindow = $0 }
+                                                ),
+                                                range: 80 ... 350,
+                                                accessibilityIdentifier: "home-row-mods-tap-window-field",
+                                                accessibilityLabel: "Tap window"
+                                            )
+                                            Text("ms").font(.caption).foregroundColor(.secondary)
+                                        }
                                     }
                                 }
                                 VStack(alignment: .leading, spacing: 4) {
@@ -215,13 +219,17 @@ struct HomeRowTimingSection: View {
                                 Slider(value: Binding(
                                     get: { 1.0 - effectiveSliderPosition },
                                     set: {
-                                        let v = TypingFeelMapping.timingValues(forSliderPosition: 1.0 - $0); config.timing.tapWindow = v.tapWindow; config.timing.holdDelay = v
-                                            .holdDelay; debouncedUpdateConfig()
+                                        let v = TypingFeelMapping.timingValues(forSliderPosition: 1.0 - $0)
+                                        if usesTimedTapWindow {
+                                            config.timing.tapWindow = v.tapWindow
+                                        }
+                                        config.timing.holdDelay = v.holdDelay
+                                        debouncedUpdateConfig()
                                     }
                                 ), in: 0 ... 1, step: 0.05)
                                     .accessibilityIdentifier("home-row-mods-hold-duration-advanced")
                                     .accessibilityLabel("Advanced hold duration")
-                                    .accessibilityValue("tap window \(config.timing.tapWindow) ms, hold delay \(config.timing.holdDelay) ms")
+                                    .accessibilityValue(timingSliderAccessibilityValue)
                                 Text("Modifiers feel snappy").font(.caption2).foregroundStyle(.secondary)
                             }
                         }
@@ -755,6 +763,17 @@ struct HomeRowTimingSection: View {
             return "No extra time added. Uses base tap window only."
         }
         return "Adds \(config.timing.quickTapTermMs)ms to the tap window during key rolls."
+    }
+
+    private var usesTimedTapWindow: Bool {
+        !config.oppositeHandMode.isEnabled
+    }
+
+    private var timingSliderAccessibilityValue: String {
+        if usesTimedTapWindow {
+            return "tap window \(config.timing.tapWindow) ms, hold delay \(config.timing.holdDelay) ms"
+        }
+        return "hold delay \(config.timing.holdDelay) ms"
     }
 
     private var hasNonDefaultTiming: Bool {

--- a/Sources/KeyPathCLI/Commands/Pack/PackConfigureCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Pack/PackConfigureCommand.swift
@@ -88,6 +88,10 @@ struct PackConfigure: AsyncParsableCommand {
             let error = CLIError.validation(settingErr.description)
             CLIOutput.writeError(error, context: ctx)
             throw error.code.exitCode
+        } catch let valueErr as CLIPackSettingValueError {
+            let error = CLIError.validation(valueErr.description)
+            CLIOutput.writeError(error, context: ctx)
+            throw error.code.exitCode
         }
     }
 }

--- a/Sources/KeyPathCLI/Commands/Pack/PackInstallCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Pack/PackInstallCommand.swift
@@ -110,6 +110,11 @@ struct PackInstall: AsyncParsableCommand {
             let error = CLIError.validation(settingErr.description)
             CLIOutput.writeError(error, context: ctx)
             throw error.code.exitCode
+        } catch let valueErr as CLIPackSettingValueError {
+            spinner.fail("Invalid setting")
+            let error = CLIError.validation(valueErr.description)
+            CLIOutput.writeError(error, context: ctx)
+            throw error.code.exitCode
         } catch let installErr as PackInstaller.InstallError {
             spinner.fail("Install failed")
             let error = switch installErr {

--- a/Tests/KeyPathTests/CLI/CLIExportImportTests.swift
+++ b/Tests/KeyPathTests/CLI/CLIExportImportTests.swift
@@ -42,6 +42,57 @@ final class CLIExportImportTests: XCTestCase {
         XCTAssertTrue(names.contains("Second"))
     }
 
+    func testExportCollectionIncludesHomeRowModsConfiguration() async throws {
+        var config = HomeRowModsConfig()
+        config.holdMode = .layers
+        config.hasUserSelectedHoldMode = true
+        config.layerAssignments["a"] = "nav"
+        config.timing.tapWindow = 240
+        config.timing.holdDelay = 260
+        config.timing.requirePriorIdleMs = 120
+        config.oppositeHandMode = .press
+
+        var collections = await RuleCollectionStore.shared.loadCollections()
+        collections.append(RuleCollection(
+            name: "Exportable HRM",
+            summary: "Config-backed",
+            category: .productivity,
+            mappings: [],
+            configuration: .homeRowMods(config)
+        ))
+        try await RuleCollectionStore.shared.saveCollections(collections)
+
+        let exportedResult = try await facade.exportCollection(nameOrId: "Exportable HRM")
+        let exported = try XCTUnwrap(exportedResult)
+        guard case let .homeRowMods(exportedConfig)? = exported.configuration else {
+            XCTFail("Expected Home Row Mods configuration in export")
+            return
+        }
+        XCTAssertEqual(exported.mappings.count, 0)
+        XCTAssertEqual(exportedConfig.holdMode, .layers)
+        XCTAssertEqual(exportedConfig.layerAssignments["a"], "nav")
+        XCTAssertEqual(exportedConfig.timing.tapWindow, 240)
+        XCTAssertEqual(exportedConfig.timing.holdDelay, 260)
+        XCTAssertEqual(exportedConfig.timing.requirePriorIdleMs, 120)
+        XCTAssertEqual(exportedConfig.oppositeHandMode, .press)
+    }
+
+    func testExportCollectionResolvesHomeRowAlias() async throws {
+        var collections = await RuleCollectionStore.shared.loadCollections()
+        collections.append(RuleCollection(
+            id: RuleCollectionIdentifier.homeRowMods,
+            name: "Home Row Mods",
+            summary: "Config-backed",
+            category: .productivity,
+            mappings: [],
+            configuration: .homeRowMods(HomeRowModsConfig())
+        ))
+        try await RuleCollectionStore.shared.saveCollections(collections)
+
+        let exported = try await facade.exportCollection(nameOrId: "home-row")
+        XCTAssertEqual(exported?.name, "Home Row Mods")
+    }
+
     // MARK: - Import
 
     func testImportCollectionCreatesNew() async throws {
@@ -117,5 +168,34 @@ final class CLIExportImportTests: XCTestCase {
         _ = try await facade.deleteCollection(nameOrId: "Round Trip")
         let imported = try await facade.importCollection(decoded)
         XCTAssertEqual(imported.name, "Round Trip")
+    }
+
+    func testExportImportRoundTripPreservesConfiguration() throws {
+        var config = HomeRowModsConfig()
+        config.holdMode = .layers
+        config.layerAssignments["f"] = "nav"
+        config.timing.holdDelay = 260
+
+        let collection = RuleCollection(
+            name: "Round Trip HRM",
+            summary: "Config-backed",
+            category: .productivity,
+            mappings: [],
+            configuration: .homeRowMods(config)
+        )
+        let exported = CLIExportedCollection(from: collection)
+
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(exported)
+        let decoded = try JSONDecoder().decode(CLIExportedCollection.self, from: data)
+        let restored = decoded.toRuleCollection()
+
+        guard case let .homeRowMods(restoredConfig) = restored.configuration else {
+            XCTFail("Expected Home Row Mods configuration after round trip")
+            return
+        }
+        XCTAssertEqual(restoredConfig.holdMode, .layers)
+        XCTAssertEqual(restoredConfig.layerAssignments["f"], "nav")
+        XCTAssertEqual(restoredConfig.timing.holdDelay, 260)
     }
 }

--- a/Tests/KeyPathTests/CLI/CLIPackCRUDTests.swift
+++ b/Tests/KeyPathTests/CLI/CLIPackCRUDTests.swift
@@ -206,6 +206,22 @@ final class CLIPackCRUDTests: XCTestCase {
         XCTAssertEqual(result.quickSettingValues["holdTimeout"], 200)
     }
 
+    func testInstallRejectsOutOfRangeQuickSetting() async throws {
+        try await ensureUninstalled("com.keypath.pack.home-row-mods")
+
+        do {
+            _ = try await facade.installPack(
+                nameOrId: "home-row-mods",
+                settingValues: ["holdTimeout": 999],
+                dryRun: true
+            )
+            XCTFail("Should throw CLIPackSettingValueError")
+        } catch let error as CLIPackSettingValueError {
+            XCTAssertEqual(error.settingKey, "holdTimeout")
+            XCTAssertTrue(error.description.contains("between 120 ms and 300 ms"))
+        }
+    }
+
     // MARK: - configurePack
 
     func testConfigurePackUpdatesSettings() async throws {
@@ -235,6 +251,23 @@ final class CLIPackCRUDTests: XCTestCase {
         // Verify actual value unchanged
         let current = await InstalledPackTracker.shared.record(for: "com.keypath.pack.home-row-mods")
         XCTAssertEqual(current?.quickSettingValues["holdTimeout"], 200)
+    }
+
+    func testConfigurePackRejectsOutOfRangeQuickSetting() async throws {
+        try await ensureUninstalled("com.keypath.pack.home-row-mods")
+        _ = try await facade.installPack(nameOrId: "home-row-mods", settingValues: ["holdTimeout": 200])
+
+        do {
+            _ = try await facade.configurePack(
+                nameOrId: "home-row-mods",
+                settingValues: ["holdTimeout": 999],
+                dryRun: true
+            )
+            XCTFail("Should throw CLIPackSettingValueError")
+        } catch let error as CLIPackSettingValueError {
+            XCTAssertEqual(error.settingKey, "holdTimeout")
+            XCTAssertTrue(error.description.contains("between 120 ms and 300 ms"))
+        }
     }
 
     func testConfigurePackNotInstalledReturnsNotInstalled() async throws {

--- a/Tests/KeyPathTests/CLI/CollectionsFacadeTests.swift
+++ b/Tests/KeyPathTests/CLI/CollectionsFacadeTests.swift
@@ -28,6 +28,40 @@ final class CollectionsFacadeTests: XCTestCase {
         XCTAssertEqual(index, 1)
     }
 
+    func testResolveByHyphenatedSlug() throws {
+        let collections = makeCollections(["Home Row Mods", "Vim Layer"])
+        let index = try facade.resolveCollectionIndex(nameOrId: "home-row-mods", in: collections)
+        XCTAssertEqual(index, 0)
+    }
+
+    func testResolveHomeRowAlias() throws {
+        let collections = [
+            RuleCollection(
+                id: RuleCollectionIdentifier.homeRowMods,
+                name: "Home Row Mods",
+                summary: "Test collection",
+                category: .productivity,
+                mappings: []
+            ),
+            RuleCollection(
+                id: RuleCollectionIdentifier.homeRowLayerToggles,
+                name: "Home Row Toggles",
+                summary: "Test collection",
+                category: .productivity,
+                mappings: []
+            ),
+        ]
+
+        let index = try facade.resolveCollectionIndex(nameOrId: "home-row", in: collections)
+        XCTAssertEqual(index, 0)
+    }
+
+    func testResolveHomeRowAliasAbsentReturnsNil() throws {
+        let collections = makeCollections(["Home Row Toggles", "Vim Layer"])
+        let index = try facade.resolveCollectionIndex(nameOrId: "home-row", in: collections)
+        XCTAssertNil(index)
+    }
+
     func testResolveReturnsNilWhenNotFound() throws {
         let collections = makeCollections(["Home Row Mods"])
         let index = try facade.resolveCollectionIndex(nameOrId: "nonexistent", in: collections)


### PR DESCRIPTION
## Summary

- Validate Home Row Mods quick-setting values for pack install/configure flows before dry-run or apply.
- Preserve collection configuration in CLI export/import so HRM timing, hold mode, and assignments round-trip even without mappings.
- Hide the raw tap-window control for opposite-hand HRM mode and keep its accessibility value aligned with the active timing controls.
- Resolve collection aliases and slugs such as `hrm`, `home-row`, and `home-row-mods`.

Closes #789.
Closes #790.
Closes #791.
Closes #792.

## Validation

- `swift test --jobs 4 --filter CLIPackCRUDTests`
- `swift test --jobs 4 --filter CollectionsFacadeTests`
- `swift test --jobs 4 --filter CLIExportImportTests`
- `swift build` via pre-push hook
- `python3 Scripts/check-accessibility.py`