### PR TITLE
Delete helper version cache

### DIFF
--- a/Sources/KeyPathAppKit/Core/HelperManager+ConnectionLifecycle.swift
+++ b/Sources/KeyPathAppKit/Core/HelperManager+ConnectionLifecycle.swift
@@ -79,8 +79,6 @@ extension HelperManager {
         AppLogger.shared.log("🧹 [HelperManager] Clearing XPC connection cache")
         connection?.invalidate()
         connection = nil
-        // Clear cached version when connection is cleared (might be stale)
-        cachedHelperVersion = nil
     }
 
     /// Check if helper process is still running

--- a/Sources/KeyPathAppKit/Core/HelperManager+Status.swift
+++ b/Sources/KeyPathAppKit/Core/HelperManager+Status.swift
@@ -44,11 +44,6 @@ extension HelperManager {
     /// Get the version of the installed helper
     /// - Returns: Version string, or nil if helper not installed or version check fails
     public func getHelperVersion() async -> String? {
-        // Return cached version if available
-        if let cached = cachedHelperVersion {
-            return cached
-        }
-
         // Bypass XPC call in tests
         if TestEnvironment.isRunningTests {
             AppLogger.shared.log("🧪 [HelperManager] Test mode - returning mock version")
@@ -122,11 +117,6 @@ extension HelperManager {
                 AppLogger.shared.log(
                     "📤 [HelperManager] proxy.getVersion() call dispatched, waiting for callback"
                 )
-            }
-            // Cache the version so subsequent calls within the same session don't
-            // repeat the full XPC round-trip. Cleared by clearConnection().
-            if let version {
-                cachedHelperVersion = version
             }
             return version
         } catch {

--- a/Sources/KeyPathAppKit/Core/HelperManager.swift
+++ b/Sources/KeyPathAppKit/Core/HelperManager.swift
@@ -76,9 +76,6 @@ public actor HelperManager {
     /// Expected helper version (should match HelperService.version)
     static let expectedHelperVersion = "1.0.0"
 
-    /// Cached helper version (lazy loaded)
-    var cachedHelperVersion: String?
-
     /// Active XPC call tracking for detecting concurrency issues
     var activeXPCCalls: Set<String> = []
 

--- a/Tests/KeyPathTests/Lint/W6DeletionPassLintTests.swift
+++ b/Tests/KeyPathTests/Lint/W6DeletionPassLintTests.swift
@@ -184,6 +184,33 @@ final class W6DeletionPassLintTests: XCTestCase {
             """
         )
     }
+
+    func testHelperManagerDoesNotRegrowCachedHelperVersion() throws {
+        let helperFiles = [
+            repositoryRoot().appendingPathComponent("Sources/KeyPathAppKit/Core/HelperManager.swift"),
+            repositoryRoot().appendingPathComponent("Sources/KeyPathAppKit/Core/HelperManager+Status.swift"),
+            repositoryRoot().appendingPathComponent("Sources/KeyPathAppKit/Core/HelperManager+ConnectionLifecycle.swift"),
+        ]
+
+        let violations = try helperFiles.flatMap { file in
+            try matchingLines(
+                in: file,
+                patterns: [
+                    #"\bcachedHelperVersion\b"#,
+                ]
+            )
+        }
+
+        XCTAssertTrue(
+            violations.isEmpty,
+            """
+            W6 collapses installer helper state into current provider/XPC \
+            evidence instead of keeping an actor-local helper-version cache. \
+            Do not regrow cachedHelperVersion:
+            \(violations.sorted().joined(separator: "\n"))
+            """
+        )
+    }
 }
 
 private func repositoryRoot(file: StaticString = #filePath) -> URL {

--- a/docs/planning/installer-reliability-phase1.md
+++ b/docs/planning/installer-reliability-phase1.md
@@ -776,7 +776,7 @@ removed):
 **Target:** the subsystem is ~34K LOC (~19% of the app). A 25–35% reduction is
 realistic without losing capability. Measure before/after.
 
-**Status (2026-07-08):** W6 deletion pass in progress.
+**Status (2026-07-08):** W6 deletion pass complete for Phase 1.
 - [x] Removed the single-implementation `KarabinerConflictManaging` protocol
   and wired its consumers to the concrete `KarabinerConflictService`. Enforced
   by
@@ -802,8 +802,16 @@ realistic without losing capability. Measure before/after.
   `ServiceLifecycleCoordinator.startKanata`, leaving one injected
   `isVirtualHIDDaemonHealthy` predicate for the start gate. Enforced by
   `W6DeletionPassLintTests.testServiceLifecycleCoordinatorDoesNotRegrowDuplicateVHIDStartCheck`.
-- [ ] Remaining single-implementation protocols, duplicate in-path checks,
-  cache consolidation, and DEBUG-only seams still need separate deletion PRs.
+- [x] Removed `HelperManager`'s actor-local `cachedHelperVersion`, so helper
+  freshness checks use current XPC/provider evidence instead of a session cache.
+  Enforced by
+  `W6DeletionPassLintTests.testHelperManagerDoesNotRegrowCachedHelperVersion`.
+- [x] Final W6 Phase 1 audit complete: the named single-implementation
+  protocols, duplicate start-path checks, and named installer caches are deleted
+  or ratcheted. Enforced by the `W6DeletionPassLintTests` ratchet suite. The
+  remaining `nonisolated(unsafe)` seams are retained outside the Phase 1
+  deletion surface or as ADR-019-style OS primitive/test seams, not as duplicate
+  installer repair state.
 
 ## Sequencing
 


### PR DESCRIPTION
## Summary
- delete `HelperManager.cachedHelperVersion` and its connection-reset invalidation hook
- make helper version/freshness checks use current XPC/provider evidence instead of a session cache
- add a W6 lint ratchet so the helper-version cache does not regrow
- update the Phase 1 plan doc to mark W6 complete for Phase 1, with retained ADR-019/test seams called out explicitly

## Acceptance Criteria
- W6 cache consolidation: `W6DeletionPassLintTests.testHelperManagerDoesNotRegrowCachedHelperVersion` enforces that `HelperManager`, `HelperManager+Status`, and `HelperManager+ConnectionLifecycle` do not regrow `cachedHelperVersion`.
- Final W6 audit: the full `W6DeletionPassLintTests` suite now ratchets the deleted single-implementation protocols, duplicate VHID start check, SMAppService pending cache, and helper-version cache.
- Helper behavior remains covered by `HelperManagerTests` and `HelperMaintenanceTests`.

## Validation
- Focused helper/W6 gate: `TEST_FILTER='HelperManagerTests|HelperMaintenanceTests|W6DeletionPassLintTests' KEYPATH_SNAPSHOTS=0 ./Scripts/run-tests-safe.sh` -> 20 passed.
- Full safe gate: `KEYPATH_SNAPSHOTS=0 ./Scripts/run-tests-safe.sh` -> 4,539 passed.
- Post-doc W6 ratchet gate: `TEST_FILTER='W6DeletionPassLintTests' KEYPATH_SNAPSHOTS=0 ./Scripts/run-tests-safe.sh` -> 7 passed.
- Branch freshness: `git rev-list --left-right --count origin/master...HEAD` -> `0 1` before push.
- Review gate: `./Scripts/review-gate.sh` selected remote review; `REVIEW_GATE_EXIT=2`. GitHub `claude-review` must pass before merge.

## Plan Notes
This PR marks Workstream 6 complete for Phase 1. No plan/code conflict found. Remaining `nonisolated(unsafe)` hits are outside this Phase 1 deletion surface or retained as ADR-019-style OS primitive/test seams rather than duplicate installer repair state.
