### PR TITLE
Fix installer repair loop for inactive VirtualHID driver

### DIFF
--- a/Sources/KeyPathAppKit/CLI/SystemFacade.swift
+++ b/Sources/KeyPathAppKit/CLI/SystemFacade.swift
@@ -474,6 +474,12 @@ public struct SystemFacade: Sendable {
         guard let first = issues.first else { return prefix }
         return "\(prefix): \(first.title). \(first.action)"
     }
+
+    fileprivate static func requiresManualApproval(_ failureReason: String) -> Bool {
+        let normalized = failureReason.lowercased()
+        return normalized.contains("waiting for macos approval")
+            || normalized.contains("system settings > privacy & security")
+    }
 }
 
 // MARK: - System Types
@@ -537,6 +543,7 @@ public struct CLIInstallerReport: Codable, Sendable {
         let finalUserActionIssues = finalIssues.filter { !$0.canAutoFix }
         let finalOperational = finalContext.map(SystemFacade.isOperational) ?? false
         let completedButStillBlocked = report.success && !finalOperational && !finalIssues.isEmpty
+        let failedForManualApproval = report.failureReason.map(SystemFacade.requiresManualApproval) ?? false
 
         success = report.success && !completedButStillBlocked
         if let reportFailure = report.failureReason {
@@ -556,7 +563,7 @@ public struct CLIInstallerReport: Codable, Sendable {
         }
         fastRepair = false
         dryRun = false
-        userActionRequired = !finalUserActionIssues.isEmpty || plan.metadata.promptsNeeded
+        userActionRequired = !finalUserActionIssues.isEmpty || plan.metadata.promptsNeeded || failedForManualApproval
         issues = finalIssues
         plannedRecipes = plan.recipes.map { "\($0.id) (\($0.type))" }
         unmetRequirements = report.unmetRequirements.map(\.name)

--- a/Sources/KeyPathAppKit/CLI/SystemFacade.swift
+++ b/Sources/KeyPathAppKit/CLI/SystemFacade.swift
@@ -438,13 +438,19 @@ public struct SystemFacade: Sendable {
             ))
         }
         if !context.services.kanataInputCaptureReady {
+            let vhidDriverNotActivated = context.services.kanataInputCaptureIssue
+                == ServiceHealthChecker.inputCaptureVHIDDriverNotActivatedReason
             issues.append(.init(
-                title: "Kanata cannot capture keyboard input",
-                category: "permissions",
-                action: context.services.kanataInputCaptureIssue
-                    ?? "Re-grant Input Monitoring for Kanata Engine in System Settings",
-                canAutoFix: false,
-                remediationURL: WizardSystemPaths.inputMonitoringSettings
+                title: vhidDriverNotActivated
+                    ? "Karabiner VirtualHIDDevice driver is not activated"
+                    : "Kanata cannot capture keyboard input",
+                category: vhidDriverNotActivated ? "service" : "permissions",
+                action: vhidDriverNotActivated
+                    ? "Activate and repair the VirtualHID daemon services"
+                    : context.services.kanataInputCaptureIssue
+                        ?? "Re-grant Input Monitoring for Kanata Engine in System Settings",
+                canAutoFix: vhidDriverNotActivated,
+                remediationURL: vhidDriverNotActivated ? nil : WizardSystemPaths.inputMonitoringSettings
             ))
         }
     }

--- a/Sources/KeyPathAppKit/CLI/SystemFacade.swift
+++ b/Sources/KeyPathAppKit/CLI/SystemFacade.swift
@@ -448,7 +448,7 @@ public struct SystemFacade: Sendable {
                 action: vhidDriverNotActivated
                     ? "Activate and repair the VirtualHID daemon services"
                     : context.services.kanataInputCaptureIssue
-                        ?? "Re-grant Input Monitoring for Kanata Engine in System Settings",
+                    ?? "Re-grant Input Monitoring for Kanata Engine in System Settings",
                 canAutoFix: vhidDriverNotActivated,
                 remediationURL: vhidDriverNotActivated ? nil : WizardSystemPaths.inputMonitoringSettings
             ))

