### PR TITLE
Route validator permission snapshot through SystemStateProvider

### DIFF
--- a/Sources/KeyPathAppKit/Services/System/SystemValidator.swift
+++ b/Sources/KeyPathAppKit/Services/System/SystemValidator.swift
@@ -381,8 +381,8 @@ public class SystemValidator {
     private func checkPermissions() async -> PermissionOracle.Snapshot {
         AppLogger.shared.log("🔍 [SystemValidator] Checking permissions via Oracle")
 
-        // Oracle has its own 1.5s cache - we don't add another layer
-        let snapshot = await PermissionOracle.shared.currentSnapshot()
+        // PermissionOracle has its own 1.5s cache - SystemStateProvider centralizes access.
+        let snapshot = await SystemStateProvider.shared.currentPermissionSnapshot()
 
         // 🚨 DEFENSIVE CHECK: Oracle snapshot should be fresh.
         // Originally an `assert` that crashed in debug builds, but under real

--- a/Tests/KeyPathTests/Lint/PermissionSnapshotLintTests.swift
+++ b/Tests/KeyPathTests/Lint/PermissionSnapshotLintTests.swift
@@ -75,6 +75,29 @@ final class PermissionSnapshotLintTests: XCTestCase {
             """
         )
     }
+
+    func testSystemValidatorDelegatesPermissionSnapshotsToSystemStateProvider() throws {
+        let validator = repositoryRootForPermissionSnapshotLint()
+            .appendingPathComponent("Sources/KeyPathAppKit/Services/System/SystemValidator.swift")
+
+        let violations = try matchingPermissionSnapshotLines(
+            in: validator,
+            patterns: [
+                #"PermissionOracle\.shared\.currentSnapshot"#,
+                #"PermissionOracle\.shared\.forceRefresh"#,
+                #"PermissionOracle\.shared"#
+            ]
+        )
+
+        XCTAssertTrue(
+            violations.isEmpty,
+            """
+            SystemValidator must delegate permission snapshot reads \
+            through SystemStateProvider:
+            \(violations.sorted().joined(separator: "\n"))
+            """
+        )
+    }
 }
 
 private func repositoryRootForPermissionSnapshotLint(file: StaticString = #filePath) -> URL {

--- a/docs/planning/installer-reliability-phase1.md
+++ b/docs/planning/installer-reliability-phase1.md
@@ -209,6 +209,9 @@ classification remains pending.
 - [x] Migrated `SystemRequirementsChecker` permission-state reads through
   `SystemStateProvider`'s permission snapshot façade. Enforced by
   `PermissionSnapshotLintTests.testSystemRequirementsCheckerDelegatesPermissionSnapshotsToSystemStateProvider`.
+- [x] Migrated `SystemValidator` permission-state reads through
+  `SystemStateProvider`'s permission snapshot façade. Enforced by
+  `PermissionSnapshotLintTests.testSystemValidatorDelegatesPermissionSnapshotsToSystemStateProvider`.
 - [ ] Migrate `SMAppService.status`, permissions, VHID state, helper freshness,
   and migrated read-only `launchctl print` evidence into a single immutable
   `SystemSnapshot`.
@@ -389,6 +392,9 @@ through 21 mocked tests).
 - [x] `SystemRequirementsChecker` permission-state reads delegate to
   `SystemStateProvider`'s permission snapshot façade. Enforced by
   `PermissionSnapshotLintTests.testSystemRequirementsCheckerDelegatesPermissionSnapshotsToSystemStateProvider`.
+- [x] `SystemValidator` permission-state reads delegate to
+  `SystemStateProvider`'s permission snapshot façade. Enforced by
+  `PermissionSnapshotLintTests.testSystemValidatorDelegatesPermissionSnapshotsToSystemStateProvider`.
 
 ## Workstream 3: Industry-Standard Repair Model
 
@@ -517,6 +523,9 @@ is listed in the state-matrix doc's enforcement section.
   `SystemStateProvider`.
 - [x] `PermissionSnapshotLintTests.testSystemRequirementsCheckerDelegatesPermissionSnapshotsToSystemStateProvider`
   prevents migrated system-requirements permission snapshot reads from bypassing
+  `SystemStateProvider`.
+- [x] `PermissionSnapshotLintTests.testSystemValidatorDelegatesPermissionSnapshotsToSystemStateProvider`
+  prevents migrated system-validator permission snapshot reads from bypassing
   `SystemStateProvider`.
 - [x] `TCPReadinessLintTests.testServiceHealthCheckerDelegatesTCPReadinessToSystemStateProvider`
   prevents `ServiceHealthChecker` from regrowing a private TCP socket probe.

--- a/docs/process/installer-repair-state-matrix.md
+++ b/docs/process/installer-repair-state-matrix.md
@@ -231,7 +231,9 @@ the result as user action required and name the approval surface.
   `PermissionSnapshotLintTests.testPermissionGateDelegatesPermissionSnapshotsToSystemStateProvider`
   prevents `PermissionGate` from bypassing it, and
   `PermissionSnapshotLintTests.testSystemRequirementsCheckerDelegatesPermissionSnapshotsToSystemStateProvider`
-  prevents `SystemRequirementsChecker` from bypassing it.
+  prevents `SystemRequirementsChecker` from bypassing it, and
+  `PermissionSnapshotLintTests.testSystemValidatorDelegatesPermissionSnapshotsToSystemStateProvider`
+  prevents `SystemValidator` from bypassing it.
 - User-facing CLI/reporting shape belongs in CLI contract tests.
 
 ## Related References


### PR DESCRIPTION
## Summary
- route `SystemValidator` permission snapshot reads through `SystemStateProvider`
- add a lint ratchet preventing `SystemValidator` from regrowing direct `PermissionOracle.shared` snapshot access
- update the Phase 1 plan and state-matrix enforcement notes with the completed acceptance criteria

## Acceptance criteria / tests
- `PermissionSnapshotLintTests.testSystemValidatorDelegatesPermissionSnapshotsToSystemStateProvider` enforces the migrated validator snapshot read.
- `SystemStateProviderPermissionTests.testPermissionSnapshotAccessDelegatesToPermissionOracle` covers the provider façade read path.
- `SystemStateProviderPermissionTests.testPermissionSnapshotRefreshBypassesCachedSnapshot` covers the provider façade refresh path.

## Validation
- `mise exec -- swiftformat Sources/KeyPathAppKit/Services/System/SystemValidator.swift Tests/KeyPathTests/Lint/PermissionSnapshotLintTests.swift` (0/2 formatted)
- `TEST_FILTER='PermissionSnapshotLintTests|SystemStateProviderPermissionTests|SystemValidatorTests' ./Scripts/run-tests-safe.sh` (14 passed)
- `git diff --check`
- `python3 Scripts/check-accessibility.py`
- `KEYPATH_SNAPSHOTS=0 ./Scripts/run-tests-safe.sh` (4492 passed)

## Gate notes
- Local `/thermo-nuclear-swift-review` could not be run because neither `thermo-nuclear-swift-review` nor `claude` is available on PATH in this shell. Relying on the GitHub `claude-review` check for the review gate.
- Snapshot-enabled `./Scripts/test-full.sh` remains blocked by pre-existing snapshot failures outside this slice: `swift-snapshot-testing` throws `NSInvalidArgumentException` from `UIImage.swift:387`, followed by xctest signal 11. The non-snapshot safe gate above is green.
