### PR TITLE
Own post-execution installer snapshots

### DIFF
--- a/Sources/KeyPathAppKit/CLI/SystemFacade.swift
+++ b/Sources/KeyPathAppKit/CLI/SystemFacade.swift
@@ -153,11 +153,10 @@ public struct SystemFacade: Sendable {
         }
         let broker = PrivilegeBroker()
         let report = await engine.execute(plan: plan, using: broker)
-        let finalContext = report.success ? await engine.inspectSystem() : nil
         return CLIInstallerReport(
             from: report,
             initialContext: context,
-            finalContext: finalContext,
+            finalContext: report.finalContext,
             plan: plan,
             title: "Installation"
         )
@@ -199,11 +198,10 @@ public struct SystemFacade: Sendable {
 
         let broker = PrivilegeBroker()
         let report = await engine.execute(plan: plan, using: broker)
-        let finalContext = report.success ? await engine.inspectSystem() : nil
         return CLIInstallerReport(
             from: report,
             initialContext: context,
-            finalContext: finalContext,
+            finalContext: report.finalContext,
             plan: plan,
             title: "Repair"
         )

--- a/Sources/KeyPathAppKit/Services/System/SystemValidator.swift
+++ b/Sources/KeyPathAppKit/Services/System/SystemValidator.swift
@@ -145,7 +145,7 @@ public class SystemValidator {
         return await checkSystem(progressCallback: progressCallback)
     }
 
-    func invalidateCaches() {
+    public func invalidateCaches() {
         latestSnapshot = nil
         cachedComponentFacts = nil
         ServiceHealthChecker.shared.invalidateHealthCache()

--- a/Sources/KeyPathInstallationWizard/Core/InstallerEngine.swift
+++ b/Sources/KeyPathInstallationWizard/Core/InstallerEngine.swift
@@ -87,6 +87,9 @@ public final class InstallerEngine {
             AppLogger.shared.log("⚠️ [InstallerEngine] systemValidator not configured — returning empty context")
             return SystemContext.empty
         }
+        if freshness == .fresh {
+            validatorInstance.invalidateCaches()
+        }
         let snapshot = await validatorInstance.checkSystem(freshness: freshness)
 
         let context = SystemContext(snapshot: snapshot)
@@ -367,6 +370,11 @@ public final class InstallerEngine {
             }
         }
 
+        // Own the final observation inside the transaction. A fresh capture
+        // invalidates validator/component/health caches before collecting the
+        // post-execution evidence, so clients do not race a second observer.
+        let finalContext = await inspectSystem(freshness: .fresh)
+
         // Generate report with aggregated logs
         let success = firstFailure == nil
         let report = InstallerReport(
@@ -376,6 +384,7 @@ public final class InstallerEngine {
             },
             unmetRequirements: success ? [] : plan.blockedBy.map { [$0] } ?? [],
             executedRecipes: executedRecipes,
+            finalContext: finalContext,
             logs: allLogs,
             repairTelemetry: repairTelemetry
         )

--- a/Sources/KeyPathInstallationWizard/Core/InstallerEngine.swift
+++ b/Sources/KeyPathInstallationWizard/Core/InstallerEngine.swift
@@ -87,9 +87,6 @@ public final class InstallerEngine {
             AppLogger.shared.log("⚠️ [InstallerEngine] systemValidator not configured — returning empty context")
             return SystemContext.empty
         }
-        if freshness == .fresh {
-            validatorInstance.invalidateCaches()
-        }
         let snapshot = await validatorInstance.checkSystem(freshness: freshness)
 
         let context = SystemContext(snapshot: snapshot)
@@ -373,7 +370,11 @@ public final class InstallerEngine {
         // Own the final observation inside the transaction. A fresh capture
         // invalidates validator/component/health caches before collecting the
         // post-execution evidence, so clients do not race a second observer.
-        let finalContext = await inspectSystem(freshness: .fresh)
+        let finalContext = if plan.intent == .inspectOnly {
+            nil
+        } else {
+            await captureFreshFinalContext()
+        }
 
         // Generate report with aggregated logs
         let success = firstFailure == nil
@@ -393,6 +394,11 @@ public final class InstallerEngine {
             "✅ [InstallerEngine] execute() complete - success: \(success), recipes executed: \(executedRecipes.count)"
         )
         return report
+    }
+
+    private func captureFreshFinalContext() async -> SystemContext {
+        systemValidator?.invalidateCaches()
+        return await inspectSystem(freshness: .fresh)
     }
 
     private func makeRepairTelemetryEvent(

--- a/Sources/KeyPathInstallationWizard/Core/InstallerEngine.swift
+++ b/Sources/KeyPathInstallationWizard/Core/InstallerEngine.swift
@@ -370,7 +370,7 @@ public final class InstallerEngine {
         // Own the final observation inside the transaction. A fresh capture
         // invalidates validator/component/health caches before collecting the
         // post-execution evidence, so clients do not race a second observer.
-        let finalContext = if plan.intent == .inspectOnly {
+        let finalContext: SystemContext? = if plan.intent == .inspectOnly {
             nil
         } else {
             await captureFreshFinalContext()

--- a/Sources/KeyPathWizardCore/WizardServiceProtocols.swift
+++ b/Sources/KeyPathWizardCore/WizardServiceProtocols.swift
@@ -15,12 +15,15 @@ public enum WizardSystemSnapshotFreshness: Sendable, Equatable {
 public protocol WizardSystemValidating: AnyObject, Sendable {
     func checkSystem() async -> SystemSnapshot
     func checkSystem(freshness: WizardSystemSnapshotFreshness) async -> SystemSnapshot
+    func invalidateCaches()
 }
 
 public extension WizardSystemValidating {
     func checkSystem(freshness _: WizardSystemSnapshotFreshness) async -> SystemSnapshot {
         await checkSystem()
     }
+
+    func invalidateCaches() {}
 }
 
 // MARK: - HelperMaintenance Protocol

--- a/Tests/KeyPathTests/InstallationEngine/InstallerEngineEndToEndTests.swift
+++ b/Tests/KeyPathTests/InstallationEngine/InstallerEngineEndToEndTests.swift
@@ -160,12 +160,36 @@ final class InstallerEngineEndToEndTests: KeyPathAsyncTestCase {
         let freshContext = await engine.inspectSystem()
 
         XCTAssertEqual(validator.freshnessRequests, [.cached, .fresh])
-        XCTAssertEqual(validator.cacheInvalidationCount, 1)
+        XCTAssertEqual(validator.cacheInvalidationCount, 0)
         XCTAssertEqual(cachedContext.system, context.system)
         XCTAssertEqual(freshContext.system, context.system)
     }
 
     func testExecuteOwnsOneFreshFinalSnapshot() async {
+        let context = SystemContextBuilder().build()
+        let validator = StubSystemValidator(snapshot: Self.snapshot(from: context))
+        let engine = InstallerEngine(
+            processLifecycleManager: ProcessLifecycleManager(),
+            systemValidator: validator
+        )
+        let plan = InstallPlan(
+            recipes: [],
+            status: .ready,
+            intent: .repair
+        )
+
+        let report = await engine.execute(
+            plan: plan,
+            using: PrivilegeBroker(coordinator: StubPrivilegedOperationsCoordinator())
+        )
+
+        XCTAssertEqual(validator.freshnessRequests, [.fresh])
+        XCTAssertEqual(validator.cacheInvalidationCount, 1)
+        XCTAssertEqual(report.finalContext?.timestamp, context.timestamp)
+        XCTAssertEqual(report.finalContext?.captureStatus, context.captureStatus)
+    }
+
+    func testInspectOnlyExecuteDoesNotCaptureRedundantFinalSnapshot() async {
         let context = SystemContextBuilder().build()
         let validator = StubSystemValidator(snapshot: Self.snapshot(from: context))
         let engine = InstallerEngine(
@@ -183,10 +207,9 @@ final class InstallerEngineEndToEndTests: KeyPathAsyncTestCase {
             using: PrivilegeBroker(coordinator: StubPrivilegedOperationsCoordinator())
         )
 
-        XCTAssertEqual(validator.freshnessRequests, [.fresh])
-        XCTAssertEqual(validator.cacheInvalidationCount, 1)
-        XCTAssertEqual(report.finalContext?.timestamp, context.timestamp)
-        XCTAssertEqual(report.finalContext?.captureStatus, context.captureStatus)
+        XCTAssertTrue(validator.freshnessRequests.isEmpty)
+        XCTAssertEqual(validator.cacheInvalidationCount, 0)
+        XCTAssertNil(report.finalContext)
     }
 
     func testFailedExecuteStillOwnsOneFreshFinalSnapshot() async {

--- a/Tests/KeyPathTests/InstallationEngine/InstallerEngineEndToEndTests.swift
+++ b/Tests/KeyPathTests/InstallationEngine/InstallerEngineEndToEndTests.swift
@@ -160,8 +160,33 @@ final class InstallerEngineEndToEndTests: KeyPathAsyncTestCase {
         let freshContext = await engine.inspectSystem()
 
         XCTAssertEqual(validator.freshnessRequests, [.cached, .fresh])
+        XCTAssertEqual(validator.cacheInvalidationCount, 1)
         XCTAssertEqual(cachedContext.system, context.system)
         XCTAssertEqual(freshContext.system, context.system)
+    }
+
+    func testExecuteOwnsOneFreshFinalSnapshot() async {
+        let context = SystemContextBuilder().build()
+        let validator = StubSystemValidator(snapshot: Self.snapshot(from: context))
+        let engine = InstallerEngine(
+            processLifecycleManager: ProcessLifecycleManager(),
+            systemValidator: validator
+        )
+        let plan = InstallPlan(
+            recipes: [],
+            status: .ready,
+            intent: .inspectOnly
+        )
+
+        let report = await engine.execute(
+            plan: plan,
+            using: PrivilegeBroker(coordinator: StubPrivilegedOperationsCoordinator())
+        )
+
+        XCTAssertEqual(validator.freshnessRequests, [.fresh])
+        XCTAssertEqual(validator.cacheInvalidationCount, 1)
+        XCTAssertEqual(report.finalContext?.timestamp, context.timestamp)
+        XCTAssertEqual(report.finalContext?.captureStatus, context.captureStatus)
     }
 
     func testExecutePlanUsesForceRefreshWithoutAppleScriptForHelperReinstall() async {
@@ -301,6 +326,7 @@ private final class StubHelperMaintenance: WizardHelperMaintaining {
 private final class StubSystemValidator: WizardSystemValidating {
     private let snapshot: SystemSnapshot
     private(set) var freshnessRequests: [WizardSystemSnapshotFreshness] = []
+    private(set) var cacheInvalidationCount = 0
 
     init(snapshot: SystemSnapshot) {
         self.snapshot = snapshot
@@ -313,5 +339,9 @@ private final class StubSystemValidator: WizardSystemValidating {
     func checkSystem(freshness: WizardSystemSnapshotFreshness) async -> SystemSnapshot {
         freshnessRequests.append(freshness)
         return snapshot
+    }
+
+    func invalidateCaches() {
+        cacheInvalidationCount += 1
     }
 }

--- a/Tests/KeyPathTests/InstallationEngine/InstallerEngineEndToEndTests.swift
+++ b/Tests/KeyPathTests/InstallationEngine/InstallerEngineEndToEndTests.swift
@@ -189,6 +189,33 @@ final class InstallerEngineEndToEndTests: KeyPathAsyncTestCase {
         XCTAssertEqual(report.finalContext?.captureStatus, context.captureStatus)
     }
 
+    func testFailedExecuteStillOwnsOneFreshFinalSnapshot() async {
+        let context = SystemContextBuilder().build()
+        let validator = StubSystemValidator(snapshot: Self.snapshot(from: context))
+        let engine = InstallerEngine(
+            processLifecycleManager: ProcessLifecycleManager(),
+            systemValidator: validator
+        )
+        let plan = InstallPlan(
+            recipes: [
+                ServiceRecipe(id: "unknown-test-recipe", type: .installComponent),
+            ],
+            status: .ready,
+            intent: .repair
+        )
+
+        let report = await engine.execute(
+            plan: plan,
+            using: PrivilegeBroker(coordinator: StubPrivilegedOperationsCoordinator())
+        )
+
+        XCTAssertFalse(report.success)
+        XCTAssertEqual(validator.freshnessRequests, [.fresh])
+        XCTAssertEqual(validator.cacheInvalidationCount, 1)
+        XCTAssertEqual(report.finalContext?.timestamp, context.timestamp)
+        XCTAssertEqual(report.finalContext?.captureStatus, context.captureStatus)
+    }
+
     func testExecutePlanUsesForceRefreshWithoutAppleScriptForHelperReinstall() async {
         let coordinator = StubPrivilegedOperationsCoordinator()
         let broker = PrivilegeBroker(coordinator: coordinator)

--- a/Tests/KeyPathTests/Lint/SnapshotConsumerLintTests.swift
+++ b/Tests/KeyPathTests/Lint/SnapshotConsumerLintTests.swift
@@ -122,4 +122,19 @@ final class SnapshotConsumerLintTests: XCTestCase {
             """
         )
     }
+
+    func testCLIInstallerConsumesEngineOwnedFinalSnapshot() throws {
+        let fileURL = LintScanner.path("Sources/KeyPathAppKit/CLI/SystemFacade.swift")
+        let source = try String(contentsOf: fileURL, encoding: .utf8)
+
+        XCTAssertEqual(
+            source.components(separatedBy: "finalContext: report.finalContext").count - 1,
+            2,
+            "CLI install and repair must consume the final context captured by InstallerEngine."
+        )
+        XCTAssertFalse(
+            source.contains("report.success ? await engine.inspectSystem() : nil"),
+            "CLI clients must not race the engine-owned post-execution snapshot with a second observer."
+        )
+    }
 }

--- a/docs/planning/installer-phase-pipeline-and-modularization.md
+++ b/docs/planning/installer-phase-pipeline-and-modularization.md
@@ -270,6 +270,10 @@ snapshot.
   waited forever to reacquire the same transaction gate.
 - The first slice removes that nested engine/plan creation while preserving the
   helper-first VHID operation and adds a lint ratchet against recurrence.
+- Installed verification after that slice exposed a second-observer race: CLI
+  repair and CLI inspect could briefly disagree about TCP readiness. The next
+  slice moves the fresh, cache-invalidating final capture into the owned engine
+  transaction and makes CLI clients consume that report evidence.
 
 ### Work
 


### PR DESCRIPTION
## Summary
- make fresh installer inspection invalidate validator, component, and service-health caches
- capture one fresh final context inside `InstallerEngine.execute` while the transaction is still owned
- make CLI install and repair consume that report context instead of racing a second inspection
- add behavioral and lint coverage for the owned final snapshot contract

This is the next Milestone 3 slice after #1080 and #1081.

## Validation
- `TEST_FILTER=InstallerEngine ./Scripts/run-tests-safe.sh` (103 passed)
- `TEST_FILTER=SnapshotConsumerLintTests ./Scripts/run-tests-safe.sh` (6 passed)
- `TEST_FILTER=CLIServiceTests ./Scripts/run-tests-safe.sh` (8 passed)
- `./Scripts/run-tests-safe.sh` (4,606 passed)
- `python3 Scripts/check-accessibility.py` (354 files)
- `./Scripts/review-gate.sh` selected the remote review gate