### PR TITLE
Sandbox ActivityLogStorage paths and Keychain key during unit tests

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -305,6 +305,7 @@ let package = Package(
                 "KeyPathAppKit",
                 "KeyPathCLI",
                 "KeyPathCore",
+                "KeyPathInsights",
                 "KeyPathPermissions",
                 "KeyPathDaemonLifecycle",
                 "KeyPathWizardCore",

--- a/Sources/KeyPathCore/AppPaths.swift
+++ b/Sources/KeyPathCore/AppPaths.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// Resolves user-scoped KeyPath directories for diagnostics and support data.
+///
+/// During unit tests every directory is redirected into a per-process sandbox
+/// under the system temporary directory so tests never pollute or delete real
+/// diagnostic data (crash logs, incident snapshots, telemetry). Production
+/// paths are unchanged. Services should resolve user-home paths through this
+/// type instead of hand-rolling `TestEnvironment.isRunningTests` checks.
+public enum AppPaths {
+    /// Per-process sandbox root used in place of the real home directory while tests run.
+    public static var testSandboxDirectory: URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent(
+                "keypath-tests-\(ProcessInfo.processInfo.processIdentifier)",
+                isDirectory: true
+            )
+    }
+
+    /// `~/Library/Logs/KeyPath` (sandboxed during tests).
+    public static var logsDirectory: URL {
+        userDirectory("Library/Logs/KeyPath")
+    }
+
+    /// `~/Library/Application Support/KeyPath` (sandboxed during tests).
+    public static var applicationSupportDirectory: URL {
+        userDirectory("Library/Application Support/KeyPath")
+    }
+
+    /// Append-only crash/service-failure log shared by the app-state and
+    /// daemon monitors: `<logsDirectory>/crashes.log`.
+    public static var crashLogFile: URL {
+        logsDirectory.appendingPathComponent("crashes.log")
+    }
+
+    private static func userDirectory(_ relativePath: String) -> URL {
+        let root = TestEnvironment.isRunningTests
+            ? testSandboxDirectory
+            : FileManager.default.homeDirectoryForCurrentUser
+        return root.appendingPathComponent(relativePath, isDirectory: true)
+    }
+}

