### PR TITLE
Wire Leader Key picker through the CLI apply path (#889)

### DIFF
--- a/Scripts/qa-leader-key-smoke.sh
+++ b/Scripts/qa-leader-key-smoke.sh
@@ -46,22 +46,27 @@ PY
 
 smoke_init
 
-# Partial fix (issue #889): the in-process app/daemon load paths
-# (RuleCollectionsManager.bootstrap / replaceCollections) now reconcile the
-# system leaderKeyPreference from the Leader Key collection's selectedOutput.
-# This script drives the standalone `keypath-cli config apply`, which generates
-# config via ConfigFacade → ConfigurationService — it reads leaderKeyPreference
-# directly and never constructs a RuleCollectionsManager, so from the CLI the
-# collection's selectedOutput is still display-only (setting it to tab here
-# still emits the leaderKeyPreference default). Unifying config generation on
-# the collection as the single source of truth is deferred to #865/#888.
-# These cases assert apply-success per preset, which still kanata-validates the
-# full config for each value.
+# Issue #889: the standalone `keypath-cli config apply` path now reconciles the
+# leader key from the Leader Key collection's selectedOutput. Previously it read
+# leaderKeyPreference directly (via ConfigFacade → ConfigurationService) and never
+# constructed a RuleCollectionsManager, so the picker was display-only from the CLI.
+# ConfigFacade.applyConfiguration now reconciles both the leaderKeyPreference and the
+# base→nav leader activator before generating config (LeaderKeyPreference.reconciled /
+# .reconcileLeaderActivators), so each preset drives its own leader binding.
+#
+# The generated config annotates the primary leader with a "Primary Leader Key
+# (System Preference)" block whose activator renders as ";; Input: <key>". We assert
+# the reconciled key drives that binding for each preset.
+#
+# NOTE: still deferred to #865/#888 — a headless edit that *disables* a previously
+# reconciled collection leaves leaderKeyPreference stale (disable-drift), and full
+# single-source-of-truth generation from the collection.
 for preset in space caps tab grv; do
   echo "==> preset: $preset"
   apply_leader "$preset"
   config="$(show_config)"
   assert_contains "$config" "Leader Key" "preset $preset config includes the Leader Key collection"
+  assert_contains "$config" ";; Input: $preset" "preset $preset drives its own leader binding (#889)"
 done
 
-echo "Leader Key smoke passed (all 4 presets apply kanata-clean). Restoring original KeyPath config."
+echo "Leader Key smoke passed (all 4 presets drive their own CLI-generated leader binding). Restoring original KeyPath config."

--- a/Sources/KeyPathAppKit/CLI/ConfigFacade.swift
+++ b/Sources/KeyPathAppKit/CLI/ConfigFacade.swift
@@ -58,14 +58,41 @@ public struct ConfigFacade: Sendable {
         let customRules = await customRuleLoader()
         let enabledCount = collections.filter(\.isEnabled).count
 
+        // Reconcile the leader key from the Leader Key collection's explicit `selectedOutput`
+        // before generating config. Config generation (ConfigurationService →
+        // KanataConfiguration) derives the primary leader binding from `leaderKeyPreference`
+        // AND emits a `;; Input:` binding per collection activator — the standalone CLI kept
+        // neither in sync with the collection, so `keypath collection`/JSON edits to
+        // `selectedOutput` were silently ignored by `keypath apply`. Reconcile both, mirroring
+        // the in-process reconcile the app does on load (RuleCollectionsManager). See #889.
+        let reconcile = await applyReconciledLeaderKeyPreference(from: collections)
+        let reconciledCollections = reconcile.map { r in
+            LeaderKeyPreference.reconcileLeaderActivators(
+                in: collections,
+                key: r.reconciled.key,
+                targetLayer: r.reconciled.targetLayer
+            )
+        } ?? collections
+        let leaderSnapshot = reconcile?.previous
+
         let service = await MainActor.run { ConfigurationService(configDirectory: configDirectory) }
 
         if dryRun {
-            let previewConfig = try await service.generateConfiguration(
-                ruleCollections: collections,
-                customRules: customRules
-            )
-            try await validateDryRunConfig(previewConfig.content)
+            // A dry run must not persist the reconciled preference. Generation reads the live
+            // shared preference, so we generate/validate against the reconciled value and then
+            // always restore the original — including when generation/validation throws
+            // (e.g. a mapping conflict) so a failed preview never leaves the store mutated.
+            do {
+                let previewConfig = try await service.generateConfiguration(
+                    ruleCollections: reconciledCollections,
+                    customRules: customRules
+                )
+                try await validateDryRunConfig(previewConfig.content)
+            } catch {
+                await restoreLeaderKeyPreference(leaderSnapshot)
+                throw error
+            }
+            await restoreLeaderKeyPreference(leaderSnapshot)
 
             return CLIApplyResult(
                 collectionsCount: collections.count,
@@ -78,7 +105,7 @@ public struct ConfigFacade: Sendable {
         }
 
         try await service.saveConfiguration(
-            ruleCollections: collections,
+            ruleCollections: reconciledCollections,
             customRules: customRules
         )
 
@@ -95,6 +122,37 @@ public struct ConfigFacade: Sendable {
             reloadSuccess: reloadSuccess,
             changeset: changeset(collections: collections, customRules: customRules)
         )
+    }
+
+    private struct LeaderReconcile {
+        let reconciled: LeaderKeyPreference
+        let previous: LeaderKeyPreference
+    }
+
+    /// Sync `PreferencesService.leaderKeyPreference` from the enabled Leader Key collection's
+    /// explicit `selectedOutput` (see `LeaderKeyPreference.reconciled`), returning both the
+    /// reconciled value (so the caller can rewrite the matching leader activators without
+    /// re-reading shared state) and the pre-reconcile `previous` (so a dry run can restore it).
+    /// On a real apply the caller keeps the reconciled value in place so it drives the generated
+    /// config and future reads, matching what the app does on load. Returns `nil` when nothing
+    /// changed.
+    @MainActor
+    private func applyReconciledLeaderKeyPreference(from collections: [RuleCollection]) -> LeaderReconcile? {
+        let current = PreferencesService.shared.leaderKeyPreference
+        guard let reconciled = LeaderKeyPreference.reconciled(from: collections, current: current) else {
+            return nil
+        }
+        AppLogger.shared.log(
+            "🔑 [ConfigFacade] Reconciling leader key from collection selectedOutput: '\(reconciled.key)' (was '\(current.key)')"
+        )
+        PreferencesService.shared.leaderKeyPreference = reconciled
+        return LeaderReconcile(reconciled: reconciled, previous: current)
+    }
+
+    @MainActor
+    private func restoreLeaderKeyPreference(_ snapshot: LeaderKeyPreference?) {
+        guard let snapshot else { return }
+        PreferencesService.shared.leaderKeyPreference = snapshot
     }
 
     // MARK: - Backup / Restore

--- a/Sources/KeyPathAppKit/Models/LeaderKeyPreference.swift
+++ b/Sources/KeyPathAppKit/Models/LeaderKeyPreference.swift
@@ -26,3 +26,78 @@ public struct LeaderKeyPreference: Codable, Equatable, Sendable {
         self.enabled = enabled
     }
 }
+
+public extension LeaderKeyPreference {
+    /// Derive the leader-key preference implied by the enabled Leader Key collection's
+    /// explicit `selectedOutput`, or `nil` if the collection expresses no opinion.
+    ///
+    /// This is the single, pure statement of the reconcile rule that keeps the collection
+    /// (`selectedOutput`) and the system `leaderKeyPreference` in agreement. It is shared by:
+    ///
+    /// - the in-process load paths (`RuleCollectionsManager.bootstrap`/`replaceCollections`),
+    ///   which mutate `PreferencesService` and the base→nav activators, and
+    /// - the standalone CLI apply path (`ConfigFacade.applyConfiguration`), which reads
+    ///   `leaderKeyPreference` directly when generating config and never constructs a
+    ///   `RuleCollectionsManager`. Without this, `keypath collection` mutations / direct
+    ///   `RuleCollections.json` edits to `selectedOutput` were silently ignored by
+    ///   `keypath apply` (issue #889).
+    ///
+    /// Guardrails (mirroring `RuleCollectionsManager.reconcileLeaderKeyFromCollection`):
+    /// - Only an *explicit* `selectedOutput` reconciles. A `nil` `selectedOutput` means the
+    ///   collection has no opinion, so a leader configured via the system-preference path is
+    ///   left untouched (no fallback to the first preset).
+    /// - A disabled collection does not reconcile — forcing it disabled here would clobber a
+    ///   leader configured via the system-preference path while the collection is off. Full
+    ///   bidirectional (disable-drift) reconciliation is deferred to #865/#888.
+    ///
+    /// - Returns: the reconciled preference (key set from `selectedOutput`, `enabled = true`),
+    ///   or `nil` when there is nothing to change (no collection, disabled, no explicit output,
+    ///   or the preference already matches).
+    static func reconciled(
+        from collections: [RuleCollection],
+        current: LeaderKeyPreference
+    ) -> LeaderKeyPreference? {
+        guard let leaderCollection = collections.first(where: { $0.id == RuleCollectionIdentifier.leaderKey }),
+              leaderCollection.isEnabled,
+              let key = leaderCollection.configuration.singleKeyPickerConfig?.selectedOutput
+        else { return nil }
+
+        guard current.key != key || !current.enabled else { return nil }
+
+        var reconciled = current
+        reconciled.key = key
+        reconciled.enabled = true
+        return reconciled
+    }
+
+    /// Rewrite the input of only the *leader* activators in `collections` — those transitioning
+    /// from the base layer into the leader's `targetLayer` (e.g. base → nav) — to `key`.
+    ///
+    /// This deliberately leaves unrelated base-layer activators alone (e.g. Home Row Arrows on
+    /// "f", Quick Launcher on "hyper") and chained sub-layer activators (`sourceLayer != .base`),
+    /// which have their own activation keys. It mirrors
+    /// `RuleCollectionsManager.applyLeaderKeyToLeaderActivators` so the CLI apply path produces a
+    /// config identical to the in-process reconcile. Rewriting the leader activator (not just the
+    /// system preference) matters because config rendering emits a `;; Input:` binding annotation
+    /// per collection activator; leaving the Leader Key collection's activator on the stale key
+    /// would keep the old binding in the generated config. See issue #889.
+    static func reconcileLeaderActivators(
+        in collections: [RuleCollection],
+        key: String,
+        targetLayer: RuleCollectionLayer
+    ) -> [RuleCollection] {
+        collections.map { collection in
+            guard let activator = collection.momentaryActivator,
+                  activator.sourceLayer == .base,
+                  activator.targetLayer == targetLayer
+            else { return collection }
+            var updated = collection
+            updated.momentaryActivator = MomentaryActivator(
+                input: key,
+                targetLayer: activator.targetLayer,
+                sourceLayer: activator.sourceLayer
+            )
+            return updated
+        }
+    }
+}

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+PublicAPI.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+PublicAPI.swift
@@ -780,20 +780,22 @@ extension RuleCollectionsManager {
     /// unrelated features (and, for Quick Launcher's "hyper", collide two base-layer
     /// bindings onto the same key). See issue #889.
     private func applyLeaderKeyToLeaderActivators(_ newKey: String, targetLayer: RuleCollectionLayer) {
-        for index in ruleCollections.indices {
-            guard let activator = ruleCollections[index].momentaryActivator,
-                  activator.sourceLayer == .base,
-                  activator.targetLayer == targetLayer
-            else { continue }
-            ruleCollections[index].momentaryActivator = MomentaryActivator(
-                input: newKey,
-                targetLayer: activator.targetLayer,
-                sourceLayer: activator.sourceLayer
-            )
+        // Shared pure transform (same one the CLI apply path uses) keeps the two reconcile
+        // sites in agreement. Logging stays here for the in-process load-path trace.
+        for index in ruleCollections.indices
+            where ruleCollections[index].momentaryActivator.map({
+                $0.sourceLayer == .base && $0.targetLayer == targetLayer
+            }) == true
+        {
             AppLogger.shared.log(
                 "🔑 [RuleCollections] Reconciled leader activator on '\(ruleCollections[index].name)' to '\(newKey)'"
             )
         }
+        ruleCollections = LeaderKeyPreference.reconcileLeaderActivators(
+            in: ruleCollections,
+            key: newKey,
+            targetLayer: targetLayer
+        )
     }
 
     private func leaderKeyOutput(from collection: RuleCollection) -> String? {
@@ -821,11 +823,11 @@ extension RuleCollectionsManager {
     /// reconciles the preference so a subsequent app/daemon config regen honors the
     /// edited collection. See issue #889.
     ///
-    /// NOT covered: the standalone `keypath-cli config apply` path generates config via
-    /// `ConfigFacade` → `ConfigurationService`, which reads `leaderKeyPreference`
-    /// directly and never constructs a `RuleCollectionsManager` — so this reconcile does
-    /// not run there. Unifying config generation on the collection is deferred to
-    /// #865/#888.
+    /// The standalone `keypath-cli config apply` path runs the equivalent reconcile in
+    /// `ConfigFacade.applyConfiguration` (it never constructs a `RuleCollectionsManager`),
+    /// sharing the pure rule in `LeaderKeyPreference.reconciled(from:current:)` /
+    /// `.reconcileLeaderActivators(in:key:targetLayer:)`. Unifying config *generation* on the
+    /// collection as the single source of truth is still deferred to #865/#888.
     ///
     /// Only an *explicit* `selectedOutput` reconciles — a nil `selectedOutput` means the
     /// collection expresses no opinion, so a leader key configured via the system
@@ -842,19 +844,18 @@ extension RuleCollectionsManager {
     ///   if it was a no-op.
     @discardableResult
     func reconcileLeaderKeyFromCollection() -> Bool {
-        guard let leaderCollection = ruleCollections.first(where: { $0.id == RuleCollectionIdentifier.leaderKey }),
-              leaderCollection.isEnabled,
-              let key = leaderCollection.configuration.singleKeyPickerConfig?.selectedOutput
-        else { return false }
-
         let current = PreferencesService.shared.leaderKeyPreference
-        guard current.key != key || !current.enabled else { return false }
+        // Shared, pure reconcile rule — same statement the CLI apply path uses
+        // (ConfigFacade), so all headless paths agree. See LeaderKeyPreference.reconciled.
+        guard let reconciled = LeaderKeyPreference.reconciled(from: ruleCollections, current: current) else {
+            return false
+        }
 
         AppLogger.shared.log(
-            "🔑 [RuleCollections] Reconciling leader key from collection selectedOutput: '\(key)' (was '\(current.key)', enabled=\(current.enabled))"
+            "🔑 [RuleCollections] Reconciling leader key from collection selectedOutput: '\(reconciled.key)' (was '\(current.key)', enabled=\(current.enabled))"
         )
-        applyLeaderKeyToLeaderActivators(key, targetLayer: current.targetLayer)
-        syncLeaderKeyPreference(key: key, enabled: true)
+        applyLeaderKeyToLeaderActivators(reconciled.key, targetLayer: current.targetLayer)
+        syncLeaderKeyPreference(key: reconciled.key, enabled: true)
         return true
     }
 

--- a/Tests/KeyPathTests/CLI/ConfigFacadeTests.swift
+++ b/Tests/KeyPathTests/CLI/ConfigFacadeTests.swift
@@ -166,6 +166,102 @@ final class ConfigFacadeTests: XCTestCase {
         XCTAssertEqual(activeItems, ["keypath.kbd"])
     }
 
+    // MARK: - #889: CLI apply must honor the Leader Key collection's selectedOutput
+
+    /// Builds the default catalog with the Leader Key collection enabled and its
+    /// `selectedOutput` set to `key` — mirrors a headless `keypath collection` / JSON edit.
+    private func leaderKeyCollections(selectedOutput key: String) -> [RuleCollection] {
+        RuleCollectionCatalog().defaultCollections().map { collection -> RuleCollection in
+            var collection = collection
+            if collection.id == RuleCollectionIdentifier.leaderKey {
+                collection.isEnabled = true
+                collection.configuration.updateSelectedOutput(key)
+            }
+            return collection
+        }
+    }
+
+    /// Issue #889: the standalone `keypath apply` path generates config via ConfigFacade →
+    /// ConfigurationService, which derives the primary leader binding from
+    /// `leaderKeyPreference`. A headless mutation of the Leader Key collection's
+    /// `selectedOutput` never touched that preference, so the generated config silently kept
+    /// the old leader key. Applying must now reconcile the preference from the collection.
+    @MainActor
+    func testApplyConfigurationReconcilesLeaderKeyFromSelectedOutput() async throws {
+        let configDirectory = tempRoot.appendingPathComponent("config", isDirectory: true)
+        try FileManager.default.createDirectory(at: configDirectory, withIntermediateDirectories: true)
+
+        // Preference starts at the default ("space"); the loaded collection asks for "tab".
+        PreferencesService.shared.leaderKeyPreference = .default
+        defer { PreferencesService.shared.leaderKeyPreference = .default }
+
+        let collections = leaderKeyCollections(selectedOutput: "tab")
+        let facade = ConfigFacade(
+            configDirectory: configDirectory.path,
+            ruleCollectionLoader: { collections },
+            customRuleLoader: { [] },
+            reloadHandler: { true }
+        )
+
+        _ = try await facade.applyConfiguration(dryRun: false)
+
+        XCTAssertEqual(
+            PreferencesService.shared.leaderKeyPreference.key, "tab",
+            "CLI apply should reconcile leaderKeyPreference from the collection's selectedOutput (#889)"
+        )
+        XCTAssertTrue(PreferencesService.shared.leaderKeyPreference.enabled)
+
+        // The generated config on disk must reflect the reconciled leader key in the
+        // Primary Leader Key block, not the stale default. The leader block is annotated with
+        // a unique "Primary Leader Key (System Preference)" header followed by ";; Input: <key>".
+        let configFile = configDirectory.appendingPathComponent("keypath.kbd")
+        let generated = try String(contentsOf: configFile, encoding: .utf8)
+        XCTAssertTrue(
+            generated.contains("Primary Leader Key (System Preference)"),
+            "An enabled leader key should emit a Primary Leader Key block"
+        )
+        XCTAssertTrue(
+            generated.contains(";; Input: tab"),
+            "Leader block should bind the reconciled leader key 'tab'"
+        )
+        XCTAssertFalse(
+            generated.contains(";; Input: space"),
+            "Leader block must not retain the stale default leader key 'space'"
+        )
+    }
+
+    /// Issue #889: a dry run previews the reconciled config but must not persist the
+    /// reconciled `leaderKeyPreference` — the store is restored afterward.
+    @MainActor
+    func testApplyConfigurationDryRunDoesNotPersistReconciledLeaderKey() async throws {
+        let configDirectory = tempRoot.appendingPathComponent("config", isDirectory: true)
+        try FileManager.default.createDirectory(at: configDirectory, withIntermediateDirectories: true)
+
+        PreferencesService.shared.leaderKeyPreference = .default
+        defer { PreferencesService.shared.leaderKeyPreference = .default }
+
+        let collections = leaderKeyCollections(selectedOutput: "tab")
+        let facade = ConfigFacade(
+            configDirectory: configDirectory.path,
+            ruleCollectionLoader: { collections },
+            customRuleLoader: { [] },
+            reloadHandler: { true }
+        )
+
+        let result = try await facade.applyConfiguration(dryRun: true)
+
+        XCTAssertEqual(result.dryRun, true)
+        XCTAssertEqual(
+            PreferencesService.shared.leaderKeyPreference.key, "space",
+            "A dry run must not persist the reconciled leader-key preference"
+        )
+        // And it must not write the active config.
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: configDirectory.appendingPathComponent("keypath.kbd").path),
+            "Dry run must not write the active config file"
+        )
+    }
+
     private func createSymlinkedConfig(link: URL, target: URL) throws {
         try FileManager.default.createDirectory(at: target, withIntermediateDirectories: true)
         try FileManager.default.createDirectory(

--- a/Tests/KeyPathTests/Models/LeaderKeyPreferenceReconcileTests.swift
+++ b/Tests/KeyPathTests/Models/LeaderKeyPreferenceReconcileTests.swift
@@ -1,0 +1,78 @@
+@testable import KeyPathAppKit
+import XCTest
+
+/// Unit tests for the pure `LeaderKeyPreference.reconciled(from:current:)` rule (#889).
+///
+/// This is the single, shared statement of the reconcile logic used by both the in-process
+/// load paths (`RuleCollectionsManager`) and the standalone CLI apply path (`ConfigFacade`).
+/// Testing it directly (no manager, no I/O) locks the rule in one place.
+final class LeaderKeyPreferenceReconcileTests: XCTestCase {
+    private func leaderCollections(enabled: Bool, selectedOutput: String?) -> [RuleCollection] {
+        RuleCollectionCatalog().defaultCollections().map { collection -> RuleCollection in
+            var collection = collection
+            if collection.id == RuleCollectionIdentifier.leaderKey {
+                collection.isEnabled = enabled
+                if let selectedOutput {
+                    collection.configuration.updateSelectedOutput(selectedOutput)
+                } else if var config = collection.configuration.singleKeyPickerConfig {
+                    config.selectedOutput = nil
+                    collection.configuration = .singleKeyPicker(config)
+                }
+            }
+            return collection
+        }
+    }
+
+    func testReconcilesFromExplicitSelectedOutput() {
+        let current = LeaderKeyPreference.default // key "space"
+        let reconciled = LeaderKeyPreference.reconciled(
+            from: leaderCollections(enabled: true, selectedOutput: "tab"),
+            current: current
+        )
+        XCTAssertEqual(reconciled?.key, "tab")
+        XCTAssertEqual(reconciled?.enabled, true)
+        XCTAssertEqual(reconciled?.targetLayer, current.targetLayer, "target layer is preserved")
+    }
+
+    func testNoOpWhenPreferenceAlreadyMatches() {
+        let current = LeaderKeyPreference(key: "tab", targetLayer: .navigation, enabled: true)
+        XCTAssertNil(
+            LeaderKeyPreference.reconciled(
+                from: leaderCollections(enabled: true, selectedOutput: "tab"),
+                current: current
+            ),
+            "already-matching preference should not reconcile"
+        )
+    }
+
+    func testReconcilesWhenPreferenceMatchesKeyButIsDisabled() {
+        let current = LeaderKeyPreference(key: "tab", targetLayer: .navigation, enabled: false)
+        let reconciled = LeaderKeyPreference.reconciled(
+            from: leaderCollections(enabled: true, selectedOutput: "tab"),
+            current: current
+        )
+        XCTAssertEqual(reconciled?.enabled, true, "a disabled preference with a matching key must be re-enabled")
+    }
+
+    func testNilSelectedOutputIsNoOp() {
+        let current = LeaderKeyPreference(key: "caps", targetLayer: .navigation, enabled: true)
+        XCTAssertNil(
+            LeaderKeyPreference.reconciled(
+                from: leaderCollections(enabled: true, selectedOutput: nil),
+                current: current
+            ),
+            "nil selectedOutput means no opinion — leave the system-preference leader untouched"
+        )
+    }
+
+    func testDisabledCollectionIsNoOp() {
+        let current = LeaderKeyPreference(key: "caps", targetLayer: .navigation, enabled: true)
+        XCTAssertNil(
+            LeaderKeyPreference.reconciled(
+                from: leaderCollections(enabled: false, selectedOutput: "tab"),
+                current: current
+            ),
+            "a disabled Leader Key collection must not reconcile"
+        )
+    }
+}

--- a/docs/bugs/2026-07-02-leader-key-headless-selectedoutput-reconcile.md
+++ b/docs/bugs/2026-07-02-leader-key-headless-selectedoutput-reconcile.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-07-02
 **Severity:** Correctness (stale generated config) + a regression caught in review
-**Status:** Partial fix in place (in-process load paths); CLI generation path deferred to #865/#888
+**Status:** In-process load paths fixed (#926/#938); standalone CLI apply path now fixed too (this change). Full single-source-of-truth generation from the collection remains deferred to #865/#888.
 
 ## Problem
 
@@ -57,13 +57,31 @@ Home Row Arrows `base → home-arrows` activator), which makes
 pre-reconcile snapshot. An `onError` spy witnesses the regen failure so the test
 can't silently pass on a no-op reconcile.
 
+## CLI apply path closed (this change)
+
+The remaining headless gap — the standalone `keypath-cli config apply` — is now
+covered. `ConfigFacade.applyConfiguration` reconciles the leader key from the
+loaded Leader Key collection's explicit `selectedOutput` before generating config:
+
+- The reconcile rule was extracted into a **pure, shared** function,
+  `LeaderKeyPreference.reconciled(from:current:)`, now used by BOTH the in-process
+  `RuleCollectionsManager.reconcileLeaderKeyFromCollection` and the CLI path — one
+  statement of the rule, so all headless paths agree.
+- Config generation emits a `;; Input:` binding annotation *per collection activator*,
+  not just from `leaderKeyPreference`. So the CLI must also rewrite the Leader Key
+  collection's base→nav activator, or the generated config keeps the stale binding.
+  A second pure helper, `LeaderKeyPreference.reconcileLeaderActivators(in:key:targetLayer:)`,
+  does that scoped rewrite (base→leader-target only, leaving Home Row Arrows "f" /
+  Quick Launcher "hyper" untouched) and is shared with the manager's
+  `applyLeaderKeyToLeaderActivators`.
+- **Dry run** reconciles for the preview but restores the pre-reconcile
+  `leaderKeyPreference` afterward (including on a generation/validation throw), so
+  `keypath apply --dry-run` never mutates persisted state.
+- `Scripts/qa-leader-key-smoke.sh` assertions were flipped: each preset now must drive
+  its own `;; Input: <key>` binding through the CLI, not just apply cleanly.
+
 ## Known limitations / follow-ups
 
-- **Standalone `keypath-cli config apply` is not covered.** It generates config via
-  `ConfigFacade` → `ConfigurationService`, reading `leaderKeyPreference` directly
-  and never constructing a `RuleCollectionsManager`, so the reconcile does not run.
-  Making config generation derive the leader key from the collection (single source
-  of truth) is deferred to #865/#888.
 - **Disable-drift is not reconciled.** A headless edit that *disables* a
   previously-reconciled collection leaves `leaderKeyPreference` stale; forcing it
   disabled would clobber a system-preference leader. Deferred to #865/#888.


### PR DESCRIPTION
## Root cause

Issue #889 was scoped down to a single remaining gap after #926/#938: the standalone `keypath-cli config apply` path. It generates config via `ConfigFacade` → `ConfigurationService`, which derives the primary leader binding from `leaderKeyPreference` (UserDefaults) **and** emits a `;; Input: <key>` annotation per collection activator. The CLI never kept either in sync with the Leader Key collection's `selectedOutput`, so `keypath collection` mutations and direct `RuleCollections.json` edits to the picker were silently ignored by `keypath apply` — the "display-only picker" symptom, from the CLI.

The in-process app/daemon load paths (`RuleCollectionsManager.bootstrap`/`replaceCollections`) were already reconciled by #926/#938. This PR closes the last headless gap short of the #865/#888 single-source-of-truth generation work.

## Fix

- **Extract the reconcile rule into pure, shared functions** on `LeaderKeyPreference`:
  - `reconciled(from:current:)` — the one statement of "derive the preference from the enabled Leader Key collection's explicit `selectedOutput`", with the existing guardrails (explicit output only; disabled collection is a no-op; disable-drift still deferred).
  - `reconcileLeaderActivators(in:key:targetLayer:)` — the scoped base→leader-target activator rewrite (leaves Home Row Arrows `f` / Quick Launcher `hyper` untouched).
  - Both the in-process `RuleCollectionsManager` reconcile and the CLI path now call these, so all headless paths agree by construction.
- **`ConfigFacade.applyConfiguration`** reconciles the `leaderKeyPreference` and the leader activator from the loaded collection before generating config. A dry run reconciles for the preview then **restores** the preference (on success and on a generation/validation throw) so it never mutates persisted state; a real apply keeps the reconciled value, matching what the app does on load.
- **`Scripts/qa-leader-key-smoke.sh`** assertions flipped: each preset must now drive its own `;; Input: <key>` binding through the CLI, not merely apply cleanly.

## Test evidence

New + existing tests pass (`swift test --filter 'ConfigFacadeTests|LeaderKeyPreferenceReconcileTests|RuleCollectionsManagerTests' --jobs 4` → 45 tests, 0 failures):

- `LeaderKeyPreferenceReconcileTests` (new) — pure-rule unit coverage: explicit output reconciles, no-op when already matching, re-enable when key matches but disabled, nil output no-op, disabled collection no-op.
- `ConfigFacadeTests` (new cases) — `testApplyConfigurationReconcilesLeaderKeyFromSelectedOutput` asserts the CLI apply reconciles both the preference and the generated config's Primary Leader Key block (`;; Input: tab`, not `space`); `testApplyConfigurationDryRunDoesNotPersistReconciledLeaderKey` asserts dry run neither persists the preference nor writes the active config. The core test was verified to **fail before** the fix (`;; Input: space` retained) and pass after.
- Existing `RuleCollectionsManager` reconcile tests unchanged and green after the pure-helper refactor.

Reviewed with `/code-review` (3 finder angles + verify): no correctness findings; the shared-pure-helper structure is the intended altitude given #865/#888 is explicitly deferred.

## Out of scope (documented, not fixed here)

- Full single-source-of-truth config generation from the collection (deferred to #865/#888).
- Disable-drift: a headless edit that *disables* a previously-reconciled collection leaves `leaderKeyPreference` stale (deferred to #865/#888).

Fixes #889

🤖 Generated with [Claude Code](https://claude.com/claude-code)