### PR TITLE
Hide overlay until initial setup completes

### DIFF
--- a/Sources/KeyPathAppKit/App.swift
+++ b/Sources/KeyPathAppKit/App.swift
@@ -277,8 +277,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 if !self.initialMainWindowShown {
                     AppLogger.shared.info("🪟 [AppDelegate] Splash fallback auto-hide (app never activated)")
                     self.initialMainWindowShown = true
-                    LiveKeyboardOverlayController.shared.showForStartup(bypassHiddenCheck: true)
-                    self.mainWindowController?.window?.orderOut(nil)
+                    if await self.hasCompletedInitialWizard() {
+                        LiveKeyboardOverlayController.shared.showForStartup(bypassHiddenCheck: true)
+                        self.mainWindowController?.window?.orderOut(nil)
+                    } else {
+                        AppLogger.shared.info("🪟 [AppDelegate] Splash fallback kept visible — initial wizard incomplete")
+                        self.mainWindowController?.show(focus: false)
+                    }
                 }
             }
         } else {
@@ -326,7 +331,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         AppLogger.shared.debug(
             "🔍 [AppDelegate] applicationShouldHandleReopen (hasVisibleWindows=\(flag))"
         )
-        presentReopenSurface(trigger: "reopen")
+        Task { @MainActor in
+            await presentReopenSurface(trigger: "reopen")
+        }
         return true
     }
 
@@ -345,11 +352,19 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     /// Present the right surface for a user-initiated "open KeyPath" action
     /// (Dock/Raycast/Spotlight reopen or menu-bar "Show KeyPath").
