### PR TITLE
Add accessibility labels to remaining icon-only controls (#486)

### DIFF
--- a/Sources/KeyPathAppKit/UI/CommandPalette/CommandPaletteView.swift
+++ b/Sources/KeyPathAppKit/UI/CommandPalette/CommandPaletteView.swift
@@ -112,6 +112,7 @@ struct CommandPaletteView: View {
                         .foregroundStyle(.secondary)
                 }
                 .buttonStyle(.plain)
+                .accessibilityLabel("Clear search")
             }
         }
         .padding(.horizontal, 14)

--- a/Sources/KeyPathAppKit/UI/Components/MapperToolbar.swift
+++ b/Sources/KeyPathAppKit/UI/Components/MapperToolbar.swift
@@ -57,6 +57,7 @@ struct MapperToolbar: View {
             .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
             .foregroundStyle(isInspectorOpen ? Color.accentColor : .secondary)
             .help(isInspectorOpen ? "Hide Inspector" : "Show Inspector")
+            .accessibilityLabel(isInspectorOpen ? "Hide inspector" : "Show inspector")
             .accessibilityIdentifier("mapper-toggle-inspector")
         }
     }

--- a/Sources/KeyPathAppKit/UI/Dialogs/ValidationFailureDialog.swift
+++ b/Sources/KeyPathAppKit/UI/Dialogs/ValidationFailureDialog.swift
@@ -41,6 +41,7 @@ struct ValidationFailureDialog: View {
                         .font(.title2)
                 }
                 .buttonStyle(.plain)
+                .accessibilityLabel("Close")
             }
 
             Divider()

--- a/Sources/KeyPathAppKit/UI/Experimental/AdvancedBehaviorContent.swift
+++ b/Sources/KeyPathAppKit/UI/Experimental/AdvancedBehaviorContent.swift
@@ -63,6 +63,7 @@ struct MiniActionKeycap: View {
             }
             onTap()
         }
+        .accessibilityLabel(isRecording ? "Recording" : (label.isEmpty ? "Add action" : label))
     }
 
     private var foregroundColor: Color {
@@ -369,6 +370,7 @@ struct AdvancedBehaviorContent: View {
                             .buttonStyle(.plain)
                             .help("Clear chord output")
                             .accessibilityIdentifier("mapper-clear-combo-output-button")
+                            .accessibilityLabel("Clear chord output")
                         }
 
                         Spacer()
@@ -398,6 +400,7 @@ struct AdvancedBehaviorContent: View {
                             .foregroundColor(viewModel.holdBehavior == behaviorType ? .accentColor : .secondary)
                     }
                     .buttonStyle(.plain)
+                    .accessibilityLabel("Select \(behaviorType.rawValue)")
 
                     VStack(alignment: .leading, spacing: 2) {
                         Text(behaviorType.rawValue)

--- a/Sources/KeyPathAppKit/UI/Experimental/MapperKeycapViews.swift
+++ b/Sources/KeyPathAppKit/UI/Experimental/MapperKeycapViews.swift
@@ -66,6 +66,7 @@ struct BehaviorSlotKeycap: View {
             }
             onTap()
         }
+        .accessibilityLabel(isConfigured || isRecording ? "\(slotName): \(label)" : "Add \(slotIdentifier) action")
     }
 
     // MARK: - Empty State (Not Configured)

--- a/Sources/KeyPathAppKit/UI/Gallery/ChordGroupsPackContent.swift
+++ b/Sources/KeyPathAppKit/UI/Gallery/ChordGroupsPackContent.swift
@@ -194,6 +194,7 @@ private struct ChordRuleRow: View {
             }
             .buttonStyle(.plain)
             .accessibilityIdentifier("chord-pack-toggle-\(chord.id.uuidString)")
