### PR TITLE
Add explicit review gate script

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,9 +87,10 @@ Notes:
   reference: `docs/process/agent-pr-workflow.md`.
 - After merging a PR, always pull `master` and deploy from `master` before
   reporting done.
-- Before creating any PR, run the required review gate for the agent in use and
-  address findings. For Claude, run `/thermo-nuclear-swift-review` against the
-  branch diff.
+- Before creating any PR, run `./Scripts/review-gate.sh` against the branch
+  diff and address findings. If local review tooling is unavailable and the
+  script reports `remote review required`, record that in the PR and do not
+  merge until GitHub `claude-review` passes.
 - Git guardrail hooks in `.claude/settings.json` block commits on `master`,
   force-pushes to `master`, `reset --hard`, and `clean -f`.
 

--- a/Scripts/review-gate.sh
+++ b/Scripts/review-gate.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    cat <<'EOF'
+Usage: Scripts/review-gate.sh [--require-local]
+
+Run the pre-PR review gate for the current branch.
+
+Exit codes:
+  0  Local review gate ran and passed.
+  2  Local review tooling is unavailable; PR must rely on GitHub claude-review.
+  1  Local review gate ran and failed, or repository state is invalid.
+
+Options:
+  --require-local  Treat unavailable local review tooling as a failure.
+
+Codex note:
+  The Codex shell does not currently provide /thermo-nuclear-swift-review or
+  claude. In that environment this script should be run before PR creation and
+  its exit code 2 recorded as "remote review required"; the PR must not merge
+  until the GitHub claude-review check passes.
+EOF
+}
+
+require_local=0
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+    usage
+    exit 0
+elif [[ "${1:-}" == "--require-local" ]]; then
+    require_local=1
+elif [[ $# -gt 0 ]]; then
+    usage >&2
+    exit 1
+fi
+
+script_dir=$(cd "$(dirname "$0")" >/dev/null && pwd)
+repo_root=$(cd "$script_dir/.." >/dev/null && pwd)
+cd "$repo_root"
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    echo "review-gate: not inside a git worktree" >&2
+    exit 1
+fi
+
+branch=$(git rev-parse --abbrev-ref HEAD)
+if [[ "$branch" == "master" ]]; then
+    echo "review-gate: refusing to review master directly; use a feature worktree" >&2
+    exit 1
+fi
+
+if ! git rev-parse --verify origin/master >/dev/null 2>&1; then
+    echo "review-gate: origin/master is unavailable; run git fetch first" >&2
+    exit 1
+fi
+
+changed_summary=$(git diff --stat origin/master...HEAD)
+if [[ -z "$changed_summary" ]] && [[ -z "$(git diff --stat)" ]]; then
+    echo "review-gate: no branch or working-tree diff to review"
+    exit 0
+fi
+
+if command -v thermo-nuclear-swift-review >/dev/null 2>&1; then
+    echo "review-gate: running thermo-nuclear-swift-review"
+    thermo-nuclear-swift-review
+    exit $?
+fi
+
+if command -v claude >/dev/null 2>&1; then
+    echo "review-gate: running claude review prompt against origin/master...HEAD"
+    diff_file=$(mktemp "${TMPDIR:-/tmp}/keypath-review-diff.XXXXXX.patch")
+    trap 'rm -f "$diff_file"' EXIT
+    git diff --find-renames origin/master...HEAD > "$diff_file"
+    claude <<EOF
+/thermo-nuclear-swift-review
+
+Review the KeyPath branch diff in this file:
+$diff_file
+
+Focus on bugs, behavioral regressions, concurrency/lifecycle hazards, installer
+postcondition violations, missing tests, and false-success paths. Classify each
+finding as CONFIRMED, PLAUSIBLE, or SPECULATIVE.
+EOF
+    exit $?
+fi
+
+message="review-gate: local review tooling unavailable; require GitHub claude-review before merge"
+if [[ "$require_local" -eq 1 ]]; then
+    echo "$message" >&2
+    exit 1
+fi
+
+echo "$message"
+exit 2

--- a/docs/process/agent-pr-invariants.md
+++ b/docs/process/agent-pr-invariants.md
@@ -23,9 +23,11 @@ What must be true at each phase boundary. The agent's job is to make these true 
 - [ ] If the change touches installer, repair, helper, launchd, SMAppService, VirtualHID, or Kanata runtime readiness: the affected row in `docs/process/installer-repair-state-matrix.md` is named in the PR summary or test plan
 - [ ] No documentation needed for internal refactors, test-only changes, or bug fixes with no UX change
 
-## After Thermonuclear Review
+## After Review Gate
 
-- [ ] `/thermo-nuclear-swift-review` run against the branch diff
+- [ ] `./Scripts/review-gate.sh` run against the branch diff
+- [ ] If local review tooling is unavailable, PR records `remote review required`
+      and GitHub `claude-review` passes before merge
 - [ ] All CONFIRMED and PLAUSIBLE findings addressed or explicitly justified
 
 ## After PR Creation

--- a/docs/process/agent-pr-workflow.md
+++ b/docs/process/agent-pr-workflow.md
@@ -26,9 +26,15 @@ End-to-end process for shepherding code from initial request through to a clean 
 6. **Run the full pre-PR gate once** — before pushing, run `./Scripts/test-full.sh` (equivalent to the snapshot-enabled safe runner). Never commit code that breaks tests. The final full run is required; repeated mid-iteration full runs are the waste.
 7. **Commit** — commit frequently as you work. Use descriptive messages. Include `Co-Authored-By` tag.
 
-## Phase 2.5: Thermonuclear Review
+## Phase 2.5: Review Gate
 
-6b. **Run `/thermo-nuclear-swift-review`** — before creating the PR, run the thermonuclear review skill against the branch diff. Address all CONFIRMED and PLAUSIBLE findings before proceeding. This is not optional — no PR goes out without passing the thermonuclear bar.
+6b. **Run `./Scripts/review-gate.sh`** — before creating the PR, run the
+review gate against the branch diff. If local review tooling is available, the
+script runs it and returns 0 only when it passes. If local review tooling is not
+available in the current agent shell, the script returns 2 and prints
+`remote review required`; record that result in the PR and do not merge until
+the GitHub `claude-review` check passes. Address all CONFIRMED and PLAUSIBLE
+findings before proceeding.
 
 ## Phase 3: PR Creation
 
@@ -52,7 +58,11 @@ Most PR clock-time is latency, not rigor. Cut the latency without dropping any g
 
 - **Risk-tier the merge.** *Mechanical / low-logic* PRs (formatting, dead-code removal with a green suite, docs, config-only) — once local build + full test + lint pass, push and `gh pr merge <n> --auto --squash`, then move on instead of sitting in a poll loop. *Logic / hot-path* PRs (runtime behavior, lifecycle, concurrency, FFI/syscalls, anything subtle) — keep the full manual babysit **and read every review comment**. **Never auto-merge a logic/hot-path PR:** review tools post real bugs as **non-blocking comments while the check still goes green** (e.g. an EPERM liveness bug that the `claude-review` check passed but a Codex comment caught — auto-merge would have shipped it).
 - **Parallelize independent PRs.** Open non-conflicting PRs together, let their CI overlap, merge each when green — don't run them strictly serially.
-- **Front-load review.** For substantive PRs, run `/code-review` locally *before* opening, with a runtime-reality lens ("what does this call actually return in the real root/unprivileged deployment?").
+- **Front-load review.** For substantive PRs, run `./Scripts/review-gate.sh`
+  before opening, with a runtime-reality lens ("what does this call actually
+  return in the real root/unprivileged deployment?"). In Codex shells where
+  local Claude tooling is unavailable, a `remote review required` result is an
+  explicit gate state; the PR must wait for GitHub `claude-review`.
 - **Keep the release path out of feature iteration.** Avoid notarized/release-candidate builds until after merge unless the branch specifically changes signing, notarization, Gatekeeper, Sparkle, or installer behavior.
 
 ## Phase 5: Merge


### PR DESCRIPTION
## Summary
- Add `Scripts/review-gate.sh` as the canonical pre-PR review gate command.
- Document Codex's missing-local-Claude path as an explicit `remote review required` state instead of an ad hoc warning.
- Update agent workflow/invariants and AGENTS.md to require GitHub `claude-review` before merge when local review tooling is unavailable.

## Validation
- `bash -n Scripts/review-gate.sh` -> passed
- `./Scripts/review-gate.sh` -> exit 2, `remote review required` as expected in Codex shell
- `./Scripts/review-gate.sh --require-local` -> exit 1 as expected when local tooling is mandatory
- `git diff --check` -> passed
- `python3 Scripts/check-accessibility.py` -> passed, 352 files checked
- `KEYPATH_SNAPSHOTS=0 ./Scripts/run-tests-safe.sh` -> passed, 4497 tests

## Review gate
- `Scripts/review-gate.sh` returned the expected Codex result: local review tooling unavailable, remote review required.
- This PR must not merge until GitHub `claude-review` passes.
