### PR TITLE
Make stuck-key recovery passive

### DIFF
--- a/Sources/KeyPathAppKit/App.swift
+++ b/Sources/KeyPathAppKit/App.swift
@@ -216,11 +216,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // Start investigation event tap if duplicate key investigation is enabled
         InvestigationEventTapService.shared.startIfNeeded()
 
-        // Wire up stuck key recovery: AutorepeatMismatch → kanata restart
-        StuckKeyRecoveryService.shared.restartKanata = { [weak self] reason in
-            await self?.kanataManager?.restartKanata(reason: reason) ?? false
-        }
-
         // Set smart default keyboard layout on first launch
         setSmartKeyboardLayoutDefault()
 

--- a/Sources/KeyPathAppKit/Services/Monitoring/StuckKeyRecoveryService.swift
+++ b/Sources/KeyPathAppKit/Services/Monitoring/StuckKeyRecoveryService.swift
@@ -1,12 +1,13 @@
 import Foundation
 import KeyPathCore
 
-/// Detects stuck keys (infinite autorepeat after kanata dies) and triggers automatic recovery.
+/// Detects stuck keys (infinite autorepeat after kanata dies) and captures diagnostics.
 ///
 /// When kanata crashes or hangs while a key is held, vhiddaemon never receives the key-up
 /// event, causing macOS to generate infinite autorepeat. This service monitors for that
-/// condition via AutorepeatMismatch correlations and triggers a kanata restart to clear the
-/// stale virtual HID state (kanata's startup F24 flush handles the actual key release).
+/// condition via AutorepeatMismatch correlations, writes an incident snapshot, and surfaces
+/// the incident for a user-initiated repair. It must not restart Kanata from this background
+/// monitor.
 ///
 /// Limitation: this service lives in the GUI app, so incidents that occur while
 /// KeyPath.app is not running are neither detected nor captured (both MAL-57
@@ -16,19 +17,26 @@ import KeyPathCore
 final class StuckKeyRecoveryService {
     static let shared = StuckKeyRecoveryService()
 
+    struct StuckKeyIncident: Equatable, Sendable {
+        let key: String
+        let keyCode: Int64
+        let msSinceAnyKanataEvent: Int?
+        let observedAt: Date
+    }
+
     /// Minimum time since last kanata event before we consider a mismatch "stuck" (not normal repeat).
     private static let kanataUnresponsiveThresholdMs = 3000
 
-    /// Minimum cooldown between recovery attempts to avoid restart loops.
-    private static let recoveryCooldownSeconds: TimeInterval = 30
+    /// Minimum cooldown between surfaced incidents to avoid notification loops.
+    private static let incidentCooldownSeconds: TimeInterval = 30
 
-    private var lastRecoveryAt: Date?
-    private var isRecovering = false
+    private var lastIncidentAt: Date?
+    private var isCapturingIncident = false
 
-    /// Called to restart kanata. Wired up by RuntimeCoordinator during bootstrap.
-    var restartKanata: ((String) async -> Bool)?
+    /// Called after diagnostic capture so app/UI code can surface user-initiated repair.
+    var onIncidentDetected: ((StuckKeyIncident) -> Void)?
 
-    /// Evaluate an AutorepeatMismatch correlation and trigger recovery if the key is truly stuck.
+    /// Evaluate an AutorepeatMismatch correlation and surface an incident if the key is truly stuck.
     ///
     /// A stuck key is distinguished from normal autorepeat by checking that kanata has been
     /// unresponsive for a significant period — normal repeat events flow through kanata and
@@ -42,39 +50,45 @@ final class StuckKeyRecoveryService {
             return
         }
 
-        guard !isRecovering else { return }
+        guard !isCapturingIncident else { return }
 
-        if let lastRecovery = lastRecoveryAt,
-           Date().timeIntervalSince(lastRecovery) < Self.recoveryCooldownSeconds
+        if let lastIncident = lastIncidentAt,
+           Date().timeIntervalSince(lastIncident) < Self.incidentCooldownSeconds
         {
             return
         }
 
-        isRecovering = true
+        isCapturingIncident = true
 
         AppLogger.shared.errorUnlessQuietTest(
-            "🚨 [StuckKeyRecovery] Stuck key detected: \(correlation.key) repeating with kanata unresponsive for \(msSinceKanata)ms — triggering automatic restart"
+            "🚨 [StuckKeyRecovery] Stuck key detected: \(correlation.key) repeating with kanata unresponsive for \(msSinceKanata)ms — capturing diagnostics for user repair"
         )
 
         Task { @MainActor [weak self] in
             guard let self else { return }
-            defer { self.isRecovering = false }
+            defer { self.isCapturingIncident = false }
 
             await writeDiagnosticSnapshot(correlation)
 
-            if let restart = restartKanata {
-                let success = await restart("Stuck key recovery (\(correlation.key))")
-                lastRecoveryAt = Date()
-                if success {
-                    AppLogger.shared.info("✅ [StuckKeyRecovery] Kanata restarted — stuck key should be cleared")
-                } else {
-                    AppLogger.shared.errorUnlessQuietTest(
-                        "❌ [StuckKeyRecovery] Kanata restart failed — user may need to intervene"
-                    )
-                }
-            } else {
-                AppLogger.shared.errorUnlessQuietTest("❌ [StuckKeyRecovery] No restart handler configured — cannot recover")
-            }
+            let incident = StuckKeyIncident(
+                key: correlation.key,
+                keyCode: correlation.keyCode,
+                msSinceAnyKanataEvent: correlation.msSinceAnyKanataEvent,
+                observedAt: correlation.observedAt
+            )
+            lastIncidentAt = Date()
+            onIncidentDetected?(incident)
+            NotificationCenter.default.post(
+                name: .stuckKeyIncidentDetected,
+                object: self,
+                userInfo: [
+                    StuckKeyIncidentNotificationKey.key: incident.key,
+                    StuckKeyIncidentNotificationKey.keyCode: incident.keyCode,
+                    StuckKeyIncidentNotificationKey.msSinceAnyKanataEvent: incident.msSinceAnyKanataEvent as Any,
+                    StuckKeyIncidentNotificationKey.observedAt: incident.observedAt
+                ]
+            )
+            AppLogger.shared.info("[StuckKeyRecovery] Incident surfaced for user-initiated repair")
         }
     }
 
