### PR TITLE
Extract raw system probes boundary

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,6 +14,10 @@ let package = Package(
             targets: ["KeyPathCore"]
         ),
         .library(
+            name: "KeyPathSystemProbes",
+            targets: ["KeyPathSystemProbes"]
+        ),
+        .library(
             name: "KeyPathPermissions",
             targets: ["KeyPathPermissions"]
         ),
@@ -87,7 +91,15 @@ let package = Package(
     targets: [
         // Core library with shared types/utilities
         .target(
+            name: "KeyPathSystemProbes",
+            path: "Sources/KeyPathSystemProbes",
+            swiftSettings: [
+                .swiftLanguageMode(.v6)
+            ]
+        ),
+        .target(
             name: "KeyPathCore",
+            dependencies: ["KeyPathSystemProbes"],
             path: "Sources/KeyPathCore",
             swiftSettings: [
                 .swiftLanguageMode(.v6)

--- a/Sources/KeyPathCore/SubprocessRunner.swift
+++ b/Sources/KeyPathCore/SubprocessRunner.swift
@@ -10,7 +10,6 @@ public protocol SubprocessRunning: Sendable {
         timeout: TimeInterval?
     ) async throws -> ProcessResult
 
-    func pgrep(_ pattern: String) async -> [pid_t]
     func launchctl(_ subcommand: String, _ args: [String]) async throws -> ProcessResult
 }
 
@@ -147,32 +146,6 @@ public actor SubprocessRunner: SubprocessRunning {
             runContext.timeoutTask?.cancel()
             runContext.resume(with: .failure(CancellationError()))
         })
-    }
-
-    /// Run pgrep to find processes matching a pattern
-    ///
-    /// - Parameter pattern: Process pattern to search for
-    /// - Returns: Array of process IDs
-    public func pgrep(_ pattern: String) async -> [pid_t] {
-        do {
-            let result = try await run("/usr/bin/pgrep", args: ["-f", pattern], timeout: 5)
-            // pgrep returns exit code 1 when no processes found (not an error)
-            if result.exitCode == 1 {
-                return []
-            }
-            if result.exitCode != 0 {
-                AppLogger.shared.warn("⚠️ [SubprocessRunner] pgrep exited with code \(result.exitCode)")
-                return []
-            }
-            return result.stdout
-                .trimmingCharacters(in: .whitespacesAndNewlines)
-                .components(separatedBy: .newlines)
-                .filter { !$0.isEmpty }
-                .compactMap { Int32($0.trimmingCharacters(in: .whitespaces)) }
-        } catch {
-            AppLogger.shared.warn("⚠️ [SubprocessRunner] pgrep failed for pattern '\(pattern)': \(error)")
-            return []
-        }
     }
 
     /// Run launchctl command

--- a/Sources/KeyPathCore/SystemStateProvider.swift
+++ b/Sources/KeyPathCore/SystemStateProvider.swift
@@ -1,5 +1,5 @@
-import Darwin
 import Foundation
+@_exported import KeyPathSystemProbes
 
 /// Central owner for system-state evidence used by installer and runtime decisions.
 ///
@@ -7,45 +7,32 @@ import Foundation
 /// process-liveness and TCP-readiness primitives so callers share one definition.
 public actor SystemStateProvider {
     public static let shared = SystemStateProvider()
+    public static let liveProbes = SystemProbeClient.live
 
-    private let subprocessRunner: any SubprocessRunning
+    private let probes: SystemProbeClient
 
-    public init(subprocessRunner: any SubprocessRunning = SubprocessRunner.shared) {
-        self.subprocessRunner = subprocessRunner
+    public init(probes: SystemProbeClient = .live) {
+        self.probes = probes
     }
 
     public nonisolated func isProcessAlive(pid: pid_t) -> Bool {
         Self.isProcessAlive(pid: pid)
     }
 
-    public nonisolated func isTCPPortResponding(port: Int, timeoutMs: Int = 300) async -> Bool {
-        await Task.detached(priority: .utility) {
-            Self.probeTCPPort(port: port, timeoutMs: timeoutMs)
-        }.value
+    public func isTCPPortResponding(port: Int, timeoutMs: Int = 300) async -> Bool {
+        probes.probeTCPPort(port: port, timeoutMs: timeoutMs)
     }
 
     public func processIDs(matching pattern: String) async -> [pid_t] {
         let trimmedPattern = pattern.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmedPattern.isEmpty else { return [] }
-        return await subprocessRunner.pgrep(trimmedPattern)
+        return await probes.processIDs(matching: trimmedPattern)
     }
 
     public func processMatches(matching pattern: String) async -> [SystemProcessMatch] {
         let trimmedPattern = pattern.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmedPattern.isEmpty else { return [] }
-
-        do {
-            let result = try await subprocessRunner.run(
-                "/usr/bin/pgrep",
-                args: ["-fl", trimmedPattern],
-                timeout: 5
-            )
-            guard result.exitCode == 0 else { return [] }
-            return Self.parseProcessMatches(result.stdout)
-        } catch {
-            AppLogger.shared.warn("⚠️ [SystemStateProvider] pgrep -fl failed for pattern '\(trimmedPattern)': \(error)")
-            return []
-        }
+        return await probes.processMatches(matching: trimmedPattern)
     }
 
     public func launchctlPrint(target: String) async -> LaunchctlPrintEvidence {
@@ -54,96 +41,22 @@ public actor SystemStateProvider {
             return LaunchctlPrintEvidence(target: "", exitCode: nil, stdout: "", stderr: "")
         }
 
-        do {
-            let result = try await subprocessRunner.launchctl("print", [trimmedTarget])
-            return LaunchctlPrintEvidence(
-                target: trimmedTarget,
-                exitCode: result.exitCode,
-                stdout: result.stdout,
-                stderr: result.stderr
-            )
-        } catch {
-            AppLogger.shared.warn("⚠️ [SystemStateProvider] launchctl print failed for target '\(trimmedTarget)': \(error)")
-            return LaunchctlPrintEvidence(
-                target: trimmedTarget,
-                exitCode: nil,
-                stdout: "",
-                stderr: String(describing: error)
-            )
-        }
+        return await probes.launchctlPrint(target: trimmedTarget)
     }
 
     public nonisolated static func processIDsSynchronously(matching pattern: String) -> [pid_t] {
         let trimmedPattern = pattern.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmedPattern.isEmpty else { return [] }
 
-        let result = BoundedProcess.run(
-            "/usr/bin/pgrep",
-            ["-f", trimmedPattern],
-            timeout: 5
-        )
-        guard result.status == 0 else { return [] }
-
-        return result.output
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-            .components(separatedBy: .newlines)
-            .filter { !$0.isEmpty }
-            .compactMap { Int32($0.trimmingCharacters(in: .whitespaces)) }
-    }
-
-    private nonisolated static func parseProcessMatches(_ output: String) -> [SystemProcessMatch] {
-        output
-            .components(separatedBy: .newlines)
-            .compactMap { rawLine in
-                let line = rawLine.trimmingCharacters(in: .whitespacesAndNewlines)
-                guard !line.isEmpty else { return nil }
-
-                let parts = line.split(separator: " ", maxSplits: 1, omittingEmptySubsequences: true)
-                guard parts.count == 2, let pid = pid_t(parts[0]) else { return nil }
-                return SystemProcessMatch(pid: pid, command: String(parts[1]))
-            }
+        return liveProbes.processIDsSynchronously(matching: trimmedPattern)
     }
 
     public nonisolated static func isProcessAlive(pid: pid_t) -> Bool {
-        guard pid > 0 else { return false }
-        if kill(pid, 0) == 0 { return true }
-        return errno == EPERM
+        liveProbes.isProcessAlive(pid: pid)
     }
 
     public nonisolated static func probeTCPPort(port: Int, timeoutMs: Int = 300) -> Bool {
-        guard (1 ... 65535).contains(port), timeoutMs >= 0 else { return false }
-
-        let sock = socket(AF_INET, SOCK_STREAM, 0)
-        guard sock >= 0 else { return false }
-        defer { close(sock) }
-
-        let flags = fcntl(sock, F_GETFL, 0)
-        guard flags >= 0 else { return false }
-        _ = fcntl(sock, F_SETFL, flags | O_NONBLOCK)
-
-        var addr = sockaddr_in()
-        addr.sin_family = sa_family_t(AF_INET)
-        addr.sin_port = in_port_t(UInt16(port).bigEndian)
-        addr.sin_addr = in_addr(s_addr: inet_addr("127.0.0.1"))
-
-        var mutableAddr = addr
-        let connectResult = withUnsafePointer(to: &mutableAddr) {
-            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
-                connect(sock, $0, socklen_t(MemoryLayout<sockaddr_in>.size))
-            }
-        }
-
-        if connectResult == 0 { return true }
-        guard errno == EINPROGRESS else { return false }
-
-        var pollFd = pollfd(fd: sock, events: Int16(POLLOUT), revents: 0)
-        let pollResult = poll(&pollFd, 1, Int32(timeoutMs))
-        guard pollResult > 0, (pollFd.revents & Int16(POLLOUT)) != 0 else { return false }
-
-        var socketError: Int32 = 0
-        var socketErrorLength = socklen_t(MemoryLayout<Int32>.size)
-        getsockopt(sock, SOL_SOCKET, SO_ERROR, &socketError, &socketErrorLength)
-        return socketError == 0
+        liveProbes.probeTCPPort(port: port, timeoutMs: timeoutMs)
     }
 
     public nonisolated static func isKanataReady(running: Bool, responding: Bool) -> Bool {
@@ -164,35 +77,5 @@ public struct KanataLivenessEvidence: Equatable, Sendable {
 
     public var ready: Bool {
         SystemStateProvider.isKanataReady(running: running, responding: responding)
-    }
-}
-
-public struct SystemProcessMatch: Equatable, Sendable {
-    public let pid: pid_t
-    public let command: String
-
-    public init(pid: pid_t, command: String) {
-        self.pid = pid
-        self.command = command
-    }
-}
-
-public struct LaunchctlPrintEvidence: Equatable, Sendable {
-    public let target: String
-    public let exitCode: Int32?
-    public let stdout: String
-    public let stderr: String
-
-    public init(target: String, exitCode: Int32?, stdout: String, stderr: String) {
-        self.target = target
-        self.exitCode = exitCode
-        self.stdout = stdout
-        self.stderr = stderr
-    }
-
-    public var hasRunningProcessEvidence: Bool {
-        stdout.range(of: #"pid\s*=\s*\d+"#, options: .regularExpression) != nil
-            || stdout.contains("\"PID\"")
-            || stdout.contains("state = running")
     }
 }

--- a/Sources/KeyPathSystemProbes/SystemProbeClient.swift
+++ b/Sources/KeyPathSystemProbes/SystemProbeClient.swift
@@ -1,0 +1,222 @@
+import Darwin
+import Foundation
+
+public struct SystemProbeClient: Sendable {
+    private let processIDsHandler: @Sendable (String) async -> [pid_t]
+    private let processMatchesHandler: @Sendable (String) async -> [SystemProcessMatch]
+    private let launchctlPrintHandler: @Sendable (String) async -> LaunchctlPrintEvidence
+    private let processIDsSynchronouslyHandler: @Sendable (String) -> [pid_t]
+    private let isProcessAliveHandler: @Sendable (pid_t) -> Bool
+    private let probeTCPPortHandler: @Sendable (Int, Int) -> Bool
+
+    public init(
+        processIDs: @escaping @Sendable (String) async -> [pid_t],
+        processMatches: @escaping @Sendable (String) async -> [SystemProcessMatch],
+        launchctlPrint: @escaping @Sendable (String) async -> LaunchctlPrintEvidence,
+        processIDsSynchronously: @escaping @Sendable (String) -> [pid_t],
+        isProcessAlive: @escaping @Sendable (pid_t) -> Bool,
+        probeTCPPort: @escaping @Sendable (Int, Int) -> Bool
+    ) {
+        processIDsHandler = processIDs
+        processMatchesHandler = processMatches
+        launchctlPrintHandler = launchctlPrint
+        processIDsSynchronouslyHandler = processIDsSynchronously
+        isProcessAliveHandler = isProcessAlive
+        probeTCPPortHandler = probeTCPPort
+    }
+
+    public func processIDs(matching pattern: String) async -> [pid_t] {
+        await processIDsHandler(pattern)
+    }
+
+    public func processMatches(matching pattern: String) async -> [SystemProcessMatch] {
+        await processMatchesHandler(pattern)
+    }
+
+    public func launchctlPrint(target: String) async -> LaunchctlPrintEvidence {
+        await launchctlPrintHandler(target)
+    }
+
+    public func processIDsSynchronously(matching pattern: String) -> [pid_t] {
+        processIDsSynchronouslyHandler(pattern)
+    }
+
+    public func isProcessAlive(pid: pid_t) -> Bool {
+        isProcessAliveHandler(pid)
+    }
+
+    public func probeTCPPort(port: Int, timeoutMs: Int) -> Bool {
+        probeTCPPortHandler(port, timeoutMs)
+    }
+}
+
+public extension SystemProbeClient {
+    static let live = SystemProbeClient(
+        processIDs: { pattern in
+            let result = await runProcess("/usr/bin/pgrep", args: ["-f", pattern], timeout: 5)
+            guard result.exitCode == 0 else { return [] }
+            return parseProcessIDs(result.stdout)
+        },
+        processMatches: { pattern in
+            let result = await runProcess("/usr/bin/pgrep", args: ["-fl", pattern], timeout: 5)
+            guard result.exitCode == 0 else { return [] }
+            return parseProcessMatches(result.stdout)
+        },
+        launchctlPrint: { target in
+            let result = await runProcess("/bin/launchctl", args: ["print", target], timeout: 10)
+            return LaunchctlPrintEvidence(
+                target: target,
+                exitCode: result.exitCode,
+                stdout: result.stdout,
+                stderr: result.stderr
+            )
+        },
+        processIDsSynchronously: { pattern in
+            let result = runProcessSynchronously("/usr/bin/pgrep", args: ["-f", pattern], timeout: 5)
+            guard result.exitCode == 0 else { return [] }
+            return parseProcessIDs(result.stdout)
+        },
+        isProcessAlive: { pid in
+            guard pid > 0 else { return false }
+            if kill(pid, 0) == 0 { return true }
+            return errno == EPERM
+        },
+        probeTCPPort: { port, timeoutMs in
+            probeLocalhostTCPPort(port: port, timeoutMs: timeoutMs)
+        }
+    )
+}
+
+public struct SystemProcessMatch: Equatable, Sendable {
+    public let pid: pid_t
+    public let command: String
+
+    public init(pid: pid_t, command: String) {
+        self.pid = pid
+        self.command = command
+    }
+}
+
+public struct LaunchctlPrintEvidence: Equatable, Sendable {
+    public let target: String
+    public let exitCode: Int32?
+    public let stdout: String
+    public let stderr: String
+
+    public init(target: String, exitCode: Int32?, stdout: String, stderr: String) {
+        self.target = target
+        self.exitCode = exitCode
+        self.stdout = stdout
+        self.stderr = stderr
+    }
+
+    public var hasRunningProcessEvidence: Bool {
+        stdout.range(of: #"pid\s*=\s*\d+"#, options: .regularExpression) != nil
+            || stdout.contains("\"PID\"")
+            || stdout.contains("state = running")
+    }
+}
+
+private struct ProbeProcessResult: Sendable {
+    let exitCode: Int32
+    let stdout: String
+    let stderr: String
+}
+
+private func parseProcessIDs(_ output: String) -> [pid_t] {
+    output
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+        .components(separatedBy: .newlines)
+        .filter { !$0.isEmpty }
+        .compactMap { Int32($0.trimmingCharacters(in: .whitespaces)) }
+}
+
+private func parseProcessMatches(_ output: String) -> [SystemProcessMatch] {
+    output
+        .components(separatedBy: .newlines)
+        .compactMap { rawLine in
+            let line = rawLine.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !line.isEmpty else { return nil }
+
+            let parts = line.split(separator: " ", maxSplits: 1, omittingEmptySubsequences: true)
+            guard parts.count == 2, let pid = pid_t(parts[0]) else { return nil }
+            return SystemProcessMatch(pid: pid, command: String(parts[1]))
+        }
+}
+
+private func runProcess(_ executable: String, args: [String], timeout: TimeInterval) async -> ProbeProcessResult {
+    await Task.detached(priority: .utility) {
+        runProcessSynchronously(executable, args: args, timeout: timeout)
+    }.value
+}
+
+private func runProcessSynchronously(_ executable: String, args: [String], timeout: TimeInterval) -> ProbeProcessResult {
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: executable)
+    process.arguments = args
+
+    let stdoutPipe = Pipe()
+    let stderrPipe = Pipe()
+    process.standardOutput = stdoutPipe
+    process.standardError = stderrPipe
+
+    do {
+        try process.run()
+    } catch {
+        return ProbeProcessResult(exitCode: 127, stdout: "", stderr: String(describing: error))
+    }
+
+    let deadline = Date().addingTimeInterval(timeout)
+    while process.isRunning, Date() < deadline {
+        usleep(50000)
+    }
+
+    if process.isRunning {
+        process.terminate()
+        usleep(200_000)
+        if process.isRunning {
+            kill(process.processIdentifier, SIGKILL)
+        }
+    }
+
+    process.waitUntilExit()
+    let stdout = String(data: stdoutPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+    let stderr = String(data: stderrPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+    return ProbeProcessResult(exitCode: process.terminationStatus, stdout: stdout, stderr: stderr)
+}
+
+private func probeLocalhostTCPPort(port: Int, timeoutMs: Int) -> Bool {
+    guard (1 ... 65535).contains(port), timeoutMs >= 0 else { return false }
+
+    let sock = socket(AF_INET, SOCK_STREAM, 0)
+    guard sock >= 0 else { return false }
+    defer { close(sock) }
+
+    let flags = fcntl(sock, F_GETFL, 0)
+    guard flags >= 0 else { return false }
+    _ = fcntl(sock, F_SETFL, flags | O_NONBLOCK)
+
+    var addr = sockaddr_in()
+    addr.sin_family = sa_family_t(AF_INET)
+    addr.sin_port = in_port_t(UInt16(port).bigEndian)
+    addr.sin_addr = in_addr(s_addr: inet_addr("127.0.0.1"))
+
+    var mutableAddr = addr
+    let connectResult = withUnsafePointer(to: &mutableAddr) {
+        $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+            connect(sock, $0, socklen_t(MemoryLayout<sockaddr_in>.size))
+        }
+    }
+
+    if connectResult == 0 { return true }
+    guard errno == EINPROGRESS else { return false }
+
+    var pollFd = pollfd(fd: sock, events: Int16(POLLOUT), revents: 0)
+    let pollResult = poll(&pollFd, 1, Int32(timeoutMs))
+    guard pollResult > 0, (pollFd.revents & Int16(POLLOUT)) != 0 else { return false }
+
+    var socketError: Int32 = 0
+    var socketErrorLength = socklen_t(MemoryLayout<Int32>.size)
+    getsockopt(sock, SOL_SOCKET, SO_ERROR, &socketError, &socketErrorLength)
+    return socketError == 0
+}

--- a/Tests/KeyPathTests/Core/HelperManagerTests.swift
+++ b/Tests/KeyPathTests/Core/HelperManagerTests.swift
@@ -116,7 +116,7 @@ final class HelperManagerTests: XCTestCase {
             }
             return ProcessResult(exitCode: 113, stdout: "", stderr: "unexpected target", duration: 0)
         }
-        HelperManager.systemStateProviderFactory = { SystemStateProvider(subprocessRunner: providerRunner) }
+        HelperManager.systemStateProviderFactory = { SystemStateProvider(probes: providerRunner.systemProbeClient()) }
 
         let installed = await HelperManager.shared.isHelperInstalled()
 
@@ -145,7 +145,7 @@ final class HelperManagerTests: XCTestCase {
             }
             return ProcessResult(exitCode: 113, stdout: "", stderr: "unexpected target", duration: 0)
         }
-        HelperManager.systemStateProviderFactory = { SystemStateProvider(subprocessRunner: providerRunner) }
+        HelperManager.systemStateProviderFactory = { SystemStateProvider(probes: providerRunner.systemProbeClient()) }
 
         let logs = await HelperManager.shared.lastHelperLogs()
 

--- a/Tests/KeyPathTests/Core/SubprocessRunnerTests.swift
+++ b/Tests/KeyPathTests/Core/SubprocessRunnerTests.swift
@@ -59,12 +59,12 @@ final class SubprocessRunnerTests: XCTestCase {
         XCTAssertEqual(result.stderr, "command not found")
     }
 
-    func testPgrepSuccess() async {
+    func testSystemProbeClientProcessIDSuccess() async {
         await fakeRunner.configurePgrepResult { _ in
             [1234, 5678]
         }
 
-        let pids = await fakeRunner.pgrep("kanata.*--cfg")
+        let pids = await fakeRunner.systemProbeClient().processIDs(matching: "kanata.*--cfg")
 
         XCTAssertEqual(pids, [1234, 5678])
         let commands = await fakeRunner.executedCommands
@@ -186,14 +186,6 @@ final class SubprocessRunnerTests: XCTestCase {
             // Should throw SubprocessError.launchFailed
             XCTAssertTrue(error is SubprocessError)
         }
-    }
-
-    func testRealSubprocessRunnerPgrep() async {
-        // Test pgrep with a pattern that won't match (to avoid flakiness)
-        let pids = await SubprocessRunner.shared.pgrep("nonexistent_process_pattern_12345")
-
-        // Should return empty array for non-matching pattern
-        XCTAssertTrue(pids.isEmpty)
     }
 
     func testRunCancellationTerminatesProcess() async {

--- a/Tests/KeyPathTests/Core/SystemStateProviderLivenessTests.swift
+++ b/Tests/KeyPathTests/Core/SystemStateProviderLivenessTests.swift
@@ -60,7 +60,7 @@ final class SystemStateProviderLivenessTests: XCTestCase {
         await runner.configurePgrepResult { pattern in
             pattern == "kanata.*--cfg" ? [1234, 5678] : []
         }
-        let provider = SystemStateProvider(subprocessRunner: runner)
+        let provider = SystemStateProvider(probes: runner.systemProbeClient())
 
         let pids = await provider.processIDs(matching: "kanata.*--cfg")
 
@@ -74,7 +74,7 @@ final class SystemStateProviderLivenessTests: XCTestCase {
             XCTFail("Blank process-discovery patterns must not invoke pgrep")
             return [9999]
         }
-        let provider = SystemStateProvider(subprocessRunner: runner)
+        let provider = SystemStateProvider(probes: runner.systemProbeClient())
 
         let pids = await provider.processIDs(matching: "  \n\t  ")
 
@@ -100,7 +100,7 @@ final class SystemStateProviderLivenessTests: XCTestCase {
             }
             return ProcessResult(exitCode: 1, stdout: "", stderr: "", duration: 0.01)
         }
-        let provider = SystemStateProvider(subprocessRunner: runner)
+        let provider = SystemStateProvider(probes: runner.systemProbeClient())
 
         let matches = await provider.processMatches(matching: "kanata")
         let commands = await runner.executedCommands
@@ -125,7 +125,7 @@ final class SystemStateProviderLivenessTests: XCTestCase {
             XCTFail("Blank process-match patterns must not invoke pgrep")
             return ProcessResult(exitCode: 0, stdout: "", stderr: "", duration: 0.01)
         }
-        let provider = SystemStateProvider(subprocessRunner: runner)
+        let provider = SystemStateProvider(probes: runner.systemProbeClient())
 
         let matches = await provider.processMatches(matching: "  \n\t  ")
 
@@ -149,7 +149,7 @@ final class SystemStateProviderLivenessTests: XCTestCase {
             }
             return ProcessResult(exitCode: 113, stdout: "", stderr: "not found", duration: 0.01)
         }
-        let provider = SystemStateProvider(subprocessRunner: runner)
+        let provider = SystemStateProvider(probes: runner.systemProbeClient())
 
         let evidence = await provider.launchctlPrint(target: "system/com.keypath.karabiner-vhiddaemon")
         let commands = await runner.executedCommands
@@ -170,7 +170,7 @@ final class SystemStateProviderLivenessTests: XCTestCase {
             XCTFail("Blank launchctl print targets must not invoke launchctl")
             return ProcessResult(exitCode: 0, stdout: "", stderr: "", duration: 0.01)
         }
-        let provider = SystemStateProvider(subprocessRunner: runner)
+        let provider = SystemStateProvider(probes: runner.systemProbeClient())
 
         let evidence = await provider.launchctlPrint(target: "  \n\t  ")
 

--- a/Tests/KeyPathTests/Lint/LaunchctlEvidenceLintTests.swift
+++ b/Tests/KeyPathTests/Lint/LaunchctlEvidenceLintTests.swift
@@ -9,7 +9,7 @@ import Foundation
 /// files cannot reintroduce ad hoc launchd evidence reads.
 final class LaunchctlEvidenceLintTests: XCTestCase {
     private static let allowList: Set<String> = [
-        "Sources/KeyPathCore/SystemStateProvider.swift"
+        "Sources/KeyPathSystemProbes/SystemProbeClient.swift"
     ]
 
     func testProductionLaunchctlPrintEvidenceReadsDelegateToSystemStateProvider() throws {

--- a/Tests/KeyPathTests/Lint/LivenessPredicateLintTests.swift
+++ b/Tests/KeyPathTests/Lint/LivenessPredicateLintTests.swift
@@ -6,11 +6,11 @@ import Foundation
 /// `kill(pid, 0)` has privilege-boundary semantics that are easy to get wrong:
 /// EPERM means the process exists but cannot be signaled by this process, while
 /// ESRCH is the dead-process condition. Keep that logic centralized in
-/// `SystemStateProvider.isProcessAlive(pid:)` and delegate to it instead of
+/// `KeyPathSystemProbes` and delegate through `SystemStateProvider` instead of
 /// reimplementing the primitive at call sites.
 final class LivenessPredicateLintTests: XCTestCase {
     private static let allowList: Set<String> = [
-        "SystemStateProvider.swift"
+        "SystemProbeClient.swift"
     ]
 
     func testKillZeroLivenessProbeIsCentralized() throws {
@@ -38,7 +38,7 @@ final class LivenessPredicateLintTests: XCTestCase {
         XCTAssertTrue(
             violations.isEmpty,
             """
-            Direct `kill(pid, 0)` liveness probes found outside SystemStateProvider. \
+            Direct `kill(pid, 0)` liveness probes found outside KeyPathSystemProbes. \
             Delegate to SystemStateProvider.isProcessAlive(pid:) instead of adding \
             another process-liveness implementation:
             \(violations.sorted().joined(separator: "\n"))

--- a/Tests/KeyPathTests/Lint/PgrepProcessDiscoveryLintTests.swift
+++ b/Tests/KeyPathTests/Lint/PgrepProcessDiscoveryLintTests.swift
@@ -3,16 +3,14 @@ import Foundation
 
 /// Guards W1/W2 process-discovery migration slices.
 ///
-/// `pgrep` remains the low-level subprocess mechanism for now, but production
-/// process-discovery consumers should call `SystemStateProvider` so Phase 1 can
-/// collapse process, TCP, and later launchd/SMAppService evidence into one
-/// executable snapshot.
+/// `pgrep` is owned by KeyPathSystemProbes. Production consumers should call
+/// `SystemStateProvider` so Phase 1 can collapse process, TCP, and later
+/// launchd/SMAppService evidence into one executable snapshot.
 final class PgrepProcessDiscoveryLintTests: XCTestCase {
     func testProductionPgrepDiscoveryIsCentralizedInCoreProvider() throws {
         let sourceRoot = repositoryRoot().appendingPathComponent("Sources")
         let allowedFiles: Set = [
-            "Sources/KeyPathCore/SubprocessRunner.swift",
-            "Sources/KeyPathCore/SystemStateProvider.swift"
+            "Sources/KeyPathSystemProbes/SystemProbeClient.swift"
         ]
 
         let violations = try swiftSourceFiles(under: sourceRoot)
@@ -34,7 +32,7 @@ final class PgrepProcessDiscoveryLintTests: XCTestCase {
             violations.isEmpty,
             """
             Production process discovery must be centralized in \
-            SystemStateProvider/SubprocessRunner, not scattered through callers:
+            SystemStateProvider/KeyPathSystemProbes, not scattered through callers:
             \(violations.sorted().joined(separator: "\n"))
             """
         )

--- a/Tests/KeyPathTests/Lint/TCPReadinessLintTests.swift
+++ b/Tests/KeyPathTests/Lint/TCPReadinessLintTests.swift
@@ -4,9 +4,10 @@ import Foundation
 /// Guards the W1/W2 TCP-readiness migration for `ServiceHealthChecker`.
 ///
 /// The wizard health checker used to carry a private POSIX socket probe because
-/// the old `TCPProbe` utility lived in AppKit. The blessed readiness probe now
-/// lives in `SystemStateProvider`; this ratchet prevents the private socket
-/// implementation from drifting back into installer health checks.
+/// the old `TCPProbe` utility lived in AppKit. Raw socket probing now lives in
+/// `KeyPathSystemProbes`; consumers still route readiness through
+/// `SystemStateProvider`. This ratchet prevents private socket implementations
+/// from drifting back into installer health checks.
 final class TCPReadinessLintTests: XCTestCase {
     func testServiceHealthCheckerDelegatesTCPReadinessToSystemStateProvider() throws {
         let serviceHealthChecker = repositoryRoot()
@@ -61,7 +62,7 @@ final class TCPReadinessLintTests: XCTestCase {
     }
 
     func testProductionRawTCPSocketProbeIsCentralized() throws {
-        let violations = try sourceFiles(excludingPathSuffixes: ["Sources/KeyPathCore/SystemStateProvider.swift"])
+        let violations = try sourceFiles(excludingPathSuffixes: ["Sources/KeyPathSystemProbes/SystemProbeClient.swift"])
             .flatMap { fileURL in
                 try matchingLines(
                     in: fileURL,
@@ -78,7 +79,7 @@ final class TCPReadinessLintTests: XCTestCase {
             violations.isEmpty,
             """
             Production raw TCP socket readiness probes must stay centralized in \
-            SystemStateProvider:
+            KeyPathSystemProbes:
             \(violations.sorted().joined(separator: "\n"))
             """
         )

--- a/Tests/KeyPathTests/Managers/KanataDaemonManagerTests.swift
+++ b/Tests/KeyPathTests/Managers/KanataDaemonManagerTests.swift
@@ -101,7 +101,7 @@ final class KanataDaemonManagerTests: XCTestCase {
             cacheTTL: 0,
             serviceFactory: { _ in mockService }
         )
-        let provider = SystemStateProvider(subprocessRunner: runner)
+        let provider = SystemStateProvider(probes: runner.systemProbeClient())
         let manager = KanataDaemonManager(
             subprocessRunner: DirectLaunchctlPoisonRunner(),
             systemStateProvider: provider
@@ -266,7 +266,7 @@ final class KanataDaemonManagerTests: XCTestCase {
             cacheTTL: 0,
             serviceFactory: { _ in mockService }
         )
-        let provider = SystemStateProvider(subprocessRunner: runner)
+        let provider = SystemStateProvider(probes: runner.systemProbeClient())
         let manager = KanataDaemonManager(subprocessRunner: runner, systemStateProvider: provider)
 
         let isStale = await manager.isRegisteredButNotLoaded()
@@ -299,7 +299,7 @@ final class KanataDaemonManagerTests: XCTestCase {
             cacheTTL: 0,
             serviceFactory: { _ in mockService }
         )
-        let provider = SystemStateProvider(subprocessRunner: runner)
+        let provider = SystemStateProvider(probes: runner.systemProbeClient())
         let manager = KanataDaemonManager(
             subprocessRunner: DirectLaunchctlPoisonRunner(),
             systemStateProvider: provider

--- a/Tests/KeyPathTests/ProcessLifecycleManagerTests.swift
+++ b/Tests/KeyPathTests/ProcessLifecycleManagerTests.swift
@@ -83,7 +83,7 @@ final class ProcessLifecycleManagerTests: XCTestCase {
             return ProcessResult(exitCode: 1, stdout: "", stderr: "", duration: 0.01)
         }
 
-        let provider = SystemStateProvider(subprocessRunner: runner)
+        let provider = SystemStateProvider(probes: runner.systemProbeClient())
         let manager = ProcessLifecycleManager(systemStateProvider: provider)
 
         let processes = try await manager.detectKanataProcesses()

--- a/Tests/KeyPathTests/Services/DiagnosticsServiceTests.swift
+++ b/Tests/KeyPathTests/Services/DiagnosticsServiceTests.swift
@@ -159,7 +159,7 @@ final class DiagnosticsServiceTests: XCTestCase {
             pattern == "karabiner_grabber" ? [1234] : []
         }
 
-        let provider = SystemStateProvider(subprocessRunner: runner)
+        let provider = SystemStateProvider(probes: runner.systemProbeClient())
         let service = DiagnosticsService(
             processLifecycleManager: processManager,
             systemStateProvider: provider
@@ -182,7 +182,7 @@ final class DiagnosticsServiceTests: XCTestCase {
             pattern == "Karabiner-VirtualHIDDevice" ? [5678] : []
         }
 
-        let provider = SystemStateProvider(subprocessRunner: runner)
+        let provider = SystemStateProvider(probes: runner.systemProbeClient())
         let service = DiagnosticsService(
             processLifecycleManager: processManager,
             systemStateProvider: provider

--- a/Tests/KeyPathTests/Services/KarabinerConflictServiceTests.swift
+++ b/Tests/KeyPathTests/Services/KarabinerConflictServiceTests.swift
@@ -16,7 +16,7 @@ struct KarabinerConflictServiceTests {
             pattern == "karabiner_grabber" ? [1111] : []
         }
 
-        let provider = SystemStateProvider(subprocessRunner: runner)
+        let provider = SystemStateProvider(probes: runner.systemProbeClient())
         let service = KarabinerConflictService(systemStateProvider: provider)
 
         let isRunning = await service.isKarabinerElementsRunning()
@@ -44,7 +44,7 @@ struct KarabinerConflictServiceTests {
             pattern == "VirtualHIDDevice-Daemon" ? [2222] : []
         }
 
-        let provider = SystemStateProvider(subprocessRunner: runner)
+        let provider = SystemStateProvider(probes: runner.systemProbeClient())
         let service = KarabinerConflictService(systemStateProvider: provider)
 
         let isRunning = await service.isKarabinerDaemonRunning()
@@ -65,7 +65,7 @@ struct KarabinerConflictServiceTests {
             pattern == "Karabiner-DriverKit-VirtualHIDDevice" ? [3333] : []
         }
 
-        let provider = SystemStateProvider(subprocessRunner: runner)
+        let provider = SystemStateProvider(probes: runner.systemProbeClient())
         let service = KarabinerConflictService(systemStateProvider: provider)
 
         let isStopped = await service.checkProcessStopped(

--- a/Tests/KeyPathTests/Services/ServiceHealthCheckerTests.swift
+++ b/Tests/KeyPathTests/Services/ServiceHealthCheckerTests.swift
@@ -194,7 +194,7 @@ final class ServiceHealthCheckerTests: XCTestCase {
             }
             return ProcessResult(exitCode: 113, stdout: "", stderr: "not found", duration: 0.01)
         }
-        let provider = SystemStateProvider(subprocessRunner: runner)
+        let provider = SystemStateProvider(probes: runner.systemProbeClient())
         let checker = await MainActor.run {
             ServiceHealthChecker(subprocessRunner: runner, systemStateProvider: provider)
         }
@@ -235,7 +235,7 @@ final class ServiceHealthCheckerTests: XCTestCase {
             }
             return ProcessResult(exitCode: 113, stdout: "", stderr: "not found", duration: 0.01)
         }
-        let provider = SystemStateProvider(subprocessRunner: runner)
+        let provider = SystemStateProvider(probes: runner.systemProbeClient())
         let checker = await MainActor.run {
             ServiceHealthChecker(subprocessRunner: runner, systemStateProvider: provider)
         }
@@ -287,7 +287,7 @@ final class ServiceHealthCheckerTests: XCTestCase {
             }
             return ProcessResult(exitCode: 113, stdout: "", stderr: "not found", duration: 0.01)
         }
-        let provider = SystemStateProvider(subprocessRunner: runner)
+        let provider = SystemStateProvider(probes: runner.systemProbeClient())
         let checker = await MainActor.run {
             ServiceHealthChecker(subprocessRunner: runner, systemStateProvider: provider)
         }

--- a/Tests/KeyPathTests/Services/SystemValidatorTests.swift
+++ b/Tests/KeyPathTests/Services/SystemValidatorTests.swift
@@ -86,7 +86,7 @@ struct SystemValidatorTests {
         }
 
         let processManager = ProcessLifecycleManager()
-        let provider = SystemStateProvider(subprocessRunner: runner)
+        let provider = SystemStateProvider(probes: runner.systemProbeClient())
         let validator = SystemValidator(
             processLifecycleManager: processManager,
             systemStateProvider: provider

--- a/Tests/KeyPathTests/Services/VHIDDeviceManagerTests.swift
+++ b/Tests/KeyPathTests/Services/VHIDDeviceManagerTests.swift
@@ -90,7 +90,7 @@ final class VHIDDeviceManagerTests: XCTestCase {
             pattern == "Karabiner-VirtualHIDDevice-Daemon" ? [12345] : []
         }
 
-        let provider = SystemStateProvider(subprocessRunner: runner)
+        let provider = SystemStateProvider(probes: runner.systemProbeClient())
         let mgr = VHIDDeviceManager(systemStateProvider: provider)
         let running = await mgr.detectRunning()
         let commands = await runner.executedCommands
@@ -111,7 +111,7 @@ final class VHIDDeviceManagerTests: XCTestCase {
             pattern == "Karabiner-VirtualHIDDevice-Daemon" ? [12345, 67890] : []
         }
 
-        let provider = SystemStateProvider(subprocessRunner: runner)
+        let provider = SystemStateProvider(probes: runner.systemProbeClient())
         let mgr = VHIDDeviceManager(systemStateProvider: provider)
         let pids = await mgr.getDaemonPIDs()
         let commands = await runner.executedCommands
@@ -141,7 +141,7 @@ final class VHIDDeviceManagerTests: XCTestCase {
             return ProcessResult(exitCode: 113, stdout: "", stderr: "not found", duration: 0.01)
         }
 
-        let provider = SystemStateProvider(subprocessRunner: runner)
+        let provider = SystemStateProvider(probes: runner.systemProbeClient())
         let mgr = VHIDDeviceManager(systemStateProvider: provider)
         let healthy = await mgr.checkLaunchctlHealth()
         let commands = await runner.executedCommands
@@ -168,7 +168,7 @@ final class VHIDDeviceManagerTests: XCTestCase {
             return ProcessResult(exitCode: 113, stdout: "", stderr: "not found", duration: 0.01)
         }
 
-        let provider = SystemStateProvider(subprocessRunner: runner)
+        let provider = SystemStateProvider(probes: runner.systemProbeClient())
         let mgr = VHIDDeviceManager(systemStateProvider: provider)
         let running = await mgr.detectRunning()
         let commands = await runner.executedCommands

--- a/Tests/KeyPathTests/TestHelpers/SubprocessRunnerFake.swift
+++ b/Tests/KeyPathTests/TestHelpers/SubprocessRunnerFake.swift
@@ -79,6 +79,56 @@ actor SubprocessRunnerFake: SubprocessRunning {
         launchctlResultProvider = provider
     }
 
+    nonisolated func systemProbeClient(
+        processIDsSynchronously: @escaping @Sendable (String) -> [pid_t] = { _ in [] },
+        isProcessAlive: @escaping @Sendable (pid_t) -> Bool = { $0 > 0 },
+        probeTCPPort: @escaping @Sendable (Int, Int) -> Bool = { _, _ in false }
+    ) -> SystemProbeClient {
+        SystemProbeClient(
+            processIDs: { pattern in
+                await self.pgrep(pattern)
+            },
+            processMatches: { pattern in
+                do {
+                    let result = try await self.run("/usr/bin/pgrep", args: ["-fl", pattern], timeout: 5)
+                    guard result.exitCode == 0 else { return [] }
+                    return result.stdout
+                        .components(separatedBy: .newlines)
+                        .compactMap { rawLine in
+                            let line = rawLine.trimmingCharacters(in: .whitespacesAndNewlines)
+                            guard !line.isEmpty else { return nil }
+                            let parts = line.split(separator: " ", maxSplits: 1, omittingEmptySubsequences: true)
+                            guard parts.count == 2, let pid = pid_t(parts[0]) else { return nil }
+                            return SystemProcessMatch(pid: pid, command: String(parts[1]))
+                        }
+                } catch {
+                    return []
+                }
+            },
+            launchctlPrint: { target in
+                do {
+                    let result = try await self.launchctl("print", [target])
+                    return LaunchctlPrintEvidence(
+                        target: target,
+                        exitCode: result.exitCode,
+                        stdout: result.stdout,
+                        stderr: result.stderr
+                    )
+                } catch {
+                    return LaunchctlPrintEvidence(
+                        target: target,
+                        exitCode: nil,
+                        stdout: "",
+                        stderr: String(describing: error)
+                    )
+                }
+            },
+            processIDsSynchronously: processIDsSynchronously,
+            isProcessAlive: isProcessAlive,
+            probeTCPPort: probeTCPPort
+        )
+    }
+
     func setShouldTimeout(_ value: Bool) {
         shouldTimeout = value
     }
@@ -141,5 +191,67 @@ actor SubprocessRunnerFake: SubprocessRunning {
         }
 
         return defaultLaunchctlResult
+    }
+}
+
+extension SubprocessRunning {
+    nonisolated func systemProbeClient(
+        processIDsSynchronously: @escaping @Sendable (String) -> [pid_t] = { _ in [] },
+        isProcessAlive: @escaping @Sendable (pid_t) -> Bool = { $0 > 0 },
+        probeTCPPort: @escaping @Sendable (Int, Int) -> Bool = { _, _ in false }
+    ) -> SystemProbeClient {
+        SystemProbeClient(
+            processIDs: { pattern in
+                do {
+                    let result = try await self.run("/usr/bin/pgrep", args: ["-f", pattern], timeout: 5)
+                    guard result.exitCode == 0 else { return [] }
+                    return result.stdout
+                        .trimmingCharacters(in: .whitespacesAndNewlines)
+                        .components(separatedBy: .newlines)
+                        .filter { !$0.isEmpty }
+                        .compactMap { Int32($0.trimmingCharacters(in: .whitespaces)) }
+                } catch {
+                    return []
+                }
+            },
+            processMatches: { pattern in
+                do {
+                    let result = try await self.run("/usr/bin/pgrep", args: ["-fl", pattern], timeout: 5)
+                    guard result.exitCode == 0 else { return [] }
+                    return result.stdout
+                        .components(separatedBy: .newlines)
+                        .compactMap { rawLine in
+                            let line = rawLine.trimmingCharacters(in: .whitespacesAndNewlines)
+                            guard !line.isEmpty else { return nil }
+                            let parts = line.split(separator: " ", maxSplits: 1, omittingEmptySubsequences: true)
+                            guard parts.count == 2, let pid = pid_t(parts[0]) else { return nil }
+                            return SystemProcessMatch(pid: pid, command: String(parts[1]))
+                        }
+                } catch {
+                    return []
+                }
+            },
+            launchctlPrint: { target in
+                do {
+                    let result = try await self.launchctl("print", [target])
+                    return LaunchctlPrintEvidence(
+                        target: target,
+                        exitCode: result.exitCode,
+                        stdout: result.stdout,
+                        stderr: result.stderr
+                    )
+                } catch {
+                    return LaunchctlPrintEvidence(
+                        target: target,
+                        exitCode: nil,
+                        stdout: "",
+                        stderr: String(describing: error)
+                    )
+                }
+            },
+            processIDsSynchronously: processIDsSynchronously,
+            isProcessAlive: isProcessAlive,
+            probeTCPPort: probeTCPPort
+        )
     }
 }

--- a/docs/adr/adr-040-process-liveness-across-privilege-boundary.md
+++ b/docs/adr/adr-040-process-liveness-across-privilege-boundary.md
@@ -31,29 +31,32 @@ From the unprivileged app, probing the **root** kanata returns `EPERM` while it 
 - Any future process-inspection helper (liveness polls, orphan detection, restart races) must apply the EPERM rule and must not assume app-side signals reach the daemon.
 - Reviews of lifecycle / process code must include a **runtime-reality** lens: "what does this syscall actually return in the real root/unprivileged topology?" — not just static diff analysis.
 - This is the signaling-side companion to the permissions rule in [ADR-001](adr-001-oracle-pattern.md) / [ADR-006](adr-006-apple-api-priority.md) ("never check permissions from root"): the privilege boundary changes the meaning of OS calls in both directions.
-- Phase 1 of installer reliability centralizes liveness and readiness probes in
-  `SystemStateProvider`. Migrated consumers must not regrow direct `kill(pid,
+- Phase 1 of installer reliability centralizes liveness and readiness decisions
+  behind `SystemStateProvider`, with raw read-only OS probes isolated in
+  `KeyPathSystemProbes`. Migrated consumers must not regrow direct `kill(pid,
   0)`, `pgrep`, launchctl read-only evidence, or TCP probe implementations.
 
 ## Reference implementation
 
-`SystemStateProvider.isProcessAlive(pid:)` is the canonical liveness primitive.
-`SystemStateProvider.isTCPPortResponding(port:timeoutMs:)` is the canonical TCP
-readiness primitive. Higher-level consumers use provider-owned process
-discovery and launchctl read-only evidence helpers.
+`KeyPathSystemProbes.SystemProbeClient` owns the raw `kill(pid, 0)`, TCP socket,
+`pgrep`, and read-only `launchctl print` implementations. `SystemStateProvider`
+is the canonical facade for consumers: `isProcessAlive(pid:)`,
+`isTCPPortResponding(port:timeoutMs:)`, process discovery, and launchctl
+read-only evidence all route through it.
 
 ## Enforcement
 
 - `SystemStateProviderLivenessTests.testProcessLivenessProbeTreatsCurrentProcessAsAliveAndExitedProcessAsDead`
   grounds the liveness primitive against real process behavior.
 - `LivenessPredicateLintTests.testKillZeroLivenessProbeIsCentralized` prevents
-  direct `kill(pid, 0)` probes outside `SystemStateProvider`.
+  direct `kill(pid, 0)` probes outside `KeyPathSystemProbes`.
 - `SystemStateProviderLivenessTests.testTCPReadinessProbeDetectsListeningAndClosedPorts`
   grounds the TCP readiness primitive.
 - `TCPReadinessLintTests.testServiceHealthCheckerDelegatesTCPReadinessToSystemStateProvider`
   prevents migrated readiness consumers from bypassing the provider.
 - `PgrepProcessDiscoveryLintTests` and `LaunchctlEvidenceLintTests` keep
-  migrated process discovery and launchctl read-only evidence centralized.
+  migrated process discovery and launchctl read-only evidence centralized in
+  `KeyPathSystemProbes`, with consumers going through `SystemStateProvider`.
 
 ## Related
 

--- a/docs/planning/installer-reliability-phase1.md
+++ b/docs/planning/installer-reliability-phase1.md
@@ -611,8 +611,8 @@ context loss across sessions, contributors, and agents. Extend it:
 | Ratchet | Rule |
 |---------|------|
 | `SMAppServiceStatusLintTests` | direct Apple `.status` only inside `SMAppServiceStatusProvider`; migrated consumers access the status cache through `SystemStateProvider` |
-| `LaunchctlEvidenceLintTests` | read-only `launchctl print` evidence only inside `SystemStateProvider` |
-| `LivenessLintTests` | `kill(`, `pgrep`, process-probe patterns only inside the blessed predicate |
+| `LaunchctlEvidenceLintTests` | read-only `launchctl print` evidence only inside `KeyPathSystemProbes`; consumers route through `SystemStateProvider` |
+| `LivenessLintTests` | `kill(`, `pgrep`, process-probe patterns only inside `KeyPathSystemProbes` / the blessed provider facade |
 | `PostconditionLintTests` | every `PrivilegedOperationsRouter` mutating verb calls the postcondition enforcer before returning success |
 | `SnapshotConsumerLintTests` | no new caches of system state outside the provider (grep for TTL/timestamp-cache patterns) |
 
@@ -656,7 +656,7 @@ is listed in the state-matrix doc's enforcement section.
 - [x] `TCPReadinessLintTests.testProductionTCPProbeAdapterIsNoLongerUsed` and
   `TCPReadinessLintTests.testProductionRawTCPSocketProbeIsCentralized` prevent
   production readiness checks from drifting back to the legacy adapter or raw
-  socket probes outside `SystemStateProvider`.
+  socket probes outside `KeyPathSystemProbes`.
 - [x] `PgrepProcessDiscoveryLintTests.testServiceLifecycleCoordinatorDelegatesPgrepDiscoveryToSystemStateProvider`
   prevents the first migrated runtime coordinator call site from regrowing
   direct `pgrep` process discovery.
@@ -682,11 +682,10 @@ is listed in the state-matrix doc's enforcement section.
   prevents command-aware Kanata process conflict detection from regrowing direct
   `pgrep` process discovery.
 - [x] `PgrepProcessDiscoveryLintTests.testProductionPgrepDiscoveryIsCentralizedInCoreProvider`
-  blocks production `pgrep` process discovery outside the core provider
-  implementation.
+  blocks production `pgrep` process discovery outside `KeyPathSystemProbes`.
 - [x] `LaunchctlEvidenceLintTests.testProductionLaunchctlPrintEvidenceReadsDelegateToSystemStateProvider`
   scans all production sources and prevents direct read-only `launchctl print`
-  evidence reads outside `SystemStateProvider`.
+  evidence reads outside `KeyPathSystemProbes`.
 - [x] `FacadeLintTests.testProductionSourcesDoNotBypassInstallerEngine` scans
   all production sources and keeps direct `PrivilegedOperationsRouter.shared`
   access limited to the wizard dependency bridge.

--- a/docs/process/installer-repair-state-matrix.md
+++ b/docs/process/installer-repair-state-matrix.md
@@ -152,12 +152,14 @@ the result as user action required and name the approval surface.
   pins the adapter contract, while
   `WizardPureLogicTests.test_systemContextStateMatrixSnapshot_classifiesStoppedRuntimeWithStaleInputCapture`
   pins the pure `SystemContext` snapshot bridge used by wizard core.
-- Process-liveness semantics belong in `SystemStateProvider.isProcessAlive(pid:)`.
+- Raw process-liveness semantics live in `KeyPathSystemProbes` and are exposed
+  to consumers through `SystemStateProvider.isProcessAlive(pid:)`.
   `SystemStateProviderLivenessTests.testProcessLivenessProbeTreatsCurrentProcessAsAliveAndExitedProcessAsDead`
   proves the real ADR-040 primitive, and
   `LivenessPredicateLintTests.testKillZeroLivenessProbeIsCentralized` blocks
-  new direct `kill(pid, 0)` probes outside the provider.
-- TCP readiness semantics belong in `SystemStateProvider.isTCPPortResponding(port:timeoutMs:)`.
+  new direct `kill(pid, 0)` probes outside the probe module.
+- Raw TCP readiness semantics live in `KeyPathSystemProbes` and are exposed to
+  consumers through `SystemStateProvider.isTCPPortResponding(port:timeoutMs:)`.
   `SystemStateProviderLivenessTests.testTCPReadinessProbeDetectsListeningAndClosedPorts`
   proves the real localhost primitive,
   `TCPReadinessLintTests.testServiceHealthCheckerDelegatesTCPReadinessToSystemStateProvider`
@@ -165,7 +167,8 @@ the result as user action required and name the approval surface.
   `TCPReadinessLintTests.testProductionTCPProbeAdapterIsNoLongerUsed` plus
   `TCPReadinessLintTests.testProductionRawTCPSocketProbeIsCentralized` block
   production readiness checks from bypassing the provider.
-- `pgrep` process discovery belongs in `SystemStateProvider.processIDs(matching:)`,
+- Raw `pgrep` process discovery lives in `KeyPathSystemProbes`; consumers use
+  `SystemStateProvider.processIDs(matching:)`,
   `SystemStateProvider.processMatches(matching:)`, or
   `SystemStateProvider.processIDsSynchronously(matching:)` for synchronous
   pre-exec/privileged-helper paths.
@@ -200,6 +203,7 @@ the result as user action required and name the approval surface.
   and `PgrepProcessDiscoveryLintTests.testProductionPgrepDiscoveryIsCentralizedInCoreProvider`
   block migrated runtime/system-validator/Karabiner-conflict/VHID/diagnostics/launcher/process-lifecycle/helper consumers from bypassing it.
 - Read-only `launchctl print` service-state evidence belongs in
+  `KeyPathSystemProbes` and is exposed through
   `SystemStateProvider.launchctlPrint(target:)`; mutating launchctl operations
   remain installer/helper actions, not state reads.
   `SystemStateProviderLivenessTests.testLaunchctlPrintDelegatesToInjectedSubprocessRunner`


### PR DESCRIPTION
## Summary
- add a `KeyPathSystemProbes` target that owns raw read-only OS probes: `pgrep`, read-only `launchctl print`, `kill(pid, 0)`, and localhost TCP probing
- keep `SystemStateProvider` as the consumer-facing facade over an injected `SystemProbeClient`
- remove `SubprocessRunner.pgrep` from the production subprocess abstraction and update tests/fakes to inject probe clients
- tighten lint ratchets and docs so raw OS probe primitives are only blessed inside `KeyPathSystemProbes`

## Validation
- `TEST_FILTER='SystemStateProviderLivenessTests|SubprocessRunnerTests|PgrepProcessDiscoveryLintTests|LaunchctlEvidenceLintTests|LivenessPredicateLintTests' ./Scripts/run-tests-safe.sh` — 36 passed
- `TEST_FILTER='SystemStateProviderLivenessTests|SubprocessRunnerTests|PgrepProcessDiscoveryLintTests|LaunchctlEvidenceLintTests|LivenessPredicateLintTests|ServiceHealthCheckerTests|KanataDaemonManagerTests|HelperManagerTests|VHIDDeviceManagerTests|KarabinerConflictServiceTests|DiagnosticsServiceTests|ProcessLifecycleManagerTests|SystemValidatorTests' ./Scripts/run-tests-safe.sh` — 145 passed
- `TEST_FILTER='TCPReadinessLintTests|LivenessPredicateLintTests|PgrepProcessDiscoveryLintTests|LaunchctlEvidenceLintTests' ./Scripts/run-tests-safe.sh` — 15 passed
- `KEYPATH_TEST_ENFORCE_CLEAN_SUMMARY=1 ./Scripts/run-tests-safe.sh` — 4,574 passed; clean-summary guardrails passed with 0 Swift warnings, 0 module-cache warnings, 0 app warnings, and 0 app errors
- `git diff --check`
- `swiftformat ...` — 0/19 files formatted

## Review gate
Local `/thermo-nuclear-swift-review` could not be run because neither `thermo-nuclear-swift-review` nor `claude` is installed on PATH in this shell. The GitHub review workflow is the enforced reviewer for this PR.
