### PR TITLE
Make installer snapshot capture fail safe

### DIFF
--- a/Sources/KeyPathAppKit/Services/System/SystemValidator.swift
+++ b/Sources/KeyPathAppKit/Services/System/SystemValidator.swift
@@ -41,8 +41,8 @@ public class SystemValidator {
 
     // NOTE: launchDaemonInstaller removed - health checks migrated to ServiceHealthChecker
     private let vhidDeviceManager: VHIDDeviceManager
-    private let processLifecycleManager: ProcessLifecycleManager
     private let systemStateProvider: SystemStateProvider
+    private let conflictDetector: () async throws -> ProcessLifecycleManager.ConflictResolution
     private weak var kanataManager: RuntimeCoordinator?
     private var cachedComponentFacts: ComponentInstallationFacts?
 
@@ -64,12 +64,15 @@ public class SystemValidator {
         vhidDeviceManager: VHIDDeviceManager = VHIDDeviceManager(),
         processLifecycleManager: ProcessLifecycleManager,
         systemStateProvider: SystemStateProvider = .shared,
-        kanataManager: RuntimeCoordinator? = nil
+        kanataManager: RuntimeCoordinator? = nil,
+        conflictDetector: (() async throws -> ProcessLifecycleManager.ConflictResolution)? = nil
     ) {
         self.vhidDeviceManager = vhidDeviceManager
-        self.processLifecycleManager = processLifecycleManager
         self.systemStateProvider = systemStateProvider
         self.kanataManager = kanataManager
+        self.conflictDetector = conflictDetector ?? {
+            try await processLifecycleManager.detectConflicts()
+        }
 
         AppLogger.shared.log("🔍 [SystemValidator] Initialized (stateless, no cache)")
 
@@ -140,6 +143,10 @@ public class SystemValidator {
             AppLogger.shared.log("🔍 [SystemValidator] Reusing recent canonical snapshot")
             progressCallback(1.0)
             return latestSnapshot
+        }
+
+        if freshness == .fresh {
+            invalidateCaches()
         }
 
         return await checkSystem(progressCallback: progressCallback)
@@ -244,7 +251,7 @@ public class SystemValidator {
             case helper(HelperStatus)
             case permissions(PermissionOracle.Snapshot)
             case components(ComponentStatus)
-            case conflicts(ConflictStatus)
+            case conflicts(ConflictCaptureEvidence)
             case health(HealthStatus)
         }
 
@@ -254,7 +261,7 @@ public class SystemValidator {
             var helperResult: HelperStatus?
             var permissionsResult: PermissionOracle.Snapshot?
             var componentsResult: ComponentStatus?
-            var conflictsResult: ConflictStatus?
+            var conflictsResult: ConflictCaptureEvidence?
             var healthResult: HealthStatus?
 
             // Add all tasks to group with progress tracking
@@ -347,10 +354,15 @@ public class SystemValidator {
                         )
                     }(),
                 componentsResult ?? ComponentStatus.empty,
-                conflictsResult ?? ConflictStatus.empty,
+                conflictsResult ?? ConflictCaptureEvidence(
+                    status: .empty,
+                    captureStatus: .failed
+                ),
                 healthResult ?? HealthStatus.empty
             )
         }
+
+        let conflictStatus = conflicts.status
 
         progressCallback(1.0) // All done: 100%
 
