### PR TITLE
Route diagnostics pgrep through SystemStateProvider

### DIFF
--- a/Sources/KeyPathAppKit/Services/Monitoring/DiagnosticsService.swift
+++ b/Sources/KeyPathAppKit/Services/Monitoring/DiagnosticsService.swift
@@ -80,16 +80,19 @@ protocol DiagnosticsServiceProtocol: Sendable {
 final class DiagnosticsService: DiagnosticsServiceProtocol, @unchecked Sendable {
     /// Dependencies
     private let processLifecycleManager: ProcessLifecycleManager
+    private let systemStateProvider: SystemStateProvider
 
     init(
-        processLifecycleManager: ProcessLifecycleManager
+        processLifecycleManager: ProcessLifecycleManager,
+        systemStateProvider: SystemStateProvider = .shared
     ) {
         self.processLifecycleManager = processLifecycleManager
+        self.systemStateProvider = systemStateProvider
     }
 
     nonisolated func virtualHIDDaemonStatus() async -> VirtualHIDDaemonStatus {
         // Get actual VirtualHID daemon status with real PIDs
-        let vhid = VHIDDeviceManager()
+        let vhid = VHIDDeviceManager(systemStateProvider: systemStateProvider)
         let pids = await vhid.getDaemonPIDs() // Get real PIDs instead of placeholder
         let installed = vhid.detectActivation()
         let running = !pids.isEmpty
@@ -559,22 +562,9 @@ final class DiagnosticsService: DiagnosticsServiceProtocol, @unchecked Sendable 
         Foundation.FileManager().fileExists(atPath: WizardSystemPaths.kanataActiveBinary)
     }
 
-    private func isKarabinerElementsRunning() async -> Bool {
-        // Skip process checks in test mode
-        if TestEnvironment.isRunningTests { return false }
-
-        // Use -x for exact match (not pattern match)
-        do {
-            let result = try await SubprocessRunner.shared.run(
-                "/usr/bin/pgrep",
-                args: ["-x", "karabiner_grabber"],
-                timeout: 5
-            )
-            // pgrep returns exit code 0 when processes found, 1 when not found
-            return result.exitCode == 0
-        } catch {
-            return false
-        }
+    func isKarabinerElementsRunning() async -> Bool {
+        let pids = await systemStateProvider.processIDs(matching: "karabiner_grabber")
+        return !pids.isEmpty
     }
 
     private func isKarabinerDriverInstalled() -> Bool {
@@ -583,11 +573,8 @@ final class DiagnosticsService: DiagnosticsServiceProtocol, @unchecked Sendable 
         )
     }
 
-    private func isKarabinerDaemonRunning() async -> Bool {
-        // Skip process checks in test mode
-        if TestEnvironment.isRunningTests { return false }
-
-        let pids = await SubprocessRunner.shared.pgrep("Karabiner-VirtualHIDDevice")
+    func isKarabinerDaemonRunning() async -> Bool {
+        let pids = await systemStateProvider.processIDs(matching: "Karabiner-VirtualHIDDevice")
         return !pids.isEmpty
     }
 

--- a/Tests/KeyPathTests/Lint/PgrepProcessDiscoveryLintTests.swift
+++ b/Tests/KeyPathTests/Lint/PgrepProcessDiscoveryLintTests.swift
@@ -122,6 +122,29 @@ final class PgrepProcessDiscoveryLintTests: XCTestCase {
             """
         )
     }
+
+    func testDiagnosticsServiceDelegatesPgrepDiscoveryToSystemStateProvider() throws {
+        let service = repositoryRoot()
+            .appendingPathComponent("Sources/KeyPathAppKit/Services/Monitoring/DiagnosticsService.swift")
+
+        let violations = try matchingLines(
+            in: service,
+            patterns: [
+                #"SubprocessRunner\.shared\.pgrep"#,
+                #"subprocessRunner\.pgrep"#,
+                #"/usr/bin/pgrep"#
+            ]
+        )
+
+        XCTAssertTrue(
+            violations.isEmpty,
+            """
+            DiagnosticsService must delegate process discovery to \
+            SystemStateProvider instead of calling pgrep directly:
+            \(violations.sorted().joined(separator: "\n"))
+            """
+        )
+    }
 }
 
 private func repositoryRoot(file: StaticString = #filePath) -> URL {

--- a/Tests/KeyPathTests/Services/DiagnosticsServiceTests.swift
+++ b/Tests/KeyPathTests/Services/DiagnosticsServiceTests.swift
@@ -152,6 +152,52 @@ final class DiagnosticsServiceTests: XCTestCase {
         XCTAssertNotNil(diagnostics)
     }
 
+    func testKarabinerGrabberDetectionUsesInjectedSystemStateProvider() async {
+        let runner = SubprocessRunnerFake.shared
+        await runner.reset()
+        await runner.configurePgrepResult { pattern in
+            pattern == "karabiner_grabber" ? [1234] : []
+        }
+
+        let provider = SystemStateProvider(subprocessRunner: runner)
+        let service = DiagnosticsService(
+            processLifecycleManager: processManager,
+            systemStateProvider: provider
+        )
+
+        let isRunning = await service.isKarabinerElementsRunning()
+        let commands = await runner.executedCommands
+
+        XCTAssertTrue(isRunning)
+        XCTAssertTrue(
+            commands.contains { $0.executable == "/usr/bin/pgrep" && $0.args == ["-f", "karabiner_grabber"] },
+            "DiagnosticsService should use the injected provider for Karabiner grabber discovery"
+        )
+    }
+
+    func testKarabinerDaemonDetectionUsesInjectedSystemStateProvider() async {
+        let runner = SubprocessRunnerFake.shared
+        await runner.reset()
+        await runner.configurePgrepResult { pattern in
+            pattern == "Karabiner-VirtualHIDDevice" ? [5678] : []
+        }
+
+        let provider = SystemStateProvider(subprocessRunner: runner)
+        let service = DiagnosticsService(
+            processLifecycleManager: processManager,
+            systemStateProvider: provider
+        )
+
+        let isRunning = await service.isKarabinerDaemonRunning()
+        let commands = await runner.executedCommands
+
+        XCTAssertTrue(isRunning)
+        XCTAssertTrue(
+            commands.contains { $0.executable == "/usr/bin/pgrep" && $0.args == ["-f", "Karabiner-VirtualHIDDevice"] },
+            "DiagnosticsService should use the injected provider for Karabiner daemon discovery"
+        )
+    }
+
     // MARK: - Log Analysis Tests
 
     func testAnalyzeLogFileNotFound() async {

--- a/docs/planning/installer-reliability-phase1.md
+++ b/docs/planning/installer-reliability-phase1.md
@@ -104,7 +104,10 @@ classification remains pending.
   `PgrepProcessDiscoveryLintTests.testKarabinerConflictServiceDelegatesPgrepDiscoveryToSystemStateProvider`,
   `VHIDDeviceManagerTests.testDetectRunningUsesInjectedSystemStateProviderForProcessDiscovery`,
   `VHIDDeviceManagerTests.testGetDaemonPIDsUsesInjectedSystemStateProviderForProcessDiscovery`,
-  and `PgrepProcessDiscoveryLintTests.testVHIDDeviceManagerDelegatesPgrepDiscoveryToSystemStateProvider`.
+  `PgrepProcessDiscoveryLintTests.testVHIDDeviceManagerDelegatesPgrepDiscoveryToSystemStateProvider`,
+  `DiagnosticsServiceTests.testKarabinerGrabberDetectionUsesInjectedSystemStateProvider`,
+  `DiagnosticsServiceTests.testKarabinerDaemonDetectionUsesInjectedSystemStateProvider`,
+  and `PgrepProcessDiscoveryLintTests.testDiagnosticsServiceDelegatesPgrepDiscoveryToSystemStateProvider`.
 - [ ] Migrate `launchctl`, `SMAppService.status`, remaining `pgrep` consumers,
   permissions, VHID state, and helper freshness into a single immutable
   `SystemSnapshot`.
@@ -174,6 +177,12 @@ through 21 mocked tests).
   `VHIDDeviceManagerTests.testGetDaemonPIDsUsesInjectedSystemStateProviderForProcessDiscovery`,
   and
   `PgrepProcessDiscoveryLintTests.testVHIDDeviceManagerDelegatesPgrepDiscoveryToSystemStateProvider`.
+- [x] `DiagnosticsService` process discovery delegates to
+  `SystemStateProvider.processIDs(matching:)`. Enforced by
+  `DiagnosticsServiceTests.testKarabinerGrabberDetectionUsesInjectedSystemStateProvider`,
+  `DiagnosticsServiceTests.testKarabinerDaemonDetectionUsesInjectedSystemStateProvider`,
+  and
+  `PgrepProcessDiscoveryLintTests.testDiagnosticsServiceDelegatesPgrepDiscoveryToSystemStateProvider`.
 - [ ] Centralize remaining `pgrep` process-discovery consumers as later W1/W2
   migration slices.
 
@@ -295,6 +304,9 @@ is listed in the state-matrix doc's enforcement section.
   `pgrep` process discovery.
 - [x] `PgrepProcessDiscoveryLintTests.testVHIDDeviceManagerDelegatesPgrepDiscoveryToSystemStateProvider`
   prevents VirtualHID daemon process checks from regrowing direct
+  `pgrep` process discovery.
+- [x] `PgrepProcessDiscoveryLintTests.testDiagnosticsServiceDelegatesPgrepDiscoveryToSystemStateProvider`
+  prevents diagnostics process checks from regrowing direct
   `pgrep` process discovery.
 - [ ] Add `launchctl`, broader `pgrep`, postcondition, and snapshot-cache
   ratchets with the corresponding migration slices.

--- a/docs/process/installer-repair-state-matrix.md
+++ b/docs/process/installer-repair-state-matrix.md
@@ -159,8 +159,11 @@ the result as user action required and name the approval surface.
   `PgrepProcessDiscoveryLintTests.testKarabinerConflictServiceDelegatesPgrepDiscoveryToSystemStateProvider`,
   `VHIDDeviceManagerTests.testDetectRunningUsesInjectedSystemStateProviderForProcessDiscovery`,
   `VHIDDeviceManagerTests.testGetDaemonPIDsUsesInjectedSystemStateProviderForProcessDiscovery`,
-  and `PgrepProcessDiscoveryLintTests.testVHIDDeviceManagerDelegatesPgrepDiscoveryToSystemStateProvider`
-  block migrated runtime/system-validator/Karabiner-conflict/VHID consumers from bypassing it.
+  `PgrepProcessDiscoveryLintTests.testVHIDDeviceManagerDelegatesPgrepDiscoveryToSystemStateProvider`,
+  `DiagnosticsServiceTests.testKarabinerGrabberDetectionUsesInjectedSystemStateProvider`,
+  `DiagnosticsServiceTests.testKarabinerDaemonDetectionUsesInjectedSystemStateProvider`,
+  and `PgrepProcessDiscoveryLintTests.testDiagnosticsServiceDelegatesPgrepDiscoveryToSystemStateProvider`
+  block migrated runtime/system-validator/Karabiner-conflict/VHID/diagnostics consumers from bypassing it.
 - User-facing CLI/reporting shape belongs in CLI contract tests.
 
 ## Related References


### PR DESCRIPTION
## Summary
- inject `SystemStateProvider` into `DiagnosticsService`
- route Karabiner grabber and VirtualHID daemon diagnostics process checks through `SystemStateProvider.processIDs(matching:)`
- pass the same provider into the `VHIDDeviceManager` used by diagnostics summaries
- add behavior coverage plus the matching `PgrepProcessDiscoveryLintTests` ratchet
- update the Phase 1/status docs with the acceptance-test citations

## Acceptance Criteria / Enforcement
- `DiagnosticsServiceTests.testKarabinerGrabberDetectionUsesInjectedSystemStateProvider` verifies Karabiner grabber detection uses the injected provider.
- `DiagnosticsServiceTests.testKarabinerDaemonDetectionUsesInjectedSystemStateProvider` verifies VirtualHID daemon detection uses the injected provider.
- `PgrepProcessDiscoveryLintTests.testDiagnosticsServiceDelegatesPgrepDiscoveryToSystemStateProvider` prevents direct `pgrep` discovery from regrowing in `DiagnosticsService`.

## Validation
- `TEST_FILTER='DiagnosticsServiceTests|PgrepProcessDiscoveryLintTests|SystemStateProviderLivenessTests' ./Scripts/run-tests-safe.sh` (32 passed)
- `git diff --check`
- `python3 Scripts/check-accessibility.py` (352 files clean)
- `./Scripts/run-tests-safe.sh` (4453 passed)

## Review Gate
Local `/thermo-nuclear-swift-review` remains unavailable in this Codex shell (`claude` is not on PATH and no local command file is present), so I am using the GitHub `claude-code-review` PR check as the review gate for this slice, consistent with the previous Phase 1 slices.

## Plan Notes
No conflict with current code reality found in this slice. `getSystemDiagnostics()` intentionally keeps its test-mode fast path, so the new tests cover the now-internal process predicates directly. Workstream 3 and Workstream 6 remain out of scope.
