### PR TITLE
Centralize TCP readiness probe

### DIFF
--- a/Sources/KeyPathAppKit/Utilities/TCPProbe.swift
+++ b/Sources/KeyPathAppKit/Utilities/TCPProbe.swift
@@ -1,9 +1,9 @@
-import Darwin
+import KeyPathCore
 
 /// Lightweight POSIX TCP probe for checking if a localhost port is accepting connections.
 ///
-/// Used by both `ServiceHealthChecker` (wizard health checks) and `KanataService`
-/// (fallback before declaring service failure when PID detection misses).
+/// Compatibility wrapper for older AppKit call sites while Phase 1 migrates TCP
+/// readiness consumers to `SystemStateProvider`.
 public enum TCPProbe: Sendable {
     /// Probe a TCP port on localhost. Blocking call — use from a detached task.
     ///
@@ -14,46 +14,6 @@ public enum TCPProbe: Sendable {
     ///   - timeoutMs: Connection timeout in milliseconds (default 300)
     /// - Returns: `true` if the port accepted the connection
     public nonisolated static func probe(port: Int, timeoutMs: Int = 300) -> Bool {
-        let sock = socket(AF_INET, SOCK_STREAM, 0)
-        if sock < 0 { return false }
-
-        var addr = sockaddr_in()
-        addr.sin_family = sa_family_t(AF_INET)
-        addr.sin_port = in_port_t(UInt16(port).bigEndian)
-        addr.sin_addr = in_addr(s_addr: inet_addr("127.0.0.1"))
-
-        // Set non-blocking
-        _ = fcntl(sock, F_SETFL, O_NONBLOCK)
-
-        var a = addr
-        let connectResult = withUnsafePointer(to: &a) {
-            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
-                connect(sock, $0, socklen_t(MemoryLayout<sockaddr_in>.size))
-            }
-        }
-
-        if connectResult == 0 {
-            close(sock)
-            return true
-        }
-
-        // EINPROGRESS is expected for non-blocking connect
-        if errno != EINPROGRESS {
-            close(sock)
-            return false
-        }
-
-        var pfd = pollfd(fd: sock, events: Int16(POLLOUT), revents: 0)
-        let ret = Darwin.poll(&pfd, 1, Int32(timeoutMs))
-        if ret > 0, (pfd.revents & Int16(POLLOUT)) != 0 {
-            var so_error: Int32 = 0
-            var len = socklen_t(MemoryLayout<Int32>.size)
-            getsockopt(sock, SOL_SOCKET, SO_ERROR, &so_error, &len)
-            close(sock)
-            return so_error == 0
-        }
-
-        close(sock)
-        return false
+        SystemStateProvider.probeTCPPort(port: port, timeoutMs: timeoutMs)
     }
 }

--- a/Sources/KeyPathCore/SystemStateProvider.swift
+++ b/Sources/KeyPathCore/SystemStateProvider.swift
@@ -3,19 +3,63 @@ import Foundation
 
 /// Central owner for system-state evidence used by installer and runtime decisions.
 ///
