### PR TITLE
Enforce privileged operation postconditions

### DIFF
--- a/Sources/KeyPathAppKit/Core/PrivilegedOperationsRouter.swift
+++ b/Sources/KeyPathAppKit/Core/PrivilegedOperationsRouter.swift
@@ -28,8 +28,10 @@ public final class PrivilegedOperationsRouter {
     private static let persistentLaunchctlNotFoundThreshold = 3
 
     private static let vhidVerifyTimeoutSeconds: Double = 1.5
-    private static let vhidVerifyInterval: Duration = .milliseconds(100)
+    private static let postconditionPollInterval: Duration = .milliseconds(100)
     private static let vhidSettleDelay: Duration = .milliseconds(150)
+    private static let processTerminationVerifyTimeoutSeconds: Double = 1.0
+    private static let kanataStopVerifyTimeoutSeconds: Double = 1.0
 
     #if DEBUG
         nonisolated(unsafe) static var operationModeOverride: OperationMode?
@@ -38,10 +40,15 @@ public final class PrivilegedOperationsRouter {
         nonisolated(unsafe) static var installAllServicesOverride: (() async throws -> Void)?
         nonisolated(unsafe) static var recoverRequiredRuntimeServicesOverride: (() async throws -> Void)?
         nonisolated(unsafe) static var killExistingKanataProcessesOverride: (() async throws -> Void)?
+        nonisolated(unsafe) static var activateVirtualHIDManagerOverride: (() async throws -> Void)?
+        nonisolated(unsafe) static var downloadAndInstallCorrectVHIDDriverOverride: (() async throws -> Void)?
         nonisolated(unsafe) static var kanataReadinessOverride:
             ((String) async -> KanataReadinessResult)?
         nonisolated(unsafe) static var helperRepairVHIDDaemonServicesOverride: (() async throws -> Void)?
         nonisolated(unsafe) static var vhidServicesPostconditionOverride: ((String) async -> Bool)?
+        nonisolated(unsafe) static var vhidDriverPostconditionOverride: ((String) async -> Bool)?
+        nonisolated(unsafe) static var processTerminatedPostconditionOverride: ((Int32, String) async -> Bool)?
+        nonisolated(unsafe) static var kanataStoppedPostconditionOverride: ((String) async -> Bool)?
 
         static func resetTestingState() {
             operationModeOverride = nil
@@ -49,15 +56,21 @@ public final class PrivilegedOperationsRouter {
             installAllServicesOverride = nil
             recoverRequiredRuntimeServicesOverride = nil
             killExistingKanataProcessesOverride = nil
+            activateVirtualHIDManagerOverride = nil
+            downloadAndInstallCorrectVHIDDriverOverride = nil
             kanataReadinessOverride = nil
             helperRepairVHIDDaemonServicesOverride = nil
             vhidServicesPostconditionOverride = nil
+            vhidDriverPostconditionOverride = nil
+            processTerminatedPostconditionOverride = nil
+            kanataStoppedPostconditionOverride = nil
             lastServiceInstallAttempt = nil
             lastSMAppApprovalNotice = nil
             ServiceInstallGuard.reset()
             KanataDaemonManager.registeredButNotLoadedOverride = nil
             ServiceHealthChecker.runtimeSnapshotOverride = nil
             ServiceHealthChecker.vhidDriverExtensionEnabledOverride = nil
+            ServiceHealthChecker.vhidDriverExtensionStatusOverride = nil
         }
     #endif
 
@@ -225,6 +238,19 @@ public final class PrivilegedOperationsRouter {
     }
 
     public func activateVirtualHIDManager() async throws {
+        #if DEBUG
+            if let override = Self.activateVirtualHIDManagerOverride {
+                try await override()
+            } else {
+                try await runActivateVirtualHIDManager()
+            }
+        #else
+            try await runActivateVirtualHIDManager()
+        #endif
+        try await enforceVHIDServicesPostcondition(after: "activateVirtualHIDManager")
+    }
+
+    private func runActivateVirtualHIDManager() async throws {
         switch Self.operationMode {
         case .privilegedHelper:
             try await helperManager.activateVirtualHIDManager()
@@ -243,6 +269,14 @@ public final class PrivilegedOperationsRouter {
     }
 
     public func downloadAndInstallCorrectVHIDDriver() async throws {
+        #if DEBUG
+            if let override = Self.downloadAndInstallCorrectVHIDDriverOverride {
+                try await override()
+                try await enforceVHIDDriverPostcondition(after: "downloadAndInstallCorrectVHIDDriver")
+                return
+            }
+        #endif
+
         switch Self.operationMode {
         case .privilegedHelper:
             do {
@@ -259,6 +293,7 @@ public final class PrivilegedOperationsRouter {
         case .directSudo:
             try await sudoInstallCorrectDriver()
         }
+        try await enforceVHIDDriverPostcondition(after: "downloadAndInstallCorrectVHIDDriver")
     }
 
     public func terminateProcess(pid: Int32) async throws {
@@ -276,6 +311,7 @@ public final class PrivilegedOperationsRouter {
         case .directSudo:
             try await sudoTerminateProcess(pid: pid)
         }
+        try await enforceProcessTerminatedPostcondition(pid: pid, after: "terminateProcess")
     }
 
     public func killAllKanataProcesses() async throws {
@@ -286,6 +322,7 @@ public final class PrivilegedOperationsRouter {
         case .directSudo:
             try await sudoKillAllKanata()
         }
+        try await enforceKanataStoppedPostcondition(after: "killAllKanataProcesses")
     }
 
     public func restartKarabinerDaemonVerified() async throws -> Bool {
@@ -472,6 +509,30 @@ public final class PrivilegedOperationsRouter {
         }
     }
 
+    private func enforceVHIDDriverPostcondition(after operation: String) async throws {
+        guard await verifyVHIDDriverPostcondition(context: operation) else {
+            throw PrivilegedOperationError.operationFailed(
+                "VHID driver postcondition failed after \(operation)"
+            )
+        }
+    }
+
+    private func enforceProcessTerminatedPostcondition(pid: Int32, after operation: String) async throws {
+        guard await verifyProcessTerminatedPostcondition(pid: pid, context: operation) else {
+            throw PrivilegedOperationError.operationFailed(
+                "Process termination postcondition failed after \(operation) for PID \(pid)"
+            )
+        }
+    }
+
+    private func enforceKanataStoppedPostcondition(after operation: String) async throws {
+        guard await verifyKanataStoppedPostcondition(context: operation) else {
+            throw PrivilegedOperationError.operationFailed(
+                "Kanata stopped postcondition failed after \(operation)"
+            )
+        }
+    }
+
     private func verifyVHIDServicesPostcondition(context: String) async -> Bool {
         #if DEBUG
             if let override = Self.vhidServicesPostconditionOverride {
@@ -492,12 +553,78 @@ public final class PrivilegedOperationsRouter {
             {
                 return true
             }
-            do { try await Task.sleep(for: Self.vhidVerifyInterval) }
+            do { try await Task.sleep(for: Self.postconditionPollInterval) }
             catch { return false }
         } while Date() < deadline
 
-        AppLogger.shared.warn(
+        AppLogger.shared.warnUnlessQuietTest(
             "⚠️ [PrivilegedOperationsRouter] VHID services postcondition failed after \(context)"
+        )
+        return false
+    }
+
+    private func verifyVHIDDriverPostcondition(context: String) async -> Bool {
+        #if DEBUG
+            if let override = Self.vhidDriverPostconditionOverride {
+                return await override(context)
+            }
+        #endif
+
+        switch await serviceHealthChecker.vhidDriverExtensionStatus() {
+        case .enabled:
+            return true
+        case .installedButNotEnabled:
+            AppLogger.shared.warnUnlessQuietTest(
+                "⚠️ [PrivilegedOperationsRouter] VHID driver installed but not enabled after \(context); user approval may be required"
+            )
+            return true
+        case .missing, .unknown:
+            AppLogger.shared.warnUnlessQuietTest(
+                "⚠️ [PrivilegedOperationsRouter] VHID driver postcondition failed after \(context)"
+            )
+            return false
+        }
+    }
+
+    private func verifyProcessTerminatedPostcondition(pid: Int32, context: String) async -> Bool {
+        #if DEBUG
+            if let override = Self.processTerminatedPostconditionOverride {
+                return await override(pid, context)
+            }
+        #endif
+
+        let deadline = Date().addingTimeInterval(Self.processTerminationVerifyTimeoutSeconds)
+        repeat {
+            if !SystemStateProvider.isProcessAlive(pid: pid) {
+                return true
+            }
+            do { try await Task.sleep(for: Self.postconditionPollInterval) }
+            catch { return false }
+        } while Date() < deadline
+
+        AppLogger.shared.warnUnlessQuietTest(
+            "⚠️ [PrivilegedOperationsRouter] Process \(pid) still alive after \(context)"
+        )
+        return false
+    }
+
+    private func verifyKanataStoppedPostcondition(context: String) async -> Bool {
+        #if DEBUG
+            if let override = Self.kanataStoppedPostconditionOverride {
+                return await override(context)
+            }
+        #endif
+
+        let deadline = Date().addingTimeInterval(Self.kanataStopVerifyTimeoutSeconds)
+        repeat {
+            let pids = await SystemStateProvider.shared.processIDs(matching: "kanata.*--cfg")
+            if pids.isEmpty { return true }
+            do { try await Task.sleep(for: Self.postconditionPollInterval) }
+            catch { return false }
+        } while Date() < deadline
+
+        AppLogger.shared.warnUnlessQuietTest(
+            "⚠️ [PrivilegedOperationsRouter] Kanata still running after \(context)"
         )
         return false
     }
@@ -611,7 +738,7 @@ public final class PrivilegedOperationsRouter {
         let start = Date()
         while Date().timeIntervalSince(start) < Self.vhidVerifyTimeoutSeconds {
             if await vhidManager.detectRunning() { return true }
-            try await Task.sleep(for: Self.vhidVerifyInterval)
+            try await Task.sleep(for: Self.postconditionPollInterval)
         }
 
         try await Task.sleep(for: Self.vhidSettleDelay)
@@ -663,7 +790,7 @@ public final class PrivilegedOperationsRouter {
         let startTime = Date()
         while Date().timeIntervalSince(startTime) < Self.vhidVerifyTimeoutSeconds {
             if await vhidManager.detectRunning() { return true }
-            try await Task.sleep(for: Self.vhidVerifyInterval)
+            try await Task.sleep(for: Self.postconditionPollInterval)
         }
 
         return false

--- a/Sources/KeyPathInstallationWizard/Core/ServiceHealthChecker.swift
+++ b/Sources/KeyPathInstallationWizard/Core/ServiceHealthChecker.swift
@@ -130,6 +130,13 @@ public final class ServiceHealthChecker: @unchecked Sendable {
         public static let ready = KanataInputCaptureStatus(isReady: true, issue: nil)
     }
 
+    public enum VHIDDriverExtensionStatus: Sendable, Equatable {
+        case enabled
+        case installedButNotEnabled
+        case missing
+        case unknown
+    }
+
     /// Unified diagnosis from a single read of the kanata daemon stderr log.
     /// Replaces the separate `checkDaemonStderrForPermissionFailure()` and
     /// `checkKanataInputCaptureStatus()` parsers that read the same file
@@ -183,6 +190,8 @@ public final class ServiceHealthChecker: @unchecked Sendable {
             (() async -> KanataInputCaptureStatus)?
         public nonisolated(unsafe) static var vhidDriverExtensionEnabledOverride:
             (() async -> Bool)?
+        public nonisolated(unsafe) static var vhidDriverExtensionStatusOverride:
+            (() async -> VHIDDriverExtensionStatus)?
     #endif
 
     // MARK: - Service Identifiers
@@ -646,14 +655,21 @@ public final class ServiceHealthChecker: @unchecked Sendable {
     }
 
     public nonisolated func isVHIDDriverExtensionEnabled() async -> Bool {
+        await vhidDriverExtensionStatus() == .enabled
+    }
+
+    public nonisolated func vhidDriverExtensionStatus() async -> VHIDDriverExtensionStatus {
         #if DEBUG
-            if let override = Self.vhidDriverExtensionEnabledOverride {
+            if let override = Self.vhidDriverExtensionStatusOverride {
                 return await override()
+            }
+            if let override = Self.vhidDriverExtensionEnabledOverride {
+                return await override() ? .enabled : .missing
             }
         #endif
 
         if TestEnvironment.shouldSkipAdminOperations {
-            return true
+            return .enabled
         }
 
         do {
@@ -663,22 +679,30 @@ public final class ServiceHealthChecker: @unchecked Sendable {
                 timeout: 5
             )
             let output = [result.stdout, result.stderr].joined(separator: "\n")
-            let enabled = Self.systemExtensionsOutputShowsVHIDDriverEnabled(output)
-            if !enabled {
+            let status = Self.classifyVHIDDriverExtensionStatus(output)
+            if status != .enabled {
                 AppLogger.shared.log("⚠️ [ServiceHealthChecker] VHID DriverKit extension is not enabled:\n\(output)")
             }
-            return enabled
+            return status
         } catch {
             AppLogger.shared.log("❌ [ServiceHealthChecker] Unable to inspect VHID DriverKit extension: \(error)")
-            return false
+            return .unknown
         }
     }
 
     public nonisolated static func systemExtensionsOutputShowsVHIDDriverEnabled(_ output: String) -> Bool {
-        output.components(separatedBy: .newlines).contains { line in
-            line.contains(karabinerDriverExtensionBundleID)
-                && line.contains("[activated enabled]")
+        classifyVHIDDriverExtensionStatus(output) == .enabled
+    }
+
+    public nonisolated static func classifyVHIDDriverExtensionStatus(_ output: String) -> VHIDDriverExtensionStatus {
+        var sawDriver = false
+        for line in output.components(separatedBy: .newlines) where line.contains(karabinerDriverExtensionBundleID) {
+            sawDriver = true
+            if line.contains("[activated enabled]") {
+                return .enabled
+            }
         }
+        return sawDriver ? .installedButNotEnabled : .missing
     }
 
     private nonisolated func evaluateKanataLaunchctlRunningState(

--- a/Tests/KeyPathTests/Core/PrivilegedOperationsCoordinatorTests.swift
+++ b/Tests/KeyPathTests/Core/PrivilegedOperationsCoordinatorTests.swift
@@ -1,3 +1,4 @@
+import Darwin
 import Foundation
 @testable import KeyPathAppKit
 @testable import KeyPathCore
@@ -339,6 +340,162 @@ final class PrivilegedOperationsRouterTests: XCTestCase {
         #if DEBUG
             XCTAssertEqual(installAllServicesCalls, 1)
         #endif
+    }
+
+    func testActivateVirtualHIDManagerFailsWhenPostconditionFails() async throws {
+        #if DEBUG
+            PrivilegedOperationsRouter.resetTestingState()
+            var activationCalls = 0
+            PrivilegedOperationsRouter.activateVirtualHIDManagerOverride = {
+                activationCalls += 1
+            }
+            PrivilegedOperationsRouter.vhidServicesPostconditionOverride = { _ in false }
+        #else
+            throw XCTSkip("Uses DEBUG-only PrivilegedOperationsRouter test overrides")
+        #endif
+
+        let coordinator = PrivilegedOperationsRouter.shared
+        do {
+            try await coordinator.activateVirtualHIDManager()
+            XCTFail("Expected activateVirtualHIDManager to fail when postcondition fails")
+        } catch let PrivilegedOperationError.operationFailed(message) {
+            XCTAssertTrue(message.contains("VHID services postcondition failed"))
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+
+        #if DEBUG
+            XCTAssertEqual(activationCalls, 1)
+        #endif
+    }
+
+    func testDownloadAndInstallCorrectVHIDDriverFailsWhenDriverPostconditionFails() async throws {
+        #if DEBUG
+            PrivilegedOperationsRouter.resetTestingState()
+            var installCalls = 0
+            PrivilegedOperationsRouter.downloadAndInstallCorrectVHIDDriverOverride = {
+                installCalls += 1
+            }
+            PrivilegedOperationsRouter.vhidDriverPostconditionOverride = { _ in false }
+        #else
+            throw XCTSkip("Uses DEBUG-only PrivilegedOperationsRouter test overrides")
+        #endif
+
+        let coordinator = PrivilegedOperationsRouter.shared
+        do {
+            try await coordinator.downloadAndInstallCorrectVHIDDriver()
+            XCTFail("Expected downloadAndInstallCorrectVHIDDriver to fail when postcondition fails")
+        } catch let PrivilegedOperationError.operationFailed(message) {
+            XCTAssertTrue(message.contains("VHID driver postcondition failed"))
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+
+        #if DEBUG
+            XCTAssertEqual(installCalls, 1)
+        #endif
+    }
+
+    func testDownloadAndInstallCorrectVHIDDriverAllowsInstalledButNotEnabledPostcondition() async throws {
+        #if DEBUG
+            PrivilegedOperationsRouter.resetTestingState()
+            var installCalls = 0
+            PrivilegedOperationsRouter.downloadAndInstallCorrectVHIDDriverOverride = {
+                installCalls += 1
+            }
+            ServiceHealthChecker.vhidDriverExtensionStatusOverride = { .installedButNotEnabled }
+        #else
+            throw XCTSkip("Uses DEBUG-only PrivilegedOperationsRouter test overrides")
+        #endif
+
+        let coordinator = PrivilegedOperationsRouter.shared
+        try await coordinator.downloadAndInstallCorrectVHIDDriver()
+
+        #if DEBUG
+            XCTAssertEqual(installCalls, 1)
+        #endif
+    }
+
+    func testTerminateProcessFailsWhenPostconditionFails() async throws {
+        #if DEBUG
+            PrivilegedOperationsRouter.resetTestingState()
+            PrivilegedOperationsRouter.processTerminatedPostconditionOverride = { _, _ in false }
+        #else
+            throw XCTSkip("Uses DEBUG-only PrivilegedOperationsRouter test overrides")
+        #endif
+        let fakeExecutor = FakeAdminCommandExecutor()
+        AdminCommandExecutorHolder.shared = fakeExecutor
+
+        let coordinator = PrivilegedOperationsRouter.shared
+        do {
+            try await coordinator.terminateProcess(pid: 12345)
+            XCTFail("Expected terminateProcess to fail when postcondition fails")
+        } catch let PrivilegedOperationError.operationFailed(message) {
+            XCTAssertTrue(message.contains("Process termination postcondition failed"))
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+
+        XCTAssertEqual(fakeExecutor.commands.count, 1)
+        XCTAssertEqual(fakeExecutor.commands.first?.description, "Terminate process 12345")
+    }
+
+    func testTerminateProcessWaitsForProcessToExitAfterCommandSuccess() async throws {
+        #if DEBUG
+            PrivilegedOperationsRouter.resetTestingState()
+        #else
+            throw XCTSkip("Uses DEBUG-only PrivilegedOperationsRouter test setup")
+        #endif
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/sleep")
+        process.arguments = ["5"]
+        try process.run()
+        defer {
+            if process.isRunning {
+                process.terminate()
+            }
+        }
+
+        let pid = Int32(process.processIdentifier)
+        let fakeExecutor = FakeAdminCommandExecutor(resultProvider: { _, description in
+            if description == "Terminate process \(pid)" {
+                DispatchQueue.global().asyncAfter(deadline: .now() + 0.2) {
+                    Darwin.kill(pid, SIGTERM)
+                }
+            }
+            return CommandExecutionResult(exitCode: 0, output: "")
+        })
+        AdminCommandExecutorHolder.shared = fakeExecutor
+
+        let coordinator = PrivilegedOperationsRouter.shared
+        try await coordinator.terminateProcess(pid: pid)
+
+        XCTAssertEqual(fakeExecutor.commands.count, 1)
+    }
+
+    func testKillAllKanataProcessesFailsWhenPostconditionFails() async throws {
+        #if DEBUG
+            PrivilegedOperationsRouter.resetTestingState()
+            PrivilegedOperationsRouter.kanataStoppedPostconditionOverride = { _ in false }
+        #else
+            throw XCTSkip("Uses DEBUG-only PrivilegedOperationsRouter test overrides")
+        #endif
+        let fakeExecutor = FakeAdminCommandExecutor()
+        AdminCommandExecutorHolder.shared = fakeExecutor
+
+        let coordinator = PrivilegedOperationsRouter.shared
+        do {
+            try await coordinator.killAllKanataProcesses()
+            XCTFail("Expected killAllKanataProcesses to fail when postcondition fails")
+        } catch let PrivilegedOperationError.operationFailed(message) {
+            XCTAssertTrue(message.contains("Kanata stopped postcondition failed"))
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+
+        XCTAssertEqual(fakeExecutor.commands.count, 1)
+        XCTAssertEqual(fakeExecutor.commands.first?.description, "Kill all Kanata processes")
     }
 
     func testRegenerateServiceConfigurationAllowsPendingApprovalPostcondition() async throws {

--- a/Tests/KeyPathTests/Lint/PostconditionLintTests.swift
+++ b/Tests/KeyPathTests/Lint/PostconditionLintTests.swift
@@ -25,9 +25,37 @@ final class PostconditionLintTests: XCTestCase {
         try assertFunctions(
             [
                 "installRequiredRuntimeServices",
-                "repairVHIDDaemonServices"
+                "repairVHIDDaemonServices",
+                "activateVirtualHIDManager"
             ],
             contain: "enforceVHIDServicesPostcondition"
+        )
+    }
+
+    func testVHIDDriverInstallEnforcesDriverPostcondition() throws {
+        try assertFunctions(
+            [
+                "downloadAndInstallCorrectVHIDDriver"
+            ],
+            contain: "enforceVHIDDriverPostcondition"
+        )
+    }
+
+    func testProcessTerminationEnforcesProcessPostcondition() throws {
+        try assertFunctions(
+            [
+                "terminateProcess"
+            ],
+            contain: "enforceProcessTerminatedPostcondition"
+        )
+    }
+
+    func testKanataStopEnforcesRuntimeStoppedPostcondition() throws {
+        try assertFunctions(
+            [
+                "killAllKanataProcesses"
+            ],
+            contain: "enforceKanataStoppedPostcondition"
         )
     }
 
@@ -44,7 +72,11 @@ final class PostconditionLintTests: XCTestCase {
             "installRequiredRuntimeServices",
             "recoverRequiredRuntimeServices",
             "regenerateServiceConfiguration",
-            "repairVHIDDaemonServices"
+            "repairVHIDDaemonServices",
+            "activateVirtualHIDManager",
+            "downloadAndInstallCorrectVHIDDriver",
+            "terminateProcess",
+            "killAllKanataProcesses"
         ]
         let postconditionDelegatedOrVerified: Set = [
             "installServicesIfUninstalled",
@@ -53,11 +85,7 @@ final class PostconditionLintTests: XCTestCase {
         let explicitFollowUpExemptions: Set = [
             "cleanupPrivilegedHelper",
             "installNewsyslogConfig",
-            "activateVirtualHIDManager",
             "uninstallVirtualHIDDrivers",
-            "downloadAndInstallCorrectVHIDDriver",
-            "terminateProcess",
-            "killAllKanataProcesses",
             "disableKarabinerGrabber",
             "sudoExecuteCommand"
         ]

--- a/Tests/KeyPathTests/Services/ServiceHealthCheckerTests.swift
+++ b/Tests/KeyPathTests/Services/ServiceHealthCheckerTests.swift
@@ -43,6 +43,7 @@ final class ServiceHealthCheckerTests: XCTestCase {
             ServiceHealthChecker.recentlyRestartedOverride = nil
             ServiceHealthChecker.inputCaptureStatusOverride = nil
             ServiceHealthChecker.vhidDriverExtensionEnabledOverride = nil
+            ServiceHealthChecker.vhidDriverExtensionStatusOverride = nil
             ServiceHealthChecker.testForcedServiceHealth = nil
             KanataDaemonManager.registeredButNotLoadedOverride = nil
         #endif
@@ -69,6 +70,7 @@ final class ServiceHealthCheckerTests: XCTestCase {
             ServiceHealthChecker.recentlyRestartedOverride = nil
             ServiceHealthChecker.inputCaptureStatusOverride = nil
             ServiceHealthChecker.vhidDriverExtensionEnabledOverride = nil
+            ServiceHealthChecker.vhidDriverExtensionStatusOverride = nil
             ServiceHealthChecker.testForcedServiceHealth = nil
             KanataDaemonManager.registeredButNotLoadedOverride = nil
         #endif
@@ -325,6 +327,27 @@ final class ServiceHealthCheckerTests: XCTestCase {
 
         XCTAssertTrue(ServiceHealthChecker.systemExtensionsOutputShowsVHIDDriverEnabled(enabled))
         XCTAssertFalse(ServiceHealthChecker.systemExtensionsOutputShowsVHIDDriverEnabled(disabled))
+    }
+
+    func testClassifyVHIDDriverExtensionStatusDistinguishesPendingApprovalFromMissingDriver() {
+        let enabled = """
+        enabled active teamID bundleID (version) name [state]
+            *    *    G43BCU2T37 org.pqrs.Karabiner-DriverKit-VirtualHIDDevice (6.0.0/6.0.0) org.pqrs.Karabiner-DriverKit-VirtualHIDDevice [activated enabled]
+        """
+        let installedButNotEnabled = """
+        enabled active teamID bundleID (version) name [state]
+            *         G43BCU2T37 org.pqrs.Karabiner-DriverKit-VirtualHIDDevice (6.0.0/6.0.0) org.pqrs.Karabiner-DriverKit-VirtualHIDDevice [activated waiting for user]
+        """
+        let missing = """
+        enabled active teamID bundleID (version) name [state]
+        """
+
+        XCTAssertEqual(ServiceHealthChecker.classifyVHIDDriverExtensionStatus(enabled), .enabled)
+        XCTAssertEqual(
+            ServiceHealthChecker.classifyVHIDDriverExtensionStatus(installedButNotEnabled),
+            .installedButNotEnabled
+        )
+        XCTAssertEqual(ServiceHealthChecker.classifyVHIDDriverExtensionStatus(missing), .missing)
     }
 
     func testRuntimeSnapshotReportsVHIDDriverNotActivatedBeforeKanataCrashLoop() async {

--- a/Tests/KeyPathTests/Support/GlobalTestSetup.swift
+++ b/Tests/KeyPathTests/Support/GlobalTestSetup.swift
@@ -49,6 +49,7 @@ enum TestSingletonReset {
             ServiceHealthChecker.recentlyRestartedOverride = nil
             ServiceHealthChecker.inputCaptureStatusOverride = nil
             ServiceHealthChecker.vhidDriverExtensionEnabledOverride = nil
+            ServiceHealthChecker.vhidDriverExtensionStatusOverride = nil
         #endif
 
         // TestEnvironment flags

--- a/docs/planning/installer-reliability-phase1.md
+++ b/docs/planning/installer-reliability-phase1.md
@@ -685,7 +685,30 @@ is listed in the state-matrix doc's enforcement section.
 - [x] `PostconditionLintTests.testRuntimeMutatingRouterVerbsEnforceRuntimePostcondition`
   and `PostconditionLintTests.testVHIDServiceRepairEnforcesVHIDPostcondition`
   pin the runtime and VHID postcondition enforcers on the currently covered
-  router verbs.
+  router verbs, including `activateVirtualHIDManager`.
+- [x] `PostconditionLintTests.testVHIDDriverInstallEnforcesDriverPostcondition`,
+  `PostconditionLintTests.testProcessTerminationEnforcesProcessPostcondition`,
+  and `PostconditionLintTests.testKanataStopEnforcesRuntimeStoppedPostcondition`
+  shrink the postcondition follow-up exemption list by requiring
+  `downloadAndInstallCorrectVHIDDriver`, `terminateProcess`, and
+  `killAllKanataProcesses` to prove their final state before reporting
+  success.
+- [x] `ServiceHealthCheckerTests.testClassifyVHIDDriverExtensionStatusDistinguishesPendingApprovalFromMissingDriver`
+  pins the driver-install postcondition evidence: enabled DriverKit is success,
+  installed-but-not-enabled is explicit manual-approval/pending evidence, and a
+  missing driver is failure.
+- [x] `PrivilegedOperationsRouterTests.testDownloadAndInstallCorrectVHIDDriverAllowsInstalledButNotEnabledPostcondition`
+  proves the router treats installed-but-not-enabled DriverKit as an explicit
+  pending/manual-approval terminal state rather than retryable failure.
+- [x] `PrivilegedOperationsRouterTests.testActivateVirtualHIDManagerFailsWhenPostconditionFails`,
+  `PrivilegedOperationsRouterTests.testDownloadAndInstallCorrectVHIDDriverFailsWhenDriverPostconditionFails`,
+  `PrivilegedOperationsRouterTests.testTerminateProcessFailsWhenPostconditionFails`,
+  and `PrivilegedOperationsRouterTests.testKillAllKanataProcessesFailsWhenPostconditionFails`
+  prove command success is not treated as repair success for the newly covered
+  privileged operations.
+- [x] `PrivilegedOperationsRouterTests.testTerminateProcessWaitsForProcessToExitAfterCommandSuccess`
+  proves process-termination postconditions tolerate normal signal-delivery
+  delay before reporting failure.
 - [x] `PostconditionLintTests.testPublicRouterOperationsAreClassifiedForPostconditionReview`
   fails if a new public router operation is added without being classified as
   postcondition-enforced, delegated/verified, or an explicit follow-up

--- a/docs/process/installer-repair-state-matrix.md
+++ b/docs/process/installer-repair-state-matrix.md
@@ -253,7 +253,18 @@ the result as user action required and name the approval surface.
 - Mutating privileged operations must be postcondition-reviewed before they can
   report success. `PostconditionLintTests.testRuntimeMutatingRouterVerbsEnforceRuntimePostcondition`
   and `PostconditionLintTests.testVHIDServiceRepairEnforcesVHIDPostcondition`
-  pin the current runtime/VHID enforcers, while
+  pin the current runtime/VHID service enforcers.
+  `PostconditionLintTests.testVHIDDriverInstallEnforcesDriverPostcondition`,
+  `PostconditionLintTests.testProcessTerminationEnforcesProcessPostcondition`,
+  and `PostconditionLintTests.testKanataStopEnforcesRuntimeStoppedPostcondition`
+  pin driver-install, process-termination, and Kanata-stop postconditions, while
+  `PrivilegedOperationsRouterTests.testTerminateProcessWaitsForProcessToExitAfterCommandSuccess`
+  pins a grace period for normal signal-delivery delay.
+  `ServiceHealthCheckerTests.testClassifyVHIDDriverExtensionStatusDistinguishesPendingApprovalFromMissingDriver`
+  pins DriverKit extension evidence for enabled vs installed-but-not-enabled
+  vs missing states, and
+  `PrivilegedOperationsRouterTests.testDownloadAndInstallCorrectVHIDDriverAllowsInstalledButNotEnabledPostcondition`
+  pins the router success path for that pending/manual-approval state.
   `PostconditionLintTests.testPublicRouterOperationsAreClassifiedForPostconditionReview`
   fails when a new public router operation is added without being classified.
 - Runtime and installer state caches must not regrow in consumers.


### PR DESCRIPTION
## Summary
- enforce postconditions for `activateVirtualHIDManager`, `downloadAndInstallCorrectVHIDDriver`, `terminateProcess`, and `killAllKanataProcesses`
- add DriverKit extension status classification so driver-install success is based on enabled or installed-but-not-enabled evidence, not package-file presence
- shrink `PostconditionLintTests` follow-up exemptions and update the Phase 1 plan/state-matrix docs with the tests that enforce the completed criteria

## Acceptance criteria completed
- `activateVirtualHIDManager` proves VHID service postcondition before success: `PostconditionLintTests.testVHIDServiceRepairEnforcesVHIDPostcondition`; failure behavior covered by `PrivilegedOperationsRouterTests.testActivateVirtualHIDManagerFailsWhenPostconditionFails`.
- `downloadAndInstallCorrectVHIDDriver` proves driver postcondition before success: `PostconditionLintTests.testVHIDDriverInstallEnforcesDriverPostcondition`; failure behavior covered by `PrivilegedOperationsRouterTests.testDownloadAndInstallCorrectVHIDDriverFailsWhenDriverPostconditionFails`.
- Driver postcondition evidence distinguishes enabled, pending/manual-approval-style installed-but-not-enabled, and missing states: `ServiceHealthCheckerTests.testClassifyVHIDDriverExtensionStatusDistinguishesPendingApprovalFromMissingDriver`.
- The router treats installed-but-not-enabled DriverKit as an explicit pending/manual-approval terminal state: `PrivilegedOperationsRouterTests.testDownloadAndInstallCorrectVHIDDriverAllowsInstalledButNotEnabledPostcondition`.
- `terminateProcess` proves target process is gone before success, with a short signal-delivery grace period: `PostconditionLintTests.testProcessTerminationEnforcesProcessPostcondition`; failure behavior covered by `PrivilegedOperationsRouterTests.testTerminateProcessFailsWhenPostconditionFails`; delayed-exit behavior covered by `PrivilegedOperationsRouterTests.testTerminateProcessWaitsForProcessToExitAfterCommandSuccess`.
- `killAllKanataProcesses` proves Kanata is stopped before success using provider-owned process discovery, avoiding `SMAppService.status` in the stop postcondition path: `PostconditionLintTests.testKanataStopEnforcesRuntimeStoppedPostcondition`; failure behavior covered by `PrivilegedOperationsRouterTests.testKillAllKanataProcessesFailsWhenPostconditionFails`.
- Every public router operation remains classified for postcondition review: `PostconditionLintTests.testPublicRouterOperationsAreClassifiedForPostconditionReview`.

## Review feedback addressed
- Added retry/grace period for process-termination postconditions before reporting failure.
- Removed the new `currentServiceState()`/service-management read from the Kanata-stop postcondition; it now uses centralized process discovery through `SystemStateProvider`.
- Added warning logs for failed postconditions in production while using quiet-test logging so expected negative-path tests do not trip the clean-log ratchet.
- Added router-level coverage for installed-but-not-enabled DriverKit as a valid pending/manual-approval terminal state.
- Renamed the shared postcondition polling cadence so process/Kanata checks do not borrow a VHID-specific name.

## Validation
- `TEST_FILTER='PrivilegedOperationsRouterTests|PostconditionLintTests|ServiceHealthCheckerTests/testClassifyVHIDDriverExtensionStatusDistinguishesPendingApprovalFromMissingDriver|ServiceHealthCheckerTests/testSystemExtensionsOutputShowsVHIDDriverEnabledOnlyForActivatedEnabled' ./Scripts/run-tests-safe.sh` - 31 passed, `test_log_app_warnings=0`
- `swiftformat --lint Sources/KeyPathAppKit/Core/PrivilegedOperationsRouter.swift Sources/KeyPathInstallationWizard/Core/ServiceHealthChecker.swift Tests/KeyPathTests/Core/PrivilegedOperationsCoordinatorTests.swift Tests/KeyPathTests/Lint/PostconditionLintTests.swift Tests/KeyPathTests/Services/ServiceHealthCheckerTests.swift Tests/KeyPathTests/Support/GlobalTestSetup.swift`
- `python3 Scripts/check-accessibility.py`
- `git diff --check`
- `KEYPATH_SNAPSHOTS=0 ./Scripts/run-tests-safe.sh` - 4544 passed, `test_log_app_warnings=0`, `test_log_app_errors=0`

## Review gate
- `./Scripts/review-gate.sh` exited 2: remote review gate selected. GitHub `claude-review` must pass before merge.

## Notes
- Local snapshot-enabled full suite remains outside this slice because of the pre-existing Swift snapshot renderer/toolchain issue observed on prior Phase 1 PRs; the non-snapshot safe gate passed.
