### PR TITLE
Route launcher pgrep through SystemStateProvider

### DIFF
--- a/Sources/KeyPathCore/SystemStateProvider.swift
+++ b/Sources/KeyPathCore/SystemStateProvider.swift
@@ -30,6 +30,24 @@ public actor SystemStateProvider {
         return await subprocessRunner.pgrep(trimmedPattern)
     }
 
+    public nonisolated static func processIDsSynchronously(matching pattern: String) -> [pid_t] {
+        let trimmedPattern = pattern.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedPattern.isEmpty else { return [] }
+
+        let result = BoundedProcess.run(
+            "/usr/bin/pgrep",
+            ["-f", trimmedPattern],
+            timeout: 5
+        )
+        guard result.status == 0 else { return [] }
+
+        return result.output
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .components(separatedBy: .newlines)
+            .filter { !$0.isEmpty }
+            .compactMap { Int32($0.trimmingCharacters(in: .whitespaces)) }
+    }
+
     public nonisolated static func isProcessAlive(pid: pid_t) -> Bool {
         guard pid > 0 else { return false }
         if kill(pid, 0) == 0 { return true }

--- a/Sources/KeyPathKanataLauncher/LauncherService.swift
+++ b/Sources/KeyPathKanataLauncher/LauncherService.swift
@@ -145,19 +145,7 @@ struct LauncherService {
 
     /// Fallback process-based check (renamed from isVHIDDaemonRunning).
     private func isVHIDDaemonProcessRunning() -> Bool {
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/pgrep")
-        process.arguments = ["-f", "VirtualHIDDevice-Daemon"]
-        let pipe = Pipe()
-        process.standardOutput = pipe
-        process.standardError = Pipe()
-        do {
-            try process.run()
-            process.waitUntilExit()
-            return process.terminationStatus == 0
-        } catch {
-            return false
-        }
+        !SystemStateProvider.processIDsSynchronously(matching: "VirtualHIDDevice-Daemon").isEmpty
     }
 
     /// Run a process and return stdout as a string, or nil if the process fails.

--- a/Tests/KeyPathTests/Core/SystemStateProviderLivenessTests.swift
+++ b/Tests/KeyPathTests/Core/SystemStateProviderLivenessTests.swift
@@ -80,6 +80,20 @@ final class SystemStateProviderLivenessTests: XCTestCase {
 
         XCTAssertEqual(pids, [])
     }
+
+    func testSynchronousProcessDiscoveryRejectsBlankPatterns() {
+        let pids = SystemStateProvider.processIDsSynchronously(matching: "  \n\t  ")
+
+        XCTAssertEqual(pids, [])
+    }
+
+    func testSynchronousProcessDiscoveryReturnsEmptyForMissingProcess() {
+        let pids = SystemStateProvider.processIDsSynchronously(
+            matching: "keypath_missing_process_pattern_7B3C9991_2A59_4F3E_AA43"
+        )
+
+        XCTAssertEqual(pids, [])
+    }
 }
 
 private final class LocalhostTCPListener {

--- a/Tests/KeyPathTests/Lint/PgrepProcessDiscoveryLintTests.swift
+++ b/Tests/KeyPathTests/Lint/PgrepProcessDiscoveryLintTests.swift
@@ -145,6 +145,29 @@ final class PgrepProcessDiscoveryLintTests: XCTestCase {
             """
         )
     }
+
+    func testLauncherServiceDelegatesPgrepDiscoveryToSystemStateProvider() throws {
+        let service = repositoryRoot()
+            .appendingPathComponent("Sources/KeyPathKanataLauncher/LauncherService.swift")
+
+        let violations = try matchingLines(
+            in: service,
+            patterns: [
+                #"SubprocessRunner\.shared\.pgrep"#,
+                #"subprocessRunner\.pgrep"#,
+                #"/usr/bin/pgrep"#
+            ]
+        )
+
+        XCTAssertTrue(
+            violations.isEmpty,
+            """
+            LauncherService must delegate process discovery to \
+            SystemStateProvider instead of calling pgrep directly:
+            \(violations.sorted().joined(separator: "\n"))
+            """
+        )
+    }
 }
 
 private func repositoryRoot(file: StaticString = #filePath) -> URL {

--- a/docs/planning/installer-reliability-phase1.md
+++ b/docs/planning/installer-reliability-phase1.md
@@ -107,7 +107,10 @@ classification remains pending.
   `PgrepProcessDiscoveryLintTests.testVHIDDeviceManagerDelegatesPgrepDiscoveryToSystemStateProvider`,
   `DiagnosticsServiceTests.testKarabinerGrabberDetectionUsesInjectedSystemStateProvider`,
   `DiagnosticsServiceTests.testKarabinerDaemonDetectionUsesInjectedSystemStateProvider`,
-  and `PgrepProcessDiscoveryLintTests.testDiagnosticsServiceDelegatesPgrepDiscoveryToSystemStateProvider`.
+  `PgrepProcessDiscoveryLintTests.testDiagnosticsServiceDelegatesPgrepDiscoveryToSystemStateProvider`,
+  `SystemStateProviderLivenessTests.testSynchronousProcessDiscoveryRejectsBlankPatterns`,
+  `SystemStateProviderLivenessTests.testSynchronousProcessDiscoveryReturnsEmptyForMissingProcess`,
+  and `PgrepProcessDiscoveryLintTests.testLauncherServiceDelegatesPgrepDiscoveryToSystemStateProvider`.
 - [ ] Migrate `launchctl`, `SMAppService.status`, remaining `pgrep` consumers,
   permissions, VHID state, and helper freshness into a single immutable
   `SystemSnapshot`.
@@ -183,6 +186,12 @@ through 21 mocked tests).
   `DiagnosticsServiceTests.testKarabinerDaemonDetectionUsesInjectedSystemStateProvider`,
   and
   `PgrepProcessDiscoveryLintTests.testDiagnosticsServiceDelegatesPgrepDiscoveryToSystemStateProvider`.
+- [x] `LauncherService` synchronous process discovery delegates to
+  `SystemStateProvider.processIDsSynchronously(matching:)`. Enforced by
+  `SystemStateProviderLivenessTests.testSynchronousProcessDiscoveryRejectsBlankPatterns`,
+  `SystemStateProviderLivenessTests.testSynchronousProcessDiscoveryReturnsEmptyForMissingProcess`,
+  and
+  `PgrepProcessDiscoveryLintTests.testLauncherServiceDelegatesPgrepDiscoveryToSystemStateProvider`.
 - [ ] Centralize remaining `pgrep` process-discovery consumers as later W1/W2
   migration slices.
 
@@ -308,6 +317,9 @@ is listed in the state-matrix doc's enforcement section.
 - [x] `PgrepProcessDiscoveryLintTests.testDiagnosticsServiceDelegatesPgrepDiscoveryToSystemStateProvider`
   prevents diagnostics process checks from regrowing direct
   `pgrep` process discovery.
+- [x] `PgrepProcessDiscoveryLintTests.testLauncherServiceDelegatesPgrepDiscoveryToSystemStateProvider`
+  prevents the launcher fallback from regrowing direct `pgrep` process
+  discovery.
 - [ ] Add `launchctl`, broader `pgrep`, postcondition, and snapshot-cache
   ratchets with the corresponding migration slices.
 

--- a/docs/process/installer-repair-state-matrix.md
+++ b/docs/process/installer-repair-state-matrix.md
@@ -144,10 +144,15 @@ the result as user action required and name the approval surface.
   `TCPReadinessLintTests.testProductionTCPProbeAdapterIsNoLongerUsed` plus
   `TCPReadinessLintTests.testProductionRawTCPSocketProbeIsCentralized` block
   production readiness checks from bypassing the provider.
-- `pgrep` process discovery belongs in `SystemStateProvider.processIDs(matching:)`.
+- `pgrep` process discovery belongs in `SystemStateProvider.processIDs(matching:)`
+  or `SystemStateProvider.processIDsSynchronously(matching:)` for synchronous
+  pre-exec/privileged-helper paths.
   `SystemStateProviderLivenessTests.testProcessDiscoveryDelegatesToInjectedSubprocessRunner`
   and `SystemStateProviderLivenessTests.testProcessDiscoveryRejectsBlankPatterns`
-  pin the provider contract, while
+  pin the async provider contract,
+  `SystemStateProviderLivenessTests.testSynchronousProcessDiscoveryRejectsBlankPatterns`
+  and `SystemStateProviderLivenessTests.testSynchronousProcessDiscoveryReturnsEmptyForMissingProcess`
+  pin the synchronous provider contract, while
   `KanataDaemonManagerTests.testRegisteredButNotLoadedUsesInjectedSystemStateProviderForProcessDiscovery`,
   `PgrepProcessDiscoveryLintTests.testServiceLifecycleCoordinatorDelegatesPgrepDiscoveryToSystemStateProvider`,
   `PgrepProcessDiscoveryLintTests.testKanataDaemonManagerDelegatesPgrepDiscoveryToSystemStateProvider`,
@@ -162,8 +167,9 @@ the result as user action required and name the approval surface.
   `PgrepProcessDiscoveryLintTests.testVHIDDeviceManagerDelegatesPgrepDiscoveryToSystemStateProvider`,
   `DiagnosticsServiceTests.testKarabinerGrabberDetectionUsesInjectedSystemStateProvider`,
   `DiagnosticsServiceTests.testKarabinerDaemonDetectionUsesInjectedSystemStateProvider`,
-  and `PgrepProcessDiscoveryLintTests.testDiagnosticsServiceDelegatesPgrepDiscoveryToSystemStateProvider`
-  block migrated runtime/system-validator/Karabiner-conflict/VHID/diagnostics consumers from bypassing it.
+  `PgrepProcessDiscoveryLintTests.testDiagnosticsServiceDelegatesPgrepDiscoveryToSystemStateProvider`,
+  and `PgrepProcessDiscoveryLintTests.testLauncherServiceDelegatesPgrepDiscoveryToSystemStateProvider`
+  block migrated runtime/system-validator/Karabiner-conflict/VHID/diagnostics/launcher consumers from bypassing it.
 - User-facing CLI/reporting shape belongs in CLI contract tests.
 
 ## Related References


### PR DESCRIPTION
## Summary
- add bounded synchronous process discovery to `SystemStateProvider` for pre-exec/helper-style callers
- route `LauncherService` VirtualHID fallback process detection through the provider
- add provider contract coverage plus the matching `PgrepProcessDiscoveryLintTests` launcher ratchet
- update the Phase 1/status docs with the acceptance-test citations

## Acceptance Criteria / Enforcement
- `SystemStateProviderLivenessTests.testSynchronousProcessDiscoveryRejectsBlankPatterns` verifies blank sync discovery patterns do not shell out.
- `SystemStateProviderLivenessTests.testSynchronousProcessDiscoveryReturnsEmptyForMissingProcess` verifies missing sync process discovery returns empty.
- `PgrepProcessDiscoveryLintTests.testLauncherServiceDelegatesPgrepDiscoveryToSystemStateProvider` prevents direct `pgrep` discovery from regrowing in `LauncherService`.

## Validation
- `TEST_FILTER='SystemStateProviderLivenessTests|PgrepProcessDiscoveryLintTests' ./Scripts/run-tests-safe.sh` (16 passed)
- `git diff --check`
- `python3 Scripts/check-accessibility.py` (352 files clean)
- `./Scripts/run-tests-safe.sh` (4456 passed)

## Review Gate
Local `/thermo-nuclear-swift-review` remains unavailable in this Codex shell (`claude` is not on PATH and no local command file is present), so I am using the GitHub `claude-code-review` PR check as the review gate for this slice, consistent with the previous Phase 1 slices.

## Plan Notes
No conflict with current code reality found in this slice. `LauncherService` is synchronous because it runs before `exec`, so this PR adds a bounded synchronous provider method instead of making the root launcher async. Workstream 3 and Workstream 6 remain out of scope.
