### PR TITLE
Install helper before privileged installer recipes

### DIFF
--- a/Sources/KeyPathInstallationWizard/Core/ActionDeterminer.swift
+++ b/Sources/KeyPathInstallationWizard/Core/ActionDeterminer.swift
@@ -65,7 +65,15 @@ public enum InstallerDecisionPipeline {
     public static func determineRepairActions(context: SystemContext) -> [AutoFixAction] {
         var actions: [AutoFixAction] = []
 
-        // Check conflicts first (highest priority)
+        // Every repair action below may need privileged XPC. Establish a working
+        // helper before planning any operation that routes through the broker.
+        if !context.helper.isReady {
+            actions.append(
+                context.helper.isInstalled ? .reinstallPrivilegedHelper : .installPrivilegedHelper
+            )
+        }
+
+        // Resolve conflicts before component and service mutations.
         if context.conflicts.hasConflicts, context.conflicts.canAutoResolve {
             actions.append(.terminateConflictingProcesses)
         }
@@ -122,19 +130,18 @@ public enum InstallerDecisionPipeline {
             actions.append(.startKarabinerDaemon)
         }
 
-        // Reinstall helper if unhealthy (use reinstall for repair)
-        if !context.helper.isReady {
-            actions.append(
-                context.helper.isInstalled ? .reinstallPrivilegedHelper : .installPrivilegedHelper
-            )
-        }
-
         return actions
     }
 
     /// Determine actions for fresh installation
     public static func determineInstallActions(context: SystemContext) -> [AutoFixAction] {
         var actions: [AutoFixAction] = []
+
+        // Clean installs have no XPC endpoint yet. Install the helper before any
+        // component, activation, or service recipe attempts privileged work.
+        if !context.helper.isReady {
+            actions.append(.installPrivilegedHelper)
+        }
 
         // Check conflicts first
         if context.conflicts.hasConflicts, context.conflicts.canAutoResolve {
@@ -176,11 +183,6 @@ public enum InstallerDecisionPipeline {
                 actions.append(.activateVHIDDeviceManager)
             }
             actions.append(.startKarabinerDaemon)
-        }
-
-        // Always install helper for fresh install (not reinstall)
-        if !context.helper.isReady {
-            actions.append(.installPrivilegedHelper)
         }
 
         if context.components.vhidRuntimeServicesNeedRepair {

--- a/Tests/KeyPathTests/InstallationEngine/InstallerEnginePlanTests.swift
+++ b/Tests/KeyPathTests/InstallationEngine/InstallerEnginePlanTests.swift
@@ -25,6 +25,46 @@ final class InstallerEnginePlanTests: KeyPathAsyncTestCase {
         XCTAssertEqual(plan.initialPostconditionStates?[.virtualHIDDriverInstalled], false)
     }
 
+    func testCleanInstallEstablishesHelperBeforePrivilegedRecipes() async throws {
+        let context = SystemContextBuilder.cleanInstall()
+        let plan = await InstallerEngine().makePlan(for: .install, context: context)
+        let ids = plan.recipes.map(\.id)
+        let helperIndex = try XCTUnwrap(ids.firstIndex(of: InstallerRecipeID.installPrivilegedHelper))
+
+        XCTAssertEqual(helperIndex, ids.startIndex)
+        for privilegedRecipeID in [
+            InstallerRecipeID.installMissingComponents,
+            InstallerRecipeID.activateVHIDManager,
+            InstallerRecipeID.startKarabinerDaemon,
+            InstallerRecipeID.installRequiredRuntimeServices
+        ] {
+            if let recipeIndex = ids.firstIndex(of: privilegedRecipeID) {
+                XCTAssertLessThan(helperIndex, recipeIndex)
+            }
+        }
+    }
+
+    func testRepairEstablishesMissingHelperBeforePrivilegedRecipes() async throws {
+        let context = SystemContextBuilder(
+            helperReady: false,
+            servicesHealthy: false,
+            componentsInstalled: true
+        ).build()
+        let plan = await InstallerEngine().makePlan(for: .repair, context: context)
+        let ids = plan.recipes.map(\.id)
+        let helperIndex = try XCTUnwrap(ids.firstIndex(of: InstallerRecipeID.installPrivilegedHelper))
+
+        XCTAssertEqual(helperIndex, ids.startIndex)
+        XCTAssertLessThan(
+            helperIndex,
+            try XCTUnwrap(ids.firstIndex(of: InstallerRecipeID.installRequiredRuntimeServices))
+        )
+        XCTAssertLessThan(
+            helperIndex,
+            try XCTUnwrap(ids.firstIndex(of: InstallerRecipeID.startKarabinerDaemon))
+        )
+    }
+
     func testRepairPlanTargetsUnhealthyServices() async {
         let engine = InstallerEngine()
         let context = SystemContextBuilder.degradedRepair()

--- a/docs/bugs/2026-07-10-clean-install-helper-order.md
+++ b/docs/bugs/2026-07-10-clean-install-helper-order.md
@@ -1,0 +1,23 @@
+# Clean install must establish the helper before privileged recipes
+
+## Symptom
+
+After a verified uninstall, `keypath-cli system install` attempted to restart the
+Karabiner daemon before installing the privileged helper. Both the restart and
+runtime-recovery XPC calls timed out after 30 seconds, so execution stopped and
+never reached the helper-install recipe.
+
+## Root cause
+
+`InstallerDecisionPipeline` emitted service and component actions before
+`.installPrivilegedHelper`. Recipe execution correctly follows the declared plan
+and stops on its first failure, so a missing XPC endpoint made the later helper
+recipe unreachable.
+
+## Invariant
+
+For install and repair intents, an absent or unhealthy helper must produce the
+first recipe. Every later component, activation, conflict-resolution, and service
+recipe may route through `PrivilegeBroker` and therefore depends on that helper.
+
+`InstallerEnginePlanTests` pins this ordering for both clean install and repair.


### PR DESCRIPTION
## Summary
- establish missing or unhealthy helper before broker-backed install and repair recipes
- pin helper-first ordering for clean install and repair plans
- document the real-Mac timeout failure and invariant

## Validation
- `TEST_FILTER=InstallerEnginePlanTests ./Scripts/run-tests-safe.sh` (7 passed)
- `python3 Scripts/check-accessibility.py`
- `git diff --check`
- installer area gate: 461 tests passed before two pre-existing environment-sensitive failures and the Xcode-beta signal crash; focused affected tests pass
- local review gate selected remote review; merge waits for GitHub `claude-review`