### PR TITLE
Route SystemValidator pgrep through SystemStateProvider

### DIFF
--- a/Sources/KeyPathAppKit/Services/System/SystemValidator.swift
+++ b/Sources/KeyPathAppKit/Services/System/SystemValidator.swift
@@ -39,6 +39,7 @@ public class SystemValidator {
     // NOTE: launchDaemonInstaller removed - health checks migrated to ServiceHealthChecker
     private let vhidDeviceManager: VHIDDeviceManager
     private let processLifecycleManager: ProcessLifecycleManager
+    private let systemStateProvider: SystemStateProvider
     private weak var kanataManager: RuntimeCoordinator?
     private var cachedComponentFacts: ComponentInstallationFacts?
 
@@ -58,10 +59,12 @@ public class SystemValidator {
     init(
         vhidDeviceManager: VHIDDeviceManager = VHIDDeviceManager(),
         processLifecycleManager: ProcessLifecycleManager,
+        systemStateProvider: SystemStateProvider = .shared,
         kanataManager: RuntimeCoordinator? = nil
     ) {
         self.vhidDeviceManager = vhidDeviceManager
         self.processLifecycleManager = processLifecycleManager
+        self.systemStateProvider = systemStateProvider
         self.kanataManager = kanataManager
 
         AppLogger.shared.log("🔍 [SystemValidator] Initialized (stateless, no cache)")
@@ -550,8 +553,8 @@ public class SystemValidator {
     /// Get PID of karabiner_grabber process.
     /// Runs pgrep in a detached task to avoid blocking a cooperative thread
     /// inside the TaskGroup (see ADR-022: no concurrent pgrep).
-    private func getKarabinerGrabberPID() async -> Int? {
-        let pids = await SubprocessRunner.shared.pgrep("karabiner_grabber")
+    func getKarabinerGrabberPID() async -> Int? {
+        let pids = await systemStateProvider.processIDs(matching: "karabiner_grabber")
         if let pid = pids.first {
             AppLogger.shared.log("🔍 [SystemValidator] Found karabiner_grabber PID: \(pid)")
             return Int(pid)

--- a/Tests/KeyPathTests/Lint/PgrepProcessDiscoveryLintTests.swift
+++ b/Tests/KeyPathTests/Lint/PgrepProcessDiscoveryLintTests.swift
@@ -53,6 +53,29 @@ final class PgrepProcessDiscoveryLintTests: XCTestCase {
             """
         )
     }
+
+    func testSystemValidatorDelegatesPgrepDiscoveryToSystemStateProvider() throws {
+        let validator = repositoryRoot()
+            .appendingPathComponent("Sources/KeyPathAppKit/Services/System/SystemValidator.swift")
+
+        let violations = try matchingLines(
+            in: validator,
+            patterns: [
+                #"SubprocessRunner\.shared\.pgrep"#,
+                #"subprocessRunner\.pgrep"#,
+                #"/usr/bin/pgrep"#
+            ]
+        )
+
+        XCTAssertTrue(
+            violations.isEmpty,
+            """
+            SystemValidator must delegate process discovery to \
+            SystemStateProvider instead of calling pgrep directly:
+            \(violations.sorted().joined(separator: "\n"))
+            """
+        )
+    }
 }
 
 private func repositoryRoot(file: StaticString = #filePath) -> URL {

--- a/Tests/KeyPathTests/Services/SystemValidatorTests.swift
+++ b/Tests/KeyPathTests/Services/SystemValidatorTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 @testable import KeyPathAppKit
+@testable import KeyPathCore
 @testable import KeyPathDaemonLifecycle
 @testable import KeyPathPermissions
 @testable import KeyPathWizardCore
@@ -72,6 +73,33 @@ struct SystemValidatorTests {
         // the stub path increments counters - either is acceptable
         #expect(stats.totalCount >= baselineStats.totalCount,
                 "totalCount should never decrease")
+    }
+
+    @Test("SystemValidator uses injected SystemStateProvider for Karabiner grabber PID")
+    func karabinerGrabberPIDUsesInjectedSystemStateProvider() async {
+        await setupTest()
+
+        let runner = SubprocessRunnerFake.shared
+        await runner.reset()
+        await runner.configurePgrepResult { pattern in
+            pattern == "karabiner_grabber" ? [9876] : []
+        }
+
+        let processManager = ProcessLifecycleManager()
+        let provider = SystemStateProvider(subprocessRunner: runner)
+        let validator = SystemValidator(
+            processLifecycleManager: processManager,
+            systemStateProvider: provider
+        )
+
+        let pid = await validator.getKarabinerGrabberPID()
+        let commands = await runner.executedCommands
+
+        #expect(pid == 9876)
+        #expect(
+            commands.contains { $0.executable == "/usr/bin/pgrep" && $0.args == ["-f", "karabiner_grabber"] },
+            "SystemValidator should use the injected provider's subprocess runner for Karabiner process discovery"
+        )
     }
 
     @Test("SystemSnapshot has fresh timestamp")

--- a/docs/planning/installer-reliability-phase1.md
+++ b/docs/planning/installer-reliability-phase1.md
@@ -88,12 +88,15 @@ classification remains pending.
   `TCPReadinessLintTests.testProductionTCPProbeAdapterIsNoLongerUsed` and
   `TCPReadinessLintTests.testProductionRawTCPSocketProbeIsCentralized`.
 - [x] Added provider-owned `pgrep` process-discovery primitive and migrated
-  `ServiceLifecycleCoordinator` and `KanataDaemonManager` to delegate to it. Enforced by
+  `ServiceLifecycleCoordinator`, `KanataDaemonManager`, and `SystemValidator`
+  to delegate to it. Enforced by
   `SystemStateProviderLivenessTests.testProcessDiscoveryDelegatesToInjectedSubprocessRunner`,
   `SystemStateProviderLivenessTests.testProcessDiscoveryRejectsBlankPatterns`,
   `PgrepProcessDiscoveryLintTests.testServiceLifecycleCoordinatorDelegatesPgrepDiscoveryToSystemStateProvider`,
   `KanataDaemonManagerTests.testRegisteredButNotLoadedUsesInjectedSystemStateProviderForProcessDiscovery`,
-  and `PgrepProcessDiscoveryLintTests.testKanataDaemonManagerDelegatesPgrepDiscoveryToSystemStateProvider`.
+  `PgrepProcessDiscoveryLintTests.testKanataDaemonManagerDelegatesPgrepDiscoveryToSystemStateProvider`,
+  `SystemValidatorTests.karabinerGrabberPIDUsesInjectedSystemStateProvider`,
+  and `PgrepProcessDiscoveryLintTests.testSystemValidatorDelegatesPgrepDiscoveryToSystemStateProvider`.
 - [ ] Migrate `launchctl`, `SMAppService.status`, remaining `pgrep` consumers,
   permissions, VHID state, and helper freshness into a single immutable
   `SystemSnapshot`.
@@ -145,6 +148,11 @@ through 21 mocked tests).
   `KanataDaemonManagerTests.testRegisteredButNotLoadedUsesInjectedSystemStateProviderForProcessDiscovery`
   and
   `PgrepProcessDiscoveryLintTests.testKanataDaemonManagerDelegatesPgrepDiscoveryToSystemStateProvider`.
+- [x] `SystemValidator` process discovery delegates to
+  `SystemStateProvider.processIDs(matching:)`. Enforced by
+  `SystemValidatorTests.karabinerGrabberPIDUsesInjectedSystemStateProvider`
+  and
+  `PgrepProcessDiscoveryLintTests.testSystemValidatorDelegatesPgrepDiscoveryToSystemStateProvider`.
 - [ ] Centralize remaining `pgrep` process-discovery consumers as later W1/W2
   migration slices.
 
@@ -257,6 +265,9 @@ is listed in the state-matrix doc's enforcement section.
   direct `pgrep` process discovery.
 - [x] `PgrepProcessDiscoveryLintTests.testKanataDaemonManagerDelegatesPgrepDiscoveryToSystemStateProvider`
   prevents the daemon-management process discovery call site from regrowing
+  direct `pgrep` process discovery.
+- [x] `PgrepProcessDiscoveryLintTests.testSystemValidatorDelegatesPgrepDiscoveryToSystemStateProvider`
+  prevents the system-validator process discovery call site from regrowing
   direct `pgrep` process discovery.
 - [ ] Add `launchctl`, broader `pgrep`, postcondition, and snapshot-cache
   ratchets with the corresponding migration slices.

--- a/docs/process/installer-repair-state-matrix.md
+++ b/docs/process/installer-repair-state-matrix.md
@@ -149,9 +149,11 @@ the result as user action required and name the approval surface.
   and `SystemStateProviderLivenessTests.testProcessDiscoveryRejectsBlankPatterns`
   pin the provider contract, while
   `KanataDaemonManagerTests.testRegisteredButNotLoadedUsesInjectedSystemStateProviderForProcessDiscovery`,
-  `PgrepProcessDiscoveryLintTests.testServiceLifecycleCoordinatorDelegatesPgrepDiscoveryToSystemStateProvider`
-  and `PgrepProcessDiscoveryLintTests.testKanataDaemonManagerDelegatesPgrepDiscoveryToSystemStateProvider`
-  block migrated runtime/daemon-manager consumers from bypassing it.
+  `PgrepProcessDiscoveryLintTests.testServiceLifecycleCoordinatorDelegatesPgrepDiscoveryToSystemStateProvider`,
+  `PgrepProcessDiscoveryLintTests.testKanataDaemonManagerDelegatesPgrepDiscoveryToSystemStateProvider`,
+  `SystemValidatorTests.karabinerGrabberPIDUsesInjectedSystemStateProvider`,
+  and `PgrepProcessDiscoveryLintTests.testSystemValidatorDelegatesPgrepDiscoveryToSystemStateProvider`
+  block migrated runtime/system-validator consumers from bypassing it.
 - User-facing CLI/reporting shape belongs in CLI contract tests.
 
 ## Related References


### PR DESCRIPTION
## Summary
- inject `SystemStateProvider` into `SystemValidator` and route the Karabiner grabber PID lookup through `processIDs(matching:)`
- add behavioral coverage proving the injected provider receives the `karabiner_grabber` process discovery request
- add a file-specific `PgrepProcessDiscoveryLintTests` ratchet for `SystemValidator`
- update the Phase 1 plan and state-matrix enforcement docs with the completed acceptance-test citations

## Acceptance criteria completed
- `SystemValidator` process discovery now delegates to `SystemStateProvider.processIDs(matching:)`. Enforced by `SystemValidatorTests.karabinerGrabberPIDUsesInjectedSystemStateProvider` and `PgrepProcessDiscoveryLintTests.testSystemValidatorDelegatesPgrepDiscoveryToSystemStateProvider`.

## Validation
- `mise exec -- swiftformat Sources/KeyPathAppKit/Services/System/SystemValidator.swift Tests/KeyPathTests/Services/SystemValidatorTests.swift Tests/KeyPathTests/Lint/PgrepProcessDiscoveryLintTests.swift`
- `git diff --check`
- `TEST_FILTER='PgrepProcessDiscoveryLintTests|SystemStateProviderLivenessTests|SystemValidatorTests' ./Scripts/run-tests-safe.sh` (18 passed)
- `python3 Scripts/check-accessibility.py` (352 files clean)
- `./Scripts/run-tests-safe.sh` (4,443 passed)
- GitHub `claude-code-review`, `code-quality`, and `build-and-test` passed

## Review gate
- The required `/thermo-nuclear-swift-review` slash command is not available as a local executable in this Codex shell (`claude` is not installed and no local command file was found). Used the available GitHub `claude-code-review` gate before marking ready.
- First Claude review requested behavioral coverage for the new injection point; addressed by `SystemValidatorTests.karabinerGrabberPIDUsesInjectedSystemStateProvider`. Rerun review passed with only non-blocking observations.

## Phase 1 progress
| Phase 1 step | Status |
| --- | --- |
| W4 identity-stability contract | Done |
| W1/W2 process liveness + TCP readiness | Done |
| W1/W2 `pgrep` process discovery | In progress: `ServiceLifecycleCoordinator`, `KanataDaemonManager`, and now `SystemValidator` migrated |
| W1/W2 launchctl / SMAppService / permissions / VHID / helper snapshot inputs | Not started |
| W1 executable snapshot + classifier + state-matrix golden tests | Not started |
| W3 repair model | Blocked until W1/W2/W5 are stable |
| W6 deletion pass | Blocked until W1-W3 are merged/stable |