### PR TITLE
Docs: strip 26 placeholder screenshots for 1.0 ship (captures tracked in #920)

### DIFF
--- a/guides/installation-wizard.md
+++ b/guides/installation-wizard.md
@@ -45,26 +45,17 @@ The wizard starts by installing a privileged helper tool. macOS will show a syst
   └─────────────────────────────────────────────────┘
 ```
 
-<!-- Screenshot: Helper installation step -->
-![Screenshot — Helper installation]({{ '/images/help/placeholder-wizard-helper.png' | relative_url }})
-
 **Why it's needed:** The keyboard driver runs at the system level. A helper tool with elevated privileges is required to manage it safely.
 
 ### 2. Accessibility permission
 
 macOS asks you to grant KeyPath Accessibility access in System Settings. The wizard shows you exactly where to click.
 
-<!-- Screenshot: Accessibility permission step with arrow pointing to System Settings -->
-![Screenshot — Accessibility permission]({{ '/images/help/placeholder-wizard-accessibility.png' | relative_url }})
-
 **Why it's needed:** Accessibility access lets KeyPath see which keys you press, so it can decide what to do with them (remap, activate a layer, trigger an action).
 
 ### 3. Input Monitoring permission
 
 Similar to Accessibility — macOS asks you to grant Input Monitoring access.
-
-<!-- Screenshot: Input Monitoring permission step -->
-![Screenshot — Input Monitoring permission]({{ '/images/help/placeholder-wizard-input-monitoring.png' | relative_url }})
 
 **Why it's needed:** Input Monitoring lets KeyPath intercept key events before they reach your apps. This is what makes remapping work — KeyPath catches the physical key, transforms it, and sends the remapped key to your app.
 
@@ -89,9 +80,6 @@ The wizard starts the Kanata remapping engine. Once it's running, your keyboard 
   │                            [ Get Started ]       │
   └─────────────────────────────────────────────────┘
 ```
-
-<!-- Screenshot: Wizard completion screen -->
-![Screenshot — Setup complete]({{ '/images/help/placeholder-wizard-complete.png' | relative_url }})
 
 ---
 

--- a/guides/layers.md
+++ b/guides/layers.md
@@ -82,9 +82,6 @@ These use a two-step activation: hold Space (the Leader key) to enter the naviga
 | **Window Snapping** | Space + W | Tile windows to halves, corners, screens |
 | **Mission Control** | Space + M | Expose, desktops, notification center |
 
-<!-- Screenshot: Overlay showing the navigation layer with key hints -->
-![Screenshot — The overlay showing layer key hints]({{ '/images/help/placeholder-overlay-nav-layer.png' | relative_url }})
-
 ### Installing a layer pack
 
 1. Open the **Pack Gallery**
@@ -100,9 +97,6 @@ See the [Packs & Layers catalog]({{ '/guides/packs/' | relative_url }}) for deta
 ## The overlay shows you where you are
 
 The keyboard overlay updates in real time as you switch layers. When you hold a trigger key, the overlay shows the current layer's key assignments — so you always know what each key does right now.
-
-<!-- Screenshot: Overlay transitioning from base to nav layer -->
-![Screenshot — Overlay showing layer transition]({{ '/images/help/placeholder-overlay-layer-transition.png' | relative_url }})
 
 This is especially useful when you're learning a new layer. Keep the overlay visible and glance at it while you build muscle memory.
 

--- a/guides/qmk-import.md
+++ b/guides/qmk-import.md
@@ -36,9 +36,6 @@ KeyPath indexes over 3,700 keyboards from the [QMK firmware](https://qmk.fm/) re
   └─────────────────────────────────────────────────┘
 ```
 
-<!-- Screenshot: QMK keyboard search showing results -->
-![Screenshot — QMK keyboard search]({{ '/images/help/placeholder-qmk-search.png' | relative_url }})
-
 Select your keyboard and KeyPath downloads the layout definition. The overlay updates immediately to show your physical key arrangement.
 
 ---
@@ -57,9 +54,6 @@ These keyboards ship with pre-built layouts — no import needed, just select fr
 | Planck | Ortholinear | 48 |
 
 If your keyboard is in this list, you don't need to import — it's already available in the overlay's layout picker.
-
-<!-- Screenshot: Layout picker showing built-in keyboards -->
-![Screenshot — Layout picker with custom keyboards]({{ '/images/help/placeholder-layout-picker-custom.png' | relative_url }})
 
 ---
 
@@ -90,9 +84,6 @@ When importing, you can configure:
 | **Keyboard type** | ANSI, ISO, or JIS — determines which key code table to use |
 | **Layout variant** | Some keyboards have multiple layouts (e.g., with/without encoder) |
 | **Custom name** | Name this layout in the picker (defaults to the QMK keyboard name) |
-
-<!-- Screenshot: QMK import dialog with options -->
-![Screenshot — QMK import options]({{ '/images/help/placeholder-qmk-import-options.png' | relative_url }})
 
 ---
 

--- a/guides/remapping.md
+++ b/guides/remapping.md
@@ -66,9 +66,6 @@ KeyPath installs Home Row Arrows by default. If it's already running, try it:
 3. Press **J, K, I, or L** to move the cursor
 4. **Release F** to go back to normal typing
 
-<!-- Screenshot: Overlay showing Home Row Arrows layer active, IJKL highlighted as arrows -->
-![Screenshot — Home Row Arrows active in the overlay]({{ '/images/help/placeholder-overlay-home-row-arrows.png' | relative_url }})
-
 That's it. Your hand never left the home row. No reaching, no looking down, no tiny arrow keys.
 
 ### Prefer Vim-style HJKL?
@@ -88,17 +85,11 @@ If you're a developer who already knows Vim's HJKL navigation, you can switch la
   └───┴───┴───┴───┘               └───┴───┴───┴───┘
 ```
 
-<!-- Screenshot: Pack detail showing layout picker with Inverted-T and Vim options -->
-![Screenshot — Home Row Arrows layout picker]({{ '/images/help/placeholder-pack-detail-arrows-picker.png' | relative_url }})
-
 ### If it's not installed yet
 
 1. Open KeyPath from the menu bar
 2. Open the **Pack Gallery**
 3. Find **Home Row Arrows** and click **Install**
-
-<!-- Screenshot: Pack Gallery showing Home Row Arrows pack -->
-![Screenshot — Home Row Arrows in the Pack Gallery]({{ '/images/help/placeholder-pack-gallery-home-row-arrows.png' | relative_url }})
 
 Or from the command line:
 
@@ -162,9 +153,6 @@ keypath remap right_option delete
 ## Seeing your remaps
 
 The keyboard overlay shows you what every key does right now. Remapped keys are highlighted so you can always tell what's been changed.
-
-<!-- Screenshot: Overlay showing remapped keys highlighted -->
-![Screenshot — The overlay highlighting remapped keys]({{ '/images/help/placeholder-overlay-remapped-keys.png' | relative_url }})
 
 Click any key to see its current mapping. If you ever forget what you've changed, the overlay is your map.
 

--- a/guides/script-execution.md
+++ b/guides/script-execution.md
@@ -24,9 +24,6 @@ Scripts are disabled by default. To turn them on:
 3. Toggle **Enable Script Execution**
 4. Confirm in the security dialog
 
-<!-- Screenshot: Settings showing the Script Execution toggle -->
-![Screenshot — Script Execution settings]({{ '/images/help/placeholder-settings-script-execution.png' | relative_url }})
-
 The confirmation dialog explains what scripts can do — run commands, access files, and make network requests. This is a one-time decision; you can disable it again at any time.
 
 ---
@@ -60,9 +57,6 @@ open "keypath://script/~/scripts/hello.sh"
 ```
 
 The first time a script runs, KeyPath shows a confirmation dialog with the script path. You can check "Don't show again" to skip the dialog for future scripts.
-
-<!-- Screenshot: Script confirmation dialog showing path and warning -->
-![Screenshot — First-run script confirmation]({{ '/images/help/placeholder-script-confirmation.png' | relative_url }})
 
 ---
 
@@ -217,9 +211,6 @@ Check "Don't show again" only if you trust all scripts you'll run. This bypasses
 ### 3. Execution log
 
 KeyPath logs every script execution — path, timestamp, success/failure, and any errors. View the log in **Settings > Script Execution > View Execution Log**.
-
-<!-- Screenshot: Execution log showing recent script runs -->
-![Screenshot — Script execution log]({{ '/images/help/placeholder-script-execution-log.png' | relative_url }})
 
 ### What scripts can't do
 

--- a/guides/vallack-nav.md
+++ b/guides/vallack-nav.md
@@ -11,9 +11,6 @@ permalink: /guides/vallack-nav/
 
 This pack is a complete home row navigation system inspired by [Ben Vallack](https://www.youtube.com/@BenVallacksKeyboards), a keyboard designer and YouTuber known for pushing the limits of what a keyboard can do. His channel explores minimal keyboard layouts, custom firmware, and the idea that your fingers should never leave the home row — for anything.
 
-<!-- Screenshot: Ben Vallack YouTube channel or a representative video thumbnail -->
-![Screenshot — Ben Vallack's keyboard customization content]({{ '/images/help/placeholder-vallack-youtube.png' | relative_url }})
-
 Ben's approach is opinionated: modifiers move to the top row, the index fingers become layer toggles, and the entire right hand becomes a navigation surface. It's a different philosophy from the default Vim Navigation pack — where that pack adds navigation alongside your normal keyboard, this one *redesigns* your keyboard around navigation.
 
 If you're new to keyboard customization, start with [Home Row Arrows]({{ '/guides/remapping/' | relative_url }}) or [Vim Navigation]({{ '/guides/vim-navigation/' | relative_url }}) first. Come back here when you're ready to go deeper.
@@ -57,9 +54,6 @@ Your right hand stays on the home row and handles all cursor movement and basic 
 
 The core navigation cluster follows the Vim HJKL layout: H is left, J is down, K is up, L is right. But unlike standalone Vim Navigation, the surrounding keys are mapped to editing actions — backspace on U, enter on I, copy on Y, paste on semicolon. Your right hand handles both movement and editing without reaching.
 
-<!-- Screenshot: Overlay showing the Vallack nav layer active with right hand keys highlighted -->
-![Screenshot — Right hand navigation keys in the overlay]({{ '/images/help/placeholder-vallack-overlay-right.png' | relative_url }})
-
 ### Left hand — switching and jumping
 
 Your left hand handles context switching — moving between apps, tabs, and positions within a document:
@@ -79,9 +73,6 @@ Your left hand handles context switching — moving between apps, tabs, and posi
 ```
 
 E and R cycle browser tabs (Ctrl+Shift+Tab and Ctrl+Tab) — invaluable when you have a dozen tabs open. A opens the app switcher (⌘Tab). S and D jump to the start and end of the current line — no more Home/End reaching. T and V navigate back and forward in apps that support ⌘[ and ⌘]. G takes a screenshot.
-
-<!-- Screenshot: Overlay showing the Vallack nav layer with left hand keys highlighted -->
-![Screenshot — Left hand switching keys in the overlay]({{ '/images/help/placeholder-vallack-overlay-left.png' | relative_url }})
 
 ---
 
@@ -127,7 +118,6 @@ Tap Q normally to type "q". Hold Q to get Control. Same for W (Option) and E (Co
 This frees the entire home row for navigation and typing. No conflicts — modifiers live on a row you don't type on as frequently, and the top row is easy to reach without moving your hands.
 
 <!-- Diagram: Side-by-side comparison of standard CAGS vs Vallack modifier placement -->
-![Diagram — Standard vs Vallack modifier placement]({{ '/images/help/placeholder-vallack-modifier-comparison.png' | relative_url }})
 
 ---
 
@@ -142,9 +132,6 @@ When you install the Ben Vallack Nav pack, KeyPath sets up three coordinated col
 | **Vallack Layer Toggles** | F and J as hold-to-activate triggers for the navigation layer |
 
 These three are designed to work as a system. Installing the pack enables all three and configures them to the Vallack defaults. You can adjust individual settings in each collection if you want to customize.
-
-<!-- Screenshot: Pack detail showing the three collections -->
-![Screenshot — Vallack pack detail with three collections]({{ '/images/help/placeholder-vallack-pack-detail.png' | relative_url }})
 
 ---
 
@@ -169,9 +156,6 @@ These three are designed to work as a system. Installing the pack enables all th
 2. Find **Ben Vallack Nav** and click **Install**
 3. KeyPath will ask about conflicts if you have Home Row Mods or Vim Navigation enabled — the Vallack system replaces both
 
-<!-- Screenshot: Pack Gallery showing Ben Vallack Nav with Install button -->
-![Screenshot — Ben Vallack Nav in the Pack Gallery]({{ '/images/help/placeholder-pack-vallack-install.png' | relative_url }})
-
 Or from the command line:
 
 ```bash
@@ -189,9 +173,6 @@ keypath pack install vallack-system
 **Tab switching last.** E (previous tab) and R (next tab) are the most powerful once you're in the flow — navigate code, switch tabs, paste a snippet, all without touching the mouse.
 
 **Give the top-row modifiers a week.** Moving modifiers off the home row feels strange at first. The payoff is that your home row is purely for typing and navigation, with no timing-sensitive tap-hold decisions on your most-used keys.
-
-<!-- Screenshot: Using Vallack nav to edit code — arrows + copy/paste workflow -->
-![Screenshot — Editing workflow with Vallack navigation]({{ '/images/help/placeholder-vallack-workflow.png' | relative_url }})
 
 ---
 

--- a/guides/window-management.md
+++ b/guides/window-management.md
@@ -42,9 +42,6 @@ Now hold Space, press W to enter the window layer, then press a key to snap:
   , = Previous Space      . = Next Space
 ```
 
-<!-- Screenshot: Overlay showing window snapping layer with position indicators -->
-![Screenshot — Window Snapping layer in the overlay]({{ '/images/help/placeholder-overlay-window-snapping.png' | relative_url }})
-
 Release Space to leave the window layer.
 
 ---
@@ -62,9 +59,6 @@ This works in every app — no per-app configuration needed.
 ### Accessibility permission required
 
 The first time you use window snapping, macOS will ask you to grant KeyPath Accessibility permission in **System Settings > Privacy & Security > Accessibility**. Window management won't work without this.
-
-<!-- Screenshot: macOS Accessibility permission prompt -->
-![Screenshot — Accessibility permission dialog]({{ '/images/help/placeholder-accessibility-permission.png' | relative_url }})
 
 ---
 
@@ -132,9 +126,6 @@ Beyond window management, KeyPath can detect which app is in the foreground and 
   │  └────────────────────────────────────────────────┘ │
   └─────────────────────────────────────────────────────┘
 ```
-
-<!-- Screenshot: Custom Rules tab with app-specific rules -->
-![Screenshot — App-specific rules in Custom Rules]({{ '/images/help/placeholder-custom-rules-app-specific.png' | relative_url }})
 
 When you switch apps, KeyPath tells Kanata to switch layers automatically. Your keyboard adapts instantly.
 


### PR DESCRIPTION
Removes never-captured `placeholder-*.png` references from 7 guides so they don't render as broken images on the public site for 1.0. Prose + ASCII mockups stand on their own; real screenshots untouched. Exact capture list preserved in #920 for 1.1. Docs only.