### PR TITLE
ci: fix claude-review max-turns exhaustion (allow read-only tools, 12-turn budget)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -87,7 +87,7 @@ jobs:
 
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-          claude_args: '--max-turns 4 --allowed-tools "Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"'
+          claude_args: '--max-turns 12 --allowed-tools "Read,Grep,Glob,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"'
 
       - name: Skip Claude review for workflow-file changes
         if: steps.changes.outputs.workflow_changed == 'true'


### PR DESCRIPTION
## Summary

Since #976 merged, **every `claude-review` run fails** with `error_max_turns` — observed twice on PR #966 (runs [28742227268](https://github.com/malpern/KeyPath/actions/runs/28742227268) and [28742282550](https://github.com/malpern/KeyPath/actions/runs/28742282550)): the job dies in ~13–20s with 3–4 `permission_denials` in 5 turns and never posts a review.

**Root cause:** the reviewer runs with the standard claude_code system prompt, whose natural first moves are file-inspection tools (Read/Grep). The #976 allowlist permits only three `Bash(gh pr ...)` patterns, so every one of those attempts is denied — and each denial consumes a turn against `--max-turns 4`. The budget is exhausted before the agent ever reaches `gh pr comment`.

## Change (one line)

```
- claude_args: '--max-turns 4 --allowed-tools "Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"'
+ claude_args: '--max-turns 12 --allowed-tools "Read,Grep,Glob,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"'
```

- **Read/Grep/Glob are read-only** and safe here: the job's `contents` permission is already read-only, and the action restores sensitive paths (`.claude`, `CLAUDE.md`, hooks) from `origin/master` before running.
- **12 turns** still bounds the job tightly (each run costs ~$0.15 and 4 turns weren't enough even for the happy path once denials count), while preserving #976's actual intent: no issue search, no PR listing, no repo-history spelunking — those remain excluded.

## Validation

- YAML parses (structure unchanged; single-line string edit).
- This PR itself won't trigger the broken check — the workflow deliberately skips self-review when this file changes — so merging it is the only way to exercise the fix, which the next code PR push will do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142A1G18McVBb1f1Dp7873M

---
_Generated by [Claude Code](https://claude.ai/code/session_0142A1G18McVBb1f1Dp7873M)_