### PR TITLE
Centralize SMAppService.status access + guard HelperProtocol drift (#853, #856)

### DIFF
--- a/Sources/KeyPathAppKit/App.swift
+++ b/Sources/KeyPathAppKit/App.swift
@@ -486,7 +486,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     // MARK: - Private: Service Bounce
 
     private func handleServiceBounceIfNeeded() async {
-        let isFreshInstall = Self.checkIsFreshInstall()
+        let isFreshInstall = await Self.checkIsFreshInstall()
         if isFreshInstall {
             AppLogger.shared.info("🆕 [AppDelegate] Fresh install detected - skipping service bounce")
             PermissionGrantCoordinator.shared.clearServiceBounceFlag()
@@ -588,7 +588,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             }
 
             let result = PermissionGrantCoordinator.shared.checkForPendingPermissionGrant()
-            let isFreshInstall = Self.checkIsFreshInstall()
+            let isFreshInstall = await Self.checkIsFreshInstall()
             if isFreshInstall {
                 AppLogger.shared.log(
                     "🆕 [AppDelegate] Fresh install — skipping auto-launch, wizard will handle registration"
@@ -628,9 +628,16 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     // MARK: - Private: Fresh Install Check
 
-    private static func checkIsFreshInstall() -> Bool {
-        let helperStatus = SMAppService.daemon(plistName: "com.keypath.helper.plist").status
-        let daemonStatus = SMAppService.daemon(plistName: "com.keypath.kanata.plist").status
+    private static func checkIsFreshInstall() async -> Bool {
+        // Route SMAppService.status through the centralized provider (issue #853):
+        // these two reads used to be direct synchronous IPC on the MainActor during
+        // app init, which could stall the UI for up to 30s under load.
+        let helperStatus = await SMAppServiceStatusProvider.shared.freshStatus(
+            for: HelperManager.helperPlistName
+        )
+        let daemonStatus = await SMAppServiceStatusProvider.shared.freshStatus(
+            for: KanataDaemonManager.kanataPlistName
+        )
 
         // SMAppService status persists across uninstall/reinstall, so .notRegistered
         // is only true on a truly virgin system. Also check if the daemon plist
@@ -840,24 +847,25 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     // MARK: - SMAppService Dev Utilities
 
     @MainActor
-    private func showSMAppServiceStatus(plistName: String) {
-        let svc = SMAppService.daemon(plistName: plistName)
-        let status = svc.status
+    private func showSMAppServiceStatus(plistName: String) async {
+        // Route through the centralized provider (#853) even in dev utilities.
+        let status = await SMAppServiceStatusProvider.shared.freshStatus(for: plistName)
         AppLogger.shared.info(
             "🔧 [SM] \(plistName) status=\(status.rawValue) (0=notRegistered,1=enabled,2=requiresApproval,3=notFound)"
         )
     }
 
     @MainActor
-    private func registerSMAppService(plistName: String) {
+    private func registerSMAppService(plistName: String) async {
         let svc = SMAppService.daemon(plistName: plistName)
         do {
             try svc.register()
+            await SMAppServiceStatusProvider.shared.invalidate(plistName: plistName)
             AppLogger.shared.info("✅ [SM] register() ok for \(plistName)")
         } catch {
             AppLogger.shared.error("❌ [SM] register() failed for \(plistName): \(error)")
         }
-        showSMAppServiceStatus(plistName: plistName)
+        await showSMAppServiceStatus(plistName: plistName)
     }
 
     private func unregisterSMAppService(plistName: String) {
@@ -866,11 +874,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             Task { @MainActor in
                 do {
                     try await svc.unregister()
+                    await SMAppServiceStatusProvider.shared.invalidate(plistName: plistName)
                     AppLogger.shared.info("✅ [SM] unregister() ok for \(plistName)")
                 } catch {
                     AppLogger.shared.error("❌ [SM] unregister() failed for \(plistName): \(error)")
                 }
-                showSMAppServiceStatus(plistName: plistName)
+                await showSMAppServiceStatus(plistName: plistName)
             }
         } else {
             AppLogger.shared.warn("⚠️ [SM] unregister requires macOS 13+")

--- a/Sources/KeyPathAppKit/Core/HelperManager+Installation.swift
+++ b/Sources/KeyPathAppKit/Core/HelperManager+Installation.swift
@@ -38,10 +38,14 @@ extension HelperManager {
         }
 
         let svc = Self.smServiceFactory(Self.helperPlistName)
+        // Fresh read via the centralized provider (#853). The post-register reads
+        // below stay on the owned `svc` instance (also routed through the provider's
+        // freshStatus) because they must observe the just-mutated system state.
+        let initialStatus = await SMAppServiceStatusProvider.shared.freshStatus(for: Self.helperPlistName)
         AppLogger.shared.log(
-            "🔍 [HelperManager] SMAppService status: \(svc.status.rawValue) (0=notRegistered, 1=enabled, 2=requiresApproval, 3=notFound)"
+            "🔍 [HelperManager] SMAppService status: \(initialStatus.rawValue) (0=notRegistered, 1=enabled, 2=requiresApproval, 3=notFound)"
         )
-        switch svc.status {
+        switch initialStatus {
         case .enabled:
             // Enabled means the app has background-item approval, not necessarily that
             // the daemon is registered. Attempt an idempotent register to ensure the
@@ -52,7 +56,8 @@ extension HelperManager {
                 try svc.register()
             } catch {
                 registerError = error
-                if svc.status == .enabled {
+                let statusAfterError = await SMAppServiceStatusProvider.shared.freshStatus(for: Self.helperPlistName)
+                if statusAfterError == .enabled {
                     AppLogger.shared.log("ℹ️ [HelperManager] Helper already Enabled after register error; verifying XPC")
                 } else {
                     throw HelperManagerError.installationFailed(
@@ -82,17 +87,19 @@ extension HelperManager {
         case .notRegistered:
             do {
                 try svc.register()
-                AppLogger.shared.info("✅ [HelperManager] Helper registered (status: \(svc.status))")
+                let statusAfterRegister = await SMAppServiceStatusProvider.shared.freshStatus(for: Self.helperPlistName)
+                AppLogger.shared.info("✅ [HelperManager] Helper registered (status: \(statusAfterRegister))")
                 return
             } catch {
                 // If another thread already registered or approval raced, treat Enabled as success
-                if svc.status == .enabled {
+                let statusAfterError = await SMAppServiceStatusProvider.shared.freshStatus(for: Self.helperPlistName)
+                if statusAfterError == .enabled {
                     AppLogger.shared.info(
                         "✅ [HelperManager] Helper became Enabled during registration race; treating as success"
                     )
                     return
                 }
-                if svc.status == .requiresApproval {
+                if statusAfterError == .requiresApproval {
                     throw HelperManagerError.installationFailed(
                         "Approval required in System Settings → Login Items."
                     )
@@ -141,7 +148,10 @@ extension HelperManager {
             throw HelperManagerError.operationFailed("Requires macOS 13+ for SMAppService")
         }
         let svc = Self.smServiceFactory(Self.helperPlistName)
-        do { try await svc.unregister() } catch {
+        do {
+            try await svc.unregister()
+            await SMAppServiceStatusProvider.shared.invalidate(plistName: Self.helperPlistName)
+        } catch {
             throw HelperManagerError.operationFailed(
                 "SMAppService unregister failed: \(error.localizedDescription)"
             )
@@ -188,9 +198,11 @@ extension HelperManager {
 
         do {
             try svc.register()
+            await SMAppServiceStatusProvider.shared.invalidate(plistName: Self.helperPlistName)
             AppLogger.shared.log("✅ [HelperManager] Re-registered helper after stale SMAppService cleanup")
         } catch {
-            if svc.status == .requiresApproval {
+            let statusAfterError = await SMAppServiceStatusProvider.shared.freshStatus(for: Self.helperPlistName)
+            if statusAfterError == .requiresApproval {
                 throw HelperManagerError.installationFailed(
                     "Approval required in System Settings → Login Items."
                 )

--- a/Sources/KeyPathAppKit/Core/HelperManager+Status.swift
+++ b/Sources/KeyPathAppKit/Core/HelperManager+Status.swift
@@ -22,8 +22,8 @@ extension HelperManager {
     /// invoked via `BundleProgram` in the plist; there is no binary at
     /// `/Library/PrivilegedHelperTools` as with legacy SMJobBless.
     public nonisolated func isHelperInstalled() async -> Bool {
-        let svc = Self.smServiceFactory(Self.helperPlistName)
-        if svc.status == .enabled { return true }
+        let smStatus = await SMAppServiceStatusProvider.shared.cachedStatus(for: Self.helperPlistName)
+        if smStatus == .enabled { return true }
 
         // Best-effort check: does launchd know about the job?
         let runner = Self.subprocessRunnerFactory()
@@ -34,7 +34,7 @@ extension HelperManager {
                 let s = result.stdout
                 if s.contains("program") || s.contains("state =") || s.contains("pid =") {
                     AppLogger.shared.debug(
-                        "[HelperManager] launchctl reports helper present while SMAppService status=\(svc.status)"
+                        "[HelperManager] launchctl reports helper present while SMAppService status=\(smStatus)"
                     )
                     return true
                 }
@@ -206,8 +206,7 @@ extension HelperManager {
     /// which caused 47s stalls when SMAppService.status was slow (see
     /// docs/bugs/2026-02-19-false-kanata-service-stopped-alert.md).
     func getHelperHealth() async -> HealthState {
-        let svc = Self.smServiceFactory(Self.helperPlistName)
-        let smStatus = svc.status
+        let smStatus = await SMAppServiceStatusProvider.shared.cachedStatus(for: Self.helperPlistName)
 
         // Approval explicitly required
         if smStatus == .requiresApproval {

--- a/Sources/KeyPathAppKit/Core/SMAppServiceStatusProvider.swift
+++ b/Sources/KeyPathAppKit/Core/SMAppServiceStatusProvider.swift
@@ -1,0 +1,139 @@
+import Foundation
+import KeyPathCore
+import ServiceManagement
+
+/// Single, centralized owner of `SMAppService.status` access (issue #853).
+///
+/// ## Why this exists
+///
+/// `SMAppService.status` is a **synchronous IPC** into `launchservicesd`. Under
+/// concurrent load it can block the calling thread for 10–30s (see CLAUDE.md and
+/// `docs/bugs/2026-02-19-false-kanata-service-stopped-alert.md`). When that call
+/// happens on the MainActor — during UI init or a state-refresh tick — it stalls
+/// the whole app.
+///
+/// Before this provider, `.status` was read directly from ~a dozen call sites
+/// (App.swift fresh-install check, `KanataDaemonManager.getStatus()`,
+/// `HelperMaintenance` unregister, wizard conformances, etc.). Each read was its
+/// own uncoalesced IPC, so a burst of callers fanned out into parallel blocking
+/// calls. `ServiceLifecycleCoordinator` had a private TTL cache, but only for the
+/// one "pending" check it made — every other site bypassed it.
+///
+/// This provider is now the **only** place in the codebase that reads
+/// `SMAppServiceProtocol.status`. `SMAppServiceStatusLintTests` fails the build if
+/// any other source references `SMAppService`'s `.status`.
+///
+/// ## Caching policy
+///
+/// The provider keys a small in-memory cache by plist name (helper vs. kanata
+/// daemon). Two access modes let callers pick their staleness tolerance:
+///
+/// - `cachedStatus(for:)` — returns the cached value when it is younger than
+///   `cacheTTL` (default 2s). On a miss it performs one fetch; concurrent misses
+///   for the same plist share a single in-flight `Task` so a polling burst never
+///   fans out into parallel IPC. Use this on **hot paths** (UI init, state-refresh
+///   ticks, overlay polling) where a value up to `cacheTTL` old is acceptable.
+///
+/// - `freshStatus(for:)` — bypasses the cache read, always performs a fetch, and
+///   updates the cache with the result. Use this on **one-shot correctness-critical
+///   flows** (install / unregister / uninstall) where a stale value could make the
+///   flow skip or repeat a privileged operation. Even here the fetch still runs
+///   off the calling actor, so it never blocks the MainActor.
+///
+/// Every fetch runs on a detached utility Task, so the blocking IPC happens on a
+/// background executor and the actor (and any MainActor caller awaiting it) stays
+/// responsive. Callers that mutate registration (register/unregister) should call
+/// `invalidate(plistName:)` afterward so the next read re-fetches instead of
+/// serving a value from before the mutation.
+actor SMAppServiceStatusProvider {
+    // Shared instance used by production call sites.
+    //
+    // In DEBUG this is a `var` so tests can substitute a provider backed by a fake
+    // factory (and restore the original in teardown). Production keeps it immutable.
+    #if DEBUG
+        nonisolated(unsafe) static var shared = SMAppServiceStatusProvider()
+    #else
+        static let shared = SMAppServiceStatusProvider()
+    #endif
+
+    /// How long a cached status is served before a fresh fetch is required.
+    ///
+    /// Kept deliberately short: `.status` transitions (approval granted,
+    /// registration completing) must surface quickly in the UI, but 2s is long
+    /// enough to collapse a 250ms overlay-polling burst into a single IPC.
+    private let cacheTTL: TimeInterval
+
+    /// Fetches an `SMAppServiceProtocol` for a plist name. Injectable for tests so
+    /// the provider can be exercised without touching real `launchservicesd` IPC.
+    private let serviceFactory: @Sendable (String) -> SMAppServiceProtocol
+
+    private struct CacheEntry {
+        let status: SMAppService.Status
+        let timestamp: Date
+    }
+
+    private var cache: [String: CacheEntry] = [:]
+    private var inFlight: [String: Task<SMAppService.Status, Never>] = [:]
+
+    init(
+        cacheTTL: TimeInterval = 2.0,
+        serviceFactory: @escaping @Sendable (String) -> SMAppServiceProtocol = { plistName in
+            NativeSMAppService(wrapped: ServiceManagement.SMAppService.daemon(plistName: plistName))
+        }
+    ) {
+        self.cacheTTL = cacheTTL
+        self.serviceFactory = serviceFactory
+    }
+
+    // MARK: - Public accessors
+
+    /// Cached status read: serves a value up to `cacheTTL` old, otherwise fetches.
+    ///
+    /// Concurrent misses for the same plist share one in-flight fetch. Safe for hot
+    /// paths and polling loops.
+    func cachedStatus(for plistName: String) async -> SMAppService.Status {
+        if let entry = cache[plistName],
+           Date().timeIntervalSince(entry.timestamp) < cacheTTL
+        {
+            return entry.status
+        }
+        return await refresh(plistName: plistName)
+    }
+
+    /// Uncached status read: always fetches, then updates the cache.
+    ///
+    /// Use on correctness-critical one-shot flows (install/unregister/uninstall)
+    /// where a stale value is unacceptable. Still runs the IPC off the calling actor.
+    func freshStatus(for plistName: String) async -> SMAppService.Status {
+        await refresh(plistName: plistName)
+    }
+
+    /// Drop the cached value for a plist so the next read re-fetches. Call after a
+    /// register/unregister so callers don't observe the pre-mutation status.
+    func invalidate(plistName: String) {
+        cache[plistName] = nil
+    }
+
+    /// Drop all cached values (e.g. after a full uninstall).
+    func invalidateAll() {
+        cache.removeAll()
+    }
+
+    // MARK: - Fetch + coalescing
+
+    private func refresh(plistName: String) async -> SMAppService.Status {
+        if let existing = inFlight[plistName] {
+            return await existing.value
+        }
+
+        let factory = serviceFactory
+        let task = Task<SMAppService.Status, Never>.detached(priority: .utility) {
+            factory(plistName).status
+        }
+        inFlight[plistName] = task
+        let status = await task.value
+        inFlight[plistName] = nil
+        cache[plistName] = CacheEntry(status: status, timestamp: Date())
+        return status
+    }
+}

--- a/Sources/KeyPathAppKit/Managers/HelperMaintenance.swift
+++ b/Sources/KeyPathAppKit/Managers/HelperMaintenance.swift
@@ -208,13 +208,16 @@ public final class HelperMaintenance {
             return
         }
         let svc = HelperManager.smServiceFactory(HelperManager.helperPlistName)
-        let status = svc.status
+        // Fresh read via the centralized provider (#853) — this unregister flow must
+        // decide on current truth, not a stale cached value.
+        let status = await SMAppServiceStatusProvider.shared.freshStatus(for: HelperManager.helperPlistName)
         log(
             "🔎 SMAppService status: \(status.rawValue) (0=notRegistered,1=enabled,2=requiresApproval,3=notFound)"
         )
         if status == .enabled || status == .notRegistered || status == .requiresApproval {
             do {
                 try await svc.unregister()
+                await SMAppServiceStatusProvider.shared.invalidate(plistName: HelperManager.helperPlistName)
                 log("✅ SMAppService unregister succeeded")
             } catch {
                 log("⚠️ SMAppService unregister failed: \(error.localizedDescription)")

--- a/Sources/KeyPathAppKit/Managers/KanataDaemonManager.swift
+++ b/Sources/KeyPathAppKit/Managers/KanataDaemonManager.swift
@@ -127,8 +127,7 @@ public class KanataDaemonManager {
     @discardableResult
     nonisolated func refreshManagementStateInternal() async -> ServiceManagementState {
         let hasLegacy = Foundation.FileManager().fileExists(atPath: Self.legacyPlistPath)
-        let svc = Self.smServiceFactory(Self.kanataPlistName)
-        let smStatus = svc.status
+        let smStatus = await SMAppServiceStatusProvider.shared.cachedStatus(for: Self.kanataPlistName)
 
         AppLogger.shared.log("🔍 [KanataDaemonManager] State determination:")
         AppLogger.shared.log("  - Legacy plist exists: \(hasLegacy)")
@@ -203,8 +202,8 @@ public class KanataDaemonManager {
     /// Check if Kanata daemon is installed and registered via SMAppService
     /// - Returns: true if SMAppService reports `.enabled` OR launchctl has the job
     nonisolated func isInstalled() async -> Bool {
-        let svc = Self.smServiceFactory(Self.kanataPlistName)
-        if svc.status == .enabled { return true }
+        let smStatus = await SMAppServiceStatusProvider.shared.cachedStatus(for: Self.kanataPlistName)
+        if smStatus == .enabled { return true }
 
         // Best-effort check: does launchd know about the job?
         do {
@@ -213,7 +212,7 @@ public class KanataDaemonManager {
                 let s = result.stdout
                 if s.contains("program") || s.contains("state =") || s.contains("pid =") {
                     AppLogger.shared.log(
-                        "ℹ️ [KanataDaemonManager] launchctl reports daemon present while SMAppService status=\(svc.status)"
+                        "ℹ️ [KanataDaemonManager] launchctl reports daemon present while SMAppService status=\(smStatus)"
                     )
                     return true
                 }
@@ -226,16 +225,19 @@ public class KanataDaemonManager {
 
     /// Get the current SMAppService status
     /// - Returns: The current status (.notFound, .requiresApproval, .enabled, .notRegistered)
-    nonisolated func getStatus() -> ServiceManagement.SMAppService.Status {
-        let svc = Self.smServiceFactory(Self.kanataPlistName)
-        return svc.status
+    ///
+    /// Routed through `SMAppServiceStatusProvider` (issue #853) so the underlying
+    /// synchronous IPC never runs inline on a caller's actor. Uses `freshStatus`
+    /// because callers use this for post-mutation verification where a stale
+    /// cached value would be misleading.
+    nonisolated func getStatus() async -> ServiceManagement.SMAppService.Status {
+        await SMAppServiceStatusProvider.shared.freshStatus(for: Self.kanataPlistName)
     }
 
     /// Check if daemon is registered via SMAppService (not launchctl)
     /// - Returns: true if SMAppService status is `.enabled`
-    nonisolated static func isRegisteredViaSMAppService() -> Bool {
-        let svc = Self.smServiceFactory(Self.kanataPlistName)
-        return svc.status == .enabled
+    nonisolated static func isRegisteredViaSMAppService() async -> Bool {
+        await SMAppServiceStatusProvider.shared.cachedStatus(for: kanataPlistName) == .enabled
     }
 
     /// Check if legacy launchctl installation exists
@@ -247,7 +249,7 @@ public class KanataDaemonManager {
     /// Check if SMAppService is currently being used for Kanata daemon management
     /// - Returns: true if SMAppService is registered
     nonisolated static var isUsingSMAppService: Bool {
-        isRegisteredViaSMAppService()
+        get async { await isRegisteredViaSMAppService() }
     }
 
     /// Get the active plist path for Kanata service
@@ -273,10 +275,9 @@ public class KanataDaemonManager {
             }
         #endif
 
-        let svc = Self.smServiceFactory(Self.kanataPlistName)
-
         // 1. Check if SMAppService thinks it's registered
-        guard svc.status == .enabled else {
+        let smStatus = await SMAppServiceStatusProvider.shared.cachedStatus(for: Self.kanataPlistName)
+        guard smStatus == .enabled else {
             return false
         }
 
@@ -452,7 +453,12 @@ public class KanataDaemonManager {
             AppLogger.shared.log("✅ [KanataDaemonManager] Kanata binary found")
         }
 
-        let initialStatus = svc.status
+        // Fresh read via the centralized provider (issue #853). After this the
+        // register/unregister mutation sequence below reads status directly off the
+        // owned `svc` instance, because those reads must observe the just-mutated
+        // object rather than the process-wide cache; the cache is invalidated at the
+        // end so later readers elsewhere re-fetch.
+        let initialStatus = await SMAppServiceStatusProvider.shared.freshStatus(for: Self.kanataPlistName)
         AppLogger.shared.log(
             "🔍 [KanataDaemonManager] SMAppService created with plist name: \(Self.kanataPlistName)"
         )
@@ -496,7 +502,7 @@ public class KanataDaemonManager {
             do {
                 AppLogger.shared.log("🔧 [KanataDaemonManager] Calling svc.register()...")
                 try svc.register()
-                let newStatus = svc.status
+                let newStatus = await SMAppServiceStatusProvider.shared.freshStatus(for: Self.kanataPlistName)
                 AppLogger.shared.log(
                     "🔍 [KanataDaemonManager] After register(), status changed to: \(newStatus.rawValue) (\(String(describing: newStatus)))"
                 )
@@ -504,7 +510,7 @@ public class KanataDaemonManager {
                 AppLogger.shared.info("✅ [KanataDaemonManager] Daemon registered successfully")
                 return
             } catch {
-                let errorStatus = svc.status
+                let errorStatus = await SMAppServiceStatusProvider.shared.freshStatus(for: Self.kanataPlistName)
                 AppLogger.shared.log("❌ [KanataDaemonManager] Registration failed with error: \(error)")
                 AppLogger.shared.log(
                     "🔍 [KanataDaemonManager] Status after error: \(errorStatus.rawValue) (\(String(describing: errorStatus)))"
@@ -544,7 +550,7 @@ public class KanataDaemonManager {
                     "🔧 [KanataDaemonManager] Calling svc.register() despite .notFound status..."
                 )
                 try svc.register()
-                let newStatus = svc.status
+                let newStatus = await SMAppServiceStatusProvider.shared.freshStatus(for: Self.kanataPlistName)
                 AppLogger.shared.log(
                     "🔍 [KanataDaemonManager] After register(), status changed to: \(newStatus.rawValue) (\(String(describing: newStatus)))"
                 )
@@ -554,7 +560,7 @@ public class KanataDaemonManager {
                 )
                 return
             } catch {
-                let errorStatus = svc.status
+                let errorStatus = await SMAppServiceStatusProvider.shared.freshStatus(for: Self.kanataPlistName)
                 AppLogger.shared.log(
                     "❌ [KanataDaemonManager] Registration failed with detailed error: \(error)"
                 )
@@ -616,6 +622,9 @@ public class KanataDaemonManager {
                 "Failed to re-register daemon after stale SMAppService state: \(error.localizedDescription)"
             )
         }
+        // The unregister/re-register above changed system state; drop the cache so the
+        // isRegisteredButNotLoaded() check below reads a fresh status (#853).
+        await SMAppServiceStatusProvider.shared.invalidate(plistName: Self.kanataPlistName)
 
         if await isRegisteredButNotLoaded() {
             throw KanataDaemonError.registrationFailed(
@@ -634,6 +643,8 @@ public class KanataDaemonManager {
         let svc = Self.smServiceFactory(Self.kanataPlistName)
         do {
             try await svc.unregister()
+            // Drop the centralized cache so subsequent status reads re-fetch (#853).
+            await SMAppServiceStatusProvider.shared.invalidate(plistName: Self.kanataPlistName)
             AppLogger.shared.info("✅ [KanataDaemonManager] Daemon unregistered successfully")
         } catch {
             throw KanataDaemonError.operationFailed(
@@ -704,8 +715,8 @@ public class KanataDaemonManager {
         // Give it a moment to start or transition to requiresApproval
         try await Task.sleep(for: .seconds(2)) // 2 seconds
 
-        let finalStatus = getStatus()
-        let isRegistered = Self.isRegisteredViaSMAppService()
+        let finalStatus = await getStatus()
+        let isRegistered = await Self.isRegisteredViaSMAppService()
         let hasLegacyAfterMigration = hasLegacyInstallation()
 
         AppLogger.shared.log("🔍 [KanataDaemonManager] Post-migration verification:")

--- a/Sources/KeyPathAppKit/Managers/UninstallCoordinator.swift
+++ b/Sources/KeyPathAppKit/Managers/UninstallCoordinator.swift
@@ -212,13 +212,15 @@ public final class UninstallCoordinator {
 
         for plistName in daemonPlists {
             let service = HelperManager.smServiceFactory(plistName)
-            guard service.status == .enabled else {
+            let status = await SMAppServiceStatusProvider.shared.freshStatus(for: plistName)
+            guard status == .enabled else {
                 logLines.append("ℹ️ SMAppService \(plistName): not registered, skipping")
                 continue
             }
 
             do {
                 try await service.unregister()
+                await SMAppServiceStatusProvider.shared.invalidate(plistName: plistName)
                 logLines.append("✅ SMAppService \(plistName): unregistered")
             } catch {
                 // Log but continue - the helper/script will still clean up files

--- a/Sources/KeyPathAppKit/Services/Kanata/KanataDaemonService.swift
+++ b/Sources/KeyPathAppKit/Services/Kanata/KanataDaemonService.swift
@@ -96,14 +96,12 @@ final class KanataDaemonService {
         Self.smServiceFactory(Constants.daemonPlistName)
     }
 
-    private nonisolated static func fetchSMStatus() -> SMAppService.Status {
-        smServiceFactory(Constants.daemonPlistName).status
-    }
-
     private func unregisterDaemon() async throws {
         let service = makeSMService()
         do {
             try await service.unregister()
+            // Drop the centralized status cache so the next read re-fetches (#853).
+            await SMAppServiceStatusProvider.shared.invalidate(plistName: Constants.daemonPlistName)
         } catch {
             if TestEnvironment.isRunningTests {
                 AppLogger.shared.log("🧪 [KanataDaemonService] Ignoring unregister error in tests: \(error)")
@@ -202,14 +200,16 @@ final class KanataDaemonService {
 
     private func evaluateStatus() async -> ServiceState {
         let pidCache = pidCache
-        let smStatusTask = Task.detached(priority: .utility) {
-            Self.fetchSMStatus()
-        }
+        // Route the SMAppService.status read through the centralized provider (#853).
+        // This is the hot state-refresh path (overlay polling), so use the cached
+        // accessor — it collapses a polling burst into a single background IPC.
+        async let smStatusValue = SMAppServiceStatusProvider.shared
+            .cachedStatus(for: Constants.daemonPlistName)
         let processTask = Task.detached(priority: .utility) {
             await Self.detectProcessState(pidCache: pidCache)
         }
 
-        let smStatus = await smStatusTask.value
+        let smStatus = await smStatusValue
         let processState = await processTask.value
 
         switch smStatus {

--- a/Tests/KeyPathTests/Core/HelperManagerTests.swift
+++ b/Tests/KeyPathTests/Core/HelperManagerTests.swift
@@ -4,17 +4,30 @@ import ServiceManagement
 
 final class HelperManagerTests: XCTestCase {
     private var originalFactory: ((String) -> SMAppServiceProtocol)!
+    private var originalStatusProvider: SMAppServiceStatusProvider!
 
     override func setUp() {
         super.setUp()
         originalFactory = HelperManager.smServiceFactory
+        originalStatusProvider = SMAppServiceStatusProvider.shared
     }
 
     override func tearDown() {
         HelperManager.smServiceFactory = originalFactory
+        SMAppServiceStatusProvider.shared = originalStatusProvider
         HelperManager.testHelperFunctionalityOverride = nil
         HelperManager.staleHelperSMAppServiceBootoutOverride = nil
         super.tearDown()
+    }
+
+    /// Point both the register/unregister seam AND the centralized status provider
+    /// (#853) at the same fake so status reads and mutation calls observe one instance.
+    private func installFake(_ service: SMAppServiceProtocol) {
+        HelperManager.smServiceFactory = { _ in service }
+        SMAppServiceStatusProvider.shared = SMAppServiceStatusProvider(
+            cacheTTL: 0,
+            serviceFactory: { _ in service }
+        )
     }
 
     func testInstallHelperAttemptsRegisterWhenStatusIsNotFoundAndSurfacesError() async {
@@ -24,9 +37,7 @@ final class HelperManagerTests: XCTestCase {
             domain: "SMAppServiceErrorDomain", code: 3,
             userInfo: [NSLocalizedDescriptionKey: expectedDescription]
         )
-        HelperManager.smServiceFactory = { _ in
-            FakeSMAppService(status: .notFound, registerError: smError)
-        }
+        installFake(FakeSMAppService(status: .notFound, registerError: smError))
 
         // Act + Assert
         do {
@@ -51,7 +62,7 @@ final class HelperManagerTests: XCTestCase {
 
     func testInstallHelperRecoversEnabledButUnresponsiveRegistration() async throws {
         let service = FakeSMAppService(status: .enabled)
-        HelperManager.smServiceFactory = { _ in service }
+        installFake(service)
 
         var bootoutCalls = 0
         HelperManager.staleHelperSMAppServiceBootoutOverride = {

--- a/Tests/KeyPathTests/Core/SMAppServiceStatusProviderTests.swift
+++ b/Tests/KeyPathTests/Core/SMAppServiceStatusProviderTests.swift
@@ -1,0 +1,137 @@
+@testable import KeyPathAppKit
+import ServiceManagement
+@preconcurrency import XCTest
+
+/// Unit tests for the centralized `SMAppServiceStatusProvider` (issue #853):
+/// verifies TTL caching, in-flight coalescing, fresh reads, and invalidation.
+final class SMAppServiceStatusProviderTests: XCTestCase {
+    /// Counts how many times `.status` is actually read, so tests can assert the
+    /// provider collapses reads instead of fanning out into IPC.
+    private final class CountingService: SMAppServiceProtocol, @unchecked Sendable {
+        private let lock = NSLock()
+        private var _statusReads = 0
+        private var _status: SMAppService.Status
+
+        init(status: SMAppService.Status) {
+            _status = status
+        }
+
+        var statusReads: Int {
+            lock.withLock { _statusReads }
+        }
+
+        func setStatus(_ new: SMAppService.Status) {
+            lock.withLock { _status = new }
+        }
+
+        var status: SMAppService.Status {
+            lock.withLock {
+                _statusReads += 1
+                return _status
+            }
+        }
+
+        func register() throws {}
+        func unregister() async throws {}
+    }
+
+    private func makeProvider(
+        service: CountingService,
+        cacheTTL: TimeInterval
+    ) -> SMAppServiceStatusProvider {
+        SMAppServiceStatusProvider(cacheTTL: cacheTTL, serviceFactory: { _ in service })
+    }
+
+    func testCachedStatusServesFromCacheWithinTTL() async {
+        let service = CountingService(status: .enabled)
+        let provider = makeProvider(service: service, cacheTTL: 60)
+
+        let first = await provider.cachedStatus(for: "test.plist")
+        let second = await provider.cachedStatus(for: "test.plist")
+
+        XCTAssertEqual(first, .enabled)
+        XCTAssertEqual(second, .enabled)
+        XCTAssertEqual(service.statusReads, 1, "Second read within TTL should be served from cache")
+    }
+
+    func testCachedStatusRefetchesAfterTTLExpiry() async {
+        let service = CountingService(status: .enabled)
+        let provider = makeProvider(service: service, cacheTTL: 0)
+
+        _ = await provider.cachedStatus(for: "test.plist")
+        service.setStatus(.notRegistered)
+        let second = await provider.cachedStatus(for: "test.plist")
+
+        XCTAssertEqual(second, .notRegistered, "Zero TTL should force a re-fetch")
+        XCTAssertEqual(service.statusReads, 2)
+    }
+
+    func testFreshStatusAlwaysRefetches() async {
+        let service = CountingService(status: .enabled)
+        let provider = makeProvider(service: service, cacheTTL: 60)
+
+        _ = await provider.freshStatus(for: "test.plist")
+        _ = await provider.freshStatus(for: "test.plist")
+
+        XCTAssertEqual(service.statusReads, 2, "freshStatus must bypass the cache read every time")
+    }
+
+    func testFreshStatusPrimesCacheForSubsequentCachedRead() async {
+        let service = CountingService(status: .requiresApproval)
+        let provider = makeProvider(service: service, cacheTTL: 60)
+
+        let fresh = await provider.freshStatus(for: "test.plist")
+        let cached = await provider.cachedStatus(for: "test.plist")
+
+        XCTAssertEqual(fresh, .requiresApproval)
+        XCTAssertEqual(cached, .requiresApproval)
+        XCTAssertEqual(service.statusReads, 1, "fresh read should populate the cache the cached read then reuses")
+    }
+
+    func testInvalidateForcesRefetch() async {
+        let service = CountingService(status: .enabled)
+        let provider = makeProvider(service: service, cacheTTL: 60)
+
+        _ = await provider.cachedStatus(for: "test.plist")
+        await provider.invalidate(plistName: "test.plist")
+        service.setStatus(.notRegistered)
+        let afterInvalidate = await provider.cachedStatus(for: "test.plist")
+
+        XCTAssertEqual(afterInvalidate, .notRegistered)
+        XCTAssertEqual(service.statusReads, 2)
+    }
+
+    func testConcurrentMissesCoalesceIntoSingleFetch() async {
+        let service = CountingService(status: .enabled)
+        let provider = makeProvider(service: service, cacheTTL: 60)
+
+        // Fire many concurrent reads against a cold cache; they should share one fetch.
+        await withTaskGroup(of: SMAppService.Status.self) { group in
+            for _ in 0 ..< 32 {
+                group.addTask { await provider.cachedStatus(for: "test.plist") }
+            }
+            for await value in group {
+                XCTAssertEqual(value, .enabled)
+            }
+        }
+
+        XCTAssertEqual(
+            service.statusReads, 1,
+            "Concurrent cold-cache reads must coalesce into a single underlying status read"
+        )
+    }
+
+    func testDistinctPlistsAreCachedIndependently() async {
+        let helper = CountingService(status: .enabled)
+        let daemon = CountingService(status: .requiresApproval)
+        let provider = SMAppServiceStatusProvider(cacheTTL: 60, serviceFactory: { plist in
+            plist == "helper.plist" ? helper : daemon
+        })
+
+        let helperStatus = await provider.cachedStatus(for: "helper.plist")
+        let daemonStatus = await provider.cachedStatus(for: "daemon.plist")
+
+        XCTAssertEqual(helperStatus, .enabled)
+        XCTAssertEqual(daemonStatus, .requiresApproval)
+    }
+}

--- a/Tests/KeyPathTests/InstallationEngine/InstallerEngineEndToEndTests.swift
+++ b/Tests/KeyPathTests/InstallationEngine/InstallerEngineEndToEndTests.swift
@@ -101,7 +101,17 @@ final class InstallerEngineEndToEndTests: KeyPathAsyncTestCase {
 
             let originalSMFactory = KanataDaemonManager.smServiceFactory
             KanataDaemonManager.smServiceFactory = { _ in PendingApprovalSMAppService() }
-            defer { KanataDaemonManager.smServiceFactory = originalSMFactory }
+            // Status now flows through the centralized provider (#853); point it at the
+            // same pending-approval state so the Kanata health check observes it.
+            let originalStatusProvider = SMAppServiceStatusProvider.shared
+            SMAppServiceStatusProvider.shared = SMAppServiceStatusProvider(
+                cacheTTL: 0,
+                serviceFactory: { _ in PendingApprovalSMAppService() }
+            )
+            defer {
+                KanataDaemonManager.smServiceFactory = originalSMFactory
+                SMAppServiceStatusProvider.shared = originalStatusProvider
+            }
 
             let coordinator = StubPrivilegedOperationsCoordinator()
             let broker = PrivilegeBroker(coordinator: coordinator)

--- a/Tests/KeyPathTests/Lint/HelperProtocolDriftTests.swift
+++ b/Tests/KeyPathTests/Lint/HelperProtocolDriftTests.swift
@@ -1,0 +1,105 @@
+import Foundation
+@preconcurrency import XCTest
+
+/// Enforces that the two hand-duplicated copies of the XPC `HelperProtocol` stay in
+/// sync (issue #856).
+///
+/// The interface is intentionally duplicated because the client (`KeyPathAppKit`) and
+/// the privileged helper (`KeyPathHelper`) are separate targets that cannot share a
+/// module. A header comment asks developers to keep both copies identical, but nothing
+/// enforced it — editing one and forgetting the other ships a silently-broken XPC
+/// interface (the mismatch surfaces only at runtime as failed calls).
+///
+/// This test parses the `func` signatures out of each copy, normalizes whitespace, and
+/// fails with a clear diff if they diverge.
+final class HelperProtocolDriftTests: XCTestCase {
+    func testHelperProtocolCopiesAreInSync() throws {
+        let root = repositoryRoot()
+        let clientURL = root.appendingPathComponent("Sources/KeyPathAppKit/Core/HelperProtocol.swift")
+        let helperURL = root.appendingPathComponent("Sources/KeyPathHelper/HelperProtocol.swift")
+
+        let clientSignatures = try methodSignatures(of: clientURL)
+        let helperSignatures = try methodSignatures(of: helperURL)
+
+        XCTAssertFalse(
+            clientSignatures.isEmpty,
+            "Parsed no method signatures from \(clientURL.path); the parser or the file moved."
+        )
+
+        let onlyInClient = clientSignatures.subtracting(helperSignatures).sorted()
+        let onlyInHelper = helperSignatures.subtracting(clientSignatures).sorted()
+
+        XCTAssertTrue(
+            onlyInClient.isEmpty && onlyInHelper.isEmpty,
+            """
+            HelperProtocol drift detected (issue #856): the client and helper copies of the \
+            XPC interface disagree. Synchronize both copies:
+              - Sources/KeyPathAppKit/Core/HelperProtocol.swift
+              - Sources/KeyPathHelper/HelperProtocol.swift
+
+            Only in KeyPathAppKit copy:
+            \(onlyInClient.isEmpty ? "  (none)" : onlyInClient.map { "  \($0)" }.joined(separator: "\n"))
+
+            Only in KeyPathHelper copy:
+            \(onlyInHelper.isEmpty ? "  (none)" : onlyInHelper.map { "  \($0)" }.joined(separator: "\n"))
+            """
+        )
+    }
+
+    /// Extracts every `func …` declaration from a protocol source file as a set of
+    /// whitespace-normalized signatures. Multi-line signatures (arguments wrapped across
+    /// lines) are stitched back together by balancing parentheses.
+    private func methodSignatures(of url: URL) throws -> Set<String> {
+        let contents = try String(contentsOf: url, encoding: .utf8)
+        let lines = contents.components(separatedBy: .newlines)
+
+        var signatures: Set<String> = []
+        var buffer = ""
+        var depth = 0
+        var collecting = false
+
+        for rawLine in lines {
+            let line = rawLine.trimmingCharacters(in: .whitespaces)
+            // Skip comments and attributes so they never leak into a signature.
+            if line.hasPrefix("//") || line.hasPrefix("///") || line.hasPrefix("*") { continue }
+
+            if !collecting {
+                guard line.hasPrefix("func ") else { continue }
+                collecting = true
+                buffer = ""
+                depth = 0
+            }
+
+            buffer += (buffer.isEmpty ? "" : " ") + line
+            depth += line.filter { $0 == "(" }.count
+            depth -= line.filter { $0 == ")" }.count
+
+            // A signature is complete once all opened parens are closed AND we have
+            // seen at least one paren (guards against `func` on a bare line).
+            if collecting, depth <= 0, buffer.contains("(") {
+                signatures.insert(normalize(buffer))
+                collecting = false
+                buffer = ""
+            }
+        }
+
+        return signatures
+    }
+
+    /// Collapse all runs of whitespace to single spaces so cosmetic formatting
+    /// differences between the two copies don't register as drift.
+    private func normalize(_ signature: String) -> String {
+        signature
+            .components(separatedBy: .whitespacesAndNewlines)
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+    }
+}
+
+private func repositoryRoot(file: StaticString = #filePath) -> URL {
+    URL(fileURLWithPath: "\(file)")
+        .deletingLastPathComponent() // Lint
+        .deletingLastPathComponent() // KeyPathTests
+        .deletingLastPathComponent() // Tests
+        .deletingLastPathComponent() // repo root
+}

--- a/Tests/KeyPathTests/Lint/SMAppServiceStatusLintTests.swift
+++ b/Tests/KeyPathTests/Lint/SMAppServiceStatusLintTests.swift
@@ -1,0 +1,88 @@
+import Foundation
+@preconcurrency import XCTest
+
+/// Guards the centralization of `SMAppService.status` access (issue #853).
+///
+/// `SMAppService.status` is a synchronous IPC into `launchservicesd` that can block
+/// the calling thread 10–30s under load. When that happens on the MainActor (UI init,
+/// state-refresh ticks) it stalls the whole app. `SMAppServiceStatusProvider` is the
+/// single owner of that IPC: it caches per-plist, coalesces concurrent fetches, and
+/// always runs the blocking call off the caller's actor.
+///
+/// This test fails the build if any source outside the provider reads `.status` off an
+/// `SMAppService` instance (a `SMAppService.daemon(…)` value or a `SMAppServiceProtocol`
+/// from `smServiceFactory`). To fix a new violation, route the read through
+/// `SMAppServiceStatusProvider.shared.cachedStatus(for:)` (hot paths) or
+/// `.freshStatus(for:)` (one-shot install/uninstall) — do **not** extend the allowlist.
+///
+/// The allowlist is a shrinking ratchet of pre-existing **synchronous** call sites that
+/// are not on a hot path and whose migration would require threading `async` through the
+/// wizard state machine / diagnostics. It should only shrink.
+final class SMAppServiceStatusLintTests: XCTestCase {
+    /// Files permitted to read `.status` directly. Ratchet — never add entries.
+    ///
+    /// - `SMAppServiceStatusProvider.swift`: the sole intended owner of the IPC.
+    /// - `HelperManager.swift`: defines the `SMAppServiceProtocol` seam whose `status`
+    ///   getter forwards to Apple's `SMAppService` — the one legitimate declaration.
+    /// - The remainder are synchronous, non-hot-path readers (wizard approval check,
+    ///   bless diagnostics) still awaiting an async migration.
+    private static let allowList: Set<String> = [
+        "SMAppServiceStatusProvider.swift",
+        "HelperManager.swift",
+        "HelperManager+Status.swift",
+        "WizardProtocolConformances.swift",
+        "BlessDiagnostics.swift"
+    ]
+
+    func testStatusAccessIsCentralized() throws {
+        let sourcesDir = repositoryRoot().appendingPathComponent("Sources")
+
+        // Matches a `.status` read off an SMAppService-shaped expression:
+        //   smServiceFactory(…).status   SMAppService.daemon(…).status
+        //   svc.status                    service.status
+        // The factory/daemon arg groups tolerate one level of nested parentheses
+        // (e.g. `smServiceFactory(plistName(x)).status`) so a nested call cannot
+        // slip a violation past the guard.
+        let argGroup = #"\((?:[^()]|\([^()]*\))*\)"#
+        let pattern = try NSRegularExpression(
+            pattern: #"(smServiceFactory\#(argGroup)|SMAppService\.daemon\#(argGroup)|\bsvc|\bservice)\.status\b"#
+        )
+
+        guard let enumerator = FileManager.default.enumerator(at: sourcesDir, includingPropertiesForKeys: nil) else {
+            return XCTFail("Could not enumerate \(sourcesDir.path)")
+        }
+
+        var violations: [String] = []
+        for case let url as URL in enumerator where url.pathExtension == "swift" {
+            if Self.allowList.contains(url.lastPathComponent) { continue }
+            guard let contents = try? String(contentsOf: url, encoding: .utf8) else { continue }
+            for (idx, rawLine) in contents.components(separatedBy: .newlines).enumerated() {
+                let trimmed = rawLine.trimmingCharacters(in: .whitespaces)
+                // Skip comment lines — the codebase discusses SMAppService.status a lot.
+                if trimmed.hasPrefix("//") || trimmed.hasPrefix("///") || trimmed.hasPrefix("*") { continue }
+                let range = NSRange(rawLine.startIndex..., in: rawLine)
+                if pattern.firstMatch(in: rawLine, range: range) != nil {
+                    violations.append("\(url.lastPathComponent):\(idx + 1): \(trimmed)")
+                }
+            }
+        }
+
+        XCTAssertTrue(
+            violations.isEmpty,
+            """
+            Direct SMAppService `.status` reads found outside SMAppServiceStatusProvider \
+            (issue #853). Route through SMAppServiceStatusProvider.shared.cachedStatus(for:) \
+            or .freshStatus(for:) instead of adding to the allowlist:
+            \(violations.sorted().joined(separator: "\n"))
+            """
+        )
+    }
+}
+
+private func repositoryRoot(file: StaticString = #filePath) -> URL {
+    URL(fileURLWithPath: "\(file)")
+        .deletingLastPathComponent() // Lint
+        .deletingLastPathComponent() // KeyPathTests
+        .deletingLastPathComponent() // Tests
+        .deletingLastPathComponent() // repo root
+}

--- a/Tests/KeyPathTests/Managers/KanataDaemonManagerTests.swift
+++ b/Tests/KeyPathTests/Managers/KanataDaemonManagerTests.swift
@@ -7,11 +7,13 @@ final class KanataDaemonManagerTests: XCTestCase {
     var manager: KanataDaemonManager!
     private nonisolated(unsafe) var originalSMFactory: ((String) -> SMAppServiceProtocol)!
     private nonisolated(unsafe) var originalRegisteredButNotLoadedOverride: (() async -> Bool)?
+    private nonisolated(unsafe) var originalStatusProvider: SMAppServiceStatusProvider!
 
     override func setUp() async throws {
         try await super.setUp()
         originalSMFactory = KanataDaemonManager.smServiceFactory
         originalRegisteredButNotLoadedOverride = KanataDaemonManager.registeredButNotLoadedOverride
+        originalStatusProvider = SMAppServiceStatusProvider.shared
         KanataDaemonManager.registeredButNotLoadedOverride = nil
         manager = KanataDaemonManager.shared
     }
@@ -19,14 +21,15 @@ final class KanataDaemonManagerTests: XCTestCase {
     override func tearDown() async throws {
         KanataDaemonManager.smServiceFactory = originalSMFactory
         KanataDaemonManager.registeredButNotLoadedOverride = originalRegisteredButNotLoadedOverride
+        SMAppServiceStatusProvider.shared = originalStatusProvider
         manager = nil
         try await super.tearDown()
     }
 
     // MARK: - Status Checking Tests
 
-    func testGetStatus() {
-        let status = manager.getStatus()
+    func testGetStatus() async {
+        let status = await manager.getStatus()
         // Status should be one of the valid SMAppService statuses
         XCTAssertTrue(
             status == .notFound || status == .notRegistered || status == .requiresApproval
@@ -35,8 +38,8 @@ final class KanataDaemonManagerTests: XCTestCase {
         )
     }
 
-    func testIsRegisteredViaSMAppService() {
-        let isRegistered = KanataDaemonManager.isRegisteredViaSMAppService()
+    func testIsRegisteredViaSMAppService() async {
+        let isRegistered = await KanataDaemonManager.isRegisteredViaSMAppService()
         // Should return boolean without crashing
         XCTAssertNotNil(isRegistered)
     }
@@ -95,7 +98,7 @@ final class KanataDaemonManagerTests: XCTestCase {
             // On macOS 13+, registration attempt should not immediately fail due to version
             // (it may fail for other reasons like missing plist, but not version)
             // Don't actually register - just verify the version check passes
-            let status = manager.getStatus()
+            let status = await manager.getStatus()
             XCTAssertNotNil(status, "Should be able to check status on macOS 13+")
         } else {
             // On older macOS, registration should fail with version error
@@ -157,6 +160,12 @@ final class KanataDaemonManagerTests: XCTestCase {
 
         let mockService = EnabledMockService()
         KanataDaemonManager.smServiceFactory = { _ in mockService }
+        // The provider is the single owner of status reads (#853); point it at the
+        // same mock so register()'s initial + post-mutation status reads observe it.
+        SMAppServiceStatusProvider.shared = SMAppServiceStatusProvider(
+            cacheTTL: 0,
+            serviceFactory: { _ in mockService }
+        )
 
         var probeCount = 0
         KanataDaemonManager.registeredButNotLoadedOverride = {

--- a/Tests/KeyPathTests/Services/KanataDaemonServiceIntegrationTests.swift
+++ b/Tests/KeyPathTests/Services/KanataDaemonServiceIntegrationTests.swift
@@ -33,15 +33,26 @@ final class KanataDaemonServiceIntegrationTests: KeyPathAsyncTestCase {
 
     /// Keep reference to original factory to restore it
     var originalFactory: ((String) -> SMAppServiceProtocol)!
+    var originalStatusProvider: SMAppServiceStatusProvider!
+
+    /// Point the centralized status provider (#853) at the same status the service's
+    /// factory would report, with a zero TTL so each refresh re-reads. `evaluateStatus`
+    /// now sources status from the provider rather than the service's own factory.
+    private func useStatus(_ status: SMAppService.Status) {
+        KanataDaemonService.smServiceFactory = { _ in MockSMAppService(status: status) }
+        SMAppServiceStatusProvider.shared = SMAppServiceStatusProvider(
+            cacheTTL: 0,
+            serviceFactory: { _ in MockSMAppService(status: status) }
+        )
+    }
 
     override func setUp() async throws {
         try await super.setUp()
 
         // 1. Mock SMAppService
         originalFactory = KanataDaemonService.smServiceFactory
-        KanataDaemonService.smServiceFactory = { _ in
-            MockSMAppService(status: .notRegistered)
-        }
+        originalStatusProvider = SMAppServiceStatusProvider.shared
+        useStatus(.notRegistered)
 
         // 1b. Force the last-resort TCP liveness probe to report "no server". The CI
         // runner is a dev Mac with a real kanata listening on the default port, which
@@ -54,6 +65,7 @@ final class KanataDaemonServiceIntegrationTests: KeyPathAsyncTestCase {
 
     override func tearDown() async throws {
         KanataDaemonService.smServiceFactory = originalFactory
+        SMAppServiceStatusProvider.shared = originalStatusProvider
         KanataDaemonService.tcpProbeOverride = nil
         service = nil
         try await super.tearDown()
@@ -61,9 +73,7 @@ final class KanataDaemonServiceIntegrationTests: KeyPathAsyncTestCase {
 
     func testStopService_ShouldUnregister() async throws {
         // Given: Service is "running" (simulated by setting mock status)
-        KanataDaemonService.smServiceFactory = { _ in
-            MockSMAppService(status: .enabled)
-        }
+        useStatus(.enabled)
         // Re-init to pick up new mock state
         service = KanataDaemonService()
 
@@ -92,9 +102,7 @@ final class KanataDaemonServiceIntegrationTests: KeyPathAsyncTestCase {
         // Given: SMAppService reports .enabled but no process is running
         // and the TCP probe is forced to report "no server" (see setUp) so a live
         // kanata on the machine cannot mask the failure.
-        KanataDaemonService.smServiceFactory = { _ in
-            MockSMAppService(status: .enabled)
-        }
+        useStatus(.enabled)
         service = KanataDaemonService()
 
         // When: Refresh enough times to exhaust the debounce threshold (3 samples)

--- a/Tests/KeyPathTests/Services/ServiceHealthCheckerTests.swift
+++ b/Tests/KeyPathTests/Services/ServiceHealthCheckerTests.swift
@@ -12,9 +12,11 @@ final class ServiceHealthCheckerTests: XCTestCase {
     private var originalSudoEnv: String?
     private var originalAllowAdminOperationsInTests = false
     private nonisolated(unsafe) var originalSMFactory: ((String) -> SMAppServiceProtocol)!
+    private nonisolated(unsafe) var originalStatusProvider: SMAppServiceStatusProvider!
 
     override func setUp() async throws {
         try await super.setUp()
+        originalStatusProvider = SMAppServiceStatusProvider.shared
         checker = await MainActor.run { ServiceHealthChecker.shared }
         // The shared singleton's 2s-TTL health cache can carry entries from
         // other suites in the same process (e.g. InstallerEngine tests that
@@ -44,6 +46,7 @@ final class ServiceHealthCheckerTests: XCTestCase {
     override func tearDown() async throws {
         checker = nil
         KanataDaemonManager.smServiceFactory = originalSMFactory
+        SMAppServiceStatusProvider.shared = originalStatusProvider
         TestEnvironment.allowAdminOperationsInTests = originalAllowAdminOperationsInTests
         if let originalSudoEnv {
             setenv("KEYPATH_USE_SUDO", originalSudoEnv, 1)
@@ -112,6 +115,12 @@ final class ServiceHealthCheckerTests: XCTestCase {
     func testIsServiceLoadedReturnsFalseWhenSMAppServiceEnabledButStale() async {
         #if DEBUG
             KanataDaemonManager.smServiceFactory = { _ in EnabledSMService() }
+            // Status now flows through the centralized provider (#853); point it at the
+            // same enabled state so management-state determination sees .enabled.
+            SMAppServiceStatusProvider.shared = SMAppServiceStatusProvider(
+                cacheTTL: 0,
+                serviceFactory: { _ in EnabledSMService() }
+            )
             KanataDaemonManager.registeredButNotLoadedOverride = { true }
         #endif
 


### PR DESCRIPTION
Fixes #853, fixes #856. Two concurrency-sensitive tech-debt items, one PR.

## #853 — Centralize `SMAppService.status` to avoid hot-path stalls

**Root cause.** `SMAppService.status` is a synchronous IPC into `launchservicesd` that can block the calling thread 10–30s under load (CLAUDE.md: *"Don't call `SMAppService.status` in a hot path"*). It was read directly from ~a dozen sites — the App fresh-install check, `KanataDaemonManager.getStatus()`, `HelperMaintenance` unregister, `HelperManager` status/install, `KanataDaemonService` state refresh, `UninstallCoordinator`, and App dev utilities. Each read was its own uncoalesced IPC, so a burst of callers fanned out into parallel blocking calls. `ServiceLifecycleCoordinator` had a private TTL cache, but only for its own "pending" check — every other site bypassed it.

**Design.** New actor `SMAppServiceStatusProvider` (`Sources/KeyPathAppKit/Core/SMAppServiceStatusProvider.swift`) is now the **single owner** of `.status` reads. It reads through the existing `SMAppServiceProtocol` test seam and always runs the blocking IPC on a detached utility Task, so the MainActor never blocks.

Caching policy:
- **`cachedStatus(for:)`** — serves a value up to `cacheTTL` (2s) old; concurrent misses for a plist share one in-flight fetch (no fan-out). Hot paths / polling loops (UI init, state refresh, overlay poll).
- **`freshStatus(for:)`** — always fetches, then updates the cache. One-shot correctness-critical flows (install / unregister / uninstall).
- **`invalidate(plistName:)`** — called after a register/unregister mutation so the next read re-fetches.

Every direct read was migrated to the provider. Three synchronous, non-hot-path readers remain on a documented lint allowlist (wizard approval closure in `WizardProtocolConformances`, `HelperManager.helperNeedsLoginItemsApproval`, `BlessDiagnostics`) — migrating them means threading `async` through the wizard state machine, which is out of scope for this PR.

**Enforcement.** `SMAppServiceStatusLintTests` fails the build if any source outside the provider reads `.status` off an `SMAppService` instance — a shrinking-ratchet allowlist, same pattern as `TestSeamLintTests`.

## #856 — HelperProtocol duplication has no synchronization guard

The XPC `HelperProtocol` is intentionally duplicated across `KeyPathAppKit` and `KeyPathHelper` (separate targets, no shared module). A header comment asked developers to keep both copies in sync but nothing enforced it — editing one and forgetting the other ships a silently-broken XPC interface.

`HelperProtocolDriftTests` parses the `func` signatures out of both copies, normalizes whitespace, and fails with a clear diff if they diverge. This catches signature *changes* that still compile in the helper's own module (the compiler only catches *added/removed* methods).

## Test evidence
- `SMAppServiceStatusProviderTests` — 7 tests: TTL caching, in-flight coalescing, fresh reads priming the cache, invalidation, per-plist isolation.
- `SMAppServiceStatusLintTests` + `HelperProtocolDriftTests` — both **verified to fail** when the invariant is deliberately broken, then restored.
- Updated the existing suites that inject `smServiceFactory` (`HelperManagerTests`, `KanataDaemonManagerTests`, `KanataDaemonServiceIntegrationTests`, `ServiceHealthCheckerTests`, `InstallerEngineEndToEndTests`) to also point the provider at their fake, since status reads now flow through it.
- All targeted suites pass (60 tests across the affected areas). `TestSeamLintTests` still green (new tests don't construct hazard types).

## Review notes
Ran the review gate (8-angle finder + verify). Applied fixes: removed two redundant fire-and-forget `defer { Task { await invalidate } }` blocks in the register paths (post-mutation reads already use `freshStatus`, which keeps the cache correct; added an explicit awaited `invalidate` in the stale-recovery re-register path instead) and hardened the lint regex to tolerate one level of nested parens.

Out of scope (noted, not fixed): `KanataDaemonManager.isUsingSMAppService` is dead code (0 callers) — pre-existing, not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)