### PR TITLE
Route app bootstrap permission snapshots through SystemStateProvider

### DIFF
--- a/Sources/KeyPathAppKit/App.swift
+++ b/Sources/KeyPathAppKit/App.swift
@@ -41,7 +41,7 @@ public struct KeyPathApp: App {
                 .environment(viewModel) // Phase 4: Inject ViewModel
                 .environment(\.services, serviceContainer)
                 .environment(\.preferencesService, PreferencesService.shared)
-                .environment(\.permissionSnapshotProvider, PermissionOracle.shared)
+                .environment(\.permissionSnapshotProvider, SystemStateProvider.shared)
         }
         .commands {
             AppMenuCommands(viewModel: viewModel, appDelegate: appDelegate)
@@ -829,7 +829,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     @MainActor
     private func startEmergencyMonitoringIfPermitted() async {
-        let snapshot = await PermissionOracle.shared.currentSnapshot()
+        let snapshot = await SystemStateProvider.shared.currentPermissionSnapshot()
         guard snapshot.keyPath.accessibility.isReady else {
             AppLogger.shared.debug("🛑 [EmergencyStop] Skipping monitor start (Accessibility not granted)")
             return

--- a/Sources/KeyPathAppKit/Core/CompositionRoot.swift
+++ b/Sources/KeyPathAppKit/Core/CompositionRoot.swift
@@ -134,7 +134,7 @@ enum CompositionRoot {
             // with kIOHIDOptionsTypeNone, which does NOT require Input Monitoring.
             // Only seize-mode (reading key events) needs IM. Start unconditionally
             // so keyboard plug-in detection always works.
-            let snapshot = await PermissionOracle.shared.currentSnapshot()
+            let snapshot = await SystemStateProvider.shared.currentPermissionSnapshot()
             if snapshot.keyPath.inputMonitoring == .granted {
                 // Start HID device monitoring for auto-detect keyboard on plug-in
                 HIDDeviceMonitor.shared.startMonitoring()

--- a/Sources/KeyPathAppKit/UI/MainWindowController.swift
+++ b/Sources/KeyPathAppKit/UI/MainWindowController.swift
@@ -17,7 +17,7 @@ final class MainWindowController: NSWindowController {
             .environment(viewModel) // Phase 4: Inject ViewModel
             .environment(\.services, serviceContainer ?? ServiceContainer())
             .environment(\.preferencesService, PreferencesService.shared)
-            .environment(\.permissionSnapshotProvider, PermissionOracle.shared)
+            .environment(\.permissionSnapshotProvider, SystemStateProvider.shared)
 
         let hostingController = NSHostingController(rootView: rootView)
 

--- a/Sources/KeyPathAppKit/Utilities/DependencyInjection.swift
+++ b/Sources/KeyPathAppKit/Utilities/DependencyInjection.swift
@@ -1,4 +1,5 @@
 import Foundation
+import KeyPathCore
 import KeyPathPermissions
 import SwiftUI
 
@@ -9,19 +10,23 @@ protocol PermissionSnapshotProviding: Sendable {
     func currentSnapshot() async -> PermissionOracle.Snapshot
 }
 
-extension PermissionOracle: PermissionSnapshotProviding {}
+extension SystemStateProvider: PermissionSnapshotProviding {
+    func currentSnapshot() async -> PermissionOracle.Snapshot {
+        await currentPermissionSnapshot()
+    }
+}
 
 /// Adapter to avoid storing actor singletons directly in nonisolated defaults
-private struct PermissionOracleAdapter: PermissionSnapshotProviding {
+private struct SystemStatePermissionSnapshotAdapter: PermissionSnapshotProviding {
     func currentSnapshot() async -> PermissionOracle.Snapshot {
-        await PermissionOracle.shared.currentSnapshot()
+        await SystemStateProvider.shared.currentPermissionSnapshot()
     }
 }
 
 /// EnvironmentKey for injecting a permission snapshot provider
 private struct PermissionSnapshotProviderKey: EnvironmentKey {
     static var defaultValue: any PermissionSnapshotProviding {
-        PermissionOracleAdapter()
+        SystemStatePermissionSnapshotAdapter()
     }
 }
 

--- a/Tests/KeyPathTests/Lint/PermissionSnapshotLintTests.swift
+++ b/Tests/KeyPathTests/Lint/PermissionSnapshotLintTests.swift
@@ -121,6 +121,82 @@ final class PermissionSnapshotLintTests: XCTestCase {
             """
         )
     }
+
+    func testAppLifecycleDelegatesPermissionSnapshotsToSystemStateProvider() throws {
+        let app = repositoryRootForPermissionSnapshotLint()
+            .appendingPathComponent("Sources/KeyPathAppKit/App.swift")
+
+        let violations = try matchingPermissionSnapshotLines(
+            in: app,
+            patterns: permissionSnapshotBypassPatterns()
+        )
+
+        XCTAssertTrue(
+            violations.isEmpty,
+            """
+            App lifecycle code must delegate permission snapshot reads \
+            through SystemStateProvider:
+            \(violations.sorted().joined(separator: "\n"))
+            """
+        )
+    }
+
+    func testMainWindowControllerDelegatesPermissionSnapshotsToSystemStateProvider() throws {
+        let controller = repositoryRootForPermissionSnapshotLint()
+            .appendingPathComponent("Sources/KeyPathAppKit/UI/MainWindowController.swift")
+
+        let violations = try matchingPermissionSnapshotLines(
+            in: controller,
+            patterns: permissionSnapshotBypassPatterns()
+        )
+
+        XCTAssertTrue(
+            violations.isEmpty,
+            """
+            MainWindowController must delegate permission snapshot reads \
+            through SystemStateProvider:
+            \(violations.sorted().joined(separator: "\n"))
+            """
+        )
+    }
+
+    func testCompositionRootDelegatesPermissionSnapshotsToSystemStateProvider() throws {
+        let compositionRoot = repositoryRootForPermissionSnapshotLint()
+            .appendingPathComponent("Sources/KeyPathAppKit/Core/CompositionRoot.swift")
+
+        let violations = try matchingPermissionSnapshotLines(
+            in: compositionRoot,
+            patterns: permissionSnapshotBypassPatterns()
+        )
+
+        XCTAssertTrue(
+            violations.isEmpty,
+            """
+            CompositionRoot must delegate permission snapshot reads \
+            through SystemStateProvider:
+            \(violations.sorted().joined(separator: "\n"))
+            """
+        )
+    }
+
+    func testPermissionSnapshotEnvironmentDefaultDelegatesToSystemStateProvider() throws {
+        let dependencyInjection = repositoryRootForPermissionSnapshotLint()
+            .appendingPathComponent("Sources/KeyPathAppKit/Utilities/DependencyInjection.swift")
+
+        let violations = try matchingPermissionSnapshotLines(
+            in: dependencyInjection,
+            patterns: permissionSnapshotBypassPatterns()
+        )
+
+        XCTAssertTrue(
+            violations.isEmpty,
+            """
+            Permission snapshot environment defaults must delegate reads \
+            through SystemStateProvider:
+            \(violations.sorted().joined(separator: "\n"))
+            """
+        )
+    }
 }
 
 private func repositoryRootForPermissionSnapshotLint(file: StaticString = #filePath) -> URL {
@@ -149,4 +225,12 @@ private func matchingPermissionSnapshotLines(in fileURL: URL, patterns: [String]
         }
     }
     return violations
+}
+
+private func permissionSnapshotBypassPatterns() -> [String] {
+    [
+        #"PermissionOracle\.shared\.currentSnapshot"#,
+        #"PermissionOracle\.shared\.forceRefresh"#,
+        #"PermissionOracle\.shared"#
+    ]
 }

--- a/docs/planning/installer-reliability-phase1.md
+++ b/docs/planning/installer-reliability-phase1.md
@@ -215,6 +215,13 @@ classification remains pending.
 - [x] Migrated `ServiceLifecycleCoordinator` permission refresh through
   `SystemStateProvider`'s permission snapshot façade. Enforced by
   `PermissionSnapshotLintTests.testServiceLifecycleCoordinatorDelegatesPermissionSnapshotsToSystemStateProvider`.
+- [x] Migrated app bootstrap permission snapshot reads and SwiftUI permission
+  snapshot provider defaults through `SystemStateProvider`. Enforced by
+  `PermissionSnapshotLintTests.testAppLifecycleDelegatesPermissionSnapshotsToSystemStateProvider`,
+  `PermissionSnapshotLintTests.testMainWindowControllerDelegatesPermissionSnapshotsToSystemStateProvider`,
+  `PermissionSnapshotLintTests.testCompositionRootDelegatesPermissionSnapshotsToSystemStateProvider`,
+  and
+  `PermissionSnapshotLintTests.testPermissionSnapshotEnvironmentDefaultDelegatesToSystemStateProvider`.
 - [ ] Migrate `SMAppService.status`, permissions, VHID state, helper freshness,
   and migrated read-only `launchctl print` evidence into a single immutable
   `SystemSnapshot`.
@@ -401,6 +408,14 @@ through 21 mocked tests).
 - [x] `ServiceLifecycleCoordinator` permission refresh delegates to
   `SystemStateProvider`'s permission snapshot façade. Enforced by
   `PermissionSnapshotLintTests.testServiceLifecycleCoordinatorDelegatesPermissionSnapshotsToSystemStateProvider`.
+- [x] App bootstrap permission snapshot reads and SwiftUI permission snapshot
+  provider defaults delegate to `SystemStateProvider`'s permission snapshot
+  façade. Enforced by
+  `PermissionSnapshotLintTests.testAppLifecycleDelegatesPermissionSnapshotsToSystemStateProvider`,
+  `PermissionSnapshotLintTests.testMainWindowControllerDelegatesPermissionSnapshotsToSystemStateProvider`,
+  `PermissionSnapshotLintTests.testCompositionRootDelegatesPermissionSnapshotsToSystemStateProvider`,
+  and
+  `PermissionSnapshotLintTests.testPermissionSnapshotEnvironmentDefaultDelegatesToSystemStateProvider`.
 
 ## Workstream 3: Industry-Standard Repair Model
 
@@ -536,6 +551,13 @@ is listed in the state-matrix doc's enforcement section.
 - [x] `PermissionSnapshotLintTests.testServiceLifecycleCoordinatorDelegatesPermissionSnapshotsToSystemStateProvider`
   prevents migrated service-lifecycle permission refreshes from bypassing
   `SystemStateProvider`.
+- [x] `PermissionSnapshotLintTests.testAppLifecycleDelegatesPermissionSnapshotsToSystemStateProvider`,
+  `PermissionSnapshotLintTests.testMainWindowControllerDelegatesPermissionSnapshotsToSystemStateProvider`,
+  `PermissionSnapshotLintTests.testCompositionRootDelegatesPermissionSnapshotsToSystemStateProvider`,
+  and
+  `PermissionSnapshotLintTests.testPermissionSnapshotEnvironmentDefaultDelegatesToSystemStateProvider`
+  prevent migrated app bootstrap/environment permission snapshot reads from
+  bypassing `SystemStateProvider`.
 - [x] `TCPReadinessLintTests.testServiceHealthCheckerDelegatesTCPReadinessToSystemStateProvider`
   prevents `ServiceHealthChecker` from regrowing a private TCP socket probe.
 - [x] `TCPReadinessLintTests.testProductionTCPProbeAdapterIsNoLongerUsed` and

--- a/docs/process/installer-repair-state-matrix.md
+++ b/docs/process/installer-repair-state-matrix.md
@@ -235,7 +235,13 @@ the result as user action required and name the approval surface.
   `PermissionSnapshotLintTests.testSystemValidatorDelegatesPermissionSnapshotsToSystemStateProvider`
   prevents `SystemValidator` from bypassing it, and
   `PermissionSnapshotLintTests.testServiceLifecycleCoordinatorDelegatesPermissionSnapshotsToSystemStateProvider`
-  prevents `ServiceLifecycleCoordinator` from bypassing it.
+  prevents `ServiceLifecycleCoordinator` from bypassing it, and
+  `PermissionSnapshotLintTests.testAppLifecycleDelegatesPermissionSnapshotsToSystemStateProvider`,
+  `PermissionSnapshotLintTests.testMainWindowControllerDelegatesPermissionSnapshotsToSystemStateProvider`,
+  `PermissionSnapshotLintTests.testCompositionRootDelegatesPermissionSnapshotsToSystemStateProvider`,
+  and
+  `PermissionSnapshotLintTests.testPermissionSnapshotEnvironmentDefaultDelegatesToSystemStateProvider`
+  prevent app bootstrap/environment permission snapshot reads from bypassing it.
 - User-facing CLI/reporting shape belongs in CLI contract tests.
 
 ## Related References


### PR DESCRIPTION
## Summary
- Route app bootstrap permission snapshot reads through `SystemStateProvider` instead of `PermissionOracle.shared`.
- Make the SwiftUI permission snapshot environment default delegate to `SystemStateProvider`.
- Add lint ratchets and update the Phase 1 plan/state-matrix docs with the enforcing tests.

## Acceptance criteria completed
- App lifecycle permission snapshot reads delegate to `SystemStateProvider`.
  - Enforced by `PermissionSnapshotLintTests.testAppLifecycleDelegatesPermissionSnapshotsToSystemStateProvider`.
- Main window permission snapshot environment injection delegates to `SystemStateProvider`.
  - Enforced by `PermissionSnapshotLintTests.testMainWindowControllerDelegatesPermissionSnapshotsToSystemStateProvider`.
- Composition root startup permission snapshot reads delegate to `SystemStateProvider`.
  - Enforced by `PermissionSnapshotLintTests.testCompositionRootDelegatesPermissionSnapshotsToSystemStateProvider`.
- Permission snapshot environment defaults delegate to `SystemStateProvider`.
  - Enforced by `PermissionSnapshotLintTests.testPermissionSnapshotEnvironmentDefaultDelegatesToSystemStateProvider`.
- The underlying provider facade remains covered by `SystemStateProviderPermissionTests.testPermissionSnapshotAccessDelegatesToPermissionOracle` and `SystemStateProviderPermissionTests.testPermissionSnapshotRefreshBypassesCachedSnapshot`.

## Validation
- `mise exec -- swiftformat Sources/KeyPathAppKit/App.swift Sources/KeyPathAppKit/Core/CompositionRoot.swift Sources/KeyPathAppKit/UI/MainWindowController.swift Sources/KeyPathAppKit/Utilities/DependencyInjection.swift Tests/KeyPathTests/Lint/PermissionSnapshotLintTests.swift` -> 0/5 files formatted
- `TEST_FILTER='PermissionSnapshotLintTests|SystemStateProviderPermissionTests|RecordingCoordinatorTests|MainAppStateControllerTests' ./Scripts/run-tests-safe.sh` -> passed, 40 tests
- `git diff --check` -> passed
- `python3 Scripts/check-accessibility.py` -> passed, 352 files checked
- `KEYPATH_SNAPSHOTS=0 ./Scripts/run-tests-safe.sh` -> passed, 4497 tests

## Gate notes
- Local `/thermo-nuclear-swift-review` could not be run because neither `thermo-nuclear-swift-review` nor `claude` is installed in this shell. This PR relies on the GitHub `claude-review` gate for that review step.
- Snapshot-enabled `./Scripts/test-full.sh` remains blocked by the pre-existing `swift-snapshot-testing` crash noted on earlier Phase 1 slices; this slice used the safe non-snapshot full gate above.
