### PR TITLE
Add explicit runtime payload evidence

### DIFF
--- a/Sources/KeyPathAppKit/Core/SystemStateProvider+InstallerStateMatrix.swift
+++ b/Sources/KeyPathAppKit/Core/SystemStateProvider+InstallerStateMatrix.swift
@@ -49,7 +49,7 @@ public extension SystemStateProvider {
 
         return InstallerStateMatrixSnapshot(
             kanataBinaryPresent: components.kanataBinaryInstalled,
-            requiredRuntimePayloadPresent: true,
+            requiredRuntimePayloadPresent: components.requiredRuntimePayloadPresent,
             smAppServiceRegistered: smAppServiceRegistered,
             launchdJobLoaded: launchdJobLoaded,
             kanataProcessRunning: runtime.isRunning,

--- a/Sources/KeyPathAppKit/Services/System/SystemValidator.swift
+++ b/Sources/KeyPathAppKit/Services/System/SystemValidator.swift
@@ -46,6 +46,7 @@ public class SystemValidator {
 
     private struct ComponentInstallationFacts: Sendable {
         let kanataBinaryInstalled: Bool
+        let requiredRuntimePayloadPresent: Bool
         let vhidInstalled: Bool
         let vhidVersionMismatch: Bool
         let karabinerDriverExtensionEnabled: Bool
@@ -437,11 +438,12 @@ public class SystemValidator {
 
         AppLogger.shared
             .log(
-                "🔍 [SystemValidator] Components: kanata=\(facts.kanataBinaryInstalled), driver=\(karabinerDriverInstalled), daemon=\(karabinerDaemonRunning), vhid=\(vhidHealthy), vhidServices=\(vhidServicesHealthy), vhidPlistMisconfigured=\(facts.vhidDaemonPlistMisconfigured), vhidVersionMismatch=\(facts.vhidVersionMismatch)"
+                "🔍 [SystemValidator] Components: kanata=\(facts.kanataBinaryInstalled), runtimePayload=\(facts.requiredRuntimePayloadPresent), driver=\(karabinerDriverInstalled), daemon=\(karabinerDaemonRunning), vhid=\(vhidHealthy), vhidServices=\(vhidServicesHealthy), vhidPlistMisconfigured=\(facts.vhidDaemonPlistMisconfigured), vhidVersionMismatch=\(facts.vhidVersionMismatch)"
             )
 
         return ComponentStatus(
             kanataBinaryInstalled: facts.kanataBinaryInstalled,
+            requiredRuntimePayloadPresent: facts.requiredRuntimePayloadPresent,
             karabinerDriverInstalled: karabinerDriverInstalled,
             karabinerDaemonRunning: karabinerDaemonRunning,
             vhidDeviceInstalled: facts.vhidInstalled,
@@ -465,6 +467,7 @@ public class SystemValidator {
         // TCC permissions survive app rebuilds at /Applications/KeyPath.app.
         let kanataBinaryDetector = KanataBinaryDetector.shared
         let kanataBinaryInstalled = kanataBinaryDetector.isInstalled()
+        let requiredRuntimePayloadPresent = Self.requiredRuntimePayloadPresent()
 
         let vhidStart = Date()
         let vhidInstalled = vhidDeviceManager.detectInstallation()
@@ -492,6 +495,7 @@ public class SystemValidator {
 
         let facts = ComponentInstallationFacts(
             kanataBinaryInstalled: kanataBinaryInstalled,
+            requiredRuntimePayloadPresent: requiredRuntimePayloadPresent,
             vhidInstalled: vhidInstalled,
             vhidVersionMismatch: vhidVersionMismatch,
             karabinerDriverExtensionEnabled: karabinerDriverExtensionEnabled,
@@ -503,6 +507,20 @@ public class SystemValidator {
             "⏱️ [TIMING] SystemValidator.checkComponents static facts completed in \(String(format: "%.3f", Date().timeIntervalSince(start)))s"
         )
         return facts
+    }
+
+    private static func requiredRuntimePayloadPresent(
+        bundle: Bundle = .main,
+        fileManager: FileManager = .default
+    ) -> Bool {
+        let launcherPresent = fileManager.fileExists(
+            atPath: WizardSystemPaths.bundledKanataLauncherPath
+        )
+        let bundledPlistPath = "\(bundle.bundlePath)/Contents/Library/LaunchDaemons/\(KanataDaemonManager.kanataPlistName)"
+        let plistPresent = fileManager.fileExists(atPath: bundledPlistPath)
+            || bundle.path(forResource: "com.keypath.kanata", ofType: "plist") != nil
+
+        return launcherPresent && plistPresent
     }
 
     // MARK: - Conflict Detection
@@ -697,6 +715,7 @@ public class SystemValidator {
             ),
             components: ComponentStatus(
                 kanataBinaryInstalled: true,
+                requiredRuntimePayloadPresent: true,
                 karabinerDriverInstalled: true,
                 karabinerDaemonRunning: true,
                 vhidDeviceInstalled: true,
@@ -727,6 +746,7 @@ public class SystemValidator {
             ),
             components: ComponentStatus(
                 kanataBinaryInstalled: false,
+                requiredRuntimePayloadPresent: false,
                 karabinerDriverInstalled: false,
                 karabinerDaemonRunning: false,
                 vhidDeviceInstalled: false,

--- a/Sources/KeyPathInstallationWizard/Core/InstallerStateMatrix.swift
+++ b/Sources/KeyPathInstallationWizard/Core/InstallerStateMatrix.swift
@@ -254,7 +254,7 @@ public extension SystemContext {
 
         return InstallerStateMatrixSnapshot(
             kanataBinaryPresent: components.kanataBinaryInstalled,
-            requiredRuntimePayloadPresent: true,
+            requiredRuntimePayloadPresent: components.requiredRuntimePayloadPresent,
             smAppServiceRegistered: services.kanataSMAppServiceRegistered ?? components.kanataBinaryInstalled,
             launchdJobLoaded: launchdJobLoaded,
             kanataProcessRunning: kanataProcessRunning,

--- a/Sources/KeyPathWizardCore/SystemSnapshot.swift
+++ b/Sources/KeyPathWizardCore/SystemSnapshot.swift
@@ -176,6 +176,10 @@ public struct SystemSnapshot: Sendable {
 
 public struct ComponentStatus: Sendable {
     public let kanataBinaryInstalled: Bool
+    /// True when the app bundle contains the non-binary runtime payload needed
+    /// to register and launch Kanata: the SMAppService plist and daemon
+    /// launcher. This is intentionally separate from `kanataBinaryInstalled`.
+    public let requiredRuntimePayloadPresent: Bool
     public let karabinerDriverInstalled: Bool
     public let karabinerDaemonRunning: Bool
     public let vhidDeviceInstalled: Bool
@@ -192,6 +196,7 @@ public struct ComponentStatus: Sendable {
 
     public init(
         kanataBinaryInstalled: Bool,
+        requiredRuntimePayloadPresent: Bool = true,
         karabinerDriverInstalled: Bool,
         karabinerDaemonRunning: Bool,
         vhidDeviceInstalled: Bool,
@@ -201,6 +206,7 @@ public struct ComponentStatus: Sendable {
         vhidVersionMismatch: Bool
     ) {
         self.kanataBinaryInstalled = kanataBinaryInstalled
+        self.requiredRuntimePayloadPresent = requiredRuntimePayloadPresent
         self.karabinerDriverInstalled = karabinerDriverInstalled
         self.karabinerDaemonRunning = karabinerDaemonRunning
         self.vhidDeviceInstalled = vhidDeviceInstalled
@@ -215,7 +221,7 @@ public struct ComponentStatus: Sendable {
     /// still runs day-to-day, so it surfaces as a repairable wizard issue
     /// rather than a missing component that would fail readiness app-wide.
     public var hasAllRequired: Bool {
-        kanataBinaryInstalled && karabinerDriverInstalled && karabinerDaemonRunning && vhidDeviceHealthy
+        kanataBinaryInstalled && requiredRuntimePayloadPresent && karabinerDriverInstalled && karabinerDaemonRunning && vhidDeviceHealthy
             && vhidServicesHealthy && !vhidVersionMismatch
     }
 
@@ -231,6 +237,7 @@ public struct ComponentStatus: Sendable {
     public static var empty: ComponentStatus {
         ComponentStatus(
             kanataBinaryInstalled: false,
+            requiredRuntimePayloadPresent: false,
             karabinerDriverInstalled: false,
             karabinerDaemonRunning: false,
             vhidDeviceInstalled: false,

--- a/Tests/KeyPathTests/Core/SystemStateProviderInstallerStateMatrixTests.swift
+++ b/Tests/KeyPathTests/Core/SystemStateProviderInstallerStateMatrixTests.swift
@@ -112,6 +112,7 @@ final class SystemStateProviderInstallerStateMatrixTests: XCTestCase {
         let snapshot = SystemStateProvider.installerStateMatrixSnapshot(
             components: ComponentStatus(
                 kanataBinaryInstalled: true,
+                requiredRuntimePayloadPresent: true,
                 karabinerDriverInstalled: true,
                 karabinerDaemonRunning: false,
                 vhidDeviceInstalled: true,
@@ -127,6 +128,28 @@ final class SystemStateProviderInstallerStateMatrixTests: XCTestCase {
 
         XCTAssertEqual(InstallerStateMatrixPlanner.classify(snapshot), .vhidServicesMissingUnhealthy)
         XCTAssertEqual(InstallerStateMatrixPlanner.plan(for: snapshot), [.repairVHIDServices])
+    }
+
+    func testStateMatrixSnapshotPreservesMissingRuntimePayloadEvidence() {
+        let snapshot = SystemStateProvider.installerStateMatrixSnapshot(
+            components: ComponentStatus(
+                kanataBinaryInstalled: true,
+                requiredRuntimePayloadPresent: false,
+                karabinerDriverInstalled: true,
+                karabinerDaemonRunning: true,
+                vhidDeviceInstalled: true,
+                vhidDeviceHealthy: true,
+                vhidServicesHealthy: true,
+                vhidVersionMismatch: false
+            ),
+            helper: healthyHelper,
+            runtime: runtime(),
+            kanataSMAppServiceStatus: .enabled,
+            helperSMAppServiceStatus: .enabled
+        )
+
+        XCTAssertEqual(InstallerStateMatrixPlanner.classify(snapshot), .freshInstallMissingComponents)
+        XCTAssertEqual(InstallerStateMatrixPlanner.plan(for: snapshot), [.installMissingComponents])
     }
 
     func testWizardSystemContextSnapshotPreservesRunningButTCPNotRespondingEvidence() {
@@ -180,6 +203,31 @@ final class SystemStateProviderInstallerStateMatrixTests: XCTestCase {
             expectedRow: .manualApprovalRequired,
             expectedPlan: [.surfaceManualApproval]
         )
+    }
+
+    func testWizardSystemContextSnapshotPreservesMissingRuntimePayloadEvidence() {
+        let components = ComponentStatus(
+            kanataBinaryInstalled: true,
+            requiredRuntimePayloadPresent: false,
+            karabinerDriverInstalled: true,
+            karabinerDaemonRunning: true,
+            vhidDeviceInstalled: true,
+            vhidDeviceHealthy: true,
+            vhidServicesHealthy: true,
+            vhidVersionMismatch: false
+        )
+        let providerSnapshot = SystemStateProvider.installerStateMatrixSnapshot(
+            components: components,
+            helper: healthyHelper,
+            runtime: runtime(),
+            kanataSMAppServiceStatus: .enabled,
+            helperSMAppServiceStatus: .enabled
+        )
+        let wizardSnapshot = systemContext(from: runtime(), components: components).installerStateMatrixSnapshot
+
+        XCTAssertEqual(wizardSnapshot, providerSnapshot)
+        XCTAssertEqual(InstallerStateMatrixPlanner.classify(wizardSnapshot), .freshInstallMissingComponents)
+        XCTAssertEqual(InstallerStateMatrixPlanner.plan(for: wizardSnapshot), [.installMissingComponents])
     }
 
     func testWizardSystemContextSnapshotTreatsUnknownHelperVersionAsNotFresh() {
@@ -252,6 +300,7 @@ final class SystemStateProviderInstallerStateMatrixTests: XCTestCase {
     private func systemContext(
         from runtime: ServiceHealthChecker.KanataServiceRuntimeSnapshot,
         helper: HelperStatus? = nil,
+        components: ComponentStatus? = nil,
         kanataSMAppServiceRegistered: Bool? = nil,
         loginItemsApprovalRequired: Bool? = nil
     ) -> SystemContext {
@@ -287,7 +336,7 @@ final class SystemStateProviderInstallerStateMatrixTests: XCTestCase {
                 loginItemsApprovalRequired: loginItemsApprovalRequired
             ),
             conflicts: .empty,
-            components: healthyComponents,
+            components: components ?? healthyComponents,
             helper: helper ?? healthyHelper,
             system: EngineSystemInfo(macOSVersion: "15.0", driverCompatible: true),
             timestamp: Date()


### PR DESCRIPTION
## Summary
- Add explicit `ComponentStatus.requiredRuntimePayloadPresent` evidence for the app-bundled Kanata runtime payload.
- Materialize that evidence from `SystemValidator` by checking the bundled Kanata launcher and SMAppService plist/resource payload.
- Feed that evidence through both `SystemStateProvider` and wizard `SystemContext` state-matrix adapters instead of hardcoding the payload as present.
- Add provider and wizard parity tests for missing runtime payload classification.

## Verification
- `TEST_FILTER=SystemStateProviderInstallerStateMatrixTests ./Scripts/run-tests-safe.sh` passed: 16 tests, clean warning/error counters.
- `KEYPATH_TEST_ENFORCE_CLEAN_SUMMARY=1 ./Scripts/run-tests-safe.sh` passed: 4,567 tests, clean-summary guardrails all zero.
- `git diff --check` passed.

## Review Gate
- Local `/thermo-nuclear-swift-review` could not be run because neither `thermo-nuclear-swift-review` nor `claude` is installed on PATH in this shell. The GitHub review workflow is the enforced reviewer for this PR.