### PR TITLE
[codex] Add installer identity stability contract

### DIFF
--- a/Scripts/build-and-sign.sh
+++ b/Scripts/build-and-sign.sh
@@ -489,6 +489,7 @@ else
 
     echo "✅ Verifying signatures..."
     kp_verify_signature "$APP_BUNDLE"
+    "$SCRIPT_DIR/verify-identity-contract.sh" --app "$APP_BUNDLE"
 fi
 
 if [ "${SKIP_NOTARIZE:-}" = "1" ]; then

--- a/Scripts/release-doctor.sh
+++ b/Scripts/release-doctor.sh
@@ -227,6 +227,13 @@ else
     echo "   Set NOTARY_PROFILE or run: xcrun notarytool store-credentials"
 fi
 
+print_section "Identity Contract"
+if "$PROJECT_DIR/Scripts/verify-identity-contract.sh" --source; then
+    pass "Installer identity-stability source contract passed"
+else
+    fail "Installer identity-stability source contract failed"
+fi
+
 print_section "Release Artifacts"
 effective_skip_sparkle="${SKIP_SPARKLE:-}"
 effective_skip_website="${SKIP_WEBSITE:-}"

--- a/Scripts/verify-identity-contract.sh
+++ b/Scripts/verify-identity-contract.sh
@@ -1,0 +1,232 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" >/dev/null && pwd)
+PROJECT_DIR=$(cd "$SCRIPT_DIR/.." >/dev/null && pwd)
+
+TEAM_ID="X2RKZ5TG99"
+DEVELOPER_ID_AUTHORITY="Developer ID Application: Micah Alpern (${TEAM_ID})"
+
+KANATA_ENGINE_ID="com.keypath.kanata-engine"
+KANATA_ENGINE_REQ='identifier "com.keypath.kanata-engine" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = X2RKZ5TG99'
+
+HELPER_ID="com.keypath.helper"
+HELPER_REQ='identifier "com.keypath.helper" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = X2RKZ5TG99'
+
+KANATA_DAEMON_ID="com.keypath.kanata"
+KANATA_LAUNCHER_ID="kanata-launcher"
+KANATA_LAUNCHER_REQ='identifier "kanata-launcher" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = X2RKZ5TG99'
+
+MODE="source"
+APP_PATH=""
+
+usage() {
+    cat <<'EOF'
+Usage: Scripts/verify-identity-contract.sh [--source] [--app PATH]
+
+Verifies the Workstream 4 identity-stability contract for KeyPath's
+permission-bearing and launchd-managed components.
+
+Modes:
+  --source    Verify committed plists/constants only. Used by release-doctor and CI.
+  --app PATH  Verify a signed KeyPath.app artifact, including codesign identities.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --source)
+            MODE="source"
+            APP_PATH=""
+            ;;
+        --app)
+            MODE="app"
+            APP_PATH="${2:-}"
+            if [[ -z "$APP_PATH" ]]; then
+                echo "Missing path after --app" >&2
+                usage >&2
+                exit 2
+            fi
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+    shift
+done
+
+failures=0
+
+pass() {
+    echo "[identity-contract] PASS: $1"
+}
+
+fail() {
+    failures=$((failures + 1))
+    echo "[identity-contract] FAIL: $1" >&2
+}
+
+plist_value() {
+    local plist=$1
+    local key_path=$2
+    /usr/libexec/PlistBuddy -c "Print :${key_path}" "$plist" 2>/dev/null || true
+}
+
+expect_file() {
+    local path=$1
+    local description=$2
+    if [[ -e "$path" ]]; then
+        pass "$description exists"
+    else
+        fail "$description missing at $path"
+    fi
+}
+
+expect_plist_value() {
+    local plist=$1
+    local key_path=$2
+    local expected=$3
+    local description=$4
+    local actual
+    actual=$(plist_value "$plist" "$key_path")
+    if [[ "$actual" == "$expected" ]]; then
+        pass "$description is $expected"
+    else
+        fail "$description expected '$expected' but found '${actual:-<missing>}' in $plist"
+    fi
+}
+
+expect_text() {
+    local file=$1
+    local needle=$2
+    local description=$3
+    if grep -F -- "$needle" "$file" >/dev/null 2>&1; then
+        pass "$description"
+    else
+        fail "$description missing '$needle' in $file"
+    fi
+}
+
+expect_codesign_identity() {
+    local path=$1
+    local expected_identifier=$2
+    local expected_requirement=$3
+    local description=$4
+    local output
+    if ! output=$(codesign -d -r- --verbose=4 "$path" 2>&1); then
+        fail "$description codesign inspection failed: $output"
+        return
+    fi
+
+    if grep -F "Identifier=${expected_identifier}" <<<"$output" >/dev/null; then
+        pass "$description signing identifier is $expected_identifier"
+    else
+        fail "$description signing identifier is not $expected_identifier"
+    fi
+
+    if grep -F "Authority=${DEVELOPER_ID_AUTHORITY}" <<<"$output" >/dev/null; then
+        pass "$description signed by ${DEVELOPER_ID_AUTHORITY}"
+    else
+        fail "$description is not signed by ${DEVELOPER_ID_AUTHORITY}"
+    fi
+
+    if grep -F "TeamIdentifier=${TEAM_ID}" <<<"$output" >/dev/null; then
+        pass "$description team identifier is ${TEAM_ID}"
+    else
+        fail "$description team identifier is not ${TEAM_ID}"
+    fi
+
+    local actual_requirement
+    actual_requirement=$(sed -n 's/^designated => //p' <<<"$output" | tail -n 1)
+    if [[ -z "$actual_requirement" ]]; then
+        fail "$description designated requirement could not be parsed from codesign output; codesign output format may have changed"
+        return
+    fi
+
+    if [[ "$actual_requirement" == "$expected_requirement" ]]; then
+        pass "$description designated requirement is stable"
+    else
+        fail "$description designated requirement changed. Expected '$expected_requirement' but found '$actual_requirement'"
+    fi
+}
+
+verify_source_contract() {
+    cd "$PROJECT_DIR"
+
+    local kanata_info="Sources/KeyPathApp/Resources/KanataEngine-Info.plist"
+    local kanata_plist="Sources/KeyPathApp/com.keypath.kanata.plist"
+    local helper_info="Sources/KeyPathHelper/Info.plist"
+    local helper_plist="Sources/KeyPathHelper/com.keypath.helper.plist"
+
+    expect_plist_value "$kanata_info" "CFBundleIdentifier" "$KANATA_ENGINE_ID" "Kanata Engine bundle ID"
+    expect_plist_value "$kanata_info" "CFBundleExecutable" "kanata" "Kanata Engine executable"
+    expect_text "Sources/KeyPathCore/KanataRuntimeHost.swift" 'Kanata Engine.app' "Kanata Engine bundle path is modeled"
+    expect_text "Sources/KeyPathCore/KanataRuntimeHost.swift" 'Contents/MacOS/kanata' "Kanata canonical bundled binary path is modeled"
+    expect_text "Sources/KeyPathCore/KeyPathConstants.swift" "public static let kanataEngineBundleID = \"$KANATA_ENGINE_ID\"" "Kanata Engine bundle ID constant is pinned"
+
+    expect_plist_value "$helper_info" "CFBundleIdentifier" "$HELPER_ID" "privileged helper bundle ID"
+    expect_plist_value "$helper_plist" "Label" "$HELPER_ID" "privileged helper launchd label"
+    expect_plist_value "$helper_plist" "BundleProgram" "Contents/Library/HelperTools/KeyPathHelper" "privileged helper BundleProgram"
+    expect_plist_value "$helper_plist" "MachServices:${HELPER_ID}" "true" "privileged helper Mach service"
+    expect_text "Sources/KeyPathCore/KeyPathConstants.swift" "public static let helperID = \"$HELPER_ID\"" "privileged helper ID constant is pinned"
+
+    expect_plist_value "$kanata_plist" "Label" "$KANATA_DAEMON_ID" "Kanata daemon label"
+    expect_plist_value "$kanata_plist" "BundleProgram" "Contents/Library/KeyPath/kanata-launcher" "Kanata daemon BundleProgram"
+    expect_plist_value "$kanata_plist" "ProgramArguments:0" "Contents/Library/KeyPath/kanata-launcher" "Kanata daemon argv[0]"
+    expect_plist_value "$kanata_plist" "AssociatedBundleIdentifiers:0" "com.keypath.KeyPath" "Kanata daemon associated bundle ID"
+    expect_text "Scripts/build-and-sign.sh" "--identifier \"$HELPER_ID\"" "release signing pins helper identifier"
+}
+
+verify_app_contract() {
+    local app=$APP_PATH
+    if [[ ! -d "$app" ]]; then
+        fail "KeyPath.app artifact missing at $app"
+        return
+    fi
+
+    local kanata_engine="$app/Contents/Library/KeyPath/Kanata Engine.app"
+    local kanata_binary="$kanata_engine/Contents/MacOS/kanata"
+    local kanata_info="$kanata_engine/Contents/Info.plist"
+    local kanata_plist="$app/Contents/Library/LaunchDaemons/com.keypath.kanata.plist"
+    local launcher="$app/Contents/Library/KeyPath/kanata-launcher"
+    local helper="$app/Contents/Library/HelperTools/KeyPathHelper"
+    local helper_plist="$app/Contents/Library/LaunchDaemons/com.keypath.helper.plist"
+
+    expect_file "$kanata_binary" "Kanata Engine binary"
+    expect_file "$launcher" "Kanata daemon shell"
+    expect_file "$helper" "privileged helper"
+    expect_file "$kanata_plist" "Kanata daemon plist"
+    expect_file "$helper_plist" "privileged helper plist"
+
+    expect_plist_value "$kanata_info" "CFBundleIdentifier" "$KANATA_ENGINE_ID" "signed Kanata Engine bundle ID"
+    expect_plist_value "$kanata_plist" "Label" "$KANATA_DAEMON_ID" "signed Kanata daemon label"
+    expect_plist_value "$kanata_plist" "BundleProgram" "Contents/Library/KeyPath/kanata-launcher" "signed Kanata daemon BundleProgram"
+    expect_plist_value "$kanata_plist" "AssociatedBundleIdentifiers:0" "com.keypath.KeyPath" "signed Kanata daemon associated bundle ID"
+    expect_plist_value "$helper_plist" "Label" "$HELPER_ID" "signed helper launchd label"
+    expect_plist_value "$helper_plist" "BundleProgram" "Contents/Library/HelperTools/KeyPathHelper" "signed helper BundleProgram"
+
+    expect_codesign_identity "$kanata_engine" "$KANATA_ENGINE_ID" "$KANATA_ENGINE_REQ" "Kanata Engine.app"
+    expect_codesign_identity "$kanata_binary" "$KANATA_ENGINE_ID" "$KANATA_ENGINE_REQ" "Kanata Engine binary"
+    expect_codesign_identity "$helper" "$HELPER_ID" "$HELPER_REQ" "KeyPathHelper"
+    expect_codesign_identity "$launcher" "$KANATA_LAUNCHER_ID" "$KANATA_LAUNCHER_REQ" "kanata-launcher"
+}
+
+if [[ "$MODE" == "source" ]]; then
+    verify_source_contract
+else
+    verify_app_contract
+fi
+
+if (( failures > 0 )); then
+    echo "[identity-contract] ${failures} failure(s)" >&2
+    exit 1
+fi
+
+echo "[identity-contract] all checks passed"

