### PR TITLE
Release prep 1.0.0: version bump, appcast cleanup, stable-release tagging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,25 +7,53 @@ Versioning once public release tags are established.
 
 ## [Unreleased]
 
+## [1.0.0] - 2026-06-13
+
+First stable public release.
+
+### Security
+
+- The bundled Kanata engine is compiled without the `cmd` feature: the root
+  daemon physically cannot execute shell commands regardless of config
+  contents — a stronger guarantee than the previous opt-in toggle. Hand-written
+  `(cmd …)` actions now fail validation with a clear message; use the
+  consent-gated **Script Execution** actions (which run as the user, not root)
+  instead.
+
 ### Added
 
+- 22 ready-to-use rule packs (Home Row Mods, Caps Lock remapping, Vim & Neovim
+  navigation, Quick Launcher, Window Snapping, Auto Shift, Numpad/Symbol/Function
+  layers, and more), each installable in one click from the Gallery with a live
+  preview.
+- Live keyboard overlay showing per-layer key behavior in real time, including
+  tap-hold and chord behavior.
+- The Mapper: visual remap builder for tap/hold/shift/combo behaviors, multi-tap,
+  app-specific overrides, system actions, app launches, and layer jumps.
+- QMK (`keymap.c`) and Karabiner (`karabiner.json`) import. QMK import is
+  comprehensive; Karabiner import covers simple key-to-key remaps.
+- Mapper/overlay support for optional per-key shifted output customization:
+  `Shift + key` can send a separate output from the tap/default output for
+  global keystroke mappings.
 - Release-governance docs: `SECURITY.md`, `CODE_OF_CONDUCT.md`, and this
   changelog.
-- CI/release-readiness tracking issues labeled as `release-blocker` in GitHub.
-- Mapper/overlay support for optional per-key shifted output customization:
-  `Shift + key` can now send a separate output from tap/default output for
-  global keystroke mappings.
 
 ### Changed
 
-- Documentation and CI policy are being aligned for open source release quality
-gates.
-- CI now enforces coverage non-regression for the narrow baseline lane:
-  `KeyPathErrorTests` + `PermissionOracleTests` with an initial floor of
-  `0.29%` TOTAL line coverage.
 - Shifted-output editing is intentionally constrained to global keystroke
   mappings and is disabled for app-specific mappings, system actions, URLs, and
   advanced hold/combo/tap-dance behaviors.
+
+### Known limitations
+
+- Home Row Layer Toggles in "Toggle" mode assume the layers they point at are
+  also enabled; if not, those keys no-op on hold (the rest of the keyboard is
+  unaffected).
+- Karabiner import covers simple remaps only — tap-hold, layer/variable, and
+  device/app-conditional rules are not translated yet and are skipped with a
+  summary.
+- Changing the Leader key is done in the Rules tab; the CLI and hand-edited
+  config files don't yet propagate Leader-key changes.
 
 ## [0.0.0-internal]
 

--- a/Scripts/release.sh
+++ b/Scripts/release.sh
@@ -226,11 +226,21 @@ fi
 git tag "v${VERSION}"
 
 echo "📤 Creating GitHub Release..."
+# Mark as pre-release only for versions carrying a semver pre-release suffix
+# (e.g. 1.0.0-beta4). Stable versions (1.0.0) publish as "Latest release".
+# Scalar + ${x:+...} keeps this safe under `set -u` on bash 3.2 (macOS).
+PRERELEASE_FLAG=""
+if [[ "$VERSION" == *-* ]]; then
+    PRERELEASE_FLAG="--prerelease"
+    echo "   $VERSION is a pre-release → marking GitHub Release as pre-release"
+else
+    echo "   $VERSION is stable → publishing as Latest release"
+fi
 gh release create "v${VERSION}" \
     "$SPARKLE_ZIP" \
     "$SPARKLE_DMG" \
     --title "KeyPath ${VERSION}" \
-    --prerelease \
+    ${PRERELEASE_FLAG:+"$PRERELEASE_FLAG"} \
     --notes "See [release notes](https://github.com/malpern/KeyPath/releases/tag/v${VERSION}) for details."
 
 echo "📝 Updating appcast.xml..."

