### PR TITLE
Add release signing contract audit

### DIFF
--- a/Scripts/build-and-sign.sh
+++ b/Scripts/build-and-sign.sh
@@ -177,6 +177,7 @@ EOF
 }
 
 keypath_ensure_kanata_submodule "$SCRIPT_DIR/.."
+"$SCRIPT_DIR/verify-release-signing-contract.sh" --source
 
 echo "🦀 Building Rust artifacts in parallel (kanata, simulator, host bridge)..."
 ./Scripts/build-kanata.sh &

--- a/Scripts/release-doctor.sh
+++ b/Scripts/release-doctor.sh
@@ -234,6 +234,13 @@ else
     fail "Installer identity-stability source contract failed"
 fi
 
+print_section "Release Signing Contract"
+if "$PROJECT_DIR/Scripts/verify-release-signing-contract.sh" --source; then
+    pass "Release signing source contract passed"
+else
+    fail "Release signing source contract failed"
+fi
+
 print_section "Release Artifacts"
 effective_skip_sparkle="${SKIP_SPARKLE:-}"
 effective_skip_website="${SKIP_WEBSITE:-}"

--- a/Scripts/verify-release-signing-contract.sh
+++ b/Scripts/verify-release-signing-contract.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" >/dev/null && pwd)
+PROJECT_DIR=$(cd "$SCRIPT_DIR/.." >/dev/null && pwd)
+
+failures=0
+
+fail() {
+    failures=$((failures + 1))
+    echo "❌ $1" >&2
+}
+
+pass() {
+    echo "✅ $1"
+}
+
+require_file() {
+    local path=$1
+    if [[ -f "$PROJECT_DIR/$path" ]]; then
+        pass "$path exists"
+    else
+        fail "$path is missing"
+    fi
+}
+
+require_executable() {
+    local path=$1
+    if [[ -x "$PROJECT_DIR/$path" ]]; then
+        pass "$path is executable"
+    else
+        fail "$path must be executable"
+    fi
+}
+
+require_contains() {
+    local path=$1
+    local needle=$2
+    local reason=$3
+    if grep -Fq -- "$needle" "$PROJECT_DIR/$path"; then
+        pass "$reason"
+    else
+        fail "$path missing required text for: $reason"
+        echo "   expected: $needle" >&2
+    fi
+}
+
+require_plist_key() {
+    local path=$1
+    local key=$2
+    local expected=$3
+    local actual
+    if ! actual=$(/usr/libexec/PlistBuddy -c "Print :$key" "$PROJECT_DIR/$path" 2>/dev/null); then
+        fail "$path missing entitlement key: $key"
+        return
+    fi
+    if [[ "$actual" == "$expected" ]]; then
+        pass "$path pins $key = $expected"
+    else
+        fail "$path expected $key = $expected, got $actual"
+    fi
+}
+
+require_valid_plist() {
+    local path=$1
+    if plutil -lint "$PROJECT_DIR/$path" >/dev/null; then
+        pass "$path is a valid plist"
+    else
+        fail "$path is not a valid plist"
+    fi
+}
+
+usage() {
+    cat <<'EOF'
+Usage: Scripts/verify-release-signing-contract.sh [--source]
+
+Validate the source-level release signing contract before build/sign/notarize:
+- entitlements files are valid plists with the expected baseline keys
+- release signing commands use hardened runtime, stable identifiers, and entitlements
+- release-doctor/build-and-sign run the identity and signing-contract gates
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --source)
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+    shift
+done
+
+cd "$PROJECT_DIR"
+
+require_file "KeyPath.entitlements"
+require_file "Sources/KeyPathHelper/KeyPathHelper.entitlements"
+require_file "kanata.entitlements"
+require_file "Scripts/build-and-sign.sh"
+require_file "Scripts/release-doctor.sh"
+require_executable "Scripts/verify-release-signing-contract.sh"
+
+for plist in \
+    "KeyPath.entitlements" \
+    "Sources/KeyPathHelper/KeyPathHelper.entitlements" \
+    "kanata.entitlements"; do
+    require_valid_plist "$plist"
+done
+
+require_plist_key "KeyPath.entitlements" "com.apple.security.app-sandbox" "false"
+require_plist_key "KeyPath.entitlements" "com.apple.security.network.client" "true"
+require_plist_key "KeyPath.entitlements" "com.apple.security.automation.apple-events" "true"
+require_plist_key "Sources/KeyPathHelper/KeyPathHelper.entitlements" "com.apple.security.app-sandbox" "false"
+require_plist_key "kanata.entitlements" "com.apple.security.device.hid" "true"
+require_plist_key "kanata.entitlements" "com.apple.security.device.input-monitoring" "true"
+
+build_script="Scripts/build-and-sign.sh"
+doctor_script="Scripts/release-doctor.sh"
+
+require_contains "$build_script" 'HELPER_ENTITLEMENTS="Sources/KeyPathHelper/KeyPathHelper.entitlements"' "helper entitlements source is explicit"
+require_contains "$build_script" '--identifier "com.keypath.helper"' "helper signing uses stable helper identifier"
+require_contains "$build_script" '--entitlements "$HELPER_ENTITLEMENTS"' "helper signing applies helper entitlements"
+require_contains "$build_script" 'ENTITLEMENTS_FILE="KeyPath.entitlements"' "main app entitlements source is explicit"
+require_contains "$build_script" '--entitlements "$ENTITLEMENTS_FILE"' "main app signing applies app entitlements"
+require_contains "$build_script" '--identifier "com.keypath.KeyPath.CLI"' "CLI signing uses helper-trusted stable identifier"
+require_contains "$build_script" '--force --options=runtime' "release signing uses hardened runtime"
+require_contains "$build_script" 'kp_sign "$CONTENTS/Library/KeyPath/Kanata Engine.app/Contents/MacOS/kanata" --force --options=runtime --sign "$SIGNING_IDENTITY"' "Kanata Engine inner binary is hardened-runtime signed"
+require_contains "$build_script" 'kp_sign "$CONTENTS/Library/KeyPath/Kanata Engine.app" --force --options=runtime --sign "$SIGNING_IDENTITY"' "Kanata Engine bundle is hardened-runtime signed"
+require_contains "$build_script" 'kp_sign "$CONTENTS/Library/KeyPath/kanata-launcher" --force --options=runtime --sign "$SIGNING_IDENTITY"' "Kanata launcher is hardened-runtime signed"
+require_contains "$build_script" 'kp_sign "$CONTENTS/Library/KeyPath/libkeypath_kanata_host_bridge.dylib" --force --options=runtime --sign "$SIGNING_IDENTITY"' "Kanata host bridge is hardened-runtime signed"
+require_contains "$build_script" 'kp_sign "$CONTENTS/Library/KeyPath/kanata-simulator" --force --options=runtime --sign "$SIGNING_IDENTITY"' "Kanata simulator is hardened-runtime signed"
+require_contains "$build_script" '"$SCRIPT_DIR/verify-identity-contract.sh" --app "$APP_BUNDLE"' "build-and-sign runs installed-app identity verification"
+require_contains "$build_script" '"$SCRIPT_DIR/verify-release-signing-contract.sh" --source' "build-and-sign runs source signing-contract verification"
+require_contains "$doctor_script" 'verify-release-signing-contract.sh" --source' "release-doctor runs source signing-contract verification"
+
+if (( failures > 0 )); then
+    echo "❌ Release signing contract failed with $failures issue(s)." >&2
+    exit 1
+fi
+
+echo "✅ Release signing contract passed."

