### PR TITLE
Add broad pgrep centralization ratchet

### DIFF
--- a/Tests/KeyPathTests/Lint/PgrepProcessDiscoveryLintTests.swift
+++ b/Tests/KeyPathTests/Lint/PgrepProcessDiscoveryLintTests.swift
@@ -8,6 +8,38 @@ import Foundation
 /// collapse process, TCP, and later launchd/SMAppService evidence into one
 /// executable snapshot.
 final class PgrepProcessDiscoveryLintTests: XCTestCase {
+    func testProductionPgrepDiscoveryIsCentralizedInCoreProvider() throws {
+        let sourceRoot = repositoryRoot().appendingPathComponent("Sources")
+        let allowedFiles: Set = [
+            "Sources/KeyPathCore/SubprocessRunner.swift",
+            "Sources/KeyPathCore/SystemStateProvider.swift"
+        ]
+
+        let violations = try swiftSourceFiles(under: sourceRoot)
+            .filter { !allowedFiles.contains(relativePath(for: $0)) }
+            .flatMap { file in
+                try matchingLines(
+                    in: file,
+                    patterns: [
+                        #"SubprocessRunner\.shared\.pgrep"#,
+                        #"SubprocessRunner\.shared\.run\("/usr/bin/pgrep"#,
+                        #"subprocessRunner\.pgrep"#,
+                        #"run\("/usr/bin/pgrep"#,
+                        #"/usr/bin/pgrep"#
+                    ]
+                )
+            }
+
+        XCTAssertTrue(
+            violations.isEmpty,
+            """
+            Production process discovery must be centralized in \
+            SystemStateProvider/SubprocessRunner, not scattered through callers:
+            \(violations.sorted().joined(separator: "\n"))
+            """
+        )
+    }
+
     func testServiceLifecycleCoordinatorDelegatesPgrepDiscoveryToSystemStateProvider() throws {
         let coordinator = repositoryRoot()
             .appendingPathComponent("Sources/KeyPathAppKit/Managers/ServiceLifecycleCoordinator.swift")
@@ -227,10 +259,30 @@ private func repositoryRoot(file: StaticString = #filePath) -> URL {
         .deletingLastPathComponent() // Tests
 }
 
+private func swiftSourceFiles(under root: URL) throws -> [URL] {
+    guard let enumerator = FileManager.default.enumerator(
+        at: root,
+        includingPropertiesForKeys: [.isRegularFileKey],
+        options: [.skipsHiddenFiles]
+    ) else {
+        return []
+    }
+
+    return try enumerator.compactMap { item in
+        guard let url = item as? URL, url.pathExtension == "swift" else { return nil }
+        let values = try url.resourceValues(forKeys: [.isRegularFileKey])
+        return values.isRegularFile == true ? url : nil
+    }
+}
+
+private func relativePath(for fileURL: URL) -> String {
+    fileURL.path.replacingOccurrences(of: repositoryRoot().path + "/", with: "")
+}
+
 private func matchingLines(in fileURL: URL, patterns: [String]) throws -> [String] {
     let contents = try String(contentsOf: fileURL, encoding: .utf8)
     let regexes = try patterns.map { try NSRegularExpression(pattern: $0) }
-    let relativePath = fileURL.path.replacingOccurrences(of: repositoryRoot().path + "/", with: "")
+    let relativePath = relativePath(for: fileURL)
 
     var violations: [String] = []
     for (idx, rawLine) in contents.components(separatedBy: .newlines).enumerated() {

--- a/docs/planning/installer-reliability-phase1.md
+++ b/docs/planning/installer-reliability-phase1.md
@@ -115,10 +115,10 @@ classification remains pending.
   `SystemStateProviderLivenessTests.testProcessMatchDiscoveryRejectsBlankPatterns`,
   `ProcessLifecycleManagerTests.testDetectKanataProcessesUsesInjectedSystemStateProvider`,
   `PgrepProcessDiscoveryLintTests.testProcessLifecycleManagerDelegatesPgrepDiscoveryToSystemStateProvider`,
-  and `PgrepProcessDiscoveryLintTests.testHelperServiceDelegatesPgrepDiscoveryToSystemStateProvider`.
-- [ ] Migrate `launchctl`, `SMAppService.status`, remaining `pgrep` consumers,
-  permissions, VHID state, and helper freshness into a single immutable
-  `SystemSnapshot`.
+  `PgrepProcessDiscoveryLintTests.testHelperServiceDelegatesPgrepDiscoveryToSystemStateProvider`,
+  and `PgrepProcessDiscoveryLintTests.testProductionPgrepDiscoveryIsCentralizedInCoreProvider`.
+- [ ] Migrate `launchctl`, `SMAppService.status`, permissions, VHID state, and
+  helper freshness into a single immutable `SystemSnapshot`.
 - [ ] Build `classify(snapshot) -> StateMatrixRow -> plan` and table-driven
   golden tests for every state-matrix row.
 
@@ -210,8 +210,10 @@ through 21 mocked tests).
   `SystemStateProviderLivenessTests.testSynchronousProcessDiscoveryReturnsEmptyForMissingProcess`,
   and
   `PgrepProcessDiscoveryLintTests.testHelperServiceDelegatesPgrepDiscoveryToSystemStateProvider`.
-- [ ] Centralize remaining `pgrep` process-discovery consumers as later W1/W2
-  migration slices.
+- [x] Production `pgrep` process discovery is centralized in
+  `SystemStateProvider`/`SubprocessRunner`, with no caller-owned production
+  uses remaining. Enforced by
+  `PgrepProcessDiscoveryLintTests.testProductionPgrepDiscoveryIsCentralizedInCoreProvider`.
 
 ## Workstream 3: Industry-Standard Repair Model
 
@@ -341,7 +343,10 @@ is listed in the state-matrix doc's enforcement section.
 - [x] `PgrepProcessDiscoveryLintTests.testProcessLifecycleManagerDelegatesPgrepDiscoveryToSystemStateProvider`
   prevents command-aware Kanata process conflict detection from regrowing direct
   `pgrep` process discovery.
-- [ ] Add `launchctl`, broader `pgrep`, postcondition, and snapshot-cache
+- [x] `PgrepProcessDiscoveryLintTests.testProductionPgrepDiscoveryIsCentralizedInCoreProvider`
+  blocks production `pgrep` process discovery outside the core provider
+  implementation.
+- [ ] Add `launchctl`, postcondition, and snapshot-cache
   ratchets with the corresponding migration slices.
 
 ## Workstream 6: Deletion Pass

--- a/docs/process/installer-repair-state-matrix.md
+++ b/docs/process/installer-repair-state-matrix.md
@@ -175,7 +175,8 @@ the result as user action required and name the approval surface.
   `PgrepProcessDiscoveryLintTests.testLauncherServiceDelegatesPgrepDiscoveryToSystemStateProvider`,
   `ProcessLifecycleManagerTests.testDetectKanataProcessesUsesInjectedSystemStateProvider`,
   `PgrepProcessDiscoveryLintTests.testProcessLifecycleManagerDelegatesPgrepDiscoveryToSystemStateProvider`,
-  and `PgrepProcessDiscoveryLintTests.testHelperServiceDelegatesPgrepDiscoveryToSystemStateProvider`
+  `PgrepProcessDiscoveryLintTests.testHelperServiceDelegatesPgrepDiscoveryToSystemStateProvider`,
+  and `PgrepProcessDiscoveryLintTests.testProductionPgrepDiscoveryIsCentralizedInCoreProvider`
   block migrated runtime/system-validator/Karabiner-conflict/VHID/diagnostics/launcher/process-lifecycle/helper consumers from bypassing it.
 - User-facing CLI/reporting shape belongs in CLI contract tests.
 


### PR DESCRIPTION
## Summary
- add a repository-wide production-source lint test that permits `pgrep` only in `SystemStateProvider`/`SubprocessRunner`
- mark the remaining `pgrep` process-discovery migration closed in the Phase 1 plan
- update the state-matrix contract with the broad centralization ratchet

## Acceptance criteria enforced
- `PgrepProcessDiscoveryLintTests.testProductionPgrepDiscoveryIsCentralizedInCoreProvider` blocks production `pgrep` process discovery outside the core provider implementation.

## Validation
- `TEST_FILTER='PgrepProcessDiscoveryLintTests' ./Scripts/run-tests-safe.sh` (10 passed)
- `git diff --check`
- `python3 Scripts/check-accessibility.py` (352 files clean)
- `./Scripts/run-tests-safe.sh` (4462 passed)

## Review gate
- Required local `/thermo-nuclear-swift-review` remains unavailable in this Codex shell (`claude` is not on `PATH`, and no local command file was found), matching the prior Phase 1 slices.
- I am using the repository `claude-code-review` GitHub check as the available review gate for this PR.