### PR TITLE
Fix leader key headless reconcile (#889) + remove try! regexes (#850)

### DIFF
--- a/Scripts/qa-leader-key-smoke.sh
+++ b/Scripts/qa-leader-key-smoke.sh
@@ -46,18 +46,18 @@ PY
 
 smoke_init
 
-# Finding (release-readiness, Thu): the Leader Key collection's
-# selectedOutput is display-only — the generated config's leader binding
-# comes from the system leaderKeyPreference (UserDefaults), which JSON/CLI
-# mutation of the collection does not touch. Setting selectedOutput=tab
-# still emits layer_nav_spc. Until that's resolved (or confirmed intended),
-# these cases assert apply-success per preset, which still kanata-validates
-# the full config for each value.
+# Fixed (issue #889): the Leader Key collection's selectedOutput is now the
+# source of truth for the leader binding even on the headless path. Loading
+# collections reconciles the system leaderKeyPreference from the collection
+# (RuleCollectionsManager.reconcileLeaderKeyFromCollection), so JSON/CLI
+# mutation of selectedOutput actually changes the generated config. Each
+# preset must emit its own leader input, not the default.
 for preset in space caps tab grv; do
   echo "==> preset: $preset"
   apply_leader "$preset"
   config="$(show_config)"
   assert_contains "$config" "Leader Key" "preset $preset config includes the Leader Key collection"
+  assert_contains "$config" ";; Input: $preset" "preset $preset drives the generated leader binding"
 done
 
-echo "Leader Key smoke passed (all 4 presets apply kanata-clean). Restoring original KeyPath config."
+echo "Leader Key smoke passed (all 4 presets drive their own leader binding, kanata-clean). Restoring original KeyPath config."

--- a/Scripts/qa-leader-key-smoke.sh
+++ b/Scripts/qa-leader-key-smoke.sh
@@ -46,18 +46,22 @@ PY
 
 smoke_init
 
-# Fixed (issue #889): the Leader Key collection's selectedOutput is now the
-# source of truth for the leader binding even on the headless path. Loading
-# collections reconciles the system leaderKeyPreference from the collection
-# (RuleCollectionsManager.reconcileLeaderKeyFromCollection), so JSON/CLI
-# mutation of selectedOutput actually changes the generated config. Each
-# preset must emit its own leader input, not the default.
+# Partial fix (issue #889): the in-process app/daemon load paths
+# (RuleCollectionsManager.bootstrap / replaceCollections) now reconcile the
+# system leaderKeyPreference from the Leader Key collection's selectedOutput.
+# This script drives the standalone `keypath-cli config apply`, which generates
+# config via ConfigFacade → ConfigurationService — it reads leaderKeyPreference
+# directly and never constructs a RuleCollectionsManager, so from the CLI the
+# collection's selectedOutput is still display-only (setting it to tab here
+# still emits the leaderKeyPreference default). Unifying config generation on
+# the collection as the single source of truth is deferred to #865/#888.
+# These cases assert apply-success per preset, which still kanata-validates the
+# full config for each value.
 for preset in space caps tab grv; do
   echo "==> preset: $preset"
   apply_leader "$preset"
   config="$(show_config)"
   assert_contains "$config" "Leader Key" "preset $preset config includes the Leader Key collection"
-  assert_contains "$config" ";; Input: $preset" "preset $preset drives the generated leader binding"
 done
 
-echo "Leader Key smoke passed (all 4 presets drive their own leader binding, kanata-clean). Restoring original KeyPath config."
+echo "Leader Key smoke passed (all 4 presets apply kanata-clean). Restoring original KeyPath config."

--- a/Sources/KeyPathAppKit/Services/LayerMapping/LayerMappingBuilder.swift
+++ b/Sources/KeyPathAppKit/Services/LayerMapping/LayerMappingBuilder.swift
@@ -269,11 +269,8 @@ enum LayerMappingBuilder {
 
     static func extractAppLaunchIdentifier(from output: String) -> String? {
         guard let pushMsgLaunchRegex,
-            let match = pushMsgLaunchRegex.firstMatch(
-                in: output,
-                range: NSRange(output.startIndex..., in: output)
-            ),
-            let range = Range(match.range(at: 1), in: output)
+              let match = pushMsgLaunchRegex.firstMatch(in: output, range: NSRange(output.startIndex..., in: output)),
+              let range = Range(match.range(at: 1), in: output)
         else {
             return nil
         }
@@ -283,11 +280,8 @@ enum LayerMappingBuilder {
 
     static func extractUrlIdentifier(from output: String) -> String? {
         guard let pushMsgOpenRegex,
-            let match = pushMsgOpenRegex.firstMatch(
-                in: output,
-                range: NSRange(output.startIndex..., in: output)
-            ),
-            let range = Range(match.range(at: 1), in: output)
+              let match = pushMsgOpenRegex.firstMatch(in: output, range: NSRange(output.startIndex..., in: output)),
+              let range = Range(match.range(at: 1), in: output)
         else {
             return nil
         }
@@ -297,11 +291,8 @@ enum LayerMappingBuilder {
 
     static func extractSystemActionIdentifier(from output: String) -> String? {
         guard let pushMsgSystemRegex,
-            let match = pushMsgSystemRegex.firstMatch(
-                in: output,
-                range: NSRange(output.startIndex..., in: output)
-            ),
-            let range = Range(match.range(at: 1), in: output)
+              let match = pushMsgSystemRegex.firstMatch(in: output, range: NSRange(output.startIndex..., in: output)),
+              let range = Range(match.range(at: 1), in: output)
         else {
             return nil
         }

--- a/Sources/KeyPathAppKit/Services/LayerMapping/LayerMappingBuilder.swift
+++ b/Sources/KeyPathAppKit/Services/LayerMapping/LayerMappingBuilder.swift
@@ -222,28 +222,29 @@ enum LayerMappingBuilder {
 
     // MARK: - Push-Msg Parsing
 
-    private static let pushMsgTypeValueRegex = try! NSRegularExpression(
+    private static let pushMsgTypeValueRegex = try? NSRegularExpression(
         pattern: #"\(push-msg\s+\"([^:\"]+):([^\"]+)\"\)"#,
         options: [.caseInsensitive]
     )
 
-    private static let pushMsgLaunchRegex = try! NSRegularExpression(
+    private static let pushMsgLaunchRegex = try? NSRegularExpression(
         pattern: #"\(push-msg\s+\"launch:([^\"]+)\"\)"#,
         options: [.caseInsensitive]
     )
 
-    private static let pushMsgOpenRegex = try! NSRegularExpression(
+    private static let pushMsgOpenRegex = try? NSRegularExpression(
         pattern: #"\(push-msg\s+\"open:([^\"]+)\"\)"#,
         options: [.caseInsensitive]
     )
 
-    private static let pushMsgSystemRegex = try! NSRegularExpression(
+    private static let pushMsgSystemRegex = try? NSRegularExpression(
         pattern: #"\(push-msg\s+\"system:([^\"]+)\"\)"#,
         options: [.caseInsensitive]
     )
 
     static func extractPushMsgInfo(from output: String, description: String?) -> LayerKeyInfo? {
-        guard let match = pushMsgTypeValueRegex.firstMatch(in: output, range: NSRange(output.startIndex..., in: output)),
+        guard let pushMsgTypeValueRegex,
+              let match = pushMsgTypeValueRegex.firstMatch(in: output, range: NSRange(output.startIndex..., in: output)),
               let typeRange = Range(match.range(at: 1), in: output),
               let valueRange = Range(match.range(at: 2), in: output)
         else {
@@ -267,10 +268,11 @@ enum LayerMappingBuilder {
     }
 
     static func extractAppLaunchIdentifier(from output: String) -> String? {
-        guard let match = pushMsgLaunchRegex.firstMatch(
-            in: output,
-            range: NSRange(output.startIndex..., in: output)
-        ),
+        guard let pushMsgLaunchRegex,
+            let match = pushMsgLaunchRegex.firstMatch(
+                in: output,
+                range: NSRange(output.startIndex..., in: output)
+            ),
             let range = Range(match.range(at: 1), in: output)
         else {
             return nil
@@ -280,10 +282,11 @@ enum LayerMappingBuilder {
     }
 
     static func extractUrlIdentifier(from output: String) -> String? {
-        guard let match = pushMsgOpenRegex.firstMatch(
-            in: output,
-            range: NSRange(output.startIndex..., in: output)
-        ),
+        guard let pushMsgOpenRegex,
+            let match = pushMsgOpenRegex.firstMatch(
+                in: output,
+                range: NSRange(output.startIndex..., in: output)
+            ),
             let range = Range(match.range(at: 1), in: output)
         else {
             return nil
@@ -293,10 +296,11 @@ enum LayerMappingBuilder {
     }
 
     static func extractSystemActionIdentifier(from output: String) -> String? {
-        guard let match = pushMsgSystemRegex.firstMatch(
-            in: output,
-            range: NSRange(output.startIndex..., in: output)
-        ),
+        guard let pushMsgSystemRegex,
+            let match = pushMsgSystemRegex.firstMatch(
+                in: output,
+                range: NSRange(output.startIndex..., in: output)
+            ),
             let range = Range(match.range(at: 1), in: output)
         else {
             return nil

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+Bootstrap.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+Bootstrap.swift
@@ -46,9 +46,15 @@ extension RuleCollectionsManager {
 
         dedupeRuleCollectionsInPlace()
         refreshLayerIndicatorState()
-        reconcileLeaderKeyFromCollection()
 
-        await regenerateConfigFromCollections()
+        let leaderSnapshot = PreferencesService.shared.leaderKeyPreference
+        let collectionsSnapshot = ruleCollections
+        let didReconcileLeader = reconcileLeaderKeyFromCollection()
+
+        let applied = await regenerateConfigFromCollections()
+        if didReconcileLeader, !applied {
+            rollbackLeaderReconcile(preference: leaderSnapshot, collections: collectionsSnapshot)
+        }
     }
 
     // MARK: - Pack Reconciliation

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+Bootstrap.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+Bootstrap.swift
@@ -46,6 +46,7 @@ extension RuleCollectionsManager {
 
         dedupeRuleCollectionsInPlace()
         refreshLayerIndicatorState()
+        reconcileLeaderKeyFromCollection()
 
         await regenerateConfigFromCollections()
     }

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+PublicAPI.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+PublicAPI.swift
@@ -781,11 +781,18 @@ extension RuleCollectionsManager {
     /// enabled Leader Key collection's `selectedOutput`.
     ///
     /// The in-app picker routes through `updateLeaderKey`, which keeps both stores in
-    /// sync. Headless mutations — direct JSON edits, `keypath collection` CLI commands,
-    /// and import/restore — change `selectedOutput` without touching `leaderKeyPreference`,
-    /// so config generation (which derives the leader key from the preference) would
-    /// silently ignore them. Calling this on every load/import path makes the collection
-    /// the source of truth those paths already assume it to be. See issue #889.
+    /// sync. Headless mutations — direct JSON edits and import/restore — change
+    /// `selectedOutput` without touching `leaderKeyPreference`, so config generation
+    /// (which derives the leader key from the preference) would silently ignore them.
+    /// Calling this on the in-process load paths (`bootstrap`/`replaceCollections`)
+    /// reconciles the preference so a subsequent app/daemon config regen honors the
+    /// edited collection. See issue #889.
+    ///
+    /// NOT covered: the standalone `keypath-cli config apply` path generates config via
+    /// `ConfigFacade` → `ConfigurationService`, which reads `leaderKeyPreference`
+    /// directly and never constructs a `RuleCollectionsManager` — so this reconcile does
+    /// not run there. Unifying config generation on the collection is deferred to
+    /// #865/#888.
     ///
     /// Only an *explicit* `selectedOutput` reconciles — a nil `selectedOutput` means the
     /// collection expresses no opinion, so a leader key configured via the system

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+PublicAPI.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+PublicAPI.swift
@@ -15,6 +15,7 @@ extension RuleCollectionsManager {
         ruleCollections = RuleCollectionDeduplicator.dedupe(collections)
         dedupeRuleCollectionsInPlace()
         refreshLayerIndicatorState()
+        reconcileLeaderKeyFromCollection()
         await regenerateConfigFromCollections()
     }
 
@@ -774,6 +775,35 @@ extension RuleCollectionsManager {
         }
         preference.enabled = enabled
         PreferencesService.shared.leaderKeyPreference = preference
+    }
+
+    /// Reconcile the system `leaderKeyPreference` (and momentary activators) from the
+    /// enabled Leader Key collection's `selectedOutput`.
+    ///
+    /// The in-app picker routes through `updateLeaderKey`, which keeps both stores in
+    /// sync. Headless mutations — direct JSON edits, `keypath collection` CLI commands,
+    /// and import/restore — change `selectedOutput` without touching `leaderKeyPreference`,
+    /// so config generation (which derives the leader key from the preference) would
+    /// silently ignore them. Calling this on every load/import path makes the collection
+    /// the source of truth those paths already assume it to be. See issue #889.
+    ///
+    /// Only an *explicit* `selectedOutput` reconciles — a nil `selectedOutput` means the
+    /// collection expresses no opinion, so a leader key configured via the system
+    /// preference path is left untouched (no fallback to the first preset).
+    func reconcileLeaderKeyFromCollection() {
+        guard let leaderCollection = ruleCollections.first(where: { $0.id == RuleCollectionIdentifier.leaderKey }),
+              leaderCollection.isEnabled,
+              let key = leaderCollection.configuration.singleKeyPickerConfig?.selectedOutput
+        else { return }
+
+        let current = PreferencesService.shared.leaderKeyPreference
+        guard current.key != key || !current.enabled else { return }
+
+        AppLogger.shared.log(
+            "🔑 [RuleCollections] Reconciling leader key from collection selectedOutput: '\(key)' (was '\(current.key)', enabled=\(current.enabled))"
+        )
+        applyLeaderKeyToMomentaryActivators(key)
+        syncLeaderKeyPreference(key: key, enabled: true)
     }
 
     /// Save or update a custom rule

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+PublicAPI.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+PublicAPI.swift
@@ -790,6 +790,13 @@ extension RuleCollectionsManager {
     /// Only an *explicit* `selectedOutput` reconciles — a nil `selectedOutput` means the
     /// collection expresses no opinion, so a leader key configured via the system
     /// preference path is left untouched (no fallback to the first preset).
+    ///
+    /// Scope (see #889): this only reconciles the enabled-with-explicit-output case. A
+    /// headless edit that *disables* a previously-reconciled collection leaves
+    /// `leaderKeyPreference` stale (still enabled with the old key). Forcing it disabled
+    /// here would clobber a leader configured via the system-preference path while the
+    /// collection is off, so full bidirectional reconciliation is deferred to the
+    /// single-source-of-truth work in #865/#888.
     func reconcileLeaderKeyFromCollection() {
         guard let leaderCollection = ruleCollections.first(where: { $0.id == RuleCollectionIdentifier.leaderKey }),
               leaderCollection.isEnabled,

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+PublicAPI.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+PublicAPI.swift
@@ -15,8 +15,15 @@ extension RuleCollectionsManager {
         ruleCollections = RuleCollectionDeduplicator.dedupe(collections)
         dedupeRuleCollectionsInPlace()
         refreshLayerIndicatorState()
-        reconcileLeaderKeyFromCollection()
-        await regenerateConfigFromCollections()
+
+        let leaderSnapshot = PreferencesService.shared.leaderKeyPreference
+        let collectionsSnapshot = ruleCollections
+        let didReconcileLeader = reconcileLeaderKeyFromCollection()
+
+        let applied = await regenerateConfigFromCollections()
+        if didReconcileLeader, !applied {
+            rollbackLeaderReconcile(preference: leaderSnapshot, collections: collectionsSnapshot)
+        }
     }
 
     /// Toggle a rule collection on/off
@@ -830,20 +837,38 @@ extension RuleCollectionsManager {
     /// here would clobber a leader configured via the system-preference path while the
     /// collection is off, so full bidirectional reconciliation is deferred to the
     /// single-source-of-truth work in #865/#888.
-    func reconcileLeaderKeyFromCollection() {
+    /// - Returns: `true` if it mutated the preference/activators (so the caller must roll
+    ///   back via `rollbackLeaderReconcile` if the subsequent config regen fails), `false`
+    ///   if it was a no-op.
+    @discardableResult
+    func reconcileLeaderKeyFromCollection() -> Bool {
         guard let leaderCollection = ruleCollections.first(where: { $0.id == RuleCollectionIdentifier.leaderKey }),
               leaderCollection.isEnabled,
               let key = leaderCollection.configuration.singleKeyPickerConfig?.selectedOutput
-        else { return }
+        else { return false }
 
         let current = PreferencesService.shared.leaderKeyPreference
-        guard current.key != key || !current.enabled else { return }
+        guard current.key != key || !current.enabled else { return false }
 
         AppLogger.shared.log(
             "🔑 [RuleCollections] Reconciling leader key from collection selectedOutput: '\(key)' (was '\(current.key)', enabled=\(current.enabled))"
         )
         applyLeaderKeyToLeaderActivators(key, targetLayer: current.targetLayer)
         syncLeaderKeyPreference(key: key, enabled: true)
+        return true
+    }
+
+    /// Silently undo a reconcile whose config regen failed. `leaderKeyPreference` is
+    /// UserDefaults-persisted via `didSet`, so leaving a reconciled-but-unapplied value in
+    /// place would permanently mask the drift (the idempotency guard in
+    /// `reconcileLeaderKeyFromCollection` would see the preference already matches and skip
+    /// retrying). Restoring both the preference and the in-memory collections lets the next
+    /// load retry cleanly. Unlike `updateLeaderKey`'s rollback this shows no user message —
+    /// it runs on passive `bootstrap`/`replaceCollections` load paths. See issue #889.
+    func rollbackLeaderReconcile(preference: LeaderKeyPreference, collections: [RuleCollection]) {
+        AppLogger.shared.log("↩️ [RuleCollections] Leader reconcile rolled back after failed config regen")
+        ruleCollections = collections
+        PreferencesService.shared.leaderKeyPreference = preference
     }
 
     /// Save or update a custom rule

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+PublicAPI.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+PublicAPI.swift
@@ -763,6 +763,32 @@ extension RuleCollectionsManager {
         }
     }
 
+    /// Rewrite the input of only the *leader* activators — those that transition from the
+    /// base layer into the leader's target layer (e.g. base → nav). Unlike
+    /// `applyLeaderKeyToMomentaryActivators`, this deliberately leaves unrelated base-layer
+    /// activators alone (e.g. Home Row Arrows on "f", Quick Launcher on "hyper") and
+    /// chained sub-layer activators (sourceLayer != .base, e.g. nav → window), which have
+    /// their own activation keys. Used by the passive reconcile path, which fires on every
+    /// headless load where the preference diverges — the broad rewrite would stomp those
+    /// unrelated features (and, for Quick Launcher's "hyper", collide two base-layer
+    /// bindings onto the same key). See issue #889.
+    private func applyLeaderKeyToLeaderActivators(_ newKey: String, targetLayer: RuleCollectionLayer) {
+        for index in ruleCollections.indices {
+            guard let activator = ruleCollections[index].momentaryActivator,
+                  activator.sourceLayer == .base,
+                  activator.targetLayer == targetLayer
+            else { continue }
+            ruleCollections[index].momentaryActivator = MomentaryActivator(
+                input: newKey,
+                targetLayer: activator.targetLayer,
+                sourceLayer: activator.sourceLayer
+            )
+            AppLogger.shared.log(
+                "🔑 [RuleCollections] Reconciled leader activator on '\(ruleCollections[index].name)' to '\(newKey)'"
+            )
+        }
+    }
+
     private func leaderKeyOutput(from collection: RuleCollection) -> String? {
         guard let config = collection.configuration.singleKeyPickerConfig else { return nil }
         return config.selectedOutput ?? config.presetOptions.first?.output
@@ -777,8 +803,8 @@ extension RuleCollectionsManager {
         PreferencesService.shared.leaderKeyPreference = preference
     }
 
-    /// Reconcile the system `leaderKeyPreference` (and momentary activators) from the
-    /// enabled Leader Key collection's `selectedOutput`.
+    /// Reconcile the system `leaderKeyPreference` (and the base→nav leader activator) from
+    /// the enabled Leader Key collection's `selectedOutput`.
     ///
     /// The in-app picker routes through `updateLeaderKey`, which keeps both stores in
     /// sync. Headless mutations — direct JSON edits and import/restore — change
@@ -816,7 +842,7 @@ extension RuleCollectionsManager {
         AppLogger.shared.log(
             "🔑 [RuleCollections] Reconciling leader key from collection selectedOutput: '\(key)' (was '\(current.key)', enabled=\(current.enabled))"
         )
-        applyLeaderKeyToMomentaryActivators(key)
+        applyLeaderKeyToLeaderActivators(key, targetLayer: current.targetLayer)
         syncLeaderKeyPreference(key: key, enabled: true)
     }
 

--- a/Tests/KeyPathTests/RuleCollections/RuleCollectionsManagerTests.swift
+++ b/Tests/KeyPathTests/RuleCollections/RuleCollectionsManagerTests.swift
@@ -593,6 +593,48 @@ final class RuleCollectionsManagerTests: XCTestCase {
         XCTAssertTrue(afterInputs.allSatisfy { $0 == "space" })
     }
 
+    /// Issue #889: a headless mutation of the Leader Key collection's
+    /// `selectedOutput` (direct JSON edit / CLI / import) does not route through
+    /// `updateLeaderKey`, so loading it must reconcile the system
+    /// `leaderKeyPreference` and momentary activators — otherwise config
+    /// generation silently keeps the old leader key.
+    @MainActor
+    func testReplaceCollectionsReconcilesLeaderKeyFromSelectedOutput() async throws {
+        let (manager, _) = try await createTestManager()
+        defer { TestEnvironment.forceTestMode = false }
+
+        // Preference starts at the default ("space"); the loaded collection asks for "tab".
+        PreferencesService.shared.leaderKeyPreference = .default
+        defer { PreferencesService.shared.leaderKeyPreference = .default }
+
+        let collections = RuleCollectionCatalog().defaultCollections().map { collection -> RuleCollection in
+            var collection = collection
+            if collection.id == RuleCollectionIdentifier.leaderKey {
+                collection.isEnabled = true
+                collection.configuration.updateSelectedOutput("tab")
+            }
+            return collection
+        }
+
+        // Simulates the headless load/import path (bootstrap uses the same reconcile).
+        await manager.replaceCollections(collections)
+
+        XCTAssertEqual(
+            PreferencesService.shared.leaderKeyPreference.key, "tab",
+            "leaderKeyPreference should be reconciled from the collection's selectedOutput"
+        )
+        XCTAssertTrue(
+            PreferencesService.shared.leaderKeyPreference.enabled,
+            "enabled leader collection should mark the preference enabled"
+        )
+        let inputs = manager.ruleCollections.compactMap(\.momentaryActivator?.input)
+        XCTAssertFalse(inputs.isEmpty)
+        XCTAssertTrue(
+            inputs.allSatisfy { $0 == "tab" },
+            "momentary activators should adopt the reconciled leader key"
+        )
+    }
+
     @MainActor
     func testToggleCustomRuleConflictKeepNew_DisablesConflictingCollection() async throws {
         let (manager, _) = try await createTestManager()

--- a/Tests/KeyPathTests/RuleCollections/RuleCollectionsManagerTests.swift
+++ b/Tests/KeyPathTests/RuleCollections/RuleCollectionsManagerTests.swift
@@ -635,6 +635,72 @@ final class RuleCollectionsManagerTests: XCTestCase {
         )
     }
 
+    /// Issue #889: a nil `selectedOutput` means the collection expresses no opinion, so
+    /// reconciliation must leave a leader key configured via the system-preference path
+    /// untouched (no fallback to the first preset). This is the regression a pre-commit
+    /// review caught; lock it in.
+    @MainActor
+    func testReconcileLeavesPreferenceUntouchedWhenSelectedOutputNil() async throws {
+        let (manager, _) = try await createTestManager()
+        defer { TestEnvironment.forceTestMode = false }
+
+        // Leader key deliberately configured via the system-preference path.
+        PreferencesService.shared.leaderKeyPreference = LeaderKeyPreference(
+            key: "caps", targetLayer: .navigation, enabled: true
+        )
+        defer { PreferencesService.shared.leaderKeyPreference = .default }
+
+        let collections = RuleCollectionCatalog().defaultCollections().map { collection -> RuleCollection in
+            var collection = collection
+            if collection.id == RuleCollectionIdentifier.leaderKey {
+                collection.isEnabled = true
+                if var config = collection.configuration.singleKeyPickerConfig {
+                    config.selectedOutput = nil
+                    collection.configuration = .singleKeyPicker(config)
+                }
+            }
+            return collection
+        }
+
+        await manager.replaceCollections(collections)
+
+        XCTAssertEqual(
+            PreferencesService.shared.leaderKeyPreference.key, "caps",
+            "nil selectedOutput must not clobber a system-preference leader key"
+        )
+        XCTAssertTrue(PreferencesService.shared.leaderKeyPreference.enabled)
+    }
+
+    /// Issue #889: reconciliation only fires for an *enabled* Leader Key collection. A
+    /// disabled collection — even one carrying an explicit selectedOutput — must not
+    /// touch the preference.
+    @MainActor
+    func testReconcileSkipsWhenLeaderCollectionDisabled() async throws {
+        let (manager, _) = try await createTestManager()
+        defer { TestEnvironment.forceTestMode = false }
+
+        PreferencesService.shared.leaderKeyPreference = LeaderKeyPreference(
+            key: "caps", targetLayer: .navigation, enabled: true
+        )
+        defer { PreferencesService.shared.leaderKeyPreference = .default }
+
+        let collections = RuleCollectionCatalog().defaultCollections().map { collection -> RuleCollection in
+            var collection = collection
+            if collection.id == RuleCollectionIdentifier.leaderKey {
+                collection.isEnabled = false
+                collection.configuration.updateSelectedOutput("tab")
+            }
+            return collection
+        }
+
+        await manager.replaceCollections(collections)
+
+        XCTAssertEqual(
+            PreferencesService.shared.leaderKeyPreference.key, "caps",
+            "a disabled Leader Key collection must not reconcile the preference"
+        )
+    }
+
     @MainActor
     func testToggleCustomRuleConflictKeepNew_DisablesConflictingCollection() async throws {
         let (manager, _) = try await createTestManager()

--- a/Tests/KeyPathTests/RuleCollections/RuleCollectionsManagerTests.swift
+++ b/Tests/KeyPathTests/RuleCollections/RuleCollectionsManagerTests.swift
@@ -627,11 +627,26 @@ final class RuleCollectionsManagerTests: XCTestCase {
             PreferencesService.shared.leaderKeyPreference.enabled,
             "enabled leader collection should mark the preference enabled"
         )
-        let inputs = manager.ruleCollections.compactMap(\.momentaryActivator?.input)
-        XCTAssertFalse(inputs.isEmpty)
+        // The leader activator (base -> nav) adopts the reconciled key...
+        let navInputs = manager.ruleCollections
+            .compactMap(\.momentaryActivator)
+            .filter { $0.sourceLayer == .base && $0.targetLayer == .navigation }
+            .map(\.input)
+        XCTAssertFalse(navInputs.isEmpty)
         XCTAssertTrue(
-            inputs.allSatisfy { $0 == "tab" },
-            "momentary activators should adopt the reconciled leader key"
+            navInputs.allSatisfy { $0 == "tab" },
+            "the leader (base -> nav) activator should adopt the reconciled leader key"
+        )
+
+        // ...but unrelated base-layer activators (Home Row Arrows "f", Quick Launcher
+        // "hyper") must NOT be stomped to the leader key (issue #889 regression guard).
+        let otherInputs = manager.ruleCollections
+            .compactMap(\.momentaryActivator)
+            .filter { !($0.sourceLayer == .base && $0.targetLayer == .navigation) }
+            .map(\.input)
+        XCTAssertFalse(
+            otherInputs.contains("tab"),
+            "non-leader momentary activators must not be rewritten to the leader key"
         )
     }
 

--- a/docs/bugs/2026-07-02-leader-key-headless-selectedoutput-reconcile.md
+++ b/docs/bugs/2026-07-02-leader-key-headless-selectedoutput-reconcile.md
@@ -1,0 +1,66 @@
+# Leader Key `selectedOutput` Ignored on Headless Loads (#889)
+
+**Date:** 2026-07-02
+**Severity:** Correctness (stale generated config) + a regression caught in review
+**Status:** Partial fix in place (in-process load paths); CLI generation path deferred to #865/#888
+
+## Problem
+
+The Leader Key collection's `selectedOutput` only drove the generated config when
+changed through the in-app picker, which routes through
+`RuleCollectionsManager.updateLeaderKey` and syncs the system
+`leaderKeyPreference` (UserDefaults). Config generation derives the primary
+leader binding from `leaderKeyPreference`, **independent of the collection**
+(see `KanataConfiguration+BlockBuilders.swift`).
+
+Headless mutations — direct `RuleCollections.json` edits and import/restore —
+change `selectedOutput` without touching `leaderKeyPreference`, so generation
+silently kept the old leader key.
+
+## Fix (proximate)
+
+`RuleCollectionsManager.reconcileLeaderKeyFromCollection()`, invoked from the two
+in-process load paths (`bootstrap()` and `replaceCollections()`), syncs
+`leaderKeyPreference` from the enabled Leader Key collection's **explicit**
+`selectedOutput` before config regeneration. A nil `selectedOutput` is treated as
+"no opinion" and does not clobber a leader configured via the system-preference
+path.
+
+## Regression caught during review (the deeper lesson)
+
+The first implementation reused the existing `applyLeaderKeyToMomentaryActivators`,
+which rewrites the `input` of **every** collection's `momentaryActivator` to the
+new leader key. That is acceptable-ish for an explicit UI "change my leader key"
+action, but wiring it into every headless load meant it would stomp unrelated,
+default-enabled features whenever the preference diverged:
+
+- **Home Row Arrows** (`base → home-arrows`, input `f`)
+- **Quick Launcher** (`base → launcher`, input `hyper`) — collapsing `hyper` onto
+  the leader key also defeats the Hyper special-casing in config generation and
+  collides two base-layer bindings on the same key.
+
+Fix: `applyLeaderKeyToLeaderActivators(_:targetLayer:)` rewrites only the
+`base → <leader target layer>` (i.e. base → nav) activators, leaving unrelated
+base-layer and chained `nav → *` sub-layer activators untouched. Regression guard
+added in `testReplaceCollectionsReconcilesLeaderKeyFromSelectedOutput`.
+
+## Known limitations / follow-ups
+
+- **Standalone `keypath-cli config apply` is not covered.** It generates config via
+  `ConfigFacade` → `ConfigurationService`, reading `leaderKeyPreference` directly
+  and never constructing a `RuleCollectionsManager`, so the reconcile does not run.
+  Making config generation derive the leader key from the collection (single source
+  of truth) is deferred to #865/#888.
+- **Disable-drift is not reconciled.** A headless edit that *disables* a
+  previously-reconciled collection leaves `leaderKeyPreference` stale; forcing it
+  disabled would clobber a system-preference leader. Deferred to #865/#888.
+- **`targetLayer` coupling.** The scoped activator update derives the leader target
+  layer from `leaderKeyPreference.targetLayer` (always `.navigation` today). If a
+  future non-navigation leader layer is introduced, this filter would match zero
+  activators; revisit alongside the #865/#888 single-source-of-truth work.
+
+## Also in the same change (#850)
+
+Four `try! NSRegularExpression` static lets in `LayerMappingBuilder` were converted
+to `try?` with guarded call sites, removing a latent force-unwrap crash path
+(audit §5.3 regression).


### PR DESCRIPTION
## Summary

Two 1.0-relevant fixes surfaced during a project-state review, with scope tightened across review rounds.

### #850 — remove `try!` regexes in `LayerMappingBuilder`
Replace four `try! NSRegularExpression` static lets with `try?`, guarding each of the four call sites. Removes a latent force-unwrap crash path; matches the codebase's existing `try? NSRegularExpression` + guard idiom. No behavior change (patterns are static literals). SwiftLint clean.

### #889 — Leader Key `selectedOutput` reconcile (in-process load paths only)
The in-app picker already worked (`updateLeaderKey` syncs `leaderKeyPreference`). The gap: headless mutations (direct `RuleCollections.json` edits, import/restore) change `selectedOutput` without syncing the preference, so config generation ignores them.

- Add `reconcileLeaderKeyFromCollection()`, called from `bootstrap()` and `replaceCollections()`, syncing `leaderKeyPreference` from the enabled Leader Key collection's **explicit** `selectedOutput` (nil → no-op, so a system-preference leader key is never clobbered).
- **Scoped activator update:** reconcile rewrites only the base→nav **leader** activator, via `applyLeaderKeyToLeaderActivators`. It does **not** use the broad `applyLeaderKeyToMomentaryActivators`, which would stomp unrelated default-enabled features (Home Row Arrows `f`, Quick Launcher `hyper`) and collide two base-layer bindings on the same key.

### Scope boundaries (deferred to #865/#888)
- **Standalone `keypath-cli config apply` is NOT covered.** That path generates config via `ConfigFacade` → `ConfigurationService`, which reads `leaderKeyPreference` directly and never constructs a `RuleCollectionsManager`, so the reconcile doesn't run there. `Scripts/qa-leader-key-smoke.sh` (which drives the CLI) documents this; its assertions were reverted to apply-success accordingly.
- The broad `applyLeaderKeyToMomentaryActivators` used by the UI `updateLeaderKey` path has the same over-broad activator rewrite — pre-existing, left untouched here.
- Disable-drift (headless *disable* leaving the preference stale) is intentionally not reconciled (would clobber a system-preference leader).

## Tests
- `testReplaceCollectionsReconcilesLeaderKeyFromSelectedOutput` — leader activator adopts the key; **unrelated activators preserved** (regression guard).
- `testReconcileLeavesPreferenceUntouchedWhenSelectedOutputNil` — nil `selectedOutput` doesn't clobber a system-preference leader.
- `testReconcileSkipsWhenLeaderCollectionDisabled` — disabled collection doesn't reconcile.

## ⚠️ Validation gate (must pass before merge)
This branch was developed on a Linux remote with **no Swift toolchain / SwiftFormat**, so nothing here was compiled or run locally. Before merge, confirm on macOS CI:
- `build-and-test` green, especially `swift test --filter RuleCollectionsManagerTests`.
- Recommended manual check: generate config with **Quick Launcher + Home Row Arrows enabled alongside a non-default leader key** and confirm their activators (`hyper`/`f`) are intact and the config is kanata-valid.
- `code-quality` (SwiftFormat 0.61.1 lint) green.

## Related
- Fixes #850
- Partial for #889 (in-process load paths). CLI generation path + full single-source-of-truth → #865/#888.

🤖 Generated with [Claude Code](https://claude.com/claude-code)