### PR TITLE
Route wizard core permission snapshots through SystemStateProvider

### DIFF
--- a/Sources/KeyPathInstallationWizard/Core/PermissionGrantCoordinator.swift
+++ b/Sources/KeyPathInstallationWizard/Core/PermissionGrantCoordinator.swift
@@ -233,7 +233,7 @@ public class PermissionGrantCoordinator {
         Task {
             logger.log("PRE-RESTART SNAPSHOT:")
 
-            let snapshot = await PermissionOracle.shared.currentSnapshot()
+            let snapshot = await SystemStateProvider.shared.currentPermissionSnapshot()
 
             let keyPathAccessibility = snapshot.keyPath.accessibility.isReady
             let keyPathInputMonitoring = snapshot.keyPath.inputMonitoring.isReady
@@ -306,7 +306,7 @@ public class PermissionGrantCoordinator {
     private func checkIfPermissionsGranted(for permissionType: CoordinatorPermissionType) async
         -> Bool
     {
-        let snapshot = await PermissionOracle.shared.currentSnapshot()
+        let snapshot = await SystemStateProvider.shared.currentPermissionSnapshot()
 
         switch permissionType {
         case .accessibility:

--- a/Sources/KeyPathInstallationWizard/Core/WizardAsyncOperationManager.swift
+++ b/Sources/KeyPathInstallationWizard/Core/WizardAsyncOperationManager.swift
@@ -318,8 +318,7 @@ public enum WizardOperations {
                 attempts += 1
                 progressCallback(0.3 + (Double(attempts) / Double(maxAttempts)) * 0.7)
 
-                // Use Oracle for permission checking
-                let snapshot = await PermissionOracle.shared.currentSnapshot()
+                let snapshot = await SystemStateProvider.shared.currentPermissionSnapshot()
                 let hasPermission =
                     switch type {
                     case .inputMonitoring:

--- a/Sources/KeyPathPermissions/SystemStateProvider+Permissions.swift
+++ b/Sources/KeyPathPermissions/SystemStateProvider+Permissions.swift
@@ -1,5 +1,4 @@
 import KeyPathCore
-import KeyPathPermissions
 
 public extension SystemStateProvider {
     /// Cached/current permission snapshot for installer and wizard decisions.

--- a/Tests/KeyPathTests/Lint/PermissionSnapshotLintTests.swift
+++ b/Tests/KeyPathTests/Lint/PermissionSnapshotLintTests.swift
@@ -197,6 +197,48 @@ final class PermissionSnapshotLintTests: XCTestCase {
             """
         )
     }
+
+    func testWizardAsyncOperationManagerDelegatesPermissionSnapshotsToSystemStateProvider() throws {
+        let manager = repositoryRootForPermissionSnapshotLint()
+            .appendingPathComponent(
+                "Sources/KeyPathInstallationWizard/Core/WizardAsyncOperationManager.swift"
+            )
+
+        let violations = try matchingPermissionSnapshotLines(
+            in: manager,
+            patterns: permissionSnapshotBypassPatterns()
+        )
+
+        XCTAssertTrue(
+            violations.isEmpty,
+            """
+            WizardAsyncOperationManager must delegate permission snapshot reads \
+            through SystemStateProvider:
+            \(violations.sorted().joined(separator: "\n"))
+            """
+        )
+    }
+
+    func testPermissionGrantCoordinatorDelegatesPermissionSnapshotsToSystemStateProvider() throws {
+        let coordinator = repositoryRootForPermissionSnapshotLint()
+            .appendingPathComponent(
+                "Sources/KeyPathInstallationWizard/Core/PermissionGrantCoordinator.swift"
+            )
+
+        let violations = try matchingPermissionSnapshotLines(
+            in: coordinator,
+            patterns: permissionSnapshotBypassPatterns()
+        )
+
+        XCTAssertTrue(
+            violations.isEmpty,
+            """
+            PermissionGrantCoordinator must delegate permission snapshot reads \
+            through SystemStateProvider:
+            \(violations.sorted().joined(separator: "\n"))
+            """
+        )
+    }
 }
 
 private func repositoryRootForPermissionSnapshotLint(file: StaticString = #filePath) -> URL {

--- a/docs/planning/installer-reliability-phase1.md
+++ b/docs/planning/installer-reliability-phase1.md
@@ -222,6 +222,11 @@ classification remains pending.
   `PermissionSnapshotLintTests.testCompositionRootDelegatesPermissionSnapshotsToSystemStateProvider`,
   and
   `PermissionSnapshotLintTests.testPermissionSnapshotEnvironmentDefaultDelegatesToSystemStateProvider`.
+- [x] Migrated wizard core permission snapshot reads through
+  `SystemStateProvider`'s permission snapshot facade. Enforced by
+  `PermissionSnapshotLintTests.testWizardAsyncOperationManagerDelegatesPermissionSnapshotsToSystemStateProvider`
+  and
+  `PermissionSnapshotLintTests.testPermissionGrantCoordinatorDelegatesPermissionSnapshotsToSystemStateProvider`.
 - [ ] Migrate `SMAppService.status`, permissions, VHID state, helper freshness,
   and migrated read-only `launchctl print` evidence into a single immutable
   `SystemSnapshot`.
@@ -416,6 +421,11 @@ through 21 mocked tests).
   `PermissionSnapshotLintTests.testCompositionRootDelegatesPermissionSnapshotsToSystemStateProvider`,
   and
   `PermissionSnapshotLintTests.testPermissionSnapshotEnvironmentDefaultDelegatesToSystemStateProvider`.
+- [x] Wizard core permission snapshot reads delegate to
+  `SystemStateProvider`'s permission snapshot façade. Enforced by
+  `PermissionSnapshotLintTests.testWizardAsyncOperationManagerDelegatesPermissionSnapshotsToSystemStateProvider`
+  and
+  `PermissionSnapshotLintTests.testPermissionGrantCoordinatorDelegatesPermissionSnapshotsToSystemStateProvider`.
 
 ## Workstream 3: Industry-Standard Repair Model
 
@@ -558,6 +568,11 @@ is listed in the state-matrix doc's enforcement section.
   `PermissionSnapshotLintTests.testPermissionSnapshotEnvironmentDefaultDelegatesToSystemStateProvider`
   prevent migrated app bootstrap/environment permission snapshot reads from
   bypassing `SystemStateProvider`.
+- [x] `PermissionSnapshotLintTests.testWizardAsyncOperationManagerDelegatesPermissionSnapshotsToSystemStateProvider`
+  and
+  `PermissionSnapshotLintTests.testPermissionGrantCoordinatorDelegatesPermissionSnapshotsToSystemStateProvider`
+  prevent migrated wizard core permission snapshot reads from bypassing
+  `SystemStateProvider`.
 - [x] `TCPReadinessLintTests.testServiceHealthCheckerDelegatesTCPReadinessToSystemStateProvider`
   prevents `ServiceHealthChecker` from regrowing a private TCP socket probe.
 - [x] `TCPReadinessLintTests.testProductionTCPProbeAdapterIsNoLongerUsed` and

--- a/docs/process/installer-repair-state-matrix.md
+++ b/docs/process/installer-repair-state-matrix.md
@@ -241,7 +241,12 @@ the result as user action required and name the approval surface.
   `PermissionSnapshotLintTests.testCompositionRootDelegatesPermissionSnapshotsToSystemStateProvider`,
   and
   `PermissionSnapshotLintTests.testPermissionSnapshotEnvironmentDefaultDelegatesToSystemStateProvider`
-  prevent app bootstrap/environment permission snapshot reads from bypassing it.
+  prevent app bootstrap/environment permission snapshot reads from bypassing it,
+  and
+  `PermissionSnapshotLintTests.testWizardAsyncOperationManagerDelegatesPermissionSnapshotsToSystemStateProvider`
+  and
+  `PermissionSnapshotLintTests.testPermissionGrantCoordinatorDelegatesPermissionSnapshotsToSystemStateProvider`
+  prevent wizard core permission snapshot reads from bypassing it.
 - User-facing CLI/reporting shape belongs in CLI contract tests.
 
 ## Related References


### PR DESCRIPTION
## Summary
- Route wizard core permission snapshot reads through `SystemStateProvider`.
- Move the `SystemStateProvider` permission facade from AppKit into `KeyPathPermissions` so both AppKit and the installation wizard can share it without a Core dependency cycle.
- Add lint ratchets and update the Phase 1 plan/state-matrix docs with the enforcing tests.

## Acceptance criteria completed
- `WizardAsyncOperationManager` permission polling delegates to `SystemStateProvider`.
  - Enforced by `PermissionSnapshotLintTests.testWizardAsyncOperationManagerDelegatesPermissionSnapshotsToSystemStateProvider`.
- `PermissionGrantCoordinator` permission snapshot logging and return checks delegate to `SystemStateProvider`.
  - Enforced by `PermissionSnapshotLintTests.testPermissionGrantCoordinatorDelegatesPermissionSnapshotsToSystemStateProvider`.
- The shared provider facade remains covered by `SystemStateProviderPermissionTests.testPermissionSnapshotAccessDelegatesToPermissionOracle` and `SystemStateProviderPermissionTests.testPermissionSnapshotRefreshBypassesCachedSnapshot`.

## Validation
- `mise exec -- swiftformat Sources/KeyPathPermissions/SystemStateProvider+Permissions.swift Sources/KeyPathInstallationWizard/Core/WizardAsyncOperationManager.swift Sources/KeyPathInstallationWizard/Core/PermissionGrantCoordinator.swift Tests/KeyPathTests/Lint/PermissionSnapshotLintTests.swift` -> 0/4 files formatted
- `TEST_FILTER='PermissionSnapshotLintTests|SystemStateProviderPermissionTests|WizardAsyncOperationManagerTests|PermissionGrantCoordinatorTests' ./Scripts/run-tests-safe.sh` -> passed, 13 tests
- `git diff --check` -> passed
- `python3 Scripts/check-accessibility.py` -> passed, 352 files checked
- `./Scripts/review-gate.sh` -> exit 2, remote review required in Codex shell
- `KEYPATH_SNAPSHOTS=0 ./Scripts/run-tests-safe.sh` -> passed, 4499 tests

## Gate notes
- `Scripts/review-gate.sh` returned the expected Codex result: local review tooling unavailable, remote review required.
- This PR must not merge until GitHub `claude-review` passes.
- Snapshot-enabled `./Scripts/test-full.sh` remains blocked by the pre-existing `swift-snapshot-testing` crash noted on earlier Phase 1 slices; this slice used the safe non-snapshot full gate above.
