### PR TITLE
Correlate installer run evidence

### DIFF
--- a/Sources/KeyPathAppKit/CLI/SystemFacade.swift
+++ b/Sources/KeyPathAppKit/CLI/SystemFacade.swift
@@ -504,12 +504,15 @@ public extension CLIInstallerReport {
         let finalIssues = SystemFacade.issues(from: finalContext ?? initialContext)
         let finalUserActionIssues = finalIssues.filter { !$0.canAutoFix }
         let finalOperational = finalContext.map(SystemFacade.isOperational) ?? false
-        let completedButStillBlocked = report.success && !finalOperational && !finalIssues.isEmpty
+        let completedButStillBlocked = report.success
+            && report.completionState != .awaitingApproval
+            && !finalOperational
+            && !finalIssues.isEmpty
         let failedForManualApproval = report.failureReason.map(SystemFacade.requiresManualApproval) ?? false
 
         let failureReason: String? = if let reportFailure = report.failureReason {
             reportFailure
-        } else if !finalUserActionIssues.isEmpty {
+        } else if report.completionState != .awaitingApproval, !finalUserActionIssues.isEmpty {
             SystemFacade.userActionFailureReason(
                 finalUserActionIssues,
                 prefix: "\(title) requires user action"
@@ -532,7 +535,17 @@ public extension CLIInstallerReport {
             plannedRecipes: plan.recipes.map { "\($0.id) (\($0.type))" },
             unmetRequirements: report.unmetRequirements.map(\.name),
             logs: report.logs,
-            repairTelemetry: CLIRepairTelemetryEvent.from(report.repairTelemetry)
+            repairTelemetry: CLIRepairTelemetryEvent.from(report.repairTelemetry),
+            recommendedRecovery: report.recommendedRecovery?.rawValue,
+            runID: report.runID.uuidString,
+            planID: report.planID?.uuidString,
+            beforeSnapshotID: report.beforeSnapshotID?.uuidString,
+            afterSnapshotID: report.afterSnapshotID?.uuidString,
+            completionState: report.completionState.rawValue,
+            recoveryPlanRecipes: report.recoveryPlan?.recipes.map(\.id),
+            failedPostconditions: report.failedPostconditions.isEmpty
+                ? nil
+                : report.failedPostconditions.map(\.rawValue)
         )
     }
 
@@ -562,7 +575,9 @@ public extension CLIInstallerReport {
             plannedRecipes: plan.recipes.map { "\($0.id) (\($0.type))" },
             unmetRequirements: blockedBy,
             logs: nil,
-            repairTelemetry: nil
+            repairTelemetry: nil,
+            planID: plan.id.uuidString,
+            beforeSnapshotID: plan.sourceSnapshotID?.uuidString
         )
     }
 }

--- a/Sources/KeyPathAppKit/CLI/SystemFacade.swift
+++ b/Sources/KeyPathAppKit/CLI/SystemFacade.swift
@@ -577,7 +577,8 @@ public extension CLIInstallerReport {
             logs: nil,
             repairTelemetry: nil,
             planID: plan.id.uuidString,
-            beforeSnapshotID: plan.sourceSnapshotID?.uuidString
+            beforeSnapshotID: plan.sourceSnapshotID?.uuidString,
+            completionState: blockedBy.isEmpty ? nil : InstallerCompletionState.blocked.rawValue
         )
     }
 }

