### PR TITLE
[codex] Require manual approval for disabled VHID driver

### DIFF
--- a/Sources/KeyPathAppKit/CLI/SystemFacade.swift
+++ b/Sources/KeyPathAppKit/CLI/SystemFacade.swift
@@ -446,11 +446,11 @@ public struct SystemFacade: Sendable {
                     : "Kanata cannot capture keyboard input",
                 category: vhidDriverNotActivated ? "service" : "permissions",
                 action: vhidDriverNotActivated
-                    ? "Activate and repair the VirtualHID daemon services"
+                    ? "Open System Settings > General > Login Items & Extensions > Driver Extensions, enable Karabiner-VirtualHIDDevice, then retry repair"
                     : context.services.kanataInputCaptureIssue
                     ?? "Re-grant Input Monitoring for Kanata Engine in System Settings",
-                canAutoFix: vhidDriverNotActivated,
-                remediationURL: vhidDriverNotActivated ? nil : WizardSystemPaths.inputMonitoringSettings
+                canAutoFix: !vhidDriverNotActivated,
+                remediationURL: vhidDriverNotActivated ? WizardSystemPaths.loginItemsSettings : WizardSystemPaths.inputMonitoringSettings
             ))
         }
     }

--- a/Sources/KeyPathInstallationWizard/Core/ActionDeterminer.swift
+++ b/Sources/KeyPathInstallationWizard/Core/ActionDeterminer.swift
@@ -54,6 +54,10 @@ public enum ActionDeterminer {
             }
         }
 
+        if context.requiresManualVHIDDriverApproval {
+            return actions
+        }
+
         // Covers a pre-MAL-57 plist (missing ProcessType=Interactive) too:
         // it needs the rewrite even when the daemon is otherwise healthy.
         if context.components.vhidRuntimeServicesNeedRepair {
@@ -111,6 +115,10 @@ public enum ActionDeterminer {
             }
         }
 
+        if context.requiresManualVHIDDriverApproval {
+            return actions
+        }
+
         // Check if daemon needs starting
         if !context.services.karabinerDaemonRunning {
             // Ensure manager is activated before starting daemon
@@ -164,5 +172,12 @@ public enum ActionDeterminer {
         if !actions.contains(.repairVHIDDaemonServices) {
             actions.append(.repairVHIDDaemonServices)
         }
+    }
+}
+
+extension SystemContext {
+    var requiresManualVHIDDriverApproval: Bool {
+        components.karabinerDriverInstalled
+            && services.kanataInputCaptureIssue == ServiceHealthChecker.inputCaptureVHIDDriverNotActivatedReason
     }
 }

--- a/Sources/KeyPathInstallationWizard/Core/InstallerEngine.swift
+++ b/Sources/KeyPathInstallationWizard/Core/InstallerEngine.swift
@@ -188,6 +188,13 @@ public final class InstallerEngine {
                 )
             }
 
+            if context.requiresManualVHIDDriverApproval {
+                return Requirement(
+                    name: "Enable Karabiner-VirtualHIDDevice in System Settings > General > Login Items & Extensions > Driver Extensions",
+                    status: .blocked
+                )
+            }
+
             if !context.helper.isReady {
                 // Helper not ready - check if SMAppService approval is needed
                 // This is a soft requirement - we can proceed but may need approval

--- a/Sources/KeyPathInstallationWizard/Core/SystemInspector.swift
+++ b/Sources/KeyPathInstallationWizard/Core/SystemInspector.swift
@@ -152,10 +152,10 @@ public enum SystemInspector {
                     title: "Kanata Isn't Capturing Keyboard Input",
                     description: "KeyPath's keyboard engine is running but isn't capturing input, so remapping won't work. "
                         + inputCaptureFailureDetail(context.services.kanataInputCaptureIssue),
-                    autoFixAction: isVHIDDriverNotActivatedReason(context.services.kanataInputCaptureIssue)
-                        ? .repairVHIDDaemonServices : nil,
+                    autoFixAction: nil,
                     userAction: isVHIDDriverNotActivatedReason(context.services.kanataInputCaptureIssue)
-                        ? nil : "Restart the keyboard service from Settings → Status (or quit and reopen KeyPath)"
+                        ? "Open System Settings → General → Login Items & Extensions → Driver Extensions, enable Karabiner-VirtualHIDDevice, then retry repair"
+                        : "Restart the keyboard service from Settings → Status (or quit and reopen KeyPath)"
                 ))
             }
         }