--- a/Tests/KeyPathTests/BuildScripts/ReleaseSigningContractTests.swift
+++ b/Tests/KeyPathTests/BuildScripts/ReleaseSigningContractTests.swift
@@ -1,0 +1,80 @@
+import Foundation
+@preconcurrency import XCTest
+
+final class ReleaseSigningContractTests: XCTestCase {
+    func testReleaseSigningContractScriptPassesFromSource() {
+        let root = repositoryRoot()
+        let script = root.appendingPathComponent("Scripts/verify-release-signing-contract.sh")
+
+        XCTAssertTrue(FileManager.default.isExecutableFile(atPath: script.path))
+
+        let result = runScript("\"\(script.path)\" --source", workingDirectory: root)
+        XCTAssertEqual(
+            result.code,
+            0,
+            """
+            Release signing contract should pass from source.
+            stdout:
+            \(result.stdout)
+            stderr:
+            \(result.stderr)
+            """
+        )
+        XCTAssertTrue(result.stdout.contains("Release signing contract passed."))
+    }
+
+    func testReleaseSigningContractIsPartOfReleaseGates() throws {
+        let root = repositoryRoot()
+        let buildAndSign = try contents(of: root.appendingPathComponent("Scripts/build-and-sign.sh"))
+        let releaseDoctor = try contents(of: root.appendingPathComponent("Scripts/release-doctor.sh"))
+
+        XCTAssertTrue(
+            buildAndSign.contains(#""$SCRIPT_DIR/verify-release-signing-contract.sh" --source"#),
+            "build-and-sign must run the source signing contract before expensive signing/notarization work."
+        )
+        XCTAssertTrue(
+            releaseDoctor.contains(#"verify-release-signing-contract.sh" --source"#),
+            "release-doctor must run the source signing contract during release preflight."
+        )
+    }
+}
+
+private func repositoryRoot(file: StaticString = #filePath) -> URL {
+    URL(fileURLWithPath: file.description)
+        .deletingLastPathComponent() // BuildScripts
+        .deletingLastPathComponent() // KeyPathTests
+        .deletingLastPathComponent() // Tests
+        .deletingLastPathComponent() // repo root
+}
+
+private func contents(of url: URL) throws -> String {
+    try String(contentsOf: url, encoding: .utf8)
+}
+
+private func runScript(_ script: String, workingDirectory: URL) -> (code: Int32, stdout: String, stderr: String) {
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/bin/bash")
+    process.arguments = ["-lc", script]
+    process.currentDirectoryURL = workingDirectory
+
+    let stdoutPipe = Pipe()
+    let stderrPipe = Pipe()
+    process.standardOutput = stdoutPipe
+    process.standardError = stderrPipe
+
+    do {
+        try process.run()
+    } catch {
+        return (code: -1, stdout: "", stderr: "Failed to start process: \(error)")
+    }
+    process.waitUntilExit()
+
+    let stdoutData = (try? stdoutPipe.fileHandleForReading.readToEnd()) ?? Data()
+    let stderrData = (try? stderrPipe.fileHandleForReading.readToEnd()) ?? Data()
+
+    return (
+        code: process.terminationStatus,
+        stdout: String(decoding: stdoutData, as: UTF8.self),
+        stderr: String(decoding: stderrData, as: UTF8.self)
+    )
+}

--- a/kanata.entitlements
+++ b/kanata.entitlements
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<\!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
     <key>com.apple.security.device.hid</key>


### PR DESCRIPTION
## Summary
- add `Scripts/verify-release-signing-contract.sh` to validate source-level release signing and entitlements assumptions
- wire the signing contract into `release-doctor` and `build-and-sign` before expensive signing/notarization work
- add executable Swift test coverage for the contract and fix the stale `kanata.entitlements` plist header

## Verification
- `Scripts/verify-release-signing-contract.sh --source` — passed
- `TEST_FILTER='ReleaseSigningContractTests|SigningPipelineTests|DeploymentScriptContractTests|IdentityStabilityContractTests|HelperTrustContractTests' ./Scripts/run-tests-safe.sh` — 12 tests passed; warning counters zero
- `KEYPATH_TEST_ENFORCE_CLEAN_SUMMARY=1 ./Scripts/run-tests-safe.sh` — 4,560 tests passed; clean-summary guardrail passed; warning counters zero

## Review Gate
- Local `/thermo-nuclear-swift-review` could not be run because neither `thermo-nuclear-swift-review` nor `claude` is installed on PATH in this shell. The GitHub review workflow is the enforced reviewer for this PR.