### PR TITLE
Generator: stub-deflayer safety net catches layer-toggle references

### DIFF
--- a/Sources/KeyPathAppKit/Infrastructure/Config/KanataConfiguration+BlockBuilders.swift
+++ b/Sources/KeyPathAppKit/Infrastructure/Config/KanataConfiguration+BlockBuilders.swift
@@ -403,11 +403,14 @@ extension KanataConfiguration {
             blocks.append(CollectionBlock(metadata: metadata, entries: [entry]))
         }
 
-        // Scan alias definitions for layer references (layer-while-held, layer-switch)
+        // Scan alias definitions for layer references (layer-while-held, layer-switch, layer-toggle)
         // that aren't already in additionalLayers. This catches cases where a collection
-        // (e.g., Home Row Layer Toggles) generates hold actions referencing layers whose
-        // source collection isn't enabled — without a matching deflayer, kanata rejects the config.
-        let layerRefPattern = #/\((?:layer-while-held|layer-switch)\s+([\w-]+)\)/#
+        // (e.g., Home Row Layer Toggles in toggle mode) generates hold actions referencing
+        // layers whose source collection isn't enabled. Without the matching deflayer:
+        //   - layer-while-held / layer-switch fail at runtime (silent no-op).
+        //   - layer-toggle fails at kanata --check time (config rejected entirely).
+        // The stub deflayer keeps kanata happy; the keys then degrade to transparent.
+        let layerRefPattern = #/\((?:layer-while-held|layer-switch|layer-toggle)\s+([\w-]+)\)/#
         for alias in aliasDefinitions {
             for match in alias.definition.matches(of: layerRefPattern) {
                 let layerName = String(match.1)

--- a/Tests/KeyPathTests/Integration/StubDeflayerSafetyNetTests.swift
+++ b/Tests/KeyPathTests/Integration/StubDeflayerSafetyNetTests.swift
@@ -1,0 +1,128 @@
+@testable import KeyPathAppKit
+import KeyPathCore
+import XCTest
+
+/// Tests the generator's orphan-layer safety net.
+///
+/// When a rule references a layer that no other enabled rule provides
+/// (most visibly: Home Row Layer Toggles in toggle mode referencing the
+/// Function/Symbol/Numpad layers when those families are disabled), the
+/// generator emits a stub `(deflayer ...)` block so kanata accepts the
+/// config. Keys mapped into the orphan layer then degrade to transparent
+/// (`_`) instead of the whole config failing to load.
+///
+/// Background: pre-fix, the scanner caught `layer-while-held` and
+/// `layer-switch` references but missed `layer-toggle`. HRL Toggles in
+/// toggle mode produced configs that kanata rejected. The fix adds
+/// `layer-toggle` to the scan pattern in `KanataConfiguration+BlockBuilders`.
+final class StubDeflayerSafetyNetTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        continueAfterFailure = true
+    }
+
+    private func findKanataBinary() -> String? {
+        let candidates: [String] = [
+            ProcessInfo.processInfo.environment["KEYPATH_KANATA_PATH"],
+            URL(fileURLWithPath: #filePath)
+                .deletingLastPathComponent() // Integration
+                .deletingLastPathComponent() // KeyPathTests
+                .deletingLastPathComponent() // Tests
+                .deletingLastPathComponent() // repo root
+                .appendingPathComponent("External/kanata/target/aarch64-apple-darwin/release/kanata")
+                .path,
+            "/Applications/KeyPath.app/Contents/Library/KeyPath/Kanata Engine.app/Contents/MacOS/kanata",
+            "/opt/homebrew/bin/kanata"
+        ].compactMap { $0 }
+        return candidates.first { FileManager.default.isExecutableFile(atPath: $0) }
+    }
+
+    @MainActor
+    private func validateWithKanata(_ config: String) async throws -> (isValid: Bool, errors: [String]) {
+        guard let binary = findKanataBinary() else {
+            throw XCTSkip("Kanata binary not found — skipping CLI validation")
+        }
+        let tempFile = FileManager.default.temporaryDirectory
+            .appendingPathComponent("stub-deflayer-\(UUID().uuidString).kbd")
+        try config.write(to: tempFile, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: tempFile) }
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: binary)
+        process.arguments = ["--cfg", tempFile.path, "--check"]
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = pipe
+        try process.run()
+        process.waitUntilExit()
+
+        if process.terminationStatus == 0 {
+            return (true, [])
+        } else {
+            let data = pipe.fileHandleForReading.readDataToEndOfFile()
+            let output = String(data: data, encoding: .utf8) ?? ""
+            let errors = output.components(separatedBy: .newlines)
+                .filter { $0.contains("[ERROR]") || $0.contains("help:") }
+            return (false, errors)
+        }
+    }
+
+    // MARK: - HRL Toggles toggle mode (the case that surfaced this fix)
+
+    /// HRL Toggles in toggle mode references `fun`, `sym`, `num` via
+    /// `(layer-toggle ...)` actions. Without the safety net these are
+    /// orphan references and kanata --check rejects the config.
+    @MainActor
+    func testHRLTogglesToggleModeAlone_StubLayersEmitted() {
+        let config = MatrixTestHelpers.enabledCollectionConfig(RuleCollectionIdentifier.homeRowLayerToggles) { coll in
+            if case var .homeRowLayerToggles(cfg) = coll.configuration {
+                cfg.toggleMode = .toggle
+                coll.configuration = .homeRowLayerToggles(cfg)
+            }
+        }
+
+        // The generated config should reference the orphan layers ...
+        XCTAssertTrue(config.contains("(layer-toggle fun)"), "Expected (layer-toggle fun) in output")
+        XCTAssertTrue(config.contains("(layer-toggle sym)"), "Expected (layer-toggle sym) in output")
+        XCTAssertTrue(config.contains("(layer-toggle num)"), "Expected (layer-toggle num) in output")
+
+        // ... AND emit matching stub deflayer blocks so kanata accepts the config.
+        XCTAssertTrue(config.contains("(deflayer fun"), "Expected stub (deflayer fun ...) block")
+        XCTAssertTrue(config.contains("(deflayer sym"), "Expected stub (deflayer sym ...) block")
+        XCTAssertTrue(config.contains("(deflayer num"), "Expected stub (deflayer num ...) block")
+    }
+
+    @MainActor
+    func testHRLTogglesToggleModeAlone_KanataAccepts() async throws {
+        let config = MatrixTestHelpers.enabledCollectionConfig(RuleCollectionIdentifier.homeRowLayerToggles) { coll in
+            if case var .homeRowLayerToggles(cfg) = coll.configuration {
+                cfg.toggleMode = .toggle
+                coll.configuration = .homeRowLayerToggles(cfg)
+            }
+        }
+
+        let result = try await validateWithKanata(config)
+        XCTAssertTrue(
+            result.isValid,
+            "Stub deflayer safety net should make this kanata-valid. Errors: \(result.errors)"
+        )
+    }
+
+    // MARK: - whileHeld mode still works (regression guard for the original scanner)
+
+    @MainActor
+    func testHRLTogglesWhileHeldMode_KanataAccepts() async throws {
+        let config = MatrixTestHelpers.enabledCollectionConfig(RuleCollectionIdentifier.homeRowLayerToggles) { coll in
+            if case var .homeRowLayerToggles(cfg) = coll.configuration {
+                cfg.toggleMode = .whileHeld
+                coll.configuration = .homeRowLayerToggles(cfg)
+            }
+        }
+
+        let result = try await validateWithKanata(config)
+        XCTAssertTrue(
+            result.isValid,
+            "whileHeld mode was already covered by the original scanner — must still validate. Errors: \(result.errors)"
+        )
+    }
+}

