### PR TITLE
Document Phase 1 installer state classification ADR

### DIFF
--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -29,6 +29,8 @@ This directory contains Architecture Decision Records (ADRs) documenting signifi
 | [ADR-029](adr-029-eliminate-fake-key-layer-notifications.md) | Eliminate Fake Key Layer Notifications via Native LayerChange | Proposed |
 | [ADR-030](adr-030-insights-companion-app.md) | Separate Activity Logging and AI Features into KeyPath Insights Companion App | Accepted |
 | [ADR-031](adr-031-kanata-service-lifecycle-invariants-and-postcondition-enforcement.md) | Kanata Service Lifecycle Invariants and Postcondition Enforcement | Accepted |
+| [ADR-032](adr-032-macos-kanata-runtime-identity.md) | Stable App-Bundled Runtime Identity for macOS Kanata Input Capture | Proposed |
+| [ADR-033](adr-033-bundled-binary-canonical-path.md) | Bundled Binary as Canonical Kanata Path | Accepted |
 | [ADR-034](adr-034-kanata-engine-app-bundle-tcc-identity.md) | Kanata Engine.app Bundle for TCC Identity | Accepted |
 | [ADR-035](adr-035-bundle-id-tcc-detection-with-path-fallback.md) | Bundle ID TCC Detection with Path Fallback | Accepted |
 | [ADR-036](adr-036-per-device-key-mappings.md) | Per-Device Key Mappings via Conditional Switch Wrapping | Accepted |
@@ -36,6 +38,8 @@ This directory contains Architecture Decision Records (ADRs) documenting signifi
 | [ADR-038](adr-038-extension-file-splitting.md) | Extension-File Splitting for Large Types | Accepted |
 | [ADR-039](adr-039-key-conflict-resolution-principles.md) | Key Conflict Detection and Resolution Principles | Accepted |
 | [ADR-040](adr-040-process-liveness-across-privilege-boundary.md) | Process Liveness and Signaling Across the Privilege Boundary | Accepted |
+| [ADR-041](adr-041-installer-identity-stability-contract.md) | Installer Identity Stability Contract | Accepted |
+| [ADR-042](adr-042-executable-installer-state-classification.md) | Executable Installer State Classification | Accepted |
 
 ## Key Decisions Summary
 
@@ -47,6 +51,8 @@ This directory contains Architecture Decision Records (ADRs) documenting signifi
 - **ADR-026**: Always validate components exist BEFORE checking service status.
 - **ADR-031**: Installer success requires verified runtime readiness (`running + TCP`) or explicit pending approval.
 - **ADR-040**: kanata is a root LaunchDaemon; the app is unprivileged. `kill(pid,0)` returns `EPERM` (not `ESRCH`) for the live daemon — treat EPERM as alive. The app cannot signal/kill the daemon; only launchd can.
+- **ADR-041**: Installer identity values for kanata, helper, and daemon shell are release-gated contracts.
+- **ADR-042**: The installer repair state matrix is executable; CLI, menu-bar, and wizard consumers share row/action vocabulary.
 
 ### Configuration
 - **ADR-023**: Never parse Kanata config files directly. Use TCP and simulator.

--- a/docs/adr/adr-031-kanata-service-lifecycle-invariants-and-postcondition-enforcement.md
+++ b/docs/adr/adr-031-kanata-service-lifecycle-invariants-and-postcondition-enforcement.md
@@ -44,6 +44,17 @@ Adopt explicit service lifecycle invariants for Kanata install/repair paths:
    - `responding`: TCP probe success
    - `ready`: `running && responding`
 
+6. **Executable state classification**
+   - The installer repair state matrix is not just a checklist. It is encoded by
+     `InstallerStateMatrixPlanner` and backed by golden tests.
+   - CLI, menu-bar, and wizard surfaces publish or consume the same
+     `InstallerStateMatrixRow` / `InstallerStateMatrixAction` vocabulary before
+     deciding whether a state is healthy, degraded, or manual-action-required.
+   - Live AppKit evidence is materialized through
+     `SystemStateProvider.currentInstallerStateMatrixSnapshot(...)`; wizard core
+     uses a pure `SystemContext -> InstallerStateMatrixSnapshot` bridge because
+     it cannot import AppKit.
+
 ## Consequences
 
 ### Positive
