### PR TITLE
Remove system context compatibility adapter

### DIFF
--- a/Sources/KeyPathAppKit/Services/MainAppStateController.swift
+++ b/Sources/KeyPathAppKit/Services/MainAppStateController.swift
@@ -581,7 +581,7 @@ class MainAppStateController {
             lastValidationDate = Date()
             lastValidationTime = Date()
             if let lastValidatedSystemContext {
-                lastAdaptedState = SystemContextAdapter.adapt(lastValidatedSystemContext).state
+                lastAdaptedState = SystemStateResult.projecting(lastValidatedSystemContext).state
             }
 
             validationState = .failed(blockingCount: 0, totalCount: issues.count)
@@ -634,9 +634,9 @@ class MainAppStateController {
             "📊 [MainAppStateController] Blocking issues: \(snapshot.blockingIssues.count)"
         )
 
-        // Adapt to wizard-style issues/state using existing adapter (keeps UI expectations stable)
+        // Project the canonical context into wizard presentation state.
         let context = SystemContext(snapshot: snapshot)
-        let adapted = SystemContextAdapter.adapt(context)
+        let adapted = SystemStateResult.projecting(context)
 
         // Update published state
         lastValidatedSystemContext = context

--- a/Sources/KeyPathInstallationWizard/Core/ActionDeterminer.swift
+++ b/Sources/KeyPathInstallationWizard/Core/ActionDeterminer.swift
@@ -61,7 +61,7 @@ public enum InstallerDecisionPipeline {
     }
 
     /// Determine actions for repair (general auto-fix)
-    /// Used by both InstallerEngine and SystemContextAdapter
+    /// Used by both InstallerEngine and the wizard presentation projection.
     public static func determineRepairActions(context: SystemContext) -> [AutoFixAction] {
         var actions: [AutoFixAction] = []
 

--- a/Sources/KeyPathInstallationWizard/Core/SystemStateResult+SystemContext.swift
+++ b/Sources/KeyPathInstallationWizard/Core/SystemStateResult+SystemContext.swift
@@ -1,15 +1,9 @@
-import Foundation
-import KeyPathCore
-import KeyPathPermissions
 import KeyPathWizardCore
 
-/// Adapter to convert SystemContext (InstallerEngine façade) to SystemStateResult (old wizard format)
-/// This allows the GUI to use InstallerEngine.inspectSystem() while maintaining backward compatibility
-@MainActor
-public struct SystemContextAdapter {
-    /// Convert SystemContext to SystemStateResult for backward compatibility.
-    /// Delegates to SystemInspector for state determination and issue generation.
-    public static func adapt(_ context: SystemContext) -> SystemStateResult {
+public extension SystemStateResult {
+    /// Projects one canonical installer context into the wizard's presentation result.
+    @MainActor
+    static func projecting(_ context: SystemContext) -> SystemStateResult {
         let (wizardState, wizardIssues) = SystemInspector.inspect(context: context)
         let decision = InstallerDecisionPipeline.decide(for: .repair, context: context)
 

--- a/Sources/KeyPathInstallationWizard/Core/WizardStateMachine.swift
+++ b/Sources/KeyPathInstallationWizard/Core/WizardStateMachine.swift
@@ -134,7 +134,7 @@ public class WizardStateMachine {
         -> SystemStateResult
     {
         let context = await InstallerEngine().inspectSystem()
-        return SystemContextAdapter.adapt(context)
+        return SystemStateResult.projecting(context)
     }
 
     /// Auto-navigate based on system state using WizardRouter.
@@ -161,7 +161,7 @@ public class WizardStateMachine {
     public func refresh(freshness: WizardSystemSnapshotFreshness = .fresh) async {
         isRefreshing = true
         let context = await InstallerEngine().inspectSystem(freshness: freshness)
-        let result = SystemContextAdapter.adapt(context)
+        let result = SystemStateResult.projecting(context)
         updateWizardState(from: result)
         isRefreshing = false
         lastRefreshTime = Date()

--- a/Sources/KeyPathInstallationWizard/UI/InstallationWizardView+Actions.swift
+++ b/Sources/KeyPathInstallationWizard/UI/InstallationWizardView+Actions.swift
@@ -171,7 +171,7 @@ public extension InstallationWizardView {
             )
             return false
         }
-        _ = applySystemStateResult(SystemContextAdapter.adapt(finalContext))
+        _ = applySystemStateResult(SystemStateResult.projecting(finalContext))
         return true
     }
 }

--- a/Tests/KeyPathTests/InstallationWizard/KarabinerComponentsStatusEvaluatorTests.swift
+++ b/Tests/KeyPathTests/InstallationWizard/KarabinerComponentsStatusEvaluatorTests.swift
@@ -55,7 +55,7 @@ final class KarabinerComponentsStatusEvaluatorTests: XCTestCase {
         )
     }
 
-    // MARK: - SystemContextAdapter Integration Tests
+    // MARK: - SystemStateResult Projection Integration Tests
 
     /// Regression test: When VHID services are healthy but Kanata service is not installed,
     /// the Karabiner Components page should NOT show issues. Only a Kanata-specific issue should appear.
@@ -103,7 +103,7 @@ final class KarabinerComponentsStatusEvaluatorTests: XCTestCase {
         )
 
         // Act: Adapt the context to wizard format
-        let result = SystemContextAdapter.adapt(context)
+        let result = SystemStateResult.projecting(context)
 
         // Assert: No stale recovery-services installation issue is generated
         let karabinerRelatedIssues = result.issues.filter { issue in
@@ -174,7 +174,7 @@ final class KarabinerComponentsStatusEvaluatorTests: XCTestCase {
             timestamp: now
         )
 
-        let result = SystemContextAdapter.adapt(context)
+        let result = SystemStateResult.projecting(context)
 
         // Should have a VHID-specific installation issue when VHID is unhealthy.
         let vhidIssues = result.issues.filter { issue in

--- a/Tests/KeyPathTests/InstallationWizard/SystemStateProjectionPermissionSeverityTests.swift
+++ b/Tests/KeyPathTests/InstallationWizard/SystemStateProjectionPermissionSeverityTests.swift
@@ -6,9 +6,9 @@ import KeyPathWizardCore
 @preconcurrency import XCTest
 
 /// End-to-end tests that validate the path:
-/// SystemContext -> SystemContextAdapter/SystemInspector -> WizardIssue severities.
+/// SystemContext -> SystemStateResult projection/SystemInspector -> WizardIssue severities.
 @MainActor
-final class SystemContextAdapterPermissionSeverityTests: XCTestCase {
+final class SystemStateProjectionPermissionSeverityTests: XCTestCase {
     func testKanataUnknownPermissionBecomesWarningIssueAndWarningPageStatus() {
         let now = Date()
 
@@ -49,10 +49,10 @@ final class SystemContextAdapterPermissionSeverityTests: XCTestCase {
             timestamp: now
         )
 
-        let result = SystemContextAdapter.adapt(context)
+        let result = SystemStateResult.projecting(context)
 
         let kanataIMIssue = result.issues.first { $0.identifier == .permission(.kanataInputMonitoring) }
-        XCTAssertNotNil(kanataIMIssue, "Adapter should surface a kanata input monitoring issue")
+        XCTAssertNotNil(kanataIMIssue, "Projection should surface a kanata input monitoring issue")
         XCTAssertEqual(kanataIMIssue?.severity, .warning, "Unknown/not-verified kanata permission should be a warning")
         XCTAssertNotNil(kanataIMIssue?.description)
         XCTAssertTrue(kanataIMIssue?.description.localizedCaseInsensitiveContains("not verified") ?? false)

--- a/Tests/KeyPathTests/InstallationWizard/WizardGoldenTests.swift
+++ b/Tests/KeyPathTests/InstallationWizard/WizardGoldenTests.swift
@@ -4,7 +4,7 @@ import Foundation
 @testable import KeyPathWizardCore
 @preconcurrency import XCTest
 
-/// Golden tests that capture the current behavior of SystemContextAdapter (issue generation)
+/// Golden tests that capture the current behavior of the SystemStateResult projection (issue generation)
 /// and WizardRouter (page routing). These tests must pass both before and after the wizard
 /// simplification refactor — they prove behavioral equivalence.
 ///
@@ -87,17 +87,17 @@ final class WizardGoldenTests: XCTestCase {
         )
     }
 
-    // MARK: - SystemContextAdapter: State Determination
+    // MARK: - SystemStateResult projection: State Determination
 
     func test_allHealthy_stateIsActive() {
         let context = makeContext()
-        let result = SystemContextAdapter.adapt(context)
+        let result = SystemStateResult.projecting(context)
         XCTAssertEqual(result.state, .active)
     }
 
     func test_timedOut_stateIsServiceNotRunning() {
         let context = makeContext(timedOut: true)
-        let result = SystemContextAdapter.adapt(context)
+        let result = SystemStateResult.projecting(context)
         XCTAssertEqual(result.state, .serviceNotRunning)
     }
 
@@ -108,7 +108,7 @@ final class WizardGoldenTests: XCTestCase {
                 canAutoResolve: true
             )
         )
-        let result = SystemContextAdapter.adapt(context)
+        let result = SystemStateResult.projecting(context)
         if case .conflictsDetected = result.state {
             // pass
         } else {
@@ -127,7 +127,7 @@ final class WizardGoldenTests: XCTestCase {
             vhidVersionMismatch: false
         )
         let context = makeContext(components: components)
-        let result = SystemContextAdapter.adapt(context)
+        let result = SystemStateResult.projecting(context)
         if case let .missingComponents(missing) = result.state {
             XCTAssertTrue(missing.contains(.karabinerDriver))
         } else {
@@ -139,7 +139,7 @@ final class WizardGoldenTests: XCTestCase {
         let context = makeContext(
             permissions: makePermissions(keyPathIM: .denied)
         )
-        let result = SystemContextAdapter.adapt(context)
+        let result = SystemStateResult.projecting(context)
         if case let .missingPermissions(missing) = result.state {
             XCTAssertTrue(missing.contains(.keyPathInputMonitoring))
         } else {
@@ -151,7 +151,7 @@ final class WizardGoldenTests: XCTestCase {
         let context = makeContext(
             permissions: makePermissions(kanataAX: .denied)
         )
-        let result = SystemContextAdapter.adapt(context)
+        let result = SystemStateResult.projecting(context)
         if case let .missingPermissions(missing) = result.state {
             XCTAssertTrue(missing.contains(.kanataAccessibility))
         } else {
@@ -163,7 +163,7 @@ final class WizardGoldenTests: XCTestCase {
         let context = makeContext(
             permissions: makePermissions(kanataIM: .unknown)
         )
-        let result = SystemContextAdapter.adapt(context)
+        let result = SystemStateResult.projecting(context)
         XCTAssertEqual(result.state, .active, "Unknown kanata IM should NOT block — it's 'not verified', not denied")
     }
 
@@ -171,7 +171,7 @@ final class WizardGoldenTests: XCTestCase {
         let context = makeContext(
             services: HealthStatus(kanataRunning: false, karabinerDaemonRunning: true, vhidHealthy: true)
         )
-        let result = SystemContextAdapter.adapt(context)
+        let result = SystemStateResult.projecting(context)
         XCTAssertEqual(result.state, .serviceNotRunning)
     }
 
@@ -179,22 +179,22 @@ final class WizardGoldenTests: XCTestCase {
         let context = makeContext(
             services: HealthStatus(kanataRunning: false, karabinerDaemonRunning: false, vhidHealthy: true)
         )
-        let result = SystemContextAdapter.adapt(context)
+        let result = SystemStateResult.projecting(context)
         XCTAssertEqual(result.state, .daemonNotRunning)
     }
 
-    // MARK: - SystemContextAdapter: Issue Generation
+    // MARK: - SystemStateResult projection: Issue Generation
 
     func test_allHealthy_noBlockingIssues() {
         let context = makeContext()
-        let result = SystemContextAdapter.adapt(context)
+        let result = SystemStateResult.projecting(context)
         let blocking = result.issues.filter { $0.severity == .error || $0.severity == .critical }
         XCTAssertTrue(blocking.isEmpty, "Healthy system should have no blocking issues, got: \(blocking.map(\.title))")
     }
 
     func test_helperNotInstalled_generatesHelperIssue() {
         let context = makeContext(helper: HelperStatus(isInstalled: false, version: nil, isWorking: false))
-        let result = SystemContextAdapter.adapt(context)
+        let result = SystemStateResult.projecting(context)
         XCTAssertTrue(
             result.issues.contains { $0.identifier == .component(.privilegedHelper) },
             "Should generate privilegedHelper issue"
@@ -203,7 +203,7 @@ final class WizardGoldenTests: XCTestCase {
 
     func test_helperInstalledButBroken_generatesUnhealthyIssue() {
         let context = makeContext(helper: HelperStatus(isInstalled: true, version: "1.0", isWorking: false))
-        let result = SystemContextAdapter.adapt(context)
+        let result = SystemStateResult.projecting(context)
         XCTAssertTrue(
             result.issues.contains { $0.identifier == .component(.privilegedHelperUnhealthy) },
             "Should generate privilegedHelperUnhealthy issue"
@@ -221,7 +221,7 @@ final class WizardGoldenTests: XCTestCase {
             vhidVersionMismatch: true
         )
         let context = makeContext(components: components)
-        let result = SystemContextAdapter.adapt(context)
+        let result = SystemStateResult.projecting(context)
         let issue = result.issues.first { $0.identifier == .component(.vhidDriverVersionMismatch) }
         XCTAssertNotNil(issue, "Should generate version mismatch issue")
         XCTAssertEqual(issue?.autoFixAction, .fixDriverVersionMismatch)
@@ -229,7 +229,7 @@ final class WizardGoldenTests: XCTestCase {
 
     func test_timedOut_generatesSingleWarningIssue() {
         let context = makeContext(timedOut: true)
-        let result = SystemContextAdapter.adapt(context)
+        let result = SystemStateResult.projecting(context)
         XCTAssertEqual(result.issues.count, 1)
         XCTAssertEqual(result.issues.first?.identifier, .validationTimeout)
         XCTAssertEqual(result.issues.first?.severity, .warning)
@@ -245,7 +245,7 @@ final class WizardGoldenTests: XCTestCase {
                 canAutoResolve: true
             )
         )
-        let result = SystemContextAdapter.adapt(context)
+        let result = SystemStateResult.projecting(context)
         let conflictIssues = result.issues.filter { $0.category == .conflicts }
         XCTAssertEqual(conflictIssues.count, 2)
         XCTAssertEqual(conflictIssues.first?.autoFixAction, .terminateConflictingProcesses)
@@ -255,7 +255,7 @@ final class WizardGoldenTests: XCTestCase {
         let context = makeContext(
             permissions: makePermissions(kanataIM: .unknown)
         )
-        let result = SystemContextAdapter.adapt(context)
+        let result = SystemStateResult.projecting(context)
         let imIssue = result.issues.first { $0.identifier == .permission(.kanataInputMonitoring) }
         XCTAssertNotNil(imIssue, "Should generate issue for unknown kanata IM")
         XCTAssertEqual(imIssue?.severity, .warning, "Unknown should be warning, not error")
@@ -265,7 +265,7 @@ final class WizardGoldenTests: XCTestCase {
         let context = makeContext(
             permissions: makePermissions(keyPathIM: .unknown)
         )
-        let result = SystemContextAdapter.adapt(context)
+        let result = SystemStateResult.projecting(context)
         let imIssue = result.issues.first { $0.identifier == .permission(.keyPathInputMonitoring) }
         XCTAssertNil(imIssue, "Unknown KeyPath IM should not generate an issue (startup mode)")
     }
@@ -440,7 +440,7 @@ final class WizardGoldenTests: XCTestCase {
 
     func test_e2e_allHealthy_routesToSummary() {
         let context = makeContext()
-        let result = SystemContextAdapter.adapt(context)
+        let result = SystemStateResult.projecting(context)
         let page = WizardRouter.route(
             state: result.state,
             issues: result.issues,
@@ -452,7 +452,7 @@ final class WizardGoldenTests: XCTestCase {
 
     func test_e2e_helperMissing_routesToHelper() {
         let context = makeContext(helper: HelperStatus(isInstalled: false, version: nil, isWorking: false))
-        let result = SystemContextAdapter.adapt(context)
+        let result = SystemStateResult.projecting(context)
         let page = WizardRouter.route(
             state: result.state,
             issues: result.issues,
@@ -464,7 +464,7 @@ final class WizardGoldenTests: XCTestCase {
 
     func test_e2e_keyPathIMDenied_routesToInputMonitoring() {
         let context = makeContext(permissions: makePermissions(keyPathIM: .denied))
-        let result = SystemContextAdapter.adapt(context)
+        let result = SystemStateResult.projecting(context)
         let page = WizardRouter.route(
             state: result.state,
             issues: result.issues,
@@ -485,7 +485,7 @@ final class WizardGoldenTests: XCTestCase {
             vhidVersionMismatch: false
         )
         let context = makeContext(components: components)
-        let result = SystemContextAdapter.adapt(context)
+        let result = SystemStateResult.projecting(context)
         let page = WizardRouter.route(
             state: result.state,
             issues: result.issues,
@@ -499,7 +499,7 @@ final class WizardGoldenTests: XCTestCase {
         let context = makeContext(
             services: HealthStatus(kanataRunning: false, karabinerDaemonRunning: true, vhidHealthy: true)
         )
-        let result = SystemContextAdapter.adapt(context)
+        let result = SystemStateResult.projecting(context)
         let page = WizardRouter.route(
             state: result.state,
             issues: result.issues,
@@ -517,7 +517,7 @@ final class WizardGoldenTests: XCTestCase {
                 canAutoResolve: true
             )
         )
-        let result = SystemContextAdapter.adapt(context)
+        let result = SystemStateResult.projecting(context)
         let page = WizardRouter.route(
             state: result.state,
             issues: result.issues,

--- a/Tests/KeyPathTests/InstallationWizard/WizardPureLogicTests.swift
+++ b/Tests/KeyPathTests/InstallationWizard/WizardPureLogicTests.swift
@@ -141,17 +141,17 @@ final class WizardPureLogicTests: XCTestCase {
         XCTAssertEqual(context.installerStateMatrixPlan, [.installRequiredRuntimeServices])
     }
 
-    func test_systemContextAdapterPublishesStateMatrixMetadata() {
+    func test_systemStateProjectionPublishesStateMatrixMetadata() {
         let context = makeContext(helper: HelperStatus(isInstalled: false, version: nil, isWorking: false))
 
-        let result = SystemContextAdapter.adapt(context)
+        let result = SystemStateResult.projecting(context)
 
         XCTAssertEqual(result.stateMatrixRow, InstallerStateMatrixRow.helperMissing.rawValue)
         XCTAssertEqual(result.stateMatrixPlan, [InstallerStateMatrixAction.installHelper.rawValue])
         XCTAssertEqual(result.autoFixActions, [.installPrivilegedHelper])
     }
 
-    func test_systemContextAdapterPublishesCapturedHelperRoutingFacts() {
+    func test_systemStateProjectionPublishesCapturedHelperRoutingFacts() {
         let context = makeContext(
             helper: HelperStatus(
                 isInstalled: false,
@@ -161,16 +161,16 @@ final class WizardPureLogicTests: XCTestCase {
             )
         )
 
-        let result = SystemContextAdapter.adapt(context)
+        let result = SystemStateResult.projecting(context)
 
         XCTAssertFalse(result.helperInstalled)
         XCTAssertTrue(result.helperNeedsApproval)
     }
 
-    func test_systemContextAdapterPreservesCaptureStatus() {
+    func test_systemStateProjectionPreservesCaptureStatus() {
         let context = makeContext(captureStatus: .cancelled)
 
-        let result = SystemContextAdapter.adapt(context)
+        let result = SystemStateResult.projecting(context)
 
         XCTAssertEqual(result.captureStatus, .cancelled)
         XCTAssertEqual(result.stateMatrixRow, InstallerStateMatrixRow.definitiveUnhealthyState.rawValue)

--- a/Tests/KeyPathTests/InstallationWizard/WizardStateRegressionTests.swift
+++ b/Tests/KeyPathTests/InstallationWizard/WizardStateRegressionTests.swift
@@ -55,8 +55,8 @@ final class WizardStateRegressionTests: XCTestCase {
         )
 
         // Run adapt twice to mimic reopen/open flows
-        let first = SystemContextAdapter.adapt(context)
-        let second = SystemContextAdapter.adapt(context)
+        let first = SystemStateResult.projecting(context)
+        let second = SystemStateResult.projecting(context)
 
         XCTAssertEqual(first.state, .active)
         XCTAssertEqual(second.state, .active)
@@ -111,7 +111,7 @@ final class WizardStateRegressionTests: XCTestCase {
             timestamp: Date()
         )
 
-        let adapted = SystemContextAdapter.adapt(context)
+        let adapted = SystemStateResult.projecting(context)
 
         XCTAssertEqual(adapted.state, .missingPermissions(missing: [.kanataInputMonitoring]))
         XCTAssertTrue(

--- a/Tests/KeyPathTests/Lint/InstallerDecisionPipelineLintTests.swift
+++ b/Tests/KeyPathTests/Lint/InstallerDecisionPipelineLintTests.swift
@@ -7,7 +7,7 @@ final class InstallerDecisionPipelineLintTests: KeyPathTestCase {
         let consumers = [
             root.appendingPathComponent("Sources/KeyPathInstallationWizard/Core/InstallerEngine.swift"),
             root.appendingPathComponent("Sources/KeyPathInstallationWizard/Core/InstallerEngine+Recipes.swift"),
-            root.appendingPathComponent("Sources/KeyPathInstallationWizard/Core/SystemContextAdapter.swift"),
+            root.appendingPathComponent("Sources/KeyPathInstallationWizard/Core/SystemStateResult+SystemContext.swift"),
         ]
         var violations: [String] = []
 

--- a/Tests/KeyPathTests/Lint/W6DeletionPassLintTests.swift
+++ b/Tests/KeyPathTests/Lint/W6DeletionPassLintTests.swift
@@ -286,6 +286,7 @@ final class W6DeletionPassLintTests: XCTestCase {
                     #"\brunFullInstall\b"#,
                     #"configure\(kanataManager"#,
                     #"InstallerEngine\(kanataManager"#,
+                    #"\bSystemContextAdapter\b"#,
                 ]
             )
         }

--- a/Tests/KeyPathTests/ModeARevertTests.swift
+++ b/Tests/KeyPathTests/ModeARevertTests.swift
@@ -9,7 +9,7 @@ import KeyPathWizardCore
 /// and that permission rejection detection works end-to-end.
 @MainActor
 final class ModeARevertTests: XCTestCase {
-    // MARK: - Permission Rejection Detection via SystemContextAdapter
+    // MARK: - Permission Rejection Detection via SystemStateResult Projection
 
     func testAdapterRoutesToPermissionsWhenPermissionRejected() {
         let context = makeContext(
@@ -18,7 +18,7 @@ final class ModeARevertTests: XCTestCase {
             permissionsGranted: true
         )
 
-        let result = SystemContextAdapter.adapt(context)
+        let result = SystemStateResult.projecting(context)
 
         XCTAssertEqual(
             result.state, .missingPermissions(missing: [.kanataAccessibility]),
@@ -33,7 +33,7 @@ final class ModeARevertTests: XCTestCase {
             permissionsGranted: true
         )
 
-        let result = SystemContextAdapter.adapt(context)
+        let result = SystemStateResult.projecting(context)
 
         let axIssue = result.issues.first { $0.identifier == .permission(.kanataAccessibility) }
         XCTAssertNotNil(axIssue, "Issues must include kanataAccessibility permission issue")
@@ -48,7 +48,7 @@ final class ModeARevertTests: XCTestCase {
             permissionsGranted: true
         )
 
-        let result = SystemContextAdapter.adapt(context)
+        let result = SystemStateResult.projecting(context)
 
         let runtimeIssue = result.issues.first { $0.identifier == .component(.keyPathRuntime) }
         XCTAssertNil(
@@ -64,7 +64,7 @@ final class ModeARevertTests: XCTestCase {
             permissionsGranted: true
         )
 
-        let result = SystemContextAdapter.adapt(context)
+        let result = SystemStateResult.projecting(context)
 
         XCTAssertEqual(
             result.state, .serviceNotRunning,
@@ -79,7 +79,7 @@ final class ModeARevertTests: XCTestCase {
             permissionsGranted: true
         )
 
-        let result = SystemContextAdapter.adapt(context)
+        let result = SystemStateResult.projecting(context)
 
         XCTAssertEqual(result.state, .active)
     }


### PR DESCRIPTION
## Summary
- replace the migration-era SystemContextAdapter type with an explicit SystemStateResult projection factory
- migrate production and test consumers without changing projection behavior
- rename adapter-specific tests and terminology
- extend the deletion ratchet so the compatibility type cannot regrow

## Validation
- focused projection/golden/wizard/lint suite: 179 passed
- `python3 Scripts/check-accessibility.py`: passed
- review gate: remote review gate selected; GitHub claude-review required