-/// Phase 1 grows this into the full snapshot provider. This first slice centralizes
-/// the process-liveness primitive so all callers share ADR-040 semantics.
+/// Phase 1 grows this into the full snapshot provider. The first slices centralize
+/// process-liveness and TCP-readiness primitives so callers share one definition.
 public actor SystemStateProvider {
+    public static let shared = SystemStateProvider()
+
     public init() {}
 
     public nonisolated func isProcessAlive(pid: pid_t) -> Bool {
         Self.isProcessAlive(pid: pid)
     }
 
+    public nonisolated func isTCPPortResponding(port: Int, timeoutMs: Int = 300) async -> Bool {
+        await Task.detached(priority: .utility) {
+            Self.probeTCPPort(port: port, timeoutMs: timeoutMs)
+        }.value
+    }
+
     public nonisolated static func isProcessAlive(pid: pid_t) -> Bool {
         guard pid > 0 else { return false }
         if kill(pid, 0) == 0 { return true }
         return errno == EPERM
+    }
+
+    public nonisolated static func probeTCPPort(port: Int, timeoutMs: Int = 300) -> Bool {
+        guard (1 ... 65535).contains(port), timeoutMs >= 0 else { return false }
+
+        let sock = socket(AF_INET, SOCK_STREAM, 0)
+        guard sock >= 0 else { return false }
+        defer { close(sock) }
+
+        let flags = fcntl(sock, F_GETFL, 0)
+        guard flags >= 0 else { return false }
+        _ = fcntl(sock, F_SETFL, flags | O_NONBLOCK)
+
+        var addr = sockaddr_in()
+        addr.sin_family = sa_family_t(AF_INET)
+        addr.sin_port = in_port_t(UInt16(port).bigEndian)
+        addr.sin_addr = in_addr(s_addr: inet_addr("127.0.0.1"))
+
+        var mutableAddr = addr
+        let connectResult = withUnsafePointer(to: &mutableAddr) {
+            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                connect(sock, $0, socklen_t(MemoryLayout<sockaddr_in>.size))
+            }
+        }
+
+        if connectResult == 0 { return true }
+        guard errno == EINPROGRESS else { return false }
+
+        var pollFd = pollfd(fd: sock, events: Int16(POLLOUT), revents: 0)
+        let pollResult = poll(&pollFd, 1, Int32(timeoutMs))
+        guard pollResult > 0, (pollFd.revents & Int16(POLLOUT)) != 0 else { return false }
+
+        var socketError: Int32 = 0
+        var socketErrorLength = socklen_t(MemoryLayout<Int32>.size)
+        getsockopt(sock, SOL_SOCKET, SO_ERROR, &socketError, &socketErrorLength)
+        return socketError == 0
     }
 
     public nonisolated static func isKanataReady(running: Bool, responding: Bool) -> Bool {

--- a/Sources/KeyPathInstallationWizard/Core/ServiceHealthChecker.swift
+++ b/Sources/KeyPathInstallationWizard/Core/ServiceHealthChecker.swift
@@ -1,8 +1,6 @@
-import Darwin
 import Foundation
 import KeyPathCore
 import KeyPathWizardCore
-import Network
 import os.lock
 
 /// Handles health checking and status reporting for LaunchDaemon services.
@@ -530,15 +528,8 @@ public final class ServiceHealthChecker: @unchecked Sendable {
         let runningState = await evaluateKanataLaunchctlRunningState(managementState: managementState, launchctlTargets: targets)
         let isRunning = runningState.isRunning
 
-        // 2) TCP probe (Hello/Status) - runs off MainActor via Task.detached for blocking socket ops
-        let tcpOK = await Task.detached { [self] in
-            if let portEnv = ProcessInfo.processInfo.environment["KEYPATH_TCP_PORT"],
-               let overridePort = Int(portEnv)
-            {
-                return probeTCP(port: overridePort, timeoutMs: timeoutMs)
-            }
-            return probeTCP(port: tcpPort, timeoutMs: timeoutMs)
-        }.value
+        // 2) TCP readiness through the shared system-state provider.
+        let tcpOK = await probeConfiguredTCPPort(defaultPort: tcpPort, timeoutMs: timeoutMs)
 
         return KanataHealthSnapshot(
             isRunning: isRunning,
@@ -634,14 +625,7 @@ public final class ServiceHealthChecker: @unchecked Sendable {
                 issue: Self.inputCaptureVHIDDriverNotActivatedReason
             )
         let inputCapture = Self.resolveInputCaptureStatus(stderrFallback: stderrFallback)
-        let tcpOK = await Task.detached { [self] in
-            if let portEnv = ProcessInfo.processInfo.environment["KEYPATH_TCP_PORT"],
-               let overridePort = Int(portEnv)
-            {
-                return probeTCP(port: overridePort, timeoutMs: timeoutMs)
-            }
-            return probeTCP(port: tcpPort, timeoutMs: timeoutMs)
-        }.value
+        let tcpOK = await probeConfiguredTCPPort(defaultPort: tcpPort, timeoutMs: timeoutMs)
 
         return KanataServiceRuntimeSnapshot(
             managementState: managementState,
@@ -1058,46 +1042,10 @@ public final class ServiceHealthChecker: @unchecked Sendable {
         return WizardSystemPaths.remapSystemPath("/Library/LaunchDaemons")
     }
 
-    /// Probe TCP port to check if service is responding.
-    ///
-    /// Uses POSIX socket with non-blocking connect and poll for timeout handling.
-    ///
-    /// - Parameters:
-    ///   - port: TCP port to probe
-    ///   - timeoutMs: Connection timeout in milliseconds
-    /// - Returns: `true` if connection succeeded
-    private nonisolated func probeTCP(port: Int, timeoutMs: Int) -> Bool {
-        // Use POSIX socket probe directly since TCPProbe is in KeyPathAppKit
-        let sock = socket(AF_INET, SOCK_STREAM, 0)
-        guard sock >= 0 else { return false }
-        defer { close(sock) }
-
-        // Set non-blocking
-        let flags = fcntl(sock, F_GETFL, 0)
-        _ = fcntl(sock, F_SETFL, flags | O_NONBLOCK)
-
-        var addr = sockaddr_in()
-        addr.sin_family = sa_family_t(AF_INET)
-        addr.sin_port = UInt16(port).bigEndian
-        addr.sin_addr.s_addr = inet_addr("127.0.0.1")
-
-        let connectResult = withUnsafePointer(to: &addr) {
-            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
-                connect(sock, $0, socklen_t(MemoryLayout<sockaddr_in>.size))
-            }
-        }
-
-        if connectResult == 0 { return true }
-        guard errno == EINPROGRESS else { return false }
-
-        var pollFd = pollfd(fd: sock, events: Int16(POLLOUT), revents: 0)
-        let pollResult = poll(&pollFd, 1, Int32(timeoutMs))
-        guard pollResult > 0 else { return false }
-
-        var optError: Int32 = 0
-        var optLen = socklen_t(MemoryLayout<Int32>.size)
-        getsockopt(sock, SOL_SOCKET, SO_ERROR, &optError, &optLen)
-        return optError == 0
+    private nonisolated func probeConfiguredTCPPort(defaultPort: Int, timeoutMs: Int) async -> Bool {
+        let effectivePort = ProcessInfo.processInfo.environment["KEYPATH_TCP_PORT"]
+            .flatMap(Int.init) ?? defaultPort
+        return await SystemStateProvider.shared.isTCPPortResponding(port: effectivePort, timeoutMs: timeoutMs)
     }
 }
 

--- a/Tests/KeyPathTests/Core/SystemStateProviderLivenessTests.swift
+++ b/Tests/KeyPathTests/Core/SystemStateProviderLivenessTests.swift
@@ -29,4 +29,90 @@ final class SystemStateProviderLivenessTests: XCTestCase {
         XCTAssertFalse(SystemStateProvider.isProcessAlive(pid: 0))
         XCTAssertFalse(SystemStateProvider.isProcessAlive(pid: -1))
     }
+
+    func testTCPReadinessProbeDetectsListeningAndClosedPorts() async throws {
+        let listener = try LocalhostTCPListener()
+
+        let respondingWhileListening = await SystemStateProvider.shared
+            .isTCPPortResponding(port: listener.port, timeoutMs: 200)
+        XCTAssertTrue(respondingWhileListening)
+
+        listener.close()
+
+        let respondingAfterClose = await SystemStateProvider.shared
+            .isTCPPortResponding(port: listener.port, timeoutMs: 50)
+        XCTAssertFalse(respondingAfterClose)
+    }
+
+    func testTCPReadinessRejectsInvalidPorts() async {
+        let zeroPort = await SystemStateProvider.shared.isTCPPortResponding(port: 0, timeoutMs: 50)
+        let tooLargePort = await SystemStateProvider.shared.isTCPPortResponding(port: 65536, timeoutMs: 50)
+        let negativeTimeout = await SystemStateProvider.shared.isTCPPortResponding(port: 37001, timeoutMs: -1)
+
+        XCTAssertFalse(zeroPort)
+        XCTAssertFalse(tooLargePort)
+        XCTAssertFalse(negativeTimeout)
+    }
+}
+
+private final class LocalhostTCPListener {
+    let port: Int
+    private var fd: Int32 = -1
+
+    init() throws {
+        let socketFD = socket(AF_INET, SOCK_STREAM, 0)
+        guard socketFD >= 0 else { throw POSIXError(.init(rawValue: errno) ?? .EIO) }
+
+        var reuse: Int32 = 1
+        setsockopt(socketFD, SOL_SOCKET, SO_REUSEADDR, &reuse, socklen_t(MemoryLayout<Int32>.size))
+
+        var addr = sockaddr_in()
+        addr.sin_family = sa_family_t(AF_INET)
+        addr.sin_port = 0
+        addr.sin_addr = in_addr(s_addr: inet_addr("127.0.0.1"))
+
+        var bindAddr = addr
+        let bindResult = withUnsafePointer(to: &bindAddr) {
+            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                bind(socketFD, $0, socklen_t(MemoryLayout<sockaddr_in>.size))
+            }
+        }
+        guard bindResult == 0 else {
+            let code = POSIXErrorCode(rawValue: errno) ?? .EIO
+            Darwin.close(socketFD)
+            throw POSIXError(code)
+        }
+
+        guard listen(socketFD, 1) == 0 else {
+            let code = POSIXErrorCode(rawValue: errno) ?? .EIO
+            Darwin.close(socketFD)
+            throw POSIXError(code)
+        }
+
+        var boundAddr = sockaddr_in()
+        var boundAddrLen = socklen_t(MemoryLayout<sockaddr_in>.size)
+        let nameResult = withUnsafeMutablePointer(to: &boundAddr) {
+            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                getsockname(socketFD, $0, &boundAddrLen)
+            }
+        }
+        guard nameResult == 0 else {
+            let code = POSIXErrorCode(rawValue: errno) ?? .EIO
+            Darwin.close(socketFD)
+            throw POSIXError(code)
+        }
+
+        port = Int(UInt16(bigEndian: boundAddr.sin_port))
+        fd = socketFD
+    }
+
+    deinit {
+        close()
+    }
+
+    func close() {
+        guard fd >= 0 else { return }
+        Darwin.close(fd)
+        fd = -1
+    }
 }

