### PR TITLE
Normalize native SwiftPM build-system override

### DIFF
--- a/Scripts/build-and-sign.sh
+++ b/Scripts/build-and-sign.sh
@@ -214,7 +214,11 @@ fi
 
 echo "🏗️  Building KeyPath and plugins..."
 # Build all products in a single SwiftPM invocation to share module compilation.
-swift build ${KEYPATH_BUILD_SYSTEM:+--build-system "$KEYPATH_BUILD_SYSTEM"} --configuration release -Xswiftc -no-whole-module-optimization
+BUILD_SYSTEM_FLAGS=()
+if [[ -n "${KEYPATH_BUILD_SYSTEM:-}" && "${KEYPATH_BUILD_SYSTEM:-}" != "native" ]]; then
+    BUILD_SYSTEM_FLAGS=(--build-system "$KEYPATH_BUILD_SYSTEM")
+fi
+swift build ${BUILD_SYSTEM_FLAGS[@]+"${BUILD_SYSTEM_FLAGS[@]}"} --configuration release -Xswiftc -no-whole-module-optimization
 
 echo "📦 Creating app bundle..."
 APP_NAME="KeyPath"

--- a/Scripts/build-helper.sh
+++ b/Scripts/build-helper.sh
@@ -35,13 +35,17 @@ fi
 # Build helper with embedded Info.plist
 echo "1️⃣  Building helper executable..."
 HELPER_INFO_PLIST="Sources/KeyPathHelper/Info.plist"
+BUILD_SYSTEM_FLAGS=()
+if [[ -n "${KEYPATH_BUILD_SYSTEM:-}" && "${KEYPATH_BUILD_SYSTEM:-}" != "native" ]]; then
+    BUILD_SYSTEM_FLAGS=(--build-system "$KEYPATH_BUILD_SYSTEM")
+fi
 
 if [ ! -f "$HELPER_INFO_PLIST" ]; then
     echo "❌ ERROR: Helper Info.plist not found: $HELPER_INFO_PLIST"
     exit 1
 fi
 
-swift build ${KEYPATH_BUILD_SYSTEM:+--build-system "$KEYPATH_BUILD_SYSTEM"} --configuration release --product "$HELPER_NAME" \
+swift build ${BUILD_SYSTEM_FLAGS[@]+"${BUILD_SYSTEM_FLAGS[@]}"} --configuration release --product "$HELPER_NAME" \
     -Xswiftc -no-whole-module-optimization \
     -Xlinker -sectcreate -Xlinker __TEXT -Xlinker __info_plist -Xlinker "$HELPER_INFO_PLIST"
 

--- a/Scripts/quick-deploy.sh
+++ b/Scripts/quick-deploy.sh
@@ -254,10 +254,10 @@ fi
 echo "🔨 Building..."
 BUILD_LOG="$BUILD_LOG_DIR/build-${BUILD_ID}.log"
 write_build_log_header "$BUILD_LOG"
-# Optional build-system override (e.g. KEYPATH_BUILD_SYSTEM=native on toolchains
-# whose default swiftbuild system is broken). Unset = use the toolchain default.
+# Optional build-system override. Unset, or the legacy value "native", means use
+# the toolchain default; SwiftPM now warns when passed --build-system native.
 BUILD_SYSTEM_FLAGS=()
-if [[ -n "${KEYPATH_BUILD_SYSTEM:-}" ]]; then
+if [[ -n "${KEYPATH_BUILD_SYSTEM:-}" && "${KEYPATH_BUILD_SYSTEM:-}" != "native" ]]; then
     BUILD_SYSTEM_FLAGS=(--build-system "$KEYPATH_BUILD_SYSTEM")
 fi
 # ${arr[@]+...} guard: bash 3.2 under `set -u` treats expanding an empty array as unbound


### PR DESCRIPTION
## Summary
- Treat legacy `KEYPATH_BUILD_SYSTEM=native` as the SwiftPM default in quick deploy, helper build, and release build scripts.
- Preserve explicit non-native `KEYPATH_BUILD_SYSTEM` overrides for future toolchain workarounds.
- Removes the repeated SwiftPM deprecation wart without requiring shell-profile cleanup.

## Validation
- `bash -n Scripts/quick-deploy.sh Scripts/build-helper.sh Scripts/build-and-sign.sh`
- `KEYPATH_BUILD_SYSTEM=native ./Scripts/quick-deploy.sh`
- `rg -- '--build-system native|deprecated|will be removed' /tmp/keypath-quick-deploy-build-system.log` returned no matches\n- `REQUIRE_NOTARIZED=0 REQUIRE_STAPLED=0 ./Scripts/verify-installed-app.sh`\n- `KEYPATH_SNAPSHOTS=0 ./Scripts/run-tests-safe.sh` -> 4539 passed\n- Branch freshness before commit: `git rev-list --left-right --count origin/master...HEAD` -> `0 0`\n- Review gate: `./Scripts/review-gate.sh` -> `REVIEW_GATE_EXIT=2` (remote GitHub claude-review gate selected)\n\n## Notes\n- Workstreams 3 and 6 are already complete on `master`; this is post-Phase-1 build-process cleanup.\n