+            .accessibilityLabel("\(chord.isEnabled ? "Disable" : "Enable") chord \(chord.keys.joined(separator: "+"))")
 
             // Rest of the row — tapping opens editor
             Button(action: onEdit) {

--- a/Sources/KeyPathAppKit/UI/Help/HelpBrowserView.swift
+++ b/Sources/KeyPathAppKit/UI/Help/HelpBrowserView.swift
@@ -248,6 +248,7 @@ struct HelpBrowserView: View {
                     .disabled(currentIndex == nil)
                     .keyboardShortcut(.leftArrow, modifiers: .command)
                     .accessibilityIdentifier("help-navigate-back")
+                    .accessibilityLabel("Previous topic")
 
                     Button { navigateForward() } label: {
                         Image(systemName: "chevron.right")
@@ -260,6 +261,7 @@ struct HelpBrowserView: View {
                     .disabled(currentIndex.map { $0 + 1 >= HelpTopic.allTopics.count } ?? false)
                     .keyboardShortcut(.rightArrow, modifiers: .command)
                     .accessibilityIdentifier("help-navigate-forward")
+                    .accessibilityLabel("Next topic")
                 }
                 .padding(.horizontal, 16)
                 .padding(.vertical, 8)

--- a/Sources/KeyPathAppKit/UI/Overlay/KeymapCard.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/KeymapCard.swift
@@ -43,6 +43,7 @@ struct KeymapCard: View {
                             .foregroundStyle(.secondary)
                     }
                     .buttonStyle(.plain)
+                    .accessibilityLabel("Learn more about \(keymap.name)")
                 }
             }
             .padding(6)

--- a/Sources/KeyPathAppKit/UI/Overlay/KeystrokeHistoryView.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/KeystrokeHistoryView.swift
@@ -27,6 +27,7 @@ struct KeystrokeHistoryView: View {
             }
             .buttonStyle(.plain)
             .help(service.isRecording ? "Pause recording" : "Resume recording")
+            .accessibilityLabel(service.isRecording ? "Pause recording" : "Resume recording")
 
             Text("\(service.eventCount) events")
                 .font(.system(size: 10, weight: .medium, design: .monospaced))
@@ -43,6 +44,7 @@ struct KeystrokeHistoryView: View {
             }
             .buttonStyle(.plain)
             .help(autoScroll ? "Auto-scroll on" : "Auto-scroll off")
+            .accessibilityLabel(autoScroll ? "Turn off auto-scroll" : "Turn on auto-scroll")
 
             Button {
                 service.clearEvents()
@@ -53,6 +55,7 @@ struct KeystrokeHistoryView: View {
             }
             .buttonStyle(.plain)
             .help("Clear history")
+            .accessibilityLabel("Clear history")
         }
         .padding(.horizontal, 8)
         .padding(.vertical, 6)

--- a/Sources/KeyPathAppKit/UI/Overlay/MultiTapSlideOverView.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/MultiTapSlideOverView.swift
@@ -91,6 +91,7 @@ private struct MultiTapRow: View {
                 }
                 .buttonStyle(.plain)
                 .accessibilityIdentifier("multitap-clear-\(count)x")
+                .accessibilityLabel("Clear \(count)-tap action")
             }
         }
     }

--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayDragHeader+LayerPicker.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayDragHeader+LayerPicker.swift
@@ -188,6 +188,7 @@ extension OverlayDragHeader {
                 .focusable(false)
                 .opacity(isHovered ? 1 : 0)
                 .accessibilityIdentifier("layer-delete-\(layer)")
+                .accessibilityLabel("Delete \(displayName) layer")
             }
         }
         .background(

--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayLaunchersSection.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayLaunchersSection.swift
@@ -349,6 +349,7 @@ private struct LauncherMappingRow: View {
                     .buttonStyle(.plain)
                     .accessibilityIdentifier("overlay-launcher-delete-\(mapping.key)")
                     .help("Delete")
+                    .accessibilityLabel("Delete \(displayName)")
                     .background(
                         GeometryReader { geo in
                             Color.clear.preference(

--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayMapperSection+AppMappingIndicators.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayMapperSection+AppMappingIndicators.swift
@@ -52,6 +52,7 @@ extension OverlayMapperSection {
         .buttonStyle(.plain)
         .help(tooltip)
         .accessibilityIdentifier("app-mapping-indicator-\(bundleId)")
+        .accessibilityLabel("Select \(displayName) mapping")
     }
 
     /// Handle tap on an app mapping indicator - switches to that app's context

--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayMapperSection+LaunchApps.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayMapperSection+LaunchApps.swift
@@ -84,6 +84,7 @@ extension OverlayMapperSection {
                 .buttonStyle(.plain)
                 .focusable(false)
                 .accessibilityIdentifier("overlay-launch-app-search-clear")
+                .accessibilityLabel("Clear search")
             }
         }
         .padding(.horizontal, 10)

--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayMapperSection.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayMapperSection.swift
@@ -583,6 +583,7 @@ struct OverlayMapperSection: View {
                                     .buttonStyle(.plain)
                                     .help("Clear mapping")
                                     .accessibilityIdentifier("overlay-mapper-reset-trigger")
+                                    .accessibilityLabel("Clear mapping")
                                     .frame(width: arrowWidth)
                                 } else {
                                     Color.clear

--- a/Sources/KeyPathAppKit/UI/Overlay/TapHoldMiniKeycap.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/TapHoldMiniKeycap.swift
@@ -61,6 +61,7 @@ struct TapHoldMiniKeycap: View {
             }
             onTap()
         }
+        .accessibilityLabel(label.isEmpty ? "Add key" : label)
     }
 
     @Environment(\.colorScheme) private var colorScheme

--- a/Sources/KeyPathAppKit/UI/Rules/AppRuleRowCompact.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/AppRuleRowCompact.swift
@@ -84,6 +84,7 @@ struct AppRuleRowCompact: View {
                                 .contentShape(Rectangle())
                         }
                         .buttonStyle(.plain)
+                        .accessibilityLabel("Edit \(prettyKeyName(override.inputKey)) rule")
 
                         Button {
                             onDelete()
@@ -95,6 +96,7 @@ struct AppRuleRowCompact: View {
                                 .contentShape(Rectangle())
                         }
                         .buttonStyle(.plain)
+                        .accessibilityLabel("Delete \(prettyKeyName(override.inputKey)) rule")
 
                         // Spacer for alignment
                         Spacer()

--- a/Sources/KeyPathAppKit/UI/Rules/InlineKeyField.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/InlineKeyField.swift
@@ -35,6 +35,7 @@ struct InlineKeyField: View {
                 }
                 .menuStyle(.borderlessButton)
                 .accessibilityIdentifier(menuIdentifier)
+                .accessibilityLabel("Choose \(title) key")
             }
         }
     }

--- a/Sources/KeyPathAppKit/UI/Rules/KeyRepeatControlView.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/KeyRepeatControlView.swift
@@ -319,6 +319,7 @@ struct KeyRepeatControlView: View {
                         Image(systemName: "xmark.circle.fill").font(.subheadline).foregroundStyle(.tertiary)
                     }.buttonStyle(.plain)
                         .accessibilityIdentifier("key-repeat-remove-custom-\(entry.key)")
+                        .accessibilityLabel("Remove custom repeat for \(entry.key)")
                 }
             }
         }

