### PR TITLE
Unify privileged helper version contract

### DIFF
--- a/Sources/KeyPathAppKit/Core/HelperManager.swift
+++ b/Sources/KeyPathAppKit/Core/HelperManager.swift
@@ -73,8 +73,8 @@ public actor HelperManager {
     /// LaunchDaemon plist name packaged inside the app bundle for SMAppService
     static let helperPlistName = "com.keypath.helper.plist"
 
-    /// Expected helper version (should match HelperService.version)
-    static let expectedHelperVersion = "1.0.0"
+    /// Expected helper version shared with the helper and wizard.
+    static let expectedHelperVersion = KeyPathHelperContract.version
 
     /// Active XPC call tracking for detecting concurrency issues
     var activeXPCCalls: Set<String> = []

--- a/Sources/KeyPathAppKit/Services/System/SystemValidator.swift
+++ b/Sources/KeyPathAppKit/Services/System/SystemValidator.swift
@@ -767,7 +767,11 @@ public class SystemValidator {
             ),
             conflicts: ConflictStatus(conflicts: [], canAutoResolve: false),
             health: HealthStatus(kanataRunning: true, karabinerDaemonRunning: true, vhidHealthy: true),
-            helper: HelperStatus(isInstalled: true, version: "1.0.0", isWorking: true),
+            helper: HelperStatus(
+                isInstalled: true,
+                version: KeyPathHelperContract.version,
+                isWorking: true
+            ),
             compatibility: SystemCompatibilityStatus(macOSVersion: "test", driverCompatible: true),
             timestamp: now
         )

--- a/Sources/KeyPathCore/KeyPathHelperContract.swift
+++ b/Sources/KeyPathCore/KeyPathHelperContract.swift
@@ -1,0 +1,5 @@
+/// Shared identity and compatibility contract for the privileged helper.
+public enum KeyPathHelperContract {
+    /// Version returned by the helper XPC service and packaged in its Info.plist.
+    public static let version = "1.1.0"
+}

