### PR TITLE
Require runtime readiness before showing overlay

### DIFF
--- a/Sources/KeyPathAppKit/App.swift
+++ b/Sources/KeyPathAppKit/App.swift
@@ -354,8 +354,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     /// (Dock/Raycast/Spotlight reopen or menu-bar "Show KeyPath").
     private func hasCompletedInitialWizard() async -> Bool {
         guard hasExistingConfig else { return false }
-        let isFreshInstall = await Self.checkIsFreshInstall()
-        return !isFreshInstall
+        let health = await ServiceHealthChecker.shared.checkKanataServiceHealth()
+        return health.isRunning && health.isResponding
     }
 
     private func presentReopenSurface(trigger: String) async {


### PR DESCRIPTION
## Summary
- tighten the initial-setup overlay guard to require Kanata running and TCP-responsive
- avoids showing the keyboard overlay when stale install metadata exists but the wizard/runtime setup is still incomplete

## Validation
- swift build
- git diff --check
- swiftformat --lint Sources/KeyPathAppKit/App.swift
- swiftlint Sources/KeyPathAppKit/App.swift
- TEST_FILTER=ReopenPolicyTests ./Scripts/run-tests-safe.sh

## Context
The first pass used non-fresh install state as the setup-complete proxy. Local post-merge verification showed this was too weak: this machine had stale config/install metadata but no registered/running system/com.keypath.kanata job, so the overlay could still appear before setup was really complete.