### PR TITLE
Add executable installer state matrix fixture

### DIFF
--- a/Sources/KeyPathInstallationWizard/Core/InstallerStateMatrix.swift
+++ b/Sources/KeyPathInstallationWizard/Core/InstallerStateMatrix.swift
@@ -1,0 +1,236 @@
+import Foundation
+
+/// Rows from `docs/process/installer-repair-state-matrix.md`.
+public enum InstallerStateMatrixRow: String, CaseIterable, Sendable, Equatable {
+    case freshInstallMissingComponents = "Fresh install, missing components"
+    case kanataNotRegistered = "Kanata not registered"
+    case registeredButNotLoaded = "Registered but not loaded"
+    case loadedButNotRunning = "Loaded but not running"
+    case runningButTCPNotResponding = "Running but TCP not responding"
+    case runningAndTCPResponding = "Running and TCP responding"
+    case runningButInputCaptureFailing = "Running but input capture failing"
+    case staleInputCaptureIssueWithKanataStopped = "Stale/non-approval input-capture issue with Kanata stopped"
+    case driverKitApprovalPendingWithKanataStopped = "DriverKit approval pending with Kanata stopped"
+    case virtualHIDDriverPayloadMissing = "VirtualHID driver payload missing"
+    case vhidServicesMissingUnhealthy = "VHID services missing/unhealthy"
+    case virtualHIDApprovalPending = "VirtualHID approval pending"
+    case helperMissing = "Helper missing"
+    case helperRespondsButMayBeStale = "Helper responds but may be stale"
+    case helperPathSucceeds = "Helper path succeeds"
+    case sudoFallbackSucceeds = "Sudo fallback succeeds"
+    case manualApprovalRequired = "Manual approval is required"
+    case definitiveUnhealthyState = "Definitive unhealthy state"
+}
+
+/// Minimal immutable evidence used by the state-matrix classifier.
+///
+/// This is intentionally pure and OS-free. `SystemStateProvider` can build this
+/// from live evidence in a later slice without changing the classifier contract.
+public struct InstallerStateMatrixSnapshot: Sendable, Equatable {
+    public var kanataBinaryPresent: Bool
+    public var requiredRuntimePayloadPresent: Bool
+    public var smAppServiceRegistered: Bool
+    public var launchdJobLoaded: Bool
+    public var kanataProcessRunning: Bool
+    public var kanataTCPResponding: Bool
+    public var currentInputCaptureIssue: Bool
+    public var staleInputCaptureIssue: Bool
+    public var driverKitApprovalPending: Bool
+    public var virtualHIDDriverPresent: Bool
+    public var virtualHIDPayloadPresent: Bool
+    public var virtualHIDServicesHealthy: Bool
+    public var virtualHIDApprovalPending: Bool
+    public var helperInstalled: Bool
+    public var helperResponding: Bool
+    public var helperFresh: Bool
+    public var helperPathReportedSuccess: Bool
+    public var sudoFallbackReportedSuccess: Bool
+    public var manualApprovalRequired: Bool
+    public var definitiveUnhealthyState: Bool
+
+    public init(
+        kanataBinaryPresent: Bool = true,
+        requiredRuntimePayloadPresent: Bool = true,
+        smAppServiceRegistered: Bool = true,
+        launchdJobLoaded: Bool = true,
+        kanataProcessRunning: Bool = true,
+        kanataTCPResponding: Bool = true,
+        currentInputCaptureIssue: Bool = false,
+        staleInputCaptureIssue: Bool = false,
+        driverKitApprovalPending: Bool = false,
+        virtualHIDDriverPresent: Bool = true,
+        virtualHIDPayloadPresent: Bool = true,
+        virtualHIDServicesHealthy: Bool = true,
+        virtualHIDApprovalPending: Bool = false,
+        helperInstalled: Bool = true,
+        helperResponding: Bool = true,
+        helperFresh: Bool = true,
+        helperPathReportedSuccess: Bool = false,
+        sudoFallbackReportedSuccess: Bool = false,
+        manualApprovalRequired: Bool = false,
+        definitiveUnhealthyState: Bool = false
+    ) {
+        self.kanataBinaryPresent = kanataBinaryPresent
+        self.requiredRuntimePayloadPresent = requiredRuntimePayloadPresent
+        self.smAppServiceRegistered = smAppServiceRegistered
+        self.launchdJobLoaded = launchdJobLoaded
+        self.kanataProcessRunning = kanataProcessRunning
+        self.kanataTCPResponding = kanataTCPResponding
+        self.currentInputCaptureIssue = currentInputCaptureIssue
+        self.staleInputCaptureIssue = staleInputCaptureIssue
+        self.driverKitApprovalPending = driverKitApprovalPending
+        self.virtualHIDDriverPresent = virtualHIDDriverPresent
+        self.virtualHIDPayloadPresent = virtualHIDPayloadPresent
+        self.virtualHIDServicesHealthy = virtualHIDServicesHealthy
+        self.virtualHIDApprovalPending = virtualHIDApprovalPending
+        self.helperInstalled = helperInstalled
+        self.helperResponding = helperResponding
+        self.helperFresh = helperFresh
+        self.helperPathReportedSuccess = helperPathReportedSuccess
+        self.sudoFallbackReportedSuccess = sudoFallbackReportedSuccess
+        self.manualApprovalRequired = manualApprovalRequired
+        self.definitiveUnhealthyState = definitiveUnhealthyState
+    }
+
+    public var runtimeReady: Bool {
+        kanataProcessRunning && kanataTCPResponding
+    }
+}
+
+public enum InstallerStateMatrixAction: String, Sendable, Equatable {
+    case installMissingComponents = "install-missing-components"
+    case installOrRegisterRuntimeServices = "install-or-register-runtime-services"
+    case recoverRuntimeRegistrationBypassingThrottle = "recover-runtime-registration-bypassing-throttle"
+    case installRequiredRuntimeServices = "install-required-runtime-services"
+    case restartOrRecoverKanataRuntime = "restart-or-recover-kanata-runtime"
+    case repairVHIDActivationServices = "repair-vhid-activation-services"
+    case installVirtualHIDPayload = "install-virtualhid-payload"
+    case repairVHIDServices = "repair-vhid-services"
+    case installHelper = "install-helper"
+    case verifyOrRefreshHelper = "verify-or-refresh-helper"
+    case verifyPostconditions = "verify-postconditions"
+    case surfaceDriverKitApproval = "surface-driverkit-approval"
+    case surfaceVirtualHIDApproval = "surface-virtualhid-approval"
+    case surfaceManualApproval = "surface-manual-approval"
+    case failWithDiagnostics = "fail-with-diagnostics"
+}
+
+public enum InstallerStateMatrixPlanner {
+    public static func classify(_ snapshot: InstallerStateMatrixSnapshot) -> InstallerStateMatrixRow {
+        if snapshot.manualApprovalRequired {
+            return .manualApprovalRequired
+        }
+
+        if snapshot.helperPathReportedSuccess {
+            return .helperPathSucceeds
+        }
+
+        if snapshot.sudoFallbackReportedSuccess {
+            return .sudoFallbackSucceeds
+        }
+
+        if snapshot.definitiveUnhealthyState {
+            return .definitiveUnhealthyState
+        }
+
+        if !snapshot.kanataBinaryPresent ||
+            !snapshot.requiredRuntimePayloadPresent ||
+            !snapshot.virtualHIDDriverPresent
+        {
+            return .freshInstallMissingComponents
+        }
+
+        if !snapshot.smAppServiceRegistered {
+            return .kanataNotRegistered
+        }
+
+        if snapshot.smAppServiceRegistered, !snapshot.launchdJobLoaded {
+            return .registeredButNotLoaded
+        }
+
+        if snapshot.launchdJobLoaded, !snapshot.kanataProcessRunning {
+            if snapshot.driverKitApprovalPending, snapshot.virtualHIDDriverPresent {
+                return .driverKitApprovalPendingWithKanataStopped
+            }
+
+            if snapshot.staleInputCaptureIssue {
+                return .staleInputCaptureIssueWithKanataStopped
+            }
+
+            return .loadedButNotRunning
+        }
+
+        if snapshot.kanataProcessRunning, !snapshot.kanataTCPResponding {
+            return .runningButTCPNotResponding
+        }
+
+        if snapshot.runtimeReady, snapshot.currentInputCaptureIssue {
+            return .runningButInputCaptureFailing
+        }
+
+        if !snapshot.virtualHIDPayloadPresent {
+            return .virtualHIDDriverPayloadMissing
+        }
+
+        if !snapshot.virtualHIDServicesHealthy {
+            return .vhidServicesMissingUnhealthy
+        }
+
+        if snapshot.virtualHIDApprovalPending {
+            return .virtualHIDApprovalPending
+        }
+
+        if !snapshot.helperInstalled {
+            return .helperMissing
+        }
+
+        if snapshot.helperResponding, !snapshot.helperFresh {
+            return .helperRespondsButMayBeStale
+        }
+
+        return .runningAndTCPResponding
+    }
+
+    public static func plan(for row: InstallerStateMatrixRow) -> [InstallerStateMatrixAction] {
+        switch row {
+        case .freshInstallMissingComponents:
+            [.installMissingComponents]
+        case .kanataNotRegistered:
+            [.installOrRegisterRuntimeServices]
+        case .registeredButNotLoaded:
+            [.recoverRuntimeRegistrationBypassingThrottle]
+        case .loadedButNotRunning:
+            [.installRequiredRuntimeServices]
+        case .runningButTCPNotResponding:
+            [.restartOrRecoverKanataRuntime]
+        case .runningAndTCPResponding:
+            []
+        case .runningButInputCaptureFailing:
+            [.repairVHIDActivationServices]
+        case .staleInputCaptureIssueWithKanataStopped:
+            [.installRequiredRuntimeServices]
+        case .driverKitApprovalPendingWithKanataStopped:
+            [.surfaceDriverKitApproval]
+        case .virtualHIDDriverPayloadMissing:
+            [.installVirtualHIDPayload]
+        case .vhidServicesMissingUnhealthy:
+            [.repairVHIDServices]
+        case .virtualHIDApprovalPending:
+            [.surfaceVirtualHIDApproval]
+        case .helperMissing:
+            [.installHelper]
+        case .helperRespondsButMayBeStale:
+            [.verifyOrRefreshHelper]
+        case .helperPathSucceeds, .sudoFallbackSucceeds:
+            [.verifyPostconditions]
+        case .manualApprovalRequired:
+            [.surfaceManualApproval]
+        case .definitiveUnhealthyState:
+            [.failWithDiagnostics]
+        }
+    }
+
+    public static func plan(for snapshot: InstallerStateMatrixSnapshot) -> [InstallerStateMatrixAction] {
+        plan(for: classify(snapshot))
+    }
+}