--- a/Sources/KeyPathCore/KeyPathConstants.swift
+++ b/Sources/KeyPathCore/KeyPathConstants.swift
@@ -20,7 +20,7 @@ public enum KeyPathConstants {
     public enum Bundle {
         public static let appName = "KeyPath"
         public static let bundleID = "com.keypath.KeyPath"
-        public static let helperID = "com.keypath.KeyPath.Helper"
+        public static let helperID = "com.keypath.helper"
         public static let daemonID = "com.keypath.kanata"
         public static let vhidDaemonID = "com.keypath.karabiner-vhiddaemon"
         public static let vhidManagerID = "com.keypath.karabiner-vhidmanager"

--- a/Tests/KeyPathTests/Lint/IdentityStabilityContractTests.swift
+++ b/Tests/KeyPathTests/Lint/IdentityStabilityContractTests.swift
@@ -1,0 +1,129 @@
+import Foundation
+import KeyPathCore
+@preconcurrency import XCTest
+
+/// Pins the Workstream 4 identity contract for the components whose identity
+/// affects TCC, SMAppService, or launchd LWCR caching.
+final class IdentityStabilityContractTests: XCTestCase {
+    private static let kanataEngineID = "com.keypath.kanata-engine"
+    private static let helperID = "com.keypath.helper"
+    private static let kanataDaemonID = "com.keypath.kanata"
+    private static let canonicalAppPath = "/Applications/KeyPath.app"
+    private static let kanataDesignatedRequirement =
+        #"identifier "com.keypath.kanata-engine" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = X2RKZ5TG99"#
+    private static let helperDesignatedRequirement =
+        #"identifier "com.keypath.helper" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = X2RKZ5TG99"#
+    private static let launcherDesignatedRequirement =
+        #"identifier "kanata-launcher" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = X2RKZ5TG99"#
+
+    func testPinnedSourceIdentityContract() throws {
+        XCTAssertEqual(KeyPathConstants.Bundle.kanataEngineBundleID, Self.kanataEngineID)
+        XCTAssertEqual(KeyPathConstants.Bundle.helperID, Self.helperID)
+        XCTAssertEqual(KeyPathConstants.Bundle.daemonID, Self.kanataDaemonID)
+
+        let runtimeHost = KanataRuntimeHost.current(bundlePath: Self.canonicalAppPath)
+        XCTAssertEqual(
+            runtimeHost.kanataEngineBundlePath,
+            "/Applications/KeyPath.app/Contents/Library/KeyPath/Kanata Engine.app"
+        )
+        XCTAssertEqual(
+            runtimeHost.bundledCorePath,
+            "/Applications/KeyPath.app/Contents/Library/KeyPath/Kanata Engine.app/Contents/MacOS/kanata"
+        )
+        XCTAssertEqual(
+            runtimeHost.launcherPath,
+            "/Applications/KeyPath.app/Contents/Library/KeyPath/kanata-launcher"
+        )
+
+        let root = repositoryRoot()
+        let kanataInfo = try plist(at: root.appendingPathComponent("Sources/KeyPathApp/Resources/KanataEngine-Info.plist"))
+        XCTAssertEqual(kanataInfo["CFBundleIdentifier"] as? String, Self.kanataEngineID)
+        XCTAssertEqual(kanataInfo["CFBundleExecutable"] as? String, "kanata")
+
+        let helperInfo = try plist(at: root.appendingPathComponent("Sources/KeyPathHelper/Info.plist"))
+        XCTAssertEqual(helperInfo["CFBundleIdentifier"] as? String, Self.helperID)
+
+        let helperPlist = try plist(at: root.appendingPathComponent("Sources/KeyPathHelper/com.keypath.helper.plist"))
+        XCTAssertEqual(helperPlist["Label"] as? String, Self.helperID)
+        XCTAssertEqual(helperPlist["BundleProgram"] as? String, "Contents/Library/HelperTools/KeyPathHelper")
+        XCTAssertEqual((helperPlist["MachServices"] as? [String: Bool])?[Self.helperID], true)
+
+        let kanataPlist = try plist(at: root.appendingPathComponent("Sources/KeyPathApp/com.keypath.kanata.plist"))
+        XCTAssertEqual(kanataPlist["Label"] as? String, Self.kanataDaemonID)
+        XCTAssertEqual(kanataPlist["BundleProgram"] as? String, "Contents/Library/KeyPath/kanata-launcher")
+        XCTAssertEqual((kanataPlist["ProgramArguments"] as? [String])?.first, "Contents/Library/KeyPath/kanata-launcher")
+        XCTAssertEqual((kanataPlist["AssociatedBundleIdentifiers"] as? [String])?.first, "com.keypath.KeyPath")
+    }
+
+    func testReleaseGateInvokesIdentityContractScript() throws {
+        let root = repositoryRoot()
+        let verifier = root.appendingPathComponent("Scripts/verify-identity-contract.sh")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: verifier.path))
+        XCTAssertTrue(FileManager.default.isExecutableFile(atPath: verifier.path))
+
+        let verifierContents = try String(contentsOf: verifier, encoding: .utf8)
+        XCTAssertTrue(verifierContents.contains(Self.kanataDesignatedRequirement))
+        XCTAssertTrue(verifierContents.contains(Self.helperDesignatedRequirement))
+        XCTAssertTrue(verifierContents.contains(Self.launcherDesignatedRequirement))
+
+        let releaseDoctor = try String(
+            contentsOf: root.appendingPathComponent("Scripts/release-doctor.sh"),
+            encoding: .utf8
+        )
+        XCTAssertTrue(releaseDoctor.contains("verify-identity-contract.sh\" --source"))
+
+        let buildAndSign = try String(
+            contentsOf: root.appendingPathComponent("Scripts/build-and-sign.sh"),
+            encoding: .utf8
+        )
+        XCTAssertTrue(buildAndSign.contains("\"$SCRIPT_DIR/verify-identity-contract.sh\" --app \"$APP_BUNDLE\""))
+    }
+
+    func testIdentityADRDocumentsPinnedContract() throws {
+        let root = repositoryRoot()
+        let adr = try String(
+            contentsOf: root.appendingPathComponent("docs/adr/adr-041-installer-identity-stability-contract.md"),
+            encoding: .utf8
+        )
+
+        for requiredText in [
+            Self.kanataEngineID,
+            Self.helperID,
+            Self.kanataDaemonID,
+            "/Applications/KeyPath.app/Contents/Library/KeyPath/Kanata Engine.app/Contents/MacOS/kanata",
+            "/Applications/KeyPath.app/Contents/Library/HelperTools/KeyPathHelper",
+            "/Applications/KeyPath.app/Contents/Library/KeyPath/kanata-launcher",
+            Self.kanataDesignatedRequirement,
+            Self.helperDesignatedRequirement,
+            Self.launcherDesignatedRequirement,
+            "installPrivilegedHelper",
+            "reinstallPrivilegedHelper",
+            "com.keypath.KeyPath.Helper",
+            "HelperMaintenance",
+            "codesign -d -r- --verbose=4",
+            "reformat the requirement string",
+            "Scripts/verify-identity-contract.sh"
+        ] {
+            XCTAssertTrue(adr.contains(requiredText), "ADR missing identity-contract text: \(requiredText)")
+        }
+    }
+}
+
+private func plist(at url: URL) throws -> [String: Any] {
+    let data = try Data(contentsOf: url)
+    let value = try PropertyListSerialization.propertyList(from: data, options: [], format: nil)
+    guard let dictionary = value as? [String: Any] else {
+        throw NSError(domain: "IdentityStabilityContractTests", code: 1, userInfo: [
+            NSLocalizedDescriptionKey: "Expected dictionary plist at \(url.path)"
+        ])
+    }
+    return dictionary
+}
+
+private func repositoryRoot(file: StaticString = #filePath) -> URL {
+    URL(fileURLWithPath: "\(file)")
+        .deletingLastPathComponent() // Lint
+        .deletingLastPathComponent() // KeyPathTests
+        .deletingLastPathComponent() // Tests
+        .deletingLastPathComponent() // repo root
+}

