### PR TITLE
Fix kanata IM detection dead-end: functional evidence + continue path (#931)

### DIFF
--- a/Sources/KeyPathAppKit/WizardProtocolConformances.swift
+++ b/Sources/KeyPathAppKit/WizardProtocolConformances.swift
@@ -198,6 +198,21 @@ public func configureWizardDependencies(runtimeCoordinator: RuntimeCoordinator) 
             onAutoFix: onAutoFix
         ))
     }
+
+    // Functional evidence for kanata's Input Monitoring resolution (#931):
+    // on macOS 26/27 a grant may never produce a readable TCC row, so the
+    // Oracle falls back to runtime proof. ServiceHealthChecker's runtime
+    // snapshot is TTL-cached, keeping this cheap under the wizard's 1s poll.
+    Task {
+        await PermissionOracle.shared.setKanataFunctionalEvidenceProvider {
+            let snapshot = await ServiceHealthChecker.shared.checkKanataServiceRuntimeSnapshot()
+            return PermissionOracle.KanataFunctionalEvidence(
+                isRunning: snapshot.isRunning,
+                isResponding: snapshot.isResponding,
+                inputCaptureReady: snapshot.inputCaptureReady
+            )
+        }
+    }
 }
 
 /// Configure WizardDependencies for app-bundled CLI repair/inspect entry points.

--- a/Sources/KeyPathInstallationWizard/UI/Pages/WizardInputMonitoringPage.swift
+++ b/Sources/KeyPathInstallationWizard/UI/Pages/WizardInputMonitoringPage.swift
@@ -20,6 +20,12 @@ public struct WizardInputMonitoringPage: View {
     /// triggered. Drives the escalation to manual guidance when the grant never
     /// registers (macOS 26/27 dead-end, #931).
     @State private var keyPathRequestAttemptedAt: Date?
+    /// When kanata-launcher's Input Monitoring was first observed `.unknown` on
+    /// this page (or when the user last launched the add flow, whichever is
+    /// later). On macOS 26/27 a completed grant may never produce a readable
+    /// TCC row, so after a wait window we must offer a way FORWARD — starting
+    /// the engine is the only reliable verification left (#931).
+    @State private var kanataUnverifiedSince: Date?
 
     @Environment(WizardStateMachine.self) private var stateMachine
 
@@ -203,6 +209,10 @@ public struct WizardInputMonitoringPage: View {
                                                 return
                                             }
                                             AppLogger.shared.log("🔧 [WizardInputMonitoringPage] Kanata Fix clicked — presenting drag-to-authorize overlay")
+                                            // Restart the escalation clock: the user is
+                                            // mid-flow, so give the full wait window
+                                            // before offering the continue path (#931).
+                                            kanataUnverifiedSince = Date()
                                             DragToAuthorizeController.shared.present(for: .inputMonitoring)
                                         }
                                     }
@@ -219,6 +229,22 @@ public struct WizardInputMonitoringPage: View {
                             // 26/27) with accurate manual "+"-to-add steps (#931).
                             if keyPathGuidance == .manualFallback {
                                 InputMonitoringManualFallbackCard()
+                            }
+
+                            // Escalation for the kanata-launcher row: an `.unknown`
+                            // that persists past the wait window usually means the
+                            // grant exists but macOS never wrote a readable TCC row
+                            // (#931). Offer a forward path — starting the engine is
+                            // the authoritative verification (the Oracle upgrades to
+                            // granted on functional evidence, and a genuinely missing
+                            // grant routes back here as a real error). Denied
+                            // (`.failed`) never gets this bypass.
+                            if kanataGuidance == .manualFallback,
+                               kanataInputMonitoringStatus == .warning
+                            {
+                                KanataUnverifiedContinueCard {
+                                    navigateToNextStep()
+                                }
                             }
                         }
                         .frame(maxWidth: .infinity)
