### PR TITLE
Move CLI report models into CLISupport

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -126,6 +126,7 @@ let package = Package(
         ),
         .target(
             name: "KeyPathCLISupport",
+            dependencies: ["KeyPathInstallationWizard"],
             path: "Sources/KeyPathCLISupport",
             swiftSettings: [
                 .swiftLanguageMode(.v6)
@@ -150,6 +151,7 @@ let package = Package(
                 "KeyPathWizardCore",
                 "KeyPathInstallationWizard",
                 "KeyPathPluginKit",
+                "KeyPathCLISupport",
                 .product(name: "Sparkle", package: "Sparkle")
             ],
             path: "Sources/KeyPathAppKit",
@@ -295,6 +297,17 @@ let package = Package(
                 "KeyPathPermissions"
             ],
             path: "Tests/KeyPathSmokeTests",
+            swiftSettings: [
+                .swiftLanguageMode(.v6)
+            ]
+        ),
+        .testTarget(
+            name: "KeyPathCLISupportTests",
+            dependencies: [
+                "KeyPathCLISupport",
+                "KeyPathInstallationWizard"
+            ],
+            path: "Tests/KeyPathCLISupportTests",
             swiftSettings: [
                 .swiftLanguageMode(.v6)
             ]

--- a/Sources/KeyPathAppKit/CLI/CLIReportModelExports.swift
+++ b/Sources/KeyPathAppKit/CLI/CLIReportModelExports.swift
@@ -1,1 +1,0 @@
-@_exported import KeyPathCLISupport

--- a/Sources/KeyPathAppKit/CLI/CLIReportModelExports.swift
+++ b/Sources/KeyPathAppKit/CLI/CLIReportModelExports.swift
@@ -1,0 +1,1 @@
+@_exported import KeyPathCLISupport

--- a/Sources/KeyPathAppKit/CLI/SystemFacade.swift
+++ b/Sources/KeyPathAppKit/CLI/SystemFacade.swift
@@ -1,5 +1,6 @@
 import AppKit
 import Foundation
+import KeyPathCLISupport
 import KeyPathCore
 import KeyPathDaemonLifecycle
 import KeyPathInstallationWizard
@@ -494,58 +495,7 @@ public struct SystemFacade: Sendable {
     }
 }
 
-// MARK: - System Types
-
-public struct CLIStatusResult: Codable, Sendable {
-    public let isOperational: Bool
-    public let helperInstalled: Bool
-    public let helperWorking: Bool
-    public let helperVersion: String?
-    public let keyPathAccessibility: Bool
-    public let keyPathInputMonitoring: Bool
-    public let kanataAccessibility: Bool
-    public let kanataInputMonitoring: Bool
-    public let kanataBinaryInstalled: Bool
-    public let karabinerDriverInstalled: Bool
-    public let vhidDeviceHealthy: Bool
-    public let kanataRunning: Bool
-    public let karabinerDaemonRunning: Bool
-    public let vhidHealthy: Bool
-    public let activeRuntimePathTitle: String?
-    public let activeRuntimePathDetail: String?
-    public let hasConflicts: Bool
-    public let timestamp: Date
-}
-
-public struct CLIInstallerReport: Codable, Sendable {
-    public let success: Bool
-    public let failureReason: String?
-    public let steps: [CLIInstallerStep]
-    public let fastRepair: Bool
-    public let dryRun: Bool?
-    public let userActionRequired: Bool?
-    public let issues: [CLISystemIssue]?
-    public let plannedRecipes: [String]?
-    public let unmetRequirements: [String]?
-    public let logs: [String]?
-    public let repairTelemetry: [CLIRepairTelemetryEvent]?
-
-    init(from report: InstallerReport) {
-        success = report.success
-        failureReason = report.failureReason
-        steps = report.executedRecipes.map {
-            CLIInstallerStep(name: $0.recipeID, success: $0.success, error: $0.error)
-        }
-        fastRepair = false
-        dryRun = nil
-        userActionRequired = nil
-        issues = nil
-        plannedRecipes = nil
-        unmetRequirements = nil
-        logs = nil
-        repairTelemetry = CLIRepairTelemetryEvent.from(report.repairTelemetry)
-    }
-
+public extension CLIInstallerReport {
     init(
         from report: InstallerReport,
         initialContext: SystemContext,
@@ -559,30 +509,33 @@ public struct CLIInstallerReport: Codable, Sendable {
         let completedButStillBlocked = report.success && !finalOperational && !finalIssues.isEmpty
         let failedForManualApproval = report.failureReason.map(SystemFacade.requiresManualApproval) ?? false
 
-        success = report.success && !completedButStillBlocked
-        if let reportFailure = report.failureReason {
-            failureReason = reportFailure
+        let failureReason: String? = if let reportFailure = report.failureReason {
+            reportFailure
         } else if !finalUserActionIssues.isEmpty {
-            failureReason = SystemFacade.userActionFailureReason(
+            SystemFacade.userActionFailureReason(
                 finalUserActionIssues,
                 prefix: "\(title) requires user action"
             )
         } else if completedButStillBlocked {
-            failureReason = "Repair completed but system still has blocking issue(s)"
+            "Repair completed but system still has blocking issue(s)"
         } else {
-            failureReason = nil
+            nil
         }
-        steps = report.executedRecipes.map {
-            CLIInstallerStep(name: $0.recipeID, success: $0.success, error: $0.error)
-        }
-        fastRepair = false
-        dryRun = false
-        userActionRequired = !finalUserActionIssues.isEmpty || plan.metadata.promptsNeeded || failedForManualApproval
-        issues = finalIssues
-        plannedRecipes = plan.recipes.map { "\($0.id) (\($0.type))" }
-        unmetRequirements = report.unmetRequirements.map(\.name)
-        logs = report.logs
-        repairTelemetry = CLIRepairTelemetryEvent.from(report.repairTelemetry)
+        self.init(
+            success: report.success && !completedButStillBlocked,
+            failureReason: failureReason,
+            steps: report.executedRecipes.map {
+                CLIInstallerStep(name: $0.recipeID, success: $0.success, error: $0.error)
+            },
+            fastRepair: false,
+            dryRun: false,
+            userActionRequired: !finalUserActionIssues.isEmpty || plan.metadata.promptsNeeded || failedForManualApproval,
+            issues: finalIssues,
+            plannedRecipes: plan.recipes.map { "\($0.id) (\($0.type))" },
+            unmetRequirements: report.unmetRequirements.map(\.name),
+            logs: report.logs,
+            repairTelemetry: CLIRepairTelemetryEvent.from(report.repairTelemetry)
+        )
     }
 
     init(dryRunPlan plan: InstallPlan, context: SystemContext, title: String) {
@@ -590,179 +543,28 @@ public struct CLIInstallerReport: Codable, Sendable {
         let userActionIssues = contextIssues.filter { !$0.canAutoFix }
         let blockedBy = plan.blockedBy.map { [$0.name] } ?? []
 
-        success = blockedBy.isEmpty && userActionIssues.isEmpty
-        if !blockedBy.isEmpty {
-            failureReason = "Plan blocked by requirement: \(blockedBy.joined(separator: ", "))"
+        let failureReason: String? = if !blockedBy.isEmpty {
+            "Plan blocked by requirement: \(blockedBy.joined(separator: ", "))"
         } else if !userActionIssues.isEmpty {
-            failureReason = SystemFacade.userActionFailureReason(
+            SystemFacade.userActionFailureReason(
                 userActionIssues,
                 prefix: "\(title) requires user action"
             )
         } else {
-            failureReason = nil
+            nil
         }
-        steps = []
-        fastRepair = false
-        dryRun = true
-        userActionRequired = !userActionIssues.isEmpty || plan.metadata.promptsNeeded
-        issues = contextIssues
-        plannedRecipes = plan.recipes.map { "\($0.id) (\($0.type))" }
-        unmetRequirements = blockedBy
-        logs = nil
-        repairTelemetry = nil
-    }
-
-    init(success: Bool, failureReason: String?, steps: [CLIInstallerStep], fastRepair: Bool) {
-        self.success = success
-        self.failureReason = failureReason
-        self.steps = steps
-        self.fastRepair = fastRepair
-        dryRun = nil
-        userActionRequired = nil
-        issues = nil
-        plannedRecipes = nil
-        unmetRequirements = nil
-        logs = nil
-        repairTelemetry = nil
-    }
-
-    init(bundleIssue: CLISystemIssue, dryRun: Bool, title: String) {
-        success = false
-        failureReason = "\(title) requires the signed KeyPath.app bundle. \(bundleIssue.action)"
-        steps = []
-        fastRepair = false
-        self.dryRun = dryRun
-        userActionRequired = true
-        issues = [bundleIssue]
-        plannedRecipes = []
-        unmetRequirements = ["Valid KeyPath.app bundle"]
-        logs = nil
-        repairTelemetry = nil
-    }
-
-    init(
-        success: Bool,
-        failureReason: String?,
-        steps: [CLIInstallerStep],
-        fastRepair: Bool,
-        dryRun: Bool?,
-        userActionRequired: Bool?,
-        issues: [CLISystemIssue]?,
-        plannedRecipes: [String]?,
-        unmetRequirements: [String]?,
-        logs: [String]?,
-        repairTelemetry: [CLIRepairTelemetryEvent]? = nil
-    ) {
-        self.success = success
-        self.failureReason = failureReason
-        self.steps = steps
-        self.fastRepair = fastRepair
-        self.dryRun = dryRun
-        self.userActionRequired = userActionRequired
-        self.issues = issues
-        self.plannedRecipes = plannedRecipes
-        self.unmetRequirements = unmetRequirements
-        self.logs = logs
-        self.repairTelemetry = repairTelemetry
-    }
-}
-
-public struct CLIInstallerStep: Codable, Sendable {
-    public let name: String
-    public let success: Bool
-    public let error: String?
-}
-
-public struct CLIRepairTelemetryEvent: Codable, Sendable {
-    public let trigger: String
-    public let intent: String
-    public let stateMatrixRow: String?
-    public let stateMatrixPlan: [String]
-    public let action: String?
-    public let recipeID: String?
-    public let recipeType: String?
-    public let postconditionResult: String
-    public let error: String?
-
-    fileprivate init(_ event: InstallerRepairTelemetryEvent) {
-        trigger = event.trigger.rawValue
-        intent = event.intent
-        stateMatrixRow = event.stateMatrixRow
-        stateMatrixPlan = event.stateMatrixPlan
-        action = event.action
-        recipeID = event.recipeID
-        recipeType = event.recipeType
-        postconditionResult = event.postconditionResult.rawValue
-        error = event.error
-    }
-
-    fileprivate static func from(_ events: [InstallerRepairTelemetryEvent]) -> [CLIRepairTelemetryEvent]? {
-        guard !events.isEmpty else { return nil }
-        return events.map(CLIRepairTelemetryEvent.init)
-    }
-}
-
-public struct CLIInspectResult: Codable, Sendable {
-    public let macOSVersion: String
-    public let driverCompatible: Bool
-    public let planStatus: String
-    public let blockedBy: String?
-    public let plannedRecipes: [String]
-    public let planIntent: String?
-    public let isOperational: Bool?
-    public let userActionRequired: Bool?
-    public let promptsNeeded: Bool?
-    public let issues: [CLISystemIssue]?
-    public let stateMatrixRow: String?
-    public let stateMatrixPlan: [String]?
-
-    public init(
-        macOSVersion: String,
-        driverCompatible: Bool,
-        planStatus: String,
-        blockedBy: String?,
-        plannedRecipes: [String],
-        planIntent: String? = nil,
-        isOperational: Bool? = nil,
-        userActionRequired: Bool? = nil,
-        promptsNeeded: Bool? = nil,
-        issues: [CLISystemIssue]? = nil,
-        stateMatrixRow: String? = nil,
-        stateMatrixPlan: [String]? = nil
-    ) {
-        self.macOSVersion = macOSVersion
-        self.driverCompatible = driverCompatible
-        self.planStatus = planStatus
-        self.blockedBy = blockedBy
-        self.plannedRecipes = plannedRecipes
-        self.planIntent = planIntent
-        self.isOperational = isOperational
-        self.userActionRequired = userActionRequired
-        self.promptsNeeded = promptsNeeded
-        self.issues = issues
-        self.stateMatrixRow = stateMatrixRow
-        self.stateMatrixPlan = stateMatrixPlan
-    }
-}
-
-public struct CLISystemIssue: Codable, Sendable {
-    public let title: String
-    public let category: String
-    public let action: String
-    public let canAutoFix: Bool
-    public let remediationURL: String?
-
-    public init(
-        title: String,
-        category: String,
-        action: String,
-        canAutoFix: Bool,
-        remediationURL: String? = nil
-    ) {
-        self.title = title
-        self.category = category
-        self.action = action
-        self.canAutoFix = canAutoFix
-        self.remediationURL = remediationURL
+        self.init(
+            success: blockedBy.isEmpty && userActionIssues.isEmpty,
+            failureReason: failureReason,
+            steps: [],
+            fastRepair: false,
+            dryRun: true,
+            userActionRequired: !userActionIssues.isEmpty || plan.metadata.promptsNeeded,
+            issues: contextIssues,
+            plannedRecipes: plan.recipes.map { "\($0.id) (\($0.type))" },
+            unmetRequirements: blockedBy,
+            logs: nil,
+            repairTelemetry: nil
+        )
     }
 }

--- a/Sources/KeyPathCLI/Commands/System/SystemInspectCommand.swift
+++ b/Sources/KeyPathCLI/Commands/System/SystemInspectCommand.swift
@@ -1,6 +1,7 @@
 import ArgumentParser
 import Foundation
 import KeyPathAppKit
+import KeyPathCLISupport
 
 struct SystemInspect: AsyncParsableCommand {
     static let configuration = CommandConfiguration(

--- a/Sources/KeyPathCLI/Commands/System/SystemInstallCommand.swift
+++ b/Sources/KeyPathCLI/Commands/System/SystemInstallCommand.swift
@@ -1,6 +1,7 @@
 import ArgumentParser
 import Foundation
 import KeyPathAppKit
+import KeyPathCLISupport
 
 struct SystemInstall: AsyncParsableCommand {
     static let configuration = CommandConfiguration(

--- a/Sources/KeyPathCLI/Commands/System/SystemRepairCommand.swift
+++ b/Sources/KeyPathCLI/Commands/System/SystemRepairCommand.swift
@@ -1,6 +1,7 @@
 import ArgumentParser
 import Foundation
 import KeyPathAppKit
+import KeyPathCLISupport
 
 struct SystemRepair: AsyncParsableCommand {
     static let configuration = CommandConfiguration(

--- a/Sources/KeyPathCLI/Commands/System/SystemUninstallCommand.swift
+++ b/Sources/KeyPathCLI/Commands/System/SystemUninstallCommand.swift
@@ -1,6 +1,7 @@
 import ArgumentParser
 import Foundation
 import KeyPathAppKit
+import KeyPathCLISupport
 
 struct SystemUninstall: AsyncParsableCommand {
     static let configuration = CommandConfiguration(

--- a/Sources/KeyPathCLI/Utilities/ApplyHelper.swift
+++ b/Sources/KeyPathCLI/Utilities/ApplyHelper.swift
@@ -1,6 +1,7 @@
 import ArgumentParser
 import Foundation
 import KeyPathAppKit
+import KeyPathCLISupport
 
 func applyConfigurationOrHint(apply: Bool, context: OutputContext) async throws {
     if apply {

--- a/Sources/KeyPathCLISupport/CLIReportModels.swift
+++ b/Sources/KeyPathCLISupport/CLIReportModels.swift
@@ -1,0 +1,253 @@
+import Foundation
+import KeyPathInstallationWizard
+
+public struct CLIStatusResult: Codable, Sendable {
+    public let isOperational: Bool
+    public let helperInstalled: Bool
+    public let helperWorking: Bool
+    public let helperVersion: String?
+    public let keyPathAccessibility: Bool
+    public let keyPathInputMonitoring: Bool
+    public let kanataAccessibility: Bool
+    public let kanataInputMonitoring: Bool
+    public let kanataBinaryInstalled: Bool
+    public let karabinerDriverInstalled: Bool
+    public let vhidDeviceHealthy: Bool
+    public let kanataRunning: Bool
+    public let karabinerDaemonRunning: Bool
+    public let vhidHealthy: Bool
+    public let activeRuntimePathTitle: String?
+    public let activeRuntimePathDetail: String?
+    public let hasConflicts: Bool
+    public let timestamp: Date
+
+    public init(
+        isOperational: Bool,
+        helperInstalled: Bool,
+        helperWorking: Bool,
+        helperVersion: String?,
+        keyPathAccessibility: Bool,
+        keyPathInputMonitoring: Bool,
+        kanataAccessibility: Bool,
+        kanataInputMonitoring: Bool,
+        kanataBinaryInstalled: Bool,
+        karabinerDriverInstalled: Bool,
+        vhidDeviceHealthy: Bool,
+        kanataRunning: Bool,
+        karabinerDaemonRunning: Bool,
+        vhidHealthy: Bool,
+        activeRuntimePathTitle: String?,
+        activeRuntimePathDetail: String?,
+        hasConflicts: Bool,
+        timestamp: Date
+    ) {
+        self.isOperational = isOperational
+        self.helperInstalled = helperInstalled
+        self.helperWorking = helperWorking
+        self.helperVersion = helperVersion
+        self.keyPathAccessibility = keyPathAccessibility
+        self.keyPathInputMonitoring = keyPathInputMonitoring
+        self.kanataAccessibility = kanataAccessibility
+        self.kanataInputMonitoring = kanataInputMonitoring
+        self.kanataBinaryInstalled = kanataBinaryInstalled
+        self.karabinerDriverInstalled = karabinerDriverInstalled
+        self.vhidDeviceHealthy = vhidDeviceHealthy
+        self.kanataRunning = kanataRunning
+        self.karabinerDaemonRunning = karabinerDaemonRunning
+        self.vhidHealthy = vhidHealthy
+        self.activeRuntimePathTitle = activeRuntimePathTitle
+        self.activeRuntimePathDetail = activeRuntimePathDetail
+        self.hasConflicts = hasConflicts
+        self.timestamp = timestamp
+    }
+}
+
+public struct CLIInstallerReport: Codable, Sendable {
+    public let success: Bool
+    public let failureReason: String?
+    public let steps: [CLIInstallerStep]
+    public let fastRepair: Bool
+    public let dryRun: Bool?
+    public let userActionRequired: Bool?
+    public let issues: [CLISystemIssue]?
+    public let plannedRecipes: [String]?
+    public let unmetRequirements: [String]?
+    public let logs: [String]?
+    public let repairTelemetry: [CLIRepairTelemetryEvent]?
+
+    public init(from report: InstallerReport) {
+        success = report.success
+        failureReason = report.failureReason
+        steps = report.executedRecipes.map {
+            CLIInstallerStep(name: $0.recipeID, success: $0.success, error: $0.error)
+        }
+        fastRepair = false
+        dryRun = nil
+        userActionRequired = nil
+        issues = nil
+        plannedRecipes = nil
+        unmetRequirements = nil
+        logs = nil
+        repairTelemetry = CLIRepairTelemetryEvent.from(report.repairTelemetry)
+    }
+
+    public init(success: Bool, failureReason: String?, steps: [CLIInstallerStep], fastRepair: Bool) {
+        self.success = success
+        self.failureReason = failureReason
+        self.steps = steps
+        self.fastRepair = fastRepair
+        dryRun = nil
+        userActionRequired = nil
+        issues = nil
+        plannedRecipes = nil
+        unmetRequirements = nil
+        logs = nil
+        repairTelemetry = nil
+    }
+
+    public init(bundleIssue: CLISystemIssue, dryRun: Bool, title: String) {
+        success = false
+        failureReason = "\(title) requires the signed KeyPath.app bundle. \(bundleIssue.action)"
+        steps = []
+        fastRepair = false
+        self.dryRun = dryRun
+        userActionRequired = true
+        issues = [bundleIssue]
+        plannedRecipes = []
+        unmetRequirements = ["Valid KeyPath.app bundle"]
+        logs = nil
+        repairTelemetry = nil
+    }
+
+    public init(
+        success: Bool,
+        failureReason: String?,
+        steps: [CLIInstallerStep],
+        fastRepair: Bool,
+        dryRun: Bool?,
+        userActionRequired: Bool?,
+        issues: [CLISystemIssue]?,
+        plannedRecipes: [String]?,
+        unmetRequirements: [String]?,
+        logs: [String]?,
+        repairTelemetry: [CLIRepairTelemetryEvent]? = nil
+    ) {
+        self.success = success
+        self.failureReason = failureReason
+        self.steps = steps
+        self.fastRepair = fastRepair
+        self.dryRun = dryRun
+        self.userActionRequired = userActionRequired
+        self.issues = issues
+        self.plannedRecipes = plannedRecipes
+        self.unmetRequirements = unmetRequirements
+        self.logs = logs
+        self.repairTelemetry = repairTelemetry
+    }
+}
+
+public struct CLIInstallerStep: Codable, Sendable {
+    public let name: String
+    public let success: Bool
+    public let error: String?
+
+    public init(name: String, success: Bool, error: String?) {
+        self.name = name
+        self.success = success
+        self.error = error
+    }
+}
+
+public struct CLIRepairTelemetryEvent: Codable, Sendable {
+    public let trigger: String
+    public let intent: String
+    public let stateMatrixRow: String?
+    public let stateMatrixPlan: [String]
+    public let action: String?
+    public let recipeID: String?
+    public let recipeType: String?
+    public let postconditionResult: String
+    public let error: String?
+
+    public init(_ event: InstallerRepairTelemetryEvent) {
+        trigger = event.trigger.rawValue
+        intent = event.intent
+        stateMatrixRow = event.stateMatrixRow
+        stateMatrixPlan = event.stateMatrixPlan
+        action = event.action
+        recipeID = event.recipeID
+        recipeType = event.recipeType
+        postconditionResult = event.postconditionResult.rawValue
+        error = event.error
+    }
+
+    public static func from(_ events: [InstallerRepairTelemetryEvent]) -> [CLIRepairTelemetryEvent]? {
+        guard !events.isEmpty else { return nil }
+        return events.map(CLIRepairTelemetryEvent.init)
+    }
+}
+
+public struct CLIInspectResult: Codable, Sendable {
+    public let macOSVersion: String
+    public let driverCompatible: Bool
+    public let planStatus: String
+    public let blockedBy: String?
+    public let plannedRecipes: [String]
+    public let planIntent: String?
+    public let isOperational: Bool?
+    public let userActionRequired: Bool?
+    public let promptsNeeded: Bool?
+    public let issues: [CLISystemIssue]?
+    public let stateMatrixRow: String?
+    public let stateMatrixPlan: [String]?
+
+    public init(
+        macOSVersion: String,
+        driverCompatible: Bool,
+        planStatus: String,
+        blockedBy: String?,
+        plannedRecipes: [String],
+        planIntent: String? = nil,
+        isOperational: Bool? = nil,
+        userActionRequired: Bool? = nil,
+        promptsNeeded: Bool? = nil,
+        issues: [CLISystemIssue]? = nil,
+        stateMatrixRow: String? = nil,
+        stateMatrixPlan: [String]? = nil
+    ) {
+        self.macOSVersion = macOSVersion
+        self.driverCompatible = driverCompatible
+        self.planStatus = planStatus
+        self.blockedBy = blockedBy
+        self.plannedRecipes = plannedRecipes
+        self.planIntent = planIntent
+        self.isOperational = isOperational
+        self.userActionRequired = userActionRequired
+        self.promptsNeeded = promptsNeeded
+        self.issues = issues
+        self.stateMatrixRow = stateMatrixRow
+        self.stateMatrixPlan = stateMatrixPlan
+    }
+}
+
+public struct CLISystemIssue: Codable, Sendable {
+    public let title: String
+    public let category: String
+    public let action: String
+    public let canAutoFix: Bool
+    public let remediationURL: String?
+
+    public init(
+        title: String,
+        category: String,
+        action: String,
+        canAutoFix: Bool,
+        remediationURL: String? = nil
+    ) {
+        self.title = title
+        self.category = category
+        self.action = action
+        self.canAutoFix = canAutoFix
+        self.remediationURL = remediationURL
+    }
+}

--- a/Tests/KeyPathCLISupportTests/CLIReportModelsTests.swift
+++ b/Tests/KeyPathCLISupportTests/CLIReportModelsTests.swift
@@ -1,0 +1,106 @@
+import Foundation
+import KeyPathCLISupport
+import KeyPathInstallationWizard
+import XCTest
+
+final class CLIReportModelsTests: XCTestCase {
+    private let encoder: JSONEncoder = {
+        let e = JSONEncoder()
+        e.outputFormatting = [.sortedKeys]
+        e.dateEncodingStrategy = .iso8601
+        return e
+    }()
+
+    private let decoder = JSONDecoder()
+
+    func testStatusJSONShape() throws {
+        let status = CLIStatusResult(
+            isOperational: true,
+            helperInstalled: true,
+            helperWorking: true,
+            helperVersion: "1.0",
+            keyPathAccessibility: true,
+            keyPathInputMonitoring: true,
+            kanataAccessibility: true,
+            kanataInputMonitoring: true,
+            kanataBinaryInstalled: true,
+            karabinerDriverInstalled: true,
+            vhidDeviceHealthy: true,
+            kanataRunning: true,
+            karabinerDaemonRunning: true,
+            vhidHealthy: true,
+            activeRuntimePathTitle: "test",
+            activeRuntimePathDetail: "detail",
+            hasConflicts: false,
+            timestamp: Date()
+        )
+        let keys = try jsonKeys(status)
+        let required: Set = [
+            "isOperational", "helperInstalled", "helperWorking",
+            "keyPathAccessibility", "keyPathInputMonitoring",
+            "kanataAccessibility", "kanataInputMonitoring",
+            "kanataBinaryInstalled", "karabinerDriverInstalled", "vhidDeviceHealthy",
+            "kanataRunning", "karabinerDaemonRunning", "vhidHealthy",
+            "hasConflicts", "timestamp",
+        ]
+        XCTAssertTrue(required.isSubset(of: keys), "Missing required keys: \(required.subtracting(keys))")
+    }
+
+    func testInstallerReportRepairTelemetryJSONShape() throws {
+        let installerReport = InstallerReport(
+            success: true,
+            executedRecipes: [
+                RecipeResult(recipeID: InstallerRecipeID.createConfigDirectories, success: true),
+            ],
+            repairTelemetry: [
+                InstallerRepairTelemetryEvent(
+                    timestamp: Date(timeIntervalSince1970: 0),
+                    trigger: .executePlan,
+                    intent: "repair",
+                    stateMatrixRow: InstallerStateMatrixRow.freshInstallMissingComponents.rawValue,
+                    stateMatrixPlan: [InstallerStateMatrixAction.installMissingComponents.rawValue],
+                    action: InstallerRecipeID.createConfigDirectories,
+                    recipeID: InstallerRecipeID.createConfigDirectories,
+                    recipeType: "install-component",
+                    postconditionResult: .succeeded
+                ),
+            ]
+        )
+
+        let report = CLIInstallerReport(from: installerReport)
+        let keys = try jsonKeys(report)
+        XCTAssertTrue(keys.contains("repairTelemetry"))
+
+        let data = try encoder.encode(report)
+        let decoded = try decoder.decode(CLIInstallerReport.self, from: data)
+        let event = try XCTUnwrap(decoded.repairTelemetry?.first)
+        XCTAssertEqual(event.trigger, "execute-plan")
+        XCTAssertEqual(event.intent, "repair")
+        XCTAssertEqual(event.stateMatrixRow, InstallerStateMatrixRow.freshInstallMissingComponents.rawValue)
+        XCTAssertEqual(event.stateMatrixPlan, [InstallerStateMatrixAction.installMissingComponents.rawValue])
+        XCTAssertEqual(event.action, InstallerRecipeID.createConfigDirectories)
+        XCTAssertEqual(event.recipeID, InstallerRecipeID.createConfigDirectories)
+        XCTAssertEqual(event.recipeType, "install-component")
+        XCTAssertEqual(event.postconditionResult, "succeeded")
+        XCTAssertNil(event.error)
+    }
+
+    func testInspectResultJSONShape() throws {
+        let json = """
+        {"macOSVersion":"15.0","driverCompatible":true,"planStatus":"ready","blockedBy":"helper","plannedRecipes":["step1"]}
+        """
+        let result = try decoder.decode(CLIInspectResult.self, from: Data(json.utf8))
+        let keys = try jsonKeys(result)
+        let required: Set = ["driverCompatible", "macOSVersion", "planStatus", "plannedRecipes"]
+        XCTAssertTrue(required.isSubset(of: keys), "Missing required keys: \(required.subtracting(keys))")
+        XCTAssertNil(result.stateMatrixRow)
+        XCTAssertNil(result.stateMatrixPlan)
+    }
+
+    private func jsonKeys(_ value: some Encodable) throws -> Set<String> {
+        let data = try encoder.encode(value)
+        let object = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        guard let object else { return [] }
+        return Set(object.keys)
+    }
+}

--- a/Tests/KeyPathTests/CLI/CLIOutputContractTests.swift
+++ b/Tests/KeyPathTests/CLI/CLIOutputContractTests.swift
@@ -1,4 +1,5 @@
 @testable import KeyPathAppKit
+import KeyPathCLISupport
 import KeyPathCore
 @testable import KeyPathInstallationWizard
 import KeyPathWizardCore

--- a/Tests/KeyPathTests/CLI/CLIOutputContractTests.swift
+++ b/Tests/KeyPathTests/CLI/CLIOutputContractTests.swift
@@ -14,39 +14,6 @@ final class CLIOutputContractTests: XCTestCase {
 
     private let decoder = JSONDecoder()
 
-    func testStatusJSONShape() throws {
-        let status = CLIStatusResult(
-            isOperational: true,
-            helperInstalled: true,
-            helperWorking: true,
-            helperVersion: "1.0",
-            keyPathAccessibility: true,
-            keyPathInputMonitoring: true,
-            kanataAccessibility: true,
-            kanataInputMonitoring: true,
-            kanataBinaryInstalled: true,
-            karabinerDriverInstalled: true,
-            vhidDeviceHealthy: true,
-            kanataRunning: true,
-            karabinerDaemonRunning: true,
-            vhidHealthy: true,
-            activeRuntimePathTitle: "test",
-            activeRuntimePathDetail: "detail",
-            hasConflicts: false,
-            timestamp: Date()
-        )
-        let keys = try jsonKeys(status)
-        let required: Set = [
-            "isOperational", "helperInstalled", "helperWorking",
-            "keyPathAccessibility", "keyPathInputMonitoring",
-            "kanataAccessibility", "kanataInputMonitoring",
-            "kanataBinaryInstalled", "karabinerDriverInstalled", "vhidDeviceHealthy",
-            "kanataRunning", "karabinerDaemonRunning", "vhidHealthy",
-            "hasConflicts", "timestamp",
-        ]
-        XCTAssertTrue(required.isSubset(of: keys), "Missing required keys: \(required.subtracting(keys))")
-    }
-
     func testRuleCollectionJSONShape() throws {
         let json = """
         {"id":"test","name":"Test","isEnabled":true,"mappingCount":5,"summary":"Test collection"}
@@ -109,45 +76,6 @@ final class CLIOutputContractTests: XCTestCase {
             decoded.issues?.first?.remediationURL,
             "x-apple.systempreferences:com.apple.preference.security?Privacy_ListenEvent"
         )
-    }
-
-    func testInstallerReportRepairTelemetryJSONShape() throws {
-        let installerReport = InstallerReport(
-            success: true,
-            executedRecipes: [
-                RecipeResult(recipeID: InstallerRecipeID.createConfigDirectories, success: true),
-            ],
-            repairTelemetry: [
-                InstallerRepairTelemetryEvent(
-                    timestamp: Date(timeIntervalSince1970: 0),
-                    trigger: .executePlan,
-                    intent: "repair",
-                    stateMatrixRow: InstallerStateMatrixRow.freshInstallMissingComponents.rawValue,
-                    stateMatrixPlan: [InstallerStateMatrixAction.installMissingComponents.rawValue],
-                    action: InstallerRecipeID.createConfigDirectories,
-                    recipeID: InstallerRecipeID.createConfigDirectories,
-                    recipeType: "install-component",
-                    postconditionResult: .succeeded
-                ),
-            ]
-        )
-
-        let report = CLIInstallerReport(from: installerReport)
-        let keys = try jsonKeys(report)
-        XCTAssertTrue(keys.contains("repairTelemetry"))
-
-        let data = try encoder.encode(report)
-        let decoded = try decoder.decode(CLIInstallerReport.self, from: data)
-        let event = try XCTUnwrap(decoded.repairTelemetry?.first)
-        XCTAssertEqual(event.trigger, "execute-plan")
-        XCTAssertEqual(event.intent, "repair")
-        XCTAssertEqual(event.stateMatrixRow, InstallerStateMatrixRow.freshInstallMissingComponents.rawValue)
-        XCTAssertEqual(event.stateMatrixPlan, [InstallerStateMatrixAction.installMissingComponents.rawValue])
-        XCTAssertEqual(event.action, InstallerRecipeID.createConfigDirectories)
-        XCTAssertEqual(event.recipeID, InstallerRecipeID.createConfigDirectories)
-        XCTAssertEqual(event.recipeType, "install-component")
-        XCTAssertEqual(event.postconditionResult, "succeeded")
-        XCTAssertNil(event.error)
     }
 
     func testInstallerReportMarksActivationApprovalTimeoutAsUserActionRequired() {
@@ -250,18 +178,6 @@ final class CLIOutputContractTests: XCTestCase {
         let keys = try jsonKeys(result)
         let required: Set = ["errors", "isValid"]
         XCTAssertTrue(required.isSubset(of: keys), "Missing required keys: \(required.subtracting(keys))")
-    }
-
-    func testInspectResultJSONShape() throws {
-        let json = """
-        {"macOSVersion":"15.0","driverCompatible":true,"planStatus":"ready","blockedBy":"helper","plannedRecipes":["step1"]}
-        """
-        let result = try decoder.decode(CLIInspectResult.self, from: Data(json.utf8))
-        let keys = try jsonKeys(result)
-        let required: Set = ["driverCompatible", "macOSVersion", "planStatus", "plannedRecipes"]
-        XCTAssertTrue(required.isSubset(of: keys), "Missing required keys: \(required.subtracting(keys))")
-        XCTAssertNil(result.stateMatrixRow)
-        XCTAssertNil(result.stateMatrixPlan)
     }
 
     func testInspectResultRepairMetadataJSONShape() throws {

--- a/Tests/KeyPathTests/CLI/CLIOutputSnapshotTests.swift
+++ b/Tests/KeyPathTests/CLI/CLIOutputSnapshotTests.swift
@@ -1,6 +1,7 @@
 import Foundation
 @testable import KeyPathAppKit
 @testable import KeyPathCLI
+import KeyPathCLISupport
 import XCTest
 
 final class CLIOutputSnapshotTests: XCTestCase {


### PR DESCRIPTION
## Summary

Move the pure CLI JSON report models out of `KeyPathAppKit` and into `KeyPathCLISupport` so their contract tests can run without compiling the app-heavy target.

This keeps the AppKit/system-derived report construction in `SystemFacade`, imports `KeyPathCLISupport` explicitly from CLI command/test files that use those DTOs, and moves the pure DTO JSON-shape tests into a new `KeyPathCLISupportTests` target.

## Compile-speed impact

This creates a smaller lane for CLI report model work:

- Old app-heavy focused lane: `TEST_FILTER='CLIOutputContractTests|CLIOutputSnapshotTests' ./Scripts/run-tests-safe.sh` -> 85s total, 80s build.
- New support-model lane: `TEST_FILTER='CLIReportModelsTests' ./Scripts/run-tests-safe.sh` -> 14s total, 11s build.
- Warm direct support target build: `swift build --target KeyPathCLISupport` -> 0.46s.

The remaining AppKit-derived CLI behavior tests stay in `KeyPathTests` because they still exercise `SystemContext`, install plans, and remediation behavior.

## Review gate

`./Scripts/review-gate.sh` selected the remote review gate because local `thermo-nuclear-swift-review` / `claude` tooling is unavailable in this shell. Per `docs/process/agent-pr-workflow.md`, this PR must wait for GitHub `claude-review` before merge.

Review follow-up: removed the original `@_exported import KeyPathCLISupport` compatibility shim and switched to explicit imports instead.

## Validation

- `KEYPATH_SNAPSHOTS=0 ./Scripts/run-tests-safe.sh` -> 4553 passed, 0 failures, no Swift warnings, no app warnings/errors.
- `TEST_FILTER='CLIReportModelsTests' ./Scripts/run-tests-safe.sh` -> 3 passed.
- `TEST_FILTER='CLIOutputContractTests|CLIOutputSnapshotTests' ./Scripts/run-tests-safe.sh` -> 30 passed after moving pure DTO tests to `KeyPathCLISupportTests`.
- `swift build --target KeyPathCLISupport --target KeyPathAppKit --target KeyPathCLI`
- `swift build --target KeyPathCLISupport`
- `swiftformat --lint` on changed files
- `git diff --check`
- `python3 Scripts/check-accessibility.py`