--- a/docs/adr/adr-041-installer-identity-stability-contract.md
+++ b/docs/adr/adr-041-installer-identity-stability-contract.md
@@ -1,0 +1,94 @@
+# ADR-041: Installer Identity Stability Contract
+
+## Status
+
+Accepted
+
+## Date
+
+2026-07-06
+
+## Context
+
+Workstream 4 of the installer reliability plan prevents repair demand at the
+source. For KeyPath's macOS stack, accidental identity drift is not cosmetic:
+
+- TCC grants depend on the Kanata Engine bundle identity.
+- SMAppService and launchd cache launch constraints and associated bundle
+  identity for privileged jobs.
+- The LaunchDaemon shell and helper designated requirements can survive updates
+  in ways that make unregister/register appear successful while launchd still
+  evaluates stale constraints.
+
+ADR-032, ADR-033, and ADR-034 established the stable Kanata runtime identity.
+This ADR pins the concrete release contract for the signed artifacts and source
+plists that implement that identity.
+
+## Decision
+
+Treat the following values as release-gated compatibility contracts. Changing
+any value requires a migration plan and explicit review of TCC, SMAppService,
+and launchd LWCR blast radius.
+
+| Component | Canonical path | Stable identity | Designated requirement |
+|-----------|----------------|-----------------|------------------------|
+| Kanata Engine | `/Applications/KeyPath.app/Contents/Library/KeyPath/Kanata Engine.app/Contents/MacOS/kanata` | bundle ID and signing identifier `com.keypath.kanata-engine` | `identifier "com.keypath.kanata-engine" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = X2RKZ5TG99` |
+| Privileged helper | `/Applications/KeyPath.app/Contents/Library/HelperTools/KeyPathHelper` | bundle ID, launchd label, Mach service, and signing identifier `com.keypath.helper` | `identifier "com.keypath.helper" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = X2RKZ5TG99` |
+| Kanata daemon shell | `/Applications/KeyPath.app/Contents/Library/KeyPath/kanata-launcher` | LaunchDaemon label `com.keypath.kanata`, `BundleProgram` `Contents/Library/KeyPath/kanata-launcher`, associated bundle ID `com.keypath.KeyPath`, signing identifier `kanata-launcher` | `identifier "kanata-launcher" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = X2RKZ5TG99` |
+
+The daemon plist is not itself code signed. The release contract verifies the
+plist values and the signed daemon shell executable; the outer app signature
+seals the embedded plist as part of the bundle.
+
+The helper constant change in this decision is intentionally behavioral.
+`KeyPathConstants.Bundle.helperID` previously used
+`com.keypath.KeyPath.Helper`, while the helper plist, Mach service, signed
+binary, `HelperManager`, and installer diagnostics already used
+`com.keypath.helper`. The only Swift call sites for that constant are the
+`installPrivilegedHelper` and `reinstallPrivilegedHelper` installer recipes, so
+the change aligns those recipes with the shipped helper service ID.
+The repair implementation itself delegates to `HelperMaintenance`, which already
+unregisters, bootouts, and removes `com.keypath.helper` artifacts using
+`HelperManager.helperPlistName` / `HelperManager.helperBundleIdentifier`; the
+recipe `serviceID` is recipe metadata and logging context, not a separate
+old-label cleanup implementation. Current runtime source contains no
+`com.keypath.KeyPath.Helper` literal outside this ADR and its ratchet test.
+
+## Enforcement
+
+- `Tests/KeyPathTests/Lint/IdentityStabilityContractTests.swift` is the CI
+  ratchet for source metadata, canonical paths, release-gate wiring, and this
+  ADR's pinned values.
+- `Scripts/verify-identity-contract.sh --source` runs from
+  `Scripts/release-doctor.sh`.
+- `Scripts/verify-identity-contract.sh --app "$APP_BUNDLE"` runs from
+  `Scripts/build-and-sign.sh` after signing and before notarization.
+
+If the designated-requirement check fails while signing identifier, authority,
+and team identifier checks still pass, first compare the raw
+`codesign -d -r- --verbose=4` output. A future Xcode/macOS toolchain could
+reformat the requirement string without changing the underlying identity. Treat
+that as a release-tooling migration: confirm no identity value drifted, then
+update the pinned strings, this ADR, and the ratchet test in the same PR.
+
+## Consequences
+
+### Positive
+
+- Accidental re-signing, bundle-ID, launchd-label, or path drift fails before it
+  can invalidate user permissions or strand launchd on stale constraints.
+- Future identity changes must declare their migration story instead of slipping
+  through packaging edits.
+- The helper identity is now aligned with the shipped helper plist and signed
+  executable: `com.keypath.helper`. Installer helper repair recipes now pass
+  that shipped service ID instead of the stale `com.keypath.KeyPath.Helper`
+  value.
+
+### Negative
+
+- Developer ID certificate/team changes now require updating tests, this ADR,
+  and release verification in the same migration PR.
+- The current daemon shell signing identifier remains `kanata-launcher`, which
+  is stable but filename-derived. Renaming the shell is therefore a breaking
+  identity change unless the release process intentionally pins a new explicit
+  signing identifier with migration notes.

