### PR TITLE
Fix stale VHID approval recovery

### DIFF
--- a/Sources/KeyPathAppKit/CLI/SystemFacade.swift
+++ b/Sources/KeyPathAppKit/CLI/SystemFacade.swift
@@ -438,19 +438,18 @@ public struct SystemFacade: Sendable {
             ))
         }
         if !context.services.kanataInputCaptureReady {
-            let vhidDriverNotActivated = context.services.kanataInputCaptureIssue
-                == ServiceHealthChecker.inputCaptureVHIDDriverNotActivatedReason
+            let needsManualVHIDApproval = context.requiresManualVHIDDriverApproval
             issues.append(.init(
-                title: vhidDriverNotActivated
+                title: needsManualVHIDApproval
                     ? "Karabiner VirtualHIDDevice driver is not activated"
                     : "Kanata cannot capture keyboard input",
-                category: vhidDriverNotActivated ? "service" : "permissions",
-                action: vhidDriverNotActivated
+                category: "service",
+                action: needsManualVHIDApproval
                     ? "Open System Settings > General > Login Items & Extensions > Driver Extensions, enable Karabiner-VirtualHIDDevice, then retry repair"
                     : context.services.kanataInputCaptureIssue
-                    ?? "Re-grant Input Monitoring for Kanata Engine in System Settings",
-                canAutoFix: !vhidDriverNotActivated,
-                remediationURL: vhidDriverNotActivated ? WizardSystemPaths.loginItemsSettings : WizardSystemPaths.inputMonitoringSettings
+                    ?? "Restart or repair the keyboard service",
+                canAutoFix: !needsManualVHIDApproval,
+                remediationURL: needsManualVHIDApproval ? WizardSystemPaths.loginItemsSettings : nil
             ))
         }
     }

--- a/Sources/KeyPathInstallationWizard/Core/ActionDeterminer.swift
+++ b/Sources/KeyPathInstallationWizard/Core/ActionDeterminer.swift
@@ -175,9 +175,10 @@ public enum ActionDeterminer {
     }
 }
 
-extension SystemContext {
+public extension SystemContext {
     var requiresManualVHIDDriverApproval: Bool {
         components.karabinerDriverInstalled
+            && !services.vhidHealthy
             && services.kanataInputCaptureIssue == ServiceHealthChecker.inputCaptureVHIDDriverNotActivatedReason
     }
 }

--- a/Sources/KeyPathInstallationWizard/Core/SystemInspector.swift
+++ b/Sources/KeyPathInstallationWizard/Core/SystemInspector.swift
@@ -151,9 +151,9 @@ public enum SystemInspector {
                     category: .daemon,
                     title: "Kanata Isn't Capturing Keyboard Input",
                     description: "KeyPath's keyboard engine is running but isn't capturing input, so remapping won't work. "
-                        + inputCaptureFailureDetail(context.services.kanataInputCaptureIssue),
-                    autoFixAction: nil,
-                    userAction: isVHIDDriverNotActivatedReason(context.services.kanataInputCaptureIssue)
+                        + inputCaptureFailureDetail(for: context),
+                    autoFixAction: shouldRepairStaleVHIDActivationFailure(context) ? .installRequiredRuntimeServices : nil,
+                    userAction: context.requiresManualVHIDDriverApproval
                         ? "Open System Settings → General → Login Items & Extensions → Driver Extensions, enable Karabiner-VirtualHIDDevice, then retry repair"
                         : "Restart the keyboard service from Settings → Status (or quit and reopen KeyPath)"
                 ))
@@ -383,11 +383,20 @@ public enum SystemInspector {
         reason == ServiceHealthChecker.inputCaptureVHIDDriverNotActivatedReason
     }
 
+    static func shouldRepairStaleVHIDActivationFailure(_ context: SystemContext) -> Bool {
+        isVHIDDriverNotActivatedReason(context.services.kanataInputCaptureIssue)
+            && !context.requiresManualVHIDDriverApproval
+    }
+
     /// Human-readable detail for a non-permission input-capture failure, using
     /// kanata's authoritative reason (from the InputGrab signal) when present.
