### PR TITLE
Fix flaky ServiceLifecycleCoordinator stale-binary tests

### DIFF
--- a/Sources/KeyPathInstallationWizard/Core/ServiceHealthChecker.swift
+++ b/Sources/KeyPathInstallationWizard/Core/ServiceHealthChecker.swift
@@ -64,6 +64,17 @@ public final class ServiceHealthChecker: @unchecked Sendable {
 
     private nonisolated static let healthCacheTTL: TimeInterval = 2.0
 
+    #if DEBUG
+        /// Test-only override for `isServiceHealthy(serviceID:)`, keyed by serviceID.
+        /// `ServiceHealthChecker.shared` is a process-wide singleton, so its real health
+        /// check (and the short-lived cache above) would otherwise reflect whatever the
+        /// test machine's actual launchd state happens to be — normally "not running",
+        /// since the real VHID daemon isn't installed in CI/dev environments. Tests that
+        /// need to simulate a healthy service set this instead of relying on real system
+        /// state. Reset in `TestSingletonReset.resetAll()`.
+        nonisolated(unsafe) static var testForcedServiceHealth: [String: Bool]?
+    #endif
+
     private let healthCache = OSAllocatedUnfairLock(initialState: [String: HealthCacheEntry]())
     private let runtimeCache = OSAllocatedUnfairLock(initialState: RuntimeCacheState())
     private let serviceStatusCache = OSAllocatedUnfairLock(initialState: ServiceStatusCacheEntry?.none)
@@ -282,6 +293,12 @@ public final class ServiceHealthChecker: @unchecked Sendable {
     /// - Parameter serviceID: The service identifier to check
     /// - Returns: `true` if the service is healthy
     public nonisolated func isServiceHealthy(serviceID: String) async -> Bool {
+        #if DEBUG
+            if let forced = Self.testForcedServiceHealth?[serviceID] {
+                return forced
+            }
+        #endif
+
         // Check short-lived cache first — avoids redundant launchctl calls within the same
         // validation cycle when multiple parallel tasks query the same service.
         if let cached = healthCache.withLock({ $0[serviceID] }),

--- a/Tests/KeyPathTests/Services/ServiceHealthCheckerTests.swift
+++ b/Tests/KeyPathTests/Services/ServiceHealthCheckerTests.swift
@@ -39,6 +39,7 @@ final class ServiceHealthCheckerTests: XCTestCase {
             ServiceHealthChecker.runtimeSnapshotOverride = nil
             ServiceHealthChecker.recentlyRestartedOverride = nil
             ServiceHealthChecker.inputCaptureStatusOverride = nil
+            ServiceHealthChecker.testForcedServiceHealth = nil
             KanataDaemonManager.registeredButNotLoadedOverride = nil
         #endif
     }
@@ -62,6 +63,7 @@ final class ServiceHealthCheckerTests: XCTestCase {
             ServiceHealthChecker.runtimeSnapshotOverride = nil
             ServiceHealthChecker.recentlyRestartedOverride = nil
             ServiceHealthChecker.inputCaptureStatusOverride = nil
+            ServiceHealthChecker.testForcedServiceHealth = nil
             KanataDaemonManager.registeredButNotLoadedOverride = nil
         #endif
         try? FileManager.default.removeItem(at: tempLaunchDaemonsDir)

--- a/Tests/KeyPathTests/Services/ServiceLifecycleCoordinatorTests.swift
+++ b/Tests/KeyPathTests/Services/ServiceLifecycleCoordinatorTests.swift
@@ -1,5 +1,6 @@
 @testable import KeyPathAppKit
 @testable import KeyPathCore
+@testable import KeyPathInstallationWizard
 @testable import KeyPathWizardCore
 @preconcurrency import XCTest
 
@@ -55,6 +56,7 @@ final class ServiceLifecycleCoordinatorTests: KeyPathTestCase {
 
     func testStartTerminatesRunningKanataWhenBinaryDoesNotMatchBundledRuntime() async {
         coordinator.isKarabinerDaemonRunning = { true }
+        ServiceHealthChecker.testForcedServiceHealth = [ServiceHealthChecker.vhidDaemonServiceID: true]
 
         let privileged = StubPrivilegedOperationsCoordinator()
         WizardDependencies.privilegedOperations = privileged
@@ -77,6 +79,7 @@ final class ServiceLifecycleCoordinatorTests: KeyPathTestCase {
 
     func testStartTerminatesRunningKanataWhenSamePathButProcessPredatesBundledBinary() async throws {
         coordinator.isKarabinerDaemonRunning = { true }
+        ServiceHealthChecker.testForcedServiceHealth = [ServiceHealthChecker.vhidDaemonServiceID: true]
 
         let privileged = StubPrivilegedOperationsCoordinator()
         WizardDependencies.privilegedOperations = privileged

--- a/Tests/KeyPathTests/Support/GlobalTestSetup.swift
+++ b/Tests/KeyPathTests/Support/GlobalTestSetup.swift
@@ -1,5 +1,6 @@
 @testable import KeyPathAppKit
 @testable import KeyPathCore
+@testable import KeyPathInstallationWizard
 import XCTest
 
 /// Resets shared singleton state to prevent cross-test contamination.
@@ -38,6 +39,12 @@ enum TestSingletonReset {
             ServiceLifecycleCoordinator.testSleep = { _ in }
             ServiceLifecycleCoordinator.testRunningKanataIdentityProvider = nil
             WizardSystemPaths.setBundledKanataPathOverride(nil)
+
+            // ServiceHealthChecker.shared is a process-wide singleton with its own
+            // short-lived cache; a real (or forced) health result from one test must
+            // not bleed into another's health check.
+            ServiceHealthChecker.shared.invalidateHealthCache()
+            ServiceHealthChecker.testForcedServiceHealth = nil
         #endif
 
         // TestEnvironment flags


### PR DESCRIPTION
## Summary
- Two tests (`testStartTerminatesRunningKanataWhenBinaryDoesNotMatchBundledRuntime`, `testStartTerminatesRunningKanataWhenSamePathButProcessPredatesBundledBinary`) failed reliably on a clean macOS 27 beta checkout because `ServiceLifecycleCoordinator.startKanata()`'s "second safety layer" VHID health check calls the real, process-wide `ServiceHealthChecker.shared.isServiceHealthy(...)`, which returns `false` on any machine (dev box or CI) without the actual Karabiner VirtualHID daemon running — so the tests never reached the stale-binary recovery path they were meant to exercise. This is not macOS-27-beta-specific; it would fail identically on any environment lacking the real VHID daemon.
- Adds a `#if DEBUG`-only `ServiceHealthChecker.testForcedServiceHealth` override (same pattern as the three sibling overrides already on that class), reset centrally via `TestSingletonReset.resetAll()`, and has the two tests force the VHID daemon healthy so they deterministically exercise the intended recovery path.
- Also resets the new override in `ServiceHealthCheckerTests`' own setUp/tearDown (it extends plain `XCTestCase`, not `KeyPathTestCase`, and already manages the class's other DEBUG overrides itself) — found and fixed during the mandatory review gate.

## Test plan
- [x] `swift test --build-system native --filter 'ServiceLifecycleCoordinatorTests|InstallerEngineSingleActionRoutingTests|InstallerEnginePlanTests|InstallerEngineEndToEndTests|InstallerEngineFailurePathTests|ServiceHealthCheckerTests'` — all green (114/114)
- [x] Full `swift test --build-system native` — 778 Swift Testing tests + all XCTest suites, exit 0, 0 failures (run twice, before and after the follow-up fix)
- [x] Max-effort 10-angle code review completed; one actionable finding (reset gap in `ServiceHealthCheckerTests`) fixed; a flagged risk in `verifyRuntimeReadinessAfterStart` was empirically refuted — `KanataDaemonManager.register()` reliably throws (codesigning failure) before that code path is ever reached in the test environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)