### PR TITLE
Document opportunistic manager consolidation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -248,6 +248,15 @@ Test targets: `KeyPathTests` (`Tests/KeyPathTests/`), `KeyPathSmokeTests`,
   - `KanataManager` for installation/repair (it's for runtime coordination only).
   - `WizardAutoFixer` (deleted — call `InstallerEngine.runSingleAction()` directly).
 
+### Opportunistic Manager Consolidation
+- When a change naturally spans overlapping Manager/Coordinator/Service types,
+  prefer moving the touched responsibility into the existing canonical owner and
+  deleting the redundant bridge instead of adding another forwarding layer.
+- Do not create broad "merge the managers" cleanup PRs. Consolidate only when
+  already touching the area for a concrete behavior, reliability, testability,
+  or compile-boundary improvement. See
+  [ADR-043](docs/adr/adr-043-opportunistic-manager-consolidation.md).
+
 ### Permissions
 - **Always use `PermissionOracle.shared`** for permission checks.
 - Never call `IOHIDCheckAccess` directly **outside of PermissionOracle**.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -40,6 +40,7 @@ This directory contains Architecture Decision Records (ADRs) documenting signifi
 | [ADR-040](adr-040-process-liveness-across-privilege-boundary.md) | Process Liveness and Signaling Across the Privilege Boundary | Accepted |
 | [ADR-041](adr-041-installer-identity-stability-contract.md) | Installer Identity Stability Contract | Accepted |
 | [ADR-042](adr-042-executable-installer-state-classification.md) | Executable Installer State Classification | Accepted |
+| [ADR-043](adr-043-opportunistic-manager-consolidation.md) | Opportunistic Manager Consolidation | Accepted |
 
 ## Key Decisions Summary
 
@@ -53,6 +54,7 @@ This directory contains Architecture Decision Records (ADRs) documenting signifi
 - **ADR-040**: kanata is a root LaunchDaemon; the app is unprivileged. `kill(pid,0)` returns `EPERM` (not `ESRCH`) for the live daemon — treat EPERM as alive. The app cannot signal/kill the daemon; only launchd can.
 - **ADR-041**: Installer identity values for kanata, helper, and daemon shell are release-gated contracts.
 - **ADR-042**: The installer repair state matrix is executable; CLI, menu-bar, and wizard consumers share row/action vocabulary.
+- **ADR-043**: Consolidate overlapping installer/runtime managers opportunistically when touching both sides for concrete work; avoid broad manager-merge refactors.
 
 ### Configuration
 - **ADR-023**: Never parse Kanata config files directly. Use TCP and simulator.

--- a/docs/adr/adr-043-opportunistic-manager-consolidation.md
+++ b/docs/adr/adr-043-opportunistic-manager-consolidation.md
@@ -1,0 +1,75 @@
+# ADR-043: Opportunistic Manager Consolidation
+
+## Status
+
+Accepted
+
+## Date
+
+2026-07-09
+
+## Context
+
+KeyPath's installer and runtime code evolved across several implementation
+eras. Some responsibilities are now split across overlapping
+Manager/Coordinator/Service types such as daemon registration, runtime
+lifecycle, health checking, helper maintenance, privileged execution, and
+system validation.
+
+Phase 1 of installer reliability made the key behavior executable through
+`probe -> snapshot -> classify -> plan -> execute -> verify`, but the older
+object boundaries still exist around that flow. A broad "merge the managers"
+refactor would create high churn during the stability window without directly
+fixing a user-visible bug. At the same time, adding new forwarding layers or
+parallel coordinators would preserve the 18-month pattern that made the repair
+system hard to reason about.
+
+## Decision
+
+Consolidate overlapping installer/runtime managers opportunistically, not as a
+standalone rewrite.
+
+When a bug fix or feature naturally touches overlapping responsibilities across
+Manager/Coordinator/Service types, prefer to move the touched responsibility
+into the canonical owner and delete the now-redundant bridge or forwarding
+method. Do this only when the local change already needs to cross that boundary
+and the resulting ownership is clearer and testable.
+
+Do not schedule broad manager-consolidation PRs whose primary goal is cleanup.
+During the stability window, behavior-preserving consolidation is acceptable
+only when it is attached to a concrete repair, reliability, testability, or
+compile-boundary improvement.
+
+## Guidance
+
+- Keep `InstallerEngine` as the facade for install, repair, uninstall, and
+  system inspection.
+- Keep `SystemStateProvider` as the owner of live system evidence and raw probe
+  access as those call sites migrate.
+- Keep `ServiceLifecycleCoordinator` as the owner of Kanata start/stop/restart
+  orchestration unless a later ADR replaces that boundary.
+- When touching two overlapping types, ask whether one method can move to the
+  owner that already owns the underlying evidence or side effect.
+- Prefer deleting adapters, duplicated state reads, and pass-through methods
+  over adding new coordination layers.
+- Convert static test override seams to injected dependencies only when the
+  touched code is already being changed for behavior or testability.
+
+## Non-Goals
+
+- No project-wide "merge all managers" refactor.
+- No generic dependency/effects framework.
+- No wizard UI rewrite as part of consolidation.
+- No removal of lint ratchets before compiler/module boundaries enforce the
+  same rule.
+
+## Consequences
+
+This keeps architectural pressure in the right direction without destabilizing
+recent installer reliability work. The codebase should gradually lose old
+era-layered abstractions as those areas are touched for real reasons, while
+large, speculative cleanup remains out of scope.
+
+The trade-off is that cleanup will be incremental and uneven. That is
+intentional: local consolidation tied to a tested behavior change has a better
+risk profile than a broad mechanical rewrite.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -46,6 +46,7 @@ This section documents significant architectural decisions in KeyPath. Each ADR 
 | [ADR-040](/adr/adr-040-process-liveness-across-privilege-boundary) | Process Liveness and Signaling Across the Privilege Boundary | Accepted |
 | [ADR-041](/adr/adr-041-installer-identity-stability-contract) | Installer Identity Stability Contract | Accepted |
 | [ADR-042](/adr/adr-042-executable-installer-state-classification) | Executable Installer State Classification | Accepted |
+| [ADR-043](/adr/adr-043-opportunistic-manager-consolidation) | Opportunistic Manager Consolidation | Accepted |
 
 ## Key Decisions Summary
 
@@ -59,6 +60,7 @@ This section documents significant architectural decisions in KeyPath. Each ADR 
 - **ADR-040**: kanata is a root LaunchDaemon; app-side process liveness treats `EPERM` from `kill(pid,0)` as alive.
 - **ADR-041**: Installer identity values for kanata, helper, and daemon shell are release-gated contracts.
 - **ADR-042**: The installer repair state matrix is executable; CLI, menu-bar, and wizard consumers share row/action vocabulary.
+- **ADR-043**: Consolidate overlapping installer/runtime managers opportunistically when touching both sides for concrete work; avoid broad manager-merge refactors.
 
 ### Configuration
 - **ADR-023**: Never parse Kanata config files directly. Use TCP and simulator.


### PR DESCRIPTION
## Summary
- Add ADR-043 documenting opportunistic manager consolidation as the standing architecture rule.
- Add the ADR to both ADR indexes.
- Add a short AGENTS.md reminder for future agent work: consolidate touched overlapping manager/coordinator/service responsibilities only when tied to concrete work; avoid broad manager-merge cleanup PRs.

## Verification
- `git diff --check` passed.
- Docs/process-only change; Swift suite not run locally.