--- a/Tests/KeyPathTests/InstallationEngine/InstallerEngineFailurePathTests.swift
+++ b/Tests/KeyPathTests/InstallationEngine/InstallerEngineFailurePathTests.swift
@@ -61,6 +61,27 @@ final class InstallerEngineFailurePathTests: KeyPathAsyncTestCase {
         }
     }
 
+    func testMakePlan_BlockedWhenVHIDDriverExtensionDisabled() async {
+        let context = SystemContextBuilder(
+            permissionsStatus: .granted,
+            helperReady: true,
+            servicesHealthy: false,
+            kanataInputCaptureReady: false,
+            kanataInputCaptureIssue: ServiceHealthChecker.inputCaptureVHIDDriverNotActivatedReason,
+            componentsInstalled: true,
+            driverCompatible: true
+        ).build()
+
+        let plan = await engine.makePlan(for: .repair, context: context)
+
+        guard case let .blocked(requirement) = plan.status else {
+            return XCTFail("Plan should be blocked until the DriverKit extension is enabled")
+        }
+        XCTAssertEqual(plan.blockedBy, requirement)
+        XCTAssertTrue(requirement.name.contains("Driver Extensions"))
+        XCTAssertTrue(plan.recipes.isEmpty)
+    }
+
     // MARK: - Recipe Execution Failure Tests
 
     func testExecute_StopsOnFirstRecipeFailure() async throws {

--- a/Tests/KeyPathTests/InstallationWizard/SystemInspectorInputCaptureTests.swift
+++ b/Tests/KeyPathTests/InstallationWizard/SystemInspectorInputCaptureTests.swift
@@ -60,7 +60,7 @@ final class SystemInspectorInputCaptureTests: XCTestCase {
         )
     }
 
