### PR TITLE
Close installer consolidation review follow-ups

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,12 @@ Notes:
   `/Applications/Xcode-26.6.0.app/Contents/Developer`, even when the machine-wide
   `xcode-select` points at a beta. Override with `KEYPATH_DEV_XCODE_DEVELOPER_DIR`
   only when intentionally testing another toolchain.
+- To advance the stable Xcode pin: (1) install and verify the intended stable
+  Xcode, (2) update both `KEYPATH_STABLE_XCODE_VERSION` and
+  `KEYPATH_STABLE_XCODE_DEVELOPER_DIR` in `Scripts/lib/xcode.sh`, (3) update the
+  matching literals in `DeploymentScriptContractTests`, and (4) run that test
+  plus one canonical build/deploy script without an override. Point releases
+  are intentional pin changes; an installed 26.6.1 does not satisfy `26.6`.
 - It intentionally does **not** redeploy the privileged helper unless
   `KEYPATH_DEPLOY_HELPER=1` is set. Avoid helper redeploys during UI work.
 - Use Poltergeist only for focused single-agent Swift/UI iteration:

--- a/Sources/KeyPathAppKit/InstallationWizard/README.md
+++ b/Sources/KeyPathAppKit/InstallationWizard/README.md
@@ -271,7 +271,7 @@ Each page is 400-600 lines and follows a consistent pattern:
 ### ✅ Completed (November 2025)
 - **ADR-012**: Driver version detection fully wired to Fix button
   - Detection: `VHIDDeviceManager.hasVersionMismatch()` → `SystemContext.components.vhidVersionMismatch`
-  - Action: `ActionDeterminer` adds `.fixDriverVersionMismatch` when version mismatch detected
+  - Action: `InstallerDecisionPipeline` adds `.fixDriverVersionMismatch` when version mismatch detected
   - Dialog: `WizardAutoFixer.fixDriverVersionMismatch()` shows confirmation dialog
   - Install: Downloads and installs v5.0.0 via `PrivilegedOperationsCoordinator`
 

--- a/Sources/KeyPathInstallationWizard/Core/InstallerDecisionPipeline.swift
+++ b/Sources/KeyPathInstallationWizard/Core/InstallerDecisionPipeline.swift
@@ -230,31 +230,6 @@ public enum InstallerDecisionPipeline {
     }
 }
 
-/// Compatibility façade for existing tests and callers during Milestone 2.
-/// Production planning must use `InstallerDecisionPipeline.decide` so matrix
-/// metadata and executable actions come from the same captured context.
-@MainActor
-public enum ActionDeterminer {
-    public static func determineActions(
-        for intent: InstallIntent,
-        context: SystemContext
-    ) -> [AutoFixAction] {
-        InstallerDecisionPipeline.decide(for: intent, context: context).autoFixActions
-    }
-
-    public static func determineRepairActions(context: SystemContext) -> [AutoFixAction] {
-        InstallerDecisionPipeline.decide(for: .repair, context: context).autoFixActions
-    }
-
-    public static func determineInstallActions(context: SystemContext) -> [AutoFixAction] {
-        InstallerDecisionPipeline.decide(for: .install, context: context).autoFixActions
-    }
-
-    public static func determineUninstallActions(context: SystemContext) -> [AutoFixAction] {
-        InstallerDecisionPipeline.decide(for: .uninstall, context: context).autoFixActions
-    }
-}
-
 public extension SystemContext {
     var requiresManualVHIDDriverApproval: Bool {
         // Matrix row: DriverKit approval pending. The specific activation

--- a/Tests/KeyPathTests/InstallationWizard/WizardPureLogicTests.swift
+++ b/Tests/KeyPathTests/InstallationWizard/WizardPureLogicTests.swift
@@ -5,7 +5,7 @@ import Foundation
 @preconcurrency import XCTest
 
 /// Unit tests for the wizard's pure logic types: SystemInspector, WizardRouter,
-/// InstallerRecipeID, and ActionDeterminer.
+/// InstallerRecipeID, and InstallerDecisionPipeline.
 /// These complement the golden tests by covering edge cases and gap scenarios.
 ///
 /// Naming convention: test_<scenario>_<expectedBehavior>
@@ -1172,11 +1172,11 @@ final class WizardPureLogicTests: XCTestCase {
         }
     }
 
-    // MARK: - ActionDeterminer: Repair Actions
+    // MARK: - InstallerDecisionPipeline: Repair Actions
 
     func test_determineRepairActions_allHealthy_returnsEmpty() {
         let context = makeContext()
-        let actions = ActionDeterminer.determineRepairActions(context: context)
+        let actions = InstallerDecisionPipeline.determineRepairActions(context: context)
         XCTAssertTrue(actions.isEmpty, "Healthy system should need no repair actions")
     }
 
@@ -1187,7 +1187,7 @@ final class WizardPureLogicTests: XCTestCase {
                 canAutoResolve: true
             )
         )
-        let actions = ActionDeterminer.determineRepairActions(context: context)
+        let actions = InstallerDecisionPipeline.determineRepairActions(context: context)
         XCTAssertTrue(actions.contains(.terminateConflictingProcesses))
     }
 
@@ -1198,7 +1198,7 @@ final class WizardPureLogicTests: XCTestCase {
                 canAutoResolve: false
             )
         )