--- a/Tests/KeyPathTests/InstallationEngine/InstallerStateMatrixGoldenTests.swift
+++ b/Tests/KeyPathTests/InstallationEngine/InstallerStateMatrixGoldenTests.swift
@@ -1,0 +1,150 @@
+@testable import KeyPathInstallationWizard
+@preconcurrency import XCTest
+
+final class InstallerStateMatrixGoldenTests: XCTestCase {
+    func testEveryDocumentedStateMatrixRowHasAGoldenFixture() {
+        XCTAssertEqual(
+            Set(goldenCases.map(\.expectedRow)),
+            Set(InstallerStateMatrixRow.allCases),
+            "Every row in docs/process/installer-repair-state-matrix.md must have one golden fixture"
+        )
+    }
+
+    func testClassifySnapshotAndPlanMatchStateMatrixGoldenFixtures() {
+        for goldenCase in goldenCases {
+            let actualRow = InstallerStateMatrixPlanner.classify(goldenCase.snapshot)
+            let actualPlan = InstallerStateMatrixPlanner.plan(for: actualRow)
+
+            XCTAssertEqual(actualRow, goldenCase.expectedRow, goldenCase.name)
+            XCTAssertEqual(actualPlan, goldenCase.expectedPlan, goldenCase.name)
+        }
+    }
+
+    private struct GoldenCase {
+        let name: String
+        let snapshot: InstallerStateMatrixSnapshot
+        let expectedRow: InstallerStateMatrixRow
+        let expectedPlan: [InstallerStateMatrixAction]
+    }
+
+    private var goldenCases: [GoldenCase] {
+        [
+            GoldenCase(
+                name: "Fresh install, missing components",
+                snapshot: InstallerStateMatrixSnapshot(kanataBinaryPresent: false),
+                expectedRow: .freshInstallMissingComponents,
+                expectedPlan: [.installMissingComponents]
+            ),
+            GoldenCase(
+                name: "Kanata not registered",
+                snapshot: InstallerStateMatrixSnapshot(smAppServiceRegistered: false),
+                expectedRow: .kanataNotRegistered,
+                expectedPlan: [.installOrRegisterRuntimeServices]
+            ),
+            GoldenCase(
+                name: "Registered but not loaded",
+                snapshot: InstallerStateMatrixSnapshot(launchdJobLoaded: false),
+                expectedRow: .registeredButNotLoaded,
+                expectedPlan: [.recoverRuntimeRegistrationBypassingThrottle]
+            ),
+            GoldenCase(
+                name: "Loaded but not running",
+                snapshot: InstallerStateMatrixSnapshot(kanataProcessRunning: false, kanataTCPResponding: false),
+                expectedRow: .loadedButNotRunning,
+                expectedPlan: [.installRequiredRuntimeServices]
+            ),
+            GoldenCase(
+                name: "Running but TCP not responding",
+                snapshot: InstallerStateMatrixSnapshot(kanataTCPResponding: false),
+                expectedRow: .runningButTCPNotResponding,
+                expectedPlan: [.restartOrRecoverKanataRuntime]
+            ),
+            GoldenCase(
+                name: "Running and TCP responding",
+                snapshot: InstallerStateMatrixSnapshot(),
+                expectedRow: .runningAndTCPResponding,
+                expectedPlan: []
+            ),
+            GoldenCase(
+                name: "Running but input capture failing",
+                snapshot: InstallerStateMatrixSnapshot(currentInputCaptureIssue: true),
+                expectedRow: .runningButInputCaptureFailing,
+                expectedPlan: [.repairVHIDActivationServices]
+            ),
+            GoldenCase(
+                name: "Stale/non-approval input-capture issue with Kanata stopped",
+                snapshot: InstallerStateMatrixSnapshot(
+                    kanataProcessRunning: false,
+                    kanataTCPResponding: false,
+                    staleInputCaptureIssue: true
+                ),
+                expectedRow: .staleInputCaptureIssueWithKanataStopped,
+                expectedPlan: [.installRequiredRuntimeServices]
+            ),
+            GoldenCase(
+                name: "DriverKit approval pending with Kanata stopped",
+                snapshot: InstallerStateMatrixSnapshot(
+                    kanataProcessRunning: false,
+                    kanataTCPResponding: false,
+                    driverKitApprovalPending: true
+                ),
+                expectedRow: .driverKitApprovalPendingWithKanataStopped,
+                expectedPlan: [.surfaceDriverKitApproval]
+            ),
+            GoldenCase(
+                name: "VirtualHID driver payload missing",
+                snapshot: InstallerStateMatrixSnapshot(virtualHIDPayloadPresent: false),
+                expectedRow: .virtualHIDDriverPayloadMissing,
+                expectedPlan: [.installVirtualHIDPayload]
+            ),
+            GoldenCase(
+                name: "VHID services missing/unhealthy",
+                snapshot: InstallerStateMatrixSnapshot(virtualHIDServicesHealthy: false),
+                expectedRow: .vhidServicesMissingUnhealthy,
+                expectedPlan: [.repairVHIDServices]
+            ),
+            GoldenCase(
+                name: "VirtualHID approval pending",
+                snapshot: InstallerStateMatrixSnapshot(virtualHIDApprovalPending: true),
+                expectedRow: .virtualHIDApprovalPending,
+                expectedPlan: [.surfaceVirtualHIDApproval]
+            ),
+            GoldenCase(
+                name: "Helper missing",
+                snapshot: InstallerStateMatrixSnapshot(helperInstalled: false, helperResponding: false, helperFresh: false),
+                expectedRow: .helperMissing,
+                expectedPlan: [.installHelper]
+            ),
+            GoldenCase(
+                name: "Helper responds but may be stale",
+                snapshot: InstallerStateMatrixSnapshot(helperFresh: false),
+                expectedRow: .helperRespondsButMayBeStale,
+                expectedPlan: [.verifyOrRefreshHelper]
+            ),
+            GoldenCase(
+                name: "Helper path succeeds",
+                snapshot: InstallerStateMatrixSnapshot(helperPathReportedSuccess: true),
+                expectedRow: .helperPathSucceeds,
+                expectedPlan: [.verifyPostconditions]
+            ),
+            GoldenCase(
+                name: "Sudo fallback succeeds",
+                snapshot: InstallerStateMatrixSnapshot(sudoFallbackReportedSuccess: true),
+                expectedRow: .sudoFallbackSucceeds,
+                expectedPlan: [.verifyPostconditions]
+            ),
+            GoldenCase(
+                name: "Manual approval is required",
+                snapshot: InstallerStateMatrixSnapshot(manualApprovalRequired: true),
+                expectedRow: .manualApprovalRequired,
+                expectedPlan: [.surfaceManualApproval]
+            ),
+            GoldenCase(
+                name: "Definitive unhealthy state",
+                snapshot: InstallerStateMatrixSnapshot(definitiveUnhealthyState: true),
+                expectedRow: .definitiveUnhealthyState,
+                expectedPlan: [.failWithDiagnostics]
+            )
+        ]
+    }
+}

