### PR TITLE
Delete service health monitor protocol seam

### DIFF
--- a/Sources/KeyPathAppKit/Managers/Diagnostics/DiagnosticsManager.swift
+++ b/Sources/KeyPathAppKit/Managers/Diagnostics/DiagnosticsManager.swift
@@ -48,14 +48,14 @@ protocol DiagnosticsManaging: Sendable {
 final class DiagnosticsManager: @preconcurrency DiagnosticsManaging { // @preconcurrency: @MainActor satisfies Sendable via isolation
     private var diagnostics: [KanataDiagnostic] = []
     private let diagnosticsService: DiagnosticsServiceProtocol
-    private let healthMonitor: ServiceHealthMonitorProtocol
+    private let healthMonitor: ServiceHealthMonitor
     private let processStatusProvider: @MainActor @Sendable () async -> ProcessHealthStatus
 
     private var logMonitorTask: Task<Void, Never>?
 
     init(
         diagnosticsService: DiagnosticsServiceProtocol,
-        healthMonitor: ServiceHealthMonitorProtocol,
+        healthMonitor: ServiceHealthMonitor,
         processStatusProvider: @escaping @MainActor @Sendable () async -> ProcessHealthStatus
     ) {
         self.diagnosticsService = diagnosticsService

--- a/Sources/KeyPathAppKit/Services/Monitoring/ServiceHealthMonitor.swift
+++ b/Sources/KeyPathAppKit/Services/Monitoring/ServiceHealthMonitor.swift
@@ -47,59 +47,6 @@ enum ServiceRecoveryAction: Sendable {
     case giveUp(reason: String)
 }
 
-// MARK: - Protocol
-
-/// Protocol for service health monitoring and recovery strategies
-@MainActor
-protocol ServiceHealthMonitorProtocol: AnyObject {
-    /// Check if the service is currently healthy
-    /// - Parameters:
-    ///   - processStatus: The current process status from LaunchDaemon
-    ///   - tcpPort: TCP port for health checks
-    /// - Returns: Health status with recommendation
-    func checkServiceHealth(
-        processStatus: ProcessHealthStatus,
-        tcpPort: Int
-    ) async -> ServiceHealthStatus
-
-    /// Check if a restart is allowed based on cooldown state
-    /// - Returns: Cooldown state indicating if restart is allowed
-    func canRestartService() async -> RestartCooldownState
-
-    /// Record that a service start was attempted
-    /// - Parameter timestamp: When the start was attempted
-    func recordStartAttempt(timestamp: Date) async
-
-    /// Record that a service start succeeded
-    func recordStartSuccess() async
-
-    /// Record that a service start failed
-    func recordStartFailure() async
-
-    /// Record a connection failure (for VirtualHID monitoring)
-    /// - Returns: True if max failures reached and recovery should be triggered
-    func recordConnectionFailure() async -> Bool
-
-    /// Record a successful connection (resets failure count)
-    func recordConnectionSuccess() async
-
-    /// Record a kanata input-grab failure (up but not grabbing the keyboard) and decide
-    /// whether to attempt recovery, with a bounded-attempts guard so a deterministic
-    /// crash (e.g. #631) doesn't restart forever. See #624/#625.
-    func recordGrabFailureAndDecideRecovery() async -> GrabRecoveryDecision
-
-    /// Record that the keyboard grab is healthy again (resets grab-recovery attempts).
-    func recordGrabSuccess() async
-
-    /// Determine the appropriate recovery action based on current state
-    /// - Parameter healthStatus: Current health status
-    /// - Returns: Recommended recovery action
-    func determineRecoveryAction(healthStatus: ServiceHealthStatus) async -> ServiceRecoveryAction
-
-    /// Reset all monitoring state (e.g., after successful recovery)
-    func resetMonitoringState() async
-}
-
 // MARK: - Grab Recovery Decision
 
 /// Outcome of a kanata input-grab-failure event: attempt a bounded recovery, or give
@@ -123,7 +70,7 @@ struct ProcessHealthStatus: Sendable {
 
 /// Monitors service health and manages restart cooldowns and recovery strategies
 @MainActor
-final class ServiceHealthMonitor: ServiceHealthMonitorProtocol {
+final class ServiceHealthMonitor {
     // MARK: - Dependencies
 
     private let processLifecycle: ProcessLifecycleManager

--- a/Tests/KeyPathTests/Lint/W6DeletionPassLintTests.swift
+++ b/Tests/KeyPathTests/Lint/W6DeletionPassLintTests.swift
@@ -35,6 +35,37 @@ final class W6DeletionPassLintTests: XCTestCase {
             """
         )
     }
+
+    func testServiceHealthMonitorSingleImplementationProtocolDoesNotRegrow() throws {
+        let monitorFile = repositoryRoot()
+            .appendingPathComponent("Sources/KeyPathAppKit/Services/Monitoring/ServiceHealthMonitor.swift")
+        let diagnosticsManager = repositoryRoot()
+            .appendingPathComponent("Sources/KeyPathAppKit/Managers/Diagnostics/DiagnosticsManager.swift")
+
+        let violations = try [
+            monitorFile,
+            diagnosticsManager,
+        ].flatMap { file in
+            try matchingLines(
+                in: file,
+                patterns: [
+                    #"protocol\s+ServiceHealthMonitorProtocol\b"#,
+                    #":\s*ServiceHealthMonitorProtocol\b"#,
+                    #"\bServiceHealthMonitorProtocol\b"#,
+                ]
+            )
+        }
+
+        XCTAssertTrue(
+            violations.isEmpty,
+            """
+            W6 removes single-implementation protocols unless they provide \
+            real injection value. ServiceHealthMonitor is the concrete \
+            dependency; do not regrow ServiceHealthMonitorProtocol:
+            \(violations.sorted().joined(separator: "\n"))
+            """
+        )
+    }
 }
 
 private func repositoryRoot(file: StaticString = #filePath) -> URL {

--- a/docs/planning/installer-reliability-phase1.md
+++ b/docs/planning/installer-reliability-phase1.md
@@ -781,6 +781,10 @@ realistic without losing capability. Measure before/after.
   and wired its consumers to the concrete `KarabinerConflictService`. Enforced
   by
   `W6DeletionPassLintTests.testKarabinerConflictSingleImplementationProtocolDoesNotRegrow`.
+- [x] Removed the single-implementation `ServiceHealthMonitorProtocol` and
+  wired `DiagnosticsManager` to the concrete `ServiceHealthMonitor`. Enforced
+  by
+  `W6DeletionPassLintTests.testServiceHealthMonitorSingleImplementationProtocolDoesNotRegrow`.
 - [ ] Remaining single-implementation protocols, duplicate in-path checks,
   cache consolidation, and DEBUG-only seams still need separate deletion PRs.
 


### PR DESCRIPTION
## Summary
- delete the single-implementation `ServiceHealthMonitorProtocol`
- wire `DiagnosticsManager` directly to `ServiceHealthMonitor`
- extend the W6 deletion-pass lint ratchet so the removed service-health protocol seam does not regrow
- update the Phase 1 plan status with the enforcing test

## Acceptance criteria
- W6 deletion pass removes another single-implementation protocol with no alternate implementation or meaningful injected mock.
  - Enforced by `W6DeletionPassLintTests.testServiceHealthMonitorSingleImplementationProtocolDoesNotRegrow`.

## Validation
- `TEST_FILTER='ServiceHealthMonitorTests|W6DeletionPassLintTests|RuntimeCoordinatorTests/testInitialState' KEYPATH_SNAPSHOTS=0 ./Scripts/run-tests-safe.sh` — 34 tests passed
- `KEYPATH_SNAPSHOTS=0 ./Scripts/run-tests-safe.sh` — 4,534 tests passed; runner summary reported `build_log_swift_warnings=0`, `test_log_swift_warnings=0`, `test_log_app_warnings=0`, `test_log_app_errors=0`
- `git rev-list --left-right --count origin/master...HEAD` — `0 1`
- `./Scripts/review-gate.sh` — `REVIEW_GATE_EXIT=2`; remote GitHub `claude-review` must pass before merge
