### PR TITLE
Auto-initialize Kanata submodule for release builds

### DIFF
--- a/Scripts/README.md
+++ b/Scripts/README.md
@@ -30,6 +30,9 @@
 - `archive/` - Deprecated or historical scripts
 - `lib/signing.sh` - Thin wrappers around codesign/notarytool/stapler with `KP_SIGN_DRY_RUN=1` for safe local runs; CI overrides hook into this.
 - `lib/deploy-lock.sh` - Shared cross-worktree lock for scripts that mutate `/Applications/KeyPath.app`.
+- `lib/submodules.sh` - Initializes required submodules for build paths. Kanata
+  is hydrated automatically by release/Rust build scripts so ordinary worktrees
+  can stay lightweight.
 - `test-installer-device.sh` - Opt-in device smoke for InstallerEngine (requires `KEYPATH_E2E_DEVICE=1`; non-destructive).
 
 ## Testing

--- a/Scripts/build-and-sign.sh
+++ b/Scripts/build-and-sign.sh
@@ -8,6 +8,7 @@ set -euo pipefail
 SCRIPT_DIR=$(cd "$(dirname "$0")" >/dev/null && pwd)
 source "$SCRIPT_DIR/lib/signing.sh"
 source "$SCRIPT_DIR/lib/deploy-lock.sh"
+source "$SCRIPT_DIR/lib/submodules.sh"
 keypath_acquire_deploy_lock "build-and-sign ($SCRIPT_DIR/..)" "${KEYPATH_RELEASE_DEPLOY_LOCK_TIMEOUT_SECONDS:-600}"
 trap keypath_release_deploy_lock EXIT
 
@@ -174,6 +175,8 @@ EOF
     echo "   📝 Appcast entry: ${SPARKLE_DIR}/${ARCHIVE_NAME}.appcast-entry.xml"
     echo "   💿 DMG: ${SPARKLE_DIR}/${DMG_NAME}"
 }
+
+keypath_ensure_kanata_submodule "$SCRIPT_DIR/.."
 
 echo "🦀 Building Rust artifacts in parallel (kanata, simulator, host bridge)..."
 ./Scripts/build-kanata.sh &

--- a/Scripts/build-kanata-host-bridge.sh
+++ b/Scripts/build-kanata-host-bridge.sh
@@ -11,12 +11,15 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+source "$SCRIPT_DIR/lib/submodules.sh"
 BRIDGE_ROOT="$PROJECT_ROOT/Rust/KeyPathKanataHostBridge"
 BUILD_DIR="$PROJECT_ROOT/build/kanata-host-bridge"
 CACHE_INFO="$BUILD_DIR/host-bridge-cache.info"
 BRIDGE_FEATURES="${KEYPATH_KANATA_HOST_BRIDGE_FEATURES:-passthru-output-spike}"
 
 echo "🧩 Building KeyPath Kanata host bridge..."
+
+keypath_ensure_kanata_submodule "$PROJECT_ROOT"
 
 if ! command -v cargo >/dev/null 2>&1; then
     echo "❌ Error: Rust toolchain (cargo) not found." >&2

--- a/Scripts/build-kanata-simulator.sh
+++ b/Scripts/build-kanata-simulator.sh
@@ -8,6 +8,7 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+source "$SCRIPT_DIR/lib/submodules.sh"
 KANATA_SOURCE="$PROJECT_ROOT/External/kanata"
 BUILD_DIR="$PROJECT_ROOT/build"
 CACHE_INFO="$BUILD_DIR/kanata-simulator-cache.info"
@@ -18,14 +19,17 @@ SKIP_CODESIGN="${SKIP_CODESIGN:-0}"
 
 echo "🔬 Building Kanata Simulator from source..."
 
+keypath_ensure_kanata_submodule "$PROJECT_ROOT"
+
 # Check prerequisites
 if ! command -v cargo >/dev/null 2>&1; then
     echo "❌ Error: Rust toolchain (cargo) not found." >&2
     exit 1
 fi
 
