### PR TITLE
[codex] Expand Claude review inspection tools

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -87,7 +87,9 @@ jobs:
 
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-          claude_args: '--max-turns 8 --allowed-tools "Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(git diff:*),Bash(git status:*),Bash(git show:*),Bash(rg:*),Bash(sed:*),Bash(nl:*)"'
+          claude_args: >-
+            --max-turns 16
+            --allowed-tools "Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(git diff:*),Bash(git status:*),Bash(git show:*),Bash(git log:*),Bash(git grep:*),Bash(rg:*),Bash(sed:*),Bash(nl:*),Bash(cat:*),Bash(head:*),Bash(tail:*),Bash(wc:*),Bash(find:*),Bash(ls:*),Bash(pwd:*),Bash(awk:*),Bash(grep:*)"
 
       - name: Skip Claude review for workflow-file changes
         if: steps.changes.outputs.workflow_changed == 'true'


### PR DESCRIPTION
## Summary

Follow-up to #995. The review gate no longer fails at 4 turns, but W4 PR #994 still hits `error_max_turns` after 8 turns and 5 permission denials before posting a review.

This keeps PR writes limited to `gh pr comment`, but broadens the allowed read-only inspection commands and raises the turn budget to 16 so Claude can complete a bounded diff review.

## Validation

Passed:
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/claude-code-review.yml"); puts "yaml ok"'`
- `git diff --check`
- `KEYPATH_TEST_DISABLE_XCTEST=1 ./Scripts/run-tests-safe.sh` passed: 789 tests

Not run / blocked:
- `/thermo-nuclear-swift-review` is not runnable from this Codex session: `claude` is not installed on PATH and no local slash-command definition is present under `~/.claude` or the repo.
- Full XCTest snapshot lane is not clean in the current repo state; this PR only changes workflow YAML.
