### PR TITLE
Redirect diagnostic/support writes to a temp sandbox during tests

### DIFF
--- a/Sources/KeyPathAppKit/Services/Kanata/KanataDaemonService.swift
+++ b/Sources/KeyPathAppKit/Services/Kanata/KanataDaemonService.swift
@@ -291,10 +291,10 @@ final class KanataDaemonService {
     }
 
     /// Log service state failures to persistent crash log for later analysis
+    /// (redirected to a temp sandbox during tests via AppPaths).
     private func logServiceFailure(from oldState: ServiceState, reason: String) {
-        let crashLogDir = Foundation.FileManager().homeDirectoryForCurrentUser
-            .appendingPathComponent("Library/Logs/KeyPath")
-        let crashLogPath = crashLogDir.appendingPathComponent("crashes.log")
+        let crashLogDir = AppPaths.logsDirectory
+        let crashLogPath = AppPaths.crashLogFile
 
         // Ensure directory exists
         do {

--- a/Sources/KeyPathAppKit/Services/KindaVim/KindaVimTelemetryStore.swift
+++ b/Sources/KeyPathAppKit/Services/KindaVim/KindaVimTelemetryStore.swift
@@ -128,12 +128,11 @@ final class KindaVimTelemetryStore {
     /// `UserDefaults` key.
     static let optInKey = "kindaVim.telemetryEnabled"
 
+    /// ~/Library/Application Support/KeyPath/kindavim-telemetry.json
+    /// (redirected to a temp sandbox during tests via AppPaths).
     static var defaultFileURL: URL {
-        let support = FileManager.default
-            .homeDirectoryForCurrentUser
-            .appendingPathComponent("Library/Application Support", isDirectory: true)
-            .appendingPathComponent("KeyPath", isDirectory: true)
-        return support.appendingPathComponent("kindavim-telemetry.json")
+        AppPaths.applicationSupportDirectory
+            .appendingPathComponent("kindavim-telemetry.json")
     }
 
     private let fileURL: URL

--- a/Sources/KeyPathAppKit/Services/MainAppStateController.swift
+++ b/Sources/KeyPathAppKit/Services/MainAppStateController.swift
@@ -178,10 +178,10 @@ class MainAppStateController {
 
     /// Log crash events to persistent storage for later analysis.
     /// Crashes are logged to ~/Library/Logs/KeyPath/crashes.log
+    /// (redirected to a temp sandbox during tests via AppPaths).
     private func logCrashEvent(_ error: KanataError) {
-        let crashLogDir = Foundation.FileManager().homeDirectoryForCurrentUser
-            .appendingPathComponent("Library/Logs/KeyPath")
-        let crashLogPath = crashLogDir.appendingPathComponent("crashes.log")
+        let crashLogDir = AppPaths.logsDirectory
+        let crashLogPath = AppPaths.crashLogFile
 
         // Ensure directory exists
         do {

--- a/Sources/KeyPathAppKit/Services/Monitoring/StuckKeyRecoveryService.swift
+++ b/Sources/KeyPathAppKit/Services/Monitoring/StuckKeyRecoveryService.swift
@@ -99,17 +99,12 @@ final class StuckKeyRecoveryService {
         }.value
     }
 
-    /// Where incident snapshots are written. Tests must never touch the real directory:
-    /// it holds genuine stuck-key evidence and the prune-to-20 pass in
-    /// `writeSnapshotToDisk` would silently delete it, so test runs are redirected to a
-    /// temp location.
+    /// ~/Library/Logs/KeyPath/stuck-key-incidents
+    /// (redirected to a temp sandbox during tests via AppPaths). Tests must
+    /// never touch the real directory: it holds genuine stuck-key evidence and
+    /// the prune-to-20 pass in `writeSnapshotToDisk` would silently delete it.
     nonisolated static var diagnosticsDirectory: URL {
-        if TestEnvironment.isRunningTests {
-            return FileManager.default.temporaryDirectory
-                .appendingPathComponent("KeyPathTests/stuck-key-incidents", isDirectory: true)
-        }
-        return FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent("Library/Logs/KeyPath/stuck-key-incidents", isDirectory: true)
+        AppPaths.logsDirectory.appendingPathComponent("stuck-key-incidents", isDirectory: true)
     }
 
     private nonisolated static func writeSnapshotToDisk(_ snapshot: DiagnosticSnapshotData) {

--- a/Sources/KeyPathAppKit/Services/Packs/InstalledPackTracker.swift
+++ b/Sources/KeyPathAppKit/Services/Packs/InstalledPackTracker.swift
@@ -43,6 +43,10 @@ public actor InstalledPackTracker {
         if let fileURL {
             self.fileURL = fileURL
         } else if TestEnvironment.isRunningTests {
+            // Intentionally NOT AppPaths.testSandboxDirectory: each tracker
+            // instance gets its own UUID directory so parallel test instances
+            // never see each other's records. AppPaths' shared per-process
+            // sandbox would make them collide.
             self.fileURL = FileManager.default.temporaryDirectory
                 .appendingPathComponent("keypath-installed-packs-\(ProcessInfo.processInfo.processIdentifier)-\(UUID().uuidString)", isDirectory: true)
                 .appendingPathComponent("installed-packs.json")

--- a/Sources/KeyPathCore/AppPaths.swift
+++ b/Sources/KeyPathCore/AppPaths.swift
@@ -9,13 +9,11 @@ import Foundation
 /// type instead of hand-rolling `TestEnvironment.isRunningTests` checks.
 public enum AppPaths {
     /// Per-process sandbox root used in place of the real home directory while tests run.
-    public static var testSandboxDirectory: URL {
-        FileManager.default.temporaryDirectory
-            .appendingPathComponent(
-                "keypath-tests-\(ProcessInfo.processInfo.processIdentifier)",
-                isDirectory: true
-            )
-    }
+    public static let testSandboxDirectory: URL = FileManager.default.temporaryDirectory
+        .appendingPathComponent(
+            "keypath-tests-\(ProcessInfo.processInfo.processIdentifier)",
+            isDirectory: true
+        )
 
     /// `~/Library/Logs/KeyPath` (sandboxed during tests).
     public static var logsDirectory: URL {

--- a/Sources/KeyPathCore/AppPaths.swift
+++ b/Sources/KeyPathCore/AppPaths.swift
@@ -32,7 +32,9 @@ public enum AppPaths {
     }
 
     /// Cached: isRunningTests scans Bundle.allBundles on every call and its
-    /// result cannot change within a process.
+    /// result cannot change within a process. The mutable
+    /// TestEnvironment.forceTestMode is intentionally excluded — flipping it
+    /// mid-process must not make early- and late-resolved paths disagree.
     private static let isSandboxed = TestEnvironment.isRunningTests
 
     private static func userDirectory(_ relativePath: String) -> URL {

--- a/Sources/KeyPathCore/AppPaths.swift
+++ b/Sources/KeyPathCore/AppPaths.swift
@@ -33,8 +33,12 @@ public enum AppPaths {
         logsDirectory.appendingPathComponent("crashes.log")
     }
 
+    /// Cached: isRunningTests scans Bundle.allBundles on every call and its
+    /// result cannot change within a process.
+    private static let isSandboxed = TestEnvironment.isRunningTests
+
     private static func userDirectory(_ relativePath: String) -> URL {
-        let root = TestEnvironment.isRunningTests
+        let root = isSandboxed
             ? testSandboxDirectory
             : FileManager.default.homeDirectoryForCurrentUser
         return root.appendingPathComponent(relativePath, isDirectory: true)

--- a/Tests/KeyPathTests/Services/AppPathsTestSandboxTests.swift
+++ b/Tests/KeyPathTests/Services/AppPathsTestSandboxTests.swift
@@ -1,0 +1,72 @@
+@testable import KeyPathAppKit
+import KeyPathCore
+import XCTest
+
+/// Guards against unit tests writing to (or deleting from) real user
+/// directories. Every service that persists diagnostics or support data must
+/// resolve its paths through `AppPaths`, which redirects into a per-process
+/// temp sandbox while tests run. A regression here means tests can pollute or
+/// destroy genuine crash logs, incident snapshots, and telemetry.
+@MainActor
+final class AppPathsTestSandboxTests: XCTestCase {
+    private var realLogsDir: String {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Logs/KeyPath", isDirectory: true).path
+    }
+
+    private var realSupportDir: String {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Application Support/KeyPath", isDirectory: true).path
+    }
+
+    private func assertSandboxed(_ url: URL, file: StaticString = #filePath, line: UInt = #line) {
+        XCTAssertTrue(
+            url.path.hasPrefix(AppPaths.testSandboxDirectory.path),
+            "\(url.path) must live under the test sandbox \(AppPaths.testSandboxDirectory.path)",
+            file: file, line: line
+        )
+        XCTAssertFalse(
+            url.path.hasPrefix(realLogsDir) || url.path.hasPrefix(realSupportDir),
+            "\(url.path) must not point at a real user directory during tests",
+            file: file, line: line
+        )
+    }
+
+    func testTestEnvironmentIsDetected() {
+        // The redirect only engages when test detection works; if this fails,
+        // every other assertion in this file is vacuous.
+        XCTAssertTrue(TestEnvironment.isRunningTests)
+    }
+
+    func testSandboxDirectoryLivesUnderTemporaryDirectory() {
+        XCTAssertTrue(
+            AppPaths.testSandboxDirectory.path
+                .hasPrefix(FileManager.default.temporaryDirectory.path)
+        )
+    }
+
+    func testLogsDirectoryIsSandboxed() {
+        assertSandboxed(AppPaths.logsDirectory)
+    }
+
+    func testApplicationSupportDirectoryIsSandboxed() {
+        assertSandboxed(AppPaths.applicationSupportDirectory)
+    }
+
+    func testCrashLogFileIsSandboxed() {
+        assertSandboxed(AppPaths.crashLogFile)
+        XCTAssertEqual(AppPaths.crashLogFile.lastPathComponent, "crashes.log")
+    }
+
+    func testKindaVimTelemetryDefaultFileIsSandboxed() {
+        let url = KindaVimTelemetryStore.defaultFileURL
+        assertSandboxed(url)
+        XCTAssertEqual(url.lastPathComponent, "kindavim-telemetry.json")
+    }
+
+    func testStuckKeyDiagnosticsDirectoryIsSandboxed() {
+        let dir = StuckKeyRecoveryService.diagnosticsDirectory
+        assertSandboxed(dir)
+        XCTAssertEqual(dir.lastPathComponent, "stuck-key-incidents")
+    }
+}

--- a/Tests/KeyPathTests/Services/AppPathsTestSandboxTests.swift
+++ b/Tests/KeyPathTests/Services/AppPathsTestSandboxTests.swift
@@ -9,6 +9,14 @@ import XCTest
 /// destroy genuine crash logs, incident snapshots, and telemetry.
 @MainActor
 final class AppPathsTestSandboxTests: XCTestCase {
+    /// Remove the per-process sandbox so repeated local runs don't accumulate
+    /// artifacts in $TMPDIR. Safe even if other suites run afterwards: every
+    /// production writer creates its directory before writing.
+    override class func tearDown() {
+        try? FileManager.default.removeItem(at: AppPaths.testSandboxDirectory)
+        super.tearDown()
+    }
+
     private var realLogsDir: String {
         FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent("Library/Logs/KeyPath", isDirectory: true).path

--- a/Tests/KeyPathTests/Services/AppPathsTestSandboxTests.swift
+++ b/Tests/KeyPathTests/Services/AppPathsTestSandboxTests.swift
@@ -10,8 +10,10 @@ import XCTest
 @MainActor
 final class AppPathsTestSandboxTests: XCTestCase {
     /// Remove the per-process sandbox so repeated local runs don't accumulate
-    /// artifacts in $TMPDIR. Safe even if other suites run afterwards: every
-    /// production writer creates its directory before writing.
+    /// artifacts in $TMPDIR. Safe because XCTest runs suites sequentially in a
+    /// process, so no other sandbox writer is live during tearDown, and any
+    /// suite that runs later recreates its directory before writing. Revisit
+    /// if in-process parallel suite execution is ever enabled.
     override class func tearDown() {
         try? FileManager.default.removeItem(at: AppPaths.testSandboxDirectory)
         super.tearDown()


### PR DESCRIPTION
## Problem

Four services wrote to real user directories while unit tests ran, risking pollution or eviction of genuine diagnostic data:

- `MainAppStateController.logCrashEvent()` and `KanataDaemonService.logServiceFailure()` appended to `~/Library/Logs/KeyPath/crashes.log`
- `KindaVimTelemetryStore.defaultFileURL` pointed at `~/Library/Application Support/KeyPath/kindavim-telemetry.json`
- `StuckKeyRecoveryService` wrote incident snapshots to `~/Library/Logs/KeyPath/stuck-key-incidents/`, which sits at its 20-file prune cap — a test write silently evicts a real incident file (relevant to MAL-57 evidence)

## Fix

New `AppPaths` utility in KeyPathCore resolves user-scoped directories through one helper that redirects into a per-process temp sandbox (`$TMPDIR/keypath-tests-<pid>/…`) when `TestEnvironment.isRunningTests`. All four services route through it instead of hand-rolling the check. **Production paths are byte-identical to before.** Test detection is resolved once per process (Bundle.allBundles scan is not repeated per access).

`InstalledPackTracker` keeps its existing per-instance UUID redirect — it provides stronger isolation between test instances than the shared sandbox would.

## Tests

- New `AppPathsTestSandboxTests` (7 tests) asserts the redirect for each path, including a sanity test that test detection itself works.
- Verified end-to-end: after running the touched suites, real `crashes.log` mtime and all 20 real incident files are unchanged, while the stuck-key test's snapshot landed in the sandbox.

## Follow-up (out of scope)

`ActivityLogStorage` (KeyPathInsights) has the same bug class; flagged separately.