### PR TITLE
Clarify remote review gate state

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,9 +88,9 @@ Notes:
 - After merging a PR, always pull `master` and deploy from `master` before
   reporting done.
 - Before creating any PR, run `./Scripts/review-gate.sh` against the branch
-  diff and address findings. If local review tooling is unavailable and the
-  script reports `remote review required`, record that in the PR and do not
-  merge until GitHub `claude-review` passes.
+  diff and address findings. If local review tooling is unavailable, exit code
+  2 means `remote review gate selected`; record that in the PR and do not merge
+  until GitHub `claude-review` passes.
 - Git guardrail hooks in `.claude/settings.json` block commits on `master`,
   force-pushes to `master`, `reset --hard`, and `clean -f`.
 

--- a/Scripts/review-gate.sh
+++ b/Scripts/review-gate.sh
@@ -9,17 +9,16 @@ Run the pre-PR review gate for the current branch.
 
 Exit codes:
   0  Local review gate ran and passed.
-  2  Local review tooling is unavailable; PR must rely on GitHub claude-review.
+  2  Remote review gate required; PR must wait for GitHub claude-review.
   1  Local review gate ran and failed, or repository state is invalid.
 
 Options:
   --require-local  Treat unavailable local review tooling as a failure.
 
-Codex note:
-  The Codex shell does not currently provide /thermo-nuclear-swift-review or
-  claude. In that environment this script should be run before PR creation and
-  its exit code 2 recorded as "remote review required"; the PR must not merge
-  until the GitHub claude-review check passes.
+Remote review note:
+  Exit 2 is the expected path when local review tooling is not configured
+  (common in Codex shells). Record it as "remote review gate selected" in the
+  PR. This is not a failure; the merge gate is the GitHub claude-review check.
 EOF
 }
 
@@ -84,9 +83,9 @@ EOF
     exit $?
 fi
 
-message="review-gate: local review tooling unavailable; require GitHub claude-review before merge"
+message="review-gate: remote review gate selected; GitHub claude-review must pass before merge"
 if [[ "$require_local" -eq 1 ]]; then
-    echo "$message" >&2
+    echo "review-gate: local review tooling required but unavailable" >&2
     exit 1
 fi
 

--- a/docs/process/agent-pr-invariants.md
+++ b/docs/process/agent-pr-invariants.md
@@ -26,8 +26,8 @@ What must be true at each phase boundary. The agent's job is to make these true 
 ## After Review Gate
 
 - [ ] `./Scripts/review-gate.sh` run against the branch diff
-- [ ] If local review tooling is unavailable, PR records `remote review required`
-      and GitHub `claude-review` passes before merge
+- [ ] If `./Scripts/review-gate.sh` exits 2, PR records `remote review gate
+      selected` and GitHub `claude-review` passes before merge
 - [ ] All CONFIRMED and PLAUSIBLE findings addressed or explicitly justified
 
 ## After PR Creation

--- a/docs/process/agent-pr-workflow.md
+++ b/docs/process/agent-pr-workflow.md
@@ -30,11 +30,10 @@ End-to-end process for shepherding code from initial request through to a clean 
 
 6b. **Run `./Scripts/review-gate.sh`** — before creating the PR, run the
 review gate against the branch diff. If local review tooling is available, the
-script runs it and returns 0 only when it passes. If local review tooling is not
-available in the current agent shell, the script returns 2 and prints
-`remote review required`; record that result in the PR and do not merge until
-the GitHub `claude-review` check passes. Address all CONFIRMED and PLAUSIBLE
-findings before proceeding.
+script runs it and returns 0 only when it passes. If local review tooling is
+unavailable, exit 2 is the expected remote-review path: record `remote review
+gate selected` in the PR and do not merge until the GitHub `claude-review`
+check passes. Address all CONFIRMED and PLAUSIBLE findings before proceeding.
 
 ## Phase 3: PR Creation
 
@@ -60,9 +59,9 @@ Most PR clock-time is latency, not rigor. Cut the latency without dropping any g
 - **Parallelize independent PRs.** Open non-conflicting PRs together, let their CI overlap, merge each when green — don't run them strictly serially.
 - **Front-load review.** For substantive PRs, run `./Scripts/review-gate.sh`
   before opening, with a runtime-reality lens ("what does this call actually
-  return in the real root/unprivileged deployment?"). In Codex shells where
-  local Claude tooling is unavailable, a `remote review required` result is an
-  explicit gate state; the PR must wait for GitHub `claude-review`.
+  return in the real root/unprivileged deployment?"). If local review tooling is
+  unavailable, `remote review gate selected` is the explicit gate state; the PR
+  must wait for GitHub `claude-review`.
 - **Keep the release path out of feature iteration.** Avoid notarized/release-candidate builds until after merge unless the branch specifically changes signing, notarization, Gatekeeper, Sparkle, or installer behavior.
 
 ## Phase 5: Merge


### PR DESCRIPTION
## Summary
- rename Codex review-gate exit 2 from a missing-tool error to the expected remote-review gate state
- update agent workflow docs and invariants to record `remote review gate selected` in PRs
- keep GitHub `claude-review` as the mandatory merge gate when local review tooling is not configured

## Validation
- `bash -n Scripts/review-gate.sh`
- `./Scripts/review-gate.sh` -> exit 2, `review-gate: remote review gate selected; GitHub claude-review must pass before merge`
- `git diff --check`
- `KEYPATH_SNAPSHOTS=0 ./Scripts/run-tests-safe.sh` -> 4503 passed

## Review gate
- Remote review gate selected locally; waiting for GitHub `claude-review` before merge.
