### PR TITLE
Harden release notarization and deploy

### DIFF
--- a/Scripts/README.md
+++ b/Scripts/README.md
@@ -20,7 +20,7 @@
 
 ## Scripts in this directory
 - `build-and-sign.sh` - The implementation of the build process
-- `release-doctor.sh` - Read-only preflight for signing, notarization, Sparkle, website, watcher, and runtime state.
+- `release-doctor.sh` - Read-only preflight for signing, notarization, Sparkle, website, watcher, and runtime state. Supports either `NOTARY_PROFILE` or `KP_NOTARY_KEY` + `KP_NOTARY_KEY_ID` + `KP_NOTARY_ISSUER`.
 - `release-candidate.sh` - Post-merge signed/notarized local build wrapper with fast defaults.
 - `release.sh` - Public release wrapper for versioned distribution artifacts.
 - `cleanup-local-build-artifacts.sh` - Safe local disk cleanup helper for generated build artifacts.

--- a/Scripts/build-and-sign.sh
+++ b/Scripts/build-and-sign.sh
@@ -10,7 +10,40 @@ source "$SCRIPT_DIR/lib/signing.sh"
 source "$SCRIPT_DIR/lib/deploy-lock.sh"
 source "$SCRIPT_DIR/lib/submodules.sh"
 keypath_acquire_deploy_lock "build-and-sign ($SCRIPT_DIR/..)" "${KEYPATH_RELEASE_DEPLOY_LOCK_TIMEOUT_SECONDS:-600}"
-trap keypath_release_deploy_lock EXIT
+DEPLOY_TMP_TO_CLEAN=""
+cleanup_release() {
+    if [ -n "$DEPLOY_TMP_TO_CLEAN" ] && [ -e "$DEPLOY_TMP_TO_CLEAN" ]; then
+        rm -rf "$DEPLOY_TMP_TO_CLEAN" 2>/dev/null || true
+    fi
+    keypath_release_deploy_lock
+}
+trap cleanup_release EXIT
+
+verify_deploy_candidate() {
+    local candidate=$1
+
+    if [ ! -d "$candidate" ]; then
+        echo "❌ ERROR: Deploy candidate is missing: $candidate" >&2
+        return 1
+    fi
+
+    if [ ! -x "$candidate/Contents/MacOS/$APP_NAME" ]; then
+        echo "❌ ERROR: Deploy candidate is missing executable: Contents/MacOS/$APP_NAME" >&2
+        return 1
+    fi
+
+    if [ ! -x "$candidate/Contents/MacOS/keypath-cli" ]; then
+        echo "❌ ERROR: Deploy candidate is missing executable: Contents/MacOS/keypath-cli" >&2
+        return 1
+    fi
+
+    codesign --verify --deep --strict "$candidate"
+
+    if [ "${SKIP_NOTARIZE:-}" != "1" ]; then
+        xcrun stapler validate "$candidate"
+        spctl -a -vvv "$candidate"
+    fi
+}
 
 # Function to create Sparkle update archive with EdDSA signature.
 #
@@ -557,25 +590,76 @@ fi
 # Stop kanata so it doesn't get killed by the bundle replacement.
 if pgrep -x "kanata" > /dev/null; then
     echo "🛑 Stopping kanata service..."
-    KANATA_PID=$(pgrep -x "kanata")
-    sudo kill "$KANATA_PID" 2>/dev/null || true
+    launchctl kill TERM system/com.keypath.kanata 2>/dev/null || true
     sleep 1
+
+    if pgrep -x "kanata" > /dev/null; then
+        echo "   kanata is still running; trying non-interactive sudo kill..."
+        sudo -n pkill -x "kanata" 2>/dev/null || true
+    fi
+    sleep 1
+fi
+
+if pgrep -x "kanata" > /dev/null; then
+    echo "   ❌ ERROR: kanata is still running, so replacing the app bundle could invalidate a live process." >&2
+    echo "   Stop the runtime from KeyPath, approve any pending helper prompt, or rerun after unloading system/com.keypath.kanata." >&2
+    echo "   Override only for emergency diagnostics with KEYPATH_ALLOW_DEPLOY_WITH_RUNNING_KANATA=1." >&2
+    if [ "${KEYPATH_ALLOW_DEPLOY_WITH_RUNNING_KANATA:-0}" != "1" ]; then
+        exit 1
+    fi
+    echo "   ⚠️  Continuing despite running kanata because KEYPATH_ALLOW_DEPLOY_WITH_RUNNING_KANATA=1"
 fi
 
 echo "📂 Deploying to /Applications..."
 SYSTEM_APPS_DIR="/Applications"
 APP_DEST="$SYSTEM_APPS_DIR/${APP_NAME}.app"
