### PR TITLE
Route permission request snapshots through SystemStateProvider

### DIFF
--- a/Sources/KeyPathAppKit/Core/SystemStateProvider+Permissions.swift
+++ b/Sources/KeyPathAppKit/Core/SystemStateProvider+Permissions.swift
@@ -1,0 +1,17 @@
+import KeyPathCore
+import KeyPathPermissions
+
+public extension SystemStateProvider {
+    /// Cached/current permission snapshot for installer and wizard decisions.
+    ///
+    /// Delegates to `PermissionOracle` while Phase 1 grows the full immutable
+    /// system snapshot, keeping OS permission reads behind `SystemStateProvider`.
+    func currentPermissionSnapshot() async -> PermissionOracle.Snapshot {
+        await PermissionOracle.shared.currentSnapshot()
+    }
+
+    /// Fresh permission snapshot after a permission prompt or related mutation.
+    func refreshPermissionSnapshot() async -> PermissionOracle.Snapshot {
+        await PermissionOracle.shared.forceRefresh()
+    }
+}

--- a/Sources/KeyPathAppKit/Services/Permissions/PermissionRequestService.swift
+++ b/Sources/KeyPathAppKit/Services/Permissions/PermissionRequestService.swift
@@ -85,7 +85,7 @@ public final class PermissionRequestService {
             return false
         }
 
