### PR TITLE
Install tier-0 reliability: bounded privileged execution, VHID ordering guard, 0-byte config fix

### DIFF
--- a/Sources/KeyPathAppKit/Core/PrivilegedOperationsRouter.swift
+++ b/Sources/KeyPathAppKit/Core/PrivilegedOperationsRouter.swift
@@ -93,6 +93,16 @@ public final class PrivilegedOperationsRouter {
     public func installRequiredRuntimeServices() async throws {
         switch Self.operationMode {
         case .privilegedHelper:
+            // Check helper responsiveness first (same as repairVHIDDaemonServices):
+            // an unresponsive helper otherwise costs a silent 30s XPC timeout
+            // before the sudo fallback fires (#930).
+            guard await helperManager.testHelperFunctionality() else {
+                AppLogger.shared.log(
+                    "⚠️ [Router] Helper not responsive — using sudo for runtime service install"
+                )
+                try await sudoInstallRequiredRuntimeServices()
+                return
+            }
             do {
                 try await helperManager.installRequiredRuntimeServices()
                 // Stale-helper guard (MAL-57): a resident helper from before
@@ -583,7 +593,7 @@ public final class PrivilegedOperationsRouter {
         if hasService {
             commands.append("""
             /bin/launchctl enable system/\(vhidLabel) 2>/dev/null || true
-            /bin/launchctl kickstart -k system/\(vhidLabel)
+            kp_timeout 15 /bin/launchctl kickstart -k system/\(vhidLabel)
             """)
         } else {
             commands.append("'\(daemonPath)' > /dev/null 2>&1 &")

--- a/Sources/KeyPathAppKit/Core/PrivilegedOperationsRouter.swift
+++ b/Sources/KeyPathAppKit/Core/PrivilegedOperationsRouter.swift
@@ -93,16 +93,6 @@ public final class PrivilegedOperationsRouter {
     public func installRequiredRuntimeServices() async throws {
         switch Self.operationMode {
         case .privilegedHelper:
-            // Check helper responsiveness first (same as repairVHIDDaemonServices):
-            // an unresponsive helper otherwise costs a silent 30s XPC timeout
-            // before the sudo fallback fires (#930).
-            guard await helperManager.testHelperFunctionality() else {
-                AppLogger.shared.log(
-                    "⚠️ [Router] Helper not responsive — using sudo for runtime service install"
-                )
-                try await sudoInstallRequiredRuntimeServices()
-                return
-            }
             do {
                 try await helperManager.installRequiredRuntimeServices()
                 // Stale-helper guard (MAL-57): a resident helper from before
@@ -122,6 +112,12 @@ public final class PrivilegedOperationsRouter {
                     try await sudoRepairVHIDServices()
                 }
             } catch {
+                // Keep the helper's actionable reason (e.g. "driver payload is
+                // not installed") visible — the sudo fallback's generic failure
+                // would otherwise bury it (#928).
+                AppLogger.shared.warn(
+                    "⚠️ [PrivilegedOperationsRouter] Helper install failed (\(error.localizedDescription)) — falling back to sudo path"
+                )
                 try await sudoInstallRequiredRuntimeServices()
             }
         case .directSudo:

--- a/Sources/KeyPathAppKit/Core/PrivilegedOperationsRouter.swift
+++ b/Sources/KeyPathAppKit/Core/PrivilegedOperationsRouter.swift
@@ -118,7 +118,13 @@ public final class PrivilegedOperationsRouter {
                 AppLogger.shared.warn(
                     "⚠️ [PrivilegedOperationsRouter] Helper install failed (\(error.localizedDescription)) — falling back to sudo path"
                 )
-                try await sudoInstallRequiredRuntimeServices()
+                do {
+                    try await sudoInstallRequiredRuntimeServices()
+                } catch let fallbackError {
+                    throw PrivilegedOperationError.installationFailed(
+                        "Runtime service installation failed. Helper: \(error.localizedDescription). Sudo fallback: \(fallbackError.localizedDescription)"
+                    )
+                }
             }
         case .directSudo:
             try await sudoInstallRequiredRuntimeServices()

--- a/Sources/KeyPathAppKit/Infrastructure/Config/ConfigurationService.swift
+++ b/Sources/KeyPathAppKit/Infrastructure/Config/ConfigurationService.swift
@@ -218,10 +218,24 @@ public final class ConfigurationService: FileConfigurationProviding {
         try await createDirectoryAsync(path: configDirectory)
         AppLogger.shared.log("✅ [ConfigService] Config directory created at \(configDirectory)")
 
-        // Check if config file exists
+        // Check if config file exists. A 0-byte/whitespace-only file counts as
+        // missing: legacy helper scaffolding used to `touch` an empty keypath.kbd
+        // (#929), which kanata can't parse and which blocked this path from ever
+        // writing the default template.
         let exists = await fileExistsAsync(path: configurationPath)
-        if !exists {
-            AppLogger.shared.log("⚠️ [ConfigService] No existing config found at \(configurationPath)")
+        let effectivelyEmpty: Bool = if exists {
+            await fileIsEffectivelyEmptyAsync(path: configurationPath)
+        } else {
+            false
+        }
+        if !exists || effectivelyEmpty {
+            if effectivelyEmpty {
+                AppLogger.shared.log(
+                    "⚠️ [ConfigService] Config at \(configurationPath) exists but is empty — rewriting default"
+                )
+            } else {
+                AppLogger.shared.log("⚠️ [ConfigService] No existing config found at \(configurationPath)")
+            }
 
             // Rehydrate from persisted rule/custom stores so user state survives file deletion/reset
             let storedCollections = await ruleCollectionStore.loadCollections()
@@ -714,6 +728,21 @@ extension ConfigurationService {
         await withCheckedContinuation { cont in
             ioQueue.async {
                 cont.resume(returning: Foundation.FileManager().fileExists(atPath: path))
+            }
+        }
+    }
+
+    /// True when the file is missing, unreadable, or contains only whitespace.
+    func fileIsEffectivelyEmptyAsync(path: String) async -> Bool {
+        await withCheckedContinuation { cont in
+            ioQueue.async {
+                guard let contents = try? String(contentsOfFile: path, encoding: .utf8) else {
+                    cont.resume(returning: true)
+                    return
+                }
+                cont.resume(
+                    returning: contents.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                )
             }
         }
     }

--- a/Sources/KeyPathAppKit/Infrastructure/Config/ConfigurationService.swift
+++ b/Sources/KeyPathAppKit/Infrastructure/Config/ConfigurationService.swift
@@ -88,10 +88,18 @@ public final class ConfigurationService: FileConfigurationProviding {
 
     public func reload() async throws -> KanataConfiguration {
         var exists = await fileExistsAsync(path: configurationPath)
+        // Same semantics as createInitialConfigIfNeeded: a truncated/empty
+        // config is as unparseable as a missing one, so let the self-heal
+        // path rewrite it too (#929).
+        let effectivelyEmpty: Bool = if exists {
+            await fileIsEffectivelyEmptyAsync(path: configurationPath)
+        } else {
+            false
+        }
 
-        if !exists {
+        if !exists || effectivelyEmpty {
             AppLogger.shared.log(
-                "⚠️ [ConfigService] Config missing at \(configurationPath) – creating default before reload"
+                "⚠️ [ConfigService] Config missing or empty at \(configurationPath) – creating default before reload"
             )
             do {
                 try await createInitialConfigIfNeeded()
@@ -732,12 +740,26 @@ extension ConfigurationService {
         }
     }
 
-    /// True when the file is missing, unreadable, or contains only whitespace.
+    /// True when the file is 0 bytes or contains only whitespace.
+    ///
+    /// Deliberately conservative: an unreadable or non-UTF-8 file returns
+    /// false — callers use this to decide whether to REPLACE the file with a
+    /// default, and a transient read failure or odd encoding must never cause
+    /// a user's hand-edited config to be overwritten.
     func fileIsEffectivelyEmptyAsync(path: String) async -> Bool {
         await withCheckedContinuation { cont in
             ioQueue.async {
-                guard let contents = try? String(contentsOfFile: path, encoding: .utf8) else {
+                let fm = Foundation.FileManager()
+                guard let size = (try? fm.attributesOfItem(atPath: path))?[.size] as? UInt64 else {
+                    cont.resume(returning: false)
+                    return
+                }
+                if size == 0 {
                     cont.resume(returning: true)
+                    return
+                }
+                guard let contents = try? String(contentsOfFile: path, encoding: .utf8) else {
+                    cont.resume(returning: false)
                     return
                 }
                 cont.resume(

--- a/Sources/KeyPathCore/BoundedProcess.swift
+++ b/Sources/KeyPathCore/BoundedProcess.swift
@@ -1,0 +1,106 @@
+import Foundation
+
+/// Runs a subprocess with a hard deadline, draining stdout+stderr concurrently.
+///
+/// Shared by the app (`PrivilegedCommandRunner`) and the privileged helper
+/// (`HelperService`, which statically links KeyPathCore): a blocked child
+/// (e.g. `launchctl kickstart -k` on an unrunnable service, #927/#930) must
+/// never hang its caller, and output is read while the child runs so a chatty
+/// command can't deadlock on a full pipe buffer.
+///
+/// Callers do their own logging — this type is used from both NSLog (helper)
+/// and AppLogger (app) contexts.
+public enum BoundedProcess {
+    /// Exit status reported when the child exceeds its deadline and is killed.
+    public static let timedOutStatus: Int32 = 124
+
+    public struct Outcome: Sendable {
+        /// Termination status; `timedOutStatus` (124) when killed on deadline,
+        /// 127 when the process could not be launched at all.
+        public let status: Int32
+        /// Combined stdout+stderr captured so far (raw — no synthetic prefix).
+        public let output: String
+        public let timedOut: Bool
+    }
+
+    /// Launch `launchPath args` and wait at most `timeout` seconds.
+    public static func run(
+        _ launchPath: String, _ args: [String], timeout: TimeInterval
+    ) -> Outcome {
+        let p = Process()
+        p.launchPath = launchPath
+        p.arguments = args
+        return run(p, timeout: timeout)
+    }
+
+    /// Run a caller-configured (not yet launched) Process with a hard deadline.
+    /// The process's stdout/stderr are replaced with a captured pipe.
+    public static func run(_ process: Process, timeout: TimeInterval) -> Outcome {
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = pipe
+
+        let buffer = OutputBuffer()
+        let readDone = DispatchSemaphore(value: 0)
+        pipe.fileHandleForReading.readabilityHandler = { handle in
+            let chunk = handle.availableData
+            if chunk.isEmpty {
+                handle.readabilityHandler = nil
+                readDone.signal()
+            } else {
+                buffer.append(chunk)
+            }
+        }
+
+        do { try process.run() } catch {
+            pipe.fileHandleForReading.readabilityHandler = nil
+            return Outcome(status: 127, output: "run failed: \(error)", timedOut: false)
+        }
+
+        let deadline = Date().addingTimeInterval(timeout)
+        while process.isRunning, Date() < deadline {
+            usleep(50000)
+        }
+
+        var timedOut = false
+        if process.isRunning {
+            timedOut = true
+            process.terminate()
+            usleep(200_000)
+            if process.isRunning {
+                kill(process.processIdentifier, SIGKILL)
+            }
+        }
+        process.waitUntilExit()
+
+        // Bounded wait for EOF so the output tail is captured. A killed child
+        // may leave the pipe's write end open in orphaned grandchildren; don't
+        // block on them.
+        _ = readDone.wait(timeout: .now() + 2)
+        pipe.fileHandleForReading.readabilityHandler = nil
+
+        return Outcome(
+            status: timedOut ? timedOutStatus : process.terminationStatus,
+            output: buffer.text,
+            timedOut: timedOut
+        )
+    }
+
+    /// Thread-safe accumulator for output read via readabilityHandler.
+    private final class OutputBuffer: @unchecked Sendable {
+        private let lock = NSLock()
+        private var data = Data()
+
+        func append(_ chunk: Data) {
+            lock.lock()
+            data.append(chunk)
+            lock.unlock()
+        }
+
+        var text: String {
+            lock.lock()
+            defer { lock.unlock() }
+            return String(data: data, encoding: .utf8) ?? ""
+        }
+    }
+}

--- a/Sources/KeyPathCore/PrivilegedCommandRunner.swift
+++ b/Sources/KeyPathCore/PrivilegedCommandRunner.swift
@@ -30,8 +30,26 @@ public enum PrivilegedCommandRunner {
             if trimmed.isEmpty {
                 return ":"
             }
-            return "set -e\n" + trimmed.joined(separator: "\n")
+            return Self.scriptPrelude + "\n" + trimmed.joined(separator: "\n")
         }
+
+        /// Shell prelude for every batch: fail-fast, plus a `kp_timeout <secs> <cmd...>`
+        /// watchdog for steps that can block indefinitely (`launchctl kickstart -k` on
+        /// an unrunnable service hung a root script for 18+ minutes in #927).
+        public static let scriptPrelude = """
+        set -e
+        kp_timeout() {
+          local t="$1"; shift
+          "$@" &
+          local cmd_pid=$!
+          ( sleep "$t"; /bin/kill -9 "$cmd_pid" 2>/dev/null ) >/dev/null 2>&1 &
+          local watchdog_pid=$!
+          local rc=0
+          wait "$cmd_pid" || rc=$?
+          /bin/kill "$watchdog_pid" 2>/dev/null || true
+          return "$rc"
+        }
+        """
     }
 
     /// Result of a privileged command execution
@@ -88,7 +106,27 @@ public enum PrivilegedCommandRunner {
         return execute(command: batch.script, prompt: batch.prompt)
     }
 
+    /// Direct entry points for callers that must force one mechanism
+    /// (e.g. PrivilegedExecutor delegation). Same bounded execution as
+    /// `execute(command:prompt:)`.
+    public static func executeSudoDirect(command: String) -> Result {
+        executeWithSudo(command: command)
+    }
+
+    public static func executeOsascriptDirect(command: String, prompt: String) -> Result {
+        executeWithOsascript(command: command, prompt: prompt)
+    }
+
     // MARK: - Private Implementation
+
+    /// Hard ceiling on any privileged execution. The osascript path includes the
+    /// admin password dialog, so this must leave the user time to type — but a
+    /// hung script must never outlive it (#927: a root script ran 18+ minutes).
+    static let osascriptTimeout: TimeInterval = 300
+    static let sudoTimeout: TimeInterval = 120
+
+    /// Exit code reported when the privileged process is killed on timeout.
+    public static let timedOutExitCode: Int32 = 124
 
     /// Execute a command using sudo -n (non-interactive).
     /// Requires sudoers NOPASSWD configuration.
@@ -100,30 +138,13 @@ public enum PrivilegedCommandRunner {
         // Use -n for non-interactive (fails if password required)
         task.arguments = ["-n", "/bin/bash", "-c", command]
 
-        let pipe = Pipe()
-        task.standardOutput = pipe
-        task.standardError = pipe
-
-        do {
-            try task.run()
-            task.waitUntilExit()
-
-            let data = pipe.fileHandleForReading.readDataToEndOfFile()
-            let output = String(data: data, encoding: .utf8) ?? ""
-            let success = task.terminationStatus == 0
-
-            if success {
-                AppLogger.shared.log("✅ [PrivilegedCommandRunner] sudo command succeeded")
-            } else {
-                AppLogger.shared.log("❌ [PrivilegedCommandRunner] sudo command failed (exit \(task.terminationStatus)): \(output)")
-            }
-
-            return Result(success: success, output: output, exitCode: task.terminationStatus)
-        } catch {
-            let errorMsg = "sudo execution failed: \(error.localizedDescription)"
-            AppLogger.shared.log("❌ [PrivilegedCommandRunner] \(errorMsg)")
-            return Result(success: false, output: errorMsg, exitCode: -1)
+        let run = runBounded(task, timeout: Self.sudoTimeout, label: "sudo")
+        if run.success {
+            AppLogger.shared.log("✅ [PrivilegedCommandRunner] sudo command succeeded")
+        } else {
+            AppLogger.shared.log("❌ [PrivilegedCommandRunner] sudo command failed (exit \(run.exitCode)): \(run.output)")
         }
+        return run
     }
 
     /// Execute a command using osascript with admin privileges dialog.
@@ -159,30 +180,74 @@ public enum PrivilegedCommandRunner {
         task.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
         task.arguments = ["-e", osascriptCommand]
 
+        let run = runBounded(task, timeout: Self.osascriptTimeout, label: "osascript")
+        if run.success {
+            AppLogger.shared.log("✅ [PrivilegedCommandRunner] osascript command succeeded")
+        } else {
+            AppLogger.shared.log("❌ [PrivilegedCommandRunner] osascript command failed (exit \(run.exitCode)): \(run.output)")
+        }
+        return run
+    }
+
+    /// Run a prepared Process with a hard deadline, draining output concurrently
+    /// so a chatty child can't deadlock on a full pipe buffer.
+    private static func runBounded(_ task: Process, timeout: TimeInterval, label: String) -> Result {
         let pipe = Pipe()
         task.standardOutput = pipe
         task.standardError = pipe
 
+        let buffer = PrivilegedOutputBuffer()
+        pipe.fileHandleForReading.readabilityHandler = { handle in
+            let chunk = handle.availableData
+            if chunk.isEmpty {
+                handle.readabilityHandler = nil
+            } else {
+                buffer.append(chunk)
+            }
+        }
+
         do {
             try task.run()
-            task.waitUntilExit()
-
-            let data = pipe.fileHandleForReading.readDataToEndOfFile()
-            let output = String(data: data, encoding: .utf8) ?? ""
-            let success = task.terminationStatus == 0
-
-            if success {
-                AppLogger.shared.log("✅ [PrivilegedCommandRunner] osascript command succeeded")
-            } else {
-                AppLogger.shared.log("❌ [PrivilegedCommandRunner] osascript command failed (exit \(task.terminationStatus)): \(output)")
-            }
-
-            return Result(success: success, output: output, exitCode: task.terminationStatus)
         } catch {
-            let errorMsg = "osascript execution failed: \(error.localizedDescription)"
+            pipe.fileHandleForReading.readabilityHandler = nil
+            let errorMsg = "\(label) execution failed: \(error.localizedDescription)"
             AppLogger.shared.log("❌ [PrivilegedCommandRunner] \(errorMsg)")
             return Result(success: false, output: errorMsg, exitCode: -1)
         }
+
+        let deadline = Date().addingTimeInterval(timeout)
+        while task.isRunning, Date() < deadline {
+            usleep(100_000)
+        }
+
+        if task.isRunning {
+            AppLogger.shared.log(
+                "⏱️ [PrivilegedCommandRunner] \(label) exceeded \(Int(timeout))s — killing. A privileged step is stuck; see #927."
+            )
+            task.terminate()
+            usleep(500_000)
+            if task.isRunning {
+                kill(task.processIdentifier, SIGKILL)
+            }
+            task.waitUntilExit()
+            pipe.fileHandleForReading.readabilityHandler = nil
+            return Result(
+                success: false,
+                output: "timed out after \(Int(timeout))s\n\(buffer.text)",
+                exitCode: Self.timedOutExitCode
+            )
+        }
+
+        task.waitUntilExit()
+        // Give the reader a beat to drain the tail, then detach.
+        usleep(50000)
+        pipe.fileHandleForReading.readabilityHandler = nil
+        let output = buffer.text
+        return Result(
+            success: task.terminationStatus == 0,
+            output: output,
+            exitCode: task.terminationStatus
+        )
     }
 
     /// Escape a command string for use in AppleScript.
@@ -207,6 +272,24 @@ public enum PrivilegedCommandRunner {
 
     private static func shellSingleQuoted(_ value: String) -> String {
         "'\(value.replacingOccurrences(of: "'", with: "'\"'\"'"))'"
+    }
+}
+
+/// Thread-safe accumulator for subprocess output read via readabilityHandler.
+private final class PrivilegedOutputBuffer: @unchecked Sendable {
+    private let lock = NSLock()
+    private var data = Data()
+
+    func append(_ chunk: Data) {
+        lock.lock()
+        data.append(chunk)
+        lock.unlock()
+    }
+
+    var text: String {
+        lock.lock()
+        defer { lock.unlock() }
+        return String(data: data, encoding: .utf8) ?? ""
     }
 }
 

--- a/Sources/KeyPathCore/PrivilegedCommandRunner.swift
+++ b/Sources/KeyPathCore/PrivilegedCommandRunner.swift
@@ -36,13 +36,15 @@ public enum PrivilegedCommandRunner {
         /// Shell prelude for every batch: fail-fast, plus a `kp_timeout <secs> <cmd...>`
         /// watchdog for steps that can block indefinitely (`launchctl kickstart -k` on
         /// an unrunnable service hung a root script for 18+ minutes in #927).
+        /// The watchdog re-checks the child's parentage before the SIGKILL so a
+        /// recycled PID is never killed by a root script.
         public static let scriptPrelude = """
         set -e
         kp_timeout() {
           local t="$1"; shift
           "$@" &
           local cmd_pid=$!
-          ( sleep "$t"; /bin/kill -9 "$cmd_pid" 2>/dev/null ) >/dev/null 2>&1 &
+          ( sleep "$t"; if [ "$(ps -o ppid= -p "$cmd_pid" 2>/dev/null | tr -d ' ')" = "$$" ]; then /bin/kill -9 "$cmd_pid" 2>/dev/null; fi ) >/dev/null 2>&1 &
           local watchdog_pid=$!
           local rc=0
           wait "$cmd_pid" || rc=$?
@@ -119,14 +121,19 @@ public enum PrivilegedCommandRunner {
 
     // MARK: - Private Implementation
 
-    /// Hard ceiling on any privileged execution. The osascript path includes the
-    /// admin password dialog, so this must leave the user time to type — but a
-    /// hung script must never outlive it (#927: a root script ran 18+ minutes).
-    static let osascriptTimeout: TimeInterval = 300
-    static let sudoTimeout: TimeInterval = 120
+    /// Hard ceiling on the osascript CLIENT process. The deadline includes the
+    /// admin password dialog, so it is deliberately generous — a user who steps
+    /// away mid-dialog must not get a spurious failure. The privileged script
+    /// itself is bounded separately by its own self-watchdog
+    /// (`scriptSelfTimeout`), because killing osascript cannot reach the root
+    /// child (#927).
+    static let osascriptTimeout: TimeInterval = 900
+    /// KEYPATH_USE_SUDO test rigs only. Sized to the slowest legitimate batch
+    /// (`installer -pkg` gets 300s on the helper path) plus headroom.
+    static let sudoTimeout: TimeInterval = 360
 
     /// Exit code reported when the privileged process is killed on timeout.
-    public static let timedOutExitCode: Int32 = 124
+    public static let timedOutExitCode: Int32 = BoundedProcess.timedOutStatus
 
     /// Execute a command using sudo -n (non-interactive).
     /// Requires sudoers NOPASSWD configuration.
@@ -189,80 +196,54 @@ public enum PrivilegedCommandRunner {
         return run
     }
 
-    /// Run a prepared Process with a hard deadline, draining output concurrently
-    /// so a chatty child can't deadlock on a full pipe buffer.
+    /// Run a prepared Process with a hard deadline via the shared BoundedProcess
+    /// runner (concurrent output draining, terminate-then-SIGKILL on expiry).
     private static func runBounded(_ task: Process, timeout: TimeInterval, label: String) -> Result {
-        let pipe = Pipe()
-        task.standardOutput = pipe
-        task.standardError = pipe
-
-        let buffer = PrivilegedOutputBuffer()
-        pipe.fileHandleForReading.readabilityHandler = { handle in
-            let chunk = handle.availableData
-            if chunk.isEmpty {
-                handle.readabilityHandler = nil
-            } else {
-                buffer.append(chunk)
-            }
-        }
-
-        do {
-            try task.run()
-        } catch {
-            pipe.fileHandleForReading.readabilityHandler = nil
-            let errorMsg = "\(label) execution failed: \(error.localizedDescription)"
-            AppLogger.shared.log("❌ [PrivilegedCommandRunner] \(errorMsg)")
-            return Result(success: false, output: errorMsg, exitCode: -1)
-        }
-
-        let deadline = Date().addingTimeInterval(timeout)
-        while task.isRunning, Date() < deadline {
-            usleep(100_000)
-        }
-
-        if task.isRunning {
+        let outcome = BoundedProcess.run(task, timeout: timeout)
+        if outcome.timedOut {
             AppLogger.shared.log(
-                "⏱️ [PrivilegedCommandRunner] \(label) exceeded \(Int(timeout))s — killing. A privileged step is stuck; see #927."
+                "⏱️ [PrivilegedCommandRunner] \(label) exceeded \(Int(timeout))s — killed. A privileged step is stuck; see #927."
             )
-            task.terminate()
-            usleep(500_000)
-            if task.isRunning {
-                kill(task.processIdentifier, SIGKILL)
-            }
-            task.waitUntilExit()
-            pipe.fileHandleForReading.readabilityHandler = nil
             return Result(
                 success: false,
-                output: "timed out after \(Int(timeout))s\n\(buffer.text)",
-                exitCode: Self.timedOutExitCode
+                output: "timed out after \(Int(timeout))s\n\(outcome.output)",
+                exitCode: outcome.status
             )
         }
-
-        task.waitUntilExit()
-        // Give the reader a beat to drain the tail, then detach.
-        usleep(50000)
-        pipe.fileHandleForReading.readabilityHandler = nil
-        let output = buffer.text
         return Result(
-            success: task.terminationStatus == 0,
-            output: output,
-            exitCode: task.terminationStatus
+            success: outcome.status == 0,
+            output: outcome.output,
+            exitCode: outcome.status
         )
     }
 
     /// Escape a command string for use in AppleScript.
-    private static func escapeForAppleScript(_ command: String) -> String {
+    /// Internal (not private) so tests cover the escaping actually executed.
+    static func escapeForAppleScript(_ command: String) -> String {
         var escaped = command
         escaped = escaped.replacingOccurrences(of: "\\", with: "\\\\")
         escaped = escaped.replacingOccurrences(of: "\"", with: "\\\"")
         return escaped
     }
 
+    /// Hard ceiling the privileged script applies to ITSELF. The script runs as
+    /// root under the security trampoline, so the unprivileged app cannot signal
+    /// it after a timeout — killing our osascript client merely orphans it
+    /// (#927's 18-minute root script). A self-watchdog is the only reliable
+    /// bound. The identity re-check via the unique script name prevents a
+    /// recycled PID from being killed.
+    static let scriptSelfTimeout: TimeInterval = 300
+
     private static func writeTemporaryShellScript(command: String) throws -> URL {
+        let scriptName = "keypath-privileged-\(UUID().uuidString).sh"
         let url = FileManager.default.temporaryDirectory
-            .appendingPathComponent("keypath-privileged-\(UUID().uuidString).sh")
+            .appendingPathComponent(scriptName)
         let script = """
         #!/bin/bash
+        KP_SELF=$$
+        ( sleep \(Int(scriptSelfTimeout)); if ps -o command= -p "$KP_SELF" 2>/dev/null | grep -qF '\(scriptName)'; then /bin/kill -9 "$KP_SELF"; fi ) >/dev/null 2>&1 &
+        KP_SELF_WATCHDOG=$!
+        trap '/bin/kill "$KP_SELF_WATCHDOG" 2>/dev/null' EXIT
         \(command)
         """
         try script.write(to: url, atomically: true, encoding: .utf8)
@@ -272,24 +253,6 @@ public enum PrivilegedCommandRunner {
 
     private static func shellSingleQuoted(_ value: String) -> String {
         "'\(value.replacingOccurrences(of: "'", with: "'\"'\"'"))'"
-    }
-}
-
-/// Thread-safe accumulator for subprocess output read via readabilityHandler.
-private final class PrivilegedOutputBuffer: @unchecked Sendable {
-    private let lock = NSLock()
-    private var data = Data()
-
-    func append(_ chunk: Data) {
-        lock.lock()
-        data.append(chunk)
-        lock.unlock()
-    }
-
-    var text: String {
-        lock.lock()
-        defer { lock.unlock() }
-        return String(data: data, encoding: .utf8) ?? ""
     }
 }
 

--- a/Sources/KeyPathHelper/HelperService.swift
+++ b/Sources/KeyPathHelper/HelperService.swift
@@ -63,7 +63,7 @@ class HelperService: NSObject, HelperProtocol {
 
                 // Services are loaded but unhealthy - just restart them
                 for id in toRestart {
-                    _ = Self.run("/bin/launchctl", ["kickstart", "-k", "system/\(id)"])
+                    _ = Self.run("/bin/launchctl", ["kickstart", "-k", "system/\(id)"], timeout: 15)
                 }
             },
             reply: reply
@@ -187,9 +187,9 @@ class HelperService: NSObject, HelperProtocol {
                 let tmp = NSTemporaryDirectory()
                 let pkg = (tmp as NSString).appendingPathComponent("Karabiner-VirtualHID-\(version).pkg")
                 // Download with curl to avoid async URLSession in XPC sync path
-                let d = Self.run("/usr/bin/curl", ["-L", "-f", "-o", pkg, downloadURL])
+                let d = Self.run("/usr/bin/curl", ["-L", "-f", "-o", pkg, downloadURL], timeout: 300)
                 if d.status != 0 { throw HelperError.operationFailed("Download failed: \(d.out)") }
-                let i = Self.run("/usr/sbin/installer", ["-pkg", pkg, "-target", "/"])
+                let i = Self.run("/usr/sbin/installer", ["-pkg", pkg, "-target", "/"], timeout: 300)
                 // Clean up regardless
                 _ = try? FileManager.default.removeItem(atPath: pkg)
                 if i.status != 0 { throw HelperError.operationFailed("Installer failed: \(i.out)") }
@@ -213,9 +213,9 @@ class HelperService: NSObject, HelperProtocol {
                     "https://github.com/pqrs-org/Karabiner-DriverKit-VirtualHIDDevice/releases/download/v\(version)/Karabiner-DriverKit-VirtualHIDDevice-\(version).pkg"
                 let tmp = NSTemporaryDirectory()
                 let pkg = (tmp as NSString).appendingPathComponent("Karabiner-VirtualHID-\(version).pkg")
-                let d = Self.run("/usr/bin/curl", ["-L", "-f", "-o", pkg, url])
+                let d = Self.run("/usr/bin/curl", ["-L", "-f", "-o", pkg, url], timeout: 300)
                 if d.status != 0 { throw HelperError.operationFailed("Download failed: \(d.out)") }
-                let i = Self.run("/usr/sbin/installer", ["-pkg", pkg, "-target", "/"])
+                let i = Self.run("/usr/sbin/installer", ["-pkg", pkg, "-target", "/"], timeout: 300)
                 _ = try? FileManager.default.removeItem(atPath: pkg)
                 if i.status != 0 { throw HelperError.operationFailed("Installer failed: \(i.out)") }
                 let a = Self.run(Self.vhidManagerPath, ["activate"])
@@ -242,7 +242,7 @@ class HelperService: NSObject, HelperProtocol {
                     throw HelperError.operationFailed("Invalid pkg path - must be within KeyPath.app bundle")
                 }
                 NSLog("[KeyPathHelper] Installing VHID driver from bundled pkg: %@", canonicalPath)
-                let i = Self.run("/usr/sbin/installer", ["-pkg", canonicalPath, "-target", "/"])
+                let i = Self.run("/usr/sbin/installer", ["-pkg", canonicalPath, "-target", "/"], timeout: 300)
                 if i.status != 0 { throw HelperError.operationFailed("Installer failed: \(i.out)") }
                 // Activate after install
                 let a = Self.run(Self.vhidManagerPath, ["activate"])
@@ -257,6 +257,18 @@ class HelperService: NSObject, HelperProtocol {
 
     /// Shared implementation for installing/repairing VHID services
     private static func installOrRepairVHIDServices() throws {
+        // Never register VHID services while the driver payload is missing: launchd
+        // spawn-loops the daemons (exit 78) and `launchctl kickstart -k` can block
+        // indefinitely on such a service, hanging this XPC call (#928, #930).
+        let missing = [vhidDaemonPath, vhidManagerPath].filter {
+            !FileManager.default.fileExists(atPath: $0)
+        }
+        guard missing.isEmpty else {
+            throw HelperError.operationFailed(
+                "Karabiner VirtualHID driver payload is not installed — install the driver before setting up its services. Missing: \(missing.joined(separator: ", "))"
+            )
+        }
+
         try ensureConsoleUserConfigArtifacts()
 
         // Boot out existing jobs (ignore failures)
@@ -296,8 +308,9 @@ class HelperService: NSObject, HelperProtocol {
         }
         _ = run("/bin/launchctl", ["enable", "system/\(vhidDaemonServiceID)"])
         _ = run("/bin/launchctl", ["enable", "system/\(vhidManagerServiceID)"])
-        _ = run("/bin/launchctl", ["kickstart", "-k", "system/\(vhidDaemonServiceID)"])
-        _ = run("/bin/launchctl", ["kickstart", "-k", "system/\(vhidManagerServiceID)"])
+        // kickstart can block when a service is unrunnable — keep the bound tight (#927)
+        _ = run("/bin/launchctl", ["kickstart", "-k", "system/\(vhidDaemonServiceID)"], timeout: 15)
+        _ = run("/bin/launchctl", ["kickstart", "-k", "system/\(vhidManagerServiceID)"], timeout: 15)
     }
 
     // MARK: - Process Management
@@ -681,6 +694,24 @@ enum HelperError: Error, LocalizedError {
 
 // MARK: - Helpers
 
+/// Thread-safe accumulator for subprocess output read via readabilityHandler.
+private final class ProcessOutputBuffer: @unchecked Sendable {
+    private let lock = NSLock()
+    private var data = Data()
+
+    func append(_ chunk: Data) {
+        lock.lock()
+        data.append(chunk)
+        lock.unlock()
+    }
+
+    var text: String {
+        lock.lock()
+        defer { lock.unlock() }
+        return String(data: data, encoding: .utf8) ?? ""
+    }
+}
+
 extension HelperService {
     /// Copy file only if content differs (quick MD5 check). Returns true if a copy occurred.
     @discardableResult
@@ -705,19 +736,74 @@ extension HelperService {
         return cp.status == 0
     }
 
+    /// Exit status reported when a command exceeds its timeout and is killed.
+    static let runTimedOutStatus: Int32 = 124
+
+    /// Run a subprocess with a hard timeout, reading output concurrently.
+    ///
+    /// The timeout is load-bearing: the helper executes synchronously inside XPC
+    /// handlers, so a blocked child (e.g. `launchctl kickstart -k` on an unrunnable
+    /// service, #927/#930) would otherwise hang the helper past the app's XPC
+    /// timeout and force an osascript password-prompt fallback. Output is drained
+    /// while the child runs so a chatty command can't deadlock on a full pipe.
     @discardableResult
-    static func run(_ launchPath: String, _ args: [String]) -> (status: Int32, out: String) {
+    static func run(
+        _ launchPath: String, _ args: [String], timeout: TimeInterval = 60
+    ) -> (status: Int32, out: String) {
         let p = Process()
         p.launchPath = launchPath
         p.arguments = args
         let outPipe = Pipe()
         p.standardOutput = outPipe
         p.standardError = outPipe
-        do { try p.run() } catch { return (127, "run failed: \(error)") }
+
+        let buffer = ProcessOutputBuffer()
+        let readDone = DispatchSemaphore(value: 0)
+        outPipe.fileHandleForReading.readabilityHandler = { handle in
+            let chunk = handle.availableData
+            if chunk.isEmpty {
+                handle.readabilityHandler = nil
+                readDone.signal()
+            } else {
+                buffer.append(chunk)
+            }
+        }
+
+        do { try p.run() } catch {
+            outPipe.fileHandleForReading.readabilityHandler = nil
+            return (127, "run failed: \(error)")
+        }
+
+        let deadline = Date().addingTimeInterval(timeout)
+        while p.isRunning, Date() < deadline {
+            usleep(50000)
+        }
+
+        var timedOut = false
+        if p.isRunning {
+            timedOut = true
+            NSLog(
+                "[KeyPathHelper] ⏱️ Command timed out after %ds, killing: %@ %@",
+                Int(timeout), launchPath, args.joined(separator: " ")
+            )
+            kill(p.processIdentifier, SIGKILL)
+        }
         p.waitUntilExit()
-        let data = outPipe.fileHandleForReading.readDataToEndOfFile()
-        let s = String(data: data, encoding: .utf8) ?? ""
-        return (p.terminationStatus, s)
+
+        // Bounded wait for EOF so the tail of the output is captured. A killed
+        // child may leave the write end open in orphaned grandchildren; don't
+        // block on them.
+        _ = readDone.wait(timeout: .now() + 2)
+        outPipe.fileHandleForReading.readabilityHandler = nil
+
+        let out = buffer.text
+        if timedOut {
+            return (
+                Self.runTimedOutStatus,
+                "timed out after \(Int(timeout))s: \(launchPath) \(args.joined(separator: " "))\n\(out)"
+            )
+        }
+        return (p.terminationStatus, out)
     }
 
     static func verifyCodeSignatureStrict(path: String) -> Bool {
@@ -847,12 +933,11 @@ extension HelperService {
             return
         }
 
+        // Only scaffold the directory. Touching keypath.kbd here created a 0-byte
+        // config that kanata can't parse AND that blocked the app's own
+        // default-config creation, which treats an existing file as done (#929).
         let configDir = "\(info.home)/.config/keypath"
-        let configFile = "\(configDir)/keypath.kbd"
-
         _ = run("/usr/bin/install", ["-d", "-o", info.name, "-g", "staff", configDir])
-        _ = run("/usr/bin/touch", [configFile])
-        _ = run("/usr/sbin/chown", ["\(info.name):staff", configFile])
     }
 
     private static func kanataArguments(binaryPath: String, cfgPath: String, tcpPort: Int) -> [String] {

--- a/Sources/KeyPathHelper/HelperService.swift
+++ b/Sources/KeyPathHelper/HelperService.swift
@@ -694,24 +694,6 @@ enum HelperError: Error, LocalizedError {
 
 // MARK: - Helpers
 
-/// Thread-safe accumulator for subprocess output read via readabilityHandler.
-private final class ProcessOutputBuffer: @unchecked Sendable {
-    private let lock = NSLock()
-    private var data = Data()
-
-    func append(_ chunk: Data) {
-        lock.lock()
-        data.append(chunk)
-        lock.unlock()
-    }
-
-    var text: String {
-        lock.lock()
-        defer { lock.unlock() }
-        return String(data: data, encoding: .utf8) ?? ""
-    }
-}
-
 extension HelperService {
     /// Copy file only if content differs (quick MD5 check). Returns true if a copy occurred.
     @discardableResult
@@ -736,74 +718,28 @@ extension HelperService {
         return cp.status == 0
     }
 
-    /// Exit status reported when a command exceeds its timeout and is killed.
-    static let runTimedOutStatus: Int32 = 124
-
     /// Run a subprocess with a hard timeout, reading output concurrently.
     ///
     /// The timeout is load-bearing: the helper executes synchronously inside XPC
     /// handlers, so a blocked child (e.g. `launchctl kickstart -k` on an unrunnable
     /// service, #927/#930) would otherwise hang the helper past the app's XPC
-    /// timeout and force an osascript password-prompt fallback. Output is drained
-    /// while the child runs so a chatty command can't deadlock on a full pipe.
+    /// timeout and force an osascript password-prompt fallback.
     @discardableResult
     static func run(
         _ launchPath: String, _ args: [String], timeout: TimeInterval = 60
     ) -> (status: Int32, out: String) {
-        let p = Process()
-        p.launchPath = launchPath
-        p.arguments = args
-        let outPipe = Pipe()
-        p.standardOutput = outPipe
-        p.standardError = outPipe
-
-        let buffer = ProcessOutputBuffer()
-        let readDone = DispatchSemaphore(value: 0)
-        outPipe.fileHandleForReading.readabilityHandler = { handle in
-            let chunk = handle.availableData
-            if chunk.isEmpty {
-                handle.readabilityHandler = nil
-                readDone.signal()
-            } else {
-                buffer.append(chunk)
-            }
-        }
-
-        do { try p.run() } catch {
-            outPipe.fileHandleForReading.readabilityHandler = nil
-            return (127, "run failed: \(error)")
-        }
-
-        let deadline = Date().addingTimeInterval(timeout)
-        while p.isRunning, Date() < deadline {
-            usleep(50000)
-        }
-
-        var timedOut = false
-        if p.isRunning {
-            timedOut = true
+        let outcome = BoundedProcess.run(launchPath, args, timeout: timeout)
+        if outcome.timedOut {
             NSLog(
-                "[KeyPathHelper] ⏱️ Command timed out after %ds, killing: %@ %@",
+                "[KeyPathHelper] ⏱️ Command timed out after %ds, killed: %@ %@",
                 Int(timeout), launchPath, args.joined(separator: " ")
             )
-            kill(p.processIdentifier, SIGKILL)
-        }
-        p.waitUntilExit()
-
-        // Bounded wait for EOF so the tail of the output is captured. A killed
-        // child may leave the write end open in orphaned grandchildren; don't
-        // block on them.
-        _ = readDone.wait(timeout: .now() + 2)
-        outPipe.fileHandleForReading.readabilityHandler = nil
-
-        let out = buffer.text
-        if timedOut {
             return (
-                Self.runTimedOutStatus,
-                "timed out after \(Int(timeout))s: \(launchPath) \(args.joined(separator: " "))\n\(out)"
+                outcome.status,
+                "timed out after \(Int(timeout))s: \(launchPath) \(args.joined(separator: " "))\n\(outcome.output)"
             )
         }
-        return (p.terminationStatus, out)
+        return (outcome.status, outcome.output)
     }
 
     static func verifyCodeSignatureStrict(path: String) -> Bool {
@@ -937,7 +873,14 @@ extension HelperService {
         // config that kanata can't parse AND that blocked the app's own
         // default-config creation, which treats an existing file as done (#929).
         let configDir = "\(info.home)/.config/keypath"
+        let configFile = "\(configDir)/keypath.kbd"
         _ = run("/usr/bin/install", ["-d", "-o", info.name, "-g", "staff", configDir])
+        // Keep the ownership repair the old touch+chown provided: a config that
+        // ended up root-owned (old launcher, sudo edit) would otherwise fail
+        // every app-side save with a permission error, with no repair path.
+        if FileManager.default.fileExists(atPath: configFile) {
+            _ = run("/usr/sbin/chown", ["\(info.name):staff", configFile])
+        }
     }
 
     private static func kanataArguments(binaryPath: String, cfgPath: String, tcpPort: Int) -> [String] {

--- a/Sources/KeyPathInstallationWizard/Core/PrivilegedExecutor.swift
+++ b/Sources/KeyPathInstallationWizard/Core/PrivilegedExecutor.swift
@@ -152,20 +152,6 @@ public final class PrivilegedExecutor: @unchecked Sendable {
         )
         return result.success
     }
-
-    // MARK: - String Escaping
-
-    /// Escape a command string for safe use in AppleScript.
-    ///
-    /// AppleScript requires special escaping for backslashes and quotes.
-    ///
-    /// - Parameter command: The raw command string
-    /// - Returns: The escaped string safe for embedding in AppleScript
-    public func escapeForAppleScript(_ command: String) -> String {
-        var escaped = command.replacingOccurrences(of: "\\", with: "\\\\")
-        escaped = escaped.replacingOccurrences(of: "\"", with: "\\\"")
-        return escaped
-    }
 }
 
 // MARK: - Convenience Extensions

--- a/Sources/KeyPathInstallationWizard/Core/PrivilegedExecutor.swift
+++ b/Sources/KeyPathInstallationWizard/Core/PrivilegedExecutor.swift
@@ -69,35 +69,10 @@ public final class PrivilegedExecutor: @unchecked Sendable {
             "🧪 [PrivilegedExecutor] Using sudo for privileged operation (KEYPATH_USE_SUDO=1)"
         )
 
-        let task = Process()
-        task.executableURL = URL(fileURLWithPath: "/usr/bin/sudo")
-        // Use -n for non-interactive (fails if password required)
-        task.arguments = ["-n", "/bin/bash", "-c", command]
-
-        let pipe = Pipe()
-        task.standardOutput = pipe
-        task.standardError = pipe
-
-        do {
-            try task.run()
-            task.waitUntilExit()
-
-            let data = pipe.fileHandleForReading.readDataToEndOfFile()
-            let output = String(data: data, encoding: .utf8) ?? ""
-
-            if task.terminationStatus == 0 {
-                AppLogger.shared.log("✅ [PrivilegedExecutor] sudo command succeeded")
-                return (true, output)
-            } else {
-                AppLogger.shared.log(
-                    "❌ [PrivilegedExecutor] sudo command failed (status \(task.terminationStatus)): \(output)"
-                )
-                return (false, output)
-            }
-        } catch {
-            AppLogger.shared.log("❌ [PrivilegedExecutor] Failed to execute sudo: \(error)")
-            return (false, error.localizedDescription)
-        }
+        // Delegate to the shared bounded runner so a hung command can't block
+        // forever (#927); keeps one implementation of the sudo path.
+        let result = PrivilegedCommandRunner.executeSudoDirect(command: command)
+        return (result.success, result.output)
     }
 
     // MARK: - OSAScript Execution
@@ -130,44 +105,14 @@ public final class PrivilegedExecutor: @unchecked Sendable {
             return (true, "Skipped in test mode")
         }
 
-        let escapedCommand = escapeForAppleScript(command)
-        let osascriptCommand = """
-        do shell script "\(escapedCommand)" with administrator privileges with prompt "\(prompt)"
-        """
-
         AppLogger.shared.log(
             "🔐 [PrivilegedExecutor] Requesting admin privileges via osascript"
         )
 
-        let task = Process()
-        task.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
-        task.arguments = ["-e", osascriptCommand]
-
-        let pipe = Pipe()
-        task.standardOutput = pipe
-        task.standardError = pipe
-
-        do {
-            try task.run()
-            task.waitUntilExit()
-
-            let data = pipe.fileHandleForReading.readDataToEndOfFile()
-            let output = String(data: data, encoding: .utf8) ?? ""
-
-            if task.terminationStatus == 0 {
-                AppLogger.shared.log("✅ [PrivilegedExecutor] osascript command succeeded")
-            } else {
-                AppLogger.shared.log(
-                    "❌ [PrivilegedExecutor] osascript command failed (exit \(task.terminationStatus)): \(output)"
-                )
-            }
-
-            return (task.terminationStatus == 0, output)
-        } catch {
-            let errorMsg = "osascript execution failed: \(error.localizedDescription)"
-            AppLogger.shared.log("❌ [PrivilegedExecutor] \(errorMsg)")
-            return (false, error.localizedDescription)
-        }
+        // Delegate to the shared bounded runner so a hung privileged script can't
+        // outlive the timeout (#927); keeps one implementation of the osascript path.
+        let result = PrivilegedCommandRunner.executeOsascriptDirect(command: command, prompt: prompt)
+        return (result.success, result.output)
     }
 
     // MARK: - Admin Dialog Testing

--- a/Sources/KeyPathInstallationWizard/Core/ServiceBootstrapper.swift
+++ b/Sources/KeyPathInstallationWizard/Core/ServiceBootstrapper.swift
@@ -244,8 +244,9 @@ public final class ServiceBootstrapper {
             return true
         }
 
-        // Build kickstart commands for all services
-        let commands = serviceIDs.map { "/bin/launchctl kickstart -k system/\($0)" }
+        // Build kickstart commands for all services. kickstart can block forever on
+        // an unrunnable service (#927), so bound each one with the batch watchdog.
+        let commands = serviceIDs.map { "kp_timeout 15 /bin/launchctl kickstart -k system/\($0)" }
         let result = await executePrivilegedBatch(
             label: "restart failing system services",
             commands: commands,
@@ -814,6 +815,22 @@ public final class ServiceBootstrapper {
             return true
         }
 
+        // Never register VHID services while the driver payload is missing: launchd
+        // spawn-loops the daemons (exit 78) and kickstart can block indefinitely.
+        // Failing here also avoids showing an admin password prompt for a repair
+        // that cannot succeed (#928).
+        let missingBinaries = [
+            VHIDDeviceManager.vhidDeviceDaemonPath, VHIDDeviceManager.vhidManagerPath
+        ].filter { !Foundation.FileManager().fileExists(atPath: $0) }
+        guard missingBinaries.isEmpty else {
+            AppLogger.shared.log(
+                "❌ [ServiceBootstrapper] Refusing VHID service repair — driver payload missing: \(missingBinaries.joined(separator: ", ")). Install the Karabiner driver first."
+            )
+            lastVHIDRepairOutput =
+                "Karabiner VirtualHID driver payload is not installed — install the driver before repairing its services."
+            return false
+        }
+
         // Reinstall plists with correct content
         let vhidDaemonPlist = PlistGenerator.generateVHIDDaemonPlist()
         let vhidManagerPlist = PlistGenerator.generateVHIDManagerPlist()
@@ -867,8 +884,8 @@ public final class ServiceBootstrapper {
             "/bin/launchctl bootstrap system '\(managerPlistPath)'",
             "/bin/launchctl enable system/\(Self.vhidDaemonServiceID)",
             "/bin/launchctl enable system/\(Self.vhidManagerServiceID)",
-            "/bin/launchctl kickstart -k system/\(Self.vhidDaemonServiceID)",
-            "/bin/launchctl kickstart -k system/\(Self.vhidManagerServiceID)"
+            "kp_timeout 15 /bin/launchctl kickstart -k system/\(Self.vhidDaemonServiceID)",
+            "kp_timeout 15 /bin/launchctl kickstart -k system/\(Self.vhidManagerServiceID)"
         ])
 
         let batchResult = await executePrivilegedBatch(

--- a/Sources/KeyPathInstallationWizard/Core/ServiceBootstrapper.swift
+++ b/Sources/KeyPathInstallationWizard/Core/ServiceBootstrapper.swift
@@ -819,12 +819,10 @@ public final class ServiceBootstrapper {
         // spawn-loops the daemons (exit 78) and kickstart can block indefinitely.
         // Failing here also avoids showing an admin password prompt for a repair
         // that cannot succeed (#928).
-        let missingBinaries = [
-            VHIDDeviceManager.vhidDeviceDaemonPath, VHIDDeviceManager.vhidManagerPath
-        ].filter { !Foundation.FileManager().fileExists(atPath: $0) }
-        guard missingBinaries.isEmpty else {
+        let vhidManager = VHIDDeviceManager()
+        if !vhidManager.detectInstallation() || !vhidManager.detectActivation() {
             AppLogger.shared.log(
-                "❌ [ServiceBootstrapper] Refusing VHID service repair — driver payload missing: \(missingBinaries.joined(separator: ", ")). Install the Karabiner driver first."
+                "❌ [ServiceBootstrapper] Refusing VHID service repair — driver payload missing. Install the Karabiner driver first."
             )
             lastVHIDRepairOutput =
                 "Karabiner VirtualHID driver payload is not installed — install the driver before repairing its services."

--- a/Sources/KeyPathKanataLauncher/LauncherService.swift
+++ b/Sources/KeyPathKanataLauncher/LauncherService.swift
@@ -193,13 +193,16 @@ struct LauncherService {
         let configPath = "\(home)/.config/keypath/keypath.kbd"
         let configDir = URL(fileURLWithPath: configPath).deletingLastPathComponent().path
         try? FileManager.default.createDirectory(atPath: configDir, withIntermediateDirectories: true)
-        if !FileManager.default.fileExists(atPath: configPath) {
-            FileManager.default.createFile(atPath: configPath, contents: Data())
-        }
+        // Never create the config file here: this runs as root, and an empty
+        // keypath.kbd is unparseable by kanata AND blocks the app's own
+        // default-config creation (#929). If it's missing, kanata fails with a
+        // clear file-not-found and the app repairs it on next launch.
 
         if user != "root", let pw = getpwnam(user) {
             _ = chown(configDir, pw.pointee.pw_uid, pw.pointee.pw_gid)
-            _ = chown(configPath, pw.pointee.pw_uid, pw.pointee.pw_gid)
+            if FileManager.default.fileExists(atPath: configPath) {
+                _ = chown(configPath, pw.pointee.pw_uid, pw.pointee.pw_gid)
+            }
         }
 
         return configPath

--- a/Tests/KeyPathTests/Core/PrivilegedCommandRunnerBatchTests.swift
+++ b/Tests/KeyPathTests/Core/PrivilegedCommandRunnerBatchTests.swift
@@ -48,13 +48,15 @@ final class PrivilegedCommandRunnerBatchTests: XCTestCase {
             commands: ["kp_timeout 5 /usr/bin/false"],
             expectedStatusNot: 0, within: 3
         )
-        // A hung command is killed at the deadline instead of blocking forever
+        // A hung command is killed at the deadline instead of blocking forever.
+        // Fractional sleep keeps the wall-clock cost minimal (CLAUDE.md: no real
+        // sleeps in tests — a wall-clock watchdog needs SOME clock; keep it tiny).
         let start = Date()
         try assertScript(
-            commands: ["kp_timeout 1 /bin/sleep 30"],
-            expectedStatusNot: 0, within: 4
+            commands: ["kp_timeout 0.3 /bin/sleep 30"],
+            expectedStatusNot: 0, within: 3
         )
-        XCTAssertLessThan(Date().timeIntervalSince(start), 4, "watchdog did not fire in time")
+        XCTAssertLessThan(Date().timeIntervalSince(start), 3, "watchdog did not fire in time")
     }
 
     private func assertScript(

--- a/Tests/KeyPathTests/Core/PrivilegedCommandRunnerBatchTests.swift
+++ b/Tests/KeyPathTests/Core/PrivilegedCommandRunnerBatchTests.swift
@@ -71,12 +71,12 @@ final class PrivilegedCommandRunnerBatchTests: XCTestCase {
         process.arguments = ["-c", batch.script]
         process.standardOutput = FileHandle.nullDevice
         process.standardError = FileHandle.nullDevice
-        try process.run()
 
-        let deadline = Date().addingTimeInterval(seconds)
-        while process.isRunning, Date() < deadline {
-            usleep(50000)
-        }
+        let exited = expectation(description: "script exits: \(commands)")
+        process.terminationHandler = { _ in exited.fulfill() }
+        try process.run()
+        wait(for: [exited], timeout: seconds)
+
         if process.isRunning {
             process.terminate()
             XCTFail("script did not finish within \(seconds)s: \(commands)")

--- a/Tests/KeyPathTests/Core/PrivilegedCommandRunnerBatchTests.swift
+++ b/Tests/KeyPathTests/Core/PrivilegedCommandRunnerBatchTests.swift
@@ -1,0 +1,90 @@
+import Foundation
+@testable import KeyPathCore
+import XCTest
+
+/// Tests for PrivilegedCommandRunner.Batch script generation, including the
+/// kp_timeout watchdog added for #927 (privileged scripts hanging forever on
+/// `launchctl kickstart -k` of an unrunnable service).
+final class PrivilegedCommandRunnerBatchTests: XCTestCase {
+    func testEmptyBatchProducesNoOpScript() {
+        let batch = PrivilegedCommandRunner.Batch(label: "empty", commands: [])
+        XCTAssertEqual(batch.script, ":")
+
+        let whitespaceOnly = PrivilegedCommandRunner.Batch(label: "blank", commands: ["  ", "\n"])
+        XCTAssertEqual(whitespaceOnly.script, ":")
+    }
+
+    func testScriptContainsPreludeAndCommandsInOrder() {
+        let batch = PrivilegedCommandRunner.Batch(
+            label: "repair",
+            commands: ["/bin/echo one", "kp_timeout 15 /bin/launchctl kickstart -k system/foo"]
+        )
+        let script = batch.script
+
+        XCTAssertTrue(script.hasPrefix(PrivilegedCommandRunner.Batch.scriptPrelude))
+        XCTAssertTrue(script.contains("set -e"))
+        XCTAssertTrue(script.contains("kp_timeout() {"))
+
+        let echoIndex = script.range(of: "/bin/echo one")!.lowerBound
+        let kickstartIndex = script.range(of: "kickstart -k system/foo")!.lowerBound
+        XCTAssertLessThan(echoIndex, kickstartIndex)
+    }
+
+    func testDefaultPromptDerivedFromLabel() {
+        let batch = PrivilegedCommandRunner.Batch(label: "Repair VirtualHID Services", commands: [":"])
+        XCTAssertEqual(batch.prompt, "KeyPath needs to repair virtualhid services.")
+    }
+
+    /// kp_timeout must kill a hung command and propagate a nonzero status,
+    /// while leaving fast commands untouched.
+    func testKpTimeoutKillsHungCommandAndPreservesExitCodes() throws {
+        // Success passes through
+        try assertScript(
+            commands: ["kp_timeout 5 /bin/echo ok"],
+            expectedStatus: 0, within: 3
+        )
+        // Failure status propagates (set -e aborts the script → nonzero)
+        try assertScript(
+            commands: ["kp_timeout 5 /usr/bin/false"],
+            expectedStatusNot: 0, within: 3
+        )
+        // A hung command is killed at the deadline instead of blocking forever
+        let start = Date()
+        try assertScript(
+            commands: ["kp_timeout 1 /bin/sleep 30"],
+            expectedStatusNot: 0, within: 4
+        )
+        XCTAssertLessThan(Date().timeIntervalSince(start), 4, "watchdog did not fire in time")
+    }
+
+    private func assertScript(
+        commands: [String],
+        expectedStatus: Int32? = nil,
+        expectedStatusNot: Int32? = nil,
+        within seconds: TimeInterval
+    ) throws {
+        let batch = PrivilegedCommandRunner.Batch(label: "test", commands: commands)
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/bash")
+        process.arguments = ["-c", batch.script]
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+        try process.run()
+
+        let deadline = Date().addingTimeInterval(seconds)
+        while process.isRunning, Date() < deadline {
+            usleep(50000)
+        }
+        if process.isRunning {
+            process.terminate()
+            XCTFail("script did not finish within \(seconds)s: \(commands)")
+            return
+        }
+        if let expectedStatus {
+            XCTAssertEqual(process.terminationStatus, expectedStatus, "commands: \(commands)")
+        }
+        if let expectedStatusNot {
+            XCTAssertNotEqual(process.terminationStatus, expectedStatusNot, "commands: \(commands)")
+        }
+    }
+}

--- a/Tests/KeyPathTests/Services/ConfigurationServiceTests.swift
+++ b/Tests/KeyPathTests/Services/ConfigurationServiceTests.swift
@@ -531,6 +531,39 @@ class ConfigurationServiceTests: XCTestCase {
         )
     }
 
+    /// #929: a pre-existing 0-byte keypath.kbd (left behind by old helper
+    /// scaffolding) must be treated as missing and replaced with the default.
+    func testCreateInitialConfigRewritesEmptyFile() async throws {
+        let configPath = tempDirectory.appendingPathComponent("keypath.kbd")
+        try "".write(to: configPath, atomically: true, encoding: .utf8)
+
+        try await configService.createInitialConfigIfNeeded()
+
+        let contents = try String(contentsOf: configPath, encoding: .utf8)
+        XCTAssertFalse(
+            contents.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+            "empty config should be rewritten with the default template"
+        )
+        XCTAssertTrue(contents.contains("process-unmapped-keys yes"))
+    }
+
+    /// A valid existing config must NOT be overwritten by the empty-file repair.
+    func testCreateInitialConfigPreservesNonEmptyFile() async throws {
+        let configPath = tempDirectory.appendingPathComponent("keypath.kbd")
+        let sentinel = """
+        (defcfg)
+        (defsrc caps)
+        (deflayer base esc)
+        ;; user-sentinel-do-not-touch
+        """
+        try sentinel.write(to: configPath, atomically: true, encoding: .utf8)
+
+        try await configService.createInitialConfigIfNeeded()
+
+        let contents = try String(contentsOf: configPath, encoding: .utf8)
+        XCTAssertTrue(contents.contains("user-sentinel-do-not-touch"))
+    }
+
     func testBackupFailedConfigAppliesSafeDefaults() async throws {
         let original = """
         (defcfg)

--- a/Tests/KeyPathTests/Services/PrivilegedExecutorTests.swift
+++ b/Tests/KeyPathTests/Services/PrivilegedExecutorTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 @testable import KeyPathAppKit
+@testable import KeyPathCore
 @testable import KeyPathInstallationWizard
 @preconcurrency import XCTest
 
@@ -30,7 +31,7 @@ final class PrivilegedExecutorTests: XCTestCase {
         // AppleScript only requires escaping backslashes and double quotes
         // Single quotes don't need escaping
         let commandWithDoubleQuotes = "echo \"hello world\""
-        let escaped = executor.escapeForAppleScript(commandWithDoubleQuotes)
+        let escaped = PrivilegedCommandRunner.escapeForAppleScript(commandWithDoubleQuotes)
 
         XCTAssertNotEqual(escaped, commandWithDoubleQuotes, "Should escape double quotes")
         XCTAssertTrue(escaped.contains("\\\""), "Should contain escaped double quotes")
@@ -38,7 +39,7 @@ final class PrivilegedExecutorTests: XCTestCase {
 
     func testEscapeForAppleScriptHandlesSpecialCharacters() {
         let command = "rm -rf /tmp/test\"file"
-        let escaped = executor.escapeForAppleScript(command)
+        let escaped = PrivilegedCommandRunner.escapeForAppleScript(command)
 
         // Should escape quotes and other special chars
         XCTAssertTrue(escaped.contains("\\"), "Should escape special characters")
@@ -46,7 +47,7 @@ final class PrivilegedExecutorTests: XCTestCase {
 
     func testEscapeForAppleScriptPreservesNormalText() {
         let command = "simple command"
-        let escaped = executor.escapeForAppleScript(command)
+        let escaped = PrivilegedCommandRunner.escapeForAppleScript(command)
 
         // May or may not escape, but should not break
         XCTAssertFalse(escaped.isEmpty, "Should not return empty string")


### PR DESCRIPTION
## Summary

Fixes the tier-0 reliability failures from the 2026-07-02 fresh-install QA session (the install dead-ended with a root repair script hung 18+ minutes, crash-looping VHID daemons, and an unparseable 0-byte config).

### #927 — privileged execution can never hang unbounded
- **Helper:** `HelperService.run()` now delegates to a shared `BoundedProcess` runner (KeyPathCore): hard timeout (60s default, 15s for `launchctl kickstart -k`, 300s for download/install), terminate→SIGKILL on expiry, concurrent pipe draining (also fixes a latent full-pipe deadlock for chatty commands like `launchctl print`).
- **App:** `PrivilegedCommandRunner` osascript/sudo paths are bounded (900s / 360s). `PrivilegedExecutor` now delegates instead of being a third unbounded copy.
- **Root script self-watchdog:** killing the osascript client can't reach the root child under the security trampoline, so every privileged temp script bounds ITSELF (300s), with identity re-verified via the unique script name before the self-kill.
- **`kp_timeout` batch watchdog:** batch scripts get a shell-level per-command watchdog; the known-hazard `kickstart -k` steps are wrapped at 15s. Parentage is re-checked before the SIGKILL so a root script can never kill a recycled PID.

### #928 — never register VHID services without the driver payload
Both the helper (`installOrRepairVHIDServices`) and the sudo path (`ServiceBootstrapper.repairVHIDDaemonServices`, via the canonical `VHIDDeviceManager.detectInstallation()/detectActivation()` predicates) now refuse to bootstrap/kickstart VHID daemons when the Karabiner payload is missing — previously this produced exit-78 spawn-loops and the kickstart hang, in a state the wizard couldn't repair. The sudo-path guard also fails *before* showing an admin password prompt for a repair that cannot succeed, and the router logs the helper's actionable error instead of swallowing it.

### #929 — 0-byte keypath.kbd eliminated at all three sources
- Helper VHID scaffolding no longer `touch`es the config (kept: directory scaffold + ownership repair of an existing root-owned config).
- **kanata-launcher** no longer creates an empty config as root on daemon start (the twin the log analysis missed initially).
- App-side self-heal: `createInitialConfigIfNeeded` and `reload()` treat a 0-byte/whitespace-only config as missing and rewrite the default — **conservatively**: an unreadable or non-UTF-8 file is never overwritten (data-loss guard).

### #930 — helper XPC timeouts
Root cause was the same kickstart hang inside the helper (it shares `installOrRepairVHIDServices`), so #927/#928 fix it at the source: the helper now answers fast with a real error instead of hanging into the app's 30s XPC timeout twice and cascading to a surprise osascript password prompt mid-permission-flow.

## Review
8-angle review (line-scan, removed-behavior, cross-file, reuse/simplification/efficiency, altitude, conventions) ran pre-PR; all confirmed findings addressed in the second commit (notably: launcher 0-byte twin, ownership-repair regression, dialog-time-in-timeout, unreadable-as-empty data-loss risk, root-script orphaning, duplicate bounded-run implementations).

## Tests
- New `PrivilegedCommandRunnerBatchTests`: prelude generation + real kp_timeout kill behavior (0.3s fractional deadline).
- New `ConfigurationServiceTests` cases: empty config rewritten; non-empty config preserved.
- Note: 3 pre-existing `ConfigurationServiceTests` cases fail on machines with real user rule stores (fail identically on master; clean on CI) — test-isolation fix tracked separately.

Closes #927. Closes #928. Closes #929. Closes #930.

🤖 Generated with [Claude Code](https://claude.com/claude-code)