### PR TITLE
Route Kanata SMAppService status through SystemStateProvider

### DIFF
--- a/Sources/KeyPathAppKit/Core/SystemStateProvider+SMAppService.swift
+++ b/Sources/KeyPathAppKit/Core/SystemStateProvider+SMAppService.swift
@@ -1,0 +1,22 @@
+import KeyPathCore
+import ServiceManagement
+
+public extension SystemStateProvider {
+    /// Cached SMAppService status read for hot paths.
+    ///
+    /// Delegates to the existing status provider so the blocking Apple IPC remains
+    /// coalesced and off the caller's actor while Phase 1 grows the full snapshot.
+    func cachedSMAppServiceStatus(for plistName: String) async -> SMAppService.Status {
+        await SMAppServiceStatusProvider.shared.cachedStatus(for: plistName)
+    }
+
+    /// Fresh SMAppService status read for post-mutation verification.
+    func freshSMAppServiceStatus(for plistName: String) async -> SMAppService.Status {
+        await SMAppServiceStatusProvider.shared.freshStatus(for: plistName)
+    }
+
+    /// Invalidates cached SMAppService status after a registration mutation.
+    func invalidateSMAppServiceStatus(plistName: String) async {
+        await SMAppServiceStatusProvider.shared.invalidate(plistName: plistName)
+    }
+}

