### PR TITLE
Link terminal repair failures to troubleshooting

### DIFF
--- a/Sources/KeyPathAppKit/CLI/SystemFacade.swift
+++ b/Sources/KeyPathAppKit/CLI/SystemFacade.swift
@@ -344,7 +344,8 @@ public struct SystemFacade: Sendable {
                 title: "Kanata binary not installed",
                 category: "component",
                 action: "Reinstall KeyPath; the bundled Kanata engine is missing",
-                canAutoFix: false
+                canAutoFix: false,
+                remediationURL: KeyPathConstants.URLs.bundledKanataTroubleshooting
             ))
         }
         if !context.components.karabinerDriverInstalled {
@@ -378,14 +379,16 @@ public struct SystemFacade: Sendable {
                     title: "Configuration error prevents remapping",
                     category: "configuration",
                     action: configError,
-                    canAutoFix: false
+                    canAutoFix: false,
+                    remediationURL: KeyPathConstants.URLs.configurationTroubleshooting
                 ))
             } else if !context.services.kanataRunning, context.services.kanataPermissionRejected {
                 issues.append(.init(
                     title: "Kanata needs Accessibility permission",
                     category: "permissions",
                     action: "Re-grant Accessibility for Kanata Engine in System Settings",
-                    canAutoFix: false
+                    canAutoFix: false,
+                    remediationURL: WizardSystemPaths.accessibilitySettings
                 ))
             } else if !context.services.kanataRunning {
                 issues.append(.init(
@@ -457,7 +460,9 @@ public struct SystemFacade: Sendable {
                     : context.services.kanataInputCaptureIssue
                     ?? "Restart or repair the keyboard service",
                 canAutoFix: !needsManualVHIDApproval,
-                remediationURL: needsManualVHIDApproval ? WizardSystemPaths.loginItemsSettings : nil
+                remediationURL: needsManualVHIDApproval
+                    ? WizardSystemPaths.loginItemsSettings
+                    : KeyPathConstants.URLs.terminalInputCaptureTroubleshooting
             ))
         }
     }