--- a/Tests/KeyPathTests/Lint/TCPReadinessLintTests.swift
+++ b/Tests/KeyPathTests/Lint/TCPReadinessLintTests.swift
@@ -1,0 +1,51 @@
+import Foundation
+@preconcurrency import XCTest
+
+/// Guards the W1/W2 TCP-readiness migration for `ServiceHealthChecker`.
+///
+/// The wizard health checker used to carry a private POSIX socket probe because
+/// the old `TCPProbe` utility lived in AppKit. The blessed readiness probe now
+/// lives in `SystemStateProvider`; this ratchet prevents the private socket
+/// implementation from drifting back into installer health checks.
+final class TCPReadinessLintTests: XCTestCase {
+    func testServiceHealthCheckerDelegatesTCPReadinessToSystemStateProvider() throws {
+        let serviceHealthChecker = repositoryRoot()
+            .appendingPathComponent("Sources/KeyPathInstallationWizard/Core/ServiceHealthChecker.swift")
+        let contents = try String(contentsOf: serviceHealthChecker, encoding: .utf8)
+
+        let forbiddenPatterns = [
+            #"probeTCP\s*\("#,
+            #"socket\s*\(\s*AF_INET"#,
+            #"connect\s*\("#,
+            #"poll\s*\("#,
+            #"getsockopt\s*\("#
+        ].map { try! NSRegularExpression(pattern: $0) }
+
+        var violations: [String] = []
+        for (idx, rawLine) in contents.components(separatedBy: .newlines).enumerated() {
+            let trimmed = rawLine.trimmingCharacters(in: .whitespaces)
+            if trimmed.hasPrefix("//") || trimmed.hasPrefix("///") || trimmed.hasPrefix("*") { continue }
+            let range = NSRange(rawLine.startIndex..., in: rawLine)
+            if forbiddenPatterns.contains(where: { $0.firstMatch(in: rawLine, range: range) != nil }) {
+                violations.append("ServiceHealthChecker.swift:\(idx + 1): \(trimmed)")
+            }
+        }
+
+        XCTAssertTrue(
+            violations.isEmpty,
+            """
+            ServiceHealthChecker must delegate TCP readiness to SystemStateProvider \
+            instead of carrying a private socket probe:
+            \(violations.sorted().joined(separator: "\n"))
+            """
+        )
+    }
+}
+
+private func repositoryRoot(file: StaticString = #filePath) -> URL {
+    URL(fileURLWithPath: "\(file)")
+        .deletingLastPathComponent() // Lint
+        .deletingLastPathComponent() // KeyPathTests
+        .deletingLastPathComponent() // Tests
+        .deletingLastPathComponent() // repo root
+}

