### PR TITLE
Route sync accessibility checks through SystemStateProvider

### DIFF
--- a/Sources/KeyPathAppKit/Services/KeyboardCapture/KeyboardCapture.swift
+++ b/Sources/KeyPathAppKit/Services/KeyboardCapture/KeyboardCapture.swift
@@ -785,7 +785,7 @@ public class KeyboardCapture {
 
     /// Check permissions without prompting - using synchronous method to avoid deadlocks
     func checkAccessibilityPermissionsSilently() -> Bool {
-        PermissionOracle.shared.keyPathAccessibilityStatus().isReady
+        SystemStateProvider.shared.keyPathAccessibilityStatus().isReady
     }
 
     /// Public method to explicitly request permissions (for use in wizard)

--- a/Sources/KeyPathAppKit/Services/System/WindowManager.swift
+++ b/Sources/KeyPathAppKit/Services/System/WindowManager.swift
@@ -110,7 +110,7 @@ public final class WindowManager {
     /// Whether Accessibility permission is granted.
     /// Window management requires this permission to control other app windows.
     public var hasAccessibilityPermission: Bool {
-        PermissionOracle.shared.keyPathAccessibilityStatus().isReady
+        SystemStateProvider.shared.keyPathAccessibilityStatus().isReady
     }
 
     /// Whether Space movement features are available.

--- a/Sources/KeyPathPermissions/SystemStateProvider+Permissions.swift
+++ b/Sources/KeyPathPermissions/SystemStateProvider+Permissions.swift
@@ -13,4 +13,12 @@ public extension SystemStateProvider {
     func refreshPermissionSnapshot() async -> PermissionOracle.Snapshot {
         await PermissionOracle.shared.forceRefresh()
     }
+
+    /// Synchronous KeyPath Accessibility status for hot paths that cannot await.
+    ///
+    /// Kept behind `SystemStateProvider` so even sync permission probes have one
+    /// owner while Phase 1 grows the immutable system snapshot.
+    nonisolated func keyPathAccessibilityStatus() -> PermissionOracle.Status {
+        PermissionOracle.shared.keyPathAccessibilityStatus()
+    }
 }

--- a/Tests/KeyPathTests/Lint/PermissionSnapshotLintTests.swift
+++ b/Tests/KeyPathTests/Lint/PermissionSnapshotLintTests.swift
@@ -323,6 +323,44 @@ final class PermissionSnapshotLintTests: XCTestCase {
             """
         )
     }
+
+    func testKeyboardCaptureDelegatesSyncAccessibilityStatusToSystemStateProvider() throws {
+        let capture = repositoryRootForPermissionSnapshotLint()
+            .appendingPathComponent("Sources/KeyPathAppKit/Services/KeyboardCapture/KeyboardCapture.swift")
+
+        let violations = try matchingPermissionSnapshotLines(
+            in: capture,
+            patterns: permissionSnapshotBypassPatterns()
+        )
+
+        XCTAssertTrue(
+            violations.isEmpty,
+            """
+            KeyboardCapture must delegate synchronous Accessibility status reads \
+            through SystemStateProvider:
+            \(violations.sorted().joined(separator: "\n"))
+            """
+        )
+    }
+
+    func testWindowManagerDelegatesSyncAccessibilityStatusToSystemStateProvider() throws {
+        let manager = repositoryRootForPermissionSnapshotLint()
+            .appendingPathComponent("Sources/KeyPathAppKit/Services/System/WindowManager.swift")
+
+        let violations = try matchingPermissionSnapshotLines(
+            in: manager,
+            patterns: permissionSnapshotBypassPatterns()
+        )
+
+        XCTAssertTrue(
+            violations.isEmpty,
+            """
+            WindowManager must delegate synchronous Accessibility status reads \
+            through SystemStateProvider:
+            \(violations.sorted().joined(separator: "\n"))
+            """
+        )
+    }
 }
 
 private func repositoryRootForPermissionSnapshotLint(file: StaticString = #filePath) -> URL {

--- a/docs/planning/installer-reliability-phase1.md
+++ b/docs/planning/installer-reliability-phase1.md
@@ -234,6 +234,11 @@ classification remains pending.
   `PermissionSnapshotLintTests.testInstallationWizardStateManagementDelegatesPermissionSnapshotsToSystemStateProvider`,
   and
   `PermissionSnapshotLintTests.testDragToAuthorizeControllerDelegatesPermissionSnapshotsToSystemStateProvider`.
+- [x] Migrated synchronous KeyPath Accessibility status reads through
+  `SystemStateProvider`'s permission facade. Enforced by
+  `PermissionSnapshotLintTests.testKeyboardCaptureDelegatesSyncAccessibilityStatusToSystemStateProvider`
+  and
+  `PermissionSnapshotLintTests.testWindowManagerDelegatesSyncAccessibilityStatusToSystemStateProvider`.
 - [ ] Migrate `SMAppService.status`, permissions, VHID state, helper freshness,
   and migrated read-only `launchctl print` evidence into a single immutable
   `SystemSnapshot`.
@@ -440,6 +445,11 @@ through 21 mocked tests).
   `PermissionSnapshotLintTests.testInstallationWizardStateManagementDelegatesPermissionSnapshotsToSystemStateProvider`,
   and
   `PermissionSnapshotLintTests.testDragToAuthorizeControllerDelegatesPermissionSnapshotsToSystemStateProvider`.
+- [x] Synchronous KeyPath Accessibility status reads delegate to
+  `SystemStateProvider`'s permission façade. Enforced by
+  `PermissionSnapshotLintTests.testKeyboardCaptureDelegatesSyncAccessibilityStatusToSystemStateProvider`
+  and
+  `PermissionSnapshotLintTests.testWindowManagerDelegatesSyncAccessibilityStatusToSystemStateProvider`.
 
 ## Workstream 3: Industry-Standard Repair Model
 
@@ -594,6 +604,11 @@ is listed in the state-matrix doc's enforcement section.
   `PermissionSnapshotLintTests.testDragToAuthorizeControllerDelegatesPermissionSnapshotsToSystemStateProvider`
   prevent migrated wizard UI permission refresh reads from bypassing
   `SystemStateProvider`.
+- [x] `PermissionSnapshotLintTests.testKeyboardCaptureDelegatesSyncAccessibilityStatusToSystemStateProvider`
+  and
+  `PermissionSnapshotLintTests.testWindowManagerDelegatesSyncAccessibilityStatusToSystemStateProvider`
+  prevent migrated synchronous KeyPath Accessibility status reads from
+  bypassing `SystemStateProvider`.
 - [x] `TCPReadinessLintTests.testServiceHealthCheckerDelegatesTCPReadinessToSystemStateProvider`
   prevents `ServiceHealthChecker` from regrowing a private TCP socket probe.
 - [x] `TCPReadinessLintTests.testProductionTCPProbeAdapterIsNoLongerUsed` and

--- a/docs/process/installer-repair-state-matrix.md
+++ b/docs/process/installer-repair-state-matrix.md
@@ -252,7 +252,11 @@ the result as user action required and name the approval surface.
   `PermissionSnapshotLintTests.testInstallationWizardStateManagementDelegatesPermissionSnapshotsToSystemStateProvider`,
   and
   `PermissionSnapshotLintTests.testDragToAuthorizeControllerDelegatesPermissionSnapshotsToSystemStateProvider`
-  prevent wizard UI permission refresh reads from bypassing it.
+  prevent wizard UI permission refresh reads from bypassing it, and
+  `PermissionSnapshotLintTests.testKeyboardCaptureDelegatesSyncAccessibilityStatusToSystemStateProvider`
+  and
+  `PermissionSnapshotLintTests.testWindowManagerDelegatesSyncAccessibilityStatusToSystemStateProvider`
+  prevent synchronous KeyPath Accessibility status reads from bypassing it.
 - User-facing CLI/reporting shape belongs in CLI contract tests.
 
 ## Related References


### PR DESCRIPTION
## Summary
- add a synchronous KeyPath Accessibility status facade on `SystemStateProvider`
- route `KeyboardCapture` and `WindowManager` sync accessibility checks through that facade
- add lint ratchets and update Phase 1/state-matrix docs for the completed acceptance criteria

## Acceptance criteria completed
- `KeyboardCapture` no longer calls `PermissionOracle.shared.keyPathAccessibilityStatus()` directly. Enforced by `PermissionSnapshotLintTests.testKeyboardCaptureDelegatesSyncAccessibilityStatusToSystemStateProvider`.
- `WindowManager` no longer calls `PermissionOracle.shared.keyPathAccessibilityStatus()` directly. Enforced by `PermissionSnapshotLintTests.testWindowManagerDelegatesSyncAccessibilityStatusToSystemStateProvider`.
- `SystemStateProvider` remains the only production owner for the direct `PermissionOracle.shared` permission reads in these migrated areas. Verified with direct-call scan and provider tests `SystemStateProviderPermissionTests.testPermissionSnapshotAccessDelegatesToPermissionOracle` / `testPermissionSnapshotRefreshBypassesCachedSnapshot`.

## Validation
- `TEST_FILTER='PermissionSnapshotLintTests|SystemStateProviderPermissionTests|KeyboardCaptureTests|WindowManagerTests' ./Scripts/run-tests-safe.sh` -> 41 passed
- `rg -n "PermissionOracle\.shared\.(currentSnapshot|forceRefresh|keyPathAccessibilityStatus)|PermissionOracle\.shared" Sources/KeyPathAppKit Sources/KeyPathInstallationWizard Sources/KeyPathPermissions Tests/KeyPathTests/Lint/PermissionSnapshotLintTests.swift` -> only `SystemStateProvider+Permissions.swift` production hits
- `git diff --check`
- `python3 Scripts/check-accessibility.py`
- `./Scripts/review-gate.sh` -> exit 2, remote review gate selected
- `KEYPATH_SNAPSHOTS=0 ./Scripts/run-tests-safe.sh` -> 4505 passed

## Review gate
- Remote review gate selected locally; waiting for GitHub `claude-review` before merge.
