### PR TITLE
Build installer state matrix snapshot from provider evidence

### DIFF
--- a/Sources/KeyPathAppKit/Core/SystemStateProvider+InstallerStateMatrix.swift
+++ b/Sources/KeyPathAppKit/Core/SystemStateProvider+InstallerStateMatrix.swift
@@ -1,0 +1,70 @@
+import Foundation
+import KeyPathCore
+import KeyPathInstallationWizard
+import KeyPathWizardCore
+import ServiceManagement
+
+public extension SystemStateProvider {
+    func currentInstallerStateMatrixSnapshot(
+        components: ComponentStatus,
+        helper: HelperStatus,
+        healthChecker: ServiceHealthChecker? = nil,
+        tcpPort: Int = KeyPathConstants.Networking.defaultTCPPort
+    ) async -> InstallerStateMatrixSnapshot {
+        let checker = if let healthChecker {
+            healthChecker
+        } else {
+            await MainActor.run { ServiceHealthChecker.shared }
+        }
+
+        async let runtimeSnapshot = checker.checkKanataServiceRuntimeSnapshot(tcpPort: tcpPort)
+        async let kanataStatus = cachedSMAppServiceStatus(for: "com.keypath.kanata.plist")
+        async let helperStatus = cachedSMAppServiceStatus(for: "com.keypath.helper.plist")
+
+        return await Self.installerStateMatrixSnapshot(
+            components: components,
+            helper: helper,
+            runtime: runtimeSnapshot,
+            kanataSMAppServiceStatus: kanataStatus,
+            helperSMAppServiceStatus: helperStatus
+        )
+    }
+
+    static func installerStateMatrixSnapshot(
+        components: ComponentStatus,
+        helper: HelperStatus,
+        runtime: ServiceHealthChecker.KanataServiceRuntimeSnapshot,
+        kanataSMAppServiceStatus: SMAppService.Status,
+        helperSMAppServiceStatus: SMAppService.Status
+    ) -> InstallerStateMatrixSnapshot {
+        let driverKitApprovalPending = components.karabinerDriverInstalled
+            && !runtime.inputCaptureReady
+            && runtime.inputCaptureIssue == ServiceHealthChecker.inputCaptureVHIDDriverNotActivatedReason
+        let smAppServiceRegistered = kanataSMAppServiceStatus == .enabled
+            || kanataSMAppServiceStatus == .requiresApproval
+        let launchdJobLoaded = !runtime.staleEnabledRegistration
+            && (runtime.launchctlExitCode == 0 || runtime.isRunning)
+        let loginItemsApprovalRequired = kanataSMAppServiceStatus == .requiresApproval
+            || helperSMAppServiceStatus == .requiresApproval
+
+        return InstallerStateMatrixSnapshot(
+            kanataBinaryPresent: components.kanataBinaryInstalled,
+            requiredRuntimePayloadPresent: true,
+            smAppServiceRegistered: smAppServiceRegistered,
+            launchdJobLoaded: launchdJobLoaded,
+            kanataProcessRunning: runtime.isRunning,
+            kanataTCPResponding: runtime.isResponding,
+            currentInputCaptureIssue: runtime.isRunning && runtime.isResponding && !runtime.inputCaptureReady,
+            staleInputCaptureIssue: !runtime.isRunning && !runtime.inputCaptureReady && !driverKitApprovalPending,
+            driverKitApprovalPending: driverKitApprovalPending,
+            virtualHIDDriverPresent: components.karabinerDriverInstalled,
+            virtualHIDPayloadPresent: components.vhidDeviceInstalled,
+            virtualHIDServicesHealthy: components.vhidServicesHealthy,
+            virtualHIDApprovalPending: driverKitApprovalPending,
+            helperInstalled: helper.isInstalled,
+            helperResponding: helper.isWorking,
+            helperFresh: helper.version == nil || helper.version == HelperManager.expectedHelperVersion,
+            manualApprovalRequired: loginItemsApprovalRequired
+        )
+    }
+}

