### PR TITLE
Route helper pgrep through SystemStateProvider

### DIFF
--- a/Sources/KeyPathHelper/HelperService.swift
+++ b/Sources/KeyPathHelper/HelperService.swift
@@ -341,7 +341,7 @@ class HelperService: NSObject, HelperProtocol {
             operation: {
                 // Try graceful then force
                 _ = Self.run("/usr/bin/pkill", ["-f", "kanata"]) // may return non-zero if none
-                let still = Self.run("/usr/bin/pgrep", ["-f", "kanata"]).status == 0
+                let still = !SystemStateProvider.processIDsSynchronously(matching: "kanata").isEmpty
                 if still { _ = Self.run("/usr/bin/pkill", ["-9", "-f", "kanata"]) }
             },
             reply: reply
@@ -758,11 +758,8 @@ extension HelperService {
 
     static func terminateStaleVHIDManagerActivationProcesses() {
         let pattern = "\(vhidManagerPath) activate"
-        let existing = run("/usr/bin/pgrep", ["-f", pattern], timeout: 5)
-        let pids = existing.out
-            .split(whereSeparator: \.isNewline)
+        let pids = SystemStateProvider.processIDsSynchronously(matching: pattern)
             .map(String.init)
-            .filter { !$0.isEmpty }
         guard !pids.isEmpty else { return }
 
         _ = run("/bin/kill", ["-KILL"] + pids, timeout: 5)

--- a/Tests/KeyPathTests/Lint/PgrepProcessDiscoveryLintTests.swift
+++ b/Tests/KeyPathTests/Lint/PgrepProcessDiscoveryLintTests.swift
@@ -192,6 +192,31 @@ final class PgrepProcessDiscoveryLintTests: XCTestCase {
             """
         )
     }
+
+    func testHelperServiceDelegatesPgrepDiscoveryToSystemStateProvider() throws {
+        let service = repositoryRoot()
+            .appendingPathComponent("Sources/KeyPathHelper/HelperService.swift")
+
+        let violations = try matchingLines(
+            in: service,
+            patterns: [
+                #"SubprocessRunner\.shared\.pgrep"#,
+                #"SubprocessRunner\.shared\.run\("/usr/bin/pgrep"#,
+                #"subprocessRunner\.pgrep"#,
+                #"run\("/usr/bin/pgrep"#,
+                #"/usr/bin/pgrep"#
+            ]
+        )
+
+        XCTAssertTrue(
+            violations.isEmpty,
+            """
+            HelperService must delegate process discovery to \
+            SystemStateProvider instead of calling pgrep directly:
+            \(violations.sorted().joined(separator: "\n"))
+            """
+        )
+    }
 }
 
 private func repositoryRoot(file: StaticString = #filePath) -> URL {

--- a/docs/planning/installer-reliability-phase1.md
+++ b/docs/planning/installer-reliability-phase1.md
@@ -114,7 +114,8 @@ classification remains pending.
   `SystemStateProviderLivenessTests.testProcessMatchDiscoveryDelegatesToInjectedSubprocessRunner`,
   `SystemStateProviderLivenessTests.testProcessMatchDiscoveryRejectsBlankPatterns`,
   `ProcessLifecycleManagerTests.testDetectKanataProcessesUsesInjectedSystemStateProvider`,
-  and `PgrepProcessDiscoveryLintTests.testProcessLifecycleManagerDelegatesPgrepDiscoveryToSystemStateProvider`.
+  `PgrepProcessDiscoveryLintTests.testProcessLifecycleManagerDelegatesPgrepDiscoveryToSystemStateProvider`,
+  and `PgrepProcessDiscoveryLintTests.testHelperServiceDelegatesPgrepDiscoveryToSystemStateProvider`.
 - [ ] Migrate `launchctl`, `SMAppService.status`, remaining `pgrep` consumers,
   permissions, VHID state, and helper freshness into a single immutable
   `SystemSnapshot`.
@@ -203,6 +204,12 @@ through 21 mocked tests).
   `ProcessLifecycleManagerTests.testDetectKanataProcessesUsesInjectedSystemStateProvider`,
   and
   `PgrepProcessDiscoveryLintTests.testProcessLifecycleManagerDelegatesPgrepDiscoveryToSystemStateProvider`.
+- [x] `HelperService` synchronous privileged-helper process discovery delegates
+  to `SystemStateProvider.processIDsSynchronously(matching:)`. Enforced by
+  `SystemStateProviderLivenessTests.testSynchronousProcessDiscoveryRejectsBlankPatterns`,
+  `SystemStateProviderLivenessTests.testSynchronousProcessDiscoveryReturnsEmptyForMissingProcess`,
+  and
+  `PgrepProcessDiscoveryLintTests.testHelperServiceDelegatesPgrepDiscoveryToSystemStateProvider`.
 - [ ] Centralize remaining `pgrep` process-discovery consumers as later W1/W2
   migration slices.
 

--- a/docs/process/installer-repair-state-matrix.md
+++ b/docs/process/installer-repair-state-matrix.md
@@ -174,8 +174,9 @@ the result as user action required and name the approval surface.
   `PgrepProcessDiscoveryLintTests.testDiagnosticsServiceDelegatesPgrepDiscoveryToSystemStateProvider`,
   `PgrepProcessDiscoveryLintTests.testLauncherServiceDelegatesPgrepDiscoveryToSystemStateProvider`,
   `ProcessLifecycleManagerTests.testDetectKanataProcessesUsesInjectedSystemStateProvider`,
-  and `PgrepProcessDiscoveryLintTests.testProcessLifecycleManagerDelegatesPgrepDiscoveryToSystemStateProvider`
-  block migrated runtime/system-validator/Karabiner-conflict/VHID/diagnostics/launcher/process-lifecycle consumers from bypassing it.
+  `PgrepProcessDiscoveryLintTests.testProcessLifecycleManagerDelegatesPgrepDiscoveryToSystemStateProvider`,
+  and `PgrepProcessDiscoveryLintTests.testHelperServiceDelegatesPgrepDiscoveryToSystemStateProvider`
+  block migrated runtime/system-validator/Karabiner-conflict/VHID/diagnostics/launcher/process-lifecycle/helper consumers from bypassing it.
 - User-facing CLI/reporting shape belongs in CLI contract tests.
 
 ## Related References


### PR DESCRIPTION
## Summary
- route privileged helper process discovery through `SystemStateProvider.processIDsSynchronously(matching:)`
- remove direct helper `pgrep` subprocess calls from Kanata kill verification and stale VHID manager activation cleanup
- add the matching helper lint ratchet and update the Phase 1/state-matrix docs with executable acceptance criteria

## Acceptance criteria enforced
- `SystemStateProviderLivenessTests.testSynchronousProcessDiscoveryRejectsBlankPatterns` verifies blank synchronous patterns never invoke process discovery.
- `SystemStateProviderLivenessTests.testSynchronousProcessDiscoveryReturnsEmptyForMissingProcess` verifies the synchronous provider returns empty for a missing process.
- `PgrepProcessDiscoveryLintTests.testHelperServiceDelegatesPgrepDiscoveryToSystemStateProvider` prevents `HelperService` from reintroducing direct `pgrep` calls.

## Validation
- `TEST_FILTER='SystemStateProviderLivenessTests|PgrepProcessDiscoveryLintTests' ./Scripts/run-tests-safe.sh` (20 passed)
- `git diff --check`
- `python3 Scripts/check-accessibility.py` (352 files clean)
- `./Scripts/run-tests-safe.sh` (4461 passed)

## Review gate
- Required local `/thermo-nuclear-swift-review` remains unavailable in this Codex shell (`claude` is not on `PATH`, and no local command file was found), matching the prior Phase 1 slices.
- I am using the repository `claude-code-review` GitHub check as the available review gate for this PR.