### PR TITLE
Drag-to-authorize parity: KeyPath.app rows + Full Disk Access (#933)

### DIFF
--- a/Sources/KeyPathInstallationWizard/UI/Helpers/DragToAuthorize/DragToAuthorizeController.swift
+++ b/Sources/KeyPathInstallationWizard/UI/Helpers/DragToAuthorize/DragToAuthorizeController.swift
@@ -130,6 +130,10 @@ public final class DragToAuthorizeController {
         state = .presenting
 
         NSWorkspace.shared.open(target.settingsURL)
+        // Record that we opened System Settings so the wizard's cleanup closes it
+        // when the flow finishes (the FDA page previously did this itself before it
+        // routed through this overlay).
+        WizardWindowManager.shared.markSystemSettingsOpened()
 
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.8) { [weak self] in
             self?.createAndShowPanel(for: target, subject: subject, sourceRect: sourceRect, sourceWindow: sourceWindow)

--- a/Sources/KeyPathInstallationWizard/UI/Helpers/DragToAuthorize/DragToAuthorizeController.swift
+++ b/Sources/KeyPathInstallationWizard/UI/Helpers/DragToAuthorize/DragToAuthorizeController.swift
@@ -358,6 +358,7 @@ public final class DragToAuthorizeController {
         panel = nil
         stateModel = nil
         currentTarget = nil
+        currentSubject = .kanata
         state = .idle
     }
 }

--- a/Sources/KeyPathInstallationWizard/UI/Helpers/DragToAuthorize/DragToAuthorizeController.swift
+++ b/Sources/KeyPathInstallationWizard/UI/Helpers/DragToAuthorize/DragToAuthorizeController.swift
@@ -40,6 +40,44 @@ public final class DragToAuthorizeController {
         }
     }
 
