### PR TITLE
[codex] Fix installer repair postconditions

### DIFF
--- a/Sources/KeyPathAppKit/Core/PrivilegedOperationsRouter.swift
+++ b/Sources/KeyPathAppKit/Core/PrivilegedOperationsRouter.swift
@@ -32,6 +32,7 @@ public final class PrivilegedOperationsRouter {
     private static let vhidSettleDelay: Duration = .milliseconds(150)
 
     #if DEBUG
+        nonisolated(unsafe) static var operationModeOverride: OperationMode?
         nonisolated(unsafe) static var serviceStateOverride:
             (() -> KanataDaemonManager.ServiceManagementState)?
         nonisolated(unsafe) static var installAllServicesOverride: (() async throws -> Void)?
@@ -39,13 +40,20 @@ public final class PrivilegedOperationsRouter {
         nonisolated(unsafe) static var killExistingKanataProcessesOverride: (() async throws -> Void)?
         nonisolated(unsafe) static var kanataReadinessOverride:
             ((String) async -> KanataReadinessResult)?
+        nonisolated(unsafe) static var helperInstallRequiredRuntimeServicesOverride: (() async throws -> Void)?
+        nonisolated(unsafe) static var helperRepairVHIDDaemonServicesOverride: (() async throws -> Void)?
+        nonisolated(unsafe) static var vhidServicesPostconditionOverride: ((String) async -> Bool)?
 
         static func resetTestingState() {
+            operationModeOverride = nil
             serviceStateOverride = nil
             installAllServicesOverride = nil
             recoverRequiredRuntimeServicesOverride = nil
             killExistingKanataProcessesOverride = nil
             kanataReadinessOverride = nil
+            helperInstallRequiredRuntimeServicesOverride = nil
+            helperRepairVHIDDaemonServicesOverride = nil
+            vhidServicesPostconditionOverride = nil
             lastServiceInstallAttempt = nil
             lastSMAppApprovalNotice = nil
             ServiceInstallGuard.reset()
@@ -60,6 +68,11 @@ public final class PrivilegedOperationsRouter {
     }
 
     static var operationMode: OperationMode {
+        #if DEBUG
+            if let override = operationModeOverride {
+                return override
+            }
+        #endif
         if TestEnvironment.isTestMode {
             return .directSudo
         }
@@ -94,7 +107,7 @@ public final class PrivilegedOperationsRouter {
         switch Self.operationMode {
         case .privilegedHelper:
             do {
-                try await helperManager.installRequiredRuntimeServices()
+                try await helperInstallRequiredRuntimeServices()
                 // Stale-helper guard (MAL-57): a resident helper from before
                 // the ProcessType=Interactive template fix reports success but
                 // rewrites the old plist — the helper binary only refreshes on
@@ -106,20 +119,24 @@ public final class PrivilegedOperationsRouter {
                 // InstallerEngine → PrivilegeBroker → this router's
                 // helper-first repairVHIDDaemonServices.
                 if serviceHealthChecker.isVHIDDaemonPlistPresentButMisconfigured() {
-                    AppLogger.shared.warn(
+                    AppLogger.shared.warnUnlessQuietTest(
                         "⚠️ [PrivilegedOperationsRouter] VHID daemon plist still misconfigured after helper install — stale helper template, rewriting via in-app sudo path"
                     )
                     try await sudoRepairVHIDServices()
                 }
+                try await enforceVHIDServicesPostcondition(after: "installRequiredRuntimeServices(helper)")
+                try await enforceKanataRuntimePostcondition(after: "installRequiredRuntimeServices(helper)")
             } catch {
                 // Keep the helper's actionable reason (e.g. "driver payload is
                 // not installed") visible — the sudo fallback's generic failure
                 // would otherwise bury it (#928).
-                AppLogger.shared.warn(
+                AppLogger.shared.warnUnlessQuietTest(
                     "⚠️ [PrivilegedOperationsRouter] Helper install failed (\(error.localizedDescription)) — falling back to sudo path"
                 )
                 do {
                     try await sudoInstallRequiredRuntimeServices()
+                    try await enforceVHIDServicesPostcondition(after: "installRequiredRuntimeServices(sudo-fallback)")
+                    try await enforceKanataRuntimePostcondition(after: "installRequiredRuntimeServices(sudo-fallback)")
                 } catch let fallbackError {
                     throw PrivilegedOperationError.installationFailed(
                         "Runtime service installation failed. Helper: \(error.localizedDescription). Sudo fallback: \(fallbackError.localizedDescription)"
@@ -128,6 +145,8 @@ public final class PrivilegedOperationsRouter {
             }
         case .directSudo:
             try await sudoInstallRequiredRuntimeServices()
+            try await enforceVHIDServicesPostcondition(after: "installRequiredRuntimeServices(sudo)")
+            try await enforceKanataRuntimePostcondition(after: "installRequiredRuntimeServices(sudo)")
         }
     }
 
@@ -224,14 +243,21 @@ public final class PrivilegedOperationsRouter {
             // when the helper isn't installed or isn't responding.
             let helperWorking = await helperManager.testHelperFunctionality()
             if helperWorking {
-                do { try await helperManager.repairVHIDDaemonServices() }
-                catch { try await sudoRepairVHIDServices() }
+                do {
+                    try await helperRepairVHIDDaemonServices()
+                    try await enforceVHIDServicesPostcondition(after: "repairVHIDDaemonServices(helper)")
+                } catch {
+                    try await sudoRepairVHIDServices()
+                    try await enforceVHIDServicesPostcondition(after: "repairVHIDDaemonServices(sudo-fallback)")
+                }
             } else {
                 AppLogger.shared.log("⚠️ [Router] Helper not responsive — using sudo for VHID repair")
                 try await sudoRepairVHIDServices()
+                try await enforceVHIDServicesPostcondition(after: "repairVHIDDaemonServices(sudo-no-helper)")
             }
         case .directSudo:
             try await sudoRepairVHIDServices()
+            try await enforceVHIDServicesPostcondition(after: "repairVHIDDaemonServices(sudo)")
         }
     }
 
@@ -427,6 +453,26 @@ public final class PrivilegedOperationsRouter {
         try await installRequiredRuntimeServices()
     }
 
+    private func helperInstallRequiredRuntimeServices() async throws {
+        #if DEBUG
+            if let override = Self.helperInstallRequiredRuntimeServicesOverride {
+                try await override()
+                return
+            }
+        #endif
+        try await helperManager.installRequiredRuntimeServices()
+    }
+
+    private func helperRepairVHIDDaemonServices() async throws {
+        #if DEBUG
+            if let override = Self.helperRepairVHIDDaemonServicesOverride {
+                try await override()
+                return
+            }
+        #endif
+        try await helperManager.repairVHIDDaemonServices()
+    }
+
     private func killExistingKanataProcessesForServiceRecovery() async throws {
         #if DEBUG
             if let override = Self.killExistingKanataProcessesOverride {
@@ -451,6 +497,44 @@ public final class PrivilegedOperationsRouter {
                 "Kanata postcondition failed after \(operation): \(readiness.failureDescription)"
             )
         }
+    }
+
+    private func enforceVHIDServicesPostcondition(after operation: String) async throws {
+        guard await verifyVHIDServicesPostcondition(context: operation) else {
+            throw PrivilegedOperationError.operationFailed(
+                "VHID services postcondition failed after \(operation)"
+            )
+        }
+    }
+
+    private func verifyVHIDServicesPostcondition(context: String) async -> Bool {
+        #if DEBUG
+            if let override = Self.vhidServicesPostconditionOverride {
+                return await override(context)
+            }
+        #endif
+
+        let deadline = Date().addingTimeInterval(Self.vhidVerifyTimeoutSeconds)
+        repeat {
+            serviceHealthChecker.invalidateHealthCache()
+            let status = await serviceHealthChecker.getServiceStatus()
+            let configured = serviceHealthChecker.isVHIDDaemonConfiguredCorrectly()
+            if status.vhidDaemonServiceLoaded,
+               status.vhidManagerServiceLoaded,
+               status.vhidDaemonServiceHealthy,
+               status.vhidManagerServiceHealthy,
+               configured
+            {
+                return true
+            }
+            do { try await Task.sleep(for: Self.vhidVerifyInterval) }
+            catch { return false }
+        } while Date() < deadline
+
+        AppLogger.shared.warn(
+            "⚠️ [PrivilegedOperationsRouter] VHID services postcondition failed after \(context)"
+        )
+        return false
     }
 
     private func verifyKanataReadinessAfterInstall(context: String) async -> KanataReadinessResult {

--- a/Sources/KeyPathInstallationWizard/Core/ActionDeterminer.swift
+++ b/Sources/KeyPathInstallationWizard/Core/ActionDeterminer.swift
@@ -42,8 +42,9 @@ public enum ActionDeterminer {
             actions.append(.fixDriverVersionMismatch)
         }
 
-        // Check missing components
-        if !context.components.hasAllRequired {
+        // Check missing installable components. Keep health/runtime failures on
+        // the narrower repair paths below instead of treating them as absent.
+        if hasMissingInstallableComponents(context.components) {
             actions.append(.installMissingComponents)
 
             // CRITICAL: Activate manager BEFORE starting daemon
@@ -98,8 +99,9 @@ public enum ActionDeterminer {
             actions.append(.fixDriverVersionMismatch)
         }
 
-        // Check missing components
-        if !context.components.hasAllRequired {
+        // Check missing installable components. Keep health/runtime failures on
+        // the narrower repair paths below instead of treating them as absent.
+        if hasMissingInstallableComponents(context.components) {
             actions.append(.installMissingComponents)
 
             // CRITICAL: Activate manager BEFORE installing daemon services
@@ -140,6 +142,12 @@ public enum ActionDeterminer {
     public static func determineUninstallActions(context _: SystemContext) -> [AutoFixAction] {
         // Uninstall is handled differently - logic is in UninstallCoordinator
         []
+    }
+
+    private static func hasMissingInstallableComponents(_ components: ComponentStatus) -> Bool {
+        !components.kanataBinaryInstalled ||
+            !components.karabinerDriverInstalled ||
+            !components.vhidDeviceInstalled
     }
 
     private static func appendVHIDActivationRepairIfNeeded(

--- a/Tests/KeyPathTests/Core/PrivilegedOperationsCoordinatorTests.swift
+++ b/Tests/KeyPathTests/Core/PrivilegedOperationsCoordinatorTests.swift
@@ -34,6 +34,7 @@ final class PrivilegedOperationsRouterTests: XCTestCase {
                 KanataDaemonManager.registeredButNotLoadedOverride = nil
                 ServiceHealthChecker.runtimeSnapshotOverride = nil
                 ServiceHealthChecker.recentlyRestartedOverride = nil
+                HelperManager.testHelperFunctionalityOverride = nil
             #endif
             TestEnvironment.allowAdminOperationsInTests = originalAllowAdminOperationsInTests
             if let originalSudoEnv {
@@ -279,6 +280,64 @@ final class PrivilegedOperationsRouterTests: XCTestCase {
 
         #if DEBUG
             XCTAssertEqual(killCalls, 1)
+        #endif
+    }
+
+    func testHelperBackedVHIDRepairFailsWhenPostconditionFails() async throws {
+        #if DEBUG
+            PrivilegedOperationsRouter.resetTestingState()
+            PrivilegedOperationsRouter.operationModeOverride = .privilegedHelper
+            HelperManager.testHelperFunctionalityOverride = { true }
+            var helperRepairCalls = 0
+            PrivilegedOperationsRouter.helperRepairVHIDDaemonServicesOverride = {
+                helperRepairCalls += 1
+            }
+            PrivilegedOperationsRouter.vhidServicesPostconditionOverride = { _ in false }
+        #else
+            throw XCTSkip("Uses DEBUG-only PrivilegedOperationsRouter test overrides")
+        #endif
+
+        let coordinator = PrivilegedOperationsRouter.shared
+        do {
+            try await coordinator.repairVHIDDaemonServices()
+            XCTFail("Expected helper-backed VHID repair to fail when postcondition fails")
+        } catch let PrivilegedOperationError.operationFailed(message) {
+            XCTAssertTrue(message.contains("VHID services postcondition failed"))
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+
+        #if DEBUG
+            XCTAssertEqual(helperRepairCalls, 1)
+        #endif
+    }
+
+    func testHelperBackedRuntimeInstallFailsWhenKanataPostconditionFails() async throws {
+        #if DEBUG
+            PrivilegedOperationsRouter.resetTestingState()
+            PrivilegedOperationsRouter.operationModeOverride = .privilegedHelper
+            var helperInstallCalls = 0
+            PrivilegedOperationsRouter.helperInstallRequiredRuntimeServicesOverride = {
+                helperInstallCalls += 1
+            }
+            PrivilegedOperationsRouter.vhidServicesPostconditionOverride = { _ in true }
+            PrivilegedOperationsRouter.kanataReadinessOverride = { _ in .timedOut }
+        #else
+            throw XCTSkip("Uses DEBUG-only PrivilegedOperationsRouter test overrides")
+        #endif
+
+        let coordinator = PrivilegedOperationsRouter.shared
+        do {
+            try await coordinator.installRequiredRuntimeServices()
+            XCTFail("Expected runtime install to fail when Kanata postcondition fails")
+        } catch let PrivilegedOperationError.installationFailed(message) {
+            XCTAssertTrue(message.contains("Kanata postcondition failed"))
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+
+        #if DEBUG
+            XCTAssertEqual(helperInstallCalls, 1)
         #endif
     }
 

--- a/Tests/KeyPathTests/InstallationWizard/WizardPureLogicTests.swift
+++ b/Tests/KeyPathTests/InstallationWizard/WizardPureLogicTests.swift
@@ -1124,6 +1124,28 @@ final class WizardPureLogicTests: XCTestCase {
         let context = makeContext(components: components)
         let actions = ActionDeterminer.determineRepairActions(context: context)
         XCTAssertTrue(actions.contains(.installRequiredRuntimeServices))
+        XCTAssertFalse(
+            actions.contains(.installMissingComponents),
+            "Installed-but-unhealthy VHID services should repair runtime services, not reinstall missing components"
+        )
+    }
+
+    func test_determineRepairActions_vhidDeviceUnhealthy_excludesInstallMissingComponents() {
+        let components = ComponentStatus(
+            kanataBinaryInstalled: true,
+            karabinerDriverInstalled: true,
+            karabinerDaemonRunning: true,
+            vhidDeviceInstalled: true,
+            vhidDeviceHealthy: false,
+            vhidServicesHealthy: true,
+            vhidVersionMismatch: false
+        )
+        let context = makeContext(components: components)
+        let actions = ActionDeterminer.determineRepairActions(context: context)
+        XCTAssertFalse(
+            actions.contains(.installMissingComponents),
+            "A present but unhealthy VHID device should not be planned as a missing component"
+        )
     }
 
     func test_determineRepairActions_vhidDaemonPlistMisconfigured_includesInstallRuntimeServices() {
@@ -1160,6 +1182,25 @@ final class WizardPureLogicTests: XCTestCase {
         let actions = ActionDeterminer.determineInstallActions(context: context)
         XCTAssertTrue(actions.contains(.installRequiredRuntimeServices),
                       "Install plans share the vhidRuntimeServicesNeedRepair trigger with repair plans")
+    }
+
+    func test_determineInstallActions_vhidServicesUnhealthy_excludesInstallMissingComponents() {
+        let components = ComponentStatus(
+            kanataBinaryInstalled: true,
+            karabinerDriverInstalled: true,
+            karabinerDaemonRunning: true,
+            vhidDeviceInstalled: true,
+            vhidDeviceHealthy: true,
+            vhidServicesHealthy: false,
+            vhidVersionMismatch: false
+        )
+        let context = makeContext(components: components)
+        let actions = ActionDeterminer.determineInstallActions(context: context)
+        XCTAssertTrue(actions.contains(.installRequiredRuntimeServices))
+        XCTAssertFalse(
+            actions.contains(.installMissingComponents),
+            "Install planning should not reinstall components just because installed VHID services are unhealthy"
+        )
     }
 
     func test_determineInstallActions_vhidDriverNotActivated_includesActivationAndRepair() {


### PR DESCRIPTION
## Summary
- enforce VHID service and Kanata runtime postconditions after helper and sudo installer repair paths
- make VHID repair fail or fall back when helper-reported success does not produce healthy services
- keep installed-but-unhealthy VHID components on narrower repair actions instead of planning missing-component installs
- add regression tests for helper-backed postcondition failures and unhealthy-present planner states

## Root cause
The installer and repair paths could treat helper or sudo command completion as success without proving the resulting service state. Separately, wizard planning reused `hasAllRequired`, which mixes physical presence with health, so present-but-unhealthy VHID state could be routed as a missing-component install.

Fixes #972.
Fixes #973.
Fixes #974.

## Validation
- `TEST_FILTER='PrivilegedOperationsRouterTests|WizardPureLogicTests' ./Scripts/run-tests-safe.sh` — 115 passed
- `./Scripts/run-tests-safe.sh` — 4414 passed
- `python3 Scripts/check-accessibility.py` — passed
- `git diff --check` — passed

Note: `./Scripts/test-fast.sh --changed` forces `KEYPATH_SNAPSHOTS=1` for this router change and hit an unrelated `KeyPathSnapshotTests` signal 11 after the main suite passed. The normal non-snapshot safe suite is green.
