### PR TITLE
Fix CLIPackCRUDTests CI failures: mapping-vs-activator conflict detection + hermetic tests

### DIFF
--- a/Sources/KeyPathAppKit/CLI/PacksFacade.swift
+++ b/Sources/KeyPathAppKit/CLI/PacksFacade.swift
@@ -2,7 +2,17 @@ import Foundation
 import KeyPathCore
 
 public struct PacksFacade: Sendable {
-    public init() {}
+    /// Test seam: overrides the manager used by install/uninstall/configure so tests
+    /// can inject temp-backed stores instead of the shared persistent ones (#953).
+    private let managerFactory: (@Sendable @MainActor () async -> RuleCollectionsManager)?
+
+    public init() {
+        managerFactory = nil
+    }
+
+    init(managerFactory: @escaping @Sendable @MainActor () async -> RuleCollectionsManager) {
+        self.managerFactory = managerFactory
+    }
 
     // MARK: - Pack Management
 
@@ -251,6 +261,10 @@ public struct PacksFacade: Sendable {
 
     @MainActor
     func makePackManager() async -> RuleCollectionsManager {
+        if let managerFactory {
+            return await managerFactory()
+        }
+
         let configService = ConfigurationService()
         let manager = RuleCollectionsManager(
             ruleCollectionStore: .shared,

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+ConflictDetection.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+ConflictDetection.swift
@@ -10,7 +10,12 @@ extension RuleCollectionsManager {
     }
 
     func normalizedKeys(for collection: RuleCollection) -> Set<String> {
-        Set(collection.mappings.map { KanataKeyConverter.convertToKanataKey($0.input) })
+        // Effective mappings include config-generated ones (Home Row Mods, Window
+        // Snapping, Launcher…) whose static `mappings` array is empty — config
+        // generation validates against these, so conflict pre-detection must too.
+        Set(KanataConfiguration.effectiveMappings(for: collection).map {
+            KanataKeyConverter.convertToKanataKey($0.input)
+        })
     }
 
     func normalizedActivator(for collection: RuleCollection) -> (input: String, layer: RuleCollectionLayer)? {
@@ -37,6 +42,27 @@ extension RuleCollectionsManager {
                 let overlap = candidateKeys.intersection(normalizedKeys(for: other))
                 if !overlap.isEmpty {
                     return RuleConflictInfo(source: .collection(other), keys: Array(overlap))
+                }
+            }
+
+            // Cross-type: a mapping and another collection's momentary activator on the
+            // same physical key is rejected by config generation (e.g. Home Row Mods maps
+            // `f` on base while Home Row Arrows holds `f` on base to activate its layer),
+            // so detect it here where toggle-time auto-resolution can handle it (#953).
+            if let otherActivator = other.momentaryActivator,
+               candidate.targetLayer == otherActivator.sourceLayer
+            {
+                let activatorKey = KanataKeyConverter.convertToKanataKey(otherActivator.input)
+                if candidateKeys.contains(activatorKey) {
+                    return RuleConflictInfo(source: .collection(other), keys: [activatorKey])
+                }
+            }
+            if let candidateRawActivator = candidate.momentaryActivator,
+               other.targetLayer == candidateRawActivator.sourceLayer
+            {
+                let activatorKey = KanataKeyConverter.convertToKanataKey(candidateRawActivator.input)
+                if normalizedKeys(for: other).contains(activatorKey) {
+                    return RuleConflictInfo(source: .collection(other), keys: [activatorKey])
                 }
             }
 

--- a/Tests/KeyPathTests/CLI/CLIPackCRUDTests.swift
+++ b/Tests/KeyPathTests/CLI/CLIPackCRUDTests.swift
@@ -1,9 +1,11 @@
 @testable import KeyPathAppKit
+import KeyPathCore
 @preconcurrency import XCTest
 
 @MainActor
 final class CLIPackCRUDTests: XCTestCase {
-    private let facade = PacksFacade()
+    private var facade: PacksFacade!
+    private var tempDir: URL!
     private var originalInstalledPacks: [InstalledPackRecord] = []
 
     // Use a pack that's unlikely to be installed in the user's environment
@@ -13,6 +15,36 @@ final class CLIPackCRUDTests: XCTestCase {
 
     override func setUp() async throws {
         try await super.setUp()
+        TestEnvironment.forceTestMode = true
+
+        // Hermetic manager: temp-backed stores + config dir so install/configure
+        // never touch the real ~/.config/keypath or shared stores. On the CI
+        // runner's persistent HOME, the shared-store path fails config regen
+        // ("could not enable associated rule collection") — see #953.
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cli-pack-crud-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        tempDir = dir
+
+        let collectionStore = RuleCollectionStore(
+            fileURL: dir.appendingPathComponent("RuleCollections.json")
+        )
+        let customStore = CustomRulesStore(
+            fileURL: dir.appendingPathComponent("CustomRules.json")
+        )
+        facade = PacksFacade(managerFactory: {
+            let manager = RuleCollectionsManager(
+                ruleCollectionStore: collectionStore,
+                customRulesStore: customStore,
+                configurationService: ConfigurationService(configDirectory: dir.path)
+            )
+            manager.ruleCollections = await RuleCollectionDeduplicator.dedupe(
+                collectionStore.loadCollections()
+            )
+            manager.customRules = await customStore.loadRules()
+            return manager
+        })
+
         originalInstalledPacks = await InstalledPackTracker.shared.allInstalled()
     }
 
@@ -28,6 +60,10 @@ final class CLIPackCRUDTests: XCTestCase {
                 try await InstalledPackTracker.shared.upsert(record)
             }
         }
+        if let tempDir {
+            try? FileManager.default.removeItem(at: tempDir)
+        }
+        TestEnvironment.forceTestMode = false
         try await super.tearDown()
     }
 

--- a/Tests/KeyPathTests/RuleCollections/RuleCollectionConflictDetectionTests.swift
+++ b/Tests/KeyPathTests/RuleCollections/RuleCollectionConflictDetectionTests.swift
@@ -263,4 +263,94 @@ final class RuleCollectionConflictDetectionTests: XCTestCase {
         let info = RuleConflictInfo(source: .customRule(rule), keys: ["a"])
         XCTAssertFalse(info.displayName.isEmpty)
     }
+
+    // MARK: - Cross-type conflicts: mapping vs momentary activator (#953)
+
+    private func makeArrowsStyleCollection(enabled: Bool = true) -> RuleCollection {
+        // Shape of Home Row Arrows: no static mappings, hold `f` on base activates a layer
+        RuleCollection(
+            id: UUID(),
+            name: "Arrows Style",
+            summary: "",
+            category: .custom,
+            mappings: [],
+            isEnabled: enabled,
+            icon: "star",
+            tags: [],
+            targetLayer: .custom("home-arrows"),
+            momentaryActivator: MomentaryActivator(
+                input: "f",
+                targetLayer: .custom("home-arrows")
+            ),
+            configuration: .list
+        )
+    }
+
+    func testConflictInfo_MappingConflictsWithOtherCollectionsActivator() {
+        let manager = makeManager()
+        manager.ruleCollections = [makeArrowsStyleCollection()]
+
+        let candidate = RuleCollection(
+            id: UUID(),
+            name: "Maps F",
+            summary: "",
+            category: .custom,
+            mappings: [KeyMapping(input: "f", action: .keystroke(key: "lmet"), description: "")],
+            isEnabled: true,
+            icon: "star",
+            tags: [],
+            targetLayer: .base,
+            configuration: .list
+        )
+
+        let conflict = manager.conflictInfo(for: candidate)
+        XCTAssertNotNil(conflict, "Base mapping on f must conflict with an activator holding f on base")
+        XCTAssertEqual(conflict?.keys, ["f"])
+    }
+
+    func testConflictInfo_ActivatorConflictsWithOtherCollectionsMapping() {
+        let manager = makeManager()
+        manager.ruleCollections = [
+            RuleCollection(
+                id: UUID(),
+                name: "Maps F",
+                summary: "",
+                category: .custom,
+                mappings: [KeyMapping(input: "f", action: .keystroke(key: "lmet"), description: "")],
+                isEnabled: true,
+                icon: "star",
+                tags: [],
+                targetLayer: .base,
+                configuration: .list
+            )
+        ]
+
+        let conflict = manager.conflictInfo(for: makeArrowsStyleCollection())
+        XCTAssertNotNil(conflict, "Activator holding f on base must conflict with a base mapping on f")
+        XCTAssertEqual(conflict?.keys, ["f"])
+    }
+
+    func testConflictInfo_HomeRowModsConfigKeysConflictWithActivator() {
+        // Home Row Mods has empty static mappings; its keys come from configuration.
+        // normalizedKeys must use effectiveMappings so this conflict is visible (#953).
+        let manager = makeManager()
+        manager.ruleCollections = [makeArrowsStyleCollection()]
+
+        let hrm = RuleCollection(
+            id: UUID(),
+            name: "HRM Style",
+            summary: "",
+            category: .custom,
+            mappings: [],
+            isEnabled: true,
+            icon: "star",
+            tags: [],
+            targetLayer: .base,
+            configuration: .homeRowMods(HomeRowModsConfig())
+        )
+
+        let conflict = manager.conflictInfo(for: hrm)
+        XCTAssertNotNil(conflict, "Config-generated HRM keys must conflict with an activator holding f")
+        XCTAssertEqual(conflict?.keys, ["f"])
+    }
 }


### PR DESCRIPTION
## Problem (#953)

Since #944 (`d604c383`) stopped bootstrapping rule collections in test-host processes, `build-and-test` fails on **every** PR with 5 `CLIPackCRUDTests` failures: `saveFailed("could not enable associated rule collection")`.

Reproduced deterministically: with **fresh/default collections**, installing the Home Row Mods pack fails — config generation rejects the `f`-key conflict with the default-enabled Home Row Arrows collection, and `toggleCollection` rolls back and returns false. Dev machines with healthy ambient store state masked it; the runner's state didn't.

## Two real defects fixed

**1. Conflict pre-detection had blind spots** ([RuleCollectionsManager+ConflictDetection.swift](Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+ConflictDetection.swift)):
- `normalizedKeys(for:)` read the static `mappings` array, but Home Row Mods generates its keys from `configuration` (static array is empty). Now uses `KanataConfiguration.effectiveMappings(for:)` — the same expansion config generation validates against (and `RuleCollectionDeduplicator` already uses).
- No check existed for a **mapping vs another collection's momentary activator** on the same physical key (HRM maps `f` on base; Home Row Arrows holds `f` on base). Added the cross-type check both directions, keyed on the activator's `sourceLayer`.

With the pre-check now seeing the conflict, `PackInstaller`'s `autoResolveConflicts: true` kicks in and a fresh HRM install auto-disables Home Row Arrows — which the pack registry already declares as `conflictsWith`. This was a **user-facing bug** too: `keypath-cli pack install home-row-mods` failed on a fresh install.

**2. `CLIPackCRUDTests` wasn't hermetic**: it ran through `PacksFacade.makePackManager()` → shared persistent stores + real `~/.config/keypath`. `PacksFacade` gains a test-only `managerFactory` seam; the tests inject temp-backed stores and a temp config dir (same pattern as `PackInstallIntegrationTests`), so results no longer depend on ambient machine state.

## Testing

- `CLIPackCRUDTests`: 25/25 pass hermetically (previously 5 failures in the fresh-store environment — the exact CI failure, now reproducible locally).
- New regression tests in `RuleCollectionConflictDetectionTests` (mapping↔activator both directions + HRM-config-generated keys).
- Broad sweep green: all `RuleCollection*`, `PackInstall*`, `Dedup*`, `ConfigRoundTrip`, `VallackSystemPack`, `GenericPackConfig`, CLI suites — 0 failures.
- swiftformat (0.61.1) clean; swiftlint: only pre-existing warnings in untouched lines.

Fixes #953. Unblocks #950 and all other open PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)