### PR TITLE
Route helper approval status through SystemStateProvider

### DIFF
--- a/Sources/KeyPathAppKit/Core/HelperManager+Status.swift
+++ b/Sources/KeyPathAppKit/Core/HelperManager+Status.swift
@@ -11,8 +11,8 @@ extension HelperManager {
     /// This is a synchronous check used by the wizard navigation engine to prioritize
     /// Login Items approval as a blocking dependency before other setup steps.
     public nonisolated func helperNeedsLoginItemsApproval() -> Bool {
-        let svc = Self.smServiceFactory(Self.helperPlistName)
-        return svc.status == .requiresApproval
+        Self.systemStateProviderFactory()
+            .smAppServiceStatusSynchronously(for: Self.helperPlistName) == .requiresApproval
     }
 
     /// Check if the privileged helper is installed and registered (SMAppService path)

--- a/Sources/KeyPathAppKit/Core/HelperManager.swift
+++ b/Sources/KeyPathAppKit/Core/HelperManager.swift
@@ -23,6 +23,10 @@ public actor HelperManager {
     #if DEBUG
         nonisolated(unsafe) static var smServiceFactory: (String) -> SMAppServiceProtocol = { plistName in
             NativeSMAppService(wrapped: ServiceManagement.SMAppService.daemon(plistName: plistName))
+        } {
+            didSet {
+                SMAppServiceStatusProvider.synchronousServiceFactory = smServiceFactory
+            }
         }
 
         nonisolated(unsafe) static var testHelperFunctionalityOverride: (() async -> Bool)?

--- a/Sources/KeyPathAppKit/Core/SMAppServiceStatusProvider.swift
+++ b/Sources/KeyPathAppKit/Core/SMAppServiceStatusProvider.swift
@@ -56,6 +56,20 @@ actor SMAppServiceStatusProvider {
         static let shared = SMAppServiceStatusProvider()
     #endif
 
+    #if DEBUG
+        /// Independent test seam for the legacy synchronous bridge. Tests that
+        /// need both helper mutation and sync-status paths faked should set this
+        /// explicitly or use HelperManager.smServiceFactory, whose didSet keeps
+        /// this bridge aligned for helper approval checks.
+        nonisolated(unsafe) static var synchronousServiceFactory: (String) -> SMAppServiceProtocol = { plistName in
+            NativeSMAppService(wrapped: ServiceManagement.SMAppService.daemon(plistName: plistName))
+        }
+    #else
+        static let synchronousServiceFactory: @Sendable (String) -> SMAppServiceProtocol = { plistName in
+            NativeSMAppService(wrapped: ServiceManagement.SMAppService.daemon(plistName: plistName))
+        }
+    #endif
+
     /// How long a cached status is served before a fresh fetch is required.
     ///
     /// Kept deliberately short: `.status` transitions (approval granted,
@@ -86,6 +100,15 @@ actor SMAppServiceStatusProvider {
     }
 
     // MARK: - Public accessors
+
+    /// Synchronous status read for legacy sync call sites that cannot yet await.
+    ///
+    /// Keep this bridge narrow. New code should prefer `cachedStatus(for:)` or
+    /// `freshStatus(for:)` through `SystemStateProvider` so blocking IPC stays
+    /// coalesced and off the caller's actor.
+    nonisolated static func statusSynchronously(for plistName: String) -> SMAppService.Status {
+        synchronousServiceFactory(plistName).status
+    }
 
     /// Cached status read: serves a value up to `cacheTTL` old, otherwise fetches.
     ///

--- a/Sources/KeyPathAppKit/Core/SystemStateProvider+SMAppService.swift
+++ b/Sources/KeyPathAppKit/Core/SystemStateProvider+SMAppService.swift
@@ -2,6 +2,15 @@ import KeyPathCore
 import ServiceManagement
 
 public extension SystemStateProvider {
+    /// Synchronous SMAppService status bridge for legacy call sites that cannot
+    /// yet await the cached provider.
+    ///
+    /// Kept behind `SystemStateProvider` so Phase 1 has one owner for status
+    /// evidence while the full immutable snapshot is introduced.
+    nonisolated func smAppServiceStatusSynchronously(for plistName: String) -> SMAppService.Status {
+        SMAppServiceStatusProvider.statusSynchronously(for: plistName)
+    }
+
     /// Cached SMAppService status read for hot paths.
     ///
     /// Delegates to the existing status provider so the blocking Apple IPC remains

--- a/Sources/KeyPathAppKit/WizardProtocolConformances.swift
+++ b/Sources/KeyPathAppKit/WizardProtocolConformances.swift
@@ -147,7 +147,7 @@ public func configureWizardDependencies(runtimeCoordinator: RuntimeCoordinator) 
         HelperManager.smServiceFactory(plistName)
     }
     WizardDependencies.helperNeedsApproval = {
-        HelperManager.smServiceFactory(HelperManager.helperPlistName).status == .requiresApproval
+        HelperManager.shared.helperNeedsLoginItemsApproval()
     }
     WizardDependencies.createUninstallCoordinator = {
         UninstallCoordinator()
@@ -218,7 +218,7 @@ func configureCLIWizardDependencies(systemValidator: SystemValidator) {
         HelperManager.smServiceFactory(plistName)
     }
     WizardDependencies.helperNeedsApproval = {
-        HelperManager.smServiceFactory(HelperManager.helperPlistName).status == .requiresApproval
+        HelperManager.shared.helperNeedsLoginItemsApproval()
     }
     WizardDependencies.createUninstallCoordinator = {
         UninstallCoordinator()

--- a/Tests/KeyPathTests/Core/HelperManagerTests.swift
+++ b/Tests/KeyPathTests/Core/HelperManagerTests.swift
@@ -5,6 +5,7 @@ import ServiceManagement
 
 final class HelperManagerTests: XCTestCase {
     private var originalFactory: ((String) -> SMAppServiceProtocol)!
+    private var originalSynchronousServiceFactory: ((String) -> SMAppServiceProtocol)!
     private var originalStatusProvider: SMAppServiceStatusProvider!
     private var originalSubprocessRunnerFactory: (() -> SubprocessRunning)!
     private var originalSystemStateProviderFactory: (() -> SystemStateProvider)!
@@ -12,6 +13,7 @@ final class HelperManagerTests: XCTestCase {
     override func setUp() {
         super.setUp()
         originalFactory = HelperManager.smServiceFactory
+        originalSynchronousServiceFactory = SMAppServiceStatusProvider.synchronousServiceFactory
         originalStatusProvider = SMAppServiceStatusProvider.shared
         originalSubprocessRunnerFactory = HelperManager.subprocessRunnerFactory
         originalSystemStateProviderFactory = HelperManager.systemStateProviderFactory
@@ -19,6 +21,7 @@ final class HelperManagerTests: XCTestCase {
 
     override func tearDown() {
         HelperManager.smServiceFactory = originalFactory
+        SMAppServiceStatusProvider.synchronousServiceFactory = originalSynchronousServiceFactory
         SMAppServiceStatusProvider.shared = originalStatusProvider
         HelperManager.subprocessRunnerFactory = originalSubprocessRunnerFactory
         HelperManager.systemStateProviderFactory = originalSystemStateProviderFactory
@@ -65,6 +68,12 @@ final class HelperManagerTests: XCTestCase {
             HelperManager.staleHelperSMAppServiceBootoutCommands(),
             ["/bin/launchctl bootout system/com.keypath.helper 2>/dev/null || true"]
         )
+    }
+
+    func testHelperNeedsLoginItemsApprovalUsesHelperManagerSMAppServiceFactory() {
+        installFake(FakeSMAppService(status: .requiresApproval))
+
+        XCTAssertTrue(HelperManager.shared.helperNeedsLoginItemsApproval())
     }
 
     func testInstallHelperRecoversEnabledButUnresponsiveRegistration() async throws {

--- a/Tests/KeyPathTests/Core/SystemStateProviderSMAppServiceTests.swift
+++ b/Tests/KeyPathTests/Core/SystemStateProviderSMAppServiceTests.swift
@@ -5,14 +5,17 @@ import ServiceManagement
 
 final class SystemStateProviderSMAppServiceTests: XCTestCase {
     private var originalStatusProvider: SMAppServiceStatusProvider!
+    private var originalSynchronousServiceFactory: ((String) -> SMAppServiceProtocol)!
 
     override func setUp() {
         super.setUp()
         originalStatusProvider = SMAppServiceStatusProvider.shared
+        originalSynchronousServiceFactory = SMAppServiceStatusProvider.synchronousServiceFactory
     }
 
     override func tearDown() {
         SMAppServiceStatusProvider.shared = originalStatusProvider
+        SMAppServiceStatusProvider.synchronousServiceFactory = originalSynchronousServiceFactory
         super.tearDown()
     }
 
@@ -62,6 +65,17 @@ final class SystemStateProviderSMAppServiceTests: XCTestCase {
         _ = await provider.freshSMAppServiceStatus(for: "com.keypath.kanata.plist")
 
         XCTAssertEqual(service.statusReads, 2)
+    }
+
+    func testSynchronousSMAppServiceStatusDelegatesToCentralStatusProviderBridge() {
+        let service = CountingSMAppService(status: .requiresApproval)
+        SMAppServiceStatusProvider.synchronousServiceFactory = { _ in service }
+
+        let status = SystemStateProvider.shared
+            .smAppServiceStatusSynchronously(for: "com.keypath.helper.plist")
+
+        XCTAssertEqual(status, .requiresApproval)
+        XCTAssertEqual(service.statusReads, 1)
     }
 }
 

--- a/Tests/KeyPathTests/Lint/SMAppServiceStatusLintTests.swift
+++ b/Tests/KeyPathTests/Lint/SMAppServiceStatusLintTests.swift
@@ -25,13 +25,11 @@ final class SMAppServiceStatusLintTests: XCTestCase {
     /// - `SMAppServiceStatusProvider.swift`: the sole intended owner of the IPC.
     /// - `HelperManager.swift`: defines the `SMAppServiceProtocol` seam whose `status`
     ///   getter forwards to Apple's `SMAppService` — the one legitimate declaration.
-    /// - The remainder are synchronous, non-hot-path readers (wizard approval check,
-    ///   bless diagnostics) still awaiting an async migration.
+    /// - The remainder are synchronous, non-hot-path diagnostic readers still
+    ///   awaiting an async migration.
     private static let allowList: Set<String> = [
         "SMAppServiceStatusProvider.swift",
         "HelperManager.swift",
-        "HelperManager+Status.swift",
-        "WizardProtocolConformances.swift",
         "BlessDiagnostics.swift"
     ]
 
@@ -114,9 +112,30 @@ final class SMAppServiceStatusLintTests: XCTestCase {
         XCTAssertTrue(
             violations.isEmpty,
             """
-            HelperManager async SMAppService status/cache access must delegate \
-            through SystemStateProvider. The synchronous helperNeedsLoginItemsApproval \
-            direct .status read remains separately guarded by the shrinking allowlist:
+            HelperManager SMAppService status/cache access must delegate \
+            through SystemStateProvider:
+            \(violations.sorted().joined(separator: "\n"))
+            """
+        )
+    }
+
+    func testWizardProtocolConformancesDelegateHelperApprovalToHelperManager() throws {
+        let conformances = repositoryRoot()
+            .appendingPathComponent("Sources/KeyPathAppKit/WizardProtocolConformances.swift")
+
+        let violations = try matchingLines(
+            in: conformances,
+            patterns: [
+                #"smServiceFactory\(.*\)\.status"#,
+                #"SMAppServiceStatusProvider\.shared"#
+            ]
+        )
+
+        XCTAssertTrue(
+            violations.isEmpty,
+            """
+            Wizard dependency glue must not read SMAppService status directly. \
+            Route helper approval checks through HelperManager/SystemStateProvider:
             \(violations.sorted().joined(separator: "\n"))
             """
         )

--- a/docs/planning/installer-reliability-phase1.md
+++ b/docs/planning/installer-reliability-phase1.md
@@ -239,6 +239,12 @@ classification remains pending.
   `PermissionSnapshotLintTests.testKeyboardCaptureDelegatesSyncAccessibilityStatusToSystemStateProvider`
   and
   `PermissionSnapshotLintTests.testWindowManagerDelegatesSyncAccessibilityStatusToSystemStateProvider`.
+- [x] Migrated the remaining synchronous helper Login Items approval reads
+  through `SystemStateProvider`'s SMAppService status facade and shrank the
+  direct `.status` allowlist. Enforced by
+  `SystemStateProviderSMAppServiceTests.testSynchronousSMAppServiceStatusDelegatesToCentralStatusProviderBridge`,
+  `SMAppServiceStatusLintTests.testStatusAccessIsCentralized`, and
+  `SMAppServiceStatusLintTests.testWizardProtocolConformancesDelegateHelperApprovalToHelperManager`.
 - [ ] Migrate `SMAppService.status`, permissions, VHID state, helper freshness,
   and migrated read-only `launchctl print` evidence into a single immutable
   `SystemSnapshot`.
@@ -609,6 +615,11 @@ is listed in the state-matrix doc's enforcement section.
   `PermissionSnapshotLintTests.testWindowManagerDelegatesSyncAccessibilityStatusToSystemStateProvider`
   prevent migrated synchronous KeyPath Accessibility status reads from
   bypassing `SystemStateProvider`.
+- [x] `SystemStateProviderSMAppServiceTests.testSynchronousSMAppServiceStatusDelegatesToCentralStatusProviderBridge`,
+  `SMAppServiceStatusLintTests.testStatusAccessIsCentralized`, and
+  `SMAppServiceStatusLintTests.testWizardProtocolConformancesDelegateHelperApprovalToHelperManager`
+  prevent synchronous helper Login Items approval reads from bypassing
+  `SystemStateProvider`.
 - [x] `TCPReadinessLintTests.testServiceHealthCheckerDelegatesTCPReadinessToSystemStateProvider`
   prevents `ServiceHealthChecker` from regrowing a private TCP socket probe.
 - [x] `TCPReadinessLintTests.testProductionTCPProbeAdapterIsNoLongerUsed` and

--- a/docs/process/installer-repair-state-matrix.md
+++ b/docs/process/installer-repair-state-matrix.md
@@ -219,7 +219,11 @@ the result as user action required and name the approval surface.
   `SMAppServiceStatusLintTests.testUninstallCoordinatorDelegatesStatusProviderAccessToSystemStateProvider`
   blocks migrated UninstallCoordinator status reads from bypassing it, and
   `SMAppServiceStatusLintTests.testAppLifecycleDelegatesStatusProviderAccessToSystemStateProvider`
-  blocks migrated App lifecycle/dev-utility status reads from bypassing it.
+  blocks migrated App lifecycle/dev-utility status reads from bypassing it, and
+  `SystemStateProviderSMAppServiceTests.testSynchronousSMAppServiceStatusDelegatesToCentralStatusProviderBridge`,
+  `SMAppServiceStatusLintTests.testStatusAccessIsCentralized`, and
+  `SMAppServiceStatusLintTests.testWizardProtocolConformancesDelegateHelperApprovalToHelperManager`
+  prevent synchronous helper Login Items approval reads from bypassing it.
 - Permission snapshot reads belong behind `SystemStateProvider`'s façade over
   `PermissionOracle`.
   `SystemStateProviderPermissionTests.testPermissionSnapshotAccessDelegatesToPermissionOracle`


### PR DESCRIPTION
## Summary
- add a narrow synchronous SMAppService status bridge behind `SystemStateProvider` for legacy sync callers
- route helper Login Items approval checks in `HelperManager` and wizard dependency glue through that bridge
- shrink the direct `.status` lint allowlist and update Phase 1/state-matrix docs with the enforcing tests

## Acceptance criteria completed
- `HelperManager.helperNeedsLoginItemsApproval()` no longer reads `SMAppService.status` directly. Enforced by `SMAppServiceStatusLintTests.testStatusAccessIsCentralized` and `SystemStateProviderSMAppServiceTests.testSynchronousSMAppServiceStatusDelegatesToCentralStatusProviderBridge`.
- `WizardProtocolConformances` no longer reads helper SMAppService status directly. Enforced by `SMAppServiceStatusLintTests.testWizardProtocolConformancesDelegateHelperApprovalToHelperManager`.
- The direct `.status` allowlist is smaller: helper/wizard approval files were removed; `BlessDiagnostics` remains as a diagnostic-only pre-existing allowlist entry for a later async diagnostics slice.

## Validation
- `mise exec -- swiftformat ...` -> 0/6 files formatted
- `TEST_FILTER='SMAppServiceStatusLintTests|SystemStateProviderSMAppServiceTests|HelperManagerTests|WizardGoldenTests|WizardPureLogicTests' ./Scripts/run-tests-safe.sh` -> 159 passed
- direct status scan -> provider facade plus pre-existing `BlessDiagnostics` diagnostic allowlist only
- `git diff --check`
- `python3 Scripts/check-accessibility.py`
- `./Scripts/review-gate.sh` -> exit 2, remote review gate selected
- `KEYPATH_SNAPSHOTS=0 ./Scripts/run-tests-safe.sh` -> 4507 passed

## Review gate
- Remote review gate selected locally; waiting for GitHub `claude-review` before merge.