--- a/docs/planning/installer-reliability-phase1.md
+++ b/docs/planning/installer-reliability-phase1.md
@@ -72,12 +72,17 @@ apply. Checklists decay; that is how the loop happened. Make it code.
 - Wizard, CLI, and menu bar cannot disagree about system state because they
   cannot read different sources.
 
-**Status (2026-07-06):** First provider slice implemented; full snapshot
+**Status (2026-07-07):** First provider slices implemented; full snapshot
 classification remains pending.
 - [x] Introduced `SystemStateProvider` as the owner for the ADR-040
   process-liveness primitive and Kanata readiness predicate. Enforced by
   `SystemStateProviderLivenessTests.testProcessLivenessProbeTreatsCurrentProcessAsAliveAndExitedProcessAsDead`
   and `SystemStateProviderLivenessTests.testKanataReadinessRequiresRunningAndResponding`.
+- [x] Moved the TCP readiness primitive into `SystemStateProvider` and migrated
+  `ServiceHealthChecker` to delegate to it. Enforced by
+  `SystemStateProviderLivenessTests.testTCPReadinessProbeDetectsListeningAndClosedPorts`,
+  `SystemStateProviderLivenessTests.testTCPReadinessRejectsInvalidPorts`, and
+  `TCPReadinessLintTests.testServiceHealthCheckerDelegatesTCPReadinessToSystemStateProvider`.
 - [ ] Migrate `launchctl`, `SMAppService.status`, `pgrep`, TCP probes,
   permissions, VHID state, and helper freshness into a single immutable
   `SystemSnapshot`.
