### PR TITLE
feat(onboarding): post-setup first-success moment — starter remap + panel tour

### DIFF
--- a/Scripts/build-kanata-host-bridge.sh
+++ b/Scripts/build-kanata-host-bridge.sh
@@ -15,6 +15,8 @@ BRIDGE_ROOT="$PROJECT_ROOT/Rust/KeyPathKanataHostBridge"
 BUILD_DIR="$PROJECT_ROOT/build/kanata-host-bridge"
 CACHE_INFO="$BUILD_DIR/host-bridge-cache.info"
 BRIDGE_FEATURES="${KEYPATH_KANATA_HOST_BRIDGE_FEATURES:-passthru-output-spike}"
+BRIDGE_DYLIB="$BUILD_DIR/libkeypath_kanata_host_bridge.dylib"
+BRIDGE_STATIC="$BUILD_DIR/libkeypath_kanata_host_bridge.a"
 
 echo "🧩 Building KeyPath Kanata host bridge..."
 
@@ -37,18 +39,42 @@ calculate_source_hash() {
         -exec shasum -a 256 {} + 2>/dev/null | shasum -a 256 | cut -d' ' -f1
 }
 
-CURRENT_HASH=$(calculate_source_hash)
+calculate_toolchain_hash() {
+    {
+        printf 'features=%s\n' "$BRIDGE_FEATURES"
+        rustc -Vv
+        cargo -V
+        xcrun --find ld 2>/dev/null || true
+        xcrun ld -v 2>&1 || true
+    } | shasum -a 256 | cut -d' ' -f1
+}
+
+verify_bridge_loads() {
+    python3 "$PROJECT_ROOT/Scripts/verify-kanata-host-bridge.py" "$BRIDGE_DYLIB" >/dev/null
+}
+
+SOURCE_HASH=$(calculate_source_hash)
+TOOLCHAIN_HASH=$(calculate_toolchain_hash)
+CURRENT_HASH="$SOURCE_HASH $TOOLCHAIN_HASH"
 CACHED_HASH=$(cat "$CACHE_INFO" 2>/dev/null || echo "")
 
 if [ "$CURRENT_HASH" = "$CACHED_HASH" ] && \
-   [ -f "$BUILD_DIR/libkeypath_kanata_host_bridge.dylib" ] && \
-   [ -f "$BUILD_DIR/libkeypath_kanata_host_bridge.a" ]; then
-    echo "🎯 Cache HIT: Host bridge source unchanged, using existing artifacts"
-    echo "✅ Host bridge ready"
-    exit 0
+   [ -f "$BRIDGE_DYLIB" ] && \
+   [ -f "$BRIDGE_STATIC" ]; then
+    if verify_bridge_loads; then
+        echo "🎯 Cache HIT: Host bridge source/toolchain unchanged, using existing artifacts"
+        echo "✅ Host bridge ready"
+        exit 0
+    fi
+    echo "⚠️ Cache HIT artifact failed dlopen verification; rebuilding host bridge..."
 fi
 
 echo "🔨 Cache miss, compiling host bridge..."
+rm -f \
+    "$BRIDGE_ROOT/target/aarch64-apple-darwin/release/libkeypath_kanata_host_bridge.a" \
+    "$BRIDGE_ROOT/target/aarch64-apple-darwin/release/libkeypath_kanata_host_bridge.dylib" \
+    "$BRIDGE_ROOT/target/aarch64-apple-darwin/release/libkeypath_kanata_host_bridge.rlib" \
+    "$BRIDGE_ROOT"/target/aarch64-apple-darwin/release/deps/libkeypath_kanata_host_bridge*
 
 if [ -n "$BRIDGE_FEATURES" ]; then
     cargo build \
@@ -64,11 +90,17 @@ else
 fi
 
 cp "$BRIDGE_ROOT/target/aarch64-apple-darwin/release/libkeypath_kanata_host_bridge.a" \
-   "$BUILD_DIR/libkeypath_kanata_host_bridge.a"
+   "$BRIDGE_STATIC"
 cp "$BRIDGE_ROOT/target/aarch64-apple-darwin/release/libkeypath_kanata_host_bridge.dylib" \
-   "$BUILD_DIR/libkeypath_kanata_host_bridge.dylib"
+   "$BRIDGE_DYLIB"
 cp "$BRIDGE_ROOT/include/keypath_kanata_host_bridge.h" \
    "$BUILD_DIR/include/keypath_kanata_host_bridge.h"
+
+if ! verify_bridge_loads; then
+    echo "❌ Error: built host bridge dylib failed dlopen verification." >&2
+    echo "   If this mentions LINKEDIT, rebuild with a stable Xcode toolchain." >&2
+    exit 1
+fi
 
 echo "$CURRENT_HASH" > "$CACHE_INFO"
 
@@ -76,6 +108,6 @@ echo "✅ Host bridge built"
 if [ -n "$BRIDGE_FEATURES" ]; then
     echo "🧪 Bridge features: $BRIDGE_FEATURES"
 fi
-echo "📍 Static library: $BUILD_DIR/libkeypath_kanata_host_bridge.a"
-echo "📍 Dynamic library: $BUILD_DIR/libkeypath_kanata_host_bridge.dylib"
+echo "📍 Static library: $BRIDGE_STATIC"
+echo "📍 Dynamic library: $BRIDGE_DYLIB"
 echo "📍 Header: $BUILD_DIR/include/keypath_kanata_host_bridge.h"

--- a/Scripts/verify-installed-app.sh
+++ b/Scripts/verify-installed-app.sh
@@ -37,6 +37,16 @@ if [[ ! -f "$SPARKLE_PATH" ]]; then
     echo "❌ Sparkle.framework binary is missing: $SPARKLE_PATH" >&2
     exit 1
 fi
+HOST_BRIDGE_PATH="$APP_PATH/Contents/Library/KeyPath/libkeypath_kanata_host_bridge.dylib"
+HOST_BRIDGE_VERIFIER="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/verify-kanata-host-bridge.py"
+if [[ ! -f "$HOST_BRIDGE_PATH" ]]; then
+    echo "❌ Host bridge dylib is missing: $HOST_BRIDGE_PATH" >&2
+    exit 1
+fi
+if ! python3 "$HOST_BRIDGE_VERIFIER" "$HOST_BRIDGE_PATH" >/dev/null; then
+    echo "❌ Host bridge dylib failed load verification: $HOST_BRIDGE_PATH" >&2
+    exit 1
+fi
 for executable in "$APP_PATH/Contents/MacOS/KeyPath" "$CLI_PATH"; do
     if ! otool -l "$executable" | grep -q "@executable_path/../Frameworks"; then
         echo "❌ $(basename "$executable") is missing @executable_path/../Frameworks rpath" >&2

--- a/Sources/KeyPathAppKit/App.swift
+++ b/Sources/KeyPathAppKit/App.swift
@@ -134,9 +134,15 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private var initialMainWindowShown = false
     private var suppressLaunchSplashAutoHide = false
     private var keyboardCapture: KeyboardCapture?
+    /// Set at the start of quit teardown. `applicationShouldTerminate` closes the
+    /// wizard, whose async onDismiss work runs after the window-close loop below —
+    /// it must not spawn new windows mid-quit (e.g. the first-success celebration
+    /// panel, #954).
+    private var isTerminating = false
 
     func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
         AppLogger.shared.log("🔍 [AppDelegate] applicationShouldTerminate called")
+        isTerminating = true
         // Close wizard and all windows so nothing blocks the quit
         WizardWindowController.shared.closeWindow()
         for window in NSApp.windows {
@@ -725,9 +731,36 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 Task { @MainActor in
                     await self?.viewModel?.updateStatus()
                     await MainAppStateController.shared.revalidate()
+                    self?.presentFirstSuccessCelebrationIfNeeded()
                 }
             }
         )
+    }
+
+    /// Post-setup celebration + starter-collection offer + short panel tour
+    /// (issue #954). Fires at most once: the first time the wizard closes healthy
+    /// after a run where the user was shown the Welcome page (#932). Must run
+    /// after `MainAppStateController.shared.revalidate()` above so `validationState`
+    /// reflects the freshly-closed wizard's outcome, not stale pre-wizard state.
+    @MainActor
+    private func presentFirstSuccessCelebrationIfNeeded() {
+        guard let vm = viewModel else { return }
+
+        // Quit teardown also fires the wizard's onDismiss (applicationShouldTerminate
+        // → closeWindow). Bail before consuming the one-shot flag so the user still
+        // gets the celebration on next launch instead of a panel mid-quit.
+        guard !isTerminating else { return }
+
+        let wizardClosedHealthy = MainAppStateController.shared.validationState?.isSuccess ?? false
+        guard OnboardingFirstSuccessGate.shouldShowFirstSuccess(wizardClosedHealthy: wizardClosedHealthy) else {
+            return
+        }
+
+        // One-shot: mark shown before presenting so a panel the user closes
+        // immediately (or an app quit mid-panel) can never resurface it later.
+        OnboardingFirstSuccessGate.markFirstSuccessShown()
+        AppLogger.shared.info("🎉 [AppDelegate] First-ever successful setup — showing first-success celebration")
+        FirstSuccessWindowController.show(viewModel: vm)
     }
 
     @MainActor

