### PR TITLE
Execute only declared installer actions

### DIFF
--- a/Sources/KeyPathInstallationWizard/Core/ActionDeterminer.swift
+++ b/Sources/KeyPathInstallationWizard/Core/ActionDeterminer.swift
@@ -113,7 +113,10 @@ public enum InstallerDecisionPipeline {
         // Check if daemon needs starting
         if !context.services.karabinerDaemonRunning {
             // Ensure manager is activated before starting daemon
-            if !context.components.vhidDeviceInstalled, !actions.contains(.activateVHIDDeviceManager) {
+            if !context.components.vhidDeviceInstalled,
+               !context.requiresManualVHIDDriverApproval,
+               !actions.contains(.activateVHIDDeviceManager)
+            {
                 actions.append(.activateVHIDDeviceManager)
             }
             actions.append(.startKarabinerDaemon)
@@ -166,7 +169,10 @@ public enum InstallerDecisionPipeline {
         // Check if daemon needs starting
         if !context.services.karabinerDaemonRunning {
             // Ensure manager is activated before starting daemon
-            if !context.components.vhidDeviceInstalled, !actions.contains(.activateVHIDDeviceManager) {
+            if !context.components.vhidDeviceInstalled,
+               !context.requiresManualVHIDDriverApproval,
+               !actions.contains(.activateVHIDDeviceManager)
+            {
                 actions.append(.activateVHIDDeviceManager)
             }
             actions.append(.startKarabinerDaemon)

--- a/Sources/KeyPathInstallationWizard/Core/ActionDeterminer.swift
+++ b/Sources/KeyPathInstallationWizard/Core/ActionDeterminer.swift
@@ -82,7 +82,9 @@ public enum InstallerDecisionPipeline {
 
             // CRITICAL: Activate manager BEFORE starting daemon
             // Per Karabiner documentation, manager activation must happen before daemon startup
-            if !context.components.karabinerDriverInstalled {
+            if !context.components.vhidDeviceInstalled,
+               !context.requiresManualVHIDDriverApproval
+            {
                 actions.append(.activateVHIDDeviceManager)
             }
         }
@@ -111,7 +113,7 @@ public enum InstallerDecisionPipeline {
         // Check if daemon needs starting
         if !context.services.karabinerDaemonRunning {
             // Ensure manager is activated before starting daemon
-            if !context.components.karabinerDriverInstalled, !actions.contains(.activateVHIDDeviceManager) {
+            if !context.components.vhidDeviceInstalled, !actions.contains(.activateVHIDDeviceManager) {
                 actions.append(.activateVHIDDeviceManager)
             }
             actions.append(.startKarabinerDaemon)
@@ -148,7 +150,9 @@ public enum InstallerDecisionPipeline {
 
             // CRITICAL: Activate manager BEFORE installing daemon services
             // Per Karabiner documentation, manager activation must happen before daemon startup
-            if !context.components.karabinerDriverInstalled {
+            if !context.components.vhidDeviceInstalled,
+               !context.requiresManualVHIDDriverApproval
+            {
                 actions.append(.activateVHIDDeviceManager)
             }
         }
@@ -162,7 +166,7 @@ public enum InstallerDecisionPipeline {
         // Check if daemon needs starting
         if !context.services.karabinerDaemonRunning {
             // Ensure manager is activated before starting daemon
-            if !context.components.karabinerDriverInstalled, !actions.contains(.activateVHIDDeviceManager) {
+            if !context.components.vhidDeviceInstalled, !actions.contains(.activateVHIDDeviceManager) {
                 actions.append(.activateVHIDDeviceManager)
             }
             actions.append(.startKarabinerDaemon)

--- a/Sources/KeyPathInstallationWizard/Core/InstallerEngine.swift
+++ b/Sources/KeyPathInstallationWizard/Core/InstallerEngine.swift
@@ -575,11 +575,6 @@ public final class InstallerEngine {
 
         switch recipe.type {
         case .installService:
-            logs.append("Checking VHID Manager activation status...")
-            let vhidManager = VHIDDeviceManager()
-            if !vhidManager.detectActivation() {
-                logs.append("VHID Manager not activated - will activate first")
-            }
             logs.append("Installing LaunchDaemon services...")
             commands.append("launchctl bootstrap system /Library/LaunchDaemons/com.keypath.*")
             try await executeInstallService(recipe, using: broker)
@@ -591,7 +586,6 @@ public final class InstallerEngine {
             logs.append("Privileged helper repair completed")
 
         case .restartService:
-            logs.append("Checking VHID Manager activation status...")
             if let serviceID = recipe.serviceID {
                 logs.append("Restarting service: \(serviceID)")
                 commands.append("launchctl kickstart -k system/\(serviceID)")
@@ -654,51 +648,18 @@ public final class InstallerEngine {
         }
     }
 
-    /// Execute installService recipe
-    /// Includes pre-check for VHID Manager activation (per Karabiner documentation)
+    /// Execute the exact service-install operation declared by the plan.
     private func executeInstallService(_: ServiceRecipe, using broker: PrivilegeBroker) async throws {
-        // CRITICAL: Ensure VHID Manager is activated BEFORE installing daemon services
-        // Per Karabiner documentation, manager activation must happen before daemon startup
-        let vhidManager = VHIDDeviceManager()
-        if !vhidManager.detectActivation() {
-            AppLogger.shared.log(
-                "⚠️ [InstallerEngine] VirtualHID Manager not activated - activating before daemon install"
-            )
-            try await broker.activateVirtualHIDManager()
-            // Wait for activation to take effect
-            _ = await WizardSleep.ms(1000) // 1 second
-
-            // Verify activation
-            if !vhidManager.detectActivation() {
-                AppLogger.shared.log(
-                    "⚠️ [InstallerEngine] Manager activation may need user approval - proceeding anyway"
-                )
-            } else {
-                AppLogger.shared.log("✅ [InstallerEngine] Manager activated successfully")
-            }
-        }
-
         // Ensure canonical Kanata binary exists at /Library/KeyPath/bin/kanata before installing services.
         // This prevents "service installed" while the daemon runs with a different path (bundle fallback),
         // which would cause permission identity drift (AX/IM entries keyed by executable path).
         try await broker.installRequiredRuntimeServices()
     }
 
-    /// Execute restartService recipe
-    /// Includes pre-check for VHID Manager activation (per Karabiner documentation)
+    /// Execute the exact service-restart operation declared by the plan.
     private func executeRestartService(_ recipe: ServiceRecipe, using broker: PrivilegeBroker)
         async throws
     {
-        // CRITICAL: Ensure VHID Manager is activated before restarting services
-        let vhidManager = VHIDDeviceManager()
-        if !vhidManager.detectActivation() {
-            AppLogger.shared.log(
-                "⚠️ [InstallerEngine] VirtualHID Manager not activated - activating before restart"
-            )
-            try await broker.activateVirtualHIDManager()
-            _ = await WizardSleep.ms(1000) // 1 second
-        }
-
         if let serviceID = recipe.serviceID, serviceID == KeyPathConstants.Bundle.vhidDaemonID {
             // Restart Karabiner daemon with verification
             let success = try await broker.restartKarabinerDaemonVerified()

--- a/Tests/KeyPathTests/InstallationEngine/InstallerEngineEndToEndTests.swift
+++ b/Tests/KeyPathTests/InstallationEngine/InstallerEngineEndToEndTests.swift
@@ -28,6 +28,10 @@ final class InstallerEngineEndToEndTests: KeyPathAsyncTestCase {
             coordinator.calls.contains("installRequiredRuntimeServices"),
             "Install service recipe should attempt to install required runtime services"
         )
+        XCTAssertFalse(
+            coordinator.calls.contains("activateVirtualHIDManager"),
+            "Service installation must not execute an activation step absent from the plan"
+        )
         XCTAssertTrue(
             coordinator.calls.contains("installNewsyslogConfig"),
             "Component recipe should install log rotation"
@@ -57,6 +61,28 @@ final class InstallerEngineEndToEndTests: KeyPathAsyncTestCase {
             report.failureReason?.contains("install-daemons") ?? false,
             "Failure should reference the failing recipe"
         )
+    }
+
+    func testExecuteRunsExplicitVHIDActivationRecipe() async {
+        let coordinator = StubPrivilegedOperationsCoordinator()
+        let plan = InstallPlan(
+            recipes: [
+                ServiceRecipe(
+                    id: InstallerRecipeID.activateVHIDManager,
+                    type: .installComponent
+                )
+            ],
+            status: .ready,
+            intent: .repair
+        )
+
+        let report = await InstallerEngine().execute(
+            plan: plan,
+            using: PrivilegeBroker(coordinator: coordinator)
+        )
+
+        XCTAssertTrue(report.success)
+        XCTAssertEqual(coordinator.calls, ["activateVirtualHIDManager"])
     }
 
     func testExecuteTreatsLostReplyAsSuccessWhenDeclaredPostconditionIsSatisfied() async {

--- a/Tests/KeyPathTests/InstallationEngine/InstallerEnginePlanTests.swift
+++ b/Tests/KeyPathTests/InstallationEngine/InstallerEnginePlanTests.swift
@@ -77,6 +77,40 @@ final class InstallerEnginePlanTests: KeyPathAsyncTestCase {
         }
     }
 
+    func testManualVHIDApprovalDoesNotPlanActivationOrDaemonStart() {
+        let base = SystemContextBuilder(
+            servicesHealthy: false,
+            kanataInputCaptureReady: false,
+            kanataInputCaptureIssue: ServiceHealthChecker.inputCaptureVHIDDriverNotActivatedReason,
+            componentsInstalled: true
+        ).build()
+        let components = ComponentStatus(
+            kanataBinaryInstalled: true,
+            karabinerDriverInstalled: true,
+            karabinerDaemonRunning: false,
+            vhidDeviceInstalled: false,
+            vhidDeviceHealthy: false,
+            vhidServicesHealthy: false,
+            vhidVersionMismatch: false
+        )
+        let context = SystemContext(
+            snapshotID: base.snapshotID,
+            permissions: base.permissions,
+            services: base.services,
+            conflicts: base.conflicts,
+            components: components,
+            helper: base.helper,
+            system: base.system,
+            timestamp: base.timestamp
+        )
+
+        for intent in [InstallIntent.install, .repair] {
+            let actions = InstallerDecisionPipeline.determineActions(for: intent, context: context)
+            XCTAssertFalse(actions.contains(.activateVHIDDeviceManager))
+            XCTAssertFalse(actions.contains(.startKarabinerDaemon))
+        }
+    }
+
     func testExecuteSkipsRecipesAfterFailure() async {
         let coordinator = StubPrivilegedOperationsCoordinator()
         coordinator.failOnCall = "installRequiredRuntimeServices"

--- a/Tests/KeyPathTests/InstallationEngine/InstallerEnginePlanTests.swift
+++ b/Tests/KeyPathTests/InstallationEngine/InstallerEnginePlanTests.swift
@@ -40,6 +40,43 @@ final class InstallerEnginePlanTests: KeyPathAsyncTestCase {
         )
     }
 
+    func testMissingVHIDDeviceProducesExplicitActivationBeforeServiceWork() async throws {
+        let base = SystemContextBuilder(
+            servicesHealthy: false,
+            componentsInstalled: true
+        ).build()
+        let components = ComponentStatus(
+            kanataBinaryInstalled: true,
+            karabinerDriverInstalled: true,
+            karabinerDaemonRunning: false,
+            vhidDeviceInstalled: false,
+            vhidDeviceHealthy: false,
+            vhidServicesHealthy: false,
+            vhidVersionMismatch: false
+        )
+        let context = SystemContext(
+            snapshotID: base.snapshotID,
+            permissions: base.permissions,
+            services: base.services,
+            conflicts: base.conflicts,
+            components: components,
+            helper: base.helper,
+            system: base.system,
+            timestamp: base.timestamp
+        )
+
+        for intent in [InstallIntent.install, .repair] {
+            let plan = await InstallerEngine().makePlan(for: intent, context: context)
+            let ids = plan.recipes.map(\.id)
+            let installIndex = try XCTUnwrap(ids.firstIndex(of: InstallerRecipeID.installMissingComponents))
+            let activationIndex = try XCTUnwrap(ids.firstIndex(of: InstallerRecipeID.activateVHIDManager))
+            let daemonIndex = try XCTUnwrap(ids.firstIndex(of: InstallerRecipeID.startKarabinerDaemon))
+
+            XCTAssertLessThan(installIndex, activationIndex)
+            XCTAssertLessThan(activationIndex, daemonIndex)
+        }
+    }
+
     func testExecuteSkipsRecipesAfterFailure() async {
         let coordinator = StubPrivilegedOperationsCoordinator()
         coordinator.failOnCall = "installRequiredRuntimeServices"

--- a/Tests/KeyPathTests/InstallationEngine/InstallerEngineTests.swift
+++ b/Tests/KeyPathTests/InstallationEngine/InstallerEngineTests.swift
@@ -574,6 +574,11 @@ final class InstallerEngineTests: KeyPathAsyncTestCase {
             .fixDriverVersionMismatch,
             .installCorrectVHIDDriver
         ]
+        let finalPostconditionExemptions: Set<String> = [
+            InstallerRecipeID.installLogRotation,
+            InstallerRecipeID.createConfigDirectories,
+            InstallerRecipeID.synchronizeConfigPaths
+        ]
 
         let context = await engine.inspectSystem()
 
@@ -583,6 +588,12 @@ final class InstallerEngineTests: KeyPathAsyncTestCase {
 
             let recipe = engine.recipeForAction(action, context: context)
             XCTAssertNotNil(recipe, "Action \(action) should produce a ServiceRecipe")
+            if let recipe, !finalPostconditionExemptions.contains(recipe.id) {
+                XCTAssertFalse(
+                    recipe.expectedPostconditions.isEmpty,
+                    "Mutating recipe \(recipe.id) must declare final observable state"
+                )
+            }
         }
     }
 

--- a/Tests/KeyPathTests/Lint/InstallerDecisionPipelineLintTests.swift
+++ b/Tests/KeyPathTests/Lint/InstallerDecisionPipelineLintTests.swift
@@ -105,6 +105,33 @@ final class InstallerDecisionPipelineLintTests: KeyPathTestCase {
             """
         )
     }
+
+    func testExecutorDoesNotMakeUndeclaredVHIDActivationDecisions() throws {
+        let file = repositoryRoot()
+            .appendingPathComponent("Sources/KeyPathInstallationWizard/Core/InstallerEngine.swift")
+        let source = try String(contentsOf: file, encoding: .utf8)
+        guard let executionStart = source.range(of: "private func executeRecipeWithDetails("),
+              let explicitActivation = source.range(
+                  of: "case InstallerRecipeID.activateVHIDManager:",
+                  range: executionStart.lowerBound ..< source.endIndex
+              )
+        else {
+            return XCTFail("Could not locate installer execution boundaries")
+        }
+
+        let genericExecution = source[executionStart.lowerBound ..< explicitActivation.lowerBound]
+        let forbiddenDecisions = [
+            "VHIDDeviceManager(",
+            "detectActivation(",
+            "activateVirtualHIDManager()"
+        ]
+        let violations = forbiddenDecisions.filter { genericExecution.contains($0) }
+
+        XCTAssertTrue(
+            violations.isEmpty,
+            "Generic recipe execution may only run declared plan steps; found: \(violations)"
+        )
+    }
 }
 
 private func repositoryRoot(file: StaticString = #filePath) -> URL {

--- a/docs/planning/installer-phase-pipeline-and-modularization.md
+++ b/docs/planning/installer-phase-pipeline-and-modularization.md
@@ -283,6 +283,10 @@ snapshot.
   correlated identities. App and CLI report paths expose one structured
   completion state, including approval-pending, verified lost replies,
   verification failure, and explicit recovery-required outcomes.
+- VHID activation is now an explicit planned recipe ordered before dependent
+  service work. Generic service executors no longer probe activation state or
+  inject an undeclared activation operation, and a lint ratchet prevents that
+  planner/executor boundary from drifting.
 
 ### Work
 


### PR DESCRIPTION
## Summary
- plan VHID activation from captured device evidence and order it before dependent service work
- remove executor-side VHID probes and injected activation branches from generic install/restart recipes
- add a lint ratchet so generic recipe execution cannot regain planning decisions
- require observable final postconditions for every mutating recipe, with three named non-runtime/no-op exemptions

## Validation
- `TEST_FILTER=InstallerEngine ./Scripts/run-tests-safe.sh` (117 passed)
- `TEST_FILTER=InstallerDecisionPipelineLintTests ./Scripts/run-tests-safe.sh` (5 passed)
- `TEST_FILTER=PostconditionLintTests ./Scripts/run-tests-safe.sh` (6 passed)
- `python3 Scripts/check-accessibility.py`

## Gate note
- local review tooling selected the remote review gate; do not merge until GitHub `claude-review` passes