@@ -105,7 +110,7 @@ through 21 mocked tests).
 - A grounding test runs the real primitive against a known-alive pid
   (`getpid()`) and a known-dead pid (ADR-040 §3), not only mocked seams.
 
-**Status (2026-07-06):** First liveness-predicate slice implemented.
+**Status (2026-07-07):** First liveness/readiness predicate slices implemented.
 - [x] `kill(pid, 0)` liveness semantics exist in exactly one production
   function, `SystemStateProvider.isProcessAlive(pid:)`. Enforced by
   `LivenessPredicateLintTests.testKillZeroLivenessProbeIsCentralized`.
@@ -114,8 +119,12 @@ through 21 mocked tests).
   `SystemStateProviderLivenessTests.testProcessLivenessProbeTreatsCurrentProcessAsAliveAndExitedProcessAsDead`.
 - [x] Kanata readiness is pinned to `running && responding`. Enforced by
   `SystemStateProviderLivenessTests.testKanataReadinessRequiresRunningAndResponding`.
-- [ ] Centralize remaining `pgrep` process discovery and TCP readiness probes
-  as later W1/W2 migration slices.
+- [x] TCP readiness has a provider-owned primitive with a real local listener
+  grounding test. Enforced by
+  `SystemStateProviderLivenessTests.testTCPReadinessProbeDetectsListeningAndClosedPorts`
+  and `SystemStateProviderLivenessTests.testTCPReadinessRejectsInvalidPorts`.
+- [ ] Centralize remaining `pgrep` process discovery and remaining TCP readiness
+  consumers as later W1/W2 migration slices.
 
 ## Workstream 3: Industry-Standard Repair Model
 
@@ -211,12 +220,14 @@ context loss across sessions, contributors, and agents. Extend it:
 **Acceptance criteria:** each ratchet lands with the workstream it protects and
 is listed in the state-matrix doc's enforcement section.
 
