### PR TITLE
Add full-suite coverage visibility lane (M0.1)

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -94,6 +94,13 @@ jobs:
   # numbers are trusted, a realistic per-file floor can be added here.
   full-coverage:
     runs-on: [self-hosted, macOS, keypath]
+    # Sequence after the narrow lane: the two jobs share the self-hosted runner's
+    # workspace/.build, so running them in parallel risks clobbering each other's
+    # default.profdata (CLAUDE.md: avoid concurrent broad Swift builds). `needs`
+    # serializes them; `if: always()` still surfaces full numbers when the narrow
+    # floor regresses or a filtered test fails.
+    needs: [narrow-coverage]
+    if: always()
     timeout-minutes: 40
     steps:
       - name: Clean stale git credentials

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -80,10 +80,72 @@ jobs:
       - name: Generate coverage summary
         if: always()
         run: |
-          echo "## Coverage" >> $GITHUB_STEP_SUMMARY
+          echo "## Coverage (narrow lane)" >> $GITHUB_STEP_SUMMARY
           if [ -f "coverage/coverage-summary.txt" ]; then
             echo "- Summary: \`$(cat coverage/coverage-summary.txt)\`" >> $GITHUB_STEP_SUMMARY
             echo "- Enforced narrow-lane floor: \`${COVERAGE_BASELINE_PERCENT}%\`" >> $GITHUB_STEP_SUMMARY
           else
             echo "- Coverage not generated." >> $GITHUB_STEP_SUMMARY
+          fi
+
+  # Visibility-only: runs the WHOLE suite under coverage instrumentation and
+  # reports real numbers (total + the core business-logic files). It does NOT
+  # enforce a floor yet — the narrow lane above is the only gate. Once these
+  # numbers are trusted, a realistic per-file floor can be added here.
+  full-coverage:
+    runs-on: [self-hosted, macOS, keypath]
+    timeout-minutes: 40
+    steps:
+      - name: Clean stale git credentials
+        run: |
+          git config --global --unset-all http.https://github.com/.extraheader 2>/dev/null || true
+          git config --global --unset-all url.https://github.com/.insteadof 2>/dev/null || true
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+          persist-credentials: false
+
+      - name: Add Homebrew to PATH
+        run: echo "/opt/homebrew/bin" >> $GITHUB_PATH
+
+      - name: Generate full-suite coverage
+        timeout-minutes: 30
+        env:
+          KP_SIGN_DRY_RUN: "1"
+          CI_ENVIRONMENT: "true"
+          SKIP_EVENT_TAP_TESTS: "1"
+        run: |
+          echo "Generating full-suite coverage (no filter)..."
+          swift test --enable-code-coverage
+          chmod +x ./Scripts/generate-coverage.sh
+          ./Scripts/generate-coverage.sh coverage-full
+
+      - name: Upload full coverage artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-full
+          path: coverage-full/
+          if-no-files-found: ignore
+          retention-days: 14
+
+      - name: Report full coverage
+        if: always()
+        run: |
+          echo "## Coverage (full suite — visibility only, not enforced)" >> $GITHUB_STEP_SUMMARY
+          if [ -f "coverage-full/coverage-summary.txt" ]; then
+            echo "- Total: \`$(cat coverage-full/coverage-summary.txt)\`" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "- Coverage not generated." >> $GITHUB_STEP_SUMMARY
+          fi
+          if [ -s "coverage-full/coverage-core.txt" ]; then
+            {
+              echo ""
+              echo "### Core business-logic files"
+              echo '```'
+              cat "coverage-full/coverage-core.txt"
+              echo '```'
+            } >> $GITHUB_STEP_SUMMARY
           fi

--- a/Scripts/generate-coverage.sh
+++ b/Scripts/generate-coverage.sh
@@ -40,4 +40,16 @@ else
   echo "WARN: TOTAL coverage line not found" | tee "$OUT_DIR/coverage-summary.txt"
 fi
 
+# Core business-logic files we care about most (privileged install, config
+# generation/parsing, service health, permissions). The full llvm-cov report
+# already lists every file; extract just these so the per-file signal isn't
+# lost in the noise. Empty when running the narrow lane (those files aren't
+# instrumented), which is expected.
+CORE_FILES_PATTERN='InstallerEngine|ConfigurationService|ServiceHealthChecker|PermissionOracle|KanataConfigurationGenerator|KanataDefcfg|VHIDDeviceManager|ServiceBootstrapper'
+grep -E "$CORE_FILES_PATTERN" "$OUT_DIR/coverage-report.txt" > "$OUT_DIR/coverage-core.txt" || true
+if [[ -s "$OUT_DIR/coverage-core.txt" ]]; then
+  echo "Core-file coverage:"
+  cat "$OUT_DIR/coverage-core.txt"
+fi
+
 echo "Coverage artifacts written to: $OUT_DIR"


### PR DESCRIPTION
Audit task **M0.1** — make real test coverage *visible*. No app code changes; CI workflow + coverage script only.

## Problem

`coverage.yml` only instruments a 2-filter narrow lane (`KeyPathErrorTests|PermissionOracleTests`). So the reported ~0.29% total and the enforced 0.27% floor reflect almost nothing — core files like `InstallerEngine`, `ConfigurationService`, `ServiceHealthChecker` show 0% **only because they're never instrumented**, despite having substantial real tests. There's currently no signal for coverage regressions on the most safety-critical code.

## Change

- **New `full-coverage` job** in `coverage.yml`: runs the *whole* suite under `swift test --enable-code-coverage` and reports real numbers — the total plus a per-file breakdown of core business-logic files (privileged install, config generation/parsing, service health, permissions).
- **`generate-coverage.sh`** now also writes `coverage-core.txt` by extracting those files from the `llvm-cov report` it already produces (the per-file data was being computed and discarded).

## Deliberately NOT included

- **No floor enforcement.** This is visibility only. The narrow lane remains the sole gate, unchanged — I didn't want to guess a threshold before the real numbers are known. Once they're trusted, a realistic per-file floor can be added to this job (a natural follow-up).
- Scheduled/`workflow_dispatch` only (not per-PR), with a 40-min budget, since a full instrumented run is slow. Writes to the gitignored `coverage-full/` so nothing gets committed.

## Verification
YAML validated (`narrow-coverage` + `full-coverage` jobs parse). I can't run `swift`/the self-hosted runner from here, so the actual full-suite numbers will appear on the first scheduled run (or a manual `workflow_dispatch`). The script change is additive and guarded (`grep ... || true`), so it can't fail the existing narrow lane.

https://claude.ai/code/session_01Rso6kv5BgJrBCHxNWH4h7P

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rso6kv5BgJrBCHxNWH4h7P)_