### PR TITLE
[codex] Improve local test lanes

### DIFF
--- a/Scripts/README.md
+++ b/Scripts/README.md
@@ -11,8 +11,8 @@
 - `./Scripts/cleanup-local-build-artifacts.sh` — Dry-run cleanup of generated `.build`/`dist`/test artifacts across local worktrees. Add `--apply` to delete.
 - `./test.sh` — Run the full test suite (root)
 - `./Scripts/test-lane.sh <lane>` — Run a named SwiftPM test lane (`smoke`,
-  `core-isolated`, `smoke-root`, `unit`, `appkit`, `installer`, `snapshot`,
-  `device`, or `full`).
+  `core-isolated`, `smoke-root`, `unit`, `appkit-ui`, `appkit-config`,
+  `appkit`, `installer`, `snapshot`, `device`, or `full`).
 - `./Scripts/measure-local-loop.sh` — Measure local feedback lanes and write a
   Markdown report under `.build/local-loop-measurements/`.
 - `./Scripts/run-installer-reliability-matrix.sh` — Automated installer reliability matrix + diagnostic artifact bundle (`test-results/installer-reliability/latest`).
@@ -42,8 +42,11 @@
   diagnostics, but not the fast path.
 - `./Scripts/test-lane.sh unit` - Fast root-package model/parser/renderer
   tests; this lane may still compile AppKit-facing targets.
-- `./Scripts/test-lane.sh appkit` - UI-adjacent app logic, services, packs,
-  config, mappers, and rule collection tests.
+- `./Scripts/test-lane.sh appkit-ui` - Focused AppKit UI/state, mapper,
+  preference, and recommendation tests.
+- `./Scripts/test-lane.sh appkit-config` - Focused AppKit config, pack,
+  catalog, and rule collection tests.
+- `./Scripts/test-lane.sh appkit` - Broad AppKit-adjacent catch-all lane.
 - `./Scripts/test-lane.sh installer` - InstallerEngine, wizard, daemon/service
   lifecycle, and health-check tests.
 - `./Scripts/test-lane.sh snapshot` - Visual snapshot tests; sets

--- a/Scripts/README.md
+++ b/Scripts/README.md
@@ -40,8 +40,8 @@
   only `KeyPathCore` and fails if `KeyPathAppKit` appears in the log.
 - `./Scripts/test-lane.sh smoke-root` - Root-package smoke target; useful for
   diagnostics, but not the fast path.
-- `./Scripts/test-lane.sh unit` - Pure or mostly pure model/parser/renderer
-  tests.
+- `./Scripts/test-lane.sh unit` - Fast root-package model/parser/renderer
+  tests; this lane may still compile AppKit-facing targets.
 - `./Scripts/test-lane.sh appkit` - UI-adjacent app logic, services, packs,
   config, mappers, and rule collection tests.
 - `./Scripts/test-lane.sh installer` - InstallerEngine, wizard, daemon/service

--- a/Scripts/README.md
+++ b/Scripts/README.md
@@ -11,8 +11,8 @@
 - `./Scripts/cleanup-local-build-artifacts.sh` — Dry-run cleanup of generated `.build`/`dist`/test artifacts across local worktrees. Add `--apply` to delete.
 - `./test.sh` — Run the full test suite (root)
 - `./Scripts/test-lane.sh <lane>` — Run a named SwiftPM test lane (`smoke`,
-  `core-isolated`, `smoke-root`, `unit`, `cli`, `appkit-ui`, `appkit-config`,
-  `appkit`, `installer`, `snapshot`, `device`, or `full`).
+  `core-isolated`, `smoke-root`, `unit`, `cli`, `runtime`, `appkit-ui`,
+  `appkit-config`, `appkit`, `installer`, `snapshot`, `device`, or `full`).
 - `./Scripts/measure-local-loop.sh` — Measure local feedback lanes and write a
   Markdown report under `.build/local-loop-measurements/`.
 - `./Scripts/run-installer-reliability-matrix.sh` — Automated installer reliability matrix + diagnostic artifact bundle (`test-results/installer-reliability/latest`).
@@ -44,6 +44,8 @@
   tests; this lane may still compile AppKit-facing targets.
 - `./Scripts/test-lane.sh cli` - Focused CLI command, facade, output contract,
   and import/export tests; this lane may still compile AppKit-facing targets.
+- `./Scripts/test-lane.sh runtime` - Focused TCP, runtime coordinator, process,
+  permission, keyboard capture, VHID, and system-support tests.
 - `./Scripts/test-lane.sh appkit-ui` - Focused AppKit UI/state, mapper,
   preference, and recommendation tests.
 - `./Scripts/test-lane.sh appkit-config` - Focused AppKit config, pack,

--- a/Scripts/README.md
+++ b/Scripts/README.md
@@ -11,7 +11,7 @@
 - `./Scripts/cleanup-local-build-artifacts.sh` — Dry-run cleanup of generated `.build`/`dist`/test artifacts across local worktrees. Add `--apply` to delete.
 - `./test.sh` — Run the full test suite (root)
 - `./Scripts/test-lane.sh <lane>` — Run a named SwiftPM test lane (`smoke`,
-  `core-isolated`, `smoke-root`, `unit`, `appkit-ui`, `appkit-config`,
+  `core-isolated`, `smoke-root`, `unit`, `cli`, `appkit-ui`, `appkit-config`,
   `appkit`, `installer`, `snapshot`, `device`, or `full`).
 - `./Scripts/measure-local-loop.sh` — Measure local feedback lanes and write a
   Markdown report under `.build/local-loop-measurements/`.
@@ -42,6 +42,8 @@
   diagnostics, but not the fast path.
 - `./Scripts/test-lane.sh unit` - Fast root-package model/parser/renderer
   tests; this lane may still compile AppKit-facing targets.
+- `./Scripts/test-lane.sh cli` - Focused CLI command, facade, output contract,
+  and import/export tests; this lane may still compile AppKit-facing targets.
 - `./Scripts/test-lane.sh appkit-ui` - Focused AppKit UI/state, mapper,
   preference, and recommendation tests.
 - `./Scripts/test-lane.sh appkit-config` - Focused AppKit config, pack,

--- a/Scripts/measure-local-loop.sh
+++ b/Scripts/measure-local-loop.sh
@@ -94,6 +94,7 @@ if [ "${#LANES[@]}" -eq 0 ]; then
 fi
 
 mkdir -p "$OUTPUT_DIR"