-    private func presentReopenSurface(trigger: String) {
+    private func hasCompletedInitialWizard() async -> Bool {
+        guard hasExistingConfig else { return false }
+        let isFreshInstall = await Self.checkIsFreshInstall()
+        return !isFreshInstall
+    }
+
+    private func presentReopenSurface(trigger: String) async {
         unhideAndActivate()
 
+        let completedInitialWizard = await hasCompletedInitialWizard()
         let surface = ReopenPolicy.surface(
             hasExistingConfig: hasExistingConfig,
+            hasCompletedInitialWizard: completedInitialWizard,
             overlayVisible: LiveKeyboardOverlayController.shared.isVisible
         )
 
@@ -445,8 +460,15 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         suppressLaunchSplashAutoHide = false
 
         if hasExistingConfig {
-            AppLogger.shared.info("🪟 [AppDelegate] Relaunch detected — skipping splash, restoring overlay directly")
-            LiveKeyboardOverlayController.shared.showForStartup(bypassHiddenCheck: true)
+            Task { @MainActor in
+                if await hasCompletedInitialWizard() {
+                    AppLogger.shared.info("🪟 [AppDelegate] Relaunch detected — skipping splash, restoring overlay directly")
+                    LiveKeyboardOverlayController.shared.showForStartup(bypassHiddenCheck: true)
+                } else {
+                    AppLogger.shared.info("🪟 [AppDelegate] Initial wizard incomplete — showing setup surface, not overlay")
+                    showSplashWindow()
+                }
+            }
             return
         }
 
@@ -462,14 +484,18 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             AppLogger.shared.info("[AppDelegate] Launch splash delay: \(splashDelayMs)ms")
             try? await Task.sleep(for: .milliseconds(splashDelayMs))
 
-            LiveKeyboardOverlayController.shared.showForStartup(bypassHiddenCheck: true)
-            AppLogger.shared.info("🪟 [AppDelegate] First activation - overlay shown")
+            if await self.hasCompletedInitialWizard() {
+                LiveKeyboardOverlayController.shared.showForStartup(bypassHiddenCheck: true)
+                AppLogger.shared.info("🪟 [AppDelegate] First activation - overlay shown")
 
-            if !self.suppressLaunchSplashAutoHide {
-                self.mainWindowController?.window?.orderOut(nil)
-                AppLogger.shared.info("🪟 [AppDelegate] Auto-hid launch splash window")
+                if !self.suppressLaunchSplashAutoHide {
+                    self.mainWindowController?.window?.orderOut(nil)
+                    AppLogger.shared.info("🪟 [AppDelegate] Auto-hid launch splash window")
+                } else {
+                    AppLogger.shared.info("🪟 [AppDelegate] Splash auto-hide suppressed (user re-opened during launch)")
+                }
             } else {
-                AppLogger.shared.info("🪟 [AppDelegate] Splash auto-hide suppressed (user re-opened during launch)")
+                AppLogger.shared.info("🪟 [AppDelegate] Initial wizard incomplete — keeping splash visible, not showing overlay")
             }
         }
 
@@ -480,8 +506,15 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         if !LiveKeyboardOverlayController.shared.isVisible,
            LiveKeyboardOverlayController.shared.canAutoShow
         {
-            LiveKeyboardOverlayController.shared.showForStartup()
-            AppLogger.shared.debug("🪟 [AppDelegate] Subsequent activation - showing overlay")
+            Task { @MainActor in
+                if await hasCompletedInitialWizard() {
+                    LiveKeyboardOverlayController.shared.showForStartup()
+                    AppLogger.shared.debug("🪟 [AppDelegate] Subsequent activation - showing overlay")
+                } else {
+                    AppLogger.shared.debug("🪟 [AppDelegate] Subsequent activation - initial wizard incomplete, not showing overlay")
+                    showSplashWindow()
+                }
+            }
         } else if !LiveKeyboardOverlayController.shared.isVisible {
             AppLogger.shared.debug("🪟 [AppDelegate] Subsequent activation - overlay hidden by user, not auto-showing")
         } else {
@@ -705,7 +738,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     private func showKeyPathFromStatusItem() {
         AppLogger.shared.debug("☰ [MenuBar] Show KeyPath requested from status item")
-        presentReopenSurface(trigger: "status item")
+        Task { @MainActor in
+            await self.presentReopenSurface(trigger: "status item")
+        }
     }
 
     // MARK: - Private: Wizard

--- a/Sources/KeyPathAppKit/Utilities/ReopenPolicy.swift
+++ b/Sources/KeyPathAppKit/Utilities/ReopenPolicy.swift
@@ -3,10 +3,10 @@ import Foundation
 /// Decides which surface to present when the user re-opens the running app
 /// (Dock click, Raycast/Spotlight launch, menu-bar "Show KeyPath").
 ///
-/// The splash/main window is a borderless poster with no dismiss affordance, so it
-/// is only a valid surface during first-run onboarding (no config yet). Once a
-/// config exists, reopen must present the overlay instead — re-showing the splash
-/// on a fully running app leaves it stuck on screen with no way to close it.
+/// The splash/main window is the onboarding surface while setup is incomplete.
+/// Once a config exists and the initial wizard has completed, reopen should
+/// present the overlay instead — re-showing the splash on a fully running app
+/// leaves it stuck on screen with no way to close it.
 enum ReopenPolicy {
     enum Surface: Equatable {
         /// Overlay already on screen — just activate and bring it forward.
@@ -17,8 +17,12 @@ enum ReopenPolicy {
         case showSplash
     }
 
-    static func surface(hasExistingConfig: Bool, overlayVisible: Bool) -> Surface {
-        guard hasExistingConfig else { return .showSplash }
+    static func surface(
+        hasExistingConfig: Bool,
+        hasCompletedInitialWizard: Bool,
+        overlayVisible: Bool
+    ) -> Surface {
+        guard hasExistingConfig, hasCompletedInitialWizard else { return .showSplash }
         return overlayVisible ? .activateOnly : .showOverlay
     }
 }

--- a/Tests/KeyPathTests/Utilities/ReopenPolicyTests.swift
+++ b/Tests/KeyPathTests/Utilities/ReopenPolicyTests.swift
@@ -5,7 +5,11 @@ import Testing
 struct ReopenPolicyTests {
     @Test("Running app with visible overlay just activates")
     func overlayVisibleActivatesOnly() {
-        let surface = ReopenPolicy.surface(hasExistingConfig: true, overlayVisible: true)
+        let surface = ReopenPolicy.surface(
+            hasExistingConfig: true,
+            hasCompletedInitialWizard: true,
+            overlayVisible: true
+        )
         #expect(surface == .activateOnly)
     }
 
@@ -13,19 +17,51 @@ struct ReopenPolicyTests {
     func overlayHiddenShowsOverlay() {
         // The Raycast relaunch bug: reopen with the overlay hidden used to fall
         // through to the splash window, which has no dismiss affordance.
-        let surface = ReopenPolicy.surface(hasExistingConfig: true, overlayVisible: false)
+        let surface = ReopenPolicy.surface(
+            hasExistingConfig: true,
+            hasCompletedInitialWizard: true,
+            overlayVisible: false
+        )
         #expect(surface == .showOverlay)
+    }
+
+    @Test("Existing config does not show overlay before initial wizard completes")
+    func configBeforeInitialWizardCompletionShowsSplash() {
+        let surface = ReopenPolicy.surface(
+            hasExistingConfig: true,
+            hasCompletedInitialWizard: false,
+            overlayVisible: false
+        )
+        #expect(surface == .showSplash)
+    }
+
+    @Test("Initial wizard completion is required even if overlay is somehow visible")
+    func incompleteWizardOverridesOverlayVisibility() {
+        let surface = ReopenPolicy.surface(
+            hasExistingConfig: true,
+            hasCompletedInitialWizard: false,
+            overlayVisible: true
+        )
+        #expect(surface == .showSplash)
     }
 
     @Test("First run (no config) shows the splash onboarding surface")
     func firstRunShowsSplash() {
-        let surface = ReopenPolicy.surface(hasExistingConfig: false, overlayVisible: false)
+        let surface = ReopenPolicy.surface(
+            hasExistingConfig: false,
+            hasCompletedInitialWizard: false,
+            overlayVisible: false
+        )
         #expect(surface == .showSplash)
     }
 
     @Test("No config always means splash, even if the overlay is somehow visible")
     func noConfigOverridesOverlayVisibility() {
-        let surface = ReopenPolicy.surface(hasExistingConfig: false, overlayVisible: true)
+        let surface = ReopenPolicy.surface(
+            hasExistingConfig: false,
+            hasCompletedInitialWizard: true,
+            overlayVisible: true
+        )
         #expect(surface == .showSplash)
     }
 }


### PR DESCRIPTION
## Summary
- require completed initial setup before app reopen/startup paths show the keyboard overlay
- keep or show the splash/setup surface when config exists but install state still looks fresh
- extend ReopenPolicy coverage for config-before-setup cases

## Validation
- swift build
- TEST_FILTER=ReopenPolicyTests ./Scripts/run-tests-safe.sh