### PR TITLE
Route helper launchctl evidence through SystemStateProvider

### DIFF
--- a/Sources/KeyPathAppKit/Core/HelperManager+Status.swift
+++ b/Sources/KeyPathAppKit/Core/HelperManager+Status.swift
@@ -26,21 +26,16 @@ extension HelperManager {
         if smStatus == .enabled { return true }
 
         // Best-effort check: does launchd know about the job?
-        let runner = Self.subprocessRunnerFactory()
-
-        do {
-            let result = try await runner.launchctl("print", ["system/\(Self.helperBundleIdentifier)"])
-            if result.exitCode == 0 {
-                let s = result.stdout
-                if s.contains("program") || s.contains("state =") || s.contains("pid =") {
-                    AppLogger.shared.debug(
-                        "[HelperManager] launchctl reports helper present while SMAppService status=\(smStatus)"
-                    )
-                    return true
-                }
+        let evidence = await Self.systemStateProviderFactory()
+            .launchctlPrint(target: "system/\(Self.helperBundleIdentifier)")
+        if evidence.exitCode == 0 {
+            let s = evidence.stdout
+            if s.contains("program") || s.contains("state =") || s.contains("pid =") {
+                AppLogger.shared.debug(
+                    "[HelperManager] launchctl reports helper present while SMAppService status=\(smStatus)"
+                )
+                return true
             }
-        } catch {
-            // Ignore; treated as not installed
         }
         return false
     }
@@ -240,23 +235,21 @@ extension HelperManager {
     /// Fetch the last N helper log messages (message text only)
     /// Uses `log show` with a tight window to avoid heavy queries.
     nonisolated func lastHelperLogs(count: Int = 3, windowSeconds: Int = 300) async -> [String] {
+        // First: if launchctl has no record of the job, surface that clearly.
+        let evidence = await Self.systemStateProviderFactory()
+            .launchctlPrint(target: "system/\(Self.helperBundleIdentifier)")
+        if evidence.exitCode != 0 {
+            let errStr = evidence.stderr
+            if errStr.contains("Could not find service") || errStr.contains("Bad request") {
+                return [
+                    "Helper not registered: launchctl has no job 'system/com.keypath.helper'",
+                    "Click 'Install Helper', then Test XPC again."
+                ]
+            }
+        }
+
         let runner = Self.subprocessRunnerFactory()
 
-        // First: if launchctl has no record of the job, surface that clearly.
-        do {
-            let result = try await runner.launchctl("print", ["system/com.keypath.helper"])
-            if result.exitCode != 0 {
-                let errStr = result.stderr
-                if errStr.contains("Could not find service") || errStr.contains("Bad request") {
-                    return [
-                        "Helper not registered: launchctl has no job 'system/com.keypath.helper'",
-                        "Click 'Install Helper', then Test XPC again."
-                    ]
-                }
-            }
-        } catch {
-            // Ignore; fall through to unified-log path
-        }
         func fetch(_ seconds: Int) async -> [String] {
             do {
                 let result = try await runner.run(

--- a/Sources/KeyPathAppKit/Core/HelperManager.swift
+++ b/Sources/KeyPathAppKit/Core/HelperManager.swift
@@ -32,6 +32,10 @@ public actor HelperManager {
         nonisolated(unsafe) static var subprocessRunnerFactory: () -> SubprocessRunning = {
             SubprocessRunner.shared
         }
+
+        nonisolated(unsafe) static var systemStateProviderFactory: () -> SystemStateProvider = {
+            SystemStateProvider.shared
+        }
     #else
         static let smServiceFactory: @Sendable (String) -> SMAppServiceProtocol = { plistName in
             NativeSMAppService(wrapped: ServiceManagement.SMAppService.daemon(plistName: plistName))
@@ -39,6 +43,10 @@ public actor HelperManager {
 
         static let subprocessRunnerFactory: @Sendable () -> SubprocessRunning = {
             SubprocessRunner.shared
+        }
+
+        static let systemStateProviderFactory: @Sendable () -> SystemStateProvider = {
+            SystemStateProvider.shared
         }
     #endif
 

--- a/Tests/KeyPathTests/Core/HelperManagerTests.swift
+++ b/Tests/KeyPathTests/Core/HelperManagerTests.swift
@@ -1,20 +1,27 @@
 @testable import KeyPathAppKit
+@testable import KeyPathCore
 import ServiceManagement
 @preconcurrency import XCTest
 
 final class HelperManagerTests: XCTestCase {
     private var originalFactory: ((String) -> SMAppServiceProtocol)!
     private var originalStatusProvider: SMAppServiceStatusProvider!
+    private var originalSubprocessRunnerFactory: (() -> SubprocessRunning)!
+    private var originalSystemStateProviderFactory: (() -> SystemStateProvider)!
 
     override func setUp() {
         super.setUp()
         originalFactory = HelperManager.smServiceFactory
         originalStatusProvider = SMAppServiceStatusProvider.shared
+        originalSubprocessRunnerFactory = HelperManager.subprocessRunnerFactory
+        originalSystemStateProviderFactory = HelperManager.systemStateProviderFactory
     }
 
     override func tearDown() {
         HelperManager.smServiceFactory = originalFactory
         SMAppServiceStatusProvider.shared = originalStatusProvider
+        HelperManager.subprocessRunnerFactory = originalSubprocessRunnerFactory
+        HelperManager.systemStateProviderFactory = originalSystemStateProviderFactory
         HelperManager.testHelperFunctionalityOverride = nil
         HelperManager.staleHelperSMAppServiceBootoutOverride = nil
         super.tearDown()
@@ -80,6 +87,72 @@ final class HelperManagerTests: XCTestCase {
         XCTAssertEqual(service.unregisterCalls, 1)
         XCTAssertEqual(bootoutCalls, 1)
     }
+
+    func testIsHelperInstalledUsesInjectedSystemStateProviderForLaunchctlEvidence() async {
+        installFake(FakeSMAppService(status: .notRegistered))
+
+        let directRunner = CapturingSubprocessRunner { _, _ in
+            ProcessResult(exitCode: 113, stdout: "", stderr: "direct runner should not be used", duration: 0)
+        }
+        HelperManager.subprocessRunnerFactory = { directRunner }
+
+        let providerRunner = CapturingSubprocessRunner { subcommand, args in
+            if subcommand == "print", args == ["system/com.keypath.helper"] {
+                return ProcessResult(
+                    exitCode: 0,
+                    stdout: "program = /Applications/KeyPath.app/Contents/Library/HelperTools/KeyPathHelper\nstate = running\npid = 42",
+                    stderr: "",
+                    duration: 0
+                )
+            }
+            return ProcessResult(exitCode: 113, stdout: "", stderr: "unexpected target", duration: 0)
+        }
+        HelperManager.systemStateProviderFactory = { SystemStateProvider(subprocessRunner: providerRunner) }
+
+        let installed = await HelperManager.shared.isHelperInstalled()
+
+        XCTAssertTrue(installed)
+        let commands = await providerRunner.executedCommands
+        XCTAssertEqual(commands.map(\.executable), ["/bin/launchctl"])
+        XCTAssertEqual(commands.map(\.args), [["print", "system/com.keypath.helper"]])
+        let directCommands = await directRunner.executedCommands
+        XCTAssertTrue(directCommands.isEmpty)
+    }
+
+    func testLastHelperLogsUsesInjectedSystemStateProviderForLaunchctlEvidence() async {
+        let directRunner = CapturingSubprocessRunner { _, _ in
+            ProcessResult(exitCode: 113, stdout: "", stderr: "direct runner should not be used", duration: 0)
+        }
+        HelperManager.subprocessRunnerFactory = { directRunner }
+
+        let providerRunner = CapturingSubprocessRunner { subcommand, args in
+            if subcommand == "print", args == ["system/com.keypath.helper"] {
+                return ProcessResult(
+                    exitCode: 113,
+                    stdout: "",
+                    stderr: "Could not find service \"com.keypath.helper\" in domain for system",
+                    duration: 0
+                )
+            }
+            return ProcessResult(exitCode: 113, stdout: "", stderr: "unexpected target", duration: 0)
+        }
+        HelperManager.systemStateProviderFactory = { SystemStateProvider(subprocessRunner: providerRunner) }
+
+        let logs = await HelperManager.shared.lastHelperLogs()
+
+        XCTAssertEqual(
+            logs,
+            [
+                "Helper not registered: launchctl has no job 'system/com.keypath.helper'",
+                "Click 'Install Helper', then Test XPC again."
+            ]
+        )
+        let commands = await providerRunner.executedCommands
+        XCTAssertEqual(commands.map(\.executable), ["/bin/launchctl"])
+        XCTAssertEqual(commands.map(\.args), [["print", "system/com.keypath.helper"]])
+        let directCommands = await directRunner.executedCommands
+        XCTAssertTrue(directCommands.isEmpty)
+    }
 }
 
 // MARK: - Test Doubles
@@ -104,5 +177,27 @@ private final class FakeSMAppService: SMAppServiceProtocol, @unchecked Sendable 
 
     func unregister() async throws {
         unregisterCalls += 1
+    }
+}
+
+private actor CapturingSubprocessRunner: SubprocessRunning {
+    private let launchctlHandler: @Sendable (String, [String]) -> ProcessResult
+    private(set) var executedCommands: [(executable: String, args: [String])] = []
+
+    init(launchctlHandler: @escaping @Sendable (String, [String]) -> ProcessResult) {
+        self.launchctlHandler = launchctlHandler
+    }
+
+    func run(_: String, args _: [String], timeout _: TimeInterval?) async throws -> ProcessResult {
+        ProcessResult(exitCode: 0, stdout: "", stderr: "", duration: 0)
+    }
+
+    func pgrep(_: String) async -> [pid_t] {
+        []
+    }
+
+    func launchctl(_ subcommand: String, _ args: [String]) async throws -> ProcessResult {
+        executedCommands.append((executable: "/bin/launchctl", args: [subcommand] + args))
+        return launchctlHandler(subcommand, args)
     }
 }

--- a/Tests/KeyPathTests/Lint/LaunchctlEvidenceLintTests.swift
+++ b/Tests/KeyPathTests/Lint/LaunchctlEvidenceLintTests.swift
@@ -27,6 +27,13 @@ final class LaunchctlEvidenceLintTests: XCTestCase {
 
         assertNoDirectLaunchctlPrintEvidenceReads(in: manager)
     }
+
+    func testHelperManagerDelegatesLaunchctlPrintEvidenceToSystemStateProvider() {
+        let managerStatus = repositoryRoot()
+            .appendingPathComponent("Sources/KeyPathAppKit/Core/HelperManager+Status.swift")
+
+        assertNoDirectLaunchctlPrintEvidenceReads(in: managerStatus)
+    }
 }
 
 private func assertNoDirectLaunchctlPrintEvidenceReads(

--- a/docs/planning/installer-reliability-phase1.md
+++ b/docs/planning/installer-reliability-phase1.md
@@ -141,8 +141,16 @@ classification remains pending.
   `KanataDaemonManagerTests.testRegisteredButNotLoadedUsesInjectedSystemStateProviderForLaunchctlEvidence`,
   and
   `LaunchctlEvidenceLintTests.testKanataDaemonManagerDelegatesLaunchctlPrintEvidenceToSystemStateProvider`.
-- [ ] Migrate `launchctl`, `SMAppService.status`, permissions, VHID state, and
-  helper freshness into a single immutable `SystemSnapshot`.
+- [x] Migrated `HelperManager`'s read-only `launchctl print` helper
+  installation and helper-log registration evidence to
+  `SystemStateProvider.launchctlPrint(target:)`. Enforced by
+  `HelperManagerTests.testIsHelperInstalledUsesInjectedSystemStateProviderForLaunchctlEvidence`,
+  `HelperManagerTests.testLastHelperLogsUsesInjectedSystemStateProviderForLaunchctlEvidence`,
+  and
+  `LaunchctlEvidenceLintTests.testHelperManagerDelegatesLaunchctlPrintEvidenceToSystemStateProvider`.
+- [ ] Migrate `SMAppService.status`, permissions, VHID state, helper freshness,
+  and migrated read-only `launchctl print` evidence into a single immutable
+  `SystemSnapshot`.
 - [ ] Build `classify(snapshot) -> StateMatrixRow -> plan` and table-driven
   golden tests for every state-matrix row.
 
@@ -261,6 +269,13 @@ through 21 mocked tests).
   `KanataDaemonManagerTests.testRegisteredButNotLoadedUsesInjectedSystemStateProviderForLaunchctlEvidence`,
   and
   `LaunchctlEvidenceLintTests.testKanataDaemonManagerDelegatesLaunchctlPrintEvidenceToSystemStateProvider`.
+- [x] `HelperManager` read-only `launchctl print` helper installation and
+  helper-log registration evidence delegates to
+  `SystemStateProvider.launchctlPrint(target:)`. Enforced by
+  `HelperManagerTests.testIsHelperInstalledUsesInjectedSystemStateProviderForLaunchctlEvidence`,
+  `HelperManagerTests.testLastHelperLogsUsesInjectedSystemStateProviderForLaunchctlEvidence`,
+  and
+  `LaunchctlEvidenceLintTests.testHelperManagerDelegatesLaunchctlPrintEvidenceToSystemStateProvider`.
 
 ## Workstream 3: Industry-Standard Repair Model
 
@@ -348,7 +363,7 @@ context loss across sessions, contributors, and agents. Extend it:
 
 | Ratchet | Rule |
 |---------|------|
-| `LaunchctlLintTests` | `launchctl` invocations only inside `SystemStateProvider`/`ServiceHealthChecker` |
+| `LaunchctlEvidenceLintTests` | read-only `launchctl print` evidence only inside `SystemStateProvider` |
 | `LivenessLintTests` | `kill(`, `pgrep`, process-probe patterns only inside the blessed predicate |
 | `PostconditionLintTests` | every `PrivilegedOperationsRouter` mutating verb calls the postcondition enforcer before returning success |
 | `SnapshotConsumerLintTests` | no new caches of system state outside the provider (grep for TTL/timestamp-cache patterns) |
@@ -402,7 +417,10 @@ is listed in the state-matrix doc's enforcement section.
 - [x] `LaunchctlEvidenceLintTests.testKanataDaemonManagerDelegatesLaunchctlPrintEvidenceToSystemStateProvider`
   prevents `KanataDaemonManager` from regrowing direct `launchctl print`
   service-state reads.
-- [ ] Add remaining `launchctl`, postcondition, and snapshot-cache
+- [x] `LaunchctlEvidenceLintTests.testHelperManagerDelegatesLaunchctlPrintEvidenceToSystemStateProvider`
+  prevents `HelperManager` from regrowing direct `launchctl print`
+  service-state reads.
+- [ ] Add remaining `SMAppService.status`, postcondition, and snapshot-cache
   ratchets with the corresponding migration slices.
 
 ## Workstream 6: Deletion Pass

--- a/docs/process/installer-repair-state-matrix.md
+++ b/docs/process/installer-repair-state-matrix.md
@@ -197,6 +197,10 @@ the result as user action required and name the approval surface.
   `KanataDaemonManagerTests.testRegisteredButNotLoadedUsesInjectedSystemStateProviderForLaunchctlEvidence`,
   and `LaunchctlEvidenceLintTests.testKanataDaemonManagerDelegatesLaunchctlPrintEvidenceToSystemStateProvider`
   block migrated Kanata daemon management checks from bypassing it.
+  `HelperManagerTests.testIsHelperInstalledUsesInjectedSystemStateProviderForLaunchctlEvidence`,
+  `HelperManagerTests.testLastHelperLogsUsesInjectedSystemStateProviderForLaunchctlEvidence`,
+  and `LaunchctlEvidenceLintTests.testHelperManagerDelegatesLaunchctlPrintEvidenceToSystemStateProvider`
+  block migrated helper installation/log-registration checks from bypassing it.
 - User-facing CLI/reporting shape belongs in CLI contract tests.
 
 ## Related References


### PR DESCRIPTION
## Summary
- routes HelperManager read-only `launchctl print` evidence through `SystemStateProvider.launchctlPrint(target:)`
- adds focused HelperManager tests proving provider injection is used and the direct subprocess runner is not used for those reads
- extends `LaunchctlEvidenceLintTests` and updates the Phase 1/state-matrix docs with the enforcing tests

## Acceptance criteria completed
- Helper installation fallback evidence is provider-owned: `HelperManagerTests.testIsHelperInstalledUsesInjectedSystemStateProviderForLaunchctlEvidence`
- Helper log registration pre-check evidence is provider-owned: `HelperManagerTests.testLastHelperLogsUsesInjectedSystemStateProviderForLaunchctlEvidence`
- HelperManager cannot regrow direct read-only `launchctl print` evidence reads: `LaunchctlEvidenceLintTests.testHelperManagerDelegatesLaunchctlPrintEvidenceToSystemStateProvider`

## Validation
- `TEST_FILTER='HelperManagerTests|LaunchctlEvidenceLintTests|SystemStateProviderLivenessTests' ./Scripts/run-tests-safe.sh` (22 passed)
- `python3 Scripts/check-accessibility.py` (352 files clean)
- `git diff --check`
- direct scan for production `launchctl print` reads: only `SystemStateProvider` and lint pattern remain
- `./Scripts/run-tests-safe.sh` (4,477 passed; runner summary exit=0, build_log_swift_warnings=0, test_log_app_errors=0)

## Plan/code reality note
- This slice keeps the established distinction from the prior PRs: read-only `launchctl print` evidence is centralized in `SystemStateProvider`; mutating launchctl actions remain in action/execution paths. The Phase 1 Workstream 5 wording was updated to say `LaunchctlEvidenceLintTests` guards read-only `launchctl print` evidence, which matches current code reality.

## Review gate
- Required local `/thermo-nuclear-swift-review` remains unavailable in this Codex shell (`claude` is not on PATH and no local command file was found). As with the prior Phase 1 slices, this PR is opened as a draft and the GitHub `claude-review` check should serve as the available review gate before merge.