### PR TITLE
[codex] Preserve HRM assignments when re-enabling keys

### DIFF
--- a/Sources/KeyPathAppKit/Models/HomeRowModsConfig.swift
+++ b/Sources/KeyPathAppKit/Models/HomeRowModsConfig.swift
@@ -103,6 +103,21 @@ public struct HomeRowModsConfig: Codable, Equatable, Sendable {
         set { oppositeHandMode = newValue ? .press : .off }
     }
 
+    public mutating func enableKeyPreservingAssignment(_ key: String, fallbackConfig: HomeRowModsConfig = HomeRowModsConfig()) {
+        enabledKeys.insert(key)
+        switch holdMode {
+        case .modifiers:
+            if modifierAssignments[key] == nil {
+                modifierAssignments[key] = fallbackConfig.modifierAssignments[key] ?? Self.cagsMacDefault[key]
+            }
+        case .layers:
+            if layerAssignments[key] == nil {
+                layerAssignments[key] = fallbackConfig.layerAssignments[key] ?? Self.defaultLayerAssignments[key]
+            }
+        }
+        keySelection = .custom
+    }
+
     /// Mac-first CAGS mapping
     /// Left hand: Shift (pinky), Control (ring), Option (middle), Command (index)
     /// Right hand: Command (index), Option (middle), Control (ring), Shift (pinky)

--- a/Sources/KeyPathAppKit/UI/Rules/HomeRowModsCollectionView+Popovers.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/HomeRowModsCollectionView+Popovers.swift
@@ -139,14 +139,7 @@ extension HomeRowModsCollectionView {
     func enableKeyPopoverContent(for key: String) -> some View {
         VStack(spacing: 0) {
             Button {
-                config.enabledKeys.insert(key)
-                // Restore default assignment for this key's position
-                if config.holdMode == .modifiers {
-                    config.modifierAssignments[key] = HomeRowModsConfig.cagsMacDefault[key]
-                } else {
-                    config.layerAssignments[key] = HomeRowModsConfig.defaultLayerAssignments[key]
-                }
-                config.keySelection = .custom
+                config.enableKeyPreservingAssignment(key, fallbackConfig: baselineConfig)
                 updateConfig()
                 selectedKey = nil
             } label: {

--- a/Sources/KeyPathAppKit/UI/Rules/HomeRowModsCollectionView.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/HomeRowModsCollectionView.swift
@@ -267,7 +267,7 @@ struct HomeRowModsCollectionView: View {
     }
 
     /// Whether the current assignments differ from defaults (for either mode)
-    private var baselineConfig: HomeRowModsConfig {
+    var baselineConfig: HomeRowModsConfig {
         usesTopRowKeys ? .vallackDefault : HomeRowModsConfig()
     }
 

--- a/Tests/KeyPathTests/HomeRowModsConfigTests.swift
+++ b/Tests/KeyPathTests/HomeRowModsConfigTests.swift
@@ -67,4 +67,27 @@ final class HomeRowModsConfigTests: XCTestCase {
 
         XCTAssertEqual(config.layerAssignments["a"], original)
     }
+
+    func testEnableKeyPreservesCustomLayerAssignment() {
+        var config = HomeRowModsConfig(holdMode: .layers)
+        config.layerAssignments["a"] = "nav"
+        config.enabledKeys.remove("a")
+
+        config.enableKeyPreservingAssignment("a")
+
+        XCTAssertTrue(config.enabledKeys.contains("a"))
+        XCTAssertEqual(config.layerAssignments["a"], "nav")
+        XCTAssertEqual(config.keySelection, .custom)
+    }
+
+    func testEnableKeyRestoresFallbackOnlyWhenAssignmentMissing() {
+        var config = HomeRowModsConfig(holdMode: .layers)
+        config.layerAssignments["a"] = nil
+        config.enabledKeys.remove("a")
+
+        config.enableKeyPreservingAssignment("a")
+
+        XCTAssertTrue(config.enabledKeys.contains("a"))
+        XCTAssertEqual(config.layerAssignments["a"], HomeRowModsConfig.defaultLayerAssignments["a"])
+    }
 }


### PR DESCRIPTION
## Summary

- Preserve an HRM key's existing modifier/layer assignment when it is disabled and later re-enabled.
- Only restore the baseline default assignment when the enabled key has no stored assignment.
- Add focused `HomeRowModsConfigTests` coverage for preserving custom layer assignments and missing-assignment fallback.

Closes #809.
Closes #808.

## Validation

- `swift test --jobs 4 --filter HomeRowModsConfigTests`
- `python3 Scripts/check-accessibility.py`
- `swiftformat --lint Sources/KeyPathAppKit/Models/HomeRowModsConfig.swift Sources/KeyPathAppKit/UI/Rules/HomeRowModsCollectionView.swift Sources/KeyPathAppKit/UI/Rules/HomeRowModsCollectionView+Popovers.swift Tests/KeyPathTests/HomeRowModsConfigTests.swift`
- `swift build` via pre-push hook