### PR TITLE
Ratchet review gate remote status wording

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,6 +91,9 @@ Notes:
   diff and address findings. If local review tooling is unavailable, exit code
   2 means `remote review gate selected`; record that in the PR and do not merge
   until GitHub `claude-review` passes.
+- Do not report missing local review tools as a PR issue. The actionable gate
+  state is `remote review gate selected`; the GitHub `claude-review` check is
+  the enforced reviewer in that path.
 - Git guardrail hooks in `.claude/settings.json` block commits on `master`,
   force-pushes to `master`, `reset --hard`, and `clean -f`.
 

--- a/Tests/KeyPathTests/Lint/ReviewGateContractTests.swift
+++ b/Tests/KeyPathTests/Lint/ReviewGateContractTests.swift
@@ -1,0 +1,61 @@
+import Foundation
+import XCTest
+
+final class ReviewGateContractTests: XCTestCase {
+    func testReviewGateRemoteFallbackUsesCanonicalStatus() throws {
+        let root = repositoryRoot()
+        let script = try contents(of: root.appendingPathComponent("Scripts/review-gate.sh"))
+
+        XCTAssertTrue(
+            script.contains("remote review gate selected"),
+            "review-gate must expose the canonical remote-review status."
+        )
+        XCTAssertTrue(
+            script.contains("exit 2"),
+            "review-gate must keep exit 2 as the expected remote-review path."
+        )
+        XCTAssertFalse(
+            script.contains("thermo-nuclear-swift-review and claude"),
+            "review-gate output must not frame missing local tools as the status."
+        )
+        XCTAssertFalse(
+            script.contains("not installed in this shell"),
+            "review-gate output must not revive the old shell-specific failure wording."
+        )
+    }
+
+    func testPRWorkflowDocumentsRemoteReviewAsTheReportedGateState() throws {
+        let root = repositoryRoot()
+        let workflow = try contents(of: root.appendingPathComponent("docs/process/agent-pr-workflow.md"))
+        let invariants = try contents(of: root.appendingPathComponent("docs/process/agent-pr-invariants.md"))
+        let agents = try contents(of: root.appendingPathComponent("AGENTS.md"))
+        let docs = [workflow, invariants, agents].joined(separator: "\n")
+
+        XCTAssertTrue(
+            docs.contains("remote review gate selected"),
+            "PR process docs must preserve the canonical status agents should report."
+        )
+        XCTAssertTrue(
+            docs.contains("Do not report missing local review tools as a PR issue"),
+            "PR process docs must tell agents not to repeat shell-specific tool-install wording."
+        )
+        XCTAssertFalse(
+            docs.contains("thermo-nuclear-swift-review and claude still are not installed"),
+            "PR process docs must not contain the old stale status wording."
+        )
+    }
+}
+
+// MARK: - Helpers
+
+private func repositoryRoot(file: StaticString = #filePath) -> URL {
+    URL(fileURLWithPath: file.description)
+        .deletingLastPathComponent() // Lint
+        .deletingLastPathComponent() // KeyPathTests
+        .deletingLastPathComponent() // Tests
+        .deletingLastPathComponent() // repo root
+}
+
+private func contents(of url: URL) throws -> String {
+    try String(contentsOf: url, encoding: .utf8)
+}

--- a/docs/process/agent-pr-invariants.md
+++ b/docs/process/agent-pr-invariants.md
@@ -28,6 +28,8 @@ What must be true at each phase boundary. The agent's job is to make these true 
 - [ ] `./Scripts/review-gate.sh` run against the branch diff
 - [ ] If `./Scripts/review-gate.sh` exits 2, PR records `remote review gate
       selected` and GitHub `claude-review` passes before merge
+- [ ] Do not report missing local review tools as a PR issue; exit 2 already
+      means the remote review gate is selected
 - [ ] All CONFIRMED and PLAUSIBLE findings addressed or explicitly justified
 
 ## After PR Creation

--- a/docs/process/agent-pr-workflow.md
+++ b/docs/process/agent-pr-workflow.md
@@ -33,7 +33,9 @@ review gate against the branch diff. If local review tooling is available, the
 script runs it and returns 0 only when it passes. If local review tooling is
 unavailable, exit 2 is the expected remote-review path: record `remote review
 gate selected` in the PR and do not merge until the GitHub `claude-review`
-check passes. Address all CONFIRMED and PLAUSIBLE findings before proceeding.
+check passes. Do not report missing local review tools as a PR issue; that is
+already represented by `remote review gate selected`. Address all CONFIRMED
+and PLAUSIBLE findings before proceeding.
 
 ## Phase 3: PR Creation
 


### PR DESCRIPTION
## Summary
- add a lint-style ratchet for the review-gate remote fallback wording
- document that agents should report `remote review gate selected`, not missing local review tools, when `Scripts/review-gate.sh` exits 2
- keep GitHub `claude-review` as the enforced reviewer for that path

## Test plan
- `TEST_FILTER='ReviewGateContractTests' ./Scripts/run-tests-safe.sh` — 2 passed
- `git diff --check`
- `python3 Scripts/check-accessibility.py`
- `KEYPATH_SNAPSHOTS=0 ./Scripts/run-tests-safe.sh` — 4518 passed
- `./Scripts/review-gate.sh` — exit 2, `remote review gate selected`

## Review gate
- Local review gate selected remote path: `review-gate: remote review gate selected; GitHub claude-review must pass before merge`
- Do not merge until GitHub `claude-review` passes.
