### PR TITLE
[codex] Speed up Claude review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -10,6 +10,10 @@ on:
     #   - "src/**/*.js"
     #   - "src/**/*.jsx"
 
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   claude-review:
     # Optional: Filter by PR author
@@ -71,20 +75,19 @@ jobs:
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
 
-            Please review this pull request and provide feedback on:
-            - Code quality and best practices
-            - Potential bugs or issues
-            - Performance considerations
-            - Security concerns
-            - Test coverage
+            Review only the changed diff in this pull request. Keep the review bounded:
+            do not search issues, list other PRs, or inspect unrelated repository history.
 
-            Use the repository's CLAUDE.md for guidance on style and conventions. Be constructive and helpful in your feedback.
+            Focus on actionable correctness, reliability, security, performance, and
+            test-coverage findings. Use the repository's CLAUDE.md for style and
+            conventions when it is directly relevant to the diff.
 
-            Use `gh pr comment` with your Bash tool to leave your review as a comment on the PR.
+            Use `gh pr comment` with your Bash tool to leave one concise review comment
+            on the PR. If there are no actionable findings, say so briefly.
 
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+          claude_args: '--max-turns 4 --allowed-tools "Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"'
 
       - name: Skip Claude review for workflow-file changes
         if: steps.changes.outputs.workflow_changed == 'true'


### PR DESCRIPTION
## Summary
- cancel stale Claude review runs when a PR is force-pushed
- bound automatic Claude review to 4 turns
- restrict automatic review tools to PR diff/view/comment only
- tighten the prompt to review the changed diff and leave one concise comment

## Why
Claude review should overlap CI and finish before or near the build/test lane. The previous setup allowed issue search/list and broad repository exploration, which made the review job the long poll on small PRs.

## Notes
This workflow intentionally skips self-review when `.github/workflows/claude-code-review.yml` changes, so the speedup will be exercised on the next non-workflow PR.

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/claude-code-review.yml"); puts "yaml ok"'`
