### PR TITLE
Fix #881: make config restore non-destructive (copy-over-then-prune)

### DIFF
--- a/Sources/KeyPathAppKit/CLI/ConfigFacade.swift
+++ b/Sources/KeyPathAppKit/CLI/ConfigFacade.swift
@@ -156,8 +156,17 @@ public struct ConfigFacade: Sendable {
             throw Self.error("Backup path resolves to the active config directory: \(sourceURL.path)")
         }
 
-        try removeDirectoryContents(at: restoreTargetURL, fileManager: fileManager)
-        try copyDirectoryContents(from: resolvedSourceURL, to: restoreTargetURL, fileManager: fileManager)
+        // Copy-over first, prune extras second: a failure at any point leaves the
+        // user with a superset of their config, never a gutted directory. The
+        // previous wipe-then-copy ordering lost data when a transient
+        // temp_validation_*.kbd file vanished mid-wipe and aborted the restore
+        // before anything was copied back (#881).
+        try overwriteDirectoryContents(from: resolvedSourceURL, to: restoreTargetURL, fileManager: fileManager)
+        try pruneExtraneousItems(
+            at: restoreTargetURL,
+            keeping: Set(fileManager.contentsOfDirectory(atPath: resolvedSourceURL.path)),
+            fileManager: fileManager
+        )
 
         let reloadSuccess = reload ? await tcpReload() : nil
         return try CLIConfigRestoreResult(
@@ -275,21 +284,75 @@ public struct ConfigFacade: Sendable {
             includingPropertiesForKeys: nil
         )
         for item in contents {
-            try fileManager.copyItem(
-                at: item,
-                to: destination.appendingPathComponent(item.lastPathComponent)
-            )
+            if isTransientValidationArtifact(item.lastPathComponent) { continue }
+            do {
+                try fileManager.copyItem(
+                    at: item,
+                    to: destination.appendingPathComponent(item.lastPathComponent)
+                )
+            } catch where isFileNotFound(error) {
+                // Vanished between enumeration and copy — transient, skip.
+            }
         }
     }
 