@@ -52,12 +63,39 @@ Adopt explicit service lifecycle invariants for Kanata install/repair paths:
 - Stale-registration repair is deterministic even during throttle windows.
 - "Green then stopped" transitions are reduced by fail-fast postconditions.
 - Health decisions are easier to test and reason about.
+- State classification now has table-driven regression coverage for every
+  documented matrix row.
 
 ### Negative
 
 - Install/repair actions can fail more often in borderline startup conditions instead of masking failures.
 - Additional polling and diagnostics add modest complexity.
+- Until the Workstream 6 deletion pass, both `SystemSnapshot`/`SystemContext`
+  and the narrower `InstallerStateMatrixSnapshot` exist.
 
 ### Follow-up
 
-- Continue hardening by unifying startup-gate and installer readiness predicates and expanding integration-style regression coverage across launchctl/TCP/stale-state combinations.
+- Workstream 3 changes repair autonomy and user-initiated repair behavior on
+  top of the Phase 1 classification contract.
+- Workstream 6 collapses remaining snapshot/cache duplication after the repair
+  model is stable.
+
+## Enforcement
+
+- `InstallerStateMatrixGoldenTests.testEveryDocumentedStateMatrixRowHasAGoldenFixture`
+  and
+  `InstallerStateMatrixGoldenTests.testClassifySnapshotAndPlanMatchStateMatrixGoldenFixtures`
+  pin the documented rows and action plans.
+- `SystemStateProviderInstallerStateMatrixTests.*` pins live matrix snapshot
+  materialization from provider-owned SMAppService, launchd/runtime, helper, and
+  component evidence.
+- `CLIOutputContractTests.testInspectResultRepairMetadataJSONShape`,
+  `MainAppStateControllerTests.menuBarHealthPrefersStateMatrixRow`, and
+  `WizardPureLogicTests.test_systemContextAdapterPublishesStateMatrixMetadata`
+  pin consumer adoption.
+
+## Related
+
+- [ADR-040: Process Liveness and Signaling Across the Privilege Boundary](adr-040-process-liveness-across-privilege-boundary.md)
+- [ADR-042: Executable Installer State Classification](adr-042-executable-installer-state-classification.md)
+- [Installer repair state matrix](../process/installer-repair-state-matrix.md)

--- a/docs/adr/adr-040-process-liveness-across-privilege-boundary.md
+++ b/docs/adr/adr-040-process-liveness-across-privilege-boundary.md
@@ -31,7 +31,32 @@ From the unprivileged app, probing the **root** kanata returns `EPERM` while it 
 - Any future process-inspection helper (liveness polls, orphan detection, restart races) must apply the EPERM rule and must not assume app-side signals reach the daemon.
 - Reviews of lifecycle / process code must include a **runtime-reality** lens: "what does this syscall actually return in the real root/unprivileged topology?" — not just static diff analysis.
 - This is the signaling-side companion to the permissions rule in [ADR-001](adr-001-oracle-pattern.md) / [ADR-006](adr-006-apple-api-priority.md) ("never check permissions from root"): the privilege boundary changes the meaning of OS calls in both directions.
+- Phase 1 of installer reliability centralizes liveness and readiness probes in
+  `SystemStateProvider`. Migrated consumers must not regrow direct `kill(pid,
+  0)`, `pgrep`, launchctl read-only evidence, or TCP probe implementations.
 
 ## Reference implementation
 