--- a/Sources/KeyPathAppKit/Services/MainAppStateController.swift
+++ b/Sources/KeyPathAppKit/Services/MainAppStateController.swift
@@ -352,6 +352,8 @@ class MainAppStateController {
 
                 // VHID safety invariant: if kanata is running but VirtualHID daemon
                 // is not healthy, emergency-stop kanata to release the keyboard.
+                // W3 safety exception: this background mutation only stops remapping
+                // to prevent unsafe keyboard capture; it must not perform repair.
                 if isHealthy {
                     let vhidHealthy = await ServiceHealthChecker.shared.isServiceHealthy(
                         serviceID: ServiceHealthChecker.vhidDaemonServiceID

--- a/Sources/KeyPathCore/KeyPathConstants.swift
+++ b/Sources/KeyPathCore/KeyPathConstants.swift
@@ -101,6 +101,10 @@ public enum KeyPathConstants {
     public enum URLs {
         public static let inputMonitoringPrivacy = "x-apple.systempreferences:com.apple.preference.security?Privacy_ListenEvent"
         public static let accessibilityPrivacy = "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility"
+        public static let kanataTroubleshooting = "https://github.com/malpern/KeyPath/blob/master/docs/troubleshooting/debugging-kanata.md"
+        public static let terminalInputCaptureTroubleshooting = "\(kanataTroubleshooting)#terminal-input-capture-failures"
+        public static let configurationTroubleshooting = "\(kanataTroubleshooting)#configuration-errors"
+        public static let bundledKanataTroubleshooting = "\(kanataTroubleshooting)#bundled-kanata-engine-missing"
     }
 
     public enum Timing {

--- a/Tests/KeyPathTests/CLI/CLIOutputContractTests.swift
+++ b/Tests/KeyPathTests/CLI/CLIOutputContractTests.swift
@@ -1,5 +1,7 @@
 @testable import KeyPathAppKit
+import KeyPathCore
 @testable import KeyPathInstallationWizard
+import KeyPathWizardCore
 import XCTest
 
 final class CLIOutputContractTests: XCTestCase {
@@ -130,6 +132,78 @@ final class CLIOutputContractTests: XCTestCase {
         )
 
         XCTAssertEqual(report.userActionRequired, true)
+    }
+
+    func testInstallerReportLinksTerminalInputCaptureFailureToTroubleshooting() {
+        let context = SystemContextBuilder(
+            permissionsStatus: .granted,
+            helperReady: true,
+            servicesHealthy: true,
+            kanataInputCaptureReady: false,
+            kanataInputCaptureIssue: ServiceHealthChecker.inputCaptureGrabFailureReason,
+            componentsInstalled: true
+        ).build()
+        let report = CLIInstallerReport(
+            dryRunPlan: InstallPlan(recipes: [], status: .ready, intent: .repair),
+            context: context,
+            title: "Repair"
+        )
+
+        let issue = report.issues?.first { $0.title == "Kanata cannot capture keyboard input" }
+        XCTAssertEqual(issue?.remediationURL, KeyPathConstants.URLs.terminalInputCaptureTroubleshooting)
+    }
+
+    func testInstallerReportLinksTerminalConfigFailureToTroubleshooting() {
+        let context = SystemContextBuilder(
+            permissionsStatus: .granted,
+            helperReady: true,
+            servicesHealthy: false,
+            kanataRunning: false,
+            kanataInputCaptureReady: true,
+            componentsInstalled: true
+        ).build()
+        let services = HealthStatus(
+            kanataRunning: false,
+            karabinerDaemonRunning: true,
+            vhidHealthy: true,
+            kanataInputCaptureReady: true,
+            configParseError: "expected defcfg"
+        )
+        let configContext = SystemContext(
+            permissions: context.permissions,
+            services: services,
+            conflicts: context.conflicts,
+            components: context.components,
+            helper: context.helper,
+            system: context.system,
+            timestamp: context.timestamp
+        )
+        let report = CLIInstallerReport(
+            dryRunPlan: InstallPlan(recipes: [], status: .ready, intent: .repair),
+            context: configContext,
+            title: "Repair"
+        )
+
+        let issue = report.issues?.first { $0.title == "Configuration error prevents remapping" }
+        XCTAssertEqual(issue?.remediationURL, KeyPathConstants.URLs.configurationTroubleshooting)
+    }
+
+    func testInstallerReportLinksMissingBundledKanataToTroubleshooting() {
+        let context = SystemContextBuilder(
+            permissionsStatus: .granted,
+            helperReady: true,
+            servicesHealthy: false,
+            kanataInputCaptureReady: true,
+            componentsInstalled: false
+        ).build()
+        let report = CLIInstallerReport(
+            dryRunPlan: InstallPlan(recipes: [], status: .ready, intent: .repair),
+            context: context,
+            title: "Repair"
+        )
+
+        let issue = report.issues?.first { $0.title == "Kanata binary not installed" }
+        XCTAssertEqual(issue?.remediationURL, KeyPathConstants.URLs.bundledKanataTroubleshooting)
     }
 
     func testValidationResultJSONShape() throws {

--- a/Tests/KeyPathTests/Lint/W3BackgroundMutationExceptionLintTests.swift
+++ b/Tests/KeyPathTests/Lint/W3BackgroundMutationExceptionLintTests.swift
@@ -1,0 +1,65 @@
+import Foundation
+@preconcurrency import XCTest
+
+final class W3BackgroundMutationExceptionLintTests: XCTestCase {
+    func testServiceHealthPollingOnlyAllowsVHIDEmergencyStopException() throws {
+        let mainAppStateController = repositoryRoot()
+            .appendingPathComponent("Sources/KeyPathAppKit/Services/MainAppStateController.swift")
+        let contents = try String(contentsOf: mainAppStateController, encoding: .utf8)
+
+        XCTAssertTrue(
+            contents.contains("W3 safety exception: this background mutation only stops remapping"),
+            "The background service-health mutation must be documented as a W3 safety exception."
+        )
+        XCTAssertTrue(
+            contents.contains(#"stopKanata(reason: "Emergency: VirtualHID not running")"#),
+            "The service-health polling exception should remain a stop-only safety action."
+        )
+
+        let forbidden = try matchingLines(
+            in: mainAppStateController,
+            patterns: [
+                #"serviceHealthTask[\s\S]*restartKanata"#,
+                #"serviceHealthTask[\s\S]*run\(intent:\s*\.repair"#,
+                #"serviceHealthTask[\s\S]*runSingleAction"#,
+            ]
+        )
+
+        XCTAssertTrue(
+            forbidden.isEmpty,
+            """
+            W3 allows the service-health polling loop to stop Kanata for the \
+            VirtualHID safety invariant, but it must not repair or restart \
+            services in the background:
+            \(forbidden.sorted().joined(separator: "\n"))
+            """
+        )
+    }
+}
+
+private func repositoryRoot(file: StaticString = #filePath) -> URL {
+    URL(fileURLWithPath: "\(file)")
+        .deletingLastPathComponent() // Lint
+        .deletingLastPathComponent() // KeyPathTests
+        .deletingLastPathComponent() // Tests
+        .deletingLastPathComponent() // repo root
+}
+
+private func matchingLines(in fileURL: URL, patterns: [String]) throws -> [String] {
+    let contents = try String(contentsOf: fileURL, encoding: .utf8)
+    let regexes = try patterns.map {
+        try NSRegularExpression(pattern: $0, options: [.dotMatchesLineSeparators])
+    }
+
+    return regexes.compactMap { regex in
+        let range = NSRange(contents.startIndex..., in: contents)
+        guard let match = regex.firstMatch(in: contents, range: range),
+              let matchRange = Range(match.range, in: contents)
+        else {
+            return nil
+        }
+        let prefix = contents[..<matchRange.lowerBound]
+        let line = prefix.reduce(1) { $1 == "\n" ? $0 + 1 : $0 }
+        return "\(fileURL.lastPathComponent):\(line): \(contents[matchRange].prefix(120))"
+    }
+}

--- a/docs/planning/installer-reliability-phase1.md
+++ b/docs/planning/installer-reliability-phase1.md
@@ -569,10 +569,20 @@ Phase 1 changes *post-install* behavior, not first-run automation.
   `RuntimeCoordinatorTests.testGrabFailureSurfacesErrorWithoutRecoveryDelay`
   and
   `GrabFailureRecoveryLintTests.testGrabFailureHandlingDoesNotAttemptBackgroundRecovery`.
-- [ ] Remaining background mutators still need W3 migration or explicit
-  first-run/user-gesture justification.
-- [ ] Terminal failure reports still need troubleshooting-guide links for the
-  unfixable tail.
+- [x] Remaining background mutators are either migrated to passive surfacing or
+  explicitly justified as non-repair safety/user-gesture paths. The remaining
+  service-health polling mutation is the VirtualHID emergency stop, which only
+  stops remapping to release the keyboard and must not repair/restart in the
+  background. Enforced by
+  `W3BackgroundMutationExceptionLintTests.testServiceHealthPollingOnlyAllowsVHIDEmergencyStopException`
+  and `VHIDSafetyInvariantTests.test_emergencyStop_triggeredWhenKanataRunningWithoutVHID`.
+- [x] Terminal failure reports link to troubleshooting guidance for the
+  unfixable tail instead of launching more automatic repair. Enforced by
+  `CLIOutputContractTests.testInstallerReportLinksTerminalInputCaptureFailureToTroubleshooting`
+  and
+  `CLIOutputContractTests.testInstallerReportLinksTerminalConfigFailureToTroubleshooting`,
+  plus
+  `CLIOutputContractTests.testInstallerReportLinksMissingBundledKanataToTroubleshooting`.
 
 ## Workstream 4: Prevention at the Source
 

--- a/docs/troubleshooting/README.md
+++ b/docs/troubleshooting/README.md
@@ -2,3 +2,10 @@
 
 Diagnostics and debugging references: general diagnostics, debugging the Kanata
 backend, and the privileged-helper troubleshooting guide.
+
+- [Debugging Kanata](debugging-kanata.md)
+  - [Terminal input capture failures](debugging-kanata.md#terminal-input-capture-failures)
+  - [Configuration errors](debugging-kanata.md#configuration-errors)
+  - [Bundled Kanata Engine missing](debugging-kanata.md#bundled-kanata-engine-missing)
+- [Diagnostics](diagnostics.md)
+- [Privileged helper troubleshooting](troubleshooting-helper.md)

--- a/docs/troubleshooting/debugging-kanata.md
+++ b/docs/troubleshooting/debugging-kanata.md
@@ -733,4 +733,38 @@ When debugging Kanata issues:
 - [ ] Karabiner Login Items manually added? (`Karabiner-Elements Non-Privileged Agents.app` and `Karabiner-Elements Privileged Daemons.app`)
 - [ ] Input Monitoring granted? (Check System Settings)
 
+## Terminal Input Capture Failures
+
+If KeyPath reports that Kanata is running and responding but cannot capture
+keyboard input, treat the state as terminal for the current repair attempt.
+Do not keep restarting services in the background. Collect diagnostics, then
+check the manual failure classes below:
+
+- Driver approval loop: open System Settings > General > Login Items &
+  Extensions > Driver Extensions and confirm Karabiner-VirtualHIDDevice is
+  enabled. If macOS keeps disabling it after approval, reboot once before
+  retrying repair.
+- Endpoint-security or device-control software: temporarily disable software
+  that can block DriverKit extensions or exclusive keyboard capture, then retry
+  KeyPath repair.
+- TCC database desync: remove and re-grant Input Monitoring and Accessibility
+  for KeyPath and Kanata Engine from System Settings. If entries do not appear,
+  reboot and retry the permission grant from the KeyPath wizard.
+- BTM/Login Items corruption: run `sfltool resetbtm`, reboot, then reopen
+  KeyPath and retry repair. This resets macOS background-task registration
+  state; it is intentionally user-initiated.
+
+## Configuration Errors
+
+If Kanata exits because the generated config is invalid, repair should stop and
+show the parse error. Fix the rule or reset to the default config, then apply
+the config again. Restarting services cannot make an invalid config load.
+
+## Bundled Kanata Engine Missing
+
+If the bundled Kanata engine is missing from KeyPath.app, reinstall KeyPath from
+a signed release or run a fresh local deploy from the repository. Repair should
+not fabricate a replacement binary from another path because that changes the
+TCC identity and can invalidate Input Monitoring grants.
+
 Remember: Many "errors" in logs are actually warnings. Focus on whether the core functionality (key remapping) is working, not whether all log messages are clean.


### PR DESCRIPTION
## Summary
- add troubleshooting URLs for terminal CLI repair issues: input-capture failures, config parse failures, and missing bundled Kanata
- document the W3 VirtualHID emergency-stop safety exception and ratchet it so the polling loop stays stop-only
- add troubleshooting doc anchors and update the Phase 1 plan status with test citations

## Acceptance criteria / tests
- Terminal failure reports link to troubleshooting docs instead of launching more automatic repair:
  - `CLIOutputContractTests.testInstallerReportLinksTerminalInputCaptureFailureToTroubleshooting`
  - `CLIOutputContractTests.testInstallerReportLinksTerminalConfigFailureToTroubleshooting`
  - `CLIOutputContractTests.testInstallerReportLinksMissingBundledKanataToTroubleshooting`
- Remaining background mutator is explicitly justified as a stop-only safety exception, not repair/restart:
  - `W3BackgroundMutationExceptionLintTests.testServiceHealthPollingOnlyAllowsVHIDEmergencyStopException`
  - `VHIDSafetyInvariantTests.test_emergencyStop_triggeredWhenKanataRunningWithoutVHID`

## Verification
- `TEST_FILTER='CLIOutputContractTests/testInstallerReportLinksTerminalInputCaptureFailureToTroubleshooting|CLIOutputContractTests/testInstallerReportLinksTerminalConfigFailureToTroubleshooting|CLIOutputContractTests/testInstallerReportLinksMissingBundledKanataToTroubleshooting|W3BackgroundMutationExceptionLintTests|VHIDSafetyInvariantTests' KEYPATH_SNAPSHOTS=0 ./Scripts/run-tests-safe.sh` - passed, 9 tests
- `KEYPATH_SNAPSHOTS=0 ./Scripts/run-tests-safe.sh` - passed, 4532 tests
- `git rev-list --left-right --count origin/master...HEAD` - `0 0` before PR
- `./Scripts/review-gate.sh` - remote review gate selected; GitHub claude-review must pass before merge (`REVIEW_GATE_EXIT=2`)

## Plan conflicts
- The literal W3 wording says no background service mutation without user gesture. Current code has one stop-only safety mutation: when kanata is running without healthy VirtualHID, KeyPath stops kanata to release the keyboard. This PR documents that conflict as a safety exception and adds a lint ratchet preventing the polling path from repairing or restarting services.
