### PR TITLE
Serialize every installer mutation route

### DIFF
--- a/Sources/KeyPathAppKit/Core/AppMenuCommands.swift
+++ b/Sources/KeyPathAppKit/Core/AppMenuCommands.swift
@@ -1,5 +1,6 @@
 import AppKit
 import KeyPathCore
+import KeyPathInstallationWizard
 import Sparkle
 import SwiftUI
 
@@ -175,16 +176,18 @@ struct AppMenuCommands: Commands {
                 action: {
                     Task { @MainActor in
                         AppLogger.shared.log("🗑️ [InstantUninstall] \u{2325}\u{2318}U triggered - performing immediate uninstall")
-                        let coordinator = UninstallCoordinator()
-                        let success = await coordinator.uninstall(deleteConfig: false)
-                        if success {
+                        let report = await InstallerEngine().uninstall(
+                            deleteConfig: false,
+                            using: PrivilegeBroker()
+                        )
+                        if report.success {
                             AppLogger.shared.log("✅ [InstantUninstall] Uninstall completed successfully")
                             NSApplication.shared.terminate(nil)
                         } else {
                             AppLogger.shared.log("❌ [InstantUninstall] Uninstall failed")
                             let alert = NSAlert()
                             alert.messageText = "Uninstall Failed"
-                            alert.informativeText = coordinator.lastError ?? "An unknown error occurred during uninstall"
+                            alert.informativeText = report.failureReason ?? "An unknown error occurred during uninstall"
                             alert.alertStyle = .critical
                             alert.runModal()
                         }

--- a/Sources/KeyPathInstallationWizard/Core/InstallerEngine.swift
+++ b/Sources/KeyPathInstallationWizard/Core/InstallerEngine.swift
@@ -27,6 +27,10 @@ actor InstallerTransactionGate {
     }
 }
 
+private enum InstallerTransactionContext {
+    @TaskLocal static var isOwned = false
+}
+
 /// Protocol for privileged routing used by Services to allow test stubs
 public protocol InstallerEnginePrivilegedRouting: AnyObject {
     func uninstallVirtualHIDDrivers(using broker: PrivilegeBroker) async throws
@@ -65,6 +69,26 @@ public final class InstallerEngine {
     /// Public initializer for app/CLI callers (no DI needed).
     public convenience init() {
         self.init(processLifecycleManager: ProcessLifecycleManager())
+    }
+
+    private func withInstallerTransaction<T>(
+        _ operation: () async throws -> T
+    ) async rethrows -> T {
+        if InstallerTransactionContext.isOwned {
+            return try await operation()
+        }
+
+        await InstallerTransactionGate.shared.acquire()
+        return try await InstallerTransactionContext.$isOwned.withValue(true) {
+            do {
+                let result = try await operation()
+                await InstallerTransactionGate.shared.release()
+                return result
+            } catch {
+                await InstallerTransactionGate.shared.release()
+                throw error
+            }
+        }
     }
 
     // MARK: - Public API
@@ -229,10 +253,9 @@ public final class InstallerEngine {
         using broker: PrivilegeBroker,
         trigger: InstallerRepairTelemetryTrigger = .executePlan
     ) async -> InstallerReport {
-        await InstallerTransactionGate.shared.acquire()
-        let report = await executeWithinTransaction(plan: plan, using: broker, trigger: trigger)
-        await InstallerTransactionGate.shared.release()
-        return report
+        await withInstallerTransaction {
+            await executeWithinTransaction(plan: plan, using: broker, trigger: trigger)
+        }
     }
 
     private func executeWithinTransaction(
@@ -869,20 +892,26 @@ public final class InstallerEngine {
     /// Convenience wrapper that chains inspectSystem() → makePlan() → execute() internally.
     /// Useful for CLI "one-button repair" automation or simple GUI flows.
     public func run(intent: InstallIntent, using broker: PrivilegeBroker) async -> InstallerReport {
-        await InstallerTransactionGate.shared.acquire()
+        await withInstallerTransaction {
+            await runWithinTransaction(intent: intent, using: broker)
+        }
+    }
+
+    private func runWithinTransaction(
+        intent: InstallIntent,
+        using broker: PrivilegeBroker
+    ) async -> InstallerReport {
         AppLogger.shared.log("🚀 [InstallerEngine] Starting run(intent: \(intent), using:)")
 
         if intent == .uninstall {
             AppLogger.shared.log(
                 "🗑️ [InstallerEngine] Delegating uninstall intent to uninstall(deleteConfig:, using:)"
             )
-            let report = await uninstallWithinTransaction(
+            return await uninstallWithinTransaction(
                 deleteConfig: false,
                 removeVirtualHID: false,
                 allowAdminFallback: false
             )
-            await InstallerTransactionGate.shared.release()
-            return report
         }
 
         // Chain the steps
@@ -891,7 +920,6 @@ public final class InstallerEngine {
         let report = await executeWithinTransaction(plan: plan, using: broker, trigger: .run)
 
         AppLogger.shared.log("✅ [InstallerEngine] run() complete - success: \(report.success)")
-        await InstallerTransactionGate.shared.release()
         return report
     }
 
@@ -904,14 +932,13 @@ public final class InstallerEngine {
         allowAdminFallback: Bool = false,
         using _: PrivilegeBroker
     ) async -> InstallerReport {
-        await InstallerTransactionGate.shared.acquire()
-        let report = await uninstallWithinTransaction(
-            deleteConfig: deleteConfig,
-            removeVirtualHID: removeVirtualHID,
-            allowAdminFallback: allowAdminFallback
-        )
-        await InstallerTransactionGate.shared.release()
-        return report
+        await withInstallerTransaction {
+            await uninstallWithinTransaction(
+                deleteConfig: deleteConfig,
+                removeVirtualHID: removeVirtualHID,
+                allowAdminFallback: allowAdminFallback
+            )
+        }
     }
 
     private func uninstallWithinTransaction(
@@ -1002,7 +1029,15 @@ public final class InstallerEngine {
     public func runSingleAction(_ action: AutoFixAction, using broker: PrivilegeBroker) async
         -> InstallerReport
     {
-        await InstallerTransactionGate.shared.acquire()
+        await withInstallerTransaction {
+            await runSingleActionWithinTransaction(action, using: broker)
+        }
+    }
+
+    private func runSingleActionWithinTransaction(
+        _ action: AutoFixAction,
+        using broker: PrivilegeBroker
+    ) async -> InstallerReport {
         AppLogger.shared.log("🔧 [InstallerEngine] runSingleAction(\(action), using:) starting")
         let context = await inspectSystem()
 
@@ -1024,7 +1059,7 @@ public final class InstallerEngine {
                 finalRecipes = [directRecipe]
             } else {
                 AppLogger.shared.log("⚠️ [InstallerEngine] No recipe available for action: \(action)")
-                let report = InstallerReport(
+                return InstallerReport(
                     planID: basePlan.id,
                     beforeSnapshotID: context.snapshotID,
                     success: false,
@@ -1033,8 +1068,6 @@ public final class InstallerEngine {
                     executedRecipes: [],
                     logs: []
                 )
-                await InstallerTransactionGate.shared.release()
-                return report
             }
         } else {
             finalRecipes = filteredRecipes
@@ -1066,7 +1099,6 @@ public final class InstallerEngine {
         AppLogger.shared.log(
             "✅ [InstallerEngine] runSingleAction(\(action), using:) complete - success: \(report.success)"
         )
-        await InstallerTransactionGate.shared.release()
         return report
     }
 
@@ -1075,22 +1107,28 @@ public final class InstallerEngine {
     /// Uninstall VirtualHID drivers (removes VHID daemon plists)
     /// Routes via InstallerEngine per AGENTS.md
     public func uninstallVirtualHIDDrivers(using broker: PrivilegeBroker) async throws {
-        AppLogger.shared.log("🗑️ [InstallerEngine] Uninstalling VirtualHID drivers")
-        try await broker.uninstallVirtualHIDDrivers()
+        try await withInstallerTransaction {
+            AppLogger.shared.log("🗑️ [InstallerEngine] Uninstalling VirtualHID drivers")
+            try await broker.uninstallVirtualHIDDrivers()
+        }
     }
 
     /// Disable Karabiner grabber (stops conflicting processes)
     /// Routes via InstallerEngine per AGENTS.md
     public func disableKarabinerGrabber(using broker: PrivilegeBroker) async throws {
-        AppLogger.shared.log("🔧 [InstallerEngine] Disabling Karabiner grabber")
-        try await broker.disableKarabinerGrabber()
+        try await withInstallerTransaction {
+            AppLogger.shared.log("🔧 [InstallerEngine] Disabling Karabiner grabber")
+            try await broker.disableKarabinerGrabber()
+        }
     }
 
     /// Restart Karabiner daemon with verification
     /// Routes via InstallerEngine per AGENTS.md
     public func restartKarabinerDaemon(using broker: PrivilegeBroker) async throws -> Bool {
-        AppLogger.shared.log("🔄 [InstallerEngine] Restarting Karabiner daemon")
-        return try await broker.restartKarabinerDaemonVerified()
+        try await withInstallerTransaction {
+            AppLogger.shared.log("🔄 [InstallerEngine] Restarting Karabiner daemon")
+            return try await broker.restartKarabinerDaemonVerified()
+        }
     }
 
     /// Execute a privileged command via sudo/osascript

--- a/Tests/KeyPathTests/InstallationEngine/InstallerEngineBrokerForwardingTests.swift
+++ b/Tests/KeyPathTests/InstallationEngine/InstallerEngineBrokerForwardingTests.swift
@@ -34,6 +34,37 @@ final class InstallerEngineBrokerForwardingTests: KeyPathTestCase {
         XCTAssertTrue(result)
         XCTAssertEqual(coordinator.restartKarabinerDaemonVerifiedCallCount, 1)
     }
+
+    func testDirectPrivilegedRoutesShareInstallerTransactionGate() async throws {
+        let coordinator = BlockingPrivilegedCoordinatorStub()
+        let broker = PrivilegeBroker(coordinator: coordinator)
+        let engine = InstallerEngine()
+
+        let disableTask = Task {
+            try await engine.disableKarabinerGrabber(using: broker)
+        }
+        await coordinator.waitUntilDisableEntered()
+
+        let restartStarted = expectation(description: "restart route started")
+        let restartTask = Task {
+            restartStarted.fulfill()
+            return try await engine.restartKarabinerDaemon(using: broker)
+        }
+        await fulfillment(of: [restartStarted])
+        await Task.yield()
+
+        XCTAssertEqual(
+            coordinator.restartKarabinerDaemonVerifiedCallCount,
+            0,
+            "A second public privileged route must wait for the active installer transaction"
+        )
+
+        coordinator.releaseDisable()
+        try await disableTask.value
+        let restartSucceeded = try await restartTask.value
+        XCTAssertTrue(restartSucceeded)
+        XCTAssertEqual(coordinator.restartKarabinerDaemonVerifiedCallCount, 1)
+    }
 }
 
 // MARK: - Test Doubles
@@ -79,5 +110,55 @@ private final class PrivilegedCoordinatorStub: PrivilegedOperationsCoordinating 
         disableKarabinerGrabberCallCount += 1
     }
 
+    func sudoExecuteCommand(_: String, description _: String) async throws {}
+}
+
+private final class BlockingPrivilegedCoordinatorStub: PrivilegedOperationsCoordinating {
+    private var disableEntered = false
+    private var disableEnteredWaiters: [CheckedContinuation<Void, Never>] = []
+    private var disableRelease: CheckedContinuation<Void, Never>?
+    private(set) var restartKarabinerDaemonVerifiedCallCount = 0
+
+    func waitUntilDisableEntered() async {
+        if disableEntered { return }
+        await withCheckedContinuation { continuation in
+            disableEnteredWaiters.append(continuation)
+        }
+    }
+
+    func releaseDisable() {
+        disableRelease?.resume()
+        disableRelease = nil
+    }
+
+    func disableKarabinerGrabber() async throws {
+        disableEntered = true
+        disableEnteredWaiters.forEach { $0.resume() }
+        disableEnteredWaiters.removeAll()
+        await withCheckedContinuation { continuation in
+            disableRelease = continuation
+        }
+    }
+
+    func restartKarabinerDaemonVerified() async throws -> Bool {
+        restartKarabinerDaemonVerifiedCallCount += 1
+        return true
+    }
+
+    func cleanupPrivilegedHelper() async throws {}
+    func installRequiredRuntimeServices() async throws {}
+    func recoverRequiredRuntimeServices() async throws {}
+    func installServicesIfUninstalled(context _: String) async throws -> Bool {
+        false
+    }
+
+    func installNewsyslogConfig() async throws {}
+    func regenerateServiceConfiguration() async throws {}
+    func repairVHIDDaemonServices() async throws {}
+    func downloadAndInstallCorrectVHIDDriver() async throws {}
+    func activateVirtualHIDManager() async throws {}
+    func terminateProcess(pid _: Int32) async throws {}
+    func killAllKanataProcesses() async throws {}
+    func uninstallVirtualHIDDrivers() async throws {}
     func sudoExecuteCommand(_: String, description _: String) async throws {}
 }

--- a/Tests/KeyPathTests/Lint/InstallerDecisionPipelineLintTests.swift
+++ b/Tests/KeyPathTests/Lint/InstallerDecisionPipelineLintTests.swift
@@ -166,6 +166,56 @@ final class InstallerDecisionPipelineLintTests: KeyPathTestCase {
         )
     }
 
+    func testUninstallCoordinatorDoesNotStartInstallerTransactions() throws {
+        let file = repositoryRoot()
+            .appendingPathComponent("Sources/KeyPathAppKit/Managers/UninstallCoordinator.swift")
+        let source = try String(contentsOf: file, encoding: .utf8)
+        let forbiddenCalls = [".run(intent:", ".runSingleAction(", ".uninstall("]
+        let violations = forbiddenCalls.filter { source.contains($0) }
+
+        XCTAssertTrue(
+            violations.isEmpty,
+            "UninstallCoordinator executes inside the InstallerEngine-owned transaction: \(violations)"
+        )
+    }
+
+    func testEveryPublicPrivilegedRouteUsesSharedTransactionWrapper() throws {
+        let file = repositoryRoot()
+            .appendingPathComponent("Sources/KeyPathInstallationWizard/Core/InstallerEngine.swift")
+        let source = try String(contentsOf: file, encoding: .utf8)
+        let routeNames = [
+            "uninstallVirtualHIDDrivers",
+            "disableKarabinerGrabber",
+            "restartKarabinerDaemon",
+        ]
+
+        for routeName in routeNames {
+            guard let start = source.range(of: "public func \(routeName)("),
+                  let end = source.range(of: "\n    }", range: start.lowerBound ..< source.endIndex)
+            else {
+                XCTFail("Could not locate public privileged route \(routeName)")
+                continue
+            }
+            let body = source[start.lowerBound ..< end.upperBound]
+            XCTAssertTrue(
+                body.contains("withInstallerTransaction"),
+                "\(routeName) must participate in the shared installer transaction"
+            )
+        }
+    }
+
+    func testInstantUninstallRoutesThroughInstallerEngine() throws {
+        let file = repositoryRoot()
+            .appendingPathComponent("Sources/KeyPathAppKit/Core/AppMenuCommands.swift")
+        let source = try String(contentsOf: file, encoding: .utf8)
+
+        XCTAssertTrue(source.contains("InstallerEngine().uninstall("))
+        XCTAssertFalse(
+            source.contains("UninstallCoordinator()"),
+            "The hidden uninstall shortcut must not bypass the shared transaction gate"
+        )
+    }
+
     func testExecutorDoesNotMakeUndeclaredVHIDActivationDecisions() throws {
         let file = repositoryRoot()
             .appendingPathComponent("Sources/KeyPathInstallationWizard/Core/InstallerEngine.swift")

--- a/docs/bugs/2026-07-10-installer-transaction-gate-bypasses.md
+++ b/docs/bugs/2026-07-10-installer-transaction-gate-bypasses.md
@@ -1,0 +1,39 @@
+# Installer transaction gate bypasses
+
+## Problem
+
+The installer transaction gate serialized the primary `run`, `execute`,
+`runSingleAction`, and `uninstall` entry points, but two production paths could
+still mutate installer-owned state outside that boundary:
+
+- the hidden instant-uninstall menu command constructed `UninstallCoordinator`
+  directly; and
+- background conflict/orphan services called public privileged broker routes
+  that did not acquire the installer transaction gate.
+
+That left uninstall, Karabiner conflict repair, and orphan cleanup able to
+overlap another install or repair transaction.
+
+## Resolution
+
+`InstallerEngine` now owns one reentrant transaction wrapper. Every public
+mutating entry point uses it, including the direct privileged routes. Nested
+operations in an already-owned installer task reuse the transaction instead of
+deadlocking on a second acquire. The instant-uninstall shortcut now calls
+`InstallerEngine.uninstall` and consumes its structured report.
+
+## Regression protection
+
+- A behavioral test starts two public privileged routes and proves the second
+  cannot reach its broker while the first owns the transaction.
+- Source ratchets require every public privileged route to use the shared
+  wrapper and prevent the menu shortcut from constructing
+  `UninstallCoordinator` directly.
+- `UninstallCoordinator` is prohibited from starting a new installer run while
+  it is executing inside the engine-owned uninstall transaction.
+
+## Invariant
+
+All production installer mutations enter through `InstallerEngine` and share
+one transaction boundary. Registration, helper, driver, daemon, and uninstall
+mutations must not add a separate public bypass.


### PR DESCRIPTION
## Summary
- route the hidden instant-uninstall shortcut through `InstallerEngine.uninstall`
- make all public privileged mutation routes participate in one reentrant installer transaction
- add behavioral production-wiring coverage and source ratchets for future bypasses
- document the transaction-boundary bug and invariant

## Installer state matrix
Affected review areas: uninstall flow, VirtualHID removal, Karabiner conflict remediation, and background orphan cleanup. The state decision rows are unchanged; this PR serializes their mutations under the existing engine-owned transaction.

## Validation
- `DEVELOPER_DIR=/Applications/Xcode-26.6.0.app/Contents/Developer TEST_FILTER='InstallerEngineBrokerForwardingTests|InstallerDecisionPipelineLintTests' ./Scripts/run-tests-safe.sh` (15 XCTest cases passed)
- `DEVELOPER_DIR=/Applications/Xcode-26.6.0.app/Contents/Developer TEST_FILTER='KeyPathTests\.' ./Scripts/run-tests-safe.sh` (4,337 passed)
- `python3 Scripts/check-accessibility.py`
- `git diff --check`
- `./Scripts/test-full.sh` reached 1,931 passes; 24 unrelated snapshot renderer cases failed with the existing `NSConcreteValue CGRectValue` exception and XCTest signal 11
- review gate: remote review gate selected