### PR TITLE
Route requirements permission checks through SystemStateProvider

### DIFF
--- a/Sources/KeyPathAppKit/Services/System/SystemRequirementsChecker.swift
+++ b/Sources/KeyPathAppKit/Services/System/SystemRequirementsChecker.swift
@@ -60,19 +60,19 @@ final class SystemRequirementsChecker {
 
     /// Check if KeyPath has Input Monitoring permission
     func hasInputMonitoringPermission() async -> Bool {
-        let snapshot = await PermissionOracle.shared.currentSnapshot()
+        let snapshot = await SystemStateProvider.shared.currentPermissionSnapshot()
         return snapshot.keyPath.inputMonitoring.isReady
     }
 
     /// Check if KeyPath has Accessibility permission
     func hasAccessibilityPermission() async -> Bool {
-        let snapshot = await PermissionOracle.shared.currentSnapshot()
+        let snapshot = await SystemStateProvider.shared.currentPermissionSnapshot()
         return snapshot.keyPath.accessibility.isReady
     }
 
     /// Check if KeyPath has all required permissions
     func hasAllRequiredPermissions() async -> Bool {
-        let snapshot = await PermissionOracle.shared.currentSnapshot()
+        let snapshot = await SystemStateProvider.shared.currentPermissionSnapshot()
         return snapshot.keyPath.hasAllPermissions
     }
 
@@ -80,7 +80,7 @@ final class SystemRequirementsChecker {
     func checkBothAppsHavePermissions() async -> (
         keyPathHasPermission: Bool, kanataHasPermission: Bool, permissionDetails: String
     ) {
-        let snapshot = await PermissionOracle.shared.currentSnapshot()
+        let snapshot = await SystemStateProvider.shared.currentPermissionSnapshot()
 
         let keyPathPath = Bundle.main.bundlePath
         let kanataPath = WizardSystemPaths.bundledKanataPath

--- a/Tests/KeyPathTests/Lint/PermissionSnapshotLintTests.swift
+++ b/Tests/KeyPathTests/Lint/PermissionSnapshotLintTests.swift
@@ -52,6 +52,29 @@ final class PermissionSnapshotLintTests: XCTestCase {
             """
         )
     }
+
+    func testSystemRequirementsCheckerDelegatesPermissionSnapshotsToSystemStateProvider() throws {
+        let checker = repositoryRootForPermissionSnapshotLint()
+            .appendingPathComponent("Sources/KeyPathAppKit/Services/System/SystemRequirementsChecker.swift")
+
+        let violations = try matchingPermissionSnapshotLines(
+            in: checker,
+            patterns: [
+                #"PermissionOracle\.shared\.currentSnapshot"#,
+                #"PermissionOracle\.shared\.forceRefresh"#,
+                #"PermissionOracle\.shared"#
+            ]
+        )
+
+        XCTAssertTrue(
+            violations.isEmpty,
+            """
+            SystemRequirementsChecker must delegate permission snapshot reads \
+            through SystemStateProvider:
+            \(violations.sorted().joined(separator: "\n"))
+            """
+        )
+    }
 }
 
 private func repositoryRootForPermissionSnapshotLint(file: StaticString = #filePath) -> URL {

--- a/docs/planning/installer-reliability-phase1.md
+++ b/docs/planning/installer-reliability-phase1.md
@@ -206,6 +206,9 @@ classification remains pending.
   `PermissionGateEvaluationTests.testKanataDeniedClassifiesAsBlocking`,
   and
   `PermissionSnapshotLintTests.testPermissionGateDelegatesPermissionSnapshotsToSystemStateProvider`.
+- [x] Migrated `SystemRequirementsChecker` permission-state reads through
+  `SystemStateProvider`'s permission snapshot façade. Enforced by
+  `PermissionSnapshotLintTests.testSystemRequirementsCheckerDelegatesPermissionSnapshotsToSystemStateProvider`.
 - [ ] Migrate `SMAppService.status`, permissions, VHID state, helper freshness,
   and migrated read-only `launchctl print` evidence into a single immutable
   `SystemSnapshot`.
@@ -383,6 +386,9 @@ through 21 mocked tests).
   `PermissionGateEvaluationTests.testKanataDeniedClassifiesAsBlocking`,
   and
   `PermissionSnapshotLintTests.testPermissionGateDelegatesPermissionSnapshotsToSystemStateProvider`.
+- [x] `SystemRequirementsChecker` permission-state reads delegate to
+  `SystemStateProvider`'s permission snapshot façade. Enforced by
+  `PermissionSnapshotLintTests.testSystemRequirementsCheckerDelegatesPermissionSnapshotsToSystemStateProvider`.
 
 ## Workstream 3: Industry-Standard Repair Model
 
@@ -508,6 +514,9 @@ is listed in the state-matrix doc's enforcement section.
   `SystemStateProvider`.
 - [x] `PermissionSnapshotLintTests.testPermissionGateDelegatesPermissionSnapshotsToSystemStateProvider`
   prevents migrated just-in-time permission gate snapshot reads from bypassing
+  `SystemStateProvider`.
+- [x] `PermissionSnapshotLintTests.testSystemRequirementsCheckerDelegatesPermissionSnapshotsToSystemStateProvider`
+  prevents migrated system-requirements permission snapshot reads from bypassing
   `SystemStateProvider`.
 - [x] `TCPReadinessLintTests.testServiceHealthCheckerDelegatesTCPReadinessToSystemStateProvider`
   prevents `ServiceHealthChecker` from regrowing a private TCP socket probe.

--- a/docs/process/installer-repair-state-matrix.md
+++ b/docs/process/installer-repair-state-matrix.md
@@ -229,7 +229,9 @@ the result as user action required and name the approval surface.
   `PermissionSnapshotLintTests.testPermissionRequestServiceDelegatesPermissionSnapshotsToSystemStateProvider`
   prevents `PermissionRequestService` from bypassing it and
   `PermissionSnapshotLintTests.testPermissionGateDelegatesPermissionSnapshotsToSystemStateProvider`
-  prevents `PermissionGate` from bypassing it.
+  prevents `PermissionGate` from bypassing it, and
+  `PermissionSnapshotLintTests.testSystemRequirementsCheckerDelegatesPermissionSnapshotsToSystemStateProvider`
+  prevents `SystemRequirementsChecker` from bypassing it.
 - User-facing CLI/reporting shape belongs in CLI contract tests.
 
 ## Related References


### PR DESCRIPTION
## Summary
- route `SystemRequirementsChecker` permission snapshot reads through `SystemStateProvider`
- add a lint ratchet preventing the requirements checker from regrowing direct `PermissionOracle.shared` snapshot access
- update the Phase 1 plan and state-matrix enforcement notes with the completed acceptance criteria

## Acceptance criteria / tests
- `PermissionSnapshotLintTests.testSystemRequirementsCheckerDelegatesPermissionSnapshotsToSystemStateProvider` enforces the migrated requirements-checker snapshot reads.
- `SystemStateProviderPermissionTests.testPermissionSnapshotAccessDelegatesToPermissionOracle` covers the provider façade read path.
- `SystemStateProviderPermissionTests.testPermissionSnapshotRefreshBypassesCachedSnapshot` covers the provider façade refresh path.

## Validation
- `mise exec -- swiftformat Sources/KeyPathAppKit/Services/System/SystemRequirementsChecker.swift Tests/KeyPathTests/Lint/PermissionSnapshotLintTests.swift` (0/2 formatted)
- `TEST_FILTER='PermissionSnapshotLintTests|SystemStateProviderPermissionTests|KanataManagerBreakageSummaryTests' ./Scripts/run-tests-safe.sh` (5 passed)
- `git diff --check`
- `python3 Scripts/check-accessibility.py`
- `KEYPATH_SNAPSHOTS=0 ./Scripts/run-tests-safe.sh` (4491 passed)

## Gate notes
- Local `/thermo-nuclear-swift-review` could not be run because neither `thermo-nuclear-swift-review` nor `claude` is available on PATH in this shell. Relying on the GitHub `claude-review` check for the review gate.
- Snapshot-enabled `./Scripts/test-full.sh` remains blocked by pre-existing snapshot failures outside this slice: `swift-snapshot-testing` throws `NSInvalidArgumentException` from `UIImage.swift:387`, followed by xctest signal 11. The non-snapshot safe gate above is green.

## Out of scope follow-up
- During post-merge verification for the previous slice, a transient reload toast appeared after `quick-deploy.sh` restarted KeyPath. Runtime verification recovered cleanly and TCP is healthy, but the toast should be handled in a separate focused PR so this migration stays limited to permission snapshot delegation.
