### PR TITLE
Make FeatureFlags test-injectable via in-memory override store (#896 class fix)

### DIFF
--- a/Sources/KeyPathCore/FeatureFlags.swift
+++ b/Sources/KeyPathCore/FeatureFlags.swift
@@ -46,6 +46,80 @@ extension FeatureFlags: @unchecked Sendable {}
 // MARK: - Persisted flags (UserDefaults-backed)
 
 public extension FeatureFlags {
+    /// In-memory flag store used instead of `UserDefaults.standard` while running tests.
+    ///
+    /// `UserDefaults.standard` is process-global AND persistent, so a test suite that
+    /// flips a flag can leak state into every other suite in the run (and into later
+    /// runs, or the developer's real app) if a throw skips its tearDown — the exact
+    /// mechanism behind the #896 RemapEndToEndTests flake. Under
+    /// `TestEnvironment.isRunningTests`, flag setters write here and readers resolve
+    /// override-then-compiled-default, never touching real UserDefaults.
+    private enum TestOverrides {
+        static let lock = NSLock()
+        nonisolated(unsafe) static var values: [String: Any] = [:]
+
+        static func value(forKey key: String) -> Any? {
+            lock.lock()
+            defer { lock.unlock() }
+            return values[key]
+        }
+
+        static func set(_ value: Any, forKey key: String) {
+            lock.lock()
+            defer { lock.unlock() }
+            values[key] = value
+        }
+
+        static func reset() {
+            lock.lock()
+            defer { lock.unlock() }
+            values.removeAll()
+        }
+    }
+
+    /// Memoized: the detection signals are process-stable, and re-evaluating them
+    /// (Bundle.allBundles scan) on every flag read is wasteful.
+    private static let isRunningTests = TestEnvironment.isRunningTests
+
+    /// Clear all in-memory test overrides, returning every flag to its compiled
+    /// default. Called between tests (KeyPathTestCase) and by suites that flip flags.
+    static func resetTestOverrides() {
+        TestOverrides.reset()
+    }
+
+    private static func boolFlag(forKey key: String, default defaultValue: Bool) -> Bool {
+        if isRunningTests {
+            return TestOverrides.value(forKey: key) as? Bool ?? defaultValue
+        }
+        if UserDefaults.standard.object(forKey: key) == nil {
+            return defaultValue
+        }
+        return UserDefaults.standard.bool(forKey: key)
+    }
+
+    private static func setBoolFlag(_ enabled: Bool, forKey key: String) {
+        if isRunningTests {
+            TestOverrides.set(enabled, forKey: key)
+            return
+        }
+        UserDefaults.standard.set(enabled, forKey: key)
+    }
+
+    private static func stringFlag(forKey key: String) -> String? {
+        if isRunningTests {
+            return TestOverrides.value(forKey: key) as? String
+        }
+        return UserDefaults.standard.string(forKey: key)
+    }
+
+    private static func setStringFlag(_ value: String, forKey key: String) {
+        if isRunningTests {
+            TestOverrides.set(value, forKey: key)
+            return
+        }
+        UserDefaults.standard.set(value, forKey: key)
+    }
+
     private static let captureListenOnlyKey = "CAPTURE_LISTEN_ONLY_ENABLED"
     private static let useSMAppServiceForDaemonKey = "USE_SMAPPSERVICE_FOR_DAEMON"
     private static let simulatorAndVirtualKeysEnabledKey = "SIMULATOR_AND_VIRTUAL_KEYS_ENABLED"
@@ -61,66 +135,53 @@ public extension FeatureFlags {
     /// CGEvent tap listen-only mode (default ON)
     /// When enabled, KeyPath only listens to key events without modifying them.
     static var captureListenOnlyEnabled: Bool {
-        if UserDefaults.standard.object(forKey: captureListenOnlyKey) == nil {
-            return true // default ON
-        }
-        return UserDefaults.standard.bool(forKey: captureListenOnlyKey)
+        boolFlag(forKey: captureListenOnlyKey, default: true)
     }
 
     static func setCaptureListenOnlyEnabled(_ enabled: Bool) {
-        UserDefaults.standard.set(enabled, forKey: captureListenOnlyKey)
+        setBoolFlag(enabled, forKey: captureListenOnlyKey)
     }
 
     /// Whether to use SMAppService for Kanata daemon management (default ON)
     /// When enabled, uses SMAppService instead of launchctl for daemon registration.
     static var useSMAppServiceForDaemon: Bool {
-        if UserDefaults.standard.object(forKey: useSMAppServiceForDaemonKey) == nil {
-            return true // default ON
-        }
-        return UserDefaults.standard.bool(forKey: useSMAppServiceForDaemonKey)
+        boolFlag(forKey: useSMAppServiceForDaemonKey, default: true)
     }
 
     static func setUseSMAppServiceForDaemon(_ enabled: Bool) {
-        UserDefaults.standard.set(enabled, forKey: useSMAppServiceForDaemonKey)
+        setBoolFlag(enabled, forKey: useSMAppServiceForDaemonKey)
     }
 
     /// Enable simulator for layer mapping and virtual key actions (default ON)
     /// Required for overlay to show correct remapped key labels.
     static var simulatorAndVirtualKeysEnabled: Bool {
-        if UserDefaults.standard.object(forKey: simulatorAndVirtualKeysEnabledKey) == nil {
-            return true // default ON - needed for correct overlay labels
-        }
-        return UserDefaults.standard.bool(forKey: simulatorAndVirtualKeysEnabledKey)
+        // default ON - needed for correct overlay labels
+        boolFlag(forKey: simulatorAndVirtualKeysEnabledKey, default: true)
     }
 
     static func setSimulatorAndVirtualKeysEnabled(_ enabled: Bool) {
-        UserDefaults.standard.set(enabled, forKey: simulatorAndVirtualKeysEnabledKey)
+        setBoolFlag(enabled, forKey: simulatorAndVirtualKeysEnabledKey)
     }
 
     /// Verbose logging for keyboard suppression decisions (default OFF).
     static var keyboardSuppressionDebugEnabled: Bool {
-        if UserDefaults.standard.object(forKey: keyboardSuppressionDebugEnabledKey) == nil {
-            return false
-        }
-        return UserDefaults.standard.bool(forKey: keyboardSuppressionDebugEnabledKey)
+        boolFlag(forKey: keyboardSuppressionDebugEnabledKey, default: false)
     }
 
     static func setKeyboardSuppressionDebugEnabled(_ enabled: Bool) {
-        UserDefaults.standard.set(enabled, forKey: keyboardSuppressionDebugEnabledKey)
+        setBoolFlag(enabled, forKey: keyboardSuppressionDebugEnabledKey)
     }
 
     /// Reset TCC permissions and preferences on uninstall for fresh install testing (default OFF)
     /// When enabled, uninstall also clears Accessibility, Input Monitoring, and Full Disk Access
     /// permissions plus UserDefaults, allowing a true "first launch" experience.
     static var uninstallForTesting: Bool {
-        if UserDefaults.standard.object(forKey: uninstallForTestingKey) == nil {
-            return false // default OFF for production
-        }
-        return UserDefaults.standard.bool(forKey: uninstallForTestingKey)
+        // default OFF for production
+        boolFlag(forKey: uninstallForTestingKey, default: false)
     }
 
     static func setUninstallForTesting(_ enabled: Bool) {
-        UserDefaults.standard.set(enabled, forKey: uninstallForTestingKey)
+        setBoolFlag(enabled, forKey: uninstallForTestingKey)
     }
 
     /// Learning tips display mode
@@ -128,7 +189,7 @@ public extension FeatureFlags {
     /// - alwaysOn: Always show tips regardless of learned state
     /// - off: Never show learning tips
     static var learningTipsMode: LearningTipsMode {
-        if let rawValue = UserDefaults.standard.string(forKey: learningTipsModeKey),
+        if let rawValue = stringFlag(forKey: learningTipsModeKey),
            let mode = LearningTipsMode(rawValue: rawValue)
         {
             return mode
@@ -137,20 +198,17 @@ public extension FeatureFlags {
     }
 
     static func setLearningTipsMode(_ mode: LearningTipsMode) {
-        UserDefaults.standard.set(mode.rawValue, forKey: learningTipsModeKey)
+        setStringFlag(mode.rawValue, forKey: learningTipsModeKey)
     }
 
     /// Context HUD floating list window (default ON)
     /// When enabled, shows a compact key list alongside or instead of the keyboard overlay.
     static var contextHUDListEnabled: Bool {
-        if UserDefaults.standard.object(forKey: contextHUDListEnabledKey) == nil {
-            return true // default ON
-        }
-        return UserDefaults.standard.bool(forKey: contextHUDListEnabledKey)
+        boolFlag(forKey: contextHUDListEnabledKey, default: true)
     }
 
     static func setContextHUDListEnabled(_ enabled: Bool) {
-        UserDefaults.standard.set(enabled, forKey: contextHUDListEnabledKey)
+        setBoolFlag(enabled, forKey: contextHUDListEnabledKey)
     }
 
     // MARK: - Future Implementation (not yet built)
@@ -158,27 +216,23 @@ public extension FeatureFlags {
     /// Phase 2: Just-in-time permission requests (NOT YET IMPLEMENTED)
     /// Will allow requesting permissions only when needed rather than upfront.
     static var useJustInTimePermissionRequests: Bool {
-        if UserDefaults.standard.object(forKey: useJustInTimePermissionRequestsKey) == nil {
-            return false // default OFF - not implemented
-        }
-        return UserDefaults.standard.bool(forKey: useJustInTimePermissionRequestsKey)
+        // default OFF - not implemented
+        boolFlag(forKey: useJustInTimePermissionRequestsKey, default: false)
     }
 
     static func setUseJustInTimePermissionRequests(_ enabled: Bool) {
-        UserDefaults.standard.set(enabled, forKey: useJustInTimePermissionRequestsKey)
+        setBoolFlag(enabled, forKey: useJustInTimePermissionRequestsKey)
     }
 
     /// Phase 3: Optional wizard - non-blocking setup (NOT YET IMPLEMENTED)
     /// Will allow skipping the wizard and configuring later.
     static var allowOptionalWizard: Bool {
-        if UserDefaults.standard.object(forKey: allowOptionalWizardKey) == nil {
-            return false // default OFF - not implemented
-        }
-        return UserDefaults.standard.bool(forKey: allowOptionalWizardKey)
+        // default OFF - not implemented
+        boolFlag(forKey: allowOptionalWizardKey, default: false)
     }
 
     static func setAllowOptionalWizard(_ enabled: Bool) {
-        UserDefaults.standard.set(enabled, forKey: allowOptionalWizardKey)
+        setBoolFlag(enabled, forKey: allowOptionalWizardKey)
     }
 }
 

--- a/Tests/KeyPathTests/FeatureFlagsTestSeamTests.swift
+++ b/Tests/KeyPathTests/FeatureFlagsTestSeamTests.swift
@@ -1,0 +1,48 @@
+@testable import KeyPathCore
+import XCTest
+
+/// Regression tests for the FeatureFlags test seam (#896 class of bug):
+/// while running tests, flag writes must go to an in-memory override store —
+/// never process-global `UserDefaults.standard` — and resetTestOverrides()
+/// must return every flag to its compiled default.
+final class FeatureFlagsTestSeamTests: XCTestCase {
+    override func tearDown() {
+        FeatureFlags.resetTestOverrides()
+        super.tearDown()
+    }
+
+    func testSetterDoesNotTouchUserDefaults() {
+        let key = "SIMULATOR_AND_VIRTUAL_KEYS_ENABLED"
+        let persistedBefore = UserDefaults.standard.object(forKey: key)
+
+        FeatureFlags.setSimulatorAndVirtualKeysEnabled(false)
+
+        XCTAssertFalse(FeatureFlags.simulatorAndVirtualKeysEnabled, "Override must be visible to readers")
+        let persistedAfter = UserDefaults.standard.object(forKey: key)
+        XCTAssertEqual(
+            persistedBefore as? Bool, persistedAfter as? Bool,
+            "Setting a flag in tests must not write to UserDefaults.standard"
+        )
+    }
+
+    func testResetRestoresCompiledDefaults() {
+        FeatureFlags.setSimulatorAndVirtualKeysEnabled(false)
+        FeatureFlags.setCaptureListenOnlyEnabled(false)
+        FeatureFlags.setLearningTipsMode(.alwaysOn)
+
+        FeatureFlags.resetTestOverrides()
+
+        XCTAssertTrue(FeatureFlags.simulatorAndVirtualKeysEnabled, "default ON")
+        XCTAssertTrue(FeatureFlags.captureListenOnlyEnabled, "default ON")
+        XCTAssertEqual(FeatureFlags.learningTipsMode, .off, "default off")
+    }
+
+    func testReadsIgnorePersistedUserDefaultsInTests() {
+        // Even if a value is persisted (e.g. left behind by an older test run or
+        // the developer's real app), test reads must resolve override-or-default.
+        XCTAssertTrue(
+            FeatureFlags.simulatorAndVirtualKeysEnabled,
+            "With no override set, reads must return the compiled default regardless of UserDefaults"
+        )
+    }
+}

--- a/Tests/KeyPathTests/KeyPathTestCase.swift
+++ b/Tests/KeyPathTests/KeyPathTestCase.swift
@@ -1,5 +1,4 @@
 @testable import KeyPathAppKit
-import KeyPathCore
 import KeyPathDaemonLifecycle
 @testable import KeyPathInstallationWizard
 import KeyPathWizardCore
@@ -43,7 +42,6 @@ import KeyPathWizardCore
 open class KeyPathTestCase: XCTestCase {
     override open func setUp() {
         super.setUp()
-        FeatureFlags.resetTestOverrides()
         MainActor.assumeIsolated {
             TestSingletonReset.resetAll()
             VHIDDeviceManager.testPIDProvider = { [] }
@@ -63,7 +61,6 @@ open class KeyPathTestCase: XCTestCase {
             WizardDependencies.reset()
             TestSingletonReset.resetAll()
         }
-        FeatureFlags.resetTestOverrides()
         super.tearDown()
     }
 }
@@ -73,7 +70,6 @@ open class KeyPathTestCase: XCTestCase {
 open class KeyPathAsyncTestCase: XCTestCase {
     override open func setUp() async throws {
         try await super.setUp()
-        FeatureFlags.resetTestOverrides()
         await MainActor.run {
             TestSingletonReset.resetAll()
             VHIDDeviceManager.testPIDProvider = { [] }
@@ -93,7 +89,6 @@ open class KeyPathAsyncTestCase: XCTestCase {
             WizardDependencies.reset()
             TestSingletonReset.resetAll()
         }
-        FeatureFlags.resetTestOverrides()
         try await super.tearDown()
     }
 }

--- a/Tests/KeyPathTests/KeyPathTestCase.swift
+++ b/Tests/KeyPathTests/KeyPathTestCase.swift
@@ -1,4 +1,5 @@
 @testable import KeyPathAppKit
+import KeyPathCore
 import KeyPathDaemonLifecycle
 @testable import KeyPathInstallationWizard
 import KeyPathWizardCore
@@ -42,6 +43,7 @@ import KeyPathWizardCore
 open class KeyPathTestCase: XCTestCase {
     override open func setUp() {
         super.setUp()
+        FeatureFlags.resetTestOverrides()
         MainActor.assumeIsolated {
             TestSingletonReset.resetAll()
             VHIDDeviceManager.testPIDProvider = { [] }
@@ -61,6 +63,7 @@ open class KeyPathTestCase: XCTestCase {
             WizardDependencies.reset()
             TestSingletonReset.resetAll()
         }
+        FeatureFlags.resetTestOverrides()
         super.tearDown()
     }
 }
@@ -70,6 +73,7 @@ open class KeyPathTestCase: XCTestCase {
 open class KeyPathAsyncTestCase: XCTestCase {
     override open func setUp() async throws {
         try await super.setUp()
+        FeatureFlags.resetTestOverrides()
         await MainActor.run {
             TestSingletonReset.resetAll()
             VHIDDeviceManager.testPIDProvider = { [] }
@@ -89,6 +93,7 @@ open class KeyPathAsyncTestCase: XCTestCase {
             WizardDependencies.reset()
             TestSingletonReset.resetAll()
         }
+        FeatureFlags.resetTestOverrides()
         try await super.tearDown()
     }
 }

--- a/Tests/KeyPathTests/Services/ActionDispatcherTests.swift
+++ b/Tests/KeyPathTests/Services/ActionDispatcherTests.swift
@@ -391,9 +391,10 @@ struct ActionDispatcherRoutingTests {
     @Test("Dispatches fakekey action")
     @MainActor
     func dispatchesFakekeyAction() throws {
-        let previous = FeatureFlags.simulatorAndVirtualKeysEnabled
+        // In tests this writes to FeatureFlags' in-memory override store,
+        // not UserDefaults, so it cannot leak into other suites.
         FeatureFlags.setSimulatorAndVirtualKeysEnabled(true)
-        defer { FeatureFlags.setSimulatorAndVirtualKeysEnabled(previous) }
+        defer { FeatureFlags.resetTestOverrides() }
 
         let uri = try #require(KeyPathActionURI(string: "keypath://fakekey/test-key/tap"))
         let result = ActionDispatcher.shared.dispatch(uri)
@@ -405,9 +406,8 @@ struct ActionDispatcherRoutingTests {
     @Test("Returns missingTarget for fakekey without name")
     @MainActor
     func returnsMissingTargetForFakekeyWithoutName() throws {
-        let previous = FeatureFlags.simulatorAndVirtualKeysEnabled
         FeatureFlags.setSimulatorAndVirtualKeysEnabled(true)
-        defer { FeatureFlags.setSimulatorAndVirtualKeysEnabled(previous) }
+        defer { FeatureFlags.resetTestOverrides() }
 
         let uri = try #require(KeyPathActionURI(string: "keypath://fakekey"))
         let result = ActionDispatcher.shared.dispatch(uri)
@@ -422,9 +422,8 @@ struct ActionDispatcherRoutingTests {
     @Test("Returns failed for fakekey when feature flag disabled")
     @MainActor
     func returnsFailedForFakekeyWhenFeatureDisabled() throws {
-        let previous = FeatureFlags.simulatorAndVirtualKeysEnabled
         FeatureFlags.setSimulatorAndVirtualKeysEnabled(false)
-        defer { FeatureFlags.setSimulatorAndVirtualKeysEnabled(previous) }
+        defer { FeatureFlags.resetTestOverrides() }
 
         let uri = try #require(KeyPathActionURI(string: "keypath://fakekey/test/tap"))
         let result = ActionDispatcher.shared.dispatch(uri)

--- a/Tests/KeyPathTests/Services/ActionDispatcherTests.swift
+++ b/Tests/KeyPathTests/Services/ActionDispatcherTests.swift
@@ -391,8 +391,6 @@ struct ActionDispatcherRoutingTests {
     @Test("Dispatches fakekey action")
     @MainActor
     func dispatchesFakekeyAction() throws {
-        // In tests this writes to FeatureFlags' in-memory override store,
-        // not UserDefaults, so it cannot leak into other suites.
         FeatureFlags.setSimulatorAndVirtualKeysEnabled(true)
         defer { FeatureFlags.resetTestOverrides() }
 

--- a/Tests/KeyPathTests/Support/GlobalTestSetup.swift
+++ b/Tests/KeyPathTests/Support/GlobalTestSetup.swift
@@ -42,5 +42,9 @@ enum TestSingletonReset {
 
         // TestEnvironment flags
         TestEnvironment.forceTestMode = false
+
+        // Feature flags — in tests these live in FeatureFlags' in-memory
+        // override store, never UserDefaults (#896); clear to compiled defaults.
+        FeatureFlags.resetTestOverrides()
     }
 }


### PR DESCRIPTION
## Summary

Fixes the *class* of bug behind the #896 RemapEndToEndTests flake (patched symptomatically for one suite in PR #944 — see that PR's out-of-scope note): `FeatureFlags` persisted flags are backed by `UserDefaults.standard`, a process-global **and persistent** store, so any suite flipping a flag in setUp/tearDown (e.g. `LayerKeyMapperPrebuildTests`) could leak state into every other suite in the run — and into later runs or the developer's real app if a throw skipped tearDown.

### The seam

Under `TestEnvironment.isRunningTests`, all UserDefaults-backed `FeatureFlags` accessors now route through private helpers:

- **Setters** write to a lock-protected in-memory override store — never `UserDefaults.standard`.
- **Readers** resolve override-then-compiled-default — never consulting real UserDefaults, so tests are hermetic against values persisted by earlier runs or the developer's installed app.
- `FeatureFlags.resetTestOverrides()` clears the store back to compiled defaults; it's wired into `TestSingletonReset.resetAll()` (already called from `KeyPathTestCase` setUp/tearDown).

Production behavior is unchanged: outside tests the helpers read/write `UserDefaults.standard` exactly as before. `TestEnvironment.isRunningTests` is memoized (`static let`, lazy, process-stable signals) so production flag reads don't pay a repeated `Bundle.allBundles` scan.

### Migrations

- `LayerKeyMapperPrebuildTests`, `LayerKeyMapperTests`: drop save/restore boilerplate; set the flag in setUp, `resetTestOverrides()` in tearDown.
- `ActionDispatcherTests` (Swift Testing): per-test set + `defer { resetTestOverrides() }`.
- New `FeatureFlagsTestSeamTests` guards the seam itself (setter doesn't touch UserDefaults; reset restores compiled defaults; reads ignore persisted defaults).

PR #944's defensive pin in `RemapEndToEndTests` keeps working through the seam (untouched here to avoid conflicting with that open PR); once both land it becomes redundant and can be dropped.

### Review gate

`/thermo-nuclear-swift-review` isn't available in this session, so the gate ran as an 8-angle multi-agent `/code-review` (high). Two findings confirmed and fixed (reset centralized in `TestSingletonReset.resetAll()` instead of scattered `KeyPathTestCase` edits; duplicated comment removed). Refuted with evidence: 'missing return' claims (implicit returns — suite compiles and passes), eager/stale memoization (Swift `static let` is lazy; detection signals are process-stable), NSLock overhead (only taken in test processes; needed because production code paths read flags from background threads during tests), parallel Swift Testing clobber (all flag-flipping `@Test`s are `@MainActor`-serialized). Possible follow-up, not done here: unify the older `testStartupMode` DEBUG seam with the new store.

## Test plan

- [x] `FeatureFlagsTestSeamTests` + `LayerKeyMapperPrebuildTests` + `ActionDispatcherTests` pass
- [x] #896 interference combo `RemapEndToEndTests|LayerKeyMapperPrebuildTests|LayerKeyMapperTests` — 3 consecutive clean runs **without** any per-suite pin on master's copy of RemapEndToEndTests (the seam alone prevents the pollution)
- [x] KeyPathTestCase-dependent suites (`VHIDDeviceManagerTests`, `KanataInputGrabConsumerTests`) pass
- [x] Full affected-suite run after review fixes: XCTest selected-tests suite + 56 Swift Testing tests, all passing
- Note: `ServiceLifecycleCoordinatorTests` has 2 failures that reproduce identically on unmodified master (pre-existing, environment-specific to this macOS 27 beta box; unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)