@@ -362,11 +374,12 @@ public class SystemValidator {
         let snapshot = SystemSnapshot(
             permissions: permissions,
             components: components,
-            conflicts: conflicts,
+            conflicts: conflictStatus,
             health: health,
             helper: helper,
             compatibility: compatibility,
-            timestamp: Date()
+            timestamp: Date(),
+            captureStatus: conflicts.captureStatus
         )
 
         let duration = Date().timeIntervalSince(startTime)
@@ -497,7 +510,9 @@ public class SystemValidator {
     }
 
     private func componentInstallationFacts() async -> ComponentInstallationFacts {
-        if let cachedComponentFacts, cachedComponentFacts.isFresh(ttl: 15.0) {
+        if let cachedComponentFacts,
+           cachedComponentFacts.isFresh(ttl: Self.canonicalSnapshotCacheTTL)
+        {
             AppLogger.shared.log("🔍 [SystemValidator] Component installation facts CACHE HIT")
             return cachedComponentFacts
         }
@@ -567,7 +582,12 @@ public class SystemValidator {
 
     // MARK: - Conflict Detection
 
-    private func checkConflicts() async -> ConflictStatus {
+    struct ConflictCaptureEvidence: Sendable {
+        let status: ConflictStatus
+        let captureStatus: SystemSnapshotCaptureStatus
+    }
+
+    func checkConflicts() async -> ConflictCaptureEvidence {
         AppLogger.shared.log("🔍 [SystemValidator] Checking for conflicts")
 
         var allConflicts: [SystemConflict] = []
@@ -575,7 +595,7 @@ public class SystemValidator {
         // Check for external kanata processes
         let conflictResolution: ProcessLifecycleManager.ConflictResolution
         do {
-            conflictResolution = try await processLifecycleManager.detectConflicts()
+            conflictResolution = try await conflictDetector()
             allConflicts.append(
                 contentsOf: conflictResolution.externalProcesses.map { process in
                     .kanataProcessRunning(pid: Int(process.pid), command: process.command)
@@ -583,7 +603,7 @@ public class SystemValidator {
             )
         } catch {
             AppLogger.shared.log("❌ [SystemValidator] Process conflict detection failed: \(error)")
-            conflictResolution = .init(externalProcesses: [], managedProcesses: [], canAutoResolve: true)
+            return ConflictCaptureEvidence(status: .empty, captureStatus: .failed)
         }
 
         // Check for Karabiner-Elements conflicts
@@ -605,9 +625,12 @@ public class SystemValidator {
                 "🔍 [SystemValidator] Total conflicts: \(allConflicts.count) (\(conflictResolution.externalProcesses.count) kanata, \(allConflicts.count - conflictResolution.externalProcesses.count) karabiner)"
             )
 
-        return ConflictStatus(
-            conflicts: allConflicts,
-            canAutoResolve: conflictResolution.canAutoResolve
+        return ConflictCaptureEvidence(
+            status: ConflictStatus(
+                conflicts: allConflicts,
+                canAutoResolve: conflictResolution.canAutoResolve
+            ),
+            captureStatus: .complete
         )
     }
 

--- a/Sources/KeyPathInstallationWizard/Core/SystemInspector.swift
+++ b/Sources/KeyPathInstallationWizard/Core/SystemInspector.swift
@@ -93,6 +93,16 @@ public enum SystemInspector {
                 autoFixAction: nil,
                 userAction: "Run the status check again."
             ))
+        } else if context.captureStatus == .failed {
+            issues.append(WizardIssue(
+                identifier: .validationTimeout,
+                severity: .warning,
+                category: .daemon,
+                title: "Status check incomplete",
+                description: "KeyPath could not capture all required system evidence.",
+                autoFixAction: nil,
+                userAction: "Run the status check again before making system changes."
+            ))
         }
 
         return issues

--- a/Sources/KeyPathWizardCore/SystemSnapshot.swift
+++ b/Sources/KeyPathWizardCore/SystemSnapshot.swift
@@ -5,6 +5,7 @@ import KeyPathPermissions
 
 public enum SystemSnapshotCaptureStatus: String, Sendable, Equatable {
     case complete
+    case failed
     case cancelled
     case timedOut
 

--- a/Tests/KeyPathTests/InstallationWizard/WizardPureLogicTests.swift
+++ b/Tests/KeyPathTests/InstallationWizard/WizardPureLogicTests.swift
@@ -177,6 +177,18 @@ final class WizardPureLogicTests: XCTestCase {
         XCTAssertTrue(result.issues.contains { $0.identifier == .validationTimeout })
     }
 
+    func test_failedCaptureProducesIncompleteStatusIssue() {
+        let context = makeContext(captureStatus: .failed)
+
+        let result = SystemStateResult.projecting(context)
+
+        XCTAssertEqual(result.captureStatus, .failed)
+        XCTAssertEqual(result.stateMatrixRow, InstallerStateMatrixRow.definitiveUnhealthyState.rawValue)
+        XCTAssertTrue(result.issues.contains {
+            $0.identifier == .validationTimeout && $0.title == "Status check incomplete"
+        })
+    }
+
     func test_emptyFallbackContextIsExplicitlyIncomplete() {
         XCTAssertEqual(SystemContext.empty.captureStatus, .cancelled)
         XCTAssertEqual(SystemContext.empty.installerStateMatrixRow, .definitiveUnhealthyState)

--- a/Tests/KeyPathTests/Lint/SnapshotConsumerLintTests.swift
+++ b/Tests/KeyPathTests/Lint/SnapshotConsumerLintTests.swift
@@ -7,6 +7,26 @@ import Foundation
 /// It prevents new runtime/installer state caches outside the known provider-style
 /// owners while follow-up work shrinks the allowlist.
 final class SnapshotConsumerLintTests: XCTestCase {
+    func testFreshCaptureInvalidatesComponentFacts() throws {
+        let validator = LintScanner.path(
+            "Sources/KeyPathAppKit/Services/System/SystemValidator.swift"
+        )
+        let source = try String(contentsOf: validator, encoding: .utf8)
+
+        XCTAssertTrue(
+            source.contains("if freshness == .fresh {") && source.contains("invalidateCaches()"),
+            "A canonical fresh capture must invalidate subordinate evidence caches."
+        )
+        XCTAssertTrue(
+            source.contains("cachedComponentFacts = nil"),
+            "SystemValidator.invalidateCaches() must clear component installation facts."
+        )
+        XCTAssertTrue(
+            source.contains("cachedComponentFacts.isFresh(ttl: Self.canonicalSnapshotCacheTTL)"),
+            "Component facts must use the canonical snapshot freshness window."
+        )
+    }
+
     func testSMAppServiceStatusProviderCacheIsOnlyConsumedThroughSystemStateProvider() throws {
         let violations = try LintScanner.matchingLines(
             under: LintScanner.path("Sources"),

--- a/Tests/KeyPathTests/Services/SystemValidatorTests.swift
+++ b/Tests/KeyPathTests/Services/SystemValidatorTests.swift
@@ -9,6 +9,10 @@ import Testing
 @MainActor
 @Suite("SystemValidator Tests")
 struct SystemValidatorTests {
+    private enum ExpectedFailure: Error {
+        case conflictProbe
+    }
+
     /// Setup: Reset counters before each test to ensure isolation
     private func setupTest() async {
         SystemValidator.resetCounters()
@@ -129,9 +133,28 @@ struct SystemValidatorTests {
 
         #expect(cached.timestamp == fresh.timestamp)
 
+        let freshAgain = await validator.checkSystem(freshness: .fresh)
+        #expect(freshAgain.id != cached.id)
+
         validator.invalidateCaches()
         let recaptured = await validator.checkSystem(freshness: .cached)
-        #expect(recaptured.timestamp >= cached.timestamp)
+        #expect(recaptured.timestamp >= freshAgain.timestamp)
+    }
+
+    @Test("Failed conflict probe produces incomplete fail-safe evidence")
+    func failedConflictProbeIsIncomplete() async {
+        await setupTest()
+
+        let validator = SystemValidator(
+            processLifecycleManager: ProcessLifecycleManager(),
+            conflictDetector: { throw ExpectedFailure.conflictProbe }
+        )
+
+        let evidence = await validator.checkConflicts()
+
+        #expect(evidence.captureStatus == .failed)
+        #expect(!evidence.status.hasConflicts)
+        #expect(!evidence.status.canAutoResolve)
     }
 
     @Test("SystemSnapshot validates staleness")

--- a/docs/bugs/2026-07-10-incomplete-probes-reported-complete.md
+++ b/docs/bugs/2026-07-10-incomplete-probes-reported-complete.md
@@ -1,0 +1,42 @@
+# Incomplete Installer Probes Reported Complete
+
+**Date:** 2026-07-10
+**Status:** Fixed
+
+## Symptom
+
+A failed process-conflict probe produced an empty, auto-resolvable conflict
+result while the enclosing system snapshot remained `complete`. Installer
+planning and postcondition verification could therefore interpret missing
+evidence as proof that no conflicts existed.
+
+Separately, a caller requesting a fresh snapshot could still receive component
+installation facts from a private 15-second cache. The snapshot timestamp was
+fresh, but some of its evidence was not.
+
+## Root Cause
+
+The conflict probe converted errors into a healthy-looking value without
+propagating capture completeness. The freshness policy only governed the
+canonical snapshot cache; it did not invalidate the subordinate component-fact
+cache.
+
+## Fix and Invariants
+
+- Conflict capture now returns both evidence and capture status.
+- A failed conflict probe yields fail-safe conflict evidence and marks the
+  enclosing snapshot `failed`, so it cannot satisfy installer state or
+  postcondition predicates.
+- `.fresh` invalidates all validator-owned evidence caches before capture,
+  including component facts and service-health evidence.
+- Cached component facts use the same 1.5-second window as the canonical
+  snapshot instead of defining a second 15-second freshness tier.
+- Incomplete capture has explicit user-facing guidance to retry the status
+  check before system mutation.
+
+## Regression Coverage
+
+- `SystemValidatorTests.failedConflictProbeIsIncomplete`
+- `SystemValidatorTests.cachedCaptureReusesRecentSnapshot`
+- `SnapshotConsumerLintTests.testFreshCaptureInvalidatesComponentFacts`
+- `WizardPureLogicTests.test_failedCaptureProducesIncompleteStatusIssue`


### PR DESCRIPTION
## Summary
- propagate conflict-probe failure into an explicit incomplete snapshot instead of fabricating healthy conflict evidence
- add a `failed` capture state with retry guidance
- invalidate subordinate validator caches for `.fresh` captures
- scope component-fact caching to the canonical 1.5-second freshness window
- add behavioral and structural regression coverage plus a durable bug record

## Validation
- `TEST_FILTER='SystemValidatorTests|SnapshotConsumerLintTests|WizardPureLogicTests' ./Scripts/run-tests-safe.sh` (125 passed)
- `TEST_FILTER='SystemValidatorTests|SnapshotConsumerLintTests' ./Scripts/run-tests-safe.sh` (17 passed)
- `python3 Scripts/check-accessibility.py`
- `git diff --check`

## Full-suite note
`./Scripts/test-fast.sh --changed` correctly fell back to the raw full suite, where local SwiftUI snapshot rendering produced the known `NSConcreteValue CGRectValue` crash/mismatch class and the XCTest process exited by signal 11. Before that harness failure, 1,931 tests passed; the focused capture/installer suites were green. Broad correctness remains gated on GitHub `build-and-test`.

## Review gate
Local review tooling selected the remote review gate; do not merge until `claude-review` passes.