### PR TITLE
Verify zero-recipe installer outcomes

### DIFF
--- a/Sources/KeyPathAppKit/CLI/SystemFacade.swift
+++ b/Sources/KeyPathAppKit/CLI/SystemFacade.swift
@@ -192,7 +192,10 @@ public struct SystemFacade: Sendable {
                 issues: initialIssues,
                 plannedRecipes: [],
                 unmetRequirements: plan.blockedBy.map { [$0.name] } ?? [],
-                logs: []
+                logs: [],
+                planID: plan.id.uuidString,
+                beforeSnapshotID: context.snapshotID.uuidString,
+                completionState: InstallerCompletionState.blocked.rawValue
             )
         }
 

--- a/Sources/KeyPathInstallationWizard/Core/InstallerEngine.swift
+++ b/Sources/KeyPathInstallationWizard/Core/InstallerEngine.swift
@@ -281,21 +281,6 @@ public final class InstallerEngine {
         var allLogs: [String] = []
         var repairTelemetry: [InstallerRepairTelemetryEvent] = []
 
-        if plan.recipes.isEmpty {
-            repairTelemetry.append(
-                InstallerRepairTelemetryEvent(
-                    trigger: trigger,
-                    intent: plan.intent.telemetryValue,
-                    stateMatrixRow: plan.metadata.stateMatrixRow,
-                    stateMatrixPlan: plan.metadata.stateMatrixPlan,
-                    action: nil,
-                    recipeID: nil,
-                    recipeType: nil,
-                    postconditionResult: .skipped
-                )
-            )
-        }
-
         for recipe in plan.recipes {
             AppLogger.shared.log(
                 "⚙️ [InstallerEngine] Executing recipe: \(recipe.id) (type: \(recipe.type))"
@@ -407,9 +392,15 @@ public final class InstallerEngine {
         } else {
             executedPostconditions
         }
-        let verificationFailure = failedPostconditions.isEmpty
+        let postconditionVerificationFailure = failedPostconditions.isEmpty
             ? nil
             : "Postcondition verification failed: \(failedPostconditions.map(\.rawValue).joined(separator: ", "))"
+
+        let noOpVerificationFailure = await verifyNoOpPlan(
+            plan,
+            finalContext: finalContext
+        )
+        let verificationFailure = postconditionVerificationFailure ?? noOpVerificationFailure
 
         if !executedPostconditions.isEmpty {
             let verificationSucceeded = failedPostconditions.isEmpty
@@ -428,6 +419,30 @@ public final class InstallerEngine {
                     recipeID: nil,
                     recipeType: nil,
                     postconditionResult: verificationSucceeded ? .succeeded : .failed,
+                    error: verificationFailure
+                )
+            )
+        }
+
+        if plan.recipes.isEmpty {
+            let noOpVerified = verificationFailure == nil && plan.intent != .inspectOnly
+            allLogs.append(
+                noOpVerified
+                    ? "[\(InstallerRecipeID.verifyPostconditions)] Final state confirms no work is required"
+                    : "[\(InstallerRecipeID.verifyPostconditions)] \(verificationFailure ?? "Inspection completed without mutations")"
+            )
+            repairTelemetry.append(
+                InstallerRepairTelemetryEvent(
+                    trigger: trigger,
+                    intent: plan.intent.telemetryValue,
+                    stateMatrixRow: plan.metadata.stateMatrixRow,
+                    stateMatrixPlan: plan.metadata.stateMatrixPlan,
+                    action: InstallerRecipeID.verifyPostconditions,
+                    recipeID: nil,
+                    recipeType: nil,
+                    postconditionResult: plan.intent == .inspectOnly
+                        ? .skipped
+                        : (noOpVerified ? .succeeded : .failed),
                     error: verificationFailure
                 )
             )
@@ -481,6 +496,8 @@ public final class InstallerEngine {
                 .awaitingApproval
             } else if firstFailure != nil {
                 .verifiedAfterOperationError
+            } else if plan.recipes.isEmpty, plan.intent != .inspectOnly {
+                .verifiedNoOp
             } else {
                 .completed
             }
@@ -527,6 +544,26 @@ public final class InstallerEngine {
         context.helper.requiresApproval
             || context.services.loginItemsApprovalRequired == true
             || context.requiresManualVHIDDriverApproval
+    }
+
+    private func verifyNoOpPlan(
+        _ plan: InstallPlan,
+        finalContext: SystemContext?
+    ) async -> String? {
+        guard plan.recipes.isEmpty, plan.intent != .inspectOnly else { return nil }
+        guard let finalContext, finalContext.captureStatus.isComplete else {
+            return "No-op verification failed: final system evidence is incomplete"
+        }
+
+        let finalPlan = await makePlan(for: plan.intent, context: finalContext)
+        switch finalPlan.status {
+        case let .blocked(requirement):
+            return "No-op verification failed: final state is blocked by \(requirement.name)"
+        case .ready where !finalPlan.recipes.isEmpty:
+            return "No-op verification failed: final state requires \(finalPlan.recipes.map(\.id).joined(separator: ", "))"
+        case .ready:
+            return nil
+        }
     }
 
     private func captureFreshContext() async -> SystemContext {
@@ -988,7 +1025,10 @@ public final class InstallerEngine {
             } else {
                 AppLogger.shared.log("⚠️ [InstallerEngine] No recipe available for action: \(action)")
                 let report = InstallerReport(
+                    planID: basePlan.id,
+                    beforeSnapshotID: context.snapshotID,
                     success: false,
+                    completionState: .executionFailed,
                     failureReason: "No recipe available for action: \(action)",
                     executedRecipes: [],
                     logs: []

--- a/Sources/KeyPathInstallationWizard/Core/InstallerEngineTypes.swift
+++ b/Sources/KeyPathInstallationWizard/Core/InstallerEngineTypes.swift
@@ -396,6 +396,7 @@ public enum InstallerRepairTelemetryResult: String, Codable, Sendable, Equatable
 /// Machine-readable terminal state shared by app and CLI clients.
 public enum InstallerCompletionState: String, Codable, Sendable, Equatable {
     case completed
+    case verifiedNoOp = "verified-no-op"
     case awaitingApproval = "awaiting-approval"
     case verifiedAfterOperationError = "verified-after-operation-error"
     case blocked

--- a/Tests/KeyPathTests/InstallationEngine/InstallerEngineEndToEndTests.swift
+++ b/Tests/KeyPathTests/InstallationEngine/InstallerEngineEndToEndTests.swift
@@ -386,7 +386,10 @@ final class InstallerEngineEndToEndTests: KeyPathAsyncTestCase {
     }
 
     func testExecuteOwnsOneFreshFinalSnapshot() async {
-        let context = SystemContextBuilder().build()
+        let context = SystemContextBuilder(
+            servicesHealthy: true,
+            componentsInstalled: true
+        ).build()
         let validator = StubSystemValidator(snapshot: Self.snapshot(from: context))
         let engine = InstallerEngine(
             processLifecycleManager: ProcessLifecycleManager(),
@@ -411,7 +414,11 @@ final class InstallerEngineEndToEndTests: KeyPathAsyncTestCase {
 
     func testExecuteCarriesPlanAndSnapshotEvidenceThroughReportAndTelemetry() async {
         let finalSnapshotID = UUID()
-        let context = SystemContextBuilder(snapshotID: finalSnapshotID).build()
+        let context = SystemContextBuilder(
+            snapshotID: finalSnapshotID,
+            servicesHealthy: true,
+            componentsInstalled: true
+        ).build()
         let validator = StubSystemValidator(snapshot: Self.snapshot(from: context))
         let engine = InstallerEngine(
             processLifecycleManager: ProcessLifecycleManager(),
@@ -434,7 +441,7 @@ final class InstallerEngineEndToEndTests: KeyPathAsyncTestCase {
         XCTAssertEqual(report.beforeSnapshotID, beforeSnapshotID)
         XCTAssertEqual(report.afterSnapshotID, finalSnapshotID)
         XCTAssertEqual(report.finalContext?.snapshotID, finalSnapshotID)
-        XCTAssertEqual(report.completionState, .completed)
+        XCTAssertEqual(report.completionState, .verifiedNoOp)
         XCTAssertFalse(report.repairTelemetry.isEmpty)
         for event in report.repairTelemetry {
             XCTAssertEqual(event.runID, report.runID)
@@ -442,6 +449,55 @@ final class InstallerEngineEndToEndTests: KeyPathAsyncTestCase {
             XCTAssertEqual(event.beforeSnapshotID, beforeSnapshotID)
             XCTAssertEqual(event.afterSnapshotID, finalSnapshotID)
         }
+    }
+
+    func testExecuteRejectsNoOpWhenFreshFinalStateRequiresRepair() async {
+        let context = SystemContextBuilder.degradedRepair()
+        let validator = StubSystemValidator(snapshot: Self.snapshot(from: context))
+        let engine = InstallerEngine(
+            processLifecycleManager: ProcessLifecycleManager(),
+            systemValidator: validator
+        )
+        let plan = InstallPlan(
+            sourceSnapshotID: UUID(),
+            recipes: [],
+            status: .ready,
+            intent: .repair
+        )
+
+        let report = await engine.execute(
+            plan: plan,
+            using: PrivilegeBroker(coordinator: StubPrivilegedOperationsCoordinator())
+        )
+
+        XCTAssertFalse(report.success)
+        XCTAssertEqual(report.completionState, .verificationFailed)
+        XCTAssertTrue(report.failureReason?.contains("No-op verification failed") == true)
+        XCTAssertFalse(report.recoveryPlan?.recipes.isEmpty ?? true)
+        XCTAssertEqual(report.repairTelemetry.last?.postconditionResult, .failed)
+    }
+
+    func testExecuteRejectsNoOpWhenFreshFinalEvidenceIsIncomplete() async {
+        let context = SystemContextBuilder(
+            servicesHealthy: true,
+            componentsInstalled: true,
+            captureStatus: .failed
+        ).build()
+        let validator = StubSystemValidator(snapshot: Self.snapshot(from: context))
+        let engine = InstallerEngine(
+            processLifecycleManager: ProcessLifecycleManager(),
+            systemValidator: validator
+        )
+        let plan = InstallPlan(recipes: [], status: .ready, intent: .repair)
+
+        let report = await engine.execute(
+            plan: plan,
+            using: PrivilegeBroker(coordinator: StubPrivilegedOperationsCoordinator())
+        )
+
+        XCTAssertFalse(report.success)
+        XCTAssertEqual(report.completionState, .verificationFailed)
+        XCTAssertEqual(report.failureReason, "No-op verification failed: final system evidence is incomplete")
     }
 
     func testExecuteReportsAwaitingApprovalFromFinalSnapshot() async {
@@ -695,7 +751,8 @@ final class InstallerEngineEndToEndTests: KeyPathAsyncTestCase {
                 macOSVersion: context.system.macOSVersion,
                 driverCompatible: context.system.driverCompatible
             ),
-            timestamp: context.timestamp
+            timestamp: context.timestamp,
+            captureStatus: context.captureStatus
         )
     }
 }

--- a/Tests/KeyPathTests/InstallationEngine/InstallerEngineTests.swift
+++ b/Tests/KeyPathTests/InstallationEngine/InstallerEngineTests.swift
@@ -337,14 +337,15 @@ final class InstallerEngineTests: KeyPathAsyncTestCase {
         let report = await engine.execute(plan: plan, using: PrivilegeBroker())
 
         XCTAssertTrue(report.success)
+        XCTAssertEqual(report.completionState, .verifiedNoOp)
         XCTAssertEqual(report.repairTelemetry.count, 1)
         let event = report.repairTelemetry[0]
         XCTAssertEqual(event.intent, "repair")
         XCTAssertEqual(event.stateMatrixRow, InstallerStateMatrixRow.runningAndTCPResponding.rawValue)
-        XCTAssertNil(event.action)
+        XCTAssertEqual(event.action, InstallerRecipeID.verifyPostconditions)
         XCTAssertNil(event.recipeID)
         XCTAssertNil(event.recipeType)
-        XCTAssertEqual(event.postconditionResult, .skipped)
+        XCTAssertEqual(event.postconditionResult, .succeeded)
     }
 
     func testExecuteExecutesRecipesInOrder() async {

--- a/Tests/KeyPathTests/Lint/InstallerDecisionPipelineLintTests.swift
+++ b/Tests/KeyPathTests/Lint/InstallerDecisionPipelineLintTests.swift
@@ -2,6 +2,33 @@ import Foundation
 @preconcurrency import XCTest
 
 final class InstallerDecisionPipelineLintTests: KeyPathTestCase {
+    func testEarlyInstallerExitsPreserveCorrelationEvidence() throws {
+        let root = repositoryRoot()
+        let engineSource = try String(
+            contentsOf: root.appendingPathComponent(
+                "Sources/KeyPathInstallationWizard/Core/InstallerEngine.swift"
+            ),
+            encoding: .utf8
+        )
+        let cliSource = try String(
+            contentsOf: root.appendingPathComponent(
+                "Sources/KeyPathAppKit/CLI/SystemFacade.swift"
+            ),
+            encoding: .utf8
+        )
+
+        XCTAssertTrue(
+            engineSource.contains("planID: basePlan.id")
+                && engineSource.contains("beforeSnapshotID: context.snapshotID"),
+            "runSingleAction no-recipe failures must preserve plan and snapshot IDs."
+        )
+        XCTAssertTrue(
+            cliSource.contains("planID: plan.id.uuidString")
+                && cliSource.contains("beforeSnapshotID: context.snapshotID.uuidString"),
+            "CLI user-action early returns must preserve plan and snapshot IDs."
+        )
+    }
+
     func testProductionPlanningUsesCanonicalDecisionPipeline() throws {
         let root = repositoryRoot()
         let consumers = [

--- a/Tests/KeyPathTests/TestSupport/SystemContextBuilder.swift
+++ b/Tests/KeyPathTests/TestSupport/SystemContextBuilder.swift
@@ -27,6 +27,7 @@ struct SystemContextBuilder {
     var componentsInstalled: Bool = false
     var conflicts: [SystemConflict] = []
     var driverCompatible: Bool = true
+    var captureStatus: SystemSnapshotCaptureStatus = .complete
 
     func build() -> SystemContext {
         let permissionSet = PermissionOracle.PermissionSet(
@@ -86,7 +87,8 @@ struct SystemContextBuilder {
             components: components,
             helper: helper,
             system: EngineSystemInfo(macOSVersion: "15.0", driverCompatible: driverCompatible),
-            timestamp: Date()
+            timestamp: Date(),
+            captureStatus: captureStatus
         )
     }
 

--- a/docs/bugs/2026-07-10-zero-recipe-run-reported-unverified-success.md
+++ b/docs/bugs/2026-07-10-zero-recipe-run-reported-unverified-success.md
@@ -1,0 +1,41 @@
+# Zero-Recipe Installer Run Reported Unverified Success
+
+**Date:** 2026-07-10
+**Status:** Fixed
+
+## Symptom
+
+An install or repair plan containing no recipes returned `success = true`
+after capturing final state, even when that final snapshot was incomplete or
+now required repair work. Consumers that trusted `InstallerReport.success`
+could therefore disagree with the attached `finalContext`.
+
+Two early-return paths also omitted correlation evidence that was already in
+scope: `runSingleAction`'s no-recipe failure and CLI repair's user-action
+result.
+
+## Root Cause
+
+Postcondition verification only considered declarations on executed recipes.
+A zero-recipe plan had no declarations, so the empty verification set passed
+vacuously. The final snapshot was attached for consumers but did not gate the
+engine's own terminal result.
+
+## Fix and Invariants
+
+- Non-inspection zero-recipe runs re-plan from the fresh final context.
+- Success requires complete final evidence and a second ready plan that still
+  contains no recipes.
+- Verified no-ops report the explicit `verified-no-op` completion state and
+  successful verification telemetry.
+- Incomplete or degraded final evidence reports `verification-failed` and
+  includes a recovery plan when available.
+- Early no-recipe and user-action results preserve plan and before-snapshot
+  identifiers.
+
+## Regression Coverage
+
+- `InstallerEngineEndToEndTests.testExecuteRejectsNoOpWhenFreshFinalStateRequiresRepair`
+- `InstallerEngineEndToEndTests.testExecuteRejectsNoOpWhenFreshFinalEvidenceIsIncomplete`
+- `InstallerEngineTests.testExecuteRecordsStructuredRepairTelemetryForNoopPlan`
+- `InstallerDecisionPipelineLintTests.testEarlyInstallerExitsPreserveCorrelationEvidence`


### PR DESCRIPTION
## Summary
- re-plan from fresh final evidence before reporting a zero-recipe install/repair as successful
- add explicit `verified-no-op` completion state and verification telemetry
- fail incomplete or newly degraded no-op outcomes with recovery planning
- preserve plan/snapshot correlation IDs on no-recipe and CLI user-action early exits
- add regression coverage and a durable bug record

## Validation
- `TEST_FILTER='InstallerEngineTests|InstallerEngineEndToEndTests|InstallerDecisionPipelineLintTests|CLIOutputContractTests' ./Scripts/run-tests-safe.sh` (76 passed)
- `python3 Scripts/check-accessibility.py`
- `git diff --check`

## Review gate
Local review tooling selected the remote review gate; do not merge until `claude-review` passes.