### PR TITLE
Route KanataDaemonService status through SystemStateProvider

### DIFF
--- a/Sources/KeyPathAppKit/Services/Kanata/KanataDaemonService.swift
+++ b/Sources/KeyPathAppKit/Services/Kanata/KanataDaemonService.swift
@@ -100,8 +100,8 @@ final class KanataDaemonService {
         let service = makeSMService()
         do {
             try await service.unregister()
-            // Drop the centralized status cache so the next read re-fetches (#853).
-            await SMAppServiceStatusProvider.shared.invalidate(plistName: Constants.daemonPlistName)
+            // Drop the centralized status cache so the next read re-fetches.
+            await SystemStateProvider.shared.invalidateSMAppServiceStatus(plistName: Constants.daemonPlistName)
         } catch {
             if TestEnvironment.isRunningTests {
                 AppLogger.shared.log("🧪 [KanataDaemonService] Ignoring unregister error in tests: \(error)")
@@ -200,11 +200,11 @@ final class KanataDaemonService {
 
     private func evaluateStatus() async -> ServiceState {
         let pidCache = pidCache
-        // Route the SMAppService.status read through the centralized provider (#853).
+        // Route the SMAppService.status read through SystemStateProvider.
         // This is the hot state-refresh path (overlay polling), so use the cached
         // accessor — it collapses a polling burst into a single background IPC.
-        async let smStatusValue = SMAppServiceStatusProvider.shared
-            .cachedStatus(for: Constants.daemonPlistName)
+        async let smStatusValue = SystemStateProvider.shared
+            .cachedSMAppServiceStatus(for: Constants.daemonPlistName)
         let processTask = Task.detached(priority: .utility) {
             await Self.detectProcessState(pidCache: pidCache)
         }

--- a/Tests/KeyPathTests/Lint/SMAppServiceStatusLintTests.swift
+++ b/Tests/KeyPathTests/Lint/SMAppServiceStatusLintTests.swift
@@ -121,6 +121,25 @@ final class SMAppServiceStatusLintTests: XCTestCase {
             """
         )
     }
+
+    func testKanataDaemonServiceDelegatesStatusProviderAccessToSystemStateProvider() throws {
+        let service = repositoryRoot()
+            .appendingPathComponent("Sources/KeyPathAppKit/Services/Kanata/KanataDaemonService.swift")
+
+        let violations = try matchingLines(
+            in: service,
+            patterns: [#"SMAppServiceStatusProvider\.shared"#]
+        )
+
+        XCTAssertTrue(
+            violations.isEmpty,
+            """
+            KanataDaemonService must delegate SMAppService status/cache access \
+            through SystemStateProvider:
+            \(violations.sorted().joined(separator: "\n"))
+            """
+        )
+    }
 }
 
 private func repositoryRoot(file: StaticString = #filePath) -> URL {

--- a/docs/planning/installer-reliability-phase1.md
+++ b/docs/planning/installer-reliability-phase1.md
@@ -166,6 +166,13 @@ classification remains pending.
   `HelperManagerTests.testInstallHelperAttemptsRegisterWhenStatusIsNotFoundAndSurfacesError`,
   and
   `HelperManagerTests.testInstallHelperRecoversEnabledButUnresponsiveRegistration`.
+- [x] Migrated `KanataDaemonService` SMAppService status/cache reads and
+  invalidations through `SystemStateProvider`'s SMAppService status façade.
+  Enforced by
+  `SMAppServiceStatusLintTests.testKanataDaemonServiceDelegatesStatusProviderAccessToSystemStateProvider`,
+  `KanataDaemonServiceIntegrationTests.testStopService_ShouldUnregister`,
+  and
+  `KanataDaemonServiceIntegrationTests.testEvaluateStatus_WhenPIDAndTCPBothFail_ShouldReportFailed`.
 - [ ] Migrate `SMAppService.status`, permissions, VHID state, helper freshness,
   and migrated read-only `launchctl print` evidence into a single immutable
   `SystemSnapshot`.
@@ -307,6 +314,12 @@ through 21 mocked tests).
   `HelperManagerTests.testInstallHelperAttemptsRegisterWhenStatusIsNotFoundAndSurfacesError`,
   and
   `HelperManagerTests.testInstallHelperRecoversEnabledButUnresponsiveRegistration`.
+- [x] `KanataDaemonService` SMAppService registration status/cache reads
+  delegate to `SystemStateProvider`'s SMAppService status façade. Enforced by
+  `SMAppServiceStatusLintTests.testKanataDaemonServiceDelegatesStatusProviderAccessToSystemStateProvider`,
+  `KanataDaemonServiceIntegrationTests.testStopService_ShouldUnregister`,
+  and
+  `KanataDaemonServiceIntegrationTests.testEvaluateStatus_WhenPIDAndTCPBothFail_ShouldReportFailed`.
 
 ## Workstream 3: Industry-Standard Repair Model
 
@@ -414,6 +427,9 @@ is listed in the state-matrix doc's enforcement section.
   `SystemStateProvider`.
 - [x] `SMAppServiceStatusLintTests.testHelperManagerAsyncStatusAccessDelegatesToSystemStateProvider`
   prevents migrated `HelperManager` async SMAppService status/cache access from
+  bypassing `SystemStateProvider`.
+- [x] `SMAppServiceStatusLintTests.testKanataDaemonServiceDelegatesStatusProviderAccessToSystemStateProvider`
+  prevents migrated `KanataDaemonService` SMAppService status/cache access from
   bypassing `SystemStateProvider`.
 - [x] `TCPReadinessLintTests.testServiceHealthCheckerDelegatesTCPReadinessToSystemStateProvider`
   prevents `ServiceHealthChecker` from regrowing a private TCP socket probe.

--- a/docs/process/installer-repair-state-matrix.md
+++ b/docs/process/installer-repair-state-matrix.md
@@ -211,7 +211,9 @@ the result as user action required and name the approval surface.
   `SMAppServiceStatusLintTests.testKanataDaemonManagerDelegatesStatusProviderAccessToSystemStateProvider`
   blocks migrated Kanata daemon status reads from bypassing it and
   `SMAppServiceStatusLintTests.testHelperManagerAsyncStatusAccessDelegatesToSystemStateProvider`
-  blocks migrated HelperManager async status reads from bypassing it.
+  blocks migrated HelperManager async status reads from bypassing it, while
+  `SMAppServiceStatusLintTests.testKanataDaemonServiceDelegatesStatusProviderAccessToSystemStateProvider`
+  blocks migrated KanataDaemonService status reads from bypassing it.
 - User-facing CLI/reporting shape belongs in CLI contract tests.
 
 ## Related References


### PR DESCRIPTION
## Summary
- route KanataDaemonService SMAppService status reads and invalidations through SystemStateProvider's SMAppService façade
- add a KanataDaemonService-specific SMAppService lint ratchet
- update the Phase 1 plan and state-matrix contract with the tests enforcing this slice

## Acceptance criteria / enforcing tests
- KanataDaemonService status/cache access delegates to SystemStateProvider: SMAppServiceStatusLintTests.testKanataDaemonServiceDelegatesStatusProviderAccessToSystemStateProvider
- SMAppService façade remains delegated to the shared status provider: SystemStateProviderSMAppServiceTests.testSMAppServiceStatusAccessDelegatesToCentralStatusProvider, SystemStateProviderSMAppServiceTests.testSMAppServiceFreshStatusBypassesCache, SystemStateProviderSMAppServiceTests.testSMAppServiceStatusInvalidationDelegatesToCentralStatusProvider
- KanataDaemonService behavior still handles unregister and enabled-but-not-running failure: KanataDaemonServiceIntegrationTests.testStopService_ShouldUnregister, KanataDaemonServiceIntegrationTests.testEvaluateStatus_WhenPIDAndTCPBothFail_ShouldReportFailed

## Validation
- TEST_FILTER='KanataDaemonServiceIntegrationTests|SMAppServiceStatusLintTests|SystemStateProviderSMAppServiceTests' ./Scripts/run-tests-safe.sh (10 passed)
- python3 Scripts/check-accessibility.py
- git diff --check
- ./Scripts/run-tests-safe.sh (4483 passed)

## Plan / code reality note
- This PR only migrates KanataDaemonService's SMAppService status/cache access. Broader app/uninstall/helper-maintenance SMAppService consumers remain pending in separate Phase 1 slices.

## Review gate
- Local /thermo-nuclear-swift-review could not be run in this Codex shell because neither thermo-nuclear-swift-review nor claude is available on PATH. This PR relies on the GitHub claude-review check as the available review gate.