### PR TITLE
Clean up Swift warning captures

### DIFF
--- a/Sources/KeyPathAppKit/Services/KeyboardCapture/KeyboardCapture.swift
+++ b/Sources/KeyPathAppKit/Services/KeyboardCapture/KeyboardCapture.swift
@@ -97,12 +97,14 @@ public class KeyboardCapture {
         guard !isCapturing else { return }
 
         if FeatureFlags.useJustInTimePermissionRequests {
-            Task { @MainActor in
+            let keyboardCapture = self
+            Task { @MainActor [weak keyboardCapture] in
+                guard let keyboardCapture else { return }
                 await PermissionGate.shared.checkAndRequestPermissions(
                     for: .keyCapture,
-                    onGranted: { [weak self] in
-                        guard let self else { return }
-                        startCaptureAfterPermissions(callback: callback)
+                    onGranted: { [weak keyboardCapture] in
+                        guard let keyboardCapture else { return }
+                        keyboardCapture.startCaptureAfterPermissions(callback: callback)
                     },
                     onDenied: {
                         callback("⚠️ Accessibility permission required")

--- a/Sources/KeyPathAppKit/UI/Components/SystemStatusIndicator.swift
+++ b/Sources/KeyPathAppKit/UI/Components/SystemStatusIndicator.swift
@@ -1,4 +1,5 @@
 import AppKit
+import Combine
 import KeyPathCore
 import SwiftUI
 

--- a/Sources/KeyPathAppKit/UI/Experimental/MapperViewModel+CaptureManagement.swift
+++ b/Sources/KeyPathAppKit/UI/Experimental/MapperViewModel+CaptureManagement.swift
@@ -57,18 +57,20 @@ extension MapperViewModel {
 
         capture.startSequenceCapture(mode: .sequence) { [weak self] sequence in
             guard let self else { return }
+            let viewModel = self
 
-            Task { @MainActor in
-                self.multiTapPendingSequence = sequence
-                let action = self.convertSequenceToKanataFormat(sequence)
-                self.multiTapUpdateHandler?(action)
-                self.multiTapFinalizeTimer?.invalidate()
-                self.multiTapFinalizeTimer = Timer.scheduledTimer(
-                    withTimeInterval: self.sequenceFinalizeDelay,
+            Task { @MainActor [weak viewModel] in
+                guard let viewModel else { return }
+                viewModel.multiTapPendingSequence = sequence
+                let action = viewModel.convertSequenceToKanataFormat(sequence)
+                viewModel.multiTapUpdateHandler?(action)
+                viewModel.multiTapFinalizeTimer?.invalidate()
+                viewModel.multiTapFinalizeTimer = Timer.scheduledTimer(
+                    withTimeInterval: viewModel.sequenceFinalizeDelay,
                     repeats: false
-                ) { [weak self] _ in
+                ) { [weak viewModel] _ in
                     Task { @MainActor in
-                        self?.finalizeMultiTapSequence()
+                        viewModel?.finalizeMultiTapSequence()
                     }
                 }
             }
@@ -289,12 +291,14 @@ extension MapperViewModel {
         // Use sequence mode for multi-key support
         capture.startSequenceCapture(mode: .sequence) { [weak self] sequence in
             guard let self else { return }
+            let viewModel = self
 
-            Task { @MainActor in
+            Task { @MainActor [weak viewModel] in
+                guard let viewModel else { return }
                 // Update the captured sequence (streaming updates)
                 if target == .input {
-                    self.inputSequence = sequence
-                    self.inputLabel = sequence.displayString
+                    viewModel.inputSequence = sequence
+                    viewModel.inputLabel = sequence.displayString
                     // Store first key's keyCode for overlay-style rendering
                     // Guard against negative keyCodes (e.g., -1 for modifier-only keys or unknown keys)
                     if let firstKey = sequence.keys.first,
@@ -302,27 +306,27 @@ extension MapperViewModel {
                        firstKey.keyCode <= Int64(UInt16.max)
                     {
                         let keyCode = UInt16(firstKey.keyCode)
-                        self.inputKeyCode = keyCode
+                        viewModel.inputKeyCode = keyCode
 
                         // Look up current mapping for this key and update output
-                        self.lookupAndSetOutput(forKeyCode: keyCode)
+                        viewModel.lookupAndSetOutput(forKeyCode: keyCode)
                     }
                 } else if target == .shiftedOutput {
-                    self.shiftedOutputSequence = sequence
-                    self.shiftedOutputLabel = sequence.displayString
+                    viewModel.shiftedOutputSequence = sequence
+                    viewModel.shiftedOutputLabel = sequence.displayString
                 } else {
-                    self.outputSequence = sequence
-                    self.outputLabel = sequence.displayString
+                    viewModel.outputSequence = sequence
+                    viewModel.outputLabel = sequence.displayString
                 }
 
                 // Reset finalize timer - wait for more keys
-                self.finalizeTimer?.invalidate()
-                self.finalizeTimer = Timer.scheduledTimer(
-                    withTimeInterval: self.sequenceFinalizeDelay,
+                viewModel.finalizeTimer?.invalidate()
+                viewModel.finalizeTimer = Timer.scheduledTimer(
+                    withTimeInterval: viewModel.sequenceFinalizeDelay,
                     repeats: false
-                ) { [weak self] _ in
+                ) { [weak viewModel] _ in
                     Task { @MainActor in
-                        self?.finalizeCapture()
+                        viewModel?.finalizeCapture()
                     }
                 }
             }

--- a/Sources/KeyPathAppKit/UI/Experimental/MapperViewModel+MacroRecording.swift
+++ b/Sources/KeyPathAppKit/UI/Experimental/MapperViewModel+MacroRecording.swift
@@ -38,18 +38,20 @@ extension MapperViewModel {
 
         capture.startSequenceCapture(mode: .sequence) { [weak self] sequence in
             guard let self else { return }
+            let viewModel = self
 
-            Task { @MainActor in
+            Task { @MainActor [weak viewModel] in
+                guard let viewModel else { return }
                 let outputs = sequence.keys.map { Self.keyOutputFromPress($0) }
-                macroBehavior = MacroBehavior(outputs: outputs, source: .keys)
+                viewModel.macroBehavior = MacroBehavior(outputs: outputs, source: .keys)
 
-                self.finalizeTimer?.invalidate()
-                self.finalizeTimer = Timer.scheduledTimer(
-                    withTimeInterval: self.sequenceFinalizeDelay,
+                viewModel.finalizeTimer?.invalidate()
+                viewModel.finalizeTimer = Timer.scheduledTimer(
+                    withTimeInterval: viewModel.sequenceFinalizeDelay,
                     repeats: false
-                ) { [weak self] _ in
+                ) { [weak viewModel] _ in
                     Task { @MainActor in
-                        self?.stopMacroRecording()
+                        viewModel?.stopMacroRecording()
                     }
                 }
             }

--- a/Sources/KeyPathAppKit/UI/Pickers/RecordingCoordinator.swift
+++ b/Sources/KeyPathAppKit/UI/Pickers/RecordingCoordinator.swift
@@ -377,40 +377,47 @@ final class RecordingCoordinator {
                 self.logFocusState(prefix: "[Coordinator:Input]")
                 capture.setEventRouter(nil, kanataManager: self.kanataManager)
                 let mode: CaptureMode = self.isSequenceMode ? .sequence : .chord
+                let coordinator = self
 
                 self.inputTimeoutTimer = Timer.scheduledTimer(withTimeInterval: 30.0, repeats: false) {
-                    [weak self] _ in
+                    [weak coordinator] _ in
                     Task { @MainActor in
-                        guard let self else { return }
-                        if self.input.isRecording {
-                            self.failInputRecording(with: "timeout")
-                            self.keyboardCapture?.stopCapture()
+                        guard let coordinator else { return }
+                        if coordinator.input.isRecording {
+                            coordinator.failInputRecording(with: "timeout")
+                            coordinator.keyboardCapture?.stopCapture()
                         }
                     }
                 }
 
-                capture.startSequenceCapture(mode: mode) { keySequence in
-                    Task { @MainActor in
-                        // Provisional streaming update
-                        self.inputTimeoutTimer?.invalidate()
-                        self.input.capturedSequence = keySequence
-                        self.refreshDisplayTexts()
-
-                        // Schedule finalize timer based on mode
-                        self.inputFinalizeTimer?.invalidate()
-                        let finalizeDelay: TimeInterval = self.finalizeDelayDuration(for: mode)
-                        self.inputFinalizeTimer = Timer.scheduledTimer(
-                            withTimeInterval: finalizeDelay, repeats: false
-                        ) { [weak self] _ in
-                            Task { @MainActor in
-                                guard let self else { return }
-                                if self.input.isRecording {
-                                    self.input.isRecording = false
-                                    self.refreshDisplayTexts()
-                                }
-                            }
-                        }
+                capture.startSequenceCapture(mode: mode) { [weak coordinator] keySequence in
+                    guard let coordinator else { return }
+                    let recordingCoordinator = coordinator
+                    Task { @MainActor [weak recordingCoordinator] in
+                        recordingCoordinator?.handleCapturedInputSequence(keySequence, mode: mode)
                     }
+                }
+            }
+        }
+    }
+
+    private func handleCapturedInputSequence(_ keySequence: KeySequence, mode: CaptureMode) {
+        // Provisional streaming update
+        inputTimeoutTimer?.invalidate()
+        input.capturedSequence = keySequence
+        refreshDisplayTexts()
+
+        // Schedule finalize timer based on mode
+        inputFinalizeTimer?.invalidate()
+        let finalizeDelay: TimeInterval = finalizeDelayDuration(for: mode)
+        inputFinalizeTimer = Timer.scheduledTimer(
+            withTimeInterval: finalizeDelay, repeats: false
+        ) { [weak self] _ in
+            Task { @MainActor in
+                guard let self else { return }
+                if self.input.isRecording {
+                    self.input.isRecording = false
+                    self.refreshDisplayTexts()
                 }
             }
         }
@@ -515,40 +522,47 @@ final class RecordingCoordinator {
                 self.logFocusState(prefix: "[Coordinator:Output]")
                 capture.setEventRouter(nil, kanataManager: self.kanataManager)
                 let mode: CaptureMode = self.isSequenceMode ? .sequence : .chord
+                let coordinator = self
 
                 self.outputTimeoutTimer = Timer.scheduledTimer(withTimeInterval: 30.0, repeats: false) {
-                    [weak self] _ in
+                    [weak coordinator] _ in
                     Task { @MainActor in
-                        guard let self else { return }
-                        if self.output.isRecording {
-                            self.failOutputRecording(with: "timeout")
-                            self.keyboardCapture?.stopCapture()
+                        guard let coordinator else { return }
+                        if coordinator.output.isRecording {
+                            coordinator.failOutputRecording(with: "timeout")
+                            coordinator.keyboardCapture?.stopCapture()
                         }
                     }
                 }
 
-                capture.startSequenceCapture(mode: mode) { keySequence in
-                    Task { @MainActor in
-                        // Provisional streaming update
-                        self.outputTimeoutTimer?.invalidate()
-                        self.output.capturedSequence = keySequence
-                        self.refreshDisplayTexts()
-
-                        // Schedule finalize timer based on mode
-                        self.outputFinalizeTimer?.invalidate()
-                        let finalizeDelay: TimeInterval = (mode == .sequence) ? 2.1 : 0.08
-                        self.outputFinalizeTimer = Timer.scheduledTimer(
-                            withTimeInterval: finalizeDelay, repeats: false
-                        ) { [weak self] _ in
-                            Task { @MainActor in
-                                guard let self else { return }
-                                if self.output.isRecording {
-                                    self.output.isRecording = false
-                                    self.refreshDisplayTexts()
-                                }
-                            }
-                        }
+                capture.startSequenceCapture(mode: mode) { [weak coordinator] keySequence in
+                    guard let coordinator else { return }
+                    let recordingCoordinator = coordinator
+                    Task { @MainActor [weak recordingCoordinator] in
+                        recordingCoordinator?.handleCapturedOutputSequence(keySequence, mode: mode)
                     }
+                }
+            }
+        }
+    }
+
+    private func handleCapturedOutputSequence(_ keySequence: KeySequence, mode: CaptureMode) {
+        // Provisional streaming update
+        outputTimeoutTimer?.invalidate()
+        output.capturedSequence = keySequence
+        refreshDisplayTexts()
+
+        // Schedule finalize timer based on mode
+        outputFinalizeTimer?.invalidate()
+        let finalizeDelay: TimeInterval = (mode == .sequence) ? 2.1 : 0.08
+        outputFinalizeTimer = Timer.scheduledTimer(
+            withTimeInterval: finalizeDelay, repeats: false
+        ) { [weak self] _ in
+            Task { @MainActor in
+                guard let self else { return }
+                if self.output.isRecording {
+                    self.output.isRecording = false
+                    self.refreshDisplayTexts()
                 }
             }
         }


### PR DESCRIPTION
## Summary
- eliminate current Swift compiler warnings in keyboard recording/capture paths by avoiding weak captures nested inside implicit strong captures
- import Combine explicitly for SystemStatusIndicator
- keep sequence-finalize behavior unchanged while moving coordinator sequence handling into small helper methods

## Verification
- `swift build --target KeyPathAppKit --target KeyPathCLI`
- `KEYPATH_TEST_ENFORCE_CLEAN_SUMMARY=1 TEST_FILTER='RecordingCoordinatorTests|KeyboardCaptureTests|MapperMultiTapTests|MapperKanataFormatTests|MapperConflictAndSaveTests' ./Scripts/run-tests-safe.sh` — 97 tests passed; Swift/app warning counters all zero
- `KEYPATH_TEST_ENFORCE_CLEAN_SUMMARY=1 ./Scripts/run-tests-safe.sh` — 4,553 tests passed; Swift/app warning counters all zero

## Review Gate
- Local `/thermo-nuclear-swift-review` could not be run because neither `thermo-nuclear-swift-review` nor `claude` is installed on PATH in this shell. The GitHub review workflow is the enforced reviewer for this PR.
