### PR TITLE
Redirect stuck-key incident snapshots to temp dir during tests

### DIFF
--- a/Sources/KeyPathAppKit/Services/Monitoring/StuckKeyRecoveryService.swift
+++ b/Sources/KeyPathAppKit/Services/Monitoring/StuckKeyRecoveryService.swift
@@ -94,9 +94,21 @@ final class StuckKeyRecoveryService {
         }.value
     }
 
+    /// Where incident snapshots are written. Tests must never touch the real directory:
+    /// it holds genuine stuck-key evidence and the prune-to-20 pass in
+    /// `writeSnapshotToDisk` would silently delete it, so test runs are redirected to a
+    /// temp location.
+    nonisolated static var diagnosticsDirectory: URL {
+        if TestEnvironment.isRunningTests {
+            return FileManager.default.temporaryDirectory
+                .appendingPathComponent("KeyPathTests/stuck-key-incidents", isDirectory: true)
+        }
+        return FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Logs/KeyPath/stuck-key-incidents", isDirectory: true)
+    }
+
     private nonisolated static func writeSnapshotToDisk(_ snapshot: DiagnosticSnapshotData) {
-        let diagnosticsDir = FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent("Library/Logs/KeyPath/stuck-key-incidents")
+        let diagnosticsDir = diagnosticsDirectory
 
         let timestamp = ISO8601DateFormatter().string(from: Date())
         let safeTimestamp = timestamp.replacingOccurrences(of: ":", with: "-")

--- a/Tests/KeyPathTests/Services/StuckKeyRecoveryServiceTests.swift
+++ b/Tests/KeyPathTests/Services/StuckKeyRecoveryServiceTests.swift
@@ -134,6 +134,25 @@ final class StuckKeyRecoveryServiceTests: KeyPathTestCase {
         XCTAssertEqual(restartCallCount, 1, "Should not fire second restart while first is in progress")
     }
 
+    // MARK: - Diagnostic Snapshot Isolation
+
+    func testDiagnosticSnapshotsRedirectToTempDirectoryDuringTests() {
+        let dir = StuckKeyRecoveryService.diagnosticsDirectory
+        let realDir = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Logs/KeyPath/stuck-key-incidents")
+
+        XCTAssertNotEqual(
+            dir.standardizedFileURL.path, realDir.standardizedFileURL.path,
+            "Test runs must not write into the real incident directory — the prune-to-20 pass would delete genuine stuck-key evidence"
+        )
+        XCTAssertTrue(
+            dir.standardizedFileURL.path.hasPrefix(
+                FileManager.default.temporaryDirectory.standardizedFileURL.path
+            ),
+            "Test snapshots should land in the temp directory, got \(dir.standardizedFileURL.path)"
+        )
+    }
+
     // MARK: - Helpers
 
     private func makeCorrelation(


### PR DESCRIPTION
## Summary

`StuckKeyRecoveryService.writeSnapshotToDisk` wrote incident captures to the real `~/Library/Logs/KeyPath/stuck-key-incidents/` directory even when running under `swift test` — the recovery-path unit tests (`testTriggersRecoveryForStuckKey`, `testDebouncesPreviousRecoveries`, …) exercise the full snapshot write. Because the same function prunes the directory to the 20 newest files, every test run risked silently deleting genuine MAL-57 stuck-key evidence. At the time of the fix the real directory was sitting at **exactly 20 files**, so the very next test-written snapshot would have evicted a real incident capture.

- The snapshot directory is now a computed `diagnosticsDirectory` helper: when `TestEnvironment.isRunningTests` it returns `<temp>/KeyPathTests/stuck-key-incidents/`; otherwise the production path is unchanged.
- Both the snapshot write and the prune pass go through the helper, so test-run pruning only ever touches temp files.
- New guard test `testDiagnosticSnapshotsRedirectToTempDirectoryDuringTests` asserts the redirect (differs from the real path, lives under the temp directory).

## Test plan

- [x] `swift test --filter StuckKeyRecoveryServiceTests` — all 7 tests pass (6 existing + new guard test)
- [x] Full `swift test` — 778 tests in 85 suites, zero failures
- [x] Test-run logs show snapshots landing in `/var/folders/…/T/KeyPathTests/stuck-key-incidents/`
- [x] Before/after `diff` of the real `~/Library/Logs/KeyPath/stuck-key-incidents/` across all test runs: byte-for-byte identical, still 20 files
- [x] Review gate (`/code-review` high) run against the branch diff — all correctness candidates refuted; systemic follow-up (other services writing to real user dirs in tests) spun off separately