-rm -rf "$APP_DEST"
-if ditto "$APP_BUNDLE" "$APP_DEST"; then
+APP_TMP="$SYSTEM_APPS_DIR/.${APP_NAME}.app.tmp.$$"
+APP_BACKUP="$SYSTEM_APPS_DIR/.${APP_NAME}.app.previous.$$"
+DEPLOY_TMP_TO_CLEAN="$APP_TMP"
+
+rm -rf "$APP_TMP" "$APP_BACKUP"
+
+echo "   Copying verified candidate to temporary bundle..."
+ditto "$APP_BUNDLE" "$APP_TMP"
+
+echo "   Verifying temporary bundle..."
+verify_deploy_candidate "$APP_TMP"
+
+if [ -d "$APP_DEST" ]; then
+    echo "   Moving current install aside..."
+    mv "$APP_DEST" "$APP_BACKUP"
+fi
+
+if mv "$APP_TMP" "$APP_DEST"; then
+    DEPLOY_TMP_TO_CLEAN=""
+    echo "   Verifying installed bundle..."
+    if ! verify_deploy_candidate "$APP_DEST"; then
+        echo "❌ ERROR: Installed bundle failed verification after deploy" >&2
+        if [ -d "$APP_BACKUP" ]; then
+            echo "   Restoring previous install..."
+            rm -rf "$APP_DEST"
+            mv "$APP_BACKUP" "$APP_DEST"
+        fi
+        exit 1
+    fi
+    rm -rf "$APP_BACKUP"
     echo "✅ Deployed latest $APP_NAME to $APP_DEST"
 else
-    echo "⚠️ WARNING: Failed to copy $APP_NAME to $APP_DEST" >&2
-    echo "💡 TIP: You may need to manually copy dist/${APP_NAME}.app to /Applications/" >&2
+    echo "❌ ERROR: Failed to move verified bundle into $APP_DEST" >&2
+    if [ -d "$APP_BACKUP" ] && [ ! -d "$APP_DEST" ]; then
+        echo "   Restoring previous install..."
+        mv "$APP_BACKUP" "$APP_DEST"
+    fi
+    rm -rf "$APP_TMP"
+    exit 1
 fi
 
 echo "🚪 Restarting app..."
 echo "   Starting new KeyPath..."
-open "$APP_DEST"
+if ! open "$APP_DEST"; then
+    echo "   ❌ ERROR: Failed to open $APP_DEST" >&2
+    exit 1
+fi
 
 # Wait for new process to start and verify
 sleep 2
@@ -583,7 +667,8 @@ if pgrep -x "KeyPath" > /dev/null; then
     NEW_PID=$(pgrep -x "KeyPath")
     echo "   ✅ KeyPath restarted successfully (PID: $NEW_PID)"
 else
-    echo "   ⚠️  WARNING: KeyPath may not have started. Run manually: open $APP_DEST" >&2
+    echo "   ❌ ERROR: KeyPath did not start after deploy. Run manually for diagnostics: open $APP_DEST" >&2
+    exit 1
 fi
 
 # ─────────────────────────────────────────────────────────────────────

--- a/Scripts/lib/signing.sh
+++ b/Scripts/lib/signing.sh
@@ -31,24 +31,60 @@ kp_verify_signature() {
     kp_run "$KP_VERIFY_CMD" -dvvv "$target" "$@"
 }
 
