### PR TITLE
Make post-update repair user initiated

### DIFF
--- a/Sources/KeyPathAppKit/Services/UpdateService.swift
+++ b/Sources/KeyPathAppKit/Services/UpdateService.swift
@@ -220,12 +220,14 @@ extension UpdateService: SPUUpdaterDelegate {
 extension UpdateService {
     enum UpdateRepairDecision: Equatable {
         case silentContinue(reason: String)
-        case softRepair(reason: String)
-        case hardRepair(reason: String)
+        case automaticRepairAllowed(reason: String)
+        case userRepairRequired(reason: String)
+        case manualAttentionRequired(reason: String)
     }
 
-    /// Called after the app relaunches following an update
-    /// We use this to re-register and restart services
+    /// Called after the app relaunches following an update.
+    /// Post-update detection must be passive: surface degraded state through
+    /// the normal status/wizard path and let the user start repair explicitly.
     public nonisolated func updaterDidRelaunchApplication(_: SPUUpdater) {
         Task { @MainActor in
             await finalizeUpdate()
@@ -249,11 +251,15 @@ extension UpdateService {
         switch Self.preUpdateDecision(for: context) {
         case let .silentContinue(reason):
             AppLogger.shared.log("✅ [UpdateService] Pre-update: no preparation needed (\(reason))")
-        case let .softRepair(reason), let .hardRepair(reason):
+        case let .automaticRepairAllowed(reason):
             AppLogger.shared.log("🔧 [UpdateService] Pre-update: running repair (\(reason))")
             let report = await engine.run(intent: .repair, using: broker)
             AppLogger.shared.log(
                 "✅ [UpdateService] Services prepared for update - success: \(report.success)"
+            )
+        case let .userRepairRequired(reason), let .manualAttentionRequired(reason):
+            AppLogger.shared.error(
+                "⚠️ [UpdateService] Pre-update repair not allowed for decision \(reason); continuing without mutation"
             )
         }
     }
@@ -261,32 +267,35 @@ extension UpdateService {
     @MainActor
     private func finalizeUpdate() async {
         let engine = InstallerEngine()
-        let broker = PrivilegeBroker()
         let context = await engine.inspectSystem()
 
         switch Self.postUpdateDecision(for: context) {
         case let .silentContinue(reason):
             AppLogger.shared.log("✅ [UpdateService] Post-update: system healthy, skipping repair (\(reason))")
-        case let .softRepair(reason):
-            AppLogger.shared.log("🔄 [UpdateService] Post-update: running targeted repair (\(reason))")
-            let report = await engine.run(intent: .repair, using: broker)
-            if report.success {
-                AppLogger.shared.log("✅ [UpdateService] Services repaired after update")
-            } else {
-                AppLogger.shared.error(
-                    "⚠️ [UpdateService] Service repair had issues - user may see wizard"
-                )
-            }
-        case let .hardRepair(reason):
-            AppLogger.shared.error(
-                "⚠️ [UpdateService] Post-update requires manual attention (\(reason)); skipping automatic repair"
+        case let .userRepairRequired(reason):
+            AppLogger.shared.warn(
+                "⚠️ [UpdateService] Post-update repair required (\(reason)); surfacing status for user-initiated repair"
             )
+            MainAppStateController.shared.invalidateValidationCooldown()
+            await MainAppStateController.shared.revalidate()
+        case let .manualAttentionRequired(reason):
+            AppLogger.shared.error(
+                "⚠️ [UpdateService] Post-update requires manual attention (\(reason)); surfacing status and skipping automatic repair"
+            )
+            MainAppStateController.shared.invalidateValidationCooldown()
+            await MainAppStateController.shared.revalidate()
+        case let .automaticRepairAllowed(reason):
+            AppLogger.shared.error(
+                "⚠️ [UpdateService] Post-update automatic repair is disallowed by Phase 1 W3 (\(reason)); surfacing status instead"
+            )
+            MainAppStateController.shared.invalidateValidationCooldown()
+            await MainAppStateController.shared.revalidate()
         }
     }
 
     nonisolated static func preUpdateDecision(for context: SystemContext) -> UpdateRepairDecision {
         if context.services.kanataRunning || context.services.karabinerDaemonRunning || context.helper.isInstalled {
-            return .softRepair(reason: "reason_code=services_or_helper_present")
+            return .automaticRepairAllowed(reason: "reason_code=services_or_helper_present")
         }
         return .silentContinue(reason: "reason_code=nothing_running")
     }
@@ -297,20 +306,20 @@ extension UpdateService {
         // must not force a hard post-update repair now that IOHIDCheckAccess makes
         // it authoritatively .denied (#931). KeyPath's Accessibility is required.
         if context.permissions.keyPath.accessibility.isBlocking {
-            return .hardRepair(reason: "reason_code=keypath_permissions_blocking")
+            return .manualAttentionRequired(reason: "reason_code=keypath_permissions_blocking")
         }
         if context.permissions.kanata.inputMonitoring.isBlocking || context.permissions.kanata.accessibility.isBlocking {
-            return .hardRepair(reason: "reason_code=kanata_permissions_blocking")
+            return .manualAttentionRequired(reason: "reason_code=kanata_permissions_blocking")
         }
 
         if !context.helper.isReady {
-            return .softRepair(reason: "reason_code=helper_not_ready")
+            return .userRepairRequired(reason: "reason_code=helper_not_ready")
         }
         if !context.components.hasAllRequired {
-            return .softRepair(reason: "reason_code=components_not_ready")
+            return .userRepairRequired(reason: "reason_code=components_not_ready")
         }
         if !context.services.backgroundServicesHealthy || !context.services.kanataRunning {
-            return .softRepair(reason: "reason_code=services_not_ready")
+            return .userRepairRequired(reason: "reason_code=services_not_ready")
         }
 
         return .silentContinue(reason: "reason_code=healthy")

--- a/Tests/KeyPathTests/Lint/PostUpdateRepairLintTests.swift
+++ b/Tests/KeyPathTests/Lint/PostUpdateRepairLintTests.swift
@@ -1,0 +1,82 @@
+import Foundation
+@preconcurrency import XCTest
+
+/// Guards Phase 1 Workstream 3's post-update repair boundary.
+///
+/// Sparkle relaunch callbacks are detection/surfacing hooks, not user repair
+/// gestures. After an update, KeyPath may inspect system state and refresh the
+/// status UI, but it must not run `InstallerEngine.run(intent: .repair)` or
+/// `runSingleAction` automatically. Users start repair explicitly from the
+/// normal status/wizard/CLI surfaces.
+final class PostUpdateRepairLintTests: XCTestCase {
+    func testPostUpdateFinalizeDoesNotRunAutomaticRepair() throws {
+        let updateService = phase1W3RepositoryRoot()
+            .appendingPathComponent("Sources/KeyPathAppKit/Services/UpdateService.swift")
+        let contents = try String(contentsOf: updateService, encoding: .utf8)
+
+        let finalizeBody = try extractFunctionBody(
+            named: "finalizeUpdate",
+            from: contents
+        )
+
+        let forbiddenPatterns = [
+            #"run\s*\(\s*intent:\s*\.repair"#,
+            #"runSingleAction\s*\("#,
+            #"PrivilegeBroker\s*\("#
+        ]
+        let violations = try forbiddenPatterns.flatMap { pattern -> [String] in
+            let regex = try NSRegularExpression(pattern: pattern)
+            return finalizeBody.components(separatedBy: .newlines).enumerated().compactMap { index, line in
+                let trimmed = line.trimmingCharacters(in: .whitespaces)
+                guard !trimmed.hasPrefix("//"), !trimmed.hasPrefix("///") else { return nil }
+                let range = NSRange(line.startIndex..., in: line)
+                guard regex.firstMatch(in: line, range: range) != nil else { return nil }
+                return "finalizeUpdate:\(index + 1): \(trimmed)"
+            }
+        }
+
+        XCTAssertTrue(
+            violations.isEmpty,
+            """
+            Post-update detection must not mutate installer/system services. \
+            Surface degraded state and require an explicit user repair action:
+            \(violations.sorted().joined(separator: "\n"))
+            """
+        )
+    }
+}
+
+private func extractFunctionBody(named functionName: String, from contents: String) throws -> String {
+    guard let nameRange = contents.range(of: "func \(functionName)") else {
+        throw XCTSkip("Could not find func \(functionName)")
+    }
+    guard let openBrace = contents[nameRange.lowerBound...].firstIndex(of: "{") else {
+        throw XCTSkip("Could not find opening brace for \(functionName)")
+    }
+
+    var depth = 0
+    var cursor = openBrace
+    while cursor < contents.endIndex {
+        let char = contents[cursor]
+        if char == "{" {
+            depth += 1
+        } else if char == "}" {
+            depth -= 1
+            if depth == 0 {
+                let bodyStart = contents.index(after: openBrace)
+                return String(contents[bodyStart ..< cursor])
+            }
+        }
+        cursor = contents.index(after: cursor)
+    }
+
+    throw XCTSkip("Could not find closing brace for \(functionName)")
+}
+
+private func phase1W3RepositoryRoot(file: StaticString = #filePath) -> URL {
+    URL(fileURLWithPath: "\(file)")
+        .deletingLastPathComponent() // Lint
+        .deletingLastPathComponent() // KeyPathTests
+        .deletingLastPathComponent() // Tests
+        .deletingLastPathComponent() // repo root
+}

--- a/Tests/KeyPathTests/Services/UpdateServiceDecisionTests.swift
+++ b/Tests/KeyPathTests/Services/UpdateServiceDecisionTests.swift
@@ -6,7 +6,7 @@ import KeyPathWizardCore
 import XCTest
 
 final class UpdateServiceDecisionTests: XCTestCase {
-    func testPreUpdateDecisionUsesSoftRepairWhenHelperPresent() {
+    func testPreUpdateDecisionAllowsAutomaticRepairDuringUpdateInstallWhenHelperPresent() {
         let context = makeContext(
             keyPathStatus: .granted,
             kanataStatus: .granted,
@@ -16,7 +16,7 @@ final class UpdateServiceDecisionTests: XCTestCase {
         )
 
         let decision = UpdateService.preUpdateDecision(for: context)
-        XCTAssertEqual(decision, .softRepair(reason: "reason_code=services_or_helper_present"))
+        XCTAssertEqual(decision, .automaticRepairAllowed(reason: "reason_code=services_or_helper_present"))
     }
 
     func testPreUpdateDecisionContinuesSilentlyWhenNothingRunning() {
@@ -32,7 +32,7 @@ final class UpdateServiceDecisionTests: XCTestCase {
         XCTAssertEqual(decision, .silentContinue(reason: "reason_code=nothing_running"))
     }
 
-    func testPostUpdateDecisionHardRepairWhenKeyPathPermissionsBlocking() {
+    func testPostUpdateDecisionRequiresManualAttentionWhenKeyPathPermissionsBlocking() {
         let context = makeContext(
             keyPathStatus: .denied,
             kanataStatus: .granted,
@@ -42,7 +42,7 @@ final class UpdateServiceDecisionTests: XCTestCase {
         )
 
         let decision = UpdateService.postUpdateDecision(for: context)
-        XCTAssertEqual(decision, .hardRepair(reason: "reason_code=keypath_permissions_blocking"))
+        XCTAssertEqual(decision, .manualAttentionRequired(reason: "reason_code=keypath_permissions_blocking"))
     }
 
     /// #931: KeyPath's own Input Monitoring is soft (overlay/record only). With
@@ -62,7 +62,7 @@ final class UpdateServiceDecisionTests: XCTestCase {
         XCTAssertEqual(decision, .silentContinue(reason: "reason_code=healthy"))
     }
 
-    func testPostUpdateDecisionHardRepairWhenKanataPermissionsBlocking() {
+    func testPostUpdateDecisionRequiresManualAttentionWhenKanataPermissionsBlocking() {
         let context = makeContext(
             keyPathStatus: .granted,
             kanataStatus: .denied,
@@ -72,10 +72,10 @@ final class UpdateServiceDecisionTests: XCTestCase {
         )
 
         let decision = UpdateService.postUpdateDecision(for: context)
-        XCTAssertEqual(decision, .hardRepair(reason: "reason_code=kanata_permissions_blocking"))
+        XCTAssertEqual(decision, .manualAttentionRequired(reason: "reason_code=kanata_permissions_blocking"))
     }
 
-    func testPostUpdateDecisionSoftRepairWhenHelperNotReady() {
+    func testPostUpdateDecisionRequiresUserRepairWhenHelperNotReady() {
         let context = makeContext(
             keyPathStatus: .granted,
             kanataStatus: .granted,
@@ -85,10 +85,10 @@ final class UpdateServiceDecisionTests: XCTestCase {
         )
 
         let decision = UpdateService.postUpdateDecision(for: context)
-        XCTAssertEqual(decision, .softRepair(reason: "reason_code=helper_not_ready"))
+        XCTAssertEqual(decision, .userRepairRequired(reason: "reason_code=helper_not_ready"))
     }
 
-    func testPostUpdateDecisionSoftRepairWhenComponentsNotReady() {
+    func testPostUpdateDecisionRequiresUserRepairWhenComponentsNotReady() {
         let context = makeContext(
             keyPathStatus: .granted,
             kanataStatus: .granted,
@@ -98,10 +98,10 @@ final class UpdateServiceDecisionTests: XCTestCase {
         )
 
         let decision = UpdateService.postUpdateDecision(for: context)
-        XCTAssertEqual(decision, .softRepair(reason: "reason_code=components_not_ready"))
+        XCTAssertEqual(decision, .userRepairRequired(reason: "reason_code=components_not_ready"))
     }
 
-    func testPostUpdateDecisionSoftRepairWhenServicesNotReady() {
+    func testPostUpdateDecisionRequiresUserRepairWhenServicesNotReady() {
         let context = makeContext(
             keyPathStatus: .granted,
             kanataStatus: .granted,
@@ -111,7 +111,7 @@ final class UpdateServiceDecisionTests: XCTestCase {
         )
 
         let decision = UpdateService.postUpdateDecision(for: context)
-        XCTAssertEqual(decision, .softRepair(reason: "reason_code=components_not_ready"))
+        XCTAssertEqual(decision, .userRepairRequired(reason: "reason_code=components_not_ready"))
     }
 
     func testPostUpdateDecisionContinuesSilentlyWhenHealthy() {

--- a/docs/planning/installer-reliability-phase1.md
+++ b/docs/planning/installer-reliability-phase1.md
@@ -546,6 +546,17 @@ Phase 1 changes *post-install* behavior, not first-run automation.
 - Every terminal failure report names either the manual approval surface or
   the troubleshooting doc for its failure class.
 
+**Status (2026-07-08):** First W3 passive-detection slice in progress.
+- [x] Post-update degraded-state handling no longer runs automatic repair after
+  Sparkle relaunch; it refreshes/surfaces status for user-initiated repair
+  instead. Enforced by
+  `PostUpdateRepairLintTests.testPostUpdateFinalizeDoesNotRunAutomaticRepair`
+  and `UpdateServiceDecisionTests.testPostUpdateDecisionRequiresUserRepairWhenHelperNotReady`.
+- [ ] Remaining background mutators still need W3 migration or explicit
+  first-run/user-gesture justification.
+- [ ] Terminal failure reports still need troubleshooting-guide links for the
+  unfixable tail.
+
 ## Workstream 4: Prevention at the Source
 
 Much of the repair demand is TCC/identity flap we can prevent instead of


### PR DESCRIPTION
## Summary
- stop running automatic post-update repair from Sparkle relaunch handling
- reclassify post-update degraded states as user repair required or manual attention required, then refresh/surface status through MainAppStateController
- add a lint ratchet that forbids post-update finalize from calling repair/single-action mutation automatically
- update the Phase 1 plan with W3 partial status and enforcing tests

## Phase 1 / W3 acceptance coverage
- No post-update service mutation without a user repair gesture: `PostUpdateRepairLintTests.testPostUpdateFinalizeDoesNotRunAutomaticRepair`
- User-repair classification for degraded post-update state: `UpdateServiceDecisionTests.testPostUpdateDecisionRequiresUserRepairWhenHelperNotReady`, `testPostUpdateDecisionRequiresUserRepairWhenComponentsNotReady`, `testPostUpdateDecisionRequiresUserRepairWhenServicesNotReady`
- Manual approval/permission terminal classification: `UpdateServiceDecisionTests.testPostUpdateDecisionRequiresManualAttentionWhenKeyPathPermissionsBlocking`, `testPostUpdateDecisionRequiresManualAttentionWhenKanataPermissionsBlocking`

## Validation
- `TEST_FILTER="UpdateServiceDecisionTests|PostUpdateRepairLintTests" KEYPATH_SNAPSHOTS=0 ./Scripts/run-tests-safe.sh` - passed, 10 tests
- `KEYPATH_SNAPSHOTS=0 ./Scripts/run-tests-safe.sh` - passed, 4524 tests, runner exit=0
- `git diff --check`
- `./Scripts/review-gate.sh` - `remote review gate selected`, exit 2

## Review gate
`./Scripts/review-gate.sh` selected the canonical remote review gate. Do not merge until GitHub `claude-review` passes.

## Notes
Pre-update preparation is intentionally left alone in this slice because Sparkle calls it during the update install lifecycle. This PR only removes the background post-relaunch repair path. Remaining background mutators are tracked in the Phase 1 plan for subsequent W3 slices.
