### PR TITLE
[codex] Fix startup gallery conflicts

### DIFF
--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+Bootstrap.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+Bootstrap.swift
@@ -75,6 +75,16 @@ extension RuleCollectionsManager {
                     continue
                 }
                 if !ruleCollections[index].isEnabled {
+                    var candidate = ruleCollections[index]
+                    candidate.isEnabled = true
+                    if let conflict = conflictInfo(for: candidate) {
+                        let keys = conflict.keys.sorted().joined(separator: ", ")
+                        AppLogger.shared.log(
+                            "⚠️ [Bootstrap] Skipped re-enabling '\(candidate.name)' for installed pack '\(pack.name)' because it conflicts with \(conflict.displayName) on \(keys)"
+                        )
+                        continue
+                    }
+
                     ruleCollections[index].isEnabled = true
                     fixedCount += 1
                     AppLogger.shared.log(

--- a/Sources/KeyPathAppKit/UI/RootView.swift
+++ b/Sources/KeyPathAppKit/UI/RootView.swift
@@ -10,6 +10,8 @@ struct RootView: View {
     @Environment(KanataViewModel.self) private var kanataVM
 
     var body: some View {
+        @Bindable var kanataVM = kanataVM
+
         SplashView()
             .sheet(isPresented: $showingWhatsNew) {
                 WhatsNewView()
@@ -27,6 +29,34 @@ struct RootView: View {
             .sheet(isPresented: $showingSimpleModsDialog) {
                 SimpleModsView(configPath: kanataVM.configPath)
                     .environment(kanataVM)
+            }
+            .sheet(isPresented: $kanataVM.showRuleConflictDialog) {
+                if let context = kanataVM.pendingRuleConflict {
+                    RuleConflictResolutionDialog(
+                        context: context,
+                        onChoice: { choice in
+                            kanataVM.resolveRuleConflict(with: choice)
+                        },
+                        onCancel: {
+                            kanataVM.resolveRuleConflict(with: nil)
+                        }
+                    )
+                    .interactiveDismissDisabled()
+                }
+            }
+            .sheet(isPresented: $kanataVM.showMappingConflictDialog) {
+                if let context = kanataVM.pendingMappingConflict {
+                    MappingConflictResolutionDialog(
+                        context: context,
+                        onChoice: { collectionID in
+                            kanataVM.resolveMappingConflict(disabling: collectionID)
+                        },
+                        onCancel: {
+                            kanataVM.resolveMappingConflict(disabling: nil)
+                        }
+                    )
+                    .interactiveDismissDisabled()
+                }
             }
             .onReceive(NotificationCenter.default.publisher(for: .showEmergencyStop)) { _ in
                 showingEmergencyStopDialog = true

--- a/Sources/KeyPathAppKit/UI/Rules/ActiveRulesView.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/ActiveRulesView.swift
@@ -53,34 +53,6 @@ struct ActiveRulesView: View {
                 .padding(.vertical, 8)
             }
             .settingsBackground()
-            .sheet(isPresented: $kanataManager.showRuleConflictDialog) {
-                if let context = kanataManager.pendingRuleConflict {
-                    RuleConflictResolutionDialog(
-                        context: context,
-                        onChoice: { choice in
-                            kanataManager.resolveRuleConflict(with: choice)
-                        },
-                        onCancel: {
-                            kanataManager.resolveRuleConflict(with: nil)
-                        }
-                    )
-                    .interactiveDismissDisabled()
-                }
-            }
-            .sheet(isPresented: $kanataManager.showMappingConflictDialog) {
-                if let context = kanataManager.pendingMappingConflict {
-                    MappingConflictResolutionDialog(
-                        context: context,
-                        onChoice: { collectionID in
-                            kanataManager.resolveMappingConflict(disabling: collectionID)
-                        },
-                        onCancel: {
-                            kanataManager.resolveMappingConflict(disabling: nil)
-                        }
-                    )
-                    .interactiveDismissDisabled()
-                }
-            }
         }
     }
 

--- a/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView.swift
@@ -554,34 +554,6 @@ struct RulesTabView: View {
         .sheet(isPresented: $showingHomeRowModsHelp) {
             MarkdownHelpSheet(resource: "home-row-mods", title: "Home Row Mods")
         }
-        .sheet(isPresented: $kanataManager.showRuleConflictDialog) {
-            if let context = kanataManager.pendingRuleConflict {
-                RuleConflictResolutionDialog(
-                    context: context,
-                    onChoice: { choice in
-                        kanataManager.resolveRuleConflict(with: choice)
-                    },
-                    onCancel: {
-                        kanataManager.resolveRuleConflict(with: nil)
-                    }
-                )
-                .interactiveDismissDisabled()
-            }
-        }
-        .sheet(isPresented: $kanataManager.showMappingConflictDialog) {
-            if let context = kanataManager.pendingMappingConflict {
-                MappingConflictResolutionDialog(
-                    context: context,
-                    onChoice: { collectionID in
-                        kanataManager.resolveMappingConflict(disabling: collectionID)
-                    },
-                    onCancel: {
-                        kanataManager.resolveMappingConflict(disabling: nil)
-                    }
-                )
-                .interactiveDismissDisabled()
-            }
-        }
         .alert("Reset Configuration?", isPresented: $showingResetConfirmation) {
             Button("Cancel", role: .cancel) {}
             Button("Open Backups Folder") {

--- a/Tests/KeyPathTests/RuleCollections/RuleCollectionsManagerTests.swift
+++ b/Tests/KeyPathTests/RuleCollections/RuleCollectionsManagerTests.swift
@@ -1015,6 +1015,54 @@ final class RuleCollectionsManagerTests: XCTestCase {
     }
 
     @MainActor
+    func testBootstrapReconciliation_DoesNotReEnableInstalledPackCollectionWhenItConflicts() async throws {
+        TestEnvironment.forceTestMode = true
+        defer { TestEnvironment.forceTestMode = false }
+
+        let originalInstalledPacks = await InstalledPackTracker.shared.allInstalled()
+        for record in originalInstalledPacks {
+            try await InstalledPackTracker.shared.remove(packID: record.packID)
+        }
+        defer {
+            Task {
+                let current = await InstalledPackTracker.shared.allInstalled()
+                for record in current {
+                    try? await InstalledPackTracker.shared.remove(packID: record.packID)
+                }
+                for record in originalInstalledPacks {
+                    try? await InstalledPackTracker.shared.upsert(record)
+                }
+            }
+        }
+
+        let (manager, tempDir) = try await createTestManager()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        try await InstalledPackTracker.shared.upsert(InstalledPackRecord(
+            packID: "com.keypath.pack.home-row-mods",
+            version: "1.0.0"
+        ))
+
+        let defaults = RuleCollectionCatalog().defaultCollections()
+        try await manager.ruleCollectionStore.saveCollections(defaults)
+
+        await manager.bootstrap()
+
+        let homeRowMods = try XCTUnwrap(manager.ruleCollections.first {
+            $0.id == RuleCollectionIdentifier.homeRowMods
+        })
+        let homeRowArrows = try XCTUnwrap(manager.ruleCollections.first {
+            $0.id == RuleCollectionIdentifier.homeRowArrows
+        })
+
+        XCTAssertFalse(
+            homeRowMods.isEnabled,
+            "Stale installed-pack state must not re-enable Home Row Mods over the default Home Row Arrows F-key activator"
+        )
+        XCTAssertTrue(homeRowArrows.isEnabled)
+    }
+
+    @MainActor
     func testBootstrapReconciliation_DoesNotEnableUninstalledPacks() async throws {
         TestEnvironment.forceTestMode = true
         defer { TestEnvironment.forceTestMode = false }


### PR DESCRIPTION
## Summary

- Prevent bootstrap pack reconciliation from re-enabling a disabled installed-pack collection when doing so would create a rule conflict.
- Move rule and mapping conflict dialogs to the root view so pending startup conflicts can be shown immediately instead of waiting for the Rules/Gallery view to mount.
- Add a regression test for stale Home Row Mods installed-pack history colliding with the default Home Row Arrows collection.

## Root Cause

A fresh/default rules catalog enables Home Row Arrows and disables Home Row Mods. On this machine, `~/.config/keypath/installed-packs.json` still had a historical `com.keypath.pack.home-row-mods` record from May 22, 2026. Bootstrap treated that installed-pack record as authoritative and re-enabled the disabled Home Row Mods collection. Home Row Mods maps the `f` key on the base layer while Home Row Arrows uses `f` as a momentary activator, so config generation surfaced the conflict.

## Validation

- `TEST_FILTER=RuleCollectionsManagerTests ./Scripts/run-tests-safe.sh`
- `python3 Scripts/check-accessibility.py`
- `./Scripts/test-fast.sh --changed`