+OUTPUT_DIR="$(cd "$OUTPUT_DIR" && pwd -P)"
 STAMP="$(date +%Y%m%d-%H%M%S)"
 REPORT="$OUTPUT_DIR/$STAMP.md"
 TSV_REPORT="$OUTPUT_DIR/$STAMP.tsv"

--- a/Scripts/test-lane.sh
+++ b/Scripts/test-lane.sh
@@ -20,7 +20,7 @@ Lanes:
   smoke-root Root-package smoke target; useful for diagnostics, not the fast path.
   core-isolated
              Experimental isolated Core harness; must avoid the KeyPathAppKit graph.
-  unit       Pure or mostly pure model/parser/renderer logic.
+  unit       Fast root-package model/parser/renderer logic; may compile AppKit-facing targets.
   appkit     UI-adjacent app logic, services, packs, config, mappers, and rule collections.
   installer  InstallerEngine, wizard, daemon/service lifecycle, and health-check tests.
   snapshot   Visual snapshot tests; sets KEYPATH_SNAPSHOTS=1.

--- a/Scripts/test-lane.sh
+++ b/Scripts/test-lane.sh
@@ -22,6 +22,7 @@ Lanes:
              Experimental isolated Core harness; must avoid the KeyPathAppKit graph.
   unit       Fast root-package model/parser/renderer logic; may compile AppKit-facing targets.
   cli        Focused CLI command, facade, output contract, and import/export tests.
+  runtime    Focused TCP, runtime coordinator, process, permission, and system-support tests.
   appkit-ui  Focused AppKit UI/state, mapper, preference, and recommendation tests.
   appkit-config
              Focused AppKit config, pack, catalog, and rule collection tests.
@@ -178,6 +179,7 @@ run_isolated_core_lane() {
 APPKIT_UI_FILTER="AppContextServiceTests|Mapper.*Tests|KeyboardVisualizationViewModel.*Tests|KeyboardDisplayContextStoreTests|OverlayKeyboardViewTests|ContentViewDebounceTests|ContextHUD.*Tests|PreferencesService.*Tests|RecordingCoordinatorTests|RecommendationEngineTests|RulesRecommendationEngineTests|MainAppState|SaveCoordinatorTests|StatePublisherServiceTests"
 APPKIT_CONFIG_FILTER="AppConfigGeneratorTests|AliasDeduplicationTests|ConfigApplyTypes.*Tests|ConfigBackupManagerTests|ConfigGenerationEndToEndTests|ConfigGoldenFileTests|ConfigHotReloadServiceTests|ConfigRoundTripTests|ConfigValidationTests|ConfigurationService.*Tests|DeviceSwitchConfigTests|ExternalizedDataTests|GenericPackConfigTests|HomeRowModsConfigTests|InstalledPackTrackerTests|KanataConfig.*Tests|KanataConfigurationGeneratorSnapshotTests|LauncherGridConfigKeyValidationTests|PackCollectionIntegrationTests|PackConfigPipelineTests|PackDependency.*Tests|PackDetailWindowTests|PackInstallIntegrationTests|PackInstallerRenderTests|PackOwnershipTests|PackRegistryTests|PackRuntimeBehaviorTests|PackSummaryProviderTests|PackZoneResolverTests|PerRuleOptionCoverageTests|QMKImportServiceTests|QMKKeyboardDatabaseTests|RuleCollection.*Tests|RuleCollections.*Tests|SequencesConfigTests|SimpleModsWriterTests|Vallack.*Tests"
 CLI_FILTER="CLICollectionCRUDTests|CLICommandValidationTests|CLIErrorTests|CLIExportImportTests|CLIHelpSchemasTests|CLIKarabinerImportTests|CLILayerCRUDTests|CLIOutputContractTests|CLIOutputSnapshotTests|CLIOutputTests|CLIPackCRUDTests|CLIParityTests|CLIRuleAddIntegrationTests|CLIRuleCRUDTests|CLIServiceTests|CLISimulateIntegrationTests|CLISimulateTests|CLISmokeTests|CollectionsFacadeResolutionTests|CollectionsFacadeTests|CommandStructureTests|ConfigFacadeTests|ConflictMergeTests|FuzzyMatchTests|HelpExamplesTests|PacksFacadeTests|SimulatorFacadeTests|UpdateCheckerTests"
+RUNTIME_FILTER="TCPClient.*Tests|TCPConnectionLeakTests|TCPReadBufferTests|TCPEventParsingTests|RuntimeCoordinator.*Tests|ProcessLifecycle.*Tests|FDADetectionTests|KeyboardCaptureTests|PermissionOracle.*Tests|PermissionGateEvaluationTests|SystemRequirementsTests|SystemValidatorTests|SystemInspectorInputCaptureTests|SystemContextAdapterPermissionSeverityTests|FullDiskAccessCheckerTests|SafetyTimeoutServiceTests|StuckKeyRecoveryServiceTests|VHIDDeviceManagerTests|VHIDSafetyInvariantTests|KanataInputGrab.*Tests|GrabRecoveryGateTests|EngineReloadSingleFlightTests|KeychainServiceTests|SubprocessRunnerTests|HelperManagerTests|ErrorHandlingTests|UtilitiesTests|SystemKeyLabelProviderTests"
 
 case "$LANE" in
   smoke)
@@ -197,6 +199,9 @@ case "$LANE" in
     ;;
   cli)
     run_safe_lane "$LANE" "$CLI_FILTER" 180 0
+    ;;
+  runtime)
+    run_safe_lane "$LANE" "$RUNTIME_FILTER" 240 0
     ;;
   appkit-ui)
     run_safe_lane "$LANE" "$APPKIT_UI_FILTER" 180 0

--- a/Scripts/test-lane.sh
+++ b/Scripts/test-lane.sh
@@ -21,6 +21,7 @@ Lanes:
   core-isolated
              Experimental isolated Core harness; must avoid the KeyPathAppKit graph.
   unit       Fast root-package model/parser/renderer logic; may compile AppKit-facing targets.
+  cli        Focused CLI command, facade, output contract, and import/export tests.
   appkit-ui  Focused AppKit UI/state, mapper, preference, and recommendation tests.
   appkit-config
              Focused AppKit config, pack, catalog, and rule collection tests.
