### PR TITLE
Route helper SMAppService status through SystemStateProvider

### DIFF
--- a/Sources/KeyPathAppKit/Core/HelperManager+Installation.swift
+++ b/Sources/KeyPathAppKit/Core/HelperManager+Installation.swift
@@ -38,10 +38,10 @@ extension HelperManager {
         }
 
         let svc = Self.smServiceFactory(Self.helperPlistName)
-        // Fresh read via the centralized provider (#853). The post-register reads
-        // below stay on the owned `svc` instance (also routed through the provider's
-        // freshStatus) because they must observe the just-mutated system state.
-        let initialStatus = await SMAppServiceStatusProvider.shared.freshStatus(for: Self.helperPlistName)
+        // Fresh read via SystemStateProvider; register/unregister mutations below
+        // invalidate the shared status cache so later readers re-fetch.
+        let initialStatus = await Self.systemStateProviderFactory()
+            .freshSMAppServiceStatus(for: Self.helperPlistName)
         AppLogger.shared.log(
             "🔍 [HelperManager] SMAppService status: \(initialStatus.rawValue) (0=notRegistered, 1=enabled, 2=requiresApproval, 3=notFound)"
         )
@@ -56,7 +56,8 @@ extension HelperManager {
                 try svc.register()
             } catch {
                 registerError = error
-                let statusAfterError = await SMAppServiceStatusProvider.shared.freshStatus(for: Self.helperPlistName)
+                let statusAfterError = await Self.systemStateProviderFactory()
+                    .freshSMAppServiceStatus(for: Self.helperPlistName)
                 if statusAfterError == .enabled {
                     AppLogger.shared.log("ℹ️ [HelperManager] Helper already Enabled after register error; verifying XPC")
                 } else {
@@ -87,12 +88,14 @@ extension HelperManager {
         case .notRegistered:
             do {
                 try svc.register()
-                let statusAfterRegister = await SMAppServiceStatusProvider.shared.freshStatus(for: Self.helperPlistName)
+                let statusAfterRegister = await Self.systemStateProviderFactory()
+                    .freshSMAppServiceStatus(for: Self.helperPlistName)
                 AppLogger.shared.info("✅ [HelperManager] Helper registered (status: \(statusAfterRegister))")
                 return
             } catch {
                 // If another thread already registered or approval raced, treat Enabled as success
-                let statusAfterError = await SMAppServiceStatusProvider.shared.freshStatus(for: Self.helperPlistName)
+                let statusAfterError = await Self.systemStateProviderFactory()
+                    .freshSMAppServiceStatus(for: Self.helperPlistName)
                 if statusAfterError == .enabled {
                     AppLogger.shared.info(
                         "✅ [HelperManager] Helper became Enabled during registration race; treating as success"
@@ -150,7 +153,8 @@ extension HelperManager {
         let svc = Self.smServiceFactory(Self.helperPlistName)
         do {
             try await svc.unregister()
-            await SMAppServiceStatusProvider.shared.invalidate(plistName: Self.helperPlistName)
+            await Self.systemStateProviderFactory()
+                .invalidateSMAppServiceStatus(plistName: Self.helperPlistName)
         } catch {
             throw HelperManagerError.operationFailed(
                 "SMAppService unregister failed: \(error.localizedDescription)"
@@ -198,10 +202,12 @@ extension HelperManager {
 
         do {
             try svc.register()
-            await SMAppServiceStatusProvider.shared.invalidate(plistName: Self.helperPlistName)
+            await Self.systemStateProviderFactory()
+                .invalidateSMAppServiceStatus(plistName: Self.helperPlistName)
             AppLogger.shared.log("✅ [HelperManager] Re-registered helper after stale SMAppService cleanup")
         } catch {
-            let statusAfterError = await SMAppServiceStatusProvider.shared.freshStatus(for: Self.helperPlistName)
+            let statusAfterError = await Self.systemStateProviderFactory()
+                .freshSMAppServiceStatus(for: Self.helperPlistName)
             if statusAfterError == .requiresApproval {
                 throw HelperManagerError.installationFailed(
                     "Approval required in System Settings → Login Items."

--- a/Sources/KeyPathAppKit/Core/HelperManager+Status.swift
+++ b/Sources/KeyPathAppKit/Core/HelperManager+Status.swift
@@ -22,7 +22,8 @@ extension HelperManager {
     /// invoked via `BundleProgram` in the plist; there is no binary at
     /// `/Library/PrivilegedHelperTools` as with legacy SMJobBless.
     public nonisolated func isHelperInstalled() async -> Bool {
-        let smStatus = await SMAppServiceStatusProvider.shared.cachedStatus(for: Self.helperPlistName)
+        let smStatus = await Self.systemStateProviderFactory()
+            .cachedSMAppServiceStatus(for: Self.helperPlistName)
         if smStatus == .enabled { return true }
 
         // Best-effort check: does launchd know about the job?
@@ -201,7 +202,8 @@ extension HelperManager {
     /// which caused 47s stalls when SMAppService.status was slow (see
     /// docs/bugs/2026-02-19-false-kanata-service-stopped-alert.md).
     func getHelperHealth() async -> HealthState {
-        let smStatus = await SMAppServiceStatusProvider.shared.cachedStatus(for: Self.helperPlistName)
+        let smStatus = await Self.systemStateProviderFactory()
+            .cachedSMAppServiceStatus(for: Self.helperPlistName)
 
         // Approval explicitly required
         if smStatus == .requiresApproval {

--- a/Tests/KeyPathTests/Lint/SMAppServiceStatusLintTests.swift
+++ b/Tests/KeyPathTests/Lint/SMAppServiceStatusLintTests.swift
@@ -97,6 +97,30 @@ final class SMAppServiceStatusLintTests: XCTestCase {
             """
         )
     }
+
+    func testHelperManagerAsyncStatusAccessDelegatesToSystemStateProvider() throws {
+        let files = [
+            repositoryRoot().appendingPathComponent("Sources/KeyPathAppKit/Core/HelperManager+Installation.swift"),
+            repositoryRoot().appendingPathComponent("Sources/KeyPathAppKit/Core/HelperManager+Status.swift")
+        ]
+
+        let violations = try files.flatMap {
+            try matchingLines(
+                in: $0,
+                patterns: [#"SMAppServiceStatusProvider\.shared"#]
+            )
+        }
+
+        XCTAssertTrue(
+            violations.isEmpty,
+            """
+            HelperManager async SMAppService status/cache access must delegate \
+            through SystemStateProvider. The synchronous helperNeedsLoginItemsApproval \
+            direct .status read remains separately guarded by the shrinking allowlist:
+            \(violations.sorted().joined(separator: "\n"))
+            """
+        )
+    }
 }
 
 private func repositoryRoot(file: StaticString = #filePath) -> URL {

--- a/docs/planning/installer-reliability-phase1.md
+++ b/docs/planning/installer-reliability-phase1.md
@@ -157,6 +157,15 @@ classification remains pending.
   `SystemStateProviderSMAppServiceTests.testSMAppServiceStatusInvalidationDelegatesToCentralStatusProvider`,
   and
   `SMAppServiceStatusLintTests.testKanataDaemonManagerDelegatesStatusProviderAccessToSystemStateProvider`.
+- [x] Migrated `HelperManager` async SMAppService status/cache reads and
+  invalidations through `SystemStateProvider`'s SMAppService status façade.
+  The synchronous `helperNeedsLoginItemsApproval()` wizard-navigation read
+  remains a later migration slice because it requires threading async state
+  through that caller. Enforced by
+  `SMAppServiceStatusLintTests.testHelperManagerAsyncStatusAccessDelegatesToSystemStateProvider`,
+  `HelperManagerTests.testInstallHelperAttemptsRegisterWhenStatusIsNotFoundAndSurfacesError`,
+  and
+  `HelperManagerTests.testInstallHelperRecoversEnabledButUnresponsiveRegistration`.
 - [ ] Migrate `SMAppService.status`, permissions, VHID state, helper freshness,
   and migrated read-only `launchctl print` evidence into a single immutable
   `SystemSnapshot`.
@@ -292,6 +301,12 @@ through 21 mocked tests).
   `SystemStateProviderSMAppServiceTests.testSMAppServiceStatusInvalidationDelegatesToCentralStatusProvider`,
   and
   `SMAppServiceStatusLintTests.testKanataDaemonManagerDelegatesStatusProviderAccessToSystemStateProvider`.
+- [x] `HelperManager` async SMAppService registration status/cache reads
+  delegate to `SystemStateProvider`'s SMAppService status façade. Enforced by
+  `SMAppServiceStatusLintTests.testHelperManagerAsyncStatusAccessDelegatesToSystemStateProvider`,
+  `HelperManagerTests.testInstallHelperAttemptsRegisterWhenStatusIsNotFoundAndSurfacesError`,
+  and
+  `HelperManagerTests.testInstallHelperRecoversEnabledButUnresponsiveRegistration`.
 
 ## Workstream 3: Industry-Standard Repair Model
 
@@ -397,6 +412,9 @@ is listed in the state-matrix doc's enforcement section.
 - [x] `SMAppServiceStatusLintTests.testKanataDaemonManagerDelegatesStatusProviderAccessToSystemStateProvider`
   prevents the first migrated SMAppService status consumer from bypassing
   `SystemStateProvider`.
+- [x] `SMAppServiceStatusLintTests.testHelperManagerAsyncStatusAccessDelegatesToSystemStateProvider`
+  prevents migrated `HelperManager` async SMAppService status/cache access from
+  bypassing `SystemStateProvider`.
 - [x] `TCPReadinessLintTests.testServiceHealthCheckerDelegatesTCPReadinessToSystemStateProvider`
   prevents `ServiceHealthChecker` from regrowing a private TCP socket probe.
 - [x] `TCPReadinessLintTests.testProductionTCPProbeAdapterIsNoLongerUsed` and

--- a/docs/process/installer-repair-state-matrix.md
+++ b/docs/process/installer-repair-state-matrix.md
@@ -209,7 +209,9 @@ the result as user action required and name the approval surface.
   and `SystemStateProviderSMAppServiceTests.testSMAppServiceStatusInvalidationDelegatesToCentralStatusProvider`
   pin the façade contract, while
   `SMAppServiceStatusLintTests.testKanataDaemonManagerDelegatesStatusProviderAccessToSystemStateProvider`
-  blocks migrated Kanata daemon status reads from bypassing it.
+  blocks migrated Kanata daemon status reads from bypassing it and
+  `SMAppServiceStatusLintTests.testHelperManagerAsyncStatusAccessDelegatesToSystemStateProvider`
+  blocks migrated HelperManager async status reads from bypassing it.
 - User-facing CLI/reporting shape belongs in CLI contract tests.
 
 ## Related References


### PR DESCRIPTION
## Summary
- route HelperManager async SMAppService status/cache reads and invalidations through SystemStateProvider's SMAppService façade
- add a HelperManager-specific SMAppService lint ratchet
- update the Phase 1 plan and state-matrix contract with the tests enforcing this slice

## Acceptance criteria / enforcing tests
- HelperManager async status/cache access delegates to SystemStateProvider: SMAppServiceStatusLintTests.testHelperManagerAsyncStatusAccessDelegatesToSystemStateProvider
- SMAppService façade remains delegated to the shared status provider: SystemStateProviderSMAppServiceTests.testSMAppServiceStatusAccessDelegatesToCentralStatusProvider, SystemStateProviderSMAppServiceTests.testSMAppServiceFreshStatusBypassesCache, SystemStateProviderSMAppServiceTests.testSMAppServiceStatusInvalidationDelegatesToCentralStatusProvider
- Helper registration behavior still handles missing and stale-enabled registrations: HelperManagerTests.testInstallHelperAttemptsRegisterWhenStatusIsNotFoundAndSurfacesError, HelperManagerTests.testInstallHelperRecoversEnabledButUnresponsiveRegistration

## Validation
- TEST_FILTER='HelperManagerTests|SMAppServiceStatusLintTests|SystemStateProviderSMAppServiceTests' ./Scripts/run-tests-safe.sh (11 passed)
- python3 Scripts/check-accessibility.py
- git diff --check
- ./Scripts/run-tests-safe.sh (4482 passed)

## Plan / code reality note
- The synchronous HelperManager.helperNeedsLoginItemsApproval() direct .status read remains intentionally allowlisted for a later async wizard-navigation slice; this PR migrates only async HelperManager status/cache paths.

## Review gate
- Local /thermo-nuclear-swift-review could not be run in this Codex shell because neither thermo-nuclear-swift-review nor claude is available on PATH. This PR relies on the GitHub claude-review check as the available review gate.