--- a/Tests/KeyPathTests/Core/SystemStateProviderInstallerStateMatrixTests.swift
+++ b/Tests/KeyPathTests/Core/SystemStateProviderInstallerStateMatrixTests.swift
@@ -1,0 +1,140 @@
+@testable import KeyPathAppKit
+@testable import KeyPathCore
+@testable import KeyPathInstallationWizard
+@testable import KeyPathWizardCore
+import ServiceManagement
+@preconcurrency import XCTest
+
+final class SystemStateProviderInstallerStateMatrixTests: XCTestCase {
+    func testStateMatrixSnapshotPreservesRunningButTCPNotRespondingEvidence() {
+        let snapshot = SystemStateProvider.installerStateMatrixSnapshot(
+            components: healthyComponents,
+            helper: healthyHelper,
+            runtime: runtime(isRunning: true, isResponding: false),
+            kanataSMAppServiceStatus: .enabled,
+            helperSMAppServiceStatus: .enabled
+        )
+
+        XCTAssertEqual(InstallerStateMatrixPlanner.classify(snapshot), .runningButTCPNotResponding)
+        XCTAssertEqual(InstallerStateMatrixPlanner.plan(for: snapshot), [.restartOrRecoverKanataRuntime])
+    }
+
+    func testStateMatrixSnapshotMapsStaleEnabledRegistrationToRegisteredButNotLoaded() {
+        let snapshot = SystemStateProvider.installerStateMatrixSnapshot(
+            components: healthyComponents,
+            helper: healthyHelper,
+            runtime: runtime(
+                isRunning: false,
+                isResponding: false,
+                launchctlExitCode: 113,
+                staleEnabledRegistration: true
+            ),
+            kanataSMAppServiceStatus: .enabled,
+            helperSMAppServiceStatus: .enabled
+        )
+
+        XCTAssertEqual(InstallerStateMatrixPlanner.classify(snapshot), .registeredButNotLoaded)
+        XCTAssertEqual(InstallerStateMatrixPlanner.plan(for: snapshot), [.recoverRuntimeRegistrationBypassingThrottle])
+    }
+
+    func testStateMatrixSnapshotMapsStoppedDriverKitApprovalToManualDriverKitRow() {
+        let snapshot = SystemStateProvider.installerStateMatrixSnapshot(
+            components: healthyComponents,
+            helper: healthyHelper,
+            runtime: runtime(
+                isRunning: false,
+                isResponding: false,
+                inputCaptureReady: false,
+                inputCaptureIssue: ServiceHealthChecker.inputCaptureVHIDDriverNotActivatedReason
+            ),
+            kanataSMAppServiceStatus: .enabled,
+            helperSMAppServiceStatus: .enabled
+        )
+
+        XCTAssertEqual(InstallerStateMatrixPlanner.classify(snapshot), .driverKitApprovalPendingWithKanataStopped)
+        XCTAssertEqual(InstallerStateMatrixPlanner.plan(for: snapshot), [.surfaceDriverKitApproval])
+    }
+
+    func testStateMatrixSnapshotMapsLoginItemsApprovalToManualApprovalRow() {
+        let snapshot = SystemStateProvider.installerStateMatrixSnapshot(
+            components: healthyComponents,
+            helper: healthyHelper,
+            runtime: runtime(),
+            kanataSMAppServiceStatus: .enabled,
+            helperSMAppServiceStatus: .requiresApproval
+        )
+
+        XCTAssertEqual(InstallerStateMatrixPlanner.classify(snapshot), .manualApprovalRequired)
+        XCTAssertEqual(InstallerStateMatrixPlanner.plan(for: snapshot), [.surfaceManualApproval])
+    }
+
+    func testStateMatrixSnapshotMapsHelperVersionMismatchToStaleHelperRow() {
+        let snapshot = SystemStateProvider.installerStateMatrixSnapshot(
+            components: healthyComponents,
+            helper: HelperStatus(isInstalled: true, version: "0.9.0", isWorking: true),
+            runtime: runtime(),
+            kanataSMAppServiceStatus: .enabled,
+            helperSMAppServiceStatus: .enabled
+        )
+
+        XCTAssertEqual(InstallerStateMatrixPlanner.classify(snapshot), .helperRespondsButMayBeStale)
+        XCTAssertEqual(InstallerStateMatrixPlanner.plan(for: snapshot), [.verifyOrRefreshHelper])
+    }
+
+    func testStateMatrixSnapshotTreatsUnhealthyVHIDServicesAsServiceRepairNotMissingPayload() {
+        let snapshot = SystemStateProvider.installerStateMatrixSnapshot(
+            components: ComponentStatus(
+                kanataBinaryInstalled: true,
+                karabinerDriverInstalled: true,
+                karabinerDaemonRunning: false,
+                vhidDeviceInstalled: true,
+                vhidDeviceHealthy: true,
+                vhidServicesHealthy: false,
+                vhidVersionMismatch: false
+            ),
+            helper: healthyHelper,
+            runtime: runtime(),
+            kanataSMAppServiceStatus: .enabled,
+            helperSMAppServiceStatus: .enabled
+        )
+
+        XCTAssertEqual(InstallerStateMatrixPlanner.classify(snapshot), .vhidServicesMissingUnhealthy)
+        XCTAssertEqual(InstallerStateMatrixPlanner.plan(for: snapshot), [.repairVHIDServices])
+    }
+
+    private var healthyComponents: ComponentStatus {
+        ComponentStatus(
+            kanataBinaryInstalled: true,
+            karabinerDriverInstalled: true,
+            karabinerDaemonRunning: true,
+            vhidDeviceInstalled: true,
+            vhidDeviceHealthy: true,
+            vhidServicesHealthy: true,
+            vhidVersionMismatch: false
+        )
+    }
+
+    private var healthyHelper: HelperStatus {
+        HelperStatus(isInstalled: true, version: "1.0.0", isWorking: true)
+    }
+
+    private func runtime(
+        isRunning: Bool = true,
+        isResponding: Bool = true,
+        inputCaptureReady: Bool = true,
+        inputCaptureIssue: String? = nil,
+        launchctlExitCode: Int32? = 0,
+        staleEnabledRegistration: Bool = false
+    ) -> ServiceHealthChecker.KanataServiceRuntimeSnapshot {
+        ServiceHealthChecker.KanataServiceRuntimeSnapshot(
+            managementState: .smappserviceActive,
+            isRunning: isRunning,
+            isResponding: isResponding,
+            inputCaptureReady: inputCaptureReady,
+            inputCaptureIssue: inputCaptureIssue,
+            launchctlExitCode: launchctlExitCode,
+            staleEnabledRegistration: staleEnabledRegistration,
+            recentlyRestarted: false
+        )
+    }
+}

