### PR TITLE
Delete diagnostics manager protocol seam

### DIFF
--- a/Sources/KeyPathAppKit/Managers/ConfigReloadCoordinator.swift
+++ b/Sources/KeyPathAppKit/Managers/ConfigReloadCoordinator.swift
@@ -13,7 +13,7 @@ final class ConfigReloadCoordinator {
 
     private let engineClient: EngineClient
     private let reloadSafetyMonitor: ReloadSafetyMonitor
-    private let diagnosticsManager: DiagnosticsManaging
+    private let healthStatusProvider: @MainActor @Sendable (Int) async -> ServiceHealthStatus
     private let processLifecycleManager: ProcessLifecycleManager
 
     // MARK: - Callbacks (set by RuntimeCoordinator after init)
@@ -26,12 +26,12 @@ final class ConfigReloadCoordinator {
     init(
         engineClient: EngineClient,
         reloadSafetyMonitor: ReloadSafetyMonitor,
-        diagnosticsManager: DiagnosticsManaging,
+        healthStatusProvider: @escaping @MainActor @Sendable (Int) async -> ServiceHealthStatus,
         processLifecycleManager: ProcessLifecycleManager
     ) {
         self.engineClient = engineClient
         self.reloadSafetyMonitor = reloadSafetyMonitor
-        self.diagnosticsManager = diagnosticsManager
+        self.healthStatusProvider = healthStatusProvider
         self.processLifecycleManager = processLifecycleManager
     }
 
@@ -62,9 +62,7 @@ final class ConfigReloadCoordinator {
         }
 
         // Skip reloads if Kanata service isn't healthy yet
-        let healthStatus = await diagnosticsManager.checkHealth(
-            tcpPort: PreferencesService.shared.tcpServerPort
-        )
+        let healthStatus = await healthStatusProvider(PreferencesService.shared.tcpServerPort)
         if !healthStatus.isHealthy {
             AppLogger.shared.warnUnlessQuietTest(
                 "⚠️ [Reload] Skipping TCP reload because Kanata service is not healthy yet: \(healthStatus.reason ?? "unknown reason")"

--- a/Sources/KeyPathAppKit/Managers/Diagnostics/DiagnosticsManager.swift
+++ b/Sources/KeyPathAppKit/Managers/Diagnostics/DiagnosticsManager.swift
@@ -2,50 +2,9 @@ import Foundation
 import KeyPathCore
 import KeyPathDaemonLifecycle
 
-/// Protocol for managing diagnostics, health monitoring, and log monitoring
-// @preconcurrency: @MainActor class conforms to Sendable protocol; actor isolation provides safety
-@preconcurrency
-protocol DiagnosticsManaging: Sendable {
-    /// Add a diagnostic
-    func addDiagnostic(_ diagnostic: KanataDiagnostic)
-
-    /// Get all current diagnostics
-    func getDiagnostics() -> [KanataDiagnostic]
-
-    /// Clear all diagnostics
-    func clearDiagnostics()
-
-    /// Start log monitoring
-    func startLogMonitoring()
-
-    /// Stop log monitoring
-    func stopLogMonitoring()
-
-    /// Check service health
-    func checkHealth(tcpPort: Int) async -> ServiceHealthStatus
-
-    /// Record a VirtualHID connection failure and report whether recovery should trigger.
-    func recordConnectionFailure() async -> Bool
-
-    /// Record a VirtualHID connection success.
-    func recordConnectionSuccess() async
-
-    /// Record a kanata input-grab failure and decide whether to recover (bounded). (#625)
-    func recordGrabFailureAndDecideRecovery() async -> GrabRecoveryDecision
-
-    /// Record that the keyboard grab is healthy again (resets grab-recovery attempts).
-    func recordGrabSuccess() async
-
-    /// Diagnose Kanata failure
-    func diagnoseFailure(exitCode: Int32, output: String) -> [KanataDiagnostic]
-
-    /// Get system diagnostics
-    func getSystemDiagnostics(engineClient: EngineClient?) async -> [KanataDiagnostic]
-}
-
 /// Manages diagnostics, health monitoring, and log monitoring
 @MainActor
-final class DiagnosticsManager: @preconcurrency DiagnosticsManaging { // @preconcurrency: @MainActor satisfies Sendable via isolation
+final class DiagnosticsManager {
     private var diagnostics: [KanataDiagnostic] = []
     private let diagnosticsService: DiagnosticsServiceProtocol
     private let healthMonitor: ServiceHealthMonitor

--- a/Sources/KeyPathAppKit/Managers/RuntimeCoordinator.swift
+++ b/Sources/KeyPathAppKit/Managers/RuntimeCoordinator.swift
@@ -154,7 +154,7 @@ public class RuntimeCoordinator: SaveCoordinatorDelegate {
     // MARK: - Manager Dependencies (Refactored Architecture)
 
     let configurationManager: ConfigurationManager
-    let diagnosticsManager: DiagnosticsManaging
+    let diagnosticsManager: DiagnosticsManager
     let configRepairService: ConfigRepairService
 
     /// Manager dependencies (exposed for extensions that need direct access)
@@ -313,7 +313,9 @@ public class RuntimeCoordinator: SaveCoordinatorDelegate {
         configReloadCoordinator = ConfigReloadCoordinator(
             engineClient: self.engineClient,
             reloadSafetyMonitor: reloadSafetyMonitor,
-            diagnosticsManager: diagnosticsManager,
+            healthStatusProvider: { [diagnosticsManager] tcpPort in
+                await diagnosticsManager.checkHealth(tcpPort: tcpPort)
+            },
             processLifecycleManager: lifecycleManager
         )
 

--- a/Tests/KeyPathTests/Lint/W6DeletionPassLintTests.swift
+++ b/Tests/KeyPathTests/Lint/W6DeletionPassLintTests.swift
@@ -97,6 +97,44 @@ final class W6DeletionPassLintTests: XCTestCase {
             """
         )
     }
+
+    func testDiagnosticsManagerSingleImplementationProtocolDoesNotRegrow() throws {
+        let managerFile = repositoryRoot()
+            .appendingPathComponent("Sources/KeyPathAppKit/Managers/Diagnostics/DiagnosticsManager.swift")
+        let runtimeCoordinator = repositoryRoot()
+            .appendingPathComponent("Sources/KeyPathAppKit/Managers/RuntimeCoordinator.swift")
+        let reloadCoordinator = repositoryRoot()
+            .appendingPathComponent("Sources/KeyPathAppKit/Managers/ConfigReloadCoordinator.swift")
+        let reloadTests = repositoryRoot()
+            .appendingPathComponent("Tests/KeyPathTests/Services/ConfigReloadCoordinatorTests.swift")
+
+        let violations = try [
+            managerFile,
+            runtimeCoordinator,
+            reloadCoordinator,
+            reloadTests,
+        ].flatMap { file in
+            try matchingLines(
+                in: file,
+                patterns: [
+                    #"protocol\s+DiagnosticsManaging\b"#,
+                    #":\s*DiagnosticsManaging\b"#,
+                    #"\bDiagnosticsManaging\b"#,
+                ]
+            )
+        }
+
+        XCTAssertTrue(
+            violations.isEmpty,
+            """
+            W6 removes broad single-implementation protocols unless they \
+            provide real injection value. DiagnosticsManager is concrete; \
+            ConfigReloadCoordinator uses a narrow healthStatusProvider seam \
+            instead of regrowing DiagnosticsManaging:
+            \(violations.sorted().joined(separator: "\n"))
+            """
+        )
+    }
 }
 
 private func repositoryRoot(file: StaticString = #filePath) -> URL {

--- a/Tests/KeyPathTests/Services/ConfigReloadCoordinatorTests.swift
+++ b/Tests/KeyPathTests/Services/ConfigReloadCoordinatorTests.swift
@@ -27,57 +27,16 @@ private final class MockEngineClient: EngineClient, @unchecked Sendable {
     }
 }
 
-/// Mock diagnostics manager with configurable health status.
+// MARK: - Thread-safe notification helpers
+
 @MainActor
-private final class MockDiagnosticsManager: @preconcurrency DiagnosticsManaging {
-    var healthStatus: ServiceHealthStatus = .healthy()
-    private var diagnostics: [KanataDiagnostic] = []
-    var connectionFailureCount = 0
+private final class MutableHealthStatus {
+    var value: ServiceHealthStatus
 
-    func addDiagnostic(_ diagnostic: KanataDiagnostic) {
-        diagnostics.append(diagnostic)
-    }
-
-    func getDiagnostics() -> [KanataDiagnostic] {
-        diagnostics
-    }
-
-    func clearDiagnostics() {
-        diagnostics.removeAll()
-    }
-
-    func startLogMonitoring() {}
-    func stopLogMonitoring() {}
-
-    func checkHealth(tcpPort _: Int) async -> ServiceHealthStatus {
-        healthStatus
-    }
-
-    func recordConnectionFailure() async -> Bool {
-        connectionFailureCount += 1
-        return connectionFailureCount >= 10
-    }
-
-    func recordConnectionSuccess() async {
-        connectionFailureCount = 0
-    }
-
-    func recordGrabFailureAndDecideRecovery() async -> GrabRecoveryDecision {
-        .recover(attempt: 1)
-    }
-
-    func recordGrabSuccess() async {}
-
-    func diagnoseFailure(exitCode _: Int32, output _: String) -> [KanataDiagnostic] {
-        []
-    }
-
-    func getSystemDiagnostics(engineClient _: EngineClient?) async -> [KanataDiagnostic] {
-        []
+    init(_ value: ServiceHealthStatus) {
+        self.value = value
     }
 }
-
-// MARK: - Thread-safe notification helpers
 
 /// Thread-safe boolean flag for use in notification observer closures.
 private final class NotificationFlag: @unchecked Sendable {
@@ -123,15 +82,14 @@ struct ConfigReloadCoordinatorTests {
     ) -> (
         coordinator: ConfigReloadCoordinator,
         engine: MockEngineClient,
-        diagnostics: MockDiagnosticsManager
+        healthStatus: MutableHealthStatus
     ) {
         let engine = MockEngineClient()
         engine.result = engineResult
 
-        let diagnostics = MockDiagnosticsManager()
-        diagnostics.healthStatus = healthy
+        let healthStatus = MutableHealthStatus(healthy
             ? .healthy()
-            : .unhealthy(reason: "Service not running")
+            : .unhealthy(reason: "Service not running"))
 
         let safetyMonitor = ReloadSafetyMonitor()
         let processLifecycle = ProcessLifecycleManager()
@@ -139,11 +97,11 @@ struct ConfigReloadCoordinatorTests {
         let coordinator = ConfigReloadCoordinator(
             engineClient: engine,
             reloadSafetyMonitor: safetyMonitor,
-            diagnosticsManager: diagnostics,
+            healthStatusProvider: { _ in healthStatus.value },
             processLifecycleManager: processLifecycle
         )
 
-        return (coordinator, engine, diagnostics)
+        return (coordinator, engine, healthStatus)
     }
 
     // MARK: - triggerConfigReload: unhealthy service
@@ -423,7 +381,7 @@ struct ConfigReloadCoordinatorTests {
         #expect(result1.isSuccess == false)
 
         // Switch to healthy
-        diagnostics.healthStatus = .healthy()
+        diagnostics.value = .healthy()
 
         // Second call: healthy -> proceeds (though TCP guard will still fire in test env)
         let result2 = await coordinator.triggerConfigReload()

--- a/docs/planning/installer-reliability-phase1.md
+++ b/docs/planning/installer-reliability-phase1.md
@@ -789,6 +789,11 @@ realistic without losing capability. Measure before/after.
   wired `RuntimeCoordinator` to the concrete `ConfigurationManager`. Enforced
   by
   `W6DeletionPassLintTests.testConfigurationManagerSingleImplementationProtocolDoesNotRegrow`.
+- [x] Removed the broad single-implementation `DiagnosticsManaging` protocol,
+  wired `RuntimeCoordinator` to the concrete `DiagnosticsManager`, and narrowed
+  `ConfigReloadCoordinator` tests to a `healthStatusProvider` closure. Enforced
+  by
+  `W6DeletionPassLintTests.testDiagnosticsManagerSingleImplementationProtocolDoesNotRegrow`.
 - [ ] Remaining single-implementation protocols, duplicate in-path checks,
   cache consolidation, and DEBUG-only seams still need separate deletion PRs.
 


### PR DESCRIPTION
## Summary
- delete the broad single-implementation `DiagnosticsManaging` protocol
- wire `RuntimeCoordinator` directly to concrete `DiagnosticsManager`
- replace `ConfigReloadCoordinator`'s diagnostics-manager dependency with a narrow `healthStatusProvider` closure
- update `ConfigReloadCoordinatorTests` to use the narrow health seam instead of a broad diagnostics mock
- extend the W6 deletion-pass lint ratchet and update the Phase 1 plan status

## Acceptance criteria
- W6 deletion pass removes another broad single-implementation protocol while preserving the useful test injection as a focused seam.
  - Enforced by `W6DeletionPassLintTests.testDiagnosticsManagerSingleImplementationProtocolDoesNotRegrow`.
- Reload health gating remains testable without a broad diagnostics protocol.
  - Enforced by `ConfigReloadCoordinatorTests` using the injected `healthStatusProvider`.

## Validation
- `TEST_FILTER='ConfigReloadCoordinatorTests|W6DeletionPassLintTests|RuntimeCoordinatorTests/testInitialState' KEYPATH_SNAPSHOTS=0 ./Scripts/run-tests-safe.sh` — 18 tests passed
- `KEYPATH_SNAPSHOTS=0 ./Scripts/run-tests-safe.sh` — 4,536 tests passed; runner summary reported `build_log_swift_warnings=0`, `test_log_swift_warnings=0`, `test_log_app_warnings=0`, `test_log_app_errors=0`
- `git rev-list --left-right --count origin/master...HEAD` — `0 1`
- `./Scripts/review-gate.sh` — `REVIEW_GATE_EXIT=2`; remote GitHub `claude-review` must pass before merge
