### PR TITLE
Fix ConfigurationServiceTests isolation: inject rule stores into ConfigurationService

### DIFF
--- a/Sources/KeyPathAppKit/Infrastructure/Config/ConfigurationService.swift
+++ b/Sources/KeyPathAppKit/Infrastructure/Config/ConfigurationService.swift
@@ -29,6 +29,9 @@ public final class ConfigurationService: FileConfigurationProviding {
     private var fileWatcher: FileWatcher?
     private var observers: [UUID: @Sendable (Config) async -> Void] = [:]
 
+    private let ruleCollectionStore: RuleCollectionStore
+    private let customRulesStore: CustomRulesStore
+
     /// Perform blocking file I/O off the main actor
     private let ioQueue = DispatchQueue(label: "com.keypath.configservice.io", qos: .utility)
     /// Protect shared state when accessed from multiple threads
@@ -36,7 +39,23 @@ public final class ConfigurationService: FileConfigurationProviding {
 
     // MARK: - Initialization
 
-    public init(configDirectory: String? = nil) {
+    public convenience init(configDirectory: String? = nil) {
+        self.init(
+            configDirectory: configDirectory,
+            ruleCollectionStore: .shared,
+            customRulesStore: .shared
+        )
+    }
+
+    /// Injectable stores keep tests hermetic: the shared stores read the real user
+    /// data directories even under XCTest, so tests must pass temp-backed stores.
+    init(
+        configDirectory: String?,
+        ruleCollectionStore: RuleCollectionStore,
+        customRulesStore: CustomRulesStore
+    ) {
+        self.ruleCollectionStore = ruleCollectionStore
+        self.customRulesStore = customRulesStore
         if let customDirectory = configDirectory {
             self.configDirectory = customDirectory
         } else {
@@ -205,8 +224,8 @@ public final class ConfigurationService: FileConfigurationProviding {
             AppLogger.shared.log("⚠️ [ConfigService] No existing config found at \(configurationPath)")
 
             // Rehydrate from persisted rule/custom stores so user state survives file deletion/reset
-            let storedCollections = await RuleCollectionStore.shared.loadCollections()
-            let storedCustomRules = await CustomRulesStore.shared.loadRules()
+            let storedCollections = await ruleCollectionStore.loadCollections()
+            let storedCustomRules = await customRulesStore.loadRules()
             let collectionsToSave = storedCollections.isEmpty
                 ? RuleCollectionCatalog().defaultCollections()
                 : storedCollections

--- a/Tests/KeyPathTests/Services/ConfigurationServiceTests.swift
+++ b/Tests/KeyPathTests/Services/ConfigurationServiceTests.swift
@@ -12,7 +12,13 @@ class ConfigurationServiceTests: XCTestCase {
         return url
     }()
 
-    lazy var configService: ConfigurationService = .init(configDirectory: tempDirectory.path)
+    /// Temp-backed stores keep these tests hermetic: the shared singletons read the
+    /// real user stores, whose collections can conflict on developer machines.
+    lazy var configService: ConfigurationService = .init(
+        configDirectory: tempDirectory.path,
+        ruleCollectionStore: .testStore(at: tempDirectory.appendingPathComponent("RuleCollections.json")),
+        customRulesStore: .testStore(at: tempDirectory.appendingPathComponent("CustomRules.json"))
+    )
 
     // MARK: - Configuration Generation Tests
 
@@ -491,6 +497,38 @@ class ConfigurationServiceTests: XCTestCase {
         XCTAssertTrue(FileManager.default.fileExists(atPath: configPath.path))
         let contents = try String(contentsOf: configPath, encoding: .utf8)
         XCTAssertTrue(contents.contains("process-unmapped-keys yes"))
+    }
+
+    func testCreateInitialConfigReadsInjectedStores() async throws {
+        let storeURL = tempDirectory.appendingPathComponent("SeededRuleCollections.json")
+        let seededStore = RuleCollectionStore.testStore(at: storeURL)
+        // f16 is not mapped by any default catalog collection, so the marker
+        // can't conflict with the defaults merged in on load.
+        let marker = RuleCollection(
+            name: "Injected Marker",
+            summary: "Proves the injected store is read",
+            category: .custom,
+            mappings: [KeyMapping(input: "f16", action: .keystroke(key: "f17"))],
+            isEnabled: true,
+            isSystemDefault: false
+        )
+        try await seededStore.saveCollections([marker])
+
+        let service = ConfigurationService(
+            configDirectory: tempDirectory.path,
+            ruleCollectionStore: seededStore,
+            customRulesStore: .testStore(at: tempDirectory.appendingPathComponent("CustomRules.json"))
+        )
+        let configPath = tempDirectory.appendingPathComponent("keypath.kbd")
+        try? FileManager.default.removeItem(at: configPath)
+
+        try await service.createInitialConfigIfNeeded()
+
+        let contents = try String(contentsOf: configPath, encoding: .utf8)
+        XCTAssertTrue(
+            contents.contains("Injected Marker"),
+            "Initial config should rehydrate from the injected store, not the shared singleton"
+        )
     }
 
     func testBackupFailedConfigAppliesSafeDefaults() async throws {


### PR DESCRIPTION
## Summary

`testCreateInitialConfigWritesDefaultFile` and `testReloadCreatesDefaultConfigWhenMissing` failed on any developer machine whose real rule stores contain conflicting collections (e.g. "Home Row Arrows" + "Home Row Mods" both enabled → `KeyPathError.ConfigurationError.mappingConflicts`). Root cause: `ConfigurationService.createInitialConfigIfNeeded()` read `RuleCollectionStore.shared` / `CustomRulesStore.shared` — the real user config-directory stores — even under XCTest, because the stores are process-global singletons (the tests already used a temp *config* directory, but not temp *stores*).

- `ConfigurationService` now takes the two stores via an internal designated initializer and uses them in `createInitialConfigIfNeeded()`.
- The `public init(configDirectory:)` becomes a convenience init defaulting to `.shared` — signature and behavior unchanged for every production call site, and identical behavior on clean CI (empty temp stores load catalog defaults, exactly what the shared stores return on a clean machine).
- `ConfigurationServiceTests` passes temp-backed stores (existing `testStore(at:)` helpers), making the suite hermetic on any machine.
- New regression test `testCreateInitialConfigReadsInjectedStores` seeds an injected store with a marker collection and asserts initial-config rehydration reads it (not the shared singletons).

## Test plan

- Reproduced the failure pre-fix on a machine with conflicting user collections: `testCreateInitialConfigWritesDefaultFile` fails with `mappingConflicts(inputKey: "f", conflictingCollections: ["Home Row Arrows", "Home Row Mods"])`.
- Post-fix: `swift test --filter ConfigurationServiceTests` → 72/72 pass on that same machine.
- Full safe suite run locally: 1761 passed; the remaining failures (snapshot rendering, CLIPackCRUD/HelperMaintenance full-lane interference) reproduce identically on master on this macOS 27 beta machine and are unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)