### PR TITLE
fix(deploy): guard empty BUILD_SYSTEM_FLAGS array under bash 3.2

### DIFF
--- a/Scripts/quick-deploy.sh
+++ b/Scripts/quick-deploy.sh
@@ -260,7 +260,8 @@ BUILD_SYSTEM_FLAGS=()
 if [[ -n "${KEYPATH_BUILD_SYSTEM:-}" ]]; then
     BUILD_SYSTEM_FLAGS=(--build-system "$KEYPATH_BUILD_SYSTEM")
 fi
-if ! swift build "${BUILD_SYSTEM_FLAGS[@]}" "${MODULE_CACHE_FLAGS[@]}" >> "$BUILD_LOG" 2>&1; then
+# ${arr[@]+...} guard: bash 3.2 under `set -u` treats expanding an empty array as unbound
+if ! swift build ${BUILD_SYSTEM_FLAGS[@]+"${BUILD_SYSTEM_FLAGS[@]}"} "${MODULE_CACHE_FLAGS[@]}" >> "$BUILD_LOG" 2>&1; then
     BUILD_END_MS=$(get_time_ms)
     DURATION=$((BUILD_END_MS - BUILD_START_MS))
     print_build_failure_diagnostics "$BUILD_LOG"
@@ -268,7 +269,7 @@ if ! swift build "${BUILD_SYSTEM_FLAGS[@]}" "${MODULE_CACHE_FLAGS[@]}" >> "$BUIL
     exit 1
 fi
 
-if ! BIN_DIR_OUTPUT=$(swift build --show-bin-path "${BUILD_SYSTEM_FLAGS[@]}" "${MODULE_CACHE_FLAGS[@]}" 2>> "$BUILD_LOG"); then
+if ! BIN_DIR_OUTPUT=$(swift build --show-bin-path ${BUILD_SYSTEM_FLAGS[@]+"${BUILD_SYSTEM_FLAGS[@]}"} "${MODULE_CACHE_FLAGS[@]}" 2>> "$BUILD_LOG"); then
     BUILD_END_MS=$(get_time_ms)
     DURATION=$((BUILD_END_MS - BUILD_START_MS))
     print_build_failure_diagnostics "$BUILD_LOG"


### PR DESCRIPTION
## Problem
`./Scripts/quick-deploy.sh` aborts immediately with `BUILD_SYSTEM_FLAGS[@]: unbound variable` whenever `KEYPATH_BUILD_SYSTEM` is unset (the default). macOS ships bash 3.2, where expanding an empty array under `set -u` is treated as an unbound variable.

## Fix
Guard both `swift build` invocations with `${BUILD_SYSTEM_FLAGS[@]+"${BUILD_SYSTEM_FLAGS[@]}"}`. Audited the rest of the script: `MODULE_CACHE_FLAGS` is always populated (never empty), so `BUILD_SYSTEM_FLAGS` is the only array needing the guard.

## Test
`./Scripts/quick-deploy.sh` with `KEYPATH_BUILD_SYSTEM` unset now proceeds to build instead of aborting. (Rescued from an abandoned worktree; supersedes the standalone bash-fix task.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)