### PR TITLE
Fix stuck splash screen when reopening running app via Raycast

### DIFF
--- a/Sources/KeyPathAppKit/App.swift
+++ b/Sources/KeyPathAppKit/App.swift
@@ -132,7 +132,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private var mainWindowController: MainWindowController?
     private var menuBarController: MenuBarController?
     private var initialMainWindowShown = false
-    private var pendingReopenShow = false
     private var suppressLaunchSplashAutoHide = false
     private var keyboardCapture: KeyboardCapture?
 
@@ -327,29 +326,56 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         AppLogger.shared.debug(
             "🔍 [AppDelegate] applicationShouldHandleReopen (hasVisibleWindows=\(flag))"
         )
+        presentReopenSurface(trigger: "reopen")
+        return true
+    }
 
+    private var hasExistingConfig: Bool {
+        Foundation.FileManager.default.fileExists(
+            atPath: KeyPathConstants.Config.mainConfigPath
+        )
+    }
+
+    private func unhideAndActivate() {
         if NSApp.isHidden {
             NSApp.unhide(nil)
         }
         NSApp.activate(ignoringOtherApps: true)
+    }
 
-        // If the app is already fully running, just activate — don't re-show the splash
-        if initialMainWindowShown, LiveKeyboardOverlayController.shared.isVisible {
-            AppLogger.shared.debug("🪟 [AppDelegate] Reopen while running - activating without splash")
-            return true
-        }
+    /// Present the right surface for a user-initiated "open KeyPath" action
+    /// (Dock/Raycast/Spotlight reopen or menu-bar "Show KeyPath").
+    private func presentReopenSurface(trigger: String) {
+        unhideAndActivate()
 
-        // On relaunch (not first-ever install), skip splash and go straight to overlay
-        let hasExistingConfig = Foundation.FileManager.default.fileExists(
-            atPath: KeyPathConstants.Config.mainConfigPath
+        let surface = ReopenPolicy.surface(
+            hasExistingConfig: hasExistingConfig,
+            overlayVisible: LiveKeyboardOverlayController.shared.isVisible
         )
-        if hasExistingConfig, !initialMainWindowShown {
-            AppLogger.shared.info("🪟 [AppDelegate] Reopen on relaunch — skipping splash, showing overlay")
-            initialMainWindowShown = true
-            LiveKeyboardOverlayController.shared.showForStartup(bypassHiddenCheck: true)
-            return true
-        }
 
+        switch surface {
+        case .activateOnly:
+            AppLogger.shared.debug("🪟 [AppDelegate] \(trigger): overlay already visible — activating only")
+            LiveKeyboardOverlayController.shared.bringToFront()
+
+        case .showOverlay:
+            AppLogger.shared.info("🪟 [AppDelegate] \(trigger): showing overlay (splash suppressed after setup)")
+            initialMainWindowShown = true
+            // If the launch splash is somehow still up (reopen racing the launch
+            // auto-hide), dismiss it — a configured app must never strand it.
+            mainWindowController?.window?.orderOut(nil)
+            LiveKeyboardOverlayController.shared.clearExplicitHideFlag()
+            LiveKeyboardOverlayController.shared.showForStartup(bypassHiddenCheck: true)
+
+        case .showSplash:
+            AppLogger.shared.info("🪟 [AppDelegate] \(trigger): first-run — showing splash window")
+            showSplashWindow()
+        }
+    }
+
+    /// Show the splash/main window and keep it up (no auto-hide). Only valid as the
+    /// first-run onboarding surface or as a host for menu-action sheets.
+    private func showSplashWindow() {
         if mainWindowController == nil {
             if NSApplication.shared.activationPolicy() != .regular {
                 NSApplication.shared.setActivationPolicy(.regular)
@@ -360,30 +386,29 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
             if let vm = viewModel {
                 mainWindowController = MainWindowController(viewModel: vm, serviceContainer: serviceContainer)
-                AppLogger.shared.debug("🪟 [AppDelegate] Created main window controller on reopen")
+                AppLogger.shared.debug("🪟 [AppDelegate] Created main window controller for splash")
                 mainWindowController?.primeForActivation()
             } else {
                 AppLogger.shared.error(
-                    "❌ [AppDelegate] Cannot create window on reopen: ViewModel is nil"
+                    "❌ [AppDelegate] Cannot create splash window: ViewModel is nil"
                 )
+                return
             }
         }
 
         suppressLaunchSplashAutoHide = true
-        pendingReopenShow = false
         mainWindowController?.show(focus: true)
         initialMainWindowShown = true
-        AppLogger.shared.debug("🪟 [AppDelegate] User-initiated reopen - showing main window immediately")
-
-        return true
     }
 
     // MARK: - Public Window Access
 
-    /// Bring the main window (splash) to the front. Used by menu actions that present sheets.
+    /// Bring the main window (splash) to the front. Used by menu actions that present
+    /// sheets — those sheets attach to this window, so it must actually be shown here.
     @MainActor
     func showMainWindow() {
-        showKeyPathFromStatusItem()
+        unhideAndActivate()
+        showSplashWindow()
     }
 
     // MARK: - Notification Handlers (must be @objc for selector-based observers)
@@ -405,8 +430,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     // MARK: - Private: First Activation
 
     private func handleFirstActivation() {
-        let suppressAutoHideBecauseReopen = pendingReopenShow
-
         let appActive = NSApp.isActive
         let appHidden = NSApp.isHidden
         AppLogger.shared.debug(
@@ -421,18 +444,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         initialMainWindowShown = true
         suppressLaunchSplashAutoHide = false
 
-        let hasExistingConfig = Foundation.FileManager.default.fileExists(
-            atPath: KeyPathConstants.Config.mainConfigPath
-        )
-
-        if hasExistingConfig, !suppressAutoHideBecauseReopen {
+        if hasExistingConfig {
             AppLogger.shared.info("🪟 [AppDelegate] Relaunch detected — skipping splash, restoring overlay directly")
             LiveKeyboardOverlayController.shared.showForStartup(bypassHiddenCheck: true)
-
-            if pendingReopenShow {
-                pendingReopenShow = false
-                mainWindowController?.show(focus: true)
-            }
             return
         }
 
@@ -451,23 +465,15 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             LiveKeyboardOverlayController.shared.showForStartup(bypassHiddenCheck: true)
             AppLogger.shared.info("🪟 [AppDelegate] First activation - overlay shown")
 
-            if !self.suppressLaunchSplashAutoHide, !suppressAutoHideBecauseReopen {
+            if !self.suppressLaunchSplashAutoHide {
                 self.mainWindowController?.window?.orderOut(nil)
                 AppLogger.shared.info("🪟 [AppDelegate] Auto-hid launch splash window")
             } else {
-                AppLogger.shared.info("🪟 [AppDelegate] Splash auto-hide suppressed (suppressAutoHide=\(self.suppressLaunchSplashAutoHide), reopen=\(suppressAutoHideBecauseReopen))")
+                AppLogger.shared.info("🪟 [AppDelegate] Splash auto-hide suppressed (user re-opened during launch)")
             }
         }
 
         AppLogger.shared.info("🪟 [AppDelegate] First activation complete (splash shown briefly)")
-
-        if pendingReopenShow {
-            AppLogger.shared.debug(
-                "🪟 [AppDelegate] Applying pending reopen show after first activation"
-            )
-            pendingReopenShow = false
-            mainWindowController?.show(focus: true)
-        }
     }
 
     private func handleSubsequentActivation() {
@@ -545,9 +551,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         mainWindowController = MainWindowController(viewModel: vm, serviceContainer: serviceContainer)
         AppLogger.shared.debug(
             "🪟 [AppDelegate] Main window controller created (deferring show until activation)"
-        )
-        let hasExistingConfig = Foundation.FileManager.default.fileExists(
-            atPath: KeyPathConstants.Config.mainConfigPath
         )
         if !hasExistingConfig {
             mainWindowController?.primeForActivation()
@@ -702,27 +705,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     private func showKeyPathFromStatusItem() {
         AppLogger.shared.debug("☰ [MenuBar] Show KeyPath requested from status item")
-
-        if mainWindowController == nil {
-            if let vm = viewModel {
-                mainWindowController = MainWindowController(viewModel: vm, serviceContainer: serviceContainer)
-                AppLogger.shared.debug("🪟 [MenuBar] Created main window controller for status item request")
-            } else {
-                AppLogger.shared.error("❌ [MenuBar] Cannot show KeyPath: ViewModel unavailable")
-                return
-            }
-        }
-
-        suppressLaunchSplashAutoHide = true
-
-        if NSApp.isHidden {
-            NSApp.unhide(nil)
-        }
-
-        NSApp.activate(ignoringOtherApps: true)
-        mainWindowController?.show(focus: true)
-        initialMainWindowShown = true
-        pendingReopenShow = false
+        presentReopenSurface(trigger: "status item")
     }
 
     // MARK: - Private: Wizard

--- a/Sources/KeyPathAppKit/Utilities/ReopenPolicy.swift
+++ b/Sources/KeyPathAppKit/Utilities/ReopenPolicy.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+/// Decides which surface to present when the user re-opens the running app
+/// (Dock click, Raycast/Spotlight launch, menu-bar "Show KeyPath").
+///
+/// The splash/main window is a borderless poster with no dismiss affordance, so it
+/// is only a valid surface during first-run onboarding (no config yet). Once a
+/// config exists, reopen must present the overlay instead — re-showing the splash
+/// on a fully running app leaves it stuck on screen with no way to close it.
+enum ReopenPolicy {
+    enum Surface: Equatable {
+        /// Overlay already on screen — just activate and bring it forward.
+        case activateOnly
+        /// Set up but overlay hidden — show the overlay, never the splash.
+        case showOverlay
+        /// First-run onboarding (no config yet) — the splash window is the surface.
+        case showSplash
+    }
+
+    static func surface(hasExistingConfig: Bool, overlayVisible: Bool) -> Surface {
+        guard hasExistingConfig else { return .showSplash }
+        return overlayVisible ? .activateOnly : .showOverlay
+    }
+}

--- a/Tests/KeyPathTests/Utilities/ReopenPolicyTests.swift
+++ b/Tests/KeyPathTests/Utilities/ReopenPolicyTests.swift
@@ -1,0 +1,31 @@
+@testable import KeyPathAppKit
+import Testing
+
+@Suite("ReopenPolicy")
+struct ReopenPolicyTests {
+    @Test("Running app with visible overlay just activates")
+    func overlayVisibleActivatesOnly() {
+        let surface = ReopenPolicy.surface(hasExistingConfig: true, overlayVisible: true)
+        #expect(surface == .activateOnly)
+    }
+
+    @Test("Running app with hidden overlay shows the overlay, never the splash")
+    func overlayHiddenShowsOverlay() {
+        // The Raycast relaunch bug: reopen with the overlay hidden used to fall
+        // through to the splash window, which has no dismiss affordance.
+        let surface = ReopenPolicy.surface(hasExistingConfig: true, overlayVisible: false)
+        #expect(surface == .showOverlay)
+    }
+
+    @Test("First run (no config) shows the splash onboarding surface")
+    func firstRunShowsSplash() {
+        let surface = ReopenPolicy.surface(hasExistingConfig: false, overlayVisible: false)
+        #expect(surface == .showSplash)
+    }
+
+    @Test("No config always means splash, even if the overlay is somehow visible")
+    func noConfigOverridesOverlayVisibility() {
+        let surface = ReopenPolicy.surface(hasExistingConfig: false, overlayVisible: true)
+        #expect(surface == .showSplash)
+    }
+}


### PR DESCRIPTION
## Problem

Launching KeyPath via Raycast (or Dock/Spotlight) while it was already running with the live overlay hidden showed the splash screen on top of everything and got stuck there.

`applicationShouldHandleReopen` only had two "skip the splash" paths — overlay visible, or first-activation pending. A reopen on a fully running app with a hidden overlay fell through to showing the main/splash window with `suppressLaunchSplashAutoHide = true`. That window is a borderless poster with no close button, and nothing ever ordered it out again.

## Fix

- **New `ReopenPolicy`** (pure decision function): no config → splash (it's the onboarding surface); config + overlay visible → activate only; config + overlay hidden → show the overlay, never the splash.
- `applicationShouldHandleReopen` and the menu-bar **"Show KeyPath"** action (same stuck-splash bug) both route through a shared `presentReopenSurface()`.
- The overlay path clears the explicit-hide flag: reopening the app is an explicit "show me KeyPath", matching the ⌘⌥K toggle semantics.
- `showMainWindow()` intentionally keeps direct splash behavior — menu-action sheets (Simple Key Mappings, Uninstall, emergency stop) attach to that window.

## Cleanup (from review gate)

- Removed dead `pendingReopenShow` state — it was read in `handleFirstActivation` but never set `true` anywhere in the repo; its branches were unreachable.
- Deduped the `hasExistingConfig` filesystem check (was inlined 3×) into a computed property, and the unhide/activate boilerplate into a helper.
- `.showOverlay` defensively orders out the splash in case a reopen races the launch auto-hide.

## Testing

- New `ReopenPolicyTests` (4 cases) covering the decision matrix, including the Raycast regression.
- `swift test --filter "ReopenPolicyTests|SingleInstanceCoordinatorTests"` — 12/12 pass.
- swiftformat (pinned 0.61.1) + swiftlint clean on changed files.

Review gate: 8-angle finder review ran; correctness candidates verified against code (Space-jump concern refuted — overlay is `.canJoinAllSpaces`; nil-viewModel sheet-host concern is pre-existing behavior, unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)