--- a/docs/planning/installer-reliability-phase1.md
+++ b/docs/planning/installer-reliability-phase1.md
@@ -72,8 +72,9 @@ apply. Checklists decay; that is how the loop happened. Make it code.
 - Wizard, CLI, and menu bar cannot disagree about system state because they
   cannot read different sources.
 
-**Status (2026-07-07):** First provider slices implemented; full snapshot
-classification remains pending.
+**Status (2026-07-08):** First provider slices implemented; pure state-matrix
+classification is executable and golden-tested. Full provider-emitted snapshot
+integration remains pending.
 - [x] Introduced `SystemStateProvider` as the owner for the ADR-040
   process-liveness primitive and Kanata readiness predicate. Enforced by
   `SystemStateProviderLivenessTests.testProcessLivenessProbeTreatsCurrentProcessAsAliveAndExitedProcessAsDead`
@@ -248,8 +249,15 @@ classification remains pending.
 - [ ] Migrate `SMAppService.status`, permissions, VHID state, helper freshness,
   and migrated read-only `launchctl print` evidence into a single immutable
   `SystemSnapshot`.
-- [ ] Build `classify(snapshot) -> StateMatrixRow -> plan` and table-driven
-  golden tests for every state-matrix row.
+- [x] Built pure `InstallerStateMatrixPlanner.classify(_:) -> InstallerStateMatrixRow`
+  and `plan(for:)` with a table-driven golden fixture for every state-matrix
+  row. Enforced by
+  `InstallerStateMatrixGoldenTests.testEveryDocumentedStateMatrixRowHasAGoldenFixture`
+  and
+  `InstallerStateMatrixGoldenTests.testClassifySnapshotAndPlanMatchStateMatrixGoldenFixtures`.
+- [ ] Wire `SystemStateProvider`'s full immutable snapshot into the state-matrix
+  classifier and migrate wizard/CLI/menu-bar consumers to the shared
+  classification.
 
 ## Workstream 2: One Liveness Predicate
 

