### PR TITLE
Delete Karabiner conflict protocol seam

### DIFF
--- a/Sources/KeyPathAppKit/Managers/RuntimeCoordinator.swift
+++ b/Sources/KeyPathAppKit/Managers/RuntimeCoordinator.swift
@@ -170,7 +170,7 @@ public class RuntimeCoordinator: SaveCoordinatorDelegate {
     let kanataDaemonService: KanataDaemonService
     nonisolated let diagnosticsService: DiagnosticsServiceProtocol
     let reloadSafetyMonitor = ReloadSafetyMonitor() // internal for use by extensions
-    let karabinerConflictService: KarabinerConflictManaging
+    let karabinerConflictService: KarabinerConflictService
     let configBackupManager: ConfigBackupManager
     let ruleCollectionsManager: RuleCollectionsManager
     let systemRequirementsChecker: SystemRequirementsChecker

--- a/Sources/KeyPathAppKit/Services/Karabiner/KarabinerConflictService.swift
+++ b/Sources/KeyPathAppKit/Services/Karabiner/KarabinerConflictService.swift
@@ -3,30 +3,9 @@ import Foundation
 import KeyPathCore
 import KeyPathInstallationWizard
 
-// MARK: - Protocol
-
-/// Service for detecting and resolving conflicts with Karabiner-Elements
-@MainActor
-protocol KarabinerConflictManaging: AnyObject {
-    // Detection
-    func isKarabinerDriverInstalled() -> Bool
-    func isKarabinerDriverExtensionEnabled() async -> Bool
-    func areKarabinerBackgroundServicesEnabled() async -> Bool
-    func isKarabinerElementsRunning() async -> Bool
-    func isKarabinerDaemonRunning() async -> Bool
-
-    // Resolution
-    func killKarabinerGrabber() async -> Bool
-    func disableKarabinerElementsPermanently() async -> Bool
-    func startKarabinerDaemon() async -> Bool
-    func restartKarabinerDaemon() async -> Bool
-}
-
-// MARK: - Implementation
-
 /// Manages detection and resolution of conflicts with Karabiner-Elements
 @MainActor
-final class KarabinerConflictService: KarabinerConflictManaging {
+final class KarabinerConflictService {
     /// Test seam: when set, `isKarabinerDaemonRunning()` returns this value
     /// instead of running a real pgrep.
     nonisolated(unsafe) static var testDaemonRunning: Bool?

--- a/Sources/KeyPathAppKit/Services/System/SystemRequirementsChecker.swift
+++ b/Sources/KeyPathAppKit/Services/System/SystemRequirementsChecker.swift
@@ -18,9 +18,9 @@ import KeyPathWizardCore
 final class SystemRequirementsChecker {
     // MARK: - Dependencies
 
-    private let karabinerConflictService: KarabinerConflictManaging
+    private let karabinerConflictService: KarabinerConflictService
 
-    init(karabinerConflictService: KarabinerConflictManaging) {
+    init(karabinerConflictService: KarabinerConflictService) {
         self.karabinerConflictService = karabinerConflictService
     }
 

--- a/Tests/KeyPathTests/Lint/W6DeletionPassLintTests.swift
+++ b/Tests/KeyPathTests/Lint/W6DeletionPassLintTests.swift
@@ -1,0 +1,62 @@
+import Foundation
+@preconcurrency import XCTest
+
+final class W6DeletionPassLintTests: XCTestCase {
+    func testKarabinerConflictSingleImplementationProtocolDoesNotRegrow() throws {
+        let serviceFile = repositoryRoot()
+            .appendingPathComponent("Sources/KeyPathAppKit/Services/Karabiner/KarabinerConflictService.swift")
+        let runtimeCoordinator = repositoryRoot()
+            .appendingPathComponent("Sources/KeyPathAppKit/Managers/RuntimeCoordinator.swift")
+        let requirementsChecker = repositoryRoot()
+            .appendingPathComponent("Sources/KeyPathAppKit/Services/System/SystemRequirementsChecker.swift")
+
+        let violations = try [
+            serviceFile,
+            runtimeCoordinator,
+            requirementsChecker,
+        ].flatMap { file in
+            try matchingLines(
+                in: file,
+                patterns: [
+                    #"protocol\s+KarabinerConflictManaging\b"#,
+                    #":\s*KarabinerConflictManaging\b"#,
+                    #"\bKarabinerConflictManaging\b"#,
+                ]
+            )
+        }
+
+        XCTAssertTrue(
+            violations.isEmpty,
+            """
+            W6 removes single-implementation protocols unless they provide \
+            real injection value. KarabinerConflictService is the concrete \
+            dependency; do not regrow KarabinerConflictManaging:
+            \(violations.sorted().joined(separator: "\n"))
+            """
+        )
+    }
+}
+
+private func repositoryRoot(file: StaticString = #filePath) -> URL {
+    URL(fileURLWithPath: "\(file)")
+        .deletingLastPathComponent() // Lint
+        .deletingLastPathComponent() // KeyPathTests
+        .deletingLastPathComponent() // Tests
+        .deletingLastPathComponent() // repo root
+}
+
+private func matchingLines(in fileURL: URL, patterns: [String]) throws -> [String] {
+    let contents = try String(contentsOf: fileURL, encoding: .utf8)
+    let regexes = try patterns.map { try NSRegularExpression(pattern: $0) }
+
+    return contents.components(separatedBy: .newlines).enumerated().compactMap { lineNumber, rawLine in
+        let trimmed = rawLine.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.hasPrefix("//"), !trimmed.hasPrefix("///") else { return nil }
+
+        let range = NSRange(rawLine.startIndex..., in: rawLine)
+        guard regexes.contains(where: { $0.firstMatch(in: rawLine, range: range) != nil }) else {
+            return nil
+        }
+        return "\(fileURL.lastPathComponent):\(lineNumber + 1): \(trimmed)"
+    }
+}

--- a/docs/planning/installer-reliability-phase1.md
+++ b/docs/planning/installer-reliability-phase1.md
@@ -776,6 +776,14 @@ removed):
 **Target:** the subsystem is ~34K LOC (~19% of the app). A 25–35% reduction is
 realistic without losing capability. Measure before/after.
 
+**Status (2026-07-08):** W6 deletion pass in progress.
+- [x] Removed the single-implementation `KarabinerConflictManaging` protocol
+  and wired its consumers to the concrete `KarabinerConflictService`. Enforced
+  by
+  `W6DeletionPassLintTests.testKarabinerConflictSingleImplementationProtocolDoesNotRegrow`.
+- [ ] Remaining single-implementation protocols, duplicate in-path checks,
+  cache consolidation, and DEBUG-only seams still need separate deletion PRs.
+
 ## Sequencing
 
 1. **W4 (prevention)** — independent, highest leverage per line, do first.


### PR DESCRIPTION
## Summary
- delete the single-implementation `KarabinerConflictManaging` protocol
- wire RuntimeCoordinator and SystemRequirementsChecker directly to `KarabinerConflictService`
- add a W6 deletion-pass lint ratchet so the removed protocol seam does not regrow
- update the Phase 1 plan status with the enforcing test

## Acceptance criteria
- W6 deletion pass started with a small, reversible deletion slice.
  - Enforced by `W6DeletionPassLintTests.testKarabinerConflictSingleImplementationProtocolDoesNotRegrow`.

## Validation
- `TEST_FILTER='KarabinerConflictServiceTests|W6DeletionPassLintTests|RuntimeCoordinatorTests/testInitialState' KEYPATH_SNAPSHOTS=0 ./Scripts/run-tests-safe.sh` — 6 tests passed
- `KEYPATH_SNAPSHOTS=0 ./Scripts/run-tests-safe.sh` — 4,533 tests passed; runner summary reported `test_log_swift_warnings=0`, `test_log_app_warnings=0`, `test_log_app_errors=0`
- `git rev-list --left-right --count origin/master...HEAD` — `0 1`
- `./Scripts/review-gate.sh` — `REVIEW_GATE_EXIT=2`; remote GitHub `claude-review` must pass before merge