--- a/docs/planning/installer-reliability-phase1.md
+++ b/docs/planning/installer-reliability-phase1.md
@@ -255,6 +255,16 @@ integration remains pending.
   `InstallerStateMatrixGoldenTests.testEveryDocumentedStateMatrixRowHasAGoldenFixture`
   and
   `InstallerStateMatrixGoldenTests.testClassifySnapshotAndPlanMatchStateMatrixGoldenFixtures`.
+- [x] Added the live `SystemStateProvider` adapter that materializes the
+  state-matrix snapshot from centralized runtime, SMAppService, component, and
+  helper evidence without collapsing `running` and `responding`. Enforced by
+  `SystemStateProviderInstallerStateMatrixTests.testStateMatrixSnapshotPreservesRunningButTCPNotRespondingEvidence`,
+  `SystemStateProviderInstallerStateMatrixTests.testStateMatrixSnapshotMapsStaleEnabledRegistrationToRegisteredButNotLoaded`,
+  `SystemStateProviderInstallerStateMatrixTests.testStateMatrixSnapshotMapsStoppedDriverKitApprovalToManualDriverKitRow`,
+  `SystemStateProviderInstallerStateMatrixTests.testStateMatrixSnapshotMapsLoginItemsApprovalToManualApprovalRow`,
+  `SystemStateProviderInstallerStateMatrixTests.testStateMatrixSnapshotMapsHelperVersionMismatchToStaleHelperRow`,
+  and
+  `SystemStateProviderInstallerStateMatrixTests.testStateMatrixSnapshotTreatsUnhealthyVHIDServicesAsServiceRepairNotMissingPayload`.
 - [ ] Wire `SystemStateProvider`'s full immutable snapshot into the state-matrix
   classifier and migrate wizard/CLI/menu-bar consumers to the shared
   classification.

