### PR TITLE
Stabilize editable SwiftUI list identities

### DIFF
--- a/Sources/KeyPathAppKit/UI/Overlay/QMKKeyboardSearchView.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/QMKKeyboardSearchView.swift
@@ -188,8 +188,7 @@ struct QMKKeyboardSearchView: View {
     private var keyboardListView: some View {
         ScrollView {
             LazyVStack(spacing: 0) {
-                ForEach(keyboards.indices, id: \.self) { index in
-                    let keyboard = keyboards[index]
+                ForEach(Array(keyboards.enumerated()), id: \.element.id) { index, keyboard in
                     PopoverKeyboardRow(
                         keyboard: keyboard,
                         isSelected: selectedIndex == index,

--- a/Sources/KeyPathAppKit/UI/Rules/ChordEditorDialog.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/ChordEditorDialog.swift
@@ -13,6 +13,7 @@ struct ChordEditorDialog: View {
     @State private var newKeyInput: String = ""
     @State private var outputMode: OutputMode
     @State private var customOutput: String = ""
+    @State private var keyIDs: [UUID]
 
     enum OutputMode: String, CaseIterable {
         case keystroke = "Keystroke"
@@ -29,6 +30,7 @@ struct ChordEditorDialog: View {
         _selectedAction = State(initialValue: chord.action)
         _description = State(initialValue: chord.description ?? "")
         _outputMode = State(initialValue: Self.modeFor(chord.action))
+        _keyIDs = State(initialValue: chord.keys.map { _ in UUID() })
         _customOutput = State(initialValue: {
             if case let .rawKanata(expr) = chord.action { return expr }
             return ""
@@ -67,21 +69,28 @@ struct ChordEditorDialog: View {
                         .frame(width: 56, alignment: .trailing)
 
                     HStack(spacing: 4) {
-                        ForEach(Array(keys.enumerated()), id: \.offset) { index, key in
-                            if !key.isEmpty {
-                                Button { keys.remove(at: index) } label: {
-                                    HStack(spacing: 3) {
-                                        Text(key.uppercased())
-                                            .font(.callout.weight(.semibold).monospaced())
-                                        Image(systemName: "xmark")
-                                            .font(.system(size: 8, weight: .bold))
-                                            .foregroundStyle(.secondary)
+                        ForEach(keyIDs, id: \.self) { id in
+                            if let index = keyIDs.firstIndex(of: id), keys.indices.contains(index) {
+                                let key = keys[index]
+
+                                if !key.isEmpty {
+                                    Button {
+                                        keys.remove(at: index)
+                                        keyIDs.remove(at: index)
+                                    } label: {
+                                        HStack(spacing: 3) {
+                                            Text(key.uppercased())
+                                                .font(.callout.weight(.semibold).monospaced())
+                                            Image(systemName: "xmark")
+                                                .font(.system(size: 8, weight: .bold))
+                                                .foregroundStyle(.secondary)
+                                        }
+                                        .padding(.horizontal, 8)
+                                        .padding(.vertical, 5)
+                                        .background(RoundedRectangle(cornerRadius: 5, style: .continuous).fill(Color.primary.opacity(0.08)))
                                     }
-                                    .padding(.horizontal, 8)
-                                    .padding(.vertical, 5)
-                                    .background(RoundedRectangle(cornerRadius: 5, style: .continuous).fill(Color.primary.opacity(0.08)))
+                                    .buttonStyle(.plain)
                                 }
-                                .buttonStyle(.plain)
                             }
                         }
                         if keys.filter({ !$0.isEmpty }).count < 4 {
@@ -93,7 +102,9 @@ struct ChordEditorDialog: View {
                                     let trimmed = newKeyInput.trimmingCharacters(in: .whitespaces).lowercased()
                                     if !trimmed.isEmpty {
                                         keys = keys.filter { !$0.isEmpty }
+                                        keyIDs = Array(keyIDs.prefix(keys.count))
                                         keys.append(trimmed)
+                                        keyIDs.append(UUID())
                                         newKeyInput = ""
                                     }
                                 }

--- a/Sources/KeyPathAppKit/UI/Rules/SequencesModalView.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/SequencesModalView.swift
@@ -23,6 +23,7 @@ struct SequencesModalView: View {
     @State private var localConfig: SequencesConfig
     @State private var selectedSequenceID: UUID?
     @State private var conflicts: [SequenceConflict] = []
+    @State private var sequenceKeyIDs: [UUID: [UUID]] = [:]
 
     // MARK: - Callbacks
 
@@ -38,6 +39,11 @@ struct SequencesModalView: View {
     ) {
         _config = config
         _localConfig = State(initialValue: config.wrappedValue)
+        _sequenceKeyIDs = State(initialValue: Dictionary(
+            uniqueKeysWithValues: config.wrappedValue.sequences.map { sequence in
+                (sequence.id, sequence.keys.map { _ in UUID() })
+            }
+        ))
         self.onSave = onSave
         self.onCancel = onCancel
     }
@@ -67,6 +73,7 @@ struct SequencesModalView: View {
         }
         .frame(width: 900, height: 600)
         .onAppear {
+            syncSequenceKeyIDs()
             detectConflicts()
             // Select first sequence if none selected
             if selectedSequenceID == nil, let first = localConfig.sequences.first {
@@ -264,40 +271,45 @@ struct SequencesModalView: View {
                 .font(.headline)
 
             HStack(spacing: 8) {
-                ForEach(sequence.keys.wrappedValue.indices, id: \.self) { index in
-                    KeyPicker(selection: Binding(
-                        get: { sequence.keys.wrappedValue[index] },
-                        set: { newValue in
-                            var keys = sequence.keys.wrappedValue
-                            keys[index] = newValue
-                            sequence.keys.wrappedValue = keys
-                            detectConflicts()
-                        }
-                    ))
-                    .accessibilityIdentifier("sequences-modal-key-picker-\(index)")
-                    .accessibilityLabel("Key \(index + 1) in sequence")
+                ForEach(keyIDs(for: sequence.wrappedValue), id: \.self) { id in
+                    if let index = sequenceKeyIDs[sequence.wrappedValue.id]?.firstIndex(of: id),
+                       sequence.keys.wrappedValue.indices.contains(index)
+                    {
+                        KeyPicker(selection: Binding(
+                            get: { sequence.keys.wrappedValue[index] },
+                            set: { newValue in
+                                var keys = sequence.keys.wrappedValue
+                                keys[index] = newValue
+                                sequence.keys.wrappedValue = keys
+                                detectConflicts()
+                            }
+                        ))
+                        .accessibilityIdentifier("sequences-modal-key-picker-\(index)")
+                        .accessibilityLabel("Key \(index + 1) in sequence")
 
-                    if index < sequence.keys.wrappedValue.count - 1 {
-                        Image(systemName: "arrow.right")
-                            .foregroundColor(.secondary)
-                            .font(.footnote)
-                    }
-
-                    // Remove button
-                    if sequence.keys.wrappedValue.count > 1 {
-                        Button {
-                            var keys = sequence.keys.wrappedValue
-                            keys.remove(at: index)
-                            sequence.keys.wrappedValue = keys
-                            detectConflicts()
-                        } label: {
-                            Image(systemName: "xmark.circle.fill")
-                                .foregroundColor(.red.opacity(0.7))
-                                .font(.body)
+                        if index < sequence.keys.wrappedValue.count - 1 {
+                            Image(systemName: "arrow.right")
+                                .foregroundColor(.secondary)
+                                .font(.footnote)
                         }
-                        .buttonStyle(.plain)
-                        .accessibilityIdentifier("sequences-modal-remove-key-\(index)")
-                        .accessibilityLabel("Remove key \(index + 1)")
+
+                        // Remove button
+                        if sequence.keys.wrappedValue.count > 1 {
+                            Button {
+                                var keys = sequence.keys.wrappedValue
+                                keys.remove(at: index)
+                                sequence.keys.wrappedValue = keys
+                                sequenceKeyIDs[sequence.wrappedValue.id]?.remove(at: index)
+                                detectConflicts()
+                            } label: {
+                                Image(systemName: "xmark.circle.fill")
+                                    .foregroundColor(.red.opacity(0.7))
+                                    .font(.body)
+                            }
+                            .buttonStyle(.plain)
+                            .accessibilityIdentifier("sequences-modal-remove-key-\(index)")
+                            .accessibilityLabel("Remove key \(index + 1)")
+                        }
                     }
                 }
 
@@ -307,6 +319,7 @@ struct SequencesModalView: View {
                         var keys = sequence.keys.wrappedValue
                         keys.append("space")
                         sequence.keys.wrappedValue = keys
+                        sequenceKeyIDs[sequence.wrappedValue.id, default: []].append(UUID())
                         detectConflicts()
                     } label: {
                         Label("Add Key", systemImage: "plus.circle")
@@ -489,19 +502,41 @@ struct SequencesModalView: View {
         )
         localConfig.sequences.append(newSequence)
         selectedSequenceID = newSequence.id
+        sequenceKeyIDs[newSequence.id] = newSequence.keys.map { _ in UUID() }
         detectConflicts()
     }
 
     private func addPreset(_ preset: SequenceDefinition) {
         localConfig.sequences.append(preset)
         selectedSequenceID = preset.id
+        sequenceKeyIDs[preset.id] = preset.keys.map { _ in UUID() }
         detectConflicts()
     }
 
     private func deleteSequence(_ id: UUID) {
         localConfig.sequences.removeAll { $0.id == id }
+        sequenceKeyIDs[id] = nil
         selectedSequenceID = localConfig.sequences.first?.id
         detectConflicts()
+    }
+
+    private func keyIDs(for sequence: SequenceDefinition) -> [UUID] {
+        if let ids = sequenceKeyIDs[sequence.id], ids.count == sequence.keys.count {
+            return ids
+        }
+
+        return sequence.keys.map { _ in UUID() }
+    }
+
+    private func syncSequenceKeyIDs() {
+        let activeSequenceIDs = Set(localConfig.sequences.map(\.id))
+        sequenceKeyIDs = sequenceKeyIDs.filter { activeSequenceIDs.contains($0.key) }
+
+        for sequence in localConfig.sequences {
+            if sequenceKeyIDs[sequence.id]?.count != sequence.keys.count {
+                sequenceKeyIDs[sequence.id] = sequence.keys.map { _ in UUID() }
+            }
+        }
     }
 
     private func detectConflicts() {

--- a/Tests/KeyPathTests/Lint/SwiftUIListIdentityLintTests.swift
+++ b/Tests/KeyPathTests/Lint/SwiftUIListIdentityLintTests.swift
@@ -1,0 +1,58 @@
+import Foundation
+@preconcurrency import XCTest
+
+/// Guards SwiftUI list identities in editable/searchable collections.
+///
+/// These call sites used collection indices or enumerated offsets as row
+/// identity even though rows can be searched, inserted, or removed. That makes
+/// SwiftUI reuse the same identity for a different element after mutation,
+/// risking focus/state loss and incorrect row animation.
+final class SwiftUIListIdentityLintTests: XCTestCase {
+    func testQMKSearchRowsUseKeyboardIdentity() throws {
+        let file = LintScanner.path("Sources/KeyPathAppKit/UI/Overlay/QMKKeyboardSearchView.swift")
+        let violations = try LintScanner.matchingLines(
+            in: file,
+            patterns: [#"ForEach\(keyboards\.indices,\s*id:\s*\\\.self\)"#]
+        )
+
+        XCTAssertTrue(
+            violations.isEmpty,
+            """
+            QMK search rows must use `KeyboardMetadata.id`, not collection indices:
+            \(violations.sorted().joined(separator: "\n"))
+            """
+        )
+    }
+
+    func testSequenceKeySlotsUseStableSessionIdentity() throws {
+        let file = LintScanner.path("Sources/KeyPathAppKit/UI/Rules/SequencesModalView.swift")
+        let violations = try LintScanner.matchingLines(
+            in: file,
+            patterns: [#"ForEach\(sequence\.keys\.wrappedValue\.indices,\s*id:\s*\\\.self\)"#]
+        )
+
+        XCTAssertTrue(
+            violations.isEmpty,
+            """
+            Editable sequence key slots must use stable session IDs, not array indices:
+            \(violations.sorted().joined(separator: "\n"))
+            """
+        )
+    }
+
+    func testChordEditorKeyChipsUseStableSessionIdentity() throws {
+        let file = LintScanner.path("Sources/KeyPathAppKit/UI/Rules/ChordEditorDialog.swift")
+        let violations = try LintScanner.matchingLines(
+            in: file,
+            patterns: [#"ForEach\(Array\(keys\.enumerated\(\)\),\s*id:\s*\\\.offset\)"#]
+        )
+
+        XCTAssertTrue(
+            violations.isEmpty,
+            """
+            Editable chord key chips must use stable session IDs, not enumerated offsets:
+            \(violations.sorted().joined(separator: "\n"))
+            """
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- use `KeyboardMetadata.id` for QMK search result row identity while preserving selection index
- give editable chord key chips and sequence key slots stable session-local IDs instead of array-index identity
- add a narrow SwiftUI list-identity lint ratchet for the fixed editable/searchable sites

## Verification
- `TEST_FILTER='SwiftUIListIdentityLintTests|SequencesConfigTests|RuleCollectionConfigurationSequencesTests|ChordGroupsConfigTests|ChordGroupsValidationTests|QMKKeyboardDatabaseTests|QMKImportServiceTests' ./Scripts/run-tests-safe.sh` — 151 tests passed; warning counters zero
- `KEYPATH_TEST_ENFORCE_CLEAN_SUMMARY=1 ./Scripts/run-tests-safe.sh` — 4,556 tests passed; clean-summary guardrail passed; warning counters zero

## Review Gate
- Local `/thermo-nuclear-swift-review` could not be run because neither `thermo-nuclear-swift-review` nor `claude` is installed on PATH in this shell. The GitHub review workflow is the enforced reviewer for this PR.