### PR TITLE
Fix Neovim Terminal detail page rendering the Home Row Mods editor

### DIFF
--- a/Sources/KeyPathAppKit/Services/Packs/PackRegistry.swift
+++ b/Sources/KeyPathAppKit/Services/Packs/PackRegistry.swift
@@ -752,29 +752,11 @@ public enum PackRegistry {
         category: "Navigation",
         iconSymbol: "terminal",
         quickSettings: [],
-        // Bindings mirror the collection's 19 mappings 1:1 —
-        // testPackBindingsMatchCollectionMappings enforces the count.
-        bindings: [
-            PackBindingTemplate(input: "h", output: "left", title: "H → Left"),
-            PackBindingTemplate(input: "j", output: "down", title: "J → Down"),
-            PackBindingTemplate(input: "k", output: "up", title: "K → Up"),
-            PackBindingTemplate(input: "l", output: "right", title: "L → Right"),
-            PackBindingTemplate(input: "w", output: "A-right", title: "W → Word forward"),
-            PackBindingTemplate(input: "b", output: "A-left", title: "B → Word back"),
-            PackBindingTemplate(input: "e", output: "A-right", title: "E → End of word"),
-            PackBindingTemplate(input: "0", output: "M-left", title: "0 → Line start"),
-            PackBindingTemplate(input: "4", output: "M-right", title: "$ → Line end"),
-            PackBindingTemplate(input: "g", output: "M-up", title: "G → Document top/bottom"),
-            PackBindingTemplate(input: "/", output: "M-f", title: "/ → Find"),
-            PackBindingTemplate(input: "n", output: "M-g", title: "N → Next match"),
-            PackBindingTemplate(input: "y", output: "M-c", title: "Y → Yank (copy)"),
-            PackBindingTemplate(input: "p", output: "M-v", title: "P → Put (paste)"),
-            PackBindingTemplate(input: "x", output: "del", title: "X → Delete character"),
-            PackBindingTemplate(input: "r", output: "M-S-z", title: "R → Redo"),
-            PackBindingTemplate(input: "d", output: "A-bspc", title: "D → Delete previous word"),
-            PackBindingTemplate(input: "u", output: "M-z", title: "U → Undo"),
-            PackBindingTemplate(input: "o", output: "M-right ret", title: "O → Open line below"),
-        ],
+        // Intentionally empty: table-style packs (Vim Navigation, Mission
+        // Control, Numpad) leave bindings empty so Pack Detail renders the
+        // collection's mappings via MappingTableContent — the collection's
+        // 19 motions are the single source of truth.
+        bindings: [],
         associatedCollectionID: RuleCollectionIdentifier.neovimTerminal
     )
 

--- a/Sources/KeyPathAppKit/UI/Gallery/PackDetailView.swift
+++ b/Sources/KeyPathAppKit/UI/Gallery/PackDetailView.swift
@@ -473,12 +473,10 @@ struct PackDetailView: View {
     /// interactive keyboard + modifier controls instead of the generic
     /// tap-hold picker.
     var isHomeRowModsPack: Bool {
-        let homeRowKeys: Set = ["a", "s", "d", "f", "j", "k", "l", "scln", ";"]
-        let inputs = Set(pack.bindings.map { $0.input.lowercased() })
-        // Consider it a home-row pack if at least 4 of its bindings are on
-        // the home row — covers light and full variants without listing
-        // every combination.
-        return inputs.intersection(homeRowKeys).count >= 4
+        // Exact match — the old ≥4-home-row-bindings heuristic misfired on
+        // any Vim-flavored pack whose bindings happen to use j/k/l/d
+        // (Neovim Terminal rendered the HRM editor as its detail body).
+        pack.associatedCollectionID == RuleCollectionIdentifier.homeRowMods
     }
 
     /// Match the pack to an existing `RuleCollection` that carries a


### PR DESCRIPTION
Micah's visual once-over of the new Neovim Terminal detail page ([#893](https://github.com/malpern/KeyPath/pull/893)) caught it rendering the **Home Row Mods interactive keyboard** instead of the pack's motions. Two compounding causes, both fixed:

## 1. `isHomeRowModsPack` was a heuristic that misfires on Vim-flavored packs

The dispatch's first branch matched any pack with **≥4 bindings on home-row keys** ([PackDetailView.swift:475](Sources/KeyPathAppKit/UI/Gallery/PackDetailView.swift)). Neovim's bindings include j, k, l, d — exactly 4. Replaced with an exact `associatedCollectionID == homeRowMods` check. Verified no other pack matched the heuristic (every other home-row-adjacent pack has empty bindings), so this is behavior-preserving outside the bug.

## 2. The pack's explicit bindings were the wrong shape

[#891](https://github.com/malpern/KeyPath/pull/891) added 19 explicit `PackBindingTemplate`s to satisfy `testPackBindingsMatchCollectionMappings` — but the idiomatic shape for table-style packs (Vim Navigation, Mission Control, Numpad) is **empty bindings**, which routes Pack Detail to `MappingTableContent` rendering the collection's mappings directly: single source of truth, identical styling to the Rules tab. Reverted to `[]`. The invariant test skips empty-bindings packs by design, so it stays green.

## Result

The Neovim detail page now shows the activation hint + the full 19-motion table — same presentation as Vim Navigation's page.

## Verification

- PackCollectionIntegration / PackOwnership / PackRegistry suites green
- Deployed via quick-deploy; awaiting Micah's visual re-check
- swiftlint warnings in output are pre-existing on untouched lines