### PR TITLE
feat(wizard): value-first 'Welcome to KeyPath' intro page (#932)

### DIFF
--- a/Sources/KeyPathInstallationWizard/Core/WizardRouter.swift
+++ b/Sources/KeyPathInstallationWizard/Core/WizardRouter.swift
@@ -141,7 +141,7 @@ public enum WizardRouter {
             default:
                 false
             }
-        case .fullDiskAccess, .kanataMigration, .stopExternalKanata, .karabinerImport:
+        case .welcome, .fullDiskAccess, .kanataMigration, .stopExternalKanata, .karabinerImport:
             false
         }
     }

--- a/Sources/KeyPathInstallationWizard/Core/WizardStateMachine.swift
+++ b/Sources/KeyPathInstallationWizard/Core/WizardStateMachine.swift
@@ -163,7 +163,7 @@ public class WizardStateMachine {
     }
 
     public var canNavigateBack: Bool {
-        currentPage != .summary
+        currentPage != .summary && currentPage != .welcome
     }
 
     public var canNavigateForward: Bool {
@@ -190,6 +190,7 @@ public class WizardStateMachine {
 
     private func determinePreviousPage(from current: WizardPage) -> WizardPage {
         switch current {
+        case .welcome: .welcome // One-shot overture: no back navigation
         case .summary: .summary
         case .kanataMigration: .summary
         case .stopExternalKanata: .kanataMigration

--- a/Sources/KeyPathInstallationWizard/Core/WizardWelcomeGate.swift
+++ b/Sources/KeyPathInstallationWizard/Core/WizardWelcomeGate.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// Decides whether the wizard should open on the one-time Welcome page (issue #932).
+///
+/// The Welcome page is an overture shown before any diagnostics on a fresh install:
+/// it explains what KeyPath is and previews the setup steps so macOS's permission
+/// prompts feel expected. It shows until the user clicks "Get Started" once, then
+/// never again (persisted via UserDefaults).
+public enum WizardWelcomeGate {
+    /// Set to true when the user clicks "Get Started" on the Welcome page.
+    public static let hasSeenWelcomeKey = "wizard_has_seen_welcome"
+
+    /// QA/debug override: forces the Welcome page on machines that are already set up.
+    public static let forceWelcomeKey = "wizard_force_welcome"
+
+    /// Pure decision: show Welcome on fresh installs (helper not yet installed)
+    /// until the user has clicked Get Started. `forced` is a QA override.
+    public static func shouldShowWelcome(
+        helperInstalled: Bool,
+        hasSeenWelcome: Bool,
+        forced: Bool
+    ) -> Bool {
+        if forced { return true }
+        return !helperInstalled && !hasSeenWelcome
+    }
+
+    /// Convenience wrapper reading the persisted flags from UserDefaults.
+    public static func shouldShowWelcome(helperInstalled: Bool) -> Bool {
+        let defaults = UserDefaults.standard
+        return shouldShowWelcome(
+            helperInstalled: helperInstalled,
+            hasSeenWelcome: defaults.bool(forKey: hasSeenWelcomeKey),
+            forced: defaults.bool(forKey: forceWelcomeKey)
+        )
+    }
+
+    /// Persist that the user has completed the Welcome page.
+    public static func markWelcomeSeen() {
+        UserDefaults.standard.set(true, forKey: hasSeenWelcomeKey)
+    }
+}

--- a/Sources/KeyPathInstallationWizard/UI/InstallationWizardView+KeyboardNavigation.swift
+++ b/Sources/KeyPathInstallationWizard/UI/InstallationWizardView+KeyboardNavigation.swift
@@ -8,7 +8,7 @@ public extension InstallationWizardView {
 
     /// Navigate to the previous page using keyboard left arrow
     func navigateToPreviousPage() {
-        guard stateMachine.currentPage != .summary else { return }
+        guard stateMachine.currentPage != .summary, stateMachine.currentPage != .welcome else { return }
         let defaultSequence: [WizardPage] = [
             .fullDiskAccess, .conflicts, .inputMonitoring, .accessibility,
             .karabinerComponents, .service, .communication
@@ -22,9 +22,11 @@ public extension InstallationWizardView {
         AppLogger.shared.log("⬅️ [Keyboard] Navigated to previous page: \(previousPage.displayName)")
     }
 
-    /// Navigate to the next page using keyboard right arrow, respecting prerequisites
+    /// Navigate to the next page using keyboard right arrow, respecting prerequisites.
+    /// Welcome is excluded: its only exit is the Get Started button, which also
+    /// persists the has-seen flag.
     func navigateToNextPage() {
-        guard stateMachine.currentPage != .summary else { return }
+        guard stateMachine.currentPage != .summary, stateMachine.currentPage != .welcome else { return }
         Task { @MainActor in
             if let next = await stateMachine.getNextPage(
                 for: stateMachine.wizardState,

--- a/Sources/KeyPathInstallationWizard/UI/InstallationWizardView+StateManagement.swift
+++ b/Sources/KeyPathInstallationWizard/UI/InstallationWizardView+StateManagement.swift
@@ -23,7 +23,13 @@ public extension InstallationWizardView {
         // Determine initial page based on cached system snapshot (if available)
         // Skip summary on initial run - go directly to helper page to start the wizard flow
         let preferredPage = await cachedPreferredPage()
-        if let preferredPage, initialPage == nil {
+        if initialPage == nil, await shouldShowWelcomePage() {
+            // Fresh install, Get Started never clicked: open on the one-time
+            // welcome page (issue #932). Validation still runs underneath;
+            // performInitialStateCheck() leaves the welcome page alone.
+            AppLogger.shared.log("👋 [Wizard] Fresh install — starting at welcome page")
+            stateMachine.navigateToPage(.welcome)
+        } else if let preferredPage, initialPage == nil {
             AppLogger.shared.log("🔍 [Wizard] Preferring cached page: \(preferredPage)")
             stateMachine.navigateToPage(preferredPage)
         } else if let initialPage {
@@ -59,6 +65,13 @@ public extension InstallationWizardView {
             guard !Task.isCancelled else { return }
             await performInitialStateCheck()
         }
+    }
+
+    /// Whether the wizard should open on the one-time Welcome page (issue #932):
+    /// fresh install (helper not installed) and Get Started never clicked.
+    internal func shouldShowWelcomePage() async -> Bool {
+        let helperInstalled = await WizardDependencies.helperManager?.isHelperInstalled() ?? false
+        return WizardWelcomeGate.shouldShowWelcome(helperInstalled: helperInstalled)
     }
 
     func performInitialStateCheck(retryAllowed: Bool = true) async {
@@ -142,7 +155,10 @@ public extension InstallationWizardView {
             if permissionsStillUnknown {
                 AppLogger.shared.log("🔍 [Wizard] Permissions still unverified — staying on summary to avoid skipping permission pages")
                 Task { @MainActor in
-                    stateMachine.navigateToPage(.summary)
+                    // Never yank the user off the welcome page; Get Started routes onward.
+                    if stateMachine.currentPage != .welcome {
+                        stateMachine.navigateToPage(.summary)
+                    }
                 }
                 return
             }
@@ -157,6 +173,9 @@ public extension InstallationWizardView {
                 helperNeedsApproval: helperNeedsApproval
             )
             Task { @MainActor in
+                // Never yank the user off the welcome page mid-read; validation has
+                // already resolved by the time they click Get Started, which routes onward.
+                guard stateMachine.currentPage != .welcome else { return }
                 if WizardRouter.shouldNavigateToSummary(
                     currentPage: stateMachine.currentPage,
                     state: result.state,

--- a/Sources/KeyPathInstallationWizard/UI/InstallationWizardView+UIComponents.swift
+++ b/Sources/KeyPathInstallationWizard/UI/InstallationWizardView+UIComponents.swift
@@ -23,6 +23,11 @@ extension InstallationWizardView {
     @ViewBuilder
     private func pageContentInner() -> some View {
         switch stateMachine.currentPage {
+        case .welcome:
+            WizardWelcomePage(onGetStarted: {
+                WizardWelcomeGate.markWelcomeSeen()
+                stateMachine.nextPage()
+            })
         case .summary:
             WizardSummaryPage(
                 onStartService: startKeyPathRuntime,

--- a/Sources/KeyPathInstallationWizard/UI/InstallationWizardView.swift
+++ b/Sources/KeyPathInstallationWizard/UI/InstallationWizardView.swift
@@ -203,7 +203,8 @@ public struct InstallationWizardView: View {
 
     @ViewBuilder
     private var navigationOverlay: some View {
-        if stateMachine.currentPage != .summary {
+        // Hidden on summary (its own layout) and welcome (clean first impression)
+        if stateMachine.currentPage != .summary, stateMachine.currentPage != .welcome {
             HStack {
                 WizardNavigationControl()
                 Spacer()

--- a/Sources/KeyPathInstallationWizard/UI/Pages/WizardWelcomePage.swift
+++ b/Sources/KeyPathInstallationWizard/UI/Pages/WizardWelcomePage.swift
@@ -1,0 +1,224 @@
+import AppKit
+import KeyPathWizardCore
+import SwiftUI
+
+/// One-time welcome page shown before any diagnostics on a fresh install (issue #932).
+///
+/// Value-first: the hero is a row of keycaps, each showing one of KeyPath's
+/// superpowers, in the same visual language as the live keyboard overlay.
+/// The setup work ahead is compressed into a single reassuring line above the
+/// CTA — the wizard's own pages explain each step when it happens.
+struct WizardWelcomePage: View {
+    let onGetStarted: () -> Void
+
+    @State private var keycapsVisible = false
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Spacer(minLength: WizardDesign.Spacing.pageVertical)
+
+            keycapHero
+
+            Spacer().frame(height: 40)
+
+            titleBlock
+
+            Spacer().frame(height: 32)
+
+            footer
+
+            Spacer(minLength: WizardDesign.Spacing.pageVertical)
+        }
+        .padding(.horizontal, WizardDesign.Spacing.pageVertical * 2)
+        .padding(.vertical, WizardDesign.Spacing.pageVertical)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(WizardDesign.Colors.wizardBackground)
+        .accessibilityIdentifier("wizard-welcome-page")
+        .onAppear { animateKeycapsIn() }
+    }
+
+    // MARK: - Hero: keycaps that show, not tell
+
+    private var keycapHero: some View {
+        HStack(alignment: .top, spacing: WizardDesign.Spacing.sectionGap + 8) {
+            HeroKeycap(
+                fill: Color(red: 0.36, green: 0.40, blue: 0.47),
+                rotation: -6,
+                yOffset: 8,
+                caption: "Supercharge\nCaps Lock",
+                visible: keycapsVisible,
+                delay: 0.0
+            ) {
+                VStack(spacing: 3) {
+                    Text("esc")
+                        .font(.system(size: 15, weight: .semibold, design: .rounded))
+                    Image(systemName: "sparkle")
+                        .font(.system(size: 12, weight: .bold))
+                        .opacity(0.85)
+                }
+            }
+            HeroKeycap(
+                fill: Color(red: 0.20, green: 0.66, blue: 0.39),
+                rotation: 4,
+                yOffset: -6,
+                caption: "Arrows on\nhome row",
+                visible: keycapsVisible,
+                delay: 0.08
+            ) {
+                Image(systemName: "arrowkeys.fill")
+                    .font(.system(size: 24, weight: .semibold))
+            }
+            HeroKeycap(
+                fill: Color(red: 0.55, green: 0.49, blue: 0.91),
+                rotation: -3,
+                yOffset: 4,
+                caption: "Tile\nwindows",
+                visible: keycapsVisible,
+                delay: 0.16
+            ) {
+                Image(systemName: "rectangle.split.2x1.fill")
+                    .font(.system(size: 20, weight: .semibold))
+            }
+            HeroKeycap(
+                fill: Color(red: 0.93, green: 0.55, blue: 0.18),
+                rotation: 6,
+                yOffset: -4,
+                caption: "Launch\nanything",
+                visible: keycapsVisible,
+                delay: 0.24
+            ) {
+                Image(systemName: "paperplane.fill")
+                    .font(.system(size: 20, weight: .semibold))
+            }
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(
+            "KeyPath superpowers: supercharge Caps Lock, arrows on the home row, tile windows without the mouse, launch anything from a key"
+        )
+        .accessibilityIdentifier("wizard-welcome-hero")
+    }
+
+    // MARK: - Title + value
+
+    private var titleBlock: some View {
+        VStack(spacing: WizardDesign.Spacing.labelGap) {
+            Text("Welcome to KeyPath")
+                .font(.system(size: 34, weight: .bold))
+                .foregroundColor(.primary)
+
+            Text("Keys that do more.")
+                .font(.title3.weight(.regular))
+                .foregroundColor(.secondary)
+                .multilineTextAlignment(.center)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityIdentifier("wizard-welcome-title")
+        .accessibilityAddTraits(.isHeader)
+    }
+
+    // MARK: - Footer: expectation + CTA
+
+    private var footer: some View {
+        VStack(spacing: WizardDesign.Spacing.elementGap) {
+            Text("Setup takes about two minutes. We'll guide you through each step.")
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 420)
+                .fixedSize(horizontal: false, vertical: true)
+                .accessibilityIdentifier("wizard-welcome-expectation")
+
+            HStack(spacing: WizardDesign.Spacing.labelGap) {
+                Image(systemName: "lock.fill")
+                    .font(.caption2)
+                    .foregroundColor(.secondary)
+                    .accessibilityHidden(true)
+                Text("Private by design — your keystrokes never leave your Mac.")
+                    .font(WizardDesign.Typography.caption)
+                    .foregroundColor(.secondary)
+            }
+            .accessibilityElement(children: .combine)
+            .accessibilityIdentifier("wizard-welcome-privacy")
+            .padding(.bottom, WizardDesign.Spacing.elementGap)
+
+            WizardButton("Get Started", style: .primary, isDefaultAction: true) {
+                onGetStarted()
+            }
+        }
+    }
+
+    // MARK: - Entrance
+
+    private func animateKeycapsIn() {
+        if NSWorkspace.shared.accessibilityDisplayShouldReduceMotion {
+            keycapsVisible = true
+        } else {
+            withAnimation(.spring(response: 0.55, dampingFraction: 0.75)) {
+                keycapsVisible = true
+            }
+        }
+    }
+}
+
+// MARK: - Hero Keycap
+
+/// A single oversized keycap in the live-overlay visual language: rounded,
+/// saturated fill, white glyph, soft colored shadow, playful tilt.
+private struct HeroKeycap<Glyph: View>: View {
+    let fill: Color
+    let rotation: Double
+    let yOffset: CGFloat
+    let caption: String
+    let visible: Bool
+    let delay: Double
+    @ViewBuilder let glyph: () -> Glyph
+
+    var body: some View {
+        VStack(spacing: WizardDesign.Spacing.itemGap) {
+            ZStack {
+                RoundedRectangle(cornerRadius: 18, style: .continuous)
+                    .fill(
+                        LinearGradient(
+                            colors: [fill.opacity(0.92), fill],
+                            startPoint: .top,
+                            endPoint: .bottom
+                        )
+                    )
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 18, style: .continuous)
+                            .strokeBorder(
+                                LinearGradient(
+                                    colors: [.white.opacity(0.35), .white.opacity(0.05)],
+                                    startPoint: .top,
+                                    endPoint: .bottom
+                                ),
+                                lineWidth: 1
+                            )
+                    )
+                    .shadow(color: fill.opacity(0.45), radius: 10, x: 0, y: 6)
+
+                glyph()
+                    .foregroundColor(.white)
+            }
+            .frame(width: 84, height: 84)
+            .rotationEffect(.degrees(rotation))
+
+            Text(caption)
+                .font(.caption)
+                .foregroundColor(.secondary)
+                .multilineTextAlignment(.center)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .offset(y: yOffset)
+        .scaleEffect(visible ? 1 : 0.6)
+        .opacity(visible ? 1 : 0)
+        .animation(
+            NSWorkspace.shared.accessibilityDisplayShouldReduceMotion
+                ? nil
+                : .spring(response: 0.55, dampingFraction: 0.72).delay(delay),
+            value: visible
+        )
+        .accessibilityHidden(true) // Combined label on the hero container
+    }
+}

--- a/Sources/KeyPathWizardCore/WizardTypes.swift
+++ b/Sources/KeyPathWizardCore/WizardTypes.swift
@@ -10,6 +10,7 @@ public enum WizardPage: String, CaseIterable, Sendable, Identifiable {
         rawValue
     }
 
+    case welcome = "Welcome"
     case summary = "Summary"
     case helper = "Privileged Helper"
     case fullDiskAccess = "Full Disk Access"
@@ -26,6 +27,7 @@ public enum WizardPage: String, CaseIterable, Sendable, Identifiable {
     /// User-friendly display name for accessibility and UI
     public var displayName: String {
         switch self {
+        case .welcome: "Welcome to KeyPath"
         case .summary: "Setup Overview"
         case .helper: "Privileged Helper Installation"
         case .fullDiskAccess: "Full Disk Access (Optional)"
@@ -44,6 +46,7 @@ public enum WizardPage: String, CaseIterable, Sendable, Identifiable {
     /// Stable identifier for automation and testing tools
     public var accessibilityIdentifier: String {
         switch self {
+        case .welcome: "welcome"
         case .summary: "overview"
         case .fullDiskAccess: "full-disk-access"
         case .conflicts: "conflicts"

--- a/Tests/KeyPathTests/InstallationWizard/WizardWelcomeTests.swift
+++ b/Tests/KeyPathTests/InstallationWizard/WizardWelcomeTests.swift
@@ -1,0 +1,91 @@
+import Foundation
+@testable import KeyPathInstallationWizard
+@testable import KeyPathWizardCore
+@preconcurrency import XCTest
+
+/// Unit tests for the one-time Welcome page (#932): the show/hide gate,
+/// and the guarantees that keep welcome out of the step sequence and routing.
+final class WizardWelcomeTests: XCTestCase {
+    // MARK: - Gate truth table
+
+    func testFreshInstallUnseenShowsWelcome() {
+        XCTAssertTrue(
+            WizardWelcomeGate.shouldShowWelcome(
+                helperInstalled: false, hasSeenWelcome: false, forced: false
+            )
+        )
+    }
+
+    func testSeenWelcomeNeverShowsAgain() {
+        XCTAssertFalse(
+            WizardWelcomeGate.shouldShowWelcome(
+                helperInstalled: false, hasSeenWelcome: true, forced: false
+            )
+        )
+    }
+
+    func testInstalledHelperSkipsWelcome() {
+        XCTAssertFalse(
+            WizardWelcomeGate.shouldShowWelcome(
+                helperInstalled: true, hasSeenWelcome: false, forced: false
+            )
+        )
+    }
+
+    func testForceOverrideAlwaysShowsWelcome() {
+        XCTAssertTrue(
+            WizardWelcomeGate.shouldShowWelcome(
+                helperInstalled: true, hasSeenWelcome: true, forced: true
+            )
+        )
+    }
+
+    // MARK: - Welcome stays out of the step sequence
+
+    func testWelcomeIsNotAnOrderedPage() {
+        XCTAssertFalse(
+            WizardPage.orderedPages.contains(.welcome),
+            "Welcome is a one-time overture, not a numbered wizard step; adding it to orderedPages would give it a step dot and back/forward slots"
+        )
+    }
+
+    func testWelcomeHasNoStepPosition() {
+        XCTAssertNil(WizardPage.welcome.stepPosition())
+    }
+
+    // MARK: - Routing never targets or lingers on welcome
+
+    func testWelcomeHasNoRelevantIssues() {
+        XCTAssertFalse(
+            WizardRouter.pageHasRelevantIssues(.welcome, issues: [], state: .initializing)
+        )
+    }
+
+    func testWelcomeIsNotABlockingPage() {
+        XCTAssertFalse(
+            WizardRouter.isBlockingPage(.welcome, helperInstalled: false, helperNeedsApproval: false)
+        )
+    }
+
+    func testNextPageFromWelcomeOnFreshInstallGoesToHelper() {
+        let next = WizardRouter.nextPage(
+            after: .welcome,
+            state: .initializing,
+            issues: [],
+            helperInstalled: false,
+            helperNeedsApproval: false
+        )
+        XCTAssertEqual(next, .helper, "Get Started on a fresh install should route to the helper page")
+    }
+
+    func testNextPageFromWelcomeOnHealthySystemFallsBackToSummary() {
+        let next = WizardRouter.nextPage(
+            after: .welcome,
+            state: .active,
+            issues: [],
+            helperInstalled: true,
+            helperNeedsApproval: false
+        )
+        XCTAssertEqual(next, .summary, "With nothing to fix (e.g. forced QA runs), Get Started should land on summary")
+    }
+}


### PR DESCRIPTION
Closes #932.

## Problem
Fresh installs auto-launched the wizard straight into a diagnostic dump of ~8 red issues — a hostile first impression right before macOS starts prompting for admin + Input Monitoring + Accessibility + a driver install.

## What this adds
A one-time **Welcome to KeyPath** page shown before diagnostics on a fresh install:

- Hero row of keycaps in the live-overlay visual language — *Supercharge Caps Lock · Arrows on home row · Tile windows · Launch anything*
- Brand line "Keys that do more."
- One reassuring setup-expectation line + a privacy note
- A single **Get Started** CTA (the terminal element)

## Design / behavior
- New `WizardPage.welcome`, deliberately **NOT** in `orderedPages` — so it gets no step dot, no back/forward slot, and never appears in routing or the summary list.
- `WizardWelcomeGate`: pure, tested show-once logic (fresh install + never clicked Get Started), persisted via `UserDefaults`. `wizard_force_welcome` QA override for screenshots/demos.
- `setupWizard()` opens on welcome when the gate passes; background validation runs underneath but is guarded so it never navigates away from welcome.
- Nav chrome + arrow-key navigation suppressed on welcome; Get Started persists the flag and routes forward through the existing router.

## Tests
`WizardWelcomeTests` — gate truth table + regression guards that `.welcome` stays out of `orderedPages` and routing.

## Verification
- `swift test --filter Wizard` green; full changed-file build clean.
- Installed-app flow verified end-to-end (opens on welcome → Get Started persists flag → routes to helper).
- Visual QA in **light and dark mode**.
- Independent pre-PR review pass: clean, no blockers.

Follow-up (post-setup first-success moment): #954.

🤖 Generated with [Claude Code](https://claude.com/claude-code)