### PR TITLE
Preserve installer matrix SMAppService evidence

### DIFF
--- a/Sources/KeyPathInstallationWizard/Core/InstallerEngine.swift
+++ b/Sources/KeyPathInstallationWizard/Core/InstallerEngine.swift
@@ -92,7 +92,9 @@ public final class InstallerEngine {
             activeRuntimePathDetail: activeRuntimePathStatus?.detail,
             kanataPermissionRejected: snapshot.health.kanataPermissionRejected,
             configParseError: snapshot.health.configParseError,
-            staleEnabledRegistration: snapshot.health.staleEnabledRegistration
+            staleEnabledRegistration: snapshot.health.staleEnabledRegistration,
+            kanataSMAppServiceRegistered: snapshot.health.kanataSMAppServiceRegistered,
+            loginItemsApprovalRequired: snapshot.health.loginItemsApprovalRequired
         )
 
         // Convert SystemSnapshot to SystemContext

--- a/Sources/KeyPathWizardCore/SystemSnapshot.swift
+++ b/Sources/KeyPathWizardCore/SystemSnapshot.swift
@@ -305,10 +305,12 @@ public struct HealthStatus: Sendable {
     public let staleEnabledRegistration: Bool
     /// True when current SMAppService evidence says the Kanata daemon is
     /// registered or pending approval. Nil means the snapshot did not capture
-    /// registration evidence and consumers should use their legacy fallback.
+    /// registration evidence; state-matrix consumers must preserve that as
+    /// unknown rather than inferring from summary health.
     public let kanataSMAppServiceRegistered: Bool?
     /// True when Kanata or helper SMAppService evidence is blocked on Login
-    /// Items approval. Nil means this snapshot did not capture that evidence.
+    /// Items approval. Nil means this snapshot did not capture that evidence;
+    /// state-matrix consumers must preserve that as unknown.
     public let loginItemsApprovalRequired: Bool?
 
     public init(

--- a/Tests/KeyPathTests/Lint/SnapshotConsumerLintTests.swift
+++ b/Tests/KeyPathTests/Lint/SnapshotConsumerLintTests.swift
@@ -54,4 +54,26 @@ final class SnapshotConsumerLintTests: XCTestCase {
             """
         )
     }
+
+    func testInstallerEnginePreservesMatrixSMAppServiceEvidence() throws {
+        let body = try LintScanner.functionBody(
+            named: "inspectSystem",
+            in: LintScanner.path("Sources/KeyPathInstallationWizard/Core/InstallerEngine.swift")
+        )
+
+        for field in [
+            "kanataSMAppServiceRegistered",
+            "loginItemsApprovalRequired"
+        ] {
+            XCTAssertTrue(
+                body.contains("\(field): snapshot.health.\(field)"),
+                """
+                InstallerEngine.inspectSystem() must preserve \(field) when \
+                converting SystemSnapshot.health to SystemContext.services. \
+                Dropping it turns explicit SMAppService evidence into unknown \
+                state-matrix evidence.
+                """
+            )
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Preserve `kanataSMAppServiceRegistered` and `loginItemsApprovalRequired` when `InstallerEngine.inspectSystem()` converts `SystemSnapshot.health` into `SystemContext.services`.
- Update `HealthStatus` comments so nil SMAppService evidence is documented as unknown, not a legacy fallback signal.
- Add a `SnapshotConsumerLintTests` ratchet that fails if the installer engine bridge drops those matrix evidence fields again.

## Verification
- `TEST_FILTER='SnapshotConsumerLintTests|SystemStateProviderInstallerStateMatrixTests|InstallerStateMatrixGoldenTests' ./Scripts/run-tests-safe.sh` passed: 32 tests, clean warning/error counters.
- `KEYPATH_TEST_ENFORCE_CLEAN_SUMMARY=1 ./Scripts/run-tests-safe.sh` passed: 4,574 tests, clean-summary guardrails all zero.
- `git diff --check` passed.

## Review Gate
- Local `/thermo-nuclear-swift-review` could not be run because neither `thermo-nuclear-swift-review` nor `claude` is installed on PATH in this shell. The GitHub review workflow is the enforced reviewer for this PR.