### PR TITLE
Preserve runtime evidence in wizard matrix snapshots

### DIFF
--- a/Sources/KeyPathAppKit/Services/System/SystemValidator.swift
+++ b/Sources/KeyPathAppKit/Services/System/SystemValidator.swift
@@ -626,13 +626,18 @@ public class SystemValidator {
         }
 
         return HealthStatus(
+            kanataLaunchdLoaded: !kanataHealth.staleEnabledRegistration &&
+                (kanataHealth.launchctlExitCode == 0 || kanataHealth.isRunning),
+            kanataProcessRunning: kanataHealth.isRunning,
+            kanataTCPResponding: kanataHealth.isResponding,
             kanataRunning: kanataRunning,
             karabinerDaemonRunning: karabinerDaemonRunning,
             vhidHealthy: vhidHealthy,
             kanataInputCaptureReady: kanataHealth.inputCaptureReady,
             kanataInputCaptureIssue: kanataHealth.inputCaptureIssue,
             kanataPermissionRejected: stderrDiagnosis.permissionRejected,
-            configParseError: configParseError
+            configParseError: configParseError,
+            staleEnabledRegistration: kanataHealth.staleEnabledRegistration
         )
     }
 

--- a/Sources/KeyPathInstallationWizard/Core/InstallerEngine.swift
+++ b/Sources/KeyPathInstallationWizard/Core/InstallerEngine.swift
@@ -80,6 +80,9 @@ public final class InstallerEngine {
         let activeRuntimePathStatus: (title: String, detail: String)? = nil
 
         let services = HealthStatus(
+            kanataLaunchdLoaded: snapshot.health.kanataLaunchdLoaded,
+            kanataProcessRunning: snapshot.health.kanataProcessRunning,
+            kanataTCPResponding: snapshot.health.kanataTCPResponding,
             kanataRunning: snapshot.health.kanataRunning,
             karabinerDaemonRunning: snapshot.health.karabinerDaemonRunning,
             vhidHealthy: snapshot.health.vhidHealthy,
@@ -87,7 +90,9 @@ public final class InstallerEngine {
             kanataInputCaptureIssue: snapshot.health.kanataInputCaptureIssue,
             activeRuntimePathTitle: activeRuntimePathStatus?.title,
             activeRuntimePathDetail: activeRuntimePathStatus?.detail,
-            kanataPermissionRejected: snapshot.health.kanataPermissionRejected
+            kanataPermissionRejected: snapshot.health.kanataPermissionRejected,
+            configParseError: snapshot.health.configParseError,
+            staleEnabledRegistration: snapshot.health.staleEnabledRegistration
         )
 
         // Convert SystemSnapshot to SystemContext

--- a/Sources/KeyPathInstallationWizard/Core/InstallerStateMatrix.swift
+++ b/Sources/KeyPathInstallationWizard/Core/InstallerStateMatrix.swift
@@ -239,8 +239,12 @@ public enum InstallerStateMatrixPlanner {
 public extension SystemContext {
     var installerStateMatrixSnapshot: InstallerStateMatrixSnapshot {
         let driverKitApprovalPending = requiresManualVHIDDriverApproval
+        let kanataProcessRunning = services.kanataProcessRunning ?? services.kanataRunning
+        let kanataTCPResponding = services.kanataTCPResponding ?? services.kanataRunning
+        let launchdJobLoaded = !services.staleEnabledRegistration && (services.kanataLaunchdLoaded
+            ?? (kanataProcessRunning || components.kanataBinaryInstalled))
         let inputCaptureIssuePresent = !services.kanataInputCaptureReady
-        let staleInputCaptureIssue = !services.kanataRunning
+        let staleInputCaptureIssue = !kanataProcessRunning
             && inputCaptureIssuePresent
             && !driverKitApprovalPending
 
@@ -248,10 +252,10 @@ public extension SystemContext {
             kanataBinaryPresent: components.kanataBinaryInstalled,
             requiredRuntimePayloadPresent: true,
             smAppServiceRegistered: components.kanataBinaryInstalled,
-            launchdJobLoaded: services.kanataRunning || components.kanataBinaryInstalled,
-            kanataProcessRunning: services.kanataRunning,
-            kanataTCPResponding: services.kanataRunning,
-            currentInputCaptureIssue: services.kanataRunning && inputCaptureIssuePresent,
+            launchdJobLoaded: launchdJobLoaded,
+            kanataProcessRunning: kanataProcessRunning,
+            kanataTCPResponding: kanataTCPResponding,
+            currentInputCaptureIssue: kanataProcessRunning && kanataTCPResponding && inputCaptureIssuePresent,
             staleInputCaptureIssue: staleInputCaptureIssue,
             driverKitApprovalPending: driverKitApprovalPending,
             virtualHIDDriverPresent: components.karabinerDriverInstalled,

--- a/Sources/KeyPathWizardCore/SystemSnapshot.swift
+++ b/Sources/KeyPathWizardCore/SystemSnapshot.swift
@@ -269,6 +269,15 @@ public struct ConflictStatus: Sendable {
 // MARK: - Health Status
 
 public struct HealthStatus: Sendable {
+    /// True when launchd can find/load the Kanata job. This is distinct from
+    /// the runtime being usable: launchd can know about a job whose process is
+    /// stopped or whose TCP server is not responding.
+    public let kanataLaunchdLoaded: Bool?
+    /// True when current process evidence shows the Kanata runtime process
+    /// exists. This must not be collapsed with TCP or input-capture readiness.
+    public let kanataProcessRunning: Bool?
+    /// True when the Kanata TCP health endpoint responds.
+    public let kanataTCPResponding: Bool?
     public let kanataRunning: Bool
     public let karabinerDaemonRunning: Bool
     public let vhidHealthy: Bool
@@ -284,8 +293,14 @@ public struct HealthStatus: Sendable {
     /// (e.g., duplicate alias, syntax error). This causes kanata to exit
     /// immediately and crash-loop. The string is a user-facing error message.
     public let configParseError: String?
+    /// True when SMAppService reports enabled but launchd/runtime evidence
+    /// cannot prove the submitted job exists or can load.
+    public let staleEnabledRegistration: Bool
 
     public init(
+        kanataLaunchdLoaded: Bool? = nil,
+        kanataProcessRunning: Bool? = nil,
+        kanataTCPResponding: Bool? = nil,
         kanataRunning: Bool,
         karabinerDaemonRunning: Bool,
         vhidHealthy: Bool,
@@ -294,8 +309,12 @@ public struct HealthStatus: Sendable {
         activeRuntimePathTitle: String? = nil,
         activeRuntimePathDetail: String? = nil,
         kanataPermissionRejected: Bool = false,
-        configParseError: String? = nil
+        configParseError: String? = nil,
+        staleEnabledRegistration: Bool = false
     ) {
+        self.kanataLaunchdLoaded = kanataLaunchdLoaded
+        self.kanataProcessRunning = kanataProcessRunning
+        self.kanataTCPResponding = kanataTCPResponding
         self.kanataRunning = kanataRunning
         self.karabinerDaemonRunning = karabinerDaemonRunning
         self.vhidHealthy = vhidHealthy
@@ -305,6 +324,7 @@ public struct HealthStatus: Sendable {
         self.activeRuntimePathDetail = activeRuntimePathDetail
         self.kanataPermissionRejected = kanataPermissionRejected
         self.configParseError = configParseError
+        self.staleEnabledRegistration = staleEnabledRegistration
     }
 
     /// Overall health (includes Kanata runtime)

--- a/Tests/KeyPathTests/Core/SystemStateProviderInstallerStateMatrixTests.swift
+++ b/Tests/KeyPathTests/Core/SystemStateProviderInstallerStateMatrixTests.swift
@@ -1,6 +1,7 @@
 @testable import KeyPathAppKit
 @testable import KeyPathCore
 @testable import KeyPathInstallationWizard
+@testable import KeyPathPermissions
 @testable import KeyPathWizardCore
 import ServiceManagement
 @preconcurrency import XCTest
@@ -102,6 +103,40 @@ final class SystemStateProviderInstallerStateMatrixTests: XCTestCase {
         XCTAssertEqual(InstallerStateMatrixPlanner.plan(for: snapshot), [.repairVHIDServices])
     }
 
+    func testWizardSystemContextSnapshotPreservesRunningButTCPNotRespondingEvidence() {
+        assertWizardAndProviderClassifySameRuntimeEvidence(
+            runtime: runtime(isRunning: true, isResponding: false),
+            expectedRow: .runningButTCPNotResponding,
+            expectedPlan: [.restartOrRecoverKanataRuntime]
+        )
+    }
+
+    func testWizardSystemContextSnapshotPreservesRunningButInputCaptureFailingEvidence() {
+        assertWizardAndProviderClassifySameRuntimeEvidence(
+            runtime: runtime(
+                isRunning: true,
+                isResponding: true,
+                inputCaptureReady: false,
+                inputCaptureIssue: ServiceHealthChecker.inputCaptureBuiltInKeyboardReason
+            ),
+            expectedRow: .runningButInputCaptureFailing,
+            expectedPlan: [.repairVHIDActivationServices]
+        )
+    }
+
+    func testWizardSystemContextSnapshotPreservesStaleEnabledRegistrationEvidence() {
+        assertWizardAndProviderClassifySameRuntimeEvidence(
+            runtime: runtime(
+                isRunning: false,
+                isResponding: false,
+                launchctlExitCode: 113,
+                staleEnabledRegistration: true
+            ),
+            expectedRow: .registeredButNotLoaded,
+            expectedPlan: [.recoverRuntimeRegistrationBypassingThrottle]
+        )
+    }
+
     private var healthyComponents: ComponentStatus {
         ComponentStatus(
             kanataBinaryInstalled: true,
@@ -116,6 +151,65 @@ final class SystemStateProviderInstallerStateMatrixTests: XCTestCase {
 
     private var healthyHelper: HelperStatus {
         HelperStatus(isInstalled: true, version: "1.0.0", isWorking: true)
+    }
+
+    private func assertWizardAndProviderClassifySameRuntimeEvidence(
+        runtime: ServiceHealthChecker.KanataServiceRuntimeSnapshot,
+        expectedRow: InstallerStateMatrixRow,
+        expectedPlan: [InstallerStateMatrixAction],
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let providerSnapshot = SystemStateProvider.installerStateMatrixSnapshot(
+            components: healthyComponents,
+            helper: healthyHelper,
+            runtime: runtime,
+            kanataSMAppServiceStatus: .enabled,
+            helperSMAppServiceStatus: .enabled
+        )
+        let wizardSnapshot = systemContext(from: runtime).installerStateMatrixSnapshot
+
+        XCTAssertEqual(wizardSnapshot, providerSnapshot, file: file, line: line)
+        XCTAssertEqual(InstallerStateMatrixPlanner.classify(wizardSnapshot), expectedRow, file: file, line: line)
+        XCTAssertEqual(InstallerStateMatrixPlanner.plan(for: wizardSnapshot), expectedPlan, file: file, line: line)
+    }
+
+    private func systemContext(from runtime: ServiceHealthChecker.KanataServiceRuntimeSnapshot) -> SystemContext {
+        let permissionSet = PermissionOracle.PermissionSet(
+            accessibility: .granted,
+            inputMonitoring: .granted,
+            source: "test",
+            confidence: .high,
+            timestamp: Date()
+        )
+        let permissions = PermissionOracle.Snapshot(
+            keyPath: permissionSet,
+            kanata: permissionSet,
+            timestamp: Date()
+        )
+        let runtimeReady = runtime.isRunning && runtime.isResponding && runtime.inputCaptureReady
+        let launchdJobLoaded = !runtime.staleEnabledRegistration &&
+            (runtime.launchctlExitCode == 0 || runtime.isRunning)
+
+        return SystemContext(
+            permissions: permissions,
+            services: HealthStatus(
+                kanataLaunchdLoaded: launchdJobLoaded,
+                kanataProcessRunning: runtime.isRunning,
+                kanataTCPResponding: runtime.isResponding,
+                kanataRunning: runtimeReady,
+                karabinerDaemonRunning: true,
+                vhidHealthy: true,
+                kanataInputCaptureReady: runtime.inputCaptureReady,
+                kanataInputCaptureIssue: runtime.inputCaptureIssue,
+                staleEnabledRegistration: runtime.staleEnabledRegistration
+            ),
+            conflicts: .empty,
+            components: healthyComponents,
+            helper: healthyHelper,
+            system: EngineSystemInfo(macOSVersion: "15.0", driverCompatible: true),
+            timestamp: Date()
+        )
     }
 
     private func runtime(

--- a/Tests/KeyPathTests/TestSupport/SystemContextBuilder.swift
+++ b/Tests/KeyPathTests/TestSupport/SystemContextBuilder.swift
@@ -9,6 +9,9 @@ struct SystemContextBuilder {
     var permissionsStatus: PermissionOracle.Status = .granted
     var helperReady: Bool = true
     var servicesHealthy: Bool = false
+    var kanataLaunchdLoaded: Bool?
+    var kanataProcessRunning: Bool?
+    var kanataTCPResponding: Bool?
     var kanataRunning: Bool?
     var karabinerDaemonRunning: Bool?
     var vhidHealthy: Bool?
@@ -52,6 +55,9 @@ struct SystemContextBuilder {
         }
 
         let services = HealthStatus(
+            kanataLaunchdLoaded: kanataLaunchdLoaded,
+            kanataProcessRunning: kanataProcessRunning,
+            kanataTCPResponding: kanataTCPResponding,
             kanataRunning: kanataRunning ?? servicesHealthy,
             karabinerDaemonRunning: karabinerDaemonRunning ?? servicesHealthy,
             vhidHealthy: vhidHealthy ?? servicesHealthy,


### PR DESCRIPTION
## Summary
- Add raw Kanata launchd/process/TCP evidence to `HealthStatus` without breaking existing callers.
- Populate those fields from `SystemValidator` and preserve them through `InstallerEngine.inspectSystem()`.
- Update the wizard `SystemContext` -> state-matrix bridge so running, TCP responding, input-capture, and stale-registration evidence are no longer collapsed into one `kanataRunning` bit.
- Add cross-path equivalence tests proving wizard materialization and the live `SystemStateProvider` adapter classify the same runtime evidence into the same row/plan.

## Review feedback addressed
This addresses the high-priority finding that the wizard bridge made `runningButTCPNotResponding`, `runningButInputCaptureFailing`, and stale enabled-registration rows unreachable or misclassified from wizard materialization.

## Validation
- `TEST_FILTER=SystemStateProviderInstallerStateMatrixTests ./Scripts/run-tests-safe.sh` -> 9 passed
- `KEYPATH_SNAPSHOTS=0 ./Scripts/run-tests-safe.sh` -> 4542 passed
- `python3 Scripts/check-accessibility.py` -> all UI elements have accessibility identifiers
- Branch freshness before commit: `git rev-list --left-right --count origin/master...HEAD` -> `0 0`
- Review gate: `./Scripts/review-gate.sh` -> `REVIEW_GATE_EXIT=2` (remote GitHub claude-review gate selected)

## Snapshot note
- `KEYPATH_SNAPSHOTS=1` / `KeyPathSnapshotTests` currently fails locally with widespread unrelated Swift snapshot rendering failures and `NSConcreteValue CGRectValue` exceptions inside `swift-snapshot-testing`. This PR does not touch UI rendering; the non-snapshot full safe gate is green.