-    static func inputCaptureFailureDetail(_ reason: String?) -> String {
-        if isVHIDDriverNotActivatedReason(reason) {
+    static func inputCaptureFailureDetail(for context: SystemContext) -> String {
+        if context.requiresManualVHIDDriverApproval {
             return "The Karabiner VirtualHIDDevice driver is installed, but macOS reports it is not activated."
+        }
+        let reason = context.services.kanataInputCaptureIssue
+        if isVHIDDriverNotActivatedReason(reason) {
+            return "Kanata last reported that the Karabiner VirtualHIDDevice driver was not activated, but the VirtualHID services now look healthy. Restart the keyboard service to retry."
         }
         guard let reason, reason != ServiceHealthChecker.inputCaptureGrabFailureReason else {
             return "The keyboard couldn't be captured — the input driver may have crashed, or another app may be holding the keyboard exclusively."

--- a/Tests/KeyPathTests/InstallationEngine/InstallerEngineFailurePathTests.swift
+++ b/Tests/KeyPathTests/InstallationEngine/InstallerEngineFailurePathTests.swift
@@ -82,6 +82,31 @@ final class InstallerEngineFailurePathTests: KeyPathAsyncTestCase {
         XCTAssertTrue(plan.recipes.isEmpty)
     }
 
+    func testMakePlan_ReadyWhenVHIDHealthyButKanataHasStaleDriverDisabledIssue() async {
+        let context = SystemContextBuilder(
+            permissionsStatus: .granted,
+            helperReady: true,
+            servicesHealthy: false,
+            kanataRunning: false,
+            karabinerDaemonRunning: true,
+            vhidHealthy: true,
+            kanataInputCaptureReady: false,
+            kanataInputCaptureIssue: ServiceHealthChecker.inputCaptureVHIDDriverNotActivatedReason,
+            componentsInstalled: true,
+            driverCompatible: true
+        ).build()
+
+        let plan = await engine.makePlan(for: .repair, context: context)
+
+        guard case .ready = plan.status else {
+            return XCTFail("Plan should repair stale Kanata state after DriverKit approval is enabled")
+        }
+        XCTAssertNil(plan.blockedBy)
+        XCTAssertTrue(plan.recipes.contains(where: { recipe in
+            recipe.id == InstallerRecipeID.installRequiredRuntimeServices
+        }))
+    }
+
     // MARK: - Recipe Execution Failure Tests
 
     func testExecute_StopsOnFirstRecipeFailure() async throws {

--- a/Tests/KeyPathTests/InstallationWizard/SystemInspectorInputCaptureTests.swift
+++ b/Tests/KeyPathTests/InstallationWizard/SystemInspectorInputCaptureTests.swift
@@ -7,11 +7,11 @@ import XCTest
 /// holding the keyboard, not root) is NOT a missing permission and is fixed by
 /// restarting, not by regranting Input Monitoring.
 final class SystemInspectorInputCaptureTests: XCTestCase {
-    private func context(inputCaptureIssue: String?) -> SystemContext {
+    private func context(inputCaptureIssue: String?, servicesHealthy: Bool = true) -> SystemContext {
         SystemContextBuilder(
             permissionsStatus: .granted,
             helperReady: true,
-            servicesHealthy: true,
+            servicesHealthy: servicesHealthy,
             kanataInputCaptureReady: false,
             kanataInputCaptureIssue: inputCaptureIssue,
             componentsInstalled: true
@@ -62,7 +62,10 @@ final class SystemInspectorInputCaptureTests: XCTestCase {
 
     func testVHIDDriverNotActivated_issueRequiresManualApproval() {
         let issues = SystemInspector.generateIssues(
-            context(inputCaptureIssue: ServiceHealthChecker.inputCaptureVHIDDriverNotActivatedReason)
+            context(
+                inputCaptureIssue: ServiceHealthChecker.inputCaptureVHIDDriverNotActivatedReason,
+                servicesHealthy: false
+            )
         )
         guard let issue = issues.first(where: { $0.identifier == .daemon }) else {
             return XCTFail("Expected a daemon issue for inactive VHID DriverKit state")
@@ -74,6 +77,19 @@ final class SystemInspectorInputCaptureTests: XCTestCase {
             "Open System Settings → General → Login Items & Extensions → Driver Extensions, enable Karabiner-VirtualHIDDevice, then retry repair"
         )
         XCTAssertTrue(issue.description.contains("not activated"))
+    }
+
+    func testStaleVHIDDriverNotActivatedIssue_afterVHIDHealthyCanRepair() {
+        let issues = SystemInspector.generateIssues(
+            context(inputCaptureIssue: ServiceHealthChecker.inputCaptureVHIDDriverNotActivatedReason)
+        )
+        guard let issue = issues.first(where: { $0.identifier == .daemon }) else {
+            return XCTFail("Expected a daemon issue for stale inactive VHID DriverKit state")
+        }
+        XCTAssertEqual(issue.title, "Kanata Isn't Capturing Keyboard Input")
+        XCTAssertEqual(issue.autoFixAction, .installRequiredRuntimeServices)
+        XCTAssertEqual(issue.userAction, "Restart the keyboard service from Settings → Status (or quit and reopen KeyPath)")
+        XCTAssertTrue(issue.description.contains("VirtualHID services now look healthy"))
     }
 
     // MARK: - Service status must not lie green on a grab failure

--- a/Tests/KeyPathTests/InstallationWizard/WizardPureLogicTests.swift
+++ b/Tests/KeyPathTests/InstallationWizard/WizardPureLogicTests.swift
@@ -1059,7 +1059,7 @@ final class WizardPureLogicTests: XCTestCase {
             services: HealthStatus(
                 kanataRunning: true,
                 karabinerDaemonRunning: true,
-                vhidHealthy: true,
+                vhidHealthy: false,
                 kanataInputCaptureReady: false,
                 kanataInputCaptureIssue: ServiceHealthChecker.inputCaptureVHIDDriverNotActivatedReason
             )
@@ -1077,7 +1077,7 @@ final class WizardPureLogicTests: XCTestCase {
             services: HealthStatus(
                 kanataRunning: false,
                 karabinerDaemonRunning: true,
-                vhidHealthy: true,
+                vhidHealthy: false,
                 kanataInputCaptureReady: false,
                 kanataInputCaptureIssue: ServiceHealthChecker.inputCaptureVHIDDriverNotActivatedReason
             )
@@ -1089,6 +1089,24 @@ final class WizardPureLogicTests: XCTestCase {
         XCTAssertFalse(actions.contains(.repairVHIDDaemonServices))
         XCTAssertFalse(actions.contains(.installRequiredRuntimeServices))
         XCTAssertTrue(actions.isEmpty, "Kanata should not be restarted until the DriverKit extension is enabled")
+    }
+
+    func test_determineRepairActions_staleVHIDIssueAfterDriverEnabledRestartsKanata() {
+        let context = makeContext(
+            services: HealthStatus(
+                kanataRunning: false,
+                karabinerDaemonRunning: true,
+                vhidHealthy: true,
+                kanataInputCaptureReady: false,
+                kanataInputCaptureIssue: ServiceHealthChecker.inputCaptureVHIDDriverNotActivatedReason
+            )
+        )
+
+        let actions = ActionDeterminer.determineRepairActions(context: context)
+
+        XCTAssertTrue(actions.contains(.activateVHIDDeviceManager))
+        XCTAssertTrue(actions.contains(.repairVHIDDaemonServices))
+        XCTAssertTrue(actions.contains(.installRequiredRuntimeServices))
     }
 
     func test_determineRepairActions_helperInstalledButBroken_includesReinstall() {
@@ -1202,7 +1220,7 @@ final class WizardPureLogicTests: XCTestCase {
             services: HealthStatus(
                 kanataRunning: true,
                 karabinerDaemonRunning: true,
-                vhidHealthy: true,
+                vhidHealthy: false,
                 kanataInputCaptureReady: false,
                 kanataInputCaptureIssue: ServiceHealthChecker.inputCaptureVHIDDriverNotActivatedReason
             )

--- a/Tests/KeyPathTests/TestSupport/SystemContextBuilder.swift
+++ b/Tests/KeyPathTests/TestSupport/SystemContextBuilder.swift
@@ -9,6 +9,9 @@ struct SystemContextBuilder {
     var permissionsStatus: PermissionOracle.Status = .granted
     var helperReady: Bool = true
     var servicesHealthy: Bool = false
+    var kanataRunning: Bool?
+    var karabinerDaemonRunning: Bool?
+    var vhidHealthy: Bool?
     var kanataInputCaptureReady: Bool = true
     /// The input-capture failure reason surfaced when not ready (#624 attribution).
     /// Defaults to the built-in-keyboard permission reason; set to a grab-failure
@@ -49,9 +52,9 @@ struct SystemContextBuilder {
         }
 
         let services = HealthStatus(
-            kanataRunning: servicesHealthy,
-            karabinerDaemonRunning: servicesHealthy,
-            vhidHealthy: servicesHealthy,
+            kanataRunning: kanataRunning ?? servicesHealthy,
+            karabinerDaemonRunning: karabinerDaemonRunning ?? servicesHealthy,
+            vhidHealthy: vhidHealthy ?? servicesHealthy,
             kanataInputCaptureReady: kanataInputCaptureReady,
             kanataInputCaptureIssue: kanataInputCaptureReady ? nil : kanataInputCaptureIssue
         )


### PR DESCRIPTION
## Summary
- Treat the DriverKit "not activated" reason as a manual approval block only while VHID health is still false
- Allow repair/restart once VHID services are healthy but Kanata is still carrying a stale activation failure
- Update wizard and CLI issue text so they stop sending users back to System Settings after approval succeeds

## Verification
- Observed local recovery: system extension [activated enabled], VHID daemon running, Kanata kickstart restored TCP readiness
- ./Scripts/verify-installed-app.sh passes on /Applications/KeyPath.app after kickstart
- TEST_FILTER='WizardPureLogicTests|InstallerEngineFailurePathTests|SystemInspectorInputCaptureTests|CLIOutputContractTests|ServiceHealthCheckerTests' ./Scripts/run-tests-safe.sh
- python3 Scripts/check-accessibility.py
- git diff --check