### PR TITLE
Pin state matrix golden tests to markdown rows

### DIFF
--- a/Tests/KeyPathTests/InstallationEngine/InstallerStateMatrixGoldenTests.swift
+++ b/Tests/KeyPathTests/InstallationEngine/InstallerStateMatrixGoldenTests.swift
@@ -2,6 +2,21 @@
 @preconcurrency import XCTest
 
 final class InstallerStateMatrixGoldenTests: XCTestCase {
+    func testStateMatrixMarkdownRowsMatchClassifierRows() throws {
+        let documentedRows = try documentedStateMatrixRows()
+        let classifierRows = InstallerStateMatrixRow.allCases.map(\.rawValue)
+
+        XCTAssertEqual(
+            documentedRows,
+            classifierRows,
+            """
+            docs/process/installer-repair-state-matrix.md is the source-of-truth \
+            state matrix. Keep the markdown table and InstallerStateMatrixRow \
+            in the same order so the golden suite pins the documented contract.
+            """
+        )
+    }
+
     func testEveryDocumentedStateMatrixRowHasAGoldenFixture() {
         XCTAssertEqual(
             Set(goldenCases.map(\.expectedRow)),
@@ -25,6 +40,38 @@ final class InstallerStateMatrixGoldenTests: XCTestCase {
         let snapshot: InstallerStateMatrixSnapshot
         let expectedRow: InstallerStateMatrixRow
         let expectedPlan: [InstallerStateMatrixAction]
+    }
+
+    private func documentedStateMatrixRows() throws -> [String] {
+        let docURL = repositoryRoot()
+            .appendingPathComponent("docs/process/installer-repair-state-matrix.md")
+        let contents = try String(contentsOf: docURL, encoding: .utf8)
+        let lines = contents.components(separatedBy: .newlines)
+
+        guard let headerIndex = lines.firstIndex(where: { line in
+            line.trimmingCharacters(in: .whitespaces) == "| State | Typical Evidence | Planner Should | Success Postcondition | Test Requirement |"
+        }) else {
+            XCTFail("Could not find state-matrix table header in \(docURL.path)")
+            return []
+        }
+
+        return lines.dropFirst(headerIndex + 2).prefix { line in
+            line.trimmingCharacters(in: .whitespaces).hasPrefix("|")
+        }.compactMap { line in
+            let columns = line
+                .split(separator: "|", omittingEmptySubsequences: false)
+                .map { $0.trimmingCharacters(in: .whitespaces) }
+            guard columns.count >= 2, !columns[1].isEmpty else { return nil }
+            return columns[1]
+        }
+    }
+
+    private func repositoryRoot(file: StaticString = #filePath) -> URL {
+        URL(fileURLWithPath: "\(file)")
+            .deletingLastPathComponent() // InstallationEngine
+            .deletingLastPathComponent() // KeyPathTests
+            .deletingLastPathComponent() // Tests
+            .deletingLastPathComponent() // repo root
     }
 
     private var goldenCases: [GoldenCase] {


### PR DESCRIPTION
## Summary
- Parse `docs/process/installer-repair-state-matrix.md` in the golden matrix test suite.
- Assert documented state rows match `InstallerStateMatrixRow.allCases` in order.
- Keep existing fixture coverage checks, but make doc/code row drift fail in tests instead of review.

## Review feedback addressed
This addresses the finding that the golden suite pinned the enum to itself rather than the state-matrix document. Conflict/priority fixtures are intentionally left for the next PR with the classifier priority fixes so we do not encode known-bad behavior.

## Validation
- `TEST_FILTER=InstallerStateMatrixGoldenTests ./Scripts/run-tests-safe.sh` -> 3 passed
- `swiftformat --lint Tests/KeyPathTests/InstallationEngine/InstallerStateMatrixGoldenTests.swift`
- `python3 Scripts/check-accessibility.py` -> all UI elements have accessibility identifiers
- `KEYPATH_SNAPSHOTS=0 ./Scripts/run-tests-safe.sh` -> 4543 passed
- Branch freshness before commit: `git rev-list --left-right --count origin/master...HEAD` -> `0 0`
- Review gate: `./Scripts/review-gate.sh` -> `REVIEW_GATE_EXIT=2` (remote GitHub claude-review gate selected)

## Snapshot note
- Local `KeyPathSnapshotTests` remain blocked by the same unrelated Swift snapshot rendering/toolchain failures noted in PR #1056. This PR only changes non-rendering golden tests.