--- a/docs/planning/installer-reliability-phase1.md
+++ b/docs/planning/installer-reliability-phase1.md
@@ -161,6 +161,16 @@ designated-requirement changes on update, (2) binary path changes,
   and daemon against pinned values.
 - Documented in an ADR so future re-signing work knows the blast radius.
 
+**Status (2026-07-06):** Implemented for Workstream 4.
+- [x] Release doctor / CI verifies identity stability for kanata binary, helper,
+  and daemon against pinned values. Enforced by
+  `IdentityStabilityContractTests.testPinnedSourceIdentityContract`,
+  `IdentityStabilityContractTests.testReleaseGateInvokesIdentityContractScript`,
+  and `Scripts/verify-identity-contract.sh`.
+- [x] Documented in an ADR so future re-signing work knows the blast radius.
+  Enforced by `IdentityStabilityContractTests.testIdentityADRDocumentsPinnedContract`
+  against `docs/adr/adr-041-installer-identity-stability-contract.md`.
+
 ## Workstream 5: Lint-Test Ratchets
 
 `SMAppServiceStatusLintTests` (build fails if any source outside the provider


### PR DESCRIPTION
## Summary

Implements Phase 1 Workstream 4: an identity-stability contract for the signed/runtime identities that affect TCC, SMAppService, and launchd LWCR caching.

Changes:
- Adds `Scripts/verify-identity-contract.sh` with source-mode checks for committed plists/constants and app-mode checks for signed artifacts/designated requirements.
- Wires source-mode verification into `Scripts/release-doctor.sh` and signed-artifact verification into `Scripts/build-and-sign.sh` after signing and before notarization.
- Adds `IdentityStabilityContractTests` as the CI ratchet for pinned bundle IDs, canonical installed paths, release-gate wiring, and ADR coverage.
- Adds ADR-041 documenting the identity contract, helper-ID behavior change, and blast radius for future signing/path changes.
- Aligns `KeyPathConstants.Bundle.helperID` with the actually shipped helper identity, `com.keypath.helper`.
- Updates the Phase 1 plan with Workstream 4 acceptance criteria checked off and test citations.

## Current-code reality note

While implementing the contract, I found `KeyPathConstants.Bundle.helperID` was `com.keypath.KeyPath.Helper`, but the helper plist, Mach service, `HelperManager`, and signed helper binary all use `com.keypath.helper`. This PR fixes the constant to match the shipped identity instead of pinning the wrong value.

Follow-up review confirmed the only constant call sites are the `installPrivilegedHelper` and `reinstallPrivilegedHelper` recipes. Helper cleanup/registration itself delegates to `HelperMaintenance`, which already unregisters, bootouts, and removes `com.keypath.helper` artifacts through `HelperManager` constants.

## Acceptance criteria covered

- Release doctor / CI verifies identity stability for kanata binary, helper, and daemon against pinned values:
  - `IdentityStabilityContractTests.testPinnedSourceIdentityContract`
  - `IdentityStabilityContractTests.testReleaseGateInvokesIdentityContractScript`
  - `Scripts/verify-identity-contract.sh --source`
  - `Scripts/verify-identity-contract.sh --app <KeyPath.app>`
- Documented in an ADR so future re-signing work knows the blast radius:
  - `IdentityStabilityContractTests.testIdentityADRDocumentsPinnedContract`
  - `docs/adr/adr-041-installer-identity-stability-contract.md`

## Validation

Branch tip: `eef35856`

Passed:
- GitHub `build-and-test`
- GitHub `code-quality`
- GitHub `claude-review`
- `./Scripts/verify-identity-contract.sh --source`
- `./Scripts/verify-identity-contract.sh --app /Applications/KeyPath.app`
- `TEST_FILTER=IdentityStabilityContractTests ./Scripts/run-tests-safe.sh`
- `./Scripts/release-doctor.sh --release-candidate` passed with local-state warnings only: dirty worktree, untracked files, master in main worktree, installed Kanata job not registered/responding.
- `KEYPATH_TEST_DISABLE_XCTEST=1 ./Scripts/run-tests-safe.sh` passed: 789 tests.
- `git diff --check`
- `bash -n Scripts/verify-identity-contract.sh Scripts/release-doctor.sh Scripts/build-and-sign.sh`

Not clean / blocked:
- `./Scripts/test-full.sh` failed in `KeyPathSnapshotTests`: 24 existing snapshot mismatches, then XCTest runner signal 11. This branch does not touch UI/snapshot rendering.
- `DEVELOPER_DIR=/Applications/Xcode-26.6.0.app/Contents/Developer ./Scripts/test-full.sh` reproduced the same snapshot mismatch class plus runner signal 11.
