### PR TITLE
Wizard polish (mechanical subset of #934): flicker, step indicator, log noise

### DIFF
--- a/Sources/KeyPathAppKit/App.swift
+++ b/Sources/KeyPathAppKit/App.swift
@@ -601,7 +601,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                         AppLogger.shared.log("✅ [AppDelegate] Auto-launch sequence completed (simple)")
                         MainAppStateController.shared.invalidateValidationCooldown()
                     } else {
-                        AppLogger.shared.error("❌ [AppDelegate] Auto-launch failed via runtime coordinator")
+                        // This is commonly the expected first-run/early-boot race (e.g.
+                        // VirtualHID daemon not yet healthy) rather than a genuine failure —
+                        // the underlying cause is already logged as an ERROR by
+                        // ServiceLifecycleCoordinator, and the wizard auto-launches below
+                        // to repair/complete setup. Log at warn to avoid a cosmetic ERROR
+                        // on every fresh install (#934).
+                        AppLogger.shared.warn("⚠️ [AppDelegate] Auto-launch did not start kanata via runtime coordinator — wizard will follow up if setup is incomplete")
                     }
                 } else {
                     AppLogger.shared.error(

--- a/Sources/KeyPathAppKit/Services/MainAppStateController.swift
+++ b/Sources/KeyPathAppKit/Services/MainAppStateController.swift
@@ -70,6 +70,40 @@ class MainAppStateController {
     @ObservationIgnored private let validationCooldown: TimeInterval = 30.0 // Skip validation if completed within last 30 seconds
     private enum ValidationError: Error { case timeout }
 
+    // MARK: - Validation Log Throttling (avoid flooding the log with repeat cycles)
+
+    /// Per-log-site dedup state: maps a log site key (e.g. "startupGate",
+    /// "validationFailure") to the signature last logged in full and how many
+    /// times it has repeated unchanged since. When an unchanged failure repeats
+    /// across periodic revalidation cycles, only the first occurrence is logged
+    /// at full WARN/ERROR verbosity; repeats are collapsed into a single
+    /// low-noise line. This does not change validation behavior — only what
+    /// gets written to the log. See #934 (122 cycles of WARN+5×ERROR in 9
+    /// minutes filled and rotated the 5MB log mid-session).
+    @ObservationIgnored private var loggedFailureSignatures: [String: (signature: String, repeatCount: Int)] = [:]
+
+    /// Returns true if this failure signature should be logged at full verbosity
+    /// (first occurrence at this site, or a change from the previously logged
+    /// signature at this site). Also updates the per-site repeat counter.
+    private func shouldLogValidationFailureInDetail(site: String, signature: String) -> Bool {
+        if let existing = loggedFailureSignatures[site], existing.signature == signature {
+            loggedFailureSignatures[site] = (signature, existing.repeatCount + 1)
+            return false
+        }
+        loggedFailureSignatures[site] = (signature, 0)
+        return true
+    }
+
+    /// Current repeat count for a log site (0 if this is the first occurrence).
+    private func repeatCount(forSite site: String) -> Int {
+        loggedFailureSignatures[site]?.repeatCount ?? 0
+    }
+
+    /// Reset failure-signature dedup state once validation succeeds again.
+    private func resetValidationFailureLogState() {
+        loggedFailureSignatures.removeAll()
+    }
+
     // MARK: - Service Health Monitoring (Fix for stale overlay state)
 
     @ObservationIgnored private var errorDetectionTask: Task<Void, Never>?
@@ -480,13 +514,25 @@ class MainAppStateController {
         case .ready:
             break
         case .transientTimeout:
-            AppLogger.shared.warn(
-                "⚠️ [MainAppStateController] Kanata still in transient startup window after \(Int(transientStartupGracePeriod))s - continuing with full validation to avoid false failure"
-            )
+            if shouldLogValidationFailureInDetail(site: "startupGate", signature: "transientTimeout") {
+                AppLogger.shared.warn(
+                    "⚠️ [MainAppStateController] Kanata still in transient startup window after \(Int(transientStartupGracePeriod))s - continuing with full validation to avoid false failure"
+                )
+            } else {
+                AppLogger.shared.debug(
+                    "⚠️ [MainAppStateController] Kanata still in transient startup window (repeat #\(repeatCount(forSite: "startupGate")), suppressing detailed log)"
+                )
+            }
         case .definitiveFailure:
-            AppLogger.shared.warn(
-                "⚠️ [MainAppStateController] Kanata service not healthy after \(definitiveStartupGracePeriod)s outside restart window - proceeding with full validation"
-            )
+            if shouldLogValidationFailureInDetail(site: "startupGate", signature: "definitiveFailure") {
+                AppLogger.shared.warn(
+                    "⚠️ [MainAppStateController] Kanata service not healthy after \(definitiveStartupGracePeriod)s outside restart window - proceeding with full validation"
+                )
+            } else {
+                AppLogger.shared.debug(
+                    "⚠️ [MainAppStateController] Kanata still not healthy outside restart window (repeat #\(repeatCount(forSite: "startupGate")), suppressing detailed log)"
+                )
+            }
         }
 
         validationState = .checking
@@ -625,6 +671,7 @@ class MainAppStateController {
                 validationState = .success
                 // Clear stale diagnostics when system is healthy
                 onSystemHealthy?()
+                resetValidationFailureLogState()
                 AppLogger.shared.info(
                     "✅ [MainAppStateController] Validation SUCCESS - adapter state is .active (kanata running), no blocking issues, TCP configured"
                 )
@@ -641,14 +688,21 @@ class MainAppStateController {
                     blockingCount: blockingIssues.count + (tcpConfigured ? 0 : 1),
                     totalCount: issues.count
                 )
-                AppLogger.shared.error(
-                    "❌ [MainAppStateController] Validation FAILED - \(reasons.joined(separator: ", "))"
-                )
-                for (index, issue) in blockingIssues.enumerated() {
-                    AppLogger.shared.log("   Blocking \(index + 1): \(issue.title)")
-                }
-                if !tcpConfigured {
-                    AppLogger.shared.log("   TCP: Communication server not properly configured")
+                let signature = "active:\(reasons.joined(separator: ",")):\(blockingIssues.map(\.title).joined(separator: ","))"
+                if shouldLogValidationFailureInDetail(site: "validationFailure", signature: signature) {
+                    AppLogger.shared.error(
+                        "❌ [MainAppStateController] Validation FAILED - \(reasons.joined(separator: ", "))"
+                    )
+                    for (index, issue) in blockingIssues.enumerated() {
+                        AppLogger.shared.log("   Blocking \(index + 1): \(issue.title)")
+                    }
+                    if !tcpConfigured {
+                        AppLogger.shared.log("   TCP: Communication server not properly configured")
+                    }
+                } else {
+                    AppLogger.shared.debug(
+                        "❌ [MainAppStateController] Validation still FAILED - \(reasons.joined(separator: ", ")) (repeat #\(repeatCount(forSite: "validationFailure")), suppressing detailed log)"
+                    )
                 }
             }
 
@@ -657,6 +711,7 @@ class MainAppStateController {
             validationState = .success
             // Clear stale diagnostics when system is healthy
             onSystemHealthy?()
+            resetValidationFailureLogState()
             AppLogger.shared.info(
                 "✅ [MainAppStateController] Validation SUCCESS - adapter state is .ready"
             )
@@ -667,14 +722,22 @@ class MainAppStateController {
                 validationState = .success
                 // Clear stale diagnostics when system is healthy
                 onSystemHealthy?()
+                resetValidationFailureLogState()
                 AppLogger.shared.info("✅ [MainAppStateController] Validation SUCCESS - no blocking issues")
             } else {
                 validationState = .failed(
                     blockingCount: blockingIssues.count, totalCount: issues.count
                 )
-                AppLogger.shared.error(
-                    "❌ [MainAppStateController] Validation FAILED - \(blockingIssues.count) blocking issues"
-                )
+                let signature = "notRunning:\(blockingIssues.map(\.title).joined(separator: ","))"
+                if shouldLogValidationFailureInDetail(site: "validationFailure", signature: signature) {
+                    AppLogger.shared.error(
+                        "❌ [MainAppStateController] Validation FAILED - \(blockingIssues.count) blocking issues"
+                    )
+                } else {
+                    AppLogger.shared.debug(
+                        "❌ [MainAppStateController] Validation still FAILED - \(blockingIssues.count) blocking issues (repeat #\(repeatCount(forSite: "validationFailure")), suppressing detailed log)"
+                    )
+                }
             }
 
         case .conflictsDetected, .missingPermissions, .missingComponents:
@@ -682,12 +745,19 @@ class MainAppStateController {
             validationState = .failed(
                 blockingCount: blockingIssues.count, totalCount: issues.count
             )
-            AppLogger.shared.error(
-                "❌ [MainAppStateController] Validation FAILED - adapter state: \(adapted.state)"
-            )
-            for issue in blockingIssues {
+            let signature = "\(adapted.state):\(blockingIssues.map(\.title).joined(separator: ","))"
+            if shouldLogValidationFailureInDetail(site: "validationFailure", signature: signature) {
                 AppLogger.shared.error(
-                    "❌ [MainAppStateController]   - \(issue.title): \(issue.description)"
+                    "❌ [MainAppStateController] Validation FAILED - adapter state: \(adapted.state)"
+                )
+                for issue in blockingIssues {
+                    AppLogger.shared.error(
+                        "❌ [MainAppStateController]   - \(issue.title): \(issue.description)"
+                    )
+                }
+            } else {
+                AppLogger.shared.debug(
+                    "❌ [MainAppStateController] Validation still FAILED - adapter state: \(adapted.state) (repeat #\(repeatCount(forSite: "validationFailure")), \(blockingIssues.count) blocking issues, suppressing detailed log)"
                 )
             }
         }

--- a/Sources/KeyPathAppKit/Services/MainAppStateController.swift
+++ b/Sources/KeyPathAppKit/Services/MainAppStateController.swift
@@ -72,20 +72,27 @@ class MainAppStateController {
 
     // MARK: - Validation Log Throttling (avoid flooding the log with repeat cycles)
 
-    /// Per-log-site dedup state: maps a log site key (e.g. "startupGate",
-    /// "validationFailure") to the signature last logged in full and how many
-    /// times it has repeated unchanged since. When an unchanged failure repeats
-    /// across periodic revalidation cycles, only the first occurrence is logged
-    /// at full WARN/ERROR verbosity; repeats are collapsed into a single
-    /// low-noise line. This does not change validation behavior — only what
-    /// gets written to the log. See #934 (122 cycles of WARN+5×ERROR in 9
-    /// minutes filled and rotated the 5MB log mid-session).
-    @ObservationIgnored private var loggedFailureSignatures: [String: (signature: String, repeatCount: Int)] = [:]
+    /// The distinct log sites that dedup repeat-failure logging. A closed enum
+    /// (rather than free-form strings) so a typo at a call site is a compile
+    /// error instead of a silently-orphaned dedup bucket.
+    private enum ValidationLogSite: Hashable {
+        case startupGate
+        case validationFailure
+    }
+
+    /// Per-log-site dedup state: maps a log site to the signature last logged
+    /// in full and how many times it has repeated unchanged since. When an
+    /// unchanged failure repeats across periodic revalidation cycles, only the
+    /// first occurrence is logged at full WARN/ERROR verbosity; repeats are
+    /// collapsed into a single low-noise line. This does not change validation
+    /// behavior — only what gets written to the log. See #934 (122 cycles of
+    /// WARN+5×ERROR in 9 minutes filled and rotated the 5MB log mid-session).
+    @ObservationIgnored private var loggedFailureSignatures: [ValidationLogSite: (signature: String, repeatCount: Int)] = [:]
 
     /// Returns true if this failure signature should be logged at full verbosity
     /// (first occurrence at this site, or a change from the previously logged
     /// signature at this site). Also updates the per-site repeat counter.
-    private func shouldLogValidationFailureInDetail(site: String, signature: String) -> Bool {
+    private func shouldLogValidationFailureInDetail(site: ValidationLogSite, signature: String) -> Bool {
         if let existing = loggedFailureSignatures[site], existing.signature == signature {
             loggedFailureSignatures[site] = (signature, existing.repeatCount + 1)
             return false
@@ -95,7 +102,7 @@ class MainAppStateController {
     }
 
     /// Current repeat count for a log site (0 if this is the first occurrence).
-    private func repeatCount(forSite site: String) -> Int {
+    private func repeatCount(forSite site: ValidationLogSite) -> Int {
         loggedFailureSignatures[site]?.repeatCount ?? 0
     }
 
@@ -514,23 +521,26 @@ class MainAppStateController {
         case .ready:
             break
         case .transientTimeout:
-            if shouldLogValidationFailureInDetail(site: "startupGate", signature: "transientTimeout") {
+            if shouldLogValidationFailureInDetail(site: .startupGate, signature: "transientTimeout") {
                 AppLogger.shared.warn(
                     "⚠️ [MainAppStateController] Kanata still in transient startup window after \(Int(transientStartupGracePeriod))s - continuing with full validation to avoid false failure"
                 )
             } else {
-                AppLogger.shared.debug(
-                    "⚠️ [MainAppStateController] Kanata still in transient startup window (repeat #\(repeatCount(forSite: "startupGate")), suppressing detailed log)"
+                // Use .info (not .debug) so this remains visible in release-build logs —
+                // .debug is below the release default minimum level and would otherwise
+                // vanish entirely, defeating "check logs first" debugging (#934).
+                AppLogger.shared.info(
+                    "⚠️ [MainAppStateController] Kanata still in transient startup window (repeat #\(repeatCount(forSite: .startupGate)), suppressing detailed log)"
                 )
             }
         case .definitiveFailure:
-            if shouldLogValidationFailureInDetail(site: "startupGate", signature: "definitiveFailure") {
+            if shouldLogValidationFailureInDetail(site: .startupGate, signature: "definitiveFailure") {
                 AppLogger.shared.warn(
                     "⚠️ [MainAppStateController] Kanata service not healthy after \(definitiveStartupGracePeriod)s outside restart window - proceeding with full validation"
                 )
             } else {
-                AppLogger.shared.debug(
-                    "⚠️ [MainAppStateController] Kanata still not healthy outside restart window (repeat #\(repeatCount(forSite: "startupGate")), suppressing detailed log)"
+                AppLogger.shared.info(
+                    "⚠️ [MainAppStateController] Kanata still not healthy outside restart window (repeat #\(repeatCount(forSite: .startupGate)), suppressing detailed log)"
                 )
             }
         }
@@ -689,7 +699,7 @@ class MainAppStateController {
                     totalCount: issues.count
                 )
                 let signature = "active:\(reasons.joined(separator: ",")):\(blockingIssues.map(\.title).joined(separator: ","))"
-                if shouldLogValidationFailureInDetail(site: "validationFailure", signature: signature) {
+                if shouldLogValidationFailureInDetail(site: .validationFailure, signature: signature) {
                     AppLogger.shared.error(
                         "❌ [MainAppStateController] Validation FAILED - \(reasons.joined(separator: ", "))"
                     )
@@ -700,8 +710,12 @@ class MainAppStateController {
                         AppLogger.shared.log("   TCP: Communication server not properly configured")
                     }
                 } else {
-                    AppLogger.shared.debug(
-                        "❌ [MainAppStateController] Validation still FAILED - \(reasons.joined(separator: ", ")) (repeat #\(repeatCount(forSite: "validationFailure")), suppressing detailed log)"
+                    // .info, not .debug: repeat failures must stay visible in release-build
+                    // logs (.debug is below the release default minimum level) so "check
+                    // logs first" debugging still works, just without the full ERROR block
+                    // re-emitted every cycle (#934).
+                    AppLogger.shared.info(
+                        "❌ [MainAppStateController] Validation still FAILED - \(reasons.joined(separator: ", ")) (repeat #\(repeatCount(forSite: .validationFailure)), suppressing detailed log)"
                     )
                 }
             }
@@ -729,13 +743,13 @@ class MainAppStateController {
                     blockingCount: blockingIssues.count, totalCount: issues.count
                 )
                 let signature = "notRunning:\(blockingIssues.map(\.title).joined(separator: ","))"
-                if shouldLogValidationFailureInDetail(site: "validationFailure", signature: signature) {
+                if shouldLogValidationFailureInDetail(site: .validationFailure, signature: signature) {
                     AppLogger.shared.error(
                         "❌ [MainAppStateController] Validation FAILED - \(blockingIssues.count) blocking issues"
                     )
                 } else {
-                    AppLogger.shared.debug(
-                        "❌ [MainAppStateController] Validation still FAILED - \(blockingIssues.count) blocking issues (repeat #\(repeatCount(forSite: "validationFailure")), suppressing detailed log)"
+                    AppLogger.shared.info(
+                        "❌ [MainAppStateController] Validation still FAILED - \(blockingIssues.count) blocking issues (repeat #\(repeatCount(forSite: .validationFailure)), suppressing detailed log)"
                     )
                 }
             }
@@ -746,7 +760,7 @@ class MainAppStateController {
                 blockingCount: blockingIssues.count, totalCount: issues.count
             )
             let signature = "\(adapted.state):\(blockingIssues.map(\.title).joined(separator: ","))"
-            if shouldLogValidationFailureInDetail(site: "validationFailure", signature: signature) {
+            if shouldLogValidationFailureInDetail(site: .validationFailure, signature: signature) {
                 AppLogger.shared.error(
                     "❌ [MainAppStateController] Validation FAILED - adapter state: \(adapted.state)"
                 )
@@ -756,8 +770,8 @@ class MainAppStateController {
                     )
                 }
             } else {
-                AppLogger.shared.debug(
-                    "❌ [MainAppStateController] Validation still FAILED - adapter state: \(adapted.state) (repeat #\(repeatCount(forSite: "validationFailure")), \(blockingIssues.count) blocking issues, suppressing detailed log)"
+                AppLogger.shared.info(
+                    "❌ [MainAppStateController] Validation still FAILED - adapter state: \(adapted.state) (repeat #\(repeatCount(forSite: .validationFailure)), \(blockingIssues.count) blocking issues, suppressing detailed log)"
                 )
             }
         }

--- a/Sources/KeyPathAppKit/Services/UpdateService.swift
+++ b/Sources/KeyPathAppKit/Services/UpdateService.swift
@@ -159,9 +159,15 @@ extension UpdateService: SPUUpdaterDelegate {
         Task { @MainActor in
             let feedURL = updaterController?.updater.feedURL?.absoluteString
                 ?? (Bundle.main.object(forInfoDictionaryKey: "SUFeedURL") as? String ?? "(missing)")
-            AppLogger.shared.error(
-                "❌ [UpdateService] Sparkle aborted update cycle: \(nsError.domain) \(nsError.code) - \(nsError.localizedDescription) | feed=\(feedURL)"
-            )
+            if Self.isCosmeticSparkleOutcome(nsError) {
+                AppLogger.shared.info(
+                    "ℹ️ [UpdateService] Sparkle update check finished with no update available: \(nsError.localizedDescription) | feed=\(feedURL)"
+                )
+            } else {
+                AppLogger.shared.error(
+                    "❌ [UpdateService] Sparkle aborted update cycle: \(nsError.domain) \(nsError.code) - \(nsError.localizedDescription) | feed=\(feedURL)"
+                )
+            }
         }
     }
 
@@ -175,15 +181,37 @@ extension UpdateService: SPUUpdaterDelegate {
             let feedURL = updaterController?.updater.feedURL?.absoluteString
                 ?? (Bundle.main.object(forInfoDictionaryKey: "SUFeedURL") as? String ?? "(missing)")
             if let nsError {
-                AppLogger.shared.error(
-                    "⚠️ [UpdateService] Sparkle finished update cycle with error (\(updateCheck.rawValue)): \(nsError.domain) \(nsError.code) - \(nsError.localizedDescription) | feed=\(feedURL)"
-                )
+                if Self.isCosmeticSparkleOutcome(nsError) {
+                    // "You're up to date!" surfaces through this delegate callback as an
+                    // NSError (SUNoUpdateError) even though it's the expected, healthy
+                    // outcome of a check — not a real failure. Log at info, not error.
+                    AppLogger.shared.info(
+                        "ℹ️ [UpdateService] Sparkle finished update cycle (\(updateCheck.rawValue)) - up to date | feed=\(feedURL)"
+                    )
+                } else {
+                    AppLogger.shared.error(
+                        "⚠️ [UpdateService] Sparkle finished update cycle with error (\(updateCheck.rawValue)): \(nsError.domain) \(nsError.code) - \(nsError.localizedDescription) | feed=\(feedURL)"
+                    )
+                }
             } else {
                 AppLogger.shared.log(
                     "✅ [UpdateService] Sparkle finished update cycle (\(updateCheck.rawValue)) | feed=\(feedURL)"
                 )
             }
         }
+    }
+
+    /// Sparkle's `SUNoUpdateError` code (see Sparkle/SUErrors.h). Sparkle reports
+    /// "You're up to date!" through the delegate's error path using this code —
+    /// referenced by raw value since the generated Swift name for this ObjC
+    /// NS_ENUM case isn't reliably importable here.
+    private static let sparkleNoUpdateErrorCode = 1001
+
+    /// Whether a Sparkle-reported "error" is actually a cosmetic, expected
+    /// outcome (e.g. "You're up to date!" is delivered via the delegate's
+    /// error path as `SUNoUpdateError`) rather than a genuine failure.
+    static func isCosmeticSparkleOutcome(_ error: NSError) -> Bool {
+        error.domain == SUSparkleErrorDomain && error.code == sparkleNoUpdateErrorCode
     }
 }
 

--- a/Sources/KeyPathInstallationWizard/Core/WizardStateMachine.swift
+++ b/Sources/KeyPathInstallationWizard/Core/WizardStateMachine.swift
@@ -96,6 +96,11 @@ public class WizardStateMachine {
         hasShownFDAPage = false
         hasShownMigrationPage = false
         hasShownKarabinerImportPage = false
+        // Clear any custom navigation sequence from a prior wizard run so
+        // navigation and the "Step X of Y" indicator fall back to the canonical
+        // ordered pages until the new run's validation derives a fresh sequence.
+        // A stale sequence here survives across wizard re-opens otherwise (#934).
+        customSequence = nil
         // One-time page tracking is reset via the properties above
     }
 

--- a/Sources/KeyPathInstallationWizard/UI/Components/WizardNavigationControl.swift
+++ b/Sources/KeyPathInstallationWizard/UI/Components/WizardNavigationControl.swift
@@ -80,6 +80,32 @@ public struct WizardNavigationControl: View {
     }
 }
 
+/// Unobtrusive "Step X of Y" progress indicator for wizard detail pages.
+/// Derives its position purely from the current page's location in the
+/// active navigation sequence (`WizardStateMachine.customSequence` when set,
+/// otherwise `WizardPage.orderedPages`) — no separate source of truth to
+/// keep in sync with navigation.
+public struct WizardStepIndicator: View {
+    @Environment(WizardStateMachine.self) var stateMachine
+
+    public init() {}
+
+    private var stepPosition: WizardPage.StepPosition? {
+        let sequence = stateMachine.customSequence ?? WizardPage.orderedPages
+        return stateMachine.currentPage.stepPosition(in: sequence)
+    }
+
+    public var body: some View {
+        if let stepPosition {
+            Text("Step \(stepPosition.step) of \(stepPosition.total)")
+                .font(.caption)
+                .foregroundColor(.secondary)
+                .accessibilityIdentifier("wizard-step-indicator")
+                .accessibilityLabel("Step \(stepPosition.step) of \(stepPosition.total)")
+        }
+    }
+}
+
 /// ViewModifier that adds navigation control overlay to wizard detail pages
 public struct WizardDetailPageModifier: ViewModifier {
     @Environment(WizardStateMachine.self) var stateMachine

--- a/Sources/KeyPathInstallationWizard/UI/InstallationWizardView+StateManagement.swift
+++ b/Sources/KeyPathInstallationWizard/UI/InstallationWizardView+StateManagement.swift
@@ -30,10 +30,15 @@ public extension InstallationWizardView {
             AppLogger.shared.log("🔍 [Wizard] Navigating to initial page override: \(initialPage)")
             stateMachine.navigateToPage(initialPage)
         } else {
-            // Start at helper page, not summary - avoids showing unverified permission status
-            // before user has had a chance to decide on enhanced diagnostics (FDA)
-            AppLogger.shared.log("🔍 [Wizard] Starting at helper page (skipping initial summary)")
-            stateMachine.navigateToPage(.helper)
+            // No cached snapshot and no explicit override: stay on summary (the
+            // default from resetNavigation()) until performInitialStateCheck()
+            // below determines the real target page. Eagerly jumping to .helper
+            // here and then bouncing back to .summary once permissions are known
+            // (see performInitialStateCheck's "Permissions still unverified" guard)
+            // caused a visible summary→helper→summary flicker on wizard open (#934).
+            // performInitialStateCheck() performs the single authoritative
+            // navigation once state + permissions are resolved.
+            AppLogger.shared.log("🔍 [Wizard] No cached page — staying on summary until initial state check completes")
         }
 
         Task {

--- a/Sources/KeyPathInstallationWizard/UI/InstallationWizardView.swift
+++ b/Sources/KeyPathInstallationWizard/UI/InstallationWizardView.swift
@@ -207,6 +207,8 @@ public struct InstallationWizardView: View {
             HStack {
                 WizardNavigationControl()
                 Spacer()
+                WizardStepIndicator()
+                Spacer()
                 CloseButton()
             }
             .environment(stateMachine)

--- a/Sources/KeyPathWizardCore/WizardTypes.swift
+++ b/Sources/KeyPathWizardCore/WizardTypes.swift
@@ -78,6 +78,30 @@ public extension WizardPage {
         .service,
         .communication
     ]
+
+    /// "Step X of Y" position of a page within a wizard navigation sequence.
+    /// Summary is the overview page, not a numbered step, so it's excluded
+    /// from both the step number and the total; a page that isn't part of
+    /// `sequence` (or `.summary` itself) has no step info.
+    struct StepPosition: Equatable {
+        public let step: Int
+        public let total: Int
+
+        public init(step: Int, total: Int) {
+            self.step = step
+            self.total = total
+        }
+    }
+
+    /// Compute this page's "Step X of Y" position within the given sequence
+    /// (defaults to `orderedPages`). Returns `nil` for `.summary` or for a
+    /// page not present in `sequence`.
+    func stepPosition(in sequence: [WizardPage] = WizardPage.orderedPages) -> StepPosition? {
+        guard self != .summary else { return nil }
+        let steps = sequence.filter { $0 != .summary }
+        guard let index = steps.firstIndex(of: self) else { return nil }
+        return StepPosition(step: index + 1, total: steps.count)
+    }
 }
 
 /// Status of individual installation or check components

--- a/Tests/KeyPathTests/InstallationWizard/WizardDeterminismTests.swift
+++ b/Tests/KeyPathTests/InstallationWizard/WizardDeterminismTests.swift
@@ -51,4 +51,23 @@ final class WizardDeterminismTests: XCTestCase {
         XCTAssertEqual(readyPage, .summary)
         XCTAssertNotEqual(conflictPage, readyPage)
     }
+
+    /// Regression test for #934: the wizard must have a single, deterministic
+    /// initial page (.summary) with no eager navigation to another page before
+    /// the first state check completes. Previously the view eagerly navigated
+    /// to .helper on setup and then bounced back to .summary once permissions
+    /// resolved, causing a visible summary→helper→summary flicker on open.
+    func testStateMachineStartsOnSummaryAndResetNavigationReturnsToSummary() {
+        let stateMachine = WizardStateMachine()
+        XCTAssertEqual(stateMachine.currentPage, .summary, "Fresh state machine must start on summary")
+
+        stateMachine.navigateToPage(.helper)
+        XCTAssertEqual(stateMachine.currentPage, .helper)
+
+        stateMachine.resetNavigation()
+        XCTAssertEqual(
+            stateMachine.currentPage, .summary,
+            "resetNavigation() must deterministically return to summary so wizard setup has a single stable starting page"
+        )
+    }
 }

--- a/Tests/KeyPathTests/InstallationWizard/WizardStateMachineNavigationTests.swift
+++ b/Tests/KeyPathTests/InstallationWizard/WizardStateMachineNavigationTests.swift
@@ -240,6 +240,18 @@ final class WizardStateMachineNavigationTests: XCTestCase {
         XCTAssertFalse(stateMachine.userInteractionMode)
     }
 
+    func testResetNavigation_clearsCustomSequence() {
+        // Given - a custom sequence left over from a prior wizard run
+        stateMachine.customSequence = [.inputMonitoring, .accessibility, .service]
+
+        // When
+        stateMachine.resetNavigation()
+
+        // Then - stale sequence must not leak into the next run's navigation
+        // or the "Step X of Y" indicator (#934)
+        XCTAssertNil(stateMachine.customSequence)
+    }
+
     // MARK: - isCurrentPage Tests
 
     func testIsCurrentPage_returnsTrue_whenMatches() {

--- a/Tests/KeyPathTests/InstallationWizard/WizardStepIndicatorTests.swift
+++ b/Tests/KeyPathTests/InstallationWizard/WizardStepIndicatorTests.swift
@@ -1,0 +1,52 @@
+import Foundation
+@testable import KeyPathWizardCore
+@preconcurrency import XCTest
+
+/// Unit tests for `WizardPage.stepPosition(in:)`, the pure derivation behind
+/// the "Step X of Y" progress indicator added for #934. Summary is the
+/// overview page, not a numbered step, so it's excluded from both the
+/// step number and the total.
+final class WizardStepIndicatorTests: XCTestCase {
+    func testSummaryHasNoStepPosition() {
+        XCTAssertNil(WizardPage.summary.stepPosition())
+    }
+
+    func testFirstNonSummaryPageInDefaultOrderIsStepOne() {
+        // orderedPages: [.summary, .kanataMigration, .stopExternalKanata, .karabinerImport, .helper, ...]
+        let position = WizardPage.kanataMigration.stepPosition()
+        XCTAssertEqual(position?.step, 1)
+    }
+
+    func testTotalMatchesNonSummaryPageCount() {
+        let expectedTotal = WizardPage.orderedPages.filter { $0 != .summary }.count
+        for page in WizardPage.orderedPages where page != .summary {
+            XCTAssertEqual(
+                page.stepPosition()?.total, expectedTotal,
+                "Total step count must be consistent across all pages in the sequence"
+            )
+        }
+    }
+
+    func testStepNumbersAreSequentialAndUnique() {
+        let nonSummaryPages = WizardPage.orderedPages.filter { $0 != .summary }
+        let steps = nonSummaryPages.compactMap { $0.stepPosition()?.step }
+        XCTAssertEqual(steps, Array(1 ... nonSummaryPages.count), "Steps must be sequential starting at 1")
+    }
+
+    func testPageNotInSequenceHasNoStepPosition() {
+        // .service is not part of a custom sequence that omits it.
+        let customSequence: [WizardPage] = [.summary, .helper, .accessibility]
+        XCTAssertNil(WizardPage.service.stepPosition(in: customSequence))
+    }
+
+    func testCustomSequenceRecomputesStepsIndependently() {
+        // A "skip green pages" custom sequence with only 2 non-summary steps.
+        let customSequence: [WizardPage] = [.summary, .accessibility, .inputMonitoring]
+
+        let first = WizardPage.accessibility.stepPosition(in: customSequence)
+        let second = WizardPage.inputMonitoring.stepPosition(in: customSequence)
+
+        XCTAssertEqual(first, WizardPage.StepPosition(step: 1, total: 2))
+        XCTAssertEqual(second, WizardPage.StepPosition(step: 2, total: 2))
+    }
+}


### PR DESCRIPTION
## Summary

Implements the **mechanical** subset of #934 (2026-07-02 fresh-install QA review). The copy/UX-judgment items in that issue (restart messaging, password prompt wording, helper narration, button vocabulary, completion moment, error recovery links, Settings discoverability) are intentionally **not** included here — reserved for the maintainer.

Addresses these #934 checklist items:
- [x] Wizard page flicker at open (summary→helper→summary in 500ms; "Permissions still unverified — staying on summary")
- [x] "Step X of Y" progress indicator (no pagination info anywhere today)
- [x] Downgrade cosmetic ERRORs: Sparkle "You're up to date!" logged as ERROR ×2; expected first-run auto-launch failure logged as ERROR
- [x] Validation-loop noise: 122 cycles of WARN+5×ERROR in 9 min filled the 5MB log and rotated it mid-session

Not addressed (left for maintainer, per issue's tier-1/tier-2 split):
- [ ] Restart-needed messaging
- [ ] Password prompt wording
- [ ] Helper Login-Items dance narration
- [ ] Consistent button vocabulary
- [ ] Completion moment / onboarding
- [ ] Error states recovery paths
- [ ] "Run Setup Wizard" discoverable in Settings

## Changes

**1. Wizard open-flicker** (`InstallationWizardView+StateManagement.swift`)
`setupWizard()` previously navigated eagerly to `.helper` on every fresh run (no cached snapshot), then `performInitialStateCheck()` force-navigated back to `.summary` once it detected permissions were still `.unknown` — a visible summary→helper→summary bounce within ~500ms. Removed the eager navigation; the wizard now stays on the default `.summary` page (from `resetNavigation()`) until `performInitialStateCheck()` makes the single authoritative navigation decision. No more bounce.

**2. "Step X of Y" indicator** (`WizardTypes.swift`, `WizardNavigationControl.swift`, `InstallationWizardView.swift`)
Added a pure `WizardPage.stepPosition(in:)` derivation from the existing `orderedPages`/`customSequence` navigation order (summary excluded, since it's the overview, not a step). Wired into a new `WizardStepIndicator` view placed in the existing navigation overlay, matching the current design system (`.caption`/`.secondary`).

**3. Downgraded cosmetic ERRORs**
- `UpdateService.swift`: Sparkle reports "You're up to date!" through the `SPUUpdaterDelegate` error path as `SUNoUpdateError` (code 1001) — added `isCosmeticSparkleOutcome` to detect this and log at `.info` instead of `.error`.
- `App.swift`: the expected early-boot race (VirtualHID daemon not yet healthy when auto-launch runs) now logs at `.warn` instead of `.error` — the underlying cause is still logged at `.error` by `ServiceLifecycleCoordinator`, and the wizard follows up to repair/complete setup.

**4. Validation-loop log throttling** (`MainAppStateController.swift`)
`performValidation()` runs every ~60s via the periodic refresh loop and previously re-logged the full WARN+5×ERROR block on every cycle even when the failure was unchanged. Added per-site (`startupGate`, `validationFailure` — a closed enum, not stringly-typed) dedup: the first occurrence of a failure signature logs at full detail; unchanged repeats collapse to a single line. Uses `.info` (not `.debug`) for the repeat line so it stays visible in release-build logs (`.debug` is below the release default minimum level). Validation *behavior* is unchanged — only log volume.

## Review

Ran the mandatory `/code-review` gate (4 parallel finder angles) against the diff before opening this PR. One real issue was caught and fixed: the repeat-failure log lines were initially `.debug`-level, which is silently dropped in release builds — fixed to `.info`. Also simplified the dedup dictionary from string keys to a closed enum per a reuse/simplification finding.

One **out-of-scope** issue was surfaced during review (not fixed here, flagged separately): if `PermissionOracle`'s permission check stays `.unknown` (e.g. slow/racy TCC on macOS 26/27), the wizard's `performInitialStateCheck()` parks on `.summary` with no automatic retry — a pre-existing gap, not introduced or made worse by this diff (this diff only changes *when* the initial page renders as `.summary` vs `.helper`, not this dead-end's reachability).

## Test plan

- [x] `swift build --jobs 4` — clean build
- [x] `swift test --filter "Installer|Wizard|MainAppStateController|SystemValidator|UpdateService" --jobs 4 --build-system native` — 31 tests passed across 4 suites
- [x] New regression test: `WizardDeterminismTests.testStateMachineStartsOnSummaryAndResetNavigationReturnsToSummary` — asserts the wizard's page-selection is deterministic (starts on `.summary`, `resetNavigation()` returns to `.summary`)
- [x] New unit tests: `WizardStepIndicatorTests` (6 tests) — covers the `stepPosition(in:)` derivation: summary has no step, sequential numbering, custom-sequence recomputation, page-not-in-sequence returns nil
- [x] `swiftformat` (pinned 0.61.1) on touched files — no churn
- [x] `swiftlint --fix --quiet` on touched files — no changes needed
- [ ] Did not run the full safe suite or clean build (per task instructions — other agents were compiling in parallel in this environment); `./Scripts/test-fast.sh --changed` fell back to the full suite due to files with no fast-lane mapping and hit an unrelated pre-existing `KeyPathSnapshotTests` signal-5 harness crash in a separate `.build-ci` scratch path — confirmed unrelated by running the targeted lane directly (passed cleanly) and by the crash being in the Swift Testing snapshot harness, not the diff's own tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)