-if [ ! -d "$KANATA_SOURCE" ]; then
+if [ ! -f "$KANATA_SOURCE/Cargo.toml" ]; then
     echo "❌ Error: Kanata source not found at $KANATA_SOURCE" >&2
+    echo "   Run: git submodule update --init --recursive External/kanata" >&2
     exit 1
 fi
 

--- a/Scripts/build-kanata.sh
+++ b/Scripts/build-kanata.sh
@@ -13,6 +13,7 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+source "$SCRIPT_DIR/lib/submodules.sh"
 KANATA_SOURCE="$PROJECT_ROOT/External/kanata"
 BUILD_DIR="$PROJECT_ROOT/build"
 CACHE_INFO="$BUILD_DIR/kanata-cache.info"
@@ -22,6 +23,8 @@ SIGNING_IDENTITY="${CODESIGN_IDENTITY:-Developer ID Application: Micah Alpern (X
 SKIP_CODESIGN="${SKIP_CODESIGN:-0}"
 
 echo "🦀 Building Kanata from source (with TCC-safe caching)..."
+
+keypath_ensure_kanata_submodule "$PROJECT_ROOT"
 
 # Check prerequisites
 if ! command -v cargo >/dev/null 2>&1; then
@@ -37,9 +40,9 @@ if ! command -v rustup >/dev/null 2>&1; then
     exit 1
 fi
 
-if [ ! -d "$KANATA_SOURCE" ]; then
+if [ ! -f "$KANATA_SOURCE/Cargo.toml" ]; then
     echo "❌ Error: Kanata source not found at $KANATA_SOURCE" >&2
-    echo "   Run: git submodule update --init --recursive" >&2
+    echo "   Run: git submodule update --init --recursive External/kanata" >&2
     exit 1
 fi
 

--- a/Scripts/lib/submodules.sh
+++ b/Scripts/lib/submodules.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# Helpers for build paths that require checked-out git submodules.
+
+keypath_ensure_kanata_submodule() {
+    local project_root="${1:?project root required}"
+    local kanata_source="$project_root/External/kanata"
+    local kanata_manifest="$kanata_source/Cargo.toml"
+
+    if [ "${KEYPATH_KANATA_SUBMODULE_READY:-0}" = "1" ] && [ -f "$kanata_manifest" ]; then
+        return 0
+    fi
+
+    if [ -f "$kanata_manifest" ]; then
+        export KEYPATH_KANATA_SUBMODULE_READY=1
+        return 0
+    fi
+
+    if [ ! -f "$project_root/.gitmodules" ]; then
+        echo "❌ Error: Kanata source is missing at $kanata_source" >&2
+        echo "   Expected $kanata_manifest, but this checkout has no .gitmodules file." >&2
+        return 1
+    fi
+
+    echo "📦 Initializing Kanata submodule..."
+    if git -C "$project_root" submodule update --init --recursive External/kanata; then
+        if [ -f "$kanata_manifest" ]; then
+            export KEYPATH_KANATA_SUBMODULE_READY=1
+            return 0
+        fi
+
+        echo "❌ Error: Kanata submodule initialized, but $kanata_manifest is still missing." >&2
+        return 1
+    fi
+
+    echo "❌ Error: Failed to initialize Kanata submodule." >&2
+    echo "   Run: git submodule update --init --recursive External/kanata" >&2
+    return 1
+}


### PR DESCRIPTION
## Summary
- add a shared submodule helper that hydrates External/kanata when Cargo.toml is missing
- run it once before the parallel release Rust artifact build
- call it from individual Kanata Rust build scripts for direct script usage
- document that build paths auto-hydrate Kanata while ordinary worktrees can stay lightweight

## Validation
- reproduced missing-submodule state in a fresh worktree: External/kanata existed but Cargo.toml was absent
- ran helper directly and confirmed it initialized External/kanata to the pinned submodule commit
- ran helper again and confirmed no-op path succeeds
- bash -n Scripts/lib/submodules.sh Scripts/build-and-sign.sh Scripts/build-kanata.sh Scripts/build-kanata-simulator.sh Scripts/build-kanata-host-bridge.sh
- git diff --check