-    private func removeDirectoryContents(at directory: URL, fileManager: FileManager) throws {
+    /// Copy every backup item over the destination, replacing existing entries
+    /// in place. Unlike wipe-then-copy, an interruption never leaves the
+    /// destination with less data than it started with.
+    private func overwriteDirectoryContents(from source: URL, to destination: URL, fileManager: FileManager) throws {
+        let contents = try fileManager.contentsOfDirectory(
+            at: source,
+            includingPropertiesForKeys: nil
+        )
+        for item in contents {
+            if isTransientValidationArtifact(item.lastPathComponent) { continue }
+            let target = destination.appendingPathComponent(item.lastPathComponent)
+            do {
+                try fileManager.removeItem(at: target)
+            } catch where isFileNotFound(error) {
+                // Nothing to replace — fine.
+            }
+            try fileManager.copyItem(at: item, to: target)
+        }
+    }
+
+    /// Remove destination items that aren't part of the backup. Tolerates
+    /// files that vanish mid-iteration (their owner cleaned up — that's the
+    /// goal state) and skips transient validation artifacts entirely.
+    private func pruneExtraneousItems(at directory: URL, keeping names: Set<String>, fileManager: FileManager) throws {
         let contents = try fileManager.contentsOfDirectory(
             at: directory,
             includingPropertiesForKeys: nil
         )
         for item in contents {
-            try fileManager.removeItem(at: item)
+            let name = item.lastPathComponent
+            if names.contains(name) || isTransientValidationArtifact(name) { continue }
+            do {
+                try fileManager.removeItem(at: item)
+            } catch where isFileNotFound(error) {
+                // Already gone — pruning succeeded by other means.
+            }
         }
+    }
+
+    /// `temp_validation_*.kbd` files (and their `.sb-*` safe-save shadows) are
+    /// written into the config directory by ConfigurationService validation and
+    /// cleaned up by their owner. Racing that cleanup aborted restores (#881).
+    private func isTransientValidationArtifact(_ name: String) -> Bool {
+        name.hasPrefix("temp_validation_")
+    }
+
+    private func isFileNotFound(_ error: Error) -> Bool {
+        let nsError = error as NSError
+        if nsError.domain == NSCocoaErrorDomain,
+           nsError.code == NSFileNoSuchFileError || nsError.code == NSFileReadNoSuchFileError
+        {
+            return true
+        }
+        if nsError.domain == NSPOSIXErrorDomain, nsError.code == Int(ENOENT) {
+            return true
+        }
+        return false
     }
 
     private func sameResolvedPath(_ lhs: URL, _ rhs: URL) -> Bool {

--- a/Tests/KeyPathTests/CLI/ConfigFacadeTests.swift
+++ b/Tests/KeyPathTests/CLI/ConfigFacadeTests.swift
@@ -57,6 +57,74 @@ final class ConfigFacadeTests: XCTestCase {
         XCTAssertTrue(isSymbolicLink(configLink), "Restore should preserve the configured ~/.config/keypath symlink.")
     }
 
+    // MARK: - #881 regression: restore must never gut the config dir
+
+    func testRestoreConfigPrunesExtraneousItemsButKeepsBackupContents() async throws {
+        let configDir = tempRoot.appendingPathComponent("config", isDirectory: true)
+        let backup = tempRoot.appendingPathComponent("backup", isDirectory: true)
+        try FileManager.default.createDirectory(at: configDir, withIntermediateDirectories: true)
+
+        try "rules".write(to: configDir.appendingPathComponent("RuleCollections.json"), atomically: true, encoding: .utf8)
+        try "kbd".write(to: configDir.appendingPathComponent("keypath.kbd"), atomically: true, encoding: .utf8)
+
+        let facade = ConfigFacade(configDirectory: configDir.path)
+        _ = try facade.backupConfig(outputPath: backup.path)
+
+        // Post-backup drift: one mutation, one new file that isn't in the backup.
+        try "mutated".write(to: configDir.appendingPathComponent("RuleCollections.json"), atomically: true, encoding: .utf8)
+        try "extra".write(to: configDir.appendingPathComponent("DeviceSelection.json"), atomically: true, encoding: .utf8)
+
+        _ = try await facade.restoreConfig(from: backup.path, reload: false)
+
+        let items = try FileManager.default.contentsOfDirectory(atPath: configDir.path).sorted()
+        XCTAssertEqual(items, ["RuleCollections.json", "keypath.kbd"], "Extraneous post-backup files should be pruned")
+        XCTAssertEqual(
+            try String(contentsOf: configDir.appendingPathComponent("RuleCollections.json"), encoding: .utf8),
+            "rules",
+            "Mutated file should be restored to its backup contents"
+        )
+    }
+
+    func testRestoreConfigSucceedsDespiteTransientValidationArtifact() async throws {
+        let configDir = tempRoot.appendingPathComponent("config", isDirectory: true)
+        let backup = tempRoot.appendingPathComponent("backup", isDirectory: true)
+        try FileManager.default.createDirectory(at: configDir, withIntermediateDirectories: true)
+
+        try "rules".write(to: configDir.appendingPathComponent("RuleCollections.json"), atomically: true, encoding: .utf8)
+
+        let facade = ConfigFacade(configDirectory: configDir.path)
+        _ = try facade.backupConfig(outputPath: backup.path)
+
+        // The #881 trigger: a transient validation temp file appears in the
+        // config dir before restore. The restore must neither fail on it nor
+        // treat it as data to prune-race against.
+        try "tmp".write(
+            to: configDir.appendingPathComponent("temp_validation_5C63A449.kbd.sb-d92874d0-FutVpa"),
+            atomically: true, encoding: .utf8
+        )
+
+        _ = try await facade.restoreConfig(from: backup.path, reload: false)
+
+        XCTAssertEqual(
+            try String(contentsOf: configDir.appendingPathComponent("RuleCollections.json"), encoding: .utf8),
+            "rules"
+        )
+    }
+
+    func testBackupConfigSkipsTransientValidationArtifacts() throws {
+        let configDir = tempRoot.appendingPathComponent("config", isDirectory: true)
+        let backup = tempRoot.appendingPathComponent("backup", isDirectory: true)
+        try FileManager.default.createDirectory(at: configDir, withIntermediateDirectories: true)
+
+        try "rules".write(to: configDir.appendingPathComponent("RuleCollections.json"), atomically: true, encoding: .utf8)
+        try "tmp".write(to: configDir.appendingPathComponent("temp_validation_AB12.kbd"), atomically: true, encoding: .utf8)
+
+        let facade = ConfigFacade(configDirectory: configDir.path)
+        let result = try facade.backupConfig(outputPath: backup.path)
+
+        XCTAssertEqual(result.copiedItems, ["RuleCollections.json"], "Backups should not capture transient validation temp files")
+    }
+
     func testRestoreConfigRejectsBackupPathThatResolvesToActiveConfigDirectory() async throws {
         let liveTarget = tempRoot.appendingPathComponent("dotfiles-keypath", isDirectory: true)
         let configLink = tempRoot.appendingPathComponent(".config/keypath", isDirectory: true)


### PR DESCRIPTION
Fixes [#881](https://github.com/malpern/KeyPath/issues/881) — the restore data-loss bug the smoke suite caught Wednesday night. **Release-blocker fix.**

## Root cause

`restoreConfig` did wipe-then-copy. The wipe enumerated the config dir, hit a transient `temp_validation_*.kbd` file (written into the config dir by `ConfigurationService` validation, cleaned up asynchronously), and by the time `removeItem` ran the file was gone — the throw aborted the restore **after partial deletion, before any copy**. Result: gutted config dir + the pre-restore collection state leaking into the live config.

## The fix

Inverted ordering plus hardening at every step:

| Step | Before | After |
|---|---|---|
| Restore | wipe everything → copy | **copy-over in place → prune extras** — interruption always leaves a superset, never less |
| Prune / wipe | any `removeItem` failure aborts | ENOENT tolerated (file vanished = pruning succeeded) |
| Transient artifacts | enumerated like real data | `temp_validation_*` skipped in backup, copy, and prune |
| Backup copy | vanished file aborts backup | ENOENT tolerated, file skipped |

## Tests

Three regressions added to `ConfigFacadeTests` (7/7 pass):
- restore prunes post-backup extras but keeps backup contents
- restore succeeds with a transient validation artifact present — named for the exact #881 trigger file
- backup skips `temp_validation_*` files

## Follow-ups (not this PR)

- Move validation temp files out of the config dir entirely (post-1.0)
- Smoke-lib manifest verification so a failed restore can never hide behind a PASS — going into [#880](https://github.com/malpern/KeyPath/pull/880) next