### PR TITLE
Fix Neovim Terminal detail sheet clipping (add to wide-pack width list)

### DIFF
--- a/Sources/KeyPathAppKit/Services/Packs/Pack.swift
+++ b/Sources/KeyPathAppKit/Services/Packs/Pack.swift
@@ -176,8 +176,14 @@ public struct Pack: Identifiable, Equatable, Sendable {
 
     /// Preferred width for Pack Detail presentation (window or sheet).
     public var preferredDetailWidth: CGFloat {
+        // Table-style packs render MappingTableContent (Key / Description /
+        // Action / +Shift / +Ctrl), which needs the wide layout. When adding
+        // a table pack, add it here too or its detail sheet clips horizontally
+        // (Neovim Terminal shipped clipped at the 560 default before being
+        // listed).
         let widePacks: Set = [
             "com.keypath.pack.vim-navigation",
+            "com.keypath.pack.neovim-terminal",
             "com.keypath.pack.window-snapping",
             "com.keypath.pack.mission-control",
             "com.keypath.pack.numpad-layer",


### PR DESCRIPTION
Second finding from Micah's visual review of the Neovim Terminal detail page ([#903](https://github.com/malpern/KeyPath/pull/903) fixed the wrong-component issue; this fixes the layout).

## Problem

The detail sheet rendered at the **560pt default width** while `MappingTableContent`'s five columns (Key / Description / Action / +Shift / +Ctrl) need the **760pt** wide layout — content clipped on both edges: icon half-cut, description truncated, +Ctrl column running off-screen.

## Cause

`Pack.preferredDetailWidth` keeps a hardcoded wide-pack allowlist. Every other table-style pack (Vim Navigation, Mission Control, Numpad, Symbol, Fun) is listed; `neovim-terminal` wasn't. Same add-a-pack-forget-the-side-table class of bug as the orange-box issue — just a different side table.

## Fix

One line: add `com.keypath.pack.neovim-terminal` to the set, plus a comment warning the next table-pack author. (A follow-up could derive width from the rendering branch instead of an allowlist — out of scope for release week.)

## Verification

- Built + quick-deployed; awaiting Micah's visual re-check at 760pt
- Sequences pack intentionally not added: its detail is description-only (no table), so the 560 default fits
- The `trailing_comma` lint warning on the set literal is pre-existing file style