### PR TITLE
fix(tests): sandbox RuleCollectionStore + config dir per-process under test

### DIFF
--- a/Sources/KeyPathAppKit/Infrastructure/Config/ConfigurationService.swift
+++ b/Sources/KeyPathAppKit/Infrastructure/Config/ConfigurationService.swift
@@ -693,6 +693,18 @@ extension ConfigurationService {
         try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
             ioQueue.async {
                 do {
+                    // Ensure the parent directory exists. An atomic write creates
+                    // its temp file in the target directory, so a missing dir
+                    // fails with ENOENT. Relying on ~/.config/keypath
+                    // pre-existing is what made concurrent runs (a peer process
+                    // removing/recreating the shared dir mid-write) fail with
+                    // "could not enable associated rule collection". Idempotent.
+                    let dir = (path as NSString).deletingLastPathComponent
+                    if !dir.isEmpty {
+                        try FileManager.default.createDirectory(
+                            atPath: dir, withIntermediateDirectories: true
+                        )
+                    }
                     try string.write(toFile: path, atomically: true, encoding: .utf8)
                     cont.resume()
                 } catch {
@@ -706,6 +718,9 @@ extension ConfigurationService {
         try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
             ioQueue.async {
                 do {
+                    try FileManager.default.createDirectory(
+                        at: url.deletingLastPathComponent(), withIntermediateDirectories: true
+                    )
                     try string.write(to: url, atomically: true, encoding: .utf8)
                     cont.resume()
                 } catch {

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionStore.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionStore.swift
@@ -52,15 +52,27 @@ actor RuleCollectionStore {
     ) {
         self.fileManager = fileManager
         self.catalog = catalog
-        let defaultDirectory = URL(
-            fileURLWithPath: WizardSystemPaths.userConfigDirectory, isDirectory: true
-        )
+        // Under test, redirect to the per-process sandbox (AppPaths) so
+        // concurrent test processes never race the same real
+        // RuleCollections.json — the root cause of CLIPackCRUDTests
+        // "could not enable associated rule collection" failures when multiple
+        // runs overlap (parallel CI PRs, or multiple local Claude sessions).
+        // InstalledPackTracker already isolates the same way; this closes the
+        // gap. Production resolution is unchanged.
+        let defaultDirectory = TestEnvironment.isRunningTests
+            ? AppPaths.configDirectory
+            : URL(fileURLWithPath: WizardSystemPaths.userConfigDirectory, isDirectory: true)
         self.fileURL = fileURL ?? defaultDirectory.appendingPathComponent("RuleCollections.json")
 
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
         self.encoder = encoder
         decoder = JSONDecoder()
+    }
+
+    /// Test-only: the resolved backing file, for asserting sandbox isolation.
+    var debugFileURL: URL {
+        fileURL
     }
 
     func loadCollections() -> [RuleCollection] {

--- a/Sources/KeyPathCore/AppPaths.swift
+++ b/Sources/KeyPathCore/AppPaths.swift
@@ -25,6 +25,15 @@ public enum AppPaths {
         userDirectory("Library/Application Support/KeyPath")
     }
 
+    /// `~/.config/keypath` (sandboxed during tests) — user keyboard config,
+    /// RuleCollections.json, installed-packs.json, and the generated
+    /// keypath.kbd. Under test this resolves into the per-process sandbox so
+    /// concurrent test processes (parallel CI PRs, or multiple local sessions)
+    /// never race the same real files.
+    public static var configDirectory: URL {
+        userDirectory(".config/keypath")
+    }
+
     /// Append-only crash/service-failure log shared by the app-state and
     /// daemon monitors: `<logsDirectory>/crashes.log`.
     public static var crashLogFile: URL {

--- a/Sources/KeyPathCore/KeyPathConstants.swift
+++ b/Sources/KeyPathCore/KeyPathConstants.swift
@@ -33,9 +33,17 @@ public enum KeyPathConstants {
     public enum Config {
         public static let fileName = "keypath.kbd"
 
-        /// The main directory for user configuration: ~/.config/keypath
+        /// The main directory for user configuration: ~/.config/keypath.
+        /// Under test this redirects to the per-process AppPaths sandbox so
+        /// concurrent test processes (parallel CI PRs, or multiple local Claude
+        /// sessions) never race the same real keypath.kbd — the second half of
+        /// the "could not enable associated rule collection" fix (the first is
+        /// RuleCollectionStore). Production resolution is unchanged.
         public static var directory: String {
-            "\(NSHomeDirectory())/.config/keypath"
+            if TestEnvironment.isRunningTests {
+                return AppPaths.configDirectory.path
+            }
+            return "\(NSHomeDirectory())/.config/keypath"
         }
 
         /// The main configuration file: ~/.config/keypath/keypath.kbd

--- a/Tests/KeyPathTests/KeyPathTests.swift
+++ b/Tests/KeyPathTests/KeyPathTests.swift
@@ -1,4 +1,5 @@
 @testable import KeyPathAppKit
+import KeyPathCore
 @testable import KeyPathInstallationWizard
 @testable import KeyPathPermissions
 @preconcurrency import XCTest
@@ -14,7 +15,7 @@ final class KeyPathTests: KeyPathTestCase {
             XCTAssertTrue(error.lowercased().contains("install"), "Unexpected init error: \(error)")
         }
         XCTAssertEqual(
-            manager.configPath, "\(NSHomeDirectory())/.config/keypath/keypath.kbd"
+            manager.configPath, KeyPathConstants.Config.mainConfigPath
         )
     }
 
@@ -606,7 +607,7 @@ final class KeyPathTests: KeyPathTestCase {
 
         // Test config path is correct
         XCTAssertEqual(
-            manager.configPath, "\(NSHomeDirectory())/.config/keypath/keypath.kbd",
+            manager.configPath, KeyPathConstants.Config.mainConfigPath,
             "Config path should be in expected location"
         )
 

--- a/Tests/KeyPathTests/Services/RuleCollectionStoreSandboxTests.swift
+++ b/Tests/KeyPathTests/Services/RuleCollectionStoreSandboxTests.swift
@@ -1,0 +1,31 @@
+import Foundation
+@testable import KeyPathAppKit
+@testable import KeyPathCore
+import XCTest
+
+/// Regression coverage for the concurrency root cause behind the CLIPackCRUDTests
+/// "could not enable associated rule collection" failures: under test,
+/// RuleCollectionStore's default file must live in the per-process AppPaths
+/// sandbox, never the real ~/.config/keypath. Otherwise concurrent test
+/// processes (parallel CI PRs, or multiple local Claude sessions) race the same
+/// RuleCollections.json. See RuleCollectionStore.init.
+final class RuleCollectionStoreSandboxTests: XCTestCase {
+    func testDefaultStoreResolvesIntoPerProcessSandbox() async {
+        // AppPaths sandbox is per-process: keypath-tests-<pid>/.config/keypath
+        let expectedDir = AppPaths.configDirectory.path
+        let sandboxRoot = AppPaths.testSandboxDirectory.path
+
+        // The default store (no injected fileURL) must resolve under the sandbox.
+        let url = await RuleCollectionStore().debugFileURL
+        XCTAssertTrue(
+            url.path.hasPrefix(sandboxRoot),
+            "RuleCollectionStore must write inside the per-process test sandbox, got \(url.path)"
+        )
+        XCTAssertEqual(url.deletingLastPathComponent().path, expectedDir)
+        XCTAssertEqual(url.lastPathComponent, "RuleCollections.json")
+        XCTAssertFalse(
+            url.path.contains(NSHomeDirectory() + "/.config/keypath"),
+            "Default store must not touch the real ~/.config/keypath during tests"
+        )
+    }
+}


### PR DESCRIPTION
## Problem
Concurrent test processes — parallel CI PRs on the shared runner, or multiple local Claude sessions — raced the same real `~/.config/keypath` files (`RuleCollections.json`, `keypath.kbd`), causing intermittent **"could not enable associated rule collection"** failures. #955 patched this hermetically for `CLIPackCRUDTests`; this fixes the root cause generally.

## Fix
- `RuleCollectionStore` resolves its backing file to the per-process `AppPaths` sandbox under test (`InstalledPackTracker` already isolates the same way).
- `KeyPathConstants.Config.directory` + new `AppPaths.configDirectory` redirect `~/.config/keypath` into the sandbox under test. **Production paths unchanged.**
- `ConfigurationService` creates the parent directory before atomic writes, so a peer process removing/recreating the shared dir mid-write no longer fails with ENOENT.

## Test
- New `RuleCollectionStoreSandboxTests` asserts the store never touches the real config dir under test.
- `swift test --filter "RuleCollectionStoreSandboxTests|CLIPackCRUDTests"` → **26 tests, 0 failures** locally.

Rescued from an abandoned worktree. Complements #955 (which can stay — this makes the whole class of test hermetic, not just one suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)