### PR TITLE
Route Kanata daemon launchctl evidence through SystemStateProvider

### DIFF
--- a/Sources/KeyPathAppKit/Managers/KanataDaemonManager.swift
+++ b/Sources/KeyPathAppKit/Managers/KanataDaemonManager.swift
@@ -210,20 +210,15 @@ public class KanataDaemonManager {
         let smStatus = await SMAppServiceStatusProvider.shared.cachedStatus(for: Self.kanataPlistName)
         if smStatus == .enabled { return true }
 
-        // Best-effort check: does launchd know about the job?
-        do {
-            let result = try await subprocessRunner.launchctl("print", ["system/\(Self.kanataServiceID)"])
-            if result.exitCode == 0 {
-                let s = result.stdout
-                if s.contains("program") || s.contains("state =") || s.contains("pid =") {
-                    AppLogger.shared.log(
-                        "ℹ️ [KanataDaemonManager] launchctl reports daemon present while SMAppService status=\(smStatus)"
-                    )
-                    return true
-                }
+        let evidence = await systemStateProvider.launchctlPrint(target: "system/\(Self.kanataServiceID)")
+        if evidence.exitCode == 0 {
+            let s = evidence.stdout
+            if s.contains("program") || s.contains("state =") || s.contains("pid =") {
+                AppLogger.shared.log(
+                    "ℹ️ [KanataDaemonManager] launchctl reports daemon present while SMAppService status=\(smStatus)"
+                )
+                return true
             }
-        } catch {
-            // Ignore; treated as not installed
         }
         return false
     }
@@ -345,16 +340,12 @@ public class KanataDaemonManager {
     {
         var outputs: [(target: String, output: String, exitCode: Int32?)] = []
         for target in Self.preferredLaunchctlTargets(for: managementState) {
-            do {
-                let result = try await subprocessRunner.launchctl("print", [target])
-                outputs.append((
-                    target: target,
-                    output: result.exitCode == 0 ? result.stdout : "",
-                    exitCode: result.exitCode
-                ))
-            } catch {
-                outputs.append((target: target, output: "", exitCode: nil))
-            }
+            let evidence = await systemStateProvider.launchctlPrint(target: target)
+            outputs.append((
+                target: target,
+                output: evidence.exitCode == 0 ? evidence.stdout : "",
+                exitCode: evidence.exitCode
+            ))
         }
         return outputs
     }

--- a/Tests/KeyPathTests/Lint/LaunchctlEvidenceLintTests.swift
+++ b/Tests/KeyPathTests/Lint/LaunchctlEvidenceLintTests.swift
@@ -20,6 +20,13 @@ final class LaunchctlEvidenceLintTests: XCTestCase {
 
         assertNoDirectLaunchctlPrintEvidenceReads(in: checker)
     }
+
+    func testKanataDaemonManagerDelegatesLaunchctlPrintEvidenceToSystemStateProvider() {
+        let manager = repositoryRoot()
+            .appendingPathComponent("Sources/KeyPathAppKit/Managers/KanataDaemonManager.swift")
+
+        assertNoDirectLaunchctlPrintEvidenceReads(in: manager)
+    }
 }
 
 private func assertNoDirectLaunchctlPrintEvidenceReads(

--- a/Tests/KeyPathTests/Managers/KanataDaemonManagerTests.swift
+++ b/Tests/KeyPathTests/Managers/KanataDaemonManagerTests.swift
@@ -27,6 +27,20 @@ final class KanataDaemonManagerTests: XCTestCase {
         try await super.tearDown()
     }
 
+    private actor DirectLaunchctlPoisonRunner: SubprocessRunning {
+        func run(_: String, args _: [String], timeout _: TimeInterval?) async throws -> ProcessResult {
+            ProcessResult(exitCode: 113, stdout: "", stderr: "direct runner must not be used", duration: 0.01)
+        }
+
+        func pgrep(_: String) async -> [pid_t] {
+            []
+        }
+
+        func launchctl(_: String, _: [String]) async throws -> ProcessResult {
+            ProcessResult(exitCode: 113, stdout: "", stderr: "direct launchctl must not be used", duration: 0.01)
+        }
+    }
+
     // MARK: - Status Checking Tests
 
     func testGetStatus() async {
@@ -55,6 +69,55 @@ final class KanataDaemonManagerTests: XCTestCase {
         let isInstalled = await manager.isInstalled()
         // Should return boolean without crashing
         XCTAssertNotNil(isInstalled)
+    }
+
+    func testIsInstalledUsesInjectedSystemStateProviderForLaunchctlEvidence() async {
+        final class NotRegisteredMockService: SMAppServiceProtocol, @unchecked Sendable {
+            var status: SMAppService.Status = .notRegistered
+
+            func register() throws {}
+            func unregister() async throws {}
+        }
+
+        let runner = SubprocessRunnerFake.shared
+        await runner.reset()
+        await runner.configureLaunchctlResult { subcommand, args in
+            if subcommand == "print", args == ["system/\(KanataDaemonManager.kanataServiceID)"] {
+                return ProcessResult(
+                    exitCode: 0,
+                    stdout: """
+                    program = Contents/Library/KeyPath/kanata-launcher
+                    state = running
+                    pid = 24680
+                    """,
+                    stderr: "",
+                    duration: 0.01
+                )
+            }
+            return ProcessResult(exitCode: 113, stdout: "", stderr: "not found", duration: 0.01)
+        }
+        let mockService = NotRegisteredMockService()
+        SMAppServiceStatusProvider.shared = SMAppServiceStatusProvider(
+            cacheTTL: 0,
+            serviceFactory: { _ in mockService }
+        )
+        let provider = SystemStateProvider(subprocessRunner: runner)
+        let manager = KanataDaemonManager(
+            subprocessRunner: DirectLaunchctlPoisonRunner(),
+            systemStateProvider: provider
+        )
+
+        let isInstalled = await manager.isInstalled()
+        let commands = await runner.executedCommands
+
+        XCTAssertTrue(isInstalled)
+        XCTAssertTrue(
+            commands.contains {
+                $0.executable == "/bin/launchctl"
+                    && $0.args == ["print", "system/\(KanataDaemonManager.kanataServiceID)"]
+            },
+            "KanataDaemonManager should use the injected provider for launchctl print evidence"
+        )
     }
 
     // MARK: - Validation Tests
@@ -213,6 +276,50 @@ final class KanataDaemonManagerTests: XCTestCase {
         XCTAssertTrue(
             commands.contains { $0.executable == "/usr/bin/pgrep" && $0.args == ["-f", "kanata.*--cfg"] },
             "KanataDaemonManager should use the injected provider's subprocess runner for process discovery"
+        )
+    }
+
+    func testRegisteredButNotLoadedUsesInjectedSystemStateProviderForLaunchctlEvidence() async {
+        final class EnabledMockService: SMAppServiceProtocol, @unchecked Sendable {
+            var status: SMAppService.Status = .enabled
+
+            func register() throws {}
+            func unregister() async throws {}
+        }
+
+        let runner = SubprocessRunnerFake.shared
+        await runner.reset()
+        await runner.configureLaunchctlResult { _, _ in
+            ProcessResult(exitCode: 113, stdout: "", stderr: "service not found", duration: 0.01)
+        }
+        await runner.configurePgrepResult { _ in [] }
+
+        let mockService = EnabledMockService()
+        SMAppServiceStatusProvider.shared = SMAppServiceStatusProvider(
+            cacheTTL: 0,
+            serviceFactory: { _ in mockService }
+        )
+        let provider = SystemStateProvider(subprocessRunner: runner)
+        let manager = KanataDaemonManager(
+            subprocessRunner: DirectLaunchctlPoisonRunner(),
+            systemStateProvider: provider
+        )
+
+        let isStale = await manager.isRegisteredButNotLoaded()
+        let commands = await runner.executedCommands
+
+        XCTAssertTrue(isStale, "Missing launchctl evidence plus no Kanata process should be stale")
+        XCTAssertTrue(
+            commands.contains {
+                $0.executable == "/bin/launchctl"
+                    && $0.args == ["print", "gui/\(getuid())/\(KanataDaemonManager.kanataServiceID)"]
+            }
+        )
+        XCTAssertTrue(
+            commands.contains {
+                $0.executable == "/bin/launchctl"
+                    && $0.args == ["print", "system/\(KanataDaemonManager.kanataServiceID)"]
+            }
         )
     }
 }

--- a/docs/planning/installer-reliability-phase1.md
+++ b/docs/planning/installer-reliability-phase1.md
@@ -134,6 +134,13 @@ classification remains pending.
   `ServiceHealthCheckerTests.testKanataRuntimeSnapshotDelegatesLaunchctlTargetsToSystemStateProvider`,
   and
   `LaunchctlEvidenceLintTests.testServiceHealthCheckerDelegatesLaunchctlPrintEvidenceToSystemStateProvider`.
+- [x] Migrated `KanataDaemonManager`'s read-only `launchctl print`
+  installation and stale-registration evidence to
+  `SystemStateProvider.launchctlPrint(target:)`. Enforced by
+  `KanataDaemonManagerTests.testIsInstalledUsesInjectedSystemStateProviderForLaunchctlEvidence`,
+  `KanataDaemonManagerTests.testRegisteredButNotLoadedUsesInjectedSystemStateProviderForLaunchctlEvidence`,
+  and
+  `LaunchctlEvidenceLintTests.testKanataDaemonManagerDelegatesLaunchctlPrintEvidenceToSystemStateProvider`.
 - [ ] Migrate `launchctl`, `SMAppService.status`, permissions, VHID state, and
   helper freshness into a single immutable `SystemSnapshot`.
 - [ ] Build `classify(snapshot) -> StateMatrixRow -> plan` and table-driven
@@ -247,6 +254,13 @@ through 21 mocked tests).
   `ServiceHealthCheckerTests.testKanataRuntimeSnapshotDelegatesLaunchctlTargetsToSystemStateProvider`,
   and
   `LaunchctlEvidenceLintTests.testServiceHealthCheckerDelegatesLaunchctlPrintEvidenceToSystemStateProvider`.
+- [x] `KanataDaemonManager` read-only `launchctl print` installation and
+  stale-registration evidence delegates to
+  `SystemStateProvider.launchctlPrint(target:)`. Enforced by
+  `KanataDaemonManagerTests.testIsInstalledUsesInjectedSystemStateProviderForLaunchctlEvidence`,
+  `KanataDaemonManagerTests.testRegisteredButNotLoadedUsesInjectedSystemStateProviderForLaunchctlEvidence`,
+  and
+  `LaunchctlEvidenceLintTests.testKanataDaemonManagerDelegatesLaunchctlPrintEvidenceToSystemStateProvider`.
 
 ## Workstream 3: Industry-Standard Repair Model
 
@@ -384,6 +398,9 @@ is listed in the state-matrix doc's enforcement section.
   service-state reads.
 - [x] `LaunchctlEvidenceLintTests.testServiceHealthCheckerDelegatesLaunchctlPrintEvidenceToSystemStateProvider`
   prevents `ServiceHealthChecker` from regrowing direct `launchctl print`
+  service-state reads.
+- [x] `LaunchctlEvidenceLintTests.testKanataDaemonManagerDelegatesLaunchctlPrintEvidenceToSystemStateProvider`
+  prevents `KanataDaemonManager` from regrowing direct `launchctl print`
   service-state reads.
 - [ ] Add remaining `launchctl`, postcondition, and snapshot-cache
   ratchets with the corresponding migration slices.

--- a/docs/process/installer-repair-state-matrix.md
+++ b/docs/process/installer-repair-state-matrix.md
@@ -193,6 +193,10 @@ the result as user action required and name the approval surface.
   `ServiceHealthCheckerTests.testKanataRuntimeSnapshotDelegatesLaunchctlTargetsToSystemStateProvider`,
   and `LaunchctlEvidenceLintTests.testServiceHealthCheckerDelegatesLaunchctlPrintEvidenceToSystemStateProvider`
   block migrated service-health checks from bypassing it.
+  `KanataDaemonManagerTests.testIsInstalledUsesInjectedSystemStateProviderForLaunchctlEvidence`,
+  `KanataDaemonManagerTests.testRegisteredButNotLoadedUsesInjectedSystemStateProviderForLaunchctlEvidence`,
+  and `LaunchctlEvidenceLintTests.testKanataDaemonManagerDelegatesLaunchctlPrintEvidenceToSystemStateProvider`
+  block migrated Kanata daemon management checks from bypassing it.
 - User-facing CLI/reporting shape belongs in CLI contract tests.
 
 ## Related References


### PR DESCRIPTION
## Summary
- route `KanataDaemonManager` read-only `launchctl print` installation fallback and stale-registration probes through `SystemStateProvider.launchctlPrint(target:)`
- add provider-injection tests that use a poison direct runner to catch bypasses
- extend `LaunchctlEvidenceLintTests` and update Phase 1/state-matrix docs

## Acceptance criteria completed
- `KanataDaemonManagerTests.testIsInstalledUsesInjectedSystemStateProviderForLaunchctlEvidence`
- `KanataDaemonManagerTests.testRegisteredButNotLoadedUsesInjectedSystemStateProviderForLaunchctlEvidence`
- `LaunchctlEvidenceLintTests.testKanataDaemonManagerDelegatesLaunchctlPrintEvidenceToSystemStateProvider`

## Validation
- `TEST_FILTER='KanataDaemonManagerTests|LaunchctlEvidenceLintTests|SystemStateProviderLivenessTests' ./Scripts/run-tests-safe.sh` passed: 31 tests
- `git diff --check` passed
- `python3 Scripts/check-accessibility.py` passed: 352 files clean
- direct launchctl-print scan only finds `SystemStateProvider` and the lint pattern string
- `./Scripts/run-tests-safe.sh` passed: 4,474 tests, runner summary `lane=full exit=0`, build/test Swift warnings 0

## Plan/code reality note
This continues the read-only `launchctl print` evidence migration. Mutating `launchctl` actions remain action/execution paths and are intentionally outside this evidence-read ratchet.

## Review gate
The required local `/thermo-nuclear-swift-review` command is still unavailable in this Codex shell: `claude` is not on `PATH`, and no local `thermo-nuclear-swift-review` command file was discoverable. I am leaving this PR as draft until the GitHub review/check gate reports.
