### PR TITLE
fix(tests): expose Sparkle to local SwiftPM test bundles

### DIFF
--- a/Scripts/run-tests-safe.sh
+++ b/Scripts/run-tests-safe.sh
@@ -437,6 +437,19 @@ if [ "$BUILD_EXIT_CODE" != "0" ]; then
   exit "$BUILD_EXIT_CODE"
 fi
 
+# Xcode 27 beta / SwiftPM can build binary-target frameworks (Sparkle) into
+# Products/Debug while the test helper only searches Products/Debug/PackageFrameworks.
+# Normalize that layout before running with --skip-build so local test bundles load.
+PRODUCTS_DEBUG_DIR="$SCRATCH_PATH/out/Products/Debug"
+SPARKLE_FRAMEWORK_SRC="$PRODUCTS_DEBUG_DIR/Sparkle.framework"
+SPARKLE_FRAMEWORK_DEST="$PRODUCTS_DEBUG_DIR/PackageFrameworks/Sparkle.framework"
+if [ -d "$SPARKLE_FRAMEWORK_SRC" ]; then
+  echo "✨ Ensuring Sparkle.framework is visible to SwiftPM test bundles"
+  mkdir -p "$(dirname "$SPARKLE_FRAMEWORK_DEST")"
+  rm -rf "$SPARKLE_FRAMEWORK_DEST"
+  ditto "$SPARKLE_FRAMEWORK_SRC" "$SPARKLE_FRAMEWORK_DEST"
+fi
+
 # 2) Run with watchdog
 EXIT_FILE="$PROJECT_DIR/.xctest.exit.$$"
 TIMEOUT_FILE="$PROJECT_DIR/.xctest.timeout.$$"


### PR DESCRIPTION
## Summary

Local SwiftPM test launches on Xcode 27 beta fail before running tests because Sparkle.framework is built into `Products/Debug`, while the SwiftPM test helper searches `Products/Debug/PackageFrameworks`.

This updates `Scripts/run-tests-safe.sh` to mirror Sparkle into `PackageFrameworks` after `swift build --build-tests` and before `swift test --skip-build`.

## Validation

- Cleared `.build-ci/out/Products/Debug/PackageFrameworks/Sparkle.framework`
- Ran `TEST_FILTER=PermissionOraclePolicyTests ./Scripts/run-tests-safe.sh`
- Safe runner emitted `Ensuring Sparkle.framework is visible to SwiftPM test bundles`
- `PermissionOraclePolicyTests` passed 5/5

## Notes

This is a local test-runner normalization only; it does not affect app packaging or release embedding, which is handled by the release/build scripts.
