### PR TITLE
Remove dead installer compatibility bridges

### DIFF
--- a/Sources/KeyPathAppKit/Managers/RuntimeCoordinator.swift
+++ b/Sources/KeyPathAppKit/Managers/RuntimeCoordinator.swift
@@ -618,17 +618,6 @@ public class RuntimeCoordinator: SaveCoordinatorDelegate {
         )
     }
 
-    func runFullRepair(reason: String = "RuntimeCoordinator repair request") async -> InstallerReport {
-        AppLogger.shared.log("🛠️ [RuntimeCoordinator] runFullRepair invoked (\(reason))")
-        return await installerEngine.run(intent: .repair, using: privilegeBroker)
-    }
-
-    /// Run full installation via InstallerEngine façade.
-    func runFullInstall(reason: String = "RuntimeCoordinator install request") async -> InstallerReport {
-        AppLogger.shared.log("🔧 [RuntimeCoordinator] runFullInstall invoked (\(reason))")
-        return await installerEngine.run(intent: .install, using: privilegeBroker)
-    }
-
     private func captureRecentKanataErrorMessage() -> String? {
         let stderrPath = KeyPathConstants.Logs.kanataStderr
         let contents: String

--- a/Sources/KeyPathAppKit/UI/ViewModels/KanataViewModel.swift
+++ b/Sources/KeyPathAppKit/UI/ViewModels/KanataViewModel.swift
@@ -493,14 +493,6 @@ class KanataViewModel {
         )
     }
 
