### PR TITLE
Preserve wizard matrix registration evidence

### DIFF
--- a/Sources/KeyPathAppKit/Services/System/SystemValidator.swift
+++ b/Sources/KeyPathAppKit/Services/System/SystemValidator.swift
@@ -5,6 +5,7 @@ import KeyPathInstallationWizard
 import KeyPathPermissions
 import KeyPathWizardCore
 import os.lock
+import ServiceManagement
 
 /// Stateless system validation service
 ///
@@ -568,6 +569,13 @@ public class SystemValidator {
         AppLogger.shared.log("🔍 [SystemValidator] checkHealth() ENTRY - Starting system health check")
         let startTime = Date()
 
+        async let kanataSMAppServiceStatus = systemStateProvider.cachedSMAppServiceStatus(
+            for: KanataDaemonManager.kanataPlistName
+        )
+        async let helperSMAppServiceStatus = systemStateProvider.cachedSMAppServiceStatus(
+            for: HelperManager.helperPlistName
+        )
+
         // Check service health via process detection + TCP probe.
         // kanata-launcher can survive (and even hold the TCP socket) after
         // kanata itself has panicked, so we also verify the kanata binary
@@ -625,6 +633,10 @@ public class SystemValidator {
             AppLogger.shared.error("🔍 [SystemValidator] checkHealth() - Config parse error detected: \(configError)")
         }
 
+        let (kanataSMStatus, helperSMStatus) = await (kanataSMAppServiceStatus, helperSMAppServiceStatus)
+        let kanataSMAppServiceRegistered = kanataSMStatus == .enabled || kanataSMStatus == .requiresApproval
+        let loginItemsApprovalRequired = kanataSMStatus == .requiresApproval || helperSMStatus == .requiresApproval
+
         return HealthStatus(
             kanataLaunchdLoaded: !kanataHealth.staleEnabledRegistration &&
                 (kanataHealth.launchctlExitCode == 0 || kanataHealth.isRunning),
@@ -637,7 +649,9 @@ public class SystemValidator {
             kanataInputCaptureIssue: kanataHealth.inputCaptureIssue,
             kanataPermissionRejected: stderrDiagnosis.permissionRejected,
             configParseError: configParseError,
-            staleEnabledRegistration: kanataHealth.staleEnabledRegistration
+            staleEnabledRegistration: kanataHealth.staleEnabledRegistration,
+            kanataSMAppServiceRegistered: kanataSMAppServiceRegistered,
+            loginItemsApprovalRequired: loginItemsApprovalRequired
         )
     }
 

--- a/Sources/KeyPathInstallationWizard/Core/InstallerStateMatrix.swift
+++ b/Sources/KeyPathInstallationWizard/Core/InstallerStateMatrix.swift
@@ -17,6 +17,8 @@ public enum InstallerStateMatrixRow: String, CaseIterable, Sendable, Equatable {
     case virtualHIDApprovalPending = "VirtualHID approval pending"
     case helperMissing = "Helper missing"
     case helperRespondsButMayBeStale = "Helper responds but may be stale"
+    // Post-action verification rows. These are produced by explicit repair
+    // action reports, not by a passive live/wizard system snapshot.
     case helperPathSucceeds = "Helper path succeeds"
     case sudoFallbackSucceeds = "Sudo fallback succeeds"
     case manualApprovalRequired = "Manual approval is required"
@@ -253,7 +255,7 @@ public extension SystemContext {
         return InstallerStateMatrixSnapshot(
             kanataBinaryPresent: components.kanataBinaryInstalled,
             requiredRuntimePayloadPresent: true,
-            smAppServiceRegistered: components.kanataBinaryInstalled,
+            smAppServiceRegistered: services.kanataSMAppServiceRegistered ?? components.kanataBinaryInstalled,
             launchdJobLoaded: launchdJobLoaded,
             kanataProcessRunning: kanataProcessRunning,
             kanataTCPResponding: kanataTCPResponding,
@@ -267,6 +269,7 @@ public extension SystemContext {
             helperInstalled: helper.isInstalled,
             helperResponding: helper.isWorking,
             helperFresh: helper.version == WizardHelperConstants.expectedHelperVersion,
+            manualApprovalRequired: services.loginItemsApprovalRequired ?? false,
             definitiveUnhealthyState: timedOut
         )
     }

--- a/Sources/KeyPathWizardCore/SystemSnapshot.swift
+++ b/Sources/KeyPathWizardCore/SystemSnapshot.swift
@@ -296,6 +296,13 @@ public struct HealthStatus: Sendable {
     /// True when SMAppService reports enabled but launchd/runtime evidence
     /// cannot prove the submitted job exists or can load.
     public let staleEnabledRegistration: Bool
+    /// True when current SMAppService evidence says the Kanata daemon is
+    /// registered or pending approval. Nil means the snapshot did not capture
+    /// registration evidence and consumers should use their legacy fallback.
+    public let kanataSMAppServiceRegistered: Bool?
+    /// True when Kanata or helper SMAppService evidence is blocked on Login
+    /// Items approval. Nil means this snapshot did not capture that evidence.
+    public let loginItemsApprovalRequired: Bool?
 
     public init(
         kanataLaunchdLoaded: Bool? = nil,
@@ -310,7 +317,9 @@ public struct HealthStatus: Sendable {
         activeRuntimePathDetail: String? = nil,
         kanataPermissionRejected: Bool = false,
         configParseError: String? = nil,
-        staleEnabledRegistration: Bool = false
+        staleEnabledRegistration: Bool = false,
+        kanataSMAppServiceRegistered: Bool? = nil,
+        loginItemsApprovalRequired: Bool? = nil
     ) {
         self.kanataLaunchdLoaded = kanataLaunchdLoaded
         self.kanataProcessRunning = kanataProcessRunning
@@ -325,6 +334,8 @@ public struct HealthStatus: Sendable {
         self.kanataPermissionRejected = kanataPermissionRejected
         self.configParseError = configParseError
         self.staleEnabledRegistration = staleEnabledRegistration
+        self.kanataSMAppServiceRegistered = kanataSMAppServiceRegistered
+        self.loginItemsApprovalRequired = loginItemsApprovalRequired
     }
 
     /// Overall health (includes Kanata runtime)

--- a/Tests/KeyPathTests/Core/SystemStateProviderInstallerStateMatrixTests.swift
+++ b/Tests/KeyPathTests/Core/SystemStateProviderInstallerStateMatrixTests.swift
@@ -163,6 +163,25 @@ final class SystemStateProviderInstallerStateMatrixTests: XCTestCase {
         )
     }
 
+    func testWizardSystemContextSnapshotPreservesKanataNotRegisteredEvidence() {
+        assertWizardAndProviderClassifySameRuntimeEvidence(
+            runtime: runtime(),
+            kanataSMAppServiceStatus: .notRegistered,
+            expectedRow: .kanataNotRegistered,
+            expectedPlan: [.installOrRegisterRuntimeServices]
+        )
+    }
+
+    func testWizardSystemContextSnapshotPreservesManualApprovalEvidence() {
+        assertWizardAndProviderClassifySameRuntimeEvidence(
+            runtime: runtime(isRunning: false, isResponding: false),
+            kanataSMAppServiceStatus: .enabled,
+            helperSMAppServiceStatus: .requiresApproval,
+            expectedRow: .manualApprovalRequired,
+            expectedPlan: [.surfaceManualApproval]
+        )
+    }
+
     func testWizardSystemContextSnapshotTreatsUnknownHelperVersionAsNotFresh() {
         let snapshot = systemContext(
             from: runtime(),
@@ -191,6 +210,8 @@ final class SystemStateProviderInstallerStateMatrixTests: XCTestCase {
 
     private func assertWizardAndProviderClassifySameRuntimeEvidence(
         runtime: ServiceHealthChecker.KanataServiceRuntimeSnapshot,
+        kanataSMAppServiceStatus: SMAppService.Status = .enabled,
+        helperSMAppServiceStatus: SMAppService.Status = .enabled,
         expectedRow: InstallerStateMatrixRow,
         expectedPlan: [InstallerStateMatrixAction],
         file: StaticString = #filePath,
@@ -200,19 +221,39 @@ final class SystemStateProviderInstallerStateMatrixTests: XCTestCase {
             components: healthyComponents,
             helper: healthyHelper,
             runtime: runtime,
-            kanataSMAppServiceStatus: .enabled,
-            helperSMAppServiceStatus: .enabled
+            kanataSMAppServiceStatus: kanataSMAppServiceStatus,
+            helperSMAppServiceStatus: helperSMAppServiceStatus
         )
-        let wizardSnapshot = systemContext(from: runtime).installerStateMatrixSnapshot
+        let wizardSnapshot = systemContext(
+            from: runtime,
+            kanataSMAppServiceRegistered: Self.isRegistered(kanataSMAppServiceStatus),
+            loginItemsApprovalRequired: Self.requiresApproval(
+                kanataSMAppServiceStatus,
+                helperSMAppServiceStatus
+            )
+        ).installerStateMatrixSnapshot
 
         XCTAssertEqual(wizardSnapshot, providerSnapshot, file: file, line: line)
         XCTAssertEqual(InstallerStateMatrixPlanner.classify(wizardSnapshot), expectedRow, file: file, line: line)
         XCTAssertEqual(InstallerStateMatrixPlanner.plan(for: wizardSnapshot), expectedPlan, file: file, line: line)
     }
 
+    private static func isRegistered(_ status: SMAppService.Status) -> Bool {
+        status == .enabled || status == .requiresApproval
+    }
+
+    private static func requiresApproval(
+        _ kanataStatus: SMAppService.Status,
+        _ helperStatus: SMAppService.Status
+    ) -> Bool {
+        kanataStatus == .requiresApproval || helperStatus == .requiresApproval
+    }
+
     private func systemContext(
         from runtime: ServiceHealthChecker.KanataServiceRuntimeSnapshot,
-        helper: HelperStatus? = nil
+        helper: HelperStatus? = nil,
+        kanataSMAppServiceRegistered: Bool? = nil,
+        loginItemsApprovalRequired: Bool? = nil
     ) -> SystemContext {
         let permissionSet = PermissionOracle.PermissionSet(
             accessibility: .granted,
@@ -241,7 +282,9 @@ final class SystemStateProviderInstallerStateMatrixTests: XCTestCase {
                 vhidHealthy: true,
                 kanataInputCaptureReady: runtime.inputCaptureReady,
                 kanataInputCaptureIssue: runtime.inputCaptureIssue,
-                staleEnabledRegistration: runtime.staleEnabledRegistration
+                staleEnabledRegistration: runtime.staleEnabledRegistration,
+                kanataSMAppServiceRegistered: kanataSMAppServiceRegistered,
+                loginItemsApprovalRequired: loginItemsApprovalRequired
             ),
             conflicts: .empty,
             components: healthyComponents,


### PR DESCRIPTION
## Summary
- Carry Kanata SMAppService registration and Login Items approval evidence on `HealthStatus` without leaking `ServiceManagement` into `KeyPathWizardCore`.
- Populate that evidence from `SystemValidator` through the centralized `SystemStateProvider` SMAppService status reads.
- Make the wizard `SystemContext` -> state-matrix bridge consume the explicit evidence when present, with the existing conservative fallbacks for older/synthetic snapshots.
- Document `helperPathSucceeds` and `sudoFallbackSucceeds` as post-action verification rows, not passive live/wizard snapshot rows.

## Verification
- `TEST_FILTER=SystemStateProviderInstallerStateMatrixTests ./Scripts/run-tests-safe.sh` passed: 14 tests, clean warning/error counters.
- `KEYPATH_TEST_ENFORCE_CLEAN_SUMMARY=1 ./Scripts/run-tests-safe.sh` passed: 4565 tests, clean-summary guardrails all zero.

## Review Gate
- Local `/thermo-nuclear-swift-review` could not be run because neither `thermo-nuclear-swift-review` nor `claude` is installed on PATH in this shell. The GitHub review workflow is the enforced reviewer for this PR.
