### PR TITLE
Delete SMAppService pending cache

### DIFF
--- a/Sources/KeyPathAppKit/Managers/ServiceLifecycleCoordinator.swift
+++ b/Sources/KeyPathAppKit/Managers/ServiceLifecycleCoordinator.swift
@@ -155,15 +155,6 @@ final class ServiceLifecycleCoordinator {
         createdAt: Date()
     )
 
-    /// Short-lived cache of the SMAppService "pending" check so the 250ms
-    /// overlay polling loop doesn't hammer SMAppService.status (synchronous
-    /// IPC, can block 10-30s under concurrent load — see CLAUDE.md).
-    private var smAppServicePendingCache: (value: Bool, timestamp: Date)?
-    private static let smAppServicePendingCacheTTL: TimeInterval = 5.0
-    /// In-flight SMAppService refresh, kept so back-to-back cache misses
-    /// don't fan out into parallel IPC calls.
-    private var smAppServiceRefreshTask: Task<Bool, Never>?
-
     // MARK: - Callbacks (set by RuntimeCoordinator after init)
 
     /// Called when an error should be surfaced to the UI.
@@ -356,38 +347,11 @@ final class ServiceLifecycleCoordinator {
         ) {
             return true
         }
-        return await isSMAppServicePendingCached()
-    }
-
-    private func isSMAppServicePendingCached() async -> Bool {
-        let now = Date()
-        if let cached = smAppServicePendingCache,
-           now.timeIntervalSince(cached.timestamp) < Self.smAppServicePendingCacheTTL
-        {
-            return cached.value
-        }
-        if let cached = smAppServicePendingCache {
-            scheduleSMAppServiceRefresh()
-            return cached.value
-        }
-        return await performSMAppServiceRefresh()
-    }
-
-    private func scheduleSMAppServiceRefresh() {
-        if smAppServiceRefreshTask != nil { return }
-        smAppServiceRefreshTask = Task { [weak self] in
-            guard let self else { return false }
-            let value = await performSMAppServiceRefresh()
-            smAppServiceRefreshTask = nil
-            return value
-        }
-    }
-
-    private func performSMAppServiceRefresh() async -> Bool {
-        let managementState = await KanataDaemonManager.shared.refreshManagementStateInternal()
-        let isPending = managementState == .smappservicePending
-        smAppServicePendingCache = (isPending, Date())
-        return isPending
+        let cached = await MainActor.run { KanataDaemonManager.shared.currentManagementState }
+        let managementState = cached == .unknown
+            ? await KanataDaemonManager.shared.refreshManagementStateInternal()
+            : cached
+        return managementState == .smappservicePending
     }
 
     private func verifyRuntimeReadinessAfterStart(reason: String) async -> RuntimeReadinessVerification {

--- a/Tests/KeyPathTests/Lint/W6DeletionPassLintTests.swift
+++ b/Tests/KeyPathTests/Lint/W6DeletionPassLintTests.swift
@@ -135,6 +135,32 @@ final class W6DeletionPassLintTests: XCTestCase {
             """
         )
     }
+
+    func testServiceLifecycleCoordinatorDoesNotRegrowSMAppServicePendingCache() throws {
+        let coordinatorFile = repositoryRoot()
+            .appendingPathComponent("Sources/KeyPathAppKit/Managers/ServiceLifecycleCoordinator.swift")
+
+        let violations = try matchingLines(
+            in: coordinatorFile,
+            patterns: [
+                #"\bsmAppServicePendingCache\b"#,
+                #"\bsmAppServicePendingCacheTTL\b"#,
+                #"\bsmAppServiceRefreshTask\b"#,
+                #"\bisSMAppServicePendingCached\b"#,
+            ]
+        )
+
+        XCTAssertTrue(
+            violations.isEmpty,
+            """
+            W6 collapses duplicate service-state caches into the provider/manager \
+            layer. ServiceLifecycleCoordinator should read \
+            KanataDaemonManager.currentManagementState and refresh only unknown \
+            state instead of regrowing a local SMAppService pending cache:
+            \(violations.sorted().joined(separator: "\n"))
+            """
+        )
+    }
 }
 
 private func repositoryRoot(file: StaticString = #filePath) -> URL {

--- a/docs/planning/installer-reliability-phase1.md
+++ b/docs/planning/installer-reliability-phase1.md
@@ -794,6 +794,10 @@ realistic without losing capability. Measure before/after.
   `ConfigReloadCoordinator` tests to a `healthStatusProvider` closure. Enforced
   by
   `W6DeletionPassLintTests.testDiagnosticsManagerSingleImplementationProtocolDoesNotRegrow`.
+- [x] Removed `ServiceLifecycleCoordinator`'s local
+  `smAppServicePendingCache`, using `KanataDaemonManager.currentManagementState`
+  as the provider-owned cache instead. Enforced by
+  `W6DeletionPassLintTests.testServiceLifecycleCoordinatorDoesNotRegrowSMAppServicePendingCache`.
 - [ ] Remaining single-implementation protocols, duplicate in-path checks,
   cache consolidation, and DEBUG-only seams still need separate deletion PRs.
 


### PR DESCRIPTION
## Summary
- remove `ServiceLifecycleCoordinator`'s duplicate SMAppService pending cache
- use `KanataDaemonManager.currentManagementState` as the provider-owned cached state, refreshing only when unknown
- add a W6 lint ratchet so the local pending cache does not regrow
- update the Phase 1 plan doc status with the enforcing test

## Acceptance Criteria
- W6 cache consolidation: `W6DeletionPassLintTests.testServiceLifecycleCoordinatorDoesNotRegrowSMAppServicePendingCache` enforces that `ServiceLifecycleCoordinator` does not regrow `smAppServicePendingCache`, `smAppServicePendingCacheTTL`, `smAppServiceRefreshTask`, or `isSMAppServicePendingCached`.
- Lifecycle behavior remains covered by `ServiceLifecycleCoordinatorTests`, including startup-window and start/stop/restart behavior.

## Validation
- Focused safe gate: `TEST_FILTER='ServiceLifecycleCoordinatorTests|W6DeletionPassLintTests|RuntimeCoordinatorTests/testInitialState' KEYPATH_SNAPSHOTS=0 ./Scripts/run-tests-safe.sh` -> 29 passed.
- Full safe gate: `KEYPATH_SNAPSHOTS=0 ./Scripts/run-tests-safe.sh` -> 4,537 passed.
- Branch freshness: `git rev-list --left-right --count origin/master...HEAD` -> `0 1` before push.
- Review gate: `./Scripts/review-gate.sh` selected remote review; `REVIEW_GATE_EXIT=2`. GitHub `claude-review` must pass before merge.

## Plan Notes
No plan/code conflict found. This is one W6 deletion-pass cache-consolidation slice; Workstreams 3 and earlier W6 slices remain landed separately.