--- a/Sources/KeyPathAppKit/Core/OneShotProbeHandler.swift
+++ b/Sources/KeyPathAppKit/Core/OneShotProbeHandler.swift
@@ -37,7 +37,8 @@ enum OneShotProbeHandler {
             || useAppleScriptFallbackRaw == "yes"
         Task { @MainActor in
             let repaired = await HelperMaintenance.shared.runCleanupAndRepair(
-                useAppleScriptFallback: useAppleScriptFallback
+                useAppleScriptFallback: useAppleScriptFallback,
+                forceFullRepair: true
             )
             let details = HelperMaintenance.shared.logLines.joined(separator: " | ")
             FileHandle.standardError.write(

--- a/Sources/KeyPathAppKit/Managers/HelperMaintenance.swift
+++ b/Sources/KeyPathAppKit/Managers/HelperMaintenance.swift
@@ -51,6 +51,16 @@ public final class HelperMaintenance {
     /// Perform a complete cleanup and repair flow.
     /// - Returns: true on success (helper registered and responding), false otherwise.
     public func runCleanupAndRepair(useAppleScriptFallback: Bool = true) async -> Bool {
+        await runCleanupAndRepair(
+            useAppleScriptFallback: useAppleScriptFallback,
+            forceFullRepair: false
+        )
+    }
+
+    public func runCleanupAndRepair(
+        useAppleScriptFallback: Bool,
+        forceFullRepair: Bool
+    ) async -> Bool {
         guard !isRunning else { return false }
         isRunning = true
         logLines.removeAll()
@@ -87,14 +97,18 @@ public final class HelperMaintenance {
         // full unregister → bootout → re-register, which is what resets the launch
         // constraint. This is what makes "Fix" reliable across re-signs and updates.
         let firstRegisterOK = await registerHelper()
-        if firstRegisterOK, await HelperManager.shared.testHelperFunctionality() {
+        if firstRegisterOK, !forceFullRepair, await HelperManager.shared.testHelperFunctionality() {
             log("✅ Helper registered and responding via XPC on first attempt")
             return true
         }
 
-        log(firstRegisterOK
-            ? "⚠️ Helper registered but not responding via XPC (likely stale launch constraint); forcing full reinstall"
-            : "⚠️ Direct helper refresh failed; attempting cleanup then retry")
+        if forceFullRepair {
+            log("⚠️ Force full helper repair requested; unregistering and re-registering helper")
+        } else {
+            log(firstRegisterOK
+                ? "⚠️ Helper registered but not responding via XPC (likely stale launch constraint); forcing full reinstall"
+                : "⚠️ Direct helper refresh failed; attempting cleanup then retry")
+        }
 
         // Step 2: Best-effort unregister via SMAppService (clears the stale launch constraint)
         await unregisterHelperIfPresent()

--- a/Sources/KeyPathAppKit/Services/System/SystemValidator.swift
+++ b/Sources/KeyPathAppKit/Services/System/SystemValidator.swift
@@ -575,6 +575,8 @@ public class SystemValidator {
             tcpPort: PreferencesService.shared.tcpServerPort
         )
         let kanataRunning = kanataHealth.isRunning
+            && kanataHealth.isResponding
+            && kanataHealth.inputCaptureReady
         let stderrDiagnosis = await ServiceHealthChecker.shared.diagnoseDaemonStderr()
         let configParseError = Self.effectiveConfigParseError(
             stderrDiagnosis.configParseError,

--- a/Sources/KeyPathHelper/HelperService.swift
+++ b/Sources/KeyPathHelper/HelperService.swift
@@ -128,6 +128,7 @@ class HelperService: NSObject, HelperProtocol {
         executePrivilegedOperation(
             name: "installRequiredRuntimeServices",
             operation: {
+                try Self.installOrRepairKanataService()
                 try Self.installOrRepairVHIDServices()
             },
             reply: reply
@@ -253,6 +254,39 @@ class HelperService: NSObject, HelperProtocol {
             },
             reply: reply
         )
+    }
+
+    /// Shared implementation for installing/repairing the Kanata service.
+    private static func installOrRepairKanataService() throws {
+        try ensureConsoleUserConfigArtifacts()
+
+        let appBundlePath = appBundlePathFromHelper()
+        let bundledPlistPath = "\(appBundlePath)/Contents/Library/LaunchDaemons/\(kanataServiceID).plist"
+        guard FileManager.default.fileExists(atPath: bundledPlistPath) else {
+            throw HelperError.operationFailed(
+                "Bundled Kanata LaunchDaemon plist is missing: \(bundledPlistPath)"
+            )
+        }
+
+        let dstDir = "/Library/LaunchDaemons"
+        _ = run("/bin/mkdir", ["-p", dstDir])
+        let dstPlistPath = "\(dstDir)/\(kanataServiceID).plist"
+
+        _ = run("/bin/launchctl", ["bootout", "system/\(kanataServiceID)"], timeout: 10)
+        _ = run("/bin/cp", [bundledPlistPath, dstPlistPath])
+        _ = run("/usr/sbin/chown", ["root:wheel", dstPlistPath])
+        _ = run("/bin/chmod", ["644", dstPlistPath])
+
+        guard FileManager.default.fileExists(atPath: dstPlistPath) else {
+            throw HelperError.operationFailed("Kanata LaunchDaemon plist was not installed at \(dstPlistPath)")
+        }
+
+        let bootstrap = run("/bin/launchctl", ["bootstrap", "system", dstPlistPath], timeout: 10)
+        if bootstrap.status != 0, !bootstrap.out.localizedCaseInsensitiveContains("service already loaded") {
+            throw HelperError.operationFailed("bootstrap kanata failed: \(bootstrap.out)")
+        }
+        _ = run("/bin/launchctl", ["enable", "system/\(kanataServiceID)"], timeout: 10)
+        _ = run("/bin/launchctl", ["kickstart", "-k", "system/\(kanataServiceID)"], timeout: 15)
     }
 
     /// Shared implementation for installing/repairing VHID services

--- a/Sources/KeyPathHelper/HelperService.swift
+++ b/Sources/KeyPathHelper/HelperService.swift
@@ -743,7 +743,7 @@ extension HelperService {
     }
 
     static func activateVHIDManagerProcess() -> (status: Int32, out: String) {
-        _ = run("/usr/bin/pkill", ["-f", "\(vhidManagerPath) activate"], timeout: 5)
+        terminateStaleVHIDManagerActivationProcesses()
         let result = run(vhidManagerPath, ["activate"], timeout: 20)
         if result.out.contains("timed out after") {
             return (
@@ -753,6 +753,19 @@ extension HelperService {
             )
         }
         return result
+    }
+
+    static func terminateStaleVHIDManagerActivationProcesses() {
+        let pattern = "\(vhidManagerPath) activate"
+        let existing = run("/usr/bin/pgrep", ["-f", pattern], timeout: 5)
+        let pids = existing.out
+            .split(whereSeparator: \.isNewline)
+            .map(String.init)
+            .filter { !$0.isEmpty }
+        guard !pids.isEmpty else { return }
+
+        _ = run("/bin/kill", ["-TERM"] + pids, timeout: 5)
+        _ = run("/bin/kill", ["-KILL"] + pids, timeout: 5)
     }
 
     static func verifyCodeSignatureStrict(path: String) -> Bool {

--- a/Sources/KeyPathHelper/HelperService.swift
+++ b/Sources/KeyPathHelper/HelperService.swift
@@ -798,7 +798,6 @@ extension HelperService {
             .filter { !$0.isEmpty }
         guard !pids.isEmpty else { return }
 
-        _ = run("/bin/kill", ["-TERM"] + pids, timeout: 5)
         _ = run("/bin/kill", ["-KILL"] + pids, timeout: 5)
     }
 

--- a/Sources/KeyPathHelper/HelperService.swift
+++ b/Sources/KeyPathHelper/HelperService.swift
@@ -141,7 +141,7 @@ class HelperService: NSObject, HelperProtocol {
         executePrivilegedOperation(
             name: "activateVirtualHIDManager",
             operation: {
-                let r = Self.run(Self.vhidManagerPath, ["activate"])
+                let r = Self.activateVHIDManagerProcess()
                 if r.status != 0 {
                     throw HelperError.operationFailed("VHID Manager activation failed: \(r.out)")
                 }
@@ -194,7 +194,7 @@ class HelperService: NSObject, HelperProtocol {
                 _ = try? FileManager.default.removeItem(atPath: pkg)
                 if i.status != 0 { throw HelperError.operationFailed("Installer failed: \(i.out)") }
                 // Activate after install
-                let a = Self.run(Self.vhidManagerPath, ["activate"])
+                let a = Self.activateVHIDManagerProcess()
                 if a.status != 0 {
                     NSLog("[KeyPathHelper] Warning: activate returned %d: %@", a.status, a.out)
                 }
@@ -218,7 +218,7 @@ class HelperService: NSObject, HelperProtocol {
                 let i = Self.run("/usr/sbin/installer", ["-pkg", pkg, "-target", "/"], timeout: 300)
                 _ = try? FileManager.default.removeItem(atPath: pkg)
                 if i.status != 0 { throw HelperError.operationFailed("Installer failed: \(i.out)") }
-                let a = Self.run(Self.vhidManagerPath, ["activate"])
+                let a = Self.activateVHIDManagerProcess()
                 if a.status != 0 {
                     NSLog("[KeyPathHelper] Warning: activate returned %d: %@", a.status, a.out)
                 }
@@ -245,7 +245,7 @@ class HelperService: NSObject, HelperProtocol {
                 let i = Self.run("/usr/sbin/installer", ["-pkg", canonicalPath, "-target", "/"], timeout: 300)
                 if i.status != 0 { throw HelperError.operationFailed("Installer failed: \(i.out)") }
                 // Activate after install
-                let a = Self.run(Self.vhidManagerPath, ["activate"])
+                let a = Self.activateVHIDManagerProcess()
                 if a.status != 0 {
                     NSLog("[KeyPathHelper] Warning: activate returned %d: %@", a.status, a.out)
                 }
@@ -740,6 +740,19 @@ extension HelperService {
             )
         }
         return (outcome.status, outcome.output)
+    }
+
+    static func activateVHIDManagerProcess() -> (status: Int32, out: String) {
+        _ = run("/usr/bin/pkill", ["-f", "\(vhidManagerPath) activate"], timeout: 5)
+        let result = run(vhidManagerPath, ["activate"], timeout: 20)
+        if result.out.contains("timed out after") {
+            return (
+                result.status,
+                result.out
+                    + "\nVirtualHID activation may be waiting for macOS approval. Open System Settings > Privacy & Security and approve the Karabiner VirtualHIDDevice system extension, then retry repair."
+            )
+        }
+        return result
     }
 
     static func verifyCodeSignatureStrict(path: String) -> Bool {

--- a/Sources/KeyPathInstallationWizard/Core/ActionDeterminer.swift
+++ b/Sources/KeyPathInstallationWizard/Core/ActionDeterminer.swift
@@ -59,11 +59,11 @@ public enum ActionDeterminer {
             actions.append(.installRequiredRuntimeServices)
         }
 
+        appendVHIDActivationRepairIfNeeded(context: context, actions: &actions)
+
         if !context.services.kanataRunning, !actions.contains(.installRequiredRuntimeServices) {
             actions.append(.installRequiredRuntimeServices)
         }
-
-        appendVHIDActivationRepairIfNeeded(context: context, actions: &actions)
 
         // Check if daemon needs starting
         if !context.services.karabinerDaemonRunning {
@@ -127,11 +127,11 @@ public enum ActionDeterminer {
             actions.append(.installRequiredRuntimeServices)
         }
 
+        appendVHIDActivationRepairIfNeeded(context: context, actions: &actions)
+
         if !context.services.kanataRunning, !actions.contains(.installRequiredRuntimeServices) {
             actions.append(.installRequiredRuntimeServices)
         }
-
-        appendVHIDActivationRepairIfNeeded(context: context, actions: &actions)
 
         return actions
     }
@@ -146,9 +146,8 @@ public enum ActionDeterminer {
         context: SystemContext,
         actions: inout [AutoFixAction]
     ) {
-        guard context.services.kanataRunning,
-              context.services.kanataInputCaptureIssue ==
-              ServiceHealthChecker.inputCaptureVHIDDriverNotActivatedReason
+        guard context.services.kanataInputCaptureIssue ==
+            ServiceHealthChecker.inputCaptureVHIDDriverNotActivatedReason
         else { return }
 
         if !actions.contains(.activateVHIDDeviceManager) {

--- a/Sources/KeyPathInstallationWizard/Core/ActionDeterminer.swift
+++ b/Sources/KeyPathInstallationWizard/Core/ActionDeterminer.swift
@@ -59,6 +59,10 @@ public enum ActionDeterminer {
             actions.append(.installRequiredRuntimeServices)
         }
 
+        if !context.services.kanataRunning, !actions.contains(.installRequiredRuntimeServices) {
+            actions.append(.installRequiredRuntimeServices)
+        }
+
         appendVHIDActivationRepairIfNeeded(context: context, actions: &actions)
 
         // Check if daemon needs starting
@@ -123,6 +127,10 @@ public enum ActionDeterminer {
             actions.append(.installRequiredRuntimeServices)
         }
 
+        if !context.services.kanataRunning, !actions.contains(.installRequiredRuntimeServices) {
+            actions.append(.installRequiredRuntimeServices)
+        }
+
         appendVHIDActivationRepairIfNeeded(context: context, actions: &actions)
 
         return actions
@@ -138,8 +146,9 @@ public enum ActionDeterminer {
         context: SystemContext,
         actions: inout [AutoFixAction]
     ) {
-        guard context.services.kanataInputCaptureIssue ==
-            ServiceHealthChecker.inputCaptureVHIDDriverNotActivatedReason
+        guard context.services.kanataRunning,
+              context.services.kanataInputCaptureIssue ==
+              ServiceHealthChecker.inputCaptureVHIDDriverNotActivatedReason
         else { return }
 
         if !actions.contains(.activateVHIDDeviceManager) {

--- a/Sources/KeyPathInstallationWizard/Core/ActionDeterminer.swift
+++ b/Sources/KeyPathInstallationWizard/Core/ActionDeterminer.swift
@@ -59,6 +59,8 @@ public enum ActionDeterminer {
             actions.append(.installRequiredRuntimeServices)
         }
 
+        appendVHIDActivationRepairIfNeeded(context: context, actions: &actions)
+
         // Check if daemon needs starting
         if !context.services.karabinerDaemonRunning {
             // Ensure manager is activated before starting daemon
@@ -121,6 +123,8 @@ public enum ActionDeterminer {
             actions.append(.installRequiredRuntimeServices)
         }
 
+        appendVHIDActivationRepairIfNeeded(context: context, actions: &actions)
+
         return actions
     }
 
@@ -128,5 +132,21 @@ public enum ActionDeterminer {
     public static func determineUninstallActions(context _: SystemContext) -> [AutoFixAction] {
         // Uninstall is handled differently - logic is in UninstallCoordinator
         []
+    }
+
+    private static func appendVHIDActivationRepairIfNeeded(
+        context: SystemContext,
+        actions: inout [AutoFixAction]
+    ) {
+        guard context.services.kanataInputCaptureIssue ==
+            ServiceHealthChecker.inputCaptureVHIDDriverNotActivatedReason
+        else { return }
+
+        if !actions.contains(.activateVHIDDeviceManager) {
+            actions.append(.activateVHIDDeviceManager)
+        }
+        if !actions.contains(.repairVHIDDaemonServices) {
+            actions.append(.repairVHIDDaemonServices)
+        }
     }
 }

--- a/Sources/KeyPathInstallationWizard/Core/InstallerEngine.swift
+++ b/Sources/KeyPathInstallationWizard/Core/InstallerEngine.swift
@@ -404,7 +404,10 @@ public final class InstallerEngine {
             throw InstallerError.healthCheckFailed("Helper maintenance is not configured")
         }
 
-        let repaired = await helperMaintenance.runCleanupAndRepair(useAppleScriptFallback: true)
+        let repaired = await helperMaintenance.runCleanupAndRepair(
+            useAppleScriptFallback: true,
+            forceFullRepair: true
+        )
         guard repaired else {
             let failure = helperMaintenance.lastErrorLine
                 ?? helperMaintenance.logLines.last

--- a/Sources/KeyPathInstallationWizard/Core/ServiceHealthChecker.swift
+++ b/Sources/KeyPathInstallationWizard/Core/ServiceHealthChecker.swift
@@ -30,6 +30,8 @@ public final class ServiceHealthChecker: @unchecked Sendable {
     /// Reason codes for input-capture failures, shared with SystemInspector.
     public nonisolated static let inputCaptureBuiltInKeyboardReason = "kanata-cannot-open-built-in-keyboard"
     public nonisolated static let inputCaptureGrabFailureReason = "kanata-failed-to-grab-keyboard"
+    public nonisolated static let inputCaptureVHIDDriverNotActivatedReason =
+        "karabiner-vhid-driver-not-activated"
 
     // MARK: - Short-lived health cache
 
@@ -818,6 +820,13 @@ public final class ServiceHealthChecker: @unchecked Sendable {
             )
         }
 
+        if inputCaptureIssue.isReady, !permissionRejected, Self.detectsVHIDDriverNotActivated(in: logChunk) {
+            inputCaptureIssue = KanataInputCaptureStatus(
+                isReady: false,
+                issue: Self.inputCaptureVHIDDriverNotActivatedReason
+            )
+        }
+
         // Check for configuration parse errors (e.g., duplicate aliases, syntax errors).
         // These cause kanata to exit immediately and crash-loop via launchd.
         let configParseError = Self.extractConfigParseError(from: logChunk)
@@ -838,6 +847,10 @@ public final class ServiceHealthChecker: @unchecked Sendable {
         return lower.contains("aborted while talking to the karabiner virtual hid daemon")
             || lower.contains("grabbing your keyboard exclusively")
             || (lower.contains("panicked at") && lower.contains("karabiner-driverkit"))
+    }
+
+    static func detectsVHIDDriverNotActivated(in logChunk: String) -> Bool {
+        logChunk.lowercased().contains("virtualhiddevice driver is not activated")
     }
 
     /// Extract a user-facing config parse error from kanata stderr output.

--- a/Sources/KeyPathInstallationWizard/Core/SystemInspector.swift
+++ b/Sources/KeyPathInstallationWizard/Core/SystemInspector.swift
@@ -152,13 +152,10 @@ public enum SystemInspector {
                     title: "Kanata Isn't Capturing Keyboard Input",
                     description: "KeyPath's keyboard engine is running but isn't capturing input, so remapping won't work. "
                         + inputCaptureFailureDetail(context.services.kanataInputCaptureIssue),
-                    // No one-click auto-fix yet: the existing recipes don't actually
-                    // bounce the wedged kanata process (they find SMAppService
-                    // "already healthy" and no-op), so a Restart button here would
-                    // be a false remedy. Point to the real restart instead; a
-                    // proper one-click kanata kickstart is a follow-up.
-                    autoFixAction: nil,
-                    userAction: "Restart the keyboard service from Settings → Status (or quit and reopen KeyPath)"
+                    autoFixAction: isVHIDDriverNotActivatedReason(context.services.kanataInputCaptureIssue)
+                        ? .repairVHIDDaemonServices : nil,
+                    userAction: isVHIDDriverNotActivatedReason(context.services.kanataInputCaptureIssue)
+                        ? nil : "Restart the keyboard service from Settings → Status (or quit and reopen KeyPath)"
                 ))
             }
         }
@@ -382,9 +379,16 @@ public enum SystemInspector {
         reason == ServiceHealthChecker.inputCaptureBuiltInKeyboardReason
     }
 
+    static func isVHIDDriverNotActivatedReason(_ reason: String?) -> Bool {
+        reason == ServiceHealthChecker.inputCaptureVHIDDriverNotActivatedReason
+    }
+
     /// Human-readable detail for a non-permission input-capture failure, using
     /// kanata's authoritative reason (from the InputGrab signal) when present.
     static func inputCaptureFailureDetail(_ reason: String?) -> String {
+        if isVHIDDriverNotActivatedReason(reason) {
+            return "The Karabiner VirtualHIDDevice driver is installed, but macOS reports it is not activated."
+        }
         guard let reason, reason != ServiceHealthChecker.inputCaptureGrabFailureReason else {
             return "The keyboard couldn't be captured — the input driver may have crashed, or another app may be holding the keyboard exclusively."
         }

--- a/Sources/KeyPathWizardCore/WizardServiceProtocols.swift
+++ b/Sources/KeyPathWizardCore/WizardServiceProtocols.swift
@@ -15,6 +15,7 @@ public protocol WizardSystemValidating: AnyObject, Sendable {
 public protocol WizardHelperMaintaining: AnyObject, Sendable {
     func detectDuplicateAppCopies() -> [String]
     func runCleanupAndRepair(useAppleScriptFallback: Bool) async -> Bool
+    func runCleanupAndRepair(useAppleScriptFallback: Bool, forceFullRepair: Bool) async -> Bool
     var logLines: [String] { get }
     /// Most recent explicit failure line (❌/⚠️-prefixed), excluding the
     /// "Cleanup & Repair started/finished" bookends. nil when no failure was logged.

--- a/Tests/KeyPathTests/CLI/CLIOutputContractTests.swift
+++ b/Tests/KeyPathTests/CLI/CLIOutputContractTests.swift
@@ -109,7 +109,7 @@ final class CLIOutputContractTests: XCTestCase {
         )
     }
 
-    func testInstallerReportMarksActivationApprovalTimeoutAsUserActionRequired() throws {
+    func testInstallerReportMarksActivationApprovalTimeoutAsUserActionRequired() {
         let context = SystemContextBuilder.degradedRepair()
         let plan = InstallPlan(
             recipes: [],

--- a/Tests/KeyPathTests/CLI/CLIOutputContractTests.swift
+++ b/Tests/KeyPathTests/CLI/CLIOutputContractTests.swift
@@ -1,4 +1,5 @@
 @testable import KeyPathAppKit
+@testable import KeyPathInstallationWizard
 import XCTest
 
 final class CLIOutputContractTests: XCTestCase {
@@ -106,6 +107,29 @@ final class CLIOutputContractTests: XCTestCase {
             decoded.issues?.first?.remediationURL,
             "x-apple.systempreferences:com.apple.preference.security?Privacy_ListenEvent"
         )
+    }
+
+    func testInstallerReportMarksActivationApprovalTimeoutAsUserActionRequired() throws {
+        let context = SystemContextBuilder.degradedRepair()
+        let plan = InstallPlan(
+            recipes: [],
+            status: .ready,
+            intent: .repair
+        )
+        let installerReport = InstallerReport(
+            success: false,
+            failureReason: "VHID Manager activation failed: timed out after 20s. VirtualHID activation may be waiting for macOS approval. Open System Settings > Privacy & Security and approve the Karabiner VirtualHIDDevice system extension, then retry repair."
+        )
+
+        let report = CLIInstallerReport(
+            from: installerReport,
+            initialContext: context,
+            finalContext: nil,
+            plan: plan,
+            title: "Repair"
+        )
+
+        XCTAssertEqual(report.userActionRequired, true)
     }
 
     func testValidationResultJSONShape() throws {

--- a/Tests/KeyPathTests/InstallationEngine/InstallerEngineEndToEndTests.swift
+++ b/Tests/KeyPathTests/InstallationEngine/InstallerEngineEndToEndTests.swift
@@ -157,4 +157,10 @@ private final class StubHelperMaintenance: WizardHelperMaintaining {
         logLines.append("helper repair invoked")
         return true
     }
+
+    func runCleanupAndRepair(useAppleScriptFallback _: Bool, forceFullRepair _: Bool) async -> Bool {
+        repairCallCount += 1
+        logLines.append("helper repair invoked")
+        return true
+    }
 }

--- a/Tests/KeyPathTests/InstallationWizard/SystemInspectorInputCaptureTests.swift
+++ b/Tests/KeyPathTests/InstallationWizard/SystemInspectorInputCaptureTests.swift
@@ -60,6 +60,19 @@ final class SystemInspectorInputCaptureTests: XCTestCase {
         )
     }
 
+    func testVHIDDriverNotActivated_issueIsAutofixable() {
+        let issues = SystemInspector.generateIssues(
+            context(inputCaptureIssue: ServiceHealthChecker.inputCaptureVHIDDriverNotActivatedReason)
+        )
+        guard let issue = issues.first(where: { $0.identifier == .daemon }) else {
+            return XCTFail("Expected a daemon issue for inactive VHID DriverKit state")
+        }
+        XCTAssertEqual(issue.title, "Kanata Isn't Capturing Keyboard Input")
+        XCTAssertEqual(issue.autoFixAction, .repairVHIDDaemonServices)
+        XCTAssertNil(issue.userAction)
+        XCTAssertTrue(issue.description.contains("not activated"))
+    }
+
     // MARK: - Service status must not lie green on a grab failure
 
     func testGrabFailure_serviceStatusIsFailed_notRunning() {

--- a/Tests/KeyPathTests/InstallationWizard/WizardPureLogicTests.swift
+++ b/Tests/KeyPathTests/InstallationWizard/WizardPureLogicTests.swift
@@ -1057,7 +1057,7 @@ final class WizardPureLogicTests: XCTestCase {
     func test_determineRepairActions_vhidDriverNotActivated_includesActivationAndRepair() {
         let context = makeContext(
             services: HealthStatus(
-                kanataRunning: false,
+                kanataRunning: true,
                 karabinerDaemonRunning: true,
                 vhidHealthy: true,
                 kanataInputCaptureReady: false,
@@ -1072,6 +1072,24 @@ final class WizardPureLogicTests: XCTestCase {
         XCTAssertNotNil(activateIdx, "DriverKit activation failure should re-run VHID manager activation")
         XCTAssertNotNil(repairIdx, "DriverKit activation failure should repair VHID daemon services")
         XCTAssertTrue(activateIdx! < repairIdx!, "Activation must run before daemon repair")
+    }
+
+    func test_determineRepairActions_stoppedKanataWithStaleVHIDIssue_installsRuntimeServices() {
+        let context = makeContext(
+            services: HealthStatus(
+                kanataRunning: false,
+                karabinerDaemonRunning: true,
+                vhidHealthy: true,
+                kanataInputCaptureReady: false,
+                kanataInputCaptureIssue: ServiceHealthChecker.inputCaptureVHIDDriverNotActivatedReason
+            )
+        )
+
+        let actions = ActionDeterminer.determineRepairActions(context: context)
+
+        XCTAssertTrue(actions.contains(.installRequiredRuntimeServices))
+        XCTAssertFalse(actions.contains(.activateVHIDDeviceManager))
+        XCTAssertFalse(actions.contains(.repairVHIDDaemonServices))
     }
 
     func test_determineRepairActions_helperInstalledButBroken_includesReinstall() {
@@ -1142,7 +1160,7 @@ final class WizardPureLogicTests: XCTestCase {
     func test_determineInstallActions_vhidDriverNotActivated_includesActivationAndRepair() {
         let context = makeContext(
             services: HealthStatus(
-                kanataRunning: false,
+                kanataRunning: true,
                 karabinerDaemonRunning: true,
                 vhidHealthy: true,
                 kanataInputCaptureReady: false,

--- a/Tests/KeyPathTests/InstallationWizard/WizardPureLogicTests.swift
+++ b/Tests/KeyPathTests/InstallationWizard/WizardPureLogicTests.swift
@@ -1054,6 +1054,26 @@ final class WizardPureLogicTests: XCTestCase {
         XCTAssertTrue(actions.contains(.startKarabinerDaemon))
     }
 
+    func test_determineRepairActions_vhidDriverNotActivated_includesActivationAndRepair() {
+        let context = makeContext(
+            services: HealthStatus(
+                kanataRunning: false,
+                karabinerDaemonRunning: true,
+                vhidHealthy: true,
+                kanataInputCaptureReady: false,
+                kanataInputCaptureIssue: ServiceHealthChecker.inputCaptureVHIDDriverNotActivatedReason
+            )
+        )
+
+        let actions = ActionDeterminer.determineRepairActions(context: context)
+
+        let activateIdx = actions.firstIndex(of: .activateVHIDDeviceManager)
+        let repairIdx = actions.firstIndex(of: .repairVHIDDaemonServices)
+        XCTAssertNotNil(activateIdx, "DriverKit activation failure should re-run VHID manager activation")
+        XCTAssertNotNil(repairIdx, "DriverKit activation failure should repair VHID daemon services")
+        XCTAssertTrue(activateIdx! < repairIdx!, "Activation must run before daemon repair")
+    }
+
     func test_determineRepairActions_helperInstalledButBroken_includesReinstall() {
         let context = makeContext(helper: HelperStatus(isInstalled: true, version: "1.0", isWorking: false))
         let actions = ActionDeterminer.determineRepairActions(context: context)
@@ -1117,6 +1137,23 @@ final class WizardPureLogicTests: XCTestCase {
         let actions = ActionDeterminer.determineInstallActions(context: context)
         XCTAssertTrue(actions.contains(.installRequiredRuntimeServices),
                       "Install plans share the vhidRuntimeServicesNeedRepair trigger with repair plans")
+    }
+
+    func test_determineInstallActions_vhidDriverNotActivated_includesActivationAndRepair() {
+        let context = makeContext(
+            services: HealthStatus(
+                kanataRunning: false,
+                karabinerDaemonRunning: true,
+                vhidHealthy: true,
+                kanataInputCaptureReady: false,
+                kanataInputCaptureIssue: ServiceHealthChecker.inputCaptureVHIDDriverNotActivatedReason
+            )
+        )
+
+        let actions = ActionDeterminer.determineInstallActions(context: context)
+
+        XCTAssertTrue(actions.contains(.activateVHIDDeviceManager))
+        XCTAssertTrue(actions.contains(.repairVHIDDaemonServices))
     }
 
     func test_determineInstallActions_allHealthy_returnsEmpty() {

--- a/Tests/KeyPathTests/InstallationWizard/WizardPureLogicTests.swift
+++ b/Tests/KeyPathTests/InstallationWizard/WizardPureLogicTests.swift
@@ -1074,7 +1074,7 @@ final class WizardPureLogicTests: XCTestCase {
         XCTAssertTrue(activateIdx! < repairIdx!, "Activation must run before daemon repair")
     }
 
-    func test_determineRepairActions_stoppedKanataWithStaleVHIDIssue_installsRuntimeServices() {
+    func test_determineRepairActions_stoppedKanataWithVHIDIssue_repairsVHIDThenInstallsRuntimeServices() {
         let context = makeContext(
             services: HealthStatus(
                 kanataRunning: false,
@@ -1087,9 +1087,14 @@ final class WizardPureLogicTests: XCTestCase {
 
         let actions = ActionDeterminer.determineRepairActions(context: context)
 
-        XCTAssertTrue(actions.contains(.installRequiredRuntimeServices))
-        XCTAssertFalse(actions.contains(.activateVHIDDeviceManager))
-        XCTAssertFalse(actions.contains(.repairVHIDDaemonServices))
+        let activateIdx = actions.firstIndex(of: .activateVHIDDeviceManager)
+        let repairIdx = actions.firstIndex(of: .repairVHIDDaemonServices)
+        let installIdx = actions.firstIndex(of: .installRequiredRuntimeServices)
+        XCTAssertNotNil(activateIdx)
+        XCTAssertNotNil(repairIdx)
+        XCTAssertNotNil(installIdx)
+        XCTAssertTrue(activateIdx! < repairIdx!)
+        XCTAssertTrue(repairIdx! < installIdx!)
     }
 
     func test_determineRepairActions_helperInstalledButBroken_includesReinstall() {

--- a/Tests/KeyPathTests/Managers/HelperMaintenanceTests.swift
+++ b/Tests/KeyPathTests/Managers/HelperMaintenanceTests.swift
@@ -167,6 +167,40 @@ final class HelperMaintenanceTests: XCTestCase {
         )
     }
 
+    func testForceFullRepairReinstallsEvenWhenHelperResponds() async {
+        HelperMaintenance.testDuplicateAppPathsOverride = { ["/Applications/KeyPath.app"] }
+
+        var unregisterCalled = false
+        var bootoutCalled = false
+        var registerAttempts = 0
+        let hooks = HelperMaintenance.TestHooks(
+            unregisterHelper: { unregisterCalled = true },
+            bootoutHelperJob: { bootoutCalled = true },
+            removeLegacyHelperArtifacts: { _ in .removed },
+            registerHelper: {
+                registerAttempts += 1
+                return true
+            }
+        )
+        HelperMaintenance.shared.applyTestHooks(hooks)
+        HelperManager.testHelperFunctionalityOverride = { true }
+
+        let success = await HelperMaintenance.shared.runCleanupAndRepair(
+            useAppleScriptFallback: false,
+            forceFullRepair: true
+        )
+
+        XCTAssertTrue(success)
+        XCTAssertTrue(unregisterCalled, "Forced helper repair must unregister even if XPC responds")
+        XCTAssertTrue(bootoutCalled, "Forced helper repair must boot out the existing helper job")
+        XCTAssertGreaterThanOrEqual(registerAttempts, 2)
+        XCTAssertTrue(
+            HelperMaintenance.shared.logLines.contains {
+                $0.localizedCaseInsensitiveContains("force full helper repair requested")
+            }
+        )
+    }
+
     func testRunCleanupIsIdempotentWithoutDuplicates() async {
         HelperMaintenance.testDuplicateAppPathsOverride = { ["/Applications/KeyPath.app"] }
         let hooks = HelperMaintenance.TestHooks(

--- a/Tests/KeyPathTests/Services/ServiceHealthCheckerTests.swift
+++ b/Tests/KeyPathTests/Services/ServiceHealthCheckerTests.swift
@@ -244,6 +244,22 @@ final class ServiceHealthCheckerTests: XCTestCase {
         XCTAssertEqual(diagnosis.inputCapture.issue, ServiceHealthChecker.inputCaptureBuiltInKeyboardReason)
     }
 
+    func testDiagnoseDaemonStderrDetectsVHIDDriverNotActivated() async throws {
+        let stderrURL = tempLaunchDaemonsDir.appendingPathComponent("kanata-stderr.log")
+        try """
+        [kanata-launcher] Launching Kanata for user=test config=/Users/test/.config/keypath/keypath.kbd
+        [ERROR] failed to open keyboard device(s): Karabiner-VirtualHIDDevice driver is not activated.
+        Error: failed to open keyboard device(s): Karabiner-VirtualHIDDevice driver is not activated.
+        """.write(to: stderrURL, atomically: true, encoding: .utf8)
+        setenv("KEYPATH_KANATA_STDERR_PATH", stderrURL.path, 1)
+        defer { unsetenv("KEYPATH_KANATA_STDERR_PATH") }
+
+        let diagnosis = await checker.diagnoseDaemonStderr()
+        XCTAssertFalse(diagnosis.permissionRejected)
+        XCTAssertFalse(diagnosis.inputCapture.isReady)
+        XCTAssertEqual(diagnosis.inputCapture.issue, ServiceHealthChecker.inputCaptureVHIDDriverNotActivatedReason)
+    }
+
     func testDiagnoseDaemonStderrDetectsAccessibilityRejection() async throws {
         let stderrURL = tempLaunchDaemonsDir.appendingPathComponent("kanata-stderr.log")
         try """


### PR DESCRIPTION
## Summary
- Detect the kanata stderr signature for `Karabiner-VirtualHIDDevice driver is not activated` and surface it as a distinct runtime reason.
- Make install/repair plans schedule VHID manager activation plus VHID daemon repair instead of returning an empty plan.
- Require Kanata runtime health to include launchd running + TCP response + input capture readiness, so crash-loop pids do not look operational.
- Harden helper VHID activation by clearing stale manager activation processes and timing out before the CLI IPC timeout with a clearer approval-needed message.

## Validation
- `swift test --filter ServiceHealthCheckerTests/testDiagnoseDaemonStderrDetectsVHIDDriverNotActivated`
- `swift test --filter SystemInspectorInputCaptureTests/testVHIDDriverNotActivated_issueIsAutofixable`
- `swift test --filter WizardPureLogicTests/test_determineRepairActions_vhidDriverNotActivated_includesActivationAndRepair`
- `swift test --filter "WizardPureLogicTests/test_determine.*vhidDriverNotActivated"`
- `swift build`
- `python3 Scripts/check-accessibility.py`
- `./Scripts/quick-deploy.sh`
- Installed CLI: `system inspect` and `system install --dry-run` now both plan `activate-vhid-manager` and `repair-vhid-daemon-services`.

## Known local blocker
The live Mac still has an old registered helper process from before this helper patch. The embedded helper was redeployed with `KEYPATH_DEPLOY_HELPER=1`, but SMAppService still needs helper re-registration before the patched helper code services XPC. The actual VirtualHID activation may also require a macOS security approval in System Settings.

## Notes
`./Scripts/test-fast.sh --changed` fell back to the full safe suite and was interrupted after 469s while still in build/pre-test work; targeted regressions and builds above passed.