--- a/Sources/KeyPathAppKit/UI/Rules/LauncherDrawerView.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/LauncherDrawerView.swift
@@ -64,6 +64,7 @@ struct LauncherDrawerView: View {
                 }
                 .menuStyle(.borderlessButton)
                 .accessibilityIdentifier("launcher-drawer-menu-button")
+                .accessibilityLabel("Mappings options")
             }
             .padding(.horizontal, 16)
             .padding(.vertical, 10)

--- a/Sources/KeyPathAppKit/UI/Rules/LauncherMappingEditor.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/LauncherMappingEditor.swift
@@ -468,6 +468,7 @@ struct LauncherMappingEditor: View {
                         .menuStyle(.borderlessButton)
                         .frame(width: 24)
                         .accessibilityIdentifier("launcher-editor-script-gear-menu")
+                        .accessibilityLabel("Script options")
                     }
                     .padding(8)
                     .background(
@@ -555,6 +556,7 @@ struct LauncherMappingEditor: View {
                     .buttonStyle(.plain)
                     .help("Remove custom icon")
                     .accessibilityIdentifier("launcher-editor-icon-clear")
+                    .accessibilityLabel("Remove custom icon")
                 }
             }
         }

--- a/Sources/KeyPathAppKit/UI/Rules/MappingBehaviorEditor.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/MappingBehaviorEditor.swift
@@ -277,6 +277,7 @@ struct MappingBehaviorEditor: View {
                                 }
                                 .buttonStyle(.plain)
                                 .accessibilityIdentifier("mapping-behavior-remove-step-\(index)")
+                                .accessibilityLabel("Remove \(tapDanceSteps[index].label) step")
                             }
                         }
                     }

--- a/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView+CreateRuleButton.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView+CreateRuleButton.swift
@@ -31,6 +31,7 @@ struct CreateRuleButton: View {
             .animation(.easeInOut(duration: 0.1), value: isMouseDown)
         }
         .buttonStyle(.plain)
+        .accessibilityLabel("Create rule")
         .onHover { hovering in
             isHovered = hovering
         }


### PR DESCRIPTION
## Summary

Finishes the accessibility-label sweep from the §8.7 audit. PR #942 labeled 3 icon-only controls; this PR covers the rest of `Sources/KeyPathAppKit/UI` — 30 new `.accessibilityLabel()` modifiers across 23 files (Overlay, Rules, Components, Experimental, Gallery, Dialogs, CommandPalette, Help).

The count is well below the audit's ~108 estimate because most candidates turned out to be already labeled (by #942 and earlier work), decorative non-interactive icons, or controls with visible text alongside the icon — each `Image(systemName:)`/`onTapGesture` hit in the tree was checked in context.

Label style matches #942: concise, sentence case, action-oriented ("Clear search", "Delete \(displayName) layer"), with dynamic interpolation to disambiguate repeated rows, and state-aware text for toggles ("Pause recording" / "Resume recording").

Purely additive — 30 insertions, 0 deletions, no behavior changes.

Fixes #486

## Verification

- `swift build` clean
- `./Scripts/test-fast.sh --changed`: 320 tests passed
- swiftformat 0.61.1 (pinned): no churn; swiftlint on changed files: no new warnings (remaining warnings pre-exist on master)
- Pre-PR review gate run on the branch diff: no findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)