### PR TITLE
Route uninstall status through SystemStateProvider

### DIFF
--- a/Sources/KeyPathAppKit/Managers/UninstallCoordinator.swift
+++ b/Sources/KeyPathAppKit/Managers/UninstallCoordinator.swift
@@ -212,7 +212,7 @@ public final class UninstallCoordinator {
 
         for plistName in daemonPlists {
             let service = HelperManager.smServiceFactory(plistName)
-            let status = await SMAppServiceStatusProvider.shared.freshStatus(for: plistName)
+            let status = await SystemStateProvider.shared.freshSMAppServiceStatus(for: plistName)
             guard status == .enabled else {
                 logLines.append("ℹ️ SMAppService \(plistName): not registered, skipping")
                 continue
@@ -220,7 +220,7 @@ public final class UninstallCoordinator {
 
             do {
                 try await service.unregister()
-                await SMAppServiceStatusProvider.shared.invalidate(plistName: plistName)
+                await SystemStateProvider.shared.invalidateSMAppServiceStatus(plistName: plistName)
                 logLines.append("✅ SMAppService \(plistName): unregistered")
             } catch {
                 // Log but continue - the helper/script will still clean up files

--- a/Tests/KeyPathTests/Lint/SMAppServiceStatusLintTests.swift
+++ b/Tests/KeyPathTests/Lint/SMAppServiceStatusLintTests.swift
@@ -159,6 +159,25 @@ final class SMAppServiceStatusLintTests: XCTestCase {
             """
         )
     }
+
+    func testUninstallCoordinatorDelegatesStatusProviderAccessToSystemStateProvider() throws {
+        let coordinator = repositoryRoot()
+            .appendingPathComponent("Sources/KeyPathAppKit/Managers/UninstallCoordinator.swift")
+
+        let violations = try matchingLines(
+            in: coordinator,
+            patterns: [#"SMAppServiceStatusProvider\.shared"#]
+        )
+
+        XCTAssertTrue(
+            violations.isEmpty,
+            """
+            UninstallCoordinator must delegate SMAppService status/cache access \
+            through SystemStateProvider:
+            \(violations.sorted().joined(separator: "\n"))
+            """
+        )
+    }
 }
 
 private func repositoryRoot(file: StaticString = #filePath) -> URL {

--- a/docs/planning/installer-reliability-phase1.md
+++ b/docs/planning/installer-reliability-phase1.md
@@ -180,6 +180,13 @@ classification remains pending.
   `HelperMaintenanceTests.testForceFullRepairReinstallsEvenWhenHelperResponds`,
   and
   `HelperMaintenanceTests.testRepairForcesReinstallWhenRegisteredButUnresponsive`.
+- [x] Migrated `UninstallCoordinator` SMAppService status/cache reads and
+  invalidations through `SystemStateProvider`'s SMAppService status façade.
+  Enforced by
+  `SMAppServiceStatusLintTests.testUninstallCoordinatorDelegatesStatusProviderAccessToSystemStateProvider`,
+  `UninstallCoordinatorTests.testUninstallRemovesPathsAndLogsSuccess`,
+  and
+  `UninstallCoordinatorTests.testUninstallFailsWhenScriptMissing`.
 - [ ] Migrate `SMAppService.status`, permissions, VHID state, helper freshness,
   and migrated read-only `launchctl print` evidence into a single immutable
   `SystemSnapshot`.
@@ -333,6 +340,12 @@ through 21 mocked tests).
   `HelperMaintenanceTests.testForceFullRepairReinstallsEvenWhenHelperResponds`,
   and
   `HelperMaintenanceTests.testRepairForcesReinstallWhenRegisteredButUnresponsive`.
+- [x] `UninstallCoordinator` SMAppService registration status/cache reads
+  delegate to `SystemStateProvider`'s SMAppService status façade. Enforced by
+  `SMAppServiceStatusLintTests.testUninstallCoordinatorDelegatesStatusProviderAccessToSystemStateProvider`,
+  `UninstallCoordinatorTests.testUninstallRemovesPathsAndLogsSuccess`,
+  and
+  `UninstallCoordinatorTests.testUninstallFailsWhenScriptMissing`.
 
 ## Workstream 3: Industry-Standard Repair Model
 
@@ -446,6 +459,9 @@ is listed in the state-matrix doc's enforcement section.
   bypassing `SystemStateProvider`.
 - [x] `SMAppServiceStatusLintTests.testHelperMaintenanceDelegatesStatusProviderAccessToSystemStateProvider`
   prevents migrated `HelperMaintenance` SMAppService status/cache access from
+  bypassing `SystemStateProvider`.
+- [x] `SMAppServiceStatusLintTests.testUninstallCoordinatorDelegatesStatusProviderAccessToSystemStateProvider`
+  prevents migrated `UninstallCoordinator` SMAppService status/cache access from
   bypassing `SystemStateProvider`.
 - [x] `TCPReadinessLintTests.testServiceHealthCheckerDelegatesTCPReadinessToSystemStateProvider`
   prevents `ServiceHealthChecker` from regrowing a private TCP socket probe.

--- a/docs/process/installer-repair-state-matrix.md
+++ b/docs/process/installer-repair-state-matrix.md
@@ -215,7 +215,9 @@ the result as user action required and name the approval surface.
   `SMAppServiceStatusLintTests.testKanataDaemonServiceDelegatesStatusProviderAccessToSystemStateProvider`
   blocks migrated KanataDaemonService status reads from bypassing it and
   `SMAppServiceStatusLintTests.testHelperMaintenanceDelegatesStatusProviderAccessToSystemStateProvider`
-  blocks migrated HelperMaintenance status reads from bypassing it.
+  blocks migrated HelperMaintenance status reads from bypassing it, while
+  `SMAppServiceStatusLintTests.testUninstallCoordinatorDelegatesStatusProviderAccessToSystemStateProvider`
+  blocks migrated UninstallCoordinator status reads from bypassing it.
 - User-facing CLI/reporting shape belongs in CLI contract tests.
 
 ## Related References


### PR DESCRIPTION
## Summary
- route UninstallCoordinator SMAppService status reads and invalidations through SystemStateProvider's SMAppService façade
- add an UninstallCoordinator-specific SMAppService lint ratchet
- update the Phase 1 plan and state-matrix contract with the tests enforcing this slice

## Acceptance criteria / enforcing tests
- UninstallCoordinator status/cache access delegates to SystemStateProvider: SMAppServiceStatusLintTests.testUninstallCoordinatorDelegatesStatusProviderAccessToSystemStateProvider
- SMAppService façade remains delegated to the shared status provider: SystemStateProviderSMAppServiceTests.testSMAppServiceStatusAccessDelegatesToCentralStatusProvider, SystemStateProviderSMAppServiceTests.testSMAppServiceFreshStatusBypassesCache, SystemStateProviderSMAppServiceTests.testSMAppServiceStatusInvalidationDelegatesToCentralStatusProvider
- Uninstall flow behavior remains covered by UninstallCoordinatorTests.testUninstallRemovesPathsAndLogsSuccess and UninstallCoordinatorTests.testUninstallFailsWhenScriptMissing

## Validation
- TEST_FILTER='UninstallCoordinatorTests|SMAppServiceStatusLintTests|SystemStateProviderSMAppServiceTests' ./Scripts/run-tests-safe.sh (13 passed)
- python3 Scripts/check-accessibility.py
- git diff --check
- ./Scripts/run-tests-safe.sh (4485 passed)

## Plan / code reality note
- This PR only migrates UninstallCoordinator's SMAppService status/cache access. App.swift remains the last production SMAppServiceStatusProvider consumer pending in a separate Phase 1 slice.

## Review gate
- Local /thermo-nuclear-swift-review could not be run in this Codex shell because neither thermo-nuclear-swift-review nor claude is available on PATH. This PR relies on the GitHub claude-review check as the available review gate.