-**Status (2026-07-06):** First liveness ratchet implemented.
+**Status (2026-07-07):** First liveness/readiness ratchets implemented.
 - [x] `LivenessPredicateLintTests.testKillZeroLivenessProbeIsCentralized`
   prevents new direct `kill(pid, 0)` liveness probes outside
   `SystemStateProvider`.
-- [ ] Add `launchctl`, `pgrep`, TCP-probe, postcondition, and snapshot-cache
-  ratchets with the corresponding migration slices.
+- [x] `TCPReadinessLintTests.testServiceHealthCheckerDelegatesTCPReadinessToSystemStateProvider`
+  prevents `ServiceHealthChecker` from regrowing a private TCP socket probe.
+- [ ] Add `launchctl`, `pgrep`, broader TCP-probe, postcondition, and
+  snapshot-cache ratchets with the corresponding migration slices.
 
 ## Workstream 6: Deletion Pass
 

--- a/docs/process/installer-repair-state-matrix.md
+++ b/docs/process/installer-repair-state-matrix.md
@@ -136,6 +136,11 @@ the result as user action required and name the approval surface.
   proves the real ADR-040 primitive, and
   `LivenessPredicateLintTests.testKillZeroLivenessProbeIsCentralized` blocks
   new direct `kill(pid, 0)` probes outside the provider.
+- TCP readiness semantics belong in `SystemStateProvider.isTCPPortResponding(port:timeoutMs:)`.
+  `SystemStateProviderLivenessTests.testTCPReadinessProbeDetectsListeningAndClosedPorts`
+  proves the real localhost primitive, and
+  `TCPReadinessLintTests.testServiceHealthCheckerDelegatesTCPReadinessToSystemStateProvider`
+  blocks `ServiceHealthChecker` from regrowing a private socket probe.
 - User-facing CLI/reporting shape belongs in CLI contract tests.
 
 ## Related References


### PR DESCRIPTION
## Summary
- Move the localhost TCP readiness primitive into `SystemStateProvider` alongside the existing process-liveness primitive.
- Migrate `ServiceHealthChecker` to delegate TCP readiness through `SystemStateProvider.shared` while preserving `KEYPATH_TCP_PORT` override behavior.
- Keep `TCPProbe` as a compatibility wrapper for remaining AppKit call sites until later W1/W2 slices migrate them.
- Add the matching W5 lint ratchet and update the Phase 1 plan plus state-matrix enforcement notes.

## Acceptance criteria completed
- TCP readiness is provider-owned and grounded against a real localhost listener: enforced by `SystemStateProviderLivenessTests.testTCPReadinessProbeDetectsListeningAndClosedPorts`.
- Invalid TCP readiness inputs fail closed: enforced by `SystemStateProviderLivenessTests.testTCPReadinessRejectsInvalidPorts`.
- `ServiceHealthChecker` cannot regrow a private POSIX TCP probe: enforced by `TCPReadinessLintTests.testServiceHealthCheckerDelegatesTCPReadinessToSystemStateProvider`.

## Out of scope
- No Workstream 3 repair-model changes.
- No Workstream 6 deletion pass.
- No full `classify(snapshot) -> row -> plan` state-matrix golden fixture yet; that belongs with the later snapshot/classifier slice.
- Remaining TCP consumers, `pgrep`, `launchctl`, `SMAppService.status`, permissions, VHID state, and helper freshness migration remain pending W1/W2 slices.

## Test plan
- ✅ `TEST_FILTER='SystemStateProviderLivenessTests|TCPReadinessLintTests|ServiceHealthCheckerTests' ./Scripts/run-tests-safe.sh` — 33 tests passed.
- ✅ `python3 Scripts/check-accessibility.py` — all 352 files clean.
- ✅ `./Scripts/run-tests-safe.sh` — 4,434 tests passed.
- ⚠️ `./Scripts/test-full.sh` — reproduced the existing snapshot-lane blocker under Xcode beta: main suite reached 4,434 passed, then `KeyPathSnapshotTests` crashed with signal 11 and reported 24 failures. This matches the known clean-master issue from the previous slice and is not introduced by this TCP-readiness PR.

## Review gate
Local `/thermo-nuclear-swift-review` is not available in this Codex shell, so this PR is opened as draft to trigger the GitHub `claude-code-review` workflow before marking ready.