-`ServiceLifecycleCoordinator.isProcessAlive(_:)` and `waitForKanataExitBeforeStart()` (#625 part-1).
+`SystemStateProvider.isProcessAlive(pid:)` is the canonical liveness primitive.
+`SystemStateProvider.isTCPPortResponding(port:timeoutMs:)` is the canonical TCP
+readiness primitive. Higher-level consumers use provider-owned process
+discovery and launchctl read-only evidence helpers.
+
+## Enforcement
+
+- `SystemStateProviderLivenessTests.testProcessLivenessProbeTreatsCurrentProcessAsAliveAndExitedProcessAsDead`
+  grounds the liveness primitive against real process behavior.
+- `LivenessPredicateLintTests.testKillZeroLivenessProbeIsCentralized` prevents
+  direct `kill(pid, 0)` probes outside `SystemStateProvider`.
+- `SystemStateProviderLivenessTests.testTCPReadinessProbeDetectsListeningAndClosedPorts`
+  grounds the TCP readiness primitive.
+- `TCPReadinessLintTests.testServiceHealthCheckerDelegatesTCPReadinessToSystemStateProvider`
+  prevents migrated readiness consumers from bypassing the provider.
+- `PgrepProcessDiscoveryLintTests` and `LaunchctlEvidenceLintTests` keep
+  migrated process discovery and launchctl read-only evidence centralized.
+
+## Related
+
+- [ADR-031: Kanata Service Lifecycle Invariants and Postcondition Enforcement](adr-031-kanata-service-lifecycle-invariants-and-postcondition-enforcement.md)
+- [ADR-042: Executable Installer State Classification](adr-042-executable-installer-state-classification.md)
+- [Installer repair state matrix](../process/installer-repair-state-matrix.md)

--- a/docs/adr/adr-042-executable-installer-state-classification.md
+++ b/docs/adr/adr-042-executable-installer-state-classification.md
@@ -1,0 +1,113 @@
+# ADR-042: Executable Installer State Classification
+
+## Status
+
+Accepted
+
+## Date
+
+2026-07-08
+
+## Context
+
+The installer reliability Phase 1 plan converted the installer repair state
+matrix from a review checklist into executable code. Before this work, wizard,
+CLI, menu-bar, and repair code could each infer "healthy", "stopped",
+"registered", "loaded", and "manual approval required" from different evidence.
+That allowed false-green states and repair loops to reappear even after
+individual bugs were fixed.
+
+ADR-031 established that install/repair success requires verified
+postconditions. ADR-040 established that process liveness across the
+root/unprivileged boundary must use the real OS semantics. Phase 1 adds the
+next layer: consumers must classify the same immutable evidence into the same
+state-matrix row before deciding what to report or which repair plan vocabulary
+to expose.
+
+## Decision
+
+Treat `InstallerStateMatrixPlanner` as the executable contract for the installer
+repair state matrix.
+
+1. **The table is executable**
+   - Each row in `docs/process/installer-repair-state-matrix.md` has a golden
+     fixture in `InstallerStateMatrixGoldenTests`.
+   - Classification is `InstallerStateMatrixSnapshot -> InstallerStateMatrixRow`.
+   - Planning vocabulary is `InstallerStateMatrixRow -> [InstallerStateMatrixAction]`.
+
+2. **Live OS evidence belongs behind `SystemStateProvider`**
+   - SMAppService status, launchctl read-only evidence, process discovery,
+     process liveness, TCP readiness, and permission snapshots are centralized
+     behind `SystemStateProvider` or its owned low-level helpers.
+   - Consumers must not call direct SMAppService status, `pgrep`, `launchctl
+     print`, `kill(pid, 0)`, or permission snapshot sources once migrated.
+   - Lint tests ratchet each migrated consumer.
+
+3. **Consumers report the same row/action vocabulary**
+   - CLI `system inspect` reports the shared state-matrix row and plan.
+   - Menu-bar health treats `runningAndTCPResponding` as the only healthy
+     classified row once validation has produced a classification.
+   - Wizard detection results publish the shared state-matrix row and plan next
+     to legacy wizard state/issues/actions.
+
+4. **Package boundaries stay honest**
+   - The live `SystemStateProvider` matrix adapter lives in AppKit because it
+     reads SMAppService and runtime evidence.
+   - Wizard core cannot import AppKit without a dependency cycle, so it consumes
+     the same classifier through a pure `SystemContext ->
+     InstallerStateMatrixSnapshot` bridge.
+   - This is an intentional Phase 1 boundary, not a second state model.
+
+5. **Repair-model changes remain out of Phase 1**
+   - Phase 1 makes detection and reporting consistent.
+   - Workstream 3 changes repair autonomy and user-initiated repair semantics.
+   - Workstream 6 collapses remaining `SystemSnapshot`/`SystemContext` and cache
+     duplication after the repair model is stable.
+
+## Enforcement
+
+- `InstallerStateMatrixGoldenTests.testEveryDocumentedStateMatrixRowHasAGoldenFixture`
+  ensures every documented row is represented by a golden fixture.
+- `InstallerStateMatrixGoldenTests.testClassifySnapshotAndPlanMatchStateMatrixGoldenFixtures`
+  pins row and plan classification for every fixture.
+- `SystemStateProviderInstallerStateMatrixTests.*` pins live AppKit matrix
+  snapshot materialization from provider-owned evidence.
+- `CLIOutputContractTests.testInspectResultRepairMetadataJSONShape` pins CLI
+  row/plan output.
+- `MainAppStateControllerTests.menuBarHealthPrefersStateMatrixRow` pins the
+  menu-bar healthy predicate.
+- `WizardPureLogicTests.test_systemContextAdapterPublishesStateMatrixMetadata`
+  pins wizard row/plan publication.
+- `WizardPureLogicTests.test_systemContextStateMatrixSnapshot_classifiesStoppedRuntimeWithStaleInputCapture`
+  pins the pure wizard-core snapshot bridge.
+- `SMAppServiceStatusLintTests`, `PermissionSnapshotLintTests`,
+  `PgrepProcessDiscoveryLintTests`, `LaunchctlEvidenceLintTests`,
+  `LivenessPredicateLintTests`, and `TCPReadinessLintTests` prevent migrated
+  consumers from regrowing direct OS evidence reads.
+
+## Consequences
+
+### Positive
+
+- Wizard, CLI, and menu-bar surfaces can no longer silently invent incompatible
+  health classifications for the same runtime state.
+- The state matrix now fails in tests when a row or action contract changes.
+- Future installer reliability work can change repair behavior against a stable
+  detection vocabulary.
+
+### Negative
+
+- There are temporarily two snapshot-shaped values: the existing
+  `SystemSnapshot`/`SystemContext` flow and the narrower
+  `InstallerStateMatrixSnapshot`.
+- The wizard bridge is less evidence-rich than the live AppKit provider adapter
+  because of package boundaries.
+- Full deletion of duplicate caches and snapshot adapters is deferred until the
+  repair model is stable.
+
+## Related
+
+- [ADR-031: Kanata Service Lifecycle Invariants and Postcondition Enforcement](adr-031-kanata-service-lifecycle-invariants-and-postcondition-enforcement.md)
+- [ADR-040: Process Liveness and Signaling Across the Privilege Boundary](adr-040-process-liveness-across-privilege-boundary.md)
+- [Installer repair state matrix](../process/installer-repair-state-matrix.md)
+- [Installer reliability Phase 1 plan](../planning/installer-reliability-phase1.md)

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -36,6 +36,16 @@ This section documents significant architectural decisions in KeyPath. Each ADR 
 | [ADR-030](/adr/adr-030-insights-companion-app) | Separate Activity Logging and AI Features into KeyPath Insights Companion App | Accepted |
 | [ADR-031](/adr/adr-031-kanata-service-lifecycle-invariants-and-postcondition-enforcement) | Kanata Service Lifecycle Invariants and Postcondition Enforcement | Accepted |
 | [ADR-032](/adr/adr-032-macos-kanata-runtime-identity) | Stable App-Bundled Runtime Identity for macOS Kanata Input Capture | Proposed |
+| [ADR-033](/adr/adr-033-bundled-binary-canonical-path) | Bundled Binary as Canonical Kanata Path | Accepted |
+| [ADR-034](/adr/adr-034-kanata-engine-app-bundle-tcc-identity) | Kanata Engine.app Bundle for TCC Identity | Accepted |
+| [ADR-035](/adr/adr-035-bundle-id-tcc-detection-with-path-fallback) | Bundle ID TCC Detection with Path Fallback | Accepted |
+| [ADR-036](/adr/adr-036-per-device-key-mappings) | Per-Device Key Mappings via Conditional Switch Wrapping | Accepted |
+| [ADR-037](/adr/adr-037-dynamic-os-key-labels) | Dynamic OS-Driven Key Labels (System Keymap) | Accepted |
+| [ADR-038](/adr/adr-038-extension-file-splitting) | Extension-File Splitting for Large Types | Accepted |
+| [ADR-039](/adr/adr-039-key-conflict-resolution-principles) | Key Conflict Detection and Resolution Principles | Accepted |
+| [ADR-040](/adr/adr-040-process-liveness-across-privilege-boundary) | Process Liveness and Signaling Across the Privilege Boundary | Accepted |
+| [ADR-041](/adr/adr-041-installer-identity-stability-contract) | Installer Identity Stability Contract | Accepted |
+| [ADR-042](/adr/adr-042-executable-installer-state-classification) | Executable Installer State Classification | Accepted |
 
 ## Key Decisions Summary
 
@@ -46,6 +56,9 @@ This section documents significant architectural decisions in KeyPath. Each ADR 
 - **ADR-015**: `InstallerEngine` is the unified façade for all install/repair/uninstall operations.
 - **ADR-026**: Always validate components exist BEFORE checking service status.
 - **ADR-031**: Installer success requires verified runtime readiness (`running + TCP`) or explicit pending approval.
+- **ADR-040**: kanata is a root LaunchDaemon; app-side process liveness treats `EPERM` from `kill(pid,0)` as alive.
+- **ADR-041**: Installer identity values for kanata, helper, and daemon shell are release-gated contracts.
+- **ADR-042**: The installer repair state matrix is executable; CLI, menu-bar, and wizard consumers share row/action vocabulary.
 
 ### Configuration
 - **ADR-023**: Never parse Kanata config files directly. Use TCP and simulator.
@@ -54,6 +67,7 @@ This section documents significant architectural decisions in KeyPath. Each ADR 
 ### Testing
 - **ADR-019**: Use `TestEnvironment.isRunningTests` for side-effect guards.
 - **ADR-022**: Never call pgrep-spawning functions concurrently in TaskGroups.
+- **ADR-040**: OS primitives hidden behind seams need at least one grounding test against real runtime behavior.
 
 ### UI & Icons
 - **ADR-024**: Key emphasis and custom icons via push-msg protocol.

--- a/docs/planning/installer-reliability-phase1.md
+++ b/docs/planning/installer-reliability-phase1.md
@@ -776,6 +776,8 @@ user interaction — is planned, gated, and preserved in
 - [Installer repair state matrix](../process/installer-repair-state-matrix.md)
 - [ADR-031: lifecycle invariants & postcondition enforcement](../adr/adr-031-kanata-service-lifecycle-invariants-and-postcondition-enforcement.md)
 - [ADR-040: process liveness across the privilege boundary](../adr/adr-040-process-liveness-across-privilege-boundary.md)
+- [ADR-041: installer identity stability contract](../adr/adr-041-installer-identity-stability-contract.md)
+- [ADR-042: executable installer state classification](../adr/adr-042-executable-installer-state-classification.md)
 - [ADR-032/033/034: runtime identity, canonical path, TCC identity](../adr/adr-032-macos-kanata-runtime-identity.md)
 - [2026-02-28 false-success incident](../bugs/2026-02-28-install-bundled-kanata-false-success-stale-throttle.md)
 - Industry references: Rogue Amoeba ACE repair flow; Karabiner-Elements v15

--- a/docs/process/installer-repair-state-matrix.md
+++ b/docs/process/installer-repair-state-matrix.md
@@ -295,4 +295,5 @@ the result as user action required and name the approval surface.
 
 - `docs/adr/adr-031-kanata-service-lifecycle-invariants-and-postcondition-enforcement.md`
 - `docs/adr/adr-040-process-liveness-across-privilege-boundary.md`
+- `docs/adr/adr-042-executable-installer-state-classification.md`
 - `docs/bugs/2026-02-28-install-bundled-kanata-false-success-stale-throttle.md`


### PR DESCRIPTION
## Summary
- add ADR-042 for executable installer state classification
- revise ADR-031 and ADR-040 with Phase 1 enforcement and provider-owned liveness references
- update ADR indexes and Phase 1/state-matrix references so ADR-041/042 are discoverable

## Validation
- `git diff --check`
- `rg -n "ADR-042|adr-042|ADR-041|adr-041" docs/adr docs/planning/installer-reliability-phase1.md docs/process/installer-repair-state-matrix.md`
- `KEYPATH_SNAPSHOTS=0 ./Scripts/run-tests-safe.sh` - passed, 4523 tests, runner exit=0
- `./Scripts/review-gate.sh` - `remote review gate selected`, exit 2

## Review gate
`./Scripts/review-gate.sh` selected the canonical remote review gate. Do not merge until GitHub `claude-review` passes.

## Notes
This PR is documentation-only. It records the already-merged Phase 1 executable state-classification contract and links the acceptance tests/lint ratchets that enforce it.
