### PR TITLE
fix(wizard): resolve dead-end when kanata permissions are unverifiable

### DIFF
--- a/Sources/KeyPathInstallationWizard/Core/WizardRouter.swift
+++ b/Sources/KeyPathInstallationWizard/Core/WizardRouter.swift
@@ -52,6 +52,31 @@ public enum WizardRouter {
         return .summary
     }
 
+    /// Adjust a routing decision when kanata's permission state could not be
+    /// verified (still `.unknown` after retries — e.g. no Full Disk Access to
+    /// read TCC.db, or a fresh install with no TCC row yet).
+    ///
+    /// Unverified permissions produce only warning-severity issues, which
+    /// `route()` deliberately ignores — but auto-advancing past the permission
+    /// pages would start the service and trigger both system permission dialogs
+    /// at once. Once the higher-priority blocking pages (conflicts/helper) are
+    /// clear, land on the first unverified permission page so the user sees the
+    /// "not verified — add manually" guidance instead of parking on summary.
+    public static func routeForUnverifiedKanataPermissions(
+        base: WizardPage,
+        inputMonitoringUnknown: Bool,
+        accessibilityUnknown: Bool
+    ) -> WizardPage {
+        switch base {
+        case .conflicts, .helper, .inputMonitoring, .accessibility:
+            return base
+        default:
+            if inputMonitoringUnknown { return .inputMonitoring }
+            if accessibilityUnknown { return .accessibility }
+            return base
+        }
+    }
+
     // MARK: - Next Page (skipping resolved pages, enforcing prerequisites)
 
     /// Find the next page that needs attention after the current one.

--- a/Sources/KeyPathInstallationWizard/UI/InstallationWizardView+StateManagement.swift
+++ b/Sources/KeyPathInstallationWizard/UI/InstallationWizardView+StateManagement.swift
@@ -74,7 +74,11 @@ public extension InstallationWizardView {
         return WizardWelcomeGate.shouldShowWelcome(helperInstalled: helperInstalled)
     }
 
