### PR TITLE
Make Kanata failure diagnosis passive

### DIFF
--- a/Sources/KeyPathAppKit/Managers/RecoveryCoordinator.swift
+++ b/Sources/KeyPathAppKit/Managers/RecoveryCoordinator.swift
@@ -186,33 +186,28 @@ final class RecoveryCoordinator {
 
     // MARK: - Failure Diagnosis
 
-    /// Diagnose Kanata failure and trigger recovery if needed
+    /// Diagnose Kanata failure and surface diagnostics for user-initiated recovery.
     ///
     /// - Parameters:
     ///   - exitCode: Process exit code
     ///   - output: Process output/stderr
     ///   - diagnostics: Diagnostics from DiagnosticsManager
     ///   - addDiagnostic: Handler to add diagnostic to system
-    ///   - attemptRecovery: Handler to attempt recovery (must be @escaping for Task)
     func diagnoseKanataFailure(
         exitCode: Int32,
         output: String,
         diagnostics: [KanataDiagnostic],
-        addDiagnostic: (KanataDiagnostic) -> Void,
-        attemptRecovery: @escaping () async -> Void
+        addDiagnostic: (KanataDiagnostic) -> Void
     ) {
-        // Check for zombie keyboard capture bug (exit code 6 with VirtualHID connection failure)
+        // The diagnostics layer already emits a fixable "VirtualHID Connection Failed"
+        // row for this case. W3 keeps this passive: user action chooses whether to fix.
         if exitCode == 6,
            output.contains("connect_failed asio.system:61")
            || output.contains("connect_failed asio.system:2")
         {
-            // This is the "zombie keyboard capture" bug - automatically attempt recovery
-            Task {
-                AppLogger.shared.log(
-                    "🚨 [Recovery] Detected zombie keyboard capture - attempting automatic recovery"
-                )
-                await attemptRecovery()
-            }
+            AppLogger.shared.warnUnlessQuietTest(
+                "🚨 [Recovery] Detected zombie keyboard capture - surfacing diagnostic for user repair"
+            )
         }
 
         // Add all diagnostics

--- a/Sources/KeyPathAppKit/Managers/RuntimeCoordinator.swift
+++ b/Sources/KeyPathAppKit/Managers/RuntimeCoordinator.swift
@@ -1583,9 +1583,6 @@ public class RuntimeCoordinator: SaveCoordinatorDelegate {
             diagnostics: diagnostics,
             addDiagnostic: { [weak self] diagnostic in
                 self?.addDiagnostic(diagnostic)
-            },
-            attemptRecovery: { [weak self] in
-                await self?.attemptKeyboardRecovery()
             }
         )
     }

--- a/Tests/KeyPathTests/Lint/KanataFailureDiagnosisLintTests.swift
+++ b/Tests/KeyPathTests/Lint/KanataFailureDiagnosisLintTests.swift
@@ -1,0 +1,60 @@
+import Foundation
+@preconcurrency import XCTest
+
+final class KanataFailureDiagnosisLintTests: XCTestCase {
+    func testKanataFailureDiagnosisDoesNotAttemptBackgroundRecovery() throws {
+        let recoveryCoordinator = repositoryRoot()
+            .appendingPathComponent("Sources/KeyPathAppKit/Managers/RecoveryCoordinator.swift")
+        let runtimeCoordinator = repositoryRoot()
+            .appendingPathComponent("Sources/KeyPathAppKit/Managers/RuntimeCoordinator.swift")
+
+        let violations = try matchingLines(
+            in: recoveryCoordinator,
+            patterns: [
+                #"attemptRecovery"#,
+                #"attempting automatic recovery"#,
+                #"automatic recovery"#,
+            ]
+        ) + matchingLines(
+            in: runtimeCoordinator,
+            patterns: [
+                #"attemptRecovery:\s*\{"#,
+                #"diagnoseKanataFailure[\s\S]*attemptKeyboardRecovery"#,
+            ]
+        )
+
+        XCTAssertTrue(
+            violations.isEmpty,
+            """
+            Kanata failure diagnosis is W3 passive detection. It may add diagnostics \
+            that expose a user-initiated Fix action, but it must not launch keyboard \
+            recovery from a background failure callback:
+            \(violations.sorted().joined(separator: "\n"))
+            """
+        )
+    }
+}
+
+private func repositoryRoot(file: StaticString = #filePath) -> URL {
+    URL(fileURLWithPath: "\(file)")
+        .deletingLastPathComponent() // Lint
+        .deletingLastPathComponent() // KeyPathTests
+        .deletingLastPathComponent() // Tests
+        .deletingLastPathComponent() // repo root
+}
+
+private func matchingLines(in fileURL: URL, patterns: [String]) throws -> [String] {
+    let contents = try String(contentsOf: fileURL, encoding: .utf8)
+    let regexes = try patterns.map { try NSRegularExpression(pattern: $0) }
+
+    return contents.components(separatedBy: .newlines).enumerated().compactMap { lineNumber, rawLine in
+        let trimmed = rawLine.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.hasPrefix("//"), !trimmed.hasPrefix("///") else { return nil }
+
+        let range = NSRange(rawLine.startIndex..., in: rawLine)
+        guard regexes.contains(where: { $0.firstMatch(in: rawLine, range: range) != nil }) else {
+            return nil
+        }
+        return "\(fileURL.lastPathComponent):\(lineNumber + 1): \(trimmed)"
+    }
+}

--- a/Tests/KeyPathTests/Services/RecoveryCoordinatorTests.swift
+++ b/Tests/KeyPathTests/Services/RecoveryCoordinatorTests.swift
@@ -220,25 +220,26 @@ struct RecoveryCoordinatorPauseResumeTests {
 @Suite("RecoveryCoordinator — Failure Diagnosis")
 @MainActor
 struct RecoveryCoordinatorFailureDiagnosisTests {
-    @Test("diagnoseKanataFailure triggers recovery on exit code 6 with VirtualHID error")
-    func triggersRecoveryOnExitCode6() async {
+    @Test("diagnoseKanataFailure surfaces VirtualHID diagnostics without recovery")
+    func surfacesVirtualHIDDiagnosticWithoutRecovery() {
         let coordinator = RecoveryCoordinator()
 
-        await confirmation("recovery triggered", expectedCount: 1) { confirm in
-            coordinator.diagnoseKanataFailure(
-                exitCode: 6,
-                output: "error: connect_failed asio.system:61",
-                diagnostics: [],
-                addDiagnostic: { _ in },
-                attemptRecovery: {
-                    confirm()
-                }
+        let diagnostics = [
+            makeDiagnostic(
+                category: .conflict,
+                title: "VirtualHID Connection Failed",
+                canAutoFix: true
             )
+        ]
+        var addedTitles: [String] = []
+        coordinator.diagnoseKanataFailure(
+            exitCode: 6,
+            output: "error: connect_failed asio.system:61",
+            diagnostics: diagnostics,
+            addDiagnostic: { addedTitles.append($0.title) }
+        )
 
-            // The recovery runs in a detached Task inside diagnoseKanataFailure,
-            // so yield briefly to let it execute.
-            await Task.yield()
-        }
+        #expect(addedTitles == ["VirtualHID Connection Failed"])
     }
 
     @Test("diagnoseKanataFailure adds all diagnostics")
@@ -256,8 +257,7 @@ struct RecoveryCoordinatorFailureDiagnosisTests {
             exitCode: 0,
             output: "",
             diagnostics: diagnostics,
-            addDiagnostic: { addedTitles.append($0.title) },
-            attemptRecovery: {}
+            addDiagnostic: { addedTitles.append($0.title) }
         )
 
         #expect(addedTitles.count == 3)
@@ -267,17 +267,16 @@ struct RecoveryCoordinatorFailureDiagnosisTests {
     @Test("diagnoseKanataFailure does not trigger recovery for normal exit")
     func doesNotTriggerRecoveryForNormalExit() {
         let coordinator = RecoveryCoordinator()
-        var recoveryCalled = false
+        var addedTitles: [String] = []
 
         coordinator.diagnoseKanataFailure(
             exitCode: 0,
             output: "",
-            diagnostics: [],
-            addDiagnostic: { _ in },
-            attemptRecovery: { recoveryCalled = true }
+            diagnostics: [makeDiagnostic(title: "Normal Exit Diagnostic")],
+            addDiagnostic: { addedTitles.append($0.title) }
         )
 
-        #expect(!recoveryCalled, "attemptRecovery should NOT be called for exit code 0")
+        #expect(addedTitles == ["Normal Exit Diagnostic"])
     }
 }
 

--- a/docs/planning/installer-reliability-phase1.md
+++ b/docs/planning/installer-reliability-phase1.md
@@ -557,6 +557,12 @@ Phase 1 changes *post-install* behavior, not first-run automation.
   user-initiated repair instead. Enforced by
   `StuckKeyRecoveryServiceTests.testSurfacesIncidentForStuckKey` and
   `StuckKeyRecoveryLintTests.testStuckKeyRecoveryDoesNotRestartKanataAutomatically`.
+- [x] Kanata failure diagnosis no longer launches keyboard recovery from a
+  background failure callback; it surfaces fixable diagnostics for user action
+  instead. Enforced by
+  `RecoveryCoordinatorFailureDiagnosisTests.surfacesVirtualHIDDiagnosticWithoutRecovery`
+  and
+  `KanataFailureDiagnosisLintTests.testKanataFailureDiagnosisDoesNotAttemptBackgroundRecovery`.
 - [ ] Remaining background mutators still need W3 migration or explicit
   first-run/user-gesture justification.
 - [ ] Terminal failure reports still need troubleshooting-guide links for the


### PR DESCRIPTION
## Summary
- remove the background recovery callback from `RecoveryCoordinator.diagnoseKanataFailure`
- keep VirtualHID/zombie-capture failures surfaced as fixable diagnostics for user action
- add a lint ratchet preventing failure diagnosis from launching automatic recovery again
- update Phase 1 W3 status with the enforcing tests

## Acceptance Criteria / Test Evidence
- Kanata failure diagnosis no longer launches keyboard recovery from a background failure callback; it surfaces fixable diagnostics for user action instead.
  - Enforced by `RecoveryCoordinatorFailureDiagnosisTests.surfacesVirtualHIDDiagnosticWithoutRecovery`
  - Enforced by `KanataFailureDiagnosisLintTests.testKanataFailureDiagnosisDoesNotAttemptBackgroundRecovery`

## Validation
- `TEST_FILTER='RecoveryCoordinatorFailureDiagnosisTests|KanataFailureDiagnosisLintTests' KEYPATH_SNAPSHOTS=0 ./Scripts/run-tests-safe.sh` — 5 tests passed
- `KEYPATH_SNAPSHOTS=0 ./Scripts/run-tests-safe.sh` — 4526 tests passed
- `./Scripts/review-gate.sh` — exited 2 with `review-gate: remote review gate selected; GitHub claude-review must pass before merge`

## Plan Notes
- This is a Workstream 3 slice only: failure detection remains passive and user repair remains explicit.
- The manual diagnostic Fix button path remains unchanged.
- No current-code conflict found beyond the expected W3 violation: failure diagnosis previously spawned automatic keyboard recovery.