--- a/Sources/KeyPathAppKit/Managers/KanataDaemonManager.swift
+++ b/Sources/KeyPathAppKit/Managers/KanataDaemonManager.swift
@@ -132,7 +132,7 @@ public class KanataDaemonManager {
     @discardableResult
     nonisolated func refreshManagementStateInternal() async -> ServiceManagementState {
         let hasLegacy = Foundation.FileManager().fileExists(atPath: Self.legacyPlistPath)
-        let smStatus = await SMAppServiceStatusProvider.shared.cachedStatus(for: Self.kanataPlistName)
+        let smStatus = await systemStateProvider.cachedSMAppServiceStatus(for: Self.kanataPlistName)
 
         AppLogger.shared.log("🔍 [KanataDaemonManager] State determination:")
         AppLogger.shared.log("  - Legacy plist exists: \(hasLegacy)")
@@ -207,7 +207,7 @@ public class KanataDaemonManager {
     /// Check if Kanata daemon is installed and registered via SMAppService
     /// - Returns: true if SMAppService reports `.enabled` OR launchctl has the job
     nonisolated func isInstalled() async -> Bool {
-        let smStatus = await SMAppServiceStatusProvider.shared.cachedStatus(for: Self.kanataPlistName)
+        let smStatus = await systemStateProvider.cachedSMAppServiceStatus(for: Self.kanataPlistName)
         if smStatus == .enabled { return true }
 
         let evidence = await systemStateProvider.launchctlPrint(target: "system/\(Self.kanataServiceID)")
@@ -226,18 +226,18 @@ public class KanataDaemonManager {
     /// Get the current SMAppService status
     /// - Returns: The current status (.notFound, .requiresApproval, .enabled, .notRegistered)
     ///
-    /// Routed through `SMAppServiceStatusProvider` (issue #853) so the underlying
-    /// synchronous IPC never runs inline on a caller's actor. Uses `freshStatus`
-    /// because callers use this for post-mutation verification where a stale
-    /// cached value would be misleading.
+    /// Routed through `SystemStateProvider` so the underlying synchronous IPC
+    /// remains coalesced/off-actor behind the shared status provider. Uses a
+    /// fresh read because callers use this for post-mutation verification where
+    /// a stale cached value would be misleading.
     nonisolated func getStatus() async -> ServiceManagement.SMAppService.Status {
-        await SMAppServiceStatusProvider.shared.freshStatus(for: Self.kanataPlistName)
+        await systemStateProvider.freshSMAppServiceStatus(for: Self.kanataPlistName)
     }
 
     /// Check if daemon is registered via SMAppService (not launchctl)
     /// - Returns: true if SMAppService status is `.enabled`
     nonisolated static func isRegisteredViaSMAppService() async -> Bool {
-        await SMAppServiceStatusProvider.shared.cachedStatus(for: kanataPlistName) == .enabled
+        await SystemStateProvider.shared.cachedSMAppServiceStatus(for: kanataPlistName) == .enabled
     }
 
     /// Check if legacy launchctl installation exists
@@ -276,7 +276,7 @@ public class KanataDaemonManager {
         #endif
 
         // 1. Check if SMAppService thinks it's registered
-        let smStatus = await SMAppServiceStatusProvider.shared.cachedStatus(for: Self.kanataPlistName)
+        let smStatus = await systemStateProvider.cachedSMAppServiceStatus(for: Self.kanataPlistName)
         guard smStatus == .enabled else {
             return false
         }
@@ -449,12 +449,9 @@ public class KanataDaemonManager {
             AppLogger.shared.log("✅ [KanataDaemonManager] Kanata binary found")
         }
 
-        // Fresh read via the centralized provider (issue #853). After this the
-        // register/unregister mutation sequence below reads status directly off the
-        // owned `svc` instance, because those reads must observe the just-mutated
-        // object rather than the process-wide cache; the cache is invalidated at the
-        // end so later readers elsewhere re-fetch.
-        let initialStatus = await SMAppServiceStatusProvider.shared.freshStatus(for: Self.kanataPlistName)
+        // Fresh read via SystemStateProvider. Register/unregister mutations below
+        // invalidate the shared status cache so later readers re-fetch.
+        let initialStatus = await systemStateProvider.freshSMAppServiceStatus(for: Self.kanataPlistName)
         AppLogger.shared.log(
             "🔍 [KanataDaemonManager] SMAppService created with plist name: \(Self.kanataPlistName)"
         )
@@ -498,7 +495,7 @@ public class KanataDaemonManager {
             do {
                 AppLogger.shared.log("🔧 [KanataDaemonManager] Calling svc.register()...")
                 try svc.register()
-                let newStatus = await SMAppServiceStatusProvider.shared.freshStatus(for: Self.kanataPlistName)
+                let newStatus = await systemStateProvider.freshSMAppServiceStatus(for: Self.kanataPlistName)
                 AppLogger.shared.log(
                     "🔍 [KanataDaemonManager] After register(), status changed to: \(newStatus.rawValue) (\(String(describing: newStatus)))"
                 )
@@ -506,7 +503,7 @@ public class KanataDaemonManager {
                 AppLogger.shared.info("✅ [KanataDaemonManager] Daemon registered successfully")
                 return
             } catch {
-                let errorStatus = await SMAppServiceStatusProvider.shared.freshStatus(for: Self.kanataPlistName)
+                let errorStatus = await systemStateProvider.freshSMAppServiceStatus(for: Self.kanataPlistName)
                 AppLogger.shared.log("❌ [KanataDaemonManager] Registration failed with error: \(error)")
                 AppLogger.shared.log(
                     "🔍 [KanataDaemonManager] Status after error: \(errorStatus.rawValue) (\(String(describing: errorStatus)))"
@@ -546,7 +543,7 @@ public class KanataDaemonManager {
                     "🔧 [KanataDaemonManager] Calling svc.register() despite .notFound status..."
                 )
                 try svc.register()
-                let newStatus = await SMAppServiceStatusProvider.shared.freshStatus(for: Self.kanataPlistName)
+                let newStatus = await systemStateProvider.freshSMAppServiceStatus(for: Self.kanataPlistName)
                 AppLogger.shared.log(
                     "🔍 [KanataDaemonManager] After register(), status changed to: \(newStatus.rawValue) (\(String(describing: newStatus)))"
                 )
@@ -556,7 +553,7 @@ public class KanataDaemonManager {
                 )
                 return
             } catch {
-                let errorStatus = await SMAppServiceStatusProvider.shared.freshStatus(for: Self.kanataPlistName)
+                let errorStatus = await systemStateProvider.freshSMAppServiceStatus(for: Self.kanataPlistName)
                 AppLogger.shared.log(
                     "❌ [KanataDaemonManager] Registration failed with detailed error: \(error)"
                 )
@@ -619,8 +616,8 @@ public class KanataDaemonManager {
             )
         }
         // The unregister/re-register above changed system state; drop the cache so the
-        // isRegisteredButNotLoaded() check below reads a fresh status (#853).
-        await SMAppServiceStatusProvider.shared.invalidate(plistName: Self.kanataPlistName)
+        // isRegisteredButNotLoaded() check below reads a fresh status.
+        await systemStateProvider.invalidateSMAppServiceStatus(plistName: Self.kanataPlistName)
 
         if await isRegisteredButNotLoaded() {
             throw KanataDaemonError.registrationFailed(
@@ -639,8 +636,8 @@ public class KanataDaemonManager {
         let svc = Self.smServiceFactory(Self.kanataPlistName)
         do {
             try await svc.unregister()
-            // Drop the centralized cache so subsequent status reads re-fetch (#853).
-            await SMAppServiceStatusProvider.shared.invalidate(plistName: Self.kanataPlistName)
+            // Drop the centralized cache so subsequent status reads re-fetch.
+            await systemStateProvider.invalidateSMAppServiceStatus(plistName: Self.kanataPlistName)
             AppLogger.shared.info("✅ [KanataDaemonManager] Daemon unregistered successfully")
         } catch {
             throw KanataDaemonError.operationFailed(

--- a/Tests/KeyPathTests/Core/SystemStateProviderSMAppServiceTests.swift
+++ b/Tests/KeyPathTests/Core/SystemStateProviderSMAppServiceTests.swift
@@ -1,0 +1,83 @@
+@testable import KeyPathAppKit
+@testable import KeyPathCore
+import ServiceManagement
+@preconcurrency import XCTest
+
+final class SystemStateProviderSMAppServiceTests: XCTestCase {
+    private var originalStatusProvider: SMAppServiceStatusProvider!
+
+    override func setUp() {
+        super.setUp()
+        originalStatusProvider = SMAppServiceStatusProvider.shared
+    }
+
+    override func tearDown() {
+        SMAppServiceStatusProvider.shared = originalStatusProvider
+        super.tearDown()
+    }
+
+    func testSMAppServiceStatusAccessDelegatesToCentralStatusProvider() async {
+        let service = CountingSMAppService(status: .requiresApproval)
+        SMAppServiceStatusProvider.shared = SMAppServiceStatusProvider(
+            cacheTTL: 60,
+            serviceFactory: { _ in service }
+        )
+
+        let provider = SystemStateProvider()
+
+        let first = await provider.cachedSMAppServiceStatus(for: "com.keypath.kanata.plist")
+        let second = await provider.cachedSMAppServiceStatus(for: "com.keypath.kanata.plist")
+
+        XCTAssertEqual(first, .requiresApproval)
+        XCTAssertEqual(second, .requiresApproval)
+        XCTAssertEqual(service.statusReads, 1)
+    }
+
+    func testSMAppServiceStatusInvalidationDelegatesToCentralStatusProvider() async {
+        let service = CountingSMAppService(status: .enabled)
+        SMAppServiceStatusProvider.shared = SMAppServiceStatusProvider(
+            cacheTTL: 60,
+            serviceFactory: { _ in service }
+        )
+
+        let provider = SystemStateProvider()
+
+        _ = await provider.cachedSMAppServiceStatus(for: "com.keypath.kanata.plist")
+        await provider.invalidateSMAppServiceStatus(plistName: "com.keypath.kanata.plist")
+        _ = await provider.cachedSMAppServiceStatus(for: "com.keypath.kanata.plist")
+
+        XCTAssertEqual(service.statusReads, 2)
+    }
+
+    func testSMAppServiceFreshStatusBypassesCache() async {
+        let service = CountingSMAppService(status: .enabled)
+        SMAppServiceStatusProvider.shared = SMAppServiceStatusProvider(
+            cacheTTL: 60,
+            serviceFactory: { _ in service }
+        )
+
+        let provider = SystemStateProvider()
+
+        _ = await provider.freshSMAppServiceStatus(for: "com.keypath.kanata.plist")
+        _ = await provider.freshSMAppServiceStatus(for: "com.keypath.kanata.plist")
+
+        XCTAssertEqual(service.statusReads, 2)
+    }
+}
+
+private final class CountingSMAppService: SMAppServiceProtocol, @unchecked Sendable {
+    var statusValue: SMAppService.Status
+    private(set) var statusReads = 0
+
+    init(status: SMAppService.Status) {
+        statusValue = status
+    }
+
+    var status: SMAppService.Status {
+        statusReads += 1
+        return statusValue
+    }
+
+    func register() throws {}
+    func unregister() async throws {}
+}

--- a/Tests/KeyPathTests/Lint/SMAppServiceStatusLintTests.swift
+++ b/Tests/KeyPathTests/Lint/SMAppServiceStatusLintTests.swift
@@ -12,8 +12,9 @@ import Foundation
 /// This test fails the build if any source outside the provider reads `.status` off an
 /// `SMAppService` instance (a `SMAppService.daemon(…)` value or a `SMAppServiceProtocol`
 /// from `smServiceFactory`). To fix a new violation, route the read through
-/// `SMAppServiceStatusProvider.shared.cachedStatus(for:)` (hot paths) or
-/// `.freshStatus(for:)` (one-shot install/uninstall) — do **not** extend the allowlist.
+/// `SystemStateProvider` or, for the low-level cache/coalescer itself,
+/// `SMAppServiceStatusProvider.shared.cachedStatus(for:)` / `.freshStatus(for:)`.
+/// Do **not** extend the allowlist.
 ///
 /// The allowlist is a shrinking ratchet of pre-existing **synchronous** call sites that
 /// are not on a hot path and whose migration would require threading `async` through the
@@ -71,8 +72,27 @@ final class SMAppServiceStatusLintTests: XCTestCase {
             violations.isEmpty,
             """
             Direct SMAppService `.status` reads found outside SMAppServiceStatusProvider \
-            (issue #853). Route through SMAppServiceStatusProvider.shared.cachedStatus(for:) \
-            or .freshStatus(for:) instead of adding to the allowlist:
+            (issue #853). Route through SystemStateProvider or the low-level \
+            SMAppServiceStatusProvider cache/coalescer instead of adding to the allowlist:
+            \(violations.sorted().joined(separator: "\n"))
+            """
+        )
+    }
+
+    func testKanataDaemonManagerDelegatesStatusProviderAccessToSystemStateProvider() throws {
+        let manager = repositoryRoot()
+            .appendingPathComponent("Sources/KeyPathAppKit/Managers/KanataDaemonManager.swift")
+
+        let violations = try matchingLines(
+            in: manager,
+            patterns: [#"SMAppServiceStatusProvider\.shared"#]
+        )
+
+        XCTAssertTrue(
+            violations.isEmpty,
+            """
+            KanataDaemonManager must delegate SMAppService status/cache access \
+            through SystemStateProvider:
             \(violations.sorted().joined(separator: "\n"))
             """
         )
@@ -85,4 +105,21 @@ private func repositoryRoot(file: StaticString = #filePath) -> URL {
         .deletingLastPathComponent() // KeyPathTests
         .deletingLastPathComponent() // Tests
         .deletingLastPathComponent() // repo root
+}
+
+private func matchingLines(in fileURL: URL, patterns: [String]) throws -> [String] {
+    let contents = try String(contentsOf: fileURL, encoding: .utf8)
+    let regexes = try patterns.map { try NSRegularExpression(pattern: $0) }
+    let relativePath = fileURL.path.replacingOccurrences(of: repositoryRoot().path + "/", with: "")
+
+    var violations: [String] = []
+    for (idx, rawLine) in contents.components(separatedBy: .newlines).enumerated() {
+        let trimmed = rawLine.trimmingCharacters(in: .whitespaces)
+        if trimmed.hasPrefix("//") || trimmed.hasPrefix("///") || trimmed.hasPrefix("*") { continue }
+        let range = NSRange(rawLine.startIndex..., in: rawLine)
+        if regexes.contains(where: { $0.firstMatch(in: rawLine, range: range) != nil }) {
+            violations.append("\(relativePath):\(idx + 1): \(trimmed)")
+        }
+    }
+    return violations
 }

--- a/docs/planning/installer-reliability-phase1.md
+++ b/docs/planning/installer-reliability-phase1.md
@@ -148,6 +148,15 @@ classification remains pending.
   `HelperManagerTests.testLastHelperLogsUsesInjectedSystemStateProviderForLaunchctlEvidence`,
   and
   `LaunchctlEvidenceLintTests.testHelperManagerDelegatesLaunchctlPrintEvidenceToSystemStateProvider`.
+- [x] Added `SystemStateProvider` SMAppService status/cache façade methods over
+  the existing `SMAppServiceStatusProvider` cache/coalescer and migrated
+  `KanataDaemonManager` status reads/invalidation through the façade. Enforced
+  by
+  `SystemStateProviderSMAppServiceTests.testSMAppServiceStatusAccessDelegatesToCentralStatusProvider`,
+  `SystemStateProviderSMAppServiceTests.testSMAppServiceFreshStatusBypassesCache`,
+  `SystemStateProviderSMAppServiceTests.testSMAppServiceStatusInvalidationDelegatesToCentralStatusProvider`,
+  and
+  `SMAppServiceStatusLintTests.testKanataDaemonManagerDelegatesStatusProviderAccessToSystemStateProvider`.
 - [ ] Migrate `SMAppService.status`, permissions, VHID state, helper freshness,
   and migrated read-only `launchctl print` evidence into a single immutable
   `SystemSnapshot`.
@@ -276,6 +285,13 @@ through 21 mocked tests).
   `HelperManagerTests.testLastHelperLogsUsesInjectedSystemStateProviderForLaunchctlEvidence`,
   and
   `LaunchctlEvidenceLintTests.testHelperManagerDelegatesLaunchctlPrintEvidenceToSystemStateProvider`.
+- [x] `KanataDaemonManager` SMAppService registration status/cache reads
+  delegate to `SystemStateProvider`'s SMAppService status façade. Enforced by
+  `SystemStateProviderSMAppServiceTests.testSMAppServiceStatusAccessDelegatesToCentralStatusProvider`,
+  `SystemStateProviderSMAppServiceTests.testSMAppServiceFreshStatusBypassesCache`,
+  `SystemStateProviderSMAppServiceTests.testSMAppServiceStatusInvalidationDelegatesToCentralStatusProvider`,
+  and
+  `SMAppServiceStatusLintTests.testKanataDaemonManagerDelegatesStatusProviderAccessToSystemStateProvider`.
 
 ## Workstream 3: Industry-Standard Repair Model
 
@@ -363,6 +379,7 @@ context loss across sessions, contributors, and agents. Extend it:
 
 | Ratchet | Rule |
 |---------|------|
+| `SMAppServiceStatusLintTests` | direct Apple `.status` only inside `SMAppServiceStatusProvider`; migrated consumers access the status cache through `SystemStateProvider` |
 | `LaunchctlEvidenceLintTests` | read-only `launchctl print` evidence only inside `SystemStateProvider` |
 | `LivenessLintTests` | `kill(`, `pgrep`, process-probe patterns only inside the blessed predicate |
 | `PostconditionLintTests` | every `PrivilegedOperationsRouter` mutating verb calls the postcondition enforcer before returning success |
@@ -374,6 +391,11 @@ is listed in the state-matrix doc's enforcement section.
 **Status (2026-07-07):** First liveness/readiness ratchets implemented.
 - [x] `LivenessPredicateLintTests.testKillZeroLivenessProbeIsCentralized`
   prevents new direct `kill(pid, 0)` liveness probes outside
+  `SystemStateProvider`.
+- [x] `SMAppServiceStatusLintTests.testStatusAccessIsCentralized` keeps direct
+  Apple `SMAppService.status` IPC centralized in `SMAppServiceStatusProvider`.
+- [x] `SMAppServiceStatusLintTests.testKanataDaemonManagerDelegatesStatusProviderAccessToSystemStateProvider`
+  prevents the first migrated SMAppService status consumer from bypassing
   `SystemStateProvider`.
 - [x] `TCPReadinessLintTests.testServiceHealthCheckerDelegatesTCPReadinessToSystemStateProvider`
   prevents `ServiceHealthChecker` from regrowing a private TCP socket probe.

--- a/docs/process/installer-repair-state-matrix.md
+++ b/docs/process/installer-repair-state-matrix.md
@@ -28,7 +28,7 @@ old stderr/log-derived diagnosis.
 
 | Term | Meaning | Evidence |
 |------|---------|----------|
-| `registered` | SMAppService has registration metadata | `SMAppService.status`, through the shared status provider |
+| `registered` | SMAppService has registration metadata | `SMAppService.status`, through `SystemStateProvider`/the shared status provider |
 | `loaded` | launchd can find the job | `ServiceHealthChecker` launchd/load evidence |
 | `running` | the process exists | `ServiceHealthChecker` process/runtime snapshot |
 | `responding` | Kanata TCP server answers | `ServiceHealthChecker` TCP probe |
@@ -201,6 +201,15 @@ the result as user action required and name the approval surface.
   `HelperManagerTests.testLastHelperLogsUsesInjectedSystemStateProviderForLaunchctlEvidence`,
   and `LaunchctlEvidenceLintTests.testHelperManagerDelegatesLaunchctlPrintEvidenceToSystemStateProvider`
   block migrated helper installation/log-registration checks from bypassing it.
+- SMAppService registration status belongs behind `SystemStateProvider`'s
+  SMAppService façade, which delegates to the existing
+  `SMAppServiceStatusProvider` cache/coalescer.
+  `SystemStateProviderSMAppServiceTests.testSMAppServiceStatusAccessDelegatesToCentralStatusProvider`,
+  `SystemStateProviderSMAppServiceTests.testSMAppServiceFreshStatusBypassesCache`,
+  and `SystemStateProviderSMAppServiceTests.testSMAppServiceStatusInvalidationDelegatesToCentralStatusProvider`
+  pin the façade contract, while
+  `SMAppServiceStatusLintTests.testKanataDaemonManagerDelegatesStatusProviderAccessToSystemStateProvider`
+  blocks migrated Kanata daemon status reads from bypassing it.
 - User-facing CLI/reporting shape belongs in CLI contract tests.
 
 ## Related References


### PR DESCRIPTION
## Summary
- adds an AppKit `SystemStateProvider` SMAppService status/cache façade over the existing `SMAppServiceStatusProvider` cache/coalescer
- migrates `KanataDaemonManager` cached/fresh/invalidate SMAppService status reads through that façade
- adds focused façade tests plus a migrated-consumer lint ratchet and updates the Phase 1/state-matrix docs

## Acceptance criteria completed
- SystemStateProvider delegates cached status reads to the central coalescing status provider: `SystemStateProviderSMAppServiceTests.testSMAppServiceStatusAccessDelegatesToCentralStatusProvider`
- SystemStateProvider delegates fresh status reads and bypasses cache: `SystemStateProviderSMAppServiceTests.testSMAppServiceFreshStatusBypassesCache`
- SystemStateProvider delegates status invalidation: `SystemStateProviderSMAppServiceTests.testSMAppServiceStatusInvalidationDelegatesToCentralStatusProvider`
- KanataDaemonManager cannot bypass SystemStateProvider for migrated SMAppService status/cache access: `SMAppServiceStatusLintTests.testKanataDaemonManagerDelegatesStatusProviderAccessToSystemStateProvider`

## Validation
- `TEST_FILTER='SystemStateProviderSMAppServiceTests|SMAppServiceStatusLintTests|KanataDaemonManagerTests' ./Scripts/run-tests-safe.sh` (20 passed)
- `python3 Scripts/check-accessibility.py` (352 files clean)
- `git diff --check`
- targeted scan: `KanataDaemonManager.swift` no longer references `SMAppServiceStatusProvider.shared`
- `./Scripts/run-tests-safe.sh` (4,481 passed; runner summary exit=0; test logs clean; build log had 4 existing Swift UI warnings)

## Plan/code reality note
- `SystemStateProvider` is in `KeyPathCore`, while the existing `SMAppServiceStatusProvider` lives in `KeyPathAppKit` because it depends on AppKit-side SMAppService protocol seams. This slice adds the Phase 1 façade as a KeyPathAppKit extension on `SystemStateProvider`, preserving module boundaries while moving migrated AppKit consumers to the SystemStateProvider API.
- `SMAppServiceStatusProvider` remains the low-level cache/coalescer for the blocking Apple IPC; `SystemStateProvider` is now the higher-level owner API for migrated consumers.

## Review gate
- Required local `/thermo-nuclear-swift-review` remains unavailable in this Codex shell (`claude` is not on PATH and no local command file was found). As with the prior Phase 1 slices, this PR is opened as a draft and the GitHub `claude-review` check should serve as the available review gate before merge.