### PR TITLE
Delete configuration manager protocol seam

### DIFF
--- a/Sources/KeyPathAppKit/Managers/Configuration/ConfigurationManager.swift
+++ b/Sources/KeyPathAppKit/Managers/Configuration/ConfigurationManager.swift
@@ -2,59 +2,9 @@ import AppKit
 import Foundation
 import KeyPathCore
 
-/// Protocol for managing Kanata configuration files
-// @preconcurrency: @MainActor class conforms to Sendable protocol; actor isolation provides safety
-@preconcurrency
-protocol ConfigurationManaging: Sendable {
-    var configPath: String { get }
-    var configDirectory: String { get }
-
-    /// Build Kanata command line arguments
-    func buildKanataArguments(checkOnly: Bool) -> [String]
-
-    /// Validate configuration file
-    func validateConfigFile() async -> (isValid: Bool, errors: [String])
-
-    /// Validate configuration content string
-    func validateConfiguration(_ content: String) async -> (isValid: Bool, errors: [String])
-
-    /// Write generated configuration to disk
-    func writeGeneratedConfig(_ content: String) async throws -> [KeyMapping]
-
-    /// Write validated configuration to disk
-    func writeValidatedConfig(_ content: String) async throws
-
-    /// Load existing mappings from config file
-    func loadExistingMappings() async -> [KeyMapping]
-
-    /// Save configuration with mappings
-    func saveConfiguration(mappings: [KeyMapping]) async throws
-
-    /// Backup current config
-    func backupCurrentConfig() async
-
-    /// Create default config if missing
-    func createDefaultIfMissing() async -> Bool
-
-    /// Open config file in editor
-    func openInEditor(_ path: String) async
-
-    /// Parse config content to mappings
-    func parseConfig(_ content: String) -> [KeyMapping]
-
-    /// Generate config from mappings
-    func generateConfig(mappings: [KeyMapping]) -> String
-
-    /// Ensure valid startup config, handling invalid configs by backing them up and resetting to default
-    func ensureValidStartupConfig() async -> (mappings: [KeyMapping], validationError: ConfigValidationError?)
-
-    /// Backup failed config and apply safe default
-    func backupFailedConfigAndApplySafe(failedConfig: String, mappings: [KeyMapping]) async throws -> String
-}
-
 /// Manages Kanata configuration files and operations
 @MainActor
-final class ConfigurationManager: @preconcurrency ConfigurationManaging { // @preconcurrency: @MainActor satisfies Sendable via isolation
+final class ConfigurationManager {
     let configPath: String
     let configDirectory: String
 

--- a/Sources/KeyPathAppKit/Managers/RuntimeCoordinator.swift
+++ b/Sources/KeyPathAppKit/Managers/RuntimeCoordinator.swift
@@ -153,7 +153,7 @@ public class RuntimeCoordinator: SaveCoordinatorDelegate {
 
     // MARK: - Manager Dependencies (Refactored Architecture)
 
-    let configurationManager: ConfigurationManaging
+    let configurationManager: ConfigurationManager
     let diagnosticsManager: DiagnosticsManaging
     let configRepairService: ConfigRepairService
 

--- a/Tests/KeyPathTests/Lint/W6DeletionPassLintTests.swift
+++ b/Tests/KeyPathTests/Lint/W6DeletionPassLintTests.swift
@@ -66,6 +66,37 @@ final class W6DeletionPassLintTests: XCTestCase {
             """
         )
     }
+
+    func testConfigurationManagerSingleImplementationProtocolDoesNotRegrow() throws {
+        let managerFile = repositoryRoot()
+            .appendingPathComponent("Sources/KeyPathAppKit/Managers/Configuration/ConfigurationManager.swift")
+        let runtimeCoordinator = repositoryRoot()
+            .appendingPathComponent("Sources/KeyPathAppKit/Managers/RuntimeCoordinator.swift")
+
+        let violations = try [
+            managerFile,
+            runtimeCoordinator,
+        ].flatMap { file in
+            try matchingLines(
+                in: file,
+                patterns: [
+                    #"protocol\s+ConfigurationManaging\b"#,
+                    #":\s*ConfigurationManaging\b"#,
+                    #"\bConfigurationManaging\b"#,
+                ]
+            )
+        }
+
+        XCTAssertTrue(
+            violations.isEmpty,
+            """
+            W6 removes single-implementation protocols unless they provide \
+            real injection value. ConfigurationManager is the concrete \
+            dependency; do not regrow ConfigurationManaging:
+            \(violations.sorted().joined(separator: "\n"))
+            """
+        )
+    }
 }
 
 private func repositoryRoot(file: StaticString = #filePath) -> URL {

--- a/docs/planning/installer-reliability-phase1.md
+++ b/docs/planning/installer-reliability-phase1.md
@@ -785,6 +785,10 @@ realistic without losing capability. Measure before/after.
   wired `DiagnosticsManager` to the concrete `ServiceHealthMonitor`. Enforced
   by
   `W6DeletionPassLintTests.testServiceHealthMonitorSingleImplementationProtocolDoesNotRegrow`.
+- [x] Removed the single-implementation `ConfigurationManaging` protocol and
+  wired `RuntimeCoordinator` to the concrete `ConfigurationManager`. Enforced
+  by
+  `W6DeletionPassLintTests.testConfigurationManagerSingleImplementationProtocolDoesNotRegrow`.
 - [ ] Remaining single-implementation protocols, duplicate in-path checks,
   cache consolidation, and DEBUG-only seams still need separate deletion PRs.
 


### PR DESCRIPTION
## Summary
- delete the single-implementation `ConfigurationManaging` protocol
- wire `RuntimeCoordinator` directly to `ConfigurationManager`
- extend the W6 deletion-pass lint ratchet so the removed configuration manager protocol seam does not regrow
- update the Phase 1 plan status with the enforcing test

## Acceptance criteria
- W6 deletion pass removes another single-implementation protocol with no alternate production implementation or meaningful injected mock.
  - Enforced by `W6DeletionPassLintTests.testConfigurationManagerSingleImplementationProtocolDoesNotRegrow`.

## Validation
- `TEST_FILTER='ConfigurationManagerTests|W6DeletionPassLintTests|RuntimeCoordinatorTests/testInitialState' KEYPATH_SNAPSHOTS=0 ./Scripts/run-tests-safe.sh` — 4 tests passed, including the W6 lint ratchet and `RuntimeCoordinatorTests/testInitialState`
- `KEYPATH_SNAPSHOTS=0 ./Scripts/run-tests-safe.sh` — 4,535 tests passed; runner summary reported `build_log_swift_warnings=0`, `test_log_swift_warnings=0`, `test_log_app_warnings=0`, `test_log_app_errors=0`
- `git rev-list --left-right --count origin/master...HEAD` — `0 1`
- `./Scripts/review-gate.sh` — `REVIEW_GATE_EXIT=2`; remote GitHub `claude-review` must pass before merge

## Notes
- There is no `ConfigurationManagerTests` suite matching the focused filter today; the full suite covers existing configuration behavior and this PR adds the explicit W6 no-regrowth lint.
