### PR TITLE
QA smoke fix: HRL Toggles drops f/j keys to sidestep Home Row Arrows collision

### DIFF
--- a/Scripts/qa-hrl-toggles-smoke.sh
+++ b/Scripts/qa-hrl-toggles-smoke.sh
@@ -59,6 +59,14 @@ assert_not_contains() {
 # Apply a desired enabled-state to a set of collections and (optionally)
 # flip HRL Toggles' toggleMode. Identifies collections by name to stay
 # robust against UUID drift.
+#
+# Home Row Arrows is a system-default that maps the `f` key to its
+# Home-Arrows layer. The catalog default HRL Toggles config also assigns
+# `f` to its `nav` mapping, which triggers the existing collision detector
+# (good — that's working as intended). To exercise the safety-net code
+# path under test, the script drops `f` from HRL Toggles' enabled keys so
+# the smoke runs past the collision check. Realistic users would either
+# disable Home Row Arrows or reconfigure HRL Toggles' keys.
 apply_state() {
   local toggle_mode="$1"      # whileHeld | toggle
   local enable_companions="$2" # true | false
@@ -91,6 +99,16 @@ for collection in collections:
                 f"Unexpected configuration type for HRL Toggles: {configuration.get('type')}"
             )
         configuration["toggleMode"] = toggle_mode
+        # Drop `f` and `j` to sidestep the Home Row Arrows collision (both nav-targeted).
+        # The remaining keys still reference fun/sym/num, which is what exercises the
+        # stub-deflayer safety net.
+        configuration["enabledKeys"] = ["a", "s", "d", "k", "l", ";"]
+        if isinstance(configuration.get("layerAssignments"), dict):
+            for key in ("f", "j"):
+                configuration["layerAssignments"].pop(key, None)
+        if isinstance(configuration.get("modifierAssignments"), dict):
+            for key in ("f", "j"):
+                configuration["modifierAssignments"].pop(key, None)
         collection["configuration"] = configuration
     elif name in companion_names:
         collection["isEnabled"] = enable_companions


### PR DESCRIPTION
Follow-up to [#872](https://github.com/malpern/KeyPath/pull/872). The smoke script as merged was running against the catalog-default HRL Toggles enabledKeys, which assign `f` and `j` to the `nav` layer — but Home Row Arrows is a system-default that also maps `f`. The existing collision detector correctly fires before the stub-deflayer safety net the smoke is meant to exercise can be reached.

## What changed

The Python config-mutation step now drops `f` and `j` from HRL Toggles' enabled keys, and removes them from the layerAssignments + modifierAssignments dicts. The remaining `a`, `s`, `d`, `k`, `l`, `;` keys still point at the `fun` / `sym` / `num` layers, which is what exercises the safety net introduced in [#871](https://github.com/malpern/KeyPath/pull/871).

A real user reaching this combination would either disable Home Row Arrows or reconfigure HRL Toggles. The smoke mirrors the second choice.

## Verification

Ran against the freshly deployed app (`./Scripts/quick-deploy.sh && ./Scripts/qa-hrl-toggles-smoke.sh`):

```
==> case 1: HRL Toggles whileHeld mode, companions disabled
==> case 2: HRL Toggles toggle mode, companions disabled (stub-deflayer safety net)
==> case 3: HRL Toggles toggle mode, companions ENABLED (no stubs needed)
HRL Toggles smoke passed. Restoring original KeyPath config.
```

All three cases pass. Closes the loop on the safety-net being live and verifiable in an installed build.

## Bonus finding worth noting

This is a good signal for the [#865](https://github.com/malpern/KeyPath/issues/865) sprint epic: the existing collision detector is already a first line of defense against the HRL+Arrows class of misconfiguration, and its message ("Either change the key assignments so they don't overlap, or disable one") is exactly the kind of actionable copy the new prerequisite dialogs should mirror.