### PR TITLE
Route permission gate snapshots through SystemStateProvider

### DIFF
--- a/Sources/KeyPathAppKit/Services/Permissions/PermissionGate.swift
+++ b/Sources/KeyPathAppKit/Services/Permissions/PermissionGate.swift
@@ -1,4 +1,5 @@
 import Foundation
+import KeyPathCore
 import KeyPathPermissions
 
 enum PGPermissionType: Hashable {
@@ -45,7 +46,6 @@ final class PermissionGate {
     private init() {}
 
     private let permissionService = PermissionRequestService.shared
-    private let oracle = PermissionOracle.shared
 
     struct Evaluation: Equatable {
         let missingKeyPath: Set<PGPermissionType>
@@ -100,7 +100,7 @@ final class PermissionGate {
         onGranted: @escaping () async -> Void,
         onDenied: @escaping () -> Void
     ) async {
-        let snapshot = await oracle.currentSnapshot()
+        let snapshot = await SystemStateProvider.shared.currentPermissionSnapshot()
         let eval = Self.evaluate(snapshot, for: feature)
 
         // If Kanata permissions are not verifiable (unknown), do NOT label them "required".
@@ -175,7 +175,7 @@ final class PermissionGate {
         // Poll until granted or timeout
         for _ in 0 ..< 30 {
             try? await Task.sleep(for: .seconds(1))
-            let snap = await oracle.currentSnapshot()
+            let snap = await SystemStateProvider.shared.currentPermissionSnapshot()
             // JIT gates only request KeyPath permissions automatically. Kanata is handled via wizard.
             // Therefore, we only require KeyPath permission to proceed here.
             let allGranted = feature.requiredPermissions.allSatisfy { p in

--- a/Tests/KeyPathTests/Lint/PermissionSnapshotLintTests.swift
+++ b/Tests/KeyPathTests/Lint/PermissionSnapshotLintTests.swift
@@ -29,6 +29,29 @@ final class PermissionSnapshotLintTests: XCTestCase {
             """
         )
     }
+
+    func testPermissionGateDelegatesPermissionSnapshotsToSystemStateProvider() throws {
+        let gate = repositoryRootForPermissionSnapshotLint()
+            .appendingPathComponent("Sources/KeyPathAppKit/Services/Permissions/PermissionGate.swift")
+
+        let violations = try matchingPermissionSnapshotLines(
+            in: gate,
+            patterns: [
+                #"PermissionOracle\.shared\.currentSnapshot"#,
+                #"PermissionOracle\.shared\.forceRefresh"#,
+                #"PermissionOracle\.shared"#
+            ]
+        )
+
+        XCTAssertTrue(
+            violations.isEmpty,
+            """
+            PermissionGate must delegate permission snapshot reads \
+            through SystemStateProvider:
+            \(violations.sorted().joined(separator: "\n"))
+            """
+        )
+    }
 }
 
 private func repositoryRootForPermissionSnapshotLint(file: StaticString = #filePath) -> URL {

--- a/docs/planning/installer-reliability-phase1.md
+++ b/docs/planning/installer-reliability-phase1.md
@@ -200,6 +200,12 @@ classification remains pending.
   `SystemStateProviderPermissionTests.testPermissionSnapshotRefreshBypassesCachedSnapshot`,
   and
   `PermissionSnapshotLintTests.testPermissionRequestServiceDelegatesPermissionSnapshotsToSystemStateProvider`.
+- [x] Migrated `PermissionGate` permission-state reads through
+  `SystemStateProvider`'s permission snapshot façade. Enforced by
+  `PermissionGateEvaluationTests.testKanataUnknownClassifiesAsNotVerifiedNotBlocking`,
+  `PermissionGateEvaluationTests.testKanataDeniedClassifiesAsBlocking`,
+  and
+  `PermissionSnapshotLintTests.testPermissionGateDelegatesPermissionSnapshotsToSystemStateProvider`.
 - [ ] Migrate `SMAppService.status`, permissions, VHID state, helper freshness,
   and migrated read-only `launchctl print` evidence into a single immutable
   `SystemSnapshot`.
@@ -371,6 +377,12 @@ through 21 mocked tests).
   `SystemStateProviderPermissionTests.testPermissionSnapshotRefreshBypassesCachedSnapshot`,
   and
   `PermissionSnapshotLintTests.testPermissionRequestServiceDelegatesPermissionSnapshotsToSystemStateProvider`.
+- [x] `PermissionGate` permission-state reads delegate to
+  `SystemStateProvider`'s permission snapshot façade. Enforced by
+  `PermissionGateEvaluationTests.testKanataUnknownClassifiesAsNotVerifiedNotBlocking`,
+  `PermissionGateEvaluationTests.testKanataDeniedClassifiesAsBlocking`,
+  and
+  `PermissionSnapshotLintTests.testPermissionGateDelegatesPermissionSnapshotsToSystemStateProvider`.
 
 ## Workstream 3: Industry-Standard Repair Model
 
@@ -493,6 +505,9 @@ is listed in the state-matrix doc's enforcement section.
   from bypassing `SystemStateProvider`.
 - [x] `PermissionSnapshotLintTests.testPermissionRequestServiceDelegatesPermissionSnapshotsToSystemStateProvider`
   prevents migrated permission-request snapshot reads from bypassing
+  `SystemStateProvider`.
+- [x] `PermissionSnapshotLintTests.testPermissionGateDelegatesPermissionSnapshotsToSystemStateProvider`
+  prevents migrated just-in-time permission gate snapshot reads from bypassing
   `SystemStateProvider`.
 - [x] `TCPReadinessLintTests.testServiceHealthCheckerDelegatesTCPReadinessToSystemStateProvider`
   prevents `ServiceHealthChecker` from regrowing a private TCP socket probe.

--- a/docs/process/installer-repair-state-matrix.md
+++ b/docs/process/installer-repair-state-matrix.md
@@ -227,7 +227,9 @@ the result as user action required and name the approval surface.
   `SystemStateProviderPermissionTests.testPermissionSnapshotRefreshBypassesCachedSnapshot`
   cover the façade, while
   `PermissionSnapshotLintTests.testPermissionRequestServiceDelegatesPermissionSnapshotsToSystemStateProvider`
-  prevents `PermissionRequestService` from bypassing it.
+  prevents `PermissionRequestService` from bypassing it and
+  `PermissionSnapshotLintTests.testPermissionGateDelegatesPermissionSnapshotsToSystemStateProvider`
+  prevents `PermissionGate` from bypassing it.
 - User-facing CLI/reporting shape belongs in CLI contract tests.
 
 ## Related References


### PR DESCRIPTION
## Summary
- route `PermissionGate` permission snapshot reads through `SystemStateProvider`
- add a lint ratchet preventing `PermissionGate` from regrowing direct `PermissionOracle.shared` snapshot access
- update the Phase 1 plan and state-matrix enforcement notes with the completed acceptance criteria

## Acceptance criteria / tests
- `PermissionGateEvaluationTests.testKanataUnknownClassifiesAsNotVerifiedNotBlocking` keeps unknown Kanata permission state non-blocking for JIT permission gates.
- `PermissionGateEvaluationTests.testKanataDeniedClassifiesAsBlocking` keeps denied Kanata permission state blocking.
- `PermissionSnapshotLintTests.testPermissionGateDelegatesPermissionSnapshotsToSystemStateProvider` enforces the new `SystemStateProvider` delegation contract.

## Validation
- `mise exec -- swiftformat Sources/KeyPathAppKit/Services/Permissions/PermissionGate.swift Tests/KeyPathTests/Lint/PermissionSnapshotLintTests.swift` (0/2 formatted)
- `TEST_FILTER='PermissionGateEvaluationTests|PermissionSnapshotLintTests|SystemStateProviderPermissionTests' ./Scripts/run-tests-safe.sh` (6 passed)
- `git diff --check`
- `python3 Scripts/check-accessibility.py`
- `KEYPATH_SNAPSHOTS=0 ./Scripts/run-tests-safe.sh` (4490 passed)

## Gate notes
- Local `/thermo-nuclear-swift-review` could not be run because neither `thermo-nuclear-swift-review` nor `claude` is available on PATH in this shell. Relying on the GitHub `claude-review` check for the review gate.
- Snapshot-enabled `./Scripts/test-full.sh` remains blocked by pre-existing snapshot failures outside this slice: `swift-snapshot-testing` throws `NSInvalidArgumentException` from `UIImage.swift:387`, followed by xctest signal 11. The non-snapshot safe gate above is green.
