### PR TITLE
Add tri-state installer matrix evidence

### DIFF
--- a/Sources/KeyPathAppKit/Core/SystemStateProvider+InstallerStateMatrix.swift
+++ b/Sources/KeyPathAppKit/Core/SystemStateProvider+InstallerStateMatrix.swift
@@ -48,23 +48,23 @@ public extension SystemStateProvider {
             || helperSMAppServiceStatus == .requiresApproval
 
         return InstallerStateMatrixSnapshot(
-            kanataBinaryPresent: components.kanataBinaryInstalled,
-            requiredRuntimePayloadPresent: components.requiredRuntimePayloadPresent,
-            smAppServiceRegistered: smAppServiceRegistered,
-            launchdJobLoaded: launchdJobLoaded,
-            kanataProcessRunning: runtime.isRunning,
-            kanataTCPResponding: runtime.isResponding,
-            currentInputCaptureIssue: runtime.isRunning && runtime.isResponding && !runtime.inputCaptureReady,
-            staleInputCaptureIssue: !runtime.isRunning && !runtime.inputCaptureReady && !driverKitApprovalPending,
-            driverKitApprovalPending: driverKitApprovalPending,
-            virtualHIDDriverPresent: components.karabinerDriverInstalled,
-            virtualHIDPayloadPresent: components.vhidDeviceInstalled,
-            virtualHIDServicesHealthy: components.vhidServicesHealthy,
-            virtualHIDApprovalPending: driverKitApprovalPending,
-            helperInstalled: helper.isInstalled,
-            helperResponding: helper.isWorking,
-            helperFresh: helper.version == HelperManager.expectedHelperVersion,
-            manualApprovalRequired: loginItemsApprovalRequired
+            kanataBinaryPresent: .known(components.kanataBinaryInstalled),
+            requiredRuntimePayloadPresent: .known(components.requiredRuntimePayloadPresent),
+            smAppServiceRegistered: .known(smAppServiceRegistered),
+            launchdJobLoaded: .known(launchdJobLoaded),
+            kanataProcessRunning: .known(runtime.isRunning),
+            kanataTCPResponding: .known(runtime.isResponding),
+            currentInputCaptureIssue: .known(runtime.isRunning && runtime.isResponding && !runtime.inputCaptureReady),
+            staleInputCaptureIssue: .known(!runtime.isRunning && !runtime.inputCaptureReady && !driverKitApprovalPending),
+            driverKitApprovalPending: .known(driverKitApprovalPending),
+            virtualHIDDriverPresent: .known(components.karabinerDriverInstalled),
+            virtualHIDPayloadPresent: .known(components.vhidDeviceInstalled),
+            virtualHIDServicesHealthy: .known(components.vhidServicesHealthy),
+            virtualHIDApprovalPending: .known(driverKitApprovalPending),
+            helperInstalled: .known(helper.isInstalled),
+            helperResponding: .known(helper.isWorking),
+            helperFresh: .known(helper.version == HelperManager.expectedHelperVersion),
+            manualApprovalRequired: .known(loginItemsApprovalRequired)
         )
     }
 }

--- a/Sources/KeyPathInstallationWizard/Core/InstallerStateMatrix.swift
+++ b/Sources/KeyPathInstallationWizard/Core/InstallerStateMatrix.swift
@@ -25,53 +25,91 @@ public enum InstallerStateMatrixRow: String, CaseIterable, Sendable, Equatable {
     case definitiveUnhealthyState = "Definitive unhealthy state"
 }
 