@@ -82,16 +96,16 @@ final class StuckKeyRecoveryService {
 
     private func writeDiagnosticSnapshot(_ correlation: InvestigationSystemEventCorrelation) async {
         let tracker = await DuplicateKeyInvestigationTracker.shared.snapshot(
-            phase: "stuck-key-recovery",
+            phase: "stuck-key-incident",
             reason: "key=\(correlation.key) ms_since_kanata=\(correlation.msSinceAnyKanataEvent ?? -1)"
         )
 
-        let lastRecoveryDescription = lastRecoveryAt.map { ISO8601DateFormatter().string(from: $0) } ?? "never"
+        let lastIncidentDescription = lastIncidentAt.map { ISO8601DateFormatter().string(from: $0) } ?? "never"
 
         let snapshot = DiagnosticSnapshotData(
             correlation: correlation,
             tracker: tracker,
-            lastRecoveryDescription: lastRecoveryDescription
+            lastIncidentDescription: lastIncidentDescription
         )
 
         await Task.detached(priority: .utility) {
@@ -127,7 +141,7 @@ final class StuckKeyRecoveryService {
         lines.append("is_autorepeat: \(snapshot.correlation.isAutorepeat)")
         lines.append("source_pid: \(snapshot.correlation.sourcePID.map(String.init) ?? "none")")
         lines.append("")
-        lines.append("=== Held Keys at Recovery ===")
+        lines.append("=== Held Keys at Incident ===")
         if snapshot.tracker.heldKeys.isEmpty {
             lines.append("(none tracked)")
         } else {
@@ -164,8 +178,8 @@ final class StuckKeyRecoveryService {
         await lines.append(contentsOf: systemLoadLines())
         lines.append("")
 
-        lines.append("=== Recovery History ===")
-        lines.append("last_recovery_at: \(snapshot.lastRecoveryDescription)")
+        lines.append("=== Incident History ===")
+        lines.append("last_incident_at: \(snapshot.lastIncidentDescription)")
         lines.append("")
 
         do {
@@ -265,7 +279,7 @@ final class StuckKeyRecoveryService {
     /// Top CPU-consuming processes via `ps`. Skipped under tests — spawning process-listing
     /// tools in the test environment can deadlock (see KeyPathTestCase). The timeout keeps a
     /// slow `ps` (plausible under the very CPU starvation being diagnosed) from stalling the
-    /// snapshot that recovery awaits before restarting kanata.
+    /// incident snapshot.
     nonisolated static func topCPUProcessLines(limit: Int) async -> [String] {
         guard !TestEnvironment.isRunningTests else {
             return ["  (skipped in tests)"]
@@ -291,5 +305,16 @@ final class StuckKeyRecoveryService {
 private struct DiagnosticSnapshotData: Sendable {
     let correlation: InvestigationSystemEventCorrelation
     let tracker: InvestigationReloadSnapshot
-    let lastRecoveryDescription: String
+    let lastIncidentDescription: String
+}
+
+extension Notification.Name {
+    static let stuckKeyIncidentDetected = Notification.Name("KeyPathStuckKeyIncidentDetected")
+}
+
+enum StuckKeyIncidentNotificationKey {
+    static let key = "key"
+    static let keyCode = "keyCode"
+    static let msSinceAnyKanataEvent = "msSinceAnyKanataEvent"
+    static let observedAt = "observedAt"
 }

--- a/Tests/KeyPathTests/Lint/StuckKeyRecoveryLintTests.swift
+++ b/Tests/KeyPathTests/Lint/StuckKeyRecoveryLintTests.swift
@@ -1,0 +1,61 @@
+import Foundation
+@preconcurrency import XCTest
+
+final class StuckKeyRecoveryLintTests: XCTestCase {
+    func testStuckKeyRecoveryDoesNotRestartKanataAutomatically() throws {
+        let service = repositoryRoot()
+            .appendingPathComponent("Sources/KeyPathAppKit/Services/Monitoring/StuckKeyRecoveryService.swift")
+        let app = repositoryRoot()
+            .appendingPathComponent("Sources/KeyPathAppKit/App.swift")
+
+        let violations = try matchingLines(
+            in: service,
+            patterns: [
+                #"restartKanata"#,
+                #"automatic restart"#,
+                #"triggering automatic restart"#
+            ]
+        ) + matchingLines(
+            in: app,
+            patterns: [
+                #"StuckKeyRecoveryService\.shared\.restartKanata"#,
+                #"StuckKeyRecoveryService.*restartKanata"#,
+                #"kanataManager\?\.restartKanata\(reason: reason\)"#
+            ]
+        )
+
+        XCTAssertTrue(
+            violations.isEmpty,
+            """
+            Stuck-key detection is a passive W3 background monitor. It may capture \
+            diagnostics and surface an incident, but it must not restart Kanata \
+            automatically. Route recovery through a user-initiated installer action:
+            \(violations.sorted().joined(separator: "\n"))
+            """
+        )
+    }
+}
+
+private func repositoryRoot(file: StaticString = #filePath) -> URL {
+    URL(fileURLWithPath: "\(file)")
+        .deletingLastPathComponent() // Lint
+        .deletingLastPathComponent() // KeyPathTests
+        .deletingLastPathComponent() // Tests
+        .deletingLastPathComponent() // repo root
+}
+
+private func matchingLines(in fileURL: URL, patterns: [String]) throws -> [String] {
+    let contents = try String(contentsOf: fileURL, encoding: .utf8)
+    let regexes = try patterns.map { try NSRegularExpression(pattern: $0) }
+
+    return contents.components(separatedBy: .newlines).enumerated().compactMap { lineNumber, rawLine in
+        let trimmed = rawLine.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.hasPrefix("//"), !trimmed.hasPrefix("///") else { return nil }
+
+        let range = NSRange(rawLine.startIndex..., in: rawLine)
+        guard regexes.contains(where: { $0.firstMatch(in: rawLine, range: range) != nil }) else {
+            return nil
+        }
+        return "\(fileURL.lastPathComponent):\(lineNumber + 1): \(trimmed)"
+    }
+}

--- a/Tests/KeyPathTests/Services/StuckKeyRecoveryServiceTests.swift
+++ b/Tests/KeyPathTests/Services/StuckKeyRecoveryServiceTests.swift
@@ -4,25 +4,22 @@ import XCTest
 @MainActor
 final class StuckKeyRecoveryServiceTests: KeyPathTestCase {
     private var service: StuckKeyRecoveryService!
-    private var restartCallCount = 0
-    private var lastRestartReason: String?
-    /// Fulfilled each time the (default) restart handler runs, so positive tests can
-    /// wait for the recovery Task to actually reach the restart instead of sleeping a
-    /// fixed interval. The recovery Task now does an awaited diagnostic snapshot before
-    /// restarting (StuckKeyRecoveryService.swift:57), so fixed sleeps are racy.
-    private var restartExpectation: XCTestExpectation?
+    private var incidentCallCount = 0
+    private var lastIncident: StuckKeyRecoveryService.StuckKeyIncident?
+    /// Fulfilled each time the incident callback runs, so positive tests can wait for
+    /// the diagnostic snapshot to complete before asserting on the surfaced incident.
+    private var incidentExpectation: XCTestExpectation?
 
     override func setUp() async throws {
         try await super.setUp()
         service = StuckKeyRecoveryService()
-        restartCallCount = 0
-        lastRestartReason = nil
-        restartExpectation = nil
-        service.restartKanata = { [weak self] reason in
-            self?.restartCallCount += 1
-            self?.lastRestartReason = reason
-            self?.restartExpectation?.fulfill()
-            return true
+        incidentCallCount = 0
+        lastIncident = nil
+        incidentExpectation = nil
+        service.onIncidentDetected = { [weak self] incident in
+            self?.incidentCallCount += 1
+            self?.lastIncident = incident
+            self?.incidentExpectation?.fulfill()
         }
     }
 
@@ -36,7 +33,7 @@ final class StuckKeyRecoveryServiceTests: KeyPathTestCase {
 
         service.handleAutorepeatMismatch(correlation)
 
-        XCTAssertEqual(restartCallCount, 0, "Should not restart for normal autorepeat with active kanata")
+        XCTAssertEqual(incidentCallCount, 0, "Should not surface an incident for normal autorepeat with active kanata")
     }
 
     func testIgnoresNonAutorepeat() {
@@ -47,12 +44,12 @@ final class StuckKeyRecoveryServiceTests: KeyPathTestCase {
 
         service.handleAutorepeatMismatch(correlation)
 
-        XCTAssertEqual(restartCallCount, 0, "Should not restart if not an unmatched autorepeat")
+        XCTAssertEqual(incidentCallCount, 0, "Should not surface an incident if not an unmatched autorepeat")
     }
 
-    func testTriggersRecoveryForStuckKey() async {
-        let expectation = expectation(description: "restart triggered for stuck key")
-        restartExpectation = expectation
+    func testSurfacesIncidentForStuckKey() async {
+        let expectation = expectation(description: "incident surfaced for stuck key")
+        incidentExpectation = expectation
 
         let correlation = makeCorrelation(
             key: "t",
@@ -63,8 +60,10 @@ final class StuckKeyRecoveryServiceTests: KeyPathTestCase {
         service.handleAutorepeatMismatch(correlation)
         await fulfillment(of: [expectation], timeout: 5.0)
 
-        XCTAssertEqual(restartCallCount, 1)
-        XCTAssertTrue(lastRestartReason?.contains("t") == true)
+        XCTAssertEqual(incidentCallCount, 1)
+        XCTAssertEqual(lastIncident?.key, "t")
+        XCTAssertEqual(lastIncident?.keyCode, 17)
+        XCTAssertEqual(lastIncident?.msSinceAnyKanataEvent, 5000)
     }
 
     func testIgnoresNilKanataEventTime() {
@@ -75,14 +74,14 @@ final class StuckKeyRecoveryServiceTests: KeyPathTestCase {
 
         service.handleAutorepeatMismatch(correlation)
 
-        XCTAssertEqual(restartCallCount, 0, "Should not restart if kanata event time is unknown")
+        XCTAssertEqual(incidentCallCount, 0, "Should not surface an incident if kanata event time is unknown")
     }
 
     // MARK: - Debouncing
 
-    func testDebouncesPreviousRecoveries() async {
-        let firstRestart = expectation(description: "first restart")
-        restartExpectation = firstRestart
+    func testDebouncesPreviousIncidents() async {
+        let firstIncident = expectation(description: "first incident")
+        incidentExpectation = firstIncident
 
         let correlation = makeCorrelation(
             suggestsUnmatchedAutorepeat: true,
@@ -90,48 +89,36 @@ final class StuckKeyRecoveryServiceTests: KeyPathTestCase {
         )
 
         service.handleAutorepeatMismatch(correlation)
-        await fulfillment(of: [firstRestart], timeout: 5.0)
-        XCTAssertEqual(restartCallCount, 1)
+        await fulfillment(of: [firstIncident], timeout: 5.0)
+        XCTAssertEqual(incidentCallCount, 1)
 
-        // Give the first recovery Task time to settle, then fire a second mismatch. It is
+        // Give the first capture Task time to settle, then fire a second mismatch. It is
         // suppressed either by the in-flight guard (if the Task tail hasn't run) or by the
-        // 30s cooldown (once lastRecoveryAt is set) — either way no second restart fires.
-        restartExpectation = nil
+        // 30s cooldown (once lastIncidentAt is set) — either way no second incident fires.
+        incidentExpectation = nil
         for _ in 0 ..< 10 {
             await Task.yield()
         }
         service.handleAutorepeatMismatch(correlation)
-        XCTAssertEqual(restartCallCount, 1, "Should not restart again within cooldown period")
+        XCTAssertEqual(incidentCallCount, 1, "Should not surface another incident within cooldown period")
     }
 
-    func testDoesNotDoubleFireWhileRecovering() async {
-        let firstRestartEntered = expectation(description: "first restart entered")
-        var continueRestart: CheckedContinuation<Void, Never>?
-        service.restartKanata = { [weak self] reason in
-            self?.restartCallCount += 1
-            self?.lastRestartReason = reason
-            firstRestartEntered.fulfill()
-            await withCheckedContinuation { continuation in
-                continueRestart = continuation
-            }
-            return true
-        }
+    func testDoesNotDoubleFireImmediateDuplicateIncident() async {
+        let firstIncident = expectation(description: "first incident")
+        incidentExpectation = firstIncident
 
         let correlation = makeCorrelation(
             suggestsUnmatchedAutorepeat: true,
             msSinceAnyKanataEvent: 5000
         )
 
-        // Wait until the first restart is actually in-flight (isRecovering == true) before
-        // sending the second mismatch — deterministic regardless of snapshot latency.
+        // Immediate duplicate mismatches should not fan out into multiple user-facing
+        // incidents while the first diagnostic capture is in flight.
         service.handleAutorepeatMismatch(correlation)
-        await fulfillment(of: [firstRestartEntered], timeout: 5.0)
-
-        // Second mismatch while the first restart is still suspended must be ignored.
         service.handleAutorepeatMismatch(correlation)
+        await fulfillment(of: [firstIncident], timeout: 5.0)
 
-        continueRestart?.resume()
-        XCTAssertEqual(restartCallCount, 1, "Should not fire second restart while first is in progress")
+        XCTAssertEqual(incidentCallCount, 1, "Should not surface duplicate incidents while capture is in progress")
     }
 
     // MARK: - Diagnostic Snapshot Isolation

--- a/docs/planning/installer-reliability-phase1.md
+++ b/docs/planning/installer-reliability-phase1.md
@@ -546,12 +546,17 @@ Phase 1 changes *post-install* behavior, not first-run automation.
 - Every terminal failure report names either the manual approval surface or
   the troubleshooting doc for its failure class.
 
-**Status (2026-07-08):** First W3 passive-detection slice in progress.
+**Status (2026-07-08):** W3 passive-detection migration in progress.
 - [x] Post-update degraded-state handling no longer runs automatic repair after
   Sparkle relaunch; it refreshes/surfaces status for user-initiated repair
   instead. Enforced by
   `PostUpdateRepairLintTests.testPostUpdateFinalizeDoesNotRunAutomaticRepair`
   and `UpdateServiceDecisionTests.testPostUpdateDecisionRequiresUserRepairWhenHelperNotReady`.
+- [x] Stuck-key autorepeat detection no longer restarts Kanata from a
+  background monitor; it captures diagnostics and surfaces an incident for
+  user-initiated repair instead. Enforced by
+  `StuckKeyRecoveryServiceTests.testSurfacesIncidentForStuckKey` and
+  `StuckKeyRecoveryLintTests.testStuckKeyRecoveryDoesNotRestartKanataAutomatically`.
 - [ ] Remaining background mutators still need W3 migration or explicit
   first-run/user-gesture justification.
 - [ ] Terminal failure reports still need troubleshooting-guide links for the


### PR DESCRIPTION
## Summary
- convert `StuckKeyRecoveryService` from background restart behavior to passive incident capture/surfacing
- remove app bootstrap wiring that restarted Kanata from autorepeat mismatch detection
- add a lint ratchet preventing the stuck-key monitor from regaining an automatic restart hook
- update Phase 1 W3 status with the enforcing tests

## Acceptance Criteria / Test Evidence
- Stuck-key autorepeat detection no longer restarts Kanata from a background monitor; it captures diagnostics and surfaces an incident for user-initiated repair instead.
  - Enforced by `StuckKeyRecoveryServiceTests.testSurfacesIncidentForStuckKey`
  - Enforced by `StuckKeyRecoveryLintTests.testStuckKeyRecoveryDoesNotRestartKanataAutomatically`

## Validation
- `TEST_FILTER='StuckKeyRecoveryServiceTests|StuckKeyRecoveryLintTests' KEYPATH_SNAPSHOTS=0 ./Scripts/run-tests-safe.sh` — 13 tests passed
- `KEYPATH_SNAPSHOTS=0 ./Scripts/run-tests-safe.sh` — 4525 tests passed
- `./Scripts/review-gate.sh` — exited 2 with `review-gate: remote review gate selected; GitHub claude-review must pass before merge`

## Plan Notes
- This is a Workstream 3 slice only: passive detection/user-initiated repair. Workstream 6 remains deferred.
- No current-code conflict found beyond the expected W3 violation: stuck-key detection was wired to restart Kanata automatically from app bootstrap.