### PR TITLE
Harden helper timeout recovery

### DIFF
--- a/Sources/KeyPathAppKit/Core/HelperManager+ConnectionLifecycle.swift
+++ b/Sources/KeyPathAppKit/Core/HelperManager+ConnectionLifecycle.swift
@@ -46,15 +46,19 @@ extension HelperManager {
         // Set up the interface
         newConnection.remoteObjectInterface = NSXPCInterface(with: HelperProtocol.self)
 
-        // Handle connection lifecycle
+        connectionGeneration &+= 1
+        let generation = connectionGeneration
+
+        // Handle connection lifecycle. The generation guard prevents a late
+        // callback from an old connection from clearing its replacement.
         newConnection.invalidationHandler = {
             AppLogger.shared.log("❌ [HelperManager] XPC connection invalidated")
-            Task { await HelperManager.shared.clearConnection() }
+            Task { await HelperManager.shared.connectionDidEnd(generation: generation) }
         }
 
         newConnection.interruptionHandler = {
             AppLogger.shared.log("⚠️ [HelperManager] XPC connection interrupted - will reconnect")
-            Task { await HelperManager.shared.clearConnection() }
+            Task { await HelperManager.shared.connectionDidEnd(generation: generation) }
         }
 
         // Start the connection
@@ -80,6 +84,33 @@ extension HelperManager {
         connection?.invalidate()
         connection = nil
     }
+
+    func clearConnection(ifGenerationMatches generation: UInt64) {
+        guard generation == connectionGeneration else {
+            AppLogger.shared.log(
+                "ℹ️ [HelperManager] Ignoring stale connection clear for generation \(generation); current=\(connectionGeneration)"
+            )
+            return
+        }
+        clearConnection()
+    }
+
+    func connectionDidEnd(generation: UInt64) {
+        guard generation == connectionGeneration else { return }
+        AppLogger.shared.log("🧹 [HelperManager] Dropping ended XPC connection generation \(generation)")
+        connection = nil
+    }
+
+    #if DEBUG
+        func setConnectionForTesting(_ connection: NSXPCConnection?, generation: UInt64) {
+            self.connection = connection
+            connectionGeneration = generation
+        }
+
+        func hasConnectionForTesting() -> Bool {
+            connection != nil
+        }
+    #endif
 
     /// Check if helper process is still running
     /// - Parameter pid: Process ID to check

--- a/Sources/KeyPathAppKit/Core/HelperManager+RequestHandlers.swift
+++ b/Sources/KeyPathAppKit/Core/HelperManager+RequestHandlers.swift
@@ -14,11 +14,16 @@ private final class HelperXPCCallCompletionState: Sendable {
     }
 }
 