--- a/Sources/KeyPathInsights/ActivityLogging/Services/ActivityLogEncryption.swift
+++ b/Sources/KeyPathInsights/ActivityLogging/Services/ActivityLogEncryption.swift
@@ -8,7 +8,12 @@ import Security
 public actor ActivityLogEncryption {
     // MARK: - Constants
 
-    private static let keychainService = "com.keypath.activitylog"
+    /// Unit tests use a separate Keychain service so a test calling
+    /// `deleteKey()` (e.g. via `ActivityLogStorage.clearAll()`) can never
+    /// delete the production key and orphan real encrypted logs.
+    static let keychainService = TestEnvironment.isRunningTests
+        ? "com.keypath.activitylog.tests"
+        : "com.keypath.activitylog"
     private static let keychainAccount = "encryption-key"
 
     // MARK: - Errors

--- a/Sources/KeyPathInsights/ActivityLogging/Services/ActivityLogStorage.swift
+++ b/Sources/KeyPathInsights/ActivityLogging/Services/ActivityLogStorage.swift
@@ -43,24 +43,22 @@ public actor ActivityLogStorage {
 
     public static let shared = ActivityLogStorage()
 
+    /// ~/Library/Application Support/KeyPath/ActivityLog
+    /// (redirected to a temp sandbox during tests via AppPaths).
+    ///
+    /// Activity logging is an optional, opt-in feature — path resolution must
+    /// degrade gracefully rather than crash the whole app. AppPaths resolves
+    /// the conventional home-relative path (the same one the old
+    /// `FileManager.urls(for:)` fallback produced) and cannot fail.
+    public static var defaultBaseDirectory: URL {
+        AppPaths.applicationSupportDirectory
+            .appendingPathComponent(directoryName, isDirectory: true)
+    }
+
     private init() {
         encryption = ActivityLogEncryption.shared
 
-        // Use ~/Library/Application Support/KeyPath/ActivityLog/
-        // Activity logging is an optional, opt-in feature — a missing
-        // Application Support directory must degrade gracefully rather than
-        // crash the whole app, so fall back to the conventional home-relative
-        // path if the API lookup ever fails.
-        let appSupportResult = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)
-        if appSupportResult.isEmpty {
-            AppLogger.shared.warn("⚠️ [ActivityLogStorage] Application Support directory unavailable — using NSHomeDirectory fallback")
-        }
-        let appSupport = appSupportResult.first ?? URL(fileURLWithPath: NSHomeDirectory())
-            .appendingPathComponent("Library")
-            .appendingPathComponent("Application Support")
-        baseDirectory = appSupport
-            .appendingPathComponent("KeyPath")
-            .appendingPathComponent(Self.directoryName)
+        baseDirectory = Self.defaultBaseDirectory
 
         encoder = JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601

--- a/Sources/KeyPathInsights/ActivityLogging/Services/ActivityLogStorage.swift
+++ b/Sources/KeyPathInsights/ActivityLogging/Services/ActivityLogStorage.swift
@@ -50,7 +50,7 @@ public actor ActivityLogStorage {
     /// degrade gracefully rather than crash the whole app. AppPaths resolves
     /// the conventional home-relative path (the same one the old
     /// `FileManager.urls(for:)` fallback produced) and cannot fail.
-    public static var defaultBaseDirectory: URL {
+    static var defaultBaseDirectory: URL {
         AppPaths.applicationSupportDirectory
             .appendingPathComponent(directoryName, isDirectory: true)
     }

--- a/Tests/KeyPathTests/Services/ActivityLogStorageSandboxTests.swift
+++ b/Tests/KeyPathTests/Services/ActivityLogStorageSandboxTests.swift
@@ -1,0 +1,32 @@
+import KeyPathCore
+import KeyPathInsights
+import XCTest
+
+/// Guards against activity-log tests writing to (or deleting from) the real
+/// `~/Library/Application Support/KeyPath/ActivityLog` directory. The storage
+/// path must resolve through `AppPaths`, which redirects into a per-process
+/// temp sandbox while tests run. A regression here means any test touching
+/// `ActivityLogStorage.shared` can pollute or destroy genuine activity logs.
+final class ActivityLogStorageSandboxTests: XCTestCase {
+    private var realSupportDir: String {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Application Support/KeyPath", isDirectory: true).path
+    }
+
+    func testDefaultBaseDirectoryIsSandboxed() {
+        // The redirect only engages when test detection works; assert it first
+        // so a detection regression fails loudly instead of vacuously passing.
+        XCTAssertTrue(TestEnvironment.isRunningTests)
+
+        let dir = ActivityLogStorage.defaultBaseDirectory
+        XCTAssertTrue(
+            dir.path.hasPrefix(AppPaths.testSandboxDirectory.path),
+            "\(dir.path) must live under the test sandbox \(AppPaths.testSandboxDirectory.path)"
+        )
+        XCTAssertFalse(
+            dir.path.hasPrefix(realSupportDir),
+            "\(dir.path) must not point at the real Application Support directory during tests"
+        )
+        XCTAssertEqual(dir.lastPathComponent, "ActivityLog")
+    }
+}

--- a/Tests/KeyPathTests/Services/ActivityLogStorageSandboxTests.swift
+++ b/Tests/KeyPathTests/Services/ActivityLogStorageSandboxTests.swift
@@ -1,5 +1,5 @@
 import KeyPathCore
-import KeyPathInsights
+@testable import KeyPathInsights
 import XCTest
 
 /// Guards against activity-log tests writing to (or deleting from) the real
@@ -18,15 +18,22 @@ final class ActivityLogStorageSandboxTests: XCTestCase {
         // so a detection regression fails loudly instead of vacuously passing.
         XCTAssertTrue(TestEnvironment.isRunningTests)
 
-        let dir = ActivityLogStorage.defaultBaseDirectory
+        let dir = ActivityLogStorage.defaultBaseDirectory.standardizedFileURL
+        let sandbox = AppPaths.testSandboxDirectory.standardizedFileURL
         XCTAssertTrue(
-            dir.path.hasPrefix(AppPaths.testSandboxDirectory.path),
-            "\(dir.path) must live under the test sandbox \(AppPaths.testSandboxDirectory.path)"
+            dir.path.hasPrefix(sandbox.path),
+            "\(dir.path) must live under the test sandbox \(sandbox.path)"
         )
         XCTAssertFalse(
             dir.path.hasPrefix(realSupportDir),
             "\(dir.path) must not point at the real Application Support directory during tests"
         )
         XCTAssertEqual(dir.lastPathComponent, "ActivityLog")
+    }
+
+    func testKeychainServiceIsSandboxed() {
+        // clearAll() deletes the encryption key; during tests that must target
+        // a separate Keychain item, never the production key.
+        XCTAssertEqual(ActivityLogEncryption.keychainService, "com.keypath.activitylog.tests")
     }
 }


### PR DESCRIPTION
## Summary

`ActivityLogStorage` resolved its base directory to the real `~/Library/Application Support/KeyPath/ActivityLog` in its singleton init, so any unit test touching `ActivityLogStorage.shared` could pollute or delete real activity-log data.

- Introduce `AppPaths` (KeyPathCore): resolves user-scoped KeyPath directories, redirected into a per-process temp sandbox while `TestEnvironment.isRunningTests`. Production paths unchanged.
- Route `ActivityLogStorage`'s base directory through `AppPaths.applicationSupportDirectory` via a new `defaultBaseDirectory`. The production path is byte-identical to before (the home-relative path the old `FileManager.urls(for:)` fallback produced), and resolution can no longer fail, preserving the graceful-degradation guarantee.
- Review gate finding: the path sandbox alone left `clearAll()` → `deleteKey()` pointed at the real Keychain item — a test could orphan real encrypted logs permanently. Tests now use a separate `com.keypath.activitylog.tests` Keychain service.
- Add `KeyPathInsights` to the `KeyPathTests` target and a sandbox regression test (`ActivityLogStorageSandboxTests`).

## Coordination note

`Sources/KeyPathCore/AppPaths.swift` is a verbatim copy of the (uncommitted) file in the in-flight `eloquent-cannon` worktree, which applies the same pattern to crash logs, incident snapshots, and telemetry. Landing this first means that branch rebases cleanly (identical content) and drops its duplicate copy.

## Testing

- New `ActivityLogStorageSandboxTests` (sandboxed path + sandboxed Keychain service) pass.
- Full safe lane (`test-fast.sh --full`) run 2× with this change: only failures are `HardViewSnapshotTests.testPackDetailCapsLockRemap` (also fails on clean master — pre-existing) plus one run-to-run environment flake (`RecordingCoordinatorTests`); `CLIPackCRUDTests` flaked once and passes in isolation and on re-run.
- swiftformat 0.61.1 / swiftlint clean.