### PR TITLE
Fix HRM Pack Detail: AX slider no-op + stale layer-mode copy

### DIFF
--- a/Sources/KeyPathAppKit/UI/Gallery/HoldTimingSliderRow.swift
+++ b/Sources/KeyPathAppKit/UI/Gallery/HoldTimingSliderRow.swift
@@ -15,6 +15,16 @@ struct HoldTimingSliderRow: View {
 
     @State private var isEditing = false
 
+    /// Debounces `onSliderReleased` for accessibility Increment/Decrement
+    /// actions. Unlike a mouse drag — which fires `onValueChanged`
+    /// continuously but `onSliderReleased` exactly once, on release — each
+    /// VoiceOver arrow-key press is its own discrete gesture, so without
+    /// debouncing, a user pressing Increment several times in a row would
+    /// trigger a full config write + TCP reload + timing-preview animation
+    /// restart (see `onSliderReleased` callers) after *every* keypress
+    /// instead of once the value settles.
+    @State private var axReleaseTask: Task<Void, Never>?
+
     private var invertedBinding: Binding<Double> {
         Binding(
             get: { range.upperBound + range.lowerBound - value },
@@ -24,6 +34,29 @@ struct HoldTimingSliderRow: View {
                 onValueChanged?(raw)
             }
         )
+    }
+
+    /// Computes the new raw (non-inverted) hold-timing value produced by an
+    /// accessibility Increment/Decrement action on the displayed (inverted)
+    /// slider position. Increment always moves the *displayed* thumb toward
+    /// "Prefer modifiers" (right), matching the visual track direction,
+    /// regardless of whether that corresponds to a larger or smaller raw
+    /// value. Pulled out as a static, pure function so it can be unit
+    /// tested without going through SwiftUI's accessibility runtime.
+    nonisolated static func adjustedValue(
+        current value: Double,
+        direction: AccessibilityAdjustmentDirection,
+        range: ClosedRange<Double>,
+        step: Double
+    ) -> Double {
+        let displayedDelta: Double = switch direction {
+        case .increment: step
+        case .decrement: -step
+        @unknown default: 0
+        }
+        let currentDisplayed = range.upperBound + range.lowerBound - value
+        let newDisplayed = min(max(currentDisplayed + displayedDelta, range.lowerBound), range.upperBound)
+        return range.upperBound + range.lowerBound - newDisplayed
     }
 
     var body: some View {
@@ -43,6 +76,23 @@ struct HoldTimingSliderRow: View {
             .accessibilityIdentifier("pack-detail-hold-timing-slider")
             .accessibilityLabel("Hold timing")
             .accessibilityValue("\(currentValue)\(suffix)")
+            .accessibilityAdjustableAction { direction in
+                let newValue = Self.adjustedValue(current: value, direction: direction, range: range, step: step)
+                guard newValue != value else { return }
+                value = newValue
+                onValueChanged?(newValue)
+
+                // Debounce: wait for a pause in Increment/Decrement actions
+                // before treating the adjustment as "released", so rapid
+                // VoiceOver keypresses coalesce into a single persist/reload
+                // instead of one per keypress.
+                axReleaseTask?.cancel()
+                axReleaseTask = Task {
+                    try? await Task.sleep(nanoseconds: 300_000_000)
+                    guard !Task.isCancelled else { return }
+                    onSliderReleased?()
+                }
+            }
             .overlay(alignment: .top) {
                 if isEditing {
                     GeometryReader { geo in

--- a/Sources/KeyPathAppKit/UI/Gallery/PackDetailView.swift
+++ b/Sources/KeyPathAppKit/UI/Gallery/PackDetailView.swift
@@ -251,7 +251,7 @@ struct PackDetailView: View {
                             if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
                         }
                     }
-                    Text(pack.tagline)
+                    Text(displayTagline)
                         .font(.body)
                         .foregroundStyle(.secondary)
                         .fixedSize(horizontal: false, vertical: true)
@@ -504,8 +504,38 @@ struct PackDetailView: View {
 
     // MARK: - Description
 
+    /// Home Row Mods' tagline/description are written for the default
+    /// "hold for a modifier" behavior. When the user has switched Hold
+    /// Behavior to Layers (`homeRowModsConfig.holdMode == .layers`), the
+    /// modifier-specific wording ("no reaching for modifier keys", "Hold
+    /// them for ⌘ ⇧ ⌥ ⌃") is misleading, so swap in layer-mode copy.
+    /// Every other pack keeps its static catalog tagline. Pulled out as a
+    /// pure static function (rather than reading `@State` directly) so it
+    /// can be unit tested without instantiating a live SwiftUI view.
+    nonisolated static func displayTagline(for pack: Pack, holdMode: HomeRowHoldMode) -> String {
+        guard pack.associatedCollectionID == RuleCollectionIdentifier.homeRowMods, holdMode == .layers else {
+            return pack.tagline
+        }
+        return "Every layer under your fingers — no reaching for the keys that trigger them"
+    }
+
+    nonisolated static func displayShortDescription(for pack: Pack, holdMode: HomeRowHoldMode) -> String {
+        guard pack.associatedCollectionID == RuleCollectionIdentifier.homeRowMods, holdMode == .layers else {
+            return pack.shortDescription
+        }
+        return "Tap home row keys normally. Hold them to activate a layer — numbers, symbols, navigation, or whatever you've assigned. Adjust the hold timing to match your typing speed."
+    }
+
+    var displayTagline: String {
+        Self.displayTagline(for: pack, holdMode: homeRowModsConfig.holdMode)
+    }
+
+    var displayShortDescription: String {
+        Self.displayShortDescription(for: pack, holdMode: homeRowModsConfig.holdMode)
+    }
+
     var descriptionBlock: some View {
-        Text(pack.shortDescription)
+        Text(displayShortDescription)
             .font(.body)
             .foregroundStyle(.primary)
             .fixedSize(horizontal: false, vertical: true)
@@ -533,7 +563,7 @@ struct PackDetailView: View {
                         icon: "exclamationmark.circle",
                         tint: .orange,
                         items: requires.compactMap { dep in
-                            PackRegistry.pack(id: dep.packID).map { ($0, dep.description) }
+                            PackRegistry.pack(id: dep.packID).map { ($0, displayDependencyDescription(dep)) }
                         }
                     )
                 }
@@ -545,7 +575,7 @@ struct PackDetailView: View {
                         icon: "sparkles",
                         tint: .blue,
                         items: enhancedBy.compactMap { dep in
-                            PackRegistry.pack(id: dep.packID).map { ($0, dep.description) }
+                            PackRegistry.pack(id: dep.packID).map { ($0, displayDependencyDescription(dep)) }
                         }
                     )
                 }
@@ -557,8 +587,8 @@ struct PackDetailView: View {
                         icon: "arrow.up.right",
                         tint: .green,
                         items: enhances.map { other in
-                            let desc = other.dependencies
-                                .first { $0.packID == pack.id }?.description ?? ""
+                            let dep = other.dependencies.first { $0.packID == pack.id }
+                            let desc = displayDependencyDescription(dep)
                             return (other, desc)
                         }
                     )
@@ -570,6 +600,35 @@ struct PackDetailView: View {
                     .fill(Color(NSColor.controlBackgroundColor).opacity(0.3))
             )
         }
+    }
+
+    /// Dependency descriptions in `PackRegistry` are written assuming Home
+    /// Row Mods is in its default "hold for a modifier" behavior (e.g. Home
+    /// Row Arrows' conflict copy: "Home Row Mods assigns F to Command").
+    /// When HRM is showing this pack's own detail page and the user has
+    /// switched Hold Behavior to Layers, that copy is stale — rewrite it to
+    /// describe the active layer-mode behavior instead. Only applies to
+    /// text this view can confirm references `com.keypath.pack.home-row-mods`
+    /// while we're rendering that pack's own detail (where the live
+    /// `homeRowModsConfig` is available); every other dependency description
+    /// passes through unchanged.
+    nonisolated static func displayDependencyDescription(
+        _ dep: PackDependency?,
+        forPack pack: Pack,
+        holdMode: HomeRowHoldMode
+    ) -> String {
+        let base = dep?.description ?? ""
+        guard pack.associatedCollectionID == RuleCollectionIdentifier.homeRowMods,
+              holdMode == .layers,
+              base.contains("Home Row Mods assigns F to Command")
+        else {
+            return base
+        }
+        return "Both use F as a hold key — Home Row Mods assigns F to a layer, Home Row Arrows assigns F to a navigation layer"
+    }
+
+    func displayDependencyDescription(_ dep: PackDependency?) -> String {
+        Self.displayDependencyDescription(dep, forPack: pack, holdMode: homeRowModsConfig.holdMode)
     }
 
     private func dependencyGroup(

--- a/Tests/KeyPathTests/HRMPackDetailCopyTests.swift
+++ b/Tests/KeyPathTests/HRMPackDetailCopyTests.swift
@@ -1,0 +1,71 @@
+@testable import KeyPathAppKit
+import XCTest
+
+/// Regression tests for GitHub issue #805: HRM Pack Detail copy stayed
+/// modifier-centric ("no reaching for modifier keys", "Hold them for
+/// ⌘ ⇧ ⌥ ⌃", "Home Row Mods assigns F to Command") even after the user
+/// switched Hold Behavior to Layers. `PackDetailView`'s mode-aware copy
+/// helpers are pure static functions (pack + holdMode in, String out) so
+/// they can be tested directly without spinning up a live SwiftUI view /
+/// `@State` hierarchy.
+final class HRMPackDetailCopyTests: XCTestCase {
+    private var homeRowMods: Pack {
+        PackRegistry.homeRowMods
+    }
+
+    private var homeRowArrows: Pack {
+        PackRegistry.homeRowArrows
+    }
+
+    func testTaglineIsModifierCentricByDefault() {
+        let tagline = PackDetailView.displayTagline(for: homeRowMods, holdMode: .modifiers)
+        XCTAssertEqual(tagline, homeRowMods.tagline)
+        XCTAssertTrue(tagline.contains("modifier keys"))
+    }
+
+    func testTaglineSwitchesAwayFromModifierCopyInLayerMode() {
+        let tagline = PackDetailView.displayTagline(for: homeRowMods, holdMode: .layers)
+        XCTAssertNotEqual(tagline, homeRowMods.tagline)
+        XCTAssertFalse(tagline.contains("modifier keys") && tagline.contains("no reaching"),
+                       "Layer-mode tagline should not claim there's 'no reaching for modifier keys'")
+    }
+
+    func testShortDescriptionIsModifierCentricByDefault() {
+        let desc = PackDetailView.displayShortDescription(for: homeRowMods, holdMode: .modifiers)
+        XCTAssertEqual(desc, homeRowMods.shortDescription)
+        XCTAssertTrue(desc.contains("⌘"))
+    }
+
+    func testShortDescriptionDropsModifierSymbolsInLayerMode() {
+        let desc = PackDetailView.displayShortDescription(for: homeRowMods, holdMode: .layers)
+        XCTAssertNotEqual(desc, homeRowMods.shortDescription)
+        XCTAssertFalse(desc.contains("⌘ ⇧ ⌥ ⌃"),
+                       "Layer-mode description should not claim modifier keys are produced")
+        XCTAssertTrue(desc.lowercased().contains("layer"))
+    }
+
+    func testDependencyDescriptionStaysModifierCentricByDefault() {
+        let homeRowArrowsDep = homeRowArrows.dependencies.first { $0.packID == homeRowMods.id }
+        XCTAssertNotNil(homeRowArrowsDep)
+        let desc = PackDetailView.displayDependencyDescription(homeRowArrowsDep, forPack: homeRowMods, holdMode: .modifiers)
+        XCTAssertTrue(desc.contains("Home Row Mods assigns F to Command"))
+    }
+
+    func testDependencyDescriptionUpdatesInLayerMode() {
+        let homeRowArrowsDep = homeRowArrows.dependencies.first { $0.packID == homeRowMods.id }
+        XCTAssertNotNil(homeRowArrowsDep)
+        let desc = PackDetailView.displayDependencyDescription(homeRowArrowsDep, forPack: homeRowMods, holdMode: .layers)
+        XCTAssertFalse(desc.contains("Home Row Mods assigns F to Command"),
+                       "Dependency copy should not claim HRM assigns F to Command once layer mode is active")
+        XCTAssertTrue(desc.contains("layer"))
+    }
+
+    func testNonHomeRowModsPackCopyIsNeverRewritten() {
+        // Guard against the mode-aware rewrite leaking into unrelated packs.
+        XCTAssertEqual(PackDetailView.displayTagline(for: homeRowArrows, holdMode: .layers), homeRowArrows.tagline)
+        XCTAssertEqual(
+            PackDetailView.displayShortDescription(for: homeRowArrows, holdMode: .layers),
+            homeRowArrows.shortDescription
+        )
+    }
+}

--- a/Tests/KeyPathTests/HoldTimingSliderRowTests.swift
+++ b/Tests/KeyPathTests/HoldTimingSliderRowTests.swift
@@ -1,0 +1,59 @@
+@testable import KeyPathAppKit
+import SwiftUI
+import XCTest
+
+/// Regression tests for GitHub issue #806: the HRM Pack Detail hold-timing
+/// slider exposed accessibility Increment/Decrement actions, but invoking
+/// them did not change the exposed value because the Slider only had a
+/// custom (inverted) `Binding` and a manually-overridden `accessibilityValue`
+/// string — nothing wired the AX adjustable action to actually mutate the
+/// bound value. `HoldTimingSliderRow.adjustedValue` is the pure function
+/// backing `.accessibilityAdjustableAction`; tested directly here since it
+/// doesn't require driving SwiftUI's accessibility runtime.
+final class HoldTimingSliderRowTests: XCTestCase {
+    private let range: ClosedRange<Double> = 120 ... 300
+    private let step: Double = 20
+
+    func testIncrementMovesDisplayedThumbTowardPreferModifiers() {
+        // Displayed (inverted) position for value=180 is 120+300-180=240.
+        // Incrementing should move the *displayed* position up by `step`,
+        // which corresponds to a smaller raw value.
+        let newValue = HoldTimingSliderRow.adjustedValue(
+            current: 180, direction: .increment, range: range, step: step
+        )
+        XCTAssertEqual(newValue, 160)
+    }
+
+    func testDecrementMovesDisplayedThumbTowardPreferLetters() {
+        let newValue = HoldTimingSliderRow.adjustedValue(
+            current: 180, direction: .decrement, range: range, step: step
+        )
+        XCTAssertEqual(newValue, 200)
+    }
+
+    func testIncrementClampsAtRangeBoundary() {
+        // Raw value 120 is already the max displayed position; incrementing
+        // further must clamp rather than exceed the range.
+        let newValue = HoldTimingSliderRow.adjustedValue(
+            current: 120, direction: .increment, range: range, step: step
+        )
+        XCTAssertEqual(newValue, 120)
+    }
+
+    func testDecrementClampsAtRangeBoundary() {
+        let newValue = HoldTimingSliderRow.adjustedValue(
+            current: 300, direction: .decrement, range: range, step: step
+        )
+        XCTAssertEqual(newValue, 300)
+    }
+
+    func testRepeatedIncrementsWalkTheFullRange() {
+        var value = 300.0
+        for _ in 0 ..< 9 {
+            value = HoldTimingSliderRow.adjustedValue(
+                current: value, direction: .increment, range: range, step: step
+            )
+        }
+        XCTAssertEqual(value, 120, "9 increments of 20 across a 180ms range should reach the far end")
+    }
+}

--- a/docs/bugs/2026-07-02-hrm-pack-detail-slider-ax-and-layer-copy.md
+++ b/docs/bugs/2026-07-02-hrm-pack-detail-slider-ax-and-layer-copy.md
@@ -1,0 +1,90 @@
+# HRM Pack Detail: slider AX increment/decrement no-op + stale modifier copy in layer mode (#806, #805)
+
+**Date:** 2026-07-02
+**Severity:** Testability (AX automation coverage) + user-facing copy correctness
+**Status:** Fixed
+
+## #806 — hold-timing slider AX increment/decrement did not change the value
+
+### Problem
+
+`HoldTimingSliderRow` (`Sources/KeyPathAppKit/UI/Gallery/HoldTimingSliderRow.swift`)
+wraps a SwiftUI `Slider` with a custom, inverted `Binding` ("Prefer letters" ↔
+"Prefer modifiers" reads backwards from the raw ms value) and overrides
+`.accessibilityValue` with a manually formatted string. Neither of those, on
+their own, wires up the accessibility Increment/Decrement actions — SwiftUI's
+automatic AX support for `Slider` does not reliably propagate through a custom
+`Binding` + a manual `accessibilityValue` override. Invoking the AX Increment
+action visually animated the preview but the underlying bound value (and thus
+the exposed AX value) never changed, and `set_value` failed outright because
+the element wasn't "settable" from the AX tree's perspective.
+
+### Fix
+
+Added an explicit `.accessibilityAdjustableAction` handler that computes the
+new value from the current displayed (inverted) position, clamps to the
+configured range, and writes it back through the same `value`/`onValueChanged`/
+`onSliderReleased` path the drag gesture uses. The math is pulled into a pure,
+`nonisolated static func adjustedValue(current:direction:range:step:)` so it's
+unit-testable without driving SwiftUI's accessibility runtime.
+
+`onSliderReleased` triggers a full config write + TCP reload + timing-preview
+animation (see `HomeRowModsCollectionView`/`PackDetailView+BindingRows.swift`).
+A mouse drag fires it exactly once, on release; a naive AX wiring would fire it
+on every single VoiceOver Increment/Decrement keypress. Debounced with a
+300ms `Task`-based coalescing window (cancel-and-restart, matching the
+existing `startTimingPreview()` cancel pattern) so rapid AX adjustments settle
+into one persist/reload instead of one per keypress.
+
+## #805 — Pack Detail copy stayed modifier-centric after switching to layer mode
+
+### Problem
+
+`PackRegistry.homeRowMods`'s `tagline`/`shortDescription`, and the "Enhances"
+dependency description on Home Row Arrows pointing back at Home Row Mods
+("...Home Row Mods assigns F to Command..."), are static catalog strings
+written for the pack's default "hold for a modifier" behavior
+(`HomeRowModsConfig.holdMode == .modifiers`). When a user switches Hold
+Behavior to `.layers` in Settings, the key chips update correctly, but this
+copy — visible on `PackDetailView` immediately, no reload needed — kept
+claiming things like "no reaching for modifier keys" and "Hold them for
+⌘ ⇧ ⌥ ⌃", which is wrong once F/A/S/D/J/K/L/; are hold-to-layer instead of
+hold-to-modifier.
+
+### Fix
+
+`PackDetailView` already has live access to `homeRowModsConfig` (populated
+from the installed `RuleCollection` when rendering the Home Row Mods pack's
+own detail page). Added three mode-aware helpers —
+`displayTagline(for:holdMode:)`, `displayShortDescription(for:holdMode:)`,
+`displayDependencyDescription(_:forPack:holdMode:)` — as pure, `nonisolated
+static` functions on `PackDetailView` that fall back to the unmodified
+catalog string for every pack/mode except Home Row Mods in `.layers` mode.
+The view's `body` now reads `displayTagline`/`displayShortDescription`
+(instance wrappers around the static functions) instead of `pack.tagline`/
+`pack.shortDescription` directly, and all three dependency groups
+("Requires", "Enhanced by", "Enhances") run their descriptions through
+`displayDependencyDescription` — not just "Enhances", which is the only one
+that happened to matter for the reported repro (Home Row Mods currently has
+no `requires`/`enhancedBy` deps of its own), but leaving the other two on the
+raw string would have been a silent trap for the next pack that adds one.
+
+Kept as pure static functions (pack + holdMode in, String out) rather than
+computed properties reading `@State` directly, specifically so they're
+testable without instantiating a live SwiftUI view — mutating `@State` on a
+detached `View` value outside its installed lifecycle does not reliably
+persist, which was the first (failed) test approach.
+
+## Tests
+
+- `Tests/KeyPathTests/HoldTimingSliderRowTests.swift` — `adjustedValue`
+  increment/decrement math, including range clamping and walking the full
+  range with repeated increments.
+- `Tests/KeyPathTests/HRMPackDetailCopyTests.swift` — tagline/description/
+  dependency-description default (modifier mode) vs. layer-mode copy, plus a
+  guard that the rewrite never leaks into non-HRM packs.
+
+## Files changed
+
+- `Sources/KeyPathAppKit/UI/Gallery/HoldTimingSliderRow.swift`
+- `Sources/KeyPathAppKit/UI/Gallery/PackDetailView.swift`


### PR DESCRIPTION
## Summary

Fixes #806 and #805 — both bugs live in the Home Row Mods Pack Detail view.

**#806 — hold-timing slider AX increment/decrement was a no-op.** `HoldTimingSliderRow` wraps its `Slider` in a custom inverted `Binding` and manually overrides `.accessibilityValue`, which broke SwiftUI's automatic AX Increment/Decrement wiring — VoiceOver/Computer Use could invoke the action, the preview animation would play, but the exposed value never changed. Added an explicit `.accessibilityAdjustableAction` handler backed by a pure `adjustedValue(current:direction:range:step:)` helper. Also debounced the resulting persist/reload callback (300ms coalescing window) so rapid AX keypresses don't each trigger a full config write + TCP reload + timing-preview restart — matching how a single mouse drag only fires that path once, on release.

**#805 — Pack Detail copy stayed modifier-centric after switching to layer mode.** `PackRegistry.homeRowMods`'s tagline/short description, and the Home Row Arrows dependency copy pointing back at it, were static strings written for the default "hold for a modifier" behavior. Switching Hold Behavior to Layers updated the key chips correctly but left the surrounding copy claiming "no reaching for modifier keys" / "Hold them for ⌘ ⇧ ⌥ ⌃" / "Home Row Mods assigns F to Command". Added mode-aware display helpers on `PackDetailView` (`displayTagline`, `displayShortDescription`, `displayDependencyDescription`) that swap in layer-appropriate copy when `homeRowModsConfig.holdMode == .layers`, and pass every dependency description (Requires / Enhanced by / Enhances) through the same helper for consistency.

Root cause and fix details: `docs/bugs/2026-07-02-hrm-pack-detail-slider-ax-and-layer-copy.md`

## Test plan

- [x] `Tests/KeyPathTests/HoldTimingSliderRowTests.swift` (new) — `adjustedValue` increment/decrement math, range clamping, full-range walk
- [x] `Tests/KeyPathTests/HRMPackDetailCopyTests.swift` (new) — tagline/description/dependency-description default vs. layer-mode copy, plus a non-HRM-pack guard
- [x] `swift test --filter "HRMPackDetailCopyTests|HoldTimingSliderRowTests|PackDetailWindowTests|HomeRowMods" --build-system native` → 71 tests, 0 failures
- [x] `./Scripts/test-fast.sh --changed` → 320 tests, 0 failures
- [x] `/code-review` (medium effort, 4 finder angles) run against the diff; both substantive findings addressed (Requires/Enhanced-by groups wired through the mode-aware helper; AX-triggered reload/preview spam debounced)
- [x] swiftformat (pinned 0.61.1) + swiftlint on changed files only — no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)