--- a/Sources/KeyPathApp/Info.plist
+++ b/Sources/KeyPathApp/Info.plist
@@ -11,9 +11,9 @@
 	<key>CFBundleDisplayName</key>
 	<string>KeyPath</string>
 	<key>CFBundleVersion</key>
-	<string>3</string>
+	<string>4</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.0-beta3</string>
+	<string>1.0.0</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleIconFile</key>

--- a/appcast.xml
+++ b/appcast.xml
@@ -107,21 +107,5 @@
             ]]></description>
         </item>
 
-        <item>
-            <title>Version 1.0.0</title>
-            <sparkle:version>1</sparkle:version>
-            <sparkle:shortVersionString>1.0.0</sparkle:shortVersionString>
-            <sparkle:minimumSystemVersion>15.0</sparkle:minimumSystemVersion>
-            <pubDate>Mon, 15 Dec 2025 22:07:37 -0800</pubDate>
-            <enclosure
-                url="https://github.com/malpern/KeyPath/releases/download/v1.0.0/KeyPath-1.0.0.zip"
-                sparkle:edSignature="qpxvopkbyBN1caU+d+gtcBG3xwYKduAkwcoEFLrNrBYzf6YPDb2lFHtFgv9SE2MT+u0907r4p5Fl/AJ+mcD+DQ=="
-                length="9078173"
-                type="application/octet-stream"/>
-            <sparkle:releaseNotesLink>
-                https://github.com/malpern/KeyPath/releases/tag/v1.0.0
-            </sparkle:releaseNotesLink>
-        </item>
-        
     </channel>
 </rss>


### PR DESCRIPTION
Prepares `master` for the **1.0.0 stable cut**. Landing this first means `release.sh` can run with **no version arg**, so its in-place `CFBundleVersion=<full-string>` auto-bump (which Sparkle would mis-compare as *older* than beta3) never runs, and the `v1.0.0` tag captures a tree that already says `1.0.0`.

## Changes

- **`Info.plist`** — `CFBundleShortVersionString` `1.0.0-beta3` → `1.0.0`; `CFBundleVersion` `3` → `4`. `build-and-sign.sh` writes `<sparkle:version>` from `CFBundleVersion`, so `4 > 3` is what makes existing beta3 users get offered the update.
- **`appcast.xml`** — remove the stale `Version 1.0.0` entry (`sparkle:version=1`, enclosure pointing at a non-existent `v1.0.0` release) left over from a prior local run. With `1 < 3` it was a permanently-unofferable broken entry; leaving it would put a bogus 1.0.0 next to the real one.
- **`release.sh`** — mark the GitHub Release `--prerelease` **only** for versions with a semver pre-release suffix (e.g. `1.0.0-beta4`); stable `X.Y.Z` now publishes as **Latest release**. Scalar + `${x:+...}` form keeps it safe under `set -u` on bash 3.2 (macOS).
- **`CHANGELOG.md`** — cut `[1.0.0]` section from `[Unreleased]` (security: `cmd`-feature removal; feature list; known limitations).

## Deliberately NOT changed

- **`Sources/KeyPathHelper/Info.plist`** stays at `1.1.0/2`. It already drifted from the app before this release; bumping it changes the bundled privileged helper and can trigger a **re-approval prompt** for existing users on auto-update. Reconciling helper versioning is a clean post-1.0 follow-up.

## Verification

- `plutil -lint Info.plist` ✓
- `xmllint --noout appcast.xml` ✓ (well-formed; only beta3 + the to-be-appended 1.0.0 entry remain)
- `bash -n release.sh` ✓ and prerelease logic unit-checked: `1.0.0 → Latest`, `1.0.0-beta4 → --prerelease`
- No Swift changes (release-config only), so the Swift review gate is N/A.

## Also done out-of-band on this clone

- Deleted 6 stale **local-only** tags (`v1.0.0`–`v1.0.4`, `v1.0.4-2`) — 2022-era inherited Kanata tags never pushed to KeyPath's origin — so `release.sh` can create `v1.0.0`. SHAs recorded; commits stay reachable.

After merge: pull master → `release-candidate.sh` (signed/notarized QA in /Applications) → smoke → `release.sh 1.0.0`.