@@ -175,7 +176,8 @@ run_isolated_core_lane() {
 }
 
 APPKIT_UI_FILTER="AppContextServiceTests|Mapper.*Tests|KeyboardVisualizationViewModel.*Tests|KeyboardDisplayContextStoreTests|OverlayKeyboardViewTests|ContentViewDebounceTests|ContextHUD.*Tests|PreferencesService.*Tests|RecordingCoordinatorTests|RecommendationEngineTests|RulesRecommendationEngineTests|MainAppState|SaveCoordinatorTests|StatePublisherServiceTests"
-APPKIT_CONFIG_FILTER="AppConfigGeneratorTests|AliasDeduplicationTests|ConfigApplyTypes.*Tests|ConfigBackupManagerTests|ConfigFacadeTests|ConfigGenerationEndToEndTests|ConfigGoldenFileTests|ConfigHotReloadServiceTests|ConfigRoundTripTests|ConfigValidationTests|ConfigurationService.*Tests|DeviceSwitchConfigTests|ExternalizedDataTests|GenericPackConfigTests|HomeRowModsConfigTests|InstalledPackTrackerTests|KanataConfig.*Tests|KanataConfigurationGeneratorSnapshotTests|LauncherGridConfigKeyValidationTests|PackCollectionIntegrationTests|PackConfigPipelineTests|PackDependency.*Tests|PackDetailWindowTests|PackInstallIntegrationTests|PackInstallerRenderTests|PackOwnershipTests|PackRegistryTests|PackRuntimeBehaviorTests|PackSummaryProviderTests|PackZoneResolverTests|PacksFacadeTests|PerRuleOptionCoverageTests|QMKImportServiceTests|QMKKeyboardDatabaseTests|RuleCollection.*Tests|RuleCollections.*Tests|SequencesConfigTests|SimpleModsWriterTests|Vallack.*Tests"
+APPKIT_CONFIG_FILTER="AppConfigGeneratorTests|AliasDeduplicationTests|ConfigApplyTypes.*Tests|ConfigBackupManagerTests|ConfigGenerationEndToEndTests|ConfigGoldenFileTests|ConfigHotReloadServiceTests|ConfigRoundTripTests|ConfigValidationTests|ConfigurationService.*Tests|DeviceSwitchConfigTests|ExternalizedDataTests|GenericPackConfigTests|HomeRowModsConfigTests|InstalledPackTrackerTests|KanataConfig.*Tests|KanataConfigurationGeneratorSnapshotTests|LauncherGridConfigKeyValidationTests|PackCollectionIntegrationTests|PackConfigPipelineTests|PackDependency.*Tests|PackDetailWindowTests|PackInstallIntegrationTests|PackInstallerRenderTests|PackOwnershipTests|PackRegistryTests|PackRuntimeBehaviorTests|PackSummaryProviderTests|PackZoneResolverTests|PerRuleOptionCoverageTests|QMKImportServiceTests|QMKKeyboardDatabaseTests|RuleCollection.*Tests|RuleCollections.*Tests|SequencesConfigTests|SimpleModsWriterTests|Vallack.*Tests"
+CLI_FILTER="CLICollectionCRUDTests|CLICommandValidationTests|CLIErrorTests|CLIExportImportTests|CLIHelpSchemasTests|CLIKarabinerImportTests|CLILayerCRUDTests|CLIOutputContractTests|CLIOutputSnapshotTests|CLIOutputTests|CLIPackCRUDTests|CLIParityTests|CLIRuleAddIntegrationTests|CLIRuleCRUDTests|CLIServiceTests|CLISimulateIntegrationTests|CLISimulateTests|CLISmokeTests|CollectionsFacadeResolutionTests|CollectionsFacadeTests|CommandStructureTests|ConfigFacadeTests|ConflictMergeTests|FuzzyMatchTests|HelpExamplesTests|PacksFacadeTests|SimulatorFacadeTests|UpdateCheckerTests"
 
 case "$LANE" in
   smoke)
@@ -192,6 +194,9 @@ case "$LANE" in
     ;;
   unit)
     run_safe_lane "$LANE" "KeyPathErrorTests|TextToKanataKeyMapperTests|KanataBehaviorParserTests|KanataBehaviorRendererTests|KanataDefseqParserTests|PhysicalLayoutTests|MappingBehaviorTests|LayerKeyMapperNormalizeTests|LayerKeyMapperLabelTests|LayerKeyInfoExtractionTests|LabelMetadataTests|ConfigApplyTypesTests|VirtualKeyParserTests|QMKLayoutParserTests|HandAssignmentTests|TypingFeelMappingTests|KindaVimTelemetryStoreTests|GlobalHotkeyMatcherTests|VimSequenceObserverTests" 180 0
+    ;;
+  cli)
+    run_safe_lane "$LANE" "$CLI_FILTER" 180 0
     ;;
   appkit-ui)
     run_safe_lane "$LANE" "$APPKIT_UI_FILTER" 180 0

--- a/Scripts/test-lane.sh
+++ b/Scripts/test-lane.sh
@@ -21,7 +21,10 @@ Lanes:
   core-isolated
              Experimental isolated Core harness; must avoid the KeyPathAppKit graph.
   unit       Fast root-package model/parser/renderer logic; may compile AppKit-facing targets.
-  appkit     UI-adjacent app logic, services, packs, config, mappers, and rule collections.
+  appkit-ui  Focused AppKit UI/state, mapper, preference, and recommendation tests.
+  appkit-config
+             Focused AppKit config, pack, catalog, and rule collection tests.
+  appkit     Broad AppKit-adjacent catch-all lane.
   installer  InstallerEngine, wizard, daemon/service lifecycle, and health-check tests.
   snapshot   Visual snapshot tests; sets KEYPATH_SNAPSHOTS=1.
   device     Opt-in real-system installer smoke; requires KEYPATH_E2E_DEVICE=1.
@@ -171,6 +174,9 @@ run_isolated_core_lane() {
   return "$exit_code"
 }
 
