### PR TITLE
Route VHID device pgrep through SystemStateProvider

### DIFF
--- a/Sources/KeyPathInstallationWizard/Core/VHIDDeviceManager.swift
+++ b/Sources/KeyPathInstallationWizard/Core/VHIDDeviceManager.swift
@@ -8,6 +8,8 @@ import KeyPathCore
 // (testPIDProvider, testShellProvider, testInstalledVersionProvider) are nonisolated(unsafe)
 // test seams only written during single-threaded test setup.
 public final class VHIDDeviceManager: @unchecked Sendable {
+    private let systemStateProvider: SystemStateProvider
+
     private enum DaemonHealthState {
         case healthy
         case notRunning
@@ -42,7 +44,9 @@ public final class VHIDDeviceManager: @unchecked Sendable {
         nonisolated(unsafe) static var testInstalledVersionProvider: (() -> String?)?
     #endif
 
-    public init() {}
+    public init(systemStateProvider: SystemStateProvider = .shared) {
+        self.systemStateProvider = systemStateProvider
+    }
 
     // MARK: - Step Progress Reporting
 
@@ -221,6 +225,7 @@ public final class VHIDDeviceManager: @unchecked Sendable {
             return isRunning ? .healthy : .notRunning
         }
 
+        let systemStateProvider = systemStateProvider
         return await Task.detached {
             // Test seam: allow mocked PID list in tests
             #if DEBUG
@@ -251,7 +256,7 @@ public final class VHIDDeviceManager: @unchecked Sendable {
             #endif
 
             let startTime = CFAbsoluteTimeGetCurrent()
-            let pids = await SubprocessRunner.shared.pgrep(Self.vhidDeviceRunningCheck)
+            let pids = await systemStateProvider.processIDs(matching: Self.vhidDeviceRunningCheck)
             let processCount = pids.count
             let isRunning = processCount > 0
 
@@ -307,7 +312,7 @@ public final class VHIDDeviceManager: @unchecked Sendable {
             }
         #endif
 
-        let pids = await SubprocessRunner.shared.pgrep(Self.vhidDeviceRunningCheck)
+        let pids = await systemStateProvider.processIDs(matching: Self.vhidDeviceRunningCheck)
         return pids.map { String($0) }
     }
 

--- a/Tests/KeyPathTests/Lint/PgrepProcessDiscoveryLintTests.swift
+++ b/Tests/KeyPathTests/Lint/PgrepProcessDiscoveryLintTests.swift
@@ -99,6 +99,29 @@ final class PgrepProcessDiscoveryLintTests: XCTestCase {
             """
         )
     }
+
+    func testVHIDDeviceManagerDelegatesPgrepDiscoveryToSystemStateProvider() throws {
+        let manager = repositoryRoot()
+            .appendingPathComponent("Sources/KeyPathInstallationWizard/Core/VHIDDeviceManager.swift")
+
+        let violations = try matchingLines(
+            in: manager,
+            patterns: [
+                #"SubprocessRunner\.shared\.pgrep"#,
+                #"subprocessRunner\.pgrep"#,
+                #"/usr/bin/pgrep"#
+            ]
+        )
+
+        XCTAssertTrue(
+            violations.isEmpty,
+            """
+            VHIDDeviceManager must delegate process discovery to \
+            SystemStateProvider instead of calling pgrep directly:
+            \(violations.sorted().joined(separator: "\n"))
+            """
+        )
+    }
 }
 
 private func repositoryRoot(file: StaticString = #filePath) -> URL {

--- a/Tests/KeyPathTests/Services/VHIDDeviceManagerTests.swift
+++ b/Tests/KeyPathTests/Services/VHIDDeviceManagerTests.swift
@@ -81,6 +81,48 @@ final class VHIDDeviceManagerTests: XCTestCase {
         XCTAssertFalse(running, "No daemon should be reported as not running")
     }
 
+    func testDetectRunningUsesInjectedSystemStateProviderForProcessDiscovery() async {
+        KeyPathCore.FeatureFlags.testStartupMode = false
+        VHIDDeviceManager.testPIDProvider = nil
+        let runner = SubprocessRunnerFake.shared
+        await runner.reset()
+        await runner.configurePgrepResult { pattern in
+            pattern == "Karabiner-VirtualHIDDevice-Daemon" ? [12345] : []
+        }
+
+        let provider = SystemStateProvider(subprocessRunner: runner)
+        let mgr = VHIDDeviceManager(systemStateProvider: provider)
+        let running = await mgr.detectRunning()
+        let commands = await runner.executedCommands
+
+        XCTAssertTrue(running, "Injected provider should report the daemon as running")
+        XCTAssertTrue(
+            commands.contains { $0.executable == "/usr/bin/pgrep" && $0.args == ["-f", "Karabiner-VirtualHIDDevice-Daemon"] },
+            "VHIDDeviceManager should use the injected provider for daemon process discovery"
+        )
+    }
+
+    func testGetDaemonPIDsUsesInjectedSystemStateProviderForProcessDiscovery() async {
+        KeyPathCore.FeatureFlags.testStartupMode = false
+        VHIDDeviceManager.testPIDProvider = nil
+        let runner = SubprocessRunnerFake.shared
+        await runner.reset()
+        await runner.configurePgrepResult { pattern in
+            pattern == "Karabiner-VirtualHIDDevice-Daemon" ? [12345, 67890] : []
+        }
+
+        let provider = SystemStateProvider(subprocessRunner: runner)
+        let mgr = VHIDDeviceManager(systemStateProvider: provider)
+        let pids = await mgr.getDaemonPIDs()
+        let commands = await runner.executedCommands
+
+        XCTAssertEqual(pids, ["12345", "67890"])
+        XCTAssertTrue(
+            commands.contains { $0.executable == "/usr/bin/pgrep" && $0.args == ["-f", "Karabiner-VirtualHIDDevice-Daemon"] },
+            "VHIDDeviceManager should use the injected provider when collecting daemon PIDs"
+        )
+    }
+
     // MARK: - Startup Mode Tests
 
     func testDetectRunning_StartupMode_DaemonRunning() async {

--- a/docs/planning/installer-reliability-phase1.md
+++ b/docs/planning/installer-reliability-phase1.md
@@ -101,7 +101,10 @@ classification remains pending.
   `KarabinerConflictServiceTests.karabinerGrabberDetectionUsesInjectedSystemStateProvider`,
   `KarabinerConflictServiceTests.virtualHIDDaemonDetectionUsesInjectedSystemStateProvider`,
   `KarabinerConflictServiceTests.stoppedProcessVerificationUsesInjectedSystemStateProvider`,
-  and `PgrepProcessDiscoveryLintTests.testKarabinerConflictServiceDelegatesPgrepDiscoveryToSystemStateProvider`.
+  `PgrepProcessDiscoveryLintTests.testKarabinerConflictServiceDelegatesPgrepDiscoveryToSystemStateProvider`,
+  `VHIDDeviceManagerTests.testDetectRunningUsesInjectedSystemStateProviderForProcessDiscovery`,
+  `VHIDDeviceManagerTests.testGetDaemonPIDsUsesInjectedSystemStateProviderForProcessDiscovery`,
+  and `PgrepProcessDiscoveryLintTests.testVHIDDeviceManagerDelegatesPgrepDiscoveryToSystemStateProvider`.
 - [ ] Migrate `launchctl`, `SMAppService.status`, remaining `pgrep` consumers,
   permissions, VHID state, and helper freshness into a single immutable
   `SystemSnapshot`.
@@ -165,6 +168,12 @@ through 21 mocked tests).
   `KarabinerConflictServiceTests.stoppedProcessVerificationUsesInjectedSystemStateProvider`,
   and
   `PgrepProcessDiscoveryLintTests.testKarabinerConflictServiceDelegatesPgrepDiscoveryToSystemStateProvider`.
+- [x] `VHIDDeviceManager` process discovery delegates to
+  `SystemStateProvider.processIDs(matching:)`. Enforced by
+  `VHIDDeviceManagerTests.testDetectRunningUsesInjectedSystemStateProviderForProcessDiscovery`,
+  `VHIDDeviceManagerTests.testGetDaemonPIDsUsesInjectedSystemStateProviderForProcessDiscovery`,
+  and
+  `PgrepProcessDiscoveryLintTests.testVHIDDeviceManagerDelegatesPgrepDiscoveryToSystemStateProvider`.
 - [ ] Centralize remaining `pgrep` process-discovery consumers as later W1/W2
   migration slices.
 
@@ -283,6 +292,9 @@ is listed in the state-matrix doc's enforcement section.
   direct `pgrep` process discovery.
 - [x] `PgrepProcessDiscoveryLintTests.testKarabinerConflictServiceDelegatesPgrepDiscoveryToSystemStateProvider`
   prevents Karabiner conflict detection from regrowing direct
+  `pgrep` process discovery.
+- [x] `PgrepProcessDiscoveryLintTests.testVHIDDeviceManagerDelegatesPgrepDiscoveryToSystemStateProvider`
+  prevents VirtualHID daemon process checks from regrowing direct
   `pgrep` process discovery.
 - [ ] Add `launchctl`, broader `pgrep`, postcondition, and snapshot-cache
   ratchets with the corresponding migration slices.

--- a/docs/process/installer-repair-state-matrix.md
+++ b/docs/process/installer-repair-state-matrix.md
@@ -156,8 +156,11 @@ the result as user action required and name the approval surface.
   `KarabinerConflictServiceTests.karabinerGrabberDetectionUsesInjectedSystemStateProvider`,
   `KarabinerConflictServiceTests.virtualHIDDaemonDetectionUsesInjectedSystemStateProvider`,
   `KarabinerConflictServiceTests.stoppedProcessVerificationUsesInjectedSystemStateProvider`,
-  and `PgrepProcessDiscoveryLintTests.testKarabinerConflictServiceDelegatesPgrepDiscoveryToSystemStateProvider`
-  block migrated runtime/system-validator/Karabiner-conflict consumers from bypassing it.
+  `PgrepProcessDiscoveryLintTests.testKarabinerConflictServiceDelegatesPgrepDiscoveryToSystemStateProvider`,
+  `VHIDDeviceManagerTests.testDetectRunningUsesInjectedSystemStateProviderForProcessDiscovery`,
+  `VHIDDeviceManagerTests.testGetDaemonPIDsUsesInjectedSystemStateProviderForProcessDiscovery`,
+  and `PgrepProcessDiscoveryLintTests.testVHIDDeviceManagerDelegatesPgrepDiscoveryToSystemStateProvider`
+  block migrated runtime/system-validator/Karabiner-conflict/VHID consumers from bypassing it.
 - User-facing CLI/reporting shape belongs in CLI contract tests.
 
 ## Related References


### PR DESCRIPTION
## Summary
- inject `SystemStateProvider` into `VHIDDeviceManager`
- route VirtualHID daemon process checks through `SystemStateProvider.processIDs(matching:)`
- add behavior coverage plus the matching `PgrepProcessDiscoveryLintTests` ratchet
- update the Phase 1/status docs with the acceptance-test citations

## Acceptance Criteria / Enforcement
- `VHIDDeviceManagerTests.testDetectRunningUsesInjectedSystemStateProviderForProcessDiscovery` verifies `detectRunning()` uses the injected provider for daemon discovery.
- `VHIDDeviceManagerTests.testGetDaemonPIDsUsesInjectedSystemStateProviderForProcessDiscovery` verifies PID collection uses the injected provider.
- `PgrepProcessDiscoveryLintTests.testVHIDDeviceManagerDelegatesPgrepDiscoveryToSystemStateProvider` prevents direct `pgrep` discovery from regrowing in `VHIDDeviceManager`.

## Validation
- `TEST_FILTER='VHIDDeviceManagerTests|PgrepProcessDiscoveryLintTests|SystemStateProviderLivenessTests' ./Scripts/run-tests-safe.sh` (32 passed)
- `git diff --check`
- `python3 Scripts/check-accessibility.py` (352 files clean)
- `./Scripts/run-tests-safe.sh` (4450 passed)

## Review Gate
Local `/thermo-nuclear-swift-review` remains unavailable in this Codex shell (`claude` is not on PATH and no local command file is present), so I am using the GitHub `claude-code-review` PR check as the review gate for this slice, consistent with the previous Phase 1 slices.

## Plan Notes
No conflict with current code reality found in this slice. Workstream 3 and Workstream 6 remain out of scope.
