### PR TITLE
Route process lifecycle pgrep through SystemStateProvider

### DIFF
--- a/Sources/KeyPathCore/SystemStateProvider.swift
+++ b/Sources/KeyPathCore/SystemStateProvider.swift
@@ -30,6 +30,24 @@ public actor SystemStateProvider {
         return await subprocessRunner.pgrep(trimmedPattern)
     }
 
+    public func processMatches(matching pattern: String) async -> [SystemProcessMatch] {
+        let trimmedPattern = pattern.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedPattern.isEmpty else { return [] }
+
+        do {
+            let result = try await subprocessRunner.run(
+                "/usr/bin/pgrep",
+                args: ["-fl", trimmedPattern],
+                timeout: 5
+            )
+            guard result.exitCode == 0 else { return [] }
+            return Self.parseProcessMatches(result.stdout)
+        } catch {
+            AppLogger.shared.warn("⚠️ [SystemStateProvider] pgrep -fl failed for pattern '\(trimmedPattern)': \(error)")
+            return []
+        }
+    }
+
     public nonisolated static func processIDsSynchronously(matching pattern: String) -> [pid_t] {
         let trimmedPattern = pattern.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmedPattern.isEmpty else { return [] }
@@ -46,6 +64,19 @@ public actor SystemStateProvider {
             .components(separatedBy: .newlines)
             .filter { !$0.isEmpty }
             .compactMap { Int32($0.trimmingCharacters(in: .whitespaces)) }
+    }
+
+    private nonisolated static func parseProcessMatches(_ output: String) -> [SystemProcessMatch] {
+        output
+            .components(separatedBy: .newlines)
+            .compactMap { rawLine in
+                let line = rawLine.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !line.isEmpty else { return nil }
+
+                let parts = line.split(separator: " ", maxSplits: 1, omittingEmptySubsequences: true)
+                guard parts.count == 2, let pid = pid_t(parts[0]) else { return nil }
+                return SystemProcessMatch(pid: pid, command: String(parts[1]))
+            }
     }
 
     public nonisolated static func isProcessAlive(pid: pid_t) -> Bool {
@@ -108,5 +139,15 @@ public struct KanataLivenessEvidence: Equatable, Sendable {
 
     public var ready: Bool {
         SystemStateProvider.isKanataReady(running: running, responding: responding)
+    }
+}
+
+public struct SystemProcessMatch: Equatable, Sendable {
+    public let pid: pid_t
+    public let command: String
+
+    public init(pid: pid_t, command: String) {
+        self.pid = pid
+        self.command = command
     }
 }

--- a/Sources/KeyPathDaemonLifecycle/ProcessLifecycleManager.swift
+++ b/Sources/KeyPathDaemonLifecycle/ProcessLifecycleManager.swift
@@ -40,7 +40,8 @@ public final class ProcessLifecycleManager {
         }
     }
 
-    public init() {
+    public init(systemStateProvider: SystemStateProvider = .shared) {
+        self.systemStateProvider = systemStateProvider
         AppLogger.shared.log(
             "🏗️ [ProcessLifecycleManager] Initialized with simplified PID-based tracking and caching"
         )
@@ -88,6 +89,8 @@ public final class ProcessLifecycleManager {
     public private(set) var lastConflictCheck: Date?
 
     // MARK: - Dependencies
+
+    private let systemStateProvider: SystemStateProvider
 
     /// Use shared singleton to ensure all ProcessLifecycleManager instances share the same cache
     private var pidCache: LaunchDaemonPIDCache {
@@ -233,25 +236,16 @@ public final class ProcessLifecycleManager {
     // MARK: - Process Detection
 
     /// Detect all kanata processes currently running
-    private func detectKanataProcesses() async throws -> [ProcessInfo] {
+    func detectKanataProcesses() async throws -> [ProcessInfo] {
         AppLogger.shared.log("🔍 [ProcessLifecycleManager] Detecting kanata processes...")
 
         var processes: [ProcessInfo] = []
 
-        let result = try await SubprocessRunner.shared.run("/usr/bin/pgrep", args: ["-fl", "kanata"])
-        if result.exitCode == 0 {
-            let lines = result.stdout.components(separatedBy: "\n").filter { !$0.isEmpty }
-            for line in lines {
-                let components = line.components(separatedBy: " ")
-                guard let pidString = components.first,
-                      let pid = pid_t(pidString),
-                      components.count > 1
-                else { continue }
-                let command = components.dropFirst().joined(separator: " ")
-                if isKanataBinary(command) {
-                    processes.append(ProcessInfo(pid: pid, command: command))
-                    AppLogger.shared.log("🔍 [ProcessLifecycleManager] Found kanata process: PID=\(pid)")
-                }
+        let matches = await systemStateProvider.processMatches(matching: "kanata")
+        for match in matches {
+            if isKanataBinary(match.command) {
+                processes.append(ProcessInfo(pid: match.pid, command: match.command))
+                AppLogger.shared.log("🔍 [ProcessLifecycleManager] Found kanata process: PID=\(match.pid)")
             }
         }
 

--- a/Tests/KeyPathTests/Core/SystemStateProviderLivenessTests.swift
+++ b/Tests/KeyPathTests/Core/SystemStateProviderLivenessTests.swift
@@ -81,6 +81,57 @@ final class SystemStateProviderLivenessTests: XCTestCase {
         XCTAssertEqual(pids, [])
     }
 
+    func testProcessMatchDiscoveryDelegatesToInjectedSubprocessRunner() async {
+        let runner = SubprocessRunnerFake.shared
+        await runner.reset()
+        await runner.configureRunResult { executable, args in
+            if executable == "/usr/bin/pgrep", args == ["-fl", "kanata"] {
+                return ProcessResult(
+                    exitCode: 0,
+                    stdout: """
+                    123 kanata --cfg /Users/example/.config/keypath/keypath.kbd
+                    invalid
+                    456 /opt/homebrew/bin/kanata --cfg /tmp/other.kbd
+
+                    """,
+                    stderr: "",
+                    duration: 0.01
+                )
+            }
+            return ProcessResult(exitCode: 1, stdout: "", stderr: "", duration: 0.01)
+        }
+        let provider = SystemStateProvider(subprocessRunner: runner)
+
+        let matches = await provider.processMatches(matching: "kanata")
+        let commands = await runner.executedCommands
+
+        XCTAssertEqual(
+            matches,
+            [
+                SystemProcessMatch(pid: 123, command: "kanata --cfg /Users/example/.config/keypath/keypath.kbd"),
+                SystemProcessMatch(pid: 456, command: "/opt/homebrew/bin/kanata --cfg /tmp/other.kbd")
+            ]
+        )
+        XCTAssertTrue(
+            commands.contains { $0.executable == "/usr/bin/pgrep" && $0.args == ["-fl", "kanata"] },
+            "SystemStateProvider should own pgrep -fl process-match discovery"
+        )
+    }
+
+    func testProcessMatchDiscoveryRejectsBlankPatterns() async {
+        let runner = SubprocessRunnerFake.shared
+        await runner.reset()
+        await runner.configureRunResult { _, _ in
+            XCTFail("Blank process-match patterns must not invoke pgrep")
+            return ProcessResult(exitCode: 0, stdout: "", stderr: "", duration: 0.01)
+        }
+        let provider = SystemStateProvider(subprocessRunner: runner)
+
+        let matches = await provider.processMatches(matching: "  \n\t  ")
+
+        XCTAssertEqual(matches, [])
+    }
+
     func testSynchronousProcessDiscoveryRejectsBlankPatterns() {
         let pids = SystemStateProvider.processIDsSynchronously(matching: "  \n\t  ")
 

--- a/Tests/KeyPathTests/Lint/PgrepProcessDiscoveryLintTests.swift
+++ b/Tests/KeyPathTests/Lint/PgrepProcessDiscoveryLintTests.swift
@@ -168,6 +168,30 @@ final class PgrepProcessDiscoveryLintTests: XCTestCase {
             """
         )
     }
+
+    func testProcessLifecycleManagerDelegatesPgrepDiscoveryToSystemStateProvider() throws {
+        let manager = repositoryRoot()
+            .appendingPathComponent("Sources/KeyPathDaemonLifecycle/ProcessLifecycleManager.swift")
+
+        let violations = try matchingLines(
+            in: manager,
+            patterns: [
+                #"SubprocessRunner\.shared\.pgrep"#,
+                #"SubprocessRunner\.shared\.run\("/usr/bin/pgrep"#,
+                #"subprocessRunner\.pgrep"#,
+                #"/usr/bin/pgrep"#
+            ]
+        )
+
+        XCTAssertTrue(
+            violations.isEmpty,
+            """
+            ProcessLifecycleManager must delegate process discovery to \
+            SystemStateProvider instead of calling pgrep directly:
+            \(violations.sorted().joined(separator: "\n"))
+            """
+        )
+    }
 }
 
 private func repositoryRoot(file: StaticString = #filePath) -> URL {

--- a/Tests/KeyPathTests/ProcessLifecycleManagerTests.swift
+++ b/Tests/KeyPathTests/ProcessLifecycleManagerTests.swift
@@ -1,6 +1,6 @@
 @testable import KeyPathAppKit
 import KeyPathCore
-import KeyPathDaemonLifecycle
+@testable import KeyPathDaemonLifecycle
 @preconcurrency import XCTest
 
 @MainActor
@@ -61,6 +61,40 @@ final class ProcessLifecycleManagerTests: XCTestCase {
         case .shouldBeStopped:
             XCTAssertTrue(true, "Correct stopped intent")
         }
+    }
+
+    func testDetectKanataProcessesUsesInjectedSystemStateProvider() async throws {
+        let runner = SubprocessRunnerFake.shared
+        await runner.reset()
+        await runner.configureRunResult { executable, args in
+            if executable == "/usr/bin/pgrep", args == ["-fl", "kanata"] {
+                return ProcessResult(
+                    exitCode: 0,
+                    stdout: """
+                    123 kanata --cfg /Users/example/.config/keypath/keypath.kbd
+                    456 pgrep -fl kanata
+                    789 /Applications/Visual Studio Code.app/Contents/MacOS/Electron kanata extension
+
+                    """,
+                    stderr: "",
+                    duration: 0.01
+                )
+            }
+            return ProcessResult(exitCode: 1, stdout: "", stderr: "", duration: 0.01)
+        }
+
+        let provider = SystemStateProvider(subprocessRunner: runner)
+        let manager = ProcessLifecycleManager(systemStateProvider: provider)
+
+        let processes = try await manager.detectKanataProcesses()
+        let commands = await runner.executedCommands
+
+        XCTAssertEqual(processes.map(\.pid), [123])
+        XCTAssertEqual(processes.first?.command, "kanata --cfg /Users/example/.config/keypath/keypath.kbd")
+        XCTAssertTrue(
+            commands.contains { $0.executable == "/usr/bin/pgrep" && $0.args == ["-fl", "kanata"] },
+            "ProcessLifecycleManager should use the injected provider for kanata process discovery"
+        )
     }
 
     func testProcessLifecycleErrors() {

--- a/docs/planning/installer-reliability-phase1.md
+++ b/docs/planning/installer-reliability-phase1.md
@@ -110,7 +110,11 @@ classification remains pending.
   `PgrepProcessDiscoveryLintTests.testDiagnosticsServiceDelegatesPgrepDiscoveryToSystemStateProvider`,
   `SystemStateProviderLivenessTests.testSynchronousProcessDiscoveryRejectsBlankPatterns`,
   `SystemStateProviderLivenessTests.testSynchronousProcessDiscoveryReturnsEmptyForMissingProcess`,
-  and `PgrepProcessDiscoveryLintTests.testLauncherServiceDelegatesPgrepDiscoveryToSystemStateProvider`.
+  `PgrepProcessDiscoveryLintTests.testLauncherServiceDelegatesPgrepDiscoveryToSystemStateProvider`,
+  `SystemStateProviderLivenessTests.testProcessMatchDiscoveryDelegatesToInjectedSubprocessRunner`,
+  `SystemStateProviderLivenessTests.testProcessMatchDiscoveryRejectsBlankPatterns`,
+  `ProcessLifecycleManagerTests.testDetectKanataProcessesUsesInjectedSystemStateProvider`,
+  and `PgrepProcessDiscoveryLintTests.testProcessLifecycleManagerDelegatesPgrepDiscoveryToSystemStateProvider`.
 - [ ] Migrate `launchctl`, `SMAppService.status`, remaining `pgrep` consumers,
   permissions, VHID state, and helper freshness into a single immutable
   `SystemSnapshot`.
@@ -192,6 +196,13 @@ through 21 mocked tests).
   `SystemStateProviderLivenessTests.testSynchronousProcessDiscoveryReturnsEmptyForMissingProcess`,
   and
   `PgrepProcessDiscoveryLintTests.testLauncherServiceDelegatesPgrepDiscoveryToSystemStateProvider`.
+- [x] `ProcessLifecycleManager` command-aware process discovery delegates to
+  `SystemStateProvider.processMatches(matching:)`. Enforced by
+  `SystemStateProviderLivenessTests.testProcessMatchDiscoveryDelegatesToInjectedSubprocessRunner`,
+  `SystemStateProviderLivenessTests.testProcessMatchDiscoveryRejectsBlankPatterns`,
+  `ProcessLifecycleManagerTests.testDetectKanataProcessesUsesInjectedSystemStateProvider`,
+  and
+  `PgrepProcessDiscoveryLintTests.testProcessLifecycleManagerDelegatesPgrepDiscoveryToSystemStateProvider`.
 - [ ] Centralize remaining `pgrep` process-discovery consumers as later W1/W2
   migration slices.
 
@@ -320,6 +331,9 @@ is listed in the state-matrix doc's enforcement section.
 - [x] `PgrepProcessDiscoveryLintTests.testLauncherServiceDelegatesPgrepDiscoveryToSystemStateProvider`
   prevents the launcher fallback from regrowing direct `pgrep` process
   discovery.
+- [x] `PgrepProcessDiscoveryLintTests.testProcessLifecycleManagerDelegatesPgrepDiscoveryToSystemStateProvider`
+  prevents command-aware Kanata process conflict detection from regrowing direct
+  `pgrep` process discovery.
 - [ ] Add `launchctl`, broader `pgrep`, postcondition, and snapshot-cache
   ratchets with the corresponding migration slices.
 

--- a/docs/process/installer-repair-state-matrix.md
+++ b/docs/process/installer-repair-state-matrix.md
@@ -144,12 +144,16 @@ the result as user action required and name the approval surface.
   `TCPReadinessLintTests.testProductionTCPProbeAdapterIsNoLongerUsed` plus
   `TCPReadinessLintTests.testProductionRawTCPSocketProbeIsCentralized` block
   production readiness checks from bypassing the provider.
-- `pgrep` process discovery belongs in `SystemStateProvider.processIDs(matching:)`
-  or `SystemStateProvider.processIDsSynchronously(matching:)` for synchronous
+- `pgrep` process discovery belongs in `SystemStateProvider.processIDs(matching:)`,
+  `SystemStateProvider.processMatches(matching:)`, or
+  `SystemStateProvider.processIDsSynchronously(matching:)` for synchronous
   pre-exec/privileged-helper paths.
   `SystemStateProviderLivenessTests.testProcessDiscoveryDelegatesToInjectedSubprocessRunner`
   and `SystemStateProviderLivenessTests.testProcessDiscoveryRejectsBlankPatterns`
   pin the async provider contract,
+  `SystemStateProviderLivenessTests.testProcessMatchDiscoveryDelegatesToInjectedSubprocessRunner`
+  and `SystemStateProviderLivenessTests.testProcessMatchDiscoveryRejectsBlankPatterns`
+  pin the command-aware provider contract,
   `SystemStateProviderLivenessTests.testSynchronousProcessDiscoveryRejectsBlankPatterns`
   and `SystemStateProviderLivenessTests.testSynchronousProcessDiscoveryReturnsEmptyForMissingProcess`
   pin the synchronous provider contract, while
@@ -168,8 +172,10 @@ the result as user action required and name the approval surface.
   `DiagnosticsServiceTests.testKarabinerGrabberDetectionUsesInjectedSystemStateProvider`,
   `DiagnosticsServiceTests.testKarabinerDaemonDetectionUsesInjectedSystemStateProvider`,
   `PgrepProcessDiscoveryLintTests.testDiagnosticsServiceDelegatesPgrepDiscoveryToSystemStateProvider`,
-  and `PgrepProcessDiscoveryLintTests.testLauncherServiceDelegatesPgrepDiscoveryToSystemStateProvider`
-  block migrated runtime/system-validator/Karabiner-conflict/VHID/diagnostics/launcher consumers from bypassing it.
+  `PgrepProcessDiscoveryLintTests.testLauncherServiceDelegatesPgrepDiscoveryToSystemStateProvider`,
+  `ProcessLifecycleManagerTests.testDetectKanataProcessesUsesInjectedSystemStateProvider`,
+  and `PgrepProcessDiscoveryLintTests.testProcessLifecycleManagerDelegatesPgrepDiscoveryToSystemStateProvider`
+  block migrated runtime/system-validator/Karabiner-conflict/VHID/diagnostics/launcher/process-lifecycle consumers from bypassing it.
 - User-facing CLI/reporting shape belongs in CLI contract tests.
 
 ## Related References


### PR DESCRIPTION
## Summary
- add `SystemStateProvider.processMatches(matching:)` for command-aware `pgrep -fl` output
- route `ProcessLifecycleManager.detectKanataProcesses()` through the injected provider
- add the matching pgrep lint ratchet and update the Phase 1/state-matrix docs with executable acceptance criteria

## Acceptance criteria enforced
- `SystemStateProviderLivenessTests.testProcessMatchDiscoveryDelegatesToInjectedSubprocessRunner` verifies command-aware process discovery delegates to the injected subprocess runner.
- `SystemStateProviderLivenessTests.testProcessMatchDiscoveryRejectsBlankPatterns` verifies blank process patterns never invoke `pgrep`.
- `ProcessLifecycleManagerTests.testDetectKanataProcessesUsesInjectedSystemStateProvider` verifies ProcessLifecycleManager uses the injected `SystemStateProvider` and filters command-aware results to real Kanata binaries.
- `PgrepProcessDiscoveryLintTests.testProcessLifecycleManagerDelegatesPgrepDiscoveryToSystemStateProvider` prevents ProcessLifecycleManager from reintroducing direct `pgrep` calls.

## Validation
- `TEST_FILTER='SystemStateProviderLivenessTests|ProcessLifecycleManagerTests|PgrepProcessDiscoveryLintTests' ./Scripts/run-tests-safe.sh` (24 passed)
- `git diff --check`
- `python3 Scripts/check-accessibility.py` (352 files clean)
- `./Scripts/run-tests-safe.sh` (4460 passed)

## Review gate
- Required local `/thermo-nuclear-swift-review` remains unavailable in this Codex shell (`claude` is not on `PATH`, and no local command file was found), matching the prior Phase 1 slices.
- I am using the repository `claude-code-review` GitHub check as the available review gate for this PR.