### PR TITLE
Add rollback test for leader-key headless reconcile (#889)

### DIFF
--- a/Tests/KeyPathTests/RuleCollections/RuleCollectionsManagerTests.swift
+++ b/Tests/KeyPathTests/RuleCollections/RuleCollectionsManagerTests.swift
@@ -716,6 +716,80 @@ final class RuleCollectionsManagerTests: XCTestCase {
         )
     }
 
+    /// Issue #889: when a reconciled leader key collides with another enabled base-layer
+    /// binding and no `onMappingConflictResolution` handler is registered,
+    /// `regenerateConfigFromCollections` fails. The reconcile must then be rolled back
+    /// atomically — both the UserDefaults-persisted `leaderKeyPreference` and the
+    /// in-memory collections revert to their pre-reconcile snapshot — so the next load
+    /// retries the drift cleanly instead of the idempotency guard permanently masking it.
+    /// Reviewers flagged this path but couldn't exercise it blind: regen only fails on a
+    /// genuine collision, which needs a real toolchain.
+    @MainActor
+    func testReconcileRollsBackWhenConfigRegenFails() async throws {
+        let (manager, _) = try await createTestManager()
+        defer { TestEnvironment.forceTestMode = false }
+
+        // Baseline leader = default ("space"). The Leader Key collection asks to reconcile
+        // to "f" — but Home Row Arrows (enabled by default) already owns the base-layer "f"
+        // activator (base → home-arrows). With no conflict-resolution handler registered,
+        // generateConfiguration throws .mappingConflicts (#463 leader-vs-activator) and
+        // regen returns false.
+        PreferencesService.shared.leaderKeyPreference = .default
+        defer { PreferencesService.shared.leaderKeyPreference = .default }
+
+        var regenFailed = false
+        manager.onError = { _ in regenFailed = true }
+
+        let collections = RuleCollectionCatalog().defaultCollections().map { collection -> RuleCollection in
+            var collection = collection
+            if collection.id == RuleCollectionIdentifier.leaderKey {
+                collection.isEnabled = true
+                collection.configuration.updateSelectedOutput("f")
+            }
+            return collection
+        }
+
+        // Test premise: an enabled base-layer "f" activator must exist to collide with.
+        XCTAssertTrue(
+            collections.contains {
+                $0.id == RuleCollectionIdentifier.homeRowArrows
+                    && $0.isEnabled
+                    && $0.momentaryActivator?.input == "f"
+                    && $0.momentaryActivator?.sourceLayer == .base
+            },
+            "test premise: an enabled base-layer 'f' activator must exist to collide with"
+        )
+
+        await manager.replaceCollections(collections)
+
+        // Regen must have failed — this proves the reconcile+collision path executed
+        // (a no-op reconcile would have left preference at "space" with no error).
+        XCTAssertTrue(regenFailed, "a colliding reconcile should make config regen fail")
+
+        // The preference reverts to the pre-reconcile snapshot (reconcile had mutated it
+        // to "f"; the failed regen rolls it back).
+        XCTAssertEqual(
+            PreferencesService.shared.leaderKeyPreference, .default,
+            "leaderKeyPreference must revert to its pre-reconcile value after a failed regen"
+        )
+
+        // The in-memory collections revert too: the base → nav leader activator that
+        // reconcile rewrote to "f" is restored to its original "space".
+        let navInputs = manager.ruleCollections
+            .compactMap(\.momentaryActivator)
+            .filter { $0.sourceLayer == .base && $0.targetLayer == .navigation }
+            .map(\.input)
+        XCTAssertFalse(navInputs.isEmpty)
+        XCTAssertTrue(
+            navInputs.allSatisfy { $0 == "space" },
+            "the base → nav activator must be restored to 'space' after rollback (was rewritten to 'f')"
+        )
+        XCTAssertFalse(
+            navInputs.contains("f"),
+            "no base → nav activator should retain the reconciled-then-rolled-back 'f'"
+        )
+    }
+
     @MainActor
     func testToggleCustomRuleConflictKeepNew_DisablesConflictingCollection() async throws {
         let (manager, _) = try await createTestManager()

--- a/docs/bugs/2026-07-02-leader-key-headless-selectedoutput-reconcile.md
+++ b/docs/bugs/2026-07-02-leader-key-headless-selectedoutput-reconcile.md
@@ -44,6 +44,19 @@ Fix: `applyLeaderKeyToLeaderActivators(_:targetLayer:)` rewrites only the
 base-layer and chained `nav → *` sub-layer activators untouched. Regression guard
 added in `testReplaceCollectionsReconcilesLeaderKeyFromSelectedOutput`.
 
+## Rollback coverage (test gap closed post-merge)
+
+The atomic rollback (`rollbackLeaderReconcile`) could not be unit-tested on the
+toolchain-less Linux remote where this shipped — regen only fails on a genuine
+collision, which needs a real macOS build. `testReconcileRollsBackWhenConfigRegenFails`
+now closes that gap: it reconciles the leader to `f` (colliding with the enabled
+Home Row Arrows `base → home-arrows` activator), which makes
+`generateConfiguration` throw `.mappingConflicts` (#463) with no
+`onMappingConflictResolution` handler registered, then asserts that **both** the
+`leaderKeyPreference` and the in-memory `ruleCollections` revert to their
+pre-reconcile snapshot. An `onError` spy witnesses the regen failure so the test
+can't silently pass on a no-op reconcile.
+
 ## Known limitations / follow-ups
 
 - **Standalone `keypath-cli config apply` is not covered.** It generates config via


### PR DESCRIPTION
## What

Closes the unit-test gap left by #926 (partial fix for #889). The atomic rollback in `RuleCollectionsManager.rollbackLeaderReconcile` shipped from a toolchain-less Linux remote, so it was never exercised — `regenerateConfigFromCollections` only returns `false` on a genuine mapping collision, which needs a real macOS build to reproduce. Two reviewers flagged this.

## The test

`testReconcileRollsBackWhenConfigRegenFails` drives the real `replaceCollections` load path:

1. Baseline leader = default (`space`, enabled).
2. The Leader Key collection asks to reconcile to `f`.
3. `f` collides with the **enabled-by-default** Home Row Arrows `base → home-arrows` activator, so `generateConfiguration` throws `.mappingConflicts` (#463 leader-vs-activator). With **no** `onMappingConflictResolution` handler registered, `tryResolveMappingConflict` returns nil and regen returns `false`.
4. Asserts **both** the UserDefaults-persisted `leaderKeyPreference` **and** the in-memory `ruleCollections` (the `base → nav` activator that reconcile rewrote to `f`) revert to their pre-reconcile snapshot.

An `onError` spy witnesses the regen failure, so the test can't silently pass on a no-op reconcile. A "test premise" assertion fails loudly if the catalog ever stops shipping an enabled base-layer `f` activator.

Run logs confirm the exact path:
```
⚠️ [ConfigService] Mapping conflicts detected: Key 'f' is mapped in both "Leader Key" and "Vim - Apple Keyboard Shortcuts" and "Home Row Arrows" (layer: Base)
↩️ [RuleCollections] Leader reconcile rolled back after failed config regen
```

## Scope

Test + doc only. The deferred CLI-path gap (`keypath-cli config apply` bypasses the reconcile) and disable-drift remain tracked under #865/#888 — #889 stays open.

## Validation (macOS, local)

- `swift build` ✅
- `RuleCollectionsManagerTests` — 31/31 pass (was 30, +1 new) ✅
- `LayerMappingBuilderTests` — 21/21 pass (#850 regexes) ✅
- SwiftFormat 0.61.1 lint — clean ✅
- SwiftLint — no errors ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)