### PR TITLE
Add structured installer repair telemetry

### DIFF
--- a/Sources/KeyPathAppKit/CLI/SystemFacade.swift
+++ b/Sources/KeyPathAppKit/CLI/SystemFacade.swift
@@ -528,6 +528,7 @@ public struct CLIInstallerReport: Codable, Sendable {
     public let plannedRecipes: [String]?
     public let unmetRequirements: [String]?
     public let logs: [String]?
+    public let repairTelemetry: [CLIRepairTelemetryEvent]?
 
     init(from report: InstallerReport) {
         success = report.success
@@ -542,6 +543,7 @@ public struct CLIInstallerReport: Codable, Sendable {
         plannedRecipes = nil
         unmetRequirements = nil
         logs = nil
+        repairTelemetry = CLIRepairTelemetryEvent.from(report.repairTelemetry)
     }
 
     init(
@@ -580,6 +582,7 @@ public struct CLIInstallerReport: Codable, Sendable {
         plannedRecipes = plan.recipes.map { "\($0.id) (\($0.type))" }
         unmetRequirements = report.unmetRequirements.map(\.name)
         logs = report.logs
+        repairTelemetry = CLIRepairTelemetryEvent.from(report.repairTelemetry)
     }
 
     init(dryRunPlan plan: InstallPlan, context: SystemContext, title: String) {
@@ -606,6 +609,7 @@ public struct CLIInstallerReport: Codable, Sendable {
         plannedRecipes = plan.recipes.map { "\($0.id) (\($0.type))" }
         unmetRequirements = blockedBy
         logs = nil
+        repairTelemetry = nil
     }
 
     init(success: Bool, failureReason: String?, steps: [CLIInstallerStep], fastRepair: Bool) {
@@ -619,6 +623,7 @@ public struct CLIInstallerReport: Codable, Sendable {
         plannedRecipes = nil
         unmetRequirements = nil
         logs = nil
+        repairTelemetry = nil
     }
 
     init(bundleIssue: CLISystemIssue, dryRun: Bool, title: String) {
@@ -632,6 +637,7 @@ public struct CLIInstallerReport: Codable, Sendable {
         plannedRecipes = []
         unmetRequirements = ["Valid KeyPath.app bundle"]
         logs = nil
+        repairTelemetry = nil
     }
 
     init(
@@ -644,7 +650,8 @@ public struct CLIInstallerReport: Codable, Sendable {
         issues: [CLISystemIssue]?,
         plannedRecipes: [String]?,
         unmetRequirements: [String]?,
-        logs: [String]?
+        logs: [String]?,
+        repairTelemetry: [CLIRepairTelemetryEvent]? = nil
     ) {
         self.success = success
         self.failureReason = failureReason
@@ -656,6 +663,7 @@ public struct CLIInstallerReport: Codable, Sendable {
         self.plannedRecipes = plannedRecipes
         self.unmetRequirements = unmetRequirements
         self.logs = logs
+        self.repairTelemetry = repairTelemetry
     }
 }
 
@@ -663,6 +671,35 @@ public struct CLIInstallerStep: Codable, Sendable {
     public let name: String
     public let success: Bool
     public let error: String?
+}
+
+public struct CLIRepairTelemetryEvent: Codable, Sendable {
+    public let trigger: String
+    public let intent: String
+    public let stateMatrixRow: String?
+    public let stateMatrixPlan: [String]
+    public let action: String?
+    public let recipeID: String?
+    public let recipeType: String?
+    public let postconditionResult: String
+    public let error: String?
+
+    fileprivate init(_ event: InstallerRepairTelemetryEvent) {
+        trigger = event.trigger.rawValue
+        intent = event.intent
+        stateMatrixRow = event.stateMatrixRow
+        stateMatrixPlan = event.stateMatrixPlan
+        action = event.action
+        recipeID = event.recipeID
+        recipeType = event.recipeType
+        postconditionResult = event.postconditionResult.rawValue
+        error = event.error
+    }
+
+    fileprivate static func from(_ events: [InstallerRepairTelemetryEvent]) -> [CLIRepairTelemetryEvent]? {
+        guard !events.isEmpty else { return nil }
+        return events.map(CLIRepairTelemetryEvent.init)
+    }
 }
 
 public struct CLIInspectResult: Codable, Sendable {

--- a/Sources/KeyPathInstallationWizard/Core/InstallerEngine.swift
+++ b/Sources/KeyPathInstallationWizard/Core/InstallerEngine.swift
@@ -117,6 +117,12 @@ public final class InstallerEngine {
     /// is marked `.blocked` with the missing requirement.
     public func makePlan(for intent: InstallIntent, context: SystemContext) async -> InstallPlan {
         AppLogger.shared.log("📋 [InstallerEngine] Starting makePlan(for: \(intent), context:)")
+        let stateMatrixRow = context.installerStateMatrixRow.rawValue
+        let stateMatrixPlan = context.installerStateMatrixPlan.map(\.rawValue)
+        let baseMetadata = PlanMetadata(
+            stateMatrixRow: stateMatrixRow,
+            stateMatrixPlan: stateMatrixPlan
+        )
 
         // Phase 3: Check requirements first
         if let blockingRequirement = await checkRequirements(for: intent, context: context) {
@@ -128,7 +134,7 @@ public final class InstallerEngine {
                 status: .blocked(requirement: blockingRequirement),
                 intent: intent,
                 blockedBy: blockingRequirement,
-                metadata: PlanMetadata()
+                metadata: baseMetadata
             )
         }
 
@@ -150,7 +156,11 @@ public final class InstallerEngine {
             status: .ready,
             intent: intent,
             blockedBy: nil,
-            metadata: PlanMetadata(promptsNeeded: actions.contains { actionNeedsPrompt($0) })
+            metadata: PlanMetadata(
+                promptsNeeded: actions.contains { actionNeedsPrompt($0) },
+                stateMatrixRow: stateMatrixRow,
+                stateMatrixPlan: stateMatrixPlan
+            )
         )
 
         AppLogger.shared.log(
@@ -237,7 +247,11 @@ public final class InstallerEngine {
     /// Execute the planned operations
     /// Returns: Structured report with success/failure details and final state.
     /// If the plan was blocked by unmet requirements, execution stops immediately and the report indicates which requirement failed.
-    public func execute(plan: InstallPlan, using broker: PrivilegeBroker) async -> InstallerReport {
+    public func execute(
+        plan: InstallPlan,
+        using broker: PrivilegeBroker,
+        trigger: InstallerRepairTelemetryTrigger = .executePlan
+    ) async -> InstallerReport {
         AppLogger.shared.log("⚙️ [InstallerEngine] Starting execute(plan:, using:)")
 
         // Check if plan is blocked
@@ -245,11 +259,23 @@ public final class InstallerEngine {
             AppLogger.shared.log(
                 "⚠️ [InstallerEngine] Plan is blocked by requirement: \(requirement.name)"
             )
+            let telemetry = InstallerRepairTelemetryEvent(
+                trigger: trigger,
+                intent: plan.intent.telemetryValue,
+                stateMatrixRow: plan.metadata.stateMatrixRow,
+                stateMatrixPlan: plan.metadata.stateMatrixPlan,
+                action: nil,
+                recipeID: nil,
+                recipeType: nil,
+                postconditionResult: .blocked,
+                error: requirement.name
+            )
             return InstallerReport(
                 success: false,
                 failureReason: "Plan blocked by requirement: \(requirement.name)",
                 unmetRequirements: [requirement],
-                executedRecipes: []
+                executedRecipes: [],
+                repairTelemetry: [telemetry]
             )
         }
 
@@ -257,6 +283,22 @@ public final class InstallerEngine {
         var executedRecipes: [RecipeResult] = []
         var firstFailure: (recipe: ServiceRecipe, error: Error)?
         var allLogs: [String] = []
+        var repairTelemetry: [InstallerRepairTelemetryEvent] = []
+
+        if plan.recipes.isEmpty {
+            repairTelemetry.append(
+                InstallerRepairTelemetryEvent(
+                    trigger: trigger,
+                    intent: plan.intent.telemetryValue,
+                    stateMatrixRow: plan.metadata.stateMatrixRow,
+                    stateMatrixPlan: plan.metadata.stateMatrixPlan,
+                    action: nil,
+                    recipeID: nil,
+                    recipeType: nil,
+                    postconditionResult: .skipped
+                )
+            )
+        }
 
         for recipe in plan.recipes {
             AppLogger.shared.log(
@@ -302,6 +344,14 @@ public final class InstallerEngine {
                         commandsRun: commandsRun
                     )
                 )
+                repairTelemetry.append(
+                    makeRepairTelemetryEvent(
+                        trigger: trigger,
+                        plan: plan,
+                        recipe: recipe,
+                        result: .succeeded
+                    )
+                )
                 AppLogger.shared.log("✅ [InstallerEngine] Recipe \(recipe.id) completed successfully")
 
             } catch {
@@ -325,6 +375,15 @@ public final class InstallerEngine {
                 AppLogger.shared.log(
                     "❌ [InstallerEngine] Recipe \(recipe.id) failed: \(recipeError ?? "Unknown error")"
                 )
+                repairTelemetry.append(
+                    makeRepairTelemetryEvent(
+                        trigger: trigger,
+                        plan: plan,
+                        recipe: recipe,
+                        result: .failed,
+                        error: recipeError
+                    )
+                )
 
                 firstFailure = (recipe, error)
                 break // Stop execution on first failure
@@ -340,13 +399,34 @@ public final class InstallerEngine {
             },
             unmetRequirements: success ? [] : plan.blockedBy.map { [$0] } ?? [],
             executedRecipes: executedRecipes,
-            logs: allLogs
+            logs: allLogs,
+            repairTelemetry: repairTelemetry
         )
 
         AppLogger.shared.log(
             "✅ [InstallerEngine] execute() complete - success: \(success), recipes executed: \(executedRecipes.count)"
         )
         return report
+    }
+
+    private func makeRepairTelemetryEvent(
+        trigger: InstallerRepairTelemetryTrigger,
+        plan: InstallPlan,
+        recipe: ServiceRecipe,
+        result: InstallerRepairTelemetryResult,
+        error: String? = nil
+    ) -> InstallerRepairTelemetryEvent {
+        InstallerRepairTelemetryEvent(
+            trigger: trigger,
+            intent: plan.intent.telemetryValue,
+            stateMatrixRow: plan.metadata.stateMatrixRow,
+            stateMatrixPlan: plan.metadata.stateMatrixPlan,
+            action: recipe.id,
+            recipeID: recipe.id,
+            recipeType: recipe.type.telemetryValue,
+            postconditionResult: result,
+            error: error
+        )
     }
 
     // MARK: - Recipe Execution
@@ -630,7 +710,7 @@ public final class InstallerEngine {
         // Chain the steps
         let context = await inspectSystem()
         let plan = await makePlan(for: intent, context: context)
-        let report = await execute(plan: plan, using: broker)
+        let report = await execute(plan: plan, using: broker, trigger: .run)
 
         AppLogger.shared.log("✅ [InstallerEngine] run() complete - success: \(report.success)")
         return report
@@ -678,7 +758,20 @@ public final class InstallerEngine {
             success: success,
             failureReason: success ? nil : failure,
             executedRecipes: [recipeResult],
-            logs: []
+            logs: [],
+            repairTelemetry: [
+                InstallerRepairTelemetryEvent(
+                    trigger: .uninstall,
+                    intent: InstallIntent.uninstall.telemetryValue,
+                    stateMatrixRow: nil,
+                    stateMatrixPlan: [],
+                    action: recipeID,
+                    recipeID: recipeID,
+                    recipeType: "uninstall",
+                    postconditionResult: success ? .succeeded : .failed,
+                    error: success ? nil : failure
+                ),
+            ]
         )
 
         AppLogger.shared.log("🗑️ [InstallerEngine] uninstall complete - success: \(success)")
@@ -733,7 +826,7 @@ public final class InstallerEngine {
             metadata: basePlan.metadata
         )
 
-        let report = await execute(plan: filteredPlan, using: broker)
+        let report = await execute(plan: filteredPlan, using: broker, trigger: .singleAction)
         AppLogger.shared.log(
             "✅ [InstallerEngine] runSingleAction(\(action), using:) complete - success: \(report.success)"
         )

--- a/Sources/KeyPathInstallationWizard/Core/InstallerEngineTypes.swift
+++ b/Sources/KeyPathInstallationWizard/Core/InstallerEngineTypes.swift
@@ -17,6 +17,21 @@ public enum InstallIntent: Sendable, Equatable {
     case inspectOnly
 }
 
+public extension InstallIntent {
+    var telemetryValue: String {
+        switch self {
+        case .install:
+            "install"
+        case .repair:
+            "repair"
+        case .uninstall:
+            "uninstall"
+        case .inspectOnly:
+            "inspect-only"
+        }
+    }
+}
+
 // MARK: - Requirement
 
 /// Status of a requirement check.
@@ -166,6 +181,23 @@ public enum RecipeType: Sendable, Equatable {
     case checkRequirement
 }
 
+public extension RecipeType {
+    var telemetryValue: String {
+        switch self {
+        case .installService:
+            "install-service"
+        case .repairPrivilegedHelper:
+            "repair-privileged-helper"
+        case .restartService:
+            "restart-service"
+        case .installComponent:
+            "install-component"
+        case .checkRequirement:
+            "check-requirement"
+        }
+    }
+}
+
 /// Launchctl action to perform.
 public enum LaunchctlAction: Sendable, Equatable {
     /// Bootstrap a service
@@ -241,10 +273,21 @@ public struct PlanMetadata: Sendable, Equatable {
     public let needsReboot: Bool
     /// Whether user prompts are needed
     public let promptsNeeded: Bool
+    /// State-matrix row that produced this plan, when available.
+    public let stateMatrixRow: String?
+    /// State-matrix actions selected for this plan, when available.
+    public let stateMatrixPlan: [String]
 
-    public init(needsReboot: Bool = false, promptsNeeded: Bool = false) {
+    public init(
+        needsReboot: Bool = false,
+        promptsNeeded: Bool = false,
+        stateMatrixRow: String? = nil,
+        stateMatrixPlan: [String] = []
+    ) {
         self.needsReboot = needsReboot
         self.promptsNeeded = promptsNeeded
+        self.stateMatrixRow = stateMatrixRow
+        self.stateMatrixPlan = stateMatrixPlan
     }
 }
 
@@ -277,6 +320,61 @@ public struct InstallPlan: Sendable, Equatable {
 }
 
 // MARK: - Installer Report
+
+public enum InstallerRepairTelemetryTrigger: String, Codable, Sendable, Equatable {
+    case executePlan = "execute-plan"
+    case run
+    case singleAction = "single-action"
+    case uninstall
+}
+
+public enum InstallerRepairTelemetryResult: String, Codable, Sendable, Equatable {
+    case succeeded
+    case failed
+    case blocked
+    case skipped
+}
+
+/// Machine-readable repair/install execution trace used by CLI JSON and tests.
+///
+/// This is intentionally local to the installer report: it is not persisted,
+/// uploaded, or used to drive repair policy.
+public struct InstallerRepairTelemetryEvent: Codable, Sendable, Equatable {
+    public let timestamp: Date
+    public let trigger: InstallerRepairTelemetryTrigger
+    public let intent: String
+    public let stateMatrixRow: String?
+    public let stateMatrixPlan: [String]
+    public let action: String?
+    public let recipeID: String?
+    public let recipeType: String?
+    public let postconditionResult: InstallerRepairTelemetryResult
+    public let error: String?
+
+    public init(
+        timestamp: Date = Date(),
+        trigger: InstallerRepairTelemetryTrigger,
+        intent: String,
+        stateMatrixRow: String?,
+        stateMatrixPlan: [String],
+        action: String?,
+        recipeID: String?,
+        recipeType: String?,
+        postconditionResult: InstallerRepairTelemetryResult,
+        error: String? = nil
+    ) {
+        self.timestamp = timestamp
+        self.trigger = trigger
+        self.intent = intent
+        self.stateMatrixRow = stateMatrixRow
+        self.stateMatrixPlan = stateMatrixPlan
+        self.action = action
+        self.recipeID = recipeID
+        self.recipeType = recipeType
+        self.postconditionResult = postconditionResult
+        self.error = error
+    }
+}
 
 /// Result of executing a single recipe
 public struct RecipeResult: Sendable, Equatable {
@@ -326,6 +424,8 @@ public struct InstallerReport: Sendable {
     public let finalContext: SystemContext?
     /// Human-readable log lines (for CLI / UI display)
     public let logs: [String]
+    /// Machine-readable execution events for installer/repair diagnostics.
+    public let repairTelemetry: [InstallerRepairTelemetryEvent]
 
     public init(
         timestamp: Date = Date(),
@@ -334,7 +434,8 @@ public struct InstallerReport: Sendable {
         unmetRequirements: [Requirement] = [],
         executedRecipes: [RecipeResult] = [],
         finalContext: SystemContext? = nil,
-        logs: [String] = []
+        logs: [String] = [],
+        repairTelemetry: [InstallerRepairTelemetryEvent] = []
     ) {
         self.timestamp = timestamp
         self.success = success
@@ -343,6 +444,7 @@ public struct InstallerReport: Sendable {
         self.executedRecipes = executedRecipes
         self.finalContext = finalContext
         self.logs = logs
+        self.repairTelemetry = repairTelemetry
     }
 }
 

--- a/Tests/KeyPathTests/CLI/CLIOutputContractTests.swift
+++ b/Tests/KeyPathTests/CLI/CLIOutputContractTests.swift
@@ -111,6 +111,45 @@ final class CLIOutputContractTests: XCTestCase {
         )
     }
 
+    func testInstallerReportRepairTelemetryJSONShape() throws {
+        let installerReport = InstallerReport(
+            success: true,
+            executedRecipes: [
+                RecipeResult(recipeID: InstallerRecipeID.createConfigDirectories, success: true),
+            ],
+            repairTelemetry: [
+                InstallerRepairTelemetryEvent(
+                    timestamp: Date(timeIntervalSince1970: 0),
+                    trigger: .executePlan,
+                    intent: "repair",
+                    stateMatrixRow: InstallerStateMatrixRow.freshInstallMissingComponents.rawValue,
+                    stateMatrixPlan: [InstallerStateMatrixAction.installMissingComponents.rawValue],
+                    action: InstallerRecipeID.createConfigDirectories,
+                    recipeID: InstallerRecipeID.createConfigDirectories,
+                    recipeType: "install-component",
+                    postconditionResult: .succeeded
+                ),
+            ]
+        )
+
+        let report = CLIInstallerReport(from: installerReport)
+        let keys = try jsonKeys(report)
+        XCTAssertTrue(keys.contains("repairTelemetry"))
+
+        let data = try encoder.encode(report)
+        let decoded = try decoder.decode(CLIInstallerReport.self, from: data)
+        let event = try XCTUnwrap(decoded.repairTelemetry?.first)
+        XCTAssertEqual(event.trigger, "execute-plan")
+        XCTAssertEqual(event.intent, "repair")
+        XCTAssertEqual(event.stateMatrixRow, InstallerStateMatrixRow.freshInstallMissingComponents.rawValue)
+        XCTAssertEqual(event.stateMatrixPlan, [InstallerStateMatrixAction.installMissingComponents.rawValue])
+        XCTAssertEqual(event.action, InstallerRecipeID.createConfigDirectories)
+        XCTAssertEqual(event.recipeID, InstallerRecipeID.createConfigDirectories)
+        XCTAssertEqual(event.recipeType, "install-component")
+        XCTAssertEqual(event.postconditionResult, "succeeded")
+        XCTAssertNil(event.error)
+    }
+
     func testInstallerReportMarksActivationApprovalTimeoutAsUserActionRequired() {
         let context = SystemContextBuilder.degradedRepair()
         let plan = InstallPlan(

--- a/Tests/KeyPathTests/InstallationEngine/InstallerEngineTests.swift
+++ b/Tests/KeyPathTests/InstallationEngine/InstallerEngineTests.swift
@@ -203,7 +203,11 @@ final class InstallerEngineTests: KeyPathAsyncTestCase {
             recipes: [],
             status: .blocked(requirement: blockedRequirement),
             intent: .install,
-            blockedBy: blockedRequirement
+            blockedBy: blockedRequirement,
+            metadata: PlanMetadata(
+                stateMatrixRow: InstallerStateMatrixRow.manualApprovalRequired.rawValue,
+                stateMatrixPlan: [InstallerStateMatrixAction.surfaceManualApproval.rawValue]
+            )
         )
         let broker = PrivilegeBroker()
 
@@ -218,6 +222,101 @@ final class InstallerEngineTests: KeyPathAsyncTestCase {
             report.unmetRequirements.first?.name, "Test requirement",
             "Report should include correct requirement name"
         )
+        XCTAssertEqual(report.repairTelemetry.count, 1)
+        XCTAssertEqual(report.repairTelemetry.first?.trigger, .executePlan)
+        XCTAssertEqual(report.repairTelemetry.first?.intent, "install")
+        XCTAssertEqual(
+            report.repairTelemetry.first?.stateMatrixRow,
+            InstallerStateMatrixRow.manualApprovalRequired.rawValue
+        )
+        XCTAssertEqual(report.repairTelemetry.first?.postconditionResult, .blocked)
+        XCTAssertEqual(report.repairTelemetry.first?.error, "Test requirement")
+    }
+
+    func testExecuteRecordsStructuredRepairTelemetryForSuccessfulRecipe() async {
+        let plan = InstallPlan(
+            recipes: [
+                ServiceRecipe(
+                    id: InstallerRecipeID.createConfigDirectories,
+                    type: .installComponent
+                ),
+            ],
+            status: .ready,
+            intent: .repair,
+            metadata: PlanMetadata(
+                stateMatrixRow: InstallerStateMatrixRow.freshInstallMissingComponents.rawValue,
+                stateMatrixPlan: [InstallerStateMatrixAction.installMissingComponents.rawValue]
+            )
+        )
+
+        let report = await engine.execute(plan: plan, using: PrivilegeBroker())
+
+        XCTAssertTrue(report.success)
+        XCTAssertEqual(report.repairTelemetry.count, 1)
+        let event = report.repairTelemetry[0]
+        XCTAssertEqual(event.trigger, .executePlan)
+        XCTAssertEqual(event.intent, "repair")
+        XCTAssertEqual(event.stateMatrixRow, InstallerStateMatrixRow.freshInstallMissingComponents.rawValue)
+        XCTAssertEqual(event.stateMatrixPlan, [InstallerStateMatrixAction.installMissingComponents.rawValue])
+        XCTAssertEqual(event.action, InstallerRecipeID.createConfigDirectories)
+        XCTAssertEqual(event.recipeID, InstallerRecipeID.createConfigDirectories)
+        XCTAssertEqual(event.recipeType, "install-component")
+        XCTAssertEqual(event.postconditionResult, .succeeded)
+        XCTAssertNil(event.error)
+    }
+
+    func testExecuteRecordsStructuredRepairTelemetryForFailedRecipe() async {
+        let plan = InstallPlan(
+            recipes: [
+                ServiceRecipe(
+                    id: "unknown-test-recipe",
+                    type: .installComponent
+                ),
+            ],
+            status: .ready,
+            intent: .repair,
+            metadata: PlanMetadata(
+                stateMatrixRow: InstallerStateMatrixRow.definitiveUnhealthyState.rawValue,
+                stateMatrixPlan: [InstallerStateMatrixAction.failWithDiagnostics.rawValue]
+            )
+        )
+
+        let report = await engine.execute(plan: plan, using: PrivilegeBroker())
+
+        XCTAssertFalse(report.success)
+        XCTAssertEqual(report.repairTelemetry.count, 1)
+        let event = report.repairTelemetry[0]
+        XCTAssertEqual(event.intent, "repair")
+        XCTAssertEqual(event.stateMatrixRow, InstallerStateMatrixRow.definitiveUnhealthyState.rawValue)
+        XCTAssertEqual(event.action, "unknown-test-recipe")
+        XCTAssertEqual(event.recipeID, "unknown-test-recipe")
+        XCTAssertEqual(event.recipeType, "install-component")
+        XCTAssertEqual(event.postconditionResult, .failed)
+        XCTAssertTrue(event.error?.contains("Unknown component recipe") == true)
+    }
+
+    func testExecuteRecordsStructuredRepairTelemetryForNoopPlan() async {
+        let plan = InstallPlan(
+            recipes: [],
+            status: .ready,
+            intent: .repair,
+            metadata: PlanMetadata(
+                stateMatrixRow: InstallerStateMatrixRow.runningAndTCPResponding.rawValue,
+                stateMatrixPlan: []
+            )
+        )
+
+        let report = await engine.execute(plan: plan, using: PrivilegeBroker())
+
+        XCTAssertTrue(report.success)
+        XCTAssertEqual(report.repairTelemetry.count, 1)
+        let event = report.repairTelemetry[0]
+        XCTAssertEqual(event.intent, "repair")
+        XCTAssertEqual(event.stateMatrixRow, InstallerStateMatrixRow.runningAndTCPResponding.rawValue)
+        XCTAssertNil(event.action)
+        XCTAssertNil(event.recipeID)
+        XCTAssertNil(event.recipeType)
+        XCTAssertEqual(event.postconditionResult, .skipped)
     }
 
     func testExecuteExecutesRecipesInOrder() async {

--- a/docs/planning/installer-reliability-phase1.md
+++ b/docs/planning/installer-reliability-phase1.md
@@ -559,6 +559,14 @@ Phase 1 changes *post-install* behavior, not first-run automation.
   `CLIOutputContractTests.testInstallerReportLinksTerminalConfigFailureToTroubleshooting`,
   plus
   `CLIOutputContractTests.testInstallerReportLinksMissingBundledKanataToTroubleshooting`.
+- [x] Repair/install attempts emit structured report telemetry for the trigger,
+  state-matrix row, matrix action plan, executed action/recipe, and
+  postcondition result. Enforced by
+  `InstallerEngineTests.testExecuteRecordsStructuredRepairTelemetryForSuccessfulRecipe`,
+  `InstallerEngineTests.testExecuteRecordsStructuredRepairTelemetryForFailedRecipe`,
+  `InstallerEngineTests.testExecuteRecordsStructuredRepairTelemetryForNoopPlan`,
+  `InstallerEngineTests.testExecuteHandlesBlockedPlan`, and
+  `CLIOutputContractTests.testInstallerReportRepairTelemetryJSONShape`.
 
 ## Workstream 4: Prevention at the Source
 
@@ -809,9 +817,14 @@ foundation, not something to replace.
 - One sustained stability window (proposal: 2 release cycles / 8 weeks) with
   zero installer/repair regressions and zero false-green or false-alert
   incidents in the debug logs of dogfood machines.
-- Repair success/failure outcomes are observable (structured log events for
+- Repair success/failure outcomes are observable (structured report events for
   every repair attempt: trigger, row, action, postcondition result) — this
-  telemetry is Phase 2's prerequisite data.
+  telemetry is Phase 2's prerequisite data. Enforced by
+  `InstallerEngineTests.testExecuteRecordsStructuredRepairTelemetryForSuccessfulRecipe`,
+  `InstallerEngineTests.testExecuteRecordsStructuredRepairTelemetryForFailedRecipe`,
+  `InstallerEngineTests.testExecuteRecordsStructuredRepairTelemetryForNoopPlan`,
+  `InstallerEngineTests.testExecuteHandlesBlockedPlan`, and
+  `CLIOutputContractTests.testInstallerReportRepairTelemetryJSONShape`.
 
 ## Non-Goals Reminder
 

--- a/docs/process/installer-repair-state-matrix.md
+++ b/docs/process/installer-repair-state-matrix.md
@@ -85,6 +85,14 @@ For any installer or repair change, answer these before merging:
   `failed with diagnostics`?
 - Does every helper path and every sudo fallback path enforce the same
   postcondition?
+- Does every installer/repair report include structured telemetry for the
+  trigger, state-matrix row, matrix plan/action, and postcondition result?
+  `InstallerEngineTests.testExecuteRecordsStructuredRepairTelemetryForSuccessfulRecipe`,
+  `InstallerEngineTests.testExecuteRecordsStructuredRepairTelemetryForFailedRecipe`,
+  `InstallerEngineTests.testExecuteRecordsStructuredRepairTelemetryForNoopPlan`,
+  `InstallerEngineTests.testExecuteHandlesBlockedPlan`, and
+  `CLIOutputContractTests.testInstallerReportRepairTelemetryJSONShape` enforce
+  the report/CLI contract.
 - If the planner uses a diagnostic string, is that diagnostic scoped to a live
   current runtime?
 - If helper code changed, how is helper freshness verified after deploy?


### PR DESCRIPTION
## Summary
- add structured installer/repair telemetry events to `InstallerReport`
- include trigger, intent, state-matrix row, matrix action plan, recipe/action, recipe type, postcondition result, and error
- expose telemetry through CLI JSON as optional `repairTelemetry`
- document the Phase 1 telemetry acceptance criterion with enforcing tests

## Acceptance criteria completed
- Repair/install attempts emit structured report telemetry for trigger / row / action / postcondition result.
  - `InstallerEngineTests.testExecuteRecordsStructuredRepairTelemetryForSuccessfulRecipe`
  - `InstallerEngineTests.testExecuteRecordsStructuredRepairTelemetryForFailedRecipe`
  - `InstallerEngineTests.testExecuteRecordsStructuredRepairTelemetryForNoopPlan`
  - `InstallerEngineTests.testExecuteHandlesBlockedPlan`
  - `CLIOutputContractTests.testInstallerReportRepairTelemetryJSONShape`

## Validation
- `TEST_FILTER='InstallerEngineTests|CLIOutputContractTests' ./Scripts/run-tests-safe.sh` — 44 passed, app warnings/errors 0
- `swiftformat --lint Sources/KeyPathInstallationWizard/Core/InstallerEngineTypes.swift Sources/KeyPathInstallationWizard/Core/InstallerEngine.swift Sources/KeyPathAppKit/CLI/SystemFacade.swift Tests/KeyPathTests/InstallationEngine/InstallerEngineTests.swift Tests/KeyPathTests/CLI/CLIOutputContractTests.swift` — passed
- `python3 Scripts/check-accessibility.py` — passed
- `git diff --check` — passed
- `KEYPATH_SNAPSHOTS=0 ./Scripts/run-tests-safe.sh` — 4552 passed, app warnings/errors 0
- `./Scripts/review-gate.sh` — remote review gate selected; GitHub `claude-review` must pass before merge

## Notes
- This is reporting-only telemetry. It does not persist data, upload data, or change repair policy.
- No Phase 2 autonomous repair behavior is introduced.