--- a/docs/process/installer-repair-state-matrix.md
+++ b/docs/process/installer-repair-state-matrix.md
@@ -262,6 +262,11 @@ the result as user action required and name the approval surface.
   `PermissionSnapshotLintTests.testWindowManagerDelegatesSyncAccessibilityStatusToSystemStateProvider`
   prevent synchronous KeyPath Accessibility status reads from bypassing it.
 - User-facing CLI/reporting shape belongs in CLI contract tests.
+- The state-matrix table itself is an executable golden fixture:
+  `InstallerStateMatrixGoldenTests.testEveryDocumentedStateMatrixRowHasAGoldenFixture`
+  requires one fixture per documented row, and
+  `InstallerStateMatrixGoldenTests.testClassifySnapshotAndPlanMatchStateMatrixGoldenFixtures`
+  asserts evidence in -> row out -> plan out for every row.
 
 ## Related References
 


### PR DESCRIPTION
## Summary
- Add a pure `InstallerStateMatrixSnapshot` / `InstallerStateMatrixRow` / planner model for the documented installer repair state matrix
- Add table-driven golden tests covering every documented state-matrix row: evidence in -> row out -> plan out
- Update the Phase 1 plan and state-matrix docs with the acceptance criterion and enforcing tests

## Scope
- Phase 1 Workstream 1 + 5 only.
- This slice intentionally does not wire production wizard/CLI/menu-bar consumers yet; the provider-emitted full snapshot integration remains a follow-up Phase 1 slice.
- Workstream 3 repair-model changes and Workstream 6 deletion work remain out of scope.

## Acceptance Criteria Completed
- Every state-matrix row has a golden test: enforced by `InstallerStateMatrixGoldenTests.testEveryDocumentedStateMatrixRowHasAGoldenFixture`.
- Evidence in -> row out -> plan out is table-driven for every row: enforced by `InstallerStateMatrixGoldenTests.testClassifySnapshotAndPlanMatchStateMatrixGoldenFixtures`.

## Validation
- `TEST_FILTER='InstallerStateMatrixGoldenTests' ./Scripts/run-tests-safe.sh` — 2 passed
- `TEST_FILTER='InstallerStateMatrixGoldenTests|InstallerEnginePlanTests|WizardRecipeParityTests|WizardPureLogicTests' ./Scripts/run-tests-safe.sh` — 108 passed
- `git diff --check`
- `python3 Scripts/check-accessibility.py`
- `KEYPATH_SNAPSHOTS=0 ./Scripts/run-tests-safe.sh` — 4510 passed
- `./Scripts/review-gate.sh` — remote review gate selected; GitHub `claude-review` must pass before merge