-    func performInitialStateCheck(retryAllowed: Bool = true) async {
+    func performInitialStateCheck(
+        retryAllowed: Bool = true,
+        permissionRetriesRemaining: Int = 2,
+        permissionRetryDelay: Double = 2.0
+    ) async {
         // Check if user has already closed wizard
         guard !Task.isCancelled else {
             AppLogger.shared.log("🔍 [Wizard] Initial state check cancelled - wizard closing")
@@ -149,28 +153,53 @@ public extension InstallationWizardView {
             // Without this, .unknown permission states (Oracle hasn't finished TCC check)
             // are treated as non-blocking, causing the wizard to skip permission pages.
             let permSnapshot = await PermissionOracle.shared.forceRefresh()
-            let permissionsStillUnknown =
-                permSnapshot.kanata.accessibility == .unknown
-                    || permSnapshot.kanata.inputMonitoring == .unknown
-            if permissionsStillUnknown {
-                AppLogger.shared.log("🔍 [Wizard] Permissions still unverified — staying on summary to avoid skipping permission pages")
-                Task { @MainActor in
-                    // Never yank the user off the welcome page; Get Started routes onward.
-                    if stateMachine.currentPage != .welcome {
-                        stateMachine.navigateToPage(.summary)
+            let kanataAccessibilityUnknown = permSnapshot.kanata.accessibility == .unknown
+            let kanataInputMonitoringUnknown = permSnapshot.kanata.inputMonitoring == .unknown
+            if kanataAccessibilityUnknown || kanataInputMonitoringUnknown {
+                if permissionRetriesRemaining > 0 {
+                    // Possibly transient (Oracle racing app startup / slow TCC read):
+                    // park on summary and retry with backoff.
+                    AppLogger.shared.log(
+                        "🔍 [Wizard] Permissions still unverified — retrying in \(permissionRetryDelay)s (\(permissionRetriesRemaining) left)"
+                    )
+                    Task { @MainActor in
+                        // Never yank the user off the welcome page; Get Started routes onward.
+                        if stateMachine.currentPage != .welcome {
+                            stateMachine.navigateToPage(.summary)
+                        }
                     }
+                    Task {
+                        _ = await WizardSleep.seconds(permissionRetryDelay)
+                        guard !Task.isCancelled, !isForceClosing else { return }
+                        await performInitialStateCheck(
+                            retryAllowed: retryAllowed,
+                            permissionRetriesRemaining: permissionRetriesRemaining - 1,
+                            permissionRetryDelay: permissionRetryDelay * 2
+                        )
+                    }
+                    return
                 }
-                return
+                // Steady-state .unknown (no Full Disk Access to read TCC.db, or a
+                // fresh install with no TCC row) — retrying won't resolve it. Fall
+                // through and let routing land on the first unverified permission
+                // page instead of dead-ending on summary (the pre-#934 gap).
+                AppLogger.shared.log(
+                    "🔍 [Wizard] Permissions unverifiable after retries — routing to first unverified permission page"
+                )
             }
 
             // Auto-navigate to the first page that needs attention
             let helperInstalled = await WizardDependencies.helperManager?.isHelperInstalled() ?? false
             let helperNeedsApproval = WizardDependencies.helperManager?.helperNeedsLoginItemsApproval() ?? false
-            let recommended = WizardRouter.route(
-                state: result.state,
-                issues: filteredIssues,
-                helperInstalled: helperInstalled,
-                helperNeedsApproval: helperNeedsApproval
+            let recommended = WizardRouter.routeForUnverifiedKanataPermissions(
+                base: WizardRouter.route(
+                    state: result.state,
+                    issues: filteredIssues,
+                    helperInstalled: helperInstalled,
+                    helperNeedsApproval: helperNeedsApproval
+                ),
+                inputMonitoringUnknown: kanataInputMonitoringUnknown,
+                accessibilityUnknown: kanataAccessibilityUnknown
             )
             Task { @MainActor in
                 // Never yank the user off the welcome page mid-read; validation has

--- a/Tests/KeyPathTests/InstallationWizard/WizardRouterUnverifiedPermissionsTests.swift
+++ b/Tests/KeyPathTests/InstallationWizard/WizardRouterUnverifiedPermissionsTests.swift
@@ -1,0 +1,78 @@
+@testable import KeyPathInstallationWizard
+import KeyPathWizardCore
+@preconcurrency import XCTest
+
+/// Routing when kanata's permissions are unverifiable (.unknown after retries).
+/// Unknown permissions produce only warning-severity issues, which route()
+/// ignores — routeForUnverifiedKanataPermissions must land the wizard on the
+/// first unverified permission page instead of dead-ending on summary, while
+/// never overriding higher-priority blocking pages (conflicts/helper).
+@MainActor
+final class WizardRouterUnverifiedPermissionsTests: XCTestCase {
+    func testUnknownInputMonitoringOverridesSummary() {
+        let page = WizardRouter.routeForUnverifiedKanataPermissions(
+            base: .summary,
+            inputMonitoringUnknown: true,
+            accessibilityUnknown: true
+        )
+        XCTAssertEqual(page, .inputMonitoring, "IM comes first in the wizard's permission order")
+    }
+
+    func testUnknownAccessibilityOnlyOverridesToAccessibility() {
+        let page = WizardRouter.routeForUnverifiedKanataPermissions(
+            base: .service,
+            inputMonitoringUnknown: false,
+            accessibilityUnknown: true
+        )
+        XCTAssertEqual(page, .accessibility)
+    }
+
+    func testNoUnknownPermissionsLeavesBaseUntouched() {
+        let page = WizardRouter.routeForUnverifiedKanataPermissions(
+            base: .service,
+            inputMonitoringUnknown: false,
+            accessibilityUnknown: false
+        )
+        XCTAssertEqual(page, .service)
+    }
+
+    func testBlockingPagesAreNeverOverridden() {
+        for base in [WizardPage.conflicts, .helper, .inputMonitoring, .accessibility] {
+            let page = WizardRouter.routeForUnverifiedKanataPermissions(
+                base: base,
+                inputMonitoringUnknown: true,
+                accessibilityUnknown: true
+            )
+            XCTAssertEqual(page, base, "\(base) must keep priority over unverified permissions")
+        }
+    }
+
+    func testUnknownPermissionsDoNotAdvancePastPermissionPages() {
+        // End-to-end shape of the dead-end fix: route() with only warning-severity
+        // "not verified" issues would pick a post-permission page; the override
+        // must pull it back to the permission page.
+        let warningIssues = [WizardIssue(
+            identifier: .permission(.kanataInputMonitoring),
+            severity: .warning,
+            category: .permissions,
+            title: "Kanata Engine Input Monitoring Permission",
+            description: "Not verified",
+            autoFixAction: nil,
+            userAction: nil
+        )]
+        let base = WizardRouter.route(
+            state: .serviceNotRunning,
+            issues: warningIssues,
+            helperInstalled: true,
+            helperNeedsApproval: false
+        )
+        XCTAssertEqual(base, .service, "warning-severity permission issues don't route on their own")
+
+        let page = WizardRouter.routeForUnverifiedKanataPermissions(
+            base: base,
+            inputMonitoringUnknown: true,
+            accessibilityUnknown: false
+        )
+        XCTAssertEqual(page, .inputMonitoring)
+    }
+}


### PR DESCRIPTION
## Problem
`performInitialStateCheck` parked the wizard on the bare **Summary** page whenever `PermissionOracle` reported kanata Accessibility/Input Monitoring as `.unknown`, and nothing re-ran the decision (the 60s monitor only checks `shouldNavigateToSummary`). Since `.unknown` is a **steady state** without Full Disk Access (TCC.db unreadable) or on a fresh install (no TCC row yet), the wizard could sit there indefinitely with no forward path.

## Fix
- **Bounded retry with backoff** (2s → 4s) in `performInitialStateCheck` for the transient case where the Oracle races app startup.
- After retries are exhausted, route via a new pure `WizardRouter.routeForUnverifiedKanataPermissions`, which lands on the **first unverified permission page** (its "not verified — add manually" guidance) instead of Summary — while preserving conflicts/helper page priority and still never auto-advancing *past* permission pages (the double-prompt hazard the original guard existed to prevent).

## Provenance & reconciliation
Rescued from an abandoned session's branch. It was built on the pre-#932 base and rewrote the same `performInitialStateCheck` block the Welcome page (#957) changed, so it did not rebase cleanly. Reconciled both conflicts by hand to **preserve the `.welcome` guards** — the retry's park-on-summary and the final routing both respect `.welcome`, so a fresh-install user is never yanked off the Welcome page (they proceed via Get Started as before; the unverified-permission routing only applies once off Welcome).

## Test
- New `WizardRouterUnverifiedPermissionsTests` (5 cases: override priority, blocking-page precedence, end-to-end warning-severity pull-back).
- Full local run of the wizard suites green: `WizardRouterUnverifiedPermissionsTests` (5), `WizardWelcomeTests` (10, regression), `WizardStateMachineNavigationTests` (26), `WizardPureLogicTests` (93) — 134 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)