### PR TITLE
Publish wizard state matrix metadata

### DIFF
--- a/Sources/KeyPathInstallationWizard/Core/InstallerStateMatrix.swift
+++ b/Sources/KeyPathInstallationWizard/Core/InstallerStateMatrix.swift
@@ -1,4 +1,5 @@
 import Foundation
+import KeyPathWizardCore
 
 /// Rows from `docs/process/installer-repair-state-matrix.md`.
 public enum InstallerStateMatrixRow: String, CaseIterable, Sendable, Equatable {
@@ -232,5 +233,43 @@ public enum InstallerStateMatrixPlanner {
 
     public static func plan(for snapshot: InstallerStateMatrixSnapshot) -> [InstallerStateMatrixAction] {
         plan(for: classify(snapshot))
+    }
+}
+
+public extension SystemContext {
+    var installerStateMatrixSnapshot: InstallerStateMatrixSnapshot {
+        let driverKitApprovalPending = requiresManualVHIDDriverApproval
+        let inputCaptureIssuePresent = !services.kanataInputCaptureReady
+        let staleInputCaptureIssue = !services.kanataRunning
+            && inputCaptureIssuePresent
+            && !driverKitApprovalPending
+
+        return InstallerStateMatrixSnapshot(
+            kanataBinaryPresent: components.kanataBinaryInstalled,
+            requiredRuntimePayloadPresent: true,
+            smAppServiceRegistered: components.kanataBinaryInstalled,
+            launchdJobLoaded: services.kanataRunning || components.kanataBinaryInstalled,
+            kanataProcessRunning: services.kanataRunning,
+            kanataTCPResponding: services.kanataRunning,
+            currentInputCaptureIssue: services.kanataRunning && inputCaptureIssuePresent,
+            staleInputCaptureIssue: staleInputCaptureIssue,
+            driverKitApprovalPending: driverKitApprovalPending,
+            virtualHIDDriverPresent: components.karabinerDriverInstalled,
+            virtualHIDPayloadPresent: components.vhidDeviceInstalled,
+            virtualHIDServicesHealthy: !components.vhidRuntimeServicesNeedRepair,
+            virtualHIDApprovalPending: driverKitApprovalPending,
+            helperInstalled: helper.isInstalled,
+            helperResponding: helper.isWorking,
+            helperFresh: helper.version == nil || helper.version == WizardHelperConstants.expectedHelperVersion,
+            definitiveUnhealthyState: timedOut
+        )
+    }
+
+    var installerStateMatrixRow: InstallerStateMatrixRow {
+        InstallerStateMatrixPlanner.classify(installerStateMatrixSnapshot)
+    }
+
+    var installerStateMatrixPlan: [InstallerStateMatrixAction] {
+        InstallerStateMatrixPlanner.plan(for: installerStateMatrixSnapshot)
     }
 }

--- a/Sources/KeyPathInstallationWizard/Core/SystemContextAdapter.swift
+++ b/Sources/KeyPathInstallationWizard/Core/SystemContextAdapter.swift
@@ -12,12 +12,16 @@ public struct SystemContextAdapter {
     public static func adapt(_ context: SystemContext) -> SystemStateResult {
         let (wizardState, wizardIssues) = SystemInspector.inspect(context: context)
         let autoFixActions = determineAutoFixActions(context)
+        let stateMatrixRow = context.installerStateMatrixRow
+        let stateMatrixPlan = InstallerStateMatrixPlanner.plan(for: stateMatrixRow)
 
         return SystemStateResult(
             state: wizardState,
             issues: wizardIssues,
             autoFixActions: autoFixActions,
-            detectionTimestamp: context.timestamp
+            detectionTimestamp: context.timestamp,
+            stateMatrixRow: stateMatrixRow.rawValue,
+            stateMatrixPlan: stateMatrixPlan.map(\.rawValue)
         )
     }
 

--- a/Sources/KeyPathWizardCore/WizardHelperManaging.swift
+++ b/Sources/KeyPathWizardCore/WizardHelperManaging.swift
@@ -19,4 +19,5 @@ public enum WizardHelperConstants {
     public static let helperPlistName = "com.keypath.helper.plist"
     public static let helperMachServiceName = "com.keypath.helper"
     public static let helperBundleIdentifier = "com.keypath.helper"
+    public static let expectedHelperVersion = "1.0.0"
 }

--- a/Sources/KeyPathWizardCore/WizardTypes.swift
+++ b/Sources/KeyPathWizardCore/WizardTypes.swift
@@ -359,15 +359,21 @@ public struct SystemStateResult: Sendable {
     public let issues: [WizardIssue]
     public let autoFixActions: [AutoFixAction]
     public let detectionTimestamp: Date
+    public let stateMatrixRow: String?
+    public let stateMatrixPlan: [String]
 
     public init(
         state: WizardSystemState, issues: [WizardIssue], autoFixActions: [AutoFixAction],
-        detectionTimestamp: Date
+        detectionTimestamp: Date,
+        stateMatrixRow: String? = nil,
+        stateMatrixPlan: [String] = []
     ) {
         self.state = state
         self.issues = issues
         self.autoFixActions = autoFixActions
         self.detectionTimestamp = detectionTimestamp
+        self.stateMatrixRow = stateMatrixRow
+        self.stateMatrixPlan = stateMatrixPlan
     }
 
     public var hasBlockingIssues: Bool {

--- a/Tests/KeyPathTests/InstallationWizard/WizardPureLogicTests.swift
+++ b/Tests/KeyPathTests/InstallationWizard/WizardPureLogicTests.swift
@@ -60,7 +60,7 @@ final class WizardPureLogicTests: XCTestCase {
     }
 
     private var healthyHelper: HelperStatus {
-        HelperStatus(isInstalled: true, version: "1.0", isWorking: true)
+        HelperStatus(isInstalled: true, version: WizardHelperConstants.expectedHelperVersion, isWorking: true)
     }
 
     private var defaultSystem: EngineSystemInfo {
@@ -112,6 +112,31 @@ final class WizardPureLogicTests: XCTestCase {
         XCTAssertEqual(state, .active)
         let blocking = issues.filter { $0.severity == .error || $0.severity == .critical }
         XCTAssertTrue(blocking.isEmpty, "Healthy system should have no blocking issues")
+    }
+
+    func test_systemContextStateMatrixSnapshot_classifiesStoppedRuntimeWithStaleInputCapture() {
+        let context = makeContext(
+            services: HealthStatus(
+                kanataRunning: false,
+                karabinerDaemonRunning: true,
+                vhidHealthy: true,
+                kanataInputCaptureReady: false,
+                kanataInputCaptureIssue: ServiceHealthChecker.inputCaptureGrabFailureReason
+            )
+        )
+
+        XCTAssertEqual(context.installerStateMatrixRow, .staleInputCaptureIssueWithKanataStopped)
+        XCTAssertEqual(context.installerStateMatrixPlan, [.installRequiredRuntimeServices])
+    }
+
+    func test_systemContextAdapterPublishesStateMatrixMetadata() {
+        let context = makeContext(helper: HelperStatus(isInstalled: false, version: nil, isWorking: false))
+
+        let result = SystemContextAdapter.adapt(context)
+
+        XCTAssertEqual(result.stateMatrixRow, InstallerStateMatrixRow.helperMissing.rawValue)
+        XCTAssertEqual(result.stateMatrixPlan, [InstallerStateMatrixAction.installHelper.rawValue])
+        XCTAssertEqual(result.autoFixActions, [.installPrivilegedHelper])
     }
 
     func test_inspect_keyPathAccessibilityDenied_producesMissingPermissionsState() {

--- a/docs/planning/installer-reliability-phase1.md
+++ b/docs/planning/installer-reliability-phase1.md
@@ -72,9 +72,10 @@ apply. Checklists decay; that is how the loop happened. Make it code.
 - Wizard, CLI, and menu bar cannot disagree about system state because they
   cannot read different sources.
 
-**Status (2026-07-08):** First provider slices implemented; pure state-matrix
-classification is executable and golden-tested. Full provider-emitted snapshot
-integration remains pending.
+**Status (2026-07-08):** Phase 1 state classification is executable and
+golden-tested. `SystemStateProvider` emits the live AppKit/CLI/menu-bar matrix
+snapshot; wizard core consumes the same classifier through a pure `SystemContext`
+bridge to avoid an AppKit dependency cycle.
 - [x] Introduced `SystemStateProvider` as the owner for the ADR-040
   process-liveness primitive and Kanata readiness predicate. Enforced by
   `SystemStateProviderLivenessTests.testProcessLivenessProbeTreatsCurrentProcessAsAliveAndExitedProcessAsDead`
@@ -246,9 +247,11 @@ integration remains pending.
   `SystemStateProviderSMAppServiceTests.testSynchronousSMAppServiceStatusDelegatesToCentralStatusProviderBridge`,
   `SMAppServiceStatusLintTests.testStatusAccessIsCentralized`, and
   `SMAppServiceStatusLintTests.testWizardProtocolConformancesDelegateHelperApprovalToHelperManager`.
-- [ ] Migrate `SMAppService.status`, permissions, VHID state, helper freshness,
-  and migrated read-only `launchctl print` evidence into a single immutable
-  `SystemSnapshot`.
+- **Deferred follow-up (not Phase 1 acceptance):** collapse `SystemSnapshot`,
+  `SystemContext`, and remaining cache/snapshot duplication into one value
+  during Workstream 6. Phase 1 keeps the existing `SystemSnapshot` boundary and
+  makes state-matrix classification executable via `InstallerStateMatrixSnapshot`
+  plus `SystemStateProvider`/`SystemContext` adapters.
 - [x] Built pure `InstallerStateMatrixPlanner.classify(_:) -> InstallerStateMatrixRow`
   and `plan(for:)` with a table-driven golden fixture for every state-matrix
   row. Enforced by
@@ -277,9 +280,21 @@ integration remains pending.
   validation fallback before the first matrix classification exists. Enforced by
   `MainAppStateControllerTests.menuBarHealthPrefersStateMatrixRow` and
   `MainAppStateControllerTests.menuBarHealthFallsBackBeforeMatrixClassification`.
-- [ ] Wire `SystemStateProvider`'s full immutable snapshot into the state-matrix
-  classifier and migrate wizard/CLI/menu-bar consumers to the shared
-  classification.
+- [x] Migrated wizard detection results to publish the shared state-matrix row
+  and state-matrix plan alongside legacy wizard state/issues/actions. Wizard
+  core uses a pure `SystemContext` → `InstallerStateMatrixSnapshot` bridge
+  because the live `SystemStateProvider` adapter lives in AppKit. Enforced by
+  `WizardPureLogicTests.test_systemContextStateMatrixSnapshot_classifiesStoppedRuntimeWithStaleInputCapture`
+  and
+  `WizardPureLogicTests.test_systemContextAdapterPublishesStateMatrixMetadata`.
+- [x] Wired `SystemStateProvider`'s live immutable snapshot into the
+  state-matrix classifier for AppKit/CLI/menu-bar consumers and migrated
+  wizard/CLI/menu-bar consumers to the shared row/action vocabulary. Enforced
+  by
+  `SystemStateProviderInstallerStateMatrixTests.testStateMatrixSnapshotPreservesRunningButTCPNotRespondingEvidence`,
+  `CLIOutputContractTests.testInspectResultRepairMetadataJSONShape`,
+  `MainAppStateControllerTests.menuBarHealthPrefersStateMatrixRow`, and
+  `WizardPureLogicTests.test_systemContextAdapterPublishesStateMatrixMetadata`.
 
 ## Workstream 2: One Liveness Predicate
 
@@ -695,8 +710,10 @@ is listed in the state-matrix doc's enforcement section.
 - [x] `LaunchctlEvidenceLintTests.testHelperManagerDelegatesLaunchctlPrintEvidenceToSystemStateProvider`
   prevents `HelperManager` from regrowing direct `launchctl print`
   service-state reads.
-- [ ] Add remaining `SMAppService.status`, postcondition, and snapshot-cache
-  ratchets with the corresponding migration slices.
+- **Deferred follow-up (not Phase 1 acceptance):** add postcondition and
+  snapshot-cache deletion ratchets with Workstreams 3 and 6, where those
+  migrations happen. Phase 1 landed the ratchets corresponding to each
+  completed W1/W2 migration above.
 
 ## Workstream 6: Deletion Pass
 

--- a/docs/process/installer-repair-state-matrix.md
+++ b/docs/process/installer-repair-state-matrix.md
@@ -139,6 +139,11 @@ the result as user action required and name the approval surface.
   classified the current system state. `MainAppStateControllerTests.menuBarHealthPrefersStateMatrixRow`
   pins that `runningAndTCPResponding` is the only matrix row treated as healthy
   by the compact status surface.
+- Wizard detection results publish the shared state-matrix row and plan next to
+  legacy wizard state/issues/actions. `WizardPureLogicTests.test_systemContextAdapterPublishesStateMatrixMetadata`
+  pins the adapter contract, while
+  `WizardPureLogicTests.test_systemContextStateMatrixSnapshot_classifiesStoppedRuntimeWithStaleInputCapture`
+  pins the pure `SystemContext` snapshot bridge used by wizard core.
 - Process-liveness semantics belong in `SystemStateProvider.isProcessAlive(pid:)`.
   `SystemStateProviderLivenessTests.testProcessLivenessProbeTreatsCurrentProcessAsAliveAndExitedProcessAsDead`
   proves the real ADR-040 primitive, and


### PR DESCRIPTION
## Summary
- add a pure `SystemContext` -> `InstallerStateMatrixSnapshot` bridge for wizard core
- publish `stateMatrixRow` and `stateMatrixPlan` on wizard `SystemStateResult` while preserving existing wizard state/issues/actions
- update the Phase 1 plan and state-matrix enforcement docs with the tests that pin the wizard, CLI, and menu-bar consumer migrations

## Boundary note
The live `SystemStateProvider` matrix adapter lives in AppKit because it reads SMAppService/runtime evidence. Wizard core cannot import AppKit without a dependency cycle, so this slice uses a pure `SystemContext` bridge and records that in the plan doc instead of pretending the wizard directly imports the live provider adapter.

## Validation
- `TEST_FILTER='WizardPureLogicTests' ./Scripts/run-tests-safe.sh` — 102 passed
- `TEST_FILTER='WizardPureLogicTests|CLIOutputContractTests|SystemStateProviderInstallerStateMatrixTests|MainAppStateControllerTests|InstallerStateMatrixGoldenTests' ./Scripts/run-tests-safe.sh` — 148 passed
- `rg -n "^- \[ \]" docs/planning/installer-reliability-phase1.md || true` — no unchecked Phase 1 boxes
- `git diff --check`
- `python3 Scripts/check-accessibility.py`
- `KEYPATH_SNAPSHOTS=0 ./Scripts/run-tests-safe.sh` — 4523 passed
- `./Scripts/review-gate.sh` — `remote review gate selected`, exit 2

## Review gate
`./Scripts/review-gate.sh` selected the canonical remote review gate. Do not merge until GitHub `claude-review` passes.
