### PR TITLE
Tighten docs CI and warm focused test lanes

### DIFF
--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -7,8 +7,10 @@ name: KeyPath CI (docs)
 # reports the same check-run names as success, so docs-only PRs satisfy branch protection
 # without an admin override. The `paths` list MUST mirror ci.yml's `paths-ignore`.
 #
-# Mixed PRs (docs + code) trigger both workflows; ci.yml's real result governs pass/fail
-# (a real failure still blocks), and this stub's success is harmless/redundant.
+# Mixed PRs (docs + code) trigger this workflow at the event level, but the
+# classifier job below keeps the required-context stubs from running unless
+# every changed file is docs/resource-only. That avoids duplicate green
+# `build-and-test` / `code-quality` checks on ordinary code PRs.
 
 on:
   pull_request:
@@ -28,13 +30,51 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  classify-docs-only:
+    runs-on: ubuntu-latest
+    outputs:
+      docs_only: ${{ steps.classify.outputs.docs_only }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Check whether all changed files are docs-only
+        id: classify
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          base="${{ github.event.pull_request.base.sha }}"
+          docs_only=true
+
+          while IFS= read -r path; do
+            [ -n "$path" ] || continue
+            case "$path" in
+              docs/*|*.md|.github/workflows/claude.yml|.github/workflows/claude-code-review.yml|Sources/KeyPathAppKit/Resources/*.md|Sources/KeyPathAppKit/Resources/*.css|Sources/KeyPathAppKit/Resources/*.png)
+                ;;
+              *)
+                docs_only=false
+                ;;
+            esac
+          done < <(git diff --name-only "$base"...HEAD)
+
+          echo "docs_only=$docs_only" >> "$GITHUB_OUTPUT"
+          echo "docs_only=$docs_only"
+
   # Job names MUST match ci.yml's required check contexts exactly.
   build-and-test:
+    needs: classify-docs-only
+    if: needs.classify-docs-only.outputs.docs_only == 'true'
     runs-on: ubuntu-latest
     steps:
       - run: echo "Docs-only change — no Swift build/test applicable; reporting success (#650)."
 
   code-quality:
+    needs: classify-docs-only
+    if: needs.classify-docs-only.outputs.docs_only == 'true'
     runs-on: ubuntu-latest
     steps:
       - run: echo "Docs-only change — no Swift code-quality applicable; reporting success (#650)."

--- a/Scripts/test-fast.sh
+++ b/Scripts/test-fast.sh
@@ -11,6 +11,10 @@ Usage: Scripts/test-fast.sh [area|--changed|--full|--list]
 
 Run the smallest useful KeyPath test scope through run-tests-safe.sh.
 
+Focused lanes reuse the Swift module cache by default to keep the local edit
+loop warm. Override with KEYPATH_TEST_RESET_MODULE_CACHE=1 when diagnosing
+cache/module-state issues.
+
 Examples:
   ./Scripts/test-fast.sh rules
   ./Scripts/test-fast.sh config
@@ -88,7 +92,8 @@ case "$area" in
             filter=$(keypath_join_filters "${filters[@]}")
             echo "🧪 test-fast --changed: lanes $(printf '%s' "$unique_lanes" | tr '\n' ' ')"
             echo "🎯 filter: $filter"
-            TEST_FILTER="$filter" "$SCRIPT_DIR/run-tests-safe.sh"
+            KEYPATH_TEST_RESET_MODULE_CACHE="${KEYPATH_TEST_RESET_MODULE_CACHE:-0}" \
+                TEST_FILTER="$filter" "$SCRIPT_DIR/run-tests-safe.sh"
             exit $?
         fi
         ;;
@@ -102,4 +107,5 @@ fi
 
 echo "🧪 test-fast: area=$area"
 echo "🎯 filter: $filter"
-TEST_FILTER="$filter" "$SCRIPT_DIR/run-tests-safe.sh"
+KEYPATH_TEST_RESET_MODULE_CACHE="${KEYPATH_TEST_RESET_MODULE_CACHE:-0}" \
+    TEST_FILTER="$filter" "$SCRIPT_DIR/run-tests-safe.sh"


### PR DESCRIPTION
## Summary
- Make the docs-only CI companion classify changed files before emitting required `build-and-test` / `code-quality` stub checks.
- Keep docs-only PRs unblocked, but avoid duplicate green required checks on mixed docs+code PRs.
- Make focused `Scripts/test-fast.sh` lanes reuse the Swift module cache by default, while preserving full/direct `run-tests-safe.sh` conservative behavior.

## Why
During the Phase 1 slices, mixed PRs showed duplicate `build-and-test` and `code-quality` checks from both `KeyPath CI` and `KeyPath CI (docs)`. Focused local runs also paid cold module-cache cost unless the caller remembered `KEYPATH_TEST_RESET_MODULE_CACHE=0`.

## Validation
- `bash -n Scripts/test-fast.sh Scripts/run-tests-safe.sh`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci-docs.yml"); puts "ci-docs yaml parsed"'`\n- Workflow text assertion for `classify-docs-only`, `docs_only`, `git diff --name-only`, and the job `if:` guard\n- `python3 Scripts/check-accessibility.py`\n- `git diff --check`\n- `./Scripts/test-fast.sh cli` cold first run: 418 passed, `reset_module_cache=0`, total 98s\n- `./Scripts/test-fast.sh cli` warm repeat: 418 passed, build 5s, test 8s, total 14s\n- `./Scripts/run-tests-safe.sh`: 4485 passed\n\n## Review gate note\nAttempted the required local review gate, but `thermo-nuclear-swift-review` and `claude` are not available on PATH in this Codex shell. This PR relies on GitHub `claude-review` for the review gate.