### PR TITLE
Expose installer state matrix in CLI inspect

### DIFF
--- a/Sources/KeyPathAppKit/CLI/SystemFacade.swift
+++ b/Sources/KeyPathAppKit/CLI/SystemFacade.swift
@@ -237,6 +237,12 @@ public struct SystemFacade: Sendable {
         let engine = InstallerEngine()
         let context = await engine.inspectSystem()
         let plan = await engine.makePlan(for: planIntent, context: context)
+        let matrixSnapshot = await SystemStateProvider.shared.currentInstallerStateMatrixSnapshot(
+            components: context.components,
+            helper: context.helper,
+            tcpPort: PreferencesService.shared.tcpServerPort
+        )
+        let matrixRow = InstallerStateMatrixPlanner.classify(matrixSnapshot)
 
         let planStatus: String
         var blockedBy: String?
@@ -258,7 +264,9 @@ public struct SystemFacade: Sendable {
             isOperational: Self.isOperational(context),
             userActionRequired: Self.issues(from: context).contains { !$0.canAutoFix },
             promptsNeeded: plan.metadata.promptsNeeded,
-            issues: Self.issues(from: context)
+            issues: Self.issues(from: context),
+            stateMatrixRow: matrixRow.rawValue,
+            stateMatrixPlan: InstallerStateMatrixPlanner.plan(for: matrixRow).map(\.rawValue)
         )
     }
 
