### PR TITLE
Add Neovim Terminal + Sequences packs — closes the orange-box gap

### DIFF
--- a/Sources/KeyPathAppKit/Services/Packs/PackRegistry.swift
+++ b/Sources/KeyPathAppKit/Services/Packs/PackRegistry.swift
@@ -16,6 +16,7 @@ public enum PackRegistry {
         deleteEnhancement,
         backupCapsLock,
         vimNavigation,
+        neovimTerminal,
         windowSnapping,
         missionControl,
         autoShiftSymbols,
@@ -26,6 +27,7 @@ public enum PackRegistry {
         leaderKey,
         keyRepeatControl,
         chordGroups,
+        sequences,
         vallackSystem,
         kindaVim,
         keystrokeHistory
@@ -735,6 +737,50 @@ public enum PackRegistry {
             PackBindingTemplate(input: "e+r", output: "C-z", title: "E+R → Undo"),
         ],
         associatedCollectionID: RuleCollectionIdentifier.chordGroups
+    )
+
+    // MARK: - Pack: Neovim Terminal
+
+    public static let neovimTerminal = Pack(
+        id: "com.keypath.pack.neovim-terminal",
+        version: "1.0.0",
+        name: "Neovim Terminal",
+        tagline: "Vim motions in your terminal — words, lines, and search",
+        shortDescription:
+        "Hold Leader for Neovim-style motions inside approved terminal apps: h/j/k/l arrows, w/b word jumps, 0/$ line ends, undo, yank, and put. App-scoped — it activates only in terminals and coexists with the other Navigation rules.",
+        longDescription: "",
+        category: "Navigation",
+        iconSymbol: "terminal",
+        quickSettings: [],
+        bindings: [
+            PackBindingTemplate(input: "h", output: "left", title: "H → Left"),
+            PackBindingTemplate(input: "j", output: "down", title: "J → Down"),
+            PackBindingTemplate(input: "k", output: "up", title: "K → Up"),
+            PackBindingTemplate(input: "l", output: "right", title: "L → Right"),
+            PackBindingTemplate(input: "w", output: "A-right", title: "W → Word forward"),
+            PackBindingTemplate(input: "b", output: "A-left", title: "B → Word back"),
+            PackBindingTemplate(input: "u", output: "M-z", title: "U → Undo"),
+            PackBindingTemplate(input: "y", output: "M-c", title: "Y → Yank (copy)"),
+            PackBindingTemplate(input: "p", output: "M-v", title: "P → Put (paste)"),
+        ],
+        associatedCollectionID: RuleCollectionIdentifier.neovimTerminal
+    )
+
+    // MARK: - Pack: Sequences
+
+    public static let sequences = Pack(
+        id: "com.keypath.pack.sequences",
+        version: "1.0.0",
+        name: "Sequences",
+        tagline: "Press keys one after another to trigger layers and actions",
+        shortDescription:
+        "Build multi-key sequences like Leader → W → M that activate layers or run actions. Like chords, but ordered — keys are pressed in succession instead of together. Starts empty; add your own sequences in the editor.",
+        longDescription: "",
+        category: "Productivity",
+        iconSymbol: "arrow.right.arrow.left.circle",
+        quickSettings: [],
+        bindings: [],
+        associatedCollectionID: RuleCollectionIdentifier.sequences
     )
 
     // MARK: - Pack: KindaVim

--- a/Tests/KeyPathTests/PackOwnershipTests.swift
+++ b/Tests/KeyPathTests/PackOwnershipTests.swift
@@ -202,4 +202,25 @@ final class PackOwnershipTests: XCTestCase {
             // expected
         }
     }
+
+    // MARK: - Rules-tab coverage (no orange boxes)
+
+    /// Every catalog collection the Rules tab renders as its own row
+    /// (not a system default, not hidden behind an owningPackID) must have
+    /// an associated pack in the starter kit. Rows without one render with
+    /// the orange "no detail page" border in RulesSummaryView+RowBuilder —
+    /// Neovim Terminal and Sequences shipped that way until their packs
+    /// were added for 1.0. This pins the invariant.
+    func testEveryRenderedCatalogCollectionHasAnAssociatedPack() {
+        let packCoveredIDs = Set(PackRegistry.starterKit.compactMap(\.associatedCollectionID))
+        let uncovered = RuleCollectionCatalog().defaultCollections().filter { collection in
+            !collection.isSystemDefault
+                && collection.owningPackID == nil
+                && !packCoveredIDs.contains(collection.id)
+        }
+        XCTAssertTrue(
+            uncovered.isEmpty,
+            "Collections rendered without a pack detail page (orange box): \(uncovered.map(\.name))"
+        )
+    }
 }


### PR DESCRIPTION
Closes the in-app "orange box" gap Micah flagged for the 1.0 release: the Rules tab draws an orange border ([RulesSummaryView+RowBuilder.swift:136](Sources/KeyPathAppKit/UI/Rules/RulesSummaryView%2BRowBuilder.swift)) around any rendered catalog collection with no associated pack — because the pack is what provides the rule's detail page. **Neovim Terminal** and **Sequences** were the only two rendered collections shipping without one.

## What's in this PR

**Two new packs in PackRegistry**, wired via `associatedCollectionID` and slotted into starterKit display order next to their nearest relatives:

| Pack | Category | Bindings |
|---|---|---|
| Neovim Terminal | Navigation (after Vim Navigation) | 9 bindings mirroring the collection's nav-layer motions — h/j/k/l, w/b word jumps, undo, yank, put |
| Sequences | Productivity (after Chord Groups) | none — the collection starts empty and is user-authored; copy explains the chords-but-ordered model |

Once `packForCollection` resolves, the orange overlay disappears by construction and both rules get the standard pack detail page.

**Regression test** in `PackOwnershipTests`: `testEveryRenderedCatalogCollectionHasAnAssociatedPack` pins the invariant — every catalog collection that the Rules tab renders as its own row (not system-default, not hidden behind `owningPackID`) must have a starter-kit pack. The orange-box state can't be silently reintroduced when the next collection is added.

## Verification

- PackOwnershipTests 13/13 (incl. the new invariant test, which also confirmed these two were the *only* gaps)
- `testEachPackProducesValidConfigIndividually` automatically picks up both new packs — each enabled solo passes `kanata --check`
- PackRegistry / PackInstallIntegration / VallackSystemPack / CLIPackCRUD suites green (CLI count assertions are relative to `starterKit.count`)
- swiftformat clean; the two swiftlint warnings in the output are pre-existing on untouched lines

## Note for manual QA (Sat RC)

Worth a visual once-over of the two new detail pages in the Gallery and confirming the orange borders are gone in the Rules tab — pack detail rendering is generic from Pack fields, but copy reads differently in situ.