### PR TITLE
Remove duplicate VHID start check

### DIFF
--- a/Sources/KeyPathAppKit/Managers/RuntimeCoordinator.swift
+++ b/Sources/KeyPathAppKit/Managers/RuntimeCoordinator.swift
@@ -362,8 +362,10 @@ public class RuntimeCoordinator: SaveCoordinatorDelegate {
         serviceLifecycleCoordinator.onStateChanged = { [weak self] in
             self?.notifyStateChanged()
         }
-        serviceLifecycleCoordinator.isKarabinerDaemonRunning = { [weak self] in
-            await self?.isKarabinerDaemonRunning() ?? false
+        serviceLifecycleCoordinator.isVirtualHIDDaemonHealthy = {
+            await ServiceHealthChecker.shared.isServiceHealthy(
+                serviceID: ServiceHealthChecker.vhidDaemonServiceID
+            )
         }
 
         // Wire up ConfigReloadCoordinator callbacks

--- a/Sources/KeyPathAppKit/Managers/ServiceLifecycleCoordinator.swift
+++ b/Sources/KeyPathAppKit/Managers/ServiceLifecycleCoordinator.swift
@@ -166,8 +166,8 @@ final class ServiceLifecycleCoordinator {
     /// Called to notify the UI of a state change.
     var onStateChanged: (() -> Void)?
 
-    /// Called to check whether the Karabiner daemon is running.
-    var isKarabinerDaemonRunning: (() async -> Bool)?
+    /// Called to check whether the VirtualHID daemon is healthy.
+    var isVirtualHIDDaemonHealthy: (() async -> Bool)?
 
     // MARK: - Init
 
@@ -197,23 +197,10 @@ final class ServiceLifecycleCoordinator {
             isStartingKanata = false
         }
 
-        if let checker = isKarabinerDaemonRunning, await !checker() {
+        let vhidHealthy = await isVirtualHIDDaemonHealthy?() ?? false
+        if !VHIDSafetyCheck.canStartKanata(vhidDaemonHealthy: vhidHealthy) {
             AppLogger.shared.errorUnlessQuietTest("❌ [Service] Cannot start Kanata - VirtualHID daemon is not running")
             onError?("Cannot start: Karabiner VirtualHID daemon is not running. Please complete the setup wizard.")
-            onStateChanged?()
-            return false
-        }
-
-        // Second safety layer: verify VirtualHID daemon via ServiceHealthChecker
-        // (the callback above relies on the caller wiring it; this is a direct check)
-        let vhidHealthy = await ServiceHealthChecker.shared.isServiceHealthy(
-            serviceID: ServiceHealthChecker.vhidDaemonServiceID
-        )
-        if !VHIDSafetyCheck.canStartKanata(vhidDaemonHealthy: vhidHealthy) {
-            AppLogger.shared.errorUnlessQuietTest(
-                "❌ [Service] Cannot start kanata — VirtualHID daemon not healthy (ServiceHealthChecker)"
-            )
-            onError?("Cannot start: VirtualHID daemon health check failed. Please reinstall drivers.")
             onStateChanged?()
             return false
         }
@@ -424,7 +411,7 @@ final class ServiceLifecycleCoordinator {
     func startKanataWithValidation() async {
         await recoveryCoordinator.startKanataWithValidation(
             isKarabinerDaemonRunning: { [weak self] in
-                guard let self, let checker = isKarabinerDaemonRunning else { return false }
+                guard let self, let checker = isVirtualHIDDaemonHealthy else { return false }
                 return await checker()
             },
             startKanata: { [weak self] in

--- a/Tests/KeyPathTests/Lint/W6DeletionPassLintTests.swift
+++ b/Tests/KeyPathTests/Lint/W6DeletionPassLintTests.swift
@@ -161,6 +161,29 @@ final class W6DeletionPassLintTests: XCTestCase {
             """
         )
     }
+
+    func testServiceLifecycleCoordinatorDoesNotRegrowDuplicateVHIDStartCheck() throws {
+        let coordinatorFile = repositoryRoot()
+            .appendingPathComponent("Sources/KeyPathAppKit/Managers/ServiceLifecycleCoordinator.swift")
+
+        let violations = try matchingLines(
+            in: coordinatorFile,
+            patterns: [
+                #"Second safety layer"#,
+                #"serviceID:\s*ServiceHealthChecker\.vhidDaemonServiceID"#,
+            ]
+        )
+
+        XCTAssertTrue(
+            violations.isEmpty,
+            """
+            W6 removes duplicated in-path service checks. startKanata should \
+            use the injected VirtualHID daemon health predicate once instead \
+            of performing a second ServiceHealthChecker query in the start path:
+            \(violations.sorted().joined(separator: "\n"))
+            """
+        )
+    }
 }
 
 private func repositoryRoot(file: StaticString = #filePath) -> URL {

--- a/Tests/KeyPathTests/Services/ServiceLifecycleCoordinatorTests.swift
+++ b/Tests/KeyPathTests/Services/ServiceLifecycleCoordinatorTests.swift
@@ -35,7 +35,7 @@ final class ServiceLifecycleCoordinatorTests: KeyPathTestCase {
     // MARK: - Start gating
 
     func testStartFailsWhenVHIDDaemonNotRunning() async {
-        coordinator.isKarabinerDaemonRunning = { false }
+        coordinator.isVirtualHIDDaemonHealthy = { false }
 
         let result = await coordinator.startKanata(reason: "test")
 
@@ -46,7 +46,7 @@ final class ServiceLifecycleCoordinatorTests: KeyPathTestCase {
     }
 
     func testStartSetsIsStartingFlag() async {
-        coordinator.isKarabinerDaemonRunning = { true }
+        coordinator.isVirtualHIDDaemonHealthy = { true }
 
         // isStartingKanata should be false before and after (defer resets it)
         XCTAssertFalse(coordinator.isStartingKanata)
@@ -55,8 +55,7 @@ final class ServiceLifecycleCoordinatorTests: KeyPathTestCase {
     }
 
     func testStartTerminatesRunningKanataWhenBinaryDoesNotMatchBundledRuntime() async {
-        coordinator.isKarabinerDaemonRunning = { true }
-        ServiceHealthChecker.testForcedServiceHealth = [ServiceHealthChecker.vhidDaemonServiceID: true]
+        coordinator.isVirtualHIDDaemonHealthy = { true }
 
         let privileged = StubPrivilegedOperationsCoordinator()
         WizardDependencies.privilegedOperations = privileged
@@ -78,8 +77,7 @@ final class ServiceLifecycleCoordinatorTests: KeyPathTestCase {
     }
 
     func testStartTerminatesRunningKanataWhenSamePathButProcessPredatesBundledBinary() async throws {
-        coordinator.isKarabinerDaemonRunning = { true }
-        ServiceHealthChecker.testForcedServiceHealth = [ServiceHealthChecker.vhidDaemonServiceID: true]
+        coordinator.isVirtualHIDDaemonHealthy = { true }
 
         let privileged = StubPrivilegedOperationsCoordinator()
         WizardDependencies.privilegedOperations = privileged
@@ -163,7 +161,7 @@ final class ServiceLifecycleCoordinatorTests: KeyPathTestCase {
         // The stop-grace exists only to swallow the OLD process's last gasp. Once a new
         // start begins (e.g. the start phase of a restart), the grace must end so a
         // genuine `active=false` from the freshly started kanata is NOT masked as benign.
-        coordinator.isKarabinerDaemonRunning = { true }
+        coordinator.isVirtualHIDDaemonHealthy = { true }
         _ = await coordinator.stopKanata(reason: "stop for restart")
         XCTAssertTrue(coordinator.isIntentionalTransitionInProgress, "Grace armed after stop")
 
@@ -178,7 +176,7 @@ final class ServiceLifecycleCoordinatorTests: KeyPathTestCase {
     // MARK: - Restart
 
     func testRestartCallsStopThenStart() async {
-        coordinator.isKarabinerDaemonRunning = { true }
+        coordinator.isVirtualHIDDaemonHealthy = { true }
 
         // Restart should call stop then start
         let result = await coordinator.restartKanata(reason: "test restart")

--- a/docs/planning/installer-reliability-phase1.md
+++ b/docs/planning/installer-reliability-phase1.md
@@ -798,6 +798,10 @@ realistic without losing capability. Measure before/after.
   `smAppServicePendingCache`, using `KanataDaemonManager.currentManagementState`
   as the provider-owned cache instead. Enforced by
   `W6DeletionPassLintTests.testServiceLifecycleCoordinatorDoesNotRegrowSMAppServicePendingCache`.
+- [x] Removed the duplicate "second safety layer" VirtualHID daemon check from
+  `ServiceLifecycleCoordinator.startKanata`, leaving one injected
+  `isVirtualHIDDaemonHealthy` predicate for the start gate. Enforced by
+  `W6DeletionPassLintTests.testServiceLifecycleCoordinatorDoesNotRegrowDuplicateVHIDStartCheck`.
 - [ ] Remaining single-implementation protocols, duplicate in-path checks,
   cache consolidation, and DEBUG-only seams still need separate deletion PRs.
 


### PR DESCRIPTION
## Summary
- remove the duplicate "second safety layer" VHID daemon check in `ServiceLifecycleCoordinator.startKanata`
- replace the old callback name with one injected `isVirtualHIDDaemonHealthy` start-gate predicate
- add a W6 lint ratchet so the direct second VHID check does not regrow
- update the Phase 1 plan doc status with the enforcing test

## Acceptance Criteria
- W6 duplicate in-path check removal: `W6DeletionPassLintTests.testServiceLifecycleCoordinatorDoesNotRegrowDuplicateVHIDStartCheck` enforces that `ServiceLifecycleCoordinator` does not regrow the old "Second safety layer" or a direct `ServiceHealthChecker.vhidDaemonServiceID` query in the start path.
- Lifecycle behavior remains covered by `ServiceLifecycleCoordinatorTests`, including `testStartFailsWhenVHIDDaemonNotRunning`, `testStartSetsIsStartingFlag`, restart, and stale runtime recovery tests.

## Validation
- Focused safe gate: `TEST_FILTER='ServiceLifecycleCoordinatorTests|W6DeletionPassLintTests|RuntimeCoordinatorTests/testInitialState' KEYPATH_SNAPSHOTS=0 ./Scripts/run-tests-safe.sh` -> 30 passed.
- Full safe gate: `KEYPATH_SNAPSHOTS=0 ./Scripts/run-tests-safe.sh` -> 4,538 passed.
- Branch freshness: `git rev-list --left-right --count origin/master...HEAD` -> `0 1` before push.
- Review gate: `./Scripts/review-gate.sh` selected remote review; `REVIEW_GATE_EXIT=2`. GitHub `claude-review` must pass before merge.

## Plan Notes
No plan/code conflict found. This is the W6 duplicate in-path VHID start-check deletion slice.