+APPKIT_UI_FILTER="AppContextServiceTests|Mapper.*Tests|KeyboardVisualizationViewModel.*Tests|KeyboardDisplayContextStoreTests|OverlayKeyboardViewTests|ContentViewDebounceTests|ContextHUD.*Tests|PreferencesService.*Tests|RecordingCoordinatorTests|RecommendationEngineTests|RulesRecommendationEngineTests|MainAppState|SaveCoordinatorTests|StatePublisherServiceTests"
+APPKIT_CONFIG_FILTER="AppConfigGeneratorTests|AliasDeduplicationTests|ConfigApplyTypes.*Tests|ConfigBackupManagerTests|ConfigFacadeTests|ConfigGenerationEndToEndTests|ConfigGoldenFileTests|ConfigHotReloadServiceTests|ConfigRoundTripTests|ConfigValidationTests|ConfigurationService.*Tests|DeviceSwitchConfigTests|ExternalizedDataTests|GenericPackConfigTests|HomeRowModsConfigTests|InstalledPackTrackerTests|KanataConfig.*Tests|KanataConfigurationGeneratorSnapshotTests|LauncherGridConfigKeyValidationTests|PackCollectionIntegrationTests|PackConfigPipelineTests|PackDependency.*Tests|PackDetailWindowTests|PackInstallIntegrationTests|PackInstallerRenderTests|PackOwnershipTests|PackRegistryTests|PackRuntimeBehaviorTests|PackSummaryProviderTests|PackZoneResolverTests|PacksFacadeTests|PerRuleOptionCoverageTests|QMKImportServiceTests|QMKKeyboardDatabaseTests|RuleCollection.*Tests|RuleCollections.*Tests|SequencesConfigTests|SimpleModsWriterTests|Vallack.*Tests"
+
 case "$LANE" in
   smoke)
     run_isolated_smoke_lane "$LANE"
@@ -186,6 +192,12 @@ case "$LANE" in
     ;;
   unit)
     run_safe_lane "$LANE" "KeyPathErrorTests|TextToKanataKeyMapperTests|KanataBehaviorParserTests|KanataBehaviorRendererTests|KanataDefseqParserTests|PhysicalLayoutTests|MappingBehaviorTests|LayerKeyMapperNormalizeTests|LayerKeyMapperLabelTests|LayerKeyInfoExtractionTests|LabelMetadataTests|ConfigApplyTypesTests|VirtualKeyParserTests|QMKLayoutParserTests|HandAssignmentTests|TypingFeelMappingTests|KindaVimTelemetryStoreTests|GlobalHotkeyMatcherTests|VimSequenceObserverTests" 180 0
+    ;;
+  appkit-ui)
+    run_safe_lane "$LANE" "$APPKIT_UI_FILTER" 180 0
+    ;;
+  appkit-config)
+    run_safe_lane "$LANE" "$APPKIT_CONFIG_FILTER" 240 0
     ;;
   appkit)
     run_safe_lane "$LANE" "AppContext|Mapper|RuleCollections|Config|RuntimeCoordinator|Pack|Services|Preferences|Keyboard|MainAppState|ContentView|FDADetection|RecordingCoordinator|RecommendationEngine|Vallack|GenericPack" 240 0

--- a/Tests/KeyPathTests/CLI/CLIOutputContractTests.swift
+++ b/Tests/KeyPathTests/CLI/CLIOutputContractTests.swift
@@ -1,7 +1,7 @@
 @testable import KeyPathAppKit
 import XCTest
 
