### PR TITLE
Route HelperMaintenance status through SystemStateProvider

### DIFF
--- a/Sources/KeyPathAppKit/Managers/HelperMaintenance.swift
+++ b/Sources/KeyPathAppKit/Managers/HelperMaintenance.swift
@@ -222,16 +222,16 @@ public final class HelperMaintenance {
             return
         }
         let svc = HelperManager.smServiceFactory(HelperManager.helperPlistName)
-        // Fresh read via the centralized provider (#853) — this unregister flow must
+        // Fresh read via SystemStateProvider — this unregister flow must
         // decide on current truth, not a stale cached value.
-        let status = await SMAppServiceStatusProvider.shared.freshStatus(for: HelperManager.helperPlistName)
+        let status = await SystemStateProvider.shared.freshSMAppServiceStatus(for: HelperManager.helperPlistName)
         log(
             "🔎 SMAppService status: \(status.rawValue) (0=notRegistered,1=enabled,2=requiresApproval,3=notFound)"
         )
         if status == .enabled || status == .notRegistered || status == .requiresApproval {
             do {
                 try await svc.unregister()
-                await SMAppServiceStatusProvider.shared.invalidate(plistName: HelperManager.helperPlistName)
+                await SystemStateProvider.shared.invalidateSMAppServiceStatus(plistName: HelperManager.helperPlistName)
                 log("✅ SMAppService unregister succeeded")
             } catch {
                 log("⚠️ SMAppService unregister failed: \(error.localizedDescription)")

--- a/Tests/KeyPathTests/Lint/SMAppServiceStatusLintTests.swift
+++ b/Tests/KeyPathTests/Lint/SMAppServiceStatusLintTests.swift
@@ -140,6 +140,25 @@ final class SMAppServiceStatusLintTests: XCTestCase {
             """
         )
     }
+
+    func testHelperMaintenanceDelegatesStatusProviderAccessToSystemStateProvider() throws {
+        let maintenance = repositoryRoot()
+            .appendingPathComponent("Sources/KeyPathAppKit/Managers/HelperMaintenance.swift")
+
+        let violations = try matchingLines(
+            in: maintenance,
+            patterns: [#"SMAppServiceStatusProvider\.shared"#]
+        )
+
+        XCTAssertTrue(
+            violations.isEmpty,
+            """
+            HelperMaintenance must delegate SMAppService status/cache access \
+            through SystemStateProvider:
+            \(violations.sorted().joined(separator: "\n"))
+            """
+        )
+    }
 }
 
 private func repositoryRoot(file: StaticString = #filePath) -> URL {

--- a/docs/planning/installer-reliability-phase1.md
+++ b/docs/planning/installer-reliability-phase1.md
@@ -173,6 +173,13 @@ classification remains pending.
   `KanataDaemonServiceIntegrationTests.testStopService_ShouldUnregister`,
   and
   `KanataDaemonServiceIntegrationTests.testEvaluateStatus_WhenPIDAndTCPBothFail_ShouldReportFailed`.
+- [x] Migrated `HelperMaintenance` SMAppService status/cache reads and
+  invalidations through `SystemStateProvider`'s SMAppService status façade.
+  Enforced by
+  `SMAppServiceStatusLintTests.testHelperMaintenanceDelegatesStatusProviderAccessToSystemStateProvider`,
+  `HelperMaintenanceTests.testForceFullRepairReinstallsEvenWhenHelperResponds`,
+  and
+  `HelperMaintenanceTests.testRepairForcesReinstallWhenRegisteredButUnresponsive`.
 - [ ] Migrate `SMAppService.status`, permissions, VHID state, helper freshness,
   and migrated read-only `launchctl print` evidence into a single immutable
   `SystemSnapshot`.
@@ -320,6 +327,12 @@ through 21 mocked tests).
   `KanataDaemonServiceIntegrationTests.testStopService_ShouldUnregister`,
   and
   `KanataDaemonServiceIntegrationTests.testEvaluateStatus_WhenPIDAndTCPBothFail_ShouldReportFailed`.
+- [x] `HelperMaintenance` SMAppService registration status/cache reads delegate
+  to `SystemStateProvider`'s SMAppService status façade. Enforced by
+  `SMAppServiceStatusLintTests.testHelperMaintenanceDelegatesStatusProviderAccessToSystemStateProvider`,
+  `HelperMaintenanceTests.testForceFullRepairReinstallsEvenWhenHelperResponds`,
+  and
+  `HelperMaintenanceTests.testRepairForcesReinstallWhenRegisteredButUnresponsive`.
 
 ## Workstream 3: Industry-Standard Repair Model
 
@@ -430,6 +443,9 @@ is listed in the state-matrix doc's enforcement section.
   bypassing `SystemStateProvider`.
 - [x] `SMAppServiceStatusLintTests.testKanataDaemonServiceDelegatesStatusProviderAccessToSystemStateProvider`
   prevents migrated `KanataDaemonService` SMAppService status/cache access from
+  bypassing `SystemStateProvider`.
+- [x] `SMAppServiceStatusLintTests.testHelperMaintenanceDelegatesStatusProviderAccessToSystemStateProvider`
+  prevents migrated `HelperMaintenance` SMAppService status/cache access from
   bypassing `SystemStateProvider`.
 - [x] `TCPReadinessLintTests.testServiceHealthCheckerDelegatesTCPReadinessToSystemStateProvider`
   prevents `ServiceHealthChecker` from regrowing a private TCP socket probe.

--- a/docs/process/installer-repair-state-matrix.md
+++ b/docs/process/installer-repair-state-matrix.md
@@ -213,7 +213,9 @@ the result as user action required and name the approval surface.
   `SMAppServiceStatusLintTests.testHelperManagerAsyncStatusAccessDelegatesToSystemStateProvider`
   blocks migrated HelperManager async status reads from bypassing it, while
   `SMAppServiceStatusLintTests.testKanataDaemonServiceDelegatesStatusProviderAccessToSystemStateProvider`
-  blocks migrated KanataDaemonService status reads from bypassing it.
+  blocks migrated KanataDaemonService status reads from bypassing it and
+  `SMAppServiceStatusLintTests.testHelperMaintenanceDelegatesStatusProviderAccessToSystemStateProvider`
+  blocks migrated HelperMaintenance status reads from bypassing it.
 - User-facing CLI/reporting shape belongs in CLI contract tests.
 
 ## Related References


### PR DESCRIPTION
## Summary
- route HelperMaintenance SMAppService status reads and invalidations through SystemStateProvider's SMAppService façade
- add a HelperMaintenance-specific SMAppService lint ratchet
- update the Phase 1 plan and state-matrix contract with the tests enforcing this slice

## Acceptance criteria / enforcing tests
- HelperMaintenance status/cache access delegates to SystemStateProvider: SMAppServiceStatusLintTests.testHelperMaintenanceDelegatesStatusProviderAccessToSystemStateProvider
- SMAppService façade remains delegated to the shared status provider: SystemStateProviderSMAppServiceTests.testSMAppServiceStatusAccessDelegatesToCentralStatusProvider, SystemStateProviderSMAppServiceTests.testSMAppServiceFreshStatusBypassesCache, SystemStateProviderSMAppServiceTests.testSMAppServiceStatusInvalidationDelegatesToCentralStatusProvider
- Helper maintenance repair behavior still forces reinstall when needed: HelperMaintenanceTests.testForceFullRepairReinstallsEvenWhenHelperResponds, HelperMaintenanceTests.testRepairForcesReinstallWhenRegisteredButUnresponsive

## Validation
- TEST_FILTER='HelperMaintenanceTests|SMAppServiceStatusLintTests|SystemStateProviderSMAppServiceTests' ./Scripts/run-tests-safe.sh (15 passed)
- python3 Scripts/check-accessibility.py
- git diff --check
- ./Scripts/run-tests-safe.sh (4484 passed)

## Plan / code reality note
- This PR only migrates HelperMaintenance's SMAppService status/cache access. App.swift and UninstallCoordinator SMAppService consumers remain pending in separate Phase 1 slices.

## Review gate
- Local /thermo-nuclear-swift-review could not be run in this Codex shell because neither thermo-nuclear-swift-review nor claude is available on PATH. This PR relies on the GitHub claude-review check as the available review gate.