### PR TITLE
Hard gate overlay until onboarding completes

### DIFF
--- a/Sources/KeyPathAppKit/App.swift
+++ b/Sources/KeyPathAppKit/App.swift
@@ -353,9 +353,14 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     /// Present the right surface for a user-initiated "open KeyPath" action
     /// (Dock/Raycast/Spotlight reopen or menu-bar "Show KeyPath").
     private func hasCompletedInitialWizard() async -> Bool {
-        guard hasExistingConfig else { return false }
+        guard hasExistingConfig else {
+            LiveKeyboardOverlayController.shared.setOnboardingCompleted(false)
+            return false
+        }
         let health = await ServiceHealthChecker.shared.checkKanataServiceHealth()
-        return health.isRunning && health.isResponding
+        let completed = health.isRunning && health.isResponding
+        LiveKeyboardOverlayController.shared.setOnboardingCompleted(completed)
+        return completed
     }
 
     private func presentReopenSurface(trigger: String) async {

--- a/Sources/KeyPathAppKit/UI/Overlay/LiveKeyboardOverlayController+LauncherSession.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/LiveKeyboardOverlayController+LauncherSession.swift
@@ -43,6 +43,8 @@ extension LiveKeyboardOverlayController {
         }
         NSApp.activate(ignoringOtherApps: true)
         showForQuickLaunch(bypassHiddenCheck: true)
+        guard canShowOverlay(reason: "launcher activation front") else { return }
+        guard isVisible else { return }
     }
 
     func noteLauncherActionDispatched() {
@@ -85,6 +87,8 @@ extension LiveKeyboardOverlayController {
         if !isVisible {
             isVisible = true
         }
+        guard canShowOverlay(reason: "bring overlay to front") else { return }
+        guard isVisible else { return }
         NSApp.activate(ignoringOtherApps: true)
         window?.orderFront(nil)
     }

--- a/Sources/KeyPathAppKit/UI/Overlay/LiveKeyboardOverlayController+Observers.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/LiveKeyboardOverlayController+Observers.swift
@@ -131,6 +131,7 @@ extension LiveKeyboardOverlayController {
             Task { @MainActor in
                 guard let self, self.overlayHiddenByWizard else { return }
                 self.overlayHiddenByWizard = false
+                guard self.canShowOverlay(reason: "wizard close restore") else { return }
                 self.window?.orderFront(nil)
                 AppLogger.shared.log("🪟 [OverlayController] Restored overlay — wizard closed")
             }
@@ -167,6 +168,7 @@ extension LiveKeyboardOverlayController {
             AppLogger.shared.log("🪟 [OverlayController] Test mode changed - window was hidden, will recreate on next show")
             return
         }
+        guard canShowOverlay(reason: "accessibility test mode recreate") else { return }
 
         createWindow()
         if let savedFrame, let window {

--- a/Sources/KeyPathAppKit/UI/Overlay/LiveKeyboardOverlayController.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/LiveKeyboardOverlayController.swift
@@ -32,6 +32,7 @@ final class LiveKeyboardOverlayController: NSObject, NSWindowDelegate {
     var hintWindowController: HideHintWindowController?
     var hintBubbleObserver: Task<Void, Never>?
     private var hiddenHintController: OverlayHiddenHintWindowController?
+    private var onboardingCompleted = false
 
     weak var kanataViewModel: KanataViewModel?
     weak var ruleCollectionsManager: RuleCollectionsManager?
@@ -146,19 +147,42 @@ final class LiveKeyboardOverlayController: NSObject, NSWindowDelegate {
 
     private static let oneShotTimeoutDuration: Duration = .seconds(5)
 
+    func setOnboardingCompleted(_ completed: Bool) {
+        onboardingCompleted = completed
+        if !completed {
+            blockOverlayBeforeOnboarding(reason: "onboarding marked incomplete")
+        }
+    }
+
+    @discardableResult
+    func canShowOverlay(reason: String) -> Bool {
+        if onboardingCompleted { return true }
+        blockOverlayBeforeOnboarding(reason: reason)
+        return false
+    }
+
+    private func blockOverlayBeforeOnboarding(reason: String) {
+        AppLogger.shared.log("⏸️ [OverlayController] Overlay blocked before onboarding completes (\(reason))")
+        UserDefaults.standard.set(false, forKey: DefaultsKey.isVisible)
+        viewModel.stopCapturing()
+        dismissHintBubble()
+        window?.orderOut(nil)
+    }
+
     /// Restore overlay state from previous session
     /// Only restores if system status is healthy (Kanata running)
     func restoreState() {
         let defaults = UserDefaults.standard
         guard defaults.bool(forKey: DefaultsKey.isVisible) else { return }
+        guard canShowOverlay(reason: "restore state") else { return }
 
         // Only restore if system is healthy
         Task { @MainActor in
             let health = await ServiceHealthChecker.shared.checkKanataServiceHealth()
-            if health.isRunning {
+            if health.isRunning, health.isResponding {
                 isVisible = true
             } else {
-                AppLogger.shared.log("⚠️ [OverlayController] Skipping overlay restore - Kanata not running")
+                AppLogger.shared.log("⚠️ [OverlayController] Skipping overlay restore - Kanata not ready")
             }
         }
     }
@@ -170,6 +194,8 @@ final class LiveKeyboardOverlayController: NSObject, NSWindowDelegate {
     /// - Parameter bypassHiddenCheck: If true, shows overlay even if user explicitly hid it.
     ///   Only use this for the initial app launch, not for subsequent activations.
     func showForStartup(bypassHiddenCheck: Bool = false) {
+        guard canShowOverlay(reason: "startup show") else { return }
+
         // IMPORTANT: Respect user's explicit hide unless bypassed (initial launch only)
         if !bypassHiddenCheck, userExplicitlyHidden {
             AppLogger.shared.log("⏸️ [OverlayController] showForStartup skipped - user explicitly hid overlay")
@@ -233,6 +259,8 @@ final class LiveKeyboardOverlayController: NSObject, NSWindowDelegate {
     /// - Parameter bypassHiddenCheck: If true, shows overlay even if user explicitly hid it.
     ///   Used for launcher layer activation which should always show the overlay temporarily.
     func showForQuickLaunch(bypassHiddenCheck: Bool = false) {
+        guard canShowOverlay(reason: "quick launch show") else { return }
+
         // IMPORTANT: Respect user's explicit hide unless bypassed
         // Launcher activation should bypass because user is actively using it
         if !bypassHiddenCheck, userExplicitlyHidden {
@@ -267,6 +295,7 @@ final class LiveKeyboardOverlayController: NSObject, NSWindowDelegate {
         get { window?.isVisible ?? false }
         set {
             if newValue {
+                guard canShowOverlay(reason: "visibility setter") else { return }
                 showWindow()
             } else {
                 hideWindow()
@@ -345,6 +374,8 @@ final class LiveKeyboardOverlayController: NSObject, NSWindowDelegate {
 
     /// Show the overlay, restore its default size, and center it on screen.
     func showResetCentered() {
+        guard canShowOverlay(reason: "reset centered show") else { return }
+
         frameStore.clear()
 
         if window == nil {
@@ -447,6 +478,8 @@ final class LiveKeyboardOverlayController: NSObject, NSWindowDelegate {
     // MARK: - Window Management
 
     private func showWindow() {
+        guard canShowOverlay(reason: "show window") else { return }
+
         if window == nil {
             createWindow()
         }


### PR DESCRIPTION
## Summary
- keep the keyboard overlay controller locked by default until onboarding/runtime readiness is confirmed
- clear persisted overlay visibility and order out any existing overlay window while onboarding is incomplete
- guard direct restore/recreate/fronting paths that could bypass AppDelegate startup policy

## Validation
- swift build
- git diff --check
- swiftformat --lint changed Swift files
- swiftlint changed Swift files
- TEST_FILTER=ReopenPolicyTests ./Scripts/run-tests-safe.sh
- ./Scripts/quick-deploy.sh
- CHECK_RUNTIME=0 REQUIRE_NOTARIZED=0 REQUIRE_STAPLED=0 ./Scripts/verify-installed-app.sh
- Window sanity check after deploy: setup surfaces only; no overlay create/show logs while Kanata reports hostRunning=false, tcpResponding=false