### PR TITLE
Route Karabiner conflict pgrep through SystemStateProvider

### DIFF
--- a/Sources/KeyPathAppKit/Services/Karabiner/KarabinerConflictService.swift
+++ b/Sources/KeyPathAppKit/Services/Karabiner/KarabinerConflictService.swift
@@ -35,13 +35,16 @@ final class KarabinerConflictService: KarabinerConflictManaging {
 
     private let engineFactory: () -> (any InstallerEnginePrivilegedRouting)
     private let brokerFactory: () -> PrivilegeBroker
+    private let systemStateProvider: SystemStateProvider
 
     init(
         engineFactory: @escaping () -> (any InstallerEnginePrivilegedRouting) = { InstallerEngine() },
-        brokerFactory: @escaping () -> PrivilegeBroker = { PrivilegeBroker() }
+        brokerFactory: @escaping () -> PrivilegeBroker = { PrivilegeBroker() },
+        systemStateProvider: SystemStateProvider = .shared
     ) {
         self.engineFactory = engineFactory
         self.brokerFactory = brokerFactory
+        self.systemStateProvider = systemStateProvider
     }
 
     // MARK: - Constants
@@ -135,7 +138,7 @@ final class KarabinerConflictService: KarabinerConflictManaging {
         // Check if Karabiner-Elements grabber is running (conflicts with Kanata)
         return await withCheckedContinuation { continuation in
             Task {
-                let pids = await SubprocessRunner.shared.pgrep("karabiner_grabber")
+                let pids = await systemStateProvider.processIDs(matching: "karabiner_grabber")
                 let isRunning = !pids.isEmpty
 
                 if isRunning {
@@ -180,7 +183,7 @@ final class KarabinerConflictService: KarabinerConflictManaging {
         return await withCheckedContinuation { continuation in
             Task {
                 let startTime = CFAbsoluteTimeGetCurrent()
-                let pids = await SubprocessRunner.shared.pgrep("VirtualHIDDevice-Daemon")
+                let pids = await systemStateProvider.processIDs(matching: "VirtualHIDDevice-Daemon")
                 let isRunning = !pids.isEmpty
 
                 let duration = CFAbsoluteTimeGetCurrent() - startTime
@@ -450,8 +453,8 @@ final class KarabinerConflictService: KarabinerConflictManaging {
         return allStopped
     }
 
-    private func checkProcessStopped(pattern: String, processName: String) async -> Bool {
-        let pids = await SubprocessRunner.shared.pgrep(pattern)
+    func checkProcessStopped(pattern: String, processName: String) async -> Bool {
+        let pids = await systemStateProvider.processIDs(matching: pattern)
         let isStopped = pids.isEmpty // pgrep returns empty array if no processes found
 
         if isStopped {

--- a/Tests/KeyPathTests/Lint/PgrepProcessDiscoveryLintTests.swift
+++ b/Tests/KeyPathTests/Lint/PgrepProcessDiscoveryLintTests.swift
@@ -76,6 +76,29 @@ final class PgrepProcessDiscoveryLintTests: XCTestCase {
             """
         )
     }
+
+    func testKarabinerConflictServiceDelegatesPgrepDiscoveryToSystemStateProvider() throws {
+        let service = repositoryRoot()
+            .appendingPathComponent("Sources/KeyPathAppKit/Services/Karabiner/KarabinerConflictService.swift")
+
+        let violations = try matchingLines(
+            in: service,
+            patterns: [
+                #"SubprocessRunner\.shared\.pgrep"#,
+                #"subprocessRunner\.pgrep"#,
+                #"/usr/bin/pgrep"#
+            ]
+        )
+
+        XCTAssertTrue(
+            violations.isEmpty,
+            """
+            KarabinerConflictService must delegate process discovery to \
+            SystemStateProvider instead of calling pgrep directly:
+            \(violations.sorted().joined(separator: "\n"))
+            """
+        )
+    }
 }
 
 private func repositoryRoot(file: StaticString = #filePath) -> URL {

--- a/Tests/KeyPathTests/Services/KarabinerConflictServiceTests.swift
+++ b/Tests/KeyPathTests/Services/KarabinerConflictServiceTests.swift
@@ -1,0 +1,83 @@
+import Foundation
+@testable import KeyPathAppKit
+@testable import KeyPathCore
+@testable import KeyPathInstallationWizard
+import Testing
+
+@MainActor
+@Suite("KarabinerConflictService Tests", .serialized)
+struct KarabinerConflictServiceTests {
+    @Test("Karabiner grabber detection uses injected SystemStateProvider")
+    func karabinerGrabberDetectionUsesInjectedSystemStateProvider() async {
+        KarabinerConflictService.testDaemonRunning = nil
+        let runner = SubprocessRunnerFake.shared
+        await runner.reset()
+        await runner.configurePgrepResult { pattern in
+            pattern == "karabiner_grabber" ? [1111] : []
+        }
+
+        let provider = SystemStateProvider(subprocessRunner: runner)
+        let service = KarabinerConflictService(systemStateProvider: provider)
+
+        let isRunning = await service.isKarabinerElementsRunning()
+        let commands = await runner.executedCommands
+
+        #expect(isRunning)
+        #expect(
+            commands.contains { $0.executable == "/usr/bin/pgrep" && $0.args == ["-f", "karabiner_grabber"] },
+            "KarabinerConflictService should use the injected provider for grabber discovery"
+        )
+    }
+
+    @Test("VirtualHID daemon detection uses injected SystemStateProvider")
+    func virtualHIDDaemonDetectionUsesInjectedSystemStateProvider() async {
+        KarabinerConflictService.testDaemonRunning = nil
+        FeatureFlags.testStartupMode = false
+        defer { FeatureFlags.testStartupMode = nil }
+        ServiceBootstrapper.setRestartTimeForTesting(
+            Date().addingTimeInterval(-60),
+            serviceID: "com.keypath.karabiner-vhiddaemon"
+        )
+        let runner = SubprocessRunnerFake.shared
+        await runner.reset()
+        await runner.configurePgrepResult { pattern in
+            pattern == "VirtualHIDDevice-Daemon" ? [2222] : []
+        }
+
+        let provider = SystemStateProvider(subprocessRunner: runner)
+        let service = KarabinerConflictService(systemStateProvider: provider)
+
+        let isRunning = await service.isKarabinerDaemonRunning()
+        let commands = await runner.executedCommands
+
+        #expect(isRunning)
+        #expect(
+            commands.contains { $0.executable == "/usr/bin/pgrep" && $0.args == ["-f", "VirtualHIDDevice-Daemon"] },
+            "KarabinerConflictService should use the injected provider for daemon discovery"
+        )
+    }
+
+    @Test("Stopped-process verification uses injected SystemStateProvider")
+    func stoppedProcessVerificationUsesInjectedSystemStateProvider() async {
+        let runner = SubprocessRunnerFake.shared
+        await runner.reset()
+        await runner.configurePgrepResult { pattern in
+            pattern == "Karabiner-DriverKit-VirtualHIDDevice" ? [3333] : []
+        }
+
+        let provider = SystemStateProvider(subprocessRunner: runner)
+        let service = KarabinerConflictService(systemStateProvider: provider)
+
+        let isStopped = await service.checkProcessStopped(
+            pattern: "Karabiner-DriverKit-VirtualHIDDevice",
+            processName: "VirtualHIDDevice Driver"
+        )
+        let commands = await runner.executedCommands
+
+        #expect(!isStopped)
+        #expect(
+            commands.contains { $0.executable == "/usr/bin/pgrep" && $0.args == ["-f", "Karabiner-DriverKit-VirtualHIDDevice"] },
+            "KarabinerConflictService should use the injected provider for stopped-process verification"
+        )
+    }
+}

--- a/docs/planning/installer-reliability-phase1.md
+++ b/docs/planning/installer-reliability-phase1.md
@@ -89,14 +89,19 @@ classification remains pending.
   `TCPReadinessLintTests.testProductionRawTCPSocketProbeIsCentralized`.
 - [x] Added provider-owned `pgrep` process-discovery primitive and migrated
   `ServiceLifecycleCoordinator`, `KanataDaemonManager`, and `SystemValidator`
-  to delegate to it. Enforced by
+  to delegate to it. Started migrating Karabiner conflict detection as a
+  follow-on process-discovery slice. Enforced by
   `SystemStateProviderLivenessTests.testProcessDiscoveryDelegatesToInjectedSubprocessRunner`,
   `SystemStateProviderLivenessTests.testProcessDiscoveryRejectsBlankPatterns`,
   `PgrepProcessDiscoveryLintTests.testServiceLifecycleCoordinatorDelegatesPgrepDiscoveryToSystemStateProvider`,
   `KanataDaemonManagerTests.testRegisteredButNotLoadedUsesInjectedSystemStateProviderForProcessDiscovery`,
   `PgrepProcessDiscoveryLintTests.testKanataDaemonManagerDelegatesPgrepDiscoveryToSystemStateProvider`,
   `SystemValidatorTests.karabinerGrabberPIDUsesInjectedSystemStateProvider`,
-  and `PgrepProcessDiscoveryLintTests.testSystemValidatorDelegatesPgrepDiscoveryToSystemStateProvider`.
+  `PgrepProcessDiscoveryLintTests.testSystemValidatorDelegatesPgrepDiscoveryToSystemStateProvider`,
+  `KarabinerConflictServiceTests.karabinerGrabberDetectionUsesInjectedSystemStateProvider`,
+  `KarabinerConflictServiceTests.virtualHIDDaemonDetectionUsesInjectedSystemStateProvider`,
+  `KarabinerConflictServiceTests.stoppedProcessVerificationUsesInjectedSystemStateProvider`,
+  and `PgrepProcessDiscoveryLintTests.testKarabinerConflictServiceDelegatesPgrepDiscoveryToSystemStateProvider`.
 - [ ] Migrate `launchctl`, `SMAppService.status`, remaining `pgrep` consumers,
   permissions, VHID state, and helper freshness into a single immutable
   `SystemSnapshot`.
@@ -153,6 +158,13 @@ through 21 mocked tests).
   `SystemValidatorTests.karabinerGrabberPIDUsesInjectedSystemStateProvider`
   and
   `PgrepProcessDiscoveryLintTests.testSystemValidatorDelegatesPgrepDiscoveryToSystemStateProvider`.
+- [x] `KarabinerConflictService` process discovery delegates to
+  `SystemStateProvider.processIDs(matching:)`. Enforced by
+  `KarabinerConflictServiceTests.karabinerGrabberDetectionUsesInjectedSystemStateProvider`,
+  `KarabinerConflictServiceTests.virtualHIDDaemonDetectionUsesInjectedSystemStateProvider`,
+  `KarabinerConflictServiceTests.stoppedProcessVerificationUsesInjectedSystemStateProvider`,
+  and
+  `PgrepProcessDiscoveryLintTests.testKarabinerConflictServiceDelegatesPgrepDiscoveryToSystemStateProvider`.
 - [ ] Centralize remaining `pgrep` process-discovery consumers as later W1/W2
   migration slices.
 
@@ -269,6 +281,9 @@ is listed in the state-matrix doc's enforcement section.
 - [x] `PgrepProcessDiscoveryLintTests.testSystemValidatorDelegatesPgrepDiscoveryToSystemStateProvider`
   prevents the system-validator process discovery call site from regrowing
   direct `pgrep` process discovery.
+- [x] `PgrepProcessDiscoveryLintTests.testKarabinerConflictServiceDelegatesPgrepDiscoveryToSystemStateProvider`
+  prevents Karabiner conflict detection from regrowing direct
+  `pgrep` process discovery.
 - [ ] Add `launchctl`, broader `pgrep`, postcondition, and snapshot-cache
   ratchets with the corresponding migration slices.
 

--- a/docs/process/installer-repair-state-matrix.md
+++ b/docs/process/installer-repair-state-matrix.md
@@ -152,8 +152,12 @@ the result as user action required and name the approval surface.
   `PgrepProcessDiscoveryLintTests.testServiceLifecycleCoordinatorDelegatesPgrepDiscoveryToSystemStateProvider`,
   `PgrepProcessDiscoveryLintTests.testKanataDaemonManagerDelegatesPgrepDiscoveryToSystemStateProvider`,
   `SystemValidatorTests.karabinerGrabberPIDUsesInjectedSystemStateProvider`,
-  and `PgrepProcessDiscoveryLintTests.testSystemValidatorDelegatesPgrepDiscoveryToSystemStateProvider`
-  block migrated runtime/system-validator consumers from bypassing it.
+  `PgrepProcessDiscoveryLintTests.testSystemValidatorDelegatesPgrepDiscoveryToSystemStateProvider`,
+  `KarabinerConflictServiceTests.karabinerGrabberDetectionUsesInjectedSystemStateProvider`,
+  `KarabinerConflictServiceTests.virtualHIDDaemonDetectionUsesInjectedSystemStateProvider`,
+  `KarabinerConflictServiceTests.stoppedProcessVerificationUsesInjectedSystemStateProvider`,
+  and `PgrepProcessDiscoveryLintTests.testKarabinerConflictServiceDelegatesPgrepDiscoveryToSystemStateProvider`
+  block migrated runtime/system-validator/Karabiner-conflict consumers from bypassing it.
 - User-facing CLI/reporting shape belongs in CLI contract tests.
 
 ## Related References


### PR DESCRIPTION
## Summary
- inject `SystemStateProvider` into `KarabinerConflictService`
- route Karabiner grabber, VirtualHID daemon, and stopped-process verification discovery through `processIDs(matching:)`
- add behavior tests for the injected provider path plus a file-specific pgrep lint ratchet
- update the Phase 1 plan and state-matrix enforcement docs with the completed acceptance-test citations

## Acceptance criteria completed
- `KarabinerConflictService` process discovery now delegates to `SystemStateProvider.processIDs(matching:)`. Enforced by:
  - `KarabinerConflictServiceTests.karabinerGrabberDetectionUsesInjectedSystemStateProvider`
  - `KarabinerConflictServiceTests.virtualHIDDaemonDetectionUsesInjectedSystemStateProvider`
  - `KarabinerConflictServiceTests.stoppedProcessVerificationUsesInjectedSystemStateProvider`
  - `PgrepProcessDiscoveryLintTests.testKarabinerConflictServiceDelegatesPgrepDiscoveryToSystemStateProvider`

## Validation
- `mise exec -- swiftformat Sources/KeyPathAppKit/Services/Karabiner/KarabinerConflictService.swift Tests/KeyPathTests/Services/KarabinerConflictServiceTests.swift Tests/KeyPathTests/Lint/PgrepProcessDiscoveryLintTests.swift`
- `git diff --check`
- `TEST_FILTER='KarabinerConflictServiceTests|PgrepProcessDiscoveryLintTests|SystemStateProviderLivenessTests' ./Scripts/run-tests-safe.sh` (15 passed)
- `python3 Scripts/check-accessibility.py` (352 files clean)
- `./Scripts/run-tests-safe.sh` (4,447 passed)

## Review gate
- The required `/thermo-nuclear-swift-review` slash command is not available as a local executable in this Codex shell (`claude` is not installed and no local command file was found). This PR is opened as draft so the GitHub `claude-code-review` workflow can serve as the available review gate before marking ready.

## Phase 1 progress
| Phase 1 step | Status |
| --- | --- |
| W4 identity-stability contract | Done |
| W1/W2 process liveness + TCP readiness | Done |
| W1/W2 `pgrep` process discovery | In progress: `ServiceLifecycleCoordinator`, `KanataDaemonManager`, `SystemValidator`, and now `KarabinerConflictService` migrated |
| W1/W2 launchctl / SMAppService / permissions / VHID / helper snapshot inputs | Not started |
| W1 executable snapshot + classifier + state-matrix golden tests | Not started |
| W3 repair model | Blocked until W1/W2/W5 are stable |
| W6 deletion pass | Blocked until W1-W3 are merged/stable |