+/// A value captured from system evidence, preserving the difference between
+/// "known false" and "not captured".
+public enum Evidence<Value: Sendable & Equatable>: Sendable, Equatable {
+    case known(Value)
+    case unknown
+}
+
+public extension Evidence {
+    var value: Value? {
+        guard case let .known(value) = self else { return nil }
+        return value
+    }
+}
+
+public extension Evidence where Value == Bool {
+    static var present: Evidence<Bool> {
+        .known(true)
+    }
+
+    static var absent: Evidence<Bool> {
+        .known(false)
+    }
+
+    var isKnownTrue: Bool {
+        value == true
+    }
+
+    var isKnownFalse: Bool {
+        value == false
+    }
+}
+
+extension Evidence: ExpressibleByBooleanLiteral where Value == Bool {
+    public init(booleanLiteral value: Bool) {
+        self = .known(value)
+    }
+}
+
 /// Minimal immutable evidence used by the state-matrix classifier.
 ///
 /// This is intentionally pure and OS-free. `SystemStateProvider` can build this
 /// from live evidence in a later slice without changing the classifier contract.
 public struct InstallerStateMatrixSnapshot: Sendable, Equatable {
-    public var kanataBinaryPresent: Bool
-    public var requiredRuntimePayloadPresent: Bool
-    public var smAppServiceRegistered: Bool
-    public var launchdJobLoaded: Bool
-    public var kanataProcessRunning: Bool
-    public var kanataTCPResponding: Bool
-    public var currentInputCaptureIssue: Bool
-    public var staleInputCaptureIssue: Bool
-    public var driverKitApprovalPending: Bool
-    public var virtualHIDDriverPresent: Bool
-    public var virtualHIDPayloadPresent: Bool
-    public var virtualHIDServicesHealthy: Bool
-    public var virtualHIDApprovalPending: Bool
-    public var helperInstalled: Bool
-    public var helperResponding: Bool
-    public var helperFresh: Bool
-    public var helperPathReportedSuccess: Bool
-    public var sudoFallbackReportedSuccess: Bool
-    public var manualApprovalRequired: Bool
-    public var definitiveUnhealthyState: Bool
+    public var kanataBinaryPresent: Evidence<Bool>
+    public var requiredRuntimePayloadPresent: Evidence<Bool>
+    public var smAppServiceRegistered: Evidence<Bool>
+    public var launchdJobLoaded: Evidence<Bool>
+    public var kanataProcessRunning: Evidence<Bool>
+    public var kanataTCPResponding: Evidence<Bool>
+    public var currentInputCaptureIssue: Evidence<Bool>
+    public var staleInputCaptureIssue: Evidence<Bool>
+    public var driverKitApprovalPending: Evidence<Bool>
+    public var virtualHIDDriverPresent: Evidence<Bool>
+    public var virtualHIDPayloadPresent: Evidence<Bool>
+    public var virtualHIDServicesHealthy: Evidence<Bool>
+    public var virtualHIDApprovalPending: Evidence<Bool>
+    public var helperInstalled: Evidence<Bool>
+    public var helperResponding: Evidence<Bool>
+    public var helperFresh: Evidence<Bool>
+    public var helperPathReportedSuccess: Evidence<Bool>
+    public var sudoFallbackReportedSuccess: Evidence<Bool>
+    public var manualApprovalRequired: Evidence<Bool>
+    public var definitiveUnhealthyState: Evidence<Bool>
 
     public init(
-        kanataBinaryPresent: Bool = true,
-        requiredRuntimePayloadPresent: Bool = true,
-        smAppServiceRegistered: Bool = true,
-        launchdJobLoaded: Bool = true,
-        kanataProcessRunning: Bool = true,
-        kanataTCPResponding: Bool = true,
-        currentInputCaptureIssue: Bool = false,
-        staleInputCaptureIssue: Bool = false,
-        driverKitApprovalPending: Bool = false,
-        virtualHIDDriverPresent: Bool = true,
-        virtualHIDPayloadPresent: Bool = true,
-        virtualHIDServicesHealthy: Bool = true,
-        virtualHIDApprovalPending: Bool = false,
-        helperInstalled: Bool = true,
-        helperResponding: Bool = true,
-        helperFresh: Bool = true,
-        helperPathReportedSuccess: Bool = false,
-        sudoFallbackReportedSuccess: Bool = false,
-        manualApprovalRequired: Bool = false,
-        definitiveUnhealthyState: Bool = false
+        kanataBinaryPresent: Evidence<Bool> = .present,
+        requiredRuntimePayloadPresent: Evidence<Bool> = .present,
+        smAppServiceRegistered: Evidence<Bool> = .present,
+        launchdJobLoaded: Evidence<Bool> = .present,
+        kanataProcessRunning: Evidence<Bool> = .present,
+        kanataTCPResponding: Evidence<Bool> = .present,
+        currentInputCaptureIssue: Evidence<Bool> = .absent,
+        staleInputCaptureIssue: Evidence<Bool> = .absent,
+        driverKitApprovalPending: Evidence<Bool> = .absent,
+        virtualHIDDriverPresent: Evidence<Bool> = .present,
+        virtualHIDPayloadPresent: Evidence<Bool> = .present,
+        virtualHIDServicesHealthy: Evidence<Bool> = .present,
+        virtualHIDApprovalPending: Evidence<Bool> = .absent,
+        helperInstalled: Evidence<Bool> = .present,
+        helperResponding: Evidence<Bool> = .present,
+        helperFresh: Evidence<Bool> = .present,
+        helperPathReportedSuccess: Evidence<Bool> = .absent,
+        sudoFallbackReportedSuccess: Evidence<Bool> = .absent,
+        manualApprovalRequired: Evidence<Bool> = .absent,
+        definitiveUnhealthyState: Evidence<Bool> = .absent
     ) {
         self.kanataBinaryPresent = kanataBinaryPresent
         self.requiredRuntimePayloadPresent = requiredRuntimePayloadPresent
@@ -96,7 +134,7 @@ public struct InstallerStateMatrixSnapshot: Sendable, Equatable {
     }
 
     public var runtimeReady: Bool {
-        kanataProcessRunning && kanataTCPResponding
+        kanataProcessRunning.isKnownTrue && kanataTCPResponding.isKnownTrue
     }
 }
 
@@ -120,76 +158,76 @@ public enum InstallerStateMatrixAction: String, Sendable, Equatable {
 
 public enum InstallerStateMatrixPlanner {
     public static func classify(_ snapshot: InstallerStateMatrixSnapshot) -> InstallerStateMatrixRow {
-        let runtimeUsable = snapshot.runtimeReady && !snapshot.currentInputCaptureIssue
+        let runtimeUsable = snapshot.runtimeReady && !snapshot.currentInputCaptureIssue.isKnownTrue
 
-        if snapshot.manualApprovalRequired, !runtimeUsable {
+        if snapshot.manualApprovalRequired.isKnownTrue, !runtimeUsable {
             return .manualApprovalRequired
         }
 
-        if snapshot.helperPathReportedSuccess {
+        if snapshot.helperPathReportedSuccess.isKnownTrue {
             return .helperPathSucceeds
         }
 
-        if snapshot.sudoFallbackReportedSuccess {
+        if snapshot.sudoFallbackReportedSuccess.isKnownTrue {
             return .sudoFallbackSucceeds
         }
 
-        if snapshot.definitiveUnhealthyState {
+        if snapshot.definitiveUnhealthyState.isKnownTrue {
             return .definitiveUnhealthyState
         }
 
-        if !snapshot.kanataBinaryPresent ||
-            !snapshot.requiredRuntimePayloadPresent ||
-            !snapshot.virtualHIDDriverPresent
+        if !snapshot.kanataBinaryPresent.isKnownTrue ||
+            !snapshot.requiredRuntimePayloadPresent.isKnownTrue ||
+            !snapshot.virtualHIDDriverPresent.isKnownTrue
         {
             return .freshInstallMissingComponents
         }
 
-        if !snapshot.smAppServiceRegistered {
+        if !snapshot.smAppServiceRegistered.isKnownTrue {
             return .kanataNotRegistered
         }
 
-        if snapshot.smAppServiceRegistered, !snapshot.launchdJobLoaded {
+        if snapshot.smAppServiceRegistered.isKnownTrue, !snapshot.launchdJobLoaded.isKnownTrue {
             return .registeredButNotLoaded
         }
 
-        if snapshot.launchdJobLoaded, !snapshot.kanataProcessRunning {
-            if snapshot.driverKitApprovalPending, snapshot.virtualHIDDriverPresent {
+        if snapshot.launchdJobLoaded.isKnownTrue, !snapshot.kanataProcessRunning.isKnownTrue {
+            if snapshot.driverKitApprovalPending.isKnownTrue, snapshot.virtualHIDDriverPresent.isKnownTrue {
                 return .driverKitApprovalPendingWithKanataStopped
             }
 
-            if snapshot.staleInputCaptureIssue {
+            if snapshot.staleInputCaptureIssue.isKnownTrue {
                 return .staleInputCaptureIssueWithKanataStopped
             }
 
             return .loadedButNotRunning
         }
 
-        if snapshot.kanataProcessRunning, !snapshot.kanataTCPResponding {
+        if snapshot.kanataProcessRunning.isKnownTrue, !snapshot.kanataTCPResponding.isKnownTrue {
             return .runningButTCPNotResponding
         }
 
-        if snapshot.virtualHIDApprovalPending {
+        if snapshot.virtualHIDApprovalPending.isKnownTrue {
             return .virtualHIDApprovalPending
         }
 
-        if snapshot.runtimeReady, snapshot.currentInputCaptureIssue {
+        if snapshot.runtimeReady, snapshot.currentInputCaptureIssue.isKnownTrue {
             return .runningButInputCaptureFailing
         }
 
-        if !snapshot.virtualHIDPayloadPresent {
+        if !snapshot.virtualHIDPayloadPresent.isKnownTrue {
             return .virtualHIDDriverPayloadMissing
         }
 
-        if !snapshot.virtualHIDServicesHealthy {
+        if !snapshot.virtualHIDServicesHealthy.isKnownTrue {
             return .vhidServicesMissingUnhealthy
         }
 
-        if !snapshot.helperInstalled || !snapshot.helperResponding {
+        if !snapshot.helperInstalled.isKnownTrue || !snapshot.helperResponding.isKnownTrue {
             return .helperMissing
         }
 
-        if snapshot.helperResponding, !snapshot.helperFresh {
+        if snapshot.helperResponding.isKnownTrue, !snapshot.helperFresh.isKnownTrue {
             return .helperRespondsButMayBeStale
         }
 
@@ -243,34 +281,50 @@ public enum InstallerStateMatrixPlanner {
 public extension SystemContext {
     var installerStateMatrixSnapshot: InstallerStateMatrixSnapshot {
         let driverKitApprovalPending = requiresManualVHIDDriverApproval
-        let kanataProcessRunning = services.kanataProcessRunning ?? services.kanataRunning
-        let kanataTCPResponding = services.kanataTCPResponding ?? services.kanataRunning
-        let launchdJobLoaded = !services.staleEnabledRegistration && (services.kanataLaunchdLoaded
-            ?? (kanataProcessRunning || components.kanataBinaryInstalled))
+        let kanataProcessRunning = services.kanataProcessRunning.map(Evidence<Bool>.known) ?? .unknown
+        let kanataTCPResponding = services.kanataTCPResponding.map(Evidence<Bool>.known) ?? .unknown
+        let launchdJobLoaded: Evidence<Bool> = if services.staleEnabledRegistration {
+            .absent
+        } else if let kanataLaunchdLoaded = services.kanataLaunchdLoaded {
+            .known(kanataLaunchdLoaded)
+        } else {
+            .unknown
+        }
         let inputCaptureIssuePresent = !services.kanataInputCaptureReady
-        let staleInputCaptureIssue = !kanataProcessRunning
-            && inputCaptureIssuePresent
-            && !driverKitApprovalPending
+        let staleInputCaptureIssue: Evidence<Bool> = if let kanataProcessRunning = services.kanataProcessRunning {
+            .known(!kanataProcessRunning
+                && inputCaptureIssuePresent
+                && !driverKitApprovalPending)
+        } else {
+            .unknown
+        }
+        let currentInputCaptureIssue: Evidence<Bool> = if let kanataProcessRunning = services.kanataProcessRunning,
+                                                          let kanataTCPResponding = services.kanataTCPResponding
+        {
+            .known(kanataProcessRunning && kanataTCPResponding && inputCaptureIssuePresent)
+        } else {
+            .unknown
+        }
 
         return InstallerStateMatrixSnapshot(
-            kanataBinaryPresent: components.kanataBinaryInstalled,
-            requiredRuntimePayloadPresent: components.requiredRuntimePayloadPresent,
-            smAppServiceRegistered: services.kanataSMAppServiceRegistered ?? components.kanataBinaryInstalled,
+            kanataBinaryPresent: .known(components.kanataBinaryInstalled),
+            requiredRuntimePayloadPresent: .known(components.requiredRuntimePayloadPresent),
+            smAppServiceRegistered: services.kanataSMAppServiceRegistered.map(Evidence<Bool>.known) ?? .unknown,
             launchdJobLoaded: launchdJobLoaded,
             kanataProcessRunning: kanataProcessRunning,
             kanataTCPResponding: kanataTCPResponding,
-            currentInputCaptureIssue: kanataProcessRunning && kanataTCPResponding && inputCaptureIssuePresent,
+            currentInputCaptureIssue: currentInputCaptureIssue,
             staleInputCaptureIssue: staleInputCaptureIssue,
-            driverKitApprovalPending: driverKitApprovalPending,
-            virtualHIDDriverPresent: components.karabinerDriverInstalled,
-            virtualHIDPayloadPresent: components.vhidDeviceInstalled,
-            virtualHIDServicesHealthy: !components.vhidRuntimeServicesNeedRepair,
-            virtualHIDApprovalPending: driverKitApprovalPending,
-            helperInstalled: helper.isInstalled,
-            helperResponding: helper.isWorking,
-            helperFresh: helper.version == WizardHelperConstants.expectedHelperVersion,
-            manualApprovalRequired: services.loginItemsApprovalRequired ?? false,
-            definitiveUnhealthyState: timedOut
+            driverKitApprovalPending: .known(driverKitApprovalPending),
+            virtualHIDDriverPresent: .known(components.karabinerDriverInstalled),
+            virtualHIDPayloadPresent: .known(components.vhidDeviceInstalled),
+            virtualHIDServicesHealthy: .known(!components.vhidRuntimeServicesNeedRepair),
+            virtualHIDApprovalPending: .known(driverKitApprovalPending),
+            helperInstalled: .known(helper.isInstalled),
+            helperResponding: .known(helper.isWorking),
+            helperFresh: .known(helper.version == WizardHelperConstants.expectedHelperVersion),
+            manualApprovalRequired: services.loginItemsApprovalRequired.map(Evidence<Bool>.known) ?? .unknown,
+            definitiveUnhealthyState: .known(timedOut)
         )
     }
 

--- a/Tests/KeyPathTests/Core/SystemStateProviderInstallerStateMatrixTests.swift
+++ b/Tests/KeyPathTests/Core/SystemStateProviderInstallerStateMatrixTests.swift
@@ -223,7 +223,12 @@ final class SystemStateProviderInstallerStateMatrixTests: XCTestCase {
             kanataSMAppServiceStatus: .enabled,
             helperSMAppServiceStatus: .enabled
         )
-        let wizardSnapshot = systemContext(from: runtime(), components: components).installerStateMatrixSnapshot
+        let wizardSnapshot = systemContext(
+            from: runtime(),
+            components: components,
+            kanataSMAppServiceRegistered: true,
+            loginItemsApprovalRequired: false
+        ).installerStateMatrixSnapshot
 
         XCTAssertEqual(wizardSnapshot, providerSnapshot)
         XCTAssertEqual(InstallerStateMatrixPlanner.classify(wizardSnapshot), .freshInstallMissingComponents)
@@ -233,11 +238,63 @@ final class SystemStateProviderInstallerStateMatrixTests: XCTestCase {
     func testWizardSystemContextSnapshotTreatsUnknownHelperVersionAsNotFresh() {
         let snapshot = systemContext(
             from: runtime(),
-            helper: HelperStatus(isInstalled: true, version: nil, isWorking: true)
+            helper: HelperStatus(isInstalled: true, version: nil, isWorking: true),
+            kanataSMAppServiceRegistered: true,
+            loginItemsApprovalRequired: false
         ).installerStateMatrixSnapshot
 
         XCTAssertEqual(InstallerStateMatrixPlanner.classify(snapshot), .helperRespondsButMayBeStale)
         XCTAssertEqual(InstallerStateMatrixPlanner.plan(for: snapshot), [.verifyOrRefreshHelper])
+    }
+
+    func testWizardSystemContextSnapshotPreservesUnknownRegistrationEvidence() {
+        let snapshot = systemContext(
+            from: runtime(),
+            kanataSMAppServiceRegistered: nil,
+            loginItemsApprovalRequired: false
+        ).installerStateMatrixSnapshot
+
+        XCTAssertEqual(snapshot.smAppServiceRegistered, .unknown)
+        XCTAssertEqual(InstallerStateMatrixPlanner.classify(snapshot), .kanataNotRegistered)
+        XCTAssertEqual(InstallerStateMatrixPlanner.plan(for: snapshot), [.installOrRegisterRuntimeServices])
+    }
+
+    func testWizardSystemContextSnapshotPreservesUnknownLaunchdEvidence() {
+        let snapshot = systemContext(
+            health: HealthStatus(
+                kanataLaunchdLoaded: nil,
+                kanataProcessRunning: true,
+                kanataTCPResponding: true,
+                kanataRunning: true,
+                karabinerDaemonRunning: true,
+                vhidHealthy: true,
+                kanataSMAppServiceRegistered: true,
+                loginItemsApprovalRequired: false
+            )
+        ).installerStateMatrixSnapshot
+
+        XCTAssertEqual(snapshot.launchdJobLoaded, .unknown)
+        XCTAssertEqual(InstallerStateMatrixPlanner.classify(snapshot), .registeredButNotLoaded)
+        XCTAssertEqual(InstallerStateMatrixPlanner.plan(for: snapshot), [.recoverRuntimeRegistrationBypassingThrottle])
+    }
+
+    func testWizardSystemContextSnapshotPreservesUnknownProcessEvidence() {
+        let snapshot = systemContext(
+            health: HealthStatus(
+                kanataLaunchdLoaded: true,
+                kanataProcessRunning: nil,
+                kanataTCPResponding: true,
+                kanataRunning: true,
+                karabinerDaemonRunning: true,
+                vhidHealthy: true,
+                kanataSMAppServiceRegistered: true,
+                loginItemsApprovalRequired: false
+            )
+        ).installerStateMatrixSnapshot
+
+        XCTAssertEqual(snapshot.kanataProcessRunning, .unknown)
+        XCTAssertEqual(InstallerStateMatrixPlanner.classify(snapshot), .loadedButNotRunning)
+        XCTAssertEqual(InstallerStateMatrixPlanner.plan(for: snapshot), [.installRequiredRuntimeServices])
     }
 
     private var healthyComponents: ComponentStatus {
@@ -295,6 +352,35 @@ final class SystemStateProviderInstallerStateMatrixTests: XCTestCase {
         _ helperStatus: SMAppService.Status
     ) -> Bool {
         kanataStatus == .requiresApproval || helperStatus == .requiresApproval
+    }
+
+    private func systemContext(
+        health: HealthStatus,
+        helper: HelperStatus? = nil,
+        components: ComponentStatus? = nil
+    ) -> SystemContext {
+        let permissionSet = PermissionOracle.PermissionSet(
+            accessibility: .granted,
+            inputMonitoring: .granted,
+            source: "test",
+            confidence: .high,
+            timestamp: Date()
+        )
+        let permissions = PermissionOracle.Snapshot(
+            keyPath: permissionSet,
+            kanata: permissionSet,
+            timestamp: Date()
+        )
+
+        return SystemContext(
+            permissions: permissions,
+            services: health,
+            conflicts: .empty,
+            components: components ?? healthyComponents,
+            helper: helper ?? healthyHelper,
+            system: EngineSystemInfo(macOSVersion: "15.0", driverCompatible: true),
+            timestamp: Date()
+        )
     }
 
     private func systemContext(

--- a/Tests/KeyPathTests/InstallationEngine/InstallerStateMatrixGoldenTests.swift
+++ b/Tests/KeyPathTests/InstallationEngine/InstallerStateMatrixGoldenTests.swift
@@ -74,6 +74,27 @@ final class InstallerStateMatrixGoldenTests: XCTestCase {
         XCTAssertEqual(InstallerStateMatrixPlanner.plan(for: snapshot), [.surfaceManualApproval])
     }
 
+    func testUnknownRegistrationEvidenceDoesNotDefaultHealthy() {
+        let snapshot = InstallerStateMatrixSnapshot(smAppServiceRegistered: .unknown)
+
+        XCTAssertEqual(InstallerStateMatrixPlanner.classify(snapshot), .kanataNotRegistered)
+        XCTAssertEqual(InstallerStateMatrixPlanner.plan(for: snapshot), [.installOrRegisterRuntimeServices])
+    }
+
+    func testUnknownRuntimeProcessEvidenceDoesNotDefaultHealthy() {
+        let snapshot = InstallerStateMatrixSnapshot(kanataProcessRunning: .unknown)
+
+        XCTAssertEqual(InstallerStateMatrixPlanner.classify(snapshot), .loadedButNotRunning)
+        XCTAssertEqual(InstallerStateMatrixPlanner.plan(for: snapshot), [.installRequiredRuntimeServices])
+    }
+
+    func testUnknownVirtualHIDPayloadEvidenceDoesNotDefaultHealthy() {
+        let snapshot = InstallerStateMatrixSnapshot(virtualHIDPayloadPresent: .unknown)
+
+        XCTAssertEqual(InstallerStateMatrixPlanner.classify(snapshot), .virtualHIDDriverPayloadMissing)
+        XCTAssertEqual(InstallerStateMatrixPlanner.plan(for: snapshot), [.installVirtualHIDPayload])
+    }
+
     private struct GoldenCase {
         let name: String
         let snapshot: InstallerStateMatrixSnapshot

--- a/Tests/KeyPathTests/InstallationWizard/WizardPureLogicTests.swift
+++ b/Tests/KeyPathTests/InstallationWizard/WizardPureLogicTests.swift
@@ -53,9 +53,14 @@ final class WizardPureLogicTests: XCTestCase {
 
     private var healthyServices: HealthStatus {
         HealthStatus(
+            kanataLaunchdLoaded: true,
+            kanataProcessRunning: true,
+            kanataTCPResponding: true,
             kanataRunning: true,
             karabinerDaemonRunning: true,
-            vhidHealthy: true
+            vhidHealthy: true,
+            kanataSMAppServiceRegistered: true,
+            loginItemsApprovalRequired: false
         )
     }
 
@@ -117,11 +122,16 @@ final class WizardPureLogicTests: XCTestCase {
     func test_systemContextStateMatrixSnapshot_classifiesStoppedRuntimeWithStaleInputCapture() {
         let context = makeContext(
             services: HealthStatus(
+                kanataLaunchdLoaded: true,
+                kanataProcessRunning: false,
+                kanataTCPResponding: false,
                 kanataRunning: false,
                 karabinerDaemonRunning: true,
                 vhidHealthy: true,
                 kanataInputCaptureReady: false,
-                kanataInputCaptureIssue: ServiceHealthChecker.inputCaptureGrabFailureReason
+                kanataInputCaptureIssue: ServiceHealthChecker.inputCaptureGrabFailureReason,
+                kanataSMAppServiceRegistered: true,
+                loginItemsApprovalRequired: false
             )
         )
 


### PR DESCRIPTION
## Summary
- Add generic `Evidence<T>` and convert `InstallerStateMatrixSnapshot` bool fields to tri-state evidence.
- Update the state-matrix classifier so unknown evidence routes conservatively instead of defaulting healthy.
- Make live `SystemStateProvider` matrix adaptation emit explicit known evidence for all captured fields.
- Tighten the wizard `SystemContext` adapter so absent registration, launchd, process, TCP, and approval evidence remains `.unknown` rather than being inferred from legacy summary booleans.
- Add golden and adapter tests for unknown registration/runtime/payload evidence.

## Verification
- `TEST_FILTER='InstallerStateMatrixGoldenTests|SystemStateProviderInstallerStateMatrixTests' ./Scripts/run-tests-safe.sh` passed: 29 tests, clean warning/error counters.
- `TEST_FILTER='InstallerStateMatrixGoldenTests|SystemStateProviderInstallerStateMatrixTests|WizardPureLogicTests' ./Scripts/run-tests-safe.sh` passed: 131 tests, clean warning/error counters.
- `KEYPATH_TEST_ENFORCE_CLEAN_SUMMARY=1 ./Scripts/run-tests-safe.sh` passed: 4,573 tests, clean-summary guardrails all zero.
- `git diff --check` passed.

## Review Gate
- Local `/thermo-nuclear-swift-review` could not be run because neither `thermo-nuclear-swift-review` nor `claude` is installed on PATH in this shell. The GitHub review workflow is the enforced reviewer for this PR.