### PR TITLE
Fix Input Monitoring detection on macOS 26/27: authoritative IOHIDCheckAccess signal (#931)

### DIFF
--- a/Sources/KeyPathAppKit/Services/UpdateService.swift
+++ b/Sources/KeyPathAppKit/Services/UpdateService.swift
@@ -264,7 +264,11 @@ extension UpdateService {
     }
 
     nonisolated static func postUpdateDecision(for context: SystemContext) -> UpdateRepairDecision {
-        if context.permissions.keyPath.inputMonitoring.isBlocking || context.permissions.keyPath.accessibility.isBlocking {
+        // KeyPath's own Input Monitoring is soft (overlay/record only, not
+        // remapping — see PermissionOracle.blockingIssue / isSystemReady), so it
+        // must not force a hard post-update repair now that IOHIDCheckAccess makes
+        // it authoritatively .denied (#931). KeyPath's Accessibility is required.
+        if context.permissions.keyPath.accessibility.isBlocking {
             return .hardRepair(reason: "reason_code=keypath_permissions_blocking")
         }
         if context.permissions.kanata.inputMonitoring.isBlocking || context.permissions.kanata.accessibility.isBlocking {

--- a/Sources/KeyPathPermissions/PermissionOracle.swift
+++ b/Sources/KeyPathPermissions/PermissionOracle.swift
@@ -87,18 +87,24 @@ public actor PermissionOracle {
 
         /// Get the first blocking permission issue (user-facing error message)
         public var blockingIssue: String? {
-            // Check KeyPath permissions first (needed for UI functionality)
+            // KeyPath's own Accessibility is required (event posting / overlay).
             if keyPath.accessibility.isBlocking {
                 return
                     "KeyPath needs Accessibility permission - enable in System Settings > Privacy & Security > Accessibility"
             }
 
-            if keyPath.inputMonitoring.isBlocking {
-                return
-                    "KeyPath needs Input Monitoring permission - enable in System Settings > Privacy & Security > Input Monitoring"
-            }
+            // NOTE: KeyPath's OWN Input Monitoring is intentionally NOT a blocking
+            // issue. It powers only seize-mode features (the live overlay / key
+            // recording), never core remapping — which is kanata's job (see
+            // CompositionRoot's HID-monitor comment and isSystemReady). This must
+            // stay consistent with isSystemReady, which also excludes it: before
+            // IOHIDCheckAccess made this signal authoritative (#931) it was
+            // perpetually .unknown and never blocked; treating it as blocking now
+            // would newly pop the wizard for a working-remap system. The wizard's
+            // Input Monitoring page still surfaces it per-row for users who want
+            // the overlay.
 
-            // Check Kanata permissions
+            // Kanata's permissions ARE required for remapping.
             if kanata.accessibility.isBlocking || kanata.inputMonitoring.isBlocking {
                 return
                     "Kanata needs permissions - use the Installation Wizard to grant Accessibility and Input Monitoring"

--- a/Sources/KeyPathPermissions/PermissionOracle.swift
+++ b/Sources/KeyPathPermissions/PermissionOracle.swift
@@ -76,8 +76,12 @@ public actor PermissionOracle {
 
         /// System is ready when both apps have all required permissions
         public var isSystemReady: Bool {
-            // KeyPath IM is always .unknown (no Apple API to query it).
-            // Only check KeyPath AX + kanata permissions for system readiness.
+            // Kanata's AX + IM are the hard requirement for remapping to work.
+            // KeyPath's own IM (now queried authoritatively via IOHIDCheckAccess —
+            // see checkKeyPathPermissions) powers the live keyboard overlay, not
+            // core remapping, so it is surfaced via blockingIssue but intentionally
+            // kept out of this hard readiness gate to avoid flipping a
+            // working-remap system to "not ready".
             keyPath.accessibility.isReady && kanata.hasAllPermissions
         }
 
@@ -274,32 +278,44 @@ public actor PermissionOracle {
 
     // MARK: - KeyPath Permission Detection (Always Authoritative)
 
-    /// Check KeyPath's own permissions using non-prompting APIs only.
+    /// Check KeyPath's own permissions using non-prompting Apple APIs, per ADR-006.
     ///
-    /// IMPORTANT: We intentionally do NOT call `IOHIDCheckAccess()` here because
-    /// it triggers the macOS "Keystroke Receiving" system prompt if the app hasn't
-    /// been granted Input Monitoring yet. That prompt should only appear during the
-    /// Installation Wizard flow (via `PermissionRequestService.requestInputMonitoringPermission()`).
+    /// Both APIs used here are passive (they never show a system prompt — only
+    /// `IOHIDRequestAccess()`, used exclusively by the wizard's
+    /// `PermissionRequestService`, prompts):
+    /// - `AXIsProcessTrusted()` for Accessibility
+    /// - `IOHIDCheckAccess(kIOHIDRequestTypeListenEvent)` for Input Monitoring
     ///
-    /// Instead, we use:
-    /// - `AXIsProcessTrusted()` for Accessibility (never prompts)
-    /// - TCC database reading for Input Monitoring (passive, no prompt)
+    /// ADR-006 makes the Apple API authoritative and uses the TCC database only
+    /// as a fallback when the API returns `.unknown`. IOHIDCheckAccess reflects
+    /// the kernel's own record of KeyPath's grant, so it stays correct even when
+    /// the TCC database / Settings pane enumeration is unreliable — as on macOS
+    /// 26/27, where a grant can leave no readable TCC row and the app never
+    /// appears in the Input Monitoring list (the root cause of #931, which left
+    /// KeyPath's own IM stuck at `.unknown` forever).
     private func checkKeyPathPermissions() async -> PermissionSet {
         let start = Date()
 
         // Accessibility check via official Apple API (no prompt)
         let accessibility = Self.checkKeyPathAccessibilityStatus()
 
-        // Input Monitoring: use TCC database reading (passive, no prompt).
-        // IOHIDCheckAccess would trigger the system permission dialog on first call,
-        // which we only want during the wizard flow.
-        let keyPathBundleID = Bundle.main.bundleIdentifier ?? "com.keypath.KeyPath"
-        let tccIM = await tccStatus(forBundleID: keyPathBundleID, service: .inputMonitoring)
-        let inputMonitoring: Status = tccIM ?? .unknown
+        // Input Monitoring: IOHIDCheckAccess is authoritative and non-prompting
+        // for our own process (ADR-006). Only fall back to a passive TCC read
+        // when it returns .unknown (never granted or denied).
+        let apiIM = Self.checkKeyPathInputMonitoringStatus()
+        let tccIM: Status?
+        if Self.keyPathInputMonitoringNeedsTCCFallback(apiStatus: apiIM) {
+            let keyPathBundleID = Bundle.main.bundleIdentifier ?? "com.keypath.KeyPath"
+            tccIM = await tccStatus(forBundleID: keyPathBundleID, service: .inputMonitoring)
+        } else {
+            tccIM = nil
+        }
+        let resolved = Self.resolveKeyPathInputMonitoring(apiStatus: apiIM, tccStatus: tccIM)
+        let inputMonitoring = resolved.status
+        let source = resolved.source
+        let confidence = resolved.confidence
 
         let duration = Date().timeIntervalSince(start)
-        let source = tccIM != nil ? "keypath.ax-api+tcc-im" : "keypath.ax-api-only"
-        let confidence: Confidence = tccIM != nil ? .high : .low
         AppLogger.shared.log(
             "🔮 [Oracle] KeyPath permission check completed in \(String(format: "%.3f", duration))s - AX: \(accessibility), IM: \(inputMonitoring) (source: \(source))"
         )
@@ -315,6 +331,46 @@ public actor PermissionOracle {
 
     private nonisolated static func checkKeyPathAccessibilityStatus() -> Status {
         AXIsProcessTrusted() ? .granted : .denied
+    }
+
+    /// Input Monitoring status for KeyPath's own process via IOHIDCheckAccess.
+    ///
+    /// This is a non-prompting query (it returns the current access level; only
+    /// `IOHIDRequestAccess()` shows the system dialog) and it is scoped to the
+    /// calling process, so it is authoritative only for KeyPath.app — never for
+    /// the kanata-launcher, whose IM state must still come from the TCC database.
+    private nonisolated static func checkKeyPathInputMonitoringStatus() -> Status {
+        switch IOHIDCheckAccess(kIOHIDRequestTypeListenEvent) {
+        case kIOHIDAccessTypeGranted: .granted
+        case kIOHIDAccessTypeDenied: .denied
+        default: .unknown
+        }
+    }
+
+    /// True when the Apple-API Input Monitoring result is inconclusive and a TCC
+    /// read should be attempted (ADR-006: TCC is a fallback for `.unknown` only).
+    nonisolated static func keyPathInputMonitoringNeedsTCCFallback(apiStatus: Status) -> Bool {
+        switch apiStatus {
+        case .granted, .denied: false
+        case .unknown, .error: true
+        }
+    }
+
+    /// ADR-006 precedence for KeyPath's own Input Monitoring: the Apple-API
+    /// result (`IOHIDCheckAccess`) is authoritative when it is granted/denied;
+    /// otherwise fall back to the TCC read, and finally to `.unknown`.
+    nonisolated static func resolveKeyPathInputMonitoring(
+        apiStatus: Status, tccStatus: Status?
+    ) -> (status: Status, source: String, confidence: Confidence) {
+        switch apiStatus {
+        case .granted, .denied:
+            return (apiStatus, "keypath.ax-api+im-api", .high)
+        case .unknown, .error:
+            if let tccStatus {
+                return (tccStatus, "keypath.ax-api+tcc-im", .high)
+            }
+            return (.unknown, "keypath.ax-api-only", .low)
+        }
     }
 
     // MARK: - Kanata Permission Detection (ADR-016: TCC Database Reading)

--- a/Tests/KeyPathTests/PermissionOracleInputMonitoringTests.swift
+++ b/Tests/KeyPathTests/PermissionOracleInputMonitoringTests.swift
@@ -1,0 +1,61 @@
+import KeyPathCore
+@testable import KeyPathPermissions
+@preconcurrency import XCTest
+
+/// Covers the ADR-006 precedence for KeyPath's OWN Input Monitoring signal
+/// (#931): IOHIDCheckAccess is authoritative when granted/denied, and the TCC
+/// database is consulted only when the Apple API is inconclusive.
+final class PermissionOracleInputMonitoringTests: XCTestCase {
+    typealias Status = PermissionOracle.Status
+
+    // MARK: - TCC-fallback gating
+
+    func testGrantedAndDeniedDoNotTriggerTCCFallback() {
+        XCTAssertFalse(PermissionOracle.keyPathInputMonitoringNeedsTCCFallback(apiStatus: .granted))
+        XCTAssertFalse(PermissionOracle.keyPathInputMonitoringNeedsTCCFallback(apiStatus: .denied))
+    }
+
+    func testUnknownAndErrorTriggerTCCFallback() {
+        XCTAssertTrue(PermissionOracle.keyPathInputMonitoringNeedsTCCFallback(apiStatus: .unknown))
+        XCTAssertTrue(PermissionOracle.keyPathInputMonitoringNeedsTCCFallback(apiStatus: .error("x")))
+    }
+
+    // MARK: - Resolution precedence
+
+    func testApiGrantedIsAuthoritativeEvenIfTCCDisagrees() {
+        // The macOS 26/27 case: kernel says granted, TCC row is missing/denied.
+        let resolved = PermissionOracle.resolveKeyPathInputMonitoring(
+            apiStatus: .granted, tccStatus: .denied
+        )
+        XCTAssertEqual(resolved.status, .granted)
+        XCTAssertEqual(resolved.source, "keypath.ax-api+im-api")
+        XCTAssertEqual(resolved.confidence, .high)
+    }
+
+    func testApiDeniedIsAuthoritative() {
+        let resolved = PermissionOracle.resolveKeyPathInputMonitoring(
+            apiStatus: .denied, tccStatus: nil
+        )
+        XCTAssertEqual(resolved.status, .denied)
+        XCTAssertEqual(resolved.source, "keypath.ax-api+im-api")
+        XCTAssertEqual(resolved.confidence, .high)
+    }
+
+    func testUnknownApiFallsBackToTCCWhenAvailable() {
+        let resolved = PermissionOracle.resolveKeyPathInputMonitoring(
+            apiStatus: .unknown, tccStatus: .granted
+        )
+        XCTAssertEqual(resolved.status, .granted)
+        XCTAssertEqual(resolved.source, "keypath.ax-api+tcc-im")
+        XCTAssertEqual(resolved.confidence, .high)
+    }
+
+    func testUnknownApiAndNoTCCStaysUnknownLowConfidence() {
+        let resolved = PermissionOracle.resolveKeyPathInputMonitoring(
+            apiStatus: .unknown, tccStatus: nil
+        )
+        XCTAssertEqual(resolved.status, .unknown)
+        XCTAssertEqual(resolved.source, "keypath.ax-api-only")
+        XCTAssertEqual(resolved.confidence, .low)
+    }
+}

--- a/Tests/KeyPathTests/PermissionOracleInputMonitoringTests.swift
+++ b/Tests/KeyPathTests/PermissionOracleInputMonitoringTests.swift
@@ -58,4 +58,51 @@ final class PermissionOracleInputMonitoringTests: XCTestCase {
         XCTAssertEqual(resolved.source, "keypath.ax-api-only")
         XCTAssertEqual(resolved.confidence, .low)
     }
+
+    // MARK: - blockingIssue treats KeyPath's own IM as soft (#931 reconciliation)
+
+    private func snapshot(
+        keyPathAX: Status, keyPathIM: Status, kanataAX: Status, kanataIM: Status
+    ) -> PermissionOracle.Snapshot {
+        let now = Date()
+        return PermissionOracle.Snapshot(
+            keyPath: .init(
+                accessibility: keyPathAX, inputMonitoring: keyPathIM,
+                source: "test", confidence: .high, timestamp: now
+            ),
+            kanata: .init(
+                accessibility: kanataAX, inputMonitoring: kanataIM,
+                source: "test", confidence: .high, timestamp: now
+            ),
+            timestamp: now
+        )
+    }
+
+    /// Denied KeyPath IM alone must not produce a blocking issue (it powers only
+    /// the overlay, not remapping) — consistent with isSystemReady.
+    func testDeniedKeyPathInputMonitoringIsNotBlocking() {
+        let snap = snapshot(
+            keyPathAX: .granted, keyPathIM: .denied, kanataAX: .granted, kanataIM: .granted
+        )
+        XCTAssertNil(snap.blockingIssue)
+        XCTAssertTrue(snap.isSystemReady)
+    }
+
+    /// KeyPath's own Accessibility remains a hard blocker.
+    func testDeniedKeyPathAccessibilityIsBlocking() {
+        let snap = snapshot(
+            keyPathAX: .denied, keyPathIM: .granted, kanataAX: .granted, kanataIM: .granted
+        )
+        XCTAssertNotNil(snap.blockingIssue)
+        XCTAssertTrue(snap.blockingIssue?.contains("Accessibility") ?? false)
+    }
+
+    /// Kanata's Input Monitoring remains a hard blocker (it drives remapping).
+    func testDeniedKanataInputMonitoringIsBlocking() {
+        let snap = snapshot(
+            keyPathAX: .granted, keyPathIM: .granted, kanataAX: .granted, kanataIM: .denied
+        )
+        XCTAssertNotNil(snap.blockingIssue)
+        XCTAssertFalse(snap.isSystemReady)
+    }
 }

--- a/Tests/KeyPathTests/Services/PermissionOraclePolicyTests.swift
+++ b/Tests/KeyPathTests/Services/PermissionOraclePolicyTests.swift
@@ -45,11 +45,12 @@ struct PermissionOraclePolicyTests {
         #expect(issue.contains("KeyPath"))
     }
 
-    @Test("Blocking issue names the specific KeyPath permission (IM)")
-    func blockingMessageSpecificityInputMonitoring() {
+    @Test("KeyPath's own Input Monitoring is soft — denied IM alone does not block (#931)")
+    func keyPathInputMonitoringIsNonBlocking() {
         let now = Date()
 
-        // KeyPath: AX granted, IM denied
+        // KeyPath: AX granted, IM denied. KeyPath's own IM powers only the
+        // overlay/record, not remapping, so it must not produce a blocking issue.
         let keyPath = PermissionOracle.PermissionSet(
             accessibility: .granted,
             inputMonitoring: .denied,
@@ -68,11 +69,9 @@ struct PermissionOraclePolicyTests {
         )
 
         let snap = PermissionOracle.Snapshot(keyPath: keyPath, kanata: kanata, timestamp: now)
-        let issue = snap.blockingIssue ?? ""
 
-        #expect(issue.contains("Input Monitoring"))
-        #expect(!issue.contains("Accessibility"))
-        #expect(issue.contains("KeyPath"))
+        #expect(snap.blockingIssue == nil)
+        #expect(snap.isSystemReady)
     }
 
     // MARK: - Precedence: KeyPath over Kanata; unknown is non-blocking

--- a/Tests/KeyPathTests/Services/PermissionOracleTests.swift
+++ b/Tests/KeyPathTests/Services/PermissionOracleTests.swift
@@ -169,7 +169,7 @@ struct PermissionOracleTests {
         )
         #expect(axIssue.blockingIssue?.contains("KeyPath needs Accessibility") == true)
 
-        // KeyPath IM blocked
+        // KeyPath IM denied — soft (overlay only), NOT a blocking issue (#931)
         let keyPathIMBlocked = PermissionOracle.PermissionSet(
             accessibility: .granted,
             inputMonitoring: .denied,
@@ -182,7 +182,7 @@ struct PermissionOracleTests {
             kanata: granted,
             timestamp: now
         )
-        #expect(imIssue.blockingIssue?.contains("KeyPath needs Input Monitoring") == true)
+        #expect(imIssue.blockingIssue == nil)
 
         // Kanata blocked (KeyPath OK)
         let kanataBlocked = PermissionOracle.PermissionSet(

--- a/Tests/KeyPathTests/Services/UpdateServiceDecisionTests.swift
+++ b/Tests/KeyPathTests/Services/UpdateServiceDecisionTests.swift
@@ -45,6 +45,23 @@ final class UpdateServiceDecisionTests: XCTestCase {
         XCTAssertEqual(decision, .hardRepair(reason: "reason_code=keypath_permissions_blocking"))
     }
 
+    /// #931: KeyPath's own Input Monitoring is soft (overlay/record only). With
+    /// KeyPath Accessibility granted, a denied KeyPath IM must NOT force a hard
+    /// post-update repair — only kanata's permissions and KeyPath AX are hard.
+    func testPostUpdateDecisionIgnoresKeyPathInputMonitoringAlone() {
+        let context = makeContext(
+            keyPathStatus: .granted,
+            kanataStatus: .granted,
+            helperReady: true,
+            componentsReady: true,
+            servicesReady: true,
+            keyPathInputMonitoring: .denied
+        )
+
+        let decision = UpdateService.postUpdateDecision(for: context)
+        XCTAssertEqual(decision, .silentContinue(reason: "reason_code=healthy"))
+    }
+
     func testPostUpdateDecisionHardRepairWhenKanataPermissionsBlocking() {
         let context = makeContext(
             keyPathStatus: .granted,
@@ -115,12 +132,13 @@ final class UpdateServiceDecisionTests: XCTestCase {
         kanataStatus: PermissionOracle.Status,
         helperReady: Bool,
         componentsReady: Bool,
-        servicesReady: Bool
+        servicesReady: Bool,
+        keyPathInputMonitoring: PermissionOracle.Status? = nil
     ) -> SystemContext {
         let now = Date()
         let keyPathPerms = PermissionOracle.PermissionSet(
             accessibility: keyPathStatus,
-            inputMonitoring: keyPathStatus,
+            inputMonitoring: keyPathInputMonitoring ?? keyPathStatus,
             source: "test",
             confidence: .high,
             timestamp: now


### PR DESCRIPTION
## Summary

Fixes the core of #931 — during fresh install on macOS 26/27 the wizard's Input Monitoring page could never resolve because KeyPath's **own** IM was stuck at `.unknown` forever.

### Root cause
`PermissionOracle.checkKeyPathPermissions()` read KeyPath's own Input Monitoring state **only** from the TCC database, guarded by a comment claiming `IOHIDCheckAccess` triggers a system prompt. That premise is wrong — `IOHIDCheckAccess` is non-prompting (only `IOHIDRequestAccess` prompts) — and it directly contradicts **ADR-006** and CLAUDE.md, both of which make the Apple API authoritative with TCC as an `.unknown`-only fallback.

On macOS 26/27 a grant can leave **no readable TCC row** and the app never appears in the Input Monitoring list, so the TCC-only path returned `.unknown` indefinitely. `IOHIDCheckAccess` reflects the kernel's own record of the grant and stays correct regardless of TCC-db/pane state.

### Change 1 — authoritative signal (ADR-006 compliance)
- `checkKeyPathPermissions()` now queries `IOHIDCheckAccess(kIOHIDRequestTypeListenEvent)` first; trusts granted/denied; falls back to the passive TCC read only on `.unknown`/`.error`.
- Precedence extracted into pure, unit-tested resolvers (`keyPathInputMonitoringNeedsTCCFallback` / `resolveKeyPathInputMonitoring`).
- Corrected the now-false comments.
- Bonus fix: `CompositionRoot`'s HID-device monitor gated on `keyPath.inputMonitoring == .granted`, which was ~never true on macOS 26/27 — keyboard plug-in auto-detect and first-launch layout refinement now start correctly.

### Change 2 — treat KeyPath's own IM as soft, consistently
Making the signal authoritative unmasked a pre-existing contradiction: `isSystemReady` deliberately **excludes** KeyPath's own IM (it powers only the overlay/record seize-mode, not remapping — see `CompositionRoot`'s HID comment), but `blockingIssue` and `UpdateService.postUpdateDecision` treated denied KeyPath IM as a **hard** blocker. Those branches never fired before (always `.unknown`); activating them would newly pop the wizard and force post-update `hardRepair` for a working-remap system that simply hasn't enabled the overlay.

Reconciled to soft everywhere (KeyPath AX and kanata AX/IM remain hard):
- `blockingIssue`: KeyPath's own IM is no longer a hard blocking issue.
- `postUpdateDecision`: only KeyPath AX (not IM) forces keypath hardRepair.

## Safety review
The one regression risk — could `IOHIDCheckAccess` prompt, given it now runs on every ~1s Oracle snapshot? — was adversarially verified against Apple's documented contract and multiple reference implementations: **confirmed non-prompting** (only `IOHIDRequestAccess` shows UI). First-call side effect (app appears in the IM pane) is benign and desirable here.

## Tests
- New `PermissionOracleInputMonitoringTests`: ADR-006 precedence (API-granted wins even when TCC disagrees — the macOS 27 case) + `blockingIssue`/`isSystemReady` soft-IM behavior.
- `UpdateServiceDecisionTests`: denied KeyPath-IM-alone → `silentContinue`; KeyPath AX and kanata IM remain hard.
- 30+ wizard/permission/state suites pass unchanged.

## Scope / follow-ups (still open on #931)
This fixes KeyPath.app's **own** IM signal. Two harder pieces remain, tracked on the issue:
- **kanata-launcher** IM (TCC-only, since `IOHIDCheckAccess` is per-process) — needs daemon self-registration so denied HID-open auto-adds it to the pane.
- Wizard **dead-end guidance** copy when a grant can't register.
- Apple Feedback for the macOS 27 TCC-row regression (companion to #919).

Contributes to #931.

🤖 Generated with [Claude Code](https://claude.com/claude-code)