### PR TITLE
[codex] Stabilize Claude review gate

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -87,7 +87,7 @@ jobs:
 
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-          claude_args: '--max-turns 4 --allowed-tools "Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"'
+          claude_args: '--max-turns 8 --allowed-tools "Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(git diff:*),Bash(git status:*),Bash(git show:*),Bash(rg:*),Bash(sed:*),Bash(nl:*)"'
 
       - name: Skip Claude review for workflow-file changes
         if: steps.changes.outputs.workflow_changed == 'true'


### PR DESCRIPTION
## Summary

Small infrastructure fix to unblock required PR review runs:
- raises the Claude review action limit from 4 to 8 turns
- keeps PR interaction bounded to `gh pr comment`, `gh pr diff`, and `gh pr view`
- adds read-only local inspection commands commonly needed for bounded diff review

## Context

This was split out from installer reliability Workstream 4 because PR #994 is currently green on build/test/code-quality but blocked by `claude-review` failing before it can post a review. The failed runs reach `error_max_turns` with `permission_denials_count: 3` and no inline or PR comments.

## Validation

Passed:
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/claude-code-review.yml"); puts "yaml ok"'`
- `git diff --check`
- `KEYPATH_TEST_DISABLE_XCTEST=1 ./Scripts/run-tests-safe.sh` passed: 789 tests

Not run / blocked:
- `/thermo-nuclear-swift-review` is not runnable from this Codex session: `claude` is not installed on PATH and no local slash-command definition is present under `~/.claude` or the repo.
- Full XCTest snapshot lane is not clean in the current repo state; this PR only changes workflow YAML.
