### PR TITLE
Route lifecycle permission refresh through SystemStateProvider

### DIFF
--- a/Sources/KeyPathAppKit/Managers/ServiceLifecycleCoordinator.swift
+++ b/Sources/KeyPathAppKit/Managers/ServiceLifecycleCoordinator.swift
@@ -476,7 +476,7 @@ final class ServiceLifecycleCoordinator {
     // MARK: - Permission Checks
 
     func shouldShowWizardForPermissions() async -> Bool {
-        let snapshot = await PermissionOracle.shared.forceRefresh()
+        let snapshot = await SystemStateProvider.shared.refreshPermissionSnapshot()
         return snapshot.blockingIssue != nil
     }
 

--- a/Tests/KeyPathTests/Lint/PermissionSnapshotLintTests.swift
+++ b/Tests/KeyPathTests/Lint/PermissionSnapshotLintTests.swift
@@ -98,6 +98,29 @@ final class PermissionSnapshotLintTests: XCTestCase {
             """
         )
     }
+
+    func testServiceLifecycleCoordinatorDelegatesPermissionSnapshotsToSystemStateProvider() throws {
+        let coordinator = repositoryRootForPermissionSnapshotLint()
+            .appendingPathComponent("Sources/KeyPathAppKit/Managers/ServiceLifecycleCoordinator.swift")
+
+        let violations = try matchingPermissionSnapshotLines(
+            in: coordinator,
+            patterns: [
+                #"PermissionOracle\.shared\.currentSnapshot"#,
+                #"PermissionOracle\.shared\.forceRefresh"#,
+                #"PermissionOracle\.shared"#
+            ]
+        )
+
+        XCTAssertTrue(
+            violations.isEmpty,
+            """
+            ServiceLifecycleCoordinator must delegate permission snapshot reads \
+            through SystemStateProvider:
+            \(violations.sorted().joined(separator: "\n"))
+            """
+        )
+    }
 }
 
 private func repositoryRootForPermissionSnapshotLint(file: StaticString = #filePath) -> URL {

--- a/docs/planning/installer-reliability-phase1.md
+++ b/docs/planning/installer-reliability-phase1.md
@@ -212,6 +212,9 @@ classification remains pending.
 - [x] Migrated `SystemValidator` permission-state reads through
   `SystemStateProvider`'s permission snapshot façade. Enforced by
   `PermissionSnapshotLintTests.testSystemValidatorDelegatesPermissionSnapshotsToSystemStateProvider`.
+- [x] Migrated `ServiceLifecycleCoordinator` permission refresh through
+  `SystemStateProvider`'s permission snapshot façade. Enforced by
+  `PermissionSnapshotLintTests.testServiceLifecycleCoordinatorDelegatesPermissionSnapshotsToSystemStateProvider`.
 - [ ] Migrate `SMAppService.status`, permissions, VHID state, helper freshness,
   and migrated read-only `launchctl print` evidence into a single immutable
   `SystemSnapshot`.
@@ -395,6 +398,9 @@ through 21 mocked tests).
 - [x] `SystemValidator` permission-state reads delegate to
   `SystemStateProvider`'s permission snapshot façade. Enforced by
   `PermissionSnapshotLintTests.testSystemValidatorDelegatesPermissionSnapshotsToSystemStateProvider`.
+- [x] `ServiceLifecycleCoordinator` permission refresh delegates to
+  `SystemStateProvider`'s permission snapshot façade. Enforced by
+  `PermissionSnapshotLintTests.testServiceLifecycleCoordinatorDelegatesPermissionSnapshotsToSystemStateProvider`.
 
 ## Workstream 3: Industry-Standard Repair Model
 
@@ -526,6 +532,9 @@ is listed in the state-matrix doc's enforcement section.
   `SystemStateProvider`.
 - [x] `PermissionSnapshotLintTests.testSystemValidatorDelegatesPermissionSnapshotsToSystemStateProvider`
   prevents migrated system-validator permission snapshot reads from bypassing
+  `SystemStateProvider`.
+- [x] `PermissionSnapshotLintTests.testServiceLifecycleCoordinatorDelegatesPermissionSnapshotsToSystemStateProvider`
+  prevents migrated service-lifecycle permission refreshes from bypassing
   `SystemStateProvider`.
 - [x] `TCPReadinessLintTests.testServiceHealthCheckerDelegatesTCPReadinessToSystemStateProvider`
   prevents `ServiceHealthChecker` from regrowing a private TCP socket probe.

--- a/docs/process/installer-repair-state-matrix.md
+++ b/docs/process/installer-repair-state-matrix.md
@@ -233,7 +233,9 @@ the result as user action required and name the approval surface.
   `PermissionSnapshotLintTests.testSystemRequirementsCheckerDelegatesPermissionSnapshotsToSystemStateProvider`
   prevents `SystemRequirementsChecker` from bypassing it, and
   `PermissionSnapshotLintTests.testSystemValidatorDelegatesPermissionSnapshotsToSystemStateProvider`
-  prevents `SystemValidator` from bypassing it.
+  prevents `SystemValidator` from bypassing it, and
+  `PermissionSnapshotLintTests.testServiceLifecycleCoordinatorDelegatesPermissionSnapshotsToSystemStateProvider`
+  prevents `ServiceLifecycleCoordinator` from bypassing it.
 - User-facing CLI/reporting shape belongs in CLI contract tests.
 
 ## Related References


### PR DESCRIPTION
## Summary
- route `ServiceLifecycleCoordinator.shouldShowWizardForPermissions()` through `SystemStateProvider.refreshPermissionSnapshot()`
- add a lint ratchet preventing `ServiceLifecycleCoordinator` from regrowing direct `PermissionOracle.shared` snapshot/refresh access
- update the Phase 1 plan and state-matrix enforcement notes with the completed acceptance criteria

## Acceptance criteria / tests
- `PermissionSnapshotLintTests.testServiceLifecycleCoordinatorDelegatesPermissionSnapshotsToSystemStateProvider` enforces the migrated lifecycle permission refresh.
- `SystemStateProviderPermissionTests.testPermissionSnapshotAccessDelegatesToPermissionOracle` covers the provider façade read path.
- `SystemStateProviderPermissionTests.testPermissionSnapshotRefreshBypassesCachedSnapshot` covers the provider façade refresh path.

## Validation
- `mise exec -- swiftformat Sources/KeyPathAppKit/Managers/ServiceLifecycleCoordinator.swift Tests/KeyPathTests/Lint/PermissionSnapshotLintTests.swift` (0/2 formatted)
- `TEST_FILTER='PermissionSnapshotLintTests|SystemStateProviderPermissionTests|ServiceLifecycleCoordinatorTests' ./Scripts/run-tests-safe.sh` (30 passed)
- `git diff --check`
- `python3 Scripts/check-accessibility.py`
- `KEYPATH_SNAPSHOTS=0 ./Scripts/run-tests-safe.sh` (4493 passed)

## Gate notes
- Local `/thermo-nuclear-swift-review` could not be run because neither `thermo-nuclear-swift-review` nor `claude` is available on PATH in this shell. Relying on the GitHub `claude-review` check for the review gate.
- Snapshot-enabled `./Scripts/test-full.sh` remains blocked by pre-existing snapshot failures outside this slice: `swift-snapshot-testing` throws `NSInvalidArgumentException` from `UIImage.swift:387`, followed by xctest signal 11. The non-snapshot safe gate above is green.