@@ -663,6 +671,36 @@ public struct CLIInspectResult: Codable, Sendable {
     public let userActionRequired: Bool?
     public let promptsNeeded: Bool?
     public let issues: [CLISystemIssue]?
+    public let stateMatrixRow: String?
+    public let stateMatrixPlan: [String]?
+
+    public init(
+        macOSVersion: String,
+        driverCompatible: Bool,
+        planStatus: String,
+        blockedBy: String?,
+        plannedRecipes: [String],
+        planIntent: String? = nil,
+        isOperational: Bool? = nil,
+        userActionRequired: Bool? = nil,
+        promptsNeeded: Bool? = nil,
+        issues: [CLISystemIssue]? = nil,
+        stateMatrixRow: String? = nil,
+        stateMatrixPlan: [String]? = nil
+    ) {
+        self.macOSVersion = macOSVersion
+        self.driverCompatible = driverCompatible
+        self.planStatus = planStatus
+        self.blockedBy = blockedBy
+        self.plannedRecipes = plannedRecipes
+        self.planIntent = planIntent
+        self.isOperational = isOperational
+        self.userActionRequired = userActionRequired
+        self.promptsNeeded = promptsNeeded
+        self.issues = issues
+        self.stateMatrixRow = stateMatrixRow
+        self.stateMatrixPlan = stateMatrixPlan
+    }
 }
 
 public struct CLISystemIssue: Codable, Sendable {

--- a/Tests/KeyPathTests/CLI/CLIOutputContractTests.swift
+++ b/Tests/KeyPathTests/CLI/CLIOutputContractTests.swift
@@ -147,6 +147,8 @@ final class CLIOutputContractTests: XCTestCase {
         let keys = try jsonKeys(result)
         let required: Set = ["driverCompatible", "macOSVersion", "planStatus", "plannedRecipes"]
         XCTAssertTrue(required.isSubset(of: keys), "Missing required keys: \(required.subtracting(keys))")
+        XCTAssertNil(result.stateMatrixRow)
+        XCTAssertNil(result.stateMatrixPlan)
     }
 
     func testInspectResultRepairMetadataJSONShape() throws {
@@ -166,15 +168,25 @@ final class CLIOutputContractTests: XCTestCase {
             isOperational: false,
             userActionRequired: false,
             promptsNeeded: true,
-            issues: [issue]
+            issues: [issue],
+            stateMatrixRow: InstallerStateMatrixRow.helperMissing.rawValue,
+            stateMatrixPlan: [
+                InstallerStateMatrixAction.installHelper.rawValue,
+            ]
         )
 
         let keys = try jsonKeys(result)
         let required: Set = [
             "driverCompatible", "issues", "isOperational", "macOSVersion", "planIntent",
-            "planStatus", "plannedRecipes", "promptsNeeded", "userActionRequired",
+            "planStatus", "plannedRecipes", "promptsNeeded", "stateMatrixPlan",
+            "stateMatrixRow", "userActionRequired",
         ]
         XCTAssertTrue(required.isSubset(of: keys), "Missing required keys: \(required.subtracting(keys))")
+
+        let data = try encoder.encode(result)
+        let decoded = try decoder.decode(CLIInspectResult.self, from: data)
+        XCTAssertEqual(decoded.stateMatrixRow, InstallerStateMatrixRow.helperMissing.rawValue)
+        XCTAssertEqual(decoded.stateMatrixPlan, [InstallerStateMatrixAction.installHelper.rawValue])
     }
 
     func testJSONRoundTripsPreserveKeys() throws {

--- a/docs/planning/installer-reliability-phase1.md
+++ b/docs/planning/installer-reliability-phase1.md
@@ -265,6 +265,13 @@ integration remains pending.
   `SystemStateProviderInstallerStateMatrixTests.testStateMatrixSnapshotMapsHelperVersionMismatchToStaleHelperRow`,
   and
   `SystemStateProviderInstallerStateMatrixTests.testStateMatrixSnapshotTreatsUnhealthyVHIDServicesAsServiceRepairNotMissingPayload`.
+- [x] Migrated CLI `system inspect` reporting to include the shared
+  state-matrix row and state-matrix plan derived from `SystemStateProvider`
+  evidence. Enforced by
+  `CLIOutputContractTests.testInspectResultRepairMetadataJSONShape`,
+  `InstallerStateMatrixGoldenTests.testClassifySnapshotAndPlanMatchStateMatrixGoldenFixtures`,
+  and
+  `SystemStateProviderInstallerStateMatrixTests.testStateMatrixSnapshotPreservesRunningButTCPNotRespondingEvidence`.
 - [ ] Wire `SystemStateProvider`'s full immutable snapshot into the state-matrix
   classifier and migrate wizard/CLI/menu-bar consumers to the shared
   classification.

--- a/docs/process/installer-repair-state-matrix.md
+++ b/docs/process/installer-repair-state-matrix.md
@@ -131,6 +131,10 @@ the result as user action required and name the approval surface.
   still be verified by the app-side router when possible.
 - Runtime readiness checks belong in `ServiceHealthChecker` and
   `SystemStateProvider`'s shared lifecycle predicates.
+- CLI `system inspect` reports the shared state-matrix classification and plan.
+  `CLIOutputContractTests.testInspectResultRepairMetadataJSONShape` pins the
+  JSON contract so CLI consumers see the same row/action vocabulary as the
+  golden state-matrix planner.
 - Process-liveness semantics belong in `SystemStateProvider.isProcessAlive(pid:)`.
   `SystemStateProviderLivenessTests.testProcessLivenessProbeTreatsCurrentProcessAsAliveAndExitedProcessAsDead`
   proves the real ADR-040 primitive, and


### PR DESCRIPTION
## Summary
- add optional `stateMatrixRow` and `stateMatrixPlan` fields to `keypath-cli system inspect` JSON
- derive those fields from the shared `SystemStateProvider` state-matrix snapshot adapter and `InstallerStateMatrixPlanner`
- update Phase 1/state-matrix docs with the completed CLI consumer slice and the enforcing tests

## Acceptance criteria completed
- CLI `system inspect` now consumes the shared state-matrix classification vocabulary instead of leaving CLI consumers to infer state independently.
  - Enforced by `CLIOutputContractTests.testInspectResultRepairMetadataJSONShape`.
  - Backed by `InstallerStateMatrixGoldenTests.testClassifySnapshotAndPlanMatchStateMatrixGoldenFixtures` for row/action golden coverage.
  - Backed by `SystemStateProviderInstallerStateMatrixTests.testStateMatrixSnapshotPreservesRunningButTCPNotRespondingEvidence` and sibling adapter tests for provider evidence mapping.

## State-matrix row(s)
- Reporting surface for all rows: CLI now serializes the classified row and plan derived from the shared state-matrix planner.
- No repair routing behavior changes in this PR.

## Out of scope
- Workstream 3 repair-model behavior changes.
- Workstream 6 deletion/collapse pass.
- Wizard/menu-bar consumer migration; those remain follow-on Phase 1 slices.

## Test plan
- `TEST_FILTER='CLIOutputContractTests|SystemStateProviderInstallerStateMatrixTests|InstallerStateMatrixGoldenTests' ./Scripts/run-tests-safe.sh` — 18 passed
- `git diff --check`
- `python3 Scripts/check-accessibility.py`
- `KEYPATH_SNAPSHOTS=0 ./Scripts/run-tests-safe.sh` — 4518 passed
- `./Scripts/review-gate.sh` — exit 2, `remote review gate selected`

## Review gate
- Local review gate selected remote path: `review-gate: remote review gate selected; GitHub claude-review must pass before merge`
- Do not merge until GitHub `claude-review` passes.
