### PR TITLE
[codex] test installer repair fallback coverage

### DIFF
--- a/Sources/KeyPathAppKit/CLI/SystemFacade.swift
+++ b/Sources/KeyPathAppKit/CLI/SystemFacade.swift
@@ -13,6 +13,7 @@ public struct SystemFacade: Sendable {
     private let runtimeTransitionTimeoutSeconds: TimeInterval
     private let pollDelayNanoseconds: UInt64
     private let restartDelayNanoseconds: UInt64
+    private let makeInstallerEngine: @MainActor @Sendable () -> InstallerEngine
 
     public init() {
         self.init(
@@ -28,13 +29,21 @@ public struct SystemFacade: Sendable {
         runtimeSnapshotProvider: @escaping @Sendable () async -> RuntimeSnapshot,
         runtimeTransitionTimeoutSeconds: TimeInterval = 5,
         pollDelayNanoseconds: UInt64 = 200_000_000,
-        restartDelayNanoseconds: UInt64 = 500_000_000
+        restartDelayNanoseconds: UInt64 = 500_000_000,
+        systemValidator: (any WizardSystemValidating)? = nil
     ) {
         self.subprocessRunner = subprocessRunner
         self.runtimeSnapshotProvider = runtimeSnapshotProvider
         self.runtimeTransitionTimeoutSeconds = runtimeTransitionTimeoutSeconds
         self.pollDelayNanoseconds = pollDelayNanoseconds
         self.restartDelayNanoseconds = restartDelayNanoseconds
+        self.makeInstallerEngine = {
+            InstallerEngine(
+                processLifecycleManager: ProcessLifecycleManager(),
+                systemValidator: systemValidator,
+                kanataManager: nil
+            )
+        }
     }
 
     // MARK: - Service Lifecycle
@@ -103,7 +112,7 @@ public struct SystemFacade: Sendable {
     @MainActor
     public func runStatus() async -> CLIStatusResult {
         CLIRuntimeBootstrap.ensureConfigured()
-        let engine = InstallerEngine()
+        let engine = makeInstallerEngine()
         let context = await engine.inspectSystem()
 
         return CLIStatusResult(
@@ -140,7 +149,7 @@ public struct SystemFacade: Sendable {
         if let bundleIssue = Self.systemRepairBundleIssue() {
             return CLIInstallerReport(bundleIssue: bundleIssue, dryRun: dryRun, title: "Installation")
         }
-        let engine = InstallerEngine()
+        let engine = makeInstallerEngine()
         let context = await engine.inspectSystem()
         let plan = await engine.makePlan(for: .install, context: context)
         if dryRun {
@@ -168,7 +177,7 @@ public struct SystemFacade: Sendable {
         if let bundleIssue = Self.systemRepairBundleIssue() {
             return CLIInstallerReport(bundleIssue: bundleIssue, dryRun: dryRun, title: "Repair")
         }
-        let engine = InstallerEngine()
+        let engine = makeInstallerEngine()
         let context = await engine.inspectSystem()
         let plan = await engine.makePlan(for: .repair, context: context)
         if dryRun {

--- a/Sources/KeyPathAppKit/Core/PrivilegedOperationsRouter.swift
+++ b/Sources/KeyPathAppKit/Core/PrivilegedOperationsRouter.swift
@@ -42,6 +42,8 @@ public final class PrivilegedOperationsRouter {
             ((String) async -> KanataReadinessResult)?
         nonisolated(unsafe) static var helperInstallRequiredRuntimeServicesOverride: (() async throws -> Void)?
         nonisolated(unsafe) static var helperRepairVHIDDaemonServicesOverride: (() async throws -> Void)?
+        nonisolated(unsafe) static var sudoInstallRequiredRuntimeServicesOverride: (() async throws -> Void)?
+        nonisolated(unsafe) static var sudoRepairVHIDDaemonServicesOverride: (() async throws -> Void)?
         nonisolated(unsafe) static var vhidServicesPostconditionOverride: ((String) async -> Bool)?
 
         static func resetTestingState() {
@@ -53,6 +55,8 @@ public final class PrivilegedOperationsRouter {
             kanataReadinessOverride = nil
             helperInstallRequiredRuntimeServicesOverride = nil
             helperRepairVHIDDaemonServicesOverride = nil
+            sudoInstallRequiredRuntimeServicesOverride = nil
+            sudoRepairVHIDDaemonServicesOverride = nil
             vhidServicesPostconditionOverride = nil
             lastServiceInstallAttempt = nil
             lastSMAppApprovalNotice = nil
@@ -354,6 +358,13 @@ public final class PrivilegedOperationsRouter {
     // MARK: - Sudo Implementations
 
     private func sudoInstallRequiredRuntimeServices() async throws {
+        #if DEBUG
+            if let override = Self.sudoInstallRequiredRuntimeServicesOverride {
+                try await override()
+                return
+            }
+        #endif
+
         let success = await ServiceBootstrapper.shared.installAllServices()
         if !success {
             throw PrivilegedOperationError.installationFailed("Required runtime service installation failed")
@@ -382,6 +393,13 @@ public final class PrivilegedOperationsRouter {
     }
 
     private func sudoRepairVHIDServices() async throws {
+        #if DEBUG
+            if let override = Self.sudoRepairVHIDDaemonServicesOverride {
+                try await override()
+                return
+            }
+        #endif
+
         let success = await ServiceBootstrapper.shared.repairVHIDDaemonServices()
         if !success {
             throw PrivilegedOperationError.operationFailed("VHID daemon repair failed")

--- a/Tests/KeyPathTests/CLI/CLIServiceTests.swift
+++ b/Tests/KeyPathTests/CLI/CLIServiceTests.swift
@@ -1,6 +1,9 @@
+import Foundation
 @testable import KeyPathAppKit
 @testable import KeyPathCore
 @testable import KeyPathInstallationWizard
+import KeyPathPermissions
+import KeyPathWizardCore
 @preconcurrency import XCTest
 
 @MainActor
@@ -24,6 +27,34 @@ final class CLIServiceTests: XCTestCase {
     func testServiceLogsDefaultsTo50Lines() {
         let lines = facade.serviceLogs()
         XCTAssertTrue(lines.count <= 50)
+    }
+
+    // MARK: - installer planning
+
+    func testRepairDryRunPlansRuntimeServicesForStaleVHIDPlist() async throws {
+        let fixture = try makeCLIRepairFixture()
+        defer { fixture.cleanup() }
+
+        #if DEBUG
+            ServiceHealthChecker.shared.invalidateHealthCache()
+        #endif
+
+        let facade = SystemFacade(
+            subprocessRunner: SubprocessRunnerFake.shared,
+            runtimeSnapshotProvider: { Self.runtimeSnapshot(running: true, responding: true) },
+            systemValidator: FixtureSystemValidator()
+        )
+        let report = await facade.runRepair(dryRun: true)
+        let plannedRecipes = try XCTUnwrap(report.plannedRecipes)
+
+        XCTAssertTrue(
+            plannedRecipes.contains("\(InstallerRecipeID.installRequiredRuntimeServices) (installComponent)"),
+            "Stale VHID LaunchDaemon config should plan the targeted runtime services repair"
+        )
+        XCTAssertFalse(
+            plannedRecipes.contains { $0.contains(InstallerRecipeID.installMissingComponents) },
+            "Stale VHID LaunchDaemon config must not fall back to the generic missing-components repair"
+        )
     }
 
     // MARK: - service lifecycle
@@ -129,6 +160,136 @@ final class CLIServiceTests: XCTestCase {
             staleEnabledRegistration: false,
             recentlyRestarted: false
         )
+    }
+
+    private func makeCLIRepairFixture() throws -> CLIRepairFixture {
+        let fileManager = FileManager.default
+        let root = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("CLIRepairFixture-\(UUID().uuidString)", isDirectory: true)
+        let launchDaemonsDir = root.appendingPathComponent("LaunchDaemons", isDirectory: true)
+        let bundledKanata = root.appendingPathComponent("kanata")
+        let bundledLauncher = root.appendingPathComponent("Kanata Engine")
+        try fileManager.createDirectory(at: launchDaemonsDir, withIntermediateDirectories: true)
+        try Data().write(to: bundledKanata)
+        try Data().write(to: bundledLauncher)
+
+        let staleVHIDPlist: [String: Any] = [
+            "Label": ServiceHealthChecker.vhidDaemonServiceID,
+            "ProgramArguments": [PlistGenerator.vhidDaemonPath],
+        ]
+        let staleVHIDData = try PropertyListSerialization.data(
+            fromPropertyList: staleVHIDPlist,
+            format: .xml,
+            options: 0
+        )
+        try staleVHIDData.write(
+            to: launchDaemonsDir.appendingPathComponent("\(ServiceHealthChecker.vhidDaemonServiceID).plist")
+        )
+
+        let bundlePath = URL(fileURLWithPath: Bundle.main.bundlePath, isDirectory: true)
+        let bundleFiles = [
+            bundlePath.appendingPathComponent("Contents/MacOS/keypath-cli"),
+            bundlePath.appendingPathComponent("Contents/Library/LaunchDaemons/com.keypath.kanata.plist"),
+            bundlePath.appendingPathComponent("Contents/Library/HelperTools/KeyPathHelper"),
+        ]
+        var createdBundleFiles: [URL] = []
+        for file in bundleFiles {
+            try fileManager.createDirectory(
+                at: file.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            if !fileManager.fileExists(atPath: file.path) {
+                try Data().write(to: file)
+                createdBundleFiles.append(file)
+            }
+        }
+
+        let environmentKeys = [
+            "KEYPATH_LAUNCH_DAEMONS_DIR",
+            "KEYPATH_BUNDLED_KANATA_OVERRIDE",
+            "KEYPATH_BUNDLED_KANATA_LAUNCHER_OVERRIDE",
+        ]
+        let originalEnvironment = Dictionary(
+            uniqueKeysWithValues: environmentKeys.map { ($0, ProcessInfo.processInfo.environment[$0]) }
+        )
+        setenv("KEYPATH_LAUNCH_DAEMONS_DIR", launchDaemonsDir.path, 1)
+        setenv("KEYPATH_BUNDLED_KANATA_OVERRIDE", bundledKanata.path, 1)
+        setenv("KEYPATH_BUNDLED_KANATA_LAUNCHER_OVERRIDE", bundledLauncher.path, 1)
+
+        return CLIRepairFixture(
+            root: root,
+            createdBundleFiles: createdBundleFiles,
+            originalEnvironment: originalEnvironment
+        )
+    }
+}
+
+@MainActor
+private final class FixtureSystemValidator: WizardSystemValidating {
+    func checkSystem() async -> SystemSnapshot {
+        let now = Date()
+        let permissionSet = PermissionOracle.PermissionSet(
+            accessibility: .granted,
+            inputMonitoring: .granted,
+            source: "fixture",
+            confidence: .high,
+            timestamp: now
+        )
+        let permissions = PermissionOracle.Snapshot(
+            keyPath: permissionSet,
+            kanata: permissionSet,
+            timestamp: now
+        )
+        let staleVHIDPlist = ServiceHealthChecker.shared.isVHIDDaemonPlistPresentButMisconfigured()
+
+        return SystemSnapshot(
+            permissions: permissions,
+            components: ComponentStatus(
+                kanataBinaryInstalled: true,
+                karabinerDriverInstalled: true,
+                karabinerDaemonRunning: true,
+                vhidDeviceInstalled: true,
+                vhidDeviceHealthy: true,
+                vhidServicesHealthy: true,
+                vhidDaemonPlistMisconfigured: staleVHIDPlist,
+                vhidVersionMismatch: false
+            ),
+            conflicts: ConflictStatus(conflicts: [], canAutoResolve: false),
+            health: HealthStatus(
+                kanataRunning: true,
+                karabinerDaemonRunning: true,
+                vhidHealthy: true,
+                kanataInputCaptureReady: true,
+                kanataInputCaptureIssue: nil
+            ),
+            helper: HelperStatus(isInstalled: true, version: "1.0.0", isWorking: true),
+            timestamp: now
+        )
+    }
+}
+
+@MainActor
+private struct CLIRepairFixture {
+    let root: URL
+    let createdBundleFiles: [URL]
+    let originalEnvironment: [String: String?]
+
+    func cleanup() {
+        let fileManager = FileManager.default
+        try? fileManager.removeItem(at: root)
+        for file in createdBundleFiles {
+            try? fileManager.removeItem(at: file)
+        }
+        for (key, value) in originalEnvironment {
+            if let value {
+                setenv(key, value, 1)
+            } else {
+                unsetenv(key)
+            }
+        }
+        #if DEBUG
+            ServiceHealthChecker.shared.invalidateHealthCache()
+        #endif
     }
 }
 

--- a/Tests/KeyPathTests/Core/PrivilegedOperationsCoordinatorTests.swift
+++ b/Tests/KeyPathTests/Core/PrivilegedOperationsCoordinatorTests.swift
@@ -312,6 +312,38 @@ final class PrivilegedOperationsRouterTests: XCTestCase {
         #endif
     }
 
+    func testHelperBackedVHIDRepairFallsBackToSudoWhenHelperPostconditionFails() async throws {
+        #if DEBUG
+            PrivilegedOperationsRouter.resetTestingState()
+            PrivilegedOperationsRouter.operationModeOverride = .privilegedHelper
+            HelperManager.testHelperFunctionalityOverride = { true }
+            var helperRepairCalls = 0
+            var sudoRepairCalls = 0
+            var postconditionCalls = 0
+            PrivilegedOperationsRouter.helperRepairVHIDDaemonServicesOverride = {
+                helperRepairCalls += 1
+            }
+            PrivilegedOperationsRouter.sudoRepairVHIDDaemonServicesOverride = {
+                sudoRepairCalls += 1
+            }
+            PrivilegedOperationsRouter.vhidServicesPostconditionOverride = { _ in
+                postconditionCalls += 1
+                return postconditionCalls > 1
+            }
+        #else
+            throw XCTSkip("Uses DEBUG-only PrivilegedOperationsRouter test overrides")
+        #endif
+
+        let coordinator = PrivilegedOperationsRouter.shared
+        try await coordinator.repairVHIDDaemonServices()
+
+        #if DEBUG
+            XCTAssertEqual(helperRepairCalls, 1)
+            XCTAssertEqual(sudoRepairCalls, 1)
+            XCTAssertEqual(postconditionCalls, 2)
+        #endif
+    }
+
     func testHelperBackedRuntimeInstallFailsWhenKanataPostconditionFails() async throws {
         #if DEBUG
             PrivilegedOperationsRouter.resetTestingState()
@@ -338,6 +370,85 @@ final class PrivilegedOperationsRouterTests: XCTestCase {
 
         #if DEBUG
             XCTAssertEqual(helperInstallCalls, 1)
+        #endif
+    }
+
+    func testHelperBackedRuntimeInstallFallsBackToSudoWhenHelperThrows() async throws {
+        #if DEBUG
+            PrivilegedOperationsRouter.resetTestingState()
+            PrivilegedOperationsRouter.operationModeOverride = .privilegedHelper
+            var helperInstallCalls = 0
+            var sudoInstallCalls = 0
+            PrivilegedOperationsRouter.helperInstallRequiredRuntimeServicesOverride = {
+                helperInstallCalls += 1
+                throw PrivilegedOperationError.operationFailed("helper unavailable")
+            }
+            PrivilegedOperationsRouter.sudoInstallRequiredRuntimeServicesOverride = {
+                sudoInstallCalls += 1
+            }
+            PrivilegedOperationsRouter.vhidServicesPostconditionOverride = { _ in true }
+            PrivilegedOperationsRouter.kanataReadinessOverride = { _ in .ready }
+        #else
+            throw XCTSkip("Uses DEBUG-only PrivilegedOperationsRouter test overrides")
+        #endif
+
+        let coordinator = PrivilegedOperationsRouter.shared
+        try await coordinator.installRequiredRuntimeServices()
+
+        #if DEBUG
+            XCTAssertEqual(helperInstallCalls, 1)
+            XCTAssertEqual(sudoInstallCalls, 1)
+        #endif
+    }
+
+    func testDirectSudoRuntimeInstallFailsWhenKanataPostconditionFails() async throws {
+        #if DEBUG
+            PrivilegedOperationsRouter.resetTestingState()
+            PrivilegedOperationsRouter.operationModeOverride = .directSudo
+            var sudoInstallCalls = 0
+            PrivilegedOperationsRouter.sudoInstallRequiredRuntimeServicesOverride = {
+                sudoInstallCalls += 1
+            }
+            PrivilegedOperationsRouter.vhidServicesPostconditionOverride = { _ in true }
+            PrivilegedOperationsRouter.kanataReadinessOverride = { _ in .timedOut }
+        #else
+            throw XCTSkip("Uses DEBUG-only PrivilegedOperationsRouter test overrides")
+        #endif
+
+        let coordinator = PrivilegedOperationsRouter.shared
+        do {
+            try await coordinator.installRequiredRuntimeServices()
+            XCTFail("Expected direct sudo install to fail when Kanata postcondition fails")
+        } catch let PrivilegedOperationError.operationFailed(message) {
+            XCTAssertTrue(message.contains("Kanata postcondition failed"))
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+
+        #if DEBUG
+            XCTAssertEqual(sudoInstallCalls, 1)
+        #endif
+    }
+
+    func testDirectSudoRuntimeInstallAllowsPendingApprovalPostcondition() async throws {
+        #if DEBUG
+            PrivilegedOperationsRouter.resetTestingState()
+            PrivilegedOperationsRouter.operationModeOverride = .directSudo
+            var sudoInstallCalls = 0
+            PrivilegedOperationsRouter.sudoInstallRequiredRuntimeServicesOverride = {
+                sudoInstallCalls += 1
+            }
+            PrivilegedOperationsRouter.vhidServicesPostconditionOverride = { _ in true }
+            PrivilegedOperationsRouter.kanataReadinessOverride = { _ in .pendingApproval }
+        #else
+            throw XCTSkip("Uses DEBUG-only PrivilegedOperationsRouter test overrides")
+        #endif
+
+        let coordinator = PrivilegedOperationsRouter.shared
+        try await coordinator.installRequiredRuntimeServices()
+
+        #if DEBUG
+            XCTAssertEqual(sudoInstallCalls, 1)
         #endif
     }
 


### PR DESCRIPTION
## Summary
- add deterministic CLI/SystemFacade dry-run coverage for stale VHID LaunchDaemon repair planning
- add router fallback/postcondition matrix coverage for helper and sudo installer repair paths
- add DEBUG-only test seams so router fallback tests do not touch privileged system services

## Why
The installer/repair fixes from #971 are now covered below the GUI layer, where CLI and GUI behavior converge. The new tests lock in that a stale VHID daemon plist plans the targeted runtime-services repair instead of generic missing-components repair, and that helper/sudo fallback behavior honors postconditions and pending SMAppService approval.

## Validation
- `TEST_FILTER='CLIServiceTests|PrivilegedOperationsRouterTests' ./Scripts/run-tests-safe.sh` passed: 29 tests
- `TEST_FILTER='InstallerEnginePlanTests|InstallerEngineFailurePathTests|WizardPureLogicTests|CLIServiceTests|PrivilegedOperationsRouterTests' ./Scripts/run-tests-safe.sh` passed: 161 tests
- `git diff --check`