--- a/Sources/KeyPathCLI/Utilities/ApplyHelper.swift
+++ b/Sources/KeyPathCLI/Utilities/ApplyHelper.swift
@@ -28,6 +28,12 @@ func formatInstallerReport(_ report: CLIInstallerReport, title: String, noColor:
         ? ANSIColor.green("Yes", noColor: noColor)
         : ANSIColor.red("No", noColor: noColor)
     lines.append("Success: \(successText)")
+    if let completionState = report.completionState {
+        lines.append("Completion State: \(completionState)")
+    }
+    if let runID = report.runID {
+        lines.append(ANSIColor.dim("Run ID: \(runID)", noColor: noColor))
+    }
 
     if let reason = report.failureReason {
         lines.append(ANSIColor.red("Failure Reason: \(reason)", noColor: noColor))
@@ -53,6 +59,22 @@ func formatInstallerReport(_ report: CLIInstallerReport, title: String, noColor:
         lines.append("Unmet Requirements:")
         for requirement in unmetRequirements {
             lines.append("  - \(requirement)")
+        }
+    }
+
+    if let failedPostconditions = report.failedPostconditions, !failedPostconditions.isEmpty {
+        lines.append("")
+        lines.append("Failed Postconditions:")
+        for postcondition in failedPostconditions {
+            lines.append("  - \(postcondition)")
+        }
+    }
+
+    if let recoveryRecipes = report.recoveryPlanRecipes, !recoveryRecipes.isEmpty {
+        lines.append("")
+        lines.append("Recommended Recovery Plan:")
+        for recipe in recoveryRecipes {
+            lines.append("  - \(recipe)")
         }
     }
 

--- a/Sources/KeyPathCLISupport/CLIReportModels.swift
+++ b/Sources/KeyPathCLISupport/CLIReportModels.swift
@@ -96,9 +96,10 @@ public struct CLIInstallerReport: Codable, Sendable {
         }
         fastRepair = false
         dryRun = nil
-        userActionRequired = report.completionState == .awaitingApproval
+        let requiresUserAction = report.completionState == .awaitingApproval
             || report.completionState == .recoveryRequired
             || report.recommendedRecovery != nil
+        userActionRequired = requiresUserAction ? true : nil
         issues = nil
         plannedRecipes = nil
         unmetRequirements = nil

--- a/Sources/KeyPathCLISupport/CLIReportModels.swift
+++ b/Sources/KeyPathCLISupport/CLIReportModels.swift
@@ -63,6 +63,11 @@ public struct CLIStatusResult: Codable, Sendable {
 }
 
 public struct CLIInstallerReport: Codable, Sendable {
+    public let runID: String?
+    public let planID: String?
+    public let beforeSnapshotID: String?
+    public let afterSnapshotID: String?
+    public let completionState: String?
     public let success: Bool
     public let failureReason: String?
     public let steps: [CLIInstallerStep]
@@ -75,8 +80,15 @@ public struct CLIInstallerReport: Codable, Sendable {
     public let logs: [String]?
     public let repairTelemetry: [CLIRepairTelemetryEvent]?
     public let recommendedRecovery: String?
+    public let recoveryPlanRecipes: [String]?
+    public let failedPostconditions: [String]?
 
     public init(from report: InstallerReport) {
+        runID = report.runID.uuidString
+        planID = report.planID?.uuidString
+        beforeSnapshotID = report.beforeSnapshotID?.uuidString
+        afterSnapshotID = report.afterSnapshotID?.uuidString
+        completionState = report.completionState.rawValue
         success = report.success
         failureReason = report.failureReason
         steps = report.executedRecipes.map {
@@ -84,16 +96,27 @@ public struct CLIInstallerReport: Codable, Sendable {
         }
         fastRepair = false
         dryRun = nil
-        userActionRequired = report.recommendedRecovery == nil ? nil : true
+        userActionRequired = report.completionState == .awaitingApproval
+            || report.completionState == .recoveryRequired
+            || report.recommendedRecovery != nil
         issues = nil
         plannedRecipes = nil
         unmetRequirements = nil
         logs = report.logs.isEmpty ? nil : report.logs
         repairTelemetry = CLIRepairTelemetryEvent.from(report.repairTelemetry)
         recommendedRecovery = report.recommendedRecovery?.rawValue
+        recoveryPlanRecipes = report.recoveryPlan?.recipes.map(\.id)
+        failedPostconditions = report.failedPostconditions.isEmpty
+            ? nil
+            : report.failedPostconditions.map(\.rawValue)
     }
 
     public init(success: Bool, failureReason: String?, steps: [CLIInstallerStep], fastRepair: Bool) {
+        runID = nil
+        planID = nil
+        beforeSnapshotID = nil
+        afterSnapshotID = nil
+        completionState = nil
         self.success = success
         self.failureReason = failureReason
         self.steps = steps
@@ -106,9 +129,16 @@ public struct CLIInstallerReport: Codable, Sendable {
         logs = nil
         repairTelemetry = nil
         recommendedRecovery = nil
+        recoveryPlanRecipes = nil
+        failedPostconditions = nil
     }
 
     public init(bundleIssue: CLISystemIssue, dryRun: Bool, title: String) {
+        runID = nil
+        planID = nil
+        beforeSnapshotID = nil
+        afterSnapshotID = nil
+        completionState = InstallerCompletionState.blocked.rawValue
         success = false
         failureReason = "\(title) requires the signed KeyPath.app bundle. \(bundleIssue.action)"
         steps = []
@@ -121,6 +151,8 @@ public struct CLIInstallerReport: Codable, Sendable {
         logs = nil
         repairTelemetry = nil
         recommendedRecovery = nil
+        recoveryPlanRecipes = nil
+        failedPostconditions = nil
     }
 
     public init(
@@ -135,8 +167,20 @@ public struct CLIInstallerReport: Codable, Sendable {
         unmetRequirements: [String]?,
         logs: [String]?,
         repairTelemetry: [CLIRepairTelemetryEvent]? = nil,
-        recommendedRecovery: String? = nil
+        recommendedRecovery: String? = nil,
+        runID: String? = nil,
+        planID: String? = nil,
+        beforeSnapshotID: String? = nil,
+        afterSnapshotID: String? = nil,
+        completionState: String? = nil,
+        recoveryPlanRecipes: [String]? = nil,
+        failedPostconditions: [String]? = nil
     ) {
+        self.runID = runID
+        self.planID = planID
+        self.beforeSnapshotID = beforeSnapshotID
+        self.afterSnapshotID = afterSnapshotID
+        self.completionState = completionState
         self.success = success
         self.failureReason = failureReason
         self.steps = steps
@@ -149,6 +193,8 @@ public struct CLIInstallerReport: Codable, Sendable {
         self.logs = logs
         self.repairTelemetry = repairTelemetry
         self.recommendedRecovery = recommendedRecovery
+        self.recoveryPlanRecipes = recoveryPlanRecipes
+        self.failedPostconditions = failedPostconditions
     }
 }
 
@@ -165,6 +211,10 @@ public struct CLIInstallerStep: Codable, Sendable {
 }
 
 public struct CLIRepairTelemetryEvent: Codable, Sendable {
+    public let runID: String?
+    public let planID: String?
+    public let beforeSnapshotID: String?
+    public let afterSnapshotID: String?
     public let trigger: String
     public let intent: String
     public let stateMatrixRow: String?
@@ -176,6 +226,10 @@ public struct CLIRepairTelemetryEvent: Codable, Sendable {
     public let error: String?
 
     public init(_ event: InstallerRepairTelemetryEvent) {
+        runID = event.runID?.uuidString
+        planID = event.planID?.uuidString
+        beforeSnapshotID = event.beforeSnapshotID?.uuidString
+        afterSnapshotID = event.afterSnapshotID?.uuidString
         trigger = event.trigger.rawValue
         intent = event.intent
         stateMatrixRow = event.stateMatrixRow

--- a/Sources/KeyPathInstallationWizard/Core/InstallerEngine.swift
+++ b/Sources/KeyPathInstallationWizard/Core/InstallerEngine.swift
@@ -400,7 +400,7 @@ public final class InstallerEngine {
         let finalContext: SystemContext? = if plan.intent == .inspectOnly {
             nil
         } else {
-            await captureFreshFinalContext()
+            await captureFreshContext()
         }
 
         var seenPostconditions = Set<InstallerPostcondition>()
@@ -535,7 +535,7 @@ public final class InstallerEngine {
             || context.requiresManualVHIDDriverApproval
     }
 
-    private func captureFreshFinalContext() async -> SystemContext {
+    private func captureFreshContext() async -> SystemContext {
         systemValidator?.invalidateCaches()
         return await inspectSystem(freshness: .fresh)
     }
@@ -944,7 +944,7 @@ public final class InstallerEngine {
                 failureReason: "Uninstall coordinator not configured"
             )
         }
-        let beforeContext = await inspectSystem()
+        let beforeContext = await captureFreshContext()
         let result = await coordinator.performUninstall(
             deleteConfig: deleteConfig,
             removeVirtualHID: removeVirtualHID,
@@ -962,7 +962,7 @@ public final class InstallerEngine {
             )
         })
 
-        let finalContext = await captureFreshFinalContext()
+        let finalContext = await captureFreshContext()
         let afterSnapshotID = finalContext.snapshotID
         let telemetry = InstallerRepairTelemetryEvent(
             runID: runID,

--- a/Sources/KeyPathInstallationWizard/Core/InstallerEngine.swift
+++ b/Sources/KeyPathInstallationWizard/Core/InstallerEngine.swift
@@ -928,7 +928,6 @@ public final class InstallerEngine {
         allowAdminFallback: Bool
     ) async -> InstallerReport {
         let runID = UUID()
-        let beforeContext = await inspectSystem()
         AppLogger.shared.log(
             "🗑️ [InstallerEngine] Starting uninstall (deleteConfig: \(deleteConfig), removeVirtualHID: \(removeVirtualHID), allowAdminFallback: \(allowAdminFallback))"
         )
@@ -940,12 +939,12 @@ public final class InstallerEngine {
             AppLogger.shared.log("⚠️ [InstallerEngine] createUninstallCoordinator not configured")
             return InstallerReport(
                 runID: runID,
-                beforeSnapshotID: beforeContext.snapshotID,
                 success: false,
                 completionState: .executionFailed,
                 failureReason: "Uninstall coordinator not configured"
             )
         }
+        let beforeContext = await inspectSystem()
         let result = await coordinator.performUninstall(
             deleteConfig: deleteConfig,
             removeVirtualHID: removeVirtualHID,

--- a/Sources/KeyPathInstallationWizard/Core/InstallerEngine.swift
+++ b/Sources/KeyPathInstallationWizard/Core/InstallerEngine.swift
@@ -116,6 +116,7 @@ public final class InstallerEngine {
                 "⚠️ [InstallerEngine] Plan blocked by requirement: \(blockingRequirement.name)"
             )
             return InstallPlan(
+                sourceSnapshotID: context.snapshotID,
                 recipes: [],
                 status: .blocked(requirement: blockingRequirement),
                 intent: intent,
@@ -138,6 +139,7 @@ public final class InstallerEngine {
         let orderedRecipes = orderRecipes(recipes)
 
         let plan = InstallPlan(
+            sourceSnapshotID: context.snapshotID,
             recipes: orderedRecipes,
             status: .ready,
             intent: intent,
@@ -245,6 +247,7 @@ public final class InstallerEngine {
         trigger: InstallerRepairTelemetryTrigger
     ) async -> InstallerReport {
         AppLogger.shared.log("⚙️ [InstallerEngine] Starting execute(plan:, using:)")
+        let runID = UUID()
 
         // Check if plan is blocked
         if case let .blocked(requirement) = plan.status {
@@ -252,6 +255,9 @@ public final class InstallerEngine {
                 "⚠️ [InstallerEngine] Plan is blocked by requirement: \(requirement.name)"
             )
             let telemetry = InstallerRepairTelemetryEvent(
+                runID: runID,
+                planID: plan.id,
+                beforeSnapshotID: plan.sourceSnapshotID,
                 trigger: trigger,
                 intent: plan.intent.telemetryValue,
                 stateMatrixRow: plan.metadata.stateMatrixRow,
@@ -263,7 +269,11 @@ public final class InstallerEngine {
                 error: requirement.name
             )
             return InstallerReport(
+                runID: runID,
+                planID: plan.id,
+                beforeSnapshotID: plan.sourceSnapshotID,
                 success: false,
+                completionState: .blocked,
                 failureReason: "Plan blocked by requirement: \(requirement.name)",
                 unmetRequirements: [requirement],
                 executedRecipes: [],
@@ -472,22 +482,57 @@ public final class InstallerEngine {
             operationFailure ?? verificationFailure
         }
 
+        let completionState: InstallerCompletionState = if success {
+            if finalContext.map(requiresManualApproval) == true {
+                .awaitingApproval
+            } else if firstFailure != nil {
+                .verifiedAfterOperationError
+            } else {
+                .completed
+            }
+        } else if verificationFailure != nil {
+            .verificationFailed
+        } else {
+            .executionFailed
+        }
+        let afterSnapshotID = finalContext?.snapshotID
+        let telemetryWithEvidence = repairTelemetry.map { event in
+            event.attachingRunEvidence(
+                runID: runID,
+                planID: plan.id,
+                beforeSnapshotID: plan.sourceSnapshotID,
+                afterSnapshotID: afterSnapshotID
+            )
+        }
+
         // Generate report with aggregated logs
         let report = InstallerReport(
+            runID: runID,
+            planID: plan.id,
+            beforeSnapshotID: plan.sourceSnapshotID,
+            afterSnapshotID: afterSnapshotID,
             success: success,
+            completionState: completionState,
             failureReason: failureReason,
             unmetRequirements: success ? [] : plan.blockedBy.map { [$0] } ?? [],
             executedRecipes: executedRecipes,
             finalContext: finalContext,
             logs: allLogs,
-            repairTelemetry: repairTelemetry,
-            recoveryPlan: recoveryPlan
+            repairTelemetry: telemetryWithEvidence,
+            recoveryPlan: recoveryPlan,
+            failedPostconditions: failedPostconditions
         )
 
         AppLogger.shared.log(
             "✅ [InstallerEngine] execute() complete - success: \(success), recipes executed: \(executedRecipes.count)"
         )
         return report
+    }
+
+    private func requiresManualApproval(_ context: SystemContext) -> Bool {
+        context.helper.requiresApproval
+            || context.services.loginItemsApprovalRequired == true
+            || context.requiresManualVHIDDriverApproval
     }
 
     private func captureFreshFinalContext() async -> SystemContext {
@@ -882,6 +927,8 @@ public final class InstallerEngine {
         removeVirtualHID: Bool,
         allowAdminFallback: Bool
     ) async -> InstallerReport {
+        let runID = UUID()
+        let beforeContext = await inspectSystem()
         AppLogger.shared.log(
             "🗑️ [InstallerEngine] Starting uninstall (deleteConfig: \(deleteConfig), removeVirtualHID: \(removeVirtualHID), allowAdminFallback: \(allowAdminFallback))"
         )
@@ -892,7 +939,10 @@ public final class InstallerEngine {
         guard let coordinator = WizardDependencies.createUninstallCoordinator?() else {
             AppLogger.shared.log("⚠️ [InstallerEngine] createUninstallCoordinator not configured")
             return InstallerReport(
+                runID: runID,
+                beforeSnapshotID: beforeContext.snapshotID,
                 success: false,
+                completionState: .executionFailed,
                 failureReason: "Uninstall coordinator not configured"
             )
         }
@@ -913,24 +963,41 @@ public final class InstallerEngine {
             )
         })
 
+        let finalContext = await captureFreshFinalContext()
+        let afterSnapshotID = finalContext.snapshotID
+        let telemetry = InstallerRepairTelemetryEvent(
+            runID: runID,
+            beforeSnapshotID: beforeContext.snapshotID,
+            afterSnapshotID: afterSnapshotID,
+            trigger: .uninstall,
+            intent: InstallIntent.uninstall.telemetryValue,
+            stateMatrixRow: nil,
+            stateMatrixPlan: [],
+            action: deleteConfig ? "uninstall-with-config" : "uninstall",
+            recipeID: deleteConfig ? "uninstall-with-config" : "uninstall",
+            recipeType: "uninstall",
+            postconditionResult: result.success ? .succeeded : .failed,
+            error: result.success ? nil : failure
+        )
+        let completionState: InstallerCompletionState = if result.success {
+            .completed
+        } else if result.recommendedRecovery != nil {
+            .recoveryRequired
+        } else {
+            .executionFailed
+        }
+
         let report = InstallerReport(
+            runID: runID,
+            beforeSnapshotID: beforeContext.snapshotID,
+            afterSnapshotID: afterSnapshotID,
             success: result.success,
+            completionState: completionState,
             failureReason: result.success ? nil : failure,
             executedRecipes: componentResults,
+            finalContext: finalContext,
             logs: result.logs,
-            repairTelemetry: [
-                InstallerRepairTelemetryEvent(
-                    trigger: .uninstall,
-                    intent: InstallIntent.uninstall.telemetryValue,
-                    stateMatrixRow: nil,
-                    stateMatrixPlan: [],
-                    action: deleteConfig ? "uninstall-with-config" : "uninstall",
-                    recipeID: deleteConfig ? "uninstall-with-config" : "uninstall",
-                    recipeType: "uninstall",
-                    postconditionResult: result.success ? .succeeded : .failed,
-                    error: result.success ? nil : failure
-                ),
-            ],
+            repairTelemetry: [telemetry],
             recommendedRecovery: result.recommendedRecovery
         )
 
@@ -985,6 +1052,7 @@ public final class InstallerEngine {
         // own failure and postcondition checks.
         let shouldPreserveBaseBlocker = !filteredRecipes.isEmpty
         let filteredPlan = InstallPlan(
+            sourceSnapshotID: context.snapshotID,
             recipes: finalRecipes,
             status: shouldPreserveBaseBlocker ? basePlan.status : .ready,
             intent: basePlan.intent,

--- a/Sources/KeyPathInstallationWizard/Core/InstallerEngineTypes.swift
+++ b/Sources/KeyPathInstallationWizard/Core/InstallerEngineTypes.swift
@@ -62,6 +62,8 @@ public struct Requirement: Sendable, Equatable {
 /// Snapshot of detected system state.
 /// Consolidates data from SystemValidator/SystemRequirements into a façade-friendly type.
 public struct SystemContext: Sendable {
+    /// Identity of the canonical snapshot projected into this context.
+    public let snapshotID: UUID
     /// Current permission status (Input Monitoring, Accessibility, Full Disk Access)
     public let permissions: PermissionOracle.Snapshot
     /// Status of all services (Kanata, VHID daemon, VHID manager)
@@ -85,6 +87,7 @@ public struct SystemContext: Sendable {
     }
 
     public init(
+        snapshotID: UUID = UUID(),
         permissions: PermissionOracle.Snapshot,
         services: HealthStatus,
         conflicts: ConflictStatus,
@@ -95,6 +98,7 @@ public struct SystemContext: Sendable {
         captureStatus: SystemSnapshotCaptureStatus = .complete,
         timedOut: Bool = false
     ) {
+        self.snapshotID = snapshotID
         self.permissions = permissions
         self.services = services
         self.conflicts = conflicts
@@ -107,6 +111,7 @@ public struct SystemContext: Sendable {
 
     public init(snapshot: SystemSnapshot) {
         self.init(
+            snapshotID: snapshot.id,
             permissions: snapshot.permissions,
             services: snapshot.health,
             conflicts: snapshot.conflicts,
@@ -327,6 +332,10 @@ public struct PlanMetadata: Sendable, Equatable {
 
 /// Ordered collection of operations to execute.
 public struct InstallPlan: Sendable, Equatable {
+    /// Stable identity for this exact ordered plan.
+    public let id: UUID
+    /// Snapshot that supplied the evidence used to build this plan.
+    public let sourceSnapshotID: UUID?
     /// Ordered list of operations (respects dependencies)
     public let recipes: [ServiceRecipe]
     /// Current plan state
@@ -348,6 +357,8 @@ public struct InstallPlan: Sendable, Equatable {
     }
 
     public init(
+        id: UUID = UUID(),
+        sourceSnapshotID: UUID? = nil,
         recipes: [ServiceRecipe],
         status: PlanStatus,
         intent: InstallIntent,
@@ -355,6 +366,8 @@ public struct InstallPlan: Sendable, Equatable {
         metadata: PlanMetadata = PlanMetadata(),
         initialPostconditionStates: [InstallerPostcondition: Bool]? = nil
     ) {
+        self.id = id
+        self.sourceSnapshotID = sourceSnapshotID
         self.recipes = recipes
         self.status = status
         self.intent = intent
@@ -380,11 +393,26 @@ public enum InstallerRepairTelemetryResult: String, Codable, Sendable, Equatable
     case skipped
 }
 
+/// Machine-readable terminal state shared by app and CLI clients.
+public enum InstallerCompletionState: String, Codable, Sendable, Equatable {
+    case completed
+    case awaitingApproval = "awaiting-approval"
+    case verifiedAfterOperationError = "verified-after-operation-error"
+    case blocked
+    case executionFailed = "execution-failed"
+    case verificationFailed = "verification-failed"
+    case recoveryRequired = "recovery-required"
+}
+
 /// Machine-readable repair/install execution trace used by CLI JSON and tests.
 ///
 /// This is intentionally local to the installer report: it is not persisted,
 /// uploaded, or used to drive repair policy.
 public struct InstallerRepairTelemetryEvent: Codable, Sendable, Equatable {
+    public let runID: UUID?
+    public let planID: UUID?
+    public let beforeSnapshotID: UUID?
+    public let afterSnapshotID: UUID?
     public let timestamp: Date
     public let trigger: InstallerRepairTelemetryTrigger
     public let intent: String
@@ -398,6 +426,10 @@ public struct InstallerRepairTelemetryEvent: Codable, Sendable, Equatable {
 
     public init(
         timestamp: Date = Date(),
+        runID: UUID? = nil,
+        planID: UUID? = nil,
+        beforeSnapshotID: UUID? = nil,
+        afterSnapshotID: UUID? = nil,
         trigger: InstallerRepairTelemetryTrigger,
         intent: String,
         stateMatrixRow: String?,
@@ -409,6 +441,10 @@ public struct InstallerRepairTelemetryEvent: Codable, Sendable, Equatable {
         error: String? = nil
     ) {
         self.timestamp = timestamp
+        self.runID = runID
+        self.planID = planID
+        self.beforeSnapshotID = beforeSnapshotID
+        self.afterSnapshotID = afterSnapshotID
         self.trigger = trigger
         self.intent = intent
         self.stateMatrixRow = stateMatrixRow
@@ -418,6 +454,30 @@ public struct InstallerRepairTelemetryEvent: Codable, Sendable, Equatable {
         self.recipeType = recipeType
         self.postconditionResult = postconditionResult
         self.error = error
+    }
+
+    public func attachingRunEvidence(
+        runID: UUID,
+        planID: UUID?,
+        beforeSnapshotID: UUID?,
+        afterSnapshotID: UUID?
+    ) -> InstallerRepairTelemetryEvent {
+        InstallerRepairTelemetryEvent(
+            timestamp: timestamp,
+            runID: runID,
+            planID: planID,
+            beforeSnapshotID: beforeSnapshotID,
+            afterSnapshotID: afterSnapshotID,
+            trigger: trigger,
+            intent: intent,
+            stateMatrixRow: stateMatrixRow,
+            stateMatrixPlan: stateMatrixPlan,
+            action: action,
+            recipeID: recipeID,
+            recipeType: recipeType,
+            postconditionResult: postconditionResult,
+            error: error
+        )
     }
 }
 
@@ -459,6 +519,12 @@ public struct RecipeResult: Sendable, Equatable {
 
 /// Comprehensive execution summary for installation/repair operations
 public struct InstallerReport: Sendable {
+    /// Stable identity for this execution attempt.
+    public let runID: UUID
+    public let planID: UUID?
+    public let beforeSnapshotID: UUID?
+    public let afterSnapshotID: UUID?
+    public let completionState: InstallerCompletionState
     /// When execution completed
     public let timestamp: Date
     /// Overall success/failure
@@ -479,10 +545,17 @@ public struct InstallerReport: Sendable {
     public let recommendedRecovery: WizardUninstallRecoveryAction?
     /// Newly planned repair work when declared post-execution state was not reached.
     public let recoveryPlan: InstallPlan?
+    /// Declared postconditions that were not satisfied by final evidence.
+    public let failedPostconditions: [InstallerPostcondition]
 
     public init(
+        runID: UUID = UUID(),
+        planID: UUID? = nil,
+        beforeSnapshotID: UUID? = nil,
+        afterSnapshotID: UUID? = nil,
         timestamp: Date = Date(),
         success: Bool,
+        completionState: InstallerCompletionState? = nil,
         failureReason: String? = nil,
         unmetRequirements: [Requirement] = [],
         executedRecipes: [RecipeResult] = [],
@@ -490,10 +563,16 @@ public struct InstallerReport: Sendable {
         logs: [String] = [],
         repairTelemetry: [InstallerRepairTelemetryEvent] = [],
         recommendedRecovery: WizardUninstallRecoveryAction? = nil,
-        recoveryPlan: InstallPlan? = nil
+        recoveryPlan: InstallPlan? = nil,
+        failedPostconditions: [InstallerPostcondition] = []
     ) {
+        self.runID = runID
+        self.planID = planID
+        self.beforeSnapshotID = beforeSnapshotID
+        self.afterSnapshotID = afterSnapshotID
         self.timestamp = timestamp
         self.success = success
+        self.completionState = completionState ?? (success ? .completed : .executionFailed)
         self.failureReason = failureReason
         self.unmetRequirements = unmetRequirements
         self.executedRecipes = executedRecipes
@@ -502,6 +581,7 @@ public struct InstallerReport: Sendable {
         self.repairTelemetry = repairTelemetry
         self.recommendedRecovery = recommendedRecovery
         self.recoveryPlan = recoveryPlan
+        self.failedPostconditions = failedPostconditions
     }
 }
 

--- a/Sources/KeyPathWizardCore/SystemSnapshot.swift
+++ b/Sources/KeyPathWizardCore/SystemSnapshot.swift
@@ -31,6 +31,8 @@ public struct SystemCompatibilityStatus: Sendable, Equatable {
 /// Complete snapshot of system state at a point in time
 /// This is a pure data structure with no side effects - just state and computed properties
 public struct SystemSnapshot: Sendable {
+    /// Stable identity for correlating the evidence across planning and reports.
+    public let id: UUID
     public let permissions: PermissionOracle.Snapshot
     public let components: ComponentStatus
     public let conflicts: ConflictStatus
@@ -41,6 +43,7 @@ public struct SystemSnapshot: Sendable {
     public let captureStatus: SystemSnapshotCaptureStatus
 
     public init(
+        id: UUID = UUID(),
         permissions: PermissionOracle.Snapshot,
         components: ComponentStatus,
         conflicts: ConflictStatus,
@@ -50,6 +53,7 @@ public struct SystemSnapshot: Sendable {
         timestamp: Date,
         captureStatus: SystemSnapshotCaptureStatus = .complete
     ) {
+        self.id = id
         self.permissions = permissions
         self.components = components
         self.conflicts = conflicts

--- a/Tests/KeyPathCLISupportTests/CLIReportModelsTests.swift
+++ b/Tests/KeyPathCLISupportTests/CLIReportModelsTests.swift
@@ -92,6 +92,7 @@ final class CLIReportModelsTests: XCTestCase {
         XCTAssertEqual(decoded.beforeSnapshotID, beforeSnapshotID.uuidString)
         XCTAssertEqual(decoded.afterSnapshotID, afterSnapshotID.uuidString)
         XCTAssertEqual(decoded.completionState, "completed")
+        XCTAssertNil(decoded.userActionRequired)
         XCTAssertEqual(event.runID, runID.uuidString)
         XCTAssertEqual(event.planID, planID.uuidString)
         XCTAssertEqual(event.beforeSnapshotID, beforeSnapshotID.uuidString)

--- a/Tests/KeyPathCLISupportTests/CLIReportModelsTests.swift
+++ b/Tests/KeyPathCLISupportTests/CLIReportModelsTests.swift
@@ -47,14 +47,27 @@ final class CLIReportModelsTests: XCTestCase {
     }
 
     func testInstallerReportRepairTelemetryJSONShape() throws {
+        let runID = UUID()
+        let planID = UUID()
+        let beforeSnapshotID = UUID()
+        let afterSnapshotID = UUID()
         let installerReport = InstallerReport(
+            runID: runID,
+            planID: planID,
+            beforeSnapshotID: beforeSnapshotID,
+            afterSnapshotID: afterSnapshotID,
             success: true,
+            completionState: .completed,
             executedRecipes: [
                 RecipeResult(recipeID: InstallerRecipeID.createConfigDirectories, success: true),
             ],
             repairTelemetry: [
                 InstallerRepairTelemetryEvent(
                     timestamp: Date(timeIntervalSince1970: 0),
+                    runID: runID,
+                    planID: planID,
+                    beforeSnapshotID: beforeSnapshotID,
+                    afterSnapshotID: afterSnapshotID,
                     trigger: .executePlan,
                     intent: "repair",
                     stateMatrixRow: InstallerStateMatrixRow.freshInstallMissingComponents.rawValue,
@@ -74,6 +87,15 @@ final class CLIReportModelsTests: XCTestCase {
         let data = try encoder.encode(report)
         let decoded = try decoder.decode(CLIInstallerReport.self, from: data)
         let event = try XCTUnwrap(decoded.repairTelemetry?.first)
+        XCTAssertEqual(decoded.runID, runID.uuidString)
+        XCTAssertEqual(decoded.planID, planID.uuidString)
+        XCTAssertEqual(decoded.beforeSnapshotID, beforeSnapshotID.uuidString)
+        XCTAssertEqual(decoded.afterSnapshotID, afterSnapshotID.uuidString)
+        XCTAssertEqual(decoded.completionState, "completed")
+        XCTAssertEqual(event.runID, runID.uuidString)
+        XCTAssertEqual(event.planID, planID.uuidString)
+        XCTAssertEqual(event.beforeSnapshotID, beforeSnapshotID.uuidString)
+        XCTAssertEqual(event.afterSnapshotID, afterSnapshotID.uuidString)
         XCTAssertEqual(event.trigger, "execute-plan")
         XCTAssertEqual(event.intent, "repair")
         XCTAssertEqual(event.stateMatrixRow, InstallerStateMatrixRow.freshInstallMissingComponents.rawValue)

--- a/Tests/KeyPathTests/CLI/CLIOutputContractTests.swift
+++ b/Tests/KeyPathTests/CLI/CLIOutputContractTests.swift
@@ -152,6 +152,23 @@ final class CLIOutputContractTests: XCTestCase {
         XCTAssertEqual(report.completionState, "awaiting-approval")
     }
 
+    func testDryRunBlockedPlanReportsStructuredBlockedState() {
+        let context = SystemContextBuilder.degradedRepair()
+        let requirement = Requirement(name: "Manual approval", status: .blocked)
+        let plan = InstallPlan(
+            sourceSnapshotID: context.snapshotID,
+            recipes: [],
+            status: .blocked(requirement: requirement),
+            intent: .repair,
+            blockedBy: requirement
+        )
+
+        let report = CLIInstallerReport(dryRunPlan: plan, context: context, title: "Repair")
+
+        XCTAssertFalse(report.success)
+        XCTAssertEqual(report.completionState, "blocked")
+    }
+
     func testInstallerReportLinksTerminalInputCaptureFailureToTroubleshooting() {
         let context = SystemContextBuilder(
             permissionsStatus: .granted,

--- a/Tests/KeyPathTests/CLI/CLIOutputContractTests.swift
+++ b/Tests/KeyPathTests/CLI/CLIOutputContractTests.swift
@@ -81,13 +81,23 @@ final class CLIOutputContractTests: XCTestCase {
 
     func testInstallerReportMarksActivationApprovalTimeoutAsUserActionRequired() {
         let context = SystemContextBuilder.degradedRepair()
+        let planID = UUID()
         let plan = InstallPlan(
+            id: planID,
+            sourceSnapshotID: context.snapshotID,
             recipes: [],
             status: .ready,
             intent: .repair
         )
+        let runID = UUID()
+        let afterSnapshotID = UUID()
         let installerReport = InstallerReport(
+            runID: runID,
+            planID: planID,
+            beforeSnapshotID: context.snapshotID,
+            afterSnapshotID: afterSnapshotID,
             success: false,
+            completionState: .verificationFailed,
             failureReason: "VHID Manager activation failed: timed out after 20s. VirtualHID activation may be waiting for macOS approval. Open System Settings > Privacy & Security and approve the Karabiner VirtualHIDDevice system extension, then retry repair."
         )
 
@@ -100,6 +110,46 @@ final class CLIOutputContractTests: XCTestCase {
         )
 
         XCTAssertEqual(report.userActionRequired, true)
+        XCTAssertEqual(report.runID, runID.uuidString)
+        XCTAssertEqual(report.planID, planID.uuidString)
+        XCTAssertEqual(report.beforeSnapshotID, context.snapshotID.uuidString)
+        XCTAssertEqual(report.afterSnapshotID, afterSnapshotID.uuidString)
+        XCTAssertEqual(report.completionState, "verification-failed")
+    }
+
+    func testInstallerReportPreservesStructuredAwaitingApprovalOutcome() {
+        let context = SystemContextBuilder(
+            helperReady: false,
+            helperRequiresApproval: true,
+            loginItemsApprovalRequired: true
+        ).build()
+        let plan = InstallPlan(
+            sourceSnapshotID: context.snapshotID,
+            recipes: [],
+            status: .ready,
+            intent: .install
+        )
+        let installerReport = InstallerReport(
+            planID: plan.id,
+            beforeSnapshotID: context.snapshotID,
+            afterSnapshotID: context.snapshotID,
+            success: true,
+            completionState: .awaitingApproval,
+            finalContext: context
+        )
+
+        let report = CLIInstallerReport(
+            from: installerReport,
+            initialContext: context,
+            finalContext: context,
+            plan: plan,
+            title: "Install"
+        )
+
+        XCTAssertTrue(report.success)
+        XCTAssertNil(report.failureReason)
+        XCTAssertEqual(report.userActionRequired, true)
+        XCTAssertEqual(report.completionState, "awaiting-approval")
     }
 
     func testInstallerReportLinksTerminalInputCaptureFailureToTroubleshooting() {

--- a/Tests/KeyPathTests/InstallationEngine/InstallerEngineEndToEndTests.swift
+++ b/Tests/KeyPathTests/InstallationEngine/InstallerEngineEndToEndTests.swift
@@ -98,6 +98,7 @@ final class InstallerEngineEndToEndTests: KeyPathAsyncTestCase {
         )
         XCTAssertEqual(report.repairTelemetry.last?.action, InstallerRecipeID.verifyPostconditions)
         XCTAssertEqual(report.repairTelemetry.last?.postconditionResult, .succeeded)
+        XCTAssertEqual(report.completionState, .verifiedAfterOperationError)
     }
 
     func testExecuteDoesNotMaskFailureWhenPostconditionWasAlreadySatisfied() async {
@@ -382,6 +383,73 @@ final class InstallerEngineEndToEndTests: KeyPathAsyncTestCase {
         XCTAssertEqual(report.finalContext?.captureStatus, context.captureStatus)
     }
 
+    func testExecuteCarriesPlanAndSnapshotEvidenceThroughReportAndTelemetry() async {
+        let finalSnapshotID = UUID()
+        let context = SystemContextBuilder(snapshotID: finalSnapshotID).build()
+        let validator = StubSystemValidator(snapshot: Self.snapshot(from: context))
+        let engine = InstallerEngine(
+            processLifecycleManager: ProcessLifecycleManager(),
+            systemValidator: validator
+        )
+        let beforeSnapshotID = UUID()
+        let plan = InstallPlan(
+            sourceSnapshotID: beforeSnapshotID,
+            recipes: [],
+            status: .ready,
+            intent: .repair
+        )
+
+        let report = await engine.execute(
+            plan: plan,
+            using: PrivilegeBroker(coordinator: StubPrivilegedOperationsCoordinator())
+        )
+
+        XCTAssertEqual(report.planID, plan.id)
+        XCTAssertEqual(report.beforeSnapshotID, beforeSnapshotID)
+        XCTAssertEqual(report.afterSnapshotID, finalSnapshotID)
+        XCTAssertEqual(report.finalContext?.snapshotID, finalSnapshotID)
+        XCTAssertEqual(report.completionState, .completed)
+        XCTAssertFalse(report.repairTelemetry.isEmpty)
+        for event in report.repairTelemetry {
+            XCTAssertEqual(event.runID, report.runID)
+            XCTAssertEqual(event.planID, plan.id)
+            XCTAssertEqual(event.beforeSnapshotID, beforeSnapshotID)
+            XCTAssertEqual(event.afterSnapshotID, finalSnapshotID)
+        }
+    }
+
+    func testExecuteReportsAwaitingApprovalFromFinalSnapshot() async {
+        let context = SystemContextBuilder(
+            helperReady: false,
+            helperRequiresApproval: true,
+            loginItemsApprovalRequired: true
+        ).build()
+        let validator = StubSystemValidator(snapshot: Self.snapshot(from: context))
+        let engine = InstallerEngine(
+            processLifecycleManager: ProcessLifecycleManager(),
+            systemValidator: validator
+        )
+        let plan = InstallPlan(
+            recipes: [
+                ServiceRecipe(
+                    id: InstallerRecipeID.createConfigDirectories,
+                    type: .installComponent,
+                    expectedPostconditions: [.helperReadyOrApprovalPending]
+                )
+            ],
+            status: .ready,
+            intent: .install
+        )
+
+        let report = await engine.execute(
+            plan: plan,
+            using: PrivilegeBroker(coordinator: StubPrivilegedOperationsCoordinator())
+        )
+
+        XCTAssertTrue(report.success)
+        XCTAssertEqual(report.completionState, .awaitingApproval)
+    }
+
     func testInspectOnlyExecuteDoesNotCaptureRedundantFinalSnapshot() async {
         let context = SystemContextBuilder().build()
         let validator = StubSystemValidator(snapshot: Self.snapshot(from: context))
@@ -466,6 +534,9 @@ final class InstallerEngineEndToEndTests: KeyPathAsyncTestCase {
         )
         XCTAssertNotNil(report.recoveryPlan)
         XCTAssertEqual(report.recoveryPlan?.intent, .repair)
+        XCTAssertEqual(report.recoveryPlan?.sourceSnapshotID, context.snapshotID)
+        XCTAssertEqual(report.completionState, .verificationFailed)
+        XCTAssertEqual(report.failedPostconditions, [.runtimeReadyOrApprovalPending])
         XCTAssertEqual(report.repairTelemetry.last?.action, InstallerRecipeID.verifyPostconditions)
         XCTAssertEqual(report.repairTelemetry.last?.postconditionResult, .failed)
     }
@@ -588,6 +659,7 @@ final class InstallerEngineEndToEndTests: KeyPathAsyncTestCase {
 
     private static func snapshot(from context: SystemContext) -> SystemSnapshot {
         SystemSnapshot(
+            id: context.snapshotID,
             permissions: context.permissions,
             components: context.components,
             conflicts: context.conflicts,

--- a/Tests/KeyPathTests/InstallationEngine/InstallerEngineFailurePathTests.swift
+++ b/Tests/KeyPathTests/InstallationEngine/InstallerEngineFailurePathTests.swift
@@ -318,6 +318,40 @@ final class InstallerEngineFailurePathTests: KeyPathAsyncTestCase {
         XCTAssertFalse(report.executedRecipes[0].success)
     }
 
+    func testUninstallCorrelatesFreshBeforeAndAfterEvidence() async {
+        let savedFactory = WizardDependencies.createUninstallCoordinator
+        let coordinator = StubWizardUninstaller(result: WizardUninstallResult(
+            success: true,
+            steps: [WizardUninstallStepResult(id: "verify-uninstall", success: true)]
+        ))
+        WizardDependencies.createUninstallCoordinator = { coordinator }
+        defer { WizardDependencies.createUninstallCoordinator = savedFactory }
+
+        let beforeContext = SystemContextBuilder(snapshotID: UUID()).build()
+        let afterContext = SystemContextBuilder(snapshotID: UUID()).build()
+        let validator = StubSystemValidator(contexts: [beforeContext, afterContext])
+        let engine = InstallerEngine(
+            processLifecycleManager: ProcessLifecycleManager(),
+            systemValidator: validator
+        )
+
+        let report = await engine.uninstall(
+            deleteConfig: false,
+            using: PrivilegeBroker(coordinator: StubPrivilegedOperationsCoordinator())
+        )
+
+        XCTAssertTrue(report.success)
+        XCTAssertEqual(report.beforeSnapshotID, beforeContext.snapshotID)
+        XCTAssertEqual(report.afterSnapshotID, afterContext.snapshotID)
+        XCTAssertEqual(report.finalContext?.snapshotID, afterContext.snapshotID)
+        XCTAssertEqual(report.completionState, .completed)
+        XCTAssertEqual(validator.freshnessRequests, [.fresh, .fresh])
+        XCTAssertEqual(validator.cacheInvalidationCount, 2)
+        XCTAssertEqual(report.repairTelemetry.first?.runID, report.runID)
+        XCTAssertEqual(report.repairTelemetry.first?.beforeSnapshotID, beforeContext.snapshotID)
+        XCTAssertEqual(report.repairTelemetry.first?.afterSnapshotID, afterContext.snapshotID)
+    }
+
     // MARK: - Report Structure Tests
 
     func testReport_FailureReasonIncludesRecipeID() async throws {

--- a/Tests/KeyPathTests/InstallationEngine/InstallerEngineFailurePathTests.swift
+++ b/Tests/KeyPathTests/InstallationEngine/InstallerEngineFailurePathTests.swift
@@ -263,12 +263,19 @@ final class InstallerEngineFailurePathTests: KeyPathAsyncTestCase {
         let savedFactory = WizardDependencies.createUninstallCoordinator
         WizardDependencies.createUninstallCoordinator = nil
         defer { WizardDependencies.createUninstallCoordinator = savedFactory }
+        let validator = StubSystemValidator(context: SystemContextBuilder.cleanInstall())
+        let engine = InstallerEngine(
+            processLifecycleManager: ProcessLifecycleManager(),
+            systemValidator: validator
+        )
 
         let broker = PrivilegeBroker(coordinator: StubPrivilegedOperationsCoordinator())
         let report = await engine.uninstall(deleteConfig: false, using: broker)
 
         XCTAssertFalse(report.success)
         XCTAssertTrue(report.failureReason?.contains("not configured") ?? false)
+        XCTAssertTrue(validator.freshnessRequests.isEmpty)
+        XCTAssertEqual(validator.cacheInvalidationCount, 0)
     }
 
     func testRun_UninstallDelegatesToUninstallMethod() async {

--- a/Tests/KeyPathTests/InstallationEngine/InstallerEnginePlanTests.swift
+++ b/Tests/KeyPathTests/InstallationEngine/InstallerEnginePlanTests.swift
@@ -14,6 +14,7 @@ final class InstallerEnginePlanTests: KeyPathAsyncTestCase {
         let ids = plan.recipes.map(\.id)
 
         XCTAssertFalse(ids.isEmpty, "Install plan should produce recipes for clean installs")
+        XCTAssertEqual(plan.sourceSnapshotID, context.snapshotID)
         XCTAssertTrue(ids.contains(InstallerRecipeID.installRequiredRuntimeServices), "Should install required runtime services")
         XCTAssertTrue(ids.contains(InstallerRecipeID.installMissingComponents), "Should install missing components")
         XCTAssertTrue(plan.expectedPostconditions.contains(.runtimeReadyOrApprovalPending))

--- a/Tests/KeyPathTests/TestSupport/StubSystemValidator.swift
+++ b/Tests/KeyPathTests/TestSupport/StubSystemValidator.swift
@@ -50,6 +50,7 @@ final class StubSystemValidator: WizardSystemValidating {
 
     private static func snapshot(from context: SystemContext) -> SystemSnapshot {
         SystemSnapshot(
+            id: context.snapshotID,
             permissions: context.permissions,
             components: context.components,
             conflicts: context.conflicts,

--- a/Tests/KeyPathTests/TestSupport/SystemContextBuilder.swift
+++ b/Tests/KeyPathTests/TestSupport/SystemContextBuilder.swift
@@ -6,8 +6,10 @@ import KeyPathWizardCore
 
 /// Tiny helper to construct SystemContext for planner/engine tests without touching real system state.
 struct SystemContextBuilder {
+    var snapshotID = UUID()
     var permissionsStatus: PermissionOracle.Status = .granted
     var helperReady: Bool = true
+    var helperRequiresApproval: Bool = false
     var servicesHealthy: Bool = false
     var kanataLaunchdLoaded: Bool?
     var kanataProcessRunning: Bool?
@@ -15,6 +17,7 @@ struct SystemContextBuilder {
     var kanataRunning: Bool?
     var karabinerDaemonRunning: Bool?
     var vhidHealthy: Bool?
+    var loginItemsApprovalRequired: Bool?
     var kanataInputCaptureReady: Bool = true
     /// The input-capture failure reason surfaced when not ready (#624 attribution).
     /// Defaults to the built-in-keyboard permission reason; set to a grab-failure
@@ -38,7 +41,12 @@ struct SystemContextBuilder {
             timestamp: Date()
         )
 
-        let helper = HelperStatus(isInstalled: helperReady, version: "1.0", isWorking: helperReady)
+        let helper = HelperStatus(
+            isInstalled: helperReady || helperRequiresApproval,
+            version: "1.0",
+            isWorking: helperReady,
+            requiresApproval: helperRequiresApproval
+        )
 
         let components: ComponentStatus = if componentsInstalled {
             ComponentStatus(
@@ -62,12 +70,14 @@ struct SystemContextBuilder {
             karabinerDaemonRunning: karabinerDaemonRunning ?? servicesHealthy,
             vhidHealthy: vhidHealthy ?? servicesHealthy,
             kanataInputCaptureReady: kanataInputCaptureReady,
-            kanataInputCaptureIssue: kanataInputCaptureReady ? nil : kanataInputCaptureIssue
+            kanataInputCaptureIssue: kanataInputCaptureReady ? nil : kanataInputCaptureIssue,
+            loginItemsApprovalRequired: loginItemsApprovalRequired
         )
 
         let conflictStatus = ConflictStatus(conflicts: conflicts, canAutoResolve: !conflicts.isEmpty)
 
         return SystemContext(
+            snapshotID: snapshotID,
             permissions: permissions,
             services: services,
             conflicts: conflictStatus,

--- a/docs/planning/installer-phase-pipeline-and-modularization.md
+++ b/docs/planning/installer-phase-pipeline-and-modularization.md
@@ -279,6 +279,10 @@ snapshot.
   lost operation reply as success only when a complete pre-run baseline proves
   the failed recipe's state transitioned from unsatisfied to satisfied, and
   attaches a newly classified repair plan when verification fails.
+- Snapshots, plans, runs, reports, and per-step telemetry now carry stable,
+  correlated identities. App and CLI report paths expose one structured
+  completion state, including approval-pending, verified lost replies,
+  verification failure, and explicit recovery-required outcomes.
 
 ### Work
 


### PR DESCRIPTION
## Summary
- assign stable IDs to snapshots, plans, and installer runs
- correlate before/after evidence through reports and per-step telemetry
- expose shared structured completion and recovery states through app and CLI report paths
- preserve approval-pending as a successful operation that still requires user action

## Validation
- `TEST_FILTER=InstallerEngine ./Scripts/run-tests-safe.sh` (114 passed)
- `TEST_FILTER=CLIReportModelsTests ./Scripts/run-tests-safe.sh` (4 passed)
- `TEST_FILTER=CLIOutputContractTests ./Scripts/run-tests-safe.sh` (12 passed)
- broad non-visual suite: 3,690 passed, 41 skipped
- `python3 Scripts/check-accessibility.py`

## Gate note
- local review tooling selected the remote review gate; do not merge until GitHub `claude-review` passes
- the separate Xcode-beta snapshot target hit its existing renderer/harness crash (`CGRectValue` exceptions and signal 11); this slice does not change UI rendering
