### PR TITLE
Migrate TCP readiness consumers to SystemStateProvider

### DIFF
--- a/Sources/KeyPathAppKit/Managers/ServiceLifecycleCoordinator.swift
+++ b/Sources/KeyPathAppKit/Managers/ServiceLifecycleCoordinator.swift
@@ -46,7 +46,7 @@ final class ServiceLifecycleCoordinator {
         /// Replaces `kill(pid, signal)` for SIGTERM/SIGKILL so tests with synthetic PIDs
         /// never signal a real, unrelated process on the machine.
         nonisolated(unsafe) static var testSignal: ((pid_t, Int32) -> Void)?
-        /// Replaces `TCPProbe.probe`. Returns `true` when something is listening.
+        /// Replaces `SystemStateProvider.isTCPPortResponding`. Returns `true` when something is listening.
         nonisolated(unsafe) static var testTCPProbe: ((Int, Int) -> Bool)?
         /// Replaces `Task.sleep` in the polling loops so tests never wait real time.
         nonisolated(unsafe) static var testSleep: ((Duration) async -> Void)?
@@ -667,9 +667,7 @@ final class ServiceLifecycleCoordinator {
         #if DEBUG
             if let probe = Self.testTCPProbe { return probe(port, timeoutMs) }
         #endif
-        return await Task.detached(priority: .utility) {
-            TCPProbe.probe(port: port, timeoutMs: timeoutMs)
-        }.value
+        return await SystemStateProvider.shared.isTCPPortResponding(port: port, timeoutMs: timeoutMs)
     }
 
     private func waitSleep(_ duration: Duration) async {

--- a/Sources/KeyPathAppKit/Services/Kanata/KanataDaemonService.swift
+++ b/Sources/KeyPathAppKit/Services/Kanata/KanataDaemonService.swift
@@ -240,14 +240,12 @@ final class KanataDaemonService {
                 if let override = Self.tcpProbeOverride {
                     tcpAlive = override(tcpPort, 300)
                 } else {
-                    tcpAlive = await Task.detached(priority: .utility) {
-                        TCPProbe.probe(port: tcpPort, timeoutMs: 300)
-                    }.value
+                    tcpAlive = await SystemStateProvider.shared
+                        .isTCPPortResponding(port: tcpPort, timeoutMs: 300)
                 }
             #else
-                tcpAlive = await Task.detached(priority: .utility) {
-                    TCPProbe.probe(port: tcpPort, timeoutMs: 300)
-                }.value
+                tcpAlive = await SystemStateProvider.shared
+                    .isTCPPortResponding(port: tcpPort, timeoutMs: 300)
             #endif
 
             if tcpAlive {

--- a/Sources/KeyPathAppKit/WizardProtocolConformances.swift
+++ b/Sources/KeyPathAppKit/WizardProtocolConformances.swift
@@ -175,9 +175,9 @@ public func configureWizardDependencies(runtimeCoordinator: RuntimeCoordinator) 
         ExternalKanataService.hasExternalKanataRunning()
     }
 
-    // TCPProbe
+    // TCP readiness probe
     WizardDependencies.tcpProbe = { port, timeoutMs in
-        TCPProbe.probe(port: port, timeoutMs: timeoutMs)
+        SystemStateProvider.probeTCPPort(port: port, timeoutMs: timeoutMs)
     }
 
     // Page view factories for pages that live in KeyPathAppKit
@@ -255,6 +255,6 @@ func configureCLIWizardDependencies(systemValidator: SystemValidator) {
         ExternalKanataService.hasExternalKanataRunning()
     }
     WizardDependencies.tcpProbe = { port, timeoutMs in
-        TCPProbe.probe(port: port, timeoutMs: timeoutMs)
+        SystemStateProvider.probeTCPPort(port: port, timeoutMs: timeoutMs)
     }
 }

--- a/Sources/KeyPathWizardCore/WizardDependencies.swift
+++ b/Sources/KeyPathWizardCore/WizardDependencies.swift
@@ -86,7 +86,7 @@ public enum WizardDependencies {
     /// Check if external Kanata is running
     public nonisolated(unsafe) static var hasExternalKanataRunning: (() -> Bool)?
 
-    // MARK: - TCPProbe (static method)
+    // MARK: - TCP readiness probe
 
     /// TCP connectivity probe
     public nonisolated(unsafe) static var tcpProbe: ((Int, Int) -> Bool)?

--- a/Sources/KeyPathWizardCore/WizardServiceProtocols.swift
+++ b/Sources/KeyPathWizardCore/WizardServiceProtocols.swift
@@ -86,7 +86,7 @@ public enum WizardSignatureHealthCheck {
     }
 }
 
-// MARK: - TCPProbe Protocol
+// MARK: - TCP readiness probe protocol
 
 public protocol WizardTCPProbing: Sendable {
     static func probe(port: Int, timeoutMs: Int) -> Bool

--- a/Tests/KeyPathTests/Lint/TCPReadinessLintTests.swift
+++ b/Tests/KeyPathTests/Lint/TCPReadinessLintTests.swift
@@ -40,12 +40,90 @@ final class TCPReadinessLintTests: XCTestCase {
             """
         )
     }
+
+    func testProductionTCPProbeAdapterIsNoLongerUsed() throws {
+        let violations = try sourceFiles(excludingPathSuffixes: ["Sources/KeyPathAppKit/Utilities/TCPProbe.swift"])
+            .flatMap { fileURL in
+                try matchingLines(
+                    in: fileURL,
+                    patterns: [#"TCPProbe\.probe\s*\("#]
+                )
+            }
+
+        XCTAssertTrue(
+            violations.isEmpty,
+            """
+            Production TCP readiness must call SystemStateProvider directly \
+            instead of the legacy TCPProbe adapter:
+            \(violations.sorted().joined(separator: "\n"))
+            """
+        )
+    }
+
+    func testProductionRawTCPSocketProbeIsCentralized() throws {
+        let violations = try sourceFiles(excludingPathSuffixes: ["Sources/KeyPathCore/SystemStateProvider.swift"])
+            .flatMap { fileURL in
+                try matchingLines(
+                    in: fileURL,
+                    patterns: [
+                        #"socket\s*\(\s*AF_INET"#,
+                        #"getsockopt\s*\("#,
+                        #"EINPROGRESS"#,
+                        #"POLLOUT"#
+                    ]
+                )
+            }
+
+        XCTAssertTrue(
+            violations.isEmpty,
+            """
+            Production raw TCP socket readiness probes must stay centralized in \
+            SystemStateProvider:
+            \(violations.sorted().joined(separator: "\n"))
+            """
+        )
+    }
 }
 
 private func repositoryRoot(file: StaticString = #filePath) -> URL {
     URL(fileURLWithPath: "\(file)")
+        .deletingLastPathComponent() // TCPReadinessLintTests.swift
         .deletingLastPathComponent() // Lint
         .deletingLastPathComponent() // KeyPathTests
         .deletingLastPathComponent() // Tests
-        .deletingLastPathComponent() // repo root
+}
+
+private func sourceFiles(excludingPathSuffixes excludedSuffixes: Set<String>) throws -> [URL] {
+    let sourcesRoot = repositoryRoot().appendingPathComponent("Sources")
+    let enumerator = FileManager.default.enumerator(
+        at: sourcesRoot,
+        includingPropertiesForKeys: [.isRegularFileKey],
+        options: [.skipsHiddenFiles]
+    )
+
+    var files: [URL] = []
+    while let fileURL = enumerator?.nextObject() as? URL {
+        guard fileURL.pathExtension == "swift" else { continue }
+        let relativePath = fileURL.path.replacingOccurrences(of: repositoryRoot().path + "/", with: "")
+        if excludedSuffixes.contains(where: { relativePath.hasSuffix($0) }) { continue }
+        files.append(fileURL)
+    }
+    return files
+}
+
+private func matchingLines(in fileURL: URL, patterns: [String]) throws -> [String] {
+    let contents = try String(contentsOf: fileURL, encoding: .utf8)
+    let regexes = try patterns.map { try NSRegularExpression(pattern: $0) }
+    let relativePath = fileURL.path.replacingOccurrences(of: repositoryRoot().path + "/", with: "")
+
+    var violations: [String] = []
+    for (idx, rawLine) in contents.components(separatedBy: .newlines).enumerated() {
+        let trimmed = rawLine.trimmingCharacters(in: .whitespaces)
+        if trimmed.hasPrefix("//") || trimmed.hasPrefix("///") || trimmed.hasPrefix("*") { continue }
+        let range = NSRange(rawLine.startIndex..., in: rawLine)
+        if regexes.contains(where: { $0.firstMatch(in: rawLine, range: range) != nil }) {
+            violations.append("\(relativePath):\(idx + 1): \(trimmed)")
+        }
+    }
+    return violations
 }

--- a/docs/planning/installer-reliability-phase1.md
+++ b/docs/planning/installer-reliability-phase1.md
@@ -83,7 +83,11 @@ classification remains pending.
   `SystemStateProviderLivenessTests.testTCPReadinessProbeDetectsListeningAndClosedPorts`,
   `SystemStateProviderLivenessTests.testTCPReadinessRejectsInvalidPorts`, and
   `TCPReadinessLintTests.testServiceHealthCheckerDelegatesTCPReadinessToSystemStateProvider`.
-- [ ] Migrate `launchctl`, `SMAppService.status`, `pgrep`, TCP probes,
+- [x] Migrated remaining production `TCPProbe.probe` consumers to
+  `SystemStateProvider`. Enforced by
+  `TCPReadinessLintTests.testProductionTCPProbeAdapterIsNoLongerUsed` and
+  `TCPReadinessLintTests.testProductionRawTCPSocketProbeIsCentralized`.
+- [ ] Migrate `launchctl`, `SMAppService.status`, `pgrep`,
   permissions, VHID state, and helper freshness into a single immutable
   `SystemSnapshot`.
 - [ ] Build `classify(snapshot) -> StateMatrixRow -> plan` and table-driven
@@ -123,8 +127,11 @@ through 21 mocked tests).
   grounding test. Enforced by
   `SystemStateProviderLivenessTests.testTCPReadinessProbeDetectsListeningAndClosedPorts`
   and `SystemStateProviderLivenessTests.testTCPReadinessRejectsInvalidPorts`.
-- [ ] Centralize remaining `pgrep` process discovery and remaining TCP readiness
-  consumers as later W1/W2 migration slices.
+- [x] Remaining production TCP readiness consumers delegate to
+  `SystemStateProvider`. Enforced by
+  `TCPReadinessLintTests.testProductionTCPProbeAdapterIsNoLongerUsed`.
+- [ ] Centralize remaining `pgrep` process discovery as later W1/W2 migration
+  slices.
 
 ## Workstream 3: Industry-Standard Repair Model
 
@@ -226,8 +233,12 @@ is listed in the state-matrix doc's enforcement section.
   `SystemStateProvider`.
 - [x] `TCPReadinessLintTests.testServiceHealthCheckerDelegatesTCPReadinessToSystemStateProvider`
   prevents `ServiceHealthChecker` from regrowing a private TCP socket probe.
-- [ ] Add `launchctl`, `pgrep`, broader TCP-probe, postcondition, and
-  snapshot-cache ratchets with the corresponding migration slices.
+- [x] `TCPReadinessLintTests.testProductionTCPProbeAdapterIsNoLongerUsed` and
+  `TCPReadinessLintTests.testProductionRawTCPSocketProbeIsCentralized` prevent
+  production readiness checks from drifting back to the legacy adapter or raw
+  socket probes outside `SystemStateProvider`.
+- [ ] Add `launchctl`, `pgrep`, postcondition, and snapshot-cache ratchets with
+  the corresponding migration slices.
 
 ## Workstream 6: Deletion Pass
 

--- a/docs/process/installer-repair-state-matrix.md
+++ b/docs/process/installer-repair-state-matrix.md
@@ -138,9 +138,12 @@ the result as user action required and name the approval surface.
   new direct `kill(pid, 0)` probes outside the provider.
 - TCP readiness semantics belong in `SystemStateProvider.isTCPPortResponding(port:timeoutMs:)`.
   `SystemStateProviderLivenessTests.testTCPReadinessProbeDetectsListeningAndClosedPorts`
-  proves the real localhost primitive, and
+  proves the real localhost primitive,
   `TCPReadinessLintTests.testServiceHealthCheckerDelegatesTCPReadinessToSystemStateProvider`
-  blocks `ServiceHealthChecker` from regrowing a private socket probe.
+  blocks `ServiceHealthChecker` from regrowing a private socket probe, and
+  `TCPReadinessLintTests.testProductionTCPProbeAdapterIsNoLongerUsed` plus
+  `TCPReadinessLintTests.testProductionRawTCPSocketProbeIsCentralized` block
+  production readiness checks from bypassing the provider.
 - User-facing CLI/reporting shape belongs in CLI contract tests.
 
 ## Related References


### PR DESCRIPTION
## Summary
- Migrate remaining production `TCPProbe.probe` consumers to `SystemStateProvider`.
- Keep existing DEBUG test seams for deterministic lifecycle tests.
- Leave the legacy `TCPProbe` wrapper/protocol in place for the later deletion pass, but add W5 ratchets preventing production code from using it or adding raw TCP socket probes outside the provider.
- Update the Phase 1 plan and state-matrix enforcement notes with the new acceptance-criteria tests.

## Acceptance criteria completed
- Remaining production TCP readiness consumers delegate to `SystemStateProvider`: enforced by `TCPReadinessLintTests.testProductionTCPProbeAdapterIsNoLongerUsed`.
- Production raw TCP socket readiness probes remain centralized in `SystemStateProvider`: enforced by `TCPReadinessLintTests.testProductionRawTCPSocketProbeIsCentralized`.
- Existing `ServiceHealthChecker` TCP ratchet remains in place: enforced by `TCPReadinessLintTests.testServiceHealthCheckerDelegatesTCPReadinessToSystemStateProvider`.

## Out of scope
- No Workstream 3 repair-model changes.
- No Workstream 6 deletion pass; `TCPProbe` compatibility scaffolding is intentionally not deleted here.
- No `classify(snapshot) -> row -> plan` matrix golden fixture yet; that belongs with the later snapshot/classifier slice.
- `pgrep`, `launchctl`, `SMAppService.status`, permissions, VHID state, helper freshness, and postcondition ratchets remain pending W1/W2/W5 slices.

## Test plan
- ✅ `TEST_FILTER='TCPReadinessLintTests|SystemStateProviderLivenessTests|KanataDaemonServiceIntegrationTests|ServiceLifecycleCoordinatorTests' ./Scripts/run-tests-safe.sh` — 34 tests passed.
- ✅ `python3 Scripts/check-accessibility.py` — all 352 files clean.
- ✅ `./Scripts/run-tests-safe.sh` — 4,436 tests passed.
- ⚠️ `./Scripts/test-full.sh` not rerun for this PR. It was rerun on the immediately preceding TCP slice (#999) and reproduced the known clean-master `KeyPathSnapshotTests` Xcode beta signal-11/snapshot-lane blocker after the main suite passed. This slice is covered by the green non-snapshot safe gate above.

## Review gate
Local `/thermo-nuclear-swift-review` is not available in this Codex shell, so this PR is opened as draft to trigger the GitHub `claude-code-review` workflow before marking ready.
