### PR TITLE
Route service health launchctl evidence through SystemStateProvider

### DIFF
--- a/Sources/KeyPathInstallationWizard/Core/ServiceHealthChecker.swift
+++ b/Sources/KeyPathInstallationWizard/Core/ServiceHealthChecker.swift
@@ -91,13 +91,16 @@ public final class ServiceHealthChecker: @unchecked Sendable {
 
     // MARK: - Dependencies
 
-    private let subprocessRunner: SubprocessRunner
+    private let subprocessRunner: any SubprocessRunning
+    private let systemStateProvider: SystemStateProvider
 
     @MainActor
     public init(
-        subprocessRunner: SubprocessRunner = .shared
+        subprocessRunner: any SubprocessRunning = SubprocessRunner.shared,
+        systemStateProvider: SystemStateProvider = .shared
     ) {
         self.subprocessRunner = subprocessRunner
+        self.systemStateProvider = systemStateProvider
     }
 
     /// Access daemon manager via WizardDependencies (async to allow actor hop).
@@ -273,19 +276,19 @@ public final class ServiceHealthChecker: @unchecked Sendable {
             return exists
         }
 
-        do {
-            let result = try await subprocessRunner.launchctl("print", ["system/\(serviceID)"])
-            let isLoaded = result.exitCode == 0
+        let evidence = await systemStateProvider.launchctlPrint(target: "system/\(serviceID)")
+        guard let exitCode = evidence.exitCode else {
             AppLogger.shared.log(
-                "🔍 [ServiceHealthChecker] (system) Service \(serviceID) loaded: \(isLoaded)"
-            )
-            return isLoaded
-        } catch {
-            AppLogger.shared.log(
-                "❌ [ServiceHealthChecker] Error checking service \(serviceID): \(error)"
+                "❌ [ServiceHealthChecker] Error checking service \(serviceID): \(evidence.stderr)"
             )
             return false
         }
+
+        let isLoaded = exitCode == 0
+        AppLogger.shared.log(
+            "🔍 [ServiceHealthChecker] (system) Service \(serviceID) loaded: \(isLoaded)"
+        )
+        return isLoaded
     }
 
     // MARK: - Service Health Check
@@ -364,85 +367,85 @@ public final class ServiceHealthChecker: @unchecked Sendable {
         }
 
         AppLogger.shared.log(
-            "🔍 [ServiceHealthChecker] About to call SubprocessRunner.launchctl(\"print\", [\"system/\(serviceID)\"])..."
+            "🔍 [ServiceHealthChecker] About to call SystemStateProvider.launchctlPrint(target: \"system/\(serviceID)\")..."
         )
-        do {
-            let result = try await subprocessRunner.launchctl("print", ["system/\(serviceID)"])
-            let launchctlDuration = Date().timeIntervalSince(startTime)
-            AppLogger.shared.log(
-                "🔍 [ServiceHealthChecker] SubprocessRunner.launchctl() returned (took \(String(format: "%.3f", launchctlDuration))s, exitCode=\(result.exitCode))"
-            )
+        let evidence = await systemStateProvider.launchctlPrint(target: "system/\(serviceID)")
+        let launchctlDuration = Date().timeIntervalSince(startTime)
+        AppLogger.shared.log(
+            "🔍 [ServiceHealthChecker] SystemStateProvider.launchctlPrint() returned (took \(String(format: "%.3f", launchctlDuration))s, exitCode=\(evidence.exitCode?.description ?? "nil"))"
+        )
 
-            guard result.exitCode == 0 else {
-                AppLogger.shared.log(
-                    "🔍 [ServiceHealthChecker] \(serviceID) not found in system domain"
-                )
-                return false
-            }
-
-            let output = result.stdout
-
-            // Extract details from 'launchctl print' output
-            let state = output.firstMatchString(pattern: #"state\s*=\s*([A-Za-z]+)"#)?.lowercased()
-            let pid =
-                output.firstMatchInt(pattern: #"\bpid\s*=\s*([0-9]+)"#)
-                    ?? output.firstMatchInt(pattern: #""PID"\s*=\s*([0-9]+)"#)
-            let lastExit =
-                output.firstMatchInt(pattern: #"last exit (?:status|code)\s*=\s*(-?\d+)"#)
-                    ?? output.firstMatchInt(pattern: #""LastExitStatus"\s*=\s*(-?\d+)"#)
-
-            let isOneShot = (serviceID == Self.vhidManagerServiceID)
-            let isRunningLike = (state == "running" || state == "launching")
-            let hasPID = (pid != nil)
-            let inWarmup = ServiceBootstrapper.wasRecentlyRestarted(serviceID)
-
-            var healthy = false
-            if isOneShot {
-                // One-shot services run once and exit - this is normal behavior
-                if let lastExit {
-                    // If we have exit status, it must be clean (0)
-                    healthy = (lastExit == 0)
-                } else if isRunningLike || hasPID || inWarmup {
-                    // Service currently running or starting up
-                    healthy = true
-                } else {
-                    // No exit status and not running - assume it ran successfully
-                    // This is normal for one-shot services that run at boot
-                    AppLogger.shared.log(
-                        "🔍 [ServiceHealthChecker] One-shot service \(serviceID) not running (normal) - assuming healthy"
-                    )
-                    healthy = true
-                }
-            } else {
-                // KeepAlive jobs should be running. Allow starting states or warm-up.
-                if isRunningLike || hasPID {
-                    healthy = true
-                } else if inWarmup {
-                    healthy = true
-                } // starting up
-                else {
-                    healthy = false
-                }
-            }
-
-            AppLogger.shared.log("🔍 [ServiceHealthChecker] HEALTH ANALYSIS \(serviceID):")
-            AppLogger.shared
-                .log(
-                    "    state=\(state ?? "nil"), pid=\(pid?.description ?? "nil"), lastExit=\(lastExit?.description ?? "nil"), oneShot=\(isOneShot), warmup=\(inWarmup), healthy=\(healthy)"
-                )
-
+        guard let exitCode = evidence.exitCode else {
             let totalDuration = Date().timeIntervalSince(startTime)
             AppLogger.shared.log(
-                "🔍 [ServiceHealthChecker] isServiceHealthy() EXIT - Returning \(healthy) for \(serviceID) (total: \(String(format: "%.3f", totalDuration))s)"
-            )
-            return healthy
-        } catch {
-            let totalDuration = Date().timeIntervalSince(startTime)
-            AppLogger.shared.log(
-                "❌ [ServiceHealthChecker] isServiceHealthy() EXIT (ERROR) - Error checking service health \(serviceID): \(error) (total: \(String(format: "%.3f", totalDuration))s)"
+                "❌ [ServiceHealthChecker] isServiceHealthy() EXIT (ERROR) - Error checking service health \(serviceID): \(evidence.stderr) (total: \(String(format: "%.3f", totalDuration))s)"
             )
             return false
         }
+
+        guard exitCode == 0 else {
+            AppLogger.shared.log(
+                "🔍 [ServiceHealthChecker] \(serviceID) not found in system domain"
+            )
+            return false
+        }
+
+        let output = evidence.stdout
+
+        // Extract details from 'launchctl print' output
+        let state = output.firstMatchString(pattern: #"state\s*=\s*([A-Za-z]+)"#)?.lowercased()
+        let pid =
+            output.firstMatchInt(pattern: #"\bpid\s*=\s*([0-9]+)"#)
+                ?? output.firstMatchInt(pattern: #""PID"\s*=\s*([0-9]+)"#)
+        let lastExit =
+            output.firstMatchInt(pattern: #"last exit (?:status|code)\s*=\s*(-?\d+)"#)
+                ?? output.firstMatchInt(pattern: #""LastExitStatus"\s*=\s*(-?\d+)"#)
+
+        let isOneShot = (serviceID == Self.vhidManagerServiceID)
+        let isRunningLike = (state == "running" || state == "launching")
+        let hasPID = (pid != nil)
+        let inWarmup = ServiceBootstrapper.wasRecentlyRestarted(serviceID)
+
+        var healthy = false
+        if isOneShot {
+            // One-shot services run once and exit - this is normal behavior
+            if let lastExit {
+                // If we have exit status, it must be clean (0)
+                healthy = (lastExit == 0)
+            } else if isRunningLike || hasPID || inWarmup {
+                // Service currently running or starting up
+                healthy = true
+            } else {
+                // No exit status and not running - assume it ran successfully
+                // This is normal for one-shot services that run at boot
+                AppLogger.shared.log(
+                    "🔍 [ServiceHealthChecker] One-shot service \(serviceID) not running (normal) - assuming healthy"
+                )
+                healthy = true
+            }
+        } else {
+            // KeepAlive jobs should be running. Allow starting states or warm-up.
+            if isRunningLike || hasPID {
+                healthy = true
+            } else if inWarmup {
+                healthy = true
+            } // starting up
+            else {
+                healthy = false
+            }
+        }
+
+        AppLogger.shared.log("🔍 [ServiceHealthChecker] HEALTH ANALYSIS \(serviceID):")
+        AppLogger.shared
+            .log(
+                "    state=\(state ?? "nil"), pid=\(pid?.description ?? "nil"), lastExit=\(lastExit?.description ?? "nil"), oneShot=\(isOneShot), warmup=\(inWarmup), healthy=\(healthy)"
+            )
+
+        let totalDuration = Date().timeIntervalSince(startTime)
+        AppLogger.shared.log(
+            "🔍 [ServiceHealthChecker] isServiceHealthy() EXIT - Returning \(healthy) for \(serviceID) (total: \(String(format: "%.3f", totalDuration))s)"
+        )
+        return healthy
     }
 
     // MARK: - Comprehensive Status
@@ -686,23 +689,22 @@ public final class ServiceHealthChecker: @unchecked Sendable {
     {
         var lastExitCode: Int32?
         for target in launchctlTargets {
-            do {
-                let result = try await subprocessRunner.launchctl("print", [target])
-                lastExitCode = result.exitCode
-                if result.exitCode != 0 {
-                    continue
+            let evidence = await systemStateProvider.launchctlPrint(target: target)
+            lastExitCode = evidence.exitCode
+            guard evidence.exitCode == 0 else {
+                if evidence.exitCode == nil {
+                    AppLogger.shared.warn("⚠️ [ServiceHealthChecker] launchctl check failed for \(target): \(evidence.stderr)")
                 }
+                continue
+            }
 
-                for line in result.stdout.components(separatedBy: "\n") where line.contains("pid =") {
-                    let components = line.components(separatedBy: "=")
-                    if components.count == 2,
-                       Int(components[1].trimmingCharacters(in: .whitespaces)) != nil
-                    {
-                        return (true, result.exitCode)
-                    }
+            for line in evidence.stdout.components(separatedBy: "\n") where line.contains("pid =") {
+                let components = line.components(separatedBy: "=")
+                if components.count == 2,
+                   Int(components[1].trimmingCharacters(in: .whitespaces)) != nil
+                {
+                    return (true, evidence.exitCode)
                 }
-            } catch {
-                AppLogger.shared.warn("⚠️ [ServiceHealthChecker] launchctl check failed for \(target): \(error)")
             }
         }
         return (false, lastExitCode)

--- a/Tests/KeyPathTests/Lint/LaunchctlEvidenceLintTests.swift
+++ b/Tests/KeyPathTests/Lint/LaunchctlEvidenceLintTests.swift
@@ -7,12 +7,29 @@ import Foundation
 /// Read-only service-state evidence (`launchctl print`) should move behind
 /// SystemStateProvider as Phase 1 builds the executable snapshot.
 final class LaunchctlEvidenceLintTests: XCTestCase {
-    func testVHIDDeviceManagerDelegatesLaunchctlPrintEvidenceToSystemStateProvider() throws {
+    func testVHIDDeviceManagerDelegatesLaunchctlPrintEvidenceToSystemStateProvider() {
         let manager = repositoryRoot()
             .appendingPathComponent("Sources/KeyPathInstallationWizard/Core/VHIDDeviceManager.swift")
 
+        assertNoDirectLaunchctlPrintEvidenceReads(in: manager)
+    }
+
+    func testServiceHealthCheckerDelegatesLaunchctlPrintEvidenceToSystemStateProvider() {
+        let checker = repositoryRoot()
+            .appendingPathComponent("Sources/KeyPathInstallationWizard/Core/ServiceHealthChecker.swift")
+
+        assertNoDirectLaunchctlPrintEvidenceReads(in: checker)
+    }
+}
+
+private func assertNoDirectLaunchctlPrintEvidenceReads(
+    in fileURL: URL,
+    file: StaticString = #filePath,
+    line: UInt = #line
+) {
+    do {
         let violations = try matchingLines(
-            in: manager,
+            in: fileURL,
             patterns: [
                 #"SubprocessRunner\.shared\.launchctl\("print""#,
                 #"subprocessRunner\.launchctl\("print""#,
@@ -23,11 +40,15 @@ final class LaunchctlEvidenceLintTests: XCTestCase {
         XCTAssertTrue(
             violations.isEmpty,
             """
-            VHIDDeviceManager must delegate launchctl print service-state \
+            Production code must delegate launchctl print service-state \
             evidence to SystemStateProvider:
             \(violations.sorted().joined(separator: "\n"))
-            """
+            """,
+            file: file,
+            line: line
         )
+    } catch {
+        XCTFail("Failed to inspect \(fileURL.path): \(error)", file: file, line: line)
     }
 }
 

--- a/Tests/KeyPathTests/Services/ServiceHealthCheckerTests.swift
+++ b/Tests/KeyPathTests/Services/ServiceHealthCheckerTests.swift
@@ -2,6 +2,7 @@ import Foundation
 @testable import KeyPathAppKit
 @testable import KeyPathCore
 @testable import KeyPathInstallationWizard
+@testable import KeyPathWizardCore
 import ServiceManagement
 @preconcurrency import XCTest
 
@@ -13,10 +14,12 @@ final class ServiceHealthCheckerTests: XCTestCase {
     private var originalAllowAdminOperationsInTests = false
     private nonisolated(unsafe) var originalSMFactory: ((String) -> SMAppServiceProtocol)!
     private nonisolated(unsafe) var originalStatusProvider: SMAppServiceStatusProvider!
+    private nonisolated(unsafe) var originalDaemonManager: (any WizardDaemonManaging)?
 
     override func setUp() async throws {
         try await super.setUp()
         originalStatusProvider = SMAppServiceStatusProvider.shared
+        originalDaemonManager = await MainActor.run { WizardDependencies.daemonManager }
         checker = await MainActor.run { ServiceHealthChecker.shared }
         // The shared singleton's 2s-TTL health cache can carry entries from
         // other suites in the same process (e.g. InstallerEngine tests that
@@ -49,6 +52,7 @@ final class ServiceHealthCheckerTests: XCTestCase {
         checker = nil
         KanataDaemonManager.smServiceFactory = originalSMFactory
         SMAppServiceStatusProvider.shared = originalStatusProvider
+        await MainActor.run { WizardDependencies.daemonManager = originalDaemonManager }
         TestEnvironment.allowAdminOperationsInTests = originalAllowAdminOperationsInTests
         if let originalSudoEnv {
             setenv("KEYPATH_USE_SUDO", originalSudoEnv, 1)
@@ -74,6 +78,7 @@ final class ServiceHealthCheckerTests: XCTestCase {
         originalSudoEnv = nil
         originalAllowAdminOperationsInTests = false
         originalSMFactory = nil
+        originalDaemonManager = nil
         try await super.tearDown()
     }
 
@@ -82,6 +87,36 @@ final class ServiceHealthCheckerTests: XCTestCase {
 
         func register() throws {}
         func unregister() async throws {}
+    }
+
+    @MainActor
+    private final class FakeDaemonManager: WizardDaemonManaging, @unchecked Sendable {
+        let state: WizardServiceManagementState
+        let targets: [String]
+        var registeredButNotLoaded = false
+        nonisolated let kanataServiceID = ServiceHealthChecker.kanataServiceID
+        nonisolated let legacyPlistPath = "/Library/LaunchDaemons/com.keypath.kanata.plist"
+
+        init(state: WizardServiceManagementState, targets: [String]) {
+            self.state = state
+            self.targets = targets
+        }
+
+        func refreshManagementState() async -> WizardServiceManagementState {
+            state
+        }
+
+        func isRegisteredButNotLoaded() async -> Bool {
+            registeredButNotLoaded
+        }
+
+        func register() async throws {}
+
+        func unregister() async throws {}
+
+        func preferredLaunchctlTargets(for _: WizardServiceManagementState) -> [String] {
+            targets
+        }
     }
 
     private func writeEmptyPlist(serviceID: String) throws {
@@ -147,10 +182,72 @@ final class ServiceHealthCheckerTests: XCTestCase {
         XCTAssertTrue(managerLoaded)
     }
 
+    func testIsServiceLoadedDelegatesLaunchctlPrintToSystemStateProvider() async {
+        TestEnvironment.allowAdminOperationsInTests = true
+        let runner = SubprocessRunnerFake.shared
+        await runner.reset()
+        await runner.configureLaunchctlResult { subcommand, args in
+            if subcommand == "print", args == ["system/\(ServiceHealthChecker.vhidManagerServiceID)"] {
+                return ProcessResult(exitCode: 0, stdout: "state = running", stderr: "", duration: 0.01)
+            }
+            return ProcessResult(exitCode: 113, stdout: "", stderr: "not found", duration: 0.01)
+        }
+        let provider = SystemStateProvider(subprocessRunner: runner)
+        let checker = await MainActor.run {
+            ServiceHealthChecker(subprocessRunner: runner, systemStateProvider: provider)
+        }
+
+        let loaded = await checker.isServiceLoaded(serviceID: ServiceHealthChecker.vhidManagerServiceID)
+        let commands = await runner.executedCommands
+
+        XCTAssertTrue(loaded)
+        XCTAssertTrue(
+            commands.contains {
+                $0.executable == "/bin/launchctl"
+                    && $0.args == ["print", "system/\(ServiceHealthChecker.vhidManagerServiceID)"]
+            }
+        )
+    }
+
     func testIsServiceHealthyUsesPlistExistenceInTestMode() async throws {
         try writeEmptyPlist(serviceID: ServiceHealthChecker.kanataServiceID)
         let healthy = await checker.isServiceHealthy(serviceID: ServiceHealthChecker.kanataServiceID)
         XCTAssertTrue(healthy)
+    }
+
+    func testIsServiceHealthyDelegatesLaunchctlPrintToSystemStateProvider() async {
+        TestEnvironment.allowAdminOperationsInTests = true
+        let runner = SubprocessRunnerFake.shared
+        await runner.reset()
+        await runner.configureLaunchctlResult { subcommand, args in
+            if subcommand == "print", args == ["system/\(ServiceHealthChecker.vhidManagerServiceID)"] {
+                return ProcessResult(
+                    exitCode: 0,
+                    stdout: """
+                    state = exited
+                    last exit status = 0
+                    """,
+                    stderr: "",
+                    duration: 0.01
+                )
+            }
+            return ProcessResult(exitCode: 113, stdout: "", stderr: "not found", duration: 0.01)
+        }
+        let provider = SystemStateProvider(subprocessRunner: runner)
+        let checker = await MainActor.run {
+            ServiceHealthChecker(subprocessRunner: runner, systemStateProvider: provider)
+        }
+
+        let healthy = await checker.isServiceHealthy(serviceID: ServiceHealthChecker.vhidManagerServiceID)
+        let commands = await runner.executedCommands
+
+        XCTAssertTrue(healthy)
+        XCTAssertTrue(
+            commands.contains {
+                $0.executable == "/bin/launchctl"
+                    && $0.args == ["print", "system/\(ServiceHealthChecker.vhidManagerServiceID)"]
+            }
+        )
     }
 
     func testIsServiceHealthyReturnsFalseForInvalidServiceID() async {
@@ -162,6 +259,58 @@ final class ServiceHealthCheckerTests: XCTestCase {
         let health = await checker.checkKanataServiceHealth()
         XCTAssertFalse(health.isRunning)
         XCTAssertFalse(health.isResponding)
+    }
+
+    func testKanataRuntimeSnapshotDelegatesLaunchctlTargetsToSystemStateProvider() async {
+        TestEnvironment.allowAdminOperationsInTests = true
+        #if DEBUG
+            ServiceHealthChecker.vhidDriverExtensionEnabledOverride = { true }
+            ServiceHealthChecker.inputCaptureStatusOverride = { .ready }
+            ServiceHealthChecker.recentlyRestartedOverride = { _, _ in false }
+        #endif
+
+        let runner = SubprocessRunnerFake.shared
+        await runner.reset()
+        await runner.configureLaunchctlResult { subcommand, args in
+            if subcommand == "print", args == ["system/\(ServiceHealthChecker.kanataServiceID)"] {
+                return ProcessResult(
+                    exitCode: 0,
+                    stdout: """
+                    state = running
+                    pid = 24680
+                    """,
+                    stderr: "",
+                    duration: 0.01
+                )
+            }
+            return ProcessResult(exitCode: 113, stdout: "", stderr: "not found", duration: 0.01)
+        }
+        let provider = SystemStateProvider(subprocessRunner: runner)
+        let checker = await MainActor.run {
+            ServiceHealthChecker(subprocessRunner: runner, systemStateProvider: provider)
+        }
+        await MainActor.run {
+            WizardDependencies.daemonManager = FakeDaemonManager(
+                state: .legacyActive,
+                targets: ["system/\(ServiceHealthChecker.kanataServiceID)"]
+            )
+        }
+
+        let snapshot = await checker.checkKanataServiceRuntimeSnapshot(
+            managementState: .legacyActive,
+            staleEnabledRegistration: false,
+            timeoutMs: 1
+        )
+        let commands = await runner.executedCommands
+
+        XCTAssertTrue(snapshot.isRunning)
+        XCTAssertEqual(snapshot.launchctlExitCode, 0)
+        XCTAssertTrue(
+            commands.contains {
+                $0.executable == "/bin/launchctl"
+                    && $0.args == ["print", "system/\(ServiceHealthChecker.kanataServiceID)"]
+            }
+        )
     }
 
     func testSystemExtensionsOutputShowsVHIDDriverEnabledOnlyForActivatedEnabled() {

--- a/docs/planning/installer-reliability-phase1.md
+++ b/docs/planning/installer-reliability-phase1.md
@@ -126,6 +126,14 @@ classification remains pending.
   `VHIDDeviceManagerTests.testDuplicateProcessRaceUsesInjectedLaunchctlEvidence`,
   and
   `LaunchctlEvidenceLintTests.testVHIDDeviceManagerDelegatesLaunchctlPrintEvidenceToSystemStateProvider`.
+- [x] Migrated `ServiceHealthChecker`'s read-only `launchctl print` loaded,
+  health, and Kanata runtime-snapshot evidence to
+  `SystemStateProvider.launchctlPrint(target:)`. Enforced by
+  `ServiceHealthCheckerTests.testIsServiceLoadedDelegatesLaunchctlPrintToSystemStateProvider`,
+  `ServiceHealthCheckerTests.testIsServiceHealthyDelegatesLaunchctlPrintToSystemStateProvider`,
+  `ServiceHealthCheckerTests.testKanataRuntimeSnapshotDelegatesLaunchctlTargetsToSystemStateProvider`,
+  and
+  `LaunchctlEvidenceLintTests.testServiceHealthCheckerDelegatesLaunchctlPrintEvidenceToSystemStateProvider`.
 - [ ] Migrate `launchctl`, `SMAppService.status`, permissions, VHID state, and
   helper freshness into a single immutable `SystemSnapshot`.
 - [ ] Build `classify(snapshot) -> StateMatrixRow -> plan` and table-driven
@@ -231,6 +239,14 @@ through 21 mocked tests).
   `VHIDDeviceManagerTests.testDuplicateProcessRaceUsesInjectedLaunchctlEvidence`,
   and
   `LaunchctlEvidenceLintTests.testVHIDDeviceManagerDelegatesLaunchctlPrintEvidenceToSystemStateProvider`.
+- [x] `ServiceHealthChecker` read-only `launchctl print` loaded, health, and
+  runtime-snapshot evidence delegates to
+  `SystemStateProvider.launchctlPrint(target:)`. Enforced by
+  `ServiceHealthCheckerTests.testIsServiceLoadedDelegatesLaunchctlPrintToSystemStateProvider`,
+  `ServiceHealthCheckerTests.testIsServiceHealthyDelegatesLaunchctlPrintToSystemStateProvider`,
+  `ServiceHealthCheckerTests.testKanataRuntimeSnapshotDelegatesLaunchctlTargetsToSystemStateProvider`,
+  and
+  `LaunchctlEvidenceLintTests.testServiceHealthCheckerDelegatesLaunchctlPrintEvidenceToSystemStateProvider`.
 
 ## Workstream 3: Industry-Standard Repair Model
 
@@ -365,6 +381,9 @@ is listed in the state-matrix doc's enforcement section.
   implementation.
 - [x] `LaunchctlEvidenceLintTests.testVHIDDeviceManagerDelegatesLaunchctlPrintEvidenceToSystemStateProvider`
   prevents `VHIDDeviceManager` from regrowing direct `launchctl print`
+  service-state reads.
+- [x] `LaunchctlEvidenceLintTests.testServiceHealthCheckerDelegatesLaunchctlPrintEvidenceToSystemStateProvider`
+  prevents `ServiceHealthChecker` from regrowing direct `launchctl print`
   service-state reads.
 - [ ] Add remaining `launchctl`, postcondition, and snapshot-cache
   ratchets with the corresponding migration slices.

--- a/docs/process/installer-repair-state-matrix.md
+++ b/docs/process/installer-repair-state-matrix.md
@@ -188,6 +188,11 @@ the result as user action required and name the approval surface.
   `VHIDDeviceManagerTests.testDuplicateProcessRaceUsesInjectedLaunchctlEvidence`,
   and `LaunchctlEvidenceLintTests.testVHIDDeviceManagerDelegatesLaunchctlPrintEvidenceToSystemStateProvider`
   block migrated VirtualHID health checks from bypassing it.
+  `ServiceHealthCheckerTests.testIsServiceLoadedDelegatesLaunchctlPrintToSystemStateProvider`,
+  `ServiceHealthCheckerTests.testIsServiceHealthyDelegatesLaunchctlPrintToSystemStateProvider`,
+  `ServiceHealthCheckerTests.testKanataRuntimeSnapshotDelegatesLaunchctlTargetsToSystemStateProvider`,
+  and `LaunchctlEvidenceLintTests.testServiceHealthCheckerDelegatesLaunchctlPrintEvidenceToSystemStateProvider`
+  block migrated service-health checks from bypassing it.
 - User-facing CLI/reporting shape belongs in CLI contract tests.
 
 ## Related References


### PR DESCRIPTION
## Summary
- inject `SystemStateProvider` into `ServiceHealthChecker`
- route read-only `launchctl print` service loaded, service health, and Kanata runtime-snapshot probes through `SystemStateProvider.launchctlPrint(target:)`
- extend `LaunchctlEvidenceLintTests` and Phase 1/state-matrix docs for this migrated consumer

## Acceptance criteria completed
- `ServiceHealthCheckerTests.testIsServiceLoadedDelegatesLaunchctlPrintToSystemStateProvider`
- `ServiceHealthCheckerTests.testIsServiceHealthyDelegatesLaunchctlPrintToSystemStateProvider`
- `ServiceHealthCheckerTests.testKanataRuntimeSnapshotDelegatesLaunchctlTargetsToSystemStateProvider`
- `LaunchctlEvidenceLintTests.testServiceHealthCheckerDelegatesLaunchctlPrintEvidenceToSystemStateProvider`

## Validation
- `TEST_FILTER='ServiceHealthCheckerTests|LaunchctlEvidenceLintTests|SystemStateProviderLivenessTests' ./Scripts/run-tests-safe.sh` passed: 45 tests
- `git diff --check` passed
- `python3 Scripts/check-accessibility.py` passed: 352 files clean
- direct launchctl-print scan only finds `SystemStateProvider` and the lint pattern string
- `./Scripts/run-tests-safe.sh` passed: 4,471 tests, runner summary `lane=full exit=0`, build/test Swift warnings 0

## Plan/code reality note
This continues the read-only `launchctl print` evidence migration. Mutating `launchctl` bootstrap/bootout/kickstart/list actions remain action/execution paths and are intentionally out of this evidence-read ratchet.

## Review gate
The required local `/thermo-nuclear-swift-review` command is still unavailable in this Codex shell: `claude` is not on `PATH`, and no local `thermo-nuclear-swift-review` command file was discoverable. I am leaving this PR as draft until the GitHub review/check gate reports.
