### PR TITLE
Route Kanata daemon pgrep through SystemStateProvider

### DIFF
--- a/Sources/KeyPathAppKit/Managers/KanataDaemonManager.swift
+++ b/Sources/KeyPathAppKit/Managers/KanataDaemonManager.swift
@@ -38,7 +38,8 @@ public class KanataDaemonManager {
 
     // MARK: - Dependencies
 
-    private let subprocessRunner: SubprocessRunner
+    private let subprocessRunner: any SubprocessRunning
+    private let systemStateProvider: SystemStateProvider
 
     // MARK: - Constants
 
@@ -55,8 +56,12 @@ public class KanataDaemonManager {
 
     // MARK: - Initialization
 
-    init(subprocessRunner: SubprocessRunner = .shared) {
+    init(
+        subprocessRunner: any SubprocessRunning = SubprocessRunner.shared,
+        systemStateProvider: SystemStateProvider = .shared
+    ) {
         self.subprocessRunner = subprocessRunner
+        self.systemStateProvider = systemStateProvider
         AppLogger.shared.log("🔧 [KanataDaemonManager] Initialized")
         Task { await refreshManagementStateInternal() }
     }
@@ -193,7 +198,7 @@ public class KanataDaemonManager {
     }
 
     private nonisolated func pgrepKanataProcessAsync() async -> Bool {
-        let pids = await subprocessRunner.pgrep("kanata.*--cfg")
+        let pids = await systemStateProvider.processIDs(matching: "kanata.*--cfg")
         return !pids.isEmpty
     }
 

--- a/Tests/KeyPathTests/Lint/PgrepProcessDiscoveryLintTests.swift
+++ b/Tests/KeyPathTests/Lint/PgrepProcessDiscoveryLintTests.swift
@@ -30,6 +30,29 @@ final class PgrepProcessDiscoveryLintTests: XCTestCase {
             """
         )
     }
+
+    func testKanataDaemonManagerDelegatesPgrepDiscoveryToSystemStateProvider() throws {
+        let manager = repositoryRoot()
+            .appendingPathComponent("Sources/KeyPathAppKit/Managers/KanataDaemonManager.swift")
+
+        let violations = try matchingLines(
+            in: manager,
+            patterns: [
+                #"SubprocessRunner\.shared\.pgrep"#,
+                #"subprocessRunner\.pgrep"#,
+                #"/usr/bin/pgrep"#
+            ]
+        )
+
+        XCTAssertTrue(
+            violations.isEmpty,
+            """
+            KanataDaemonManager must delegate process discovery to \
+            SystemStateProvider instead of calling pgrep directly:
+            \(violations.sorted().joined(separator: "\n"))
+            """
+        )
+    }
 }
 
 private func repositoryRoot(file: StaticString = #filePath) -> URL {

--- a/Tests/KeyPathTests/Managers/KanataDaemonManagerTests.swift
+++ b/Tests/KeyPathTests/Managers/KanataDaemonManagerTests.swift
@@ -1,4 +1,5 @@
 @testable import KeyPathAppKit
+@testable import KeyPathCore
 import ServiceManagement
 @preconcurrency import XCTest
 
@@ -178,5 +179,40 @@ final class KanataDaemonManagerTests: XCTestCase {
         XCTAssertEqual(mockService.unregisterCalls, 1, "Should unregister stale enabled registration")
         XCTAssertEqual(mockService.registerCalls, 1, "Should re-register after unregistering stale state")
         XCTAssertGreaterThanOrEqual(probeCount, 2, "Should probe stale state before and after recovery")
+    }
+
+    func testRegisteredButNotLoadedUsesInjectedSystemStateProviderForProcessDiscovery() async {
+        final class EnabledMockService: SMAppServiceProtocol, @unchecked Sendable {
+            var status: SMAppService.Status = .enabled
+
+            func register() throws {}
+            func unregister() async throws {}
+        }
+
+        let runner = SubprocessRunnerFake.shared
+        await runner.reset()
+        await runner.configureLaunchctlResult { _, _ in
+            ProcessResult(exitCode: 113, stdout: "", stderr: "service not found", duration: 0.01)
+        }
+        await runner.configurePgrepResult { pattern in
+            pattern == "kanata.*--cfg" ? [4242] : []
+        }
+
+        let mockService = EnabledMockService()
+        SMAppServiceStatusProvider.shared = SMAppServiceStatusProvider(
+            cacheTTL: 0,
+            serviceFactory: { _ in mockService }
+        )
+        let provider = SystemStateProvider(subprocessRunner: runner)
+        let manager = KanataDaemonManager(subprocessRunner: runner, systemStateProvider: provider)
+
+        let isStale = await manager.isRegisteredButNotLoaded()
+        let commands = await runner.executedCommands
+
+        XCTAssertFalse(isStale, "A live Kanata process should suppress stale-registration recovery")
+        XCTAssertTrue(
+            commands.contains { $0.executable == "/usr/bin/pgrep" && $0.args == ["-f", "kanata.*--cfg"] },
+            "KanataDaemonManager should use the injected provider's subprocess runner for process discovery"
+        )
     }
 }

--- a/docs/planning/installer-reliability-phase1.md
+++ b/docs/planning/installer-reliability-phase1.md
@@ -88,10 +88,12 @@ classification remains pending.
   `TCPReadinessLintTests.testProductionTCPProbeAdapterIsNoLongerUsed` and
   `TCPReadinessLintTests.testProductionRawTCPSocketProbeIsCentralized`.
 - [x] Added provider-owned `pgrep` process-discovery primitive and migrated
-  `ServiceLifecycleCoordinator` to delegate to it. Enforced by
+  `ServiceLifecycleCoordinator` and `KanataDaemonManager` to delegate to it. Enforced by
   `SystemStateProviderLivenessTests.testProcessDiscoveryDelegatesToInjectedSubprocessRunner`,
   `SystemStateProviderLivenessTests.testProcessDiscoveryRejectsBlankPatterns`,
-  and `PgrepProcessDiscoveryLintTests.testServiceLifecycleCoordinatorDelegatesPgrepDiscoveryToSystemStateProvider`.
+  `PgrepProcessDiscoveryLintTests.testServiceLifecycleCoordinatorDelegatesPgrepDiscoveryToSystemStateProvider`,
+  `KanataDaemonManagerTests.testRegisteredButNotLoadedUsesInjectedSystemStateProviderForProcessDiscovery`,
+  and `PgrepProcessDiscoveryLintTests.testKanataDaemonManagerDelegatesPgrepDiscoveryToSystemStateProvider`.
 - [ ] Migrate `launchctl`, `SMAppService.status`, remaining `pgrep` consumers,
   permissions, VHID state, and helper freshness into a single immutable
   `SystemSnapshot`.
@@ -138,6 +140,11 @@ through 21 mocked tests).
 - [x] `ServiceLifecycleCoordinator` process discovery delegates to
   `SystemStateProvider.processIDs(matching:)`. Enforced by
   `PgrepProcessDiscoveryLintTests.testServiceLifecycleCoordinatorDelegatesPgrepDiscoveryToSystemStateProvider`.
+- [x] `KanataDaemonManager` process discovery delegates to
+  `SystemStateProvider.processIDs(matching:)`. Enforced by
+  `KanataDaemonManagerTests.testRegisteredButNotLoadedUsesInjectedSystemStateProviderForProcessDiscovery`
+  and
+  `PgrepProcessDiscoveryLintTests.testKanataDaemonManagerDelegatesPgrepDiscoveryToSystemStateProvider`.
 - [ ] Centralize remaining `pgrep` process-discovery consumers as later W1/W2
   migration slices.
 
@@ -247,6 +254,9 @@ is listed in the state-matrix doc's enforcement section.
   socket probes outside `SystemStateProvider`.
 - [x] `PgrepProcessDiscoveryLintTests.testServiceLifecycleCoordinatorDelegatesPgrepDiscoveryToSystemStateProvider`
   prevents the first migrated runtime coordinator call site from regrowing
+  direct `pgrep` process discovery.
+- [x] `PgrepProcessDiscoveryLintTests.testKanataDaemonManagerDelegatesPgrepDiscoveryToSystemStateProvider`
+  prevents the daemon-management process discovery call site from regrowing
   direct `pgrep` process discovery.
 - [ ] Add `launchctl`, broader `pgrep`, postcondition, and snapshot-cache
   ratchets with the corresponding migration slices.

--- a/docs/process/installer-repair-state-matrix.md
+++ b/docs/process/installer-repair-state-matrix.md
@@ -148,8 +148,10 @@ the result as user action required and name the approval surface.
   `SystemStateProviderLivenessTests.testProcessDiscoveryDelegatesToInjectedSubprocessRunner`
   and `SystemStateProviderLivenessTests.testProcessDiscoveryRejectsBlankPatterns`
   pin the provider contract, while
+  `KanataDaemonManagerTests.testRegisteredButNotLoadedUsesInjectedSystemStateProviderForProcessDiscovery`,
   `PgrepProcessDiscoveryLintTests.testServiceLifecycleCoordinatorDelegatesPgrepDiscoveryToSystemStateProvider`
-  blocks the first migrated runtime coordinator consumer from bypassing it.
+  and `PgrepProcessDiscoveryLintTests.testKanataDaemonManagerDelegatesPgrepDiscoveryToSystemStateProvider`
+  block migrated runtime/daemon-manager consumers from bypassing it.
 - User-facing CLI/reporting shape belongs in CLI contract tests.
 
 ## Related References


### PR DESCRIPTION
## Summary

- route `KanataDaemonManager`'s `kanata.*--cfg` process discovery through an injected `SystemStateProvider`
- keep `.shared` as the production default while preserving test injection via `SystemStateProvider(subprocessRunner:)`
- extend the W5 `pgrep` lint ratchet to keep `KanataDaemonManager` from regrowing direct process discovery
- update the Phase 1 plan and installer state-matrix docs with the enforcing test citations

## Acceptance criteria completed

- `KanataDaemonManager` process discovery delegates to `SystemStateProvider.processIDs(matching:)`: `PgrepProcessDiscoveryLintTests.testKanataDaemonManagerDelegatesPgrepDiscoveryToSystemStateProvider`
- `KanataDaemonManager` remains testable through an injected provider/subprocess fake: `KanataDaemonManagerTests.testRegisteredButNotLoadedUsesInjectedSystemStateProviderForProcessDiscovery`
- The underlying provider-owned process-discovery primitive remains pinned by `SystemStateProviderLivenessTests.testProcessDiscoveryDelegatesToInjectedSubprocessRunner` and `SystemStateProviderLivenessTests.testProcessDiscoveryRejectsBlankPatterns`

## Scope notes

This is a narrow W1/W2/W5 incremental slice. Remaining `pgrep` consumers, `launchctl`, `SMAppService.status`, permissions/VHID/helper freshness, full `SystemSnapshot`, state-matrix classifier/golden tests, Workstream 3, and Workstream 6 remain out of scope.

No plan/code conflict found in this slice.

## Review gate

Local `/thermo-nuclear-swift-review` is not callable from this Codex session, so this PR is opened as draft for the repo's GitHub Claude review gate before marking ready.

## Test plan

- `mise exec -- swiftformat Sources/KeyPathAppKit/Managers/KanataDaemonManager.swift Tests/KeyPathTests/Managers/KanataDaemonManagerTests.swift Tests/KeyPathTests/Lint/PgrepProcessDiscoveryLintTests.swift`
- `git diff --check`
- `TEST_FILTER='PgrepProcessDiscoveryLintTests|SystemStateProviderLivenessTests|KanataDaemonManagerTests' ./Scripts/run-tests-safe.sh` (22 passed)
- `python3 Scripts/check-accessibility.py` (352 files clean)
- `./Scripts/run-tests-safe.sh` (4,441 passed)