+struct HelperRemoteProxy {
+    let proxy: HelperProtocol
+    let connectionGeneration: UInt64
+}
+
 extension HelperManager {
     // MARK: - XPC Protocol Wrappers
 
     /// Get the remote object proxy with a per-call error handler so callers can resume awaits
-    func getRemoteProxy(errorHandler: @escaping (Error) -> Void) async throws -> HelperProtocol {
+    func getRemoteProxy(errorHandler: @escaping (Error) -> Void) async throws -> HelperRemoteProxy {
         let connection = try await getConnection()
         guard
             let proxy = connection.remoteObjectProxyWithErrorHandler({ (err: Error) in
@@ -53,7 +58,46 @@ extension HelperManager {
         else {
             throw HelperManagerError.connectionFailed("Failed to create remote proxy")
         }
-        return proxy
+        return HelperRemoteProxy(
+            proxy: proxy,
+            connectionGeneration: connectionGeneration
+        )
+    }
+
+    static func normalizedProxyError(_ error: Error, operation: String) -> Error {
+        let nsError = error as NSError
+        if nsError.domain == NSCocoaErrorDomain, nsError.code == 4097 {
+            return HelperManagerError.ambiguousOutcome(
+                "XPC connection interrupted during '\(operation)'; the helper may have completed without delivering its reply"
+            )
+        }
+        return error
+    }
+
+    func withHelperOperationPermit<T>(
+        _ operation: () async throws -> T
+    ) async throws -> T {
+        try await operationGate.acquireUnlessCancelled()
+        do {
+            let result = try await operation()
+            await operationGate.release()
+            return result
+        } catch {
+            await operationGate.release()
+            throw error
+        }
+    }
+
+    func recordAmbiguousMutationTimeout() {
+        lastAmbiguousMutationAt = Date()
+    }
+
+    func isWithinAmbiguousMutationProbeWindow(now: Date = Date()) -> Bool {
+        HelperProbeRecoveryPolicy.isWithinAmbiguousMutationWindow(
+            lastAmbiguousMutationAt: lastAmbiguousMutationAt,
+            now: now,
+            window: Self.ambiguousMutationProbeWindow
+        )
     }
 
     /// Execute an XPC call with async/await conversion
@@ -66,47 +110,51 @@ extension HelperManager {
         timeout: TimeInterval = KeyPathConstants.Timing.helperRequestTimeout,
         _ call: @escaping @Sendable (HelperProtocol, @escaping (Bool, String?) -> Void) -> Void
     ) async throws {
-        await operationGate.acquire()
-        defer { Task { await self.operationGate.release() } }
-
-        // Detect concurrent XPC calls (indicates a bug in caller logic)
-        if activeXPCCalls.contains(name) {
-            AppLogger.shared.log("⚠️ [HelperManager] CONCURRENT XPC CALL DETECTED: \(name)")
-            AppLogger.shared.log("   → This may cause race conditions or hangs")
-            AppLogger.shared.log("   → Active calls: \(activeXPCCalls.joined(separator: ", "))")
-        }
-
-        activeXPCCalls.insert(name)
-        defer { activeXPCCalls.remove(name) }
-
-        AppLogger.shared.log("📤 [HelperManager] Calling \(name)")
-
-        let proxy = try await getRemoteProxy { _ in }
-
-        // Execute with timeout to prevent infinite hangs when XPC connection is interrupted
-        // Use a class with lock for thread-safe completion tracking
-        let completionState = HelperXPCCallCompletionState()
-
-        return try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-            // Set up timeout
-            Task {
-                try? await Task.sleep(for: .seconds(timeout))
-                guard completionState.tryComplete() else { return } // Already completed by XPC callback
-                AppLogger.shared.log("⏱️ [HelperManager] \(name) timed out after \(Int(timeout))s")
-                continuation.resume(throwing: HelperManagerError.ambiguousOutcome("XPC call '\(name)' timed out after \(Int(timeout))s; its reply may have been lost"))
+        try await withHelperOperationPermit {
+            if activeXPCCalls.contains(name) {
+                AppLogger.shared.log("⚠️ [HelperManager] CONCURRENT XPC CALL DETECTED: \(name)")
+                AppLogger.shared.log("   → Active calls: \(activeXPCCalls.joined(separator: ", "))")
             }
 
-            // Execute the XPC call
-            call(proxy) { success, errorMessage in
-                guard completionState.tryComplete() else { return } // Already timed out
+            activeXPCCalls.insert(name)
+            defer { activeXPCCalls.remove(name) }
+            try Task.checkCancellation()
+            AppLogger.shared.log("📤 [HelperManager] Calling \(name)")
 
-                if success {
-                    AppLogger.shared.info("✅ [HelperManager] \(name) succeeded")
-                    continuation.resume()
-                } else {
-                    let error = errorMessage ?? "Unknown error"
-                    AppLogger.shared.log("❌ [HelperManager] \(name) failed: \(error)")
-                    continuation.resume(throwing: HelperManagerError.operationFailed(error))
+            let completionState = HelperXPCCallCompletionState()
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                Task {
+                    try? await Task.sleep(for: .seconds(timeout))
+                    guard completionState.tryComplete() else { return }
+                    recordAmbiguousMutationTimeout()
+                    AppLogger.shared.log("⏱️ [HelperManager] \(name) timed out after \(Int(timeout))s")
+                    continuation.resume(throwing: HelperManagerError.ambiguousOutcome("XPC call '\(name)' timed out after \(Int(timeout))s; its reply may have been lost"))
+                }
+
+                Task {
+                    do {
+                        try Task.checkCancellation()
+                        let remote = try await getRemoteProxy { error in
+                            guard completionState.tryComplete() else { return }
+                            continuation.resume(
+                                throwing: Self.normalizedProxyError(error, operation: name)
+                            )
+                        }
+                        call(remote.proxy) { success, errorMessage in
+                            guard completionState.tryComplete() else { return }
+                            if success {
+                                AppLogger.shared.info("✅ [HelperManager] \(name) succeeded")
+                                continuation.resume()
+                            } else {
+                                let error = errorMessage ?? "Unknown error"
+                                AppLogger.shared.log("❌ [HelperManager] \(name) failed: \(error)")
+                                continuation.resume(throwing: HelperManagerError.operationFailed(error))
+                            }
+                        }
+                    } catch {
+                        guard completionState.tryComplete() else { return }
+                        continuation.resume(throwing: error)
+                    }
                 }
             }
         }
@@ -122,52 +170,53 @@ extension HelperManager {
             @escaping @Sendable (Result<T, Error>) -> Void
         ) -> Void
     ) async throws -> T {
-        await operationGate.acquire()
-        defer { Task { await self.operationGate.release() } }
-
-        if activeXPCCalls.contains(name) {
-            AppLogger.shared.log("⚠️ [HelperManager] CONCURRENT XPC CALL DETECTED: \(name)")
-            AppLogger.shared.log("   → This may cause race conditions or hangs")
-            AppLogger.shared.log("   → Active calls: \(activeXPCCalls.joined(separator: ", "))")
-        }
-
-        activeXPCCalls.insert(name)
-        defer { activeXPCCalls.remove(name) }
-
-        AppLogger.shared.log("📤 [HelperManager] Calling \(name)")
-
-        let completionState = HelperXPCCallCompletionState()
-
-        return try await withCheckedThrowingContinuation { continuation in
-            Task {
-                try? await Task.sleep(for: .seconds(timeout))
-                guard completionState.tryComplete() else { return }
-                AppLogger.shared.log("⏱️ [HelperManager] \(name) timed out after \(Int(timeout))s")
-                continuation.resume(throwing: HelperManagerError.ambiguousOutcome("XPC call '\(name)' timed out after \(Int(timeout))s; its reply may have been lost"))
+        try await withHelperOperationPermit {
+            if activeXPCCalls.contains(name) {
+                AppLogger.shared.log("⚠️ [HelperManager] CONCURRENT XPC CALL DETECTED: \(name)")
+                AppLogger.shared.log("   → Active calls: \(activeXPCCalls.joined(separator: ", "))")
             }
 
-            Task {
-                do {
-                    let proxy = try await self.getRemoteProxy { error in
+            activeXPCCalls.insert(name)
+            defer { activeXPCCalls.remove(name) }
+            try Task.checkCancellation()
+            AppLogger.shared.log("📤 [HelperManager] Calling \(name)")
+
+            let completionState = HelperXPCCallCompletionState()
+            return try await withCheckedThrowingContinuation { continuation in
+                Task {
+                    try? await Task.sleep(for: .seconds(timeout))
+                    guard completionState.tryComplete() else { return }
+                    recordAmbiguousMutationTimeout()
+                    AppLogger.shared.log("⏱️ [HelperManager] \(name) timed out after \(Int(timeout))s")
+                    continuation.resume(throwing: HelperManagerError.ambiguousOutcome("XPC call '\(name)' timed out after \(Int(timeout))s; its reply may have been lost"))
+                }
+
+                Task {
+                    do {
+                        try Task.checkCancellation()
+                        let remote = try await self.getRemoteProxy { error in
+                            guard completionState.tryComplete() else { return }
+                            continuation.resume(
+                                throwing: Self.normalizedProxyError(error, operation: name)
+                            )
+                        }
+
+                        call(remote.proxy) { result in
+                            guard completionState.tryComplete() else { return }
+
+                            switch result {
+                            case let .success(value):
+                                AppLogger.shared.info("✅ [HelperManager] \(name) succeeded")
+                                continuation.resume(returning: value)
+                            case let .failure(error):
+                                AppLogger.shared.log("❌ [HelperManager] \(name) failed: \(error.localizedDescription)")
+                                continuation.resume(throwing: error)
+                            }
+                        }
+                    } catch {
                         guard completionState.tryComplete() else { return }
                         continuation.resume(throwing: error)
                     }
-
-                    call(proxy) { result in
-                        guard completionState.tryComplete() else { return }
-
-                        switch result {
-                        case let .success(value):
-                            AppLogger.shared.info("✅ [HelperManager] \(name) succeeded")
-                            continuation.resume(returning: value)
-                        case let .failure(error):
-                            AppLogger.shared.log("❌ [HelperManager] \(name) failed: \(error.localizedDescription)")
-                            continuation.resume(throwing: error)
-                        }
-                    }
-                } catch {
-                    guard completionState.tryComplete() else { return }
-                    continuation.resume(throwing: error)
                 }
             }
         }

--- a/Sources/KeyPathAppKit/Core/HelperManager+Status.swift
+++ b/Sources/KeyPathAppKit/Core/HelperManager+Status.swift
@@ -50,80 +50,86 @@ extension HelperManager {
             return Self.expectedHelperVersion
         }
 
-        await operationGate.acquire()
-        defer { Task { await self.operationGate.release() } }
-
-        // Query version from helper
-        guard await isHelperInstalled() else {
-            AppLogger.shared.log("⚠️ [HelperManager] Helper not installed, cannot get version")
-            return nil
-        }
-
         do {
-            let proxy = try await getRemoteProxy { _ in /* proxy error handled by timeout path */ }
-            let version: String? = await withCheckedContinuation { (continuation: CheckedContinuation<String?, Never>) in
-                // Guard ensures the continuation is resumed exactly once.
-                // The lock protects a Bool: false = not yet resumed, true = already resumed.
-                let resumed = OSAllocatedUnfairLock(initialState: false)
-
-                // Schedule a timeout task that will fire if the XPC callback is too slow.
-                let timeoutTask = Task { @Sendable in
-                    try await Task.sleep(for: .seconds(3))
-                    // If we get here, the sleep was NOT cancelled, so we timed out.
-                    let alreadyResumed = resumed.withLock { flag -> Bool in
-                        if flag { return true }
-                        flag = true
-                        return false
-                    }
-                    guard !alreadyResumed else { return }
-                    AppLogger.shared.log(
-                        "⚠️ [HelperManager] getVersion timed out; preserving the shared connection because another operation may still be completing"
-                    )
-                    continuation.resume(returning: nil)
-                }
-
-                AppLogger.shared.log("📤 [HelperManager] Calling proxy.getVersion()")
-                proxy.getVersion { version, error in
-                    AppLogger.shared.log(
-                        "📥 [HelperManager] getVersion callback received"
-                    )
-
-                    // Cancel the timeout since the callback arrived.
-                    timeoutTask.cancel()
-
-                    let alreadyResumed = resumed.withLock { flag -> Bool in
-                        if flag { return true }
-                        flag = true
-                        return false
-                    }
-                    guard !alreadyResumed else {
-                        AppLogger.shared.log(
-                            "⚠️ [HelperManager] getVersion callback arrived after timeout - ignoring"
-                        )
-                        return
-                    }
-
-                    if let version {
-                        AppLogger.shared.info("✅ [HelperManager] Helper version: \(version)")
-                        continuation.resume(returning: version)
-                    } else {
-                        let msg = error ?? "Unknown error"
-                        AppLogger.shared.log("❌ [HelperManager] getVersion callback error: \(msg)")
-                        AppLogger.shared.log(
-                            "⚠️ [HelperManager] getVersion callback completed but no version received - clearing connection cache"
-                        )
-                        Task { await HelperManager.shared.clearConnection() }
-                        continuation.resume(returning: nil)
-                    }
-                }
+            if isWithinAmbiguousMutationProbeWindow() {
                 AppLogger.shared.log(
-                    "📤 [HelperManager] proxy.getVersion() call dispatched, waiting for callback"
+                    "⏳ [HelperManager] Deferring version probe after ambiguous mutation timeout"
                 )
+                try await Task.sleep(for: .seconds(1))
+                try Task.checkCancellation()
             }
-            return version
+
+            return try await withHelperOperationPermit {
+                try Task.checkCancellation()
+
+                guard await isHelperInstalled() else {
+                    AppLogger.shared.log("⚠️ [HelperManager] Helper not installed, cannot get version")
+                    return nil
+                }
+
+                return await withCheckedContinuation { (continuation: CheckedContinuation<String?, Never>) in
+                    let resumed = OSAllocatedUnfairLock(initialState: false)
+                    let complete: @Sendable (String?) -> Void = { value in
+                        let alreadyResumed = resumed.withLock { flag -> Bool in
+                            if flag { return true }
+                            flag = true
+                            return false
+                        }
+                        guard !alreadyResumed else { return }
+                        continuation.resume(returning: value)
+                    }
+
+                    let timeoutTask = Task { @Sendable in
+                        try await Task.sleep(for: .seconds(3))
+                        AppLogger.shared.log(
+                            "⚠️ [HelperManager] getVersion timed out; preserving the shared connection because another operation may still be completing"
+                        )
+                        complete(nil)
+                    }
+
+                    Task {
+                        do {
+                            try Task.checkCancellation()
+                            let remote = try await getRemoteProxy { error in
+                                AppLogger.shared.log(
+                                    "❌ [HelperManager] getVersion proxy error: \(Self.normalizedProxyError(error, operation: "getVersion"))"
+                                )
+                                timeoutTask.cancel()
+                                complete(nil)
+                            }
+                            AppLogger.shared.log("📤 [HelperManager] Calling proxy.getVersion()")
+                            remote.proxy.getVersion { version, error in
+                                timeoutTask.cancel()
+                                if let version {
+                                    AppLogger.shared.info("✅ [HelperManager] Helper version: \(version)")
+                                    complete(version)
+                                } else {
+                                    let message = error ?? "Unknown error"
+                                    let generation = remote.connectionGeneration
+                                    AppLogger.shared.log(
+                                        "❌ [HelperManager] getVersion callback error: \(message)"
+                                    )
+                                    Task {
+                                        await HelperManager.shared.clearConnection(
+                                            ifGenerationMatches: generation
+                                        )
+                                    }
+                                    complete(nil)
+                                }
+                            }
+                        } catch {
+                            timeoutTask.cancel()
+                            AppLogger.shared.log(
+                                "❌ [HelperManager] Failed to connect for version check: \(error)"
+                            )
+                            complete(nil)
+                        }
+                    }
+                }
+            }
         } catch {
             AppLogger.shared.log(
-                "❌ [HelperManager] Failed to connect to helper for version check: \(error)"
+                "ℹ️ [HelperManager] Version check cancelled before dispatch: \(error)"
             )
             return nil
         }
@@ -211,6 +217,12 @@ extension HelperManager {
         // No need to call testHelperFunctionality() separately.
         if let version = await getHelperVersion() {
             return .healthy(version: version)
+        }
+
+        if isWithinAmbiguousMutationProbeWindow() {
+            return .temporarilyUnavailable(
+                "Helper mutation timed out recently; responsiveness is temporarily unknown"
+            )
         }
 
         // Installed but XPC failing

--- a/Sources/KeyPathAppKit/Core/HelperManager.swift
+++ b/Sources/KeyPathAppKit/Core/HelperManager.swift
@@ -13,6 +13,7 @@ public actor HelperManager {
         case notInstalled
         case requiresApproval(String?)
         case registeredButUnresponsive(String?)
+        case temporarilyUnavailable(String?)
         case healthy(version: String?)
     }
 
@@ -63,6 +64,7 @@ public actor HelperManager {
     /// XPC connection to the privileged helper
     /// Internal so lifecycle/IPC extensions in separate files can manage connection state.
     var connection: NSXPCConnection?
+    var connectionGeneration: UInt64 = 0
 
     /// Mach service name for the helper (type-level constant)
     static let helperMachServiceName = "com.keypath.helper"
@@ -78,6 +80,12 @@ public actor HelperManager {
 
     /// Active XPC call tracking for detecting concurrency issues
     var activeXPCCalls: Set<String> = []
+
+    /// A helper mutation may continue after the app-side timeout. Health probes
+    /// within this window must not turn that ambiguity into a false unhealthy
+    /// classification.
+    var lastAmbiguousMutationAt: Date?
+    static let ambiguousMutationProbeWindow: TimeInterval = 10
 
     /// Serializes all helper IPC. The helper processes requests serially, so allowing a
     /// health probe to queue behind a mutation on the same connection only creates a
@@ -178,11 +186,33 @@ actor HelperOperationGate {
         await withCheckedContinuation { waiters.append($0) }
     }
 
+    func acquireUnlessCancelled() async throws {
+        await acquire()
+        do {
+            try Task.checkCancellation()
+        } catch {
+            release()
+            throw error
+        }
+    }
+
     func release() {
         guard !waiters.isEmpty else {
             isOccupied = false
             return
         }
         waiters.removeFirst().resume()
+    }
+}
+
+enum HelperProbeRecoveryPolicy {
+    static func isWithinAmbiguousMutationWindow(
+        lastAmbiguousMutationAt: Date?,
+        now: Date,
+        window: TimeInterval
+    ) -> Bool {
+        guard let lastAmbiguousMutationAt else { return false }
+        let elapsed = now.timeIntervalSince(lastAmbiguousMutationAt)
+        return elapsed >= 0 && elapsed <= window
     }
 }

--- a/Sources/KeyPathAppKit/Services/System/SystemValidator.swift
+++ b/Sources/KeyPathAppKit/Services/System/SystemValidator.swift
@@ -60,6 +60,11 @@ public class SystemValidator {
         }
     }
 
+    private struct HelperCaptureEvidence: Sendable {
+        let status: HelperStatus
+        let captureStatus: SystemSnapshotCaptureStatus
+    }
+
     init(
         vhidDeviceManager: VHIDDeviceManager = VHIDDeviceManager(),
         processLifecycleManager: ProcessLifecycleManager,
@@ -248,7 +253,7 @@ public class SystemValidator {
         // Run all checks in parallel, tracking progress as each completes
         // Use a Sendable enum to wrap results
         enum ValidationResult: Sendable {
-            case helper(HelperStatus)
+            case helper(HelperCaptureEvidence)
             case permissions(PermissionOracle.Snapshot)
             case components(ComponentStatus)
             case conflicts(ConflictCaptureEvidence)
@@ -258,7 +263,7 @@ public class SystemValidator {
         let (helper, permissions, components, conflicts, health) = await withTaskGroup(
             of: ValidationResult.self
         ) { group in
-            var helperResult: HelperStatus?
+            var helperResult: HelperCaptureEvidence?
             var permissionsResult: PermissionOracle.Snapshot?
             var componentsResult: ComponentStatus?
             var conflictsResult: ConflictCaptureEvidence?
@@ -336,7 +341,10 @@ public class SystemValidator {
 
             // Extract results with fallback values if cast fails
             return (
-                helperResult ?? HelperStatus.empty,
+                helperResult ?? HelperCaptureEvidence(
+                    status: .empty,
+                    captureStatus: .failed
+                ),
                 permissionsResult
                     ?? {
                         let now = Date()
@@ -362,7 +370,12 @@ public class SystemValidator {
             )
         }
 
+        let helperStatus = helper.status
         let conflictStatus = conflicts.status
+        let captureStatus = Self.combinedCaptureStatus([
+            helper.captureStatus,
+            conflicts.captureStatus,
+        ])
 
         progressCallback(1.0) // All done: 100%
 
@@ -376,10 +389,10 @@ public class SystemValidator {
             components: components,
             conflicts: conflictStatus,
             health: health,
-            helper: helper,
+            helper: helperStatus,
             compatibility: compatibility,
             timestamp: Date(),
-            captureStatus: conflicts.captureStatus
+            captureStatus: captureStatus
         )
 
         let duration = Date().timeIntervalSince(startTime)
@@ -396,9 +409,18 @@ public class SystemValidator {
         return snapshot
     }
 
+    static func combinedCaptureStatus(
+        _ statuses: [SystemSnapshotCaptureStatus]
+    ) -> SystemSnapshotCaptureStatus {
+        if statuses.contains(.failed) { return .failed }
+        if statuses.contains(.cancelled) { return .cancelled }
+        if statuses.contains(.timedOut) { return .timedOut }
+        return .complete
+    }
+
     // MARK: - Helper Checking
 
-    private func checkHelper() async -> HelperStatus {
+    private func checkHelper() async -> HelperCaptureEvidence {
         AppLogger.shared.log("🔍 [SystemValidator] Checking privileged helper")
 
         let health = await HelperManager.shared.getHelperHealth()
@@ -406,30 +428,51 @@ public class SystemValidator {
         switch health {
         case .notInstalled:
             AppLogger.shared.log("🔍 [SystemValidator] Helper state: notInstalled")
-            return HelperStatus(isInstalled: false, version: nil, isWorking: false)
+            return HelperCaptureEvidence(
+                status: HelperStatus(isInstalled: false, version: nil, isWorking: false),
+                captureStatus: .complete
+            )
 
         case let .requiresApproval(reason):
             AppLogger.shared.log(
                 "🔍 [SystemValidator] Helper state: requiresApproval \(reason ?? "")"
             )
-            return HelperStatus(
-                isInstalled: false,
-                version: nil,
-                isWorking: false,
-                requiresApproval: true
+            return HelperCaptureEvidence(
+                status: HelperStatus(
+                    isInstalled: false,
+                    version: nil,
+                    isWorking: false,
+                    requiresApproval: true
+                ),
+                captureStatus: .complete
             )
 
         case let .registeredButUnresponsive(reason):
             AppLogger.shared.log(
                 "🔍 [SystemValidator] Helper state: registeredButUnresponsive \(reason ?? "")"
             )
-            return HelperStatus(isInstalled: true, version: nil, isWorking: false)
+            return HelperCaptureEvidence(
+                status: HelperStatus(isInstalled: true, version: nil, isWorking: false),
+                captureStatus: .complete
+            )
+
+        case let .temporarilyUnavailable(reason):
+            AppLogger.shared.log(
+                "🔍 [SystemValidator] Helper state temporarily unknown: \(reason ?? "")"
+            )
+            return HelperCaptureEvidence(
+                status: HelperStatus(isInstalled: true, version: nil, isWorking: false),
+                captureStatus: .timedOut
+            )
 
         case let .healthy(version):
             AppLogger.shared.log(
                 "🔍 [SystemValidator] Helper state: healthy (v\(version ?? "unknown"))"
             )
-            return HelperStatus(isInstalled: true, version: version, isWorking: true)
+            return HelperCaptureEvidence(
+                status: HelperStatus(isInstalled: true, version: version, isWorking: true),
+                captureStatus: .complete
+            )
         }
     }
 

--- a/Tests/KeyPathTests/Core/HelperManagerTests.swift
+++ b/Tests/KeyPathTests/Core/HelperManagerTests.swift
@@ -4,6 +4,88 @@ import ServiceManagement
 @preconcurrency import XCTest
 
 final class HelperManagerTests: XCTestCase {
+    func testCancelledGateWaiterDoesNotRunOperationAfterAcquiring() async {
+        let gate = HelperOperationGate()
+        await gate.acquire()
+        let operationStarted = AsyncTestFlag()
+
+        let cancelledWaiter = Task {
+            try await gate.acquireUnlessCancelled()
+            await operationStarted.set()
+            await gate.release()
+        }
+        await Task.yield()
+        cancelledWaiter.cancel()
+        await gate.release()
+
+        do {
+            try await cancelledWaiter.value
+            XCTFail("Expected the queued operation to observe cancellation")
+        } catch is CancellationError {
+            // Expected.
+        } catch {
+            XCTFail("Expected CancellationError, got \(error)")
+        }
+
+        let didStart = await operationStarted.value
+        XCTAssertFalse(didStart)
+        do {
+            try await gate.acquireUnlessCancelled()
+            await gate.release()
+        } catch {
+            XCTFail("Cancelled waiter must release the permit for the next operation: \(error)")
+        }
+    }
+
+    func testInterruptedProxyErrorIsAmbiguous() {
+        let interruption = NSError(domain: NSCocoaErrorDomain, code: 4097)
+
+        let normalized = HelperManager.normalizedProxyError(
+            interruption,
+            operation: "repairVHIDDaemonServices"
+        )
+
+        guard case .ambiguousOutcome = normalized as? HelperManagerError else {
+            return XCTFail("XPC interruption must preserve an ambiguous mutation outcome")
+        }
+    }
+
+    func testProbeRecoveryWindowIsBounded() {
+        let timeout = Date(timeIntervalSince1970: 100)
+
+        XCTAssertTrue(HelperProbeRecoveryPolicy.isWithinAmbiguousMutationWindow(
+            lastAmbiguousMutationAt: timeout,
+            now: timeout.addingTimeInterval(9),
+            window: 10
+        ))
+        XCTAssertFalse(HelperProbeRecoveryPolicy.isWithinAmbiguousMutationWindow(
+            lastAmbiguousMutationAt: timeout,
+            now: timeout.addingTimeInterval(11),
+            window: 10
+        ))
+        XCTAssertFalse(HelperProbeRecoveryPolicy.isWithinAmbiguousMutationWindow(
+            lastAmbiguousMutationAt: timeout,
+            now: timeout.addingTimeInterval(-1),
+            window: 10
+        ))
+    }
+
+    func testStaleConnectionEndCannotClearReplacementConnection() async {
+        let manager = HelperManager.shared
+        let replacement = NSXPCConnection(
+            machServiceName: "com.keypath.tests.replacement", options: []
+        )
+        await manager.setConnectionForTesting(replacement, generation: 2)
+
+        await manager.connectionDidEnd(generation: 1)
+        let survivedStaleCallback = await manager.hasConnectionForTesting()
+        XCTAssertTrue(survivedStaleCallback)
+
+        await manager.connectionDidEnd(generation: 2)
+        let clearedForCurrentCallback = await manager.hasConnectionForTesting()
+        XCTAssertFalse(clearedForCurrentCallback)
+    }
+
     func testHealthProbeWaitsForActiveHelperMutation() async {
         let gate = HelperOperationGate()
         await gate.acquire()

--- a/Tests/KeyPathTests/Services/SystemValidatorTests.swift
+++ b/Tests/KeyPathTests/Services/SystemValidatorTests.swift
@@ -249,4 +249,12 @@ struct SystemValidatorTests {
 
         #expect(error == "Duplicate alias: beh_base_a")
     }
+
+    @Test("Capture status keeps the most conservative probe result")
+    func combinedCaptureStatusIsConservative() {
+        #expect(SystemValidator.combinedCaptureStatus([.complete, .timedOut]) == .timedOut)
+        #expect(SystemValidator.combinedCaptureStatus([.timedOut, .cancelled]) == .cancelled)
+        #expect(SystemValidator.combinedCaptureStatus([.cancelled, .failed]) == .failed)
+        #expect(SystemValidator.combinedCaptureStatus([.complete, .complete]) == .complete)
+    }
 }

--- a/docs/bugs/2026-07-10-helper-timeout-probe-starvation.md
+++ b/docs/bugs/2026-07-10-helper-timeout-probe-starvation.md
@@ -1,0 +1,34 @@
+# Helper timeout probe starvation
+
+## Symptom
+
+After an XPC mutation timed out or lost its reply, the follow-up helper health
+probe could wait behind the abandoned mutation, clear a newer connection from a
+late callback, or classify the helper as unhealthy before the XPC service had a
+chance to recover. That could turn an ambiguous transport failure into an
+incorrect repair decision.
+
+## Root cause
+
+The helper operation gate did not re-check cancellation after a queued waiter
+acquired its permit. XPC proxy errors were also allowed to fall through to the
+generic callback timeout, and connection invalidation handlers were not tied to
+the connection generation that installed them.
+
+## Fix
+
+- Re-check cancellation immediately after acquiring the helper operation gate
+  and release the permit before throwing.
+- Normalize XPC interruption errors as ambiguous mutation outcomes and complete
+  the request immediately when the proxy reports an error.
+- Associate invalidation, interruption, and empty-version callbacks with a
+  connection generation so stale callbacks cannot clear a replacement.
+- Give a recently timed-out mutation a bounded recovery window before probing.
+- Mark a probe in that recovery window as incomplete (`timedOut`) evidence in
+  `SystemValidator`, rather than complete evidence that the helper is unhealthy.
+
+## Regression coverage
+
+`HelperManagerTests` covers cancellation-safe gate acquisition, XPC interruption
+normalization, the bounded recovery window, and rejection of stale connection-end
+callbacks. `SystemValidatorTests` covers conservative capture-status aggregation.


### PR DESCRIPTION
## Summary
- make queued helper gate cancellation safe and normalize interrupted XPC replies as ambiguous outcomes
- guard connection cleanup by generation so late callbacks cannot clear a replacement
- give ambiguous mutations a bounded recovery window and propagate incomplete helper evidence into the canonical snapshot
- document the incident and add focused regression coverage

## Validation
- stable Xcode 26.6 KeyPath product build passed
- focused safe gate passed: 55 tests
- accessibility check passed
- full safe suite: 1,932 passed; 24 pre-existing AppKit snapshot harness failures and xctest signal 11, tracked as the approved snapshot-harness follow-up

## Review gate
Local gate selected the enforced remote claude-review path (exit 2). Do not merge until that check passes.