-        let actions = ActionDeterminer.determineRepairActions(context: context)
+        let actions = InstallerDecisionPipeline.determineRepairActions(context: context)
         XCTAssertFalse(actions.contains(.terminateConflictingProcesses))
     }
 
@@ -1213,7 +1213,7 @@ final class WizardPureLogicTests: XCTestCase {
             vhidVersionMismatch: true
         )
         let context = makeContext(components: components)
-        let actions = ActionDeterminer.determineRepairActions(context: context)
+        let actions = InstallerDecisionPipeline.determineRepairActions(context: context)
         XCTAssertTrue(actions.contains(.fixDriverVersionMismatch))
     }
 
@@ -1228,7 +1228,7 @@ final class WizardPureLogicTests: XCTestCase {
             vhidVersionMismatch: false
         )
         let context = makeContext(components: components)
-        let actions = ActionDeterminer.determineRepairActions(context: context)
+        let actions = InstallerDecisionPipeline.determineRepairActions(context: context)
         XCTAssertTrue(actions.contains(.installMissingComponents))
         XCTAssertTrue(actions.contains(.activateVHIDDeviceManager),
                       "Should activate manager when driver is missing")
@@ -1238,7 +1238,7 @@ final class WizardPureLogicTests: XCTestCase {
         let context = makeContext(
             services: HealthStatus(kanataRunning: false, karabinerDaemonRunning: false, vhidHealthy: true)
         )
-        let actions = ActionDeterminer.determineRepairActions(context: context)
+        let actions = InstallerDecisionPipeline.determineRepairActions(context: context)
         XCTAssertTrue(actions.contains(.startKarabinerDaemon))
     }
 
@@ -1253,7 +1253,7 @@ final class WizardPureLogicTests: XCTestCase {
             )
         )
 
-        let actions = ActionDeterminer.determineRepairActions(context: context)
+        let actions = InstallerDecisionPipeline.determineRepairActions(context: context)
 
         XCTAssertFalse(actions.contains(.activateVHIDDeviceManager))
         XCTAssertFalse(actions.contains(.repairVHIDDaemonServices))
@@ -1271,7 +1271,7 @@ final class WizardPureLogicTests: XCTestCase {
             )
         )
 
-        let actions = ActionDeterminer.determineRepairActions(context: context)
+        let actions = InstallerDecisionPipeline.determineRepairActions(context: context)
 
         XCTAssertFalse(actions.contains(.activateVHIDDeviceManager))
         XCTAssertFalse(actions.contains(.repairVHIDDaemonServices))
@@ -1290,7 +1290,7 @@ final class WizardPureLogicTests: XCTestCase {
             )
         )
 
-        let actions = ActionDeterminer.determineRepairActions(context: context)
+        let actions = InstallerDecisionPipeline.determineRepairActions(context: context)
 
         XCTAssertTrue(actions.contains(.activateVHIDDeviceManager))
         XCTAssertTrue(actions.contains(.repairVHIDDaemonServices))
@@ -1308,7 +1308,7 @@ final class WizardPureLogicTests: XCTestCase {
             )
         )
 
