### PR TITLE
ci: reset ~/.config/keypath between runs on self-hosted runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,28 @@ jobs:
         chmod +x ./Scripts/lint-no-subprocess-in-autofixer.sh
         ./Scripts/lint-no-subprocess-in-autofixer.sh
 
+    - name: Reset persistent test state
+      # The self-hosted runner's $HOME persists between runs (same lesson as the
+      # kanata engine-sha stamp above). Tests that install packs or toggle rule
+      # collections write to ~/.config/keypath via NSHomeDirectory() — there is
+      # no config-dir env override. A crashed or interrupted prior run can leave
+      # that directory in a state where enabling a collection fails, which then
+      # breaks CLIPackCRUDTests (and any other pack/collection test) on *every*
+      # subsequent run on the same runner until it is cleared by hand — a
+      # deterministic wedge, not a flake. This was the root cause of the #945 CI
+      # block (5 CLIPackCRUDTests failures: "could not enable associated rule
+      # collection"), the same persistent-state class as #896/#891. Reset to a
+      # clean slate so each run is hermetic; the suite recreates what it needs.
+      run: |
+        STATE_DIR="$HOME/.config/keypath"
+        if [ -d "$STATE_DIR" ]; then
+          echo "🧹 Removing persistent test state at $STATE_DIR"
+          ls -la "$STATE_DIR" || true
+          rm -rf "$STATE_DIR"
+        else
+          echo "✅ No persistent test state to clean ($STATE_DIR absent)"
+        fi
+
     - name: Run Test Lane - full
       env:
         KP_SIGN_DRY_RUN: "1"


### PR DESCRIPTION
## Problem

The self-hosted runner's `\$HOME` persists between runs. Pack/collection tests write to `~/.config/keypath` via `NSHomeDirectory()` ([KeyPathConstants.swift](Sources/KeyPathCore/KeyPathConstants.swift) — no config-dir env override), and `installed-packs.json` lives there too. A crashed or interrupted prior run can leave that directory in a state where enabling a rule collection fails at [PackInstaller.swift:132](Sources/KeyPathAppKit/Services/Packs/PackInstaller.swift) (`toggleCollection(isEnabled: true)` → `saveFailed("could not enable associated rule collection")`).

Because re-runs land on the **same** runner with the **same** `\$HOME`, this is a **deterministic wedge, not a flake**: once the state goes bad, every subsequent run fails until someone clears it by hand.

## Evidence

This blocked PR #945 across **three** runs — 5 `CLIPackCRUDTests` failures each time, all `could not enable associated rule collection` — even though #945's diff is **view-only** (`HoldTimingSliderRow.swift`, `PackDetailView.swift`) and cannot reach the `PackInstaller` path. `master` was green only because it last ran *before* the state went bad. Same persistent-state class as #896 / #891 (the kanata engine-sha stamp already fights the same "workspace persists" reality for the binary).

## Fix

Add a **Reset persistent test state** step before the test lane in the `build-and-test` job that clears `~/.config/keypath`, so every run starts hermetic. The suite recreates whatever it needs.

**Self-healing:** this PR's own CI run executes the new step first, clearing the currently-poisoned state — so it should go green on its own, and unblock #945 once #945 is rebased onto it.

## Scope

- Only the `build-and-test` self-hosted job needs it; `code-quality` only lints changed Swift files and never touches `~/.config/keypath`.
- Safe on a dedicated CI runner: `~/.config/keypath` there is purely test scratch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)