--- a/Sources/KeyPathHelper/HelperService.swift
+++ b/Sources/KeyPathHelper/HelperService.swift
@@ -11,8 +11,8 @@ import SystemConfiguration
 class HelperService: NSObject, HelperProtocol {
     // MARK: - Constants
 
-    /// Helper version (must match app version for compatibility)
-    private static let version = "1.1.0"
+    /// Helper version shared with the app and wizard for compatibility checks.
+    private static let version = KeyPathHelperContract.version
     private static let vhidRootOnlyDirectory = "/Library/Application Support/org.pqrs/tmp/rootonly"
     private let logger = Logger(subsystem: "com.keypath.helper", category: "service")
 

--- a/Sources/KeyPathHelper/main.swift
+++ b/Sources/KeyPathHelper/main.swift
@@ -1,4 +1,5 @@
 import Foundation
+import KeyPathCore
 import os
 import Security
 
@@ -145,8 +146,8 @@ class HelperDelegate: NSObject, NSXPCListenerDelegate {
 /// Main entry point for the privileged helper
 func main() {
     let logger = Logger(subsystem: "com.keypath.helper", category: "lifecycle")
-    NSLog("[KeyPathHelper] Starting privileged helper (version 1.1.0)")
-    logger.info("Starting privileged helper (v1.1.0)")
+    NSLog("[KeyPathHelper] Starting privileged helper (version \(KeyPathHelperContract.version))")
+    logger.info("Starting privileged helper (v\(KeyPathHelperContract.version))")
 
     // Create the XPC listener on the Mach service
     let delegate = HelperDelegate()

--- a/Sources/KeyPathInstallationWizard/UI/Pages/WizardHelperPage.swift
+++ b/Sources/KeyPathInstallationWizard/UI/Pages/WizardHelperPage.swift
@@ -628,7 +628,7 @@ public struct WizardHelperPage: View {
 
         // Read version from helper's Info.plist in Sources
         // For now, return the known bundled version
-        return "1.1.0"
+        return KeyPathHelperContract.version
     }
 }
 

--- a/Sources/KeyPathWizardCore/WizardHelperManaging.swift
+++ b/Sources/KeyPathWizardCore/WizardHelperManaging.swift
@@ -19,5 +19,5 @@ public enum WizardHelperConstants {
     public static let helperPlistName = "com.keypath.helper.plist"
     public static let helperMachServiceName = "com.keypath.helper"
     public static let helperBundleIdentifier = "com.keypath.helper"
-    public static let expectedHelperVersion = "1.0.0"
+    public static let expectedHelperVersion = KeyPathHelperContract.version
 }

--- a/Tests/KeyPathTests/InstallationWizard/WizardStateRegressionTests.swift
+++ b/Tests/KeyPathTests/InstallationWizard/WizardStateRegressionTests.swift
@@ -45,7 +45,11 @@ final class WizardStateRegressionTests: XCTestCase {
             services: health,
             conflicts: .init(conflicts: [], canAutoResolve: false),
             components: components,
-            helper: HelperStatus(isInstalled: true, version: "1.0.0", isWorking: true),
+            helper: HelperStatus(
+                isInstalled: true,
+                version: WizardHelperConstants.expectedHelperVersion,
+                isWorking: true
+            ),
             system: EngineSystemInfo(macOSVersion: "26.0.1", driverCompatible: true),
             timestamp: Date()
         )
@@ -98,7 +102,11 @@ final class WizardStateRegressionTests: XCTestCase {
             services: health,
             conflicts: .init(conflicts: [], canAutoResolve: false),
             components: components,
-            helper: HelperStatus(isInstalled: true, version: "1.0.0", isWorking: true),
+            helper: HelperStatus(
+                isInstalled: true,
+                version: WizardHelperConstants.expectedHelperVersion,
+                isWorking: true
+            ),
             system: EngineSystemInfo(macOSVersion: "26.0.1", driverCompatible: true),
             timestamp: Date()
         )

--- a/Tests/KeyPathTests/Lint/HelperVersionContractTests.swift
+++ b/Tests/KeyPathTests/Lint/HelperVersionContractTests.swift
@@ -1,5 +1,5 @@
-import KeyPathCore
 @testable import KeyPathAppKit
+import KeyPathCore
 @testable import KeyPathInstallationWizard
 @testable import KeyPathWizardCore
 @preconcurrency import XCTest

--- a/Tests/KeyPathTests/Lint/HelperVersionContractTests.swift
+++ b/Tests/KeyPathTests/Lint/HelperVersionContractTests.swift
@@ -1,0 +1,64 @@
+import KeyPathCore
+@testable import KeyPathAppKit
+@testable import KeyPathInstallationWizard
+@testable import KeyPathWizardCore
+@preconcurrency import XCTest
+
+final class HelperVersionContractTests: KeyPathTestCase {
+    func testAllHelperVersionConsumersUseSharedContract() throws {
+        XCTAssertEqual(HelperManager.expectedHelperVersion, KeyPathHelperContract.version)
+        XCTAssertEqual(WizardHelperConstants.expectedHelperVersion, KeyPathHelperContract.version)
+
+        let infoURL = repositoryRoot()
+            .appendingPathComponent("Sources/KeyPathHelper/Info.plist")
+        let data = try Data(contentsOf: infoURL)
+        let plist = try XCTUnwrap(
+            PropertyListSerialization.propertyList(from: data, format: nil) as? [String: Any]
+        )
+        XCTAssertEqual(plist["CFBundleShortVersionString"] as? String, KeyPathHelperContract.version)
+
+        let contractConsumers = [
+            "Sources/KeyPathHelper/HelperService.swift",
+            "Sources/KeyPathHelper/main.swift",
+            "Sources/KeyPathAppKit/Core/HelperManager.swift",
+            "Sources/KeyPathWizardCore/WizardHelperManaging.swift",
+            "Sources/KeyPathInstallationWizard/UI/Pages/WizardHelperPage.swift",
+        ]
+        for relativePath in contractConsumers {
+            let source = try String(
+                contentsOf: repositoryRoot().appendingPathComponent(relativePath),
+                encoding: .utf8
+            )
+            XCTAssertTrue(
+                source.contains("KeyPathHelperContract.version"),
+                "\(relativePath) must use the shared helper version contract"
+            )
+        }
+    }
+
+    @MainActor
+    func testHealthyHelperVersionProducesHealthyAssessmentAndEmptyPlan() {
+        let context = SystemContextBuilder(
+            servicesHealthy: true,
+            kanataLaunchdLoaded: true,
+            kanataProcessRunning: true,
+            kanataTCPResponding: true,
+            kanataSMAppServiceRegistered: true,
+            loginItemsApprovalRequired: false,
+            componentsInstalled: true
+        ).build()
+        let decision = InstallerDecisionPipeline.decide(for: .repair, context: context)
+
+        XCTAssertEqual(decision.assessment, .runningAndTCPResponding)
+        XCTAssertTrue(decision.matrixActions.isEmpty)
+        XCTAssertTrue(decision.autoFixActions.isEmpty)
+    }
+}
+
+private func repositoryRoot(file: StaticString = #filePath) -> URL {
+    URL(fileURLWithPath: "\(file)")
+        .deletingLastPathComponent() // Lint
+        .deletingLastPathComponent() // KeyPathTests
+        .deletingLastPathComponent() // Tests
+        .deletingLastPathComponent() // repo root
+}

--- a/Tests/KeyPathTests/TestSupport/SystemContextBuilder.swift
+++ b/Tests/KeyPathTests/TestSupport/SystemContextBuilder.swift
@@ -14,6 +14,7 @@ struct SystemContextBuilder {
     var kanataLaunchdLoaded: Bool?
     var kanataProcessRunning: Bool?
     var kanataTCPResponding: Bool?
+    var kanataSMAppServiceRegistered: Bool?
     var kanataRunning: Bool?
     var karabinerDaemonRunning: Bool?
     var vhidHealthy: Bool?
@@ -43,7 +44,7 @@ struct SystemContextBuilder {
 
         let helper = HelperStatus(
             isInstalled: helperReady || helperRequiresApproval,
-            version: "1.0",
+            version: WizardHelperConstants.expectedHelperVersion,
             isWorking: helperReady,
             requiresApproval: helperRequiresApproval
         )
@@ -71,6 +72,7 @@ struct SystemContextBuilder {
             vhidHealthy: vhidHealthy ?? servicesHealthy,
             kanataInputCaptureReady: kanataInputCaptureReady,
             kanataInputCaptureIssue: kanataInputCaptureReady ? nil : kanataInputCaptureIssue,
+            kanataSMAppServiceRegistered: kanataSMAppServiceRegistered,
             loginItemsApprovalRequired: loginItemsApprovalRequired
         )
 


### PR DESCRIPTION
## Summary
- define one shared privileged-helper version contract in KeyPathCore
- make the helper, app, wizard, and test fixtures consume that contract
- add a ratchet proving a healthy matching helper yields a healthy assessment and empty repair plan

## Validation
- `./Scripts/test-fast.sh installer`: 563 XCTest cases passed; one unrelated Swift Testing case failed from cross-suite shared state
- `TEST_FILTER=KarabinerConflictService ./Scripts/run-tests-safe.sh`: 5 passed
- `python3 Scripts/check-accessibility.py`: passed
- review gate: remote review gate selected; GitHub claude-review required