@@ -246,7 +272,9 @@ public struct WizardInputMonitoringPage: View {
             }
         }
         .task {
-            permissionSnapshot = await PermissionOracle.shared.forceRefresh()
+            let snapshot = await PermissionOracle.shared.forceRefresh()
+            permissionSnapshot = snapshot
+            updateKanataUnverifiedClock(snapshot)
         }
         .onAppear {
             checkForStaleEntries()
@@ -291,6 +319,35 @@ public struct WizardInputMonitoringPage: View {
     private var kanataInputMonitoringStatus: InstallationStatus {
         guard let snapshot = permissionSnapshot else { return .inProgress }
         return installationStatus(for: snapshot.kanata.inputMonitoring)
+    }
+
+    /// Escalation state for the kanata-launcher row (#931). Reuses the
+    /// permission-agnostic resolver: "requestAttempted" here means the unknown
+    /// state has been observed (clock started on page load / add-flow launch).
+    /// A longer window than KeyPath.app's own prompt because the manual
+    /// Settings drag flow legitimately takes a while.
+    private var kanataGuidance: AutomaticPromptGuidance {
+        resolveAutomaticPromptGuidance(
+            AutomaticPromptGuidanceInput(
+                keyPathReady: permissionSnapshot?.kanata.inputMonitoring.isReady ?? false,
+                requestAttempted: kanataUnverifiedSince != nil,
+                secondsSinceRequest: kanataUnverifiedSince.map { Date().timeIntervalSince($0) },
+                waitWindow: 30
+            )
+        )
+    }
+
+    /// Start/clear the kanata unverified clock from a fresh Oracle snapshot.
+    /// Called by every writer of `permissionSnapshot` so the escalation can
+    /// fire no matter which poll is active.
+    private func updateKanataUnverifiedClock(_ snapshot: PermissionOracle.Snapshot) {
+        if snapshot.kanata.inputMonitoring == .unknown {
+            if kanataUnverifiedSince == nil {
+                kanataUnverifiedSince = Date()
+            }
+        } else {
+            kanataUnverifiedSince = nil
+        }
     }
 
     private func installationStatus(for status: PermissionOracle.Status) -> InstallationStatus {
@@ -395,6 +452,7 @@ public struct WizardInputMonitoringPage: View {
                 if Task.isCancelled { return }
                 let snapshot = await PermissionOracle.shared.forceRefresh()
                 permissionSnapshot = snapshot
+                updateKanataUnverifiedClock(snapshot)
 
                 let bothGranted = snapshot.keyPath.inputMonitoring.isReady
                     && snapshot.kanata.inputMonitoring.isReady
@@ -429,6 +487,7 @@ public struct WizardInputMonitoringPage: View {
                 attempts += 1
                 let snapshot = await PermissionOracle.shared.forceRefresh()
                 permissionSnapshot = snapshot
+                updateKanataUnverifiedClock(snapshot)
                 let hasPermission: Bool =
                     switch type {
                     case .accessibility:
@@ -560,6 +619,46 @@ private struct InputMonitoringManualFallbackCard: View {
                 CleanupStep(number: 2, text: "Click the \"+\" button below the list.")
                 CleanupStep(number: 3, text: "Choose KeyPath.app from your Applications folder, then turn its switch on.")
             }
+            .padding(.top, 4)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(WizardDesign.Spacing.cardPadding)
+        .background(
+            WizardDesign.Colors.warning.opacity(0.06),
+            in: RoundedRectangle(cornerRadius: WizardDesign.Layout.cornerRadius)
+        )
+    }
+}
+
+/// Shown when kanata-launcher's Input Monitoring stays `.unknown` past the wait
+/// window (#931). On macOS 26/27 a completed grant may never produce a readable
+/// TCC row, so pre-flight detection can't confirm it — the only authoritative
+/// check left is starting the engine. The Oracle upgrades to granted on
+/// functional evidence once kanata is running; a genuinely missing grant makes
+/// the service fail with an input-capture error that routes back to this page.
+private struct KanataUnverifiedContinueCard: View {
+    let onContinue: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Label("Already added kanata-launcher?", systemImage: "arrow.right.circle")
+                .font(.headline)
+
+            Text(
+                "On some macOS versions KeyPath can't confirm this permission until the engine runs. If you've turned on kanata-launcher in System Settings, continue — KeyPath verifies the permission when it starts the engine, and will bring you back here if it's still missing."
+            )
+            .font(.callout)
+            .foregroundColor(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
+
+            Button("Continue Setup") {
+                AppLogger.shared.log(
+                    "🔧 [WizardInputMonitoringPage] Continuing past unverified kanata IM — engine start will verify (#931)"
+                )
+                onContinue()
+            }
+            .buttonStyle(WizardDesign.Component.SecondaryButton())
+            .accessibilityIdentifier("wizard_input_monitoring_kanata_continue_unverified")
             .padding(.top, 4)
         }
         .frame(maxWidth: .infinity, alignment: .leading)

--- a/Sources/KeyPathInstallationWizard/UI/Pages/WizardInputMonitoringPage.swift
+++ b/Sources/KeyPathInstallationWizard/UI/Pages/WizardInputMonitoringPage.swift
@@ -632,9 +632,12 @@ private struct InputMonitoringManualFallbackCard: View {
 /// Shown when kanata-launcher's Input Monitoring stays `.unknown` past the wait
 /// window (#931). On macOS 26/27 a completed grant may never produce a readable
 /// TCC row, so pre-flight detection can't confirm it — the only authoritative
-/// check left is starting the engine. The Oracle upgrades to granted on
-/// functional evidence once kanata is running; a genuinely missing grant makes
-/// the service fail with an input-capture error that routes back to this page.
+/// check left is running the engine. Continue navigates to the next wizard step
+/// (typically the Service page, where the user starts the engine — deliberately
+/// NOT auto-started from here, to preserve the one-permission-prompt-at-a-time
+/// flow). Once kanata runs, the Oracle upgrades to granted on functional
+/// evidence; a genuinely missing grant makes the service fail with an
+/// input-capture error that routes back to this page.
 private struct KanataUnverifiedContinueCard: View {
     let onContinue: () -> Void
 
@@ -644,7 +647,7 @@ private struct KanataUnverifiedContinueCard: View {
                 .font(.headline)
 
             Text(
-                "On some macOS versions KeyPath can't confirm this permission until the engine runs. If you've turned on kanata-launcher in System Settings, continue — KeyPath verifies the permission when it starts the engine, and will bring you back here if it's still missing."
+                "On some macOS versions KeyPath can't confirm this permission until the engine runs. If you've turned on kanata-launcher in System Settings, continue — you'll start the engine on the next step, and KeyPath verifies the permission then, bringing you back here if it's still missing."
             )
             .font(.callout)
             .foregroundColor(.secondary)

--- a/Sources/KeyPathInstallationWizard/UI/Pages/WizardInputMonitoringPage.swift
+++ b/Sources/KeyPathInstallationWizard/UI/Pages/WizardInputMonitoringPage.swift
@@ -339,15 +339,14 @@ public struct WizardInputMonitoringPage: View {
 
     /// Start/clear the kanata unverified clock from a fresh Oracle snapshot.
     /// Called by every writer of `permissionSnapshot` so the escalation can
-    /// fire no matter which poll is active.
+    /// fire no matter which poll is active. Logic lives in the pure
+    /// `advanceUnverifiedClock` (KeyPathWizardCore) for unit testing.
     private func updateKanataUnverifiedClock(_ snapshot: PermissionOracle.Snapshot) {
-        if snapshot.kanata.inputMonitoring == .unknown {
-            if kanataUnverifiedSince == nil {
-                kanataUnverifiedSince = Date()
-            }
-        } else {
-            kanataUnverifiedSince = nil
-        }
+        kanataUnverifiedSince = advanceUnverifiedClock(
+            previous: kanataUnverifiedSince,
+            statusIsUnknown: snapshot.kanata.inputMonitoring == .unknown,
+            now: Date()
+        )
     }
 
     private func installationStatus(for status: PermissionOracle.Status) -> InstallationStatus {

--- a/Sources/KeyPathPermissions/PermissionOracle.swift
+++ b/Sources/KeyPathPermissions/PermissionOracle.swift
@@ -497,6 +497,10 @@ public actor PermissionOracle {
             break
         }
         if resolvedIM.usedFunctionalEvidence {
+            // TODO(#931): confidence stays .high here even though functional
+            // evidence is a heuristic, not a TCC read. Inert today (Confidence
+            // is logging-only); if Confidence ever gates behavior, give this
+            // path its own tier instead of reusing .high.
             sourceParts.append("functional-im")
         } else {
             switch inputMonitoring {

--- a/Sources/KeyPathPermissions/PermissionOracle.swift
+++ b/Sources/KeyPathPermissions/PermissionOracle.swift
@@ -162,10 +162,14 @@ public actor PermissionOracle {
             self.inputCaptureReady = inputCaptureReady
         }
 
-        /// Kernel-level proof that Input Monitoring is effectively granted: the
-        /// daemon is alive, serving TCP, and has successfully opened input
-        /// devices. macOS does not deliver keyboard events to a process without
-        /// the grant, so this is at least as authoritative as any TCC row.
+        /// Strong runtime evidence that Input Monitoring is effectively granted:
+        /// the daemon is alive, serving TCP, and no input-capture failure has
+        /// been diagnosed. NOTE: `inputCaptureReady` is optimistic-by-default
+        /// upstream (ServiceHealthChecker reports `.ready` unless a failure was
+        /// affirmatively diagnosed via the grab-status store or stderr), so this
+        /// is evidence, not proof — which is why the resolver only lets it
+        /// upgrade an *absent* TCC answer and never override an explicit
+        /// `.denied` row (e.g. a grant revoked while kanata is still running).
         public var provesInputCapture: Bool {
             isRunning && isResponding && inputCaptureReady
         }
@@ -466,12 +470,13 @@ public actor PermissionOracle {
 
         // Functional fallback for Input Monitoring (#931): when TCC has no
         // readable row (macOS 26/27 can grant without ever writing one), a
-        // running, TCP-responding kanata that has opened input devices is
-        // kernel-level proof of the grant. Only consulted when TCC didn't
-        // already say granted; positive evidence also overrides a stale denied
-        // row, mirroring ADR-006's Apple-API-over-TCC precedence.
+        // running, TCP-responding kanata with no diagnosed capture failure is
+        // strong evidence of the grant. Consulted ONLY when the TCC read is
+        // inconclusive (nil) — an explicit granted/denied row is authoritative
+        // and is never overridden, because the underlying capture signal is
+        // optimistic-by-default and could race a mid-run revoke.
         var functionalEvidence: KanataFunctionalEvidence?
-        if tccIM != .granted, let provider = kanataFunctionalEvidenceProvider {
+        if tccIM == nil, let provider = kanataFunctionalEvidenceProvider {
             functionalEvidence = await provider()
         }
         let resolvedIM = Self.resolveKanataInputMonitoring(
@@ -522,18 +527,23 @@ public actor PermissionOracle {
     /// evidence (#931). Pure and static for unit testing, mirroring
     /// `resolveKeyPathInputMonitoring`.
     ///
-    /// Precedence: positive functional evidence (`provesInputCapture`) wins over
-    /// any TCC result including a stale `.denied` row — the kernel delivering
-    /// events to kanata is ground truth. Anything less conclusive falls back to
-    /// the TCC result; negative or absent evidence never *downgrades* a TCC
-    /// answer (a stopped daemon says nothing about the grant).
+    /// Precedence: an explicit TCC answer (granted OR denied) is authoritative
+    /// and always stands — the runtime capture signal is optimistic-by-default,
+    /// so letting it override `.denied` would show green during a mid-run
+    /// revoke. Functional evidence only upgrades an *absent* TCC read (the
+    /// macOS 26/27 grant-without-a-row case this exists for); negative or
+    /// missing evidence never downgrades anything (a stopped daemon says
+    /// nothing about the grant).
     nonisolated static func resolveKanataInputMonitoring(
         tccStatus: Status?, evidence: KanataFunctionalEvidence?
     ) -> (status: Status, usedFunctionalEvidence: Bool) {
+        if let tccStatus {
+            return (tccStatus, false)
+        }
         if let evidence, evidence.provesInputCapture {
             return (.granted, true)
         }
-        return (tccStatus ?? .unknown, false)
+        return (.unknown, false)
     }
 
     /// Additional timeout wrapper to prevent hanging

--- a/Sources/KeyPathPermissions/PermissionOracle.swift
+++ b/Sources/KeyPathPermissions/PermissionOracle.swift
@@ -469,11 +469,14 @@ public actor PermissionOracle {
         let accessibility: Status = tccAX ?? .unknown
 
         // Functional fallback for Input Monitoring (#931): when TCC has no
-        // readable row (macOS 26/27 can grant without ever writing one), a
-        // running, TCP-responding kanata with no diagnosed capture failure is
-        // strong evidence of the grant. Consulted ONLY when the TCC read is
-        // inconclusive (nil) — an explicit granted/denied row is authoritative
-        // and is never overridden, because the underlying capture signal is
+        // readable row, a running, TCP-responding kanata with no diagnosed
+        // capture failure is strong evidence of the grant. Note the nil branch
+        // is NOT rare: it covers macOS 26/27 granting without writing a row,
+        // but also every install where KeyPath lacks Full Disk Access to read
+        // TCC.db at all — so this path runs for a meaningful slice of ordinary
+        // installs. Consulted ONLY when the TCC read is inconclusive (nil) —
+        // an explicit granted/denied row is authoritative and is never
+        // overridden, because the underlying capture signal is
         // optimistic-by-default and could race a mid-run revoke.
         var functionalEvidence: KanataFunctionalEvidence?
         if tccIM == nil, let provider = kanataFunctionalEvidenceProvider {

--- a/Sources/KeyPathPermissions/PermissionOracle.swift
+++ b/Sources/KeyPathPermissions/PermissionOracle.swift
@@ -143,6 +143,34 @@ public actor PermissionOracle {
         }
     }
 
+    /// Runtime evidence about the kanata daemon, used to resolve its Input
+    /// Monitoring status when the TCC database is unreadable or has no row
+    /// (#931: on macOS 26/27 a grant may never produce a readable TCC row, and
+    /// `IOHIDCheckAccess` only answers for the calling process — so a healthy
+    /// running daemon is the only trustworthy signal left).
+    public struct KanataFunctionalEvidence: Sendable, Equatable {
+        /// The kanata daemon process is running.
+        public let isRunning: Bool
+        /// Kanata's TCP server is responding on the expected port.
+        public let isResponding: Bool
+        /// No input-capture failure was diagnosed (kanata opened the keyboard).
+        public let inputCaptureReady: Bool
+
+        public init(isRunning: Bool, isResponding: Bool, inputCaptureReady: Bool) {
+            self.isRunning = isRunning
+            self.isResponding = isResponding
+            self.inputCaptureReady = inputCaptureReady
+        }
+
+        /// Kernel-level proof that Input Monitoring is effectively granted: the
+        /// daemon is alive, serving TCP, and has successfully opened input
+        /// devices. macOS does not deliver keyboard events to a process without
+        /// the grant, so this is at least as authoritative as any TCC row.
+        public var provesInputCapture: Bool {
+            isRunning && isResponding && inputCaptureReady
+        }
+    }
+
     // MARK: - State Management
 
     private var lastSnapshot: Snapshot?
@@ -152,6 +180,16 @@ public actor PermissionOracle {
     /// Prevents concurrent callers from spawning duplicate sqlite3 processes,
     /// which can exhaust the cooperative thread pool and cause deadlock.
     private var inFlightSnapshot: Task<Snapshot, Never>?
+
+    /// Injected by the app layer (see `configureWizardDependencies`) so this
+    /// module never depends on service-health code. Consulted only when the TCC
+    /// read for kanata's Input Monitoring is inconclusive or negative — positive
+    /// functional evidence upgrades the status to `.granted` (#931). The
+    /// provider must be cheap under repeated calls (ServiceHealthChecker's
+    /// runtime snapshot is TTL-cached), because wizard pages poll the Oracle
+    /// every second.
+    private var kanataFunctionalEvidenceProvider:
+        (@Sendable () async -> KanataFunctionalEvidence?)?
 
     /// Cache TTL for sub-2-second goal
     private let cacheTTL: TimeInterval = 1.5
@@ -165,6 +203,17 @@ public actor PermissionOracle {
     /// Force cache invalidation - useful after UDP configuration changes
     public func invalidateCache() {
         AppLogger.shared.log("🔮 [Oracle] Cache invalidated - next check will be fresh")
+        lastSnapshot = nil
+        lastSnapshotTime = nil
+    }
+
+    /// Install the functional-evidence source for kanata's Input Monitoring
+    /// resolution (#931). Called once at app startup; also invalidates the
+    /// cache so the next snapshot reflects the richer signal.
+    public func setKanataFunctionalEvidenceProvider(
+        _ provider: @escaping @Sendable () async -> KanataFunctionalEvidence?
+    ) {
+        kanataFunctionalEvidenceProvider = provider
         lastSnapshot = nil
         lastSnapshotTime = nil
     }
@@ -414,7 +463,21 @@ public actor PermissionOracle {
         let (tccAX, tccIM) = await checkTCCForKanata(executablePath: kanataPath)
 
         let accessibility: Status = tccAX ?? .unknown
-        let inputMonitoring: Status = tccIM ?? .unknown
+
+        // Functional fallback for Input Monitoring (#931): when TCC has no
+        // readable row (macOS 26/27 can grant without ever writing one), a
+        // running, TCP-responding kanata that has opened input devices is
+        // kernel-level proof of the grant. Only consulted when TCC didn't
+        // already say granted; positive evidence also overrides a stale denied
+        // row, mirroring ADR-006's Apple-API-over-TCC precedence.
+        var functionalEvidence: KanataFunctionalEvidence?
+        if tccIM != .granted, let provider = kanataFunctionalEvidenceProvider {
+            functionalEvidence = await provider()
+        }
+        let resolvedIM = Self.resolveKanataInputMonitoring(
+            tccStatus: tccIM, evidence: functionalEvidence
+        )
+        let inputMonitoring = resolvedIM.status
 
         var sourceParts: [String] = []
         var confidence: Confidence = .high
@@ -425,11 +488,15 @@ public actor PermissionOracle {
         default:
             break
         }
-        switch inputMonitoring {
-        case .granted, .denied:
-            sourceParts.append("tcc-im")
-        default:
-            break
+        if resolvedIM.usedFunctionalEvidence {
+            sourceParts.append("functional-im")
+        } else {
+            switch inputMonitoring {
+            case .granted, .denied:
+                sourceParts.append("tcc-im")
+            default:
+                break
+            }
         }
 
         if sourceParts.isEmpty {
@@ -451,11 +518,22 @@ public actor PermissionOracle {
         )
     }
 
-    /// Functional verification disabled in TCP-only mode
-    /// TCP connectivity check would require protocol implementation
-    private func checkKanataFunctionalStatus() async -> Status {
-        AppLogger.shared.log("🔮 [Oracle] Functional status check disabled (TCP-only mode)")
-        return .unknown
+    /// Resolve kanata's Input Monitoring status from the TCC read plus runtime
+    /// evidence (#931). Pure and static for unit testing, mirroring
+    /// `resolveKeyPathInputMonitoring`.
+    ///
+    /// Precedence: positive functional evidence (`provesInputCapture`) wins over
+    /// any TCC result including a stale `.denied` row — the kernel delivering
+    /// events to kanata is ground truth. Anything less conclusive falls back to
+    /// the TCC result; negative or absent evidence never *downgrades* a TCC
+    /// answer (a stopped daemon says nothing about the grant).
+    nonisolated static func resolveKanataInputMonitoring(
+        tccStatus: Status?, evidence: KanataFunctionalEvidence?
+    ) -> (status: Status, usedFunctionalEvidence: Bool) {
+        if let evidence, evidence.provesInputCapture {
+            return (.granted, true)
+        }
+        return (tccStatus ?? .unknown, false)
     }
 
     /// Additional timeout wrapper to prevent hanging

--- a/Sources/KeyPathWizardCore/AutomaticPromptGuidance.swift
+++ b/Sources/KeyPathWizardCore/AutomaticPromptGuidance.swift
@@ -90,3 +90,19 @@ public func resolveAutomaticPromptGuidance(
     }
     return .manualFallback
 }
+
+/// Advance the "how long has this permission been unverified" clock from a
+/// fresh status observation (#931, kanata-launcher row). Pure so the wizard
+/// page's escalation timing is unit-testable without a running UI.
+///
+/// - The clock starts at `now` on the first `.unknown` observation and is
+///   deliberately NOT refreshed while the status stays `.unknown` — the window
+///   measures total time stranded, not time since the last poll.
+/// - Any conclusive status (granted/denied/error) clears it, so a later return
+///   to `.unknown` restarts the wait window from scratch.
+public func advanceUnverifiedClock(
+    previous: Date?, statusIsUnknown: Bool, now: Date
+) -> Date? {
+    guard statusIsUnknown else { return nil }
+    return previous ?? now
+}

--- a/Tests/KeyPathTests/AutomaticPromptGuidanceTests.swift
+++ b/Tests/KeyPathTests/AutomaticPromptGuidanceTests.swift
@@ -75,3 +75,43 @@ final class AutomaticPromptGuidanceTests: XCTestCase {
         XCTAssertEqual(resolve(keyPathReady: false, requestAttempted: true, secondsSinceRequest: 2, waitWindow: 1), .manualFallback)
     }
 }
+
+// MARK: - Unverified clock (#931, kanata-launcher row)
+
+final class UnverifiedClockTests: XCTestCase {
+    func testClockStartsOnFirstUnknownObservation() {
+        let now = Date(timeIntervalSince1970: 1000)
+        XCTAssertEqual(
+            advanceUnverifiedClock(previous: nil, statusIsUnknown: true, now: now), now
+        )
+    }
+
+    func testClockIsNotRefreshedWhileStillUnknown() {
+        // The window measures total time stranded — repeated polls must not
+        // push the escalation out indefinitely.
+        let start = Date(timeIntervalSince1970: 1000)
+        let later = Date(timeIntervalSince1970: 1029)
+        XCTAssertEqual(
+            advanceUnverifiedClock(previous: start, statusIsUnknown: true, now: later), start
+        )
+    }
+
+    func testConclusiveStatusClearsClock() {
+        let start = Date(timeIntervalSince1970: 1000)
+        XCTAssertNil(
+            advanceUnverifiedClock(previous: start, statusIsUnknown: false, now: start + 5)
+        )
+    }
+
+    func testReturnToUnknownRestartsWindowFromScratch() {
+        let firstRun = Date(timeIntervalSince1970: 1000)
+        let cleared = advanceUnverifiedClock(
+            previous: firstRun, statusIsUnknown: false, now: firstRun + 10
+        )
+        let secondStart = Date(timeIntervalSince1970: 2000)
+        XCTAssertEqual(
+            advanceUnverifiedClock(previous: cleared, statusIsUnknown: true, now: secondStart),
+            secondStart
+        )
+    }
+}

--- a/Tests/KeyPathTests/PermissionOracleInputMonitoringTests.swift
+++ b/Tests/KeyPathTests/PermissionOracleInputMonitoringTests.swift
@@ -105,4 +105,76 @@ final class PermissionOracleInputMonitoringTests: XCTestCase {
         XCTAssertNotNil(snap.blockingIssue)
         XCTAssertFalse(snap.isSystemReady)
     }
+
+    // MARK: - Kanata IM functional-evidence resolution (#931)
+
+    private typealias Evidence = PermissionOracle.KanataFunctionalEvidence
+
+    /// The macOS 26/27 gap this exists for: a grant that never wrote a TCC row,
+    /// but the engine is verifiably capturing input.
+    func testFunctionalEvidenceUpgradesUnreadableTCCToGranted() {
+        let resolved = PermissionOracle.resolveKanataInputMonitoring(
+            tccStatus: nil,
+            evidence: Evidence(isRunning: true, isResponding: true, inputCaptureReady: true)
+        )
+        XCTAssertEqual(resolved.status, .granted)
+        XCTAssertTrue(resolved.usedFunctionalEvidence)
+    }
+
+    /// A stale TCC denied row loses to a running, capturing engine — same
+    /// kernel-over-TCC precedence as ADR-006.
+    func testFunctionalEvidenceOverridesStaleDeniedRow() {
+        let resolved = PermissionOracle.resolveKanataInputMonitoring(
+            tccStatus: .denied,
+            evidence: Evidence(isRunning: true, isResponding: true, inputCaptureReady: true)
+        )
+        XCTAssertEqual(resolved.status, .granted)
+        XCTAssertTrue(resolved.usedFunctionalEvidence)
+    }
+
+    /// A stopped daemon proves nothing — the TCC answer stands untouched.
+    func testStoppedDaemonNeverDowngradesTCCAnswer() {
+        for tcc: Status? in [.granted, .denied, nil] {
+            let resolved = PermissionOracle.resolveKanataInputMonitoring(
+                tccStatus: tcc,
+                evidence: Evidence(isRunning: false, isResponding: false, inputCaptureReady: true)
+            )
+            XCTAssertEqual(resolved.status, tcc ?? .unknown)
+            XCTAssertFalse(resolved.usedFunctionalEvidence)
+        }
+    }
+
+    /// Running but with a diagnosed input-capture failure is NOT proof of the
+    /// grant — fall back to TCC (or unknown) so the wizard keeps guiding.
+    func testCaptureFailureIsNotProofOfGrant() {
+        let resolved = PermissionOracle.resolveKanataInputMonitoring(
+            tccStatus: nil,
+            evidence: Evidence(isRunning: true, isResponding: true, inputCaptureReady: false)
+        )
+        XCTAssertEqual(resolved.status, .unknown)
+        XCTAssertFalse(resolved.usedFunctionalEvidence)
+    }
+
+    /// Running but not serving TCP could be a half-started or wedged process —
+    /// insufficient evidence, keep the TCC answer.
+    func testRunningWithoutTCPIsInsufficientEvidence() {
+        let resolved = PermissionOracle.resolveKanataInputMonitoring(
+            tccStatus: nil,
+            evidence: Evidence(isRunning: true, isResponding: false, inputCaptureReady: true)
+        )
+        XCTAssertEqual(resolved.status, .unknown)
+        XCTAssertFalse(resolved.usedFunctionalEvidence)
+    }
+
+    /// No provider wired (CLI contexts, tests) behaves exactly as before #931's
+    /// functional layer: pure TCC passthrough.
+    func testAbsentEvidenceIsPureTCCPassthrough() {
+        for tcc: Status? in [.granted, .denied, nil] {
+            let resolved = PermissionOracle.resolveKanataInputMonitoring(
+                tccStatus: tcc, evidence: nil
+            )
+            XCTAssertEqual(resolved.status, tcc ?? .unknown)
+            XCTAssertFalse(resolved.usedFunctionalEvidence)
+        }
+    }
 }

--- a/Tests/KeyPathTests/PermissionOracleInputMonitoringTests.swift
+++ b/Tests/KeyPathTests/PermissionOracleInputMonitoringTests.swift
@@ -121,15 +121,18 @@ final class PermissionOracleInputMonitoringTests: XCTestCase {
         XCTAssertTrue(resolved.usedFunctionalEvidence)
     }
 
-    /// A stale TCC denied row loses to a running, capturing engine — same
-    /// kernel-over-TCC precedence as ADR-006.
-    func testFunctionalEvidenceOverridesStaleDeniedRow() {
-        let resolved = PermissionOracle.resolveKanataInputMonitoring(
-            tccStatus: .denied,
-            evidence: Evidence(isRunning: true, isResponding: true, inputCaptureReady: true)
-        )
-        XCTAssertEqual(resolved.status, .granted)
-        XCTAssertTrue(resolved.usedFunctionalEvidence)
+    /// An explicit TCC answer is authoritative in BOTH directions: the runtime
+    /// capture signal is optimistic-by-default, so it must never flip a real
+    /// `.denied` row to green (revoke-while-running race).
+    func testExplicitTCCAnswerIsNeverOverriddenByEvidence() {
+        let strongEvidence = Evidence(isRunning: true, isResponding: true, inputCaptureReady: true)
+        for tcc: Status in [.granted, .denied] {
+            let resolved = PermissionOracle.resolveKanataInputMonitoring(
+                tccStatus: tcc, evidence: strongEvidence
+            )
+            XCTAssertEqual(resolved.status, tcc)
+            XCTAssertFalse(resolved.usedFunctionalEvidence)
+        }
     }
 
     /// A stopped daemon proves nothing — the TCC answer stands untouched.


### PR DESCRIPTION
## Summary

Part of #931 (not auto-closed: on-device verification remains — the human-in-loop half of the ticket).

The KeyPath.app half of #931 was fixed by #937/#939 (authoritative `IOHIDCheckAccess` + manual-fallback escalation). The **kanata-launcher row still had the identical dead-end one level down**: its Input Monitoring state came only from the TCC database, so on macOS 26/27 — where a completed grant may never produce a readable TCC row — the wizard showed "Not yet added" forever, with no forward navigation on the page.

### Oracle: functional evidence for kanata IM

- New injectable `KanataFunctionalEvidence` provider on `PermissionOracle` (#931). A running, TCP-responding kanata with no diagnosed input-capture failure is strong evidence of the grant, so it upgrades an **absent** TCC read to `granted`.
- **Explicit TCC answers are authoritative in both directions** (revised per review): the underlying capture signal is optimistic-by-default upstream, so evidence never overrides an explicit `granted` or `denied` row — a mid-run revoke shows `denied` correctly. Evidence is only consulted when the TCC read is inconclusive (`nil`), the exact grant-without-a-row case this exists for.
- Negative or absent evidence never downgrades anything (a stopped daemon proves nothing).
- Wired from `configureWizardDependencies` via `ServiceHealthChecker`'s TTL-cached runtime snapshot — cheap under the wizard's 1s poll, and the `KeyPathPermissions` module gains no new dependency (closure injection only).
- Pure static resolver `resolveKanataInputMonitoring(tccStatus:evidence:)` mirrors the #937 pattern for unit testing.

### Wizard: the kanata row gets a forward path

- The kanata row now escalates like the KeyPath row (#939): when `unknown` persists past a 30s window (clock restarts when the drag-to-authorize flow is launched), a card offers **"Continue Setup"** — it navigates to the next wizard step (typically the Service page; deliberately **not** an auto-start, preserving the one-permission-prompt-at-a-time flow). Once the user starts the engine there, the Oracle upgrades on functional evidence; a genuinely missing grant fails with an input-capture error that `SystemInspector` routes straight back to this page. The loop is closed; the page can no longer strand the user.
- `denied` never reaches the bypass at either layer: the escalation card is gated on `.warning` (unknown), and the Oracle keeps an explicit denied row denied.
- Clock logic extracted to pure `advanceUnverifiedClock` (KeyPathWizardCore) with unit tests (start-once, no refresh while unknown, clear on conclusive, restart on re-entry).
- New accessibility id: `wizard_input_monitoring_kanata_continue_unverified`.

### Tests

- `PermissionOracleInputMonitoringTests`: truth table for the resolver — evidence upgrade from absent TCC, explicit granted/denied never overridden, stopped/half-started daemon never downgrades, diagnosed capture failure is not proof, nil-provider passthrough identical to pre-#931.
- `UnverifiedClockTests`: the four clock transitions.

## Validation

- **Authored on Linux — CI is the compile gate.** All API signatures verified against the codebase by reading.
- The `/thermo-nuclear-swift-review` gate should run against this branch before merge (unavailable in the authoring environment). Two adversarial review passes already ran; findings fixed in `2e94dfb` (denied-override race, clock test coverage) and `0e95578` (continue-card copy matched to actual flow).
- Known accepted looseness: provider registration happens in an un-awaited `Task` at startup — a snapshot taken in that window just sees no evidence (conservative), and the wizard's 1s poll self-heals. `functional-im` results report `.high` confidence, which is inert today (logging only) — if `Confidence` ever gates behavior, introduce a distinct tier.
- On-device test plan (macOS 26/27, fresh install): reach the IM page with kanata-launcher granted-but-rowless → after 30s the continue card appears → Continue Setup → Service page → click Start → IM row flips green via `kanata.functional-im` source (check log), wizard completes. Negative paths: skip the grant → engine start fails with input-capture error → routed back with error severity; revoke the grant while running → row shows denied (TCC), no false green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142A1G18McVBb1f1Dp7873M