--- a/docs/process/installer-repair-state-matrix.md
+++ b/docs/process/installer-repair-state-matrix.md
@@ -267,6 +267,16 @@ the result as user action required and name the approval surface.
   requires one fixture per documented row, and
   `InstallerStateMatrixGoldenTests.testClassifySnapshotAndPlanMatchStateMatrixGoldenFixtures`
   asserts evidence in -> row out -> plan out for every row.
+- Live state-matrix snapshot materialization belongs behind
+  `SystemStateProvider.currentInstallerStateMatrixSnapshot(...)`. The adapter is
+  pinned by
+  `SystemStateProviderInstallerStateMatrixTests.testStateMatrixSnapshotPreservesRunningButTCPNotRespondingEvidence`,
+  `SystemStateProviderInstallerStateMatrixTests.testStateMatrixSnapshotMapsStaleEnabledRegistrationToRegisteredButNotLoaded`,
+  `SystemStateProviderInstallerStateMatrixTests.testStateMatrixSnapshotMapsStoppedDriverKitApprovalToManualDriverKitRow`,
+  `SystemStateProviderInstallerStateMatrixTests.testStateMatrixSnapshotMapsLoginItemsApprovalToManualApprovalRow`,
+  `SystemStateProviderInstallerStateMatrixTests.testStateMatrixSnapshotMapsHelperVersionMismatchToStaleHelperRow`,
+  and
+  `SystemStateProviderInstallerStateMatrixTests.testStateMatrixSnapshotTreatsUnhealthyVHIDServicesAsServiceRepairNotMissingPayload`.
 
 ## Related References
 


### PR DESCRIPTION
## Summary
- Add `SystemStateProvider.currentInstallerStateMatrixSnapshot(...)` to materialize the executable installer state matrix from centralized runtime, SMAppService, component, and helper evidence
- Preserve separate `running` and `responding` signals by using `ServiceHealthChecker.KanataServiceRuntimeSnapshot` instead of collapsed health bits
- Add adapter tests for stale enabled registration, TCP-not-responding, DriverKit approval, Login Items approval, helper freshness, and VHID service repair classification
- Update the Phase 1 plan and state-matrix docs with enforcing test names

## Scope
- Phase 1 Workstream 1 + 5 only.
- This PR adds the live snapshot adapter but does not yet migrate wizard/CLI/menu-bar consumers to it.
- Workstream 3 repair-model changes and Workstream 6 deletion work remain out of scope.

## Acceptance Criteria Completed
- Live state-matrix snapshot materialization is behind `SystemStateProvider.currentInstallerStateMatrixSnapshot(...)`.
- Runtime `running` and TCP `responding` stay distinct: enforced by `SystemStateProviderInstallerStateMatrixTests.testStateMatrixSnapshotPreservesRunningButTCPNotRespondingEvidence`.
- Stale enabled registration maps to the documented state-matrix row: enforced by `SystemStateProviderInstallerStateMatrixTests.testStateMatrixSnapshotMapsStaleEnabledRegistrationToRegisteredButNotLoaded`.
- Manual approval/helper freshness/VHID service evidence is mapped into the executable matrix by the new provider adapter tests.

## Validation
- `TEST_FILTER='SystemStateProviderInstallerStateMatrixTests|InstallerStateMatrixGoldenTests' ./Scripts/run-tests-safe.sh` — 8 passed
- `git diff --check`
- `python3 Scripts/check-accessibility.py`
- `KEYPATH_SNAPSHOTS=0 ./Scripts/run-tests-safe.sh` — 4516 passed
- `./Scripts/review-gate.sh` — remote review gate selected; GitHub `claude-review` must pass before merge
