### PR TITLE
Route VHID launchctl evidence through SystemStateProvider

### DIFF
--- a/Sources/KeyPathCore/SystemStateProvider.swift
+++ b/Sources/KeyPathCore/SystemStateProvider.swift
@@ -48,6 +48,31 @@ public actor SystemStateProvider {
         }
     }
 
+    public func launchctlPrint(target: String) async -> LaunchctlPrintEvidence {
+        let trimmedTarget = target.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedTarget.isEmpty else {
+            return LaunchctlPrintEvidence(target: "", exitCode: nil, stdout: "", stderr: "")
+        }
+
+        do {
+            let result = try await subprocessRunner.launchctl("print", [trimmedTarget])
+            return LaunchctlPrintEvidence(
+                target: trimmedTarget,
+                exitCode: result.exitCode,
+                stdout: result.stdout,
+                stderr: result.stderr
+            )
+        } catch {
+            AppLogger.shared.warn("⚠️ [SystemStateProvider] launchctl print failed for target '\(trimmedTarget)': \(error)")
+            return LaunchctlPrintEvidence(
+                target: trimmedTarget,
+                exitCode: nil,
+                stdout: "",
+                stderr: String(describing: error)
+            )
+        }
+    }
+
     public nonisolated static func processIDsSynchronously(matching pattern: String) -> [pid_t] {
         let trimmedPattern = pattern.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmedPattern.isEmpty else { return [] }
@@ -149,5 +174,25 @@ public struct SystemProcessMatch: Equatable, Sendable {
     public init(pid: pid_t, command: String) {
         self.pid = pid
         self.command = command
+    }
+}
+
+public struct LaunchctlPrintEvidence: Equatable, Sendable {
+    public let target: String
+    public let exitCode: Int32?
+    public let stdout: String
+    public let stderr: String
+
+    public init(target: String, exitCode: Int32?, stdout: String, stderr: String) {
+        self.target = target
+        self.exitCode = exitCode
+        self.stdout = stdout
+        self.stderr = stderr
+    }
+
+    public var hasRunningProcessEvidence: Bool {
+        stdout.range(of: #"pid\s*=\s*\d+"#, options: .regularExpression) != nil
+            || stdout.contains("\"PID\"")
+            || stdout.contains("state = running")
     }
 }

--- a/Sources/KeyPathInstallationWizard/Core/VHIDDeviceManager.swift
+++ b/Sources/KeyPathInstallationWizard/Core/VHIDDeviceManager.swift
@@ -151,7 +151,7 @@ public final class VHIDDeviceManager: @unchecked Sendable {
                 return false
             case .timeout:
                 // Treat timeout as inconclusive; use fallback launchctl check before giving up
-                if await Self.fastLaunchctlCheck() { return true }
+                if await fastLaunchctlCheck() { return true }
                 if attempt < maxAttempts {
                     AppLogger.shared.log(
                         "⏳ [VHIDManager] Timeout while checking daemon; retrying to avoid false negatives"
@@ -261,8 +261,7 @@ public final class VHIDDeviceManager: @unchecked Sendable {
             let isRunning = processCount > 0
 
             if isRunning, processCount > 1 {
-                let vhidManager = VHIDDeviceManager()
-                let launchctlHealthy = await vhidManager.checkLaunchctlHealth()
+                let launchctlHealthy = await Self.checkVHIDLaunchctlHealth(using: systemStateProvider)
                 if launchctlHealthy == true {
                     AppLogger.shared.log(
                         "⚠️ [VHIDManager] pgrep reported \(processCount) processes but launchctl is healthy - likely race condition"
@@ -286,15 +285,14 @@ public final class VHIDDeviceManager: @unchecked Sendable {
 
     /// Fast check using launchctl print; used as a fallback when pgrep stalls.
     /// Note: Uses system domain since VHID daemon is a LaunchDaemon, not a user agent.
-    private static func fastLaunchctlCheck() async -> Bool {
-        do {
-            let result = try await SubprocessRunner.shared.launchctl("print", ["system/com.keypath.karabiner-vhiddaemon"])
-            // Check for running state or PID presence
-            return result.exitCode == 0 && (result.stdout.contains("pid =") || result.stdout.contains("state = running"))
-        } catch {
-            AppLogger.shared.log("❌ [VHIDManager] fastLaunchctlCheck failed: \(error)")
+    private func fastLaunchctlCheck() async -> Bool {
+        let evidence = await systemStateProvider.launchctlPrint(target: "system/com.keypath.karabiner-vhiddaemon")
+        guard evidence.exitCode == 0 else {
+            AppLogger.shared.log("❌ [VHIDManager] fastLaunchctlCheck failed: \(evidence.stderr)")
             return false
         }
+
+        return evidence.hasRunningProcessEvidence
     }
 
     /// Get actual PIDs of running VirtualHID daemon processes
@@ -321,26 +319,29 @@ public final class VHIDDeviceManager: @unchecked Sendable {
     /// - false if launchctl reports the service but unhealthy,
     /// - nil if the call fails (permission/lookup).
     public func checkLaunchctlHealth() async -> Bool? {
-        do {
-            let result = try await SubprocessRunner.shared.launchctl("print", ["system/com.keypath.karabiner-vhiddaemon"])
+        await Self.checkVHIDLaunchctlHealth(using: systemStateProvider)
+    }
 
-            guard result.exitCode == 0 else {
-                AppLogger.shared.log(
-                    "⚠️ [VHIDManager] launchctl health check exit=\(result.exitCode)"
-                )
-                return false
-            }
-
-            // Consider it healthy if a PID line exists
-            let healthy = result.stdout.contains("pid =") || result.stdout.contains("\"PID\"")
-            AppLogger.shared.log(
-                "🔍 [VHIDManager] launchctl health check healthy=\(healthy)"
-            )
-            return healthy
-        } catch {
-            AppLogger.shared.log("⚠️ [VHIDManager] launchctl health check failed: \(error)")
+    private static func checkVHIDLaunchctlHealth(using systemStateProvider: SystemStateProvider) async -> Bool? {
+        let evidence = await systemStateProvider.launchctlPrint(target: "system/com.keypath.karabiner-vhiddaemon")
+        guard let exitCode = evidence.exitCode else {
+            AppLogger.shared.log("⚠️ [VHIDManager] launchctl health check failed: \(evidence.stderr)")
             return nil
         }
+
+        guard exitCode == 0 else {
+            AppLogger.shared.log(
+                "⚠️ [VHIDManager] launchctl health check exit=\(exitCode)"
+            )
+            return false
+        }
+
+        // Consider it healthy if a PID line exists
+        let healthy = evidence.hasRunningProcessEvidence
+        AppLogger.shared.log(
+            "🔍 [VHIDManager] launchctl health check healthy=\(healthy)"
+        )
+        return healthy
     }
 
     /// Checks if VirtualHID daemon is functioning correctly (wizard prerequisite)

--- a/Tests/KeyPathTests/Core/SystemStateProviderLivenessTests.swift
+++ b/Tests/KeyPathTests/Core/SystemStateProviderLivenessTests.swift
@@ -132,6 +132,51 @@ final class SystemStateProviderLivenessTests: XCTestCase {
         XCTAssertEqual(matches, [])
     }
 
+    func testLaunchctlPrintDelegatesToInjectedSubprocessRunner() async {
+        let runner = SubprocessRunnerFake.shared
+        await runner.reset()
+        await runner.configureLaunchctlResult { subcommand, args in
+            if subcommand == "print", args == ["system/com.keypath.karabiner-vhiddaemon"] {
+                return ProcessResult(
+                    exitCode: 0,
+                    stdout: """
+                    state = running
+                    pid = 12345
+                    """,
+                    stderr: "",
+                    duration: 0.01
+                )
+            }
+            return ProcessResult(exitCode: 113, stdout: "", stderr: "not found", duration: 0.01)
+        }
+        let provider = SystemStateProvider(subprocessRunner: runner)
+
+        let evidence = await provider.launchctlPrint(target: "system/com.keypath.karabiner-vhiddaemon")
+        let commands = await runner.executedCommands
+
+        XCTAssertEqual(evidence.target, "system/com.keypath.karabiner-vhiddaemon")
+        XCTAssertEqual(evidence.exitCode, 0)
+        XCTAssertTrue(evidence.hasRunningProcessEvidence)
+        XCTAssertTrue(
+            commands.contains { $0.executable == "/bin/launchctl" && $0.args == ["print", "system/com.keypath.karabiner-vhiddaemon"] },
+            "SystemStateProvider should own launchctl print service-state evidence"
+        )
+    }
+
+    func testLaunchctlPrintRejectsBlankTargets() async {
+        let runner = SubprocessRunnerFake.shared
+        await runner.reset()
+        await runner.configureLaunchctlResult { _, _ in
+            XCTFail("Blank launchctl print targets must not invoke launchctl")
+            return ProcessResult(exitCode: 0, stdout: "", stderr: "", duration: 0.01)
+        }
+        let provider = SystemStateProvider(subprocessRunner: runner)
+
+        let evidence = await provider.launchctlPrint(target: "  \n\t  ")
+
+        XCTAssertEqual(evidence, LaunchctlPrintEvidence(target: "", exitCode: nil, stdout: "", stderr: ""))
+    }
+
     func testSynchronousProcessDiscoveryRejectsBlankPatterns() {
         let pids = SystemStateProvider.processIDsSynchronously(matching: "  \n\t  ")
 

--- a/Tests/KeyPathTests/Lint/LaunchctlEvidenceLintTests.swift
+++ b/Tests/KeyPathTests/Lint/LaunchctlEvidenceLintTests.swift
@@ -1,0 +1,57 @@
+import Foundation
+@preconcurrency import XCTest
+
+/// Guards launchctl evidence-read migration slices.
+///
+/// Mutating launchctl operations still belong to installer/helper execution paths.
+/// Read-only service-state evidence (`launchctl print`) should move behind
+/// SystemStateProvider as Phase 1 builds the executable snapshot.
+final class LaunchctlEvidenceLintTests: XCTestCase {
+    func testVHIDDeviceManagerDelegatesLaunchctlPrintEvidenceToSystemStateProvider() throws {
+        let manager = repositoryRoot()
+            .appendingPathComponent("Sources/KeyPathInstallationWizard/Core/VHIDDeviceManager.swift")
+
+        let violations = try matchingLines(
+            in: manager,
+            patterns: [
+                #"SubprocessRunner\.shared\.launchctl\("print""#,
+                #"subprocessRunner\.launchctl\("print""#,
+                #"/bin/launchctl print"#
+            ]
+        )
+
+        XCTAssertTrue(
+            violations.isEmpty,
+            """
+            VHIDDeviceManager must delegate launchctl print service-state \
+            evidence to SystemStateProvider:
+            \(violations.sorted().joined(separator: "\n"))
+            """
+        )
+    }
+}
+
+private func repositoryRoot(file: StaticString = #filePath) -> URL {
+    URL(fileURLWithPath: "\(file)")
+        .deletingLastPathComponent() // LaunchctlEvidenceLintTests.swift
+        .deletingLastPathComponent() // Lint
+        .deletingLastPathComponent() // KeyPathTests
+        .deletingLastPathComponent() // Tests
+}
+
+private func matchingLines(in fileURL: URL, patterns: [String]) throws -> [String] {
+    let contents = try String(contentsOf: fileURL, encoding: .utf8)
+    let regexes = try patterns.map { try NSRegularExpression(pattern: $0) }
+    let relativePath = fileURL.path.replacingOccurrences(of: repositoryRoot().path + "/", with: "")
+
+    var violations: [String] = []
+    for (idx, rawLine) in contents.components(separatedBy: .newlines).enumerated() {
+        let trimmed = rawLine.trimmingCharacters(in: .whitespaces)
+        if trimmed.hasPrefix("//") || trimmed.hasPrefix("///") || trimmed.hasPrefix("*") { continue }
+        let range = NSRange(rawLine.startIndex..., in: rawLine)
+        if regexes.contains(where: { $0.firstMatch(in: rawLine, range: range) != nil }) {
+            violations.append("\(relativePath):\(idx + 1): \(trimmed)")
+        }
+    }
+    return violations
+}

--- a/Tests/KeyPathTests/Services/VHIDDeviceManagerTests.swift
+++ b/Tests/KeyPathTests/Services/VHIDDeviceManagerTests.swift
@@ -123,6 +123,65 @@ final class VHIDDeviceManagerTests: XCTestCase {
         )
     }
 
+    func testCheckLaunchctlHealthUsesInjectedSystemStateProvider() async {
+        let runner = SubprocessRunnerFake.shared
+        await runner.reset()
+        await runner.configureLaunchctlResult { subcommand, args in
+            if subcommand == "print", args == ["system/com.keypath.karabiner-vhiddaemon"] {
+                return ProcessResult(
+                    exitCode: 0,
+                    stdout: """
+                    state = running
+                    pid = 24680
+                    """,
+                    stderr: "",
+                    duration: 0.01
+                )
+            }
+            return ProcessResult(exitCode: 113, stdout: "", stderr: "not found", duration: 0.01)
+        }
+
+        let provider = SystemStateProvider(subprocessRunner: runner)
+        let mgr = VHIDDeviceManager(systemStateProvider: provider)
+        let healthy = await mgr.checkLaunchctlHealth()
+        let commands = await runner.executedCommands
+
+        XCTAssertEqual(healthy, true)
+        XCTAssertTrue(
+            commands.contains { $0.executable == "/bin/launchctl" && $0.args == ["print", "system/com.keypath.karabiner-vhiddaemon"] },
+            "VHIDDeviceManager should use its injected provider for launchctl service-state evidence"
+        )
+    }
+
+    func testDuplicateProcessRaceUsesInjectedLaunchctlEvidence() async {
+        KeyPathCore.FeatureFlags.testStartupMode = false
+        VHIDDeviceManager.testPIDProvider = nil
+        let runner = SubprocessRunnerFake.shared
+        await runner.reset()
+        await runner.configurePgrepResult { pattern in
+            pattern == "Karabiner-VirtualHIDDevice-Daemon" ? [111, 222] : []
+        }
+        await runner.configureLaunchctlResult { subcommand, args in
+            if subcommand == "print", args == ["system/com.keypath.karabiner-vhiddaemon"] {
+                return ProcessResult(exitCode: 0, stdout: "pid = 111", stderr: "", duration: 0.01)
+            }
+            return ProcessResult(exitCode: 113, stdout: "", stderr: "not found", duration: 0.01)
+        }
+
+        let provider = SystemStateProvider(subprocessRunner: runner)
+        let mgr = VHIDDeviceManager(systemStateProvider: provider)
+        let running = await mgr.detectRunning()
+        let commands = await runner.executedCommands
+
+        XCTAssertTrue(running, "Injected launchctl evidence should suppress duplicate-process false positives")
+        XCTAssertTrue(
+            commands.contains { $0.executable == "/usr/bin/pgrep" && $0.args == ["-f", "Karabiner-VirtualHIDDevice-Daemon"] }
+        )
+        XCTAssertTrue(
+            commands.contains { $0.executable == "/bin/launchctl" && $0.args == ["print", "system/com.keypath.karabiner-vhiddaemon"] }
+        )
+    }
+
     // MARK: - Startup Mode Tests
 
     func testDetectRunning_StartupMode_DaemonRunning() async {

--- a/docs/planning/installer-reliability-phase1.md
+++ b/docs/planning/installer-reliability-phase1.md
@@ -117,6 +117,15 @@ classification remains pending.
   `PgrepProcessDiscoveryLintTests.testProcessLifecycleManagerDelegatesPgrepDiscoveryToSystemStateProvider`,
   `PgrepProcessDiscoveryLintTests.testHelperServiceDelegatesPgrepDiscoveryToSystemStateProvider`,
   and `PgrepProcessDiscoveryLintTests.testProductionPgrepDiscoveryIsCentralizedInCoreProvider`.
+- [x] Added provider-owned `launchctl print` service-state evidence and migrated
+  `VHIDDeviceManager`'s read-only VirtualHID launchd health checks to delegate
+  to it. Enforced by
+  `SystemStateProviderLivenessTests.testLaunchctlPrintDelegatesToInjectedSubprocessRunner`,
+  `SystemStateProviderLivenessTests.testLaunchctlPrintRejectsBlankTargets`,
+  `VHIDDeviceManagerTests.testCheckLaunchctlHealthUsesInjectedSystemStateProvider`,
+  `VHIDDeviceManagerTests.testDuplicateProcessRaceUsesInjectedLaunchctlEvidence`,
+  and
+  `LaunchctlEvidenceLintTests.testVHIDDeviceManagerDelegatesLaunchctlPrintEvidenceToSystemStateProvider`.
 - [ ] Migrate `launchctl`, `SMAppService.status`, permissions, VHID state, and
   helper freshness into a single immutable `SystemSnapshot`.
 - [ ] Build `classify(snapshot) -> StateMatrixRow -> plan` and table-driven
@@ -214,6 +223,14 @@ through 21 mocked tests).
   `SystemStateProvider`/`SubprocessRunner`, with no caller-owned production
   uses remaining. Enforced by
   `PgrepProcessDiscoveryLintTests.testProductionPgrepDiscoveryIsCentralizedInCoreProvider`.
+- [x] `VHIDDeviceManager` read-only `launchctl print` service-state evidence
+  delegates to `SystemStateProvider.launchctlPrint(target:)`. Enforced by
+  `SystemStateProviderLivenessTests.testLaunchctlPrintDelegatesToInjectedSubprocessRunner`,
+  `SystemStateProviderLivenessTests.testLaunchctlPrintRejectsBlankTargets`,
+  `VHIDDeviceManagerTests.testCheckLaunchctlHealthUsesInjectedSystemStateProvider`,
+  `VHIDDeviceManagerTests.testDuplicateProcessRaceUsesInjectedLaunchctlEvidence`,
+  and
+  `LaunchctlEvidenceLintTests.testVHIDDeviceManagerDelegatesLaunchctlPrintEvidenceToSystemStateProvider`.
 
 ## Workstream 3: Industry-Standard Repair Model
 
@@ -346,7 +363,10 @@ is listed in the state-matrix doc's enforcement section.
 - [x] `PgrepProcessDiscoveryLintTests.testProductionPgrepDiscoveryIsCentralizedInCoreProvider`
   blocks production `pgrep` process discovery outside the core provider
   implementation.
-- [ ] Add `launchctl`, postcondition, and snapshot-cache
+- [x] `LaunchctlEvidenceLintTests.testVHIDDeviceManagerDelegatesLaunchctlPrintEvidenceToSystemStateProvider`
+  prevents `VHIDDeviceManager` from regrowing direct `launchctl print`
+  service-state reads.
+- [ ] Add remaining `launchctl`, postcondition, and snapshot-cache
   ratchets with the corresponding migration slices.
 
 ## Workstream 6: Deletion Pass

--- a/docs/process/installer-repair-state-matrix.md
+++ b/docs/process/installer-repair-state-matrix.md
@@ -178,6 +178,16 @@ the result as user action required and name the approval surface.
   `PgrepProcessDiscoveryLintTests.testHelperServiceDelegatesPgrepDiscoveryToSystemStateProvider`,
   and `PgrepProcessDiscoveryLintTests.testProductionPgrepDiscoveryIsCentralizedInCoreProvider`
   block migrated runtime/system-validator/Karabiner-conflict/VHID/diagnostics/launcher/process-lifecycle/helper consumers from bypassing it.
+- Read-only `launchctl print` service-state evidence belongs in
+  `SystemStateProvider.launchctlPrint(target:)`; mutating launchctl operations
+  remain installer/helper actions, not state reads.
+  `SystemStateProviderLivenessTests.testLaunchctlPrintDelegatesToInjectedSubprocessRunner`
+  and `SystemStateProviderLivenessTests.testLaunchctlPrintRejectsBlankTargets`
+  pin the provider contract, while
+  `VHIDDeviceManagerTests.testCheckLaunchctlHealthUsesInjectedSystemStateProvider`,
+  `VHIDDeviceManagerTests.testDuplicateProcessRaceUsesInjectedLaunchctlEvidence`,
+  and `LaunchctlEvidenceLintTests.testVHIDDeviceManagerDelegatesLaunchctlPrintEvidenceToSystemStateProvider`
+  block migrated VirtualHID health checks from bypassing it.
 - User-facing CLI/reporting shape belongs in CLI contract tests.
 
 ## Related References


### PR DESCRIPTION
## Summary
- add `SystemStateProvider.launchctlPrint(target:)` as the provider-owned primitive for read-only launchd service-state evidence
- route `VHIDDeviceManager` VirtualHID `launchctl print` health and fallback checks through the injected `SystemStateProvider`
- add the matching `LaunchctlEvidenceLintTests` ratchet and update the Phase 1/state-matrix docs

## Acceptance criteria completed
- `SystemStateProviderLivenessTests.testLaunchctlPrintDelegatesToInjectedSubprocessRunner`
- `SystemStateProviderLivenessTests.testLaunchctlPrintRejectsBlankTargets`
- `VHIDDeviceManagerTests.testCheckLaunchctlHealthUsesInjectedSystemStateProvider`
- `VHIDDeviceManagerTests.testDuplicateProcessRaceUsesInjectedLaunchctlEvidence`
- `LaunchctlEvidenceLintTests.testVHIDDeviceManagerDelegatesLaunchctlPrintEvidenceToSystemStateProvider`

## Validation
- `TEST_FILTER='SystemStateProviderLivenessTests|VHIDDeviceManagerTests|LaunchctlEvidenceLintTests' ./Scripts/run-tests-safe.sh` passed: 36 tests
- `git diff --check` passed
- `python3 Scripts/check-accessibility.py` passed: 352 files clean
- `./Scripts/run-tests-safe.sh` passed: 4,467 tests, runner summary `lane=full exit=0`, build/test Swift warnings 0

## Plan/code reality note
This PR centralizes read-only `launchctl print` evidence. It does not ban or migrate mutating `launchctl` bootstrap/bootout/kickstart actions because those remain installer/helper action execution paths, not state reads. The state-matrix doc is updated in this PR to make that boundary explicit.

## Review gate
The required local `/thermo-nuclear-swift-review` command is still unavailable in this Codex shell: `claude` is not on `PATH`, and no local `thermo-nuclear-swift-review` command file was discoverable. I am leaving this PR as draft until the GitHub review/check gate reports.
