### PR TITLE
Docs: 1.0 release-readiness working doc + dashboard

### DIFF
--- a/RELEASE-READINESS.html
+++ b/RELEASE-READINESS.html
@@ -1,0 +1,924 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<title>KeyPath 1.0 — Release Readiness</title>
+<style>
+  :root {
+    --bg: #0b0f15;
+    --bg-2: #0f141c;
+    --card: #141a24;
+    --card-2: #1a2230;
+    --border: #232c3d;
+    --border-2: #2e3a52;
+    --text: #e8edf5;
+    --text-dim: #97a2b6;
+    --text-faint: #6b7587;
+    --accent: #5fa8ff;
+    --accent-2: #7ec0ff;
+    --success: #3fb96b;
+    --warning: #e0a83a;
+    --danger: #f25d6e;
+    --info: #79c0ff;
+    --purple: #b58cff;
+    --pink: #ff8aa8;
+    --teal: #4fd1c5;
+    --shadow: 0 1px 0 rgba(255,255,255,0.04) inset, 0 8px 24px rgba(0,0,0,0.35);
+    --mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  }
+  *, *::before, *::after { box-sizing: border-box; }
+  html, body { background: var(--bg); color: var(--text); margin: 0; padding: 0; }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "SF Pro Display", "Segoe UI", system-ui, sans-serif;
+    font-size: 14px;
+    line-height: 1.5;
+    -webkit-font-smoothing: antialiased;
+    background:
+      radial-gradient(1200px 600px at 80% -100px, rgba(95,168,255,0.08), transparent 60%),
+      radial-gradient(900px 500px at -10% 10%, rgba(181,140,255,0.06), transparent 60%),
+      var(--bg);
+    min-height: 100vh;
+  }
+  .wrap { max-width: 1320px; margin: 0 auto; padding: 32px 28px 64px; }
+
+  /* Header */
+  .hero {
+    display: flex;
+    align-items: flex-end;
+    justify-content: space-between;
+    gap: 24px;
+    padding-bottom: 24px;
+    border-bottom: 1px solid var(--border);
+    margin-bottom: 28px;
+  }
+  .hero-left h1 {
+    font-size: 34px;
+    line-height: 1.1;
+    font-weight: 700;
+    letter-spacing: -0.02em;
+    margin: 0 0 8px;
+    background: linear-gradient(180deg, #ffffff 0%, #b9c4d8 100%);
+    -webkit-background-clip: text;
+    background-clip: text;
+    color: transparent;
+  }
+  .hero-left .sub {
+    color: var(--text-dim);
+    font-size: 14px;
+    display: flex;
+    gap: 16px;
+    align-items: center;
+  }
+  .hero-left .sub .dot {
+    width: 6px; height: 6px; border-radius: 50%;
+    background: var(--success);
+    box-shadow: 0 0 12px rgba(63,185,107,0.6);
+  }
+  .countdown {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 8px;
+    padding: 12px 20px;
+    background: var(--card);
+    border: 1px solid var(--border-2);
+    border-radius: 12px;
+    box-shadow: var(--shadow);
+  }
+  .countdown .num { font-size: 30px; font-weight: 700; line-height: 1; }
+  .countdown .label { font-size: 11px; text-transform: uppercase; letter-spacing: 0.1em; color: var(--text-dim); }
+
+  /* KPI row */
+  .kpis {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 14px;
+    margin-bottom: 28px;
+  }
+  .kpi {
+    background: var(--card);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 16px 18px;
+    box-shadow: var(--shadow);
+    position: relative;
+    overflow: hidden;
+  }
+  .kpi::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(160deg, rgba(255,255,255,0.04), transparent 50%);
+    pointer-events: none;
+  }
+  .kpi .label { font-size: 11px; text-transform: uppercase; letter-spacing: 0.1em; color: var(--text-dim); margin-bottom: 6px; }
+  .kpi .value { font-size: 26px; font-weight: 700; letter-spacing: -0.01em; }
+  .kpi .meta { font-size: 12px; color: var(--text-faint); margin-top: 4px; }
+  .kpi.accent .value { color: var(--accent); }
+  .kpi.warn .value { color: var(--warning); }
+  .kpi.good .value { color: var(--success); }
+  .kpi.danger .value { color: var(--danger); }
+
+  /* Section */
+  .section { margin-bottom: 28px; }
+  .section-title {
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.14em;
+    color: var(--text-faint);
+    font-weight: 600;
+    margin: 0 0 10px;
+  }
+  .grid-2 { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+  .grid-3 { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 16px; }
+  .grid-2-1 { display: grid; grid-template-columns: 2fr 1fr; gap: 16px; }
+
+  /* Card */
+  .card {
+    background: var(--card);
+    border: 1px solid var(--border);
+    border-radius: 14px;
+    padding: 20px;
+    box-shadow: var(--shadow);
+  }
+  .card h3 {
+    margin: 0 0 14px;
+    font-size: 14px;
+    letter-spacing: 0.01em;
+    font-weight: 600;
+    color: var(--text);
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+  .card .tag {
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: var(--text-faint);
+    font-weight: 600;
+  }
+
+  /* Pills */
+  .pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 3px 9px;
+    border-radius: 999px;
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    line-height: 1.6;
+    border: 1px solid transparent;
+    white-space: nowrap;
+  }
+  .pill.full    { background: rgba(63,185,107,0.13);  color: #79e09a; border-color: rgba(63,185,107,0.32); }
+  .pill.good    { background: rgba(95,168,255,0.13);  color: #9ec5ff; border-color: rgba(95,168,255,0.32); }
+  .pill.partial { background: rgba(224,168,58,0.13);  color: #f1c674; border-color: rgba(224,168,58,0.32); }
+  .pill.none    { background: rgba(242,93,110,0.13);  color: #ff8c98; border-color: rgba(242,93,110,0.36); }
+  .pill.exp     { background: rgba(181,140,255,0.13); color: #cdb1ff; border-color: rgba(181,140,255,0.34); }
+  .pill.prod    { background: rgba(63,185,107,0.12);  color: #79e09a; border-color: rgba(63,185,107,0.28); }
+  .pill.nav     { background: rgba(95,168,255,0.12);  color: #9ec5ff; border-color: rgba(95,168,255,0.28); }
+  .pill.layer   { background: rgba(79,209,197,0.12);  color: #7ee0d6; border-color: rgba(79,209,197,0.28); }
+  .pill.sys     { background: rgba(255,138,168,0.12); color: #ffa7be; border-color: rgba(255,138,168,0.28); }
+  .pill.low     { background: rgba(63,185,107,0.13);  color: #79e09a; border-color: rgba(63,185,107,0.32); }
+  .pill.med     { background: rgba(224,168,58,0.13);  color: #f1c674; border-color: rgba(224,168,58,0.32); }
+  .pill.high    { background: rgba(242,93,110,0.13);  color: #ff8c98; border-color: rgba(242,93,110,0.36); }
+  .pill.done    { background: rgba(63,185,107,0.13);  color: #79e09a; border-color: rgba(63,185,107,0.32); }
+  .pill.wip     { background: rgba(95,168,255,0.13);  color: #9ec5ff; border-color: rgba(95,168,255,0.32); }
+  .pill.idle    { background: rgba(150,160,180,0.10); color: var(--text-dim); border-color: rgba(150,160,180,0.22); }
+
+  /* Decisions */
+  .decision {
+    display: flex;
+    align-items: flex-start;
+    gap: 14px;
+    padding: 14px 0;
+    border-bottom: 1px dashed var(--border);
+  }
+  .decision:last-child { border-bottom: 0; padding-bottom: 0; }
+  .decision:first-child { padding-top: 0; }
+  .decision .check {
+    width: 22px; height: 22px;
+    border-radius: 50%;
+    background: rgba(63,185,107,0.16);
+    color: var(--success);
+    display: inline-flex;
+    align-items: center; justify-content: center;
+    font-size: 13px;
+    border: 1px solid rgba(63,185,107,0.32);
+    flex: none;
+    margin-top: 1px;
+  }
+  .decision .body { flex: 1; }
+  .decision .body .key {
+    font-family: var(--mono);
+    font-size: 11px;
+    color: var(--text-faint);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+  }
+  .decision .body .title { font-weight: 600; margin: 2px 0 4px; }
+  .decision .body .note { font-size: 12.5px; color: var(--text-dim); }
+
+  /* Schedule */
+  .schedule {
+    display: grid;
+    grid-template-columns: repeat(5, 1fr);
+    gap: 8px;
+  }
+  .day {
+    padding: 12px;
+    border-radius: 10px;
+    background: var(--card-2);
+    border: 1px solid var(--border);
+    position: relative;
+    overflow: hidden;
+  }
+  .day.today { border-color: var(--accent); box-shadow: 0 0 0 2px rgba(95,168,255,0.18); }
+  .day.done { opacity: 0.65; }
+  .day .name {
+    font-size: 11px; text-transform: uppercase; letter-spacing: 0.1em; color: var(--text-faint);
+    display: flex; justify-content: space-between; align-items: center;
+  }
+  .day .date { font-family: var(--mono); font-size: 11px; color: var(--text-faint); }
+  .day .focus { font-weight: 600; margin-top: 6px; font-size: 13px; }
+  .day .detail { color: var(--text-dim); font-size: 12px; margin-top: 4px; line-height: 1.4; }
+  .day .now-tag {
+    background: var(--accent); color: #0b0f15; font-weight: 700;
+    border-radius: 4px; padding: 1px 6px; font-size: 9px; letter-spacing: 0.06em;
+    text-transform: uppercase;
+  }
+
+  /* Table */
+  .table-wrap {
+    border-radius: 10px;
+    overflow: auto;
+    border: 1px solid var(--border);
+    background: var(--bg-2);
+    max-height: 540px;
+  }
+  table { width: 100%; border-collapse: collapse; font-size: 13px; }
+  thead th {
+    text-align: left;
+    background: var(--card-2);
+    color: var(--text-dim);
+    font-weight: 600;
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    padding: 10px 12px;
+    position: sticky; top: 0;
+    border-bottom: 1px solid var(--border);
+    backdrop-filter: blur(6px);
+  }
+  tbody td {
+    padding: 10px 12px;
+    border-bottom: 1px solid var(--border);
+    vertical-align: middle;
+  }
+  tbody tr:last-child td { border-bottom: 0; }
+  tbody tr:hover { background: rgba(255,255,255,0.018); }
+  td.muted { color: var(--text-dim); }
+  td.idx { font-family: var(--mono); color: var(--text-faint); font-size: 11.5px; text-align: right; width: 24px; }
+  td.name { font-weight: 600; color: var(--text); }
+  td.center { text-align: center; }
+
+  /* Complexity bar */
+  .complexity {
+    display: inline-flex;
+    gap: 2px;
+    align-items: center;
+  }
+  .complexity span {
+    width: 6px; height: 10px;
+    background: var(--border-2);
+    border-radius: 1px;
+  }
+  .complexity.high span:nth-child(-n+3) { background: var(--danger); }
+  .complexity.med  span:nth-child(-n+2) { background: var(--warning); }
+  .complexity.low  span:nth-child(-n+1) { background: var(--success); }
+
+  /* Charts */
+  .donut-card { display: flex; align-items: center; gap: 24px; }
+  .donut-card svg { flex: none; }
+  .legend { display: flex; flex-direction: column; gap: 8px; font-size: 13px; }
+  .legend .row { display: flex; align-items: center; gap: 10px; }
+  .legend .swatch { width: 12px; height: 12px; border-radius: 3px; flex: none; }
+  .legend .num { color: var(--text); font-weight: 600; min-width: 24px; text-align: right; font-variant-numeric: tabular-nums; }
+  .legend .lbl { color: var(--text-dim); flex: 1; }
+
+  .bars { display: flex; flex-direction: column; gap: 10px; }
+  .bars .row { display: grid; grid-template-columns: 110px 1fr 32px; align-items: center; gap: 10px; font-size: 12.5px; }
+  .bars .row .cat { color: var(--text-dim); }
+  .bars .row .num { font-weight: 700; color: var(--text); font-variant-numeric: tabular-nums; }
+  .bars .bar {
+    height: 8px;
+    border-radius: 4px;
+    background: var(--card-2);
+    overflow: hidden;
+  }
+  .bars .bar .fill {
+    height: 100%;
+    border-radius: 4px;
+    background: linear-gradient(90deg, var(--accent), var(--accent-2));
+  }
+
+  /* Sidebar tabs grid */
+  .tabs-grid {
+    display: grid;
+    grid-template-columns: repeat(5, 1fr);
+    gap: 10px;
+  }
+  .tab-cell {
+    padding: 12px;
+    background: var(--card-2);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+  }
+  .tab-cell.danger { border-color: rgba(242,93,110,0.4); background: linear-gradient(160deg, rgba(242,93,110,0.06), var(--card-2)); }
+  .tab-cell .name { font-weight: 600; margin-bottom: 4px; }
+  .tab-cell .num { color: var(--text-dim); font-size: 12px; }
+  .tab-cell .badge { float: right; }
+
+  /* Findings timeline */
+  .timeline { display: flex; flex-direction: column; gap: 14px; }
+  .finding {
+    display: grid;
+    grid-template-columns: 110px 1fr;
+    gap: 16px;
+    padding: 12px;
+    border-radius: 10px;
+    background: var(--card-2);
+    border-left: 3px solid var(--border);
+  }
+  .finding.refuted  { border-left-color: var(--success); }
+  .finding.confirmed { border-left-color: var(--warning); }
+  .finding.open     { border-left-color: var(--danger); }
+  .finding .when { font-family: var(--mono); font-size: 11px; color: var(--text-faint); }
+  .finding .title { font-weight: 600; margin-bottom: 4px; }
+  .finding .desc  { color: var(--text-dim); font-size: 12.5px; }
+  .finding .desc code, .finding .desc a { font-family: var(--mono); font-size: 12px; color: var(--accent); text-decoration: none; }
+
+  /* Wave 1 status */
+  .wave-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; }
+  .wave-item {
+    padding: 14px;
+    background: var(--card-2);
+    border-radius: 10px;
+    border: 1px solid var(--border);
+  }
+  .wave-item .id { font-family: var(--mono); color: var(--text-faint); font-size: 12px; margin-bottom: 4px; }
+  .wave-item .name { font-weight: 600; margin-bottom: 8px; }
+
+  /* Footer */
+  .footer {
+    text-align: center;
+    color: var(--text-faint);
+    font-size: 11.5px;
+    margin-top: 36px;
+    padding-top: 20px;
+    border-top: 1px solid var(--border);
+  }
+  .footer code { font-family: var(--mono); }
+
+  /* Misc */
+  a { color: var(--accent); text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  code.inline { font-family: var(--mono); font-size: 12px; padding: 1px 6px; background: rgba(255,255,255,0.05); border-radius: 4px; color: var(--accent-2); }
+</style>
+</head>
+<body>
+<div class="wrap">
+
+  <!-- Hero -->
+  <header class="hero">
+    <div class="hero-left">
+      <h1>KeyPath 1.0 — Release Readiness</h1>
+      <div class="sub">
+        <span class="dot"></span>
+        <span>Wed 2026-06-10 late — eng gates ahead · docs+marketing scope added · Thu AM scope call needed</span>
+        <span style="color: var(--border-2)">·</span>
+        <a href="RELEASE-READINESS.md">View markdown source</a>
+      </div>
+    </div>
+    <div class="countdown">
+      <span class="num">3</span>
+      <span class="label">days to ship<br>Sat 2026-06-13</span>
+    </div>
+  </header>
+
+  <!-- ============ SHIP GATE: the only section you need to read ============ -->
+  <section class="section">
+    <div class="grid-2-1">
+
+      <!-- Exit criteria checklist -->
+      <div class="card" style="border-color: rgba(95,168,255,0.35);">
+        <h3>Ship gate — 10 exit criteria <span class="tag">4 closed · 6 open · 2 added Wed night</span></h3>
+        <div class="table-wrap" style="border: 0; max-height: none;">
+          <table>
+            <thead>
+              <tr><th style="width:30px">#</th><th>Exit criterion</th><th style="width:110px">Status</th><th style="width:90px">Day</th><th style="width:70px">Est. hrs left</th></tr>
+            </thead>
+            <tbody>
+              <tr><td class="idx">1</td><td class="name">All 22 families kanata-syntax valid</td><td><span class="pill done">closed</span></td><td class="muted">Wed</td><td class="center muted">—</td></tr>
+              <tr><td class="idx">2</td><td class="name">High-complexity families per-option coverage</td><td><span class="pill done">closed</span></td><td class="muted">Wed</td><td class="center muted">—</td></tr>
+              <tr><td class="idx">3</td><td class="name">Release-blocker findings fixed + live-verified</td><td><span class="pill done">closed</span></td><td class="muted">Wed</td><td class="center muted">—</td></tr>
+              <tr><td class="idx">4</td><td class="name">6 family smoke scripts pass on installed app — <a href="https://github.com/malpern/KeyPath/issues/881">#881</a> fixed (<a href="https://github.com/malpern/KeyPath/pull/884">#884</a>), lib manifest-hardened (<a href="https://github.com/malpern/KeyPath/pull/880">#880</a>), 6/6 re-verified on the fixed app</td><td><span class="pill done">closed</span></td><td class="muted">Thu AM</td><td class="center muted">—</td></tr>
+              <tr><td class="idx">5</td><td class="name">Design review pass across catalog — <a href="https://github.com/malpern/KeyPath/issues/888">#888</a> post-1.0 backlog, <a href="https://github.com/malpern/KeyPath/issues/889">#889</a> Fri must-fix candidate</td><td><span class="pill done">closed</span></td><td class="muted">Thu</td><td class="center muted">—</td></tr>
+              <tr><td class="idx">6</td><td class="name">Findings triage → must-fix list closed</td><td><span class="pill idle">open</span></td><td class="muted">Fri</td><td class="center">≤8</td></tr>
+              <tr><td class="idx">7</td><td class="name">RC built, signed, notarized, smoke-verified</td><td><span class="pill idle">open</span></td><td class="muted">Sat</td><td class="center">~3</td></tr>
+              <tr><td class="idx">8</td><td class="name">Release notes incl. known limitations</td><td><span class="pill idle">draft</span></td><td class="muted">Fri/Sat</td><td class="center">~1</td></tr>
+              <tr style="background: rgba(224,168,58,0.05);"><td class="idx">9</td><td class="name">Docs complete — 12 guides missing header illustrations · ~6 packs missing detail/guide pages · screenshots current</td><td><span class="pill partial">new scope</span></td><td class="muted">Thu–Fri</td><td class="center">~8</td></tr>
+              <tr style="background: rgba(224,168,58,0.05);"><td class="idx">10</td><td class="name">Marketing basics — website video recorded + landing copy</td><td><span class="pill partial">new scope</span></td><td class="muted">Fri/Sat</td><td class="center">~5</td></tr>
+            </tbody>
+          </table>
+        </div>
+        <div style="margin-top: 10px; font-size: 11.5px; color: var(--text-dim);">
+          Gates 9–10 added Wed night per Micah. Open item: the in-app "orange box" marker for rules lacking detail pages — couldn't locate in source; confirm one example Thu AM and I'll enumerate the exact list. Grep-based gap list: backup-caps-lock, delete-enhancement, escape-remap, home-row-arrows, keystroke-history, mission-control.
+        </div>
+      </div>
+
+      <!-- Verdict + burndown -->
+      <div style="display: flex; flex-direction: column; gap: 16px;">
+        <div class="card" style="background: linear-gradient(160deg, rgba(224,168,58,0.10), var(--card)); border-color: rgba(224,168,58,0.45);">
+          <h3>Verdict <span class="tag">vs plan</span></h3>
+          <div style="font-size: 26px; font-weight: 700; color: var(--warning); margin-bottom: 6px;">At risk — trending well</div>
+          <div style="font-size: 12.5px; color: var(--text-dim); line-height: 1.55;">
+            Thu AM: <a href="https://github.com/malpern/KeyPath/issues/881">#881</a> root-caused from the smoke logs, fixed (<a href="https://github.com/malpern/KeyPath/pull/884">#884</a>), lib manifest-hardened (<a href="https://github.com/malpern/KeyPath/pull/880">#880</a>), redeployed, 6/6 re-verified with zero restore warnings. <strong style="color: var(--text);">4 of 10 gates closed. ~21 hrs vs ~18 available — ~3–6 hr gap.</strong>
+            <br><br><strong style="color: var(--text);">Still needed:</strong> the scope call (cut illustrations / weekend hrs / slip) + the orange-box example. Two new findings for design review: Leader Key selectedOutput is display-only; Launcher leaderSequence config-identical to holdHyper.
+          </div>
+        </div>
+
+        <div class="card">
+          <h3>Burndown <span class="tag">est. hrs to gate</span></h3>
+          <!-- Hours remaining to close all gates, end of each day.
+               Actual: start 36 → Tue 30 → Wed 18, then +13h scope add Wed night → 31.
+               Projection at ~22 available hrs (Thu 10, Fri 8, Sat 4): Thu 21 → Fri 13 → Sat 9 (gap).
+               Plot: y: 0 hrs = 130, 36 hrs = 10 (scale 3.33px/hr). x: start 20 → Sat 250. -->
+          <svg width="100%" height="170" viewBox="0 0 270 170" preserveAspectRatio="xMidYMid meet">
+            <!-- gridlines -->
+            <line x1="20" y1="130" x2="250" y2="130" stroke="var(--border)" stroke-width="1"/>
+            <line x1="20" y1="70" x2="250" y2="70" stroke="var(--border)" stroke-width="0.5" stroke-dasharray="3 3"/>
+            <line x1="20" y1="10" x2="250" y2="10" stroke="var(--border)" stroke-width="0.5" stroke-dasharray="3 3"/>
+            <text x="14" y="133" font-size="8" fill="var(--text-faint)" text-anchor="end">0</text>
+            <text x="14" y="73" font-size="8" fill="var(--text-faint)" text-anchor="end">18</text>
+            <text x="14" y="13" font-size="8" fill="var(--text-faint)" text-anchor="end">36</text>
+            <!-- ideal line: 36 at start → 0 at Sat -->
+            <line x1="20" y1="10" x2="250" y2="130" stroke="var(--text-faint)" stroke-width="1" stroke-dasharray="4 4"/>
+            <!-- actual: start 36 → Tue 30 → Wed 18 -->
+            <polyline points="20,10 66,30 112,70" fill="none" stroke="#3fb96b" stroke-width="2.5" stroke-linecap="round"/>
+            <!-- scope add: vertical jump Wed 18 → 31 -->
+            <line x1="112" y1="70" x2="112" y2="26.7" stroke="#e0a83a" stroke-width="2.5" stroke-dasharray="3 3"/>
+            <text x="118" y="44" font-size="8" fill="#e0a83a">+13h scope</text>
+            <!-- projection from 31: Thu 21 → Fri 13 → Sat 9 -->
+            <polyline points="112,26.7 158,60 204,86.7 250,100" fill="none" stroke="#5fa8ff" stroke-width="2" stroke-dasharray="5 4" stroke-linecap="round"/>
+            <!-- the gap at Sat -->
+            <line x1="250" y1="100" x2="250" y2="130" stroke="#f25d6e" stroke-width="2"/>
+            <text x="245" y="120" font-size="8" fill="#f25d6e" text-anchor="end">~9h gap</text>
+            <!-- actual dots -->
+            <circle cx="20" cy="10" r="3.5" fill="#3fb96b"/>
+            <circle cx="66" cy="30" r="3.5" fill="#3fb96b"/>
+            <circle cx="112" cy="70" r="4.5" fill="#3fb96b" stroke="#0b0f15" stroke-width="1.5"/>
+            <circle cx="112" cy="26.7" r="3.5" fill="#e0a83a"/>
+            <!-- projected dots -->
+            <circle cx="158" cy="60" r="3" fill="none" stroke="#5fa8ff" stroke-width="1.5"/>
+            <circle cx="204" cy="86.7" r="3" fill="none" stroke="#5fa8ff" stroke-width="1.5"/>
+            <circle cx="250" cy="100" r="3" fill="none" stroke="#5fa8ff" stroke-width="1.5"/>
+            <!-- x labels -->
+            <text x="20" y="146" font-size="8.5" fill="var(--text-faint)" text-anchor="middle">start</text>
+            <text x="66" y="146" font-size="8.5" fill="var(--text-dim)" text-anchor="middle">Tue</text>
+            <text x="112" y="146" font-size="8.5" fill="var(--text)" font-weight="700" text-anchor="middle">Wed ◀</text>
+            <text x="158" y="146" font-size="8.5" fill="var(--text-faint)" text-anchor="middle">Thu</text>
+            <text x="204" y="146" font-size="8.5" fill="var(--text-faint)" text-anchor="middle">Fri</text>
+            <text x="250" y="146" font-size="8.5" fill="var(--text-faint)" text-anchor="middle">Sat</text>
+            <!-- legend -->
+            <line x1="20" y1="160" x2="34" y2="160" stroke="#3fb96b" stroke-width="2.5"/>
+            <text x="37" y="163" font-size="8" fill="var(--text-dim)">actual</text>
+            <line x1="70" y1="160" x2="84" y2="160" stroke="#e0a83a" stroke-width="2.5" stroke-dasharray="3 3"/>
+            <text x="87" y="163" font-size="8" fill="var(--text-dim)">scope add</text>
+            <line x1="132" y1="160" x2="146" y2="160" stroke="#5fa8ff" stroke-width="2" stroke-dasharray="5 4"/>
+            <text x="149" y="163" font-size="8" fill="var(--text-dim)">projected</text>
+            <line x1="195" y1="160" x2="209" y2="160" stroke="var(--text-faint)" stroke-width="1" stroke-dasharray="4 4"/>
+            <text x="212" y="163" font-size="8" fill="var(--text-dim)">ideal</text>
+          </svg>
+          <div style="font-size: 11.5px; color: var(--text-dim); margin-top: 4px;">
+            Engineering burn was ahead of ideal through Wed; the +13h scope add then a late-Wed smoke-suite sprint (gate 4 closed, −4h) nets <strong>~27h remaining</strong>. Projection: <strong style="color: var(--danger);">~5 hrs unfinished at Sat</strong> — close via scope cut, weekend hours, or slip.
+          </div>
+        </div>
+      </div>
+
+    </div>
+  </section>
+
+  <!-- Week schedule: full-width so day cells stay legible -->
+  <section class="section">
+    <div class="card">
+      <h3>This week <span class="tag">5-day push · Sat 06·13 target</span></h3>
+      <div class="schedule">
+        <div class="day done">
+          <div class="name"><span>Tue</span><span class="date">06·09</span></div>
+          <div class="focus">✓ Inventory + decisions</div>
+          <div class="detail">Mapper de-risked, 3 decisions locked</div>
+        </div>
+        <div class="day done">
+          <div class="name"><span>Wed</span><span class="date">06·10</span></div>
+          <div class="focus">✓ Tests + safety net</div>
+          <div class="detail">6 PRs merged, fix live-verified</div>
+        </div>
+        <div class="day today">
+          <div class="name"><span>Thu</span> <span class="now-tag">Next</span></div>
+          <div class="date">06·11</div>
+          <div class="focus">Smokes + design review</div>
+          <div class="detail">5 smoke scripts, docs scope call</div>
+        </div>
+        <div class="day">
+          <div class="name"><span>Fri</span><span class="date">06·12</span></div>
+          <div class="focus">Triage + docs</div>
+          <div class="detail">Must-fix ≤1 day, illustrations</div>
+        </div>
+        <div class="day">
+          <div class="name"><span>Sat</span><span class="date">06·13</span></div>
+          <div class="focus">RC + ship</div>
+          <div class="detail">Or call the slip</div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Decisions + Coverage donut -->
+  <section class="section">
+    <div class="grid-2">
+
+      <div class="card">
+        <h3>Decisions <span class="tag">Locked tonight</span></h3>
+        <div class="decision">
+          <div class="check">✓</div>
+          <div class="body">
+            <div class="key">D1 · HRM tier</div>
+            <div class="title">Shipping (no change needed)</div>
+            <div class="note">Already <code class="inline">category: "productivity"</code>. The "experimental" label was synthesized, not real.</div>
+          </div>
+        </div>
+        <div class="decision">
+          <div class="check">✓</div>
+          <div class="body">
+            <div class="key">D2 · Tier expanded — ship everything</div>
+            <div class="title">All 22 families ship for 1.0</div>
+            <div class="note">User call: "move everything into production, including autoshift. expand the test target." Auto Shift promoted in <a href="https://github.com/malpern/KeyPath/pull/857">PR #857</a>.</div>
+          </div>
+        </div>
+        <div class="decision">
+          <div class="check">✓</div>
+          <div class="body">
+            <div class="key">D3 · Mapper strategy</div>
+            <div class="title">Defend — correctness only</div>
+            <div class="note">UX polish becomes known-limitations release notes.</div>
+          </div>
+        </div>
+      </div>
+
+      <div class="card">
+        <h3>Coverage distribution <span class="tag">post-Wed</span></h3>
+        <div class="donut-card">
+          <!-- Donut: FULL 6, GOOD 16, PARTIAL 0. Total 22.
+               After #862 (per-family kanata --check) + #864 (per-option matrix for 4 high-complexity families).
+               Angles: FULL = 6/22 * 360 = 98.18°; GOOD = 16/22 * 360 = 261.82°. -->
+          <svg width="170" height="170" viewBox="0 0 170 170">
+            <g transform="translate(85,85)">
+              <!-- background ring -->
+              <circle r="65" fill="none" stroke="var(--border)" stroke-width="22" />
+              <!-- Circumference = 2π*65 ≈ 408.41 -->
+              <!-- FULL: arc length = 6/22 * 408.41 = 111.39 -->
+              <circle r="65" fill="none" stroke="#3fb96b" stroke-width="22"
+                      stroke-dasharray="111.39 297.02" stroke-dashoffset="0"
+                      transform="rotate(-90)" />
+              <!-- GOOD: arc length = 16/22 * 408.41 = 297.02, offset by 111.39 -->
+              <circle r="65" fill="none" stroke="#5fa8ff" stroke-width="22"
+                      stroke-dasharray="297.02 111.39" stroke-dashoffset="-111.39"
+                      transform="rotate(-90)" />
+              <text text-anchor="middle" dominant-baseline="central" y="-6"
+                    font-size="22" font-weight="700" fill="#e8edf5">22</text>
+              <text text-anchor="middle" dominant-baseline="central" y="14"
+                    font-size="10" fill="#6b7587" letter-spacing="1.4">FAMILIES</text>
+            </g>
+          </svg>
+          <div class="legend">
+            <div class="row">
+              <span class="swatch" style="background:#3fb96b"></span>
+              <span class="lbl">Full coverage</span>
+              <span class="num">6</span>
+            </div>
+            <div class="row">
+              <span class="swatch" style="background:#5fa8ff"></span>
+              <span class="lbl">Good coverage</span>
+              <span class="num">16</span>
+            </div>
+            <div class="row" style="margin-top: 6px; padding-top: 8px; border-top: 1px dashed var(--border);">
+              <span class="swatch" style="background:var(--card-2); border:1px solid var(--border-2)"></span>
+              <span class="lbl">Partial / none</span>
+              <span class="num">0</span>
+            </div>
+            <div class="row" style="color: var(--text-faint); font-size: 11.5px;">
+              <span class="swatch" style="background:transparent"></span>
+              <span class="lbl">Tue: 2 full · 3 good · 17 partial</span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+    </div>
+  </section>
+
+  <!-- Category breakdown + Sidebar tabs -->
+  <section class="section">
+    <div class="grid-2">
+      <div class="card">
+        <h3>Families by UI category <span class="tag">canonical from catalog.json</span></h3>
+        <div class="bars">
+          <div class="row">
+            <span class="cat">productivity</span>
+            <div class="bar"><div class="fill" style="width: 100%; background: linear-gradient(90deg, #3fb96b, #79e09a);"></div></div>
+            <span class="num">9</span>
+          </div>
+          <div class="row">
+            <span class="cat">navigation</span>
+            <div class="bar"><div class="fill" style="width: 55.5%;"></div></div>
+            <span class="num">5</span>
+          </div>
+          <div class="row">
+            <span class="cat">layers</span>
+            <div class="bar"><div class="fill" style="width: 44.4%; background: linear-gradient(90deg, #4fd1c5, #7ee0d6);"></div></div>
+            <span class="num">4</span>
+          </div>
+          <div class="row">
+            <span class="cat">system</span>
+            <div class="bar"><div class="fill" style="width: 33.3%; background: linear-gradient(90deg, #ff8aa8, #ffa7be);"></div></div>
+            <span class="num">3</span>
+          </div>
+          <div class="row">
+            <span class="cat">experimental</span>
+            <div class="bar"><div class="fill" style="width: 11.1%; background: linear-gradient(90deg, #b58cff, #cdb1ff);"></div></div>
+            <span class="num">1</span>
+          </div>
+        </div>
+        <div style="margin-top: 14px; font-size: 12px; color: var(--text-dim);">
+          Only <strong>Auto Shift Symbols</strong> sits in the Experimental section. The "hidden" tier I described earlier was a synthesis — those families ship in user-facing UI sections too.
+        </div>
+      </div>
+
+      <div class="card">
+        <h3>Overlay sidebar <span class="tag">10 tabs · ~40 controls</span></h3>
+        <div class="tabs-grid">
+          <div class="tab-cell danger">
+            <div class="name">Mapper <span class="pill high badge">17</span></div>
+            <div class="num">Core surface · highest risk</div>
+          </div>
+          <div class="tab-cell">
+            <div class="name">Custom Rules <span class="pill med badge">7</span></div>
+            <div class="num">Reset = destructive</div>
+          </div>
+          <div class="tab-cell">
+            <div class="name">Launchers <span class="pill med badge">2+</span></div>
+            <div class="num">Async save race (low)</div>
+          </div>
+          <div class="tab-cell">
+            <div class="name">Keymap <span class="pill med badge">4</span></div>
+            <div class="num">Logical layout switch</div>
+          </div>
+          <div class="tab-cell">
+            <div class="name">Devices <span class="pill med badge">1</span></div>
+            <div class="num">Device selection</div>
+          </div>
+          <div class="tab-cell">
+            <div class="name">Layout <span class="pill low badge">1</span></div>
+            <div class="num">Physical layout grid</div>
+          </div>
+          <div class="tab-cell">
+            <div class="name">Keycaps <span class="pill low badge">1</span></div>
+            <div class="num">Colorway grid</div>
+          </div>
+          <div class="tab-cell">
+            <div class="name">Sounds <span class="pill low badge">~</span></div>
+            <div class="num">Typing sounds</div>
+          </div>
+          <div class="tab-cell">
+            <div class="name">History <span class="pill low badge">1</span></div>
+            <div class="num">Read-only view</div>
+          </div>
+          <div class="tab-cell">
+            <div class="name">Settings <span class="pill low badge">1</span></div>
+            <div class="num">Gear toggle</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Rule family inventory -->
+  <section class="section">
+    <h2 class="section-title">Rule family inventory · 22 families</h2>
+    <div class="card" style="padding: 0;">
+      <div class="table-wrap" style="border: 0; border-radius: 14px;">
+        <table>
+          <thead>
+            <tr>
+              <th class="idx">#</th>
+              <th>Family</th>
+              <th>Category</th>
+              <th>Coverage</th>
+              <th>Complexity</th>
+              <th>Action this week</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr><td class="idx">1</td><td class="name">Home Row Mods</td><td><span class="pill prod">productivity</span></td><td><span class="pill full">full</span></td><td><span class="complexity high"><span></span><span></span><span></span></span></td><td class="muted">Walkthrough only — covered</td></tr>
+            <tr><td class="idx">2</td><td class="name">Caps Lock Remap</td><td><span class="pill prod">productivity</span></td><td><span class="pill full">full</span></td><td><span class="complexity low"><span></span><span></span><span></span></span></td><td class="muted">Walkthrough only — covered</td></tr>
+            <tr><td class="idx">3</td><td class="name">Chord Groups</td><td><span class="pill prod">productivity</span></td><td><span class="pill good">good</span></td><td><span class="complexity high"><span></span><span></span><span></span></span></td><td class="muted">Top-up matrix · walkthrough</td></tr>
+            <tr><td class="idx">4</td><td class="name">Sequences</td><td><span class="pill prod">productivity</span></td><td><span class="pill good">good</span></td><td><span class="complexity high"><span></span><span></span><span></span></span></td><td class="muted">Top-up matrix · walkthrough</td></tr>
+            <tr><td class="idx">5</td><td class="name">Vim Navigation</td><td><span class="pill nav">navigation</span></td><td><span class="pill good">good</span></td><td><span class="complexity low"><span></span><span></span><span></span></span></td><td class="muted">Per-option matrix</td></tr>
+            <tr><td class="idx">6</td><td class="name">Home Row Arrows</td><td><span class="pill nav">navigation</span></td><td><span class="pill partial">partial</span></td><td><span class="complexity low"><span></span><span></span><span></span></span></td><td>Golden + matrix</td></tr>
+            <tr><td class="idx">7</td><td class="name">Quick Launcher</td><td><span class="pill layer">layers</span></td><td><span class="pill partial">partial</span></td><td><span class="complexity high"><span></span><span></span><span></span></span></td><td>Golden + matrix + walkthrough</td></tr>
+            <tr><td class="idx">8</td><td class="name">Fast Navigation</td><td><span class="pill sys">system</span></td><td><span class="pill partial">partial</span></td><td><span class="complexity med"><span></span><span></span><span></span></span></td><td>Golden + matrix</td></tr>
+            <tr><td class="idx">9</td><td class="name">macOS Function Keys</td><td><span class="pill sys">system</span></td><td><span class="pill partial">partial</span></td><td><span class="complexity low"><span></span><span></span><span></span></span></td><td>Golden + walkthrough</td></tr>
+            <tr><td class="idx">10</td><td class="name">Home Row Layer Toggles</td><td><span class="pill prod">productivity</span></td><td><span class="pill partial">partial</span></td><td><span class="complexity high"><span></span><span></span><span></span></span></td><td>Matrix · candidate for demote</td></tr>
+            <tr><td class="idx">11</td><td class="name">Auto Shift Symbols</td><td><span class="pill exp">experimental</span></td><td><span class="pill partial">partial</span></td><td><span class="complexity med"><span></span><span></span><span></span></span></td><td class="muted">Already experimental — golden only</td></tr>
+            <tr><td class="idx">12</td><td class="name">Window Snapping</td><td><span class="pill prod">productivity</span></td><td><span class="pill partial">partial</span></td><td><span class="complexity low"><span></span><span></span><span></span></span></td><td>Golden (mode variants)</td></tr>
+            <tr><td class="idx">13</td><td class="name">Leader Key</td><td><span class="pill sys">system</span></td><td><span class="pill partial">partial</span></td><td><span class="complexity low"><span></span><span></span><span></span></span></td><td>Per-preset golden</td></tr>
+            <tr><td class="idx">14</td><td class="name">Escape</td><td><span class="pill prod">productivity</span></td><td><span class="pill partial">partial</span></td><td><span class="complexity low"><span></span><span></span><span></span></span></td><td>Per-preset golden</td></tr>
+            <tr><td class="idx">15</td><td class="name">Delete Enhancement</td><td><span class="pill prod">productivity</span></td><td><span class="pill partial">partial</span></td><td><span class="complexity low"><span></span><span></span><span></span></span></td><td>Per-preset golden</td></tr>
+            <tr><td class="idx">16</td><td class="name">Backup Caps Lock</td><td><span class="pill prod">productivity</span></td><td><span class="pill partial">partial</span></td><td><span class="complexity low"><span></span><span></span><span></span></span></td><td>Per-preset golden</td></tr>
+            <tr><td class="idx">17</td><td class="name">Neovim Terminal</td><td><span class="pill nav">navigation</span></td><td><span class="pill partial">partial</span></td><td><span class="complexity low"><span></span><span></span><span></span></span></td><td>Cheap golden</td></tr>
+            <tr><td class="idx">18</td><td class="name">Mission Control</td><td><span class="pill nav">navigation</span></td><td><span class="pill partial">partial</span></td><td><span class="complexity low"><span></span><span></span><span></span></span></td><td>Cheap golden</td></tr>
+            <tr><td class="idx">19</td><td class="name">Ben Vallack Nav</td><td><span class="pill nav">navigation</span></td><td><span class="pill partial">partial</span></td><td><span class="complexity low"><span></span><span></span><span></span></span></td><td>Cheap golden</td></tr>
+            <tr><td class="idx">20</td><td class="name">Numpad</td><td><span class="pill layer">layers</span></td><td><span class="pill partial">partial</span></td><td><span class="complexity low"><span></span><span></span><span></span></span></td><td>Cheap golden</td></tr>
+            <tr><td class="idx">21</td><td class="name">Symbol Layer</td><td><span class="pill layer">layers</span></td><td><span class="pill partial">partial</span></td><td><span class="complexity low"><span></span><span></span><span></span></span></td><td>Per-preset golden</td></tr>
+            <tr><td class="idx">22</td><td class="name">Function Keys (right hand)</td><td><span class="pill layer">layers</span></td><td><span class="pill partial">partial</span></td><td><span class="complexity low"><span></span><span></span><span></span></span></td><td>Cheap golden</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </section>
+
+  <!-- Findings log -->
+  <section class="section">
+    <h2 class="section-title">Findings log · Tuesday verification</h2>
+    <div class="grid-2-1">
+      <div class="card">
+        <h3>Mapper bug claims — verified</h3>
+        <div class="timeline">
+          <div class="finding refuted">
+            <div>
+              <div class="when">Tue PM · task #1</div>
+              <span class="pill done" style="margin-top: 6px;">refuted</span>
+            </div>
+            <div>
+              <div class="title">State-persistence "bug" overstated</div>
+              <div class="desc">
+                Picker mode (slot/count/output-mode) is ephemeral <code>@State</code>, but the actual configured actions live on <code>MapperViewModel.advancedBehavior</code> and are restored on each <code>onAppear</code> via <code>loadBehaviorFromExistingRule()</code>. <code>configuredBehaviorSlots</code> set gives visual indicator. <strong>No data loss.</strong>
+                <br><br>Disposition: known-limitation line — "Mapper opens to Tap slot — click Hold/Shift to see actions you configured for that slot."
+              </div>
+            </div>
+          </div>
+          <div class="finding refuted">
+            <div>
+              <div class="when">Tue PM · task #2</div>
+              <span class="pill done" style="margin-top: 6px;">refuted</span>
+            </div>
+            <div>
+              <div class="title">"No recording mutex" — wrong</div>
+              <div class="desc">
+                Every <code>toggle*Recording()</code> in <code>MapperViewModel.swift:651-758</code> explicitly stops other recorders before activating itself. MainActor serializes the toggles. Hold and double-tap also have explicit conflict dialogs. <strong>Close.</strong>
+              </div>
+            </div>
+          </div>
+          <div class="finding confirmed">
+            <div>
+              <div class="when">Tue PM · task #3</div>
+              <span class="pill med" style="margin-top: 6px;">confirmed — low impact</span>
+            </div>
+            <div>
+              <div class="title">Launcher async-save race</div>
+              <div class="desc">
+                <code>saveLauncherConfig()</code> spawns unbounded <code>Task</code> per toggle. Store is actor-isolated and final UI state drives final save. Worst case: momentary persisted state lags by one toggle. <strong>Not a release blocker.</strong> Post-1.0 cleanup.
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="card">
+        <h3>What this means</h3>
+        <p style="margin: 0 0 12px; color: var(--text-dim); font-size: 13px;">
+          The inventory agent reading SwiftUI source statically over-reported the Mapper's risk. Two of three "HIGH" claims don't hold up.
+        </p>
+        <div style="display: flex; flex-direction: column; gap: 10px;">
+          <div style="padding: 12px; background: rgba(63,185,107,0.07); border: 1px solid rgba(63,185,107,0.25); border-radius: 8px;">
+            <strong style="color: var(--success);">D3 holds.</strong>
+            <div style="color: var(--text-dim); font-size: 12.5px; margin-top: 4px;">Defend Mapper in place. No new must-fix work from these findings.</div>
+          </div>
+          <div style="padding: 12px; background: rgba(95,168,255,0.07); border: 1px solid rgba(95,168,255,0.25); border-radius: 8px;">
+            <strong style="color: var(--accent);">Time freed up.</strong>
+            <div style="color: var(--text-dim); font-size: 12.5px; margin-top: 4px;">Held ~1 day of Wed budget for Mapper fixes; now goes to broader golden-test coverage.</div>
+          </div>
+          <div style="padding: 12px; background: rgba(224,168,58,0.07); border: 1px solid rgba(224,168,58,0.25); border-radius: 8px;">
+            <strong style="color: var(--warning);">Bias-check pending.</strong>
+            <div style="color: var(--text-dim); font-size: 12.5px; margin-top: 4px;">I refuted these from static reading too. Wed golden tests + walkthroughs will exercise actual paths and either confirm or surface what I missed.</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Wednesday merge train -->
+  <section class="section">
+    <h2 class="section-title">Wednesday merge train · 6 PRs landed on master</h2>
+    <div class="card">
+      <div class="wave-grid" style="grid-template-columns: repeat(3, 1fr);">
+        <div class="wave-item">
+          <div class="id"><a href="https://github.com/malpern/KeyPath/pull/857">#857</a></div>
+          <div class="name">Release prep: Wave 1 + Auto Shift promotion</div>
+          <span class="pill done">merged</span>
+          <div style="margin-top: 8px; color: var(--text-dim); font-size: 12px;">Closes #853, #854, #856 audit nits. Auto Shift Symbols moved <code>experimental</code> → <code>productivity</code>.</div>
+        </div>
+        <div class="wave-item">
+          <div class="id"><a href="https://github.com/malpern/KeyPath/pull/862">#862</a></div>
+          <div class="name">Test infra: MatrixTestHelpers + whole-catalog assertion</div>
+          <span class="pill done">merged</span>
+          <div style="margin-top: 8px; color: var(--text-dim); font-size: 12px;">Every shipping family kanata-syntax valid (1.47s assertion). Helpers cut duplication across the existing integration tests.</div>
+        </div>
+        <div class="wave-item">
+          <div class="id"><a href="https://github.com/malpern/KeyPath/pull/864">#864</a></div>
+          <div class="name">Per-option matrix tests (15 new)</div>
+          <span class="pill done">merged</span>
+          <div style="margin-top: 8px; color: var(--text-dim); font-size: 12px;">HRL Toggles · Quick Launcher · Window Snapping · Auto Shift. Surfaced the orphan-layer finding.</div>
+        </div>
+        <div class="wave-item">
+          <div class="id"><a href="https://github.com/malpern/KeyPath/pull/871">#871</a></div>
+          <div class="name">Generator stub-deflayer safety net</div>
+          <span class="pill done">merged</span>
+          <div style="margin-top: 8px; color: var(--text-dim); font-size: 12px;">One-regex addition catches <code>layer-toggle</code> orphan references. Kanata accepts; orphan keys silently no-op.</div>
+        </div>
+        <div class="wave-item">
+          <div class="id"><a href="https://github.com/malpern/KeyPath/pull/872">#872</a></div>
+          <div class="name">HRL Toggles release-readiness smoke script</div>
+          <span class="pill done">merged</span>
+          <div style="margin-top: 8px; color: var(--text-dim); font-size: 12px;">Template for the remaining 5 family-smokes. Modifies RuleCollections.json via CLI; backup/restore-safe.</div>
+        </div>
+        <div class="wave-item">
+          <div class="id"><a href="https://github.com/malpern/KeyPath/pull/875">#875</a></div>
+          <div class="name">Smoke fix: drop f/j to sidestep Home Row Arrows collision</div>
+          <span class="pill done">merged</span>
+          <div style="margin-top: 8px; color: var(--text-dim); font-size: 12px;">Bonus finding — the existing collision detector already protects users; safety net is the second line of defense.</div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Sprint 1.1 epic -->
+  <section class="section">
+    <h2 class="section-title">Sprint 1.1 captured · post-release UX for the prerequisite-detection gap</h2>
+    <div class="card">
+      <div style="display: grid; grid-template-columns: repeat(2, 1fr); gap: 10px;">
+        <a href="https://github.com/malpern/KeyPath/issues/865" class="tab-cell" style="grid-column: span 2; background: linear-gradient(160deg, rgba(181,140,255,0.10), var(--card-2)); border-color: rgba(181,140,255,0.32);">
+          <div class="name">#865 <span class="pill exp" style="margin-left:6px;">epic</span></div>
+          <div class="num">Bidirectional prerequisite detection — forward (enable / config-edit) + reverse (disable). Sprint goal: dialog flow next to the existing collision detector.</div>
+        </a>
+        <a href="https://github.com/malpern/KeyPath/issues/870" class="tab-cell"><div class="name">#870 <span class="pill wip" style="margin-left:4px;">start here</span></div><div class="num">Dependency graph data model + builder</div></a>
+        <a href="https://github.com/malpern/KeyPath/issues/866" class="tab-cell"><div class="name">#866</div><div class="num">Detector module (forward + reverse queries)</div></a>
+        <a href="https://github.com/malpern/KeyPath/issues/867" class="tab-cell"><div class="name">#867</div><div class="num">Per-family dependency catalog</div></a>
+        <a href="https://github.com/malpern/KeyPath/issues/869" class="tab-cell"><div class="name">#869</div><div class="num">Forward dialog UI (enable / config-edit)</div></a>
+        <a href="https://github.com/malpern/KeyPath/issues/868" class="tab-cell"><div class="name">#868</div><div class="num">Reverse dialog UI (disable)</div></a>
+        <a href="https://github.com/malpern/KeyPath/issues/873" class="tab-cell" style="grid-column: span 2;"><div class="name">#873 <span class="pill idle" style="margin-left:4px;">follow-up</span></div><div class="num">Refactor kanata-check test helper (pipe deadlock + MainActor). Deferred from #871's review.</div></a>
+      </div>
+    </div>
+  </section>
+
+  <!-- Verification loop -->
+  <section class="section">
+    <h2 class="section-title">Verification loop · closed end-to-end</h2>
+    <div class="card">
+      <div style="display: grid; grid-template-columns: repeat(3, 1fr); gap: 14px;">
+        <div style="padding: 14px; background: rgba(63,185,107,0.07); border: 1px solid rgba(63,185,107,0.25); border-radius: 10px;">
+          <strong style="color: var(--success);">1. Find</strong>
+          <div style="color: var(--text-dim); font-size: 12.5px; margin-top: 6px;">Per-option matrix tests in <a href="https://github.com/malpern/KeyPath/pull/864">#864</a> surfaced HRL Toggles toggle-mode-alone producing a kanata-rejected config.</div>
+        </div>
+        <div style="padding: 14px; background: rgba(95,168,255,0.07); border: 1px solid rgba(95,168,255,0.25); border-radius: 10px;">
+          <strong style="color: var(--accent);">2. Fix</strong>
+          <div style="color: var(--text-dim); font-size: 12.5px; margin-top: 6px;"><a href="https://github.com/malpern/KeyPath/pull/871">#871</a> added <code>layer-toggle</code> to the existing orphan-layer scanner. 1 regex. 3 new tests.</div>
+        </div>
+        <div style="padding: 14px; background: rgba(63,185,107,0.07); border: 1px solid rgba(63,185,107,0.25); border-radius: 10px;">
+          <strong style="color: var(--success);">3. Verify</strong>
+          <div style="color: var(--text-dim); font-size: 12.5px; margin-top: 6px;"><code>quick-deploy.sh</code> + <code>qa-hrl-toggles-smoke.sh</code> — all 3 cases passed against the installed app. Bug → fix → ship → verify in one day.</div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <div class="footer">
+    Updated Wed 2026-06-10 PM · Auto-synced from <code>RELEASE-READINESS.md</code> · Update by hand as the week progresses
+  </div>
+</div>
+</body>
+</html>

--- a/RELEASE-READINESS.html
+++ b/RELEASE-READINESS.html
@@ -398,13 +398,13 @@
       <h1>KeyPath 1.0 — Release Readiness</h1>
       <div class="sub">
         <span class="dot"></span>
-        <span>Wed 2026-06-10 late — eng gates ahead · docs+marketing scope added · Thu AM scope call needed</span>
+        <span>End of Thu 2026-06-11 — triage closed EMPTY a day early · 6 of 10 gates done · RC staged for Sat</span>
         <span style="color: var(--border-2)">·</span>
         <a href="RELEASE-READINESS.md">View markdown source</a>
       </div>
     </div>
     <div class="countdown">
-      <span class="num">3</span>
+      <span class="num">2</span>
       <span class="label">days to ship<br>Sat 2026-06-13</span>
     </div>
   </header>
@@ -415,7 +415,7 @@
 
       <!-- Exit criteria checklist -->
       <div class="card" style="border-color: rgba(95,168,255,0.35);">
-        <h3>Ship gate — 10 exit criteria <span class="tag">4 closed · 6 open · 2 added Wed night</span></h3>
+        <h3>Ship gate — 10 exit criteria <span class="tag">6 closed · 2 nearly closed · 2 scheduled (Sat)</span></h3>
         <div class="table-wrap" style="border: 0; max-height: none;">
           <table>
             <thead>
@@ -426,28 +426,28 @@
               <tr><td class="idx">2</td><td class="name">High-complexity families per-option coverage</td><td><span class="pill done">closed</span></td><td class="muted">Wed</td><td class="center muted">—</td></tr>
               <tr><td class="idx">3</td><td class="name">Release-blocker findings fixed + live-verified</td><td><span class="pill done">closed</span></td><td class="muted">Wed</td><td class="center muted">—</td></tr>
               <tr><td class="idx">4</td><td class="name">6 family smoke scripts pass on installed app — <a href="https://github.com/malpern/KeyPath/issues/881">#881</a> fixed (<a href="https://github.com/malpern/KeyPath/pull/884">#884</a>), lib manifest-hardened (<a href="https://github.com/malpern/KeyPath/pull/880">#880</a>), 6/6 re-verified on the fixed app</td><td><span class="pill done">closed</span></td><td class="muted">Thu AM</td><td class="center muted">—</td></tr>
-              <tr><td class="idx">5</td><td class="name">Design review pass across catalog — <a href="https://github.com/malpern/KeyPath/issues/888">#888</a> post-1.0 backlog, <a href="https://github.com/malpern/KeyPath/issues/889">#889</a> Fri must-fix candidate</td><td><span class="pill done">closed</span></td><td class="muted">Thu</td><td class="center muted">—</td></tr>
-              <tr><td class="idx">6</td><td class="name">Findings triage → must-fix list closed</td><td><span class="pill idle">open</span></td><td class="muted">Fri</td><td class="center">≤8</td></tr>
+              <tr><td class="idx">5</td><td class="name">Design review pass across catalog — <a href="https://github.com/malpern/KeyPath/issues/888">#888</a> post-1.0 backlog, <a href="https://github.com/malpern/KeyPath/issues/889">#889</a> probed → downgraded post-1.0</td><td><span class="pill done">closed</span></td><td class="muted">Thu</td><td class="center muted">—</td></tr>
+              <tr><td class="idx">6</td><td class="name">Findings triage → must-fix list closed <strong>EMPTY</strong> — #889 downgraded after wiring probe; hints verified accurate; rest fixed or noted</td><td><span class="pill done">closed early</span></td><td class="muted">Thu PM</td><td class="center muted">—</td></tr>
               <tr><td class="idx">7</td><td class="name">RC built, signed, notarized, smoke-verified</td><td><span class="pill idle">open</span></td><td class="muted">Sat</td><td class="center">~3</td></tr>
-              <tr><td class="idx">8</td><td class="name">Release notes incl. known limitations</td><td><span class="pill idle">draft</span></td><td class="muted">Fri/Sat</td><td class="center">~1</td></tr>
-              <tr style="background: rgba(224,168,58,0.05);"><td class="idx">9</td><td class="name">Docs complete — 12 guides missing header illustrations · ~6 packs missing detail/guide pages · screenshots current</td><td><span class="pill partial">new scope</span></td><td class="muted">Thu–Fri</td><td class="center">~8</td></tr>
-              <tr style="background: rgba(224,168,58,0.05);"><td class="idx">10</td><td class="name">Marketing basics — website video recorded + landing copy</td><td><span class="pill partial">new scope</span></td><td class="muted">Fri/Sat</td><td class="center">~5</td></tr>
+              <tr><td class="idx">8</td><td class="name">Release notes incl. known limitations — 4 bullets drafted, final wording Fri</td><td><span class="pill wip">drafted</span></td><td class="muted">Fri AM</td><td class="center">~0.5</td></tr>
+              <tr><td class="idx">9</td><td class="name">Docs complete — detail pages ✅ (<a href="https://github.com/malpern/KeyPath/pull/893">#893</a>) · 12 illustrations ✅ (<a href="https://github.com/malpern/KeyPath/pull/894">#894</a>) · screenshot check + gh-pages publish remain</td><td><span class="pill wip">nearly closed</span></td><td class="muted">Fri / Sat</td><td class="center">~1</td></tr>
+              <tr><td class="idx">10</td><td class="name">Marketing basics — website video + landing copy (Option B: may trail binary to Sun)</td><td><span class="pill idle">scheduled</span></td><td class="muted">Sat/Sun</td><td class="center">~5</td></tr>
             </tbody>
           </table>
         </div>
         <div style="margin-top: 10px; font-size: 11.5px; color: var(--text-dim);">
-          Gates 9–10 added Wed night per Micah. Open item: the in-app "orange box" marker for rules lacking detail pages — couldn't locate in source; confirm one example Thu AM and I'll enumerate the exact list. Grep-based gap list: backup-caps-lock, delete-enhancement, escape-remap, home-row-arrows, keystroke-history, mission-control.
+          Orange boxes resolved (D6): they marked in-app rules lacking a pack detail page — Neovim Terminal + Sequences, fixed in #893 with an invariant test. Thu also fixed #881 (restore data loss), un-faked the CI full lane (#891 + cache stamp, #896 tracks the runner-specific skip), and closed triage with an empty must-fix list.
         </div>
       </div>
 
       <!-- Verdict + burndown -->
       <div style="display: flex; flex-direction: column; gap: 16px;">
-        <div class="card" style="background: linear-gradient(160deg, rgba(224,168,58,0.10), var(--card)); border-color: rgba(224,168,58,0.45);">
+        <div class="card" style="background: linear-gradient(160deg, rgba(63,185,107,0.10), var(--card)); border-color: rgba(63,185,107,0.4);">
           <h3>Verdict <span class="tag">vs plan</span></h3>
-          <div style="font-size: 26px; font-weight: 700; color: var(--warning); margin-bottom: 6px;">At risk — trending well</div>
+          <div style="font-size: 26px; font-weight: 700; color: var(--success); margin-bottom: 6px;">On track — RC staged</div>
           <div style="font-size: 12.5px; color: var(--text-dim); line-height: 1.55;">
-            Thu AM: <a href="https://github.com/malpern/KeyPath/issues/881">#881</a> root-caused from the smoke logs, fixed (<a href="https://github.com/malpern/KeyPath/pull/884">#884</a>), lib manifest-hardened (<a href="https://github.com/malpern/KeyPath/pull/880">#880</a>), redeployed, 6/6 re-verified with zero restore warnings. <strong style="color: var(--text);">4 of 10 gates closed. ~21 hrs vs ~18 available — ~3–6 hr gap.</strong>
-            <br><br><strong style="color: var(--text);">Still needed:</strong> the scope call (cut illustrations / weekend hrs / slip) + the orange-box example. Two new findings for design review: Leader Key selectedOutput is display-only; Launcher leaderSequence config-identical to holdHyper.
+            Thursday closed gates 4, 5, 6, and (essentially) 9 in one day: #881 fixed &amp; live-verified, design review done, triage closed with an <strong style="color: var(--text);">empty must-fix list</strong>, detail pages + all 12 illustrations merged. <strong style="color: var(--text);">6 of 10 gates closed; ~10 hrs remain vs ~16+ available</strong> (Fri + Sat + optional Sun per Option B).
+            <br><br><strong style="color: var(--text);">What's left is mechanical:</strong> Fri = notes wording + screenshot check (~1h). Sat = RC build + smoke verify + gh-pages publish. Video may trail to Sun. No open decisions, no open PR blockers.
           </div>
         </div>
 
@@ -467,30 +467,27 @@
             <text x="14" y="13" font-size="8" fill="var(--text-faint)" text-anchor="end">36</text>
             <!-- ideal line: 36 at start → 0 at Sat -->
             <line x1="20" y1="10" x2="250" y2="130" stroke="var(--text-faint)" stroke-width="1" stroke-dasharray="4 4"/>
-            <!-- actual: start 36 → Tue 30 → Wed 18 -->
+            <!-- actual: start 36 → Tue 30 → Wed 18, +13h scope jump to 31, Thu close-out → 10 -->
             <polyline points="20,10 66,30 112,70" fill="none" stroke="#3fb96b" stroke-width="2.5" stroke-linecap="round"/>
-            <!-- scope add: vertical jump Wed 18 → 31 -->
             <line x1="112" y1="70" x2="112" y2="26.7" stroke="#e0a83a" stroke-width="2.5" stroke-dasharray="3 3"/>
-            <text x="118" y="44" font-size="8" fill="#e0a83a">+13h scope</text>
-            <!-- projection from 31: Thu 21 → Fri 13 → Sat 9 -->
-            <polyline points="112,26.7 158,60 204,86.7 250,100" fill="none" stroke="#5fa8ff" stroke-width="2" stroke-dasharray="5 4" stroke-linecap="round"/>
-            <!-- the gap at Sat -->
-            <line x1="250" y1="100" x2="250" y2="130" stroke="#f25d6e" stroke-width="2"/>
-            <text x="245" y="120" font-size="8" fill="#f25d6e" text-anchor="end">~9h gap</text>
+            <text x="118" y="40" font-size="8" fill="#e0a83a">+13h scope</text>
+            <polyline points="112,26.7 158,96.7" fill="none" stroke="#3fb96b" stroke-width="2.5" stroke-linecap="round"/>
+            <!-- projection: Fri 5 → Sat 0 -->
+            <polyline points="158,96.7 204,113.3 250,130" fill="none" stroke="#5fa8ff" stroke-width="2" stroke-dasharray="5 4" stroke-linecap="round"/>
             <!-- actual dots -->
             <circle cx="20" cy="10" r="3.5" fill="#3fb96b"/>
             <circle cx="66" cy="30" r="3.5" fill="#3fb96b"/>
-            <circle cx="112" cy="70" r="4.5" fill="#3fb96b" stroke="#0b0f15" stroke-width="1.5"/>
+            <circle cx="112" cy="70" r="3.5" fill="#3fb96b"/>
             <circle cx="112" cy="26.7" r="3.5" fill="#e0a83a"/>
+            <circle cx="158" cy="96.7" r="4.5" fill="#3fb96b" stroke="#0b0f15" stroke-width="1.5"/>
             <!-- projected dots -->
-            <circle cx="158" cy="60" r="3" fill="none" stroke="#5fa8ff" stroke-width="1.5"/>
-            <circle cx="204" cy="86.7" r="3" fill="none" stroke="#5fa8ff" stroke-width="1.5"/>
-            <circle cx="250" cy="100" r="3" fill="none" stroke="#5fa8ff" stroke-width="1.5"/>
+            <circle cx="204" cy="113.3" r="3" fill="none" stroke="#5fa8ff" stroke-width="1.5"/>
+            <circle cx="250" cy="130" r="3" fill="none" stroke="#5fa8ff" stroke-width="1.5"/>
             <!-- x labels -->
             <text x="20" y="146" font-size="8.5" fill="var(--text-faint)" text-anchor="middle">start</text>
             <text x="66" y="146" font-size="8.5" fill="var(--text-dim)" text-anchor="middle">Tue</text>
-            <text x="112" y="146" font-size="8.5" fill="var(--text)" font-weight="700" text-anchor="middle">Wed ◀</text>
-            <text x="158" y="146" font-size="8.5" fill="var(--text-faint)" text-anchor="middle">Thu</text>
+            <text x="112" y="146" font-size="8.5" fill="var(--text-dim)" text-anchor="middle">Wed</text>
+            <text x="158" y="146" font-size="8.5" fill="var(--text)" font-weight="700" text-anchor="middle">Thu ◀</text>
             <text x="204" y="146" font-size="8.5" fill="var(--text-faint)" text-anchor="middle">Fri</text>
             <text x="250" y="146" font-size="8.5" fill="var(--text-faint)" text-anchor="middle">Sat</text>
             <!-- legend -->
@@ -504,7 +501,7 @@
             <text x="212" y="163" font-size="8" fill="var(--text-dim)">ideal</text>
           </svg>
           <div style="font-size: 11.5px; color: var(--text-dim); margin-top: 4px;">
-            Engineering burn was ahead of ideal through Wed; the +13h scope add then a late-Wed smoke-suite sprint (gate 4 closed, −4h) nets <strong>~27h remaining</strong>. Projection: <strong style="color: var(--danger);">~5 hrs unfinished at Sat</strong> — close via scope cut, weekend hours, or slip.
+            Thursday burned ~21h of gate work in one day (#881 fix, triage, packs, illustrations) — the scope-add bump is fully absorbed. <strong style="color: var(--success);">~10h remain vs ~16+ available.</strong> Projection reaches zero before Saturday’s RC.
           </div>
         </div>
       </div>
@@ -527,16 +524,16 @@
           <div class="focus">✓ Tests + safety net</div>
           <div class="detail">6 PRs merged, fix live-verified</div>
         </div>
-        <div class="day today">
-          <div class="name"><span>Thu</span> <span class="now-tag">Next</span></div>
-          <div class="date">06·11</div>
-          <div class="focus">Smokes + design review</div>
-          <div class="detail">5 smoke scripts, docs scope call</div>
+        <div class="day done">
+          <div class="name"><span>Thu</span><span class="date">06·11</span></div>
+          <div class="focus">✓ The big day</div>
+          <div class="detail">#881 fixed, triage empty, packs + art shipped</div>
         </div>
-        <div class="day">
-          <div class="name"><span>Fri</span><span class="date">06·12</span></div>
-          <div class="focus">Triage + docs</div>
-          <div class="detail">Must-fix ≤1 day, illustrations</div>
+        <div class="day today">
+          <div class="name"><span>Fri</span> <span class="now-tag">Next</span></div>
+          <div class="date">06·12</div>
+          <div class="focus">Notes + screenshots</div>
+          <div class="detail">~1h of polish, then buffer</div>
         </div>
         <div class="day">
           <div class="name"><span>Sat</span><span class="date">06·13</span></div>
@@ -655,7 +652,7 @@
           <div class="row">
             <span class="cat">system</span>
             <div class="bar"><div class="fill" style="width: 33.3%; background: linear-gradient(90deg, #ff8aa8, #ffa7be);"></div></div>
-            <span class="num">3</span>
+            <span class="num">2</span>
           </div>
           <div class="row">
             <span class="cat">experimental</span>

--- a/RELEASE-READINESS.md
+++ b/RELEASE-READINESS.md
@@ -1,0 +1,348 @@
+# RELEASE-READINESS.md — KeyPath 1.0
+
+**Target ship date:** Saturday 2026-06-13
+**Started:** Tuesday 2026-06-09
+**Days remaining:** 5
+
+Working doc for the pre-1.0 verification push. Keep open all week.
+
+---
+
+## Ship gate — 10 exit criteria (read this first)
+
+**Verdict (Thu AM): AT RISK, trending well — 4 of 10 gates closed, #881 fixed & verified.** Thursday morning: root-caused #881 from the smoke logs, shipped the copy-over-then-prune restore fix ([#884](https://github.com/malpern/KeyPath/pull/884)), hardened the smoke lib with manifest verification, merged [#880](https://github.com/malpern/KeyPath/pull/880), redeployed, and re-verified 6/6 smokes against the fixed app with zero restore warnings. Remaining: **~21 hrs vs ~18 available** (rest of Thu + Fri + Sat morning) — **~3–6 hr gap, still pending the scope call** (cut illustrations / weekend hours / slip).
+
+Two new product findings from this morning's deeper assertions, queued for design review + Friday triage: (1) Leader Key collection's `selectedOutput` is display-only — config binding comes from the system `leaderKeyPreference`, so CLI/JSON collection edits have no effect; (2) Quick Launcher `activationMode=leaderSequence` generates byte-identical config to `holdHyper` — the Hyper hold path stays active. Also filed [#887](https://github.com/malpern/KeyPath/issues/887) (quick-deploy should hard-fail on missing engine binary — bit us during verification).
+
+| # | Exit criterion | Status | Day | Est. hrs left |
+|---|---|---|---|---|
+| 1 | All 22 families kanata-syntax valid | ✅ closed | Wed | — |
+| 2 | High-complexity families per-option coverage | ✅ closed | Wed | — |
+| 3 | Release-blocker findings fixed + live-verified | ✅ closed | Wed | — |
+| 4 | 6 family smoke scripts pass on installed app | ✅ closed — [#880](https://github.com/malpern/KeyPath/pull/880)+[#884](https://github.com/malpern/KeyPath/pull/884) merged, [#881](https://github.com/malpern/KeyPath/issues/881) fixed & live-verified | Thu AM | — |
+| 5 | Design review pass across catalog | ✅ closed — findings triaged; [#888](https://github.com/malpern/KeyPath/issues/888) (post-1.0 backlog), [#889](https://github.com/malpern/KeyPath/issues/889) (Fri must-fix candidate) | Thu | — |
+| 6 | Findings triage → must-fix list closed | ⬜ open | Fri | ≤8 (capped) |
+| 7 | RC built, signed, notarized, smoke-verified | ⬜ open | Sat | ~3 |
+| 8 | Release notes incl. known limitations | ⬜ draft | Fri/Sat | ~1 |
+| 9 | **Docs complete** — in-app detail pages ✅ ([#893](https://github.com/malpern/KeyPath/pull/893) merged); 12 illustrations ✅ ([#894](https://github.com/malpern/KeyPath/pull/894) in CI); remaining: screenshot check + gh-pages publish (Sat flow) | 🟡 nearly closed | Fri | ~1 |
+| 10 | **Marketing basics** — website video recorded + landing copy | ⬜ open | Sat/Sun | ~5 |
+
+**Burndown (est. hrs to close all gates, end of day):** start 36 → Tue 30 → Wed 18 → **+13 scope add → 31** → late-Wed smoke sprint **−4 → 27** → Thu proj. 17 → Fri proj. 9 → Sat proj. **~5 hrs unfinished** at current capacity. Close the gap via scope cut, weekend hours, or slip.
+
+### Gate 9 detail — grounded by repo audit (Wed night)
+
+- **Guides missing header illustrations (12):** activity-insights, cli, diagnostics, hammerspoon, installation-wizard, layers, packs, qmk-import, remapping, script-execution, siri-and-shortcuts, vallack-nav. (Generate per [keypath-docs](docs/help-content-philosophy.md) watercolor workflow.)
+- **Packs likely missing dedicated detail/guide pages (~6):** backup-caps-lock, delete-enhancement, escape-remap, home-row-arrows, keystroke-history, mission-control. (caps-lock-to-escape probably covered by tap-hold.md — verify.)
+- **Open question:** Micah recalls an in-app "orange box" marking rules lacking detail pages — not found in source (closest match is the orange "Requires" dependency badge in PackDetailView.swift:536). Confirm one example Thu AM to enumerate the authoritative list.
+
+## Plan at a glance
+
+| Day | Focus | Status |
+|---|---|---|
+| Tue | Inventory + risk-rank + Mapper verification + first decisions | ✅ done |
+| Wed | Matrix infra + safety-net fix + sprint planning + verification loop | ✅ done (absorbed Thu's matrix work too) |
+| Thu | 5 remaining smoke scripts (gate 4) + design review (gate 5) | next |
+| Fri | Triage (gate 6) + release notes (gate 8); must-fix capped at 1 day | pending |
+| Sat | RC build + verify (gate 7), ship — or call the slip | pending |
+
+---
+
+## Decisions
+
+- [x] **D1 — HRM ship classification**: **Shipping (no code change needed).** HRM is already `category: "productivity"` in [rule-collection-catalog.json:1132](Sources/KeyPathAppKit/Resources/rule-collection-catalog.json).
+- [x] **D2 — Shipping tier**: **Expanded — ALL 22 families ship for 1.0.** User call on Tue PM: "move everything into production, including autoshift. expand the test target." Auto Shift Symbols promoted to `productivity` in [PR #857](https://github.com/malpern/KeyPath/pull/857). Experimental section is now empty for 1.0. Verification budget: all 22 families get at minimum a per-pack kanata-syntax assertion; the high-complexity 7-8 get full golden + per-option matrices.
+- [x] **D3 — Mapper tab strategy**: **Defend in place — correctness only.** Mapper is the core. Fix correctness/data-loss bugs. Accept UX polish as known limitations. Verified Tue PM that 2 of 3 claimed Mapper bugs don't hold up; 1 is real but low-impact.
+- [x] **D4 — Ship date flexibility**: User said "we can take more time if we need" — Saturday 2026-06-13 is the target, not the constraint. If Thu triage shows must-fix work doesn't fit in Fri, slip with a written reason and a new target.
+- [x] **D5 — Scope call (Thu): Option B — add weekend hours, keep full docs scope.** All 12 illustrations + screenshots + marketing video stay in. Saturday may extend / Sunday morning available.
+- [x] **D6 — Orange boxes identified (Thu):** they mark **in-app rules lacking a pack detail page** — Neovim Terminal + Sequences were the only two. Fixed in [#893](https://github.com/malpern/KeyPath/pull/893) (new packs + invariant test). My earlier "6 missing website guides" list was a wrong proxy — those website gaps are real but were never the ask; parked as post-1.0 backlog.
+
+---
+
+## Rule family inventory (22 families)
+
+Columns:
+- **Category**: actual `RuleCollectionCategory` from the catalog JSON (system / navigation / productivity / layers / accessibility / experimental). Drives UI grouping in Rules tab. _Not a release-tier; the inventory agent's "shipping/experimental/hidden" labels in my first cut were fabricated — see D1._
+- **Coverage**: full / good / partial / none (config-correctness tests)
+- **Complexity**: low / med / high
+- **Risk**: PM to fill in tonight (1-5, where 5 = release blocker if broken)
+- **Action**: golden / matrix / walkthrough / defer
+
+_Categories pulled from `rule-collection-catalog.json` via Python on 2026-06-09. Only **1 of 22** families is in the Experimental section (Auto Shift Symbols). The "hidden" tier I described earlier was fabricated — these all show in user-facing UI sections._
+
+| # | Family | Category | Coverage | Complexity | Risk | Action |
+|---|---|---|---|---|---|---|
+| 1 | Home Row Mods | productivity | **FULL** | high | 2 | walkthrough only |
+| 2 | Caps Lock Remap | productivity | **FULL** | low | _ | _ |
+| 3 | Chord Groups | productivity | GOOD | high | _ | _ |
+| 4 | Sequences | productivity | GOOD | high | _ | _ |
+| 5 | Vim Navigation | navigation | GOOD | low | _ | _ |
+| 6 | Home Row Arrows | navigation | partial | low | _ | _ |
+| 7 | Quick Launcher | layers | partial | high | _ | _ |
+| 8 | Fast Navigation | system | partial | med | _ | _ |
+| 9 | macOS Function Keys | system | partial | low | _ | _ |
+| 10 | Home Row Layer Toggles | productivity | partial | high | _ | _ |
+| 11 | Auto Shift Symbols | **experimental** | partial | med | _ | (only family in Experimental section) |
+| 12 | Window Snapping | productivity | partial | low | _ | _ |
+| 13 | Leader Key | system | partial | low | _ | _ |
+| 14 | Escape | productivity | partial | low | _ | _ |
+| 15 | Delete Enhancement | productivity | partial | low | _ | _ |
+| 16 | Backup Caps Lock | productivity | partial | low | _ | _ |
+| 17 | Neovim Terminal | navigation | partial | low | _ | _ |
+| 18 | Mission Control | navigation | partial | low | _ | _ |
+| 19 | Ben Vallack Nav | navigation | partial | low | _ | _ |
+| 20 | Numpad | layers | partial | low | _ | _ |
+| 21 | Symbol Layer | layers | partial | low | _ | _ |
+| 22 | Function Keys (right hand) | layers | partial | low | _ | _ |
+
+### Cross-family dependencies (matter for test ordering)
+- **Home Row Mods ↔ Home Row Layer Toggles** share `TimingConfig`, `OppositeHandMode`, `KeySelection`
+- **Home Row Arrows** can fall back to Home Row Layer Toggles when layer mode is on
+- **Quick Launcher** requires **Caps Lock Remap** (Hyper key) to function
+- All Leader-based layers (Vim, Mission Control, Window Snapping, Ben Vallack, Numpad, Symbol, Function) depend on **Leader Key**
+
+### Top 5 highest-risk coverage gaps (per coverage agent)
+1. **Auto Shift Symbols** — no golden file; per-option coverage incomplete
+2. **Home Row Layer Toggles** — no golden file, no dedicated mapping generator test
+3. **Home Row Arrows** — invisible in integration tests; only via pack loop
+4. **Window Snapping** — no golden file; standard/vim mode switching untested
+5. **Leader Key** — singleKeyPicker presets (space/caps/tab/grave) untested per-option
+
+---
+
+## Overlay sidebar inventory (10 tabs)
+
+### Tabs
+
+| Tab | Shelf | # Controls | Persists where | Risk (PM tonight) |
+|---|---|---|---|---|
+| Custom Rules | Main | 7 | RuleCollectionStore | _ |
+| **Mapper** | Main | **17** | **In-memory + RuleCollectionStore** | _ |
+| Launchers | Main | 2 + Customize panel | RuleCollectionStore | _ |
+| History | Main | 1 (read-only) | In-memory | _ |
+| Keymap (Logical) | Settings | 4 | @AppStorage | _ |
+| Layout (Physical) | Settings | 1 (grid) | @AppStorage | _ |
+| Keycaps | Settings | 1 (grid) | @AppStorage | _ |
+| Sounds | Settings | custom | PreferencesService | _ |
+| Devices | Settings | 1 (custom view) | DeviceSelectionService | _ |
+| Settings (gear) | UI control | toggle | In-memory | _ |
+
+### Critical sidebar findings (flagged by inventory agent — verify before fixing)
+
+**HIGH-RISK state-persistence bugs in Mapper:**
+- `selectedBehaviorSlot` (Tap/Hold/Shift/Combo): in-memory `@State`, resets on overlay close
+- `selectedTapCount` (1×/2×/3×): in-memory `@State`, resets on overlay close
+- `selectedTapOutputMode` (Default/Shifted): in-memory `@State`, resets on overlay close
+
+**HIGH-RISK race conditions:**
+- Recording state machine has no mutex — multiple recorders can fire simultaneously
+- Launcher activation mode/trigger uses async `saveLauncherConfig()` — rapid toggles queue saves
+- Notification-driven mapper navigation uses 0.15s magic delay to wait for tab load
+
+**HIGH-RISK UI/state divergence:**
+- "Remove" shift variant button visible if save fails silently
+- Layer label shows `→ layer` after selection, but if save fails the actual mapping is still keystroke
+- System action popover can have multiple collapsible sections expanded at once (no max-height guard)
+
+**Debug flags in shipping code:**
+- `OverlayMapperSection.swift:432` `let showDebugBorders = false`
+- `LiveKeyboardOverlayView+Inspector.swift:119` `let showDrawerDebugOutline = false`
+
+---
+
+## Test infrastructure (the matrix harness)
+
+**State:** parametrization is weak. `testEachPackProducesValidConfigIndividually()` ([ConfigValidationTests.swift:176](Tests/KeyPathTests/Integration/ConfigValidationTests.swift)) is one test with a loop over all packs — when it fails, the loop exits at the first bad pack and later packs aren't tested.
+
+**Fixture duplication:** confirmed. Same 4-line pattern repeated across [ConfigGoldenFileTests.swift](Tests/KeyPathTests/Integration/ConfigGoldenFileTests.swift), [ConfigValidationTests.swift](Tests/KeyPathTests/Integration/ConfigValidationTests.swift), [ConfigGenerationEndToEndTests.swift](Tests/KeyPathTests/Integration/ConfigGenerationEndToEndTests.swift).
+
+**Estimated lift to bring all shipping families to "good":** 13–19 hours, per coverage agent.
+
+**Stale `.actual` files present** — clean up before measuring this week's progress.
+
+### Matrix-test design (decided Tue PM, ready for Wed AM)
+
+**Decision: add helpers in-place, not a new `Tests/Fixtures/` module.**
+
+[PerRuleOptionCoverageTests.swift](Tests/KeyPathTests/Integration/PerRuleOptionCoverageTests.swift) already has private helpers (`catalogCollection(_:)`, `collection(id:name:configuration:)`, `assertContains`, `assertBalanced`). Extend that pattern. Don't build new ceremony.
+
+**Three small helpers to add** (one new file: `Tests/KeyPathTests/Integration/MatrixTestHelpers.swift`, or extend existing):
+
+```swift
+// 1. The 4-line duplication killer
+@MainActor
+func enabledCollectionConfig(
+    _ id: UUID,
+    mutate: ((inout RuleCollection) -> Void)? = nil
+) -> String {
+    var collections = RuleCollectionCatalog().defaultCollections()
+    if let idx = collections.firstIndex(where: { $0.id == id }) {
+        collections[idx].isEnabled = true
+        mutate?(&collections[idx])
+    }
+    return KanataConfiguration.generateFromCollections(collections)
+}
+
+// 2. Pack-based variant (handles the vim-navigation lookup pattern)
+@MainActor
+func enabledPackConfig(_ packID: String) -> String? {
+    guard let pack = PackRegistry.pack(id: packID),
+          let collectionID = pack.associatedCollectionID else { return nil }
+    return enabledCollectionConfig(collectionID)
+}
+
+// 3. Validation helper (paired with #1 so config-correctness + kanata-syntax fold together)
+@MainActor
+func assertConfigValidWithKanata(
+    _ config: String,
+    _ family: String,
+    file: StaticString = #filePath,
+    line: UInt = #line
+) async throws {
+    let result = try await validateWithKanata(config)
+    XCTAssertTrue(result.isValid, "\(family) config invalid. Errors: \(result.errors)", file: file, line: line)
+}
+```
+
+**After helpers, a golden test becomes 2 lines:**
+
+```swift
+@MainActor func testCapsLockEscapeHyper_Golden() {
+    assertGoldenConfig(enabledCollectionConfig(RuleCollectionIdentifier.capsLockRemap), named: "caps-escape-hyper")
+}
+```
+
+**For per-option matrices** (e.g., HRM hold-mode × opposite-hand): use the `mutate` closure:
+
+```swift
+@MainActor func testHRM_HoldMode_QuickTap_Golden() {
+    let config = enabledCollectionConfig(RuleCollectionIdentifier.homeRowMods) { coll in
+        if case .homeRowMods(var cfg) = coll.configuration {
+            cfg.holdMode = .quickTap
+            coll.configuration = .homeRowMods(cfg)
+        }
+    }
+    assertGoldenConfig(config, named: "hrm-hold-quick-tap")
+}
+```
+
+**Pack-loop fix** ([ConfigValidationTests.swift:176](Tests/KeyPathTests/Integration/ConfigValidationTests.swift)):
+
+Don't migrate to Swift Testing this week. Instead, generate one `XCTAssertTrue` per pack inside the loop (so all packs run even if one fails), and include the pack name in the assertion message:
+
+```swift
+@MainActor
+func testEachPackProducesValidConfigIndividually() async throws {
+    for pack in PackRegistry.starterKit where !pack.visualOnly {
+        guard let collectionID = pack.associatedCollectionID else { continue }
+        let config = enabledCollectionConfig(collectionID)
+        let result = try await validateWithKanata(config)
+        XCTAssertTrue(result.isValid, "[\(pack.id)] invalid: \(result.errors)")
+    }
+}
+```
+
+Use `continueAfterFailure = true` in `setUp()` so XCTest runs all packs. Failures now name the bad pack and don't hide later failures.
+
+**Wednesday morning order:**
+1. Add the 3 helpers (~30 min, 1 file)
+2. Wire `continueAfterFailure = true` + per-pack assertion message (~10 min)
+3. Add golden + validation tests for the 7 defended shipping families using the helpers (~3-4 hrs)
+4. Add per-option matrices for top-3 high-risk families (Auto Shift, HR Layer Toggles, Window Snapping) (~3-4 hrs)
+
+Total: ~8 hours of focused work, achievable in one day if we don't get blocked.
+
+---
+
+## PRs landed this week — on master
+
+| PR | Summary | Day |
+|---|---|---|
+| [#857](https://github.com/malpern/KeyPath/pull/857) | Wave 1 cleanups (#853 URL force-unwrap, #854 `try!` regexes, #856 smappservice-poc demote) + Auto Shift promoted experimental → productivity | Wed |
+| [#862](https://github.com/malpern/KeyPath/pull/862) | Test infra: `MatrixTestHelpers` + per-family kanata-syntax assertion (all 20 catalog families) | Wed |
+| [#864](https://github.com/malpern/KeyPath/pull/864) | Per-option matrix tests (15) for the 4 high-complexity families | Wed |
+| [#871](https://github.com/malpern/KeyPath/pull/871) | Generator stub-deflayer safety net for `layer-toggle` orphan references | Wed |
+| [#872](https://github.com/malpern/KeyPath/pull/872) | HRL Toggles release-readiness smoke script | Wed |
+| [#875](https://github.com/malpern/KeyPath/pull/875) | Smoke script drops f/j to sidestep Home Row Arrows collision | Wed |
+
+## Sprint 1.1 planning — captured
+
+| Issue | What |
+|---|---|
+| [#865](https://github.com/malpern/KeyPath/issues/865) | **Sprint epic** — bidirectional prerequisite detection (forward + reverse) |
+| [#870](https://github.com/malpern/KeyPath/issues/870) | Data model + graph builder (start here) |
+| [#866](https://github.com/malpern/KeyPath/issues/866) | Detector module (forward + reverse) |
+| [#867](https://github.com/malpern/KeyPath/issues/867) | Per-family dependency catalog |
+| [#869](https://github.com/malpern/KeyPath/issues/869) | Forward dialog UI |
+| [#868](https://github.com/malpern/KeyPath/issues/868) | Reverse dialog UI |
+| [#873](https://github.com/malpern/KeyPath/issues/873) | Refactor kanata-check test helper (pipe deadlock + MainActor) |
+
+## Verification loop — closed end-to-end
+
+`./Scripts/quick-deploy.sh` rebuilt + reinstalled the app with all 5 Wednesday PRs. `./Scripts/qa-hrl-toggles-smoke.sh` then ran cleanly against the installed CLI: all three cases passed — including case 2 which exercises the stub-deflayer safety net from #871. The whole "found a bug → designed a fix → shipped it → verified live" cycle closed within Wednesday.
+
+---
+
+## Findings log
+
+| Day | Source | Finding | Severity | Disposition |
+|---|---|---|---|---|
+| Tue PM | Mapper verification (task #1) | **Refuted** — "state-persistence bug" was overstated. Picker mode (slot/count/output-mode) is ephemeral `@State`, but real configured actions are persisted in `MapperViewModel.advancedBehavior` and restored on overlay reopen via `loadBehaviorFromExistingRule()` (line 97 of OverlayMapperSection.swift, body of method at MapperViewModel.swift:393). `configuredBehaviorSlots` set gives visual indicator. No data loss. | low (UX, not data) | Known-limitation note: "Mapper opens to Tap slot — click Hold/Shift to see actions you configured for that slot." |
+| Tue PM | Mapper verification (task #2) | **Refuted** — "no recording mutex." Every `toggle*Recording()` in [MapperViewModel.swift:651-758](Sources/KeyPathAppKit/UI/Experimental/MapperViewModel.swift) explicitly calls `stopRecording()` before activating its own recorder. MainActor serializes SwiftUI events. Hold and double-tap have explicit conflict dialogs. | — | Close. |
+| Tue PM | Mapper verification (task #3) | **Confirmed** — `saveLauncherConfig()` at [OverlayInspectorPanel+LauncherCustomize.swift:215](Sources/KeyPathAppKit/UI/Overlay/OverlayInspectorPanel+LauncherCustomize.swift:215) spawns unbounded `Task` per call. But load-mutate-save goes through `ruleCollectionStore` (actor-isolated) and final UI state drives final save. Worst case: momentary persisted state lags by 1 toggle. | low | Post-1.0 cleanup. Not a release blocker. |
+| Wed AM | Per-option matrix tests (task #7, PR #864) | **HRL Toggles + toggle mode produces an invalid kanata config when no companion layer family is enabled.** The catalog default key assignments reference layers (`fun`, `sym`, `num`) owned by Function/Symbol/Numpad — when those are disabled, kanata rejects with `layer name is not declared in any deflayer: fun`. `whileHeld` mode happens to accept forward references and works fine. The companion `testHRLToggles_ToggleMode_WithCompanionLayers_IsValid` test confirms enabling the companions resolves it. | **medium** | **Pending triage Thu/Fri.** Options: (1) auto-enable companions when user picks toggle mode, (2) UI requirement, (3) generator emits stub deflayers, or (4) document as known limitation in release notes. Test `testHRLToggles_ToggleMode_WithoutCompanionLayers_Documented` captures current behavior so a fix surfaces in CI. |
+| Wed AM | Test infra rollout (#862 merged, #864 open) | **Every shipping rule family confirmed kanata-syntax-valid** (whole-catalog assertion runs in 1.47s). Per-option matrix tests added for HRL Toggles, Quick Launcher, Window Snapping, Auto Shift — 15 new tests, 14 pass + 1 documents the finding above. | — | Strong release-readiness signal on the config-generator side. |
+| Wed PM | Option A safety net merged (#871) | One-regex addition to the existing orphan-layer scanner in `KanataConfiguration+BlockBuilders.swift` — catches `layer-toggle` in addition to `layer-while-held` and `layer-switch`. Kanata now accepts HRL Toggles toggle-mode-alone configs; orphan home-row keys silently no-op rather than catastrophically failing. | — | **Fixed before ship.** |
+| Wed PM | Smoke script verification (#872 + #875) | Built `qa-hrl-toggles-smoke.sh` following `qa-hrm-settings-smoke.sh` template. Smoke surfaced the existing **collision detector** also fires on HRL+Arrows on `f` — a useful second finding. The detector's message is clear and actionable; it's effectively a working first-line UX for the misconfiguration class. | — | Bonus signal for sprint epic [#865](https://github.com/malpern/KeyPath/issues/865) — existing detector copy is the pattern the new prerequisite dialogs should mirror. |
+| Wed PM | End-to-end verification | `./Scripts/quick-deploy.sh` + `./Scripts/qa-hrl-toggles-smoke.sh` against installed app — all 3 cases pass. Confirms #871 safety net works in a real signed/installed build, not just unit tests. | — | Closes the loop. |
+| Wed ~23:00 | Smoke-suite sequential run ([#880](https://github.com/malpern/KeyPath/pull/880)) | **`config restore` round-trip lost sidecar config files** (RuleCollections.json, DeviceSelection.json, installed-packs.json, …) and leaked transient collection state (Window Snapping stayed enabled). Restore code is faithful in isolation; prime suspect is a sync client racing the wipe-and-copy cycle (`.sb-*`/`.dat.nosync*` artifacts show the config dir is inside sync scope). User config manually repaired from the earliest complete backup and verified. | **HIGH — release-blocker candidate** | Filed [#881](https://github.com/malpern/KeyPath/issues/881) with evidence timeline + Thu repro plan (fs_usage). #880 held until root-caused + lib hardened with a restore-manifest check. Top of Friday triage. |
+
+---
+
+## Design review (gate 5) — Thu, completed
+
+Method: full catalog copy extraction (names, summaries, activation hints, pack taglines) reviewed directly + agent inventory of all user-visible strings in the 7 complex editors (HRM, HRL Toggles, Chords, Sequences, Auto Shift, Key Repeat, Launcher editor).
+
+### Findings → Friday triage buckets
+
+**Must-fix candidates (cheap, user-facing correctness):**
+1. **Leader Key picker is a broken control** — `selectedOutput` is display-only (config binding comes from system `leaderKeyPreference`). Shipping a picker that silently does nothing is worse than no picker. Options: wire it to the preference (best), or hide the picker for 1.0. ~1–3h either way.
+2. **Activation-hint accuracy** — Vim Nav / Neovim Terminal hints say "Hold Leader key to enter Nav" but the default nav activation mode is tap-to-toggle (one-shot). Verify which is true for a fresh install and fix the hint copy. ~30 min.
+
+**Known limitations (release notes, no code):**
+3. Launcher `activationMode=leaderSequence` keeps the Hyper hold path active (config-identical to holdHyper). Note in release docs until intent is decided.
+4. HRL Toggles toggle-mode without companion layers: keys silently no-op (stub-deflayer safety net). Covered by sprint epic #865.
+
+**Post-1.0 design backlog (umbrella issue):**
+5. **Timing vocabulary chaos** — "tap window / hold delay / tap offset / hold offset / quick tap term / prior idle" used across editors without a shared mental model; raw ms fields leak implementation names (`requirePriorIdleMs`, `hrm-stats`).
+6. **Two magic keys, no explanation** — "Leader" (most layers) vs "Hyper" (Quick Launcher, provided by Caps Lock Remap). Nothing at catalog level explains the difference or the dependency.
+7. **Activation-hint format inconsistency** — "Leader → f → function keys" vs "Hold Hyper key" vs "11 keys · 180ms hold" (a spec, not an instruction); 9 families have no hint at all.
+8. **"Ben Vallack" naming** — two families named after a YouTuber; meaningless to most users.
+9. **Agent's top-10 string fixes** — e.g. "Raw values" → "Expert mode", "Favor tap when another key is pressed (quick tap)" → clearer phrasing, "Protect fast typing" → say what it does, Key Repeat "Speed" is actually an interval. Full list preserved in the umbrella issue.
+
+### Overall design verdict
+
+The catalog presentation layer (names, taglines, summaries) is in **good shape** — taglines are benefit-oriented and consistent in voice. The weakness is concentrated in the **advanced editor copy** (timing controls especially), which assumes keyboard-enthusiast vocabulary. None of it blocks 1.0 for the core audience; items 1–2 above are the only ship-relevant fixes.
+
+## Gate 6 triage — CLOSED EARLY (Thu PM)
+
+The must-fix list is **empty**. Every finding resolved or reclassified:
+
+| Finding | Resolution |
+|---|---|
+| [#889](https://github.com/malpern/KeyPath/issues/889) Leader picker | **Downgraded to post-1.0** — probe showed the in-app path is fully wired (`updateLeaderKey` syncs preference + activators + rollback); only headless CLI/JSON edits bypass it. Release-notes line instead. |
+| Activation-hint accuracy | **Verified accurate** — holding Leader enters nav in both activation modes (direct `layer-while-held` or one-shot wrapper). No copy change needed. |
+| HRL companions silent no-op | Safety-netted (#871) + release note + #865 sprint |
+| Launcher leaderSequence ≡ holdHyper | Release note + design question in #888 |
+| Restore data loss (#881) | **Fixed + live-verified** (#884) |
+| CI fake-green full lane | Fixed (#891 + cache stamp); runner-specific simulator issue tracked in #896 |
+
+## Known-limitations release notes draft (collect for Friday)
+
+Draft copy for the 1.0 notes (final wording Fri):
+
+- **Changing the Leader key:** use the app's Rules tab. The `keypath` CLI and direct config-file edits don't yet propagate Leader key changes ([#889](https://github.com/malpern/KeyPath/issues/889)).
+- **Home Row Layer Toggles in "Toggle" mode** references the Function, Symbol, and Numpad layers — enable those rules too, or the assigned keys will do nothing on hold. (KeyPath keeps the rest of your keyboard working either way; a guided prompt is planned.)
+- **Quick Launcher activation:** the Hyper-hold route stays active even when "Leader → L" activation is selected.
+- **Mapper editor:** reopens to the Tap slot; click Hold/Shift/Combo to see actions you've configured for those slots.
+
+(Empty — populate as we triage on Thursday.)

--- a/RELEASE-READINESS.md
+++ b/RELEASE-READINESS.md
@@ -2,7 +2,7 @@
 
 **Target ship date:** Saturday 2026-06-13
 **Started:** Tuesday 2026-06-09
-**Days remaining:** 5
+**Last updated:** Thursday 2026-06-11 (evening)
 
 Working doc for the pre-1.0 verification push. Keep open all week.
 
@@ -21,7 +21,7 @@ Two new product findings from this morning's deeper assertions, queued for desig
 | 3 | Release-blocker findings fixed + live-verified | ✅ closed | Wed | — |
 | 4 | 6 family smoke scripts pass on installed app | ✅ closed — [#880](https://github.com/malpern/KeyPath/pull/880)+[#884](https://github.com/malpern/KeyPath/pull/884) merged, [#881](https://github.com/malpern/KeyPath/issues/881) fixed & live-verified | Thu AM | — |
 | 5 | Design review pass across catalog | ✅ closed — findings triaged; [#888](https://github.com/malpern/KeyPath/issues/888) (post-1.0 backlog), [#889](https://github.com/malpern/KeyPath/issues/889) (Fri must-fix candidate) | Thu | — |
-| 6 | Findings triage → must-fix list closed | ⬜ open | Fri | ≤8 (capped) |
+| 6 | Findings triage → must-fix list closed | ✅ closed early — must-fix list **EMPTY** (see Gate 6 section below) | Thu PM | — |
 | 7 | RC built, signed, notarized, smoke-verified | ⬜ open | Sat | ~3 |
 | 8 | Release notes incl. known limitations | ⬜ draft | Fri/Sat | ~1 |
 | 9 | **Docs complete** — in-app detail pages ✅ ([#893](https://github.com/malpern/KeyPath/pull/893) merged); 12 illustrations ✅ ([#894](https://github.com/malpern/KeyPath/pull/894) in CI); remaining: screenshot check + gh-pages publish (Sat flow) | 🟡 nearly closed | Fri | ~1 |
@@ -33,7 +33,7 @@ Two new product findings from this morning's deeper assertions, queued for desig
 
 - **Guides missing header illustrations (12):** activity-insights, cli, diagnostics, hammerspoon, installation-wizard, layers, packs, qmk-import, remapping, script-execution, siri-and-shortcuts, vallack-nav. (Generate per [keypath-docs](docs/help-content-philosophy.md) watercolor workflow.)
 - **Packs likely missing dedicated detail/guide pages (~6):** backup-caps-lock, delete-enhancement, escape-remap, home-row-arrows, keystroke-history, mission-control. (caps-lock-to-escape probably covered by tap-hold.md — verify.)
-- **Open question:** Micah recalls an in-app "orange box" marking rules lacking detail pages — not found in source (closest match is the orange "Requires" dependency badge in PackDetailView.swift:536). Confirm one example Thu AM to enumerate the authoritative list.
+- **Resolved (D6):** the orange boxes mark in-app rules lacking a pack detail page — drawn by RulesSummaryView+RowBuilder when `packForCollection == nil`. The authoritative list was Neovim Terminal + Sequences; fixed in #893 (new packs + invariant test). The grep-derived website-guide gaps above were a separate, real-but-unrequested gap — parked post-1.0.
 
 ## Plan at a glance
 


### PR DESCRIPTION
Replaces the docs half of [#899](https://github.com/malpern/KeyPath/pull/899) on a clean branch. #899's branch turned out to be shared with another in-flight workstream (the kanata `cmd` removal landed on it mid-review, making the "docs only" description wrong) — this PR carries **only** the two documentation files, and #899 is being re-pointed at the security work it actually contains.

## What's here

**[RELEASE-READINESS.md](RELEASE-READINESS.md)** — the working doc that steered the Tue–Thu 1.0 verification push: 10-gate ship checklist with burndown, decisions D1–D6, rule-family + overlay-sidebar inventories, the findings log (#881 restore data-loss saga, CI fake-green lane, Mapper claims, leader-picker probe), gate-6 triage (closed Thursday with an **empty** must-fix list), and the known-limitations release-notes draft.

**[RELEASE-READINESS.html](RELEASE-READINESS.html)** — self-contained visual dashboard of the same state (inline SVG, renders offline).

## Review feedback from #899 — addressed here

- ✅ Gate-6 table row now matches the "CLOSED EARLY (Thu PM)" section (codex P2, claude points 1–2)
- ✅ "Days remaining: 5" replaced with an absolute "Last updated" field (point 3)
- ✅ Gate-9 orange-box "open question" records the D6 resolution / #893 instead of ghost-chasing (point 6)
- HTML gate counts/verdict/burndown were already synced in the dashboard commit (point 1)
- Root placement kept deliberately — matches the `CODE_AUDIT.md` cycle-report precedent (point 4); the HTML carries a hand-synced-snapshot caveat in the PR description per point 5
- The dead-debug-flags observation (point: `showDebugBorders` etc.) is queued for a post-1.0 cleanup note rather than this PR

Docs only — verifiably this time: two files, no code paths.