### PR TITLE
Tighten installer freshness evidence

### DIFF
--- a/Sources/KeyPathAppKit/Core/SystemStateProvider+InstallerStateMatrix.swift
+++ b/Sources/KeyPathAppKit/Core/SystemStateProvider+InstallerStateMatrix.swift
@@ -63,7 +63,7 @@ public extension SystemStateProvider {
             virtualHIDApprovalPending: driverKitApprovalPending,
             helperInstalled: helper.isInstalled,
             helperResponding: helper.isWorking,
-            helperFresh: helper.version == nil || helper.version == HelperManager.expectedHelperVersion,
+            helperFresh: helper.version == HelperManager.expectedHelperVersion,
             manualApprovalRequired: loginItemsApprovalRequired
         )
     }

--- a/Sources/KeyPathAppKit/Managers/ConfigReloadCoordinator.swift
+++ b/Sources/KeyPathAppKit/Managers/ConfigReloadCoordinator.swift
@@ -40,14 +40,10 @@ final class ConfigReloadCoordinator {
     /// Main reload method using TCP protocol.
     /// Checks service health, permission gates, and delegates to TCP reload.
     func triggerConfigReload() async -> ReloadResult {
-        // Use cached state to avoid synchronous IPC to SMAppService in hot path
-        let smState: KanataDaemonManager.ServiceManagementState
-        let cached = await MainActor.run { KanataDaemonManager.shared.currentManagementState }
-        if cached == .unknown {
-            smState = await KanataDaemonManager.shared.refreshManagementStateInternal()
-        } else {
-            smState = cached
-        }
+        // Use the manager refresh path instead of the unbounded synchronous
+        // currentManagementState cache; the underlying SMAppService provider
+        // still coalesces IPC with a short TTL.
+        let smState = await KanataDaemonManager.shared.refreshManagementStateInternal()
         if smState == .smappservicePending {
             AppLogger.shared.warn(
                 "⚠️ [Reload] Skipping TCP reload because SMAppService requires approval"

--- a/Sources/KeyPathAppKit/Managers/ServiceLifecycleCoordinator.swift
+++ b/Sources/KeyPathAppKit/Managers/ServiceLifecycleCoordinator.swift
@@ -334,10 +334,7 @@ final class ServiceLifecycleCoordinator {
         ) {
             return true
         }
-        let cached = await MainActor.run { KanataDaemonManager.shared.currentManagementState }
-        let managementState = cached == .unknown
-            ? await KanataDaemonManager.shared.refreshManagementStateInternal()
-            : cached
+        let managementState = await KanataDaemonManager.shared.refreshManagementStateInternal()
         return managementState == .smappservicePending
     }
 

--- a/Sources/KeyPathInstallationWizard/Core/InstallerStateMatrix.swift
+++ b/Sources/KeyPathInstallationWizard/Core/InstallerStateMatrix.swift
@@ -266,7 +266,7 @@ public extension SystemContext {
             virtualHIDApprovalPending: driverKitApprovalPending,
             helperInstalled: helper.isInstalled,
             helperResponding: helper.isWorking,
-            helperFresh: helper.version == nil || helper.version == WizardHelperConstants.expectedHelperVersion,
+            helperFresh: helper.version == WizardHelperConstants.expectedHelperVersion,
             definitiveUnhealthyState: timedOut
         )
     }

--- a/Tests/KeyPathTests/Core/SystemStateProviderInstallerStateMatrixTests.swift
+++ b/Tests/KeyPathTests/Core/SystemStateProviderInstallerStateMatrixTests.swift
@@ -95,6 +95,19 @@ final class SystemStateProviderInstallerStateMatrixTests: XCTestCase {
         XCTAssertEqual(InstallerStateMatrixPlanner.plan(for: snapshot), [.verifyOrRefreshHelper])
     }
 
+    func testStateMatrixSnapshotTreatsUnknownHelperVersionAsNotFresh() {
+        let snapshot = SystemStateProvider.installerStateMatrixSnapshot(
+            components: healthyComponents,
+            helper: HelperStatus(isInstalled: true, version: nil, isWorking: true),
+            runtime: runtime(),
+            kanataSMAppServiceStatus: .enabled,
+            helperSMAppServiceStatus: .enabled
+        )
+
+        XCTAssertEqual(InstallerStateMatrixPlanner.classify(snapshot), .helperRespondsButMayBeStale)
+        XCTAssertEqual(InstallerStateMatrixPlanner.plan(for: snapshot), [.verifyOrRefreshHelper])
+    }
+
     func testStateMatrixSnapshotTreatsUnhealthyVHIDServicesAsServiceRepairNotMissingPayload() {
         let snapshot = SystemStateProvider.installerStateMatrixSnapshot(
             components: ComponentStatus(
@@ -150,6 +163,16 @@ final class SystemStateProviderInstallerStateMatrixTests: XCTestCase {
         )
     }
 
+    func testWizardSystemContextSnapshotTreatsUnknownHelperVersionAsNotFresh() {
+        let snapshot = systemContext(
+            from: runtime(),
+            helper: HelperStatus(isInstalled: true, version: nil, isWorking: true)
+        ).installerStateMatrixSnapshot
+
+        XCTAssertEqual(InstallerStateMatrixPlanner.classify(snapshot), .helperRespondsButMayBeStale)
+        XCTAssertEqual(InstallerStateMatrixPlanner.plan(for: snapshot), [.verifyOrRefreshHelper])
+    }
+
     private var healthyComponents: ComponentStatus {
         ComponentStatus(
             kanataBinaryInstalled: true,
@@ -187,7 +210,10 @@ final class SystemStateProviderInstallerStateMatrixTests: XCTestCase {
         XCTAssertEqual(InstallerStateMatrixPlanner.plan(for: wizardSnapshot), expectedPlan, file: file, line: line)
     }
 
-    private func systemContext(from runtime: ServiceHealthChecker.KanataServiceRuntimeSnapshot) -> SystemContext {
+    private func systemContext(
+        from runtime: ServiceHealthChecker.KanataServiceRuntimeSnapshot,
+        helper: HelperStatus? = nil
+    ) -> SystemContext {
         let permissionSet = PermissionOracle.PermissionSet(
             accessibility: .granted,
             inputMonitoring: .granted,
@@ -219,7 +245,7 @@ final class SystemStateProviderInstallerStateMatrixTests: XCTestCase {
             ),
             conflicts: .empty,
             components: healthyComponents,
-            helper: healthyHelper,
+            helper: helper ?? healthyHelper,
             system: EngineSystemInfo(macOSVersion: "15.0", driverCompatible: true),
             timestamp: Date()
         )

--- a/Tests/KeyPathTests/Lint/W6DeletionPassLintTests.swift
+++ b/Tests/KeyPathTests/Lint/W6DeletionPassLintTests.swift
@@ -162,6 +162,36 @@ final class W6DeletionPassLintTests: XCTestCase {
         )
     }
 
+    func testAsyncRepairGatesDoNotConsumeUnboundedManagementStateCache() throws {
+        let lifecycleCoordinator = repositoryRoot()
+            .appendingPathComponent("Sources/KeyPathAppKit/Managers/ServiceLifecycleCoordinator.swift")
+        let reloadCoordinator = repositoryRoot()
+            .appendingPathComponent("Sources/KeyPathAppKit/Managers/ConfigReloadCoordinator.swift")
+
+        let violations = try [
+            lifecycleCoordinator,
+            reloadCoordinator,
+        ].flatMap { file in
+            try matchingLines(
+                in: file,
+                patterns: [
+                    #"\bcurrentManagementState\b"#,
+                ]
+            )
+        }
+
+        XCTAssertTrue(
+            violations.isEmpty,
+            """
+            W6 removes unbounded duplicate management-state reads from async \
+            repair/start/reload gates. These paths should call \
+            refreshManagementStateInternal(), leaving freshness and IPC \
+            coalescing to the centralized provider-backed manager:
+            \(violations.sorted().joined(separator: "\n"))
+            """
+        )
+    }
+
     func testServiceLifecycleCoordinatorDoesNotRegrowDuplicateVHIDStartCheck() throws {
         let coordinatorFile = repositoryRoot()
             .appendingPathComponent("Sources/KeyPathAppKit/Managers/ServiceLifecycleCoordinator.swift")
@@ -180,6 +210,32 @@ final class W6DeletionPassLintTests: XCTestCase {
             W6 removes duplicated in-path service checks. startKanata should \
             use the injected VirtualHID daemon health predicate once instead \
             of performing a second ServiceHealthChecker query in the start path:
+            \(violations.sorted().joined(separator: "\n"))
+            """
+        )
+    }
+
+    func testMatrixAdaptersDoNotTreatUnknownHelperVersionAsFresh() throws {
+        let adapters = [
+            repositoryRoot().appendingPathComponent("Sources/KeyPathAppKit/Core/SystemStateProvider+InstallerStateMatrix.swift"),
+            repositoryRoot().appendingPathComponent("Sources/KeyPathInstallationWizard/Core/InstallerStateMatrix.swift"),
+        ]
+
+        let violations = try adapters.flatMap { file in
+            try matchingLines(
+                in: file,
+                patterns: [
+                    #"helper\.version\s*==\s*nil\s*\|\|"#,
+                ]
+            )
+        }
+
+        XCTAssertTrue(
+            violations.isEmpty,
+            """
+            Helper responsiveness is not helper freshness. Matrix adapters \
+            must treat an unknown helper version as not fresh and route to \
+            helper verification/refresh instead of reporting green:
             \(violations.sorted().joined(separator: "\n"))
             """
         )

--- a/docs/planning/installer-reliability-phase1.md
+++ b/docs/planning/installer-reliability-phase1.md
@@ -762,17 +762,24 @@ realistic without losing capability. Measure before/after.
   by
   `W6DeletionPassLintTests.testDiagnosticsManagerSingleImplementationProtocolDoesNotRegrow`.
 - [x] Removed `ServiceLifecycleCoordinator`'s local
-  `smAppServicePendingCache`, using `KanataDaemonManager.currentManagementState`
-  as the provider-owned cache instead. Enforced by
-  `W6DeletionPassLintTests.testServiceLifecycleCoordinatorDoesNotRegrowSMAppServicePendingCache`.
+  `smAppServicePendingCache`; async repair/start/reload gates now refresh
+  through `KanataDaemonManager.refreshManagementStateInternal()` instead of
+  consuming the unbounded `currentManagementState` cache. Enforced by
+  `W6DeletionPassLintTests.testServiceLifecycleCoordinatorDoesNotRegrowSMAppServicePendingCache`
+  and
+  `W6DeletionPassLintTests.testAsyncRepairGatesDoNotConsumeUnboundedManagementStateCache`.
 - [x] Removed the duplicate "second safety layer" VirtualHID daemon check from
   `ServiceLifecycleCoordinator.startKanata`, leaving one injected
   `isVirtualHIDDaemonHealthy` predicate for the start gate. Enforced by
   `W6DeletionPassLintTests.testServiceLifecycleCoordinatorDoesNotRegrowDuplicateVHIDStartCheck`.
 - [x] Removed `HelperManager`'s actor-local `cachedHelperVersion`, so helper
   freshness checks use current XPC/provider evidence instead of a session cache.
-  Enforced by
-  `W6DeletionPassLintTests.testHelperManagerDoesNotRegrowCachedHelperVersion`.
+  Unknown helper version is not treated as fresh. Enforced by
+  `W6DeletionPassLintTests.testHelperManagerDoesNotRegrowCachedHelperVersion`,
+  `W6DeletionPassLintTests.testMatrixAdaptersDoNotTreatUnknownHelperVersionAsFresh`,
+  `SystemStateProviderInstallerStateMatrixTests.testStateMatrixSnapshotTreatsUnknownHelperVersionAsNotFresh`,
+  and
+  `SystemStateProviderInstallerStateMatrixTests.testWizardSystemContextSnapshotTreatsUnknownHelperVersionAsNotFresh`.
 - [x] Final W6 Phase 1 audit complete: the named single-implementation
   protocols, duplicate start-path checks, and named installer caches are deleted
   or ratcheted. Enforced by the `W6DeletionPassLintTests` ratchet suite. The

--- a/docs/process/installer-repair-state-matrix.md
+++ b/docs/process/installer-repair-state-matrix.md
@@ -273,6 +273,17 @@ the result as user action required and name the approval surface.
   `SystemStateProvider`, and
   `SnapshotConsumerLintTests.testRuntimeAndInstallerStateCachesStayInKnownOwners`
   prevents new runtime/installer state caches outside the current known owners.
+  `W6DeletionPassLintTests.testAsyncRepairGatesDoNotConsumeUnboundedManagementStateCache`
+  prevents async repair/start/reload gates from consuming the unbounded
+  `currentManagementState` cache instead of refreshing through the
+  provider-backed manager.
+- Helper responsiveness is not helper freshness.
+  `W6DeletionPassLintTests.testMatrixAdaptersDoNotTreatUnknownHelperVersionAsFresh`,
+  `SystemStateProviderInstallerStateMatrixTests.testStateMatrixSnapshotTreatsUnknownHelperVersionAsNotFresh`,
+  and
+  `SystemStateProviderInstallerStateMatrixTests.testWizardSystemContextSnapshotTreatsUnknownHelperVersionAsNotFresh`
+  enforce that an unknown helper version routes to helper verification/refresh
+  rather than a healthy row.
 - User-facing CLI/reporting shape belongs in CLI contract tests.
 - The state-matrix table itself is an executable golden fixture:
   `InstallerStateMatrixGoldenTests.testEveryDocumentedStateMatrixRowHasAGoldenFixture`


### PR DESCRIPTION
## Summary
- treat unknown helper version as not fresh in both AppKit and wizard state-matrix adapters
- make async lifecycle/reload gates refresh management state instead of consuming the unbounded `currentManagementState` cache
- add W6 lint ratchets and update Phase 1/state-matrix docs with the enforcing tests

## Acceptance criteria completed
- Unknown helper version routes to helper verification/refresh instead of a healthy row: `SystemStateProviderInstallerStateMatrixTests.testStateMatrixSnapshotTreatsUnknownHelperVersionAsNotFresh` and `SystemStateProviderInstallerStateMatrixTests.testWizardSystemContextSnapshotTreatsUnknownHelperVersionAsNotFresh`.
- Matrix adapters cannot reintroduce nil-helper-version-as-fresh logic: `W6DeletionPassLintTests.testMatrixAdaptersDoNotTreatUnknownHelperVersionAsFresh`.
- Async repair/start/reload gates do not read the unbounded management-state cache: `W6DeletionPassLintTests.testAsyncRepairGatesDoNotConsumeUnboundedManagementStateCache`.
- Existing W6 deletion ratchets remain green: `W6DeletionPassLintTests.testServiceLifecycleCoordinatorDoesNotRegrowSMAppServicePendingCache`, `W6DeletionPassLintTests.testHelperManagerDoesNotRegrowCachedHelperVersion`, and the rest of `W6DeletionPassLintTests`.

## Validation
- `TEST_FILTER='SystemStateProviderInstallerStateMatrixTests|W6DeletionPassLintTests' ./Scripts/run-tests-safe.sh` - 21 passed, `test_log_app_warnings=0`
- `TEST_FILTER='ConfigReloadCoordinatorTests|ServiceLifecycleCoordinatorTests' ./Scripts/run-tests-safe.sh` - 36 passed, `test_log_app_warnings=0`
- `swiftformat --lint Sources/KeyPathAppKit/Core/SystemStateProvider+InstallerStateMatrix.swift Sources/KeyPathAppKit/Managers/ConfigReloadCoordinator.swift Sources/KeyPathAppKit/Managers/ServiceLifecycleCoordinator.swift Sources/KeyPathInstallationWizard/Core/InstallerStateMatrix.swift Tests/KeyPathTests/Core/SystemStateProviderInstallerStateMatrixTests.swift Tests/KeyPathTests/Lint/W6DeletionPassLintTests.swift`
- `python3 Scripts/check-accessibility.py`
- `git diff --check`
- `KEYPATH_SNAPSHOTS=0 ./Scripts/run-tests-safe.sh` - 4548 passed, `test_log_app_warnings=0`, `test_log_app_errors=0`

## Review gate
- `./Scripts/review-gate.sh` exited 2: remote review gate selected. GitHub `claude-review` must pass before merge.

## Notes
- This addresses the senior-review freshness cleanup: helper responsiveness is not helper freshness, and async repair/start/reload gates should not rely on the unbounded `currentManagementState` cache.
