### PR TITLE
Clarify Phase 1 workstream sequencing

### DIFF
--- a/docs/adr/adr-042-executable-installer-state-classification.md
+++ b/docs/adr/adr-042-executable-installer-state-classification.md
@@ -58,11 +58,15 @@ repair state matrix.
      InstallerStateMatrixSnapshot` bridge.
    - This is an intentional Phase 1 boundary, not a second state model.
 
-5. **Repair-model changes remain out of Phase 1**
-   - Phase 1 makes detection and reporting consistent.
-   - Workstream 3 changes repair autonomy and user-initiated repair semantics.
-   - Workstream 6 collapses remaining `SystemSnapshot`/`SystemContext` and cache
-     duplication after the repair model is stable.
+5. **Repair-model and deletion work stay sequenced later in Phase 1**
+   - This ADR records the Workstream 1/2/5 detection contract only.
+   - Workstream 3 remains Phase 1 work, but starts after migrated consumers are
+     using the shared snapshot/row/action vocabulary and the lint ratchets are
+     stable.
+   - Workstream 6 remains Phase 1 work, but runs last so it deletes code that
+     Workstream 3 has made obsolete instead of polishing code about to be
+     removed.
+   - Phase 2 remains limited to autonomous/background repair behaviors.
 
 ## Enforcement
 
@@ -102,8 +106,8 @@ repair state matrix.
   `InstallerStateMatrixSnapshot`.
 - The wizard bridge is less evidence-rich than the live AppKit provider adapter
   because of package boundaries.
-- Full deletion of duplicate caches and snapshot adapters is deferred until the
-  repair model is stable.
+- Full deletion of duplicate caches and snapshot adapters is deferred within
+  Phase 1 until Workstream 3 has stabilized the repair model.
 
 ## Related
 


### PR DESCRIPTION
## Summary
- correct ADR-042 wording that incorrectly implied Workstream 3 was outside Phase 1
- clarify Workstream 3 and Workstream 6 are later Phase 1 work, sequenced after W1/W2/W5 stability
- keep Phase 2 scoped to autonomous/background repair behavior

## Validation
- `git diff --check`
- `KEYPATH_SNAPSHOTS=0 ./Scripts/run-tests-safe.sh` - passed, 4523 tests, runner exit=0
- `./Scripts/review-gate.sh` - `remote review gate selected`, exit 2

## Review gate
`./Scripts/review-gate.sh` selected the canonical remote review gate. Do not merge until GitHub `claude-review` passes.

## Why
The Phase 1 plan says W3 and W6 remain Phase 1 work. ADR-042 was intended to record only the completed W1/W2/W5 detection contract, but one heading said repair-model changes were out of Phase 1. This PR fixes that drift.
