### PR TITLE
Fix Input Monitoring wizard dead-end: escalate to manual add + keep poll alive (#931)

### DIFF
--- a/Sources/KeyPathInstallationWizard/UI/Pages/WizardInputMonitoringPage.swift
+++ b/Sources/KeyPathInstallationWizard/UI/Pages/WizardInputMonitoringPage.swift
@@ -463,15 +463,18 @@ public struct WizardInputMonitoringPage: View {
             "🔧 [WizardInputMonitoringPage] Fix button clicked - permission flow starting"
         )
 
-        // Record the attempt so guidance escalates to manual steps if the
-        // automatic prompt never registers a grant (macOS 26/27 dead-end, #931).
-        keyPathRequestAttemptedAt = Date()
-
         // Use automatic prompt via IOHIDRequestAccess()
         guard let permissionRequestService = WizardDependencies.permissionRequestService else {
             AppLogger.shared.log("⚠️ [WizardInputMonitoringPage] permissionRequestService not configured")
             return
         }
+
+        // Record the attempt so guidance escalates to manual steps if the
+        // automatic prompt never registers a grant (macOS 26/27 dead-end, #931).
+        // Set only after the guard so the escalation clock never starts on a path
+        // where no request was actually made.
+        keyPathRequestAttemptedAt = Date()
+
         Task { @MainActor in
             let alreadyGranted = await permissionRequestService.requestInputMonitoringPermission(
                 ignoreCooldown: true

--- a/Sources/KeyPathInstallationWizard/UI/Pages/WizardInputMonitoringPage.swift
+++ b/Sources/KeyPathInstallationWizard/UI/Pages/WizardInputMonitoringPage.swift
@@ -454,6 +454,12 @@ public struct WizardInputMonitoringPage: View {
             // the page keeps refreshing (drives the #931 manual-fallback card and
             // still detects a later manual grant). Without this the page would go
             // static and the escalation could never appear.
+            //
+            // Note: startBackgroundPermissionPolling() begins by cancelling
+            // `permissionPollingTask`, which still points at THIS fast-poll task —
+            // an intentional self-cancel. It is harmless: cancellation only flips
+            // `Task.isCancelled`, and there is no further code or await point in
+            // this closure after the call. Do not "simplify" it away.
             startBackgroundPermissionPolling()
         }
     }

--- a/Sources/KeyPathInstallationWizard/UI/Pages/WizardInputMonitoringPage.swift
+++ b/Sources/KeyPathInstallationWizard/UI/Pages/WizardInputMonitoringPage.swift
@@ -16,6 +16,10 @@ public struct WizardInputMonitoringPage: View {
     @State private var permissionPollingTask: Task<Void, Never>?
     @State private var showSuccessBurst = false
     @State private var permissionSnapshot: PermissionOracle.Snapshot?
+    /// When the automatic `IOHIDRequestAccess` prompt for KeyPath.app was last
+    /// triggered. Drives the escalation to manual guidance when the grant never
+    /// registers (macOS 26/27 dead-end, #931).
+    @State private var keyPathRequestAttemptedAt: Date?
 
     @Environment(WizardStateMachine.self) private var stateMachine
 
@@ -208,6 +212,14 @@ public struct WizardInputMonitoringPage: View {
                                 }
                             }
                             .help(kanataInputMonitoringIssues.asTooltipText())
+
+                            // Escalation: if the automatic prompt for KeyPath.app
+                            // never registered a grant, augment the "Turn On" retry
+                            // (whose deep-linked Settings row may not exist on macOS
+                            // 26/27) with accurate manual "+"-to-add steps (#931).
+                            if keyPathGuidance == .manualFallback {
+                                InputMonitoringManualFallbackCard()
+                            }
                         }
                         .frame(maxWidth: .infinity)
                         .padding(WizardDesign.Spacing.cardPadding)
@@ -238,29 +250,7 @@ public struct WizardInputMonitoringPage: View {
         }
         .onAppear {
             checkForStaleEntries()
-            permissionPollingTask?.cancel()
-            permissionPollingTask = Task { @MainActor [onRefresh] in
-                var hasEverCelebrated = false
-                while !Task.isCancelled {
-                    _ = await WizardSleep.ms(1000)
-                    let snapshot = await PermissionOracle.shared.forceRefresh()
-                    permissionSnapshot = snapshot
-
-                    let bothGranted = snapshot.keyPath.inputMonitoring.isReady
-                        && snapshot.kanata.inputMonitoring.isReady
-                    if bothGranted, !hasEverCelebrated {
-                        hasEverCelebrated = true
-                        WizardWindowManager.shared.bounceDocIcon()
-                        withAnimation(.spring(response: 0.3)) {
-                            showSuccessBurst = true
-                        }
-                        _ = await WizardSleep.ms(1500)
-                        showSuccessBurst = false
-                        await onRefresh()
-                        return
-                    }
-                }
-            }
+            startBackgroundPermissionPolling()
         }
         .onDisappear {
             permissionPollingTask?.cancel()
@@ -282,6 +272,20 @@ public struct WizardInputMonitoringPage: View {
     private var keyPathInputMonitoringStatus: InstallationStatus {
         guard let snapshot = permissionSnapshot else { return .inProgress }
         return installationStatus(for: snapshot.keyPath.inputMonitoring)
+    }
+
+    /// Escalation state for KeyPath.app's own Input Monitoring grant. Recomputed
+    /// on every render (the 1s poll updates `permissionSnapshot`), so once the
+    /// automatic-prompt wait window elapses without a grant the manual-add card
+    /// appears instead of leaving the user stranded at the "Turn On" button (#931).
+    private var keyPathGuidance: InputMonitoringGuidance {
+        resolveInputMonitoringGuidance(
+            InputMonitoringGuidanceInput(
+                keyPathReady: permissionSnapshot?.keyPath.inputMonitoring.isReady ?? false,
+                requestAttempted: keyPathRequestAttemptedAt != nil,
+                secondsSinceRequest: keyPathRequestAttemptedAt.map { Date().timeIntervalSince($0) }
+            )
+        )
     }
 
     private var kanataInputMonitoringStatus: InstallationStatus {
@@ -376,7 +380,44 @@ public struct WizardInputMonitoringPage: View {
         }
     }
 
-    /// Automatic prompt polling (Phase 1)
+    /// Durable 1s permission poll for the lifetime of the page. It is the single
+    /// writer of `permissionSnapshot` after first load, so it drives both grant
+    /// detection (celebrate + advance) AND time-based re-renders that let
+    /// `keyPathGuidance` escalate to the manual-fallback card (#931). It must keep
+    /// running whenever the page is visible and not fully granted — the automatic
+    /// "Turn On" flow resumes it after its fast poll exhausts.
+    private func startBackgroundPermissionPolling() {
+        permissionPollingTask?.cancel()
+        permissionPollingTask = Task { @MainActor [onRefresh] in
+            var hasEverCelebrated = false
+            while !Task.isCancelled {
+                _ = await WizardSleep.ms(1000)
+                if Task.isCancelled { return }
+                let snapshot = await PermissionOracle.shared.forceRefresh()
+                permissionSnapshot = snapshot
+
+                let bothGranted = snapshot.keyPath.inputMonitoring.isReady
+                    && snapshot.kanata.inputMonitoring.isReady
+                if bothGranted, !hasEverCelebrated {
+                    hasEverCelebrated = true
+                    WizardWindowManager.shared.bounceDocIcon()
+                    withAnimation(.spring(response: 0.3)) {
+                        showSuccessBurst = true
+                    }
+                    _ = await WizardSleep.ms(1500)
+                    showSuccessBurst = false
+                    await onRefresh()
+                    return
+                }
+            }
+        }
+    }
+
+    /// Fast (250ms) poll used immediately after the automatic prompt for snappy
+    /// grant detection. It also keeps `permissionSnapshot` fresh so the page
+    /// re-renders, and — critically — hands back to the durable 1s poll when it
+    /// exhausts without a grant, so re-renders and grant detection continue and
+    /// the #931 manual-fallback escalation can still fire.
     private func startPermissionPolling(for type: CoordinatorPermissionType) {
         permissionPollingTask?.cancel()
         permissionPollingTask = Task { @MainActor [onRefresh] in
@@ -384,8 +425,10 @@ public struct WizardInputMonitoringPage: View {
             let maxAttempts = 20 // ~5s at 250ms intervals
             while attempts < maxAttempts {
                 _ = await WizardSleep.ms(250)
+                if Task.isCancelled { return }
                 attempts += 1
                 let snapshot = await PermissionOracle.shared.forceRefresh()
+                permissionSnapshot = snapshot
                 let hasPermission: Bool =
                     switch type {
                     case .accessibility:
@@ -406,8 +449,12 @@ public struct WizardInputMonitoringPage: View {
                     await onRefresh()
                     return
                 }
-                if Task.isCancelled { return }
             }
+            // Grant did not arrive in the fast window: resume the durable poll so
+            // the page keeps refreshing (drives the #931 manual-fallback card and
+            // still detects a later manual grant). Without this the page would go
+            // static and the escalation could never appear.
+            startBackgroundPermissionPolling()
         }
     }
 
@@ -415,6 +462,10 @@ public struct WizardInputMonitoringPage: View {
         AppLogger.shared.log(
             "🔧 [WizardInputMonitoringPage] Fix button clicked - permission flow starting"
         )
+
+        // Record the attempt so guidance escalates to manual steps if the
+        // automatic prompt never registers a grant (macOS 26/27 dead-end, #931).
+        keyPathRequestAttemptedAt = Date()
 
         // Use automatic prompt via IOHIDRequestAccess()
         guard let permissionRequestService = WizardDependencies.permissionRequestService else {
@@ -463,6 +514,47 @@ private func openInputMonitoringPreferencesPanel() {
                 WizardWindowManager.shared.markSystemSettingsOpened()
             }
         }
+    }
+}
+
+// MARK: - Manual fallback guidance (#931)
+
+/// Shown when the automatic Input Monitoring prompt for KeyPath.app never
+/// registers a grant. Gives accurate manual steps instead of leaving the user at
+/// a "Turn On" button that deep-links to a Settings row which may not exist on
+/// macOS 26/27.
+private struct InputMonitoringManualFallbackCard: View {
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Label("Didn't see a permission prompt?", systemImage: "hand.raised.circle")
+                .font(.headline)
+
+            Text(
+                "On some macOS versions the automatic prompt doesn't appear. You can add KeyPath to Input Monitoring yourself:"
+            )
+            .font(.callout)
+            .foregroundColor(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
+
+            VStack(alignment: .leading, spacing: 6) {
+                CleanupStep(number: 1, text: "Open System Settings → Privacy & Security → Input Monitoring.")
+                CleanupStep(number: 2, text: "Click the \"+\" button below the list.")
+                CleanupStep(number: 3, text: "Choose KeyPath.app from your Applications folder, then turn its switch on.")
+            }
+
+            Button("Open Input Monitoring Settings") {
+                Task { @MainActor in openInputMonitoringPreferencesPanel() }
+            }
+            .buttonStyle(WizardDesign.Component.SecondaryButton())
+            .accessibilityIdentifier("wizard_input_monitoring_manual_fallback")
+            .padding(.top, 4)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(WizardDesign.Spacing.cardPadding)
+        .background(
+            WizardDesign.Colors.warning.opacity(0.06),
+            in: RoundedRectangle(cornerRadius: WizardDesign.Layout.cornerRadius)
+        )
     }
 }
 

--- a/Sources/KeyPathWizardCore/InputMonitoringGuidance.swift
+++ b/Sources/KeyPathWizardCore/InputMonitoringGuidance.swift
@@ -39,13 +39,20 @@ public struct InputMonitoringGuidanceInput: Equatable, Sendable {
     /// unknown. `nil` while `requestAttempted` is true is treated as "elapsed".
     public var secondsSinceRequest: TimeInterval?
     /// How long to wait for an automatic grant before escalating to manual steps.
+    ///
+    /// Tuned to outlast a *working* system prompt: when `IOHIDRequestAccess` does
+    /// show the macOS dialog, a first-run user often takes several seconds to read
+    /// and click "Allow". The window must be long enough that we don't flash
+    /// "Didn't see a prompt?" while that real dialog is still on screen, yet short
+    /// enough that a genuinely stuck user (macOS 26/27, no dialog at all) isn't
+    /// stranded. 12s balances the two.
     public var waitWindow: TimeInterval
 
     public init(
         keyPathReady: Bool,
         requestAttempted: Bool,
         secondsSinceRequest: TimeInterval?,
-        waitWindow: TimeInterval = 6
+        waitWindow: TimeInterval = 12
     ) {
         self.keyPathReady = keyPathReady
         self.requestAttempted = requestAttempted

--- a/Sources/KeyPathWizardCore/InputMonitoringGuidance.swift
+++ b/Sources/KeyPathWizardCore/InputMonitoringGuidance.swift
@@ -1,0 +1,81 @@
+import Foundation
+
+/// Pure decision logic for the guidance the Input Monitoring wizard page should
+/// present for **KeyPath.app's own** Input Monitoring grant. Extracted so the
+/// escalation behavior can be unit-tested without a running UI (mirrors the pure
+/// resolvers added for the Oracle signal in #931/#937).
+///
+/// Background (#931): clicking "Turn On" fires `IOHIDRequestAccess`, but on
+/// macOS 26/27 tccd can silently produce nothing — no system prompt, no TCC row,
+/// and the app never appears in the Input Monitoring list. The page used to leave
+/// a bare "Turn On" button pointing at a Settings entry that does not exist, so a
+/// fresh install dead-ended here at `unknown`/`denied` with no accurate guidance.
+///
+/// This resolver drives an escalation: try the automatic prompt first, and if the
+/// grant has not landed within a short wait window, switch to explicit manual
+/// "add it yourself in System Settings" instructions so the user is never
+/// stranded.
+public enum InputMonitoringGuidance: Equatable, Sendable {
+    /// KeyPath.app already has Input Monitoring — no guidance needed.
+    case granted
+    /// No automatic request has been attempted yet — offer the one-click "Turn On".
+    case offerAutomatic
+    /// A request was attempted and we are still within the wait window — treat as
+    /// a transient "waiting for the grant to register" state, not a dead-end.
+    case awaitingGrant
+    /// The automatic request did not register within the wait window — show
+    /// explicit manual instructions so the user is never stranded (#931).
+    case manualFallback
+}
+
+/// Inputs for `resolveInputMonitoringGuidance`. All fields describe KeyPath.app's
+/// own Input Monitoring state and the automatic-prompt attempt against it.
+public struct InputMonitoringGuidanceInput: Equatable, Sendable {
+    /// Whether KeyPath.app's own Input Monitoring is granted (Oracle `isReady`).
+    public var keyPathReady: Bool
+    /// Whether the user has triggered the automatic `IOHIDRequestAccess` prompt.
+    public var requestAttempted: Bool
+    /// Seconds elapsed since the most recent automatic request, or nil if none /
+    /// unknown. `nil` while `requestAttempted` is true is treated as "elapsed".
+    public var secondsSinceRequest: TimeInterval?
+    /// How long to wait for an automatic grant before escalating to manual steps.
+    public var waitWindow: TimeInterval
+
+    public init(
+        keyPathReady: Bool,
+        requestAttempted: Bool,
+        secondsSinceRequest: TimeInterval?,
+        waitWindow: TimeInterval = 6
+    ) {
+        self.keyPathReady = keyPathReady
+        self.requestAttempted = requestAttempted
+        self.secondsSinceRequest = secondsSinceRequest
+        self.waitWindow = waitWindow
+    }
+}
+
+/// Resolve what the Input Monitoring page should show for KeyPath.app's own grant.
+///
+/// - A granted app short-circuits to `.granted` regardless of any prior attempt.
+/// - Before any attempt, the automatic one-click path is offered.
+/// - After an attempt we allow a brief window for the grant to register before
+///   escalating to manual instructions, so a normally-working prompt isn't
+///   immediately buried under fallback copy.
+public func resolveInputMonitoringGuidance(
+    _ input: InputMonitoringGuidanceInput
+) -> InputMonitoringGuidance {
+    if input.keyPathReady {
+        return .granted
+    }
+    guard input.requestAttempted else {
+        return .offerAutomatic
+    }
+    // Only keep waiting for a well-formed elapsed time inside the window. A nil
+    // (unknown) or negative (wall-clock moved backwards) elapsed must escalate
+    // rather than strand the user in an endless "waiting" state — the whole point
+    // of #931 is that guidance is always eventually reached.
+    if let elapsed = input.secondsSinceRequest, elapsed >= 0, elapsed < input.waitWindow {
+        return .awaitingGrant
+    }
+    return .manualFallback
+}

--- a/Tests/KeyPathTests/InputMonitoringGuidanceTests.swift
+++ b/Tests/KeyPathTests/InputMonitoringGuidanceTests.swift
@@ -1,0 +1,62 @@
+import KeyPathWizardCore
+@preconcurrency import XCTest
+
+/// Covers the Input Monitoring wizard escalation logic (#931): the page must
+/// never sit at an unresolved grant without guidance. The pure resolver decides
+/// when to offer the automatic prompt, when to keep waiting, and when to fall
+/// back to explicit manual instructions.
+final class InputMonitoringGuidanceTests: XCTestCase {
+    private func resolve(
+        keyPathReady: Bool,
+        requestAttempted: Bool,
+        secondsSinceRequest: TimeInterval?,
+        waitWindow: TimeInterval = 6
+    ) -> InputMonitoringGuidance {
+        resolveInputMonitoringGuidance(
+            InputMonitoringGuidanceInput(
+                keyPathReady: keyPathReady,
+                requestAttempted: requestAttempted,
+                secondsSinceRequest: secondsSinceRequest,
+                waitWindow: waitWindow
+            )
+        )
+    }
+
+    func testGrantedShortCircuitsRegardlessOfAttempt() {
+        XCTAssertEqual(resolve(keyPathReady: true, requestAttempted: false, secondsSinceRequest: nil), .granted)
+        // A granted app must never show fallback copy even long after an attempt.
+        XCTAssertEqual(resolve(keyPathReady: true, requestAttempted: true, secondsSinceRequest: 999), .granted)
+    }
+
+    func testNoAttemptOffersAutomaticPath() {
+        XCTAssertEqual(resolve(keyPathReady: false, requestAttempted: false, secondsSinceRequest: nil), .offerAutomatic)
+    }
+
+    func testWithinWaitWindowKeepsWaiting() {
+        XCTAssertEqual(resolve(keyPathReady: false, requestAttempted: true, secondsSinceRequest: 0), .awaitingGrant)
+        XCTAssertEqual(resolve(keyPathReady: false, requestAttempted: true, secondsSinceRequest: 5.9), .awaitingGrant)
+    }
+
+    func testAtOrAfterWaitWindowEscalatesToManualFallback() {
+        // Boundary is inclusive of the window: at exactly the window we escalate.
+        XCTAssertEqual(resolve(keyPathReady: false, requestAttempted: true, secondsSinceRequest: 6), .manualFallback)
+        XCTAssertEqual(resolve(keyPathReady: false, requestAttempted: true, secondsSinceRequest: 30), .manualFallback)
+    }
+
+    func testAttemptedWithUnknownElapsedEscalatesRatherThanStalling() {
+        // A missing timestamp must not strand the user in an infinite "waiting"
+        // state — the whole point of #931 is to always reach guidance.
+        XCTAssertEqual(resolve(keyPathReady: false, requestAttempted: true, secondsSinceRequest: nil), .manualFallback)
+    }
+
+    func testNegativeElapsedFromClockRewindEscalatesRatherThanStalling() {
+        // Wall-clock moving backwards after the click yields a negative elapsed;
+        // it must escalate, not pin the user at .awaitingGrant forever (#931).
+        XCTAssertEqual(resolve(keyPathReady: false, requestAttempted: true, secondsSinceRequest: -50), .manualFallback)
+    }
+
+    func testCustomWaitWindowIsHonored() {
+        XCTAssertEqual(resolve(keyPathReady: false, requestAttempted: true, secondsSinceRequest: 2, waitWindow: 10), .awaitingGrant)
+        XCTAssertEqual(resolve(keyPathReady: false, requestAttempted: true, secondsSinceRequest: 2, waitWindow: 1), .manualFallback)
+    }
+}

--- a/Tests/KeyPathTests/InputMonitoringGuidanceTests.swift
+++ b/Tests/KeyPathTests/InputMonitoringGuidanceTests.swift
@@ -55,6 +55,20 @@ final class InputMonitoringGuidanceTests: XCTestCase {
         XCTAssertEqual(resolve(keyPathReady: false, requestAttempted: true, secondsSinceRequest: -50), .manualFallback)
     }
 
+    func testProductionDefaultWaitWindowIsTwelveSeconds() {
+        // The page relies on the init default (it never passes waitWindow), so the
+        // shipped escalation timing is locked in here: still waiting at 11s so a
+        // real system dialog isn't contradicted, escalated by 12s (#931, review obs).
+        let stillWaiting = resolveInputMonitoringGuidance(
+            InputMonitoringGuidanceInput(keyPathReady: false, requestAttempted: true, secondsSinceRequest: 11)
+        )
+        XCTAssertEqual(stillWaiting, .awaitingGrant)
+        let escalated = resolveInputMonitoringGuidance(
+            InputMonitoringGuidanceInput(keyPathReady: false, requestAttempted: true, secondsSinceRequest: 12)
+        )
+        XCTAssertEqual(escalated, .manualFallback)
+    }
+
     func testCustomWaitWindowIsHonored() {
         XCTAssertEqual(resolve(keyPathReady: false, requestAttempted: true, secondsSinceRequest: 2, waitWindow: 10), .awaitingGrant)
         XCTAssertEqual(resolve(keyPathReady: false, requestAttempted: true, secondsSinceRequest: 2, waitWindow: 1), .manualFallback)


### PR DESCRIPTION
## Summary

Closes the fresh-install **Input Monitoring dead-end** on macOS 26/27 — the spot where the 2026-07-02 QA session "effectively died" (#931). #937 already fixed KeyPath.app's own IM *signal* (`IOHIDCheckAccess`); this fixes the wizard **UX** that was still stranded, plus a root-cause polling-lifecycle bug that would have defeated the fix.

### The problem
Clicking **Turn On** fires `IOHIDRequestAccess`, but on macOS 26/27 tccd can produce **no prompt and no TCC row** — the app never appears in the Input Monitoring list. The page kept showing only a bare "Turn On" button that deep-links to a Settings row which doesn't exist, giving the user no accurate way forward.

### The fix
- **Pure, unit-tested resolver** (`InputMonitoringGuidance`, in `KeyPathWizardCore`) that escalates KeyPath.app's own IM guidance: offer the automatic prompt first, then after a short wait window without a grant switch to explicit manual **"+"-to-add** steps. A `nil` or negative (clock-rewind) elapsed escalates rather than stranding the user in an endless "waiting" state.
- **`InputMonitoringManualFallbackCard`** rendered from that state, so the page never sits unresolved without accurate manual instructions — satisfying the #931 acceptance criterion ("never sits at `unknown` indefinitely without guidance").

### Root-cause polling fix (caught in review)
The escalation relies on periodic re-renders driven by the 1s `permissionSnapshot` poll. But the fast post-prompt poll (`startPermissionPolling`) **cancelled** the durable 1s poll, **stopped writing** `permissionSnapshot`, and **never restarted** it — so after ~5s the page went static: no re-renders (the card could never appear) and no detection of a later *manual* grant (the wizard could never advance). Fixed by extracting a durable `startBackgroundPermissionPolling()`, having the fast poll also refresh the snapshot, and resuming the durable poll when the fast poll exhausts.

## Testing
- New `InputMonitoringGuidanceTests` cover every resolver transition, the wait-window boundary, and the `nil`/negative-elapsed escalation guards.
- ⚠️ Swift build, full `swift test`, `swiftformat`, and `swiftlint` **were not run** here — this change was authored in a Linux container with no Swift/macOS toolchain. Please run the pre-PR gate on macOS.
- Manual first-run QA (#747) still required on a Mac without pre-granted permissions, ideally on a macOS 26 and a macOS 27 machine.

## Scope / follow-ups
Deliberately scoped to the KeyPath.app IM escalation. Still open on #931 and tracked separately:
- kanata-launcher self-registration / daemon-before-IM-step (#931)
- Welcome intro page (#932), drag-to-authorize parity + FDA polling (#933), wizard polish batch (#934)

## Review gate
CLAUDE.md's mandated `/thermo-nuclear-swift-review` command isn't present in this checkout, so the built-in `/code-review` (high effort) was run against the diff instead; all confirmed findings — the fatal dead-poll bug, the clock-rewind edge, and the design-token/comment drift — were addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015fnREsXoC9obKsFkF7eKPB

---
_Generated by [Claude Code](https://claude.ai/code/session_015fnREsXoC9obKsFkF7eKPB)_