### PR TITLE
build: gate SwiftPM build system behind KEYPATH_BUILD_SYSTEM env var

### DIFF
--- a/Scripts/build-and-sign.sh
+++ b/Scripts/build-and-sign.sh
@@ -211,7 +211,7 @@ fi
 
 echo "🏗️  Building KeyPath and plugins..."
 # Build all products in a single SwiftPM invocation to share module compilation.
-swift build --configuration release -Xswiftc -no-whole-module-optimization
+swift build ${KEYPATH_BUILD_SYSTEM:+--build-system "$KEYPATH_BUILD_SYSTEM"} --configuration release -Xswiftc -no-whole-module-optimization
 
 echo "📦 Creating app bundle..."
 APP_NAME="KeyPath"

--- a/Scripts/build-helper.sh
+++ b/Scripts/build-helper.sh
@@ -41,7 +41,7 @@ if [ ! -f "$HELPER_INFO_PLIST" ]; then
     exit 1
 fi
 
-swift build --configuration release --product "$HELPER_NAME" \
+swift build ${KEYPATH_BUILD_SYSTEM:+--build-system "$KEYPATH_BUILD_SYSTEM"} --configuration release --product "$HELPER_NAME" \
     -Xswiftc -no-whole-module-optimization \
     -Xlinker -sectcreate -Xlinker __TEXT -Xlinker __info_plist -Xlinker "$HELPER_INFO_PLIST"
 

--- a/Scripts/quick-deploy.sh
+++ b/Scripts/quick-deploy.sh
@@ -254,7 +254,13 @@ fi
 echo "🔨 Building..."
 BUILD_LOG="$BUILD_LOG_DIR/build-${BUILD_ID}.log"
 write_build_log_header "$BUILD_LOG"
-if ! swift build "${MODULE_CACHE_FLAGS[@]}" >> "$BUILD_LOG" 2>&1; then
+# Optional build-system override (e.g. KEYPATH_BUILD_SYSTEM=native on toolchains
+# whose default swiftbuild system is broken). Unset = use the toolchain default.
+BUILD_SYSTEM_FLAGS=()
+if [[ -n "${KEYPATH_BUILD_SYSTEM:-}" ]]; then
+    BUILD_SYSTEM_FLAGS=(--build-system "$KEYPATH_BUILD_SYSTEM")
+fi
+if ! swift build "${BUILD_SYSTEM_FLAGS[@]}" "${MODULE_CACHE_FLAGS[@]}" >> "$BUILD_LOG" 2>&1; then
     BUILD_END_MS=$(get_time_ms)
     DURATION=$((BUILD_END_MS - BUILD_START_MS))
     print_build_failure_diagnostics "$BUILD_LOG"
@@ -262,7 +268,7 @@ if ! swift build "${MODULE_CACHE_FLAGS[@]}" >> "$BUILD_LOG" 2>&1; then
     exit 1
 fi
 
-if ! BIN_DIR_OUTPUT=$(swift build --show-bin-path "${MODULE_CACHE_FLAGS[@]}" 2>> "$BUILD_LOG"); then
+if ! BIN_DIR_OUTPUT=$(swift build --show-bin-path "${BUILD_SYSTEM_FLAGS[@]}" "${MODULE_CACHE_FLAGS[@]}" 2>> "$BUILD_LOG"); then
     BUILD_END_MS=$(get_time_ms)
     DURATION=$((BUILD_END_MS - BUILD_START_MS))
     print_build_failure_diagnostics "$BUILD_LOG"


### PR DESCRIPTION
## Why

On macOS 27 beta with Xcode-beta, SwiftPM defaults to the new `swiftbuild` build system, which:
- Fails the KeyPath build with `error: unable to open dependencies file (...KeyPathCore-primary.d)`
- Writes artifacts to `.build/out/...` instead of the `.build/arm64-apple-macosx/release` layout these scripts already assume

The build scripts were written for the classic `native` build system (see the hardcoded path in `build-and-sign.sh`). A toolchain flipping the default to `swiftbuild` silently breaks the pipeline.

## What

Gate the build system behind an optional `KEYPATH_BUILD_SYSTEM` env var in the three scripts that invoke `swift build`:
- `Scripts/build-and-sign.sh`
- `Scripts/build-helper.sh`
- `Scripts/quick-deploy.sh`

When the var is **unset, behavior is unchanged** (no `--build-system` flag passed) — safe for CI and any toolchain that doesn't recognize the flag. On affected machines, set `export KEYPATH_BUILD_SYSTEM=native`.

## Test

- `bash -n` passes on all three scripts
- Full `./build.sh` (build → sign → notarize → staple → deploy → launch) verified end-to-end on macOS 27 beta with `KEYPATH_BUILD_SYSTEM=native`

🤖 Generated with [Claude Code](https://claude.com/claude-code)