### PR TITLE
Ratchet stale review gate wording

### DIFF
--- a/Tests/KeyPathTests/Lint/ReviewGateContractTests.swift
+++ b/Tests/KeyPathTests/Lint/ReviewGateContractTests.swift
@@ -2,6 +2,21 @@ import Foundation
 import XCTest
 
 final class ReviewGateContractTests: XCTestCase {
+    private let staleToolingStatus = [
+        "thermo-nuclear-swift-review",
+        "and claude",
+    ].joined(separator: " ")
+
+    private let staleShellStatus = [
+        "not installed",
+        "in this shell",
+    ].joined(separator: " ")
+
+    private let staleFullStatus = [
+        ["thermo-nuclear-swift-review", "and claude"].joined(separator: " "),
+        "still are not installed",
+    ].joined(separator: " ")
+
     func testReviewGateRemoteFallbackUsesCanonicalStatus() throws {
         let root = repositoryRoot()
         let script = try contents(of: root.appendingPathComponent("Scripts/review-gate.sh"))
@@ -15,11 +30,11 @@ final class ReviewGateContractTests: XCTestCase {
             "review-gate must keep exit 2 as the expected remote-review path."
         )
         XCTAssertFalse(
-            script.contains("thermo-nuclear-swift-review and claude"),
+            script.contains(staleToolingStatus),
             "review-gate output must not frame missing local tools as the status."
         )
         XCTAssertFalse(
-            script.contains("not installed in this shell"),
+            script.contains(staleShellStatus),
             "review-gate output must not revive the old shell-specific failure wording."
         )
     }
@@ -40,9 +55,34 @@ final class ReviewGateContractTests: XCTestCase {
             "PR process docs must tell agents not to repeat shell-specific tool-install wording."
         )
         XCTAssertFalse(
-            docs.contains("thermo-nuclear-swift-review and claude still are not installed"),
+            docs.contains(staleFullStatus),
             "PR process docs must not contain the old stale status wording."
         )
+    }
+
+    func testProcessSurfaceDoesNotContainStaleReviewGatePhrasing() throws {
+        let root = repositoryRoot()
+        let processSurface = [
+            "AGENTS.md",
+            "Scripts/review-gate.sh",
+            "docs/process/agent-pr-workflow.md",
+            "docs/process/agent-pr-invariants.md",
+            "Tests/KeyPathTests/Lint/ReviewGateContractTests.swift",
+        ]
+
+        for relativePath in processSurface {
+            let file = root.appendingPathComponent(relativePath)
+            let text = try contents(of: file)
+
+            XCTAssertFalse(
+                text.contains(staleShellStatus),
+                "\(relativePath) must not contain the stale shell-specific review-gate wording."
+            )
+            XCTAssertFalse(
+                text.contains(staleFullStatus),
+                "\(relativePath) must not contain the stale local-tooling review-gate wording."
+            )
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- remove the stale local-tooling phrase from the review-gate ratchet source itself
- add a process-surface denylist check so AGENTS, review-gate script, PR workflow docs, invariants, and the ratchet test cannot reintroduce that wording

## Validation
- `rg -n "not installed in this shell|thermo-nuclear-swift-review and claude still are not installed|thermo-nuclear-swift-review and claude" Tests/KeyPathTests/Lint Scripts docs AGENTS.md || true` returned no matches
- `TEST_FILTER='ReviewGateContractTests' ./Scripts/run-tests-safe.sh` — 3 passed
- `git diff --check`
- `python3 Scripts/check-accessibility.py`
- `KEYPATH_SNAPSHOTS=0 ./Scripts/run-tests-safe.sh` — 4521 passed
- `./Scripts/review-gate.sh` — `remote review gate selected`, exit 2

## Review gate
Local review tooling is unavailable in this shell, so `./Scripts/review-gate.sh` selected the canonical remote gate. Do not merge until GitHub `claude-review` passes.