--- a/Tests/KeyPathTests/Integration/StubDeflayerSafetyNetTests.swift
+++ b/Tests/KeyPathTests/Integration/StubDeflayerSafetyNetTests.swift
@@ -18,6 +18,8 @@ import XCTest
 final class StubDeflayerSafetyNetTests: XCTestCase {
     override func setUp() {
         super.setUp()
+        // Run every assertion in this suite even if one fails — surfacing all
+        // safety-net regressions in one CI run instead of stopping at the first.
         continueAfterFailure = true
     }
 


### PR DESCRIPTION
The smallest possible fix for the catalog integration bug surfaced by [PR #864](https://github.com/malpern/KeyPath/pull/864)'s `testHRLTogglesToggleMode_WithoutCompanionLayers_Documented` test.

## What was broken

When a user enabled Home Row Layer Toggles in **toggle mode** without enabling Function/Symbol/Numpad, the generated config referenced layers that no `(deflayer ...)` declared. Kanata `--check` rejected the entire config:

```
× Error in configuration
help: layer name is not declared in any deflayer: fun
```

The downstream UX was severe: enabling that one rule broke every other rule, because kanata couldn't load the config at all.

## The fix

The generator already has an orphan-layer scanner at [`KanataConfiguration+BlockBuilders.swift:410`](Sources/KeyPathAppKit/Infrastructure/Config/KanataConfiguration+BlockBuilders.swift). It scans alias definitions for layer references and emits stub `(deflayer ...)` blocks for any layer that isn't otherwise declared. It just missed `layer-toggle`:

\`\`\`diff
- #/\((?:layer-while-held|layer-switch)\s+([\w-]+)\)/#
+ #/\((?:layer-while-held|layer-switch|layer-toggle)\s+([\w-]+)\)/#
\`\`\`

`layer-while-held` and `layer-switch` were already covered — `layer-toggle` is what HRL Toggles emits in toggle mode. The existing render path already produces all-`_` (transparent) deflayers for stubbed layers, so no other code change is needed.

## What this means for the user

- Kanata loads the config. Every other rule in the user's setup keeps working.
- The orphan home-row keys in the unmapped layers silently no-op rather than catastrophically failing.
- The "proper" UX (configure-time dialog offering to enable the supporting rules) is the next-sprint goal — tracked as the epic in [#865](https://github.com/malpern/KeyPath/issues/865).

## Verification

- `swift test --filter StubDeflayerSafetyNetTests` — 3/3 pass (new file)
- `swift test --filter ConfigGoldenFileTests` — 6/6 pass
- `swift test --filter ConfigValidationTests` — 9/9 pass (whole-catalog assertion + every per-pack assertion still green)
- `swiftformat Sources Tests` — clean
- `swiftlint --quiet` — no new warnings

## Coordination with PR #864

[#864](https://github.com/malpern/KeyPath/pull/864) added `testHRLTogglesToggleMode_WithoutCompanionLayers_Documented` to capture the broken behavior, with explicit guidance: *"if this starts failing, the catalog integration was fixed — revisit the limitation note."*

After both this PR and #864 merge, that test will start failing exactly as designed. The follow-up is one quick commit on master updating the `_Documented` test's assertion to the new (safety-net'd) reality — "kanata accepts; keys silently no-op."