-        let actions = ActionDeterminer.determineRepairActions(context: context)
+        let actions = InstallerDecisionPipeline.determineRepairActions(context: context)
 
         XCTAssertTrue(
             actions.contains(.installRequiredRuntimeServices),
@@ -1319,7 +1319,7 @@ final class WizardPureLogicTests: XCTestCase {
 
     func test_determineRepairActions_helperInstalledButBroken_includesReinstall() {
         let context = makeContext(helper: HelperStatus(isInstalled: true, version: "1.0", isWorking: false))
-        let actions = ActionDeterminer.determineRepairActions(context: context)
+        let actions = InstallerDecisionPipeline.determineRepairActions(context: context)
         XCTAssertTrue(actions.contains(.reinstallPrivilegedHelper),
                       "Repair should reinstall (not install) existing broken helper")
         XCTAssertFalse(actions.contains(.installPrivilegedHelper))
@@ -1327,7 +1327,7 @@ final class WizardPureLogicTests: XCTestCase {
 
     func test_determineRepairActions_helperMissing_includesInstall() {
         let context = makeContext(helper: HelperStatus(isInstalled: false, version: nil, isWorking: false))
-        let actions = ActionDeterminer.determineRepairActions(context: context)
+        let actions = InstallerDecisionPipeline.determineRepairActions(context: context)
         XCTAssertTrue(actions.contains(.installPrivilegedHelper))
     }
 
@@ -1342,7 +1342,7 @@ final class WizardPureLogicTests: XCTestCase {
             vhidVersionMismatch: false
         )
         let context = makeContext(components: components)
-        let actions = ActionDeterminer.determineRepairActions(context: context)
+        let actions = InstallerDecisionPipeline.determineRepairActions(context: context)
         XCTAssertTrue(actions.contains(.installRequiredRuntimeServices))
         XCTAssertFalse(
             actions.contains(.installMissingComponents),
@@ -1361,7 +1361,7 @@ final class WizardPureLogicTests: XCTestCase {
             vhidVersionMismatch: false
         )
         let context = makeContext(components: components)
-        let actions = ActionDeterminer.determineRepairActions(context: context)
+        let actions = InstallerDecisionPipeline.determineRepairActions(context: context)
         XCTAssertFalse(
             actions.contains(.installMissingComponents),
             "A present but unhealthy VHID device should not be planned as a missing component"
@@ -1380,12 +1380,12 @@ final class WizardPureLogicTests: XCTestCase {
             vhidVersionMismatch: false
         )
         let context = makeContext(components: components)
-        let actions = ActionDeterminer.determineRepairActions(context: context)
+        let actions = InstallerDecisionPipeline.determineRepairActions(context: context)
         XCTAssertTrue(actions.contains(.installRequiredRuntimeServices),
                       "Stale VHID daemon plist needs the runtime-services rewrite even when the daemon is healthy")
     }
 
-    // MARK: - ActionDeterminer: Install Actions
+    // MARK: - InstallerDecisionPipeline: Install Actions
 
     func test_determineInstallActions_vhidDaemonPlistMisconfigured_includesInstallRuntimeServices() {
         let components = ComponentStatus(
@@ -1399,7 +1399,7 @@ final class WizardPureLogicTests: XCTestCase {
             vhidVersionMismatch: false
         )
         let context = makeContext(components: components)
-        let actions = ActionDeterminer.determineInstallActions(context: context)
+        let actions = InstallerDecisionPipeline.determineInstallActions(context: context)
         XCTAssertTrue(actions.contains(.installRequiredRuntimeServices),
                       "Install plans share the vhidRuntimeServicesNeedRepair trigger with repair plans")
     }
@@ -1415,7 +1415,7 @@ final class WizardPureLogicTests: XCTestCase {
             vhidVersionMismatch: false
         )
         let context = makeContext(components: components)
-        let actions = ActionDeterminer.determineInstallActions(context: context)
+        let actions = InstallerDecisionPipeline.determineInstallActions(context: context)
         XCTAssertTrue(actions.contains(.installRequiredRuntimeServices))
         XCTAssertFalse(
             actions.contains(.installMissingComponents),
@@ -1434,7 +1434,7 @@ final class WizardPureLogicTests: XCTestCase {
             )
         )
 
-        let actions = ActionDeterminer.determineInstallActions(context: context)
+        let actions = InstallerDecisionPipeline.determineInstallActions(context: context)
 
         XCTAssertFalse(actions.contains(.activateVHIDDeviceManager))
         XCTAssertFalse(actions.contains(.repairVHIDDaemonServices))
@@ -1443,13 +1443,13 @@ final class WizardPureLogicTests: XCTestCase {
 
     func test_determineInstallActions_allHealthy_returnsEmpty() {
         let context = makeContext()
-        let actions = ActionDeterminer.determineInstallActions(context: context)
+        let actions = InstallerDecisionPipeline.determineInstallActions(context: context)
         XCTAssertTrue(actions.isEmpty, "Healthy system should need no install actions")
     }
 
     func test_determineInstallActions_helperMissing_usesInstallNotReinstall() {
         let context = makeContext(helper: HelperStatus(isInstalled: false, version: nil, isWorking: false))
-        let actions = ActionDeterminer.determineInstallActions(context: context)
+        let actions = InstallerDecisionPipeline.determineInstallActions(context: context)
         XCTAssertTrue(actions.contains(.installPrivilegedHelper),
                       "Fresh install should use installPrivilegedHelper")
         XCTAssertFalse(actions.contains(.reinstallPrivilegedHelper),
@@ -1458,40 +1458,40 @@ final class WizardPureLogicTests: XCTestCase {
 
     func test_determineInstallActions_helperInstalledButBroken_stillUsesInstall() {
         let context = makeContext(helper: HelperStatus(isInstalled: true, version: "1.0", isWorking: false))
-        let actions = ActionDeterminer.determineInstallActions(context: context)
+        let actions = InstallerDecisionPipeline.determineInstallActions(context: context)
         // For install intent, it always uses install (not reinstall)
         XCTAssertTrue(actions.contains(.installPrivilegedHelper))
     }
 
-    // MARK: - ActionDeterminer: Uninstall Actions
+    // MARK: - InstallerDecisionPipeline: Uninstall Actions
 
     func test_determineUninstallActions_returnsEmpty() {
         let context = makeContext()
-        let actions = ActionDeterminer.determineUninstallActions(context: context)
-        XCTAssertTrue(actions.isEmpty, "Uninstall is handled by UninstallCoordinator, not ActionDeterminer")
+        let actions = InstallerDecisionPipeline.determineUninstallActions(context: context)
+        XCTAssertTrue(actions.isEmpty, "Uninstall is handled by UninstallCoordinator, not InstallerDecisionPipeline")
     }
 
-    // MARK: - ActionDeterminer: determineActions with Intent
+    // MARK: - InstallerDecisionPipeline: determineActions with Intent
 
     func test_determineActions_inspectOnly_returnsEmpty() {
         let context = makeContext(helper: HelperStatus(isInstalled: false, version: nil, isWorking: false))
-        let actions = ActionDeterminer.determineActions(for: .inspectOnly, context: context)
+        let actions = InstallerDecisionPipeline.determineActions(for: .inspectOnly, context: context)
         XCTAssertTrue(actions.isEmpty, "Inspect-only should never produce actions")
     }
 
     func test_determineActions_repairIntent_delegatesToRepairActions() {
         let context = makeContext(helper: HelperStatus(isInstalled: true, version: "1.0", isWorking: false))
-        let actions = ActionDeterminer.determineActions(for: .repair, context: context)
+        let actions = InstallerDecisionPipeline.determineActions(for: .repair, context: context)
         XCTAssertTrue(actions.contains(.reinstallPrivilegedHelper))
     }
 
     func test_determineActions_installIntent_delegatesToInstallActions() {
         let context = makeContext(helper: HelperStatus(isInstalled: false, version: nil, isWorking: false))
-        let actions = ActionDeterminer.determineActions(for: .install, context: context)
+        let actions = InstallerDecisionPipeline.determineActions(for: .install, context: context)
         XCTAssertTrue(actions.contains(.installPrivilegedHelper))
     }
 
-    // MARK: - ActionDeterminer: Ordering Guarantees
+    // MARK: - InstallerDecisionPipeline: Ordering Guarantees
 
     func test_determineRepairActions_conflictsBeforeComponents() {
         let components = ComponentStatus(
@@ -1510,7 +1510,7 @@ final class WizardPureLogicTests: XCTestCase {
             ),
             components: components
         )
-        let actions = ActionDeterminer.determineRepairActions(context: context)
+        let actions = InstallerDecisionPipeline.determineRepairActions(context: context)
         let terminateIdx = actions.firstIndex(of: .terminateConflictingProcesses)
         let installIdx = actions.firstIndex(of: .installMissingComponents)
         XCTAssertNotNil(terminateIdx)
@@ -1533,7 +1533,7 @@ final class WizardPureLogicTests: XCTestCase {
             services: HealthStatus(kanataRunning: false, karabinerDaemonRunning: false, vhidHealthy: true),
             components: components
         )
-        let actions = ActionDeterminer.determineRepairActions(context: context)
+        let actions = InstallerDecisionPipeline.determineRepairActions(context: context)
         let activateIdx = try XCTUnwrap(actions.firstIndex(of: .activateVHIDDeviceManager))
         let startIdx = try XCTUnwrap(actions.firstIndex(of: .startKarabinerDaemon))
         XCTAssertLessThan(

--- a/Tests/KeyPathTests/Lint/InstallerDecisionPipelineLintTests.swift
+++ b/Tests/KeyPathTests/Lint/InstallerDecisionPipelineLintTests.swift
@@ -2,6 +2,24 @@ import Foundation
 @preconcurrency import XCTest
 
 final class InstallerDecisionPipelineLintTests: KeyPathTestCase {
+    func testDeprecatedActionDeterminerFacadeIsDeleted() throws {
+        let root = repositoryRoot()
+        XCTAssertFalse(
+            FileManager.default.fileExists(
+                atPath: root.appendingPathComponent(
+                    "Sources/KeyPathInstallationWizard/Core/ActionDeterminer.swift"
+                ).path
+            )
+        )
+        let pipeline = try String(
+            contentsOf: root.appendingPathComponent(
+                "Sources/KeyPathInstallationWizard/Core/InstallerDecisionPipeline.swift"
+            ),
+            encoding: .utf8
+        )
+        XCTAssertFalse(pipeline.contains("enum ActionDeterminer"))
+    }
+
     func testEarlyInstallerExitsPreserveCorrelationEvidence() throws {
         let root = repositoryRoot()
         let engineSource = try String(

--- a/Tests/KeyPathTests/Services/KarabinerConflictServiceTests.swift
+++ b/Tests/KeyPathTests/Services/KarabinerConflictServiceTests.swift
@@ -9,7 +9,7 @@ import Testing
 struct KarabinerConflictServiceTests {
     @Test("Karabiner grabber detection uses injected SystemStateProvider")
     func karabinerGrabberDetectionUsesInjectedSystemStateProvider() async {
-        KarabinerConflictService.testDaemonRunning = nil
+        TestSingletonReset.resetAll()
         let runner = SubprocessRunnerFake.shared
         await runner.reset()
         await runner.configurePgrepResult { pattern in
@@ -31,7 +31,7 @@ struct KarabinerConflictServiceTests {
 
     @Test("VirtualHID daemon detection uses injected SystemStateProvider")
     func virtualHIDDaemonDetectionUsesInjectedSystemStateProvider() async {
-        KarabinerConflictService.testDaemonRunning = nil
+        TestSingletonReset.resetAll()
         FeatureFlags.testStartupMode = false
         defer { FeatureFlags.testStartupMode = nil }
         ServiceBootstrapper.setRestartTimeForTesting(
@@ -59,6 +59,7 @@ struct KarabinerConflictServiceTests {
 
     @Test("Stopped-process verification uses injected SystemStateProvider")
     func stoppedProcessVerificationUsesInjectedSystemStateProvider() async {
+        TestSingletonReset.resetAll()
         let runner = SubprocessRunnerFake.shared
         await runner.reset()
         await runner.configurePgrepResult { pattern in

--- a/Tests/KeyPathTests/Support/GlobalTestSetup.swift
+++ b/Tests/KeyPathTests/Support/GlobalTestSetup.swift
@@ -26,6 +26,10 @@ enum TestSingletonReset {
         // so a value left by one test must not bleed into another's health check.
         KanataGrabStatusStore.shared.reset()
 
+        // Karabiner conflict detection has a process-wide daemon seam. Reset it
+        // with the other shared state so suites cannot inherit a forced result.
+        KarabinerConflictService.testDaemonRunning = nil
+
         // Wait-for-exit seams (#625 part-1): safe defaults so any test reaching
         // ServiceLifecycleCoordinator.startKanata neither spawns real `pgrep`
         // (parallel-run deadlock risk) nor waits real time. Tests that exercise the

--- a/docs/adr/adr-026-validation-ordering.md
+++ b/docs/adr/adr-026-validation-ordering.md
@@ -1,6 +1,6 @@
 # ADR-026: System Validation Ordering - Components Before Service Status
 
-**Status:** Accepted
+**Status:** Accepted; implementation updated by installer pipeline consolidation
 **Date:** December 2025
 
 ## Context
@@ -9,7 +9,8 @@ The wizard displayed all green checkmarks (system healthy) but mappings failed w
 
 ## Root Cause
 
-`SystemContextAdapter.adaptSystemState()` checked if `kanataRunning == true` BEFORE verifying components existed.
+The former `SystemContextAdapter.adaptSystemState()` checked if
+`kanataRunning == true` before verifying components existed.
 
 If `ServiceHealthChecker.isServiceHealthy()` returned a false positive (during the 2-second warmup period after service restart, or due to any health check bug), the system would be declared `.active` without ever checking if the Kanata binary existed.
 
@@ -18,7 +19,7 @@ If `ServiceHealthChecker.isServiceHealthy()` returned a false positive (during t
 Validation checks MUST follow this order:
 
 ```swift
-// ✅ CORRECT ORDER (enforced in SystemContextAdapter.adaptSystemState)
+// Correct priority order (enforced by the canonical snapshot projection)
 1. Conflicts          // Highest priority - blocks everything
 2. Components         // Must exist before anything can run
 3. Permissions        // Required for services to work
@@ -35,9 +36,13 @@ Validation checks MUST follow this order:
 | Fail-fast on missing components | Better to show "missing binary" than "everything's working" |
 | Prevents confusion | Users shouldn't see green checkmarks when critical files are missing |
 
-## Code Location
+## Current Implementation
 
-`Sources/KeyPathAppKit/InstallationWizard/Core/SystemContextAdapter.swift:28-71`
+`SystemContextAdapter` was deleted in PR #1092. `SystemValidator` now captures
+the canonical `SystemSnapshot`; `SystemStateResult+SystemContext.swift` projects
+that immutable evidence into `SystemContext`, and `InstallerDecisionPipeline`
+classifies and plans from it. The ordering invariant remains: component
+prerequisites outrank derived service-health evidence.
 
 ## Rules
 

--- a/docs/adr/adr-031-kanata-service-lifecycle-invariants-and-postcondition-enforcement.md
+++ b/docs/adr/adr-031-kanata-service-lifecycle-invariants-and-postcondition-enforcement.md
@@ -50,10 +50,10 @@ Adopt explicit service lifecycle invariants for Kanata install/repair paths:
    - CLI, menu-bar, and wizard surfaces publish or consume the same
      `InstallerStateMatrixRow` / `InstallerStateMatrixAction` vocabulary before
      deciding whether a state is healthy, degraded, or manual-action-required.
-   - Live AppKit evidence is materialized through
-     `SystemStateProvider.currentInstallerStateMatrixSnapshot(...)`; wizard core
-     uses a pure `SystemContext -> InstallerStateMatrixSnapshot` bridge because
-     it cannot import AppKit.
+   - Live evidence is captured once by `SystemValidator` into the canonical
+     snapshot and projected into the context consumed by
+     `InstallerDecisionPipeline`. The deleted provider/wizard adapters must not
+     be restored.
 
 ## Consequences
 
@@ -70,15 +70,13 @@ Adopt explicit service lifecycle invariants for Kanata install/repair paths:
 
 - Install/repair actions can fail more often in borderline startup conditions instead of masking failures.
 - Additional polling and diagnostics add modest complexity.
-- Until the Workstream 6 deletion pass, both `SystemSnapshot`/`SystemContext`
-  and the narrower `InstallerStateMatrixSnapshot` exist.
+- The canonical snapshot, context projection, and narrower pure matrix input
+  remain separate value shapes and therefore require anti-regrowth ratchets.
 
 ### Follow-up
 
-- Workstream 3 changes repair autonomy and user-initiated repair behavior on
-  top of the Phase 1 classification contract.
-- Workstream 6 collapses remaining snapshot/cache duplication after the repair
-  model is stable.
+- The owned-run pipeline and compatibility deletion completed in July 2026;
+  future changes must preserve the single-capture contract.
 
 ## Enforcement
 
@@ -86,12 +84,11 @@ Adopt explicit service lifecycle invariants for Kanata install/repair paths:
   and
   `InstallerStateMatrixGoldenTests.testClassifySnapshotAndPlanMatchStateMatrixGoldenFixtures`
   pin the documented rows and action plans.
-- `SystemStateProviderInstallerStateMatrixTests.*` pins live matrix snapshot
-  materialization from provider-owned SMAppService, launchd/runtime, helper, and
-  component evidence.
+- `WizardPureLogicTests.test_systemStateProjectionPublishesStateMatrixMetadata`
+  pins canonical projection into presentation state.
 - `CLIOutputContractTests.testInspectResultRepairMetadataJSONShape`,
   `MainAppStateControllerTests.menuBarHealthPrefersStateMatrixRow`, and
-  `WizardPureLogicTests.test_systemContextAdapterPublishesStateMatrixMetadata`
+  `SnapshotConsumerLintTests` and `InstallerDecisionPipelineLintTests`
   pin consumer adoption.
 
 ## Related

--- a/docs/adr/adr-042-executable-installer-state-classification.md
+++ b/docs/adr/adr-042-executable-installer-state-classification.md
@@ -35,10 +35,11 @@ repair state matrix.
    - Classification is `InstallerStateMatrixSnapshot -> InstallerStateMatrixRow`.
    - Planning vocabulary is `InstallerStateMatrixRow -> [InstallerStateMatrixAction]`.
 
-2. **Live OS evidence belongs behind `SystemStateProvider`**
+2. **Live OS evidence belongs in the canonical snapshot capture**
    - SMAppService status, launchctl read-only evidence, process discovery,
      process liveness, TCP readiness, and permission snapshots are centralized
-     behind `SystemStateProvider` or its owned low-level helpers.
+     behind `SystemValidator`, `SystemStateProvider`, or their owned low-level
+     helpers and is recorded in one `SystemSnapshot`.
    - Consumers must not call direct SMAppService status, `pgrep`, `launchctl
      print`, `kill(pid, 0)`, or permission snapshot sources once migrated.
    - Lint tests ratchet each migrated consumer.
@@ -47,26 +48,20 @@ repair state matrix.
    - CLI `system inspect` reports the shared state-matrix row and plan.
    - Menu-bar health treats `runningAndTCPResponding` as the only healthy
      classified row once validation has produced a classification.
-   - Wizard detection results publish the shared state-matrix row and plan next
-     to legacy wizard state/issues/actions.
+   - Wizard detection results publish the shared state-matrix row and plan from
+     the same canonical context used by the engine.
 
 4. **Package boundaries stay honest**
-   - The live `SystemStateProvider` matrix adapter lives in AppKit because it
-     reads SMAppService and runtime evidence.
-   - Wizard core cannot import AppKit without a dependency cycle, so it consumes
-     the same classifier through a pure `SystemContext ->
-     InstallerStateMatrixSnapshot` bridge.
-   - This is an intentional Phase 1 boundary, not a second state model.
+   - `SystemValidator` captures OS evidence and projects it into the canonical
+     context consumed by `InstallerDecisionPipeline`.
+   - The former live-provider and `SystemContextAdapter` compatibility paths
+     were deleted in PRs #1091 and #1092 after clients migrated.
+   - Package boundaries must not recreate a second live evidence path.
 
-5. **Repair-model and deletion work stay sequenced later in Phase 1**
-   - This ADR records the Workstream 1/2/5 detection contract only.
-   - Workstream 3 remains Phase 1 work, but starts after migrated consumers are
-     using the shared snapshot/row/action vocabulary and the lint ratchets are
-     stable.
-   - Workstream 6 remains Phase 1 work, but runs last so it deletes code that
-     Workstream 3 has made obsolete instead of polishing code about to be
-     removed.
-   - Phase 2 remains limited to autonomous/background repair behaviors.
+5. **Deletion follows migration**
+   - The compatibility bridge was retained during migration, then deleted once
+     production consumers used the shared snapshot/row/action vocabulary.
+   - Lint ratchets now prevent those deleted paths from regrowing.
 
 ## Enforcement
 
@@ -74,16 +69,16 @@ repair state matrix.
   ensures every documented row is represented by a golden fixture.
 - `InstallerStateMatrixGoldenTests.testClassifySnapshotAndPlanMatchStateMatrixGoldenFixtures`
   pins row and plan classification for every fixture.
-- `SystemStateProviderInstallerStateMatrixTests.*` pins live AppKit matrix
-  snapshot materialization from provider-owned evidence.
+- `WizardPureLogicTests.test_systemStateProjectionPublishesStateMatrixMetadata`
+  pins canonical context-to-presentation projection.
 - `CLIOutputContractTests.testInspectResultRepairMetadataJSONShape` pins CLI
   row/plan output.
 - `MainAppStateControllerTests.menuBarHealthPrefersStateMatrixRow` pins the
   menu-bar healthy predicate.
-- `WizardPureLogicTests.test_systemContextAdapterPublishesStateMatrixMetadata`
-  pins wizard row/plan publication.
 - `WizardPureLogicTests.test_systemContextStateMatrixSnapshot_classifiesStoppedRuntimeWithStaleInputCapture`
-  pins the pure wizard-core snapshot bridge.
+  pins pure classification of canonical context evidence.
+- `SnapshotConsumerLintTests` and `InstallerDecisionPipelineLintTests` prevent
+  duplicate capture, adapter, and decision paths.
 - `SMAppServiceStatusLintTests`, `PermissionSnapshotLintTests`,
   `PgrepProcessDiscoveryLintTests`, `LaunchctlEvidenceLintTests`,
   `LivenessPredicateLintTests`, and `TCPReadinessLintTests` prevent migrated
@@ -101,15 +96,11 @@ repair state matrix.
 
 ### Negative
 
-- There are temporarily two snapshot-shaped values: the existing
-  `SystemSnapshot`/`SystemContext` flow and the narrower
-  `InstallerStateMatrixSnapshot`.
-- The wizard bridge still exists because of package boundaries, but it preserves
-  the matrix-critical registration, approval, runtime payload, runtime
-  readiness, input-capture, and helper freshness evidence and is pinned against
-  the live provider adapter by focused equivalence tests.
-- Full deletion of duplicate caches and snapshot adapters is deferred within
-  Phase 1 until Workstream 3 has stabilized the repair model.
+- `SystemSnapshot`, its canonical `SystemContext` projection, and the narrower
+  pure matrix input remain distinct value shapes, but no longer trigger
+  independent live captures.
+- Maintaining the single-capture boundary requires explicit lint ratchets as
+  new consumers are added.
 
 ## Related
 

--- a/docs/planning/installer-phase-pipeline-and-modularization.md
+++ b/docs/planning/installer-phase-pipeline-and-modularization.md
@@ -193,8 +193,9 @@ single pure classification/planning path used by the engine and clients.
   seconds; normal refresh, install, and repair inspection remains fresh.
 - `InstallerDecisionPipeline` now produces the matrix assessment, diagnostic
   matrix actions, and executable auto-fix actions together from one context and
-  intent. `InstallerEngine` and the wizard compatibility adapter both consume
-  that result; `ActionDeterminer` remains only as a migration façade.
+  intent. `InstallerEngine` and wizard projection both consume that result. The
+  temporary `ActionDeterminer` migration façade was deleted after the client
+  migration completed.
 - `SystemSnapshot` now carries explicit complete/cancelled/timed-out capture
   status alongside its timestamp. Compatibility projections and wizard timeout
   results preserve that fact, and incomplete captures are excluded from the
@@ -337,7 +338,9 @@ separate ownership demonstrably simplifies the code.
 
 - Every executed operation appears in the original plan.
 - No bootstrapper or operation creates another installer plan.
-- Command or helper success without postconditions remains failure.
+- For recipes with declared postconditions, command or helper success without
+  satisfying those postconditions remains failure. Low-risk filesystem recipes
+  that intentionally declare no postcondition continue to rely on their reply.
 - Lost replies with satisfied postconditions become verified success.
 - Failed verification produces a newly planned recovery rather than an
   unplanned executor branch.
@@ -375,6 +378,11 @@ workflows select stable Xcode 26.6.
 - PR #1092 removed `SystemContextAdapter`. Wizard presentation state is now an
   explicit pure projection from the canonical installer context, protected by
   golden tests and an anti-regrowth ratchet.
+- PRs #1094-#1097 closed the senior-review correctness findings: every
+  helper-first fallback rechecks authoritative state, failed sub-probes cannot
+  produce complete snapshots, fresh capture invalidates component facts,
+  zero-recipe runs are verified no-ops with preserved correlation IDs, and all
+  production mutation routes share the installer transaction.
 
 ### Client Consolidation
 

--- a/docs/planning/installer-reliability-phase1.md
+++ b/docs/planning/installer-reliability-phase1.md
@@ -1,9 +1,15 @@
 # Installer Reliability Phase 1: Foundation Before Autonomy
 
-**Status:** Proposed
+**Status:** Completed and superseded by the successor plan
 **Date:** 2026-07-06
 **Companion:** [autonomous-repair-roadmap.md](autonomous-repair-roadmap.md) (Phase 2 — deferred, not abandoned)
 **Successor plan:** [Installer Phase Pipeline and Swift Module Plan](installer-phase-pipeline-and-modularization.md)
+
+> Historical note: this document preserves the workstream evidence and test
+> names used during Phase 1. PRs #1091-#1092 later deleted the temporary live
+> state-matrix and `SystemContextAdapter` compatibility paths. Current
+> ownership and enforcement are documented in the successor plan,
+> ADR-042, and the installer repair state matrix.
 
 ## Purpose
 

--- a/docs/process/installer-repair-state-matrix.md
+++ b/docs/process/installer-repair-state-matrix.md
@@ -148,7 +148,8 @@ the result as user action required and name the approval surface.
 
 ## Where To Put Enforcement
 
-- Planner routing belongs in `ActionDeterminer` and pure wizard logic tests.
+- Planner routing belongs in `InstallerDecisionPipeline` and pure wizard logic
+  tests.
 - Privileged command routing belongs in `PrivilegedOperationsRouter`.
 - Helper-owned root mutations belong in `HelperService`, but helper success must
   still be verified by the app-side router when possible.
@@ -163,8 +164,8 @@ the result as user action required and name the approval surface.
   pins that `runningAndTCPResponding` is the only matrix row treated as healthy
   by the compact status surface.
 - Wizard detection results publish the shared state-matrix row and plan next to
-  legacy wizard state/issues/actions. `WizardPureLogicTests.test_systemContextAdapterPublishesStateMatrixMetadata`
-  pins the adapter contract, while
+  legacy wizard state/issues/actions. `WizardPureLogicTests.test_systemStateProjectionPublishesStateMatrixMetadata`
+  pins the projection contract, while
   `WizardPureLogicTests.test_systemContextStateMatrixSnapshot_classifiesStoppedRuntimeWithStaleInputCapture`
   pins the pure `SystemContext` snapshot bridge used by wizard core.
 - Raw process-liveness semantics live in `KeyPathSystemProbes` and are exposed
@@ -306,9 +307,7 @@ the result as user action required and name the approval surface.
   provider-backed manager.
 - Helper responsiveness is not helper freshness.
   `W6DeletionPassLintTests.testMatrixAdaptersDoNotTreatUnknownHelperVersionAsFresh`,
-  `SystemStateProviderInstallerStateMatrixTests.testStateMatrixSnapshotTreatsUnknownHelperVersionAsNotFresh`,
-  and
-  `SystemStateProviderInstallerStateMatrixTests.testWizardSystemContextSnapshotTreatsUnknownHelperVersionAsNotFresh`
+  `HelperVersionContractTests`, and the matrix golden fixtures
   enforce that an unknown helper version routes to helper verification/refresh
   rather than a healthy row.
 - User-facing CLI/reporting shape belongs in CLI contract tests.
@@ -317,25 +316,13 @@ the result as user action required and name the approval surface.
   requires one fixture per documented row, and
   `InstallerStateMatrixGoldenTests.testClassifySnapshotAndPlanMatchStateMatrixGoldenFixtures`
   asserts evidence in -> row out -> plan out for every row.
-- Live state-matrix snapshot materialization belongs behind
-  `SystemStateProvider.currentInstallerStateMatrixSnapshot(...)`. The adapter is
-  pinned by
-  `SystemStateProviderInstallerStateMatrixTests.testStateMatrixSnapshotPreservesRunningButTCPNotRespondingEvidence`,
-  `SystemStateProviderInstallerStateMatrixTests.testStateMatrixSnapshotMapsStaleEnabledRegistrationToRegisteredButNotLoaded`,
-  `SystemStateProviderInstallerStateMatrixTests.testStateMatrixSnapshotMapsStoppedDriverKitApprovalToManualDriverKitRow`,
-  `SystemStateProviderInstallerStateMatrixTests.testStateMatrixSnapshotMapsStoppedRuntimeWithLoginItemsApprovalToManualApprovalRow`,
-  `SystemStateProviderInstallerStateMatrixTests.testStateMatrixSnapshotMapsHelperVersionMismatchToStaleHelperRow`,
-  and
-  `SystemStateProviderInstallerStateMatrixTests.testStateMatrixSnapshotTreatsUnhealthyVHIDServicesAsServiceRepairNotMissingPayload`.
-  Wizard/provider parity for registration evidence, Login Items approval,
-  runtime payload presence, and unknown helper freshness is pinned by
-  `SystemStateProviderInstallerStateMatrixTests.testWizardSystemContextSnapshotPreservesKanataNotRegisteredEvidence`,
-  `SystemStateProviderInstallerStateMatrixTests.testWizardSystemContextSnapshotPreservesManualApprovalEvidence`,
-  `SystemStateProviderInstallerStateMatrixTests.testWizardSystemContextSnapshotPreservesMissingRuntimePayloadEvidence`,
-  `SystemStateProviderInstallerStateMatrixTests.testWizardSystemContextSnapshotPreservesUnknownRegistrationEvidence`,
-  `SystemStateProviderInstallerStateMatrixTests.testWizardSystemContextSnapshotTreatsUnknownHelperVersionAsNotFresh`,
-  and
-  `SnapshotConsumerLintTests.testInstallerEnginePreservesMatrixEvidenceThroughSystemSnapshotBridge`.
+- Live state-matrix materialization is a pure projection of the canonical
+  `SystemSnapshot` captured by `SystemValidator`; the deleted live-provider and
+  wizard adapters must not be restored. `WizardPureLogicTests` pins projection
+  and classification behavior, while
+  `SnapshotConsumerLintTests.testInstallerEnginePreservesMatrixEvidenceThroughSystemSnapshotBridge`
+  and `InstallerDecisionPipelineLintTests` prevent duplicate recapture or
+  planning paths.
 
 ## Related References
 


### PR DESCRIPTION
## Summary
- delete the test-only `ActionDeterminer` migration façade and rename the canonical source file
- add an anti-regrowth ratchet and reset the Karabiner daemon test seam with shared singleton state
- update ADRs, state-matrix guidance, and milestone docs to describe the post-consolidation architecture
- document the four-step stable Xcode pin advance procedure

## Installer state matrix
No classification or repair behavior changes. This PR updates ownership/enforcement documentation for all matrix rows and preserves the existing pure `InstallerDecisionPipeline`.

## Validation
- `DEVELOPER_DIR=/Applications/Xcode-26.6.0.app/Contents/Developer TEST_FILTER='WizardPureLogicTests|KarabinerConflictServiceTests|InstallerDecisionPipelineLintTests|DeploymentScriptContractTests' ./Scripts/run-tests-safe.sh` (127 passed)
- `DEVELOPER_DIR=/Applications/Xcode-26.6.0.app/Contents/Developer TEST_FILTER='KeyPathTests\.' ./Scripts/run-tests-safe.sh` (4,338 passed)
- `python3 Scripts/check-accessibility.py`
- `git diff --check`
- review gate: remote review gate selected