+kp_notary_uses_api_key() {
+    [ -n "${KP_NOTARY_KEY:-}" ] || [ -n "${KP_NOTARY_KEY_ID:-}" ] || [ -n "${KP_NOTARY_ISSUER:-}" ]
+}
+
+kp_notary_validate_api_key_env() {
+    local missing=()
+    [ -n "${KP_NOTARY_KEY:-}" ] || missing+=("KP_NOTARY_KEY")
+    [ -n "${KP_NOTARY_KEY_ID:-}" ] || missing+=("KP_NOTARY_KEY_ID")
+    [ -n "${KP_NOTARY_ISSUER:-}" ] || missing+=("KP_NOTARY_ISSUER")
+
+    if [ "${#missing[@]}" -gt 0 ]; then
+        echo "❌ ERROR: incomplete App Store Connect notarization credentials." >&2
+        echo "   Missing: ${missing[*]}" >&2
+        echo "   Set all of KP_NOTARY_KEY, KP_NOTARY_KEY_ID, and KP_NOTARY_ISSUER, or unset them to use NOTARY_PROFILE." >&2
+        return 1
+    fi
+
+    if [ ! -f "$KP_NOTARY_KEY" ]; then
+        echo "❌ ERROR: KP_NOTARY_KEY does not exist: $KP_NOTARY_KEY" >&2
+        return 1
+    fi
+}
+
+kp_notary_args() {
+    local profile=$1
+    if kp_notary_uses_api_key; then
+        kp_notary_validate_api_key_env || return 1
+        printf '%s\n' --key "$KP_NOTARY_KEY" --key-id "$KP_NOTARY_KEY_ID" --issuer "$KP_NOTARY_ISSUER"
+    else
+        printf '%s\n' --keychain-profile "$profile"
+        if [ -n "${KP_NOTARY_KEYCHAIN:-}" ]; then
+            printf '%s\n' --keychain "$KP_NOTARY_KEYCHAIN"
+        fi
+    fi
+}
+
 kp_notarize_zip() {
     local zip_path=$1
     local profile=$2
     shift 2
+    local notary_args=()
+    if kp_notary_uses_api_key; then
+        kp_notary_validate_api_key_env || return 1
+    fi
+    while IFS= read -r arg; do
+        notary_args+=("$arg")
+    done < <(kp_notary_args "$profile")
+
     if [ "$KP_SIGN_DRY_RUN" = "1" ]; then
-        if [ -n "${KP_NOTARY_KEYCHAIN:-}" ]; then
-            echo "[DRY RUN] $KP_NOTARY_CMD submit $zip_path --keychain-profile $profile --keychain $KP_NOTARY_KEYCHAIN --wait $*"
-        else
-            echo "[DRY RUN] $KP_NOTARY_CMD submit $zip_path --keychain-profile $profile --wait $*"
-        fi
+        echo "[DRY RUN] $KP_NOTARY_CMD submit $zip_path ${notary_args[*]} --wait $*"
         return 0
     fi
     # Use word-splitting for multi-word command (xcrun notarytool)
-    if [ -n "${KP_NOTARY_KEYCHAIN:-}" ]; then
-        $KP_NOTARY_CMD submit "$zip_path" --keychain-profile "$profile" --keychain "$KP_NOTARY_KEYCHAIN" --wait "$@"
-    else
-        $KP_NOTARY_CMD submit "$zip_path" --keychain-profile "$profile" --wait "$@"
-    fi
+    $KP_NOTARY_CMD submit "$zip_path" "${notary_args[@]}" --wait "$@"
 }
 
 kp_staple() {

--- a/Scripts/release-candidate.sh
+++ b/Scripts/release-candidate.sh
@@ -34,6 +34,9 @@ Options:
 Environment:
   CODESIGN_IDENTITY   Developer ID Application identity override.
   NOTARY_PROFILE      notarytool keychain profile override.
+  KP_NOTARY_KEY       App Store Connect API key .p8 path; requires KP_NOTARY_KEY_ID and KP_NOTARY_ISSUER.
+  KP_NOTARY_KEY_ID    App Store Connect API key id.
+  KP_NOTARY_ISSUER    App Store Connect issuer id.
 EOF
 }
 

--- a/Scripts/release-doctor.sh
+++ b/Scripts/release-doctor.sh
@@ -27,6 +27,9 @@ Environment checked:
   CODESIGN_IDENTITY    Developer ID Application identity override.
   NOTARY_PROFILE       notarytool keychain profile override.
   KP_NOTARY_KEYCHAIN   Optional notarytool keychain override.