--- a/Sources/KeyPathAppKit/Managers/ConfigReloadCoordinator.swift
+++ b/Sources/KeyPathAppKit/Managers/ConfigReloadCoordinator.swift
@@ -120,8 +120,8 @@ final class ConfigReloadCoordinator {
             // error sound — the next reload attempt will fire when cooldown
             // expires. Real failures (validation, network, etc.) still
             // notify as before.
-            if isCooldownBlockMessage(errorMessage) {
-                scheduleDeferredReloadAfterCooldown()
+            if isDeferredReloadMessage(errorMessage) {
+                scheduleDeferredReload(for: errorMessage)
             } else {
                 NotificationCenter.default.post(
                     name: .configReloadFailed,
@@ -143,7 +143,7 @@ final class ConfigReloadCoordinator {
     }
 
     private func disposition(for tcpResult: TCPReloadResult, message: String) -> ReloadDisposition {
-        if isCooldownBlockMessage(message) {
+        if isDeferredReloadMessage(message) {
             return .pending
         }
 
@@ -163,19 +163,30 @@ final class ConfigReloadCoordinator {
         message.contains("Reload blocked") && message.contains("cooldown")
     }
 
-    /// When a reload is blocked by the cooldown, we still want it to actually
-    /// happen so the config file we just wrote reaches kanata. Schedule a
-    /// deferred retry once the cooldown expires; de-duped via a single
-    /// outstanding task so rapid edits coalesce into one final reload.
+    /// Connection closure/reset can happen during launch while kanata is
+    /// restarting around a freshly deployed app. Treat it like a pending reload:
+    /// retry quietly instead of showing a scary toast for a transient startup race.
+    private func isTransientConnectionMessage(_ message: String) -> Bool {
+        message.contains("Connection closed") || message.contains("reset by peer")
+    }
+
+    private func isDeferredReloadMessage(_ message: String) -> Bool {
+        isCooldownBlockMessage(message) || isTransientConnectionMessage(message)
+    }
+
+    /// When a reload is deferred, we still want it to actually happen so the
+    /// config file we just wrote reaches kanata. Schedule a retry; de-duped via
+    /// a single outstanding task so rapid edits coalesce into one final reload.
     private var deferredReloadTask: Task<Void, Never>?
 
-    private func scheduleDeferredReloadAfterCooldown() {
+    private func scheduleDeferredReload(for message: String) {
         deferredReloadTask?.cancel()
+        let isCooldown = isCooldownBlockMessage(message)
+        let delayNanoseconds: UInt64 = isCooldown ? 3_200_000_000 : 1_000_000_000
         deferredReloadTask = Task { [weak self] in
-            // 3s cooldown + a little slop so the safety check passes.
-            try? await Task.sleep(nanoseconds: 3_200_000_000)
+            try? await Task.sleep(nanoseconds: delayNanoseconds)
             guard let self, !Task.isCancelled else { return }
-            AppLogger.shared.log("🔁 [Reload] Firing deferred reload after cooldown expiry")
+            AppLogger.shared.log("🔁 [Reload] Firing deferred reload after pending condition: \(message)")
             await triggerReload()
             deferredReloadTask = nil
         }
@@ -216,9 +227,13 @@ final class ConfigReloadCoordinator {
     /// Main reload method that should be used by new code
     func triggerReload() async {
         let result = await triggerConfigReload()
-        if !result.isSuccess {
+        if !result.isSuccess, result.disposition != .pending {
             AppLogger.shared.warnUnlessQuietTest(
                 "⚠️ [Reload] Reload failed (no automatic restart): \(result.errorMessage ?? "Unknown")"
+            )
+        } else if result.disposition == .pending {
+            AppLogger.shared.debug(
+                "ℹ️ [Reload] Reload pending retry: \(result.errorMessage ?? "Unknown")"
             )
         }
     }

--- a/Sources/KeyPathAppKit/Managers/RuleCollectionsCoordinator.swift
+++ b/Sources/KeyPathAppKit/Managers/RuleCollectionsCoordinator.swift
@@ -75,16 +75,22 @@ final class RuleCollectionsCoordinator {
     }
 
     /// Update a single-key picker collection's selected output
-    func updateCollectionOutput(id: UUID, output: String) async {
-        await ruleCollectionsManager.updateCollectionOutput(id: id, output: output)
+    @discardableResult
+    func updateCollectionOutput(id: UUID, output: String) async -> Bool {
+        let applied = await ruleCollectionsManager.updateCollectionOutput(id: id, output: output)
         applyMappings(ruleCollectionsManager.enabledMappings())
         notifyStateChanged()
+        return applied
     }
 
     /// Update a tap-hold picker collection's tap output
     @discardableResult
-    func updateCollectionTapOutput(id: UUID, tapOutput: String) async -> Bool {
-        let applied = await ruleCollectionsManager.updateCollectionTapOutput(id: id, tapOutput: tapOutput)
+    func updateCollectionTapOutput(id: UUID, tapOutput: String, reportRollbackError: Bool = true) async -> Bool {
+        let applied = await ruleCollectionsManager.updateCollectionTapOutput(
+            id: id,
+            tapOutput: tapOutput,
+            reportRollbackError: reportRollbackError
+        )
         applyMappings(ruleCollectionsManager.enabledMappings())
         notifyStateChanged()
         return applied

--- a/Sources/KeyPathAppKit/Managers/RuleCollectionsCoordinator.swift
+++ b/Sources/KeyPathAppKit/Managers/RuleCollectionsCoordinator.swift
@@ -82,10 +82,12 @@ final class RuleCollectionsCoordinator {
     }
 
     /// Update a tap-hold picker collection's tap output
-    func updateCollectionTapOutput(id: UUID, tapOutput: String) async {
-        await ruleCollectionsManager.updateCollectionTapOutput(id: id, tapOutput: tapOutput)
+    @discardableResult
+    func updateCollectionTapOutput(id: UUID, tapOutput: String) async -> Bool {
+        let applied = await ruleCollectionsManager.updateCollectionTapOutput(id: id, tapOutput: tapOutput)
         applyMappings(ruleCollectionsManager.enabledMappings())
         notifyStateChanged()
+        return applied
     }
 
     /// Update a tap-hold picker collection's hold output

--- a/Sources/KeyPathAppKit/Managers/RuntimeCoordinator+RuleCollections.swift
+++ b/Sources/KeyPathAppKit/Managers/RuntimeCoordinator+RuleCollections.swift
@@ -38,7 +38,8 @@ extension RuntimeCoordinator {
         await ruleCollectionsCoordinator.updateCollectionOutput(id: id, output: output)
     }
 
-    func updateCollectionTapOutput(id: UUID, tapOutput: String) async {
+    @discardableResult
+    func updateCollectionTapOutput(id: UUID, tapOutput: String) async -> Bool {
         await ruleCollectionsCoordinator.updateCollectionTapOutput(id: id, tapOutput: tapOutput)
     }
 

--- a/Sources/KeyPathAppKit/Managers/RuntimeCoordinator+RuleCollections.swift
+++ b/Sources/KeyPathAppKit/Managers/RuntimeCoordinator+RuleCollections.swift
@@ -34,13 +34,18 @@ extension RuntimeCoordinator {
         await ruleCollectionsCoordinator.addRuleCollection(collection)
     }
 
-    func updateCollectionOutput(id: UUID, output: String) async {
+    @discardableResult
+    func updateCollectionOutput(id: UUID, output: String) async -> Bool {
         await ruleCollectionsCoordinator.updateCollectionOutput(id: id, output: output)
     }
 
     @discardableResult
-    func updateCollectionTapOutput(id: UUID, tapOutput: String) async -> Bool {
-        await ruleCollectionsCoordinator.updateCollectionTapOutput(id: id, tapOutput: tapOutput)
+    func updateCollectionTapOutput(id: UUID, tapOutput: String, reportRollbackError: Bool = true) async -> Bool {
+        await ruleCollectionsCoordinator.updateCollectionTapOutput(
+            id: id,
+            tapOutput: tapOutput,
+            reportRollbackError: reportRollbackError
+        )
     }
 
     func updateCollectionHoldOutput(id: UUID, holdOutput: String) async {

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+ConflictResolution.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+ConflictResolution.swift
@@ -97,12 +97,16 @@ extension RuleCollectionsManager {
 
     /// Restore state snapshot and attempt to re-apply previous config.
     @discardableResult
-    func rollbackToSnapshot(_ snapshot: RuleStateSnapshot, userMessage: String) async -> Bool {
+    func rollbackToSnapshot(_ snapshot: RuleStateSnapshot, userMessage: String, notifyUser: Bool = true) async -> Bool {
         ruleCollections = snapshot.collections
         customRules = snapshot.customRules
         refreshLayerIndicatorState()
 
-        let rollbackApplied = await regenerateConfigFromCollections()
+        let rollbackApplied = await regenerateConfigFromCollections(reportErrors: notifyUser)
+        guard notifyUser else {
+            return rollbackApplied
+        }
+
         if rollbackApplied {
             onError?(userMessage)
         } else {

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+Migrations.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+Migrations.swift
@@ -36,7 +36,7 @@ extension RuleCollectionsManager {
     /// Regenerates the Kanata configuration from collections and custom rules.
     /// Returns `true` on success, `false` if validation or saving fails.
     @discardableResult
-    func regenerateConfigFromCollections(skipReload: Bool = false, conflictResolutionDepth: Int = 0) async -> Bool {
+    func regenerateConfigFromCollections(skipReload: Bool = false, conflictResolutionDepth: Int = 0, reportErrors: Bool = true) async -> Bool {
         dedupeRuleCollectionsInPlace()
 
         AppLogger.shared.log("🔄 [RuleCollections] regenerateConfigFromCollections: \(ruleCollections.count) collections, \(customRules.count) custom rules")
@@ -129,12 +129,14 @@ extension RuleCollectionsManager {
                 "Failed to save configuration: \(error.localizedDescription)"
             }
 
-            // Notify user via callback
-            AppLogger.shared.debug("🚨 [RuleCollectionsManager] About to call onError, callback is \(onError == nil ? "nil" : "set"): \(userMessage)")
-            onError?(userMessage)
+            if reportErrors {
+                // Notify user via callback
+                AppLogger.shared.debug("🚨 [RuleCollectionsManager] About to call onError, callback is \(onError == nil ? "nil" : "set"): \(userMessage)")
+                onError?(userMessage)
 
-            await MainActor.run {
-                SoundManager.shared.playErrorSound()
+                await MainActor.run {
+                    SoundManager.shared.playErrorSound()
+                }
             }
 
             return false

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+PublicAPI.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+PublicAPI.swift
@@ -296,55 +296,69 @@ extension RuleCollectionsManager {
         AppLogger.shared.log("📚 [RuleCollections] Created new layer: \(sanitizedName) (Leader → \(activatorKey.uppercased()))")
     }
 
-    /// Update a single-key picker collection's selected output and regenerate its mapping
-    func updateCollectionOutput(id: UUID, output: String) async {
-        guard let index = ruleCollections.firstIndex(where: { $0.id == id }) else {
-            // Try to find in catalog and add it
-            let catalog = RuleCollectionCatalog()
-            if var catalogCollection = catalog.defaultCollections().first(where: { $0.id == id }) {
-                catalogCollection.configuration.updateSelectedOutput(output)
-                catalogCollection.isEnabled = true
-                // Update the mapping based on selected output
-                if let config = catalogCollection.configuration.singleKeyPickerConfig {
-                    let description = config.presetOptions.first { $0.output == output }?.label ?? "Custom"
-                    let keyAction: KeyAction = output.hasPrefix("(") ? .rawKanata(output) : .keystroke(key: output)
-                    catalogCollection.mappings = [KeyMapping(input: config.inputKey, action: keyAction, description: description)]
-                }
-                ruleCollections.append(catalogCollection)
-                dedupeRuleCollectionsInPlace()
-                refreshLayerIndicatorState()
-                await regenerateConfigFromCollections()
-            }
+    private func updateSingleKeyPickerMapping(at index: Int, output: String) {
+        guard index >= ruleCollections.startIndex, index < ruleCollections.endIndex else { return }
+        guard let config = ruleCollections[index].configuration.singleKeyPickerConfig,
+              config.inputKey != "leader"
+        else {
             return
         }
 
-        ruleCollections[index].configuration.updateSelectedOutput(output)
-        ruleCollections[index].isEnabled = true
+        let description = config.presetOptions.first { $0.output == output }?.label ?? "Custom"
+        let keyAction: KeyAction = output.hasPrefix("(") ? .rawKanata(output) : .keystroke(key: output)
+        ruleCollections[index].mappings = [
+            KeyMapping(input: config.inputKey, action: keyAction, description: description)
+        ]
+    }
 
-        // Update the mapping based on selected output (skip for Leader Key which has no mappings)
-        if let config = ruleCollections[index].configuration.singleKeyPickerConfig,
-           config.inputKey != "leader"
-        {
-            let description = config.presetOptions.first { $0.output == output }?.label ?? "Custom"
-            let keyAction: KeyAction = output.hasPrefix("(") ? .rawKanata(output) : .keystroke(key: output)
-            ruleCollections[index].mappings = [KeyMapping(input: config.inputKey, action: keyAction, description: description)]
+    /// Update a single-key picker collection's selected output and regenerate its mapping
+    @discardableResult
+    func updateCollectionOutput(id: UUID, output: String, reportRollbackError: Bool = true) async -> Bool {
+        let snapshot = snapshotRuleState()
+        let leaderPreferenceSnapshot = PreferencesService.shared.leaderKeyPreference
+
+        if let index = ruleCollections.firstIndex(where: { $0.id == id }) {
+            ruleCollections[index].configuration.updateSelectedOutput(output)
+            ruleCollections[index].isEnabled = true
+            updateSingleKeyPickerMapping(at: index, output: output)
+        } else {
+            // Try to find in catalog and add it
+            let catalog = RuleCollectionCatalog()
+            guard var catalogCollection = catalog.defaultCollections().first(where: { $0.id == id }) else {
+                return false
+            }
+            catalogCollection.configuration.updateSelectedOutput(output)
+            catalogCollection.isEnabled = true
+            ruleCollections.append(catalogCollection)
+            updateSingleKeyPickerMapping(at: ruleCollections.count - 1, output: output)
         }
 
         dedupeRuleCollectionsInPlace()
 
         // Special handling: If this is the Leader Key collection, update all momentary activators
         if id == RuleCollectionIdentifier.leaderKey {
-            await updateLeaderKey(output)
-            return
+            applyLeaderKeyToMomentaryActivators(output)
+            syncLeaderKeyPreference(key: output, enabled: true)
         }
 
         refreshLayerIndicatorState()
-        await regenerateConfigFromCollections()
+        let applied = await regenerateConfigFromCollections(reportErrors: false)
+        if !applied {
+            if id == RuleCollectionIdentifier.leaderKey {
+                PreferencesService.shared.leaderKeyPreference = leaderPreferenceSnapshot
+            }
+            await rollbackToSnapshot(
+                snapshot,
+                userMessage: "Could not apply this rule change. Your previous rule state was restored.",
+                notifyUser: reportRollbackError
+            )
+        }
+        return applied
     }
 
     /// Update a tap-hold picker collection's tap output
     @discardableResult
-    func updateCollectionTapOutput(id: UUID, tapOutput: String) async -> Bool {
+    func updateCollectionTapOutput(id: UUID, tapOutput: String, reportRollbackError: Bool = true) async -> Bool {
         let snapshot = snapshotRuleState()
 
         guard let index = ruleCollections.firstIndex(where: { $0.id == id }) else {
@@ -356,9 +370,13 @@ extension RuleCollectionsManager {
                 ruleCollections.append(catalogCollection)
                 dedupeRuleCollectionsInPlace()
                 refreshLayerIndicatorState()
-                let applied = await regenerateConfigFromCollections()
+                let applied = await regenerateConfigFromCollections(reportErrors: false)
                 if !applied {
-                    await rollbackToSnapshot(snapshot, userMessage: "Could not apply this rule change. Your previous rule state was restored.")
+                    await rollbackToSnapshot(
+                        snapshot,
+                        userMessage: "Could not apply this rule change. Your previous rule state was restored.",
+                        notifyUser: reportRollbackError
+                    )
                 }
                 return applied
             }
@@ -369,9 +387,13 @@ extension RuleCollectionsManager {
         ruleCollections[index].isEnabled = true
         dedupeRuleCollectionsInPlace()
         refreshLayerIndicatorState()
-        let applied = await regenerateConfigFromCollections()
+        let applied = await regenerateConfigFromCollections(reportErrors: false)
         if !applied {
-            await rollbackToSnapshot(snapshot, userMessage: "Could not apply this rule change. Your previous rule state was restored.")
+            await rollbackToSnapshot(
+                snapshot,
+                userMessage: "Could not apply this rule change. Your previous rule state was restored.",
+                notifyUser: reportRollbackError
+            )
         }
         return applied
     }

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+PublicAPI.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+PublicAPI.swift
@@ -343,7 +343,10 @@ extension RuleCollectionsManager {
     }
 
     /// Update a tap-hold picker collection's tap output
-    func updateCollectionTapOutput(id: UUID, tapOutput: String) async {
+    @discardableResult
+    func updateCollectionTapOutput(id: UUID, tapOutput: String) async -> Bool {
+        let snapshot = snapshotRuleState()
+
         guard let index = ruleCollections.firstIndex(where: { $0.id == id }) else {
             // Try to find in catalog and add it
             let catalog = RuleCollectionCatalog()
@@ -353,16 +356,24 @@ extension RuleCollectionsManager {
                 ruleCollections.append(catalogCollection)
                 dedupeRuleCollectionsInPlace()
                 refreshLayerIndicatorState()
-                await regenerateConfigFromCollections()
+                let applied = await regenerateConfigFromCollections()
+                if !applied {
+                    await rollbackToSnapshot(snapshot, userMessage: "Could not apply this rule change. Your previous rule state was restored.")
+                }
+                return applied
             }
-            return
+            return false
         }
 
         ruleCollections[index].configuration.updateSelectedTapOutput(tapOutput)
         ruleCollections[index].isEnabled = true
         dedupeRuleCollectionsInPlace()
         refreshLayerIndicatorState()
-        await regenerateConfigFromCollections()
+        let applied = await regenerateConfigFromCollections()
+        if !applied {
+            await rollbackToSnapshot(snapshot, userMessage: "Could not apply this rule change. Your previous rule state was restored.")
+        }
+        return applied
     }
 
     /// Update a tap-hold picker collection's hold output

--- a/Sources/KeyPathAppKit/UI/Onboarding/FirstSuccessDialog.swift
+++ b/Sources/KeyPathAppKit/UI/Onboarding/FirstSuccessDialog.swift
@@ -201,7 +201,8 @@ struct FirstSuccessDialog: View {
             // the TCP reload plumbing is untouched.
             let applied = await kanataManager.updateCollectionTapOutput(
                 RuleCollectionIdentifier.capsLockRemap,
-                tapOutput: "esc"
+                tapOutput: "esc",
+                reportRollbackError: false
             )
             isEnabling = false
             if applied {

--- a/Sources/KeyPathAppKit/UI/Onboarding/FirstSuccessDialog.swift
+++ b/Sources/KeyPathAppKit/UI/Onboarding/FirstSuccessDialog.swift
@@ -15,6 +15,7 @@ struct FirstSuccessDialog: View {
 
     @State private var currentStep: Step = .celebration
     @State private var isEnabling = false
+    @State private var starterErrorMessage: String?
 
     enum Step {
         case celebration
@@ -95,7 +96,7 @@ struct FirstSuccessDialog: View {
                     .font(.largeTitle)
                     .fontWeight(.bold)
 
-                Text("Want your first remap? One click and Caps Lock becomes Escape.")
+                Text(celebrationMessage)
                     .font(.title3)
                     .foregroundColor(.secondary)
                     .multilineTextAlignment(.center)
@@ -105,13 +106,22 @@ struct FirstSuccessDialog: View {
             Spacer()
 
             VStack(spacing: 12) {
-                Button(action: enableStarterRemap) {
+                if let starterErrorMessage {
+                    Text(starterErrorMessage)
+                        .font(.callout)
+                        .foregroundColor(.red)
+                        .multilineTextAlignment(.center)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .accessibilityIdentifier("first-success-enable-error")
+                }
+
+                Button(action: primaryCelebrationAction) {
                     HStack {
                         if isEnabling {
                             ProgressView()
                                 .controlSize(.small)
                         }
-                        Text("Enable Caps Lock → Escape")
+                        Text(primaryButtonTitle)
                     }
                     .frame(maxWidth: .infinity)
                 }
@@ -132,9 +142,54 @@ struct FirstSuccessDialog: View {
         }
     }
 
+    private var capsLockTapOutput: String? {
+        guard
+            let collection = kanataManager.ruleCollections.first(where: { $0.id == RuleCollectionIdentifier.capsLockRemap }),
+            case let .tapHoldPicker(config) = collection.configuration
+        else {
+            return nil
+        }
+        return config.selectedTapOutput ?? config.tapOptions.first?.output
+    }
+
+    private var capsLockAlreadyEscape: Bool {
+        capsLockTapOutput == "esc"
+    }
+
+    private var capsLockTapIsCustomized: Bool {
+        guard let capsLockTapOutput else { return false }
+        return capsLockTapOutput != "hyper" && capsLockTapOutput != "esc"
+    }
+
+    private var celebrationMessage: String {
+        if capsLockAlreadyEscape {
+            return "Caps Lock already sends Escape. Want a quick tour of what you can do next?"
+        }
+        if capsLockTapIsCustomized {
+            return "Caps Lock already has a custom tap binding, so we'll keep it as-is. Want a quick tour?"
+        }
+        return "Want your first remap? One click and Caps Lock becomes Escape."
+    }
+
+    private var primaryButtonTitle: String {
+        if capsLockAlreadyEscape || capsLockTapIsCustomized {
+            return "Start Tour"
+        }
+        return "Enable Caps Lock → Escape"
+    }
+
+    private func primaryCelebrationAction() {
+        if capsLockAlreadyEscape || capsLockTapIsCustomized {
+            currentStep = .tourOverlay
+        } else {
+            enableStarterRemap()
+        }
+    }
+
     private func enableStarterRemap() {
         guard !isEnabling else { return }
         isEnabling = true
+        starterErrorMessage = nil
         Task { @MainActor in
             // Caps Lock Remap ships enabled by default (tap+hold both bound to
             // Hyper), so a plain add would collide with itself. Re-pointing its
@@ -144,12 +199,16 @@ struct FirstSuccessDialog: View {
             // collection's decorative `mappings` field. Still goes through
             // RuleCollectionsCoordinator → regenerateConfigFromCollections, so
             // the TCP reload plumbing is untouched.
-            await kanataManager.updateCollectionTapOutput(
+            let applied = await kanataManager.updateCollectionTapOutput(
                 RuleCollectionIdentifier.capsLockRemap,
                 tapOutput: "esc"
             )
             isEnabling = false
-            currentStep = .success
+            if applied {
+                currentStep = .success
+            } else {
+                starterErrorMessage = "KeyPath couldn't save that remap. Your current setup was left unchanged."
+            }
         }
     }
 

--- a/Sources/KeyPathAppKit/UI/Onboarding/FirstSuccessDialog.swift
+++ b/Sources/KeyPathAppKit/UI/Onboarding/FirstSuccessDialog.swift
@@ -1,0 +1,235 @@
+import SwiftUI
+
+/// Post-setup celebration + short panel tour (issue #954).
+///
+/// Shown exactly once, the moment the wizard first closes healthy after a fresh
+/// install (see `OnboardingFirstSuccessGate`). Ends the setup arc that #932 started
+/// in a working mapping instead of a closed wizard: a guaranteed one-click win
+/// (Caps Lock → Escape) followed by a short tour of the surfaces users reach for
+/// next — the live overlay, the Rules tab, and the custom-rule inline editor.
+struct FirstSuccessDialog: View {
+    @Environment(KanataViewModel.self) private var kanataManager
+
+    /// Called when the user dismisses the dialog, at any step.
+    let onFinished: () -> Void
+
+    @State private var currentStep: Step = .celebration
+    @State private var isEnabling = false
+
+    enum Step {
+        case celebration
+        case success
+        case tourOverlay
+        case tourRules
+        case tourCustomRule
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Group {
+                switch currentStep {
+                case .celebration:
+                    celebrationStep
+                case .success:
+                    successStep
+                case .tourOverlay:
+                    tourStep(
+                        icon: "keyboard",
+                        title: "Your Live Keyboard",
+                        description: "This floating overlay shows your mappings in real time. Glance down anytime to see what a key does.",
+                        identifier: "first-success-tour-overlay",
+                        next: .tourRules
+                    )
+                case .tourRules:
+                    tourStep(
+                        icon: "list.bullet.rectangle",
+                        title: "The Rules Tab",
+                        description: "Every collection you turn on shows up here. Toggle any of them on or off whenever you like.",
+                        identifier: "first-success-tour-rules",
+                        next: .tourCustomRule
+                    )
+                case .tourCustomRule:
+                    tourStep(
+                        icon: "square.and.pencil",
+                        title: "Make Your Own",
+                        description: "When you're ready to make your own, the inline editor lets you map any key to anything — no config file required.",
+                        identifier: "first-success-tour-custom-rule",
+                        next: nil
+                    )
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+        .frame(width: 480, height: 460)
+        .overlay(alignment: .topTrailing) {
+            Button(action: onFinished) {
+                Image(systemName: "xmark.circle.fill")
+                    .font(.title2)
+                    .foregroundColor(.secondary)
+            }
+            .buttonStyle(.plain)
+            .padding(16)
+            .accessibilityIdentifier("first-success-close-button")
+            .accessibilityLabel("Close")
+        }
+    }
+
+    // MARK: - Celebration Step
+
+    private var celebrationStep: some View {
+        VStack(spacing: 24) {
+            Spacer()
+
+            VStack(spacing: 16) {
+                Image(systemName: "checkmark.seal.fill")
+                    .font(.system(size: 56))
+                    .foregroundStyle(
+                        LinearGradient(
+                            colors: [.green, .blue],
+                            startPoint: .topLeading,
+                            endPoint: .bottomTrailing
+                        )
+                    )
+
+                Text("You're All Set")
+                    .font(.largeTitle)
+                    .fontWeight(.bold)
+
+                Text("Want your first remap? One click and Caps Lock becomes Escape.")
+                    .font(.title3)
+                    .foregroundColor(.secondary)
+                    .multilineTextAlignment(.center)
+            }
+            .padding(.horizontal, 40)
+
+            Spacer()
+
+            VStack(spacing: 12) {
+                Button(action: enableStarterRemap) {
+                    HStack {
+                        if isEnabling {
+                            ProgressView()
+                                .controlSize(.small)
+                        }
+                        Text("Enable Caps Lock → Escape")
+                    }
+                    .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.large)
+                .disabled(isEnabling)
+                .accessibilityIdentifier("first-success-enable-button")
+
+                Button("Not Now") {
+                    currentStep = .tourOverlay
+                }
+                .buttonStyle(.plain)
+                .foregroundColor(.secondary)
+                .accessibilityIdentifier("first-success-skip-button")
+            }
+            .padding(.horizontal, 40)
+            .padding(.bottom, 24)
+        }
+    }
+
+    private func enableStarterRemap() {
+        guard !isEnabling else { return }
+        isEnabling = true
+        Task { @MainActor in
+            // Caps Lock Remap ships enabled by default (tap+hold both bound to
+            // Hyper), so a plain add would collide with itself. Re-pointing its
+            // tap output to Escape via the same coordinator-backed mutator the
+            // Rules tab picker uses is what actually changes the applied
+            // behavior — the tap-hold generator reads `configuration`, not the
+            // collection's decorative `mappings` field. Still goes through
+            // RuleCollectionsCoordinator → regenerateConfigFromCollections, so
+            // the TCP reload plumbing is untouched.
+            await kanataManager.updateCollectionTapOutput(
+                RuleCollectionIdentifier.capsLockRemap,
+                tapOutput: "esc"
+            )
+            isEnabling = false
+            currentStep = .success
+        }
+    }
+
+    // MARK: - Success Step
+
+    private var successStep: some View {
+        VStack(spacing: 24) {
+            Spacer()
+
+            VStack(spacing: 16) {
+                Image(systemName: "escape")
+                    .font(.system(size: 56))
+                    .foregroundColor(.green)
+
+                Text("Press Caps Lock")
+                    .font(.largeTitle)
+                    .fontWeight(.bold)
+
+                Text("It's Escape now.")
+                    .font(.title3)
+                    .foregroundColor(.secondary)
+            }
+
+            Spacer()
+
+            Button("Continue") {
+                currentStep = .tourOverlay
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.large)
+            .accessibilityIdentifier("first-success-continue-button")
+            .padding(.horizontal, 40)
+            .padding(.bottom, 24)
+        }
+    }
+
+    // MARK: - Tour Steps
+
+    private func tourStep(
+        icon: String,
+        title: String,
+        description: String,
+        identifier: String,
+        next: Step?
+    ) -> some View {
+        VStack(spacing: 24) {
+            Spacer()
+
+            VStack(spacing: 16) {
+                Image(systemName: icon)
+                    .font(.system(size: 48))
+                    .foregroundColor(.accentColor)
+
+                Text(title)
+                    .font(.title)
+                    .fontWeight(.semibold)
+
+                Text(description)
+                    .font(.body)
+                    .foregroundColor(.secondary)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, 32)
+            }
+
+            Spacer()
+
+            Button(next == nil ? "Got It" : "Next") {
+                if let next {
+                    currentStep = next
+                } else {
+                    onFinished()
+                }
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.large)
+            .accessibilityIdentifier(next == nil ? "first-success-tour-done-button" : "first-success-tour-next-button")
+            .padding(.horizontal, 40)
+            .padding(.bottom, 24)
+        }
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier(identifier)
+    }
+}

--- a/Sources/KeyPathAppKit/UI/Onboarding/FirstSuccessWindowController.swift
+++ b/Sources/KeyPathAppKit/UI/Onboarding/FirstSuccessWindowController.swift
@@ -1,0 +1,104 @@
+import AppKit
+import SwiftUI
+
+/// Window controller for the `FirstSuccessDialog` (issue #954).
+/// Presents the celebration + tour as an independent floating panel, following the
+/// same pattern as `LauncherWelcomeWindowController`.
+@MainActor
+final class FirstSuccessWindowController: NSWindowController {
+    /// Singleton to prevent multiple instances
+    private static var currentController: FirstSuccessWindowController?
+
+    /// Shows the first-success celebration panel centered on screen.
+    /// - Parameter viewModel: Injected into the SwiftUI environment so the dialog
+    ///   can enable the starter collection via the existing rule-collections
+    ///   coordinator plumbing.
+    static func show(viewModel: KanataViewModel) {
+        // Dismiss any existing instance
+        currentController?.close()
+        currentController = nil
+
+        let controller = FirstSuccessWindowController(viewModel: viewModel)
+        currentController = controller
+        controller.showWindow(nil)
+    }
+
+    /// Dismisses the current celebration panel if one is showing
+    static func dismiss() {
+        currentController?.close()
+        currentController = nil
+    }
+
+    private init(viewModel: KanataViewModel) {
+        let dialogView = FirstSuccessDialog(onFinished: {
+            FirstSuccessWindowController.dismiss()
+        })
+        .environment(viewModel)
+        .background(VisualEffectBlur())
+
+        let hostingController = NSHostingController(rootView: dialogView)
+
+        // Create a panel-style window (floats above other windows)
+        let window = NSPanel(
+            contentRect: NSRect(x: 0, y: 0, width: 480, height: 460),
+            styleMask: [.titled, .closable, .fullSizeContentView, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+
+        // Configure window appearance
+        window.title = ""
+        window.titlebarAppearsTransparent = true
+        window.titleVisibility = .hidden
+        window.isOpaque = false
+        window.backgroundColor = .clear
+        window.hasShadow = true
+        window.isMovableByWindowBackground = true
+
+        // Make it float above other windows but not aggressively
+        window.level = .floating
+        window.hidesOnDeactivate = false
+
+        // Center on screen
+        window.center()
+
+        super.init(window: window)
+
+        window.contentViewController = hostingController
+        window.delegate = self
+    }
+
+    @available(*, unavailable)
+    required init?(coder _: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func showWindow(_ sender: Any?) {
+        super.showWindow(sender)
+        window?.makeKeyAndOrderFront(nil)
+    }
+}
+
+// MARK: - NSWindowDelegate
+
+extension FirstSuccessWindowController: NSWindowDelegate {
+    func windowWillClose(_: Notification) {
+        FirstSuccessWindowController.currentController = nil
+    }
+}
+
+// MARK: - Visual Effect Blur
+
+/// Visual effect blur background for the panel (hudWindow material, matching the
+/// Launcher welcome panel's floating-panel treatment).
+private struct VisualEffectBlur: NSViewRepresentable {
+    func makeNSView(context _: Context) -> NSVisualEffectView {
+        let view = NSVisualEffectView()
+        view.material = .hudWindow
+        view.blendingMode = .behindWindow
+        view.state = .active
+        return view
+    }
+
+    func updateNSView(_: NSVisualEffectView, context _: Context) {}
+}

--- a/Sources/KeyPathAppKit/UI/Onboarding/FirstSuccessWindowController.swift
+++ b/Sources/KeyPathAppKit/UI/Onboarding/FirstSuccessWindowController.swift
@@ -34,7 +34,7 @@ final class FirstSuccessWindowController: NSWindowController {
             FirstSuccessWindowController.dismiss()
         })
         .environment(viewModel)
-        .background(VisualEffectBlur())
+        .background(PanelVisualEffectBlur())
 
         let hostingController = NSHostingController(rootView: dialogView)
 
@@ -85,20 +85,4 @@ extension FirstSuccessWindowController: NSWindowDelegate {
     func windowWillClose(_: Notification) {
         FirstSuccessWindowController.currentController = nil
     }
-}
-
-// MARK: - Visual Effect Blur
-
-/// Visual effect blur background for the panel (hudWindow material, matching the
-/// Launcher welcome panel's floating-panel treatment).
-private struct VisualEffectBlur: NSViewRepresentable {
-    func makeNSView(context _: Context) -> NSVisualEffectView {
-        let view = NSVisualEffectView()
-        view.material = .hudWindow
-        view.blendingMode = .behindWindow
-        view.state = .active
-        return view
-    }
-
-    func updateNSView(_: NSVisualEffectView, context _: Context) {}
 }

--- a/Sources/KeyPathAppKit/UI/Rules/LauncherWelcomeWindowController.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/LauncherWelcomeWindowController.swift
@@ -119,19 +119,6 @@ private struct LauncherWelcomeDialogWrapper: View {
             config: $config,
             onComplete: onComplete
         )
-        .background(VisualEffectBlur())
+        .background(PanelVisualEffectBlur())
     }
-}
-
-/// Visual effect blur background for the dialog
-private struct VisualEffectBlur: NSViewRepresentable {
-    func makeNSView(context _: Context) -> NSVisualEffectView {
-        let view = NSVisualEffectView()
-        view.material = .hudWindow
-        view.blendingMode = .behindWindow
-        view.state = .active
-        return view
-    }
-
-    func updateNSView(_: NSVisualEffectView, context _: Context) {}
 }

--- a/Sources/KeyPathAppKit/UI/Shared/PanelVisualEffectBlur.swift
+++ b/Sources/KeyPathAppKit/UI/Shared/PanelVisualEffectBlur.swift
@@ -1,0 +1,15 @@
+import AppKit
+import SwiftUI
+
+/// Shared HUD-style blur background for floating SwiftUI panels.
+struct PanelVisualEffectBlur: NSViewRepresentable {
+    func makeNSView(context _: Context) -> NSVisualEffectView {
+        let view = NSVisualEffectView()
+        view.material = .hudWindow
+        view.blendingMode = .behindWindow
+        view.state = .active
+        return view
+    }
+
+    func updateNSView(_: NSVisualEffectView, context _: Context) {}
+}

--- a/Sources/KeyPathAppKit/UI/ViewModels/KanataViewModel.swift
+++ b/Sources/KeyPathAppKit/UI/ViewModels/KanataViewModel.swift
@@ -326,14 +326,20 @@ class KanataViewModel {
         await manager.addRuleCollection(collection)
     }
 
-    func updateCollectionOutput(_ id: UUID, output: String) async {
-        await manager.updateCollectionOutput(id: id, output: output)
+    @discardableResult
+    func updateCollectionOutput(_ id: UUID, output: String) async -> Bool {
+        let applied = await manager.updateCollectionOutput(id: id, output: output)
         ruleCollections = manager.rulesManager.ruleCollections
+        return applied
     }
 
     @discardableResult
-    func updateCollectionTapOutput(_ id: UUID, tapOutput: String) async -> Bool {
-        let applied = await manager.updateCollectionTapOutput(id: id, tapOutput: tapOutput)
+    func updateCollectionTapOutput(_ id: UUID, tapOutput: String, reportRollbackError: Bool = true) async -> Bool {
+        let applied = await manager.updateCollectionTapOutput(
+            id: id,
+            tapOutput: tapOutput,
+            reportRollbackError: reportRollbackError
+        )
         ruleCollections = manager.rulesManager.ruleCollections
         return applied
     }

--- a/Sources/KeyPathAppKit/UI/ViewModels/KanataViewModel.swift
+++ b/Sources/KeyPathAppKit/UI/ViewModels/KanataViewModel.swift
@@ -331,9 +331,11 @@ class KanataViewModel {
         ruleCollections = manager.rulesManager.ruleCollections
     }
 
-    func updateCollectionTapOutput(_ id: UUID, tapOutput: String) async {
-        await manager.updateCollectionTapOutput(id: id, tapOutput: tapOutput)
+    @discardableResult
+    func updateCollectionTapOutput(_ id: UUID, tapOutput: String) async -> Bool {
+        let applied = await manager.updateCollectionTapOutput(id: id, tapOutput: tapOutput)
         ruleCollections = manager.rulesManager.ruleCollections
+        return applied
     }
 
     func updateCollectionHoldOutput(_ id: UUID, holdOutput: String) async {

--- a/Sources/KeyPathInstallationWizard/Core/OnboardingFirstSuccessGate.swift
+++ b/Sources/KeyPathInstallationWizard/Core/OnboardingFirstSuccessGate.swift
@@ -12,27 +12,38 @@ public enum OnboardingFirstSuccessGate {
     /// shows again after this, even across later wizard repairs/reopens.
     public static let hasShownFirstSuccessKey = "onboarding_first_success_shown"
 
+    /// Set when this version's Welcome page starts a fresh setup flow. This is
+    /// intentionally separate from `wizard_has_seen_welcome`, which already
+    /// exists on older installs and would otherwise make the rollout celebrate
+    /// routine repair/recheck wizard closes for established users.
+    public static let isEligibleForFirstSuccessKey = "onboarding_first_success_eligible"
+
     /// Pure decision: show the celebration only for a user who has been through
-    /// the Welcome page, has never seen the celebration before, and whose wizard
-    /// run just closed with the system validating healthy.
+    /// this version's Welcome-started onboarding flow, has never seen the
+    /// celebration before, and whose wizard run just closed with the system
+    /// validating healthy.
     public static func shouldShowFirstSuccess(
-        hasSeenWelcome: Bool,
+        isEligibleForFirstSuccess: Bool,
         hasShownFirstSuccess: Bool,
         wizardClosedHealthy: Bool
     ) -> Bool {
-        hasSeenWelcome && !hasShownFirstSuccess && wizardClosedHealthy
+        isEligibleForFirstSuccess && !hasShownFirstSuccess && wizardClosedHealthy
     }
 
     /// Convenience wrapper reading the persisted flags from UserDefaults.
-    /// Reuses `WizardWelcomeGate.hasSeenWelcomeKey` so the celebration is gated on
-    /// the same "did this user go through onboarding" signal as the Welcome page.
     public static func shouldShowFirstSuccess(wizardClosedHealthy: Bool) -> Bool {
         let defaults = UserDefaults.standard
         return shouldShowFirstSuccess(
-            hasSeenWelcome: defaults.bool(forKey: WizardWelcomeGate.hasSeenWelcomeKey),
+            isEligibleForFirstSuccess: defaults.bool(forKey: isEligibleForFirstSuccessKey),
             hasShownFirstSuccess: defaults.bool(forKey: hasShownFirstSuccessKey),
             wizardClosedHealthy: wizardClosedHealthy
         )
+    }
+
+    /// Persist that this install started the fresh onboarding flow. Kept separate
+    /// from Welcome's own one-shot so upgrades from #932 do not look fresh.
+    public static func markFreshOnboardingEligible() {
+        UserDefaults.standard.set(true, forKey: isEligibleForFirstSuccessKey)
     }
 
     /// Persist that the celebration has been shown (one-shot, regardless of how

--- a/Sources/KeyPathInstallationWizard/Core/OnboardingFirstSuccessGate.swift
+++ b/Sources/KeyPathInstallationWizard/Core/OnboardingFirstSuccessGate.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+/// Decides whether to show the post-setup "first success" celebration (issue #954).
+///
+/// Today the wizard simply closes back to the splash window on success: no
+/// celebration, no next step. This gate fills that gap by recognizing "setup just
+/// completed for the first time" — the moment the wizard closes healthy on a run
+/// where the user was shown the one-time Welcome page (issue #932) — and gates the
+/// celebration + starter-collection offer + short panel tour to show exactly once.
+public enum OnboardingFirstSuccessGate {
+    /// Set to true once the celebration panel has been shown. One-shot: never
+    /// shows again after this, even across later wizard repairs/reopens.
+    public static let hasShownFirstSuccessKey = "onboarding_first_success_shown"
+
+    /// Pure decision: show the celebration only for a user who has been through
+    /// the Welcome page, has never seen the celebration before, and whose wizard
+    /// run just closed with the system validating healthy.
+    public static func shouldShowFirstSuccess(
+        hasSeenWelcome: Bool,
+        hasShownFirstSuccess: Bool,
+        wizardClosedHealthy: Bool
+    ) -> Bool {
+        hasSeenWelcome && !hasShownFirstSuccess && wizardClosedHealthy
+    }
+
+    /// Convenience wrapper reading the persisted flags from UserDefaults.
+    /// Reuses `WizardWelcomeGate.hasSeenWelcomeKey` so the celebration is gated on
+    /// the same "did this user go through onboarding" signal as the Welcome page.
+    public static func shouldShowFirstSuccess(wizardClosedHealthy: Bool) -> Bool {
+        let defaults = UserDefaults.standard
+        return shouldShowFirstSuccess(
+            hasSeenWelcome: defaults.bool(forKey: WizardWelcomeGate.hasSeenWelcomeKey),
+            hasShownFirstSuccess: defaults.bool(forKey: hasShownFirstSuccessKey),
+            wizardClosedHealthy: wizardClosedHealthy
+        )
+    }
+
+    /// Persist that the celebration has been shown (one-shot, regardless of how
+    /// far the user got through it).
+    public static func markFirstSuccessShown() {
+        UserDefaults.standard.set(true, forKey: hasShownFirstSuccessKey)
+    }
+}

--- a/Sources/KeyPathInstallationWizard/UI/InstallationWizardView+UIComponents.swift
+++ b/Sources/KeyPathInstallationWizard/UI/InstallationWizardView+UIComponents.swift
@@ -25,6 +25,7 @@ extension InstallationWizardView {
         switch stateMachine.currentPage {
         case .welcome:
             WizardWelcomePage(onGetStarted: {
+                OnboardingFirstSuccessGate.markFreshOnboardingEligible()
                 WizardWelcomeGate.markWelcomeSeen()
                 stateMachine.nextPage()
             })

--- a/Tests/KeyPathTests/InstallationWizard/OnboardingFirstSuccessGateTests.swift
+++ b/Tests/KeyPathTests/InstallationWizard/OnboardingFirstSuccessGateTests.swift
@@ -11,7 +11,7 @@ final class OnboardingFirstSuccessGateTests: XCTestCase {
     func testFirstEverSuccessfulCloseShowsCelebration() {
         XCTAssertTrue(
             OnboardingFirstSuccessGate.shouldShowFirstSuccess(
-                hasSeenWelcome: true, hasShownFirstSuccess: false, wizardClosedHealthy: true
+                isEligibleForFirstSuccess: true, hasShownFirstSuccess: false, wizardClosedHealthy: true
             )
         )
     }
@@ -19,18 +19,17 @@ final class OnboardingFirstSuccessGateTests: XCTestCase {
     func testAlreadyShownNeverShowsAgain() {
         XCTAssertFalse(
             OnboardingFirstSuccessGate.shouldShowFirstSuccess(
-                hasSeenWelcome: true, hasShownFirstSuccess: true, wizardClosedHealthy: true
+                isEligibleForFirstSuccess: true, hasShownFirstSuccess: true, wizardClosedHealthy: true
             )
         )
     }
 
-    func testNeverSawWelcomePageSkipsCelebration() {
-        // A user who never went through the Welcome page (e.g. upgraded from an
-        // older install, or the helper was already present) didn't take the
-        // fresh-install onboarding arc, so the "first success" moment doesn't apply.
+    func testExistingWelcomeFlagWithoutNewEligibilitySkipsCelebration() {
+        // Existing users may already have wizard_has_seen_welcome from #932. The
+        // new rollout must not treat that old flag as a fresh setup completion.
         XCTAssertFalse(
             OnboardingFirstSuccessGate.shouldShowFirstSuccess(
-                hasSeenWelcome: false, hasShownFirstSuccess: false, wizardClosedHealthy: true
+                isEligibleForFirstSuccess: false, hasShownFirstSuccess: false, wizardClosedHealthy: true
             )
         )
     }
@@ -40,7 +39,7 @@ final class OnboardingFirstSuccessGateTests: XCTestCase {
         // don't celebrate a setup that isn't actually done.
         XCTAssertFalse(
             OnboardingFirstSuccessGate.shouldShowFirstSuccess(
-                hasSeenWelcome: true, hasShownFirstSuccess: false, wizardClosedHealthy: false
+                isEligibleForFirstSuccess: true, hasShownFirstSuccess: false, wizardClosedHealthy: false
             )
         )
     }
@@ -48,7 +47,7 @@ final class OnboardingFirstSuccessGateTests: XCTestCase {
     func testAllConditionsFalseSkipsCelebration() {
         XCTAssertFalse(
             OnboardingFirstSuccessGate.shouldShowFirstSuccess(
-                hasSeenWelcome: false, hasShownFirstSuccess: true, wizardClosedHealthy: false
+                isEligibleForFirstSuccess: false, hasShownFirstSuccess: true, wizardClosedHealthy: false
             )
         )
     }
@@ -59,6 +58,7 @@ final class OnboardingFirstSuccessGateTests: XCTestCase {
     /// silently reset every existing install's one-shot state. Pin them explicitly.
     func testPersistedKeyNamesAreStable() {
         XCTAssertEqual(OnboardingFirstSuccessGate.hasShownFirstSuccessKey, "onboarding_first_success_shown")
+        XCTAssertEqual(OnboardingFirstSuccessGate.isEligibleForFirstSuccessKey, "onboarding_first_success_eligible")
         XCTAssertEqual(WizardWelcomeGate.hasSeenWelcomeKey, "wizard_has_seen_welcome")
     }
 }

--- a/Tests/KeyPathTests/InstallationWizard/OnboardingFirstSuccessGateTests.swift
+++ b/Tests/KeyPathTests/InstallationWizard/OnboardingFirstSuccessGateTests.swift
@@ -1,0 +1,64 @@
+import Foundation
+@testable import KeyPathInstallationWizard
+@preconcurrency import XCTest
+
+/// Unit tests for the post-setup "first success" celebration gate (#954): the
+/// one-shot show/hide decision that fills the "setup just completed for the first
+/// time" gap left after the wizard closes.
+final class OnboardingFirstSuccessGateTests: XCTestCase {
+    // MARK: - Gate truth table
+
+    func testFirstEverSuccessfulCloseShowsCelebration() {
+        XCTAssertTrue(
+            OnboardingFirstSuccessGate.shouldShowFirstSuccess(
+                hasSeenWelcome: true, hasShownFirstSuccess: false, wizardClosedHealthy: true
+            )
+        )
+    }
+
+    func testAlreadyShownNeverShowsAgain() {
+        XCTAssertFalse(
+            OnboardingFirstSuccessGate.shouldShowFirstSuccess(
+                hasSeenWelcome: true, hasShownFirstSuccess: true, wizardClosedHealthy: true
+            )
+        )
+    }
+
+    func testNeverSawWelcomePageSkipsCelebration() {
+        // A user who never went through the Welcome page (e.g. upgraded from an
+        // older install, or the helper was already present) didn't take the
+        // fresh-install onboarding arc, so the "first success" moment doesn't apply.
+        XCTAssertFalse(
+            OnboardingFirstSuccessGate.shouldShowFirstSuccess(
+                hasSeenWelcome: false, hasShownFirstSuccess: false, wizardClosedHealthy: true
+            )
+        )
+    }
+
+    func testUnhealthyCloseSkipsCelebration() {
+        // Wizard closed but validation still shows blocking issues — not a success,
+        // don't celebrate a setup that isn't actually done.
+        XCTAssertFalse(
+            OnboardingFirstSuccessGate.shouldShowFirstSuccess(
+                hasSeenWelcome: true, hasShownFirstSuccess: false, wizardClosedHealthy: false
+            )
+        )
+    }
+
+    func testAllConditionsFalseSkipsCelebration() {
+        XCTAssertFalse(
+            OnboardingFirstSuccessGate.shouldShowFirstSuccess(
+                hasSeenWelcome: false, hasShownFirstSuccess: true, wizardClosedHealthy: false
+            )
+        )
+    }
+
+    // MARK: - Persisted key stability
+
+    /// The UserDefaults key names are load-bearing: a typo'd rename here would
+    /// silently reset every existing install's one-shot state. Pin them explicitly.
+    func testPersistedKeyNamesAreStable() {
+        XCTAssertEqual(OnboardingFirstSuccessGate.hasShownFirstSuccessKey, "onboarding_first_success_shown")
+        XCTAssertEqual(WizardWelcomeGate.hasSeenWelcomeKey, "wizard_has_seen_welcome")
+    }
+}

--- a/Tests/KeyPathTests/RuleCollections/RuleCollectionsManagerTests.swift
+++ b/Tests/KeyPathTests/RuleCollections/RuleCollectionsManagerTests.swift
@@ -278,6 +278,108 @@ final class RuleCollectionsManagerTests: XCTestCase {
     }
 
     @MainActor
+    func testUpdateCollectionTapOutputRollsBackExistingCollectionWhenConfigApplyFails() async throws {
+        let (manager, _) = try await createTestManager()
+        defer { TestEnvironment.forceTestMode = false }
+
+        var collections = RuleCollectionCatalog().defaultCollections()
+        let capsIndex = try XCTUnwrap(collections.firstIndex {
+            $0.id == RuleCollectionIdentifier.capsLockRemap
+        })
+        collections[capsIndex].isEnabled = false
+        await manager.replaceCollections(collections)
+
+        manager.customRules = [
+            CustomRule(input: "caps", action: .keystroke(key: "tab"), isEnabled: true)
+        ]
+
+        var errorMessages: [String] = []
+        manager.onError = { errorMessages.append($0) }
+
+        let applied = await manager.updateCollectionTapOutput(
+            id: RuleCollectionIdentifier.capsLockRemap,
+            tapOutput: "esc"
+        )
+
+        XCTAssertFalse(applied, "The conflicting tap-output change should fail validation")
+        XCTAssertTrue(
+            manager.ruleCollections.contains {
+                $0.id == RuleCollectionIdentifier.capsLockRemap && !$0.isEnabled
+            },
+            "Failed tap-output updates should restore the previously disabled collection"
+        )
+        XCTAssertEqual(errorMessages.count, 1, "Default rollback behavior should surface one shared error")
+    }
+
+    @MainActor
+    func testUpdateCollectionTapOutputRollsBackCatalogAddWhenConfigApplyFails() async throws {
+        let (manager, _) = try await createTestManager()
+        defer { TestEnvironment.forceTestMode = false }
+
+        let collections = RuleCollectionCatalog().defaultCollections().filter {
+            $0.id != RuleCollectionIdentifier.capsLockRemap
+        }
+        await manager.replaceCollections(collections)
+
+        manager.customRules = [
+            CustomRule(input: "caps", action: .keystroke(key: "tab"), isEnabled: true)
+        ]
+
+        var didShowSharedError = false
+        manager.onError = { _ in didShowSharedError = true }
+
+        let applied = await manager.updateCollectionTapOutput(
+            id: RuleCollectionIdentifier.capsLockRemap,
+            tapOutput: "esc",
+            reportRollbackError: false
+        )
+
+        XCTAssertFalse(applied, "The catalog-add tap-output change should fail validation")
+        XCTAssertFalse(
+            manager.ruleCollections.contains { $0.id == RuleCollectionIdentifier.capsLockRemap },
+            "Failed catalog-add tap-output updates should remove the appended collection"
+        )
+        XCTAssertFalse(
+            didShowSharedError,
+            "Callers with their own inline error surface should be able to suppress the shared rollback error"
+        )
+    }
+
+    @MainActor
+    func testUpdateCollectionOutputRollsBackSingleKeyPickerWhenConfigApplyFails() async throws {
+        let (manager, _) = try await createTestManager()
+        defer { TestEnvironment.forceTestMode = false }
+
+        var collections = RuleCollectionCatalog().defaultCollections()
+        let escapeIndex = try XCTUnwrap(collections.firstIndex {
+            $0.id == RuleCollectionIdentifier.escapeRemap
+        })
+        collections[escapeIndex].isEnabled = false
+        await manager.replaceCollections(collections)
+
+        manager.customRules = [
+            CustomRule(input: "esc", action: .keystroke(key: "tab"), isEnabled: true)
+        ]
+
+        var errorMessages: [String] = []
+        manager.onError = { errorMessages.append($0) }
+
+        let applied = await manager.updateCollectionOutput(
+            id: RuleCollectionIdentifier.escapeRemap,
+            output: "caps"
+        )
+
+        XCTAssertFalse(applied, "The conflicting single-key output change should fail validation")
+        XCTAssertTrue(
+            manager.ruleCollections.contains {
+                $0.id == RuleCollectionIdentifier.escapeRemap && !$0.isEnabled
+            },
+            "Failed single-key output updates should restore the previously disabled collection"
+        )
+        XCTAssertEqual(errorMessages.count, 1)
+    }
+
+    @MainActor
     func testCustomRuleConflictWithCollectionOnCustomLayer_WarnsButAllows() async throws {
         let (manager, _) = try await createTestManager()
         defer { TestEnvironment.forceTestMode = false }


### PR DESCRIPTION
## Summary

Second half of the onboarding arc started in #932. Today the wizard simply closes back to the splash window on success — no celebration, no next step. This PR makes the first-ever healthy wizard close end in a **working mapping** plus a short tour of the core panel surfaces.

Closes #954

### Trigger (the "setup just completed for the first time" signal that didn't exist)

- **`OnboardingFirstSuccessGate`** (KeyPathInstallationWizard/Core, alongside `WizardWelcomeGate`): pure one-shot decision. Fires only when:
  - the user went through the Welcome page (reuses the existing `wizard_has_seen_welcome` UserDefaults flag), and
  - the new one-shot `onboarding_first_success_shown` flag is unset, and
  - the wizard run just closed with `MainAppStateController.validationState.isSuccess` (i.e. closed healthy).
- Wired into `AppDelegate.showWizard`'s `onDismiss` closure — the single call site behind both `.wizardStartupRevalidate`-driven dismissal and window-close (`WizardWindowController.handleWindowClosed()`) — **after** `updateStatus()` + `revalidate()`, so the health check reflects the run that just finished rather than stale pre-wizard state.
- The one-shot flag is marked **before** presenting, so closing the panel immediately (or quitting mid-panel) can never resurface it.
- **Quit-race fix** (found in the pre-PR review pass): `applicationShouldTerminate` also fires the wizard's `onDismiss` via `closeWindow()`, and the un-awaited async continuation would otherwise create a brand-new floating panel mid-quit-teardown. A new `AppDelegate.isTerminating` flag, set at the top of `applicationShouldTerminate`, bails out **before** consuming the one-shot flag — quitting neither shows the panel nor burns the moment.

### The moment

- **`FirstSuccessDialog` + `FirstSuccessWindowController`** (new `UI/Onboarding/`): floating NSPanel following the `LauncherWelcomeWindowController` / `LauncherWelcomeDialog` pattern faithfully (multi-step, `.hudWindow` material, `.floating` level, singleton controller, close button overlay).
- **Celebration step** — "You're All Set. Want your first remap?" One-click enable of Caps Lock → Escape. Payoff copy per spec: *"Press Caps Lock — it's Escape now."*
- **Tour** — 3 steps pointing at the live keyboard overlay, the Rules tab (`ActiveRulesView` toggles), and the custom-rule inline editor as "when you're ready to make your own."
- New controls carry kebab-case accessibility identifiers (`first-success-enable-button`, `first-success-tour-next-button`, etc.) matching the `launcher-welcome-*` convention, for Computer Use QA.

### Implementation note on the starter remap (spec deviation, deliberate)

The issue suggests `RuntimeCoordinator.addRuleCollection(_:)`, but the Caps Lock Remap collection **ships enabled by default** with tap+hold both bound to Hyper, and it's a `tapHoldPicker` collection whose *applied* config derives from `configuration.selectedTapOutput` — not from the collection's `mappings` array. A plain `addRuleCollection` would re-add the same collection and change nothing user-visible. Instead the dialog calls the existing `KanataViewModel.updateCollectionTapOutput(id:tapOutput:)` (the exact path the Rules-tab picker uses), which flows through `RuleCollectionsCoordinator` → `RuleCollectionsManager.regenerateConfigFromCollections()` → validated config save + TCP reload. The review pass traced this chain end-to-end (`generateTapHoldPickerMappings` reads `configuration`) and confirmed it changes the live Kanata config. No direct TCP, no manual launchctl — all coordinator-mediated per CLAUDE.md.

### Tests

- `OnboardingFirstSuccessGateTests`: gate truth table (first-success shows once; already-shown, welcome-never-seen, and unhealthy-close all skip) + persisted-key-name stability guards (a renamed key would silently reset every install's one-shot state).
- Trigger wiring and panel UI are not unit-testable without a host app; manual test plan below.

### Manual test plan (needs macOS)

1. Fresh install (or `defaults delete com.keypath.KeyPath wizard_has_seen_welcome onboarding_first_success_shown`): run wizard through Welcome → complete setup → close healthy → celebration panel appears.
2. Click "Enable Caps Lock → Escape" → tap Caps Lock → Escape fires; panel shows the payoff step, then the 3-step tour.
3. Close and reopen the wizard → panel does **not** reappear (one-shot).
4. Complete the wizard then immediately Cmd+Q before the panel shows → no panel mid-quit; on next launch, closing the wizard healthy still shows the celebration (flag not burned).
5. "Not Now" path skips straight to the tour without touching config.

### Notes for review

- **Authored on Linux — CI must validate the build.** I could not run `swift build` / `swift test` locally; all API signatures were verified against the codebase by reading, and a dedicated review pass checked Swift 6 strict-concurrency soundness, environment injection into the manually-hosted `NSHostingController`, and the config-generation chain — but the compile gate is CI's.
- Celebration/tour copy is per-spec but very open to wording tweaks.
- No user guide added: the moment is a one-shot transient panel, not a discoverable feature surface. Happy to add a short section to `guides/installation-wizard.md` if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142A1G18McVBb1f1Dp7873M

---
_Generated by [Claude Code](https://claude.ai/code/session_0142A1G18McVBb1f1Dp7873M)_