### PR TITLE
Fix setup helper and uninstall flows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,8 +45,18 @@ Notes:
   ./Scripts/run-tests-safe.sh` over full-suite reruns after every edit.
 - Run `./Scripts/quick-deploy.sh` only when you need to inspect installed app
   behavior. It is not required for model/parser/service-only changes.
+- For visual SwiftUI/AppKit iteration, prefer `./Scripts/ui-deploy.sh`. It
+  builds only the KeyPath app product, deploys to `/Applications/KeyPath.app`,
+  signs locally, and restarts the app if needed. It intentionally does not
+  notarize and does not refresh the CLI, helper, or Rust host bridge.
 - `quick-deploy.sh` updates `/Applications/KeyPath.app`, re-signs locally, and
-  restarts KeyPath only if it was running.
+  restarts KeyPath only if it was running. Its default scope is app-only; set
+  `KEYPATH_QUICK_DEPLOY_BUILD_SCOPE=full` when you need the older broad package
+  deploy that refreshes companion binaries.
+- Fast deploy scripts default to the stable Xcode at
+  `/Applications/Xcode-26.6.0.app/Contents/Developer` when `DEVELOPER_DIR` is
+  unset. Override with `KEYPATH_DEV_XCODE_DEVELOPER_DIR` only when intentionally
+  testing another toolchain.
 - It intentionally does **not** redeploy the privileged helper unless
   `KEYPATH_DEPLOY_HELPER=1` is set. Avoid helper redeploys during UI work.
 - Use Poltergeist only for focused single-agent Swift/UI iteration:

--- a/Scripts/README.md
+++ b/Scripts/README.md
@@ -1,7 +1,12 @@
 # Scripts
 
 ## Supported commands (recommended)
-- `./Scripts/quick-deploy.sh` — Incremental local dev (fast, deploys to /Applications; run `./build.sh` once first).
+- `./Scripts/ui-deploy.sh` — Fast installed-app UI iteration. Builds only the
+  KeyPath app product, deploys to /Applications, signs locally, restarts if
+  running, and intentionally does not notarize.
+- `./Scripts/quick-deploy.sh` — Incremental local dev deploy. Defaults to the
+  same app-only scope as `ui-deploy.sh`; set
+  `KEYPATH_QUICK_DEPLOY_BUILD_SCOPE=full` to refresh companion binaries.
 - `./Scripts/release-doctor.sh` — Read-only preflight for signed/notarized release-candidate or public ship builds.
 - `./Scripts/release-candidate.sh` — Signed/notarized post-merge manual-testing build; skips snapshots, Sparkle, and website publishing by default.
 - `./build.sh` — Canonical build & sign entry (root). Use `SKIP_CODESIGN=1` to bypass signing for local dev.
@@ -20,6 +25,7 @@
 
 ## Scripts in this directory
 - `build-and-sign.sh` - The implementation of the build process
+- `ui-deploy.sh` - App-only local deploy wrapper for SwiftUI/AppKit iteration.
 - `release-doctor.sh` - Read-only preflight for signing, notarization, Sparkle, website, watcher, and runtime state.
 - `release-candidate.sh` - Post-merge signed/notarized local build wrapper with fast defaults.
 - `release.sh` - Public release wrapper for versioned distribution artifacts.

--- a/Scripts/quick-deploy.sh
+++ b/Scripts/quick-deploy.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
-# Quick deploy for development: build, copy to /Applications, restart
-# No signing or notarization - just fast iteration (~3-4 seconds)
+# Quick deploy for development: build, copy to /Applications, sign locally, restart.
+# This intentionally does not notarize. By default it builds only the KeyPath app
+# product for UI iteration; set KEYPATH_QUICK_DEPLOY_BUILD_SCOPE=full to refresh
+# companion binaries such as keypath-cli.
 #
 # Features:
 # - Lock-based concurrency control (skips if another build is running)
@@ -20,6 +22,25 @@ MACOS_DIR="$APP_BUNDLE/Contents/MacOS"
 RESOURCES_DIR="$APP_BUNDLE/Contents/Resources"
 ENTITLEMENTS="$PROJECT_DIR/KeyPath.entitlements"
 WAS_RUNNING=0
+DEFAULT_DEVELOPER_DIR="/Applications/Xcode-26.6.0.app/Contents/Developer"
+if [[ -n "${KEYPATH_DEV_XCODE_DEVELOPER_DIR:-}" ]]; then
+    export DEVELOPER_DIR="$KEYPATH_DEV_XCODE_DEVELOPER_DIR"
+elif [[ -z "${DEVELOPER_DIR:-}" && -d "$DEFAULT_DEVELOPER_DIR" ]]; then
+    export DEVELOPER_DIR="$DEFAULT_DEVELOPER_DIR"
+fi
+BUILD_SCOPE="${KEYPATH_QUICK_DEPLOY_BUILD_SCOPE:-app}"
+if [[ "$BUILD_SCOPE" != "app" && "$BUILD_SCOPE" != "full" ]]; then
+    echo "❌ KEYPATH_QUICK_DEPLOY_BUILD_SCOPE must be 'app' or 'full' (got '$BUILD_SCOPE')" >&2
+    exit 1
+fi
+HOST_BRIDGE_MODE="${KEYPATH_QUICK_DEPLOY_HOST_BRIDGE:-}"
+if [[ -z "$HOST_BRIDGE_MODE" ]]; then
+    if [[ "$BUILD_SCOPE" == "full" ]]; then
+        HOST_BRIDGE_MODE=1
+    else
+        HOST_BRIDGE_MODE=0
+    fi
+fi
 
 # KeepAlive LaunchAgent that runs the headless KeyPath instance. We unload it for
 # the build+sign window so launchd can't respawn KeyPath onto a bundle whose
@@ -78,6 +99,9 @@ write_build_log_header() {
         echo "project_dir: $PROJECT_DIR"
         echo "branch: $(git branch --show-current 2>/dev/null || echo unknown)"
         echo "commit: $(git rev-parse --short HEAD 2>/dev/null || echo unknown)"
+        echo "DEVELOPER_DIR: ${DEVELOPER_DIR:-}"
+        echo "build_scope: $BUILD_SCOPE"
+        echo "host_bridge_mode: $HOST_BRIDGE_MODE"
         echo "CLANG_MODULECACHE_PATH: ${CLANG_MODULECACHE_PATH:-}"
         echo "SWIFT_MODULECACHE_PATH: ${SWIFT_MODULECACHE_PATH:-}"
         echo "module_cache_flags: ${MODULE_CACHE_FLAGS[*]}"
@@ -250,8 +274,15 @@ if pgrep -x "$APP_NAME" > /dev/null; then
     fi
 fi
 
-# Build debug (fast - incremental)
-echo "🔨 Building..."
+# Build debug (incremental). The default app scope keeps UI loops away from
+# companion products that are irrelevant for visual iteration.
+if [[ "$BUILD_SCOPE" == "app" ]]; then
+    echo "🔨 Building KeyPath app product..."
+    PRODUCT_FLAGS=(--product KeyPath)
+else
+    echo "🔨 Building full package..."
+    PRODUCT_FLAGS=()
+fi
 BUILD_LOG="$BUILD_LOG_DIR/build-${BUILD_ID}.log"
 write_build_log_header "$BUILD_LOG"
 # Optional build-system override. Unset, or the legacy value "native", means use
@@ -261,7 +292,7 @@ if [[ -n "${KEYPATH_BUILD_SYSTEM:-}" && "${KEYPATH_BUILD_SYSTEM:-}" != "native" 
     BUILD_SYSTEM_FLAGS=(--build-system "$KEYPATH_BUILD_SYSTEM")
 fi
 # ${arr[@]+...} guard: bash 3.2 under `set -u` treats expanding an empty array as unbound
-if ! swift build ${BUILD_SYSTEM_FLAGS[@]+"${BUILD_SYSTEM_FLAGS[@]}"} "${MODULE_CACHE_FLAGS[@]}" >> "$BUILD_LOG" 2>&1; then
+if ! swift build ${BUILD_SYSTEM_FLAGS[@]+"${BUILD_SYSTEM_FLAGS[@]}"} "${MODULE_CACHE_FLAGS[@]}" ${PRODUCT_FLAGS[@]+"${PRODUCT_FLAGS[@]}"} >> "$BUILD_LOG" 2>&1; then
     BUILD_END_MS=$(get_time_ms)
     DURATION=$((BUILD_END_MS - BUILD_START_MS))
     print_build_failure_diagnostics "$BUILD_LOG"
@@ -297,16 +328,22 @@ if [[ ! -f "$DEBUG_BIN" ]]; then
     log_build_event "FAILED_NO_BINARY"
     exit 1
 fi
-if [[ ! -f "$CLI_BIN" ]]; then
-    echo "❌ Build failed - CLI binary not found"
-    log_build_event "FAILED_NO_CLI_BINARY"
-    exit 1
+if [[ "$BUILD_SCOPE" == "full" ]]; then
+    if [[ ! -f "$CLI_BIN" ]]; then
+        echo "❌ Build failed - CLI binary not found"
+        log_build_event "FAILED_NO_CLI_BINARY"
+        exit 1
+    fi
+else
+    echo "ℹ️  Keeping the installed keypath-cli; set KEYPATH_QUICK_DEPLOY_BUILD_SCOPE=full to refresh it."
 fi
 
 # Copy binary to app bundle
 echo "📦 Deploying..."
 cp "$DEBUG_BIN" "$MACOS_DIR/$APP_NAME"
-cp "$CLI_BIN" "$MACOS_DIR/keypath-cli"
+if [[ "$BUILD_SCOPE" == "full" && -f "$CLI_BIN" ]]; then
+    cp "$CLI_BIN" "$MACOS_DIR/keypath-cli"
+fi
 
 # Do not hot-swap the embedded privileged helper by default.
 #
@@ -374,19 +411,23 @@ _MAIN_BUILD=$(defaults read "$PROJECT_DIR/Sources/KeyPathApp/Info" CFBundleVersi
 # Sync the current bundled runtime host executable.
 KANATA_LAUNCHER_BIN="$BIN_DIR/KeyPathKanataLauncher"
 KANATA_LAUNCHER_DST="$APP_BUNDLE/Contents/Library/KeyPath/kanata-launcher"
-if [[ -f "$KANATA_LAUNCHER_BIN" ]]; then
+if [[ "$BUILD_SCOPE" == "full" && -f "$KANATA_LAUNCHER_BIN" ]]; then
     mkdir -p "$(dirname "$KANATA_LAUNCHER_DST")"
     cp "$KANATA_LAUNCHER_BIN" "$KANATA_LAUNCHER_DST"
     chmod 755 "$KANATA_LAUNCHER_DST"
 fi
 
-# Rebuild the Rust host bridge so the installed app does not silently reuse a stale
-# dylib without the passthru runtime feature set required by the split-runtime host.
-./Scripts/build-kanata-host-bridge.sh >/dev/null
+# Rebuild the Rust host bridge only for full deploys or explicit opt-in. UI-only
+# changes do not need to pay this cost on every cycle.
+if [[ "$HOST_BRIDGE_MODE" == "1" ]]; then
+    ./Scripts/build-kanata-host-bridge.sh >/dev/null
+else
+    echo "ℹ️  Skipping host bridge rebuild; set KEYPATH_QUICK_DEPLOY_HOST_BRIDGE=1 to refresh it."
+fi
 
 KANATA_HOST_BRIDGE_SRC="$PROJECT_DIR/build/kanata-host-bridge/libkeypath_kanata_host_bridge.dylib"
 KANATA_HOST_BRIDGE_DST="$APP_BUNDLE/Contents/Library/KeyPath/libkeypath_kanata_host_bridge.dylib"
-if [[ -f "$KANATA_HOST_BRIDGE_SRC" ]]; then
+if [[ "$HOST_BRIDGE_MODE" == "1" && -f "$KANATA_HOST_BRIDGE_SRC" ]]; then
     mkdir -p "$(dirname "$KANATA_HOST_BRIDGE_DST")"
     cp "$KANATA_HOST_BRIDGE_SRC" "$KANATA_HOST_BRIDGE_DST"
 fi
@@ -412,14 +453,18 @@ done
 if ! otool -l "$MACOS_DIR/$APP_NAME" | grep -q "@executable_path/../Frameworks"; then
     install_name_tool -add_rpath "@executable_path/../Frameworks" "$MACOS_DIR/$APP_NAME" 2>/dev/null || true
 fi
-if ! otool -l "$MACOS_DIR/keypath-cli" | grep -q "@executable_path/../Frameworks"; then
+if [[ -f "$MACOS_DIR/keypath-cli" ]] && ! otool -l "$MACOS_DIR/keypath-cli" | grep -q "@executable_path/../Frameworks"; then
     install_name_tool -add_rpath "@executable_path/../Frameworks" "$MACOS_DIR/keypath-cli" 2>/dev/null || true
 fi
 if [[ ! -f "$APP_BUNDLE/Contents/Frameworks/Sparkle.framework/Versions/B/Sparkle" ]]; then
     echo "❌ Sparkle.framework is missing from the deployed app bundle" >&2
     exit 1
 fi
-for executable in "$MACOS_DIR/$APP_NAME" "$MACOS_DIR/keypath-cli"; do
+RPATH_EXECUTABLES=("$MACOS_DIR/$APP_NAME")
+if [[ -f "$MACOS_DIR/keypath-cli" ]]; then
+    RPATH_EXECUTABLES+=("$MACOS_DIR/keypath-cli")
+fi
+for executable in "${RPATH_EXECUTABLES[@]}"; do
     if ! otool -l "$executable" | grep -q "@executable_path/../Frameworks"; then
         echo "❌ $(basename "$executable") is missing @executable_path/../Frameworks rpath" >&2
         echo "   Without this, dyld cannot load the embedded Sparkle.framework at launch." >&2

--- a/Scripts/ui-deploy.sh
+++ b/Scripts/ui-deploy.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Fast installed-app UI iteration. Builds only the KeyPath app product, deploys it
+# into /Applications/KeyPath.app, signs locally, and restarts KeyPath if it was
+# already running. This lane intentionally does not notarize.
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" >/dev/null && pwd)
+
+export KEYPATH_QUICK_DEPLOY_BUILD_SCOPE="${KEYPATH_QUICK_DEPLOY_BUILD_SCOPE:-app}"
+export KEYPATH_QUICK_DEPLOY_HOST_BRIDGE="${KEYPATH_QUICK_DEPLOY_HOST_BRIDGE:-0}"
+
+exec "$SCRIPT_DIR/quick-deploy.sh"

--- a/Sources/KeyPathAppKit/App.swift
+++ b/Sources/KeyPathAppKit/App.swift
@@ -383,8 +383,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             LiveKeyboardOverlayController.shared.showForStartup(bypassHiddenCheck: true)
 
         case .showSplash:
-            AppLogger.shared.info("🪟 [AppDelegate] \(trigger): first-run — showing splash window")
-            showSplashWindow()
+            AppLogger.shared.info("🪟 [AppDelegate] \(trigger): setup incomplete — showing wizard")
+            showSetupWizardSurface()
         }
     }
 
@@ -414,6 +414,32 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         suppressLaunchSplashAutoHide = true
         mainWindowController?.show(focus: true)
         initialMainWindowShown = true
+    }
+
+    private var launchSplashDelayMs: Int {
+        #if DEBUG
+            Int(ProcessInfo.processInfo.environment["KEYPATH_SPLASH_DELAY_MS"] ?? "") ?? 650
+        #else
+            1200
+        #endif
+    }
+
+    /// Show the setup host window and bring the installer wizard forward. The
+    /// splash alone has no controls, so incomplete setup must always hand off to
+    /// the actionable wizard surface.
+    private func showSetupWizardSurface(targetPage: WizardPage? = nil) {
+        showSplashWindow()
+        showWizard(targetPage: targetPage)
+    }
+
+    /// Preserve the branded launch beat, then hand off to the actionable wizard.
+    /// Reopen/subsequent activation paths intentionally skip this delay.
+    private func showSetupWizardAfterLaunchSplash(targetPage: WizardPage? = nil) async {
+        showSplashWindow()
+        let splashDelayMs = launchSplashDelayMs
+        AppLogger.shared.info("[AppDelegate] Launch splash delay: \(splashDelayMs)ms")
+        try? await Task.sleep(for: .milliseconds(splashDelayMs))
+        showWizard(targetPage: targetPage)
     }
 
     // MARK: - Public Window Access
@@ -465,8 +491,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                     AppLogger.shared.info("🪟 [AppDelegate] Relaunch detected — skipping splash, restoring overlay directly")
                     LiveKeyboardOverlayController.shared.showForStartup(bypassHiddenCheck: true)
                 } else {
-                    AppLogger.shared.info("🪟 [AppDelegate] Initial wizard incomplete — showing setup surface, not overlay")
-                    showSplashWindow()
+                    AppLogger.shared.info("🪟 [AppDelegate] Initial wizard incomplete — showing launch splash before setup wizard")
+                    await showSetupWizardAfterLaunchSplash()
                 }
             }
             return
@@ -475,12 +501,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         mainWindowController?.show(focus: true)
 
         Task { @MainActor in
-            #if DEBUG
-                let splashDelayMs = Int(ProcessInfo.processInfo.environment["KEYPATH_SPLASH_DELAY_MS"] ?? "")
-                    ?? 650
-            #else
-                let splashDelayMs = 420
-            #endif
+            let splashDelayMs = launchSplashDelayMs
             AppLogger.shared.info("[AppDelegate] Launch splash delay: \(splashDelayMs)ms")
             try? await Task.sleep(for: .milliseconds(splashDelayMs))
 
@@ -495,7 +516,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                     AppLogger.shared.info("🪟 [AppDelegate] Splash auto-hide suppressed (user re-opened during launch)")
                 }
             } else {
-                AppLogger.shared.info("🪟 [AppDelegate] Initial wizard incomplete — keeping splash visible, not showing overlay")
+                AppLogger.shared.info("🪟 [AppDelegate] Initial wizard incomplete — showing setup wizard, not overlay")
+                self.showSetupWizardSurface()
             }
         }
 
@@ -511,8 +533,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                     LiveKeyboardOverlayController.shared.showForStartup()
                     AppLogger.shared.debug("🪟 [AppDelegate] Subsequent activation - showing overlay")
                 } else {
-                    AppLogger.shared.debug("🪟 [AppDelegate] Subsequent activation - initial wizard incomplete, not showing overlay")
-                    showSplashWindow()
+                    AppLogger.shared.debug("🪟 [AppDelegate] Subsequent activation - initial wizard incomplete, showing setup wizard")
+                    showSetupWizardSurface()
                 }
             }
         } else if !LiveKeyboardOverlayController.shared.isVisible {

--- a/Sources/KeyPathAppKit/Managers/HelperMaintenance.swift
+++ b/Sources/KeyPathAppKit/Managers/HelperMaintenance.swift
@@ -48,8 +48,49 @@ public final class HelperMaintenance {
 
     // MARK: - Public API
 
-    /// Perform a complete cleanup and repair flow.
+    /// Register the privileged helper and verify XPC without legacy cleanup.
     /// - Returns: true on success (helper registered and responding), false otherwise.
+    public func installOrRefresh() async -> Bool {
+        guard !isRunning else { return false }
+        isRunning = true
+        logLines.removeAll()
+        log("🔐 Helper install started")
+
+        defer {
+            isRunning = false
+            log("🔐 Helper install finished")
+        }
+
+        let copies = detectDuplicateAppCopies()
+        if copies.filter({ !$0.hasPrefix("/Applications/KeyPath.app") }).count > 0 {
+            log("⚠️ Multiple KeyPath.app copies detected:")
+            for c in copies {
+                log("   - \(c)")
+            }
+            log("❗ Background Item approval may point at a non-/Applications copy.")
+        } else {
+            log("✅ App copy check: OK (\(copies.first ?? "unknown"))")
+        }
+
+        let registered = await registerHelper()
+        guard registered else { return false }
+
+        var healthy = false
+        let maxAttempts = 6
+        for attempt in 1 ... maxAttempts {
+            if await HelperManager.shared.testHelperFunctionality() {
+                healthy = true
+                break
+            }
+            if attempt < maxAttempts {
+                log("⏳ Helper not responding yet (attempt \(attempt)/\(maxAttempts)); waiting for spawn…")
+                try? await Task.sleep(for: .milliseconds(500))
+            }
+        }
+        log(healthy ? "✅ Helper responding via XPC" : "❌ Helper still not responding via XPC")
+        return healthy
+    }
+
     public func runCleanupAndRepair(useAppleScriptFallback: Bool = true) async -> Bool {
         await runCleanupAndRepair(
             useAppleScriptFallback: useAppleScriptFallback,
@@ -281,33 +322,49 @@ public final class HelperMaintenance {
         if let override = testHooks?.removeLegacyHelperArtifacts {
             return await override(useAppleScriptFallback)
         }
-        let (removedDirectly, _) = await Task.detached { () -> (Bool, Bool) in
+        let paths = legacyHelperArtifactPaths()
+        let legacyArtifactPaths = [paths.legacyBin, paths.legacyPlist]
+        let cleanup = await Task.detached { () -> (found: Bool, removed: Bool, failed: Bool) in
             let fm = Foundation.FileManager()
-            let legacyBin = "/Library/PrivilegedHelperTools/com.keypath.helper"
-            let legacyPlist = "/Library/LaunchDaemons/com.keypath.helper.plist"
+            var found = false
+            var removed = false
+            var failed = false
 
             func tryRemove(_ path: String) -> Bool {
                 if fm.fileExists(atPath: path) {
+                    found = true
                     do {
                         try fm.removeItem(atPath: path)
                         return true
-                    } catch { return false }
+                    } catch {
+                        failed = true
+                        return false
+                    }
                 }
                 return false
             }
-            let a = tryRemove(legacyBin)
-            let b = tryRemove(legacyPlist)
-            return (a || b, !(a || b))
+            for path in legacyArtifactPaths where tryRemove(path) {
+                removed = true
+            }
+            return (found, removed, failed)
         }.value
 
-        if removedDirectly {
+        if cleanup.removed, !cleanup.failed {
             log("✅ Removed legacy helper artifacts directly")
             return .removed
         }
 
-        guard useAppleScriptFallback else { return .skipped }
-        let legacyBin = "/Library/PrivilegedHelperTools/com.keypath.helper"
-        let legacyPlist = "/Library/LaunchDaemons/com.keypath.helper.plist"
+        if !cleanup.found {
+            log("ℹ️ No legacy helper artifacts present")
+            return .skipped
+        }
+
+        guard useAppleScriptFallback else {
+            log("⚠️ Legacy helper artifacts present but direct cleanup failed")
+            return .failed
+        }
+        let legacyBin = paths.legacyBin
+        let legacyPlist = paths.legacyPlist
         let command = """
         /bin/launchctl bootout system/com.keypath.helper || true && \
         /bin/rm -f '\(legacyBin)' && \
@@ -367,6 +424,18 @@ public final class HelperMaintenance {
         return candidates.isEmpty ? defaults : candidates
     }
 
+    private nonisolated func legacyHelperArtifactPaths() -> (legacyBin: String, legacyPlist: String) {
+        #if DEBUG
+            if let override = Self.testLegacyHelperArtifactPathsOverride?() {
+                return override
+            }
+        #endif
+        return (
+            "/Library/PrivilegedHelperTools/com.keypath.helper",
+            "/Library/LaunchDaemons/com.keypath.helper.plist"
+        )
+    }
+
     private func log(_ line: String) {
         AppLogger.shared.log(line)
         logLines.append(line)
@@ -374,6 +443,10 @@ public final class HelperMaintenance {
 }
 
 extension HelperMaintenance {
+    #if DEBUG
+        nonisolated(unsafe) static var testLegacyHelperArtifactPathsOverride: (() -> (legacyBin: String, legacyPlist: String)?)?
+    #endif
+
     struct TestHooks {
         let unregisterHelper: (() async -> Void)?
         let bootoutHelperJob: (() async -> Void)?

--- a/Sources/KeyPathAppKit/Managers/UninstallCoordinator.swift
+++ b/Sources/KeyPathAppKit/Managers/UninstallCoordinator.swift
@@ -14,13 +14,18 @@ public final class UninstallCoordinator {
 
     @ObservationIgnored private let resolveUninstallerURLClosure: () -> URL?
     @ObservationIgnored private let runWithAdminPrivilegesClosure: (URL, Bool) async -> AppleScriptResult
+    @ObservationIgnored private let uninstallPostconditionsSatisfiedClosure: () -> Bool
 
     init(
         resolveUninstallerURL: @escaping () -> URL?,
-        runWithAdminPrivileges: @escaping (URL, Bool) async -> AppleScriptResult
+        runWithAdminPrivileges: @escaping (URL, Bool) async -> AppleScriptResult,
+        uninstallPostconditionsSatisfied: (() -> Bool)? = nil
     ) {
         resolveUninstallerURLClosure = resolveUninstallerURL
         runWithAdminPrivilegesClosure = runWithAdminPrivileges
+        uninstallPostconditionsSatisfiedClosure = uninstallPostconditionsSatisfied ?? {
+            UninstallCoordinator.defaultUninstallPostconditionsSatisfied()
+        }
     }
 
     convenience init() {
@@ -50,6 +55,14 @@ public final class UninstallCoordinator {
             didSucceed = true
             await resetForTestingIfEnabled()
             logLines.append("✅ Uninstall completed")
+            return true
+        }
+
+        if uninstallPostconditionsSatisfiedClosure() {
+            didSucceed = true
+            lastError = nil
+            await resetForTestingIfEnabled()
+            logLines.append("✅ Uninstall completed; cleanup already satisfied")
             return true
         }
 
@@ -244,6 +257,18 @@ public final class UninstallCoordinator {
         }
 
         return nil
+    }
+
+    private static func defaultUninstallPostconditionsSatisfied() -> Bool {
+        let paths = [
+            "/Applications/KeyPath.app",
+            "/Library/PrivilegedHelperTools/com.keypath.helper",
+            "/Library/LaunchDaemons/com.keypath.kanata.plist",
+            "/Library/LaunchDaemons/com.keypath.karabiner-vhiddaemon.plist",
+            "/Library/LaunchDaemons/com.keypath.karabiner-vhidmanager.plist",
+            "/Library/LaunchDaemons/com.keypath.helper.plist"
+        ]
+        return paths.allSatisfy { !FileManager.default.fileExists(atPath: $0) }
     }
 
     private static func defaultRunWithAdminPrivileges(scriptURL: URL, deleteConfig: Bool) async

--- a/Sources/KeyPathAppKit/UI/SplashView.swift
+++ b/Sources/KeyPathAppKit/UI/SplashView.swift
@@ -120,11 +120,17 @@ struct SplashView: View {
                     Spacer()
                     Text("v\(buildInfo.version) (\(buildInfo.build))")
                         .font(.caption2)
-                        .foregroundStyle(.secondary)
+                        .fontWeight(.semibold)
+                        .foregroundStyle(.white)
                         .padding(.horizontal, 10)
                         .padding(.vertical, 6)
-                        .background(.black.opacity(0.18))
+                        .background(.black.opacity(0.58))
                         .clipShape(Capsule())
+                        .overlay {
+                            Capsule()
+                                .stroke(.white.opacity(0.18), lineWidth: 1)
+                        }
+                        .shadow(color: .black.opacity(0.35), radius: 5, x: 0, y: 2)
                         .accessibilityIdentifier("main-window-splash-build")
                 }
                 .padding(12)

--- a/Sources/KeyPathHelper/HelperService.swift
+++ b/Sources/KeyPathHelper/HelperService.swift
@@ -420,8 +420,11 @@ class HelperService: NSObject, HelperProtocol {
             try Self.performUninstallExceptSelfDestruct(deleteConfig: deleteConfig)
             NSLog("[KeyPathHelper] ✅ uninstallKeyPath succeeded (sending reply before self-destruct)")
             reply(true, nil)
-            // Now self-destruct after reply is sent
-            Self.selfDestruct()
+            // Self-destruct after this XPC method returns so the reply can flush
+            // before the helper removes its own service and binary.
+            DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 0.25) {
+                Self.selfDestruct()
+            }
         } catch let error as HelperError {
             NSLog("[KeyPathHelper] ❌ uninstallKeyPath failed: \(error.localizedDescription)")
             reply(false, error.localizedDescription)

--- a/Sources/KeyPathInstallationWizard/Core/InstallerEngine.swift
+++ b/Sources/KeyPathInstallationWizard/Core/InstallerEngine.swift
@@ -458,7 +458,7 @@ public final class InstallerEngine {
 
         case .repairPrivilegedHelper:
             logs.append("Repairing privileged helper registration...")
-            try await executeRepairPrivilegedHelper()
+            try await executeRepairPrivilegedHelper(recipe: recipe)
             logs.append("Privileged helper repair completed")
 
         case .restartService:
@@ -493,15 +493,25 @@ public final class InstallerEngine {
     }
 
     /// Execute privileged helper repair via the helper-maintenance workflow.
-    private func executeRepairPrivilegedHelper() async throws {
+    private func executeRepairPrivilegedHelper(recipe: ServiceRecipe) async throws {
         guard let helperMaintenance = WizardDependencies.helperMaintenance else {
             throw InstallerError.healthCheckFailed("Helper maintenance is not configured")
         }
 
-        let repaired = await helperMaintenance.runCleanupAndRepair(
-            useAppleScriptFallback: true,
-            forceFullRepair: true
-        )
+        let repaired = switch recipe.id {
+        case InstallerRecipeID.installPrivilegedHelper:
+            await helperMaintenance.installOrRefresh()
+        case InstallerRecipeID.reinstallPrivilegedHelper:
+            await helperMaintenance.runCleanupAndRepair(
+                useAppleScriptFallback: false,
+                forceFullRepair: true
+            )
+        default:
+            await helperMaintenance.runCleanupAndRepair(
+                useAppleScriptFallback: false,
+                forceFullRepair: true
+            )
+        }
         guard repaired else {
             let failure = helperMaintenance.lastErrorLine
                 ?? helperMaintenance.logLines.last

--- a/Sources/KeyPathInstallationWizard/UI/Components/WizardHeroSection.swift
+++ b/Sources/KeyPathInstallationWizard/UI/Components/WizardHeroSection.swift
@@ -202,6 +202,32 @@ public extension WizardHeroSection {
         )
     }
 
+    /// Convenience initializer for first-run setup steps. These are required
+    /// actions, but not failures; keep the tone instructional and value-first.
+    static func setup(
+        icon: String,
+        title: String,
+        subtitle: String,
+        animated: Bool = true,
+        actionButtonTitle: String? = nil,
+        actionButtonAction: (() -> Void)? = nil,
+        iconTapAction: (() -> Void)? = nil
+    ) -> WizardHeroSection {
+        WizardHeroSection(
+            icon: icon,
+            iconColor: WizardDesign.Colors.info,
+            overlayIcon: "arrow.right.circle.fill",
+            overlayColor: WizardDesign.Colors.info,
+            overlaySize: .large,
+            title: title,
+            subtitle: subtitle,
+            actionButtonTitle: actionButtonTitle,
+            actionButtonAction: actionButtonAction,
+            iconTapAction: iconTapAction,
+            animated: animated
+        )
+    }
+
     /// Convenience initializer for info state with question mark overlay
     static func info(
         icon: String,
@@ -276,6 +302,11 @@ public struct InlineStatusView: View {
                         Image(systemName: "checkmark.circle.fill")
                             .font(.headline)
                             .foregroundColor(WizardDesign.Colors.success)
+
+                    case .attention:
+                        Image(systemName: "info.circle.fill")
+                            .font(.headline)
+                            .foregroundColor(WizardDesign.Colors.warning)
 
                     case .error:
                         Image(systemName: "exclamationmark.triangle.fill")

--- a/Sources/KeyPathInstallationWizard/UI/Pages/WizardAccessibilityPage.swift
+++ b/Sources/KeyPathInstallationWizard/UI/Pages/WizardAccessibilityPage.swift
@@ -139,10 +139,10 @@ public struct WizardAccessibilityPage: View {
                 } else {
                     // Use hero design for error state too, with blue links below
                     VStack(spacing: WizardDesign.Spacing.sectionGap) {
-                        WizardHeroSection.warning(
+                        WizardHeroSection.setup(
                             icon: "accessibility",
-                            title: "Accessibility",
-                            subtitle: "Turn on KeyPath in Accessibility, then add and turn on kanata-launcher",
+                            title: "Enable Keyboard Control",
+                            subtitle: "Allow KeyPath to monitor safety shortcuts and let Kanata Engine apply your remaps.",
                             iconTapAction: {
                                 Task {
                                     await onRefresh()

--- a/Sources/KeyPathInstallationWizard/UI/Pages/WizardConflictsPage.swift
+++ b/Sources/KeyPathInstallationWizard/UI/Pages/WizardConflictsPage.swift
@@ -59,10 +59,10 @@ public struct WizardConflictsPage: View {
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else {
                 VStack(spacing: WizardDesign.Spacing.sectionGap) {
-                    WizardHeroSection.error(
+                    WizardHeroSection.warning(
                         icon: "exclamationmark.triangle.fill",
-                        title: "Conflicts Detected",
-                        subtitle: "\(issues.count) conflicting process\(issues.count == 1 ? "" : "es") found that must be resolved",
+                        title: "Pause Other Remappers",
+                        subtitle: "\(issues.count) keyboard remapper\(issues.count == 1 ? "" : "s") may intercept the same keys. Pause them so KeyPath can take over cleanly.",
                         iconTapAction: { onRefresh() }
                     )
 

--- a/Sources/KeyPathInstallationWizard/UI/Pages/WizardHelperPage.swift
+++ b/Sources/KeyPathInstallationWizard/UI/Pages/WizardHelperPage.swift
@@ -102,21 +102,42 @@ public struct WizardHelperPage: View {
     /// Contextual headline for the setup view - adapts to current state
     private var contextualHeadline: String {
         if needsLoginItemsApproval {
-            "Login Items Approval Required"
+            "Approve KeyPath in Login Items"
         } else if isInstalled {
-            "Privileged Helper Not Responding"
+            "Reconnect System Helper"
         } else {
-            "Privileged Helper Not Installed"
+            "Enable One-Click System Setup"
         }
     }
 
     /// Contextual description for the setup view - adapts to current state
     private var contextualDescription: String {
         if needsLoginItemsApproval {
-            "Open System Settings → Login Items, find KeyPath under Background Items, and toggle it ON (see screenshot)."
+            "macOS needs one approval before KeyPath can finish setting up its background helper."
+        } else if isInstalled {
+            "KeyPath found the helper, but it is not responding yet. Refresh it to continue setup."
         } else {
-            "Enables system operations without repeated password prompts."
+            "KeyPath uses a small helper to install, repair, and update its keyboard service without repeated password prompts."
         }
+    }
+
+    private var setupIconName: String {
+        needsLoginItemsApproval ? "switch.2" : "shield.lefthalf.filled"
+    }
+
+    private var setupIconColor: Color {
+        isInstalled ? WizardDesign.Colors.warning : WizardDesign.Colors.info
+    }
+
+    private var setupOverlayIconName: String {
+        if needsLoginItemsApproval {
+            return "hand.tap.fill"
+        }
+        return isInstalled ? "exclamationmark.circle.fill" : "arrow.right.circle.fill"
+    }
+
+    private var setupOverlayColor: Color {
+        isInstalled ? WizardDesign.Colors.warning : WizardDesign.Colors.info
     }
 
     // MARK: - Body
@@ -270,26 +291,22 @@ public struct WizardHelperPage: View {
         .heroSectionContainer()
     }
 
-    // MARK: - Setup View (Hero Style for Error State)
+    // MARK: - Setup View
 
     private var setupView: some View {
         VStack(spacing: 16) { // Reduced from sectionGap to fixed 16pt
-            // Icon with warning/error overlay
             ZStack {
-                Image(systemName: "shield.checkered")
+                Image(systemName: setupIconName)
                     .font(.system(size: 80, weight: .light)) // Reduced from 115 to 80
-                    .foregroundColor(isInstalled ? WizardDesign.Colors.warning : WizardDesign.Colors.error)
+                    .foregroundColor(setupIconColor)
                     .symbolRenderingMode(.hierarchical)
 
-                // Warning/Error overlay
                 VStack {
                     HStack {
                         Spacer()
-                        Image(systemName: isInstalled ? "exclamationmark.triangle.fill" : "xmark.circle.fill")
+                        Image(systemName: setupOverlayIconName)
                             .font(.title.weight(.medium)) // Reduced from 40 to 32
-                            .foregroundColor(
-                                isInstalled ? WizardDesign.Colors.warning : WizardDesign.Colors.error
-                            )
+                            .foregroundColor(setupOverlayColor)
                             .background(WizardDesign.Colors.wizardBackground)
                             .clipShape(Circle())
                             .offset(x: 12, y: -4) // Adjusted for smaller icon
@@ -311,6 +328,11 @@ public struct WizardHelperPage: View {
                 .foregroundColor(.secondary)
                 .multilineTextAlignment(.center)
                 .padding(.horizontal, 32) // Reduced from 40 to 32
+
+            if !needsLoginItemsApproval, !isInstalled {
+                HelperValueStrip()
+                    .padding(.top, 2)
+            }
 
             // Inline action status
             if actionStatus.isActive, let message = actionStatus.message {
@@ -365,7 +387,7 @@ public struct WizardHelperPage: View {
                 .accessibilityIdentifier("wizard-helper-open-login-items-button")
             } else {
                 // Single idempotent action: install or repair (performs cleanup + install)
-                Button(isInstalled ? "Fix" : "Install Helper") {
+                Button(isInstalled ? "Reconnect Helper" : "Enable Helper") {
                     Task { await installOrRepairHelper() }
                 }
                 .buttonStyle(WizardDesign.Component.PrimaryButton())
@@ -446,18 +468,12 @@ public struct WizardHelperPage: View {
     private func installOrRepairHelper() async {
         await MainActor.run {
             isWorking = true
-            actionStatus = .inProgress(message: "Installing helper…")
+            actionStatus = .inProgress(message: isInstalled ? "Reconnecting helper…" : "Enabling helper…")
         }
 
-        guard let helperMaintenance = WizardDependencies.helperMaintenance else {
-            AppLogger.shared.log("⚠️ [WizardHelperPage] helperMaintenance not configured")
-            await MainActor.run {
-                isWorking = false
-                actionStatus = .error(message: "Wizard not fully configured")
-            }
-            return
-        }
-        let ok = await helperMaintenance.runCleanupAndRepair(useAppleScriptFallback: true)
+        let report = await InstallerEngine()
+            .runSingleAction(.installPrivilegedHelper, using: PrivilegeBroker())
+        let ok = report.success
 
         // Re-check approval status after install attempt
         let approvalNeeded = checkLoginItemsApprovalNeeded()
@@ -468,7 +484,7 @@ public struct WizardHelperPage: View {
 
             if ok {
                 helperVersion = nil // Will be refreshed
-                actionStatus = .success(message: "Helper installed successfully")
+                actionStatus = .success(message: "Helper enabled and ready")
                 scheduleStatusClear()
             } else if approvalNeeded {
                 // Registration succeeded but needs Login Items approval
@@ -480,8 +496,8 @@ public struct WizardHelperPage: View {
             } else {
                 // Surface the most informative failure line. Fall back to the
                 // last log line only if no explicit ❌/⚠️ marker is present.
-                let hint = helperMaintenance.lastErrorLine
-                    ?? helperMaintenance.logLines.last
+                let hint = report.failureReason
+                    ?? report.executedRecipes.last?.error
                     ?? "Unknown error (helper XPC not reachable)"
                 actionStatus = .error(message: "Install failed: \(hint)")
             }
@@ -613,5 +629,35 @@ public struct WizardHelperPage: View {
         // Read version from helper's Info.plist in Sources
         // For now, return the known bundled version
         return "1.1.0"
+    }
+}
+
+private struct HelperValueStrip: View {
+    var body: some View {
+        HStack(spacing: 14) {
+            HelperValuePill(icon: "wrench.and.screwdriver.fill", text: "Installs")
+            HelperValuePill(icon: "arrow.triangle.2.circlepath", text: "Repairs")
+            HelperValuePill(icon: "lock.shield.fill", text: "Local only")
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Helper unlocks installs, repairs, and local system setup")
+        .accessibilityIdentifier("wizard-helper-value-strip")
+    }
+}
+
+private struct HelperValuePill: View {
+    let icon: String
+    let text: String
+
+    var body: some View {
+        Label(text, systemImage: icon)
+            .font(.caption.weight(.medium))
+            .foregroundStyle(WizardDesign.Colors.info)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .background(
+                WizardDesign.Colors.info.opacity(0.10),
+                in: Capsule()
+            )
     }
 }

--- a/Sources/KeyPathInstallationWizard/UI/Pages/WizardInputMonitoringPage.swift
+++ b/Sources/KeyPathInstallationWizard/UI/Pages/WizardInputMonitoringPage.swift
@@ -141,11 +141,11 @@ public struct WizardInputMonitoringPage: View {
                 } else {
                     // Use hero design for error state too, with blue links below
                     VStack(spacing: WizardDesign.Spacing.sectionGap) {
-                        WizardHeroSection.warning(
+                        WizardHeroSection.setup(
                             icon: "eye",
-                            title: "Input Monitoring Required",
+                            title: "Enable Keyboard Remapping",
                             subtitle:
-                            "KeyPath needs Input Monitoring permission to capture keyboard events for remapping",
+                            "Allow KeyPath to read keyboard events locally so your remaps, layers, and shortcuts can run.",
                             iconTapAction: {
                                 Task {
                                     await onRefresh()

--- a/Sources/KeyPathInstallationWizard/UI/Pages/WizardKarabinerComponentsPage.swift
+++ b/Sources/KeyPathInstallationWizard/UI/Pages/WizardKarabinerComponentsPage.swift
@@ -23,6 +23,7 @@ public struct WizardKarabinerComponentsPage: View {
     @State private var queuedFixTimeoutTask: Task<Void, Never>?
     @State private var actionStatus: WizardDesign.ActionStatus = .idle
     @State private var lastKarabinerHealthy = false
+    @State private var isDriverApprovalPending = false
     @State private var stepProgressCancellable: AnyCancellable?
     @Environment(WizardStateMachine.self) private var stateMachine
 
@@ -110,11 +111,11 @@ public struct WizardKarabinerComponentsPage: View {
             } else {
                 // Simplified error state: hero + centered Fix button
                 VStack(spacing: WizardDesign.Spacing.sectionGap) {
-                    WizardHeroSection.error(
+                    WizardHeroSection.setup(
                         icon: "keyboard.macwindow",
-                        title: "Karabiner Driver Required",
+                        title: "Enable the Virtual Keyboard Driver",
                         subtitle:
-                        "Karabiner virtual keyboard driver needs to be installed & configured for input capture",
+                        "KeyPath uses this driver to send remapped keys back to macOS safely.",
                         iconTapAction: {
                             Task {
                                 onRefresh()
@@ -127,7 +128,7 @@ public struct WizardKarabinerComponentsPage: View {
                     InlineStatusView(status: actionStatus, message: actionStatus.message ?? " ")
                         .opacity(actionStatus.isActive ? 1 : 0)
 
-                    Button("Fix") {
+                    Button(driverActionButtonTitle) {
                         handleFixButtonTapped()
                     }
                     .buttonStyle(WizardDesign.Component.PrimaryButton(isLoading: isCombinedFixLoading))
@@ -158,6 +159,9 @@ public struct WizardKarabinerComponentsPage: View {
             } else {
                 AppLogger.shared.log("ℹ️ [Wizard] Karabiner page observed issues present; keeping error state")
                 lastKarabinerHealthy = false
+                Task {
+                    _ = await showPendingDriverApprovalIfNeeded(openSettings: false)
+                }
             }
         }
         .onAppear {
@@ -172,6 +176,9 @@ public struct WizardKarabinerComponentsPage: View {
                 AppLogger.shared.log(
                     "ℹ️ [Wizard] Karabiner page onAppear with hasKarabinerIssues=true; issues=\(issues.count)"
                 )
+                Task {
+                    _ = await showPendingDriverApprovalIfNeeded(openSettings: false)
+                }
             }
         }
         .onChange(of: isFixing) { _, newValue in
@@ -198,6 +205,10 @@ public struct WizardKarabinerComponentsPage: View {
 
     private var nextStepButtonTitle: String {
         issues.isEmpty ? "Return to Summary" : "Next Issue"
+    }
+
+    private var driverActionButtonTitle: String {
+        isDriverApprovalPending ? "Open System Settings" : "Fix"
     }
 
     private var karabinerRelatedIssues: [WizardIssue] {
@@ -286,11 +297,24 @@ public struct WizardKarabinerComponentsPage: View {
         }
     }
 
+    private func openDriverExtensionsSettings() {
+        if let url = URL(string: "x-apple.systempreferences:com.apple.LoginItems-Settings.extension?ExtensionItems") {
+            NSWorkspace.shared.open(url)
+        } else {
+            openLoginItemsSettings()
+        }
+    }
+
     // MARK: - Smart Fix Handlers
 
     /// Smart handler for Karabiner Driver Fix button
     /// Detects if Karabiner is installed vs needs installation
     private func handleFixButtonTapped() {
+        if isDriverApprovalPending {
+            openDriverExtensionsSettings()
+            return
+        }
+
         guard !isCombinedFixLoading else {
             AppLogger.shared.log("⚠️ [Karabiner Fix] Fix tapped while already loading")
             return
@@ -335,6 +359,7 @@ public struct WizardKarabinerComponentsPage: View {
 
         AppLogger.shared.log("🔧 [Karabiner Fix] startCombinedFix() START")
         isCombinedFixLoading = true
+        isDriverApprovalPending = false
         actionStatus = .inProgress(message: "Preparing...")
 
         // Subscribe to step progress updates from VHIDDeviceManager
@@ -386,6 +411,11 @@ public struct WizardKarabinerComponentsPage: View {
                 AppLogger.shared.log("🔧 [Karabiner Fix] Calling performAutomaticServiceRepair()...")
                 _ = await performAutomaticServiceRepair()
                 AppLogger.shared.log("🔧 [Karabiner Fix] performAutomaticServiceRepair() returned")
+            } else if await showPendingDriverApprovalIfNeeded(openSettings: true) {
+                AppLogger.shared.log("💡 [Karabiner Fix] Driver install is pending user approval")
+                return
+            } else {
+                actionStatus = .error(message: "Driver setup is incomplete. Try Fix again, or restart KeyPath.")
             }
             AppLogger.shared.log("🔧 [Karabiner Fix] All fix steps complete, defer will release spinner")
             // Note: Both performAutomaticDriverRepair() and performAutomaticServiceRepair()
@@ -438,6 +468,24 @@ public struct WizardKarabinerComponentsPage: View {
             AppLogger.shared.log("💡 [Karabiner Fix] Showing approval-needed toast for Login Items")
             openLoginItemsSettings()
         }
+    }
+
+    @MainActor
+    private func showPendingDriverApprovalIfNeeded(openSettings: Bool) async -> Bool {
+        let extensionStatus = await ServiceHealthChecker.shared.vhidDriverExtensionStatus()
+        guard extensionStatus == .installedButNotEnabled else {
+            isDriverApprovalPending = false
+            return false
+        }
+
+        isDriverApprovalPending = true
+        actionStatus = .attention(
+            message: "Approve the driver in System Settings, then return to KeyPath."
+        )
+        if openSettings {
+            openDriverExtensionsSettings()
+        }
+        return true
     }
 
     // Smart handler for Background Services Fix button. Attempts repair first, falls back to system settings.

--- a/Sources/KeyPathInstallationWizard/UI/WizardDesignSystem.swift
+++ b/Sources/KeyPathInstallationWizard/UI/WizardDesignSystem.swift
@@ -218,13 +218,14 @@ public enum WizardDesign {
     public enum ActionStatus: Equatable {
         case idle
         case inProgress(message: String)
+        case attention(message: String)
         case success(message: String)
         case error(message: String)
 
         public var isActive: Bool {
             switch self {
             case .idle: false
-            case .inProgress, .success, .error: true
+            case .inProgress, .attention, .success, .error: true
             }
         }
 
@@ -232,6 +233,7 @@ public enum WizardDesign {
             switch self {
             case .idle: nil
             case let .inProgress(message): message
+            case let .attention(message): message
             case let .success(message): message
             case let .error(message): message
             }
@@ -241,6 +243,7 @@ public enum WizardDesign {
             switch self {
             case .idle: .secondary
             case .inProgress: Colors.inProgress
+            case .attention: Colors.warning
             case .success: Colors.success
             case .error: Colors.error
             }

--- a/Sources/KeyPathWizardCore/WizardServiceProtocols.swift
+++ b/Sources/KeyPathWizardCore/WizardServiceProtocols.swift
@@ -14,6 +14,7 @@ public protocol WizardSystemValidating: AnyObject, Sendable {
 @MainActor
 public protocol WizardHelperMaintaining: AnyObject, Sendable {
     func detectDuplicateAppCopies() -> [String]
+    func installOrRefresh() async -> Bool
     func runCleanupAndRepair(useAppleScriptFallback: Bool) async -> Bool
     func runCleanupAndRepair(useAppleScriptFallback: Bool, forceFullRepair: Bool) async -> Bool
     var logLines: [String] { get }

--- a/Tests/KeyPathTests/InstallationEngine/InstallerEngineEndToEndTests.swift
+++ b/Tests/KeyPathTests/InstallationEngine/InstallerEngineEndToEndTests.swift
@@ -88,6 +88,64 @@ final class InstallerEngineEndToEndTests: KeyPathAsyncTestCase {
         )
     }
 
+    func testExecutePlanUsesInstallOnlyPathForMissingPrivilegedHelper() async {
+        let coordinator = StubPrivilegedOperationsCoordinator()
+        let broker = PrivilegeBroker(coordinator: coordinator)
+        let engine = InstallerEngine()
+        let helperMaintenance = StubHelperMaintenance()
+        WizardDependencies.helperMaintenance = helperMaintenance
+        defer { WizardDependencies.helperMaintenance = nil }
+
+        let plan = InstallPlan(
+            recipes: [
+                ServiceRecipe(
+                    id: InstallerRecipeID.installPrivilegedHelper,
+                    type: .repairPrivilegedHelper,
+                    serviceID: "com.keypath.helper"
+                )
+            ],
+            status: .ready,
+            intent: .install
+        )
+
+        let report = await engine.execute(plan: plan, using: broker)
+
+        XCTAssertTrue(report.success)
+        XCTAssertEqual(helperMaintenance.installCallCount, 1)
+        XCTAssertEqual(helperMaintenance.repairCallCount, 0)
+        XCTAssertNil(helperMaintenance.lastForceFullRepair)
+        XCTAssertNil(helperMaintenance.lastUseAppleScriptFallback)
+    }
+
+    func testExecutePlanUsesForceRefreshWithoutAppleScriptForHelperReinstall() async {
+        let coordinator = StubPrivilegedOperationsCoordinator()
+        let broker = PrivilegeBroker(coordinator: coordinator)
+        let engine = InstallerEngine()
+        let helperMaintenance = StubHelperMaintenance()
+        WizardDependencies.helperMaintenance = helperMaintenance
+        defer { WizardDependencies.helperMaintenance = nil }
+
+        let plan = InstallPlan(
+            recipes: [
+                ServiceRecipe(
+                    id: InstallerRecipeID.reinstallPrivilegedHelper,
+                    type: .repairPrivilegedHelper,
+                    serviceID: "com.keypath.helper"
+                )
+            ],
+            status: .ready,
+            intent: .repair
+        )
+
+        let report = await engine.execute(plan: plan, using: broker)
+
+        XCTAssertTrue(report.success)
+        XCTAssertEqual(helperMaintenance.installCallCount, 0)
+        XCTAssertEqual(helperMaintenance.repairCallCount, 1)
+        XCTAssertEqual(helperMaintenance.lastForceFullRepair, true)
+        XCTAssertEqual(helperMaintenance.lastUseAppleScriptFallback, false)
+    }
+
     func testExecutePlanTreatsPendingApprovalAsHealthyForKanataHealthCheck() async throws {
         #if DEBUG
             final class PendingApprovalSMAppService: SMAppServiceProtocol, @unchecked Sendable {
@@ -144,7 +202,10 @@ final class InstallerEngineEndToEndTests: KeyPathAsyncTestCase {
 
 @MainActor
 private final class StubHelperMaintenance: WizardHelperMaintaining {
+    private(set) var installCallCount = 0
     private(set) var repairCallCount = 0
+    private(set) var lastUseAppleScriptFallback: Bool?
+    private(set) var lastForceFullRepair: Bool?
     var logLines: [String] = []
     var lastErrorLine: String?
 
@@ -152,14 +213,23 @@ private final class StubHelperMaintenance: WizardHelperMaintaining {
         ["/Applications/KeyPath.app"]
     }
 
+    func installOrRefresh() async -> Bool {
+        installCallCount += 1
+        logLines.append("helper install invoked")
+        return true
+    }
+
     func runCleanupAndRepair(useAppleScriptFallback _: Bool) async -> Bool {
         repairCallCount += 1
+        lastUseAppleScriptFallback = false
         logLines.append("helper repair invoked")
         return true
     }
 
-    func runCleanupAndRepair(useAppleScriptFallback _: Bool, forceFullRepair _: Bool) async -> Bool {
+    func runCleanupAndRepair(useAppleScriptFallback: Bool, forceFullRepair: Bool) async -> Bool {
         repairCallCount += 1
+        lastUseAppleScriptFallback = useAppleScriptFallback
+        lastForceFullRepair = forceFullRepair
         logLines.append("helper repair invoked")
         return true
     }

--- a/Tests/KeyPathTests/Managers/HelperMaintenanceTests.swift
+++ b/Tests/KeyPathTests/Managers/HelperMaintenanceTests.swift
@@ -13,6 +13,7 @@ final class HelperMaintenanceTests: XCTestCase {
     override func tearDown() async throws {
         try await super.tearDown()
         HelperMaintenance.testDuplicateAppPathsOverride = nil
+        HelperMaintenance.testLegacyHelperArtifactPathsOverride = nil
         HelperMaintenance.shared.applyTestHooks(nil)
         HelperManager.testHelperFunctionalityOverride = nil
         HelperManager.testInstallHelperOverride = nil
@@ -69,6 +70,11 @@ final class HelperMaintenanceTests: XCTestCase {
 
     func testAdminCleanupFallbackFailureAbortsRun() async {
         HelperMaintenance.testDuplicateAppPathsOverride = { ["/Applications/KeyPath.app"] }
+        let protectedPaths = makeProtectedLegacyArtifactPaths()
+        defer { protectedPaths.cleanup() }
+        HelperMaintenance.testLegacyHelperArtifactPathsOverride = {
+            (legacyBin: protectedPaths.bin, legacyPlist: protectedPaths.plist)
+        }
 
         let fakeExecutor = FakeAdminCommandExecutor(resultProvider: { _, _ in
             CommandExecutionResult(exitCode: 1, output: "Permission denied")
@@ -96,8 +102,78 @@ final class HelperMaintenanceTests: XCTestCase {
         )
     }
 
+    func testAbsentLegacyArtifactsDoNotInvokeAdminCleanupFallback() async {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let missingBin = tempDir.appendingPathComponent("missing-helper").path
+        let missingPlist = tempDir.appendingPathComponent("missing-helper.plist").path
+        HelperMaintenance.testDuplicateAppPathsOverride = { ["/Applications/KeyPath.app"] }
+        HelperMaintenance.testLegacyHelperArtifactPathsOverride = {
+            (legacyBin: missingBin, legacyPlist: missingPlist)
+        }
+        let fakeExecutor = FakeAdminCommandExecutor()
+        AdminCommandExecutorHolder.shared = fakeExecutor
+
+        var attempts = 0
+        let hooks = HelperMaintenance.TestHooks(
+            unregisterHelper: {},
+            bootoutHelperJob: {},
+            registerHelper: {
+                attempts += 1
+                return attempts > 1
+            }
+        )
+        HelperMaintenance.shared.applyTestHooks(hooks)
+        HelperManager.testHelperFunctionalityOverride = { true }
+
+        let success = await HelperMaintenance.shared.runCleanupAndRepair(useAppleScriptFallback: true)
+
+        XCTAssertTrue(success)
+        XCTAssertTrue(fakeExecutor.commands.isEmpty, "No admin cleanup should run when legacy files are absent")
+        XCTAssertTrue(
+            HelperMaintenance.shared.logLines.contains { $0.contains("No legacy helper artifacts present") }
+        )
+    }
+
+    func testInstallOrRefreshDoesNotRunCleanupOrAdminFallback() async {
+        HelperMaintenance.testDuplicateAppPathsOverride = { ["/Applications/KeyPath.app"] }
+        let fakeExecutor = FakeAdminCommandExecutor()
+        AdminCommandExecutorHolder.shared = fakeExecutor
+
+        var unregisterCalled = false
+        var bootoutCalled = false
+        var cleanupCalled = false
+        let hooks = HelperMaintenance.TestHooks(
+            unregisterHelper: { unregisterCalled = true },
+            bootoutHelperJob: { bootoutCalled = true },
+            removeLegacyHelperArtifacts: { _ in
+                cleanupCalled = true
+                return .removed
+            },
+            registerHelper: { true }
+        )
+        HelperMaintenance.shared.applyTestHooks(hooks)
+        HelperManager.testHelperFunctionalityOverride = { true }
+
+        let success = await HelperMaintenance.shared.installOrRefresh()
+
+        XCTAssertTrue(success)
+        XCTAssertFalse(unregisterCalled)
+        XCTAssertFalse(bootoutCalled)
+        XCTAssertFalse(cleanupCalled)
+        XCTAssertTrue(fakeExecutor.commands.isEmpty)
+    }
+
     func testAdminCleanupFallbackSucceedsWithExecutor() async {
         HelperMaintenance.testDuplicateAppPathsOverride = { ["/Applications/KeyPath.app"] }
+        let protectedPaths = makeProtectedLegacyArtifactPaths()
+        defer { protectedPaths.cleanup() }
+        HelperMaintenance.testLegacyHelperArtifactPathsOverride = {
+            (legacyBin: protectedPaths.bin, legacyPlist: protectedPaths.plist)
+        }
 
         let fakeExecutor = FakeAdminCommandExecutor()
         AdminCommandExecutorHolder.shared = fakeExecutor
@@ -216,5 +292,29 @@ final class HelperMaintenanceTests: XCTestCase {
         XCTAssertTrue(first)
         let second = await HelperMaintenance.shared.runCleanupAndRepair(useAppleScriptFallback: false)
         XCTAssertTrue(second)
+    }
+
+    private func makeProtectedLegacyArtifactPaths() -> (
+        bin: String,
+        plist: String,
+        cleanup: () -> Void
+    ) {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let protectedDir = tempDir.appendingPathComponent("protected", isDirectory: true)
+        let bin = protectedDir.appendingPathComponent("com.keypath.helper")
+        let plist = protectedDir.appendingPathComponent("com.keypath.helper.plist")
+        try? FileManager.default.createDirectory(at: protectedDir, withIntermediateDirectories: true)
+        FileManager.default.createFile(atPath: bin.path, contents: Data())
+        FileManager.default.createFile(atPath: plist.path, contents: Data())
+        try? FileManager.default.setAttributes([.posixPermissions: 0o500], ofItemAtPath: protectedDir.path)
+        return (
+            bin.path,
+            plist.path,
+            {
+                try? FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: protectedDir.path)
+                try? FileManager.default.removeItem(at: tempDir)
+            }
+        )
     }
 }

--- a/Tests/KeyPathTests/Managers/UninstallCoordinatorTests.swift
+++ b/Tests/KeyPathTests/Managers/UninstallCoordinatorTests.swift
@@ -69,7 +69,8 @@ final class UninstallCoordinatorTests: XCTestCase {
                         success: false, output: "", error: error.localizedDescription, exitStatus: -1
                     )
                 }
-            }
+            },
+            uninstallPostconditionsSatisfied: { false }
         )
         let success = await coordinator.uninstall()
 
@@ -90,7 +91,8 @@ final class UninstallCoordinatorTests: XCTestCase {
             resolveUninstallerURL: { nil },
             runWithAdminPrivileges: { _, _ in
                 AppleScriptResult(success: false, output: "", error: "", exitStatus: -1)
-            }
+            },
+            uninstallPostconditionsSatisfied: { false }
         )
 
         let success = await coordinator.uninstall()
@@ -101,6 +103,26 @@ final class UninstallCoordinatorTests: XCTestCase {
         XCTAssertTrue(coordinator.logLines.contains { $0.contains("Uninstaller script wasn't found") })
     }
 
+    func testUninstallTreatsSatisfiedPostconditionsAsSuccessWithoutFallback() async {
+        var fallbackRan = false
+        let coordinator = UninstallCoordinator(
+            resolveUninstallerURL: { nil },
+            runWithAdminPrivileges: { _, _ in
+                fallbackRan = true
+                return AppleScriptResult(success: false, output: "", error: "fallback should not run", exitStatus: 1)
+            },
+            uninstallPostconditionsSatisfied: { true }
+        )
+
+        let success = await coordinator.uninstall()
+
+        XCTAssertTrue(success)
+        XCTAssertTrue(coordinator.didSucceed)
+        XCTAssertNil(coordinator.lastError)
+        XCTAssertFalse(fallbackRan)
+        XCTAssertTrue(coordinator.logLines.contains { $0.contains("cleanup already satisfied") })
+    }
+
     func testUninstallLogsAdminError() async {
         let errorURL = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true).appendingPathComponent(
             "uninstall-fail.sh"
@@ -109,7 +131,8 @@ final class UninstallCoordinatorTests: XCTestCase {
             resolveUninstallerURL: { errorURL },
             runWithAdminPrivileges: { _, _ in
                 AppleScriptResult(success: false, output: "", error: "Permission denied", exitStatus: 1)
-            }
+            },
+            uninstallPostconditionsSatisfied: { false }
         )
 
         let success = await coordinator.uninstall()
@@ -128,7 +151,8 @@ final class UninstallCoordinatorTests: XCTestCase {
             resolveUninstallerURL: { errorURL },
             runWithAdminPrivileges: { _, _ in
                 AppleScriptResult(success: false, output: "", error: "", exitStatus: 42)
-            }
+            },
+            uninstallPostconditionsSatisfied: { false }
         )
 
         let success = await coordinator.uninstall()


### PR DESCRIPTION
## Summary
- route helper setup through InstallerEngine install intent and preserve friendlier onboarding copy
- handle pending virtual keyboard driver approval by opening the exact System Settings extension sheet
- make uninstall success postcondition-based when the helper removes itself before XPC/fallback can report cleanly
- add app-only ui-deploy lane for fast installed-app visual iteration

## Validation
- python3 Scripts/check-accessibility.py
- git diff --check
- swiftformat --lint on touched Swift files
- TEST_FILTER=UninstallCoordinatorTests ./Scripts/run-tests-safe.sh
- TEST_FILTER=HelperMaintenanceTests ./Scripts/run-tests-safe.sh
- TEST_FILTER=InstallerEngineEndToEndTests ./Scripts/run-tests-safe.sh
- TEST_FILTER=KarabinerComponentsStatusEvaluatorTests ./Scripts/run-tests-safe.sh
- ./Scripts/review-gate.sh selected remote review gate; GitHub claude-review must pass before merge

## Notes
- This branch was manually dev-deployed once after the local app was removed during uninstall testing. Post-merge deploy should happen from master.
