### PR TITLE
[codex] Fix runtime service repair for SMAppService Kanata

### DIFF
--- a/Sources/KeyPathAppKit/Core/PrivilegedOperationsRouter.swift
+++ b/Sources/KeyPathAppKit/Core/PrivilegedOperationsRouter.swift
@@ -40,7 +40,6 @@ public final class PrivilegedOperationsRouter {
         nonisolated(unsafe) static var killExistingKanataProcessesOverride: (() async throws -> Void)?
         nonisolated(unsafe) static var kanataReadinessOverride:
             ((String) async -> KanataReadinessResult)?
-        nonisolated(unsafe) static var helperInstallRequiredRuntimeServicesOverride: (() async throws -> Void)?
         nonisolated(unsafe) static var helperRepairVHIDDaemonServicesOverride: (() async throws -> Void)?
         nonisolated(unsafe) static var vhidServicesPostconditionOverride: ((String) async -> Bool)?
 
@@ -51,7 +50,6 @@ public final class PrivilegedOperationsRouter {
             recoverRequiredRuntimeServicesOverride = nil
             killExistingKanataProcessesOverride = nil
             kanataReadinessOverride = nil
-            helperInstallRequiredRuntimeServicesOverride = nil
             helperRepairVHIDDaemonServicesOverride = nil
             vhidServicesPostconditionOverride = nil
             lastServiceInstallAttempt = nil
@@ -59,6 +57,7 @@ public final class PrivilegedOperationsRouter {
             ServiceInstallGuard.reset()
             KanataDaemonManager.registeredButNotLoadedOverride = nil
             ServiceHealthChecker.runtimeSnapshotOverride = nil
+            ServiceHealthChecker.vhidDriverExtensionEnabledOverride = nil
         }
     #endif
 
@@ -104,50 +103,14 @@ public final class PrivilegedOperationsRouter {
     }
 
     public func installRequiredRuntimeServices() async throws {
-        switch Self.operationMode {
-        case .privilegedHelper:
-            do {
-                try await helperInstallRequiredRuntimeServices()
-                // Stale-helper guard (MAL-57): a resident helper from before
-                // the ProcessType=Interactive template fix reports success but
-                // rewrites the old plist — the helper binary only refreshes on
-                // process restart, so it can lag the app across an update.
-                // Verify the result and redo the rewrite via the in-app sudo
-                // path (ServiceBootstrapper + current PlistGenerator, with its
-                // own configured-postflight). Must NOT route back through the
-                // helper — sudoInstallRequiredRuntimeServices would, via
-                // InstallerEngine → PrivilegeBroker → this router's
-                // helper-first repairVHIDDaemonServices.
-                if serviceHealthChecker.isVHIDDaemonPlistPresentButMisconfigured() {
-                    AppLogger.shared.warnUnlessQuietTest(
-                        "⚠️ [PrivilegedOperationsRouter] VHID daemon plist still misconfigured after helper install — stale helper template, rewriting via in-app sudo path"
-                    )
-                    try await sudoRepairVHIDServices()
-                }
-                try await enforceVHIDServicesPostcondition(after: "installRequiredRuntimeServices(helper)")
-                try await enforceKanataRuntimePostcondition(after: "installRequiredRuntimeServices(helper)")
-            } catch {
-                // Keep the helper's actionable reason (e.g. "driver payload is
-                // not installed") visible — the sudo fallback's generic failure
-                // would otherwise bury it (#928).
-                AppLogger.shared.warnUnlessQuietTest(
-                    "⚠️ [PrivilegedOperationsRouter] Helper install failed (\(error.localizedDescription)) — falling back to sudo path"
-                )
-                do {
-                    try await sudoInstallRequiredRuntimeServices()
-                    try await enforceVHIDServicesPostcondition(after: "installRequiredRuntimeServices(sudo-fallback)")
-                    try await enforceKanataRuntimePostcondition(after: "installRequiredRuntimeServices(sudo-fallback)")
-                } catch let fallbackError {
-                    throw PrivilegedOperationError.installationFailed(
-                        "Runtime service installation failed. Helper: \(error.localizedDescription). Sudo fallback: \(fallbackError.localizedDescription)"
-                    )
-                }
-            }
-        case .directSudo:
-            try await sudoInstallRequiredRuntimeServices()
-            try await enforceVHIDServicesPostcondition(after: "installRequiredRuntimeServices(sudo)")
-            try await enforceKanataRuntimePostcondition(after: "installRequiredRuntimeServices(sudo)")
-        }
+        // Kanata is registered by KeyPath.app through SMAppService. Do not ask
+        // the privileged helper to copy/bootstrap the app-bundled BundleProgram
+        // plist as a legacy LaunchDaemon; launchd rejects that path and BTM state
+        // becomes noisy. ServiceBootstrapper still uses privileged repair for
+        // VHID services, then registers Kanata with SMAppService in-process.
+        try await sudoInstallRequiredRuntimeServices()
+        try await enforceVHIDServicesPostcondition(after: "installRequiredRuntimeServices")
+        try await enforceKanataRuntimePostcondition(after: "installRequiredRuntimeServices")
     }
 
     public func recoverRequiredRuntimeServices() async throws {
@@ -354,6 +317,12 @@ public final class PrivilegedOperationsRouter {
     // MARK: - Sudo Implementations
 
     private func sudoInstallRequiredRuntimeServices() async throws {
+        #if DEBUG
+            if let override = Self.installAllServicesOverride {
+                try await override()
+                return
+            }
+        #endif
         let success = await ServiceBootstrapper.shared.installAllServices()
         if !success {
             throw PrivilegedOperationError.installationFailed("Required runtime service installation failed")
@@ -451,16 +420,6 @@ public final class PrivilegedOperationsRouter {
             }
         #endif
         try await installRequiredRuntimeServices()
-    }
-
-    private func helperInstallRequiredRuntimeServices() async throws {
-        #if DEBUG
-            if let override = Self.helperInstallRequiredRuntimeServicesOverride {
-                try await override()
-                return
-            }
-        #endif
-        try await helperManager.installRequiredRuntimeServices()
     }
 
     private func helperRepairVHIDDaemonServices() async throws {

--- a/Sources/KeyPathHelper/HelperService.swift
+++ b/Sources/KeyPathHelper/HelperService.swift
@@ -128,7 +128,7 @@ class HelperService: NSObject, HelperProtocol {
         executePrivilegedOperation(
             name: "installRequiredRuntimeServices",
             operation: {
-                try Self.installOrRepairKanataService()
+                NSLog("[KeyPathHelper] Kanata is SMAppService-managed by KeyPath.app; repairing VHID services only")
                 try Self.installOrRepairVHIDServices()
             },
             reply: reply
@@ -254,39 +254,6 @@ class HelperService: NSObject, HelperProtocol {
             },
             reply: reply
         )
-    }
-
-    /// Shared implementation for installing/repairing the Kanata service.
-    private static func installOrRepairKanataService() throws {
-        try ensureConsoleUserConfigArtifacts()
-
-        let appBundlePath = appBundlePathFromHelper()
-        let bundledPlistPath = "\(appBundlePath)/Contents/Library/LaunchDaemons/\(kanataServiceID).plist"
-        guard FileManager.default.fileExists(atPath: bundledPlistPath) else {
-            throw HelperError.operationFailed(
-                "Bundled Kanata LaunchDaemon plist is missing: \(bundledPlistPath)"
-            )
-        }
-
-        let dstDir = "/Library/LaunchDaemons"
-        _ = run("/bin/mkdir", ["-p", dstDir])
-        let dstPlistPath = "\(dstDir)/\(kanataServiceID).plist"
-
-        _ = run("/bin/launchctl", ["bootout", "system/\(kanataServiceID)"], timeout: 10)
-        _ = run("/bin/cp", [bundledPlistPath, dstPlistPath])
-        _ = run("/usr/sbin/chown", ["root:wheel", dstPlistPath])
-        _ = run("/bin/chmod", ["644", dstPlistPath])
-
-        guard FileManager.default.fileExists(atPath: dstPlistPath) else {
-            throw HelperError.operationFailed("Kanata LaunchDaemon plist was not installed at \(dstPlistPath)")
-        }
-
-        let bootstrap = run("/bin/launchctl", ["bootstrap", "system", dstPlistPath], timeout: 10)
-        if bootstrap.status != 0, !bootstrap.out.localizedCaseInsensitiveContains("service already loaded") {
-            throw HelperError.operationFailed("bootstrap kanata failed: \(bootstrap.out)")
-        }
-        _ = run("/bin/launchctl", ["enable", "system/\(kanataServiceID)"], timeout: 10)
-        _ = run("/bin/launchctl", ["kickstart", "-k", "system/\(kanataServiceID)"], timeout: 15)
     }
 
     /// Shared implementation for installing/repairing VHID services
@@ -895,17 +862,6 @@ extension HelperService {
     // The helper doesn't have access to KeyPathCore, so we maintain a copy here
     // This is only used for the deprecated download fallback path
     private static let requiredVHIDVersion = "6.0.0"
-
-    fileprivate static func appBundlePathFromHelper() -> String {
-        let exe =
-            CommandLine.arguments.first
-                ?? "/Applications/KeyPath.app/Contents/Library/HelperTools/KeyPathHelper"
-        if let range = exe.range(of: "/Contents/Library/HelperTools/KeyPathHelper") {
-            return String(exe[..<range.lowerBound])
-        }
-        // Fallback to /Applications
-        return "/Applications/KeyPath.app"
-    }
 
     private static func consoleUserInfo() -> (name: String, home: String)? {
         var uid: uid_t = 0

--- a/Sources/KeyPathInstallationWizard/Core/ServiceHealthChecker.swift
+++ b/Sources/KeyPathInstallationWizard/Core/ServiceHealthChecker.swift
@@ -180,6 +180,8 @@ public final class ServiceHealthChecker: @unchecked Sendable {
             ((String, TimeInterval?) -> Bool)?
         public nonisolated(unsafe) static var inputCaptureStatusOverride:
             (() async -> KanataInputCaptureStatus)?
+        public nonisolated(unsafe) static var vhidDriverExtensionEnabledOverride:
+            (() async -> Bool)?
     #endif
 
     // MARK: - Service Identifiers
@@ -192,6 +194,9 @@ public final class ServiceHealthChecker: @unchecked Sendable {
 
     /// Service identifier for the Karabiner Virtual HID Device manager
     public static let vhidManagerServiceID = "com.keypath.karabiner-vhidmanager"
+
+    private static let karabinerDriverExtensionBundleID =
+        "org.pqrs.Karabiner-DriverKit-VirtualHIDDevice"
 
     // MARK: - Service Loaded Check
 
@@ -348,6 +353,16 @@ public final class ServiceHealthChecker: @unchecked Sendable {
                 "🔍 [ServiceHealthChecker] (test) Service \(serviceID) considered healthy: \(exists)"
             )
             return exists
+        }
+
+        if serviceID == Self.vhidDaemonServiceID {
+            let driverEnabled = await isVHIDDriverExtensionEnabled()
+            guard driverEnabled else {
+                AppLogger.shared.log(
+                    "🔍 [ServiceHealthChecker] VHID daemon has launchd state but DriverKit extension is not [activated enabled]"
+                )
+                return false
+            }
         }
 
         AppLogger.shared.log(
@@ -611,7 +626,14 @@ public final class ServiceHealthChecker: @unchecked Sendable {
         let targets = await getDaemonManager()?.preferredLaunchctlTargets(for: managementState) ?? []
         let runningState = await evaluateKanataLaunchctlRunningState(managementState: managementState, launchctlTargets: targets)
         let stderrDiagnosis = await diagnoseDaemonStderr()
-        let inputCapture = Self.resolveInputCaptureStatus(stderrFallback: stderrDiagnosis.inputCapture)
+        let driverEnabled = await isVHIDDriverExtensionEnabled()
+        let stderrFallback = driverEnabled
+            ? stderrDiagnosis.inputCapture
+            : KanataInputCaptureStatus(
+                isReady: false,
+                issue: Self.inputCaptureVHIDDriverNotActivatedReason
+            )
+        let inputCapture = Self.resolveInputCaptureStatus(stderrFallback: stderrFallback)
         let tcpOK = await Task.detached { [self] in
             if let portEnv = ProcessInfo.processInfo.environment["KEYPATH_TCP_PORT"],
                let overridePort = Int(portEnv)
@@ -634,6 +656,42 @@ public final class ServiceHealthChecker: @unchecked Sendable {
                 within: Self.kanataRestartGraceWindow
             )
         )
+    }
+
+    public nonisolated func isVHIDDriverExtensionEnabled() async -> Bool {
+        #if DEBUG
+            if let override = Self.vhidDriverExtensionEnabledOverride {
+                return await override()
+            }
+        #endif
+
+        if TestEnvironment.shouldSkipAdminOperations {
+            return true
+        }
+
+        do {
+            let result = try await subprocessRunner.run(
+                "/usr/bin/systemextensionsctl",
+                args: ["list"],
+                timeout: 5
+            )
+            let output = [result.stdout, result.stderr].joined(separator: "\n")
+            let enabled = Self.systemExtensionsOutputShowsVHIDDriverEnabled(output)
+            if !enabled {
+                AppLogger.shared.log("⚠️ [ServiceHealthChecker] VHID DriverKit extension is not enabled:\n\(output)")
+            }
+            return enabled
+        } catch {
+            AppLogger.shared.log("❌ [ServiceHealthChecker] Unable to inspect VHID DriverKit extension: \(error)")
+            return false
+        }
+    }
+
+    public nonisolated static func systemExtensionsOutputShowsVHIDDriverEnabled(_ output: String) -> Bool {
+        output.components(separatedBy: .newlines).contains { line in
+            line.contains(karabinerDriverExtensionBundleID)
+                && line.contains("[activated enabled]")
+        }
     }
 
     private nonisolated func evaluateKanataLaunchctlRunningState(

--- a/Sources/KeyPathKanataLauncher/LauncherService.swift
+++ b/Sources/KeyPathKanataLauncher/LauncherService.swift
@@ -94,14 +94,23 @@ struct LauncherService {
             return false
         }
 
-        // 2. Check launchctl for daemon service (authoritative — we run as root)
+        // 2. Check the DriverKit extension state. The daemon process can be
+        // running while macOS still reports the extension as [activated disabled];
+        // Kanata then exits with "driver is not activated" on every launch.
+        let driverEnabled = isVHIDDriverExtensionEnabled()
+        logLine("VHID check: DriverKit extension [activated enabled] = \(driverEnabled)")
+        if !driverEnabled {
+            return false
+        }
+
+        // 3. Check launchctl for daemon service (authoritative — we run as root)
         let daemonServiceID = "system/com.keypath.karabiner-vhiddaemon"
         if let daemonOutput = runProcess("/bin/launchctl", arguments: ["print", daemonServiceID]) {
             // Parse for "pid = <number>" which means the service has an active process
             let hasPID = daemonOutput.range(of: #"pid\s*=\s*\d+"#, options: .regularExpression) != nil
             logLine("VHID check: launchctl daemon service has active pid = \(hasPID)")
             if hasPID {
-                // 3. Also verify the manager service is loaded
+                // 4. Also verify the manager service is loaded
                 let managerServiceID = "system/com.keypath.karabiner-vhidmanager"
                 if let _ = runProcess("/bin/launchctl", arguments: ["print", managerServiceID]) {
                     logLine("VHID check: launchctl manager service is loaded")
@@ -117,10 +126,21 @@ struct LauncherService {
             logLine("VHID check: launchctl print for daemon service failed (not loaded?)")
         }
 
-        // 4. Fallback: pgrep for backward compatibility
+        // 5. Fallback: pgrep for backward compatibility
         let pgrepResult = isVHIDDaemonProcessRunning()
         logLine("VHID check: pgrep fallback = \(pgrepResult)")
         return pgrepResult
+    }
+
+    func isVHIDDriverExtensionEnabled() -> Bool {
+        guard let output = runProcess("/usr/bin/systemextensionsctl", arguments: ["list"]) else {
+            logLine("VHID check: systemextensionsctl list failed")
+            return false
+        }
+        return output.components(separatedBy: .newlines).contains { line in
+            line.contains("org.pqrs.Karabiner-DriverKit-VirtualHIDDevice")
+                && line.contains("[activated enabled]")
+        }
     }
 
     /// Fallback process-based check (renamed from isVHIDDaemonRunning).

--- a/Tests/KeyPathTests/Core/PrivilegedOperationsCoordinatorTests.swift
+++ b/Tests/KeyPathTests/Core/PrivilegedOperationsCoordinatorTests.swift
@@ -312,13 +312,13 @@ final class PrivilegedOperationsRouterTests: XCTestCase {
         #endif
     }
 
-    func testHelperBackedRuntimeInstallFailsWhenKanataPostconditionFails() async throws {
+    func testRuntimeInstallUsesSMAppServiceAwareInstallPathBeforeKanataPostcondition() async throws {
         #if DEBUG
             PrivilegedOperationsRouter.resetTestingState()
             PrivilegedOperationsRouter.operationModeOverride = .privilegedHelper
-            var helperInstallCalls = 0
-            PrivilegedOperationsRouter.helperInstallRequiredRuntimeServicesOverride = {
-                helperInstallCalls += 1
+            var installAllServicesCalls = 0
+            PrivilegedOperationsRouter.installAllServicesOverride = {
+                installAllServicesCalls += 1
             }
             PrivilegedOperationsRouter.vhidServicesPostconditionOverride = { _ in true }
             PrivilegedOperationsRouter.kanataReadinessOverride = { _ in .timedOut }
@@ -330,14 +330,14 @@ final class PrivilegedOperationsRouterTests: XCTestCase {
         do {
             try await coordinator.installRequiredRuntimeServices()
             XCTFail("Expected runtime install to fail when Kanata postcondition fails")
-        } catch let PrivilegedOperationError.installationFailed(message) {
+        } catch let PrivilegedOperationError.operationFailed(message) {
             XCTAssertTrue(message.contains("Kanata postcondition failed"))
         } catch {
             XCTFail("Unexpected error type: \(error)")
         }
 
         #if DEBUG
-            XCTAssertEqual(helperInstallCalls, 1)
+            XCTAssertEqual(installAllServicesCalls, 1)
         #endif
     }
 

--- a/Tests/KeyPathTests/Services/ServiceHealthCheckerTests.swift
+++ b/Tests/KeyPathTests/Services/ServiceHealthCheckerTests.swift
@@ -39,6 +39,7 @@ final class ServiceHealthCheckerTests: XCTestCase {
             ServiceHealthChecker.runtimeSnapshotOverride = nil
             ServiceHealthChecker.recentlyRestartedOverride = nil
             ServiceHealthChecker.inputCaptureStatusOverride = nil
+            ServiceHealthChecker.vhidDriverExtensionEnabledOverride = nil
             ServiceHealthChecker.testForcedServiceHealth = nil
             KanataDaemonManager.registeredButNotLoadedOverride = nil
         #endif
@@ -63,6 +64,7 @@ final class ServiceHealthCheckerTests: XCTestCase {
             ServiceHealthChecker.runtimeSnapshotOverride = nil
             ServiceHealthChecker.recentlyRestartedOverride = nil
             ServiceHealthChecker.inputCaptureStatusOverride = nil
+            ServiceHealthChecker.vhidDriverExtensionEnabledOverride = nil
             ServiceHealthChecker.testForcedServiceHealth = nil
             KanataDaemonManager.registeredButNotLoadedOverride = nil
         #endif
@@ -160,6 +162,41 @@ final class ServiceHealthCheckerTests: XCTestCase {
         let health = await checker.checkKanataServiceHealth()
         XCTAssertFalse(health.isRunning)
         XCTAssertFalse(health.isResponding)
+    }
+
+    func testSystemExtensionsOutputShowsVHIDDriverEnabledOnlyForActivatedEnabled() {
+        let enabled = """
+        enabled active teamID bundleID (version) name [state]
+            *    *    G43BCU2T37 org.pqrs.Karabiner-DriverKit-VirtualHIDDevice (1.8.0/1.8.0) org.pqrs.Karabiner-DriverKit-VirtualHIDDevice [activated enabled]
+        """
+        let disabled = """
+        enabled active teamID bundleID (version) name [state]
+            *    G43BCU2T37 org.pqrs.Karabiner-DriverKit-VirtualHIDDevice (1.8.0/1.8.0) org.pqrs.Karabiner-DriverKit-VirtualHIDDevice [activated disabled]
+        """
+
+        XCTAssertTrue(ServiceHealthChecker.systemExtensionsOutputShowsVHIDDriverEnabled(enabled))
+        XCTAssertFalse(ServiceHealthChecker.systemExtensionsOutputShowsVHIDDriverEnabled(disabled))
+    }
+
+    func testRuntimeSnapshotReportsVHIDDriverNotActivatedBeforeKanataCrashLoop() async {
+        #if DEBUG
+            ServiceHealthChecker.vhidDriverExtensionEnabledOverride = { false }
+            ServiceHealthChecker.inputCaptureStatusOverride = { .ready }
+            ServiceHealthChecker.recentlyRestartedOverride = { _, _ in false }
+        #endif
+
+        let snapshot = await checker.checkKanataServiceRuntimeSnapshot(
+            managementState: .smappserviceActive,
+            staleEnabledRegistration: false,
+            timeoutMs: 1
+        )
+
+        XCTAssertFalse(snapshot.inputCaptureReady)
+        XCTAssertEqual(snapshot.inputCaptureIssue, ServiceHealthChecker.inputCaptureVHIDDriverNotActivatedReason)
+        XCTAssertEqual(
+            ServiceHealthChecker.decideKanataHealth(for: snapshot),
+            .unhealthy(reason: ServiceHealthChecker.inputCaptureVHIDDriverNotActivatedReason)
+        )
     }
 
     func testKanataDecisionNotFoundWithoutRuntimeIsUnhealthy() {

--- a/Tests/KeyPathTests/Support/GlobalTestSetup.swift
+++ b/Tests/KeyPathTests/Support/GlobalTestSetup.swift
@@ -45,6 +45,10 @@ enum TestSingletonReset {
             // not bleed into another's health check.
             ServiceHealthChecker.shared.invalidateHealthCache()
             ServiceHealthChecker.testForcedServiceHealth = nil
+            ServiceHealthChecker.runtimeSnapshotOverride = nil
+            ServiceHealthChecker.recentlyRestartedOverride = nil
+            ServiceHealthChecker.inputCaptureStatusOverride = nil
+            ServiceHealthChecker.vhidDriverExtensionEnabledOverride = nil
         #endif
 
         // TestEnvironment flags


### PR DESCRIPTION
## Summary
- route runtime service installation through the app-owned SMAppService flow instead of helper raw-bootstrapping Kanata
- keep the privileged helper responsible for VHID service repair only
- treat Karabiner DriverKit `[activated disabled]` as unhealthy before starting/probing Kanata, so the UI can surface the real blocker

## Root Cause
The helper was trying to install/repair Kanata by copying and raw-bootstrapping the app-bundled `com.keypath.kanata.plist`. That plist uses `BundleProgram`, which is valid for SMAppService-managed jobs but not for direct `launchctl bootstrap` from `/Library/LaunchDaemons`, leading to repeated privileged prompts and `Bootstrap failed: 5` behavior during repair/reinstall. Separately, launchd process presence was being treated as enough VHID health even when the Karabiner DriverKit extension was `[activated disabled]`, so Kanata could be started into a known-bad driver state.

## Validation
- `TEST_FILTER='ServiceHealthCheckerTests|PrivilegedOperationsRouterTests' ./Scripts/run-tests-safe.sh`
- `python3 Scripts/check-accessibility.py`
- `KEYPATH_SNAPSHOTS=0 ./Scripts/run-tests-safe.sh`

## Notes
- `./Scripts/test-fast.sh --changed` falls back to `KEYPATH_SNAPSHOTS=1` for this diff and currently fails in `KeyPathSnapshotTests` with snapshot-testing/AppKit failures unrelated to this runtime-service patch, including `-[NSConcreteValue CGRectValue]` from `swift-snapshot-testing` and several reference image diffs.
