### PR TITLE
Bump kanata engine: report-set sync + stamped telemetry (MAL-57 Layer 3); fix engine cache hash

### DIFF
--- a/Scripts/build-kanata.sh
+++ b/Scripts/build-kanata.sh
@@ -51,9 +51,13 @@ echo "📁 Build directory: $BUILD_DIR"
 
 # TCC-Safe Caching Logic
 function calculate_source_hash() {
-    # Generate hash based on kanata source files (excluding build artifacts)
+    # Generate hash based on kanata source files (excluding build artifacts).
+    # Includes C/C++ sources: the fork vendors the karabiner-driverkit crate
+    # (driverkit/c_src), and a .cpp/.hpp-only change must invalidate the cache
+    # or a stale engine silently ships (bit MAL-57 Layer 3).
     cd "$KANATA_SOURCE"
-    find . \( -name "*.rs" -o -name "*.toml" -o -name "*.lock" \) \
+    find . \( -name "*.rs" -o -name "*.toml" -o -name "*.lock" \
+              -o -name "*.c" -o -name "*.cpp" -o -name "*.h" -o -name "*.hpp" \) \
         -not -path "./target/*" \
         -exec shasum -a 256 {} + 2>/dev/null | shasum -a 256 | cut -d' ' -f1
 }


### PR DESCRIPTION
## Summary

Submodule bump pulling [malpern/kanata#28](https://github.com/malpern/kanata/pull/28) (closes the MAL-57 fix-layer plan; fixes [kanata#27](https://github.com/malpern/kanata/issues/27)):

- **Layer 3 — report-set divergence fix.** `send_key` returned unready *before* the per-page template mutated the full-state key set, so a dropped Release left a stale key that the next report re-pressed indefinitely. The readiness check now lives after the mutation: dropped events still update intent, only the post is skipped, and the next successful report converges.
- **Telemetry.** All VHID client connection lines now carry timestamps, and the previously-silent heartbeat-deadline reconnect path logs a stamped reason — the 2026-06-10 incidents were attributable to it only by elimination.

Also fixes a real build-system bug found while preparing this bump: **the engine cache hash in `Scripts/build-kanata.sh` only covered `*.rs/*.toml/*.lock`**, so this C++-only change served a stale cached engine on first build. The hash now includes C/C++ sources.

Fast-forward proof for the fork bump (`6a05a4a → 12b64a6`): merge commit's first parent is the old tip; `git merge-base --is-ancestor` confirms append-only.

## Test plan

- kanata `cargo build` + `cargo test` green (42 tests) on the fork branch
- Engine release build via fixed `build-kanata.sh`: cache correctly invalidated, binary contains the Layer 3 telemetry marker, signs and smoke-tests
- Post-deploy: stamped `vhid-client:` lines in the daemon stdout log