-    func runFullRepair(reason: String) async -> InstallerReport {
-        await manager.runFullRepair(reason: reason)
-    }
-
-    func runFullInstall(reason: String) async -> InstallerReport {
-        await manager.runFullInstall(reason: reason)
-    }
-
     // MARK: - Service Controls
 
     func startKanata(reason: String = "User action") async -> Bool {

--- a/Sources/KeyPathAppKit/WizardProtocolConformances.swift
+++ b/Sources/KeyPathAppKit/WizardProtocolConformances.swift
@@ -52,16 +52,6 @@ extension RuntimeCoordinator: RuntimeCoordinating {
     public func isInTransientRuntimeStartupWindow() async -> Bool {
         await serviceLifecycleCoordinator.isInTransientRuntimeStartupWindow()
     }
-
-    public func runFullRepair(reason _: String) async -> WizardRepairReport {
-        let report = await installerEngine.run(intent: .repair, using: privilegeBroker)
-        return WizardRepairReport(
-            success: report.success,
-            successCount: report.executedRecipes.filter(\.success).count,
-            totalCount: report.executedRecipes.count,
-            failureReason: report.failureReason
-        )
-    }
 }
 
 // MARK: - HelperManager + WizardHelperManaging

--- a/Sources/KeyPathInstallationWizard/Core/InstallerEngine.swift
+++ b/Sources/KeyPathInstallationWizard/Core/InstallerEngine.swift
@@ -38,7 +38,7 @@ public protocol InstallerEnginePrivilegedRouting: AnyObject {
 ///
 /// - Provides a stable, unified API for install/repair/uninstall flows.
 /// - Wraps extracted services (ServiceBootstrapper, ServiceHealthChecker, etc.).
-/// - Backward-compatible with legacy wizard outputs (SystemContext/SystemContextAdapter).
+/// - Projects canonical system evidence into the planner's SystemContext input.
 @MainActor
 public final class InstallerEngine {
     // MARK: - Dependencies
@@ -55,8 +55,7 @@ public final class InstallerEngine {
     /// Internal designated initializer to share construction logic
     public init(
         processLifecycleManager _: ProcessLifecycleManager,
-        systemValidator injectedValidator: (any WizardSystemValidating)? = nil,
-        kanataManager _: (any RuntimeCoordinating)? = nil
+        systemValidator injectedValidator: (any WizardSystemValidating)? = nil
     ) {
         self.injectedValidator = injectedValidator
 
@@ -65,12 +64,7 @@ public final class InstallerEngine {
 
     /// Public initializer for app/CLI callers (no DI needed).
     public convenience init() {
-        self.init(processLifecycleManager: ProcessLifecycleManager(), kanataManager: nil)
-    }
-
-    /// Internal convenience initializer used by the wizard to surface live Kanata health.
-    public convenience init(kanataManager: any RuntimeCoordinating) {
-        self.init(processLifecycleManager: ProcessLifecycleManager(), kanataManager: kanataManager)
+        self.init(processLifecycleManager: ProcessLifecycleManager())
     }
 
     // MARK: - Public API

--- a/Sources/KeyPathInstallationWizard/Core/WizardStateMachine.swift
+++ b/Sources/KeyPathInstallationWizard/Core/WizardStateMachine.swift
@@ -129,12 +129,6 @@ public class WizardStateMachine {
         // One-time page tracking is reset via the properties above
     }
 
-    // MARK: - Legacy Compatibility
-
-    /// Configure with RuntimeCoordinating — no-op in simplified architecture.
-    /// Kept for call-site compatibility during migration.
-    public func configure(kanataManager _: any RuntimeCoordinating) {}
-
     /// Detect current state via InstallerEngine (used by existing refresh paths).
     public func detectCurrentState(progressCallback _: @escaping @Sendable (Double) -> Void = { _ in }) async
         -> SystemStateResult

--- a/Sources/KeyPathInstallationWizard/UI/InstallationWizardView+StateManagement.swift
+++ b/Sources/KeyPathInstallationWizard/UI/InstallationWizardView+StateManagement.swift
@@ -13,12 +13,10 @@ public extension InstallationWizardView {
         // Always reset navigation state for fresh run
         stateMachine.resetNavigation()
 
-        // Configure state providers
-        guard let kanataManager else {
+        guard kanataManager != nil else {
             AppLogger.shared.log("⚠️ [Wizard] kanataManager not configured — skipping wizard setup")
             return
         }
-        stateMachine.configure(kanataManager: kanataManager)
 
         // Determine initial page based on cached system snapshot (if available)
         // Skip summary on initial run - go directly to helper page to start the wizard flow

--- a/Sources/KeyPathWizardCore/RuntimeCoordinating.swift
+++ b/Sources/KeyPathWizardCore/RuntimeCoordinating.swift
@@ -17,24 +17,6 @@ public enum WizardRuntimeStatus: Equatable, Sendable {
     }
 }
 
-// MARK: - Repair Report
-
-/// Simplified repair result for cross-module use.
-/// RuntimeCoordinator maps InstallerReport → WizardRepairReport in its conformance.
-public struct WizardRepairReport: Sendable {
-    public let success: Bool
-    public let successCount: Int
-    public let totalCount: Int
-    public let failureReason: String?
-
-    public init(success: Bool, successCount: Int, totalCount: Int, failureReason: String?) {
-        self.success = success
-        self.successCount = successCount
-        self.totalCount = totalCount
-        self.failureReason = failureReason
-    }
-}
-
 // MARK: - RuntimeCoordinating Protocol
 
 /// Protocol abstracting RuntimeCoordinator for use by the wizard module.
@@ -72,8 +54,4 @@ public protocol RuntimeCoordinating: AnyObject, Sendable {
     // MARK: - State
 
     var lastError: String? { get }
-
-    // MARK: - Repair
-
-    func runFullRepair(reason: String) async -> WizardRepairReport
 }

--- a/Tests/KeyPathTests/Lint/W6DeletionPassLintTests.swift
+++ b/Tests/KeyPathTests/Lint/W6DeletionPassLintTests.swift
@@ -266,6 +266,40 @@ final class W6DeletionPassLintTests: XCTestCase {
             """
         )
     }
+
+    func testInstallerCompatibilityBridgesDoNotRegrow() throws {
+        let productionFiles = [
+            "Sources/KeyPathWizardCore/RuntimeCoordinating.swift",
+            "Sources/KeyPathAppKit/WizardProtocolConformances.swift",
+            "Sources/KeyPathAppKit/Managers/RuntimeCoordinator.swift",
+            "Sources/KeyPathAppKit/UI/ViewModels/KanataViewModel.swift",
+            "Sources/KeyPathInstallationWizard/Core/WizardStateMachine.swift",
+            "Sources/KeyPathInstallationWizard/Core/InstallerEngine.swift",
+        ].map { repositoryRoot().appendingPathComponent($0) }
+
+        let violations = try productionFiles.flatMap { file in
+            try matchingLines(
+                in: file,
+                patterns: [
+                    #"\bWizardRepairReport\b"#,
+                    #"\brunFullRepair\b"#,
+                    #"\brunFullInstall\b"#,
+                    #"configure\(kanataManager"#,
+                    #"InstallerEngine\(kanataManager"#,
+                ]
+            )
+        }
+
+        XCTAssertTrue(
+            violations.isEmpty,
+            """
+            Installer mutations belong directly to InstallerEngine. Do not \
+            regrow unused RuntimeCoordinator/ViewModel forwarding methods, \
+            lossy repair reports, or no-op wizard configuration bridges:
+            \(violations.sorted().joined(separator: "\n"))
+            """
+        )
+    }
 }
 
 private func repositoryRoot(file: StaticString = #filePath) -> URL {


### PR DESCRIPTION
## Summary
- remove unused full-install/full-repair forwarding methods from RuntimeCoordinator and KanataViewModel
- remove the lossy WizardRepairReport compatibility type and protocol requirement
- remove the no-op wizard manager configuration bridge
- simplify InstallerEngine construction by deleting its ignored RuntimeCoordinating parameter
- add an anti-regrowth deletion ratchet

## Validation
- `TEST_FILTER='W6DeletionPassLintTests|WizardStateMachine|InstallerEngine' ./Scripts/run-tests-safe.sh`: 158 passed
- `python3 Scripts/check-accessibility.py`: passed
- review gate: remote review gate selected; GitHub claude-review required