### PR TITLE
Centralize pgrep process discovery primitive

### DIFF
--- a/Sources/KeyPathAppKit/Managers/ServiceLifecycleCoordinator.swift
+++ b/Sources/KeyPathAppKit/Managers/ServiceLifecycleCoordinator.swift
@@ -39,7 +39,7 @@ final class ServiceLifecycleCoordinator {
     // inject deterministic closures; production always uses the real subprocess /
     // syscall / TCP probe. DEBUG-only and nil in production.
     #if DEBUG
-        /// Replaces `SubprocessRunner.shared.pgrep`. Returns matching PIDs for a name.
+        /// Replaces provider-backed process discovery. Returns matching PIDs for a name.
         nonisolated(unsafe) static var testPgrepProvider: ((String) -> [pid_t])?
         /// Replaces `kill(pid, 0)`. Returns `true` when the process is still alive.
         nonisolated(unsafe) static var testLivenessProbe: ((pid_t) -> Bool)?
@@ -586,7 +586,7 @@ final class ServiceLifecycleCoordinator {
         // (see CLAUDE.md) and would let synthetic PIDs reach a real `kill`. Tests that
         // need orphan PIDs inject `testPgrepProvider`; everything else gets a clean slate.
         if TestEnvironment.isRunningTests { return [] }
-        return await SubprocessRunner.shared.pgrep(name)
+        return await SystemStateProvider.shared.processIDs(matching: name)
     }
 
     private func detectRunningKanataIdentity() async -> RunningKanataIdentity? {

--- a/Sources/KeyPathCore/SystemStateProvider.swift
+++ b/Sources/KeyPathCore/SystemStateProvider.swift
@@ -8,7 +8,11 @@ import Foundation
 public actor SystemStateProvider {
     public static let shared = SystemStateProvider()
 
-    public init() {}
+    private let subprocessRunner: any SubprocessRunning
+
+    public init(subprocessRunner: any SubprocessRunning = SubprocessRunner.shared) {
+        self.subprocessRunner = subprocessRunner
+    }
 
     public nonisolated func isProcessAlive(pid: pid_t) -> Bool {
         Self.isProcessAlive(pid: pid)
@@ -18,6 +22,12 @@ public actor SystemStateProvider {
         await Task.detached(priority: .utility) {
             Self.probeTCPPort(port: port, timeoutMs: timeoutMs)
         }.value
+    }
+
+    public func processIDs(matching pattern: String) async -> [pid_t] {
+        let trimmedPattern = pattern.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedPattern.isEmpty else { return [] }
+        return await subprocessRunner.pgrep(trimmedPattern)
     }
 
     public nonisolated static func isProcessAlive(pid: pid_t) -> Bool {

--- a/Tests/KeyPathTests/Core/SystemStateProviderLivenessTests.swift
+++ b/Tests/KeyPathTests/Core/SystemStateProviderLivenessTests.swift
@@ -53,6 +53,33 @@ final class SystemStateProviderLivenessTests: XCTestCase {
         XCTAssertFalse(tooLargePort)
         XCTAssertFalse(negativeTimeout)
     }
+
+    func testProcessDiscoveryDelegatesToInjectedSubprocessRunner() async {
+        let runner = SubprocessRunnerFake.shared
+        await runner.reset()
+        await runner.configurePgrepResult { pattern in
+            pattern == "kanata.*--cfg" ? [1234, 5678] : []
+        }
+        let provider = SystemStateProvider(subprocessRunner: runner)
+
+        let pids = await provider.processIDs(matching: "kanata.*--cfg")
+
+        XCTAssertEqual(pids, [1234, 5678])
+    }
+
+    func testProcessDiscoveryRejectsBlankPatterns() async {
+        let runner = SubprocessRunnerFake.shared
+        await runner.reset()
+        await runner.configurePgrepResult { _ in
+            XCTFail("Blank process-discovery patterns must not invoke pgrep")
+            return [9999]
+        }
+        let provider = SystemStateProvider(subprocessRunner: runner)
+
+        let pids = await provider.processIDs(matching: "  \n\t  ")
+
+        XCTAssertEqual(pids, [])
+    }
 }
 
 private final class LocalhostTCPListener {

--- a/Tests/KeyPathTests/Lint/PgrepProcessDiscoveryLintTests.swift
+++ b/Tests/KeyPathTests/Lint/PgrepProcessDiscoveryLintTests.swift
@@ -1,0 +1,58 @@
+import Foundation
+@preconcurrency import XCTest
+
+/// Guards W1/W2 process-discovery migration slices.
+///
+/// `pgrep` remains the low-level subprocess mechanism for now, but production
+/// process-discovery consumers should call `SystemStateProvider` so Phase 1 can
+/// collapse process, TCP, and later launchd/SMAppService evidence into one
+/// executable snapshot.
+final class PgrepProcessDiscoveryLintTests: XCTestCase {
+    func testServiceLifecycleCoordinatorDelegatesPgrepDiscoveryToSystemStateProvider() throws {
+        let coordinator = repositoryRoot()
+            .appendingPathComponent("Sources/KeyPathAppKit/Managers/ServiceLifecycleCoordinator.swift")
+
+        let violations = try matchingLines(
+            in: coordinator,
+            patterns: [
+                #"SubprocessRunner\.shared\.pgrep"#,
+                #"subprocessRunner\.pgrep"#,
+                #"/usr/bin/pgrep"#
+            ]
+        )
+
+        XCTAssertTrue(
+            violations.isEmpty,
+            """
+            ServiceLifecycleCoordinator must delegate process discovery to \
+            SystemStateProvider instead of calling pgrep directly:
+            \(violations.sorted().joined(separator: "\n"))
+            """
+        )
+    }
+}
+
+private func repositoryRoot(file: StaticString = #filePath) -> URL {
+    URL(fileURLWithPath: "\(file)")
+        .deletingLastPathComponent() // PgrepProcessDiscoveryLintTests.swift
+        .deletingLastPathComponent() // Lint
+        .deletingLastPathComponent() // KeyPathTests
+        .deletingLastPathComponent() // Tests
+}
+
+private func matchingLines(in fileURL: URL, patterns: [String]) throws -> [String] {
+    let contents = try String(contentsOf: fileURL, encoding: .utf8)
+    let regexes = try patterns.map { try NSRegularExpression(pattern: $0) }
+    let relativePath = fileURL.path.replacingOccurrences(of: repositoryRoot().path + "/", with: "")
+
+    var violations: [String] = []
+    for (idx, rawLine) in contents.components(separatedBy: .newlines).enumerated() {
+        let trimmed = rawLine.trimmingCharacters(in: .whitespaces)
+        if trimmed.hasPrefix("//") || trimmed.hasPrefix("///") || trimmed.hasPrefix("*") { continue }
+        let range = NSRange(rawLine.startIndex..., in: rawLine)
+        if regexes.contains(where: { $0.firstMatch(in: rawLine, range: range) != nil }) {
+            violations.append("\(relativePath):\(idx + 1): \(trimmed)")
+        }
+    }
+    return violations
+}

--- a/docs/planning/installer-reliability-phase1.md
+++ b/docs/planning/installer-reliability-phase1.md
@@ -87,7 +87,12 @@ classification remains pending.
   `SystemStateProvider`. Enforced by
   `TCPReadinessLintTests.testProductionTCPProbeAdapterIsNoLongerUsed` and
   `TCPReadinessLintTests.testProductionRawTCPSocketProbeIsCentralized`.
-- [ ] Migrate `launchctl`, `SMAppService.status`, `pgrep`,
+- [x] Added provider-owned `pgrep` process-discovery primitive and migrated
+  `ServiceLifecycleCoordinator` to delegate to it. Enforced by
+  `SystemStateProviderLivenessTests.testProcessDiscoveryDelegatesToInjectedSubprocessRunner`,
+  `SystemStateProviderLivenessTests.testProcessDiscoveryRejectsBlankPatterns`,
+  and `PgrepProcessDiscoveryLintTests.testServiceLifecycleCoordinatorDelegatesPgrepDiscoveryToSystemStateProvider`.
+- [ ] Migrate `launchctl`, `SMAppService.status`, remaining `pgrep` consumers,
   permissions, VHID state, and helper freshness into a single immutable
   `SystemSnapshot`.
 - [ ] Build `classify(snapshot) -> StateMatrixRow -> plan` and table-driven
@@ -130,8 +135,11 @@ through 21 mocked tests).
 - [x] Remaining production TCP readiness consumers delegate to
   `SystemStateProvider`. Enforced by
   `TCPReadinessLintTests.testProductionTCPProbeAdapterIsNoLongerUsed`.
-- [ ] Centralize remaining `pgrep` process discovery as later W1/W2 migration
-  slices.
+- [x] `ServiceLifecycleCoordinator` process discovery delegates to
+  `SystemStateProvider.processIDs(matching:)`. Enforced by
+  `PgrepProcessDiscoveryLintTests.testServiceLifecycleCoordinatorDelegatesPgrepDiscoveryToSystemStateProvider`.
+- [ ] Centralize remaining `pgrep` process-discovery consumers as later W1/W2
+  migration slices.
 
 ## Workstream 3: Industry-Standard Repair Model
 
@@ -237,8 +245,11 @@ is listed in the state-matrix doc's enforcement section.
   `TCPReadinessLintTests.testProductionRawTCPSocketProbeIsCentralized` prevent
   production readiness checks from drifting back to the legacy adapter or raw
   socket probes outside `SystemStateProvider`.
-- [ ] Add `launchctl`, `pgrep`, postcondition, and snapshot-cache ratchets with
-  the corresponding migration slices.
+- [x] `PgrepProcessDiscoveryLintTests.testServiceLifecycleCoordinatorDelegatesPgrepDiscoveryToSystemStateProvider`
+  prevents the first migrated runtime coordinator call site from regrowing
+  direct `pgrep` process discovery.
+- [ ] Add `launchctl`, broader `pgrep`, postcondition, and snapshot-cache
+  ratchets with the corresponding migration slices.
 
 ## Workstream 6: Deletion Pass
 

--- a/docs/process/installer-repair-state-matrix.md
+++ b/docs/process/installer-repair-state-matrix.md
@@ -144,6 +144,12 @@ the result as user action required and name the approval surface.
   `TCPReadinessLintTests.testProductionTCPProbeAdapterIsNoLongerUsed` plus
   `TCPReadinessLintTests.testProductionRawTCPSocketProbeIsCentralized` block
   production readiness checks from bypassing the provider.
+- `pgrep` process discovery belongs in `SystemStateProvider.processIDs(matching:)`.
+  `SystemStateProviderLivenessTests.testProcessDiscoveryDelegatesToInjectedSubprocessRunner`
+  and `SystemStateProviderLivenessTests.testProcessDiscoveryRejectsBlankPatterns`
+  pin the provider contract, while
+  `PgrepProcessDiscoveryLintTests.testServiceLifecycleCoordinatorDelegatesPgrepDiscoveryToSystemStateProvider`
+  blocks the first migrated runtime coordinator consumer from bypassing it.
 - User-facing CLI/reporting shape belongs in CLI contract tests.
 
 ## Related References


### PR DESCRIPTION
## Summary

- add `SystemStateProvider.processIDs(matching:)` as the provider-owned `pgrep` process-discovery primitive
- migrate `ServiceLifecycleCoordinator` process discovery to delegate through `SystemStateProvider`
- add the first W5 `pgrep` lint ratchet and update the Phase 1/state-matrix docs with acceptance-test citations

## Acceptance criteria completed

- Provider-owned process discovery delegates to the injected subprocess runner: `SystemStateProviderLivenessTests.testProcessDiscoveryDelegatesToInjectedSubprocessRunner`
- Blank process-discovery patterns fail closed without invoking `pgrep`: `SystemStateProviderLivenessTests.testProcessDiscoveryRejectsBlankPatterns`
- `ServiceLifecycleCoordinator` cannot regrow direct `pgrep` process discovery: `PgrepProcessDiscoveryLintTests.testServiceLifecycleCoordinatorDelegatesPgrepDiscoveryToSystemStateProvider`

## Scope notes

This is the next W1/W2/W5 incremental slice only. Remaining `pgrep` consumers, `launchctl`, `SMAppService.status`, permissions/VHID/helper freshness, state-matrix classifier/golden tests, Workstream 3, and Workstream 6 remain out of scope for this PR.

No plan/code conflict found in this slice.

## Review gate

Local `/thermo-nuclear-swift-review` is not callable from this Codex session, so this PR is opened as draft for the repo's GitHub Claude review gate before marking ready.

## Test plan

- `mise exec -- swiftformat Sources/KeyPathCore/SystemStateProvider.swift Sources/KeyPathAppKit/Managers/ServiceLifecycleCoordinator.swift Tests/KeyPathTests/Core/SystemStateProviderLivenessTests.swift Tests/KeyPathTests/Lint/PgrepProcessDiscoveryLintTests.swift`
- `git diff --check`
- `TEST_FILTER='SystemStateProviderLivenessTests|PgrepProcessDiscoveryLintTests|ServiceLifecycleCoordinatorTests' ./Scripts/run-tests-safe.sh` (31 passed)
- `python3 Scripts/check-accessibility.py` (352 files clean)
- `./Scripts/run-tests-safe.sh` (4,439 passed)

`./Scripts/test-full.sh` was not rerun for this slice; previous Phase 1 validation found its snapshot lane blocked by the existing Xcode beta `KeyPathSnapshotTests`/`xctest` crash, so the safe wrapper is the local acceptance gate here.