-        let beforePrompt = await PermissionOracle.shared.currentSnapshot()
+        let beforePrompt = await SystemStateProvider.shared.currentPermissionSnapshot()
         if beforePrompt.keyPath.inputMonitoring.isReady {
             AppLogger.shared.log("✅ [PermissionRequest] Input Monitoring already granted (Oracle)")
             return true
@@ -111,7 +111,7 @@ public final class PermissionRequestService {
             "🔐 [PermissionRequest] Requesting Input Monitoring via IOHIDRequestAccess()"
         )
         _ = IOHIDRequestAccess(kIOHIDRequestTypeListenEvent)
-        let refreshed = await PermissionOracle.shared.forceRefresh()
+        let refreshed = await SystemStateProvider.shared.refreshPermissionSnapshot()
         let granted = refreshed.keyPath.inputMonitoring.isReady
         if granted {
             AppLogger.shared.log("✅ [PermissionRequest] Input Monitoring granted after Oracle refresh")
@@ -132,7 +132,7 @@ public final class PermissionRequestService {
             return false
         }
 
-        let beforePrompt = await PermissionOracle.shared.currentSnapshot()
+        let beforePrompt = await SystemStateProvider.shared.currentPermissionSnapshot()
         if beforePrompt.keyPath.accessibility.isReady {
             AppLogger.shared.log("✅ [PermissionRequest] Accessibility already granted (Oracle)")
             return true
@@ -157,7 +157,7 @@ public final class PermissionRequestService {
             "🔐 [PermissionRequest] Requesting Accessibility via AXIsProcessTrustedWithOptions()"
         )
         _ = AXIsProcessTrustedWithOptions(options)
-        let refreshed = await PermissionOracle.shared.forceRefresh()
+        let refreshed = await SystemStateProvider.shared.refreshPermissionSnapshot()
         let trusted = refreshed.keyPath.accessibility.isReady
         if trusted {
             AppLogger.shared.log("✅ [PermissionRequest] Accessibility granted after Oracle refresh")

--- a/Tests/KeyPathTests/Core/SystemStateProviderPermissionTests.swift
+++ b/Tests/KeyPathTests/Core/SystemStateProviderPermissionTests.swift
@@ -1,0 +1,26 @@
+@testable import KeyPathAppKit
+@testable import KeyPathCore
+@testable import KeyPathPermissions
+@preconcurrency import XCTest
+
+final class SystemStateProviderPermissionTests: XCTestCase {
+    func testPermissionSnapshotAccessDelegatesToPermissionOracle() async {
+        let provider = SystemStateProvider()
+
+        let snapshot = await provider.currentPermissionSnapshot()
+
+        XCTAssertEqual(snapshot.keyPath.source, "test.placeholder")
+        XCTAssertEqual(snapshot.kanata.source, "test.placeholder")
+        XCTAssertEqual(snapshot.keyPath.confidence, .low)
+        XCTAssertEqual(snapshot.kanata.confidence, .low)
+    }
+
+    func testPermissionSnapshotRefreshBypassesCachedSnapshot() async {
+        let provider = SystemStateProvider()
+
+        let first = await provider.currentPermissionSnapshot()
+        let refreshed = await provider.refreshPermissionSnapshot()
+
+        XCTAssertGreaterThanOrEqual(refreshed.timestamp, first.timestamp)
+    }
+}

--- a/Tests/KeyPathTests/Lint/PermissionSnapshotLintTests.swift
+++ b/Tests/KeyPathTests/Lint/PermissionSnapshotLintTests.swift
@@ -1,0 +1,60 @@
+import Foundation
+@preconcurrency import XCTest
+
+/// Guards the Phase 1 migration of permission-state reads behind `SystemStateProvider`.
+///
+/// `PermissionOracle` remains the low-level authority for permissions, but installer
+/// and wizard consumers should ask `SystemStateProvider` so the eventual immutable
+/// system snapshot has one owner for OS evidence reads.
+final class PermissionSnapshotLintTests: XCTestCase {
+    func testPermissionRequestServiceDelegatesPermissionSnapshotsToSystemStateProvider() throws {
+        let service = repositoryRootForPermissionSnapshotLint()
+            .appendingPathComponent("Sources/KeyPathAppKit/Services/Permissions/PermissionRequestService.swift")
+
+        let violations = try matchingPermissionSnapshotLines(
+            in: service,
+            patterns: [
+                #"PermissionOracle\.shared\.currentSnapshot"#,
+                #"PermissionOracle\.shared\.forceRefresh"#,
+                #"PermissionOracle\.shared"#
+            ]
+        )
+
+        XCTAssertTrue(
+            violations.isEmpty,
+            """
+            PermissionRequestService must delegate permission snapshot reads \
+            through SystemStateProvider:
+            \(violations.sorted().joined(separator: "\n"))
+            """
+        )
+    }
+}
+
+private func repositoryRootForPermissionSnapshotLint(file: StaticString = #filePath) -> URL {
+    URL(fileURLWithPath: "\(file)")
+        .deletingLastPathComponent() // Lint
+        .deletingLastPathComponent() // KeyPathTests
+        .deletingLastPathComponent() // Tests
+        .deletingLastPathComponent() // repo root
+}
+
+private func matchingPermissionSnapshotLines(in fileURL: URL, patterns: [String]) throws -> [String] {
+    let contents = try String(contentsOf: fileURL, encoding: .utf8)
+    let regexes = try patterns.map { try NSRegularExpression(pattern: $0) }
+    let relativePath = fileURL.path.replacingOccurrences(
+        of: repositoryRootForPermissionSnapshotLint().path + "/",
+        with: ""
+    )
+
+    var violations: [String] = []
+    for (idx, rawLine) in contents.components(separatedBy: .newlines).enumerated() {
+        let trimmed = rawLine.trimmingCharacters(in: .whitespaces)
+        if trimmed.hasPrefix("//") || trimmed.hasPrefix("///") || trimmed.hasPrefix("*") { continue }
+        let range = NSRange(rawLine.startIndex..., in: rawLine)
+        if regexes.contains(where: { $0.firstMatch(in: rawLine, range: range) != nil }) {
+            violations.append("\(relativePath):\(idx + 1): \(trimmed)")
+        }
+    }
+    return violations
+}

--- a/docs/planning/installer-reliability-phase1.md
+++ b/docs/planning/installer-reliability-phase1.md
@@ -193,6 +193,13 @@ classification remains pending.
   `SMAppServiceStatusLintTests.testAppLifecycleDelegatesStatusProviderAccessToSystemStateProvider`
   and
   `SystemStateProviderSMAppServiceTests.testSMAppServiceStatusAccessDelegatesToCentralStatusProvider`.
+- [x] Added `SystemStateProvider` permission snapshot façade methods over
+  `PermissionOracle` and migrated `PermissionRequestService`
+  permission-state reads/refreshes through them. Enforced by
+  `SystemStateProviderPermissionTests.testPermissionSnapshotAccessDelegatesToPermissionOracle`,
+  `SystemStateProviderPermissionTests.testPermissionSnapshotRefreshBypassesCachedSnapshot`,
+  and
+  `PermissionSnapshotLintTests.testPermissionRequestServiceDelegatesPermissionSnapshotsToSystemStateProvider`.
 - [ ] Migrate `SMAppService.status`, permissions, VHID state, helper freshness,
   and migrated read-only `launchctl print` evidence into a single immutable
   `SystemSnapshot`.
@@ -358,6 +365,12 @@ through 21 mocked tests).
   `SMAppServiceStatusLintTests.testAppLifecycleDelegatesStatusProviderAccessToSystemStateProvider`
   and
   `SystemStateProviderSMAppServiceTests.testSMAppServiceStatusAccessDelegatesToCentralStatusProvider`.
+- [x] `PermissionRequestService` permission-state reads delegate to
+  `SystemStateProvider`'s permission snapshot façade. Enforced by
+  `SystemStateProviderPermissionTests.testPermissionSnapshotAccessDelegatesToPermissionOracle`,
+  `SystemStateProviderPermissionTests.testPermissionSnapshotRefreshBypassesCachedSnapshot`,
+  and
+  `PermissionSnapshotLintTests.testPermissionRequestServiceDelegatesPermissionSnapshotsToSystemStateProvider`.
 
 ## Workstream 3: Industry-Standard Repair Model
 
@@ -478,6 +491,9 @@ is listed in the state-matrix doc's enforcement section.
 - [x] `SMAppServiceStatusLintTests.testAppLifecycleDelegatesStatusProviderAccessToSystemStateProvider`
   prevents migrated app lifecycle/dev-utility SMAppService status/cache access
   from bypassing `SystemStateProvider`.
+- [x] `PermissionSnapshotLintTests.testPermissionRequestServiceDelegatesPermissionSnapshotsToSystemStateProvider`
+  prevents migrated permission-request snapshot reads from bypassing
+  `SystemStateProvider`.
 - [x] `TCPReadinessLintTests.testServiceHealthCheckerDelegatesTCPReadinessToSystemStateProvider`
   prevents `ServiceHealthChecker` from regrowing a private TCP socket probe.
 - [x] `TCPReadinessLintTests.testProductionTCPProbeAdapterIsNoLongerUsed` and

--- a/docs/process/installer-repair-state-matrix.md
+++ b/docs/process/installer-repair-state-matrix.md
@@ -220,6 +220,14 @@ the result as user action required and name the approval surface.
   blocks migrated UninstallCoordinator status reads from bypassing it, and
   `SMAppServiceStatusLintTests.testAppLifecycleDelegatesStatusProviderAccessToSystemStateProvider`
   blocks migrated App lifecycle/dev-utility status reads from bypassing it.
+- Permission snapshot reads belong behind `SystemStateProvider`'s façade over
+  `PermissionOracle`.
+  `SystemStateProviderPermissionTests.testPermissionSnapshotAccessDelegatesToPermissionOracle`
+  and
+  `SystemStateProviderPermissionTests.testPermissionSnapshotRefreshBypassesCachedSnapshot`
+  cover the façade, while
+  `PermissionSnapshotLintTests.testPermissionRequestServiceDelegatesPermissionSnapshotsToSystemStateProvider`
+  prevents `PermissionRequestService` from bypassing it.
 - User-facing CLI/reporting shape belongs in CLI contract tests.
 
 ## Related References


### PR DESCRIPTION
## Summary
- add a `SystemStateProvider` permission snapshot facade over `PermissionOracle`
- migrate `PermissionRequestService` current/refresh permission reads through the facade
- add the matching W5 lint ratchet and update the Phase 1/state-matrix docs with enforcing tests

## Acceptance criteria covered
- `SystemStateProviderPermissionTests.testPermissionSnapshotAccessDelegatesToPermissionOracle` covers the provider facade
- `SystemStateProviderPermissionTests.testPermissionSnapshotRefreshBypassesCachedSnapshot` covers refresh semantics after prompts/mutations
- `PermissionSnapshotLintTests.testPermissionRequestServiceDelegatesPermissionSnapshotsToSystemStateProvider` prevents this migrated consumer from bypassing `SystemStateProvider`

## Validation
- `mise exec -- swiftformat Sources/KeyPathAppKit/Core/SystemStateProvider+Permissions.swift Sources/KeyPathAppKit/Services/Permissions/PermissionRequestService.swift Tests/KeyPathTests/Core/SystemStateProviderPermissionTests.swift Tests/KeyPathTests/Lint/PermissionSnapshotLintTests.swift`
- `TEST_FILTER='SystemStateProviderPermissionTests|PermissionSnapshotLintTests' ./Scripts/run-tests-safe.sh` — 3 passed
- `git diff --check`
- `python3 Scripts/check-accessibility.py` — all UI elements have accessibility identifiers
- `KEYPATH_SNAPSHOTS=0 ./Scripts/run-tests-safe.sh` — 4489 passed

## Gate notes
- Required local `/thermo-nuclear-swift-review` could not run: neither `thermo-nuclear-swift-review` nor `claude` is available on PATH in this Codex shell. Relying on GitHub `claude-review` for this PR.
- Required snapshot-enabled `./Scripts/test-full.sh` is currently blocked by pre-existing snapshot lane failures unrelated to this permission slice. Reproduced with both Xcode beta and stable Xcode: `./Scripts/test-lane.sh snapshot` fails with snapshot diffs, `NSInvalidArgumentException` from `swift-snapshot-testing` (`UIImage.swift:387`, `-[NSConcreteValue CGRectValue]`), then xctest signal 11. This PR does not touch UI/snapshot surfaces.