-final class OutputContractTests: XCTestCase {
+final class CLIOutputContractTests: XCTestCase {
     private let encoder: JSONEncoder = {
         let e = JSONEncoder()
         e.outputFormatting = [.sortedKeys]

--- a/Tests/KeyPathTests/CLI/CLIOutputTests.swift
+++ b/Tests/KeyPathTests/CLI/CLIOutputTests.swift
@@ -1,7 +1,7 @@
 @testable import KeyPathCLI
 import XCTest
 
-final class OutputTests: XCTestCase {
+final class CLIOutputTests: XCTestCase {
     func testShouldOutputJSON_whenForceJSON() {
         let ctx = OutputContext(isInteractive: true, forceJSON: true, forceHuman: false, noColor: false)
         XCTAssertTrue(ctx.shouldOutputJSON)

--- a/docs/MACBOOK_AIR_LOCAL_LOOP.md
+++ b/docs/MACBOOK_AIR_LOCAL_LOOP.md
@@ -13,6 +13,7 @@ Run the smallest lane that covers the files you changed:
 | Core APIs, permissions, parser smoke coverage | `./Scripts/test-lane.sh smoke` |
 | Core-only runtime, parser, and environment behavior | `./Scripts/test-lane.sh core-isolated` |
 | Fast root-package model/parser/renderer logic | `./Scripts/test-lane.sh unit` |
+| CLI commands, facades, output contracts, import/export | `./Scripts/test-lane.sh cli` |
 | AppKit UI/state, mappers, preferences, recommendations | `./Scripts/test-lane.sh appkit-ui` |
 | AppKit config, packs, catalog, rule collections | `./Scripts/test-lane.sh appkit-config` |
 | Broad AppKit-adjacent handoff check | `./Scripts/test-lane.sh appkit` |
@@ -29,7 +30,7 @@ KEYPATH_TEST_FILTER=SaveCoordinatorTests ./Scripts/test-lane.sh appkit
 
 ## Warm Cache Policy
 
-The local named lanes `unit`, `appkit-ui`, `appkit-config`, `appkit`,
+The local named lanes `unit`, `cli`, `appkit-ui`, `appkit-config`, `appkit`,
 `installer`, and `snapshot` reuse the normalized Swift module cache by default.
 This is the right default for the MacBook Air edit-test loop.
 

--- a/docs/MACBOOK_AIR_LOCAL_LOOP.md
+++ b/docs/MACBOOK_AIR_LOCAL_LOOP.md
@@ -14,6 +14,7 @@ Run the smallest lane that covers the files you changed:
 | Core-only runtime, parser, and environment behavior | `./Scripts/test-lane.sh core-isolated` |
 | Fast root-package model/parser/renderer logic | `./Scripts/test-lane.sh unit` |
 | CLI commands, facades, output contracts, import/export | `./Scripts/test-lane.sh cli` |
+| TCP, runtime coordinator, process, permissions, keyboard capture, system support | `./Scripts/test-lane.sh runtime` |
 | AppKit UI/state, mappers, preferences, recommendations | `./Scripts/test-lane.sh appkit-ui` |
 | AppKit config, packs, catalog, rule collections | `./Scripts/test-lane.sh appkit-config` |
 | Broad AppKit-adjacent handoff check | `./Scripts/test-lane.sh appkit` |
@@ -30,9 +31,9 @@ KEYPATH_TEST_FILTER=SaveCoordinatorTests ./Scripts/test-lane.sh appkit
 
 ## Warm Cache Policy
 
-The local named lanes `unit`, `cli`, `appkit-ui`, `appkit-config`, `appkit`,
-`installer`, and `snapshot` reuse the normalized Swift module cache by default.
-This is the right default for the MacBook Air edit-test loop.
+The local named lanes `unit`, `cli`, `runtime`, `appkit-ui`, `appkit-config`,
+`appkit`, `installer`, and `snapshot` reuse the normalized Swift module cache by
+default. This is the right default for the MacBook Air edit-test loop.
 
 The `full` lane keeps the stricter reset behavior by default. Override either
 mode explicitly when needed:

--- a/docs/MACBOOK_AIR_LOCAL_LOOP.md
+++ b/docs/MACBOOK_AIR_LOCAL_LOOP.md
@@ -13,7 +13,9 @@ Run the smallest lane that covers the files you changed:
 | Core APIs, permissions, parser smoke coverage | `./Scripts/test-lane.sh smoke` |
 | Core-only runtime, parser, and environment behavior | `./Scripts/test-lane.sh core-isolated` |
 | Fast root-package model/parser/renderer logic | `./Scripts/test-lane.sh unit` |
-| AppKit-adjacent logic, services, config, packs, mappers | `./Scripts/test-lane.sh appkit` |
+| AppKit UI/state, mappers, preferences, recommendations | `./Scripts/test-lane.sh appkit-ui` |
+| AppKit config, packs, catalog, rule collections | `./Scripts/test-lane.sh appkit-config` |
+| Broad AppKit-adjacent handoff check | `./Scripts/test-lane.sh appkit` |
 | InstallerEngine, wizard, daemon lifecycle, health checks | `./Scripts/test-lane.sh installer` |
 | Snapshot or visual output changes | `./Scripts/test-lane.sh snapshot` |
 | Device/system installer surface | `KEYPATH_E2E_DEVICE=1 ./Scripts/test-lane.sh device` |
@@ -27,9 +29,9 @@ KEYPATH_TEST_FILTER=SaveCoordinatorTests ./Scripts/test-lane.sh appkit
 
 ## Warm Cache Policy
 
-The local named lanes `unit`, `appkit`, `installer`, and `snapshot` reuse the
-normalized Swift module cache by default. This is the right default for the
-MacBook Air edit-test loop.
+The local named lanes `unit`, `appkit-ui`, `appkit-config`, `appkit`,
+`installer`, and `snapshot` reuse the normalized Swift module cache by default.
+This is the right default for the MacBook Air edit-test loop.
 
 The `full` lane keeps the stricter reset behavior by default. Override either
 mode explicitly when needed:

--- a/docs/MACBOOK_AIR_LOCAL_LOOP.md
+++ b/docs/MACBOOK_AIR_LOCAL_LOOP.md
@@ -12,7 +12,7 @@ Run the smallest lane that covers the files you changed:
 | --- | --- |
 | Core APIs, permissions, parser smoke coverage | `./Scripts/test-lane.sh smoke` |
 | Core-only runtime, parser, and environment behavior | `./Scripts/test-lane.sh core-isolated` |
-| Pure model/parser/renderer logic | `./Scripts/test-lane.sh unit` |
+| Fast root-package model/parser/renderer logic | `./Scripts/test-lane.sh unit` |
 | AppKit-adjacent logic, services, config, packs, mappers | `./Scripts/test-lane.sh appkit` |
 | InstallerEngine, wizard, daemon lifecycle, health checks | `./Scripts/test-lane.sh installer` |
 | Snapshot or visual output changes | `./Scripts/test-lane.sh snapshot` |

--- a/docs/TEST_HYGIENE_PLAN.md
+++ b/docs/TEST_HYGIENE_PLAN.md
@@ -605,11 +605,12 @@ Milestone 6 is implemented with the MacBook Air local loop as the target:
   broad-lane spillover was concentrated in TCP/client robustness, runtime
   coordinator, process lifecycle, permission/system checks, keyboard capture,
   VHID, helper, and low-level utility suites. A focused `runtime` lane was added
-  for that surface and selected 346 tests with a clean warning/error summary.
-  Its timing still needs a quiet-machine rerun because this first pass overlapped
-  other local testing. This lane also surfaces verbose XCTest performance metric
-  output from runtime/utility tests; treat that as a future hygiene question if
-  quiet-machine runs show log noise or instability.
+  for that surface. A quiet-machine run of `./Scripts/measure-local-loop.sh
+  runtime` passed in 18s total, with 5s build time, 12s test execution, 346
+  passed tests, and zero Swift warnings, module-cache warnings, app warnings, or
+  app errors. This lane also surfaces verbose XCTest performance metric output
+  from runtime/utility tests; treat that as a future hygiene question if runs
+  show log noise or instability.
 - Current warm installer audit from `./Scripts/measure-local-loop.sh
   installer`: 15s total, 266 passed, and zero Swift warnings,
   module-cache warnings, app warnings, or app errors. The measured cost is
@@ -621,18 +622,18 @@ Milestone 6 is implemented with the MacBook Air local loop as the target:
 - Installer-lane hygiene required keeping `run-tests-safe.sh` hermetic by
   default (`KEYPATH_USE_SUDO=0` unless explicitly overridden) and downgrading
   expected installer failure-path diagnostics to debug in quiet test runs.
-- Current warm full baseline from `./Scripts/measure-local-loop.sh full`: 45s
-  total, 4s build, 40s test execution, zero Swift warnings, zero module-cache
-  warnings, zero app warnings, and zero app errors. This is now suitable as the
-  broad local confidence check when the narrower lane for a change passes first.
+- Current quiet warm full baseline from `./Scripts/measure-local-loop.sh full`:
+  33s total, 4s build, 29s test execution, 4,227 passed tests, and zero Swift
+  warnings, zero module-cache warnings, zero app warnings, and zero app errors.
+  This is now suitable as the broad local confidence check when the narrower
+  lane for a change passes first.
 
 The Mac mini workflow is deferred. Revisit it only after the MacBook Air loop is
 fast and boring enough that remote execution would solve a measured capacity
 problem instead of compensating for harness noise.
 
-Next planned milestone: rerun the new `runtime` lane on a quiet machine and
-decide whether the remaining full-lane cost is acceptable as broad handoff
-coverage. CLI/AppKit extraction is worth revisiting only if a measured workflow
-needs true build isolation; the current `cli` lane already gives a fast, stable
-selection path. Installer/wizard splits should follow only after the remaining
-lane timings justify the extra dependency work.
+Next planned milestone: treat the current lane set as the stable local loop and
+watch for regressions. CLI/AppKit extraction is worth revisiting only if a
+measured workflow needs true build isolation; the current `cli` lane already
+gives a fast, stable selection path. Installer/wizard splits should follow only
+after the remaining lane timings justify the extra dependency work.

--- a/docs/TEST_HYGIENE_PLAN.md
+++ b/docs/TEST_HYGIENE_PLAN.md
@@ -515,6 +515,7 @@ runner; `smoke` now uses the isolated harness from Milestone 4b:
 - `smoke-root` for the root-package `KeyPathSmokeTests` target, retained as a
   diagnostic lane rather than the fast path;
 - `unit` for fast root-package model/parser/renderer logic;
+- `cli` for focused command, facade, output contract, and import/export tests;
 - `appkit-ui` for focused UI/state, mapper, preference, and recommendation
   tests;
 - `appkit-config` for focused config, pack, catalog, and rule collection tests;
@@ -585,11 +586,19 @@ Milestone 6 is implemented with the MacBook Air local loop as the target:
   isolation. The `core-isolated` lane remains the true Core-only fast path.
 - Follow-up appkit-lane audit: the broad `appkit` lane passed in 26s with 1,429
   tests, with 6s spent building and 20s in test execution. A focused
-  `appkit-ui` lane passed in 11s with 442 tests, and a focused
-  `appkit-config` lane passed in 15s with 861 tests after tightening the pack
-  filter to avoid CLI/package-manager spillover. Keep the broad `appkit` lane
-  as a catch-all, but use the focused lanes for ordinary UI/state and
-  config/pack edits.
+  `appkit-ui` lane passed in 11s with 442 tests. After removing CLI facade
+  spillover, the focused `appkit-config` lane passed in 14s with 835 tests and
+  zero Swift warnings, module-cache warnings, app warnings, or app errors. Keep
+  the broad `appkit` lane as a catch-all, but use the focused lanes for ordinary
+  UI/state and config/pack edits.
+- Follow-up CLI-lane audit: `KeyPathCLI` still depends on `KeyPathAppKit`, so
+  a focused root-package CLI lane improves test selection and log scope but is
+  not build isolation. Ambiguous `OutputTests` and `OutputContractTests` were
+  renamed to `CLIOutputTests` and `CLIOutputContractTests` so the lane can
+  select CLI output coverage without pulling unrelated output suites. The
+  `cli` lane passed warm in 8s with 333 tests and zero Swift warnings,
+  module-cache warnings, app warnings, or app errors. The `appkit-config` lane
+  now excludes CLI facade tests.
 - Current warm installer baseline from `./Scripts/measure-local-loop.sh
   installer`: 11s total, 263 passed, and zero Swift warnings,
   module-cache warnings, app warnings, or app errors. This required keeping
@@ -605,6 +614,9 @@ The Mac mini workflow is deferred. Revisit it only after the MacBook Air loop is
 fast and boring enough that remote execution would solve a measured capacity
 problem instead of compensating for harness noise.
 
-Next planned milestone: audit CLI spillover now that the appkit lane has
-focused local-loop variants. Installer/wizard splits should follow only after
-the remaining lane timings justify the extra dependency work.
+Next planned milestone: continue tightening the local loop by auditing the
+remaining broad-lane spillover before taking on dependency extraction. CLI/AppKit
+extraction is worth revisiting only if a measured workflow needs true build
+isolation; the current `cli` lane already gives a fast, stable selection path.
+Installer/wizard splits should follow only after the remaining lane timings
+justify the extra dependency work.

--- a/docs/TEST_HYGIENE_PLAN.md
+++ b/docs/TEST_HYGIENE_PLAN.md
@@ -515,8 +515,10 @@ runner; `smoke` now uses the isolated harness from Milestone 4b:
 - `smoke-root` for the root-package `KeyPathSmokeTests` target, retained as a
   diagnostic lane rather than the fast path;
 - `unit` for fast root-package model/parser/renderer logic;
-- `appkit` for UI-adjacent app logic, services, packs, config, mappers, and rule
-  collections;
+- `appkit-ui` for focused UI/state, mapper, preference, and recommendation
+  tests;
+- `appkit-config` for focused config, pack, catalog, and rule collection tests;
+- `appkit` for the broad AppKit-adjacent catch-all lane;
 - `installer` for InstallerEngine, wizard, daemon/service lifecycle, and
   health-check tests;
 - `snapshot` for visual snapshot tests with `KEYPATH_SNAPSHOTS=1`;
@@ -581,6 +583,13 @@ Milestone 6 is implemented with the MacBook Air local loop as the target:
   Because the root-package build dominates this lane, keep the current filter
   and treat `unit` as fast model/parser/renderer coverage, not true Core
   isolation. The `core-isolated` lane remains the true Core-only fast path.
+- Follow-up appkit-lane audit: the broad `appkit` lane passed in 26s with 1,429
+  tests, with 6s spent building and 20s in test execution. A focused
+  `appkit-ui` lane passed in 11s with 442 tests, and a focused
+  `appkit-config` lane passed in 15s with 861 tests after tightening the pack
+  filter to avoid CLI/package-manager spillover. Keep the broad `appkit` lane
+  as a catch-all, but use the focused lanes for ordinary UI/state and
+  config/pack edits.
 - Current warm installer baseline from `./Scripts/measure-local-loop.sh
   installer`: 11s total, 263 passed, and zero Swift warnings,
   module-cache warnings, app warnings, or app errors. This required keeping
@@ -596,6 +605,6 @@ The Mac mini workflow is deferred. Revisit it only after the MacBook Air loop is
 fast and boring enough that remote execution would solve a measured capacity
 problem instead of compensating for harness noise.
 
-Next planned milestone: continue Milestone 7 by auditing the remaining `appkit`
-lane. CLI and installer/wizard splits should follow only after the remaining
-lane timings justify the extra dependency work.
+Next planned milestone: audit CLI spillover now that the appkit lane has
+focused local-loop variants. Installer/wizard splits should follow only after
+the remaining lane timings justify the extra dependency work.

--- a/docs/TEST_HYGIENE_PLAN.md
+++ b/docs/TEST_HYGIENE_PLAN.md
@@ -599,12 +599,17 @@ Milestone 6 is implemented with the MacBook Air local loop as the target:
   `cli` lane passed warm in 8s with 333 tests and zero Swift warnings,
   module-cache warnings, app warnings, or app errors. The `appkit-config` lane
   now excludes CLI facade tests.
-- Current warm installer baseline from `./Scripts/measure-local-loop.sh
-  installer`: 11s total, 263 passed, and zero Swift warnings,
-  module-cache warnings, app warnings, or app errors. This required keeping
-  `run-tests-safe.sh` hermetic by default (`KEYPATH_USE_SUDO=0` unless
-  explicitly overridden) and downgrading expected installer failure-path
-  diagnostics to debug in quiet test runs.
+- Current warm installer audit from `./Scripts/measure-local-loop.sh
+  installer`: 15s total, 266 passed, and zero Swift warnings,
+  module-cache warnings, app warnings, or app errors. The measured cost is
+  mostly shared build time plus `InstallerEngineTests`, `PackageManagerTests`,
+  and `MockPackageManagerTests`; wizard-specific coverage is not the dominant
+  cost. Do not split installer/wizard lanes yet. Keep the existing installer
+  lane as the right local check unless future edits show a repeated need for
+  narrower package-manager or wizard feedback.
+- Installer-lane hygiene required keeping `run-tests-safe.sh` hermetic by
+  default (`KEYPATH_USE_SUDO=0` unless explicitly overridden) and downgrading
+  expected installer failure-path diagnostics to debug in quiet test runs.
 - Current warm full baseline from `./Scripts/measure-local-loop.sh full`: 45s
   total, 4s build, 40s test execution, zero Swift warnings, zero module-cache
   warnings, zero app warnings, and zero app errors. This is now suitable as the

--- a/docs/TEST_HYGIENE_PLAN.md
+++ b/docs/TEST_HYGIENE_PLAN.md
@@ -123,7 +123,7 @@ Work:
 
 - Define named lanes for common feedback needs:
   - `smoke`: fastest sanity checks for core compile and critical unit tests.
-  - `unit`: pure logic and mocked tests.
+  - `unit`: fast root-package model/parser/renderer tests.
   - `appkit`: UI-adjacent logic that requires KeyPathAppKit.
   - `snapshot`: visual snapshots, gated by `KEYPATH_SNAPSHOTS=1`.
   - `installer`: mocked installer and service lifecycle tests.
@@ -410,6 +410,10 @@ Work:
   until measurements justify it.
 - Measure cold and warm harness runs against the current `smoke` and `unit`
   lanes, including whether `KeyPathAppKit` appears in the log.
+- Audit the remaining root-package `unit` lane before changing its filter. If
+  duplicated smoke/Core coverage does not materially affect elapsed time, keep
+  the coverage and document that `unit` is a fast root-package lane rather than
+  true Core isolation.
 - Stop the harness effort if it does not materially outperform the root
   filtered lane or if the copied-test maintenance burden starts to outweigh the
   local-loop gain.
@@ -431,6 +435,8 @@ Acceptance criteria:
 - The harness either earns a permanent lane with clear speed evidence or is
   explicitly retired so root-package organization work does not masquerade as
   build-speed work.
+- The unit-lane audit records whether trimming duplicated smoke/Core suites
+  improves elapsed time before any coverage is removed.
 - The CLI/AppKit dependency audit produces either a scoped extraction plan or a
   measured decision to defer it.
 - Installer/wizard follow-up is based on lane timing and dependency evidence,
@@ -508,7 +514,7 @@ runner; `smoke` now uses the isolated harness from Milestone 4b:
 - `smoke` for fast isolated product-level sanity coverage;
 - `smoke-root` for the root-package `KeyPathSmokeTests` target, retained as a
   diagnostic lane rather than the fast path;
-- `unit` for pure or mostly pure model/parser/renderer logic;
+- `unit` for fast root-package model/parser/renderer logic;
 - `appkit` for UI-adjacent app logic, services, packs, config, mappers, and rule
   collections;
 - `installer` for InstallerEngine, wizard, daemon/service lifecycle, and
@@ -568,6 +574,13 @@ Milestone 6 is implemented with the MacBook Air local loop as the target:
   reported `appkit_in_log=0`; the root-package lanes reported zero Swift
   warnings, module-cache warnings, app warnings, and app errors in their final
   summaries.
+- Follow-up unit-lane audit: sequential measurements passed at 9s warm and 7s
+  with `KEYPATH_TEST_RESET_MODULE_CACHE=1`. A candidate filter that removed the
+  smoke/Core-duplicated `KeyPathErrorTests` and `KanataDefseqParserTests`
+  reduced coverage from 329 passed tests to 288 passed tests but still took 9s.
+  Because the root-package build dominates this lane, keep the current filter
+  and treat `unit` as fast model/parser/renderer coverage, not true Core
+  isolation. The `core-isolated` lane remains the true Core-only fast path.
 - Current warm installer baseline from `./Scripts/measure-local-loop.sh
   installer`: 11s total, 263 passed, and zero Swift warnings,
   module-cache warnings, app warnings, or app errors. This required keeping
@@ -583,8 +596,6 @@ The Mac mini workflow is deferred. Revisit it only after the MacBook Air loop is
 fast and boring enough that remote execution would solve a measured capacity
 problem instead of compensating for harness noise.
 
-Next planned milestone: continue Milestone 7 by measuring the new
-`core-isolated` lane in the baseline preset and then auditing the remaining
-`unit` and `appkit` lanes. CLI and installer/wizard splits should follow only
-after the isolated Core harness earns its keep over repeated local runs and the
-remaining lane timings justify the extra dependency work.
+Next planned milestone: continue Milestone 7 by auditing the remaining `appkit`
+lane. CLI and installer/wizard splits should follow only after the remaining
+lane timings justify the extra dependency work.

--- a/docs/TEST_HYGIENE_PLAN.md
+++ b/docs/TEST_HYGIENE_PLAN.md
@@ -516,6 +516,8 @@ runner; `smoke` now uses the isolated harness from Milestone 4b:
   diagnostic lane rather than the fast path;
 - `unit` for fast root-package model/parser/renderer logic;
 - `cli` for focused command, facade, output contract, and import/export tests;
+- `runtime` for focused TCP, runtime coordinator, process lifecycle,
+  permission, keyboard capture, VHID, and system-support tests;
 - `appkit-ui` for focused UI/state, mapper, preference, and recommendation
   tests;
 - `appkit-config` for focused config, pack, catalog, and rule collection tests;
@@ -599,6 +601,15 @@ Milestone 6 is implemented with the MacBook Air local loop as the target:
   `cli` lane passed warm in 8s with 333 tests and zero Swift warnings,
   module-cache warnings, app warnings, or app errors. The `appkit-config` lane
   now excludes CLI facade tests.
+- Follow-up runtime-lane audit: older full-suite logs showed the remaining
+  broad-lane spillover was concentrated in TCP/client robustness, runtime
+  coordinator, process lifecycle, permission/system checks, keyboard capture,
+  VHID, helper, and low-level utility suites. A focused `runtime` lane was added
+  for that surface and selected 346 tests with a clean warning/error summary.
+  Its timing still needs a quiet-machine rerun because this first pass overlapped
+  other local testing. This lane also surfaces verbose XCTest performance metric
+  output from runtime/utility tests; treat that as a future hygiene question if
+  quiet-machine runs show log noise or instability.
 - Current warm installer audit from `./Scripts/measure-local-loop.sh
   installer`: 15s total, 266 passed, and zero Swift warnings,
   module-cache warnings, app warnings, or app errors. The measured cost is
@@ -619,9 +630,9 @@ The Mac mini workflow is deferred. Revisit it only after the MacBook Air loop is
 fast and boring enough that remote execution would solve a measured capacity
 problem instead of compensating for harness noise.
 
-Next planned milestone: continue tightening the local loop by auditing the
-remaining broad-lane spillover before taking on dependency extraction. CLI/AppKit
-extraction is worth revisiting only if a measured workflow needs true build
-isolation; the current `cli` lane already gives a fast, stable selection path.
-Installer/wizard splits should follow only after the remaining lane timings
-justify the extra dependency work.
+Next planned milestone: rerun the new `runtime` lane on a quiet machine and
+decide whether the remaining full-lane cost is acceptable as broad handoff
+coverage. CLI/AppKit extraction is worth revisiting only if a measured workflow
+needs true build isolation; the current `cli` lane already gives a fast, stable
+selection path. Installer/wizard splits should follow only after the remaining
+lane timings justify the extra dependency work.

--- a/docs/plans/cli-phase-0-foundation.md
+++ b/docs/plans/cli-phase-0-foundation.md
@@ -235,7 +235,7 @@ The CLI is an agent contract — if a JSON field changes or an exit code shifts,
 
 #### New test files
 
-**`Tests/KeyPathTests/CLI/OutputTests.swift`** — Output infrastructure
+**`Tests/KeyPathTests/CLI/CLIOutputTests.swift`** — Output infrastructure
 - `testShouldOutputJSON_whenForceJSON` — `--json` flag forces JSON even in TTY
 - `testShouldOutputJSON_whenNotInteractive` — piped output auto-selects JSON
 - `testShouldOutputHuman_whenInteractiveNoFlags` — TTY defaults to human
@@ -250,7 +250,7 @@ The CLI is an agent contract — if a JSON field changes or an exit code shifts,
 - `testErrorHintIsNonEmpty` — every CLIError factory method provides a hint (agents need actionable guidance)
 - `testNotFoundErrorSuggestsListCommand` — hint for `.notFound` includes the relevant `list` subcommand
 
-**`Tests/KeyPathTests/CLI/OutputContractTests.swift`** — JSON shape stability (snapshot-style)
+**`Tests/KeyPathTests/CLI/CLIOutputContractTests.swift`** — JSON shape stability (snapshot-style)
 - `testStatusJSONShape` — CLIStatusResult encodes with every expected key; new keys are additive-only
 - `testRuleCollectionJSONShape` — CLIRuleCollection JSON has id, name, isEnabled, mappingCount, summary
 - `testApplyResultJSONShape` — CLIApplyResult JSON has collectionsCount, enabledCount, customRulesCount, reloadSuccess
@@ -369,9 +369,9 @@ All files in the new directory structure (Section 4), plus:
 - `Sources/KeyPathCLI/Utilities/CLIError.swift`
 - `Sources/KeyPathCLI/Utilities/GlobalOptions.swift`
 - `Sources/KeyPathAppKit/CLI/CLIActionDescription.swift` (parity guard)
-- `Tests/KeyPathTests/CLI/OutputTests.swift`
+- `Tests/KeyPathTests/CLI/CLIOutputTests.swift`
 - `Tests/KeyPathTests/CLI/CLIErrorTests.swift`
-- `Tests/KeyPathTests/CLI/OutputContractTests.swift`
+- `Tests/KeyPathTests/CLI/CLIOutputContractTests.swift`
 - `Tests/KeyPathTests/CLI/CommandStructureTests.swift`
 - `Tests/KeyPathTests/CLI/CLIParityTests.swift`
 


### PR DESCRIPTION
## Summary
- add focused local test lanes for CLI, runtime, AppKit UI, and AppKit config work
- document the unit/appkit/cli/runtime/installer/full lane audit findings and MacBook Air local loop guidance
- tighten lane filters and rename ambiguous CLI output tests so focused lanes avoid unrelated spillover
- fix relative --out handling in measure-local-loop.sh so latest.md/latest.tsv links resolve correctly

## Validation
- ./Scripts/test-lane.sh runtime
- ./Scripts/measure-local-loop.sh --out .build/local-loop-measurements-runtime-quiet runtime
- ./Scripts/measure-local-loop.sh --out .build/local-loop-measurements-full-quiet full
- bash -n Scripts/test-lane.sh Scripts/measure-local-loop.sh
- git diff --check
- pre-push build hook passed

## Current quiet warm baselines
- runtime: 18s total, 346 passed, clean warning/error summary
- full: 33s total, 4,227 passed, clean warning/error summary