### PR TITLE
Verify owned installer operation sequencing

### DIFF
--- a/Sources/KeyPathInstallationWizard/Core/ServiceBootstrapper.swift
+++ b/Sources/KeyPathInstallationWizard/Core/ServiceBootstrapper.swift
@@ -966,10 +966,21 @@ public final class ServiceBootstrapper {
     ///
     /// - Returns: `true` if all services were installed successfully
     @MainActor
-    public func installAllServices(
-        repairVHIDServices: @escaping () async throws -> Void = {
-            try await PrivilegeBroker().repairVHIDDaemonServices()
-        }
+    public func installAllServices() async -> Bool {
+        await installAllServices(
+            repairVHIDServices: {
+                try await PrivilegeBroker().repairVHIDDaemonServices()
+            },
+            registerKanataService: {
+                await self.registerKanataWithSMAppService()
+            }
+        )
+    }
+
+    @MainActor
+    func installAllServices(
+        repairVHIDServices: () async throws -> Void,
+        registerKanataService: () async -> Bool
     ) async -> Bool {
         AppLogger.shared.log("🔧 [ServiceBootstrapper] Installing all services (VHID + Kanata)")
 
@@ -982,21 +993,23 @@ public final class ServiceBootstrapper {
         let vhidSnapshot = await captureVHIDInstallSnapshot()
 
         // Step 1: Execute the declared VHID sub-operation through the privilege
-        // broker. Never create another InstallerEngine or plan from inside an
-        // active plan execution; doing so deadlocks on the transaction gate.
+        // broker. The broker's coordinator contract postcondition-verifies the
+        // VHID services before returning. Never create another InstallerEngine
+        // or plan from inside an active plan execution; doing so deadlocks on
+        // the transaction gate.
         AppLogger.shared.log("📱 [ServiceBootstrapper] Step 1: Installing VirtualHID services via privilege broker")
         do {
             try await repairVHIDServices()
         } catch {
             AppLogger.shared.log(
-                "❌ [ServiceBootstrapper] VirtualHID installation failed: \(error.localizedDescription)"
+                "❌ [ServiceBootstrapper] VirtualHID installation failed: \(error.localizedDescription) (\(String(reflecting: error)))"
             )
             return false
         }
 
         // Step 2: Install Kanata via SMAppService
         AppLogger.shared.log("📱 [ServiceBootstrapper] Step 2: Installing Kanata via SMAppService")
-        let kanataSuccess = await registerKanataWithSMAppService()
+        let kanataSuccess = await registerKanataService()
 
         if !kanataSuccess {
             AppLogger.shared.log("⚠️ [ServiceBootstrapper] SMAppService registration failed")

--- a/Tests/KeyPathTests/Services/ServiceBootstrapperTests.swift
+++ b/Tests/KeyPathTests/Services/ServiceBootstrapperTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 @testable import KeyPathAppKit
+@testable import KeyPathCore
 @testable import KeyPathInstallationWizard
 @preconcurrency import XCTest
 
@@ -273,6 +274,46 @@ final class ServiceBootstrapperTests: XCTestCase {
             await bootstrapper.installAllServices()
         }
         XCTAssertTrue(installResult)
+    }
+
+    func testInstallAllServicesRunsInjectedOperationsInOrder() async {
+        TestEnvironment.allowAdminOperationsInTests = true
+        defer { TestEnvironment.allowAdminOperationsInTests = false }
+
+        var operations: [String] = []
+        let result = await ServiceBootstrapper.shared.installAllServices(
+            repairVHIDServices: {
+                operations.append("repair-vhid")
+            },
+            registerKanataService: {
+                operations.append("register-kanata")
+                return true
+            }
+        )
+
+        XCTAssertTrue(result)
+        XCTAssertEqual(operations, ["repair-vhid", "register-kanata"])
+    }
+
+    func testInstallAllServicesStopsWhenInjectedVHIDRepairThrows() async {
+        struct ExpectedFailure: Error {}
+
+        TestEnvironment.allowAdminOperationsInTests = true
+        defer { TestEnvironment.allowAdminOperationsInTests = false }
+
+        var registrationCalled = false
+        let result = await ServiceBootstrapper.shared.installAllServices(
+            repairVHIDServices: {
+                throw ExpectedFailure()
+            },
+            registerKanataService: {
+                registrationCalled = true
+                return true
+            }
+        )
+
+        XCTAssertFalse(result)
+        XCTAssertFalse(registrationCalled)
     }
 
     func testStaleSMAppServiceBootoutCommandsTargetGuiAndSystemDomains() {


### PR DESCRIPTION
## Summary
- keep the production `installAllServices()` API narrow while exposing an internal operation seam for behavioral tests
- document that the broker coordinator postcondition-verifies VHID repair before returning
- test VHID-before-Kanata ordering and fail-fast behavior when VHID repair throws
- preserve full reflected error context in the failure log

Follow-up to the review feedback on #1080. Existing router tests prove failed VHID postconditions throw rather than report success.

## Validation
- `TEST_FILTER=ServiceBootstrapperTests ./Scripts/run-tests-safe.sh` (22 passed)
- `TEST_FILTER=PrivilegedOperationsRouterTests ./Scripts/run-tests-safe.sh` (26 passed)
- `TEST_FILTER=PostconditionLintTests ./Scripts/run-tests-safe.sh` (7 passed)
- `./Scripts/run-tests-safe.sh` (4,604 passed)
- `python3 Scripts/check-accessibility.py` (354 files)
- `./Scripts/review-gate.sh` selected the remote review gate