### PR TITLE
Rename guidance resolver (permission-agnostic) + extract FDA advance decision

### DIFF
--- a/Sources/KeyPathInstallationWizard/UI/Pages/WizardAccessibilityPage.swift
+++ b/Sources/KeyPathInstallationWizard/UI/Pages/WizardAccessibilityPage.swift
@@ -325,13 +325,13 @@ public struct WizardAccessibilityPage: View {
         return installationStatus(for: snapshot.kanata.accessibility)
     }
 
-    /// Escalation state for KeyPath.app's own Accessibility grant. Reuses the
-    /// permission-agnostic guidance resolver (its logic is not IM-specific): once
-    /// the automatic-prompt wait window elapses without a grant, the drag-to-authorize
-    /// fallback appears instead of stranding the user at "Turn On" (#933).
-    private var keyPathAccessibilityGuidance: InputMonitoringGuidance {
-        resolveInputMonitoringGuidance(
-            InputMonitoringGuidanceInput(
+    /// Escalation state for KeyPath.app's own Accessibility grant. Uses the shared
+    /// permission-agnostic `AutomaticPromptGuidance` resolver: once the automatic-prompt
+    /// wait window elapses without a grant, the drag-to-authorize fallback appears
+    /// instead of stranding the user at "Turn On" (#933).
+    private var keyPathAccessibilityGuidance: AutomaticPromptGuidance {
+        resolveAutomaticPromptGuidance(
+            AutomaticPromptGuidanceInput(
                 keyPathReady: permissionSnapshot?.keyPath.accessibility.isReady ?? false,
                 requestAttempted: keyPathRequestAttemptedAt != nil,
                 secondsSinceRequest: keyPathRequestAttemptedAt.map { Date().timeIntervalSince($0) }

--- a/Sources/KeyPathInstallationWizard/UI/Pages/WizardFullDiskAccessPage.swift
+++ b/Sources/KeyPathInstallationWizard/UI/Pages/WizardFullDiskAccessPage.swift
@@ -10,6 +10,10 @@ public struct WizardFullDiskAccessPage: View {
     @State private var hasCheckedPermission = false
     @State private var hasFullDiskAccess = false
     @State private var showSuccessAnimation = false
+    /// Whether FDA was already granted when this page appeared. Gates the celebrate +
+    /// auto-advance so a *review visit* to an already-granted page doesn't navigate the
+    /// user off it — only a grant that lands during the visit advances (#933).
+    @State private var wasGrantedOnAppear = false
     /// Durable 1s poll so the page auto-detects a grant and advances, matching the
     /// Accessibility / Input Monitoring pages (previously FDA only re-checked on
     /// `didBecomeActive`, so a grant made without leaving the app went unnoticed) (#933).
@@ -113,14 +117,9 @@ public struct WizardFullDiskAccessPage: View {
         .wizardDetailPage()
         .onAppear {
             checkFullDiskAccess()
-            // If FDA was already granted before this visit (the Summary row is always
-            // navigable, so the user may have opened this page just to review it),
-            // mark it acknowledged so the onChange handler below does NOT celebrate or
-            // auto-advance — otherwise they'd be navigated off a page they never acted
-            // on. Only a grant that lands *during* the visit should advance.
-            if hasFullDiskAccess {
-                showSuccessAnimation = true
-            }
+            // Snapshot the appear-time grant so the onChange handler can tell a fresh
+            // grant (advance) from a review visit to an already-granted page (stay).
+            wasGrantedOnAppear = hasFullDiskAccess
             startFDAPolling()
         }
         .onDisappear {
@@ -139,8 +138,11 @@ public struct WizardFullDiskAccessPage: View {
             FullDiskAccessDetailsSheet()
         }
         .onChange(of: hasFullDiskAccess) { _, newValue in
-            if newValue, !showSuccessAnimation {
-                // Permission was just granted — celebrate, then auto-advance so the
+            let shouldAdvance = shouldAdvanceOnFullDiskAccessGrant(
+                isGrantedNow: newValue, wasGrantedOnAppear: wasGrantedOnAppear
+            )
+            if shouldAdvance, !showSuccessAnimation {
+                // Grant landed during this visit — celebrate, then auto-advance so the
                 // FDA page matches the other permission pages (#933).
                 showSuccessAnimation = true
                 WizardWindowManager.shared.bounceDocIcon()

--- a/Sources/KeyPathInstallationWizard/UI/Pages/WizardInputMonitoringPage.swift
+++ b/Sources/KeyPathInstallationWizard/UI/Pages/WizardInputMonitoringPage.swift
@@ -278,9 +278,9 @@ public struct WizardInputMonitoringPage: View {
     /// on every render (the 1s poll updates `permissionSnapshot`), so once the
     /// automatic-prompt wait window elapses without a grant the manual-add card
     /// appears instead of leaving the user stranded at the "Turn On" button (#931).
-    private var keyPathGuidance: InputMonitoringGuidance {
-        resolveInputMonitoringGuidance(
-            InputMonitoringGuidanceInput(
+    private var keyPathGuidance: AutomaticPromptGuidance {
+        resolveAutomaticPromptGuidance(
+            AutomaticPromptGuidanceInput(
                 keyPathReady: permissionSnapshot?.keyPath.inputMonitoring.isReady ?? false,
                 requestAttempted: keyPathRequestAttemptedAt != nil,
                 secondsSinceRequest: keyPathRequestAttemptedAt.map { Date().timeIntervalSince($0) }

--- a/Sources/KeyPathWizardCore/AutomaticPromptGuidance.swift
+++ b/Sources/KeyPathWizardCore/AutomaticPromptGuidance.swift
@@ -1,22 +1,26 @@
 import Foundation
 
-/// Pure decision logic for the guidance the Input Monitoring wizard page should
-/// present for **KeyPath.app's own** Input Monitoring grant. Extracted so the
-/// escalation behavior can be unit-tested without a running UI (mirrors the pure
-/// resolvers added for the Oracle signal in #931/#937).
+/// Pure decision logic for how a wizard permission page should guide **KeyPath.app's
+/// own** grant of a permission it can request via an automatic system prompt
+/// (Input Monitoring via `IOHIDRequestAccess`, Accessibility via the AX prompt).
+/// Extracted so the escalation behavior can be unit-tested without a running UI
+/// (mirrors the pure resolvers added for the Oracle signal in #931/#937).
 ///
-/// Background (#931): clicking "Turn On" fires `IOHIDRequestAccess`, but on
+/// The logic is permission-agnostic — it only reasons about "is it granted", "was
+/// the automatic prompt attempted", and "how long ago" — so a single resolver backs
+/// both the Input Monitoring and Accessibility pages (#933).
+///
+/// Background (#931): clicking "Turn On" fires the automatic prompt, but on
 /// macOS 26/27 tccd can silently produce nothing — no system prompt, no TCC row,
-/// and the app never appears in the Input Monitoring list. The page used to leave
-/// a bare "Turn On" button pointing at a Settings entry that does not exist, so a
-/// fresh install dead-ended here at `unknown`/`denied` with no accurate guidance.
+/// and the app never appears in the privacy list. The page used to leave a bare
+/// "Turn On" button pointing at a Settings entry that does not exist, so a fresh
+/// install dead-ended at `unknown`/`denied` with no accurate guidance.
 ///
 /// This resolver drives an escalation: try the automatic prompt first, and if the
 /// grant has not landed within a short wait window, switch to explicit manual
-/// "add it yourself in System Settings" instructions so the user is never
-/// stranded.
-public enum InputMonitoringGuidance: Equatable, Sendable {
-    /// KeyPath.app already has Input Monitoring — no guidance needed.
+/// "add it yourself in System Settings" guidance so the user is never stranded.
+public enum AutomaticPromptGuidance: Equatable, Sendable {
+    /// KeyPath.app already has the permission — no guidance needed.
     case granted
     /// No automatic request has been attempted yet — offer the one-click "Turn On".
     case offerAutomatic
@@ -24,23 +28,23 @@ public enum InputMonitoringGuidance: Equatable, Sendable {
     /// a transient "waiting for the grant to register" state, not a dead-end.
     case awaitingGrant
     /// The automatic request did not register within the wait window — show
-    /// explicit manual instructions so the user is never stranded (#931).
+    /// explicit manual guidance so the user is never stranded (#931).
     case manualFallback
 }
 
-/// Inputs for `resolveInputMonitoringGuidance`. All fields describe KeyPath.app's
-/// own Input Monitoring state and the automatic-prompt attempt against it.
-public struct InputMonitoringGuidanceInput: Equatable, Sendable {
-    /// Whether KeyPath.app's own Input Monitoring is granted (Oracle `isReady`).
+/// Inputs for `resolveAutomaticPromptGuidance`. All fields describe KeyPath.app's
+/// own state for one permission and the automatic-prompt attempt against it.
+public struct AutomaticPromptGuidanceInput: Equatable, Sendable {
+    /// Whether KeyPath.app's own permission is granted (Oracle `isReady`).
     public var keyPathReady: Bool
-    /// Whether the user has triggered the automatic `IOHIDRequestAccess` prompt.
+    /// Whether the user has triggered the automatic system prompt.
     public var requestAttempted: Bool
     /// Seconds elapsed since the most recent automatic request, or nil if none /
     /// unknown. `nil` while `requestAttempted` is true is treated as "elapsed".
     public var secondsSinceRequest: TimeInterval?
     /// How long to wait for an automatic grant before escalating to manual steps.
     ///
-    /// Tuned to outlast a *working* system prompt: when `IOHIDRequestAccess` does
+    /// Tuned to outlast a *working* system prompt: when the automatic request does
     /// show the macOS dialog, a first-run user often takes several seconds to read
     /// and click "Allow". The window must be long enough that we don't flash
     /// "Didn't see a prompt?" while that real dialog is still on screen, yet short
@@ -61,16 +65,16 @@ public struct InputMonitoringGuidanceInput: Equatable, Sendable {
     }
 }
 
-/// Resolve what the Input Monitoring page should show for KeyPath.app's own grant.
+/// Resolve what a permission page should show for KeyPath.app's own grant.
 ///
 /// - A granted app short-circuits to `.granted` regardless of any prior attempt.
 /// - Before any attempt, the automatic one-click path is offered.
 /// - After an attempt we allow a brief window for the grant to register before
 ///   escalating to manual instructions, so a normally-working prompt isn't
 ///   immediately buried under fallback copy.
-public func resolveInputMonitoringGuidance(
-    _ input: InputMonitoringGuidanceInput
-) -> InputMonitoringGuidance {
+public func resolveAutomaticPromptGuidance(
+    _ input: AutomaticPromptGuidanceInput
+) -> AutomaticPromptGuidance {
     if input.keyPathReady {
         return .granted
     }

--- a/Sources/KeyPathWizardCore/FullDiskAccessAdvance.swift
+++ b/Sources/KeyPathWizardCore/FullDiskAccessAdvance.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+/// Whether a Full Disk Access state observed on the FDA wizard page should trigger
+/// its celebrate + auto-advance flow.
+///
+/// Only a grant that lands **during** the visit advances. A grant that was already
+/// in place when the page appeared is a *review visit* — the Summary row is always
+/// navigable, so the user may open the page just to look at it — and must NOT
+/// navigate them off a page they never acted on (the bug fixed in #933).
+///
+/// Extracted as a pure function so this "should I auto-advance" decision is unit
+/// testable independent of the view's `@State`, timers, and `onChange` plumbing.
+///
+/// - Parameters:
+///   - isGrantedNow: the freshly-observed FDA state (`hasFullDiskAccess`).
+///   - wasGrantedOnAppear: whether FDA was already granted when the page appeared.
+public func shouldAdvanceOnFullDiskAccessGrant(
+    isGrantedNow: Bool,
+    wasGrantedOnAppear: Bool
+) -> Bool {
+    isGrantedNow && !wasGrantedOnAppear
+}

--- a/Tests/KeyPathTests/AutomaticPromptGuidanceTests.swift
+++ b/Tests/KeyPathTests/AutomaticPromptGuidanceTests.swift
@@ -1,19 +1,20 @@
 import KeyPathWizardCore
 @preconcurrency import XCTest
 
-/// Covers the Input Monitoring wizard escalation logic (#931): the page must
-/// never sit at an unresolved grant without guidance. The pure resolver decides
-/// when to offer the automatic prompt, when to keep waiting, and when to fall
-/// back to explicit manual instructions.
-final class InputMonitoringGuidanceTests: XCTestCase {
+/// Covers the shared automatic-prompt escalation logic (#931/#933): a permission
+/// page must never sit at an unresolved grant without guidance. The pure resolver
+/// decides when to offer the automatic prompt, when to keep waiting, and when to
+/// fall back to explicit manual instructions — the same logic backs both the Input
+/// Monitoring and Accessibility pages.
+final class AutomaticPromptGuidanceTests: XCTestCase {
     private func resolve(
         keyPathReady: Bool,
         requestAttempted: Bool,
         secondsSinceRequest: TimeInterval?,
         waitWindow: TimeInterval = 6
-    ) -> InputMonitoringGuidance {
-        resolveInputMonitoringGuidance(
-            InputMonitoringGuidanceInput(
+    ) -> AutomaticPromptGuidance {
+        resolveAutomaticPromptGuidance(
+            AutomaticPromptGuidanceInput(
                 keyPathReady: keyPathReady,
                 requestAttempted: requestAttempted,
                 secondsSinceRequest: secondsSinceRequest,
@@ -56,15 +57,15 @@ final class InputMonitoringGuidanceTests: XCTestCase {
     }
 
     func testProductionDefaultWaitWindowIsTwelveSeconds() {
-        // The page relies on the init default (it never passes waitWindow), so the
+        // The pages rely on the init default (they never pass waitWindow), so the
         // shipped escalation timing is locked in here: still waiting at 11s so a
         // real system dialog isn't contradicted, escalated by 12s (#931, review obs).
-        let stillWaiting = resolveInputMonitoringGuidance(
-            InputMonitoringGuidanceInput(keyPathReady: false, requestAttempted: true, secondsSinceRequest: 11)
+        let stillWaiting = resolveAutomaticPromptGuidance(
+            AutomaticPromptGuidanceInput(keyPathReady: false, requestAttempted: true, secondsSinceRequest: 11)
         )
         XCTAssertEqual(stillWaiting, .awaitingGrant)
-        let escalated = resolveInputMonitoringGuidance(
-            InputMonitoringGuidanceInput(keyPathReady: false, requestAttempted: true, secondsSinceRequest: 12)
+        let escalated = resolveAutomaticPromptGuidance(
+            AutomaticPromptGuidanceInput(keyPathReady: false, requestAttempted: true, secondsSinceRequest: 12)
         )
         XCTAssertEqual(escalated, .manualFallback)
     }

--- a/Tests/KeyPathTests/InstallationWizard/FullDiskAccessAdvanceTests.swift
+++ b/Tests/KeyPathTests/InstallationWizard/FullDiskAccessAdvanceTests.swift
@@ -1,0 +1,23 @@
+import KeyPathWizardCore
+@preconcurrency import XCTest
+
+/// Covers the FDA page's "should I auto-advance" decision (#933). The page must
+/// advance only on a grant that lands *during* the visit — never on a review visit
+/// to an already-granted page (the regression this guard fixes).
+final class FullDiskAccessAdvanceTests: XCTestCase {
+    func testFreshGrantDuringVisitAdvances() {
+        // Not granted on appear, granted now → the user just enabled it → advance.
+        XCTAssertTrue(shouldAdvanceOnFullDiskAccessGrant(isGrantedNow: true, wasGrantedOnAppear: false))
+    }
+
+    func testReviewVisitToAlreadyGrantedPageDoesNotAdvance() {
+        // Granted before the visit → the user only opened the page to review it →
+        // must NOT navigate them away.
+        XCTAssertFalse(shouldAdvanceOnFullDiskAccessGrant(isGrantedNow: true, wasGrantedOnAppear: true))
+    }
+
+    func testNotGrantedNeverAdvances() {
+        XCTAssertFalse(shouldAdvanceOnFullDiskAccessGrant(isGrantedNow: false, wasGrantedOnAppear: false))
+        XCTAssertFalse(shouldAdvanceOnFullDiskAccessGrant(isGrantedNow: false, wasGrantedOnAppear: true))
+    }
+}


### PR DESCRIPTION
## Summary

Two non-behavioral follow-ups flagged in the #933 review (both reviewers + the PR bot):

### 1. Rename `InputMonitoringGuidance` → `AutomaticPromptGuidance`
Since #933 this resolver has gated **both** the Input Monitoring and Accessibility pages' escalation, so the IM-specific name read as a misnomer at the AX call site. Pure mechanical rename — enum, `…Input` struct, `resolve…` function, the source file, and the test file — with the doc comments generalized to be permission-agnostic. The resolver logic is byte-for-byte unchanged.

### 2. Extract the FDA auto-advance decision into a pure, testable function
The FDA page's "should this grant auto-advance?" decision — the exact spot the #933 review caught a regression (advancing on a *review visit* to an already-granted page) — is now a pure `shouldAdvanceOnFullDiskAccessGrant(isGrantedNow:wasGrantedOnAppear:)` in `KeyPathWizardCore`, unit-tested independent of the view's timers. The page now snapshots `wasGrantedOnAppear` explicitly instead of the previous `showSuccessAnimation`-on-appear trick. Behavior is identical (review visit → stay; grant during visit → celebrate + advance).

## Testing
- `swift build` clean (native, macOS 27).
- `AutomaticPromptGuidanceTests` (8, renamed) + `FullDiskAccessAdvanceTests` (3, new) + `DragToAuthorizeGrantResolverTests` (5) all pass.
- swiftformat 0.61.1 clean, swiftlint scoped, no churn.
- Review gate run — no findings (mechanical rename with unchanged logic + a trivially-correct, tested pure function).

No user-facing behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