+  KP_NOTARY_KEY        App Store Connect API key .p8 path; requires KP_NOTARY_KEY_ID and KP_NOTARY_ISSUER.
+  KP_NOTARY_KEY_ID     App Store Connect API key id.
+  KP_NOTARY_ISSUER     App Store Connect issuer id.
   SKIP_SPARKLE         If 1, skip Sparkle checks.
   SKIP_WEBSITE         If 1, skip gh-pages website checks.
 EOF
@@ -98,6 +101,31 @@ check_optional_command() {
 
 notarytool() {
     xcrun notarytool "$@"
+}
+
+notary_api_env_present() {
+    [[ -n "${KP_NOTARY_KEY:-}" || -n "${KP_NOTARY_KEY_ID:-}" || -n "${KP_NOTARY_ISSUER:-}" ]]
+}
+
+validate_notary_api_env() {
+    local missing=()
+    [[ -n "${KP_NOTARY_KEY:-}" ]] || missing+=("KP_NOTARY_KEY")
+    [[ -n "${KP_NOTARY_KEY_ID:-}" ]] || missing+=("KP_NOTARY_KEY_ID")
+    [[ -n "${KP_NOTARY_ISSUER:-}" ]] || missing+=("KP_NOTARY_ISSUER")
+
+    if (( ${#missing[@]} > 0 )); then
+        fail "Incomplete App Store Connect notarization credentials"
+        echo "   Missing: ${missing[*]}"
+        echo "   Set all of KP_NOTARY_KEY, KP_NOTARY_KEY_ID, and KP_NOTARY_ISSUER, or unset them to use NOTARY_PROFILE."
+        return 1
+    fi
+
+    if [[ ! -f "$KP_NOTARY_KEY" ]]; then
+        fail "KP_NOTARY_KEY does not exist: $KP_NOTARY_KEY"
+        return 1
+    fi
+
+    return 0
 }
 
 resolve_sign_update() {
@@ -215,16 +243,29 @@ else
     echo "   Set CODESIGN_IDENTITY or install the Developer ID Application certificate."
 fi
 
-notary_args=(history --keychain-profile "$notary_profile" --output-format json)
-if [[ -n "${KP_NOTARY_KEYCHAIN:-}" ]]; then
-    notary_args+=(--keychain "$KP_NOTARY_KEYCHAIN")
-fi
-
-if notarytool "${notary_args[@]}" >/dev/null 2>&1; then
-    pass "notarytool profile validated: $notary_profile"
+if notary_api_env_present; then
+    if validate_notary_api_env; then
+        notary_args=(history --key "$KP_NOTARY_KEY" --key-id "$KP_NOTARY_KEY_ID" --issuer "$KP_NOTARY_ISSUER" --output-format json)
+        if notarytool "${notary_args[@]}" >/dev/null 2>&1; then
+            pass "notarytool App Store Connect API key validated: $KP_NOTARY_KEY_ID"
+        else
+            fail "notarytool App Store Connect API key failed validation: $KP_NOTARY_KEY_ID"
+            echo "   Check KP_NOTARY_KEY, KP_NOTARY_KEY_ID, and KP_NOTARY_ISSUER."
+        fi
+    fi
 else
-    fail "notarytool profile failed validation: $notary_profile"
-    echo "   Set NOTARY_PROFILE or run: xcrun notarytool store-credentials"
+    notary_args=(history --keychain-profile "$notary_profile" --output-format json)
+    if [[ -n "${KP_NOTARY_KEYCHAIN:-}" ]]; then
+        notary_args+=(--keychain "$KP_NOTARY_KEYCHAIN")
+    fi
+
+    if notarytool "${notary_args[@]}" >/dev/null 2>&1; then
+        pass "notarytool profile validated: $notary_profile"
+    else
+        fail "notarytool profile failed validation: $notary_profile"
+        echo "   Set NOTARY_PROFILE or run: xcrun notarytool store-credentials"
+        echo "   In non-interactive shells, prefer KP_NOTARY_KEY + KP_NOTARY_KEY_ID + KP_NOTARY_ISSUER."
+    fi
 fi
 
 print_section "Release Artifacts"

--- a/Tests/KeyPathTests/BuildScripts/SigningPipelineTests.swift
+++ b/Tests/KeyPathTests/BuildScripts/SigningPipelineTests.swift
@@ -72,4 +72,36 @@ final class SigningPipelineTests: XCTestCase {
         let result = runScript(script)
         XCTAssertNotEqual(result.code, 0, "notary wrapper should bubble up failures")
     }
+
+    func testNotaryWrapperSupportsAppStoreConnectAPIKeyDryRun() {
+        let tempKey = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true).appendingPathComponent(UUID().uuidString)
+        FileManager.default.createFile(atPath: tempKey.path, contents: Data())
+
+        let script = """
+        source \(signingLibPath)
+        KP_SIGN_DRY_RUN=1 \\
+        KP_NOTARY_KEY="\(tempKey.path)" \\
+        KP_NOTARY_KEY_ID=ABC123 \\
+        KP_NOTARY_ISSUER=00000000-0000-0000-0000-000000000000 \\
+        kp_notarize_zip "/tmp/fake.zip" "NoProfile"
+        """
+
+        let result = runScript(script)
+        XCTAssertEqual(result.code, 0, "API-key dry run should succeed. stderr: \(result.stderr)")
+        XCTAssertTrue(result.stdout.contains("--key \(tempKey.path)"))
+        XCTAssertTrue(result.stdout.contains("--key-id ABC123"))
+        XCTAssertTrue(result.stdout.contains("--issuer 00000000-0000-0000-0000-000000000000"))
+        XCTAssertFalse(result.stdout.contains("--keychain-profile"))
+    }
+
+    func testNotaryWrapperRejectsPartialAPIKeyEnvironment() {
+        let script = """
+        source \(signingLibPath)
+        KP_SIGN_DRY_RUN=1 KP_NOTARY_KEY=/tmp/missing.p8 KP_NOTARY_KEY_ID=ABC123 kp_notarize_zip "/tmp/fake.zip" "NoProfile"
+        """
+
+        let result = runScript(script)
+        XCTAssertNotEqual(result.code, 0, "Partial API-key env must fail before invoking notarytool")
+        XCTAssertTrue(result.stderr.contains("Missing: KP_NOTARY_ISSUER"))
+    }
 }

--- a/Tests/KeyPathTests/Lint/DeploymentScriptContractTests.swift
+++ b/Tests/KeyPathTests/Lint/DeploymentScriptContractTests.swift
@@ -33,8 +33,38 @@ final class DeploymentScriptContractTests: XCTestCase {
             "build-and-sign must acquire the shared deploy lock."
         )
         XCTAssertTrue(
-            buildAndSign.contains("trap keypath_release_deploy_lock EXIT"),
+            buildAndSign.contains("trap cleanup_release EXIT"),
             "build-and-sign must release the shared deploy lock on exit."
+        )
+    }
+
+    func testReleaseDeployCopiesAndVerifiesBeforeReplacingInstalledApp() throws {
+        let root = repositoryRoot()
+        let buildAndSign = try contents(of: root.appendingPathComponent("Scripts/build-and-sign.sh"))
+
+        XCTAssertTrue(
+            buildAndSign.contains(#"APP_TMP="$SYSTEM_APPS_DIR/.${APP_NAME}.app.tmp.$$""#),
+            "release deploy must stage the candidate in a temporary app bundle."
+        )
+        XCTAssertTrue(
+            buildAndSign.contains(#"ditto "$APP_BUNDLE" "$APP_TMP""#),
+            "release deploy must copy the candidate to the temporary bundle first."
+        )
+        XCTAssertTrue(
+            buildAndSign.contains(#"verify_deploy_candidate "$APP_TMP""#),
+            "release deploy must verify the temporary bundle before replacing the installed app."
+        )
+        XCTAssertTrue(
+            buildAndSign.contains(#"mv "$APP_DEST" "$APP_BACKUP""#),
+            "release deploy must move the previous install aside instead of deleting it first."
+        )
+        XCTAssertTrue(
+            buildAndSign.contains("Restoring previous install"),
+            "release deploy must restore the previous install when the swap or final verification fails."
+        )
+        XCTAssertFalse(
+            buildAndSign.contains("rm -rf \"$APP_DEST\"\nif ditto \"$APP_BUNDLE\" \"$APP_DEST\"; then"),
+            "release deploy must not delete /Applications/KeyPath.app before copying a verified replacement."
         )
     }
 

--- a/docs/process/release-process.md
+++ b/docs/process/release-process.md
@@ -50,6 +50,18 @@ The release-candidate wrapper first runs:
 ./Scripts/release-doctor.sh --release-candidate
 ```
 
+Notarization can use either the configured `notarytool` keychain profile or an
+App Store Connect API key. In unattended agent shells, prefer the API key path
+because keychain profile reads can fail when macOS disallows non-interactive
+Keychain access:
+
+```bash
+KP_NOTARY_KEY=/path/to/AuthKey_XXXXXXXXXX.p8 \
+KP_NOTARY_KEY_ID=XXXXXXXXXX \
+KP_NOTARY_ISSUER=00000000-0000-0000-0000-000000000000 \
+./Scripts/release-candidate.sh
+```
+
 Then it delegates to `build-and-sign.sh` with fast release-candidate defaults:
 
 - `SKIP_SNAPSHOTS=1`
@@ -59,6 +71,14 @@ Then it delegates to `build-and-sign.sh` with fast release-candidate defaults:
 
 It deploys to `/Applications/KeyPath.app` and runs
 `./Scripts/verify-installed-app.sh` after the build.
+
+Deploy is fail-closed: the script copies to a temporary bundle in
+`/Applications`, verifies bundle structure, signature, stapling, and Gatekeeper
+assessment, then swaps the verified bundle into place. The previous installed
+app is moved aside only during the final swap and is restored if that swap
+fails. If Kanata is still running and cannot be stopped non-interactively, the
+deploy stops before replacing the app; use
+`KEYPATH_ALLOW_DEPLOY_WITH_RUNNING_KANATA=1` only for emergency diagnostics.
 
 Release-candidate and public release builds hold the shared deploy lock for the
 whole build/sign/notarize/deploy flow. Update old worktrees before running
@@ -153,7 +173,7 @@ the expensive build starts:
 - required tools (`swift`, `xcrun`, `codesign`, `security`, `git`, `gh`, `nc`)
 - current git branch, dirty state, and master worktree ownership
 - Developer ID signing identity
-- notarytool keychain profile
+- notarytool keychain profile or App Store Connect API key credentials
 - Sparkle `sign_update` when Sparkle artifacts are enabled
 - `gh-pages` worktree state when website publishing is enabled
 - currently installed KeyPath/Kanata runtime state


### PR DESCRIPTION
## Summary
- add App Store Connect API-key notarization support to the signing helper and release-doctor preflight
- make release deploy copy, verify, swap, and rollback instead of deleting /Applications/KeyPath.app first
- fail closed when Kanata remains running before bundle replacement, with an explicit diagnostic override
- document the unattended notarization path and add tests for the new release-script contracts

## Validation
- bash -n Scripts/lib/signing.sh Scripts/release-doctor.sh Scripts/release-candidate.sh Scripts/build-and-sign.sh
- git diff --check
- KP_SIGN_DRY_RUN=1 API-key notarization dry run
- KP_SIGN_DRY_RUN=1 partial API-key env negative dry run
- KP_NOTARY_KEY=/Users/malpern/.appstoreconnect/private_keys/AuthKey_XQ4565NYZ7.p8 KP_NOTARY_KEY_ID=XQ4565NYZ7 KP_NOTARY_ISSUER=60b8eb46-ca64-4580-a43b-850d92fcc7ab ./Scripts/release-doctor.sh --release-candidate
- python3 Scripts/check-accessibility.py
- ./Scripts/test-lane.sh smoke
- TEST_FILTER=SigningPipelineTests ./Scripts/run-tests-safe.sh
- TEST_FILTER=DeploymentScriptContractTests ./Scripts/run-tests-safe.sh

## Known unrelated validation caveat
- ./Scripts/test-fast.sh --changed fell back to the full safe suite and failed in KeyPathSnapshotTests with xctest signal 11 after the non-snapshot suites had run; this matches the current macOS 27/Xcode beta snapshot-harness noise we have been tracking separately.