### PR TITLE
Make danger-enable-cmd opt-in: default OFF with grandfathering (M1.1)

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -94,6 +94,13 @@ jobs:
   # numbers are trusted, a realistic per-file floor can be added here.
   full-coverage:
     runs-on: [self-hosted, macOS, keypath]
+    # Sequence after the narrow lane: the two jobs share the self-hosted runner's
+    # workspace/.build, so running them in parallel risks clobbering each other's
+    # default.profdata (CLAUDE.md: avoid concurrent broad Swift builds). `needs`
+    # serializes them; `if: always()` still surfaces full numbers when the narrow
+    # floor regresses or a filtered test fails.
+    needs: [narrow-coverage]
+    if: always()
     timeout-minutes: 40
     steps:
       - name: Clean stale git credentials

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -80,10 +80,72 @@ jobs:
       - name: Generate coverage summary
         if: always()
         run: |
-          echo "## Coverage" >> $GITHUB_STEP_SUMMARY
+          echo "## Coverage (narrow lane)" >> $GITHUB_STEP_SUMMARY
           if [ -f "coverage/coverage-summary.txt" ]; then
             echo "- Summary: \`$(cat coverage/coverage-summary.txt)\`" >> $GITHUB_STEP_SUMMARY
             echo "- Enforced narrow-lane floor: \`${COVERAGE_BASELINE_PERCENT}%\`" >> $GITHUB_STEP_SUMMARY
           else
             echo "- Coverage not generated." >> $GITHUB_STEP_SUMMARY
+          fi
+
+  # Visibility-only: runs the WHOLE suite under coverage instrumentation and
+  # reports real numbers (total + the core business-logic files). It does NOT
+  # enforce a floor yet — the narrow lane above is the only gate. Once these
+  # numbers are trusted, a realistic per-file floor can be added here.
+  full-coverage:
+    runs-on: [self-hosted, macOS, keypath]
+    timeout-minutes: 40
+    steps:
+      - name: Clean stale git credentials
+        run: |
+          git config --global --unset-all http.https://github.com/.extraheader 2>/dev/null || true
+          git config --global --unset-all url.https://github.com/.insteadof 2>/dev/null || true
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+          persist-credentials: false
+
+      - name: Add Homebrew to PATH
+        run: echo "/opt/homebrew/bin" >> $GITHUB_PATH
+
+      - name: Generate full-suite coverage
+        timeout-minutes: 30
+        env:
+          KP_SIGN_DRY_RUN: "1"
+          CI_ENVIRONMENT: "true"
+          SKIP_EVENT_TAP_TESTS: "1"
+        run: |
+          echo "Generating full-suite coverage (no filter)..."
+          swift test --enable-code-coverage
+          chmod +x ./Scripts/generate-coverage.sh
+          ./Scripts/generate-coverage.sh coverage-full
+
+      - name: Upload full coverage artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-full
+          path: coverage-full/
+          if-no-files-found: ignore
+          retention-days: 14
+
+      - name: Report full coverage
+        if: always()
+        run: |
+          echo "## Coverage (full suite — visibility only, not enforced)" >> $GITHUB_STEP_SUMMARY
+          if [ -f "coverage-full/coverage-summary.txt" ]; then
+            echo "- Total: \`$(cat coverage-full/coverage-summary.txt)\`" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "- Coverage not generated." >> $GITHUB_STEP_SUMMARY
+          fi
+          if [ -s "coverage-full/coverage-core.txt" ]; then
+            {
+              echo ""
+              echo "### Core business-logic files"
+              echo '```'
+              cat "coverage-full/coverage-core.txt"
+              echo '```'
+            } >> $GITHUB_STEP_SUMMARY
           fi

--- a/Scripts/generate-coverage.sh
+++ b/Scripts/generate-coverage.sh
@@ -40,4 +40,16 @@ else
   echo "WARN: TOTAL coverage line not found" | tee "$OUT_DIR/coverage-summary.txt"
 fi
 
+# Core business-logic files we care about most (privileged install, config
+# generation/parsing, service health, permissions). The full llvm-cov report
+# already lists every file; extract just these so the per-file signal isn't
+# lost in the noise. Empty when running the narrow lane (those files aren't
+# instrumented), which is expected.
+CORE_FILES_PATTERN='InstallerEngine|ConfigurationService|ServiceHealthChecker|PermissionOracle|KanataConfigurationGenerator|KanataDefcfg|VHIDDeviceManager|ServiceBootstrapper'
+grep -E "$CORE_FILES_PATTERN" "$OUT_DIR/coverage-report.txt" > "$OUT_DIR/coverage-core.txt" || true
+if [[ -s "$OUT_DIR/coverage-core.txt" ]]; then
+  echo "Core-file coverage:"
+  cat "$OUT_DIR/coverage-core.txt"
+fi
+
 echo "Coverage artifacts written to: $OUT_DIR"

--- a/Sources/KeyPathAppKit/Infrastructure/Config/ConfigurationService.swift
+++ b/Sources/KeyPathAppKit/Infrastructure/Config/ConfigurationService.swift
@@ -91,6 +91,11 @@ public final class ConfigurationService: FileConfigurationProviding {
         do {
             let content = try await readFileAsync(path: configurationPath)
 
+            // One-time migration for the danger-enable-cmd default flip: a pre-existing
+            // config that uses (cmd ...) actions grandfathers the policy ON before any
+            // regeneration could strip the header line. No-op once decided.
+            KanataCommandActionsPolicy.grandfatherIfNeeded(configContent: content)
+
             let contentHash = SHA256.hash(data: Data(content.utf8))
                 .map { String(format: "%02x", $0) }.joined()
             if contentHash == lastContentHash, let cached = currentConfiguration {
@@ -462,7 +467,9 @@ public final class ConfigurationService: FileConfigurationProviding {
             if lowerError.contains("missing"), lowerError.contains("defcfg") {
                 // Add missing defcfg using the shared single-source-of-truth header.
                 if !repairedConfig.contains("(defcfg") {
-                    let defcfgSection = KanataDefcfg.repairFallback.render() + "\n\n"
+                    let defcfgSection = KanataDefcfg.repairFallback(
+                        allowCommandActions: KanataCommandActionsPolicy.isEnabled()
+                    ).render() + "\n\n"
                     repairedConfig = defcfgSection + repairedConfig
                 }
             }

--- a/Sources/KeyPathAppKit/Infrastructure/Config/ConfigurationService.swift
+++ b/Sources/KeyPathAppKit/Infrastructure/Config/ConfigurationService.swift
@@ -284,7 +284,7 @@ public final class ConfigurationService: FileConfigurationProviding {
         // overwritten. Generation below evaluates the policy via the
         // allowCommandActions default, so the decision must be recorded first.
         if !KanataCommandActionsPolicy.hasRecordedDecision(),
-           Foundation.FileManager().fileExists(atPath: configurationPath),
+           Foundation.FileManager.default.fileExists(atPath: configurationPath),
            let existingContent = try? String(contentsOfFile: configurationPath, encoding: .utf8)
         {
             KanataCommandActionsPolicy.grandfatherIfNeeded(configContent: existingContent)

--- a/Sources/KeyPathAppKit/Infrastructure/Config/ConfigurationService.swift
+++ b/Sources/KeyPathAppKit/Infrastructure/Config/ConfigurationService.swift
@@ -277,6 +277,19 @@ public final class ConfigurationService: FileConfigurationProviding {
         ruleCollections: [RuleCollection],
         customRules: [CustomRule] = []
     ) async throws -> KanataConfiguration {
+        // Grandfather the cmd-actions policy against the on-disk config BEFORE
+        // generating: startup bootstrap regenerates (and saves) without any prior
+        // reload(), so the reload() hook alone would run too late — after the
+        // hand-written (cmd ...) config this migration must inspect was already
+        // overwritten. Generation below evaluates the policy via the
+        // allowCommandActions default, so the decision must be recorded first.
+        if !KanataCommandActionsPolicy.hasRecordedDecision(),
+           Foundation.FileManager().fileExists(atPath: configurationPath),
+           let existingContent = try? String(contentsOfFile: configurationPath, encoding: .utf8)
+        {
+            KanataCommandActionsPolicy.grandfatherIfNeeded(configContent: existingContent)
+        }
+
         // Custom rules come first so they take priority over preset collections
         let customRuleCollections = customRules.asRuleCollections()
         AppLogger.shared.log("🔧 [ConfigService] Converting \(customRules.count) custom rules to \(customRuleCollections.count) collections")

--- a/Sources/KeyPathAppKit/Infrastructure/Config/ConfigurationService.swift
+++ b/Sources/KeyPathAppKit/Infrastructure/Config/ConfigurationService.swift
@@ -283,6 +283,9 @@ public final class ConfigurationService: FileConfigurationProviding {
         // hand-written (cmd ...) config this migration must inspect was already
         // overwritten. Generation below evaluates the policy via the
         // allowCommandActions default, so the decision must be recorded first.
+        // Check-then-act is safe here: grandfatherIfNeeded re-checks internally
+        // and always records the same value for the same config (idempotent), so
+        // concurrent callers can't disagree.
         if !KanataCommandActionsPolicy.hasRecordedDecision(),
            Foundation.FileManager.default.fileExists(atPath: configurationPath),
            let existingContent = try? String(contentsOfFile: configurationPath, encoding: .utf8)

--- a/Sources/KeyPathAppKit/Infrastructure/Config/KanataCommandActionsPolicy.swift
+++ b/Sources/KeyPathAppKit/Infrastructure/Config/KanataCommandActionsPolicy.swift
@@ -1,0 +1,73 @@
+import Foundation
+import KeyPathCore
+
+/// Policy for whether KeyPath-written configs grant kanata permission to execute
+/// shell commands (`danger-enable-cmd yes` in `defcfg`).
+///
+/// KeyPath itself never emits `(cmd ...)` actions: launchers, URL/folder/script
+/// actions, system actions, notifications, and layer signals are all
+/// `(push-msg ...)` TCP messages executed app-side by `ActionDispatcher`, and
+/// kanata does not gate `push-msg` behind `danger-enable-cmd`. The flag only
+/// matters for hand-written `(cmd ...)` actions in a user-edited config — so it
+/// defaults to OFF. Kanata runs as root under the LaunchDaemon; an unused grant
+/// of arbitrary command execution is pure attack surface.
+///
+/// Users who hand-wrote `(cmd ...)` actions before this default changed are
+/// grandfathered: the first load of a pre-existing config that *uses* cmd
+/// actions records the policy as enabled, so regeneration keeps emitting the
+/// header line. The presence of `danger-enable-cmd yes` alone does NOT
+/// grandfather — every legacy generated config carries that line (it used to be
+/// hardcoded) without using `(cmd ...)`.
+///
+/// Backed by `UserDefaults` directly (not `@MainActor`) because config
+/// generation runs off the main actor.
+public enum KanataCommandActionsPolicy {
+    static let defaultsKey = "KeyPath.Security.ConfigCommandActionsEnabled"
+
+    /// Whether generated configs should include `danger-enable-cmd yes`.
+    /// Defaults to `false` when the user has never decided.
+    public static func isEnabled(defaults: UserDefaults = .standard) -> Bool {
+        defaults.bool(forKey: defaultsKey)
+    }
+
+    /// True once the user (or the grandfathering migration) has recorded a decision.
+    public static func hasRecordedDecision(defaults: UserDefaults = .standard) -> Bool {
+        defaults.object(forKey: defaultsKey) != nil
+    }
+
+    public static func setEnabled(_ enabled: Bool, defaults: UserDefaults = .standard) {
+        defaults.set(enabled, forKey: defaultsKey)
+        AppLogger.shared.log(
+            "🔐 [CommandActionsPolicy] Config command actions \(enabled ? "ENABLED" : "DISABLED")"
+        )
+    }
+
+    /// True when the config *uses* command-execution actions, as opposed to merely
+    /// carrying the `danger-enable-cmd` defcfg line. Matches the kanata action
+    /// family that `danger-enable-cmd` gates — `cmd`, `cmd-log`,
+    /// `cmd-output-keys`, and the clipboard cmd variants — all of which appear as
+    /// `(cmd…` at use sites. `danger-enable-cmd yes` itself never matches (no
+    /// opening paren before `cmd`).
+    public static func configUsesCommandActions(_ content: String) -> Bool {
+        content.range(of: #"\(\s*cmd[\s)-]"#, options: .regularExpression) != nil
+    }
+
+    /// One-time migration run when an existing config is first loaded after the
+    /// default flipped to OFF. Records `true` when the config actually uses
+    /// `(cmd ...)` actions (preserving the user's mappings across regeneration)
+    /// and `false` otherwise. No-op once a decision has been recorded, so a later
+    /// explicit Settings choice is never overridden.
+    public static func grandfatherIfNeeded(
+        configContent: String,
+        defaults: UserDefaults = .standard
+    ) {
+        guard !hasRecordedDecision(defaults: defaults) else { return }
+        let usesCommands = configUsesCommandActions(configContent)
+        setEnabled(usesCommands, defaults: defaults)
+        if usesCommands {
+            AppLogger.shared.log(
+                "🔐 [CommandActionsPolicy] Existing config uses (cmd ...) actions — grandfathering command actions ON"
+            )
+        }
+    }
+}

--- a/Sources/KeyPathAppKit/Infrastructure/Config/KanataConfigurationGenerator.swift
+++ b/Sources/KeyPathAppKit/Infrastructure/Config/KanataConfigurationGenerator.swift
@@ -38,13 +38,16 @@ public struct KanataConfiguration: Sendable {
 
     /// Generate configuration content from rule collections.
     /// Flattens enabled collections to `defsrc`/`deflayer` for backward compatibility with Kanata config format.
+    /// `allowCommandActions` controls the `danger-enable-cmd` defcfg line; it defaults to the
+    /// user's recorded `KanataCommandActionsPolicy` (OFF unless opted in or grandfathered).
     public static func generateFromCollections(
         _ collections: [RuleCollection],
         leaderKeyPreference: LeaderKeyPreference? = nil,
         navActivationMode: ContextHUDTriggerMode = .tapToToggle,
         navHoldDelayMs: Int = 200,
         chordGroups: [ChordGroupConfig] = [],
-        sequences: [KanataDefseqParser.ParsedSequence] = []
+        sequences: [KanataDefseqParser.ParsedSequence] = [],
+        allowCommandActions: Bool = KanataCommandActionsPolicy.isEnabled()
     ) -> String {
         var resolvedCollections = collections.isEmpty ? defaultSystemCollections : collections
         if !resolvedCollections.contains(where: { $0.id == RuleCollectionIdentifier.macFunctionKeys }) {
@@ -108,7 +111,7 @@ public struct KanataConfiguration: Sendable {
             return (krc.globalDelayMs, krc.globalIntervalMs)
         }()
         let defcfg = KanataDefcfg.standard(
-            allowCommandActions: true,
+            allowCommandActions: allowCommandActions,
             managedRepeatTiming: repeatTiming,
             requirePriorIdleMs: requirePriorIdleMs > 0 ? requirePriorIdleMs : nil,
             hasChords: !chordMappings.isEmpty,

--- a/Sources/KeyPathAppKit/Infrastructure/Config/KanataDefcfg.swift
+++ b/Sources/KeyPathAppKit/Infrastructure/Config/KanataDefcfg.swift
@@ -154,9 +154,13 @@ public extension KanataDefcfg {
     )
 
     /// Minimal header injected by rule-based repair when a config is missing its
-    /// `defcfg` entirely. Mirrors the generator's command-execution posture.
-    static let repairFallback = KanataDefcfg(
-        processUnmappedKeys: true,
-        allowCommandActions: true
-    )
+    /// `defcfg` entirely. The caller passes the user's `KanataCommandActionsPolicy`
+    /// so repair mirrors the generator's command-execution posture instead of
+    /// silently (re)enabling `cmd` actions.
+    static func repairFallback(allowCommandActions: Bool) -> KanataDefcfg {
+        KanataDefcfg(
+            processUnmappedKeys: true,
+            allowCommandActions: allowCommandActions
+        )
+    }
 }

--- a/Sources/KeyPathAppKit/Services/AI/AnthropicConfigRepairService.swift
+++ b/Sources/KeyPathAppKit/Services/AI/AnthropicConfigRepairService.swift
@@ -20,9 +20,11 @@ public actor AnthropicConfigRepairService: ConfigRepairService {
     public func repairConfig(config: String, errors: [String], mappings: [KeyMapping]) async throws -> String {
         // Mirror the user's command-actions policy: repair must not (re)enable cmd
         // execution for users who have it off, nor strip it for grandfathered users.
+        // process-unmapped-keys yes matches KanataDefcfg.repairFallback (the prompt
+        // previously said "no", contradicting the rule-based injector).
         let defcfgInstruction = KanataCommandActionsPolicy.isEnabled()
-            ? "Includes defcfg with process-unmapped-keys no and danger-enable-cmd yes"
-            : "Includes defcfg with process-unmapped-keys no, and does NOT include danger-enable-cmd or any (cmd ...) actions"
+            ? "Includes defcfg with process-unmapped-keys yes and danger-enable-cmd yes"
+            : "Includes defcfg with process-unmapped-keys yes, and does NOT include danger-enable-cmd or any (cmd ...) actions"
         let prompt = """
         The following Kanata keyboard configuration file is invalid and needs to be repaired:
 

--- a/Sources/KeyPathAppKit/Services/AI/AnthropicConfigRepairService.swift
+++ b/Sources/KeyPathAppKit/Services/AI/AnthropicConfigRepairService.swift
@@ -18,6 +18,11 @@ public actor AnthropicConfigRepairService: ConfigRepairService {
     }
 
     public func repairConfig(config: String, errors: [String], mappings: [KeyMapping]) async throws -> String {
+        // Mirror the user's command-actions policy: repair must not (re)enable cmd
+        // execution for users who have it off, nor strip it for grandfathered users.
+        let defcfgInstruction = KanataCommandActionsPolicy.isEnabled()
+            ? "Includes defcfg with process-unmapped-keys no and danger-enable-cmd yes"
+            : "Includes defcfg with process-unmapped-keys no, and does NOT include danger-enable-cmd or any (cmd ...) actions"
         let prompt = """
         The following Kanata keyboard configuration file is invalid and needs to be repaired:
 
@@ -36,7 +41,7 @@ public actor AnthropicConfigRepairService: ConfigRepairService {
         1. Fixes all validation errors
         2. Preserves the intended key mappings
         3. Uses proper Kanata syntax
-        4. Includes defcfg with process-unmapped-keys no and danger-enable-cmd yes
+        4. \(defcfgInstruction)
         5. Has proper defsrc and deflayer sections
 
         Return ONLY the corrected configuration file content, no explanations.

--- a/Sources/KeyPathAppKit/UI/Settings/ExperimentalSettingsSection.swift
+++ b/Sources/KeyPathAppKit/UI/Settings/ExperimentalSettingsSection.swift
@@ -38,6 +38,11 @@ struct ExperimentalSettingsSection: View {
                     ScriptExecutionSettingsSection()
                 }
 
+                // Config Command Actions Section
+                SettingsCard {
+                    CommandActionsSettingsSection()
+                }
+
                 // AI Config Section
                 SettingsCard {
                     VStack(alignment: .leading, spacing: 12) {

--- a/Sources/KeyPathAppKit/UI/Settings/SettingsView+ScriptExecution.swift
+++ b/Sources/KeyPathAppKit/UI/Settings/SettingsView+ScriptExecution.swift
@@ -114,6 +114,80 @@ struct ScriptExecutionSettingsSection: View {
     }
 }
 
+// MARK: - Config Command Actions Settings Section
+
+/// Settings section for kanata `(cmd ...)` actions in hand-edited configs.
+///
+/// KeyPath's own features (launchers, system actions, …) use `push-msg` and never
+/// need this; the toggle exists only for users who hand-write `(cmd ...)` actions.
+/// Default is OFF because kanata runs as root — see `KanataCommandActionsPolicy`.
+struct CommandActionsSettingsSection: View {
+    @State private var commandActionsEnabled = KanataCommandActionsPolicy.isEnabled()
+    @State private var showingEnableConfirmation = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(spacing: 8) {
+                Image(systemName: "exclamationmark.shield")
+                    .foregroundColor(.orange)
+                    .font(.body)
+                Text("Config Command Actions")
+                    .font(.headline)
+                    .foregroundColor(.primary)
+            }
+
+            HStack {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Allow (cmd ...) actions in the Kanata config")
+                        .font(.body)
+                        .fontWeight(.medium)
+                    Text("Only needed for hand-written (cmd ...) actions. The keyboard engine runs with root privileges, so enabled commands run as root. KeyPath's own launchers and actions don't use this.")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+                Spacer()
+                Toggle("", isOn: Binding(
+                    get: { commandActionsEnabled },
+                    set: { newValue in
+                        if newValue {
+                            // Enabling grants root command execution — confirm it.
+                            showingEnableConfirmation = true
+                        } else {
+                            applyChange(false)
+                        }
+                    }
+                ))
+                .toggleStyle(.switch)
+                .labelsHidden()
+            }
+            .accessibilityIdentifier("settings-command-actions-toggle")
+            .accessibilityLabel("Allow command actions in config")
+            .confirmationDialog(
+                "Allow the keyboard engine to run shell commands?",
+                isPresented: $showingEnableConfirmation,
+                titleVisibility: .visible
+            ) {
+                Button("Allow Command Actions", role: .destructive) {
+                    applyChange(true)
+                }
+                .accessibilityIdentifier("settings-command-actions-confirm")
+                Button("Cancel", role: .cancel) {}
+                    .accessibilityIdentifier("settings-command-actions-cancel")
+            } message: {
+                Text("Any (cmd ...) action in your config will execute as root. Only enable this if you hand-edited your config and trust every command in it.")
+            }
+        }
+    }
+
+    private func applyChange(_ enabled: Bool) {
+        commandActionsEnabled = enabled
+        KanataCommandActionsPolicy.setEnabled(enabled)
+        // Regenerate + reload the config so the danger-enable-cmd header reflects
+        // the new policy immediately (handled by RuntimeCoordinator's observer).
+        NotificationCenter.default.post(name: .configAffectingPreferenceChanged, object: nil)
+    }
+}
+
 // MARK: - Script Execution Log View
 
 /// Shows the history of script executions for audit purposes

--- a/Sources/KeyPathAppKit/UI/Settings/SettingsView+ScriptExecution.swift
+++ b/Sources/KeyPathAppKit/UI/Settings/SettingsView+ScriptExecution.swift
@@ -177,6 +177,12 @@ struct CommandActionsSettingsSection: View {
                 Text("Any (cmd ...) action in your config will execute as root. Only enable this if you hand-edited your config and trust every command in it.")
             }
         }
+        // The policy lives in UserDefaults (not an observable object), so re-read it
+        // whenever the section appears — grandfathering may have flipped it ON after
+        // this view's @State captured its initial snapshot.
+        .onAppear {
+            commandActionsEnabled = KanataCommandActionsPolicy.isEnabled()
+        }
     }
 
     private func applyChange(_ enabled: Bool) {

--- a/Sources/KeyPathAppKit/UI/Settings/SettingsView+ScriptExecution.swift
+++ b/Sources/KeyPathAppKit/UI/Settings/SettingsView+ScriptExecution.swift
@@ -141,7 +141,7 @@ struct CommandActionsSettingsSection: View {
                     Text("Allow (cmd ...) actions in the Kanata config")
                         .font(.body)
                         .fontWeight(.medium)
-                    Text("Only needed for hand-written (cmd ...) actions. The keyboard engine runs with root privileges, so enabled commands run as root. KeyPath's own launchers and actions don't use this.")
+                    Text("Only for hand-written (cmd ...) actions — KeyPath's own launchers and actions don't use this. The keyboard engine runs as root, so enabled commands run as root.")
                         .font(.caption)
                         .foregroundColor(.secondary)
                 }
@@ -185,6 +185,7 @@ struct CommandActionsSettingsSection: View {
         }
     }
 
+    @MainActor
     private func applyChange(_ enabled: Bool) {
         commandActionsEnabled = enabled
         KanataCommandActionsPolicy.setEnabled(enabled)

--- a/Tests/KeyPathTests/Infrastructure/Config/KanataCommandActionsPolicyTests.swift
+++ b/Tests/KeyPathTests/Infrastructure/Config/KanataCommandActionsPolicyTests.swift
@@ -1,0 +1,146 @@
+@testable import KeyPathAppKit
+import XCTest
+
+/// Tests for the `danger-enable-cmd` default-OFF policy (M1.1): default state,
+/// opt-in, and the one-time grandfathering migration for hand-written `(cmd ...)`
+/// configs. Uses an isolated UserDefaults suite so test-runner state never leaks.
+final class KanataCommandActionsPolicyTests: XCTestCase {
+    private var defaults: UserDefaults!
+    private let suiteName = "com.keypath.tests.command-actions-policy"
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+    }
+
+    override func tearDownWithError() throws {
+        defaults.removePersistentDomain(forName: suiteName)
+        try super.tearDownWithError()
+    }
+
+    // MARK: - Default posture
+
+    func testDefaultsToDisabledWithNoRecordedDecision() {
+        XCTAssertFalse(KanataCommandActionsPolicy.isEnabled(defaults: defaults))
+        XCTAssertFalse(KanataCommandActionsPolicy.hasRecordedDecision(defaults: defaults))
+    }
+
+    func testSetEnabledRecordsDecision() {
+        KanataCommandActionsPolicy.setEnabled(true, defaults: defaults)
+        XCTAssertTrue(KanataCommandActionsPolicy.isEnabled(defaults: defaults))
+        XCTAssertTrue(KanataCommandActionsPolicy.hasRecordedDecision(defaults: defaults))
+
+        KanataCommandActionsPolicy.setEnabled(false, defaults: defaults)
+        XCTAssertFalse(KanataCommandActionsPolicy.isEnabled(defaults: defaults))
+        XCTAssertTrue(KanataCommandActionsPolicy.hasRecordedDecision(defaults: defaults))
+    }
+
+    // MARK: - Usage detection
+
+    func testDetectsCmdActionUsage() {
+        XCTAssertTrue(KanataCommandActionsPolicy.configUsesCommandActions(
+            #"(defalias launch-obsidian (cmd open -a Obsidian))"#
+        ))
+        XCTAssertTrue(KanataCommandActionsPolicy.configUsesCommandActions(
+            #"(defalias log-it (cmd-log debug error echo hi))"#
+        ))
+    }
+
+    func testDefcfgHeaderLineAloneIsNotUsage() {
+        // Every legacy generated config carries this line without using (cmd ...);
+        // it must NOT grandfather the policy on.
+        let legacyGenerated = """
+        (defcfg
+          process-unmapped-keys yes
+          danger-enable-cmd yes
+        )
+        (defsrc caps)
+        (deflayer base esc)
+        """
+        XCTAssertFalse(KanataCommandActionsPolicy.configUsesCommandActions(legacyGenerated))
+    }
+
+    func testPushMsgActionsAreNotUsage() {
+        // push-msg is not gated by danger-enable-cmd — KeyPath's launchers,
+        // system actions, and layer signals must not trip the detector.
+        let generated = """
+        (defalias
+          act_f3 (push-msg "system:mission-control")
+          act_c (push-msg "launch:com.apple.iCal")
+          kp-layer-nav-enter (push-msg "layer:nav")
+        )
+        """
+        XCTAssertFalse(KanataCommandActionsPolicy.configUsesCommandActions(generated))
+    }
+
+    func testCmdPrefixedAliasNamesAreNotUsage() {
+        // `cmd` as an output key name (lmet alias) or inside words must not match.
+        XCTAssertFalse(KanataCommandActionsPolicy.configUsesCommandActions(
+            "(deflayer base cmd a (macro cmdish))"
+        ))
+    }
+
+    // MARK: - Grandfathering
+
+    func testGrandfatherEnablesWhenConfigUsesCmd() {
+        let config = """
+        (defcfg
+          process-unmapped-keys yes
+          danger-enable-cmd yes
+        )
+        (defalias open-notes (cmd open -a Notes))
+        """
+        KanataCommandActionsPolicy.grandfatherIfNeeded(configContent: config, defaults: defaults)
+        XCTAssertTrue(KanataCommandActionsPolicy.isEnabled(defaults: defaults))
+        XCTAssertTrue(KanataCommandActionsPolicy.hasRecordedDecision(defaults: defaults))
+    }
+
+    func testGrandfatherRecordsDisabledForLegacyHeaderOnlyConfig() {
+        let config = """
+        (defcfg
+          process-unmapped-keys yes
+          danger-enable-cmd yes
+        )
+        (defsrc caps)
+        (deflayer base (push-msg "layer:base"))
+        """
+        KanataCommandActionsPolicy.grandfatherIfNeeded(configContent: config, defaults: defaults)
+        XCTAssertFalse(KanataCommandActionsPolicy.isEnabled(defaults: defaults))
+        XCTAssertTrue(
+            KanataCommandActionsPolicy.hasRecordedDecision(defaults: defaults),
+            "Migration must record its decision so it runs exactly once"
+        )
+    }
+
+    func testGrandfatherNeverOverridesRecordedDecision() {
+        // User explicitly disabled; a later load of a (cmd ...) config must not flip it back.
+        KanataCommandActionsPolicy.setEnabled(false, defaults: defaults)
+        KanataCommandActionsPolicy.grandfatherIfNeeded(
+            configContent: "(defalias x (cmd rm -rf /))",
+            defaults: defaults
+        )
+        XCTAssertFalse(KanataCommandActionsPolicy.isEnabled(defaults: defaults))
+    }
+
+    // MARK: - Generator integration
+
+    @MainActor
+    func testGeneratedConfigOmitsDangerEnableCmdByDefault() {
+        let config = KanataConfiguration.generateFromCollections(
+            RuleCollectionCatalog().defaultCollections(),
+            allowCommandActions: false
+        )
+        XCTAssertFalse(config.contains("danger-enable-cmd"))
+        XCTAssertTrue(config.contains("process-unmapped-keys yes"))
+    }
+
+    @MainActor
+    func testGeneratedConfigIncludesDangerEnableCmdWhenOptedIn() {
+        let config = KanataConfiguration.generateFromCollections(
+            RuleCollectionCatalog().defaultCollections(),
+            allowCommandActions: true
+        )
+        XCTAssertTrue(config.contains("danger-enable-cmd yes"))
+    }
+}

--- a/Tests/KeyPathTests/Infrastructure/Config/KanataDefcfgTests.swift
+++ b/Tests/KeyPathTests/Infrastructure/Config/KanataDefcfgTests.swift
@@ -10,7 +10,8 @@ final class KanataDefcfgTests: XCTestCase {
     // MARK: - standard()
 
     func testStandardDefaultMatchesGeneratedHeader() {
-        // Mirrors GoldenConfigs/default.kbd (key-repeat enabled, no prior-idle, no chords).
+        // Opted-in variant of GoldenConfigs/default.kbd (key-repeat enabled, no prior-idle,
+        // no chords). The golden itself renders with allowCommandActions: false since M1.1.
         let defcfg = KanataDefcfg.standard(
             allowCommandActions: true,
             managedRepeatTiming: (delayMs: 500, intervalMs: 30),
@@ -31,7 +32,8 @@ final class KanataDefcfgTests: XCTestCase {
     }
 
     func testStandardWithPriorIdleAndChords() {
-        // Mirrors GoldenConfigs/home-row-mods.kbd plus a chord-triggered concurrent-tap-hold.
+        // Opted-in variant of GoldenConfigs/home-row-mods.kbd plus a chord-triggered
+        // concurrent-tap-hold. The golden renders with allowCommandActions: false since M1.1.
         let defcfg = KanataDefcfg.standard(
             allowCommandActions: true,
             managedRepeatTiming: (delayMs: 500, intervalMs: 30),
@@ -135,12 +137,18 @@ final class KanataDefcfgTests: XCTestCase {
         XCTAssertEqual(KanataDefcfg.minimalSafe, KanataDefcfg.validationWrapper)
     }
 
-    func testRepairFallbackProfile() {
-        // ConfigurationService rule-based repair injection (mirrors generator posture).
-        XCTAssertEqual(KanataDefcfg.repairFallback.render(), """
+    func testRepairFallbackProfileFollowsPolicy() {
+        // ConfigurationService rule-based repair injection mirrors the user's
+        // command-actions policy instead of hardcoding danger-enable-cmd.
+        XCTAssertEqual(KanataDefcfg.repairFallback(allowCommandActions: true).render(), """
         (defcfg
           process-unmapped-keys yes
           danger-enable-cmd yes
+        )
+        """)
+        XCTAssertEqual(KanataDefcfg.repairFallback(allowCommandActions: false).render(), """
+        (defcfg
+          process-unmapped-keys yes
         )
         """)
     }
@@ -149,8 +157,8 @@ final class KanataDefcfgTests: XCTestCase {
 
     func testRepairFallbackSpliceMatchesLegacyString() {
         // ConfigurationService injects the block followed by a blank line. The legacy
-        // multiline literal rendered to exactly this byte sequence.
-        let spliced = KanataDefcfg.repairFallback.render() + "\n\n"
+        // multiline literal rendered to exactly this byte sequence (for an opted-in user).
+        let spliced = KanataDefcfg.repairFallback(allowCommandActions: true).render() + "\n\n"
         let legacy = "(defcfg\n  process-unmapped-keys yes\n  danger-enable-cmd yes\n)\n\n"
         XCTAssertEqual(spliced, legacy)
     }

--- a/Tests/KeyPathTests/Integration/ConfigGoldenFileTests.swift
+++ b/Tests/KeyPathTests/Integration/ConfigGoldenFileTests.swift
@@ -29,6 +29,12 @@ final class ConfigGoldenFileTests: XCTestCase {
         }
     }
 
+    override func tearDownWithError() throws {
+        // Mirror setUp: never leak policy state to later test classes.
+        UserDefaults.standard.removeObject(forKey: KanataCommandActionsPolicy.defaultsKey)
+        try super.tearDownWithError()
+    }
+
     // MARK: - Assertions
 
     private func normalizeConfig(_ config: String) -> String {

--- a/Tests/KeyPathTests/Integration/ConfigGoldenFileTests.swift
+++ b/Tests/KeyPathTests/Integration/ConfigGoldenFileTests.swift
@@ -21,6 +21,9 @@ final class ConfigGoldenFileTests: XCTestCase {
 
     override func setUpWithError() throws {
         try super.setUpWithError()
+        // Pin the command-actions policy to its default (unset → OFF) so golden
+        // output doesn't depend on test-runner UserDefaults state.
+        UserDefaults.standard.removeObject(forKey: KanataCommandActionsPolicy.defaultsKey)
         if shouldUpdate {
             try FileManager.default.createDirectory(at: goldenDir, withIntermediateDirectories: true)
         }

--- a/Tests/KeyPathTests/Integration/GoldenConfigs/caps-escape-hyper.actual.kbd
+++ b/Tests/KeyPathTests/Integration/GoldenConfigs/caps-escape-hyper.actual.kbd
@@ -3,7 +3,6 @@
 
 (defcfg
   process-unmapped-keys yes
-  danger-enable-cmd yes
   managed-repeat yes
   managed-repeat-unlisted no
   managed-repeat-delay 500

--- a/Tests/KeyPathTests/Integration/GoldenConfigs/caps-escape-hyper.kbd
+++ b/Tests/KeyPathTests/Integration/GoldenConfigs/caps-escape-hyper.kbd
@@ -3,7 +3,6 @@
 
 (defcfg
   process-unmapped-keys yes
-  danger-enable-cmd yes
   managed-repeat yes
   managed-repeat-unlisted no
   managed-repeat-delay 500

--- a/Tests/KeyPathTests/Integration/GoldenConfigs/default.actual.kbd
+++ b/Tests/KeyPathTests/Integration/GoldenConfigs/default.actual.kbd
@@ -3,7 +3,6 @@
 
 (defcfg
   process-unmapped-keys yes
-  danger-enable-cmd yes
   managed-repeat yes
   managed-repeat-unlisted no
   managed-repeat-delay 500

--- a/Tests/KeyPathTests/Integration/GoldenConfigs/default.kbd
+++ b/Tests/KeyPathTests/Integration/GoldenConfigs/default.kbd
@@ -3,7 +3,6 @@
 
 (defcfg
   process-unmapped-keys yes
-  danger-enable-cmd yes
   managed-repeat yes
   managed-repeat-unlisted no
   managed-repeat-delay 500

--- a/Tests/KeyPathTests/Integration/GoldenConfigs/home-row-mods.actual.kbd
+++ b/Tests/KeyPathTests/Integration/GoldenConfigs/home-row-mods.actual.kbd
@@ -3,7 +3,6 @@
 
 (defcfg
   process-unmapped-keys yes
-  danger-enable-cmd yes
   managed-repeat yes
   managed-repeat-unlisted no
   managed-repeat-delay 500

--- a/Tests/KeyPathTests/Integration/GoldenConfigs/home-row-mods.kbd
+++ b/Tests/KeyPathTests/Integration/GoldenConfigs/home-row-mods.kbd
@@ -3,7 +3,6 @@
 
 (defcfg
   process-unmapped-keys yes
-  danger-enable-cmd yes
   managed-repeat yes
   managed-repeat-unlisted no
   managed-repeat-delay 500

--- a/Tests/KeyPathTests/Integration/GoldenConfigs/remap-with-shifted-output.actual.kbd
+++ b/Tests/KeyPathTests/Integration/GoldenConfigs/remap-with-shifted-output.actual.kbd
@@ -3,7 +3,6 @@
 
 (defcfg
   process-unmapped-keys yes
-  danger-enable-cmd yes
   managed-repeat yes
   managed-repeat-unlisted no
   managed-repeat-delay 500

--- a/Tests/KeyPathTests/Integration/GoldenConfigs/remap-with-shifted-output.kbd
+++ b/Tests/KeyPathTests/Integration/GoldenConfigs/remap-with-shifted-output.kbd
@@ -3,7 +3,6 @@
 
 (defcfg
   process-unmapped-keys yes
-  danger-enable-cmd yes
   managed-repeat yes
   managed-repeat-unlisted no
   managed-repeat-delay 500

--- a/Tests/KeyPathTests/Integration/GoldenConfigs/simple-remap-a-to-b.actual.kbd
+++ b/Tests/KeyPathTests/Integration/GoldenConfigs/simple-remap-a-to-b.actual.kbd
@@ -3,7 +3,6 @@
 
 (defcfg
   process-unmapped-keys yes
-  danger-enable-cmd yes
   managed-repeat yes
   managed-repeat-unlisted no
   managed-repeat-delay 500

--- a/Tests/KeyPathTests/Integration/GoldenConfigs/simple-remap-a-to-b.kbd
+++ b/Tests/KeyPathTests/Integration/GoldenConfigs/simple-remap-a-to-b.kbd
@@ -3,7 +3,6 @@
 
 (defcfg
   process-unmapped-keys yes
-  danger-enable-cmd yes
   managed-repeat yes
   managed-repeat-unlisted no
   managed-repeat-delay 500

--- a/Tests/KeyPathTests/Integration/GoldenConfigs/vim-navigation.actual.kbd
+++ b/Tests/KeyPathTests/Integration/GoldenConfigs/vim-navigation.actual.kbd
@@ -3,7 +3,6 @@
 
 (defcfg
   process-unmapped-keys yes
-  danger-enable-cmd yes
   managed-repeat yes
   managed-repeat-unlisted no
   managed-repeat-delay 500

--- a/Tests/KeyPathTests/Integration/GoldenConfigs/vim-navigation.kbd
+++ b/Tests/KeyPathTests/Integration/GoldenConfigs/vim-navigation.kbd
@@ -3,7 +3,6 @@
 
 (defcfg
   process-unmapped-keys yes
-  danger-enable-cmd yes
   managed-repeat yes
   managed-repeat-unlisted no
   managed-repeat-delay 500

--- a/Tests/KeyPathTests/Services/ConfigurationServiceTests.swift
+++ b/Tests/KeyPathTests/Services/ConfigurationServiceTests.swift
@@ -759,6 +759,9 @@ class ConfigurationServiceTests: XCTestCase {
     }
 
     func testRepairConfiguration_MissingDefcfg() async throws {
+        // Pin the command-actions policy to its default (unset → OFF) so the
+        // repaired header is deterministic regardless of prior test-runner state.
+        UserDefaults.standard.removeObject(forKey: KanataCommandActionsPolicy.defaultsKey)
         let brokenConfig = """
         (defsrc caps)
         (deflayer base esc)
@@ -777,9 +780,9 @@ class ConfigurationServiceTests: XCTestCase {
             repairedConfig.contains("process-unmapped-keys yes"),
             "Repaired config should have safe defaults"
         )
-        XCTAssertTrue(
-            repairedConfig.contains("danger-enable-cmd yes"),
-            "Repaired config should include command key safety toggle"
+        XCTAssertFalse(
+            repairedConfig.contains("danger-enable-cmd"),
+            "Repaired config must not grant cmd execution unless the user opted in (KanataCommandActionsPolicy defaults OFF)"
         )
     }
 

--- a/Tests/KeyPathTests/Services/ConfigurationServiceTests.swift
+++ b/Tests/KeyPathTests/Services/ConfigurationServiceTests.swift
@@ -823,6 +823,7 @@ class ConfigurationServiceTests: XCTestCase {
         // Pin the command-actions policy to its default (unset → OFF) so the
         // repaired header is deterministic regardless of prior test-runner state.
         UserDefaults.standard.removeObject(forKey: KanataCommandActionsPolicy.defaultsKey)
+        defer { UserDefaults.standard.removeObject(forKey: KanataCommandActionsPolicy.defaultsKey) }
         let brokenConfig = """
         (defsrc caps)
         (deflayer base esc)

--- a/Tests/KeyPathTests/Services/ConfigurationServiceTests.swift
+++ b/Tests/KeyPathTests/Services/ConfigurationServiceTests.swift
@@ -758,6 +758,67 @@ class ConfigurationServiceTests: XCTestCase {
         XCTAssertTrue(safeContent.contains("esc"), "Safe config should use escape key")
     }
 
+    /// Regression: startup bootstrap regenerates (and saves) the config without any
+    /// prior reload(), so generateConfiguration must grandfather the cmd-actions
+    /// policy from the on-disk config BEFORE generating — otherwise a hand-written
+    /// (cmd ...) config would be overwritten with the header stripped.
+    func testGenerateConfiguration_GrandfathersCmdUsageFromExistingConfigBeforeRegenerating() async throws {
+        UserDefaults.standard.removeObject(forKey: KanataCommandActionsPolicy.defaultsKey)
+        defer { UserDefaults.standard.removeObject(forKey: KanataCommandActionsPolicy.defaultsKey) }
+
+        let existingConfig = """
+        (defcfg
+          process-unmapped-keys yes
+          danger-enable-cmd yes
+        )
+        (defalias open-notes (cmd open -a Notes))
+        (defsrc caps)
+        (deflayer base @open-notes)
+        """
+        try existingConfig.write(
+            toFile: configService.configurationPath, atomically: true, encoding: .utf8
+        )
+
+        let generated = try await configService.generateConfiguration(ruleCollections: [])
+
+        XCTAssertTrue(
+            KanataCommandActionsPolicy.isEnabled(),
+            "Regenerating over a config that uses (cmd ...) must grandfather the policy ON"
+        )
+        XCTAssertTrue(
+            generated.content.contains("danger-enable-cmd yes"),
+            "Grandfathered regeneration must keep emitting the danger-enable-cmd header"
+        )
+    }
+
+    func testGenerateConfiguration_HeaderOnlyLegacyConfigDoesNotGrandfather() async throws {
+        UserDefaults.standard.removeObject(forKey: KanataCommandActionsPolicy.defaultsKey)
+        defer { UserDefaults.standard.removeObject(forKey: KanataCommandActionsPolicy.defaultsKey) }
+
+        let legacyGenerated = """
+        (defcfg
+          process-unmapped-keys yes
+          danger-enable-cmd yes
+        )
+        (defsrc caps)
+        (deflayer base (push-msg "layer:base"))
+        """
+        try legacyGenerated.write(
+            toFile: configService.configurationPath, atomically: true, encoding: .utf8
+        )
+
+        let generated = try await configService.generateConfiguration(ruleCollections: [])
+
+        XCTAssertFalse(
+            KanataCommandActionsPolicy.isEnabled(),
+            "The legacy hardcoded header alone must not grandfather cmd execution back on"
+        )
+        XCTAssertFalse(
+            generated.content.contains("danger-enable-cmd"),
+            "Regenerated config must drop the unused danger-enable-cmd grant"
+        )
+    }
+
     func testRepairConfiguration_MissingDefcfg() async throws {
         // Pin the command-actions policy to its default (unset → OFF) so the
         // repaired header is deterministic regardless of prior test-runner state.


### PR DESCRIPTION
Audit task **M1.1** — stop granting the root kanata daemon arbitrary shell-command execution by default.

## Problem

Every generated config hardcoded `danger-enable-cmd yes`, allowing `(cmd ...)` actions to spawn processes **as root** (kanata runs under the LaunchDaemon). No KeyPath feature uses this: launchers, URL/folder/script actions, system actions, notifications, and layer signals are all `(push-msg ...)` TCP messages executed app-side by `ActionDispatcher` — and in the bundled kanata fork's parser, `push-msg` is **not** gated by `danger-enable-cmd` (only the `(cmd ...)`/`cmd-log`/clipboard-cmd family checks `is_cmd_enabled`). The grant was pure, unused attack surface for ~100% of users.

## Change

- **`KanataCommandActionsPolicy`** (UserDefaults-backed, default **OFF**) decides whether generated configs emit the header line. `generateFromCollections` takes `allowCommandActions` defaulting to the policy; `KanataDefcfg.repairFallback` takes the posture from its caller instead of hardcoding `yes`; the AI repair prompt mirrors the policy.
- **Grandfathering:** the first time a pre-existing config is seen, if it actually *uses* `(cmd ...)` actions the policy is recorded ON, so regeneration keeps the header and nothing breaks silently. The header line alone does **not** grandfather — every legacy generated config carries it without using cmd. The check runs at the top of `generateConfiguration()` (the choke point for all regeneration paths, including startup bootstrap which saves without any prior `reload()`) plus in `reload()` for read-only paths.
- **Settings → Experimental:** "Config Command Actions" toggle, confirm-on-enable with an explicit runs-as-root warning; flipping it regenerates + reloads the config via `.configAffectingPreferenceChanged`.
- **Loud failure, never silent:** a config with `(cmd ...)` while the policy is OFF fails `kanata --check` with kanata's own "put danger-enable-cmd yes in defcfg" error, surfaced by the existing validation UX.

## User impact

- New + existing users of only KeyPath-built features: zero visible change.
- Existing configs are never rewritten on upgrade; on the next rule save the header is dropped (nothing generated uses it).
- Hand-edited `(cmd ...)` configs: grandfathered ON automatically; the toggle shows the state and allows opting out.

## Review gate

7-angle review found one real ordering bug (grandfathering hooked only into `reload()` ran too late vs. startup bootstrap regeneration) — fixed in the second commit with regression tests covering both grandfather directions. The "malformed regex" candidate was refuted empirically (trailing `-` in a character class is literal); detector behavior is pinned by unit tests.

## Tests

New `KanataCommandActionsPolicyTests` (default posture, opt-in, grandfather semantics, detector false-positive guards for push-msg/header/alias names), defcfg + repair test updates, golden fixtures regenerated without the header, policy pinned in golden/repair test setup for determinism.

https://claude.ai/code/session_01Rso6kv5BgJrBCHxNWH4h7P

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rso6kv5BgJrBCHxNWH4h7P)_