+    /// Which app the overlay authorizes — i.e. which file the user drags into the
+    /// privacy list and whose permission is polled. Historically the overlay only
+    /// added kanata-launcher; `.keyPath` extends it to KeyPath.app's own rows and
+    /// the Full Disk Access page (#933).
+    public enum PermissionSubject: Equatable, Sendable {
+        /// KeyPath.app's own bundle (its Accessibility / Input Monitoring / Full
+        /// Disk Access grant). Drags the `.app` bundle; polled via `snapshot.keyPath`
+        /// (or the FDA checker for Full Disk Access).
+        case keyPath
+        /// The bundled kanata-launcher binary (the remapping engine's grant).
+        /// Drags the launcher executable; polled via `snapshot.kanata`.
+        case kanata
+
+        /// File dragged into the System Settings privacy list for this subject.
+        var fileURL: URL {
+            switch self {
+            case .keyPath: URL(fileURLWithPath: Bundle.main.bundlePath)
+            case .kanata: URL(fileURLWithPath: WizardSystemPaths.bundledKanataLauncherPath)
+            }
+        }
+
+        /// Primary label shown on the draggable tile.
+        var displayName: String {
+            switch self {
+            case .keyPath: "KeyPath"
+            case .kanata: "kanata-launcher"
+            }
+        }
+
+        /// Secondary label shown under the tile's primary label.
+        var subtitle: String {
+            switch self {
+            case .keyPath: "Main application"
+            case .kanata: "KeyPath Engine"
+            }
+        }
+    }
+
     public enum OverlayState: Equatable {
         case idle
         case presenting
@@ -54,6 +92,7 @@ public final class DragToAuthorizeController {
 
     public private(set) var state: OverlayState = .idle
     public private(set) var currentTarget: PermissionTarget?
+    public private(set) var currentSubject: PermissionSubject = .kanata
 
     // MARK: - Private Properties
 
@@ -69,25 +108,34 @@ public final class DragToAuthorizeController {
 
     /// Present the drag-to-authorize overlay for the given permission target.
     /// Opens System Settings and shows the floating panel anchored below it.
-    public func present(for target: PermissionTarget, sourceRect: NSRect? = nil, in sourceWindow: NSWindow? = nil) {
+    ///
+    /// - Parameter subject: which app the user drags into the list (defaults to
+    ///   `.kanata` for backward compatibility with the kanata-launcher rows).
+    public func present(
+        for target: PermissionTarget,
+        subject: PermissionSubject = .kanata,
+        sourceRect: NSRect? = nil,
+        in sourceWindow: NSWindow? = nil
+    ) {
         guard state == .idle else {
             dismiss(animated: false)
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
-                self?.present(for: target, sourceRect: sourceRect, in: sourceWindow)
+                self?.present(for: target, subject: subject, sourceRect: sourceRect, in: sourceWindow)
             }
             return
         }
 
         currentTarget = target
+        currentSubject = subject
         state = .presenting
 
         NSWorkspace.shared.open(target.settingsURL)
 
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.8) { [weak self] in
-            self?.createAndShowPanel(for: target, sourceRect: sourceRect, sourceWindow: sourceWindow)
+            self?.createAndShowPanel(for: target, subject: subject, sourceRect: sourceRect, sourceWindow: sourceWindow)
         }
 
-        AppLogger.shared.log("🎯 [DragToAuthorize] Presenting for \(target.displayName)")
+        AppLogger.shared.log("🎯 [DragToAuthorize] Presenting \(subject.displayName) for \(target.displayName)")
     }
 
     /// Dismiss the overlay with optional animation.
@@ -144,7 +192,7 @@ public final class DragToAuthorizeController {
 
     // MARK: - Private Implementation
 
-    private func createAndShowPanel(for target: PermissionTarget, sourceRect: NSRect?, sourceWindow: NSWindow?) {
+    private func createAndShowPanel(for target: PermissionTarget, subject: PermissionSubject, sourceRect: NSRect?, sourceWindow: NSWindow?) {
         let panelWidth: CGFloat = 300
         let panelHeight: CGFloat = 170
 
@@ -152,7 +200,7 @@ public final class DragToAuthorizeController {
             x: 0, y: 0, width: panelWidth, height: panelHeight
         ))
 
-        let model = DragToAuthorizeStateModel(target: target, controller: self)
+        let model = DragToAuthorizeStateModel(target: target, subject: subject, controller: self)
         stateModel = model
 
         let overlayView = DragToAuthorizeOverlayView(model: model)
@@ -161,9 +209,7 @@ public final class DragToAuthorizeController {
         hosting.autoresizingMask = [.width, .height]
 
         // Embed drag source on top of the tile area
-        let launcherPath = WizardSystemPaths.bundledKanataLauncherPath
-        let launcherURL = URL(fileURLWithPath: launcherPath)
-        let dragSource = DragToAuthorizeDragSource(fileURL: launcherURL, frame: NSRect(
+        let dragSource = DragToAuthorizeDragSource(fileURL: subject.fileURL, frame: NSRect(
             x: 24, y: 16, width: panelWidth - 48, height: 52
         ))
         dragSource.onDragBegan = { [weak self] in
@@ -204,7 +250,7 @@ public final class DragToAuthorizeController {
         newTracker.startTracking()
         tracker = newTracker
 
-        startPermissionPolling(for: target)
+        startPermissionPolling(for: target, subject: subject)
     }
 
     private func animatePresentation(panel: DragToAuthorizePanel, sourceRect: NSRect?, sourceWindow: NSWindow?) {
@@ -262,28 +308,44 @@ public final class DragToAuthorizeController {
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.8, execute: dismissWorkItem!)
     }
 
-    private func startPermissionPolling(for target: PermissionTarget) {
+    private func startPermissionPolling(for target: PermissionTarget, subject: PermissionSubject) {
         permissionPollTimer = Timer.scheduledTimer(withTimeInterval: 0.5, repeats: true) { [weak self] _ in
             Task { @MainActor [weak self] in
-                await self?.checkPermission(for: target)
+                await self?.checkPermission(for: target, subject: subject)
             }
         }
     }
 
-    private func checkPermission(for target: PermissionTarget) async {
+    private func checkPermission(for target: PermissionTarget, subject: PermissionSubject) async {
         let snapshot = await PermissionOracle.shared.forceRefresh()
+        // Full Disk Access is not represented in the Oracle snapshot; it is read
+        // separately (and only ever applies to KeyPath.app, i.e. `.keyPath`).
+        let fdaGranted = WizardDependencies.fullDiskAccessChecker?.hasFullDiskAccess() ?? false
 
-        let granted: Bool = switch target {
-        case .accessibility:
-            snapshot.kanata.accessibility == .granted
-        case .inputMonitoring:
-            snapshot.kanata.inputMonitoring == .granted
-        case .fullDiskAccess:
-            WizardDependencies.fullDiskAccessChecker?.hasFullDiskAccess() ?? false
-        }
-
-        if granted {
+        if Self.grantResolved(
+            target: target, subject: subject, snapshot: snapshot, fullDiskAccessGranted: fdaGranted
+        ) {
             permissionGrantDetected()
+        }
+    }
+
+    /// Pure decision: is `subject`'s `target` permission granted in this snapshot?
+    /// Extracted so the target×subject → PermissionSet mapping is unit-testable
+    /// without AppKit (mirrors the resolver pattern in #931/#937/#939).
+    ///
+    /// - Note: Full Disk Access is not in the Oracle snapshot, so it is passed in
+    ///   via `fullDiskAccessGranted`; it always describes KeyPath.app.
+    nonisolated static func grantResolved(
+        target: PermissionTarget,
+        subject: PermissionSubject,
+        snapshot: PermissionOracle.Snapshot,
+        fullDiskAccessGranted: Bool
+    ) -> Bool {
+        let permissions = subject == .keyPath ? snapshot.keyPath : snapshot.kanata
+        switch target {
+        case .accessibility: return permissions.accessibility == .granted
+        case .inputMonitoring: return permissions.inputMonitoring == .granted
+        case .fullDiskAccess: return fullDiskAccessGranted
         }
     }
 

--- a/Sources/KeyPathInstallationWizard/UI/Helpers/DragToAuthorize/DragToAuthorizeOverlayView.swift
+++ b/Sources/KeyPathInstallationWizard/UI/Helpers/DragToAuthorize/DragToAuthorizeOverlayView.swift
@@ -82,15 +82,15 @@ struct DragToAuthorizeOverlayView: View {
 
     private var draggableTile: some View {
         HStack(spacing: 12) {
-            Image(nsImage: model.launcherIcon)
+            Image(nsImage: model.subjectIcon)
                 .resizable()
                 .frame(width: 32, height: 32)
 
             VStack(alignment: .leading, spacing: 2) {
-                Text("kanata-launcher")
+                Text(model.subject.displayName)
                     .font(.system(size: 12, weight: .semibold))
                     .foregroundStyle(.primary)
-                Text("KeyPath Engine")
+                Text(model.subject.subtitle)
                     .font(.system(size: 10))
                     .foregroundStyle(.tertiary)
             }

--- a/Sources/KeyPathInstallationWizard/UI/Helpers/DragToAuthorize/DragToAuthorizeStateModel.swift
+++ b/Sources/KeyPathInstallationWizard/UI/Helpers/DragToAuthorize/DragToAuthorizeStateModel.swift
@@ -8,6 +8,7 @@ import SwiftUI
 @Observable
 final class DragToAuthorizeStateModel {
     let target: DragToAuthorizeController.PermissionTarget
+    let subject: DragToAuthorizeController.PermissionSubject
     private weak var controller: DragToAuthorizeController?
 
     // Animation-driving state
@@ -20,18 +21,20 @@ final class DragToAuthorizeStateModel {
     var dismissOpacity: Double = 1.0
     var dismissOffset: CGFloat = 0
 
-    var launcherPath: String {
-        WizardSystemPaths.bundledKanataLauncherPath
-    }
-
-    var launcherIcon: NSImage {
-        let icon = NSWorkspace.shared.icon(forFile: launcherPath)
+    /// Icon for the subject being dragged (KeyPath.app or kanata-launcher).
+    var subjectIcon: NSImage {
+        let icon = NSWorkspace.shared.icon(forFile: subject.fileURL.path)
         icon.size = NSSize(width: 32, height: 32)
         return icon
     }
 
-    init(target: DragToAuthorizeController.PermissionTarget, controller: DragToAuthorizeController) {
+    init(
+        target: DragToAuthorizeController.PermissionTarget,
+        subject: DragToAuthorizeController.PermissionSubject,
+        controller: DragToAuthorizeController
+    ) {
         self.target = target
+        self.subject = subject
         self.controller = controller
     }
 

--- a/Sources/KeyPathInstallationWizard/UI/Pages/WizardAccessibilityPage.swift
+++ b/Sources/KeyPathInstallationWizard/UI/Pages/WizardAccessibilityPage.swift
@@ -13,6 +13,10 @@ public struct WizardAccessibilityPage: View {
     @State private var permissionPollingTask: Task<Void, Never>?
     @State private var showSuccessBurst = false
     @State private var permissionSnapshot: PermissionOracle.Snapshot?
+    /// When the automatic Accessibility prompt for KeyPath.app was last triggered.
+    /// Drives escalation to the drag-to-authorize helper if the grant never
+    /// registers, mirroring the Input Monitoring page (#933).
+    @State private var keyPathRequestAttemptedAt: Date?
 
     @Environment(WizardStateMachine.self) private var stateMachine
 
@@ -226,6 +230,13 @@ public struct WizardAccessibilityPage: View {
                                 }
                             }
                             .help(kanataAccessibilityIssues.asTooltipText())
+
+                            // Escalation: if the automatic prompt for KeyPath.app never
+                            // registered a grant, offer the drag-to-authorize helper
+                            // instead of leaving the user at a "Turn On" button (#933).
+                            if keyPathAccessibilityGuidance == .manualFallback {
+                                AccessibilityManualFallbackCard()
+                            }
                         }
                         .frame(maxWidth: .infinity)
                         .padding(WizardDesign.Spacing.cardPadding)
@@ -314,6 +325,20 @@ public struct WizardAccessibilityPage: View {
         return installationStatus(for: snapshot.kanata.accessibility)
     }
 
+    /// Escalation state for KeyPath.app's own Accessibility grant. Reuses the
+    /// permission-agnostic guidance resolver (its logic is not IM-specific): once
+    /// the automatic-prompt wait window elapses without a grant, the drag-to-authorize
+    /// fallback appears instead of stranding the user at "Turn On" (#933).
+    private var keyPathAccessibilityGuidance: InputMonitoringGuidance {
+        resolveInputMonitoringGuidance(
+            InputMonitoringGuidanceInput(
+                keyPathReady: permissionSnapshot?.keyPath.accessibility.isReady ?? false,
+                requestAttempted: keyPathRequestAttemptedAt != nil,
+                secondsSinceRequest: keyPathRequestAttemptedAt.map { Date().timeIntervalSince($0) }
+            )
+        )
+    }
+
     private func installationStatus(for status: PermissionOracle.Status) -> InstallationStatus {
         switch status {
         case .granted: .completed
@@ -350,6 +375,12 @@ public struct WizardAccessibilityPage: View {
             AppLogger.shared.log("⚠️ [WizardAccessibilityPage] permissionRequestService not configured")
             return
         }
+
+        // Record the attempt so guidance escalates to the drag-to-authorize helper
+        // if the automatic prompt never registers a grant (#933). Set only after the
+        // guard so the escalation clock never starts on a path with no real request.
+        keyPathRequestAttemptedAt = Date()
+
         Task { @MainActor in
             let alreadyGranted = await permissionRequestService.requestAccessibilityPermission(
                 ignoreCooldown: true
@@ -360,7 +391,7 @@ public struct WizardAccessibilityPage: View {
             }
             // Poll for grant (KeyPath + Kanata) using Oracle snapshot
             permissionPollingTask?.cancel()
-            permissionPollingTask = Task { [onRefresh] in
+            permissionPollingTask = Task { @MainActor [onRefresh] in
                 var attempts = 0
                 let maxAttempts = 30
                 var lastKeyPathGranted: Bool?
@@ -369,6 +400,9 @@ public struct WizardAccessibilityPage: View {
                     _ = await WizardSleep.ms(1000)
                     attempts += 1
                     let snapshot = await PermissionOracle.shared.forceRefresh()
+                    // Keep the snapshot fresh each tick so the page re-renders and the
+                    // #933 escalation card can appear once the wait window elapses.
+                    permissionSnapshot = snapshot
                     let kpGranted = snapshot.keyPath.accessibility.isReady
                     let kaGranted = snapshot.kanata.accessibility.isReady
 
@@ -461,5 +495,40 @@ public struct WizardAccessibilityPage: View {
 
     private func copyKanataEngineAppPathToClipboard() {
         WizardPermissionFinderHelper.copyPathToClipboard()
+    }
+}
+
+// MARK: - Manual fallback guidance (#933)
+
+/// Shown when the automatic Accessibility prompt for KeyPath.app never registers a
+/// grant. Offers the drag-to-authorize helper — opens System Settings and floats a
+/// tile the user drags KeyPath into — instead of leaving them at a "Turn On" button
+/// that appeared to do nothing. Mirrors the Input Monitoring fallback card.
+private struct AccessibilityManualFallbackCard: View {
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Label("Didn't see a permission prompt?", systemImage: "hand.raised.circle")
+                .font(.headline)
+
+            Text(
+                "On some macOS versions the automatic prompt doesn't appear. You can add KeyPath to Accessibility yourself:"
+            )
+            .font(.callout)
+            .foregroundColor(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
+
+            Button("Add KeyPath to Accessibility") {
+                DragToAuthorizeController.shared.present(for: .accessibility, subject: .keyPath)
+            }
+            .buttonStyle(WizardDesign.Component.SecondaryButton())
+            .accessibilityIdentifier("wizard_accessibility_manual_fallback")
+            .padding(.top, 4)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(WizardDesign.Spacing.cardPadding)
+        .background(
+            WizardDesign.Colors.warning.opacity(0.06),
+            in: RoundedRectangle(cornerRadius: WizardDesign.Layout.cornerRadius)
+        )
     }
 }

--- a/Sources/KeyPathInstallationWizard/UI/Pages/WizardFullDiskAccessPage.swift
+++ b/Sources/KeyPathInstallationWizard/UI/Pages/WizardFullDiskAccessPage.swift
@@ -141,6 +141,9 @@ public struct WizardFullDiskAccessPage: View {
 
                 Task { @MainActor in
                     try? await Task.sleep(nanoseconds: 1_500_000_000)
+                    // Only advance if still on this page — the user may have hit Skip
+                    // (which navigates immediately) during the celebration delay.
+                    guard stateMachine.currentPage == .fullDiskAccess else { return }
                     navigateToNextStep()
                 }
             }

--- a/Sources/KeyPathInstallationWizard/UI/Pages/WizardFullDiskAccessPage.swift
+++ b/Sources/KeyPathInstallationWizard/UI/Pages/WizardFullDiskAccessPage.swift
@@ -137,7 +137,9 @@ public struct WizardFullDiskAccessPage: View {
                 showSuccessAnimation = true
                 WizardWindowManager.shared.bounceDocIcon()
                 AppLogger.shared.log("✅ [Wizard] Full Disk Access granted - celebrating + advancing")
-                DragToAuthorizeController.shared.dismiss(animated: true)
+                // Don't force-dismiss the overlay here — it runs its own poll and
+                // plays a ~1.8s success animation, then dismisses itself; cutting it
+                // off would diverge from the AX/IM pages. onDisappear cleans it up.
 
                 Task { @MainActor in
                     try? await Task.sleep(nanoseconds: 1_500_000_000)

--- a/Sources/KeyPathInstallationWizard/UI/Pages/WizardFullDiskAccessPage.swift
+++ b/Sources/KeyPathInstallationWizard/UI/Pages/WizardFullDiskAccessPage.swift
@@ -113,6 +113,14 @@ public struct WizardFullDiskAccessPage: View {
         .wizardDetailPage()
         .onAppear {
             checkFullDiskAccess()
+            // If FDA was already granted before this visit (the Summary row is always
+            // navigable, so the user may have opened this page just to review it),
+            // mark it acknowledged so the onChange handler below does NOT celebrate or
+            // auto-advance — otherwise they'd be navigated off a page they never acted
+            // on. Only a grant that lands *during* the visit should advance.
+            if hasFullDiskAccess {
+                showSuccessAnimation = true
+            }
             startFDAPolling()
         }
         .onDisappear {

--- a/Sources/KeyPathInstallationWizard/UI/Pages/WizardFullDiskAccessPage.swift
+++ b/Sources/KeyPathInstallationWizard/UI/Pages/WizardFullDiskAccessPage.swift
@@ -9,8 +9,11 @@ public struct WizardFullDiskAccessPage: View {
     @State private var showingDetails = false
     @State private var hasCheckedPermission = false
     @State private var hasFullDiskAccess = false
-    @State private var isChecking = false
     @State private var showSuccessAnimation = false
+    /// Durable 1s poll so the page auto-detects a grant and advances, matching the
+    /// Accessibility / Input Monitoring pages (previously FDA only re-checked on
+    /// `didBecomeActive`, so a grant made without leaving the app went unnoticed) (#933).
+    @State private var fdaPollingTask: Task<Void, Never>?
 
     // Cache FDA status to avoid repeated checks
     @State private var lastFDACheckTime: Date?
@@ -88,7 +91,6 @@ public struct WizardFullDiskAccessPage: View {
                     }
                     .buttonStyle(WizardDesign.Component.PrimaryButton())
                     .keyboardShortcut(.defaultAction)
-                    .disabled(!hasFullDiskAccess && isChecking)
                     .accessibilityIdentifier("wizard-fda-primary-button")
 
                     if !hasFullDiskAccess {
@@ -111,6 +113,12 @@ public struct WizardFullDiskAccessPage: View {
         .wizardDetailPage()
         .onAppear {
             checkFullDiskAccess()
+            startFDAPolling()
+        }
+        .onDisappear {
+            fdaPollingTask?.cancel()
+            fdaPollingTask = nil
+            DragToAuthorizeController.shared.dismiss(animated: false)
         }
         .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
             // Re-check FDA when app becomes active (user may have granted it in System Settings)
@@ -124,14 +132,17 @@ public struct WizardFullDiskAccessPage: View {
         }
         .onChange(of: hasFullDiskAccess) { _, newValue in
             if newValue, !showSuccessAnimation {
-                // Permission was just granted!
+                // Permission was just granted — celebrate, then auto-advance so the
+                // FDA page matches the other permission pages (#933).
                 showSuccessAnimation = true
-                // Bounce dock icon to get user's attention back to KeyPath
                 WizardWindowManager.shared.bounceDocIcon()
-                AppLogger.shared.log("✅ [Wizard] Full Disk Access granted - showing success animation")
+                AppLogger.shared.log("✅ [Wizard] Full Disk Access granted - celebrating + advancing")
+                DragToAuthorizeController.shared.dismiss(animated: true)
 
-                // Don't auto-navigate - let user navigate manually
-                // User can use navigation buttons or close dialog
+                Task { @MainActor in
+                    try? await Task.sleep(nanoseconds: 1_500_000_000)
+                    navigateToNextStep()
+                }
             }
         }
     }
@@ -142,7 +153,7 @@ public struct WizardFullDiskAccessPage: View {
         if hasFullDiskAccess {
             navigateToNextStep()
         } else {
-            openSystemSettingsCTA()
+            presentFullDiskAccessOverlay()
         }
     }
 
@@ -168,12 +179,32 @@ public struct WizardFullDiskAccessPage: View {
         }
     }
 
-    private func openSystemSettingsCTA() {
-        guard !isChecking else { return }
-        isChecking = true
-        openFullDiskAccessSettings()
-        // Detection happens automatically via didBecomeActiveNotification when user returns
-        isChecking = false
+    /// Present the drag-to-authorize overlay: opens System Settings → Full Disk
+    /// Access and lets the user drag KeyPath.app into the list. The grant is
+    /// detected by both the overlay's own poll and this page's `fdaPollingTask` (#933).
+    private func presentFullDiskAccessOverlay() {
+        AppLogger.shared.log("🔐 [Wizard] Presenting drag-to-authorize overlay for Full Disk Access")
+        DragToAuthorizeController.shared.present(for: .fullDiskAccess, subject: .keyPath)
+    }
+
+    /// Durable 1s poll mirroring the Accessibility / Input Monitoring pages: keeps
+    /// re-checking FDA while the page is visible so a grant is noticed (and the page
+    /// advances) even when the user grants it without the app losing/regaining focus.
+    private func startFDAPolling() {
+        fdaPollingTask?.cancel()
+        fdaPollingTask = Task { @MainActor in
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: 1_000_000_000)
+                if Task.isCancelled { return }
+                if hasFullDiskAccess { return } // onChange handles celebrate + advance
+                let granted = performFDACheck()
+                if granted {
+                    hasFullDiskAccess = true // triggers onChange → celebrate + advance
+                    WizardDependencies.fullDiskAccessChecker?.updateCachedValue(true)
+                    return
+                }
+            }
+        }
     }
 
     private func checkFullDiskAccess() {
@@ -247,15 +278,6 @@ public struct WizardFullDiskAccessPage: View {
 
         AppLogger.shared.log("❌ [Wizard] FDA not granted - cannot read system TCC database")
         return false
-    }
-
-    private func openFullDiskAccessSettings() {
-        if let url = URL(string: WizardSystemPaths.fullDiskAccessSettings) {
-            if NSWorkspace.shared.open(url) {
-                WizardWindowManager.shared.markSystemSettingsOpened()
-            }
-            AppLogger.shared.log("🔗 [Wizard] Opened Full Disk Access settings")
-        }
     }
 }
 

--- a/Sources/KeyPathInstallationWizard/UI/Pages/WizardInputMonitoringPage.swift
+++ b/Sources/KeyPathInstallationWizard/UI/Pages/WizardInputMonitoringPage.swift
@@ -539,23 +539,27 @@ private struct InputMonitoringManualFallbackCard: View {
                 .font(.headline)
 
             Text(
-                "On some macOS versions the automatic prompt doesn't appear. You can add KeyPath to Input Monitoring yourself:"
+                "On some macOS versions the automatic prompt doesn't appear. Add KeyPath to Input Monitoring below — or do it manually."
             )
             .font(.callout)
             .foregroundColor(.secondary)
             .fixedSize(horizontal: false, vertical: true)
 
+            // Primary: opens Settings and floats a helper you drag KeyPath from,
+            // straight into the Input Monitoring list (#933).
+            Button("Add KeyPath to Input Monitoring") {
+                DragToAuthorizeController.shared.present(for: .inputMonitoring, subject: .keyPath)
+            }
+            .buttonStyle(WizardDesign.Component.SecondaryButton())
+            .accessibilityIdentifier("wizard_input_monitoring_manual_fallback")
+            .padding(.top, 4)
+
+            // Manual alternative for anyone who would rather not drag.
             VStack(alignment: .leading, spacing: 6) {
                 CleanupStep(number: 1, text: "Open System Settings → Privacy & Security → Input Monitoring.")
                 CleanupStep(number: 2, text: "Click the \"+\" button below the list.")
                 CleanupStep(number: 3, text: "Choose KeyPath.app from your Applications folder, then turn its switch on.")
             }
-
-            Button("Open Input Monitoring Settings") {
-                Task { @MainActor in openInputMonitoringPreferencesPanel() }
-            }
-            .buttonStyle(WizardDesign.Component.SecondaryButton())
-            .accessibilityIdentifier("wizard_input_monitoring_manual_fallback")
             .padding(.top, 4)
         }
         .frame(maxWidth: .infinity, alignment: .leading)

--- a/Tests/KeyPathTests/InstallationWizard/DragToAuthorizeGrantResolverTests.swift
+++ b/Tests/KeyPathTests/InstallationWizard/DragToAuthorizeGrantResolverTests.swift
@@ -1,7 +1,6 @@
+@testable import KeyPathInstallationWizard
 import KeyPathPermissions
 @preconcurrency import XCTest
-
-@testable import KeyPathInstallationWizard
 
 /// Covers the pure target×subject → grant mapping used by the drag-to-authorize
 /// overlay (#933). The overlay must poll the correct app's correct permission:

--- a/Tests/KeyPathTests/InstallationWizard/DragToAuthorizeGrantResolverTests.swift
+++ b/Tests/KeyPathTests/InstallationWizard/DragToAuthorizeGrantResolverTests.swift
@@ -1,0 +1,76 @@
+import KeyPathPermissions
+@preconcurrency import XCTest
+
+@testable import KeyPathInstallationWizard
+
+/// Covers the pure target×subject → grant mapping used by the drag-to-authorize
+/// overlay (#933). The overlay must poll the correct app's correct permission:
+/// `.keyPath` reads `snapshot.keyPath`, `.kanata` reads `snapshot.kanata`, and
+/// Full Disk Access comes from the separate FDA signal, not the snapshot.
+final class DragToAuthorizeGrantResolverTests: XCTestCase {
+    private typealias Target = DragToAuthorizeController.PermissionTarget
+    private typealias Subject = DragToAuthorizeController.PermissionSubject
+
+    private func permissionSet(ax: PermissionOracle.Status, im: PermissionOracle.Status)
+        -> PermissionOracle.PermissionSet
+    {
+        PermissionOracle.PermissionSet(
+            accessibility: ax, inputMonitoring: im, source: "test", confidence: .high, timestamp: Date()
+        )
+    }
+
+    private func snapshot(
+        keyPathAX: PermissionOracle.Status = .denied,
+        keyPathIM: PermissionOracle.Status = .denied,
+        kanataAX: PermissionOracle.Status = .denied,
+        kanataIM: PermissionOracle.Status = .denied
+    ) -> PermissionOracle.Snapshot {
+        PermissionOracle.Snapshot(
+            keyPath: permissionSet(ax: keyPathAX, im: keyPathIM),
+            kanata: permissionSet(ax: kanataAX, im: kanataIM),
+            timestamp: Date()
+        )
+    }
+
+    private func resolve(
+        _ target: Target, _ subject: Subject,
+        _ snapshot: PermissionOracle.Snapshot, fda: Bool = false
+    ) -> Bool {
+        DragToAuthorizeController.grantResolved(
+            target: target, subject: subject, snapshot: snapshot, fullDiskAccessGranted: fda
+        )
+    }
+
+    func testAccessibilityReadsTheChosenSubjectsRow() {
+        let snap = snapshot(keyPathAX: .granted, kanataAX: .denied)
+        XCTAssertTrue(resolve(.accessibility, .keyPath, snap))
+        XCTAssertFalse(resolve(.accessibility, .kanata, snap))
+    }
+
+    func testInputMonitoringReadsTheChosenSubjectsRow() {
+        let snap = snapshot(keyPathIM: .denied, kanataIM: .granted)
+        XCTAssertFalse(resolve(.inputMonitoring, .keyPath, snap))
+        XCTAssertTrue(resolve(.inputMonitoring, .kanata, snap))
+    }
+
+    func testTargetSelectsPermissionWithinTheSameSubject() {
+        // KeyPath AX granted but IM denied — target must not cross-read.
+        let snap = snapshot(keyPathAX: .granted, keyPathIM: .denied)
+        XCTAssertTrue(resolve(.accessibility, .keyPath, snap))
+        XCTAssertFalse(resolve(.inputMonitoring, .keyPath, snap))
+    }
+
+    func testNonGrantedStatusesAreNotTreatedAsGranted() {
+        for status in [PermissionOracle.Status.denied, .unknown, .error("x")] {
+            let snap = snapshot(keyPathAX: status)
+            XCTAssertFalse(resolve(.accessibility, .keyPath, snap), "\(status) must not count as granted")
+        }
+    }
+
+    func testFullDiskAccessUsesTheSeparateSignalNotTheSnapshot() {
+        // Snapshot rows are all denied; FDA is driven solely by the passed-in flag.
+        let snap = snapshot()
+        XCTAssertTrue(resolve(.fullDiskAccess, .keyPath, snap, fda: true))
+        XCTAssertFalse(resolve(.fullDiskAccess, .keyPath, snap, fda: false))
+    }
+}


### PR DESCRIPTION
## Summary

Extends the **drag-to-authorize** wizard overlay — previously wired only to the **kanata-launcher** rows on Accessibility + Input Monitoring — to also authorize **KeyPath.app's own** grant, and brings the **Full Disk Access** page up to parity with the other permission pages. Closes #933.

### What changed
- **Parameterize the drag *subject*** (`DragToAuthorizeController`): new `PermissionSubject` (`.keyPath` drags the KeyPath.app bundle and polls `snapshot.keyPath.*`; `.kanata` drags the launcher and polls `snapshot.kanata.*`). Threaded through `present(for:subject:)`, the drag-source file URL, the state model, and the overlay copy. Extracted a **pure, unit-tested** `grantResolved(target:subject:snapshot:fullDiskAccessGranted:)` for the target×subject → PermissionSet mapping (mirrors the #931/#937/#939 resolver pattern).
- **Full Disk Access page**: replaced the `didBecomeActive`-only re-check with a **durable 1s poll + celebrate + auto-advance** (parity with AX/IM — previously a grant made without losing/regaining focus went unnoticed and the page never advanced). "Enable" now presents the drag overlay for KeyPath.app. "Skip" preserved.
- **Input Monitoring page**: the #931 fallback card now offers the **drag helper** for KeyPath.app (keeping the manual "+"-to-add steps as a backup).
- **Accessibility page**: added the same escalation — after the automatic prompt fails to register within the window, offer the drag helper for KeyPath.app. Its grant-poll now refreshes the snapshot each tick so the escalation card can render.

Per the agreed design, the automatic prompt stays the **first** attempt on the KeyPath.app rows; the drag helper is the **escalation** (not a replacement).

## Testing done
- `swift build` clean (native build system, macOS 27 beta).
- New `DragToAuthorizeGrantResolverTests` (5) pass; installer-lane regression **470 tests pass** (includes #939's IM tests).
- swiftformat 0.61.1 clean, no churn.
- Review gate run (8 finder angles + verify). Findings addressed in a follow-up commit:
  - `present()` now calls `markSystemSettingsOpened()` so the wizard closes Settings it opened (fixes a cleanup gap for FDA, and unifies the pre-existing kanata-row behavior).
  - FDA celebration auto-advance guarded to only navigate if still on the FDA page (no double-navigate if Skip is pressed during the 1.5s delay).

## ⚠️ Remaining: on-hardware drag QA
Not yet done in-session — driving a file drag from the floating panel into a System Settings privacy list is hard to automate reliably. Manual QA plan:
1. On an account where KeyPath.app is **not** granted AX/IM (or force via the debug approach used for #939), open the wizard → each of Accessibility, Input Monitoring, Full Disk Access.
2. Verify the overlay tile shows **"KeyPath / Main application"** (not kanata-launcher) for the KeyPath.app rows and on FDA.
3. Drag KeyPath into each list → overlay celebrates, page detects the grant and auto-advances.
4. Confirm the **kanata-launcher** rows still drag the launcher and work unchanged.
5. FDA: grant without leaving the app → page now notices within ~1s and advances.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
