### PR TITLE
Tighten test-environment detection: drop leak-prone env signals

### DIFF
--- a/Sources/KeyPathAppKit/Utilities/AppRestarter.swift
+++ b/Sources/KeyPathAppKit/Utilities/AppRestarter.swift
@@ -47,11 +47,7 @@ enum AppRestarter {
         AppLogger.shared.log("💾 [AppRestarter] Saved wizard state: \(wizardPage)")
 
         // Skip actual restart in test environment (UserDefaults save is what we test)
-        let env = ProcessInfo.processInfo.environment
-        if env["XCTestConfigurationFilePath"] != nil
-            || ProcessInfo.processInfo.processName.lowercased().contains("xctest")
-            || env["SWIFTPM_MODULECACHE_OVERRIDE"] != nil
-        {
+        if TestEnvironment.isRunningTests {
             AppLogger.shared.log("🧪 [AppRestarter] Test mode - skipping app restart")
             return
         }

--- a/Sources/KeyPathCore/TestEnvironment.swift
+++ b/Sources/KeyPathCore/TestEnvironment.swift
@@ -18,45 +18,45 @@ public enum TestEnvironment {
     /// - `DYLD_LIBRARY_PATH` containing ".build" — leaks from any `swift run` shell
     /// - the generic `CI` env var — set by various tools/editors
     public static var isRunningTests: Bool {
-        // Check if a test bundle is actually loaded (not just XCTest classes existing).
-        // On macOS 26+, XCTestSupport.framework is loaded into all apps, making
-        // NSClassFromString("XCTestCase") unreliable for test detection.
-        if Bundle.allBundles.contains(where: { $0.bundlePath.hasSuffix(".xctest") }) {
-            return true
-        }
+        detectionSignals.contains(where: \.present)
+    }
 
-        // Set by the XCTest/Xcode harness only for actual test invocations
-        // (unlike __XCODE_BUILT_PRODUCTS_DIR_PATHS, which any Xcode run gets).
-        if ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil
-            || ProcessInfo.processInfo.environment["XCTestSessionIdentifier"] != nil
-        {
-            return true
-        }
+    /// Specific CI systems only, NOT the generic "CI" env var — that one is too
+    /// common (set by various tools, editors, etc.) and causes false positives
+    /// when inherited from a user's shell environment.
+    private static let ciIndicators = ["GITHUB_ACTIONS", "TRAVIS", "CIRCLE_CI", "JENKINS_URL"]
 
-        // Explicit project opt-in, exported by the test scripts
-        // (run-tests-safe.sh, test-lane.sh, run-installer-reliability-matrix.sh)
-        // and inherited by any subprocess they spawn.
-        if ProcessInfo.processInfo.environment["SWIFT_TEST"] != nil {
-            return true
-        }
-
-        // Check for test process names
+    /// The named signals behind `isRunningTests`, in evaluation order. Shared
+    /// with `logEnvironmentStatus()` and the detection regression tests so the
+    /// implementation, diagnostics, and tests cannot drift apart.
+    public static var detectionSignals: [(name: String, present: Bool)] {
+        let env = ProcessInfo.processInfo.environment
         let processName = ProcessInfo.processInfo.processName
-        if processName.contains("xctest") || processName.contains("KeyPathPackageTests")
-            || processName.contains("swift-test") || processName.contains("swiftpm-testing")
-        {
-            return true
-        }
-
-        // Check for CI environment variables - but only specific CI systems, NOT just "CI"
-        // The generic "CI" env var is too common (can be set by various tools, editors, etc.)
-        // and causes false positives when inherited from user's shell environment
-        let ciIndicators = ["GITHUB_ACTIONS", "TRAVIS", "CIRCLE_CI", "JENKINS_URL"]
-        for indicator in ciIndicators where ProcessInfo.processInfo.environment[indicator] != nil {
-            return true
-        }
-
-        return false
+        return [
+            // A test bundle is actually loaded (not just XCTest classes existing).
+            // On macOS 26+, XCTestSupport.framework is loaded into all apps, making
+            // NSClassFromString("XCTestCase") unreliable for test detection.
+            (
+                "xctest-bundle-loaded",
+                Bundle.allBundles.contains { $0.bundlePath.hasSuffix(".xctest") }
+            ),
+            // Set by the XCTest/Xcode harness only for actual test invocations
+            // (unlike __XCODE_BUILT_PRODUCTS_DIR_PATHS, which any Xcode run gets).
+            ("XCTestConfigurationFilePath", env["XCTestConfigurationFilePath"] != nil),
+            ("XCTestSessionIdentifier", env["XCTestSessionIdentifier"] != nil),
+            // Explicit project opt-in, exported by the test scripts
+            // (run-tests-safe.sh, test-lane.sh, run-installer-reliability-matrix.sh)
+            // and inherited by any subprocess they spawn.
+            ("SWIFT_TEST", env["SWIFT_TEST"] != nil),
+            // Test runner process names. swiftpm-testing-helper hosts Swift Testing
+            // (@Test) runs, which load no .xctest bundle.
+            (
+                "test-process-name",
+                processName.contains("xctest") || processName.contains("KeyPathPackageTests")
+                    || processName.contains("swift-test") || processName.contains("swiftpm-testing")
+            ),
+            ("ci-environment", ciIndicators.contains { env[$0] != nil })
+        ]
     }
 
     /// Allow tests to override admin operation skipping
@@ -174,18 +174,9 @@ public enum TestEnvironment {
         AppLogger.shared.log("🧪 [TestEnvironment] Process name: \(ProcessInfo.processInfo.processName)")
 
         if isRunningTests {
-            let xctestExists = NSClassFromString("XCTestCase") != nil
-            let swiftTestEnv = ProcessInfo.processInfo.environment["SWIFT_TEST"] != nil
-            let ciDetected = ["CI", "GITHUB_ACTIONS", "TRAVIS", "CIRCLE_CI", "JENKINS_URL"].contains {
-                ProcessInfo.processInfo.environment[$0] != nil
-            }
-            let testIndicators = [
-                "XCTest class exists: \(xctestExists)",
-                "SWIFT_TEST env: \(swiftTestEnv)",
-                "CI env detected: \(ciDetected)"
-            ]
+            let active = detectionSignals.filter(\.present).map(\.name)
             AppLogger.shared.log(
-                "🧪 [TestEnvironment] Test indicators: \(testIndicators.joined(separator: ", "))"
+                "🧪 [TestEnvironment] Active test signals: \(active.joined(separator: ", "))"
             )
         }
     }

--- a/Sources/KeyPathCore/TestEnvironment.swift
+++ b/Sources/KeyPathCore/TestEnvironment.swift
@@ -16,6 +16,9 @@ public enum TestEnvironment {
     /// - `__XCODE_BUILT_PRODUCTS_DIR_PATHS` — Xcode sets it for any scheme run,
     ///   including launching the real app
     /// - `DYLD_LIBRARY_PATH` containing ".build" — leaks from any `swift run` shell
+    /// - `SWIFTPM_MODULECACHE_OVERRIDE` (formerly checked by AppRestarter) — a
+    ///   SwiftPM build setting any SwiftPM shell can carry, not a test marker;
+    ///   in-process signals cover every real test invocation
     /// - the generic `CI` env var — set by various tools/editors
     public static var isRunningTests: Bool {
         detectionSignals.contains(where: \.present)

--- a/Sources/KeyPathCore/TestEnvironment.swift
+++ b/Sources/KeyPathCore/TestEnvironment.swift
@@ -3,6 +3,20 @@ import Foundation
 /// Utility for detecting test environment and controlling system operations during testing
 public enum TestEnvironment {
     /// Check if code is running in test environment
+    ///
+    /// A false positive here is destructive, not just cosmetic: AppPaths redirects
+    /// real user data (~/Library/Logs/KeyPath, ~/Library/Application Support/KeyPath)
+    /// into a purgeable temp sandbox, and ActivityLogEncryption switches Keychain
+    /// keys. Every signal below must therefore be either in-process proof of a test
+    /// run or an explicit test-only opt-in — never an env var that can leak from a
+    /// developer's shell into a real KeyPath.app/keypath-cli launch. Signals
+    /// rejected for exactly that reason:
+    /// - `KEYPATH_USE_SUDO=1` — a dev-workflow flag for *real* app runs (see
+    ///   useSudoForPrivilegedOps); it proves nothing about tests
+    /// - `__XCODE_BUILT_PRODUCTS_DIR_PATHS` — Xcode sets it for any scheme run,
+    ///   including launching the real app
+    /// - `DYLD_LIBRARY_PATH` containing ".build" — leaks from any `swift run` shell
+    /// - the generic `CI` env var — set by various tools/editors
     public static var isRunningTests: Bool {
         // Check if a test bundle is actually loaded (not just XCTest classes existing).
         // On macOS 26+, XCTestSupport.framework is loaded into all apps, making
@@ -11,14 +25,18 @@ public enum TestEnvironment {
             return true
         }
 
-        // Check for Swift test runner env var
-        if ProcessInfo.processInfo.environment["SWIFT_TEST"] != nil {
+        // Set by the XCTest/Xcode harness only for actual test invocations
+        // (unlike __XCODE_BUILT_PRODUCTS_DIR_PATHS, which any Xcode run gets).
+        if ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil
+            || ProcessInfo.processInfo.environment["XCTestSessionIdentifier"] != nil
+        {
             return true
         }
 
-        // Check for KEYPATH_USE_SUDO - if set, we're definitely in test mode
-        // This is the explicit test environment flag
-        if ProcessInfo.processInfo.environment["KEYPATH_USE_SUDO"] == "1" {
+        // Explicit project opt-in, exported by the test scripts
+        // (run-tests-safe.sh, test-lane.sh, run-installer-reliability-matrix.sh)
+        // and inherited by any subprocess they spawn.
+        if ProcessInfo.processInfo.environment["SWIFT_TEST"] != nil {
             return true
         }
 
@@ -26,14 +44,6 @@ public enum TestEnvironment {
         let processName = ProcessInfo.processInfo.processName
         if processName.contains("xctest") || processName.contains("KeyPathPackageTests")
             || processName.contains("swift-test") || processName.contains("swiftpm-testing")
-        {
-            return true
-        }
-
-        // Check if running in swift-testing worker process
-        // Swift Testing uses worker processes with specific environment
-        if ProcessInfo.processInfo.environment["__XCODE_BUILT_PRODUCTS_DIR_PATHS"] != nil
-            || ProcessInfo.processInfo.environment["DYLD_LIBRARY_PATH"]?.contains(".build") == true
         {
             return true
         }

--- a/Tests/KeyPathTests/TestEnvironmentDetectionTests.swift
+++ b/Tests/KeyPathTests/TestEnvironmentDetectionTests.swift
@@ -28,6 +28,38 @@ final class TestEnvironmentDetectionTests: XCTestCase {
         )
     }
 
+    func testDetection_StrongSignalsSufficeWithoutLeakProneEnvVars() {
+        // isRunningTests must never rely on env vars that can leak from a dev
+        // shell into a real app launch (KEYPATH_USE_SUDO,
+        // __XCODE_BUILT_PRODUCTS_DIR_PATHS, DYLD_LIBRARY_PATH containing
+        // ".build"). A false positive redirects real user data into a purgeable
+        // temp sandbox via AppPaths. This test verifies every real test run
+        // carries at least one strong in-process signal, so the leak-prone vars
+        // are never needed for detection.
+        let env = ProcessInfo.processInfo.environment
+        let processName = ProcessInfo.processInfo.processName
+        let strongSignals = [
+            Bundle.allBundles.contains { $0.bundlePath.hasSuffix(".xctest") },
+            env["XCTestConfigurationFilePath"] != nil,
+            env["XCTestSessionIdentifier"] != nil,
+            env["SWIFT_TEST"] != nil,
+            processName.contains("xctest"),
+            processName.contains("KeyPathPackageTests"),
+            processName.contains("swift-test"),
+            processName.contains("swiftpm-testing")
+        ]
+        XCTAssertTrue(
+            strongSignals.contains(true),
+            """
+            No strong test signal present in this test run. If detection needs a \
+            new signal for this runner, add an in-process or explicitly \
+            test-scoped one — do NOT reintroduce leak-prone env vars like \
+            KEYPATH_USE_SUDO or DYLD_LIBRARY_PATH.
+            """
+        )
+        XCTAssertTrue(TestEnvironment.isRunningTests)
+    }
+
     @MainActor
     func testForceTestMode_CanBeToggled() {
         let original = TestEnvironment.forceTestMode

--- a/Tests/KeyPathTests/TestEnvironmentDetectionTests.swift
+++ b/Tests/KeyPathTests/TestEnvironmentDetectionTests.swift
@@ -34,22 +34,11 @@ final class TestEnvironmentDetectionTests: XCTestCase {
         // __XCODE_BUILT_PRODUCTS_DIR_PATHS, DYLD_LIBRARY_PATH containing
         // ".build"). A false positive redirects real user data into a purgeable
         // temp sandbox via AppPaths. This test verifies every real test run
-        // carries at least one strong in-process signal, so the leak-prone vars
-        // are never needed for detection.
-        let env = ProcessInfo.processInfo.environment
-        let processName = ProcessInfo.processInfo.processName
-        let strongSignals = [
-            Bundle.allBundles.contains { $0.bundlePath.hasSuffix(".xctest") },
-            env["XCTestConfigurationFilePath"] != nil,
-            env["XCTestSessionIdentifier"] != nil,
-            env["SWIFT_TEST"] != nil,
-            processName.contains("xctest"),
-            processName.contains("KeyPathPackageTests"),
-            processName.contains("swift-test"),
-            processName.contains("swiftpm-testing")
-        ]
+        // carries at least one strong signal besides the CI env vars, so the
+        // leak-prone vars are never needed for detection.
+        let strongSignals = TestEnvironment.detectionSignals.filter { $0.name != "ci-environment" }
         XCTAssertTrue(
-            strongSignals.contains(true),
+            strongSignals.contains(where: \.present),
             """
             No strong test signal present in this test run. If detection needs a \
             new signal for this runner, add an in-process or explicitly \


### PR DESCRIPTION
## Problem

`TestEnvironment.isRunningTests` treated several leak-prone environment signals as proof of a test run: `KEYPATH_USE_SUDO=1`, `__XCODE_BUILT_PRODUCTS_DIR_PATHS`, and `DYLD_LIBRARY_PATH` containing `.build`. Any of these can leak from a developer's shell into a real `KeyPath.app`/`keypath-cli` launch — and the blast radius is no longer cosmetic: since #886/#892, `AppPaths` redirects real user data (`~/Library/Logs/KeyPath`, `~/Library/Application Support/KeyPath`) into a per-process temp sandbox whenever `isRunningTests` is true, so a false positive silently writes activity logs, crash logs, and incident snapshots into a dir macOS later purges. `ActivityLogEncryption` likewise switches Keychain keys.

`KEYPATH_USE_SUDO=1` was doubly wrong: it's the flag for the *real-app* sudo dev workflow (`useSudoForPrivilegedOps`), so setting it flipped the entire app into mock-data test mode — breaking the very workflow it enables. `__XCODE_BUILT_PRODUCTS_DIR_PATHS` is set by Xcode for **any** scheme run, including launching the real app. This is the same false-positive class previously fixed in 98c51b292 (NSClassFromString) and already documented for the generic `CI` var.

## Change

- Detection now requires in-process proof (`.xctest` bundle loaded, test-runner process name, `XCTestConfigurationFilePath`/`XCTestSessionIdentifier`) or an explicit opt-in (`SWIFT_TEST`, exported by all test scripts). Specific CI vars (`GITHUB_ACTIONS` etc.) are kept — CI machines hold no real user data.
- Signals are consolidated into `TestEnvironment.detectionSignals`, shared by `isRunningTests`, `logEnvironmentStatus()` (which was stale — it logged the unreliable `NSClassFromString` check and the banned generic `CI` var), and the new regression test, so the three can't drift.
- `AppRestarter` now uses `TestEnvironment.isRunningTests` instead of a third hand-rolled signal set.
- New regression test asserts every test run carries a strong (non-CI) signal and documents why the leak-prone vars must not return.

## Why removal is safe (caller audit + verification)

Audited all ~90 `isRunningTests`/`isTestMode`/`shouldSkipAdminOperations` call sites and every test/script launch path:

- Swift Testing (`@Test`) runs execute in `swiftpm-testing-helper` (verified empirically) — caught by the kept process-name check.
- No test spawns a built KeyPath binary; subprocesses spawned by tests are kanata/bash/system tools that never consult `TestEnvironment`. The one script that runs `keypath-cli` during a test harness (`run-installer-reliability-matrix.sh`) explicitly passes `SWIFT_TEST=1`.
- `useSudoForPrivilegedOps` still reads `KEYPATH_USE_SUDO` directly — sudo-backed test runs and the DEBUG dev workflow behave as before; in release builds it now correctly falls back to osascript, matching its own doc comment.

**Known residual (accepted):** a developer who manually `export SWIFT_TEST=1`s (or a self-hosted runner with `GITHUB_ACTIONS` set machine-wide) and then launches the real app would still sandbox user data. `SWIFT_TEST` is an explicitly test-named opt-in the scripts depend on for subprocess inheritance, so it stays.

## Validation

- `./Scripts/test-fast.sh --changed`: 4367 passed. Two failures are pre-existing on clean `origin/master` (verified by stash/checkout): `HardViewSnapshotTests.testPackDetailCapsLockRemap` (environment-dependent snapshot) and `PackCollectionIntegrationTests.testPackBindingsMatchCollectionMappings` (introduced by #893, local-env-dependent, passed in #893's CI; tracked separately).
- Review gate: multi-angle review run; 3 correctness candidates refuted with evidence, 3 cleanup findings fixed in the second commit.