### PR TITLE
Route wizard UI permission refreshes through SystemStateProvider

### DIFF
--- a/Sources/KeyPathInstallationWizard/UI/Helpers/DragToAuthorize/DragToAuthorizeController.swift
+++ b/Sources/KeyPathInstallationWizard/UI/Helpers/DragToAuthorize/DragToAuthorizeController.swift
@@ -321,7 +321,7 @@ public final class DragToAuthorizeController {
     }
 
     private func checkPermission(for target: PermissionTarget, subject: PermissionSubject) async {
-        let snapshot = await PermissionOracle.shared.forceRefresh()
+        let snapshot = await SystemStateProvider.shared.refreshPermissionSnapshot()
         // Full Disk Access is not represented in the Oracle snapshot; it is read
         // separately (and only ever applies to KeyPath.app, i.e. `.keyPath`).
         let fdaGranted = WizardDependencies.fullDiskAccessChecker?.hasFullDiskAccess() ?? false

--- a/Sources/KeyPathInstallationWizard/UI/InstallationWizardView+StateManagement.swift
+++ b/Sources/KeyPathInstallationWizard/UI/InstallationWizardView+StateManagement.swift
@@ -152,7 +152,7 @@ public extension InstallationWizardView {
             // Ensure permissions are verified before auto-advancing.
             // Without this, .unknown permission states (Oracle hasn't finished TCC check)
             // are treated as non-blocking, causing the wizard to skip permission pages.
-            let permSnapshot = await PermissionOracle.shared.forceRefresh()
+            let permSnapshot = await SystemStateProvider.shared.refreshPermissionSnapshot()
             let kanataAccessibilityUnknown = permSnapshot.kanata.accessibility == .unknown
             let kanataInputMonitoringUnknown = permSnapshot.kanata.inputMonitoring == .unknown
             if kanataAccessibilityUnknown || kanataInputMonitoringUnknown {

--- a/Sources/KeyPathInstallationWizard/UI/Pages/WizardAccessibilityPage.swift
+++ b/Sources/KeyPathInstallationWizard/UI/Pages/WizardAccessibilityPage.swift
@@ -213,7 +213,7 @@ public struct WizardAccessibilityPage: View {
                                 if kanataAccessibilityStatus != .completed {
                                     Button("Add in Settings") {
                                         Task {
-                                            let snapshot = await PermissionOracle.shared.forceRefresh()
+                                            let snapshot = await SystemStateProvider.shared.refreshPermissionSnapshot()
                                             if snapshot.kanata.accessibility.isReady {
                                                 AppLogger.shared.log("🔘 [WizardAccessibilityPage] Fix clicked — permission already granted, navigating to summary")
                                                 await onRefresh()
@@ -265,7 +265,7 @@ public struct WizardAccessibilityPage: View {
         .task {
             // Set initial snapshot immediately so the page renders correct state
             // before the polling loop's first 500ms tick.
-            permissionSnapshot = await PermissionOracle.shared.forceRefresh()
+            permissionSnapshot = await SystemStateProvider.shared.refreshPermissionSnapshot()
         }
         .onAppear {
             // Always restart polling on appear — SwiftUI may have cancelled
@@ -275,7 +275,7 @@ public struct WizardAccessibilityPage: View {
                 var hasEverCelebrated = false
                 while !Task.isCancelled {
                     _ = await WizardSleep.ms(1000)
-                    let snapshot = await PermissionOracle.shared.forceRefresh()
+                    let snapshot = await SystemStateProvider.shared.refreshPermissionSnapshot()
                     permissionSnapshot = snapshot
 
                     let bothGranted = snapshot.keyPath.accessibility.isReady
@@ -389,7 +389,7 @@ public struct WizardAccessibilityPage: View {
                 await onRefresh()
                 return
             }
-            // Poll for grant (KeyPath + Kanata) using Oracle snapshot
+            // Poll for grant (KeyPath + Kanata) using the shared system-state facade.
             permissionPollingTask?.cancel()
             permissionPollingTask = Task { @MainActor [onRefresh] in
                 var attempts = 0
@@ -399,7 +399,7 @@ public struct WizardAccessibilityPage: View {
                 while attempts < maxAttempts {
                     _ = await WizardSleep.ms(1000)
                     attempts += 1
-                    let snapshot = await PermissionOracle.shared.forceRefresh()
+                    let snapshot = await SystemStateProvider.shared.refreshPermissionSnapshot()
                     // Keep the snapshot fresh each tick so the page re-renders and the
                     // #933 escalation card can appear once the wait window elapses.
                     permissionSnapshot = snapshot
@@ -425,7 +425,7 @@ public struct WizardAccessibilityPage: View {
             }
             // Fallback: if not granted shortly, open Accessibility settings so the user can toggle
             _ = await WizardSleep.ms(1500) // 1.5s
-            let snapshot = await PermissionOracle.shared.forceRefresh()
+            let snapshot = await SystemStateProvider.shared.refreshPermissionSnapshot()
             let granted =
                 snapshot.keyPath.accessibility.isReady && snapshot.kanata.accessibility.isReady
             if !granted {
@@ -462,7 +462,7 @@ public struct WizardAccessibilityPage: View {
         // Check if Input Monitoring is already granted - if so, we can close System Settings early
         // since the user won't need to visit it again for permissions
         Task { @MainActor in
-            let snapshot = await PermissionOracle.shared.forceRefresh()
+            let snapshot = await SystemStateProvider.shared.refreshPermissionSnapshot()
             let inputMonitoringGranted = snapshot.keyPath.inputMonitoring.isReady
                 && snapshot.kanata.inputMonitoring.isReady
 

--- a/Sources/KeyPathInstallationWizard/UI/Pages/WizardInputMonitoringPage.swift
+++ b/Sources/KeyPathInstallationWizard/UI/Pages/WizardInputMonitoringPage.swift
@@ -195,7 +195,7 @@ public struct WizardInputMonitoringPage: View {
                                 if kanataInputMonitoringStatus != .completed {
                                     Button("Add in Settings") {
                                         Task {
-                                            let snapshot = await PermissionOracle.shared.forceRefresh()
+                                            let snapshot = await SystemStateProvider.shared.refreshPermissionSnapshot()
                                             if snapshot.kanata.inputMonitoring.isReady {
                                                 AppLogger.shared.log("🔧 [WizardInputMonitoringPage] Fix clicked — permission already granted, navigating to summary")
                                                 await onRefresh()
@@ -246,7 +246,7 @@ public struct WizardInputMonitoringPage: View {
             }
         }
         .task {
-            permissionSnapshot = await PermissionOracle.shared.forceRefresh()
+            permissionSnapshot = await SystemStateProvider.shared.refreshPermissionSnapshot()
         }
         .onAppear {
             checkForStaleEntries()
@@ -417,7 +417,7 @@ public struct WizardInputMonitoringPage: View {
             while !Task.isCancelled {
                 _ = await WizardSleep.ms(1000)
                 if Task.isCancelled { return }
-                let snapshot = await PermissionOracle.shared.forceRefresh()
+                let snapshot = await SystemStateProvider.shared.refreshPermissionSnapshot()
                 permissionSnapshot = snapshot
 
                 let bothGranted = snapshot.keyPath.inputMonitoring.isReady
@@ -451,7 +451,7 @@ public struct WizardInputMonitoringPage: View {
                 _ = await WizardSleep.ms(250)
                 if Task.isCancelled { return }
                 attempts += 1
-                let snapshot = await PermissionOracle.shared.forceRefresh()
+                let snapshot = await SystemStateProvider.shared.refreshPermissionSnapshot()
                 permissionSnapshot = snapshot
                 let hasPermission: Bool =
                     switch type {
@@ -514,13 +514,13 @@ public struct WizardInputMonitoringPage: View {
                 return
             }
 
-            // Poll for grant (KeyPath + Kanata) using Oracle snapshot
+            // Poll for grant (KeyPath + Kanata) using the shared system-state facade.
             startPermissionPolling(for: .inputMonitoring)
 
             // Fallback: if still not granted shortly after, open System Settings panel
             for _ in 0 ..< 6 { // ~1.5s at 250ms
                 _ = await WizardSleep.ms(250)
-                let snapshot = await PermissionOracle.shared.forceRefresh()
+                let snapshot = await SystemStateProvider.shared.refreshPermissionSnapshot()
                 let granted =
                     snapshot.keyPath.inputMonitoring.isReady && snapshot.kanata.inputMonitoring.isReady
                 if granted { return }

--- a/Tests/KeyPathTests/Lint/PermissionSnapshotLintTests.swift
+++ b/Tests/KeyPathTests/Lint/PermissionSnapshotLintTests.swift
@@ -239,6 +239,90 @@ final class PermissionSnapshotLintTests: XCTestCase {
             """
         )
     }
+
+    func testWizardAccessibilityPageDelegatesPermissionSnapshotsToSystemStateProvider() throws {
+        let page = repositoryRootForPermissionSnapshotLint()
+            .appendingPathComponent(
+                "Sources/KeyPathInstallationWizard/UI/Pages/WizardAccessibilityPage.swift"
+            )
+
+        let violations = try matchingPermissionSnapshotLines(
+            in: page,
+            patterns: permissionSnapshotBypassPatterns()
+        )
+
+        XCTAssertTrue(
+            violations.isEmpty,
+            """
+            WizardAccessibilityPage must delegate permission snapshot reads \
+            through SystemStateProvider:
+            \(violations.sorted().joined(separator: "\n"))
+            """
+        )
+    }
+
+    func testWizardInputMonitoringPageDelegatesPermissionSnapshotsToSystemStateProvider() throws {
+        let page = repositoryRootForPermissionSnapshotLint()
+            .appendingPathComponent(
+                "Sources/KeyPathInstallationWizard/UI/Pages/WizardInputMonitoringPage.swift"
+            )
+
+        let violations = try matchingPermissionSnapshotLines(
+            in: page,
+            patterns: permissionSnapshotBypassPatterns()
+        )
+
+        XCTAssertTrue(
+            violations.isEmpty,
+            """
+            WizardInputMonitoringPage must delegate permission snapshot reads \
+            through SystemStateProvider:
+            \(violations.sorted().joined(separator: "\n"))
+            """
+        )
+    }
+
+    func testInstallationWizardStateManagementDelegatesPermissionSnapshotsToSystemStateProvider() throws {
+        let stateManagement = repositoryRootForPermissionSnapshotLint()
+            .appendingPathComponent(
+                "Sources/KeyPathInstallationWizard/UI/InstallationWizardView+StateManagement.swift"
+            )
+
+        let violations = try matchingPermissionSnapshotLines(
+            in: stateManagement,
+            patterns: permissionSnapshotBypassPatterns()
+        )
+
+        XCTAssertTrue(
+            violations.isEmpty,
+            """
+            InstallationWizardView state management must delegate permission snapshot reads \
+            through SystemStateProvider:
+            \(violations.sorted().joined(separator: "\n"))
+            """
+        )
+    }
+
+    func testDragToAuthorizeControllerDelegatesPermissionSnapshotsToSystemStateProvider() throws {
+        let controller = repositoryRootForPermissionSnapshotLint()
+            .appendingPathComponent(
+                "Sources/KeyPathInstallationWizard/UI/Helpers/DragToAuthorize/DragToAuthorizeController.swift"
+            )
+
+        let violations = try matchingPermissionSnapshotLines(
+            in: controller,
+            patterns: permissionSnapshotBypassPatterns()
+        )
+
+        XCTAssertTrue(
+            violations.isEmpty,
+            """
+            DragToAuthorizeController must delegate permission snapshot reads \
+            through SystemStateProvider:
+            \(violations.sorted().joined(separator: "\n"))
+            """
+        )
+    }
 }
 
 private func repositoryRootForPermissionSnapshotLint(file: StaticString = #filePath) -> URL {

--- a/docs/planning/installer-reliability-phase1.md
+++ b/docs/planning/installer-reliability-phase1.md
@@ -227,6 +227,13 @@ classification remains pending.
   `PermissionSnapshotLintTests.testWizardAsyncOperationManagerDelegatesPermissionSnapshotsToSystemStateProvider`
   and
   `PermissionSnapshotLintTests.testPermissionGrantCoordinatorDelegatesPermissionSnapshotsToSystemStateProvider`.
+- [x] Migrated wizard UI permission refresh reads through `SystemStateProvider`'s
+  permission snapshot facade. Enforced by
+  `PermissionSnapshotLintTests.testWizardAccessibilityPageDelegatesPermissionSnapshotsToSystemStateProvider`,
+  `PermissionSnapshotLintTests.testWizardInputMonitoringPageDelegatesPermissionSnapshotsToSystemStateProvider`,
+  `PermissionSnapshotLintTests.testInstallationWizardStateManagementDelegatesPermissionSnapshotsToSystemStateProvider`,
+  and
+  `PermissionSnapshotLintTests.testDragToAuthorizeControllerDelegatesPermissionSnapshotsToSystemStateProvider`.
 - [ ] Migrate `SMAppService.status`, permissions, VHID state, helper freshness,
   and migrated read-only `launchctl print` evidence into a single immutable
   `SystemSnapshot`.
@@ -426,6 +433,13 @@ through 21 mocked tests).
   `PermissionSnapshotLintTests.testWizardAsyncOperationManagerDelegatesPermissionSnapshotsToSystemStateProvider`
   and
   `PermissionSnapshotLintTests.testPermissionGrantCoordinatorDelegatesPermissionSnapshotsToSystemStateProvider`.
+- [x] Wizard UI permission refresh reads delegate to `SystemStateProvider`'s
+  permission snapshot façade. Enforced by
+  `PermissionSnapshotLintTests.testWizardAccessibilityPageDelegatesPermissionSnapshotsToSystemStateProvider`,
+  `PermissionSnapshotLintTests.testWizardInputMonitoringPageDelegatesPermissionSnapshotsToSystemStateProvider`,
+  `PermissionSnapshotLintTests.testInstallationWizardStateManagementDelegatesPermissionSnapshotsToSystemStateProvider`,
+  and
+  `PermissionSnapshotLintTests.testDragToAuthorizeControllerDelegatesPermissionSnapshotsToSystemStateProvider`.
 
 ## Workstream 3: Industry-Standard Repair Model
 
@@ -572,6 +586,13 @@ is listed in the state-matrix doc's enforcement section.
   and
   `PermissionSnapshotLintTests.testPermissionGrantCoordinatorDelegatesPermissionSnapshotsToSystemStateProvider`
   prevent migrated wizard core permission snapshot reads from bypassing
+  `SystemStateProvider`.
+- [x] `PermissionSnapshotLintTests.testWizardAccessibilityPageDelegatesPermissionSnapshotsToSystemStateProvider`,
+  `PermissionSnapshotLintTests.testWizardInputMonitoringPageDelegatesPermissionSnapshotsToSystemStateProvider`,
+  `PermissionSnapshotLintTests.testInstallationWizardStateManagementDelegatesPermissionSnapshotsToSystemStateProvider`,
+  and
+  `PermissionSnapshotLintTests.testDragToAuthorizeControllerDelegatesPermissionSnapshotsToSystemStateProvider`
+  prevent migrated wizard UI permission refresh reads from bypassing
   `SystemStateProvider`.
 - [x] `TCPReadinessLintTests.testServiceHealthCheckerDelegatesTCPReadinessToSystemStateProvider`
   prevents `ServiceHealthChecker` from regrowing a private TCP socket probe.

--- a/docs/process/installer-repair-state-matrix.md
+++ b/docs/process/installer-repair-state-matrix.md
@@ -246,7 +246,13 @@ the result as user action required and name the approval surface.
   `PermissionSnapshotLintTests.testWizardAsyncOperationManagerDelegatesPermissionSnapshotsToSystemStateProvider`
   and
   `PermissionSnapshotLintTests.testPermissionGrantCoordinatorDelegatesPermissionSnapshotsToSystemStateProvider`
-  prevent wizard core permission snapshot reads from bypassing it.
+  prevent wizard core permission snapshot reads from bypassing it, and
+  `PermissionSnapshotLintTests.testWizardAccessibilityPageDelegatesPermissionSnapshotsToSystemStateProvider`,
+  `PermissionSnapshotLintTests.testWizardInputMonitoringPageDelegatesPermissionSnapshotsToSystemStateProvider`,
+  `PermissionSnapshotLintTests.testInstallationWizardStateManagementDelegatesPermissionSnapshotsToSystemStateProvider`,
+  and
+  `PermissionSnapshotLintTests.testDragToAuthorizeControllerDelegatesPermissionSnapshotsToSystemStateProvider`
+  prevent wizard UI permission refresh reads from bypassing it.
 - User-facing CLI/reporting shape belongs in CLI contract tests.
 
 ## Related References


### PR DESCRIPTION
## Summary
- Route wizard UI permission refresh reads through `SystemStateProvider`.
- Add lint ratchets for the two wizard permission pages, wizard state-management refresh, and drag-to-authorize polling.
- Update the Phase 1 plan and state-matrix enforcement docs with the completed acceptance criteria.

## Acceptance criteria completed
- `WizardAccessibilityPage` permission refreshes delegate to `SystemStateProvider`.
  - Enforced by `PermissionSnapshotLintTests.testWizardAccessibilityPageDelegatesPermissionSnapshotsToSystemStateProvider`.
- `WizardInputMonitoringPage` permission refreshes delegate to `SystemStateProvider`.
  - Enforced by `PermissionSnapshotLintTests.testWizardInputMonitoringPageDelegatesPermissionSnapshotsToSystemStateProvider`.
- `InstallationWizardView+StateManagement` permission refreshes delegate to `SystemStateProvider`.
  - Enforced by `PermissionSnapshotLintTests.testInstallationWizardStateManagementDelegatesPermissionSnapshotsToSystemStateProvider`.
- `DragToAuthorizeController` permission polling delegates to `SystemStateProvider`.
  - Enforced by `PermissionSnapshotLintTests.testDragToAuthorizeControllerDelegatesPermissionSnapshotsToSystemStateProvider`.

## Validation
- `mise exec -- swiftformat ...` -> 0/5 files formatted
- `TEST_FILTER='PermissionSnapshotLintTests|SystemStateProviderPermissionTests|DragToAuthorizeGrantResolutionTests|AutomaticPromptGuidanceTests|FullDiskAccessAdvanceTests' ./Scripts/run-tests-safe.sh` -> passed, 28 tests
- `git diff --check` -> passed
- `python3 Scripts/check-accessibility.py` -> passed, 352 files checked
- `./Scripts/review-gate.sh` -> exit 2, remote review required in Codex shell
- `KEYPATH_SNAPSHOTS=0 ./Scripts/run-tests-safe.sh` -> passed, 4503 tests

## Gate notes
- `Scripts/review-gate.sh` returned the expected Codex result: local review tooling unavailable, remote review required.
- This PR must not merge until GitHub `claude-review` passes.
- Snapshot-enabled `./Scripts/test-full.sh` remains blocked by the pre-existing `swift-snapshot-testing` crash noted on earlier Phase 1 slices; this slice used the safe non-snapshot full gate above.
