### PR TITLE
Verify postconditions before privileged fallback

### DIFF
--- a/Sources/KeyPathAppKit/Core/PrivilegedOperationsRouter.swift
+++ b/Sources/KeyPathAppKit/Core/PrivilegedOperationsRouter.swift
@@ -40,6 +40,17 @@ public final class PrivilegedOperationsRouter {
         nonisolated(unsafe) static var installAllServicesOverride: (() async throws -> Void)?
         nonisolated(unsafe) static var recoverRequiredRuntimeServicesOverride: (() async throws -> Void)?
         nonisolated(unsafe) static var killExistingKanataProcessesOverride: (() async throws -> Void)?
+        nonisolated(unsafe) static var helperRecoverRequiredRuntimeServicesOverride: (() async throws -> Void)?
+        nonisolated(unsafe) static var sudoRestartServicesOverride: (() async throws -> Void)?
+        nonisolated(unsafe) static var helperInstallNewsyslogConfigOverride: (() async throws -> Void)?
+        nonisolated(unsafe) static var sudoInstallNewsyslogConfigOverride: (() async throws -> Void)?
+        nonisolated(unsafe) static var helperInstallCorrectVHIDDriverOverride: (() async throws -> Void)?
+        nonisolated(unsafe) static var sudoInstallCorrectVHIDDriverOverride: (() async throws -> Void)?
+        nonisolated(unsafe) static var bundledVHIDDriverPackagePathOverride: (() -> String?)?
+        nonisolated(unsafe) static var helperTerminateProcessOverride: ((Int32) async throws -> Void)?
+        nonisolated(unsafe) static var sudoTerminateProcessOverride: ((Int32) async throws -> Void)?
+        nonisolated(unsafe) static var helperKillAllKanataOverride: (() async throws -> Void)?
+        nonisolated(unsafe) static var sudoKillAllKanataOverride: (() async throws -> Void)?
         nonisolated(unsafe) static var activateVirtualHIDManagerOverride: (() async throws -> Void)?
         nonisolated(unsafe) static var downloadAndInstallCorrectVHIDDriverOverride: (() async throws -> Void)?
         nonisolated(unsafe) static var kanataReadinessOverride:
@@ -50,6 +61,7 @@ public final class PrivilegedOperationsRouter {
         nonisolated(unsafe) static var vhidDriverPostconditionOverride: ((String) async -> Bool)?
         nonisolated(unsafe) static var processTerminatedPostconditionOverride: ((Int32, String) async -> Bool)?
         nonisolated(unsafe) static var kanataStoppedPostconditionOverride: ((String) async -> Bool)?
+        nonisolated(unsafe) static var newsyslogPostconditionOverride: (() -> Bool)?
 
         static func resetTestingState() {
             operationModeOverride = nil
@@ -57,6 +69,17 @@ public final class PrivilegedOperationsRouter {
             installAllServicesOverride = nil
             recoverRequiredRuntimeServicesOverride = nil
             killExistingKanataProcessesOverride = nil
+            helperRecoverRequiredRuntimeServicesOverride = nil
+            sudoRestartServicesOverride = nil
+            helperInstallNewsyslogConfigOverride = nil
+            sudoInstallNewsyslogConfigOverride = nil
+            helperInstallCorrectVHIDDriverOverride = nil
+            sudoInstallCorrectVHIDDriverOverride = nil
+            bundledVHIDDriverPackagePathOverride = nil
+            helperTerminateProcessOverride = nil
+            sudoTerminateProcessOverride = nil
+            helperKillAllKanataOverride = nil
+            sudoKillAllKanataOverride = nil
             activateVirtualHIDManagerOverride = nil
             downloadAndInstallCorrectVHIDDriverOverride = nil
             kanataReadinessOverride = nil
@@ -66,6 +89,7 @@ public final class PrivilegedOperationsRouter {
             vhidDriverPostconditionOverride = nil
             processTerminatedPostconditionOverride = nil
             kanataStoppedPostconditionOverride = nil
+            newsyslogPostconditionOverride = nil
             lastServiceInstallAttempt = nil
             lastSMAppApprovalNotice = nil
             ServiceInstallGuard.reset()
@@ -146,9 +170,25 @@ public final class PrivilegedOperationsRouter {
         switch Self.operationMode {
         case .privilegedHelper:
             do {
-                try await helperManager.recoverRequiredRuntimeServices()
+                try await helperRecoverRequiredRuntimeServices()
+                try await enforceKanataRuntimePostcondition(after: "recoverRequiredRuntimeServices(helper)")
             } catch {
-                try await sudoRestartServices()
+                try await resolveHelperFailure(
+                    operation: "recoverRequiredRuntimeServices",
+                    error: error,
+                    postcondition: { [self] in
+                        await verifyKanataReadinessAfterInstall(
+                            context: "recoverRequiredRuntimeServices(helper-error)"
+                        ).isSuccess
+                    },
+                    fallback: { [self] in try await sudoRestartServices() },
+                    enforcePostcondition: { [self] in
+                        try await enforceKanataRuntimePostcondition(
+                            after: "recoverRequiredRuntimeServices(sudo-fallback)"
+                        )
+                    }
+                )
+                return
             }
         case .directSudo:
             try await sudoRestartServices()
@@ -207,10 +247,23 @@ public final class PrivilegedOperationsRouter {
     public func installNewsyslogConfig() async throws {
         switch Self.operationMode {
         case .privilegedHelper:
-            do { try await helperManager.installNewsyslogConfig() }
-            catch { try await sudoInstallNewsyslogConfig() }
+            do {
+                try await helperInstallNewsyslogConfig()
+                try enforceNewsyslogPostcondition(after: "installNewsyslogConfig(helper)")
+            } catch {
+                try await resolveHelperFailure(
+                    operation: "installNewsyslogConfig",
+                    error: error,
+                    postcondition: { [self] in verifyNewsyslogPostcondition() },
+                    fallback: { [self] in try await sudoInstallNewsyslogConfig() },
+                    enforcePostcondition: { [self] in
+                        try enforceNewsyslogPostcondition(after: "installNewsyslogConfig(sudo-fallback)")
+                    }
+                )
+            }
         case .directSudo:
             try await sudoInstallNewsyslogConfig()
+            try enforceNewsyslogPostcondition(after: "installNewsyslogConfig(sudo)")
         }
     }
 
@@ -221,15 +274,21 @@ public final class PrivilegedOperationsRouter {
                 try await helperRepairVHIDDaemonServices()
                 try await enforceVHIDServicesPostcondition(after: "repairVHIDDaemonServices(helper)")
             } catch {
-                // A timeout or interrupted reply does not prove the helper mutation failed.
-                // Verify current system state before prompting for administrator fallback.
-                if await verifyVHIDServicesPostcondition(context: "repairVHIDDaemonServices(helper-error)") {
-                    AppLogger.shared.log("✅ [Router] Helper reply failed, but VHID postcondition is satisfied; skipping administrator fallback")
-                    return
-                }
-                AppLogger.shared.log("⚠️ [Router] Helper repair did not satisfy the VHID postcondition — using allowed sudo fallback once")
-                try await sudoRepairVHIDServices()
-                try await enforceVHIDServicesPostcondition(after: "repairVHIDDaemonServices(sudo-fallback)")
+                try await resolveHelperFailure(
+                    operation: "repairVHIDDaemonServices",
+                    error: error,
+                    postcondition: { [self] in
+                        await verifyVHIDServicesPostcondition(
+                            context: "repairVHIDDaemonServices(helper-error)"
+                        )
+                    },
+                    fallback: { [self] in try await sudoRepairVHIDServices() },
+                    enforcePostcondition: { [self] in
+                        try await enforceVHIDServicesPostcondition(
+                            after: "repairVHIDDaemonServices(sudo-fallback)"
+                        )
+                    }
+                )
             }
         case .directSudo:
             try await sudoRepairVHIDServices()
@@ -280,20 +339,44 @@ public final class PrivilegedOperationsRouter {
         switch Self.operationMode {
         case .privilegedHelper:
             do {
-                let bundledPkgPath = WizardSystemPaths.bundledVHIDDriverPkgPath
-                guard WizardSystemPaths.bundledVHIDDriverPkgExists else {
+                #if DEBUG
+                    let bundledPkgPath = Self.bundledVHIDDriverPackagePathOverride?()
+                        ?? (WizardSystemPaths.bundledVHIDDriverPkgExists
+                            ? WizardSystemPaths.bundledVHIDDriverPkgPath
+                            : nil)
+                #else
+                    let bundledPkgPath = WizardSystemPaths.bundledVHIDDriverPkgExists
+                        ? WizardSystemPaths.bundledVHIDDriverPkgPath
+                        : nil
+                #endif
+                guard let bundledPkgPath else {
                     throw PrivilegedOperationError.operationFailed(
                         "Bundled VHID driver package not found."
                     )
                 }
-                try await helperManager.installBundledVHIDDriver(pkgPath: bundledPkgPath)
+                try await helperInstallCorrectVHIDDriver(pkgPath: bundledPkgPath)
+                try await enforceVHIDDriverPostcondition(after: "downloadAndInstallCorrectVHIDDriver(helper)")
             } catch {
-                try await sudoInstallCorrectDriver()
+                try await resolveHelperFailure(
+                    operation: "downloadAndInstallCorrectVHIDDriver",
+                    error: error,
+                    postcondition: { [self] in
+                        await verifyVHIDDriverPostcondition(
+                            context: "downloadAndInstallCorrectVHIDDriver(helper-error)"
+                        )
+                    },
+                    fallback: { [self] in try await sudoInstallCorrectDriver() },
+                    enforcePostcondition: { [self] in
+                        try await enforceVHIDDriverPostcondition(
+                            after: "downloadAndInstallCorrectVHIDDriver(sudo-fallback)"
+                        )
+                    }
+                )
             }
         case .directSudo:
             try await sudoInstallCorrectDriver()
+            try await enforceVHIDDriverPostcondition(after: "downloadAndInstallCorrectVHIDDriver(sudo)")
         }
-        try await enforceVHIDDriverPostcondition(after: "downloadAndInstallCorrectVHIDDriver")
     }
 
     public func terminateProcess(pid: Int32) async throws {
@@ -306,23 +389,61 @@ public final class PrivilegedOperationsRouter {
 
         switch Self.operationMode {
         case .privilegedHelper:
-            do { try await helperManager.terminateProcess(pid) }
-            catch { try await sudoTerminateProcess(pid: pid) }
+            do {
+                try await helperTerminateProcess(pid: pid)
+                try await enforceProcessTerminatedPostcondition(pid: pid, after: "terminateProcess(helper)")
+            } catch {
+                try await resolveHelperFailure(
+                    operation: "terminateProcess",
+                    error: error,
+                    postcondition: { [self] in
+                        await verifyProcessTerminatedPostcondition(
+                            pid: pid,
+                            context: "terminateProcess(helper-error)"
+                        )
+                    },
+                    fallback: { [self] in try await sudoTerminateProcess(pid: pid) },
+                    enforcePostcondition: { [self] in
+                        try await enforceProcessTerminatedPostcondition(
+                            pid: pid,
+                            after: "terminateProcess(sudo-fallback)"
+                        )
+                    }
+                )
+            }
         case .directSudo:
             try await sudoTerminateProcess(pid: pid)
+            try await enforceProcessTerminatedPostcondition(pid: pid, after: "terminateProcess(sudo)")
         }
-        try await enforceProcessTerminatedPostcondition(pid: pid, after: "terminateProcess")
     }
 
     public func killAllKanataProcesses() async throws {
         switch Self.operationMode {
         case .privilegedHelper:
-            do { try await helperManager.killAllKanataProcesses() }
-            catch { try await sudoKillAllKanata() }
+            do {
+                try await helperKillAllKanataProcesses()
+                try await enforceKanataStoppedPostcondition(after: "killAllKanataProcesses(helper)")
+            } catch {
+                try await resolveHelperFailure(
+                    operation: "killAllKanataProcesses",
+                    error: error,
+                    postcondition: { [self] in
+                        await verifyKanataStoppedPostcondition(
+                            context: "killAllKanataProcesses(helper-error)"
+                        )
+                    },
+                    fallback: { [self] in try await sudoKillAllKanata() },
+                    enforcePostcondition: { [self] in
+                        try await enforceKanataStoppedPostcondition(
+                            after: "killAllKanataProcesses(sudo-fallback)"
+                        )
+                    }
+                )
+            }
         case .directSudo:
             try await sudoKillAllKanata()
+            try await enforceKanataStoppedPostcondition(after: "killAllKanataProcesses(sudo)")
         }
-        try await enforceKanataStoppedPostcondition(after: "killAllKanataProcesses")
     }
 
     public func restartKarabinerDaemonVerified() async throws -> Bool {
@@ -367,6 +488,12 @@ public final class PrivilegedOperationsRouter {
     }
 
     private func sudoRestartServices() async throws {
+        #if DEBUG
+            if let override = Self.sudoRestartServicesOverride {
+                try await override()
+                return
+            }
+        #endif
         let success = await ServiceBootstrapper.shared.recoverRequiredRuntimeServices()
         if !success {
             throw PrivilegedOperationError.operationFailed("Service restart failed")
@@ -381,6 +508,12 @@ public final class PrivilegedOperationsRouter {
     }
 
     private func sudoInstallNewsyslogConfig() async throws {
+        #if DEBUG
+            if let override = Self.sudoInstallNewsyslogConfigOverride {
+                try await override()
+                return
+            }
+        #endif
         let success = await ServiceBootstrapper.shared.installNewsyslogConfig()
         if !success {
             throw PrivilegedOperationError.operationFailed("Newsyslog config installation failed")
@@ -415,6 +548,12 @@ public final class PrivilegedOperationsRouter {
     }
 
     private func sudoInstallCorrectDriver() async throws {
+        #if DEBUG
+            if let override = Self.sudoInstallCorrectVHIDDriverOverride {
+                try await override()
+                return
+            }
+        #endif
         let vhidManager = VHIDDeviceManager()
         if await !(vhidManager.downloadAndInstallCorrectVersion()) {
             throw PrivilegedOperationError.operationFailed("Driver installation failed")
@@ -422,6 +561,12 @@ public final class PrivilegedOperationsRouter {
     }
 
     private func sudoTerminateProcess(pid: Int32) async throws {
+        #if DEBUG
+            if let override = Self.sudoTerminateProcessOverride {
+                try await override(pid)
+                return
+            }
+        #endif
         do {
             try await sudoExecuteCommand("/bin/kill -TERM \(pid)", description: "Terminate process \(pid)")
         } catch {
@@ -430,6 +575,12 @@ public final class PrivilegedOperationsRouter {
     }
 
     private func sudoKillAllKanata() async throws {
+        #if DEBUG
+            if let override = Self.sudoKillAllKanataOverride {
+                try await override()
+                return
+            }
+        #endif
         try await sudoExecuteCommand("/usr/bin/pkill -f kanata", description: "Kill all Kanata processes")
     }
 
@@ -475,6 +626,56 @@ public final class PrivilegedOperationsRouter {
         try await helperManager.repairVHIDDaemonServices()
     }
 
+    private func helperRecoverRequiredRuntimeServices() async throws {
+        #if DEBUG
+            if let override = Self.helperRecoverRequiredRuntimeServicesOverride {
+                try await override()
+                return
+            }
+        #endif
+        try await helperManager.recoverRequiredRuntimeServices()
+    }
+
+    private func helperInstallNewsyslogConfig() async throws {
+        #if DEBUG
+            if let override = Self.helperInstallNewsyslogConfigOverride {
+                try await override()
+                return
+            }
+        #endif
+        try await helperManager.installNewsyslogConfig()
+    }
+
+    private func helperInstallCorrectVHIDDriver(pkgPath: String) async throws {
+        #if DEBUG
+            if let override = Self.helperInstallCorrectVHIDDriverOverride {
+                try await override()
+                return
+            }
+        #endif
+        try await helperManager.installBundledVHIDDriver(pkgPath: pkgPath)
+    }
+
+    private func helperTerminateProcess(pid: Int32) async throws {
+        #if DEBUG
+            if let override = Self.helperTerminateProcessOverride {
+                try await override(pid)
+                return
+            }
+        #endif
+        try await helperManager.terminateProcess(pid)
+    }
+
+    private func helperKillAllKanataProcesses() async throws {
+        #if DEBUG
+            if let override = Self.helperKillAllKanataOverride {
+                try await override()
+                return
+            }
+        #endif
+        try await helperManager.killAllKanataProcesses()
+    }
+
     private func killExistingKanataProcessesForServiceRecovery() async throws {
         #if DEBUG
             if let override = Self.killExistingKanataProcessesOverride {
@@ -485,11 +686,61 @@ public final class PrivilegedOperationsRouter {
 
         switch Self.operationMode {
         case .privilegedHelper:
-            do { try await helperManager.killAllKanataProcesses() }
-            catch { try await sudoKillAllKanata() }
+            do {
+                try await helperKillAllKanataProcesses()
+                try await enforceKanataStoppedPostcondition(
+                    after: "killExistingKanataProcessesForServiceRecovery(helper)"
+                )
+            } catch {
+                try await resolveHelperFailure(
+                    operation: "killExistingKanataProcessesForServiceRecovery",
+                    error: error,
+                    postcondition: { [self] in
+                        await verifyKanataStoppedPostcondition(
+                            context: "killExistingKanataProcessesForServiceRecovery(helper-error)"
+                        )
+                    },
+                    fallback: { [self] in try await sudoKillAllKanata() },
+                    enforcePostcondition: { [self] in
+                        try await enforceKanataStoppedPostcondition(
+                            after: "killExistingKanataProcessesForServiceRecovery(sudo-fallback)"
+                        )
+                    }
+                )
+            }
         case .directSudo:
             try await sudoKillAllKanata()
+            try await enforceKanataStoppedPostcondition(
+                after: "killExistingKanataProcessesForServiceRecovery(sudo)"
+            )
         }
+    }
+
+    private func resolveHelperFailure(
+        operation: String,
+        error: Error,
+        postcondition: () async -> Bool,
+        fallback: () async throws -> Void,
+        enforcePostcondition: () async throws -> Void
+    ) async throws {
+        if await postcondition() {
+            AppLogger.shared.log(
+                "✅ [Router] \(operation) helper reply failed, but its postcondition is satisfied; skipping administrator fallback"
+            )
+            return
+        }
+
+        if case .ambiguousOutcome = error as? HelperManagerError {
+            AppLogger.shared.log(
+                "⚠️ [Router] \(operation) helper outcome is ambiguous and its postcondition is unsatisfied — using allowed administrator fallback once"
+            )
+        } else {
+            AppLogger.shared.log(
+                "⚠️ [Router] \(operation) helper failed and its postcondition is unsatisfied — using allowed administrator fallback once"
+            )
+        }
+        try await fallback()
+        try await enforcePostcondition()
     }
 
     private func enforceKanataRuntimePostcondition(after operation: String) async throws {
@@ -502,6 +753,23 @@ public final class PrivilegedOperationsRouter {
                 "Kanata postcondition failed after \(operation): \(readiness.failureDescription)"
             )
         }
+    }
+
+    private func enforceNewsyslogPostcondition(after operation: String) throws {
+        guard verifyNewsyslogPostcondition() else {
+            throw PrivilegedOperationError.operationFailed(
+                "Newsyslog config postcondition failed after \(operation)"
+            )
+        }
+    }
+
+    private func verifyNewsyslogPostcondition() -> Bool {
+        #if DEBUG
+            if let override = Self.newsyslogPostconditionOverride {
+                return override()
+            }
+        #endif
+        return ServiceBootstrapper.shared.isNewsyslogConfigInstalled()
     }
 
     private func enforceVHIDServicesPostcondition(after operation: String) async throws {

--- a/Sources/KeyPathAppKit/Core/PrivilegedOperationsRouter.swift
+++ b/Sources/KeyPathAppKit/Core/PrivilegedOperationsRouter.swift
@@ -188,7 +188,6 @@ public final class PrivilegedOperationsRouter {
                         )
                     }
                 )
-                return
             }
         case .directSudo:
             try await sudoRestartServices()

--- a/Sources/KeyPathAppKit/Managers/UninstallCoordinator.swift
+++ b/Sources/KeyPathAppKit/Managers/UninstallCoordinator.swift
@@ -245,6 +245,43 @@ public final class UninstallCoordinator {
             logLines.append("⚠️ \(helperFailure!)")
         }
 
+        // A timeout or interrupted helper reply is ambiguous. Before invoking
+        // Emergency Cleanup, verify whether the helper already removed the
+        // requested components. Only tear down helper registration after the
+        // filesystem postcondition proves the uninstall completed.
+        let filesRemovedAfterHelperError = await waitForUninstallPostconditions()
+        if filesRemovedAfterHelperError {
+            let driverRemoved: Bool = if removeVirtualHID {
+                await waitForVirtualHIDRemoval()
+            } else {
+                true
+            }
+            if driverRemoved {
+                let helperUnregistered = await unregisterHelperClosure()
+                steps.append(WizardUninstallStepResult(
+                    id: "unregister-uninstall-helper",
+                    success: helperUnregistered,
+                    error: helperUnregistered ? nil : "The system helper registration remains active."
+                ))
+                steps.append(WizardUninstallStepResult(
+                    id: "verify-uninstall",
+                    success: helperUnregistered,
+                    error: helperUnregistered ? nil : "The system helper registration remains active."
+                ))
+                if helperUnregistered {
+                    await resetForTestingIfEnabled()
+                    logLines.append(
+                        "✅ System helper reply failed, but uninstall postconditions are satisfied; skipping Emergency Cleanup"
+                    )
+                    return finish(WizardUninstallResult(
+                        success: true,
+                        steps: steps,
+                        logs: logLines
+                    ))
+                }
+            }
+        }
+
         if allowAdminFallback {
             return await performEmergencyCleanup(
                 deleteConfig: deleteConfig,

--- a/Sources/KeyPathAppKit/Managers/UninstallCoordinator.swift
+++ b/Sources/KeyPathAppKit/Managers/UninstallCoordinator.swift
@@ -164,6 +164,7 @@ public final class UninstallCoordinator {
         }
 
         var helperFailure: String?
+        var helperReplyFailed = false
         var virtualHIDFailure: String?
         if helperReady {
             logLines.append("🔧 Using the system helper for uninstall...")
@@ -232,6 +233,7 @@ public final class UninstallCoordinator {
                     ? "Some KeyPath system components remain installed."
                     : "The system helper registration could not be removed."
             } catch {
+                helperReplyFailed = true
                 helperFailure = error.localizedDescription
                 steps.append(WizardUninstallStepResult(
                     id: "uninstall-via-helper",
@@ -249,7 +251,9 @@ public final class UninstallCoordinator {
         // Emergency Cleanup, verify whether the helper already removed the
         // requested components. Only tear down helper registration after the
         // filesystem postcondition proves the uninstall completed.
-        let filesRemovedAfterHelperError = await waitForUninstallPostconditions()
+        let filesRemovedAfterHelperError = helperReplyFailed
+            ? await waitForUninstallPostconditions()
+            : false
         if filesRemovedAfterHelperError {
             let driverRemoved: Bool = if removeVirtualHID {
                 await waitForVirtualHIDRemoval()

--- a/Tests/KeyPathTests/Core/PrivilegedOperationsCoordinatorTests.swift
+++ b/Tests/KeyPathTests/Core/PrivilegedOperationsCoordinatorTests.swift
@@ -360,6 +360,166 @@ final class PrivilegedOperationsRouterTests: XCTestCase {
         #endif
     }
 
+    func testRuntimeRecoveryLostHelperReplyWithReadyRuntimeSkipsFallback() async throws {
+        #if DEBUG
+            PrivilegedOperationsRouter.resetTestingState()
+            PrivilegedOperationsRouter.operationModeOverride = .privilegedHelper
+            PrivilegedOperationsRouter.serviceStateOverride = { .smappserviceActive }
+            KanataDaemonManager.registeredButNotLoadedOverride = { false }
+            PrivilegedOperationsRouter.killExistingKanataProcessesOverride = {}
+            PrivilegedOperationsRouter.helperRecoverRequiredRuntimeServicesOverride = {
+                throw HelperManagerError.ambiguousOutcome("reply lost")
+            }
+            PrivilegedOperationsRouter.kanataReadinessOverride = { _ in .ready }
+            var fallbackCalls = 0
+            PrivilegedOperationsRouter.sudoRestartServicesOverride = { fallbackCalls += 1 }
+        #else
+            throw XCTSkip("Uses DEBUG-only PrivilegedOperationsRouter test overrides")
+        #endif
+
+        try await PrivilegedOperationsRouter.shared.recoverRequiredRuntimeServices()
+
+        #if DEBUG
+            XCTAssertEqual(fallbackCalls, 0)
+        #endif
+    }
+
+    func testRuntimeRecoveryLostKillReplyWithStoppedRuntimeSkipsKillFallback() async throws {
+        #if DEBUG
+            PrivilegedOperationsRouter.resetTestingState()
+            PrivilegedOperationsRouter.operationModeOverride = .privilegedHelper
+            PrivilegedOperationsRouter.serviceStateOverride = { .smappserviceActive }
+            KanataDaemonManager.registeredButNotLoadedOverride = { false }
+            PrivilegedOperationsRouter.helperKillAllKanataOverride = {
+                throw HelperManagerError.ambiguousOutcome("reply lost")
+            }
+            PrivilegedOperationsRouter.kanataStoppedPostconditionOverride = { _ in true }
+            var killFallbackCalls = 0
+            PrivilegedOperationsRouter.sudoKillAllKanataOverride = { killFallbackCalls += 1 }
+            PrivilegedOperationsRouter.helperRecoverRequiredRuntimeServicesOverride = {}
+            PrivilegedOperationsRouter.kanataReadinessOverride = { _ in .ready }
+        #else
+            throw XCTSkip("Uses DEBUG-only PrivilegedOperationsRouter test overrides")
+        #endif
+
+        try await PrivilegedOperationsRouter.shared.recoverRequiredRuntimeServices()
+
+        #if DEBUG
+            XCTAssertEqual(killFallbackCalls, 0)
+        #endif
+    }
+
+    func testNewsyslogLostHelperReplyWithInstalledConfigSkipsFallback() async throws {
+        #if DEBUG
+            PrivilegedOperationsRouter.resetTestingState()
+            PrivilegedOperationsRouter.operationModeOverride = .privilegedHelper
+            PrivilegedOperationsRouter.helperInstallNewsyslogConfigOverride = {
+                throw HelperManagerError.ambiguousOutcome("reply lost")
+            }
+            PrivilegedOperationsRouter.newsyslogPostconditionOverride = { true }
+            var fallbackCalls = 0
+            PrivilegedOperationsRouter.sudoInstallNewsyslogConfigOverride = { fallbackCalls += 1 }
+        #else
+            throw XCTSkip("Uses DEBUG-only PrivilegedOperationsRouter test overrides")
+        #endif
+
+        try await PrivilegedOperationsRouter.shared.installNewsyslogConfig()
+
+        #if DEBUG
+            XCTAssertEqual(fallbackCalls, 0)
+        #endif
+    }
+
+    func testDriverInstallLostHelperReplyWithInstalledDriverSkipsFallback() async throws {
+        #if DEBUG
+            PrivilegedOperationsRouter.resetTestingState()
+            PrivilegedOperationsRouter.operationModeOverride = .privilegedHelper
+            PrivilegedOperationsRouter.bundledVHIDDriverPackagePathOverride = { "/tmp/test-driver.pkg" }
+            PrivilegedOperationsRouter.helperInstallCorrectVHIDDriverOverride = {
+                throw HelperManagerError.ambiguousOutcome("reply lost")
+            }
+            PrivilegedOperationsRouter.vhidDriverPostconditionOverride = { _ in true }
+            var fallbackCalls = 0
+            PrivilegedOperationsRouter.sudoInstallCorrectVHIDDriverOverride = { fallbackCalls += 1 }
+        #else
+            throw XCTSkip("Uses DEBUG-only PrivilegedOperationsRouter test overrides")
+        #endif
+
+        try await PrivilegedOperationsRouter.shared.downloadAndInstallCorrectVHIDDriver()
+
+        #if DEBUG
+            XCTAssertEqual(fallbackCalls, 0)
+        #endif
+    }
+
+    func testProcessTerminationLostHelperReplyWithExitedProcessSkipsFallback() async throws {
+        #if DEBUG
+            PrivilegedOperationsRouter.resetTestingState()
+            PrivilegedOperationsRouter.operationModeOverride = .privilegedHelper
+            PrivilegedOperationsRouter.helperTerminateProcessOverride = { _ in
+                throw HelperManagerError.ambiguousOutcome("reply lost")
+            }
+            PrivilegedOperationsRouter.processTerminatedPostconditionOverride = { _, _ in true }
+            var fallbackCalls = 0
+            PrivilegedOperationsRouter.sudoTerminateProcessOverride = { _ in fallbackCalls += 1 }
+        #else
+            throw XCTSkip("Uses DEBUG-only PrivilegedOperationsRouter test overrides")
+        #endif
+
+        try await PrivilegedOperationsRouter.shared.terminateProcess(pid: 42)
+
+        #if DEBUG
+            XCTAssertEqual(fallbackCalls, 0)
+        #endif
+    }
+
+    func testKillAllLostHelperReplyWithStoppedRuntimeSkipsFallback() async throws {
+        #if DEBUG
+            PrivilegedOperationsRouter.resetTestingState()
+            PrivilegedOperationsRouter.operationModeOverride = .privilegedHelper
+            PrivilegedOperationsRouter.helperKillAllKanataOverride = {
+                throw HelperManagerError.ambiguousOutcome("reply lost")
+            }
+            PrivilegedOperationsRouter.kanataStoppedPostconditionOverride = { _ in true }
+            var fallbackCalls = 0
+            PrivilegedOperationsRouter.sudoKillAllKanataOverride = { fallbackCalls += 1 }
+        #else
+            throw XCTSkip("Uses DEBUG-only PrivilegedOperationsRouter test overrides")
+        #endif
+
+        try await PrivilegedOperationsRouter.shared.killAllKanataProcesses()
+
+        #if DEBUG
+            XCTAssertEqual(fallbackCalls, 0)
+        #endif
+    }
+
+    func testKillAllFailedHelperWithRunningRuntimeInvokesFallbackOnce() async throws {
+        #if DEBUG
+            PrivilegedOperationsRouter.resetTestingState()
+            PrivilegedOperationsRouter.operationModeOverride = .privilegedHelper
+            PrivilegedOperationsRouter.helperKillAllKanataOverride = {
+                throw HelperManagerError.operationFailed("failed")
+            }
+            var verificationCalls = 0
+            PrivilegedOperationsRouter.kanataStoppedPostconditionOverride = { _ in
+                verificationCalls += 1
+                return verificationCalls > 1
+            }
+            var fallbackCalls = 0
+            PrivilegedOperationsRouter.sudoKillAllKanataOverride = { fallbackCalls += 1 }
+        #else
+            throw XCTSkip("Uses DEBUG-only PrivilegedOperationsRouter test overrides")
+        #endif
+
+        try await PrivilegedOperationsRouter.shared.killAllKanataProcesses()
+
+        #if DEBUG
+            XCTAssertEqual(fallbackCalls, 1)
+            XCTAssertEqual(verificationCalls, 2)
+        #endif
+    }
+
     func testRuntimeInstallUsesSMAppServiceAwareInstallPathBeforeKanataPostcondition() async throws {
         #if DEBUG
             PrivilegedOperationsRouter.resetTestingState()

--- a/Tests/KeyPathTests/Core/PrivilegedOperationsCoordinatorTests.swift
+++ b/Tests/KeyPathTests/Core/PrivilegedOperationsCoordinatorTests.swift
@@ -370,7 +370,11 @@ final class PrivilegedOperationsRouterTests: XCTestCase {
             PrivilegedOperationsRouter.helperRecoverRequiredRuntimeServicesOverride = {
                 throw HelperManagerError.ambiguousOutcome("reply lost")
             }
-            PrivilegedOperationsRouter.kanataReadinessOverride = { _ in .ready }
+            var readinessChecks = 0
+            PrivilegedOperationsRouter.kanataReadinessOverride = { _ in
+                readinessChecks += 1
+                return .ready
+            }
             var fallbackCalls = 0
             PrivilegedOperationsRouter.sudoRestartServicesOverride = { fallbackCalls += 1 }
         #else
@@ -381,6 +385,7 @@ final class PrivilegedOperationsRouterTests: XCTestCase {
 
         #if DEBUG
             XCTAssertEqual(fallbackCalls, 0)
+            XCTAssertEqual(readinessChecks, 2, "Recovery must still run its final post-restart verification")
         #endif
     }
 

--- a/Tests/KeyPathTests/Lint/PostconditionLintTests.swift
+++ b/Tests/KeyPathTests/Lint/PostconditionLintTests.swift
@@ -32,6 +32,15 @@ final class PostconditionLintTests: XCTestCase {
         )
     }
 
+    func testNewsyslogInstallEnforcesFilePostcondition() throws {
+        try assertFunctions(
+            [
+                "installNewsyslogConfig"
+            ],
+            contain: "enforceNewsyslogPostcondition"
+        )
+    }
+
     func testVHIDDriverInstallEnforcesDriverPostcondition() throws {
         try assertFunctions(
             [
@@ -72,6 +81,7 @@ final class PostconditionLintTests: XCTestCase {
             "installRequiredRuntimeServices",
             "recoverRequiredRuntimeServices",
             "regenerateServiceConfiguration",
+            "installNewsyslogConfig",
             "repairVHIDDaemonServices",
             "activateVirtualHIDManager",
             "downloadAndInstallCorrectVHIDDriver",
@@ -84,7 +94,6 @@ final class PostconditionLintTests: XCTestCase {
         ]
         let explicitFollowUpExemptions: Set = [
             "cleanupPrivilegedHelper",
-            "installNewsyslogConfig",
             "uninstallVirtualHIDDrivers",
             "disableKarabinerGrabber",
             "sudoExecuteCommand"

--- a/Tests/KeyPathTests/Managers/UninstallCoordinatorTests.swift
+++ b/Tests/KeyPathTests/Managers/UninstallCoordinatorTests.swift
@@ -207,6 +207,30 @@ final class UninstallCoordinatorTests: XCTestCase {
         XCTAssertTrue(coordinator.logLines.contains { $0.contains("cleanup already satisfied") })
     }
 
+    func testLostHelperReplyWithSatisfiedPostconditionsSkipsEmergencyCleanup() async {
+        var helperAttempted = false
+        var adminFallbackCalls = 0
+        let coordinator = makeCoordinator(
+            runWithAdminPrivileges: { _, _, _ in
+                adminFallbackCalls += 1
+                return .failure("Emergency Cleanup should not run")
+            },
+            postconditionsSatisfied: { helperAttempted },
+            uninstallViaHelper: { _ in
+                helperAttempted = true
+                throw HelperManagerError.ambiguousOutcome("reply lost")
+            }
+        )
+
+        let result = await coordinator.performUninstall(allowAdminFallback: true)
+
+        XCTAssertTrue(result.success)
+        XCTAssertEqual(adminFallbackCalls, 0)
+        XCTAssertTrue(result.steps.contains { $0.id == "uninstall-via-helper" && !$0.success })
+        XCTAssertTrue(result.steps.contains { $0.id == "verify-uninstall" && $0.success })
+        XCTAssertTrue(coordinator.logLines.contains { $0.contains("skipping Emergency Cleanup") })
+    }
+
     private func makeCoordinator(
         resolveUninstallerURL: @escaping () -> URL? = {
             URL(fileURLWithPath: "/tmp/keypath-test-uninstall.sh")

--- a/Tests/KeyPathTests/Managers/UninstallCoordinatorTests.swift
+++ b/Tests/KeyPathTests/Managers/UninstallCoordinatorTests.swift
@@ -231,6 +231,26 @@ final class UninstallCoordinatorTests: XCTestCase {
         XCTAssertTrue(coordinator.logLines.contains { $0.contains("skipping Emergency Cleanup") })
     }
 
+    func testCompletedHelperReplyDoesNotDuplicateStepsWhenEmergencyCleanupRuns() async {
+        var postconditionChecks = 0
+        let coordinator = makeCoordinator(
+            runWithAdminPrivileges: { _, _, _ in .success },
+            postconditionsSatisfied: {
+                postconditionChecks += 1
+                return postconditionChecks > 9
+            },
+            uninstallViaHelper: { _ in },
+            unregisterHelper: { false }
+        )
+
+        let result = await coordinator.performUninstall(allowAdminFallback: true)
+
+        XCTAssertTrue(result.success)
+        XCTAssertEqual(result.steps.filter { $0.id == "unregister-uninstall-helper" }.count, 1)
+        XCTAssertEqual(result.steps.filter { $0.id == "verify-uninstall" }.count, 1)
+        XCTAssertEqual(result.steps.filter { $0.id == "emergency-admin-cleanup" }.count, 1)
+    }
+
     private func makeCoordinator(
         resolveUninstallerURL: @escaping () -> URL? = {
             URL(fileURLWithPath: "/tmp/keypath-test-uninstall.sh")

--- a/docs/bugs/2026-07-09-helper-health-probe-invalidated-active-mutation.md
+++ b/docs/bugs/2026-07-09-helper-health-probe-invalidated-active-mutation.md
@@ -1,7 +1,7 @@
 # Helper Health Probe Invalidated an Active Mutation
 
 **Date:** 2026-07-09
-**Status:** Fixed in Milestone 1 execution-safety work
+**Status:** Fixed in Milestone 1 execution-safety work; generalized 2026-07-10
 
 ## Symptom
 
@@ -41,9 +41,13 @@ and a final restart to the same repair recipe during one button action.
 - A health-probe timeout never invalidates the shared connection.
 - Helper mutation timeouts are represented as ambiguous because the helper may
   have completed after the reply path was lost.
-- VHID repair verifies the authoritative postcondition after any helper error.
-  A satisfied postcondition returns success without fallback; an unsatisfied
-  postcondition permits exactly one configured administrator fallback.
+- Every helper-first router operation with an administrator fallback verifies
+  its operation-specific postcondition after any helper error. A satisfied
+  postcondition returns success without fallback; an unsatisfied postcondition
+  permits exactly one configured administrator fallback, followed by the same
+  postcondition check.
+- Uninstall rechecks filesystem and optional driver postconditions after a
+  failed helper reply before offering or running Emergency Cleanup.
 - `InstallerEngine.run` and `runSingleAction` share one transaction gate.
 - The Karabiner page requests at most one equivalent VHID daemon repair per
   automatic repair action.
@@ -54,6 +58,13 @@ and a final restart to the same repair recipe during one button action.
 - `HelperManagerTests.testPrivilegedHelperOperationsAcquireGateSerially`
 - `PrivilegedOperationsRouterTests.testLostHelperReplyWithSatisfiedPostconditionSkipsFallback`
 - `PrivilegedOperationsRouterTests.testFailedHelperWithUnsatisfiedPostconditionInvokesFallbackOnce`
+- `PrivilegedOperationsRouterTests.testRuntimeRecoveryLostHelperReplyWithReadyRuntimeSkipsFallback`
+- `PrivilegedOperationsRouterTests.testRuntimeRecoveryLostKillReplyWithStoppedRuntimeSkipsKillFallback`
+- `PrivilegedOperationsRouterTests.testNewsyslogLostHelperReplyWithInstalledConfigSkipsFallback`
+- `PrivilegedOperationsRouterTests.testDriverInstallLostHelperReplyWithInstalledDriverSkipsFallback`
+- `PrivilegedOperationsRouterTests.testProcessTerminationLostHelperReplyWithExitedProcessSkipsFallback`
+- `PrivilegedOperationsRouterTests.testKillAllLostHelperReplyWithStoppedRuntimeSkipsFallback`
+- `UninstallCoordinatorTests.testLostHelperReplyWithSatisfiedPostconditionsSkipsEmergencyCleanup`
 
 ## Runtime Verification
 


### PR DESCRIPTION
## Summary
- generalize postcondition-before-fallback handling across helper-first runtime recovery, newsyslog install, VHID driver install, process termination, and Kanata shutdown
- recheck uninstall postconditions after a failed helper reply before Emergency Cleanup
- add per-operation regression coverage and move newsyslog out of the postcondition exemption list
- update the helper race bug record with the generalized invariant

## Validation
- `TEST_FILTER='PrivilegedOperationsRouterTests|UninstallCoordinatorTests|PostconditionLintTests' ./Scripts/run-tests-safe.sh` (50 passed)
- `TEST_FILTER=KarabinerConflictServiceTests ./Scripts/run-tests-safe.sh` (4 passed)
- `python3 Scripts/check-accessibility.py`
- `git diff --check`

## Broad gate note
`KEYPATH_TEST_RESET_MODULE_CACHE=1 ./Scripts/test-fast.sh installer` passes 613 selected tests and fails only `VirtualHID daemon detection uses injected SystemStateProvider`. The exact same failure reproduces from untouched `origin/master` in a separate clean worktree, while the conflict-service suite passes in isolation. This is baseline global-state interference, not introduced by this diff.

## Review gate
Local review tooling selected the remote review gate; do not merge until `claude-review` passes.