### PR TITLE
Route app SMAppService status through SystemStateProvider

### DIFF
--- a/Sources/KeyPathAppKit/App.swift
+++ b/Sources/KeyPathAppKit/App.swift
@@ -676,13 +676,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     // MARK: - Private: Fresh Install Check
 
     private static func checkIsFreshInstall() async -> Bool {
-        // Route SMAppService.status through the centralized provider (issue #853):
+        // Route SMAppService.status through SystemStateProvider (issue #853):
         // these two reads used to be direct synchronous IPC on the MainActor during
         // app init, which could stall the UI for up to 30s under load.
-        let helperStatus = await SMAppServiceStatusProvider.shared.freshStatus(
+        let helperStatus = await SystemStateProvider.shared.freshSMAppServiceStatus(
             for: HelperManager.helperPlistName
         )
-        let daemonStatus = await SMAppServiceStatusProvider.shared.freshStatus(
+        let daemonStatus = await SystemStateProvider.shared.freshSMAppServiceStatus(
             for: KanataDaemonManager.kanataPlistName
         )
 
@@ -877,8 +877,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     @MainActor
     private func showSMAppServiceStatus(plistName: String) async {
-        // Route through the centralized provider (#853) even in dev utilities.
-        let status = await SMAppServiceStatusProvider.shared.freshStatus(for: plistName)
+        // Route through SystemStateProvider (#853) even in dev utilities.
+        let status = await SystemStateProvider.shared.freshSMAppServiceStatus(for: plistName)
         AppLogger.shared.info(
             "🔧 [SM] \(plistName) status=\(status.rawValue) (0=notRegistered,1=enabled,2=requiresApproval,3=notFound)"
         )
@@ -889,7 +889,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         let svc = SMAppService.daemon(plistName: plistName)
         do {
             try svc.register()
-            await SMAppServiceStatusProvider.shared.invalidate(plistName: plistName)
+            await SystemStateProvider.shared.invalidateSMAppServiceStatus(plistName: plistName)
             AppLogger.shared.info("✅ [SM] register() ok for \(plistName)")
         } catch {
             AppLogger.shared.error("❌ [SM] register() failed for \(plistName): \(error)")
@@ -903,7 +903,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             Task { @MainActor in
                 do {
                     try await svc.unregister()
-                    await SMAppServiceStatusProvider.shared.invalidate(plistName: plistName)
+                    await SystemStateProvider.shared.invalidateSMAppServiceStatus(plistName: plistName)
                     AppLogger.shared.info("✅ [SM] unregister() ok for \(plistName)")
                 } catch {
                     AppLogger.shared.error("❌ [SM] unregister() failed for \(plistName): \(error)")

--- a/Tests/KeyPathTests/Lint/SMAppServiceStatusLintTests.swift
+++ b/Tests/KeyPathTests/Lint/SMAppServiceStatusLintTests.swift
@@ -178,6 +178,25 @@ final class SMAppServiceStatusLintTests: XCTestCase {
             """
         )
     }
+
+    func testAppLifecycleDelegatesStatusProviderAccessToSystemStateProvider() throws {
+        let app = repositoryRoot()
+            .appendingPathComponent("Sources/KeyPathAppKit/App.swift")
+
+        let violations = try matchingLines(
+            in: app,
+            patterns: [#"SMAppServiceStatusProvider\.shared"#]
+        )
+
+        XCTAssertTrue(
+            violations.isEmpty,
+            """
+            App lifecycle code must delegate SMAppService status/cache access \
+            through SystemStateProvider:
+            \(violations.sorted().joined(separator: "\n"))
+            """
+        )
+    }
 }
 
 private func repositoryRoot(file: StaticString = #filePath) -> URL {

--- a/docs/planning/installer-reliability-phase1.md
+++ b/docs/planning/installer-reliability-phase1.md
@@ -187,6 +187,12 @@ classification remains pending.
   `UninstallCoordinatorTests.testUninstallRemovesPathsAndLogsSuccess`,
   and
   `UninstallCoordinatorTests.testUninstallFailsWhenScriptMissing`.
+- [x] Migrated `App.swift` lifecycle/dev-utility SMAppService status/cache
+  reads and invalidations through `SystemStateProvider`'s SMAppService status
+  façade. Enforced by
+  `SMAppServiceStatusLintTests.testAppLifecycleDelegatesStatusProviderAccessToSystemStateProvider`
+  and
+  `SystemStateProviderSMAppServiceTests.testSMAppServiceStatusAccessDelegatesToCentralStatusProvider`.
 - [ ] Migrate `SMAppService.status`, permissions, VHID state, helper freshness,
   and migrated read-only `launchctl print` evidence into a single immutable
   `SystemSnapshot`.
@@ -346,6 +352,12 @@ through 21 mocked tests).
   `UninstallCoordinatorTests.testUninstallRemovesPathsAndLogsSuccess`,
   and
   `UninstallCoordinatorTests.testUninstallFailsWhenScriptMissing`.
+- [x] `App.swift` lifecycle/dev-utility SMAppService registration status/cache
+  reads delegate to `SystemStateProvider`'s SMAppService status façade.
+  Enforced by
+  `SMAppServiceStatusLintTests.testAppLifecycleDelegatesStatusProviderAccessToSystemStateProvider`
+  and
+  `SystemStateProviderSMAppServiceTests.testSMAppServiceStatusAccessDelegatesToCentralStatusProvider`.
 
 ## Workstream 3: Industry-Standard Repair Model
 
@@ -463,6 +475,9 @@ is listed in the state-matrix doc's enforcement section.
 - [x] `SMAppServiceStatusLintTests.testUninstallCoordinatorDelegatesStatusProviderAccessToSystemStateProvider`
   prevents migrated `UninstallCoordinator` SMAppService status/cache access from
   bypassing `SystemStateProvider`.
+- [x] `SMAppServiceStatusLintTests.testAppLifecycleDelegatesStatusProviderAccessToSystemStateProvider`
+  prevents migrated app lifecycle/dev-utility SMAppService status/cache access
+  from bypassing `SystemStateProvider`.
 - [x] `TCPReadinessLintTests.testServiceHealthCheckerDelegatesTCPReadinessToSystemStateProvider`
   prevents `ServiceHealthChecker` from regrowing a private TCP socket probe.
 - [x] `TCPReadinessLintTests.testProductionTCPProbeAdapterIsNoLongerUsed` and

--- a/docs/process/installer-repair-state-matrix.md
+++ b/docs/process/installer-repair-state-matrix.md
@@ -217,7 +217,9 @@ the result as user action required and name the approval surface.
   `SMAppServiceStatusLintTests.testHelperMaintenanceDelegatesStatusProviderAccessToSystemStateProvider`
   blocks migrated HelperMaintenance status reads from bypassing it, while
   `SMAppServiceStatusLintTests.testUninstallCoordinatorDelegatesStatusProviderAccessToSystemStateProvider`
-  blocks migrated UninstallCoordinator status reads from bypassing it.
+  blocks migrated UninstallCoordinator status reads from bypassing it, and
+  `SMAppServiceStatusLintTests.testAppLifecycleDelegatesStatusProviderAccessToSystemStateProvider`
+  blocks migrated App lifecycle/dev-utility status reads from bypassing it.
 - User-facing CLI/reporting shape belongs in CLI contract tests.
 
 ## Related References


### PR DESCRIPTION
## Summary
- Route App.swift fresh-install and DEBUG SMAppService utility status/cache calls through SystemStateProvider.
- Add an SMAppServiceStatusLintTests ratchet so App lifecycle code cannot call SMAppServiceStatusProvider.shared directly again.
- Update the Phase 1 plan and state-matrix enforcement docs with the completed acceptance evidence.

## Acceptance criteria / tests
- App lifecycle/dev-utility SMAppService status/cache migration is enforced by `SMAppServiceStatusLintTests.testAppLifecycleDelegatesStatusProviderAccessToSystemStateProvider`.
- SystemStateProvider SMAppService façade behavior is enforced by `SystemStateProviderSMAppServiceTests.testSMAppServiceStatusAccessDelegatesToCentralStatusProvider`, `testSMAppServiceFreshStatusBypassesCache`, and `testSMAppServiceStatusInvalidationDelegatesToCentralStatusProvider`.
- Full regression net passed with `./Scripts/run-tests-safe.sh` (4486 tests).

## Validation
- `TEST_FILTER='SMAppServiceStatusLintTests|SystemStateProviderSMAppServiceTests' ./Scripts/run-tests-safe.sh` — 10 passed.
- `git diff --check`
- `python3 Scripts/check-accessibility.py`
- `rg -n "SMAppServiceStatusProvider\.shared" Sources/KeyPathAppKit Tests/KeyPathTests/Lint/SMAppServiceStatusLintTests.swift docs/planning/installer-reliability-phase1.md docs/process/installer-repair-state-matrix.md` — production references remain only in `Sources/KeyPathAppKit/Core/SystemStateProvider+SMAppService.swift`.
- `./Scripts/run-tests-safe.sh` — 4486 passed.

## Plan / code reality note
No conflict found. App.swift lifecycle paths did not need behavior changes; this slice only moves status/cache access behind the Phase 1 SystemStateProvider façade and adds the matching ratchet.

## Review gate note
Attempted the required local review gate, but `thermo-nuclear-swift-review` and `claude` are not available on PATH in this Codex shell. This PR relies on GitHub `claude-review` for the review gate, matching the prior Phase 1 slices.