### PR TITLE
Prevent recursive installer plan execution

### DIFF
--- a/Sources/KeyPathInstallationWizard/Core/ServiceBootstrapper.swift
+++ b/Sources/KeyPathInstallationWizard/Core/ServiceBootstrapper.swift
@@ -966,7 +966,11 @@ public final class ServiceBootstrapper {
     ///
     /// - Returns: `true` if all services were installed successfully
     @MainActor
-    public func installAllServices() async -> Bool {
+    public func installAllServices(
+        repairVHIDServices: @escaping () async throws -> Void = {
+            try await PrivilegeBroker().repairVHIDDaemonServices()
+        }
+    ) async -> Bool {
         AppLogger.shared.log("🔧 [ServiceBootstrapper] Installing all services (VHID + Kanata)")
 
         // Skip in test mode
@@ -977,13 +981,15 @@ public final class ServiceBootstrapper {
 
         let vhidSnapshot = await captureVHIDInstallSnapshot()
 
-        // Step 1: Install VirtualHID services (helper-first, falls back to osascript)
-        AppLogger.shared.log("📱 [ServiceBootstrapper] Step 1: Installing VirtualHID services via InstallerEngine")
-        let report = await InstallerEngine()
-            .runSingleAction(.repairVHIDDaemonServices, using: PrivilegeBroker())
-        if !report.success {
+        // Step 1: Execute the declared VHID sub-operation through the privilege
+        // broker. Never create another InstallerEngine or plan from inside an
+        // active plan execution; doing so deadlocks on the transaction gate.
+        AppLogger.shared.log("📱 [ServiceBootstrapper] Step 1: Installing VirtualHID services via privilege broker")
+        do {
+            try await repairVHIDServices()
+        } catch {
             AppLogger.shared.log(
-                "❌ [ServiceBootstrapper] VirtualHID installation failed: \(report.failureReason ?? "Unknown error")"
+                "❌ [ServiceBootstrapper] VirtualHID installation failed: \(error.localizedDescription)"
             )
             return false
         }

--- a/Tests/KeyPathTests/Lint/InstallerDecisionPipelineLintTests.swift
+++ b/Tests/KeyPathTests/Lint/InstallerDecisionPipelineLintTests.swift
@@ -1,7 +1,7 @@
 import Foundation
 @preconcurrency import XCTest
 
-final class InstallerDecisionPipelineLintTests: XCTestCase {
+final class InstallerDecisionPipelineLintTests: KeyPathTestCase {
     func testProductionPlanningUsesCanonicalDecisionPipeline() throws {
         let root = repositoryRoot()
         let consumers = [
@@ -86,6 +86,23 @@ final class InstallerDecisionPipelineLintTests: XCTestCase {
         XCTAssertTrue(
             violations.isEmpty,
             "Planning must be a pure projection of captured context; found: \(violations)"
+        )
+    }
+
+    func testBootstrapperDoesNotRecursivelyInvokeInstallerEngine() throws {
+        let file = repositoryRoot()
+            .appendingPathComponent("Sources/KeyPathInstallationWizard/Core/ServiceBootstrapper.swift")
+        let source = try String(contentsOf: file, encoding: .utf8)
+        let forbiddenCalls = ["InstallerEngine(", ".runSingleAction("]
+        let violations = forbiddenCalls.filter { source.contains($0) }
+
+        XCTAssertTrue(
+            violations.isEmpty,
+            """
+            ServiceBootstrapper executes inside an InstallerEngine transaction. \
+            It must execute declared operations without creating another plan or \
+            reacquiring the transaction gate; found: \(violations)
+            """
         )
     }
 }

--- a/docs/planning/installer-phase-pipeline-and-modularization.md
+++ b/docs/planning/installer-phase-pipeline-and-modularization.md
@@ -261,6 +261,16 @@ beside them. If a proposed new type duplicates `SystemSnapshot` or
 **Goal:** Execute the complete plan once, then verify it with one fresh
 snapshot.
 
+### Progress
+
+- Started on 2026-07-10 after PR #1079 merged Milestones 1 and 2.
+- Post-merge installed CLI repair reproduced the recursive-run deadlock: the
+  outer transaction executed `install-required-runtime-services`, then
+  `ServiceBootstrapper.installAllServices()` called `runSingleAction()` and
+  waited forever to reacquire the same transaction gate.
+- The first slice removes that nested engine/plan creation while preserving the
+  helper-first VHID operation and adds a lint ratchet against recurrence.
+
 ### Work
 
 - Give each plan a stable ID, ordered steps, prerequisites, expected


### PR DESCRIPTION
## Summary

- remove `ServiceBootstrapper -> InstallerEngine.runSingleAction()` recursion
- execute the VHID sub-operation through the existing privilege broker instead of creating a nested plan
- preserve helper-first routing, ambiguous-result verification, and allowed fallback behavior
- add a lint ratchet forbidding bootstrapper-to-engine recursion
- record the live Milestone 3 reproduction in the installer consolidation plan

## Root cause

An outer `InstallerEngine.run()` acquired the single-flight transaction gate and executed `install-required-runtime-services`. That recipe reached `ServiceBootstrapper.installAllServices()`, which constructed another `InstallerEngine` and called `runSingleAction(.repairVHIDDaemonServices)`. The nested run waited forever to reacquire the non-reentrant transaction gate held by its caller.

This was reproduced with the installed CLI after PR #1079:

```
keypath-cli system repair
  -> install-required-runtime-services
  -> ServiceBootstrapper.installAllServices()
  -> InstallerEngine.runSingleAction()
  -> waits forever on InstallerTransactionGate
```

## Validation

- focused installer/bootstrapper suite: 63 passed
- full non-snapshot safe suite: 4,602 passed
- accessibility identifier check passes across 354 files
- SwiftFormat lint and `git diff --check` pass
- local review gate selected enforced remote `claude-review`
- deployed the feature build and reran the installed CLI repair; it returned successfully instead of hanging
- installed inspection reports `isOperational: true`
- installed app verification confirms managed Kanata launchd job, running process, and TCP readiness on `127.0.0.1:37001`

Snapshot tests remain excluded because of the existing snapshot renderer `CGRectValue` crash/reference mismatch issue documented on PR #1079.
