### PR TITLE
Centralize process liveness predicate

### DIFF
--- a/Sources/KeyPathAppKit/Core/HelperManager+ConnectionLifecycle.swift
+++ b/Sources/KeyPathAppKit/Core/HelperManager+ConnectionLifecycle.swift
@@ -1,4 +1,3 @@
-import Darwin
 import Foundation
 import KeyPathCore
 
@@ -88,17 +87,7 @@ extension HelperManager {
     /// - Parameter pid: Process ID to check
     /// - Returns: true if process exists, false otherwise
     private func isHelperProcessRunning(pid: Int32) -> Bool {
-        // Use kill(pid, 0) to check if process exists (doesn't actually kill, just checks)
-        // Returns 0 if process exists, -1 with errno set if it doesn't
-        // EPERM means process exists but we don't have permission (still means it's running)
-        let result = kill(pid, 0)
-        if result == 0 {
-            return true
-        }
-        // Check errno - EPERM means process exists but we can't signal it (still running)
-        // ESRCH means process doesn't exist
-        let error = errno
-        return error == EPERM
+        SystemStateProvider.isProcessAlive(pid: pid)
     }
 
     /// Verify the embedded helper's designated requirement roughly matches expectations.

--- a/Sources/KeyPathAppKit/Managers/ServiceLifecycleCoordinator.swift
+++ b/Sources/KeyPathAppKit/Managers/ServiceLifecycleCoordinator.swift
@@ -650,13 +650,7 @@ final class ServiceLifecycleCoordinator {
         #if DEBUG
             if let probe = Self.testLivenessProbe { return probe(pid) }
         #endif
-        if kill(pid, 0) == 0 { return true }
-        // kanata runs as a root LaunchDaemon while this app is unprivileged, so
-        // `kill(pid, 0)` returns EPERM ("exists, but you may not signal it") — that
-        // is still ALIVE. Only ESRCH means the process is actually gone. Treating
-        // EPERM as dead would make the wait return immediately for the very process
-        // (the root kanata) this fix exists to wait out.
-        return errno == EPERM
+        return SystemStateProvider.isProcessAlive(pid: pid)
     }
 
     private nonisolated func sendSignal(_ pid: pid_t, _ signal: Int32) {

--- a/Sources/KeyPathCore/SystemStateProvider.swift
+++ b/Sources/KeyPathCore/SystemStateProvider.swift
@@ -1,0 +1,40 @@
+import Darwin
+import Foundation
+
+/// Central owner for system-state evidence used by installer and runtime decisions.
+///
+/// Phase 1 grows this into the full snapshot provider. This first slice centralizes
+/// the process-liveness primitive so all callers share ADR-040 semantics.
+public actor SystemStateProvider {
+    public init() {}
+
+    public nonisolated func isProcessAlive(pid: pid_t) -> Bool {
+        Self.isProcessAlive(pid: pid)
+    }
+
+    public nonisolated static func isProcessAlive(pid: pid_t) -> Bool {
+        guard pid > 0 else { return false }
+        if kill(pid, 0) == 0 { return true }
+        return errno == EPERM
+    }
+
+    public nonisolated static func isKanataReady(running: Bool, responding: Bool) -> Bool {
+        running && responding
+    }
+}
+
+public struct KanataLivenessEvidence: Equatable, Sendable {
+    public let pid: pid_t?
+    public let running: Bool
+    public let responding: Bool
+
+    public init(pid: pid_t?, running: Bool, responding: Bool) {
+        self.pid = pid
+        self.running = running
+        self.responding = responding
+    }
+
+    public var ready: Bool {
+        SystemStateProvider.isKanataReady(running: running, responding: responding)
+    }
+}

--- a/Sources/KeyPathDaemonLifecycle/LaunchDaemonPIDCache.swift
+++ b/Sources/KeyPathDaemonLifecycle/LaunchDaemonPIDCache.swift
@@ -185,7 +185,7 @@ public actor LaunchDaemonPIDCache {
 
         Task.detached {
             try? await Task.sleep(for: .milliseconds(200))
-            if pid > 0, kill(pid, 0) == 0 {
+            if pid > 0, SystemStateProvider.isProcessAlive(pid: pid) {
                 AppLogger.shared.log("⛔️ [PIDCache] launchctl did not exit, sending SIGKILL (pid=\(pid))")
                 _ = kill(pid, SIGKILL)
             }

--- a/Sources/KeyPathDaemonLifecycle/PIDFileManager.swift
+++ b/Sources/KeyPathDaemonLifecycle/PIDFileManager.swift
@@ -96,8 +96,7 @@ public enum PIDFileManager {
 
     /// Check if a process with given PID is still running
     public static func isProcessRunning(pid: pid_t) -> Bool {
-        let result = kill(pid, 0)
-        return result == 0
+        SystemStateProvider.isProcessAlive(pid: pid)
     }
 
     /// Check if we own the currently running kanata process

--- a/Tests/KeyPathTests/Core/SystemStateProviderLivenessTests.swift
+++ b/Tests/KeyPathTests/Core/SystemStateProviderLivenessTests.swift
@@ -1,0 +1,32 @@
+import Darwin
+import Foundation
+@testable import KeyPathCore
+@preconcurrency import XCTest
+
+final class SystemStateProviderLivenessTests: XCTestCase {
+    func testProcessLivenessProbeTreatsCurrentProcessAsAliveAndExitedProcessAsDead() throws {
+        XCTAssertTrue(SystemStateProvider.isProcessAlive(pid: getpid()))
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/sh")
+        process.arguments = ["-c", "exit 0"]
+
+        try process.run()
+        let childPID = pid_t(process.processIdentifier)
+        process.waitUntilExit()
+
+        XCTAssertFalse(SystemStateProvider.isProcessAlive(pid: childPID))
+    }
+
+    func testKanataReadinessRequiresRunningAndResponding() {
+        XCTAssertTrue(KanataLivenessEvidence(pid: getpid(), running: true, responding: true).ready)
+        XCTAssertFalse(KanataLivenessEvidence(pid: getpid(), running: true, responding: false).ready)
+        XCTAssertFalse(KanataLivenessEvidence(pid: nil, running: false, responding: true).ready)
+        XCTAssertFalse(KanataLivenessEvidence(pid: nil, running: false, responding: false).ready)
+    }
+
+    func testProcessLivenessRejectsNonPositivePIDs() {
+        XCTAssertFalse(SystemStateProvider.isProcessAlive(pid: 0))
+        XCTAssertFalse(SystemStateProvider.isProcessAlive(pid: -1))
+    }
+}

--- a/Tests/KeyPathTests/Lint/LivenessPredicateLintTests.swift
+++ b/Tests/KeyPathTests/Lint/LivenessPredicateLintTests.swift
@@ -1,0 +1,56 @@
+import Foundation
+@preconcurrency import XCTest
+
+/// Guards Workstream 2's blessed process-liveness predicate.
+///
+/// `kill(pid, 0)` has privilege-boundary semantics that are easy to get wrong:
+/// EPERM means the process exists but cannot be signaled by this process, while
+/// ESRCH is the dead-process condition. Keep that logic centralized in
+/// `SystemStateProvider.isProcessAlive(pid:)` and delegate to it instead of
+/// reimplementing the primitive at call sites.
+final class LivenessPredicateLintTests: XCTestCase {
+    private static let allowList: Set<String> = [
+        "SystemStateProvider.swift"
+    ]
+
+    func testKillZeroLivenessProbeIsCentralized() throws {
+        let sourcesDir = repositoryRoot().appendingPathComponent("Sources")
+        let pattern = try NSRegularExpression(pattern: #"kill\s*\([^,\n]+,\s*0\s*\)"#)
+
+        guard let enumerator = FileManager.default.enumerator(at: sourcesDir, includingPropertiesForKeys: nil) else {
+            return XCTFail("Could not enumerate \(sourcesDir.path)")
+        }
+
+        var violations: [String] = []
+        for case let url as URL in enumerator where url.pathExtension == "swift" {
+            if Self.allowList.contains(url.lastPathComponent) { continue }
+            guard let contents = try? String(contentsOf: url, encoding: .utf8) else { continue }
+            for (idx, rawLine) in contents.components(separatedBy: .newlines).enumerated() {
+                let trimmed = rawLine.trimmingCharacters(in: .whitespaces)
+                if trimmed.hasPrefix("//") || trimmed.hasPrefix("///") || trimmed.hasPrefix("*") { continue }
+                let range = NSRange(rawLine.startIndex..., in: rawLine)
+                if pattern.firstMatch(in: rawLine, range: range) != nil {
+                    violations.append("\(url.lastPathComponent):\(idx + 1): \(trimmed)")
+                }
+            }
+        }
+
+        XCTAssertTrue(
+            violations.isEmpty,
+            """
+            Direct `kill(pid, 0)` liveness probes found outside SystemStateProvider. \
+            Delegate to SystemStateProvider.isProcessAlive(pid:) instead of adding \
+            another process-liveness implementation:
+            \(violations.sorted().joined(separator: "\n"))
+            """
+        )
+    }
+}
+
+private func repositoryRoot(file: StaticString = #filePath) -> URL {
+    URL(fileURLWithPath: "\(file)")
+        .deletingLastPathComponent() // Lint
+        .deletingLastPathComponent() // KeyPathTests
+        .deletingLastPathComponent() // Tests
+        .deletingLastPathComponent() // repo root
+}

--- a/docs/planning/installer-reliability-phase1.md
+++ b/docs/planning/installer-reliability-phase1.md
@@ -72,6 +72,18 @@ apply. Checklists decay; that is how the loop happened. Make it code.
 - Wizard, CLI, and menu bar cannot disagree about system state because they
   cannot read different sources.
 
+**Status (2026-07-06):** First provider slice implemented; full snapshot
+classification remains pending.
+- [x] Introduced `SystemStateProvider` as the owner for the ADR-040
+  process-liveness primitive and Kanata readiness predicate. Enforced by
+  `SystemStateProviderLivenessTests.testProcessLivenessProbeTreatsCurrentProcessAsAliveAndExitedProcessAsDead`
+  and `SystemStateProviderLivenessTests.testKanataReadinessRequiresRunningAndResponding`.
+- [ ] Migrate `launchctl`, `SMAppService.status`, `pgrep`, TCP probes,
+  permissions, VHID state, and helper freshness into a single immutable
+  `SystemSnapshot`.
+- [ ] Build `classify(snapshot) -> StateMatrixRow -> plan` and table-driven
+  golden tests for every state-matrix row.
+
 ## Workstream 2: One Liveness Predicate
 
 Today there are 10+ independent implementations of "is kanata running" across
@@ -92,6 +104,18 @@ through 21 mocked tests).
 - `kill(pid, 0)` / process-probe logic exists in exactly one function.
 - A grounding test runs the real primitive against a known-alive pid
   (`getpid()`) and a known-dead pid (ADR-040 §3), not only mocked seams.
+
+**Status (2026-07-06):** First liveness-predicate slice implemented.
+- [x] `kill(pid, 0)` liveness semantics exist in exactly one production
+  function, `SystemStateProvider.isProcessAlive(pid:)`. Enforced by
+  `LivenessPredicateLintTests.testKillZeroLivenessProbeIsCentralized`.
+- [x] The real primitive is tested against `getpid()` and an exited child
+  process. Enforced by
+  `SystemStateProviderLivenessTests.testProcessLivenessProbeTreatsCurrentProcessAsAliveAndExitedProcessAsDead`.
+- [x] Kanata readiness is pinned to `running && responding`. Enforced by
+  `SystemStateProviderLivenessTests.testKanataReadinessRequiresRunningAndResponding`.
+- [ ] Centralize remaining `pgrep` process discovery and TCP readiness probes
+  as later W1/W2 migration slices.
 
 ## Workstream 3: Industry-Standard Repair Model
 
@@ -186,6 +210,13 @@ context loss across sessions, contributors, and agents. Extend it:
 
 **Acceptance criteria:** each ratchet lands with the workstream it protects and
 is listed in the state-matrix doc's enforcement section.
+
+**Status (2026-07-06):** First liveness ratchet implemented.
+- [x] `LivenessPredicateLintTests.testKillZeroLivenessProbeIsCentralized`
+  prevents new direct `kill(pid, 0)` liveness probes outside
+  `SystemStateProvider`.
+- [ ] Add `launchctl`, `pgrep`, TCP-probe, postcondition, and snapshot-cache
+  ratchets with the corresponding migration slices.
 
 ## Workstream 6: Deletion Pass
 

--- a/docs/process/installer-repair-state-matrix.md
+++ b/docs/process/installer-repair-state-matrix.md
@@ -129,8 +129,13 @@ the result as user action required and name the approval surface.
 - Privileged command routing belongs in `PrivilegedOperationsRouter`.
 - Helper-owned root mutations belong in `HelperService`, but helper success must
   still be verified by the app-side router when possible.
-- Runtime readiness checks belong in `ServiceHealthChecker` and the shared
-  lifecycle predicates.
+- Runtime readiness checks belong in `ServiceHealthChecker` and
+  `SystemStateProvider`'s shared lifecycle predicates.
+- Process-liveness semantics belong in `SystemStateProvider.isProcessAlive(pid:)`.
+  `SystemStateProviderLivenessTests.testProcessLivenessProbeTreatsCurrentProcessAsAliveAndExitedProcessAsDead`
+  proves the real ADR-040 primitive, and
+  `LivenessPredicateLintTests.testKillZeroLivenessProbeIsCentralized` blocks
+  new direct `kill(pid, 0)` probes outside the provider.
 - User-facing CLI/reporting shape belongs in CLI contract tests.
 
 ## Related References


### PR DESCRIPTION
## Summary

- Introduce `SystemStateProvider` as the first W1/W2 slice and make it own the ADR-040 process-liveness primitive plus `running && responding` Kanata readiness predicate.
- Route existing direct `kill(pid, 0)` liveness call sites through the provider.
- Add the W5 lint ratchet that blocks new direct `kill(pid, 0)` liveness probes outside the provider.
- Update the Phase 1 plan and state-matrix enforcement section with the exact tests that enforce this slice.

## Acceptance criteria covered in this slice

- `kill(pid, 0)` liveness semantics exist in exactly one production function: `SystemStateProvider.isProcessAlive(pid:)`, enforced by `LivenessPredicateLintTests.testKillZeroLivenessProbeIsCentralized`.
- The real primitive is grounded against a known-alive PID and a known-dead PID, enforced by `SystemStateProviderLivenessTests.testProcessLivenessProbeTreatsCurrentProcessAsAliveAndExitedProcessAsDead`.
- Kanata readiness is pinned to `running && responding`, enforced by `SystemStateProviderLivenessTests.testKanataReadinessRequiresRunningAndResponding`.
- Non-positive PIDs are rejected before reaching `kill`, enforced by `SystemStateProviderLivenessTests.testProcessLivenessRejectsNonPositivePIDs`.

## Out of scope / remaining Phase 1 work

- This does not build the full `SystemSnapshot`, `classify(snapshot) -> StateMatrixRow`, or state-matrix golden fixture yet.
- `launchctl`, `SMAppService.status`, `pgrep`, TCP probes, permissions, VHID state, and helper freshness still need later W1/W2/W5 migration slices.
- Workstreams 3 and 6 remain intentionally untouched.

## Test plan

- `mise exec -- swiftformat Sources/KeyPathCore/SystemStateProvider.swift Sources/KeyPathAppKit/Core/HelperManager+ConnectionLifecycle.swift Tests/KeyPathTests/Core/SystemStateProviderLivenessTests.swift Tests/KeyPathTests/Lint/LivenessPredicateLintTests.swift`
- `python3 Scripts/check-accessibility.py`
- `TEST_FILTER='SystemStateProviderLivenessTests|LivenessPredicateLintTests' ./Scripts/run-tests-safe.sh` -> 4 passed
- `TEST_FILTER='ServiceLifecycleCoordinatorTests|HelperManagerTests|SystemStateProviderLivenessTests|LivenessPredicateLintTests' ./Scripts/run-tests-safe.sh` -> 29 passed
- `./Scripts/run-tests-safe.sh` -> 4431 passed

## Gate note

`./Scripts/test-full.sh` currently fails in `KeyPathSnapshotTests` under `/Applications/Xcode-beta.app/Contents/Developer` with `NSConcreteValue CGRectValue` snapshot-testing exceptions, snapshot mismatches, and an XCTest signal 11. I reproduced the same snapshot failure on clean `origin/master` at `23b99047` in a detached worktree, so this is not introduced by this PR. The non-snapshot full safe suite is green.

The local `/thermo-nuclear-swift-review` slash command is not executable from this Codex shell. This PR is draft so the repo's `claude-code-review` workflow can run as the available review gate before it is marked ready.