-    func testVHIDDriverNotActivated_issueIsAutofixable() {
+    func testVHIDDriverNotActivated_issueRequiresManualApproval() {
         let issues = SystemInspector.generateIssues(
             context(inputCaptureIssue: ServiceHealthChecker.inputCaptureVHIDDriverNotActivatedReason)
         )
@@ -68,8 +68,11 @@ final class SystemInspectorInputCaptureTests: XCTestCase {
             return XCTFail("Expected a daemon issue for inactive VHID DriverKit state")
         }
         XCTAssertEqual(issue.title, "Kanata Isn't Capturing Keyboard Input")
-        XCTAssertEqual(issue.autoFixAction, .repairVHIDDaemonServices)
-        XCTAssertNil(issue.userAction)
+        XCTAssertNil(issue.autoFixAction)
+        XCTAssertEqual(
+            issue.userAction,
+            "Open System Settings → General → Login Items & Extensions → Driver Extensions, enable Karabiner-VirtualHIDDevice, then retry repair"
+        )
         XCTAssertTrue(issue.description.contains("not activated"))
     }
 

--- a/Tests/KeyPathTests/InstallationWizard/WizardPureLogicTests.swift
+++ b/Tests/KeyPathTests/InstallationWizard/WizardPureLogicTests.swift
@@ -1054,7 +1054,7 @@ final class WizardPureLogicTests: XCTestCase {
         XCTAssertTrue(actions.contains(.startKarabinerDaemon))
     }
 
-    func test_determineRepairActions_vhidDriverNotActivated_includesActivationAndRepair() {
+    func test_determineRepairActions_vhidDriverNotActivatedWaitsForManualApproval() {
         let context = makeContext(
             services: HealthStatus(
                 kanataRunning: true,
@@ -1067,14 +1067,12 @@ final class WizardPureLogicTests: XCTestCase {
 
         let actions = ActionDeterminer.determineRepairActions(context: context)
 
-        let activateIdx = actions.firstIndex(of: .activateVHIDDeviceManager)
-        let repairIdx = actions.firstIndex(of: .repairVHIDDaemonServices)
-        XCTAssertNotNil(activateIdx, "DriverKit activation failure should re-run VHID manager activation")
-        XCTAssertNotNil(repairIdx, "DriverKit activation failure should repair VHID daemon services")
-        XCTAssertTrue(activateIdx! < repairIdx!, "Activation must run before daemon repair")
+        XCTAssertFalse(actions.contains(.activateVHIDDeviceManager))
+        XCTAssertFalse(actions.contains(.repairVHIDDaemonServices))
+        XCTAssertTrue(actions.isEmpty, "A disabled DriverKit extension needs user approval, not another repair loop")
     }
 
-    func test_determineRepairActions_stoppedKanataWithVHIDIssue_repairsVHIDThenInstallsRuntimeServices() {
+    func test_determineRepairActions_stoppedKanataWithVHIDIssueWaitsForManualApproval() {
         let context = makeContext(
             services: HealthStatus(
                 kanataRunning: false,
@@ -1087,14 +1085,10 @@ final class WizardPureLogicTests: XCTestCase {
 
         let actions = ActionDeterminer.determineRepairActions(context: context)
 
-        let activateIdx = actions.firstIndex(of: .activateVHIDDeviceManager)
-        let repairIdx = actions.firstIndex(of: .repairVHIDDaemonServices)
-        let installIdx = actions.firstIndex(of: .installRequiredRuntimeServices)
-        XCTAssertNotNil(activateIdx)
-        XCTAssertNotNil(repairIdx)
-        XCTAssertNotNil(installIdx)
-        XCTAssertTrue(activateIdx! < repairIdx!)
-        XCTAssertTrue(repairIdx! < installIdx!)
+        XCTAssertFalse(actions.contains(.activateVHIDDeviceManager))
+        XCTAssertFalse(actions.contains(.repairVHIDDaemonServices))
+        XCTAssertFalse(actions.contains(.installRequiredRuntimeServices))
+        XCTAssertTrue(actions.isEmpty, "Kanata should not be restarted until the DriverKit extension is enabled")
     }
 
     func test_determineRepairActions_helperInstalledButBroken_includesReinstall() {
@@ -1203,7 +1197,7 @@ final class WizardPureLogicTests: XCTestCase {
         )
     }
 
-    func test_determineInstallActions_vhidDriverNotActivated_includesActivationAndRepair() {
+    func test_determineInstallActions_vhidDriverNotActivatedWaitsForManualApproval() {
         let context = makeContext(
             services: HealthStatus(
                 kanataRunning: true,
@@ -1216,8 +1210,9 @@ final class WizardPureLogicTests: XCTestCase {
 
         let actions = ActionDeterminer.determineInstallActions(context: context)
 
-        XCTAssertTrue(actions.contains(.activateVHIDDeviceManager))
-        XCTAssertTrue(actions.contains(.repairVHIDDaemonServices))
+        XCTAssertFalse(actions.contains(.activateVHIDDeviceManager))
+        XCTAssertFalse(actions.contains(.repairVHIDDaemonServices))
+        XCTAssertTrue(actions.isEmpty, "Install should wait for DriverKit approval before scheduling runtime service repair")
     }
 
     func test_determineInstallActions_allHealthy_returnsEmpty() {

--- a/Tests/KeyPathTests/TestSupport/SystemContextBuilder.swift
+++ b/Tests/KeyPathTests/TestSupport/SystemContextBuilder.swift
@@ -48,15 +48,13 @@ struct SystemContextBuilder {
             .empty
         }
 
-        let services = servicesHealthy
-            ? HealthStatus(
-                kanataRunning: true,
-                karabinerDaemonRunning: true,
-                vhidHealthy: true,
-                kanataInputCaptureReady: kanataInputCaptureReady,
-                kanataInputCaptureIssue: kanataInputCaptureReady ? nil : kanataInputCaptureIssue
-            )
-            : HealthStatus.empty
+        let services = HealthStatus(
+            kanataRunning: servicesHealthy,
+            karabinerDaemonRunning: servicesHealthy,
+            vhidHealthy: servicesHealthy,
+            kanataInputCaptureReady: kanataInputCaptureReady,
+            kanataInputCaptureIssue: kanataInputCaptureReady ? nil : kanataInputCaptureIssue
+        )
 
         let conflictStatus = ConflictStatus(conflicts: conflicts, canAutoResolve: !conflicts.isEmpty)
 


### PR DESCRIPTION
## Summary
- treat an installed-but-disabled Karabiner DriverKit extension as manual user action, not an auto-fixable repair
- block install/repair planning on the Driver Extensions approval requirement instead of scheduling another activation/daemon repair loop
- update wizard and CLI issue copy to point to System Settings > General > Login Items & Extensions > Driver Extensions

## Root Cause
After #984, the launcher correctly stops when `systemextensionsctl` reports Karabiner VirtualHID as `[activated disabled]`, but the installer planner and CLI still described the state as ready/auto-fixable. That left the app able to keep offering repair actions for a macOS approval toggle it cannot complete programmatically.

## Validation
- `TEST_FILTER='SystemInspectorInputCaptureTests|WizardPureLogicTests|InstallerEngineFailurePathTests|CLIOutputContractTests' ./Scripts/run-tests-safe.sh`
- `python3 Scripts/check-accessibility.py`
