### PR TITLE
Route menu bar health through state matrix

### DIFF
--- a/Sources/KeyPathAppKit/MenuBar/MenuBarController.swift
+++ b/Sources/KeyPathAppKit/MenuBar/MenuBarController.swift
@@ -140,11 +140,8 @@ final class MenuBarController: NSObject, NSMenuDelegate {
     private func updateStatusIcon() {
         guard let button = statusItem.button else { return }
 
-        let isHealthy = appStateController?.validationState?.isSuccess ?? true
-        let hasIssues = !(appStateController?.issues.isEmpty ?? true)
-
         // Update tooltip based on state
-        if !isHealthy || hasIssues {
+        if appStateController?.menuBarSystemHealthy == false {
             button.toolTip = "KeyPath - Needs Setup"
             button.alphaValue = 0.5 // Dim when unhealthy
         } else {
@@ -177,7 +174,7 @@ final class MenuBarController: NSObject, NSMenuDelegate {
     private func rebuildMenu() {
         menu.removeAllItems()
 
-        let isHealthy = appStateController?.validationState?.isSuccess ?? true
+        let isHealthy = appStateController?.menuBarSystemHealthy ?? true
         let issues = appStateController?.issues ?? []
 
         if isHealthy, issues.isEmpty {

--- a/Sources/KeyPathAppKit/Services/MainAppStateController.swift
+++ b/Sources/KeyPathAppKit/Services/MainAppStateController.swift
@@ -32,6 +32,10 @@ class MainAppStateController {
     private(set) var lastAdaptedState: WizardSystemState = .initializing
     /// TCP configuration status from the last validation — consumed by Settings Status tab.
     private(set) var lastTCPConfigured: Bool?
+    /// Latest shared installer state-matrix row — consumed by CLI/status/menu surfaces.
+    var lastInstallerStateMatrixRow: InstallerStateMatrixRow?
+    /// Latest shared installer state-matrix plan — consumed by CLI/status/menu surfaces.
+    var lastInstallerStateMatrixPlan: [InstallerStateMatrixAction] = []
 
     // MARK: - Validation State (compatible with StartupValidator)
 
@@ -647,6 +651,14 @@ class MainAppStateController {
         lastValidatedSystemContext = context
         lastAdaptedState = adapted.state
         lastTCPConfigured = await checkTCPConfiguration()
+        let matrixSnapshot = await SystemStateProvider.shared.currentInstallerStateMatrixSnapshot(
+            components: context.components,
+            helper: context.helper,
+            tcpPort: PreferencesService.shared.tcpServerPort
+        )
+        let matrixRow = InstallerStateMatrixPlanner.classify(matrixSnapshot)
+        lastInstallerStateMatrixRow = matrixRow
+        lastInstallerStateMatrixPlan = InstallerStateMatrixPlanner.plan(for: matrixRow)
         issues = adapted.issues
         lastValidationDate = Date()
         lastValidationTime = Date() // Track for cooldown optimization
@@ -910,6 +922,18 @@ class MainAppStateController {
                 return "\(totalCount) minor issues found (click to review)"
             }
         }
+    }
+
+    /// Shared health policy for compact status surfaces.
+    ///
+    /// Prefer the executable state-matrix row once validation has produced it.
+    /// Before the first matrix classification exists, preserve the legacy
+    /// validation-state behavior so startup UI does not pessimistically flip red.
+    var menuBarSystemHealthy: Bool {
+        if let lastInstallerStateMatrixRow {
+            return lastInstallerStateMatrixRow == .runningAndTCPResponding
+        }
+        return (validationState?.isSuccess ?? true) && issues.isEmpty
     }
 
     /// Get status message for display

--- a/Tests/KeyPathTests/MainAppStateControllerTests.swift
+++ b/Tests/KeyPathTests/MainAppStateControllerTests.swift
@@ -141,6 +141,55 @@ struct MainAppStateControllerTests {
         #expect(controller.issues.isEmpty)
     }
 
+    @Test("Menu bar health falls back to validation before matrix classification")
+    func menuBarHealthFallsBackBeforeMatrixClassification() {
+        let controller = MainAppStateController()
+
+        controller.validationState = .success
+        controller.issues = []
+        #expect(controller.menuBarSystemHealthy == true)
+
+        controller.issues = [
+            WizardIssue(
+                identifier: .daemon,
+                severity: .error,
+                category: .daemon,
+                title: "Runtime stopped",
+                description: "Kanata is not running",
+                autoFixAction: nil,
+                userAction: nil
+            ),
+        ]
+        #expect(controller.menuBarSystemHealthy == false)
+    }
+
+    @Test("Menu bar health prefers shared state matrix row when available")
+    func menuBarHealthPrefersStateMatrixRow() {
+        let controller = MainAppStateController()
+
+        controller.validationState = .success
+        controller.issues = []
+        controller.lastInstallerStateMatrixRow = .runningButTCPNotResponding
+        controller.lastInstallerStateMatrixPlan = [.restartOrRecoverKanataRuntime]
+        #expect(controller.menuBarSystemHealthy == false)
+
+        controller.validationState = .failed(blockingCount: 1, totalCount: 1)
+        controller.issues = [
+            WizardIssue(
+                identifier: .daemon,
+                severity: .error,
+                category: .daemon,
+                title: "Stale issue",
+                description: "Legacy validation state is stale",
+                autoFixAction: nil,
+                userAction: nil
+            ),
+        ]
+        controller.lastInstallerStateMatrixRow = .runningAndTCPResponding
+        controller.lastInstallerStateMatrixPlan = []
+        #expect(controller.menuBarSystemHealthy == true)
+    }
+
     @Test("lastValidationDate is settable")
     func lastValidationDateSettable() {
         let controller = MainAppStateController()

--- a/docs/planning/installer-reliability-phase1.md
+++ b/docs/planning/installer-reliability-phase1.md
@@ -272,6 +272,11 @@ integration remains pending.
   `InstallerStateMatrixGoldenTests.testClassifySnapshotAndPlanMatchStateMatrixGoldenFixtures`,
   and
   `SystemStateProviderInstallerStateMatrixTests.testStateMatrixSnapshotPreservesRunningButTCPNotRespondingEvidence`.
+- [x] Migrated the menu-bar health indicator policy to prefer the shared
+  state-matrix row produced by app validation, while preserving the legacy
+  validation fallback before the first matrix classification exists. Enforced by
+  `MainAppStateControllerTests.menuBarHealthPrefersStateMatrixRow` and
+  `MainAppStateControllerTests.menuBarHealthFallsBackBeforeMatrixClassification`.
 - [ ] Wire `SystemStateProvider`'s full immutable snapshot into the state-matrix
   classifier and migrate wizard/CLI/menu-bar consumers to the shared
   classification.

--- a/docs/process/installer-repair-state-matrix.md
+++ b/docs/process/installer-repair-state-matrix.md
@@ -135,6 +135,10 @@ the result as user action required and name the approval surface.
   `CLIOutputContractTests.testInspectResultRepairMetadataJSONShape` pins the
   JSON contract so CLI consumers see the same row/action vocabulary as the
   golden state-matrix planner.
+- Menu-bar health uses the shared state-matrix row once app validation has
+  classified the current system state. `MainAppStateControllerTests.menuBarHealthPrefersStateMatrixRow`
+  pins that `runningAndTCPResponding` is the only matrix row treated as healthy
+  by the compact status surface.
 - Process-liveness semantics belong in `SystemStateProvider.isProcessAlive(pid:)`.
   `SystemStateProviderLivenessTests.testProcessLivenessProbeTreatsCurrentProcessAsAliveAndExitedProcessAsDead`
   proves the real ADR-040 primitive, and


### PR DESCRIPTION
## Summary
- publish the latest shared installer state-matrix row/plan from app validation
- make the menu-bar health policy prefer that row when available, falling back to legacy validation only before first classification
- update Phase 1/state-matrix docs with the completed menu-bar consumer slice and enforcing tests

## Acceptance criteria completed
- Menu-bar status now consumes the shared state-matrix classification vocabulary instead of independently interpreting validation state once classification exists.
  - Enforced by `MainAppStateControllerTests.menuBarHealthPrefersStateMatrixRow`.
  - Startup fallback is preserved and enforced by `MainAppStateControllerTests.menuBarHealthFallsBackBeforeMatrixClassification`.

## State-matrix row(s)
- Compact menu-bar health treats `runningAndTCPResponding` as healthy once matrix classification is available.
- Other rows surface as setup-needed in the menu bar.
- No repair routing behavior changes in this PR.

## Out of scope
- Workstream 3 repair-model behavior changes.
- Workstream 6 deletion/collapse pass.
- Wizard routing migration; remains a follow-on Phase 1 slice.

## Test plan
- `TEST_FILTER='MainAppStateControllerTests|CLIOutputContractTests|SystemStateProviderInstallerStateMatrixTests' ./Scripts/run-tests-safe.sh` — 44 passed
- `git diff --check`
- `python3 Scripts/check-accessibility.py`
- `KEYPATH_SNAPSHOTS=0 ./Scripts/run-tests-safe.sh` — 4520 passed
- `./Scripts/review-gate.sh` — exit 2, `remote review gate selected`

## Review gate
- Local review gate selected remote path: `review-gate: remote review gate selected; GitHub claude-review must pass before merge`
- Do not merge until GitHub `claude-review` passes.
