### PR TITLE
Make grab failure handling passive

### DIFF
--- a/Sources/KeyPathAppKit/Managers/RuntimeCoordinator.swift
+++ b/Sources/KeyPathAppKit/Managers/RuntimeCoordinator.swift
@@ -94,12 +94,11 @@ public class RuntimeCoordinator: SaveCoordinatorDelegate {
     // Core status tracking
     public var lastError: String?
     var lastWarning: String?
-    /// Single-flight guard for grab-failure auto-recovery (#625). A recovery is a
-    /// ~5s kill→restart sequence that itself produces more grab-status events;
-    /// without this, a burst of `active=false` events would launch overlapping
-    /// recoveries. MainActor isolation makes the check-and-set atomic.
+    /// Legacy single-flight guard for grab-failure recovery (#625).
+    /// W3 keeps grab-failure detection passive, but the guard remains until the
+    /// deletion pass removes the old recovery state machine.
     private var isRecoveringGrab = false
-    /// True while `lastError` holds the grab-recovery give-up message (#625), so a
+    /// True while `lastError` holds the grab-failure message (#625), so a
     /// later authoritative grab success can clear exactly that error without
     /// stomping an unrelated error someone else set in the meantime.
     private var grabGiveUpErrorActive = false
@@ -1238,9 +1237,9 @@ public class RuntimeCoordinator: SaveCoordinatorDelegate {
     /// React to an authoritative kanata `InputGrab` status (#625).
     ///
     /// `active == false` means kanata is up (process + TCP) but failed to seize the
-    /// keyboard — remapping is silently dead. Drive a bounded auto-recovery, gated so
-    /// it never fires on a benign `active=false` (intentional stop) and never overlaps
-    /// an in-flight recovery. `active == true` clears the recovery budget.
+    /// keyboard — remapping is silently dead. W3 keeps this passive: record/surface
+    /// the degraded state, but do not mutate services from this background signal.
+    /// `active == true` clears the failure budget.
     func handleGrabStatusChanged(active: Bool, reason: String?) async {
         switch Self.decideGrabRecoveryGate(
             active: active,
@@ -1281,17 +1280,17 @@ public class RuntimeCoordinator: SaveCoordinatorDelegate {
             // surfaced on the next health check.
             switch await diagnosticsManager.recordGrabFailureAndDecideRecovery() {
             case let .recover(attempt):
-                AppLogger.shared.warn(
-                    "🚨 [RuntimeCoordinator] kanata failed to grab the keyboard (reason: \(reason ?? "unknown")) — recovery attempt \(attempt), restarting"
+                AppLogger.shared.info(
+                    "🚨 [RuntimeCoordinator] kanata failed to grab the keyboard (reason: \(reason ?? "unknown")) — surfacing degraded state (observation \(attempt))"
                 )
-                isRecoveringGrab = true
-                defer { isRecoveringGrab = false }
-                await attemptKeyboardRecovery()
+                lastError = "Keyboard remapping is not active: kanata could not capture the keyboard. Try quitting other keyboard tools, then restart KeyPath."
+                grabGiveUpErrorActive = true
+                notifyStateChanged()
             case let .giveUp(attempts):
                 AppLogger.shared.error(
-                    "❌ [RuntimeCoordinator] kanata still not grabbing the keyboard after \(attempts) recovery attempts — giving up (manual intervention / reboot likely needed)"
+                    "❌ [RuntimeCoordinator] kanata still not grabbing the keyboard after \(attempts) observations — manual intervention / reboot may be needed"
                 )
-                lastError = "Keyboard remapping is not active: kanata could not capture the keyboard after \(attempts) automatic recovery attempts. Try quitting other keyboard tools, then restart KeyPath."
+                lastError = "Keyboard remapping is not active: kanata could not capture the keyboard after repeated checks. Try quitting other keyboard tools, then restart KeyPath."
                 grabGiveUpErrorActive = true
                 notifyStateChanged()
             }

--- a/Tests/KeyPathTests/Lint/GrabFailureRecoveryLintTests.swift
+++ b/Tests/KeyPathTests/Lint/GrabFailureRecoveryLintTests.swift
@@ -1,0 +1,52 @@
+import Foundation
+@preconcurrency import XCTest
+
+final class GrabFailureRecoveryLintTests: XCTestCase {
+    func testGrabFailureHandlingDoesNotAttemptBackgroundRecovery() throws {
+        let runtimeCoordinator = repositoryRoot()
+            .appendingPathComponent("Sources/KeyPathAppKit/Managers/RuntimeCoordinator.swift")
+
+        let violations = try matchingLines(
+            in: runtimeCoordinator,
+            patterns: [
+                #"await attemptKeyboardRecovery\(\)"#,
+                #"automatic recovery attempts"#,
+                #"recovery attempt .*restarting"#,
+            ]
+        )
+
+        XCTAssertTrue(
+            violations.isEmpty,
+            """
+            Grab-failure detection is W3 passive detection. It may record and \
+            surface degraded state, but it must not run keyboard recovery from \
+            the background InputGrab status path:
+            \(violations.sorted().joined(separator: "\n"))
+            """
+        )
+    }
+}
+
+private func repositoryRoot(file: StaticString = #filePath) -> URL {
+    URL(fileURLWithPath: "\(file)")
+        .deletingLastPathComponent() // Lint
+        .deletingLastPathComponent() // KeyPathTests
+        .deletingLastPathComponent() // Tests
+        .deletingLastPathComponent() // repo root
+}
+
+private func matchingLines(in fileURL: URL, patterns: [String]) throws -> [String] {
+    let contents = try String(contentsOf: fileURL, encoding: .utf8)
+    let regexes = try patterns.map { try NSRegularExpression(pattern: $0) }
+
+    return contents.components(separatedBy: .newlines).enumerated().compactMap { lineNumber, rawLine in
+        let trimmed = rawLine.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.hasPrefix("//"), !trimmed.hasPrefix("///") else { return nil }
+
+        let range = NSRange(rawLine.startIndex..., in: rawLine)
+        guard regexes.contains(where: { $0.firstMatch(in: rawLine, range: range) != nil }) else {
+            return nil
+        }
+        return "\(fileURL.lastPathComponent):\(lineNumber + 1): \(trimmed)"
+    }
+}

--- a/Tests/KeyPathTests/RuntimeCoordinatorTests.swift
+++ b/Tests/KeyPathTests/RuntimeCoordinatorTests.swift
@@ -93,4 +93,20 @@ final class RuntimeCoordinatorTests: KeyPathTestCase {
             "Grab success should leave an unrelated error untouched"
         )
     }
+
+    func testGrabFailureSurfacesErrorWithoutRecoveryDelay() async {
+        let started = Date()
+
+        await manager.handleGrabStatusChanged(active: false, reason: "test grab failure")
+
+        XCTAssertLessThan(
+            Date().timeIntervalSince(started),
+            1.0,
+            "Grab failure handling should surface state instead of running the old multi-second recovery sequence"
+        )
+        XCTAssertEqual(
+            manager.lastError,
+            "Keyboard remapping is not active: kanata could not capture the keyboard. Try quitting other keyboard tools, then restart KeyPath."
+        )
+    }
 }

--- a/docs/planning/installer-reliability-phase1.md
+++ b/docs/planning/installer-reliability-phase1.md
@@ -563,6 +563,12 @@ Phase 1 changes *post-install* behavior, not first-run automation.
   `RecoveryCoordinatorFailureDiagnosisTests.surfacesVirtualHIDDiagnosticWithoutRecovery`
   and
   `KanataFailureDiagnosisLintTests.testKanataFailureDiagnosisDoesNotAttemptBackgroundRecovery`.
+- [x] Runtime grab-failure handling no longer runs keyboard recovery from the
+  background `InputGrab(active: false)` path; it records and surfaces degraded
+  state for user action instead. Enforced by
+  `RuntimeCoordinatorTests.testGrabFailureSurfacesErrorWithoutRecoveryDelay`
+  and
+  `GrabFailureRecoveryLintTests.testGrabFailureHandlingDoesNotAttemptBackgroundRecovery`.
 - [ ] Remaining background mutators still need W3 migration or explicit
   first-run/user-gesture justification.
 - [ ] Terminal failure reports still need troubleshooting-guide links for the


### PR DESCRIPTION
## Summary
- make `RuntimeCoordinator.handleGrabStatusChanged(active:false)` surface degraded grab state instead of restarting Kanata from a background status signal
- add a lint ratchet preventing the grab-failure path from reintroducing automatic keyboard recovery
- update the Phase 1 plan with the completed W3 acceptance criterion and enforcing tests

## Acceptance criteria / tests
- Runtime grab-failure handling no longer runs keyboard recovery from background `InputGrab(active:false)` and returns promptly: `RuntimeCoordinatorTests.testGrabFailureSurfacesErrorWithoutRecoveryDelay`
- Lint ratchet prevents the background grab-failure path from reintroducing recovery calls/logging: `GrabFailureRecoveryLintTests.testGrabFailureHandlingDoesNotAttemptBackgroundRecovery`

## Verification
- `TEST_FILTER='RuntimeCoordinatorTests/testGrabFailureSurfacesErrorWithoutRecoveryDelay|GrabFailureRecoveryLintTests' KEYPATH_SNAPSHOTS=0 ./Scripts/run-tests-safe.sh` - passed, 2 tests
- `KEYPATH_SNAPSHOTS=0 ./Scripts/run-tests-safe.sh` - passed, 4528 tests
- `git rev-list --left-right --count origin/master...HEAD` - `0 0` before PR
- `./Scripts/review-gate.sh` - remote review gate selected; GitHub claude-review must pass before merge (`REVIEW_GATE_EXIT=2`)

## Plan conflicts
- None. Workstream 6 deletion/renaming remains deferred; this PR intentionally leaves legacy recovery budget names in place where deletion is out of scope.
