### PR TITLE
Centralize system capture timeout policy

### DIFF
--- a/Sources/KeyPathAppKit/Services/MainAppStateController.swift
+++ b/Sources/KeyPathAppKit/Services/MainAppStateController.swift
@@ -72,7 +72,6 @@ class MainAppStateController {
 
     @ObservationIgnored private var lastValidationTime: Date?
     @ObservationIgnored private let validationCooldown: TimeInterval = 30.0 // Skip validation if completed within last 30 seconds
-    private enum ValidationError: Error { case timeout }
 
     // MARK: - Validation Log Throttling (avoid flooding the log with repeat cycles)
 
@@ -557,36 +556,10 @@ class MainAppStateController {
         AppLogger.shared.log("🎯 [MainAppStateController] Running SystemValidator (Phase 3)")
         AppLogger.shared.log("⏱️ [TIMING] Main screen validation START")
 
-        // Get fresh state from validator with a watchdog to avoid indefinite "checking"
-        // Note: Main screen doesn't use progress callback (wizard does)
-        AppLogger.shared.log("🔍 [MainAppStateController] Validation run started (watchdog=12s)")
-        let snapshot: SystemSnapshot
-        do {
-            snapshot = try await withThrowingTaskGroup(of: SystemSnapshot.self) { group in
-                group.addTask { await validator.checkSystem() }
-                group.addTask {
-                    try await Task.sleep(for: .seconds(12)) // 12s watchdog
-                    throw ValidationError.timeout
-                }
-                guard let first = try await group.next() else {
-                    throw ValidationError.timeout
-                }
-                group.cancelAll()
-                AppLogger.shared.log("✅ [MainAppStateController] Validation run completed within watchdog")
-                return first
-            }
-        } catch {
-            AppLogger.shared.error("⏱️ [MainAppStateController] Validation watchdog fired – preserving last state and surfacing timeout warning")
-            issues = [Self.validationTimeoutIssue()]
-            lastValidationDate = Date()
-            lastValidationTime = Date()
-            if let lastValidatedSystemContext {
-                lastAdaptedState = SystemStateResult.projecting(lastValidatedSystemContext).state
-            }
-
-            validationState = .failed(blockingCount: 0, totalCount: issues.count)
-            return
-        }
+        // SystemValidator owns the canonical capture timeout so every consumer
+        // receives the same first-class `.timedOut` snapshot evidence.
+        AppLogger.shared.log("🔍 [MainAppStateController] Canonical validation run started")
+        let snapshot = await validator.checkSystem()
 
         let validationDuration = Date().timeIntervalSince(validationStart)
         AppLogger.shared.log(
@@ -782,18 +755,6 @@ class MainAppStateController {
             )
             validationState = .checking
         }
-    }
-
-    static func validationTimeoutIssue() -> WizardIssue {
-        WizardIssue(
-            identifier: .validationTimeout,
-            severity: .warning,
-            category: .daemon,
-            title: "Status check timed out",
-            description: "System validation exceeded the 12s watchdog. This is usually transient; the next check should succeed.",
-            autoFixAction: nil,
-            userAction: "If this persists, try restarting KeyPath."
-        )
     }
 
     private func evaluateKanataStartupGate() async -> KanataStartupGateResult {

--- a/Sources/KeyPathAppKit/Services/System/SystemValidator.swift
+++ b/Sources/KeyPathAppKit/Services/System/SystemValidator.swift
@@ -28,6 +28,7 @@ public class SystemValidator {
     private var inProgressValidation: Task<SystemSnapshot, Never>?
     private var latestSnapshot: SystemSnapshot?
     private static let canonicalSnapshotCacheTTL: TimeInterval = 1.5
+    static let canonicalCaptureTimeout: TimeInterval = 12
 
     /// Track validation timing to detect rapid-fire calls (indicates automatic triggers)
     private static var lastValidationStart: Date?
@@ -125,7 +126,9 @@ public class SystemValidator {
 
         // Start new validation
         let validationTask = Task<SystemSnapshot, Never> { @MainActor in
-            await self.performValidation(progressCallback: progressCallback)
+            await Self.boundedCapture(timeout: Self.canonicalCaptureTimeout) {
+                await self.performValidation(progressCallback: progressCallback)
+            }
         }
 
         inProgressValidation = validationTask
@@ -134,6 +137,51 @@ public class SystemValidator {
         let snapshot = await validationTask.value
         cacheIfComplete(snapshot)
         return snapshot
+    }
+
+    static func boundedCapture(
+        timeout: TimeInterval,
+        operation: @MainActor @Sendable @escaping () async -> SystemSnapshot
+    ) async -> SystemSnapshot {
+        let completionState = SystemCaptureCompletionState()
+
+        return await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                completionState.setContinuation(continuation)
+
+                let operationTask = Task { @MainActor in
+                    let snapshot = await operation()
+                    _ = completionState.complete(with: snapshot)
+                }
+                completionState.setOperationTask(operationTask)
+
+                let timeoutTask = Task { @MainActor in
+                    do {
+                        try await Task.sleep(for: .seconds(timeout))
+                    } catch {
+                        return
+                    }
+                    let didTimeOut = completionState.complete(with: .unavailable(
+                        captureStatus: .timedOut,
+                        source: "system-validator-timeout"
+                    ))
+                    if didTimeOut {
+                        let message = "⏱️ [SystemValidator] Canonical capture timed out after \(String(format: "%.2f", timeout))s"
+                        if TestEnvironment.isRunningTests {
+                            AppLogger.shared.info(message)
+                        } else {
+                            AppLogger.shared.warn(message)
+                        }
+                    }
+                }
+                completionState.setTimeoutTask(timeoutTask)
+            }
+        } onCancel: {
+            _ = completionState.complete(with: .unavailable(
+                captureStatus: .cancelled,
+                source: "system-validator-cancelled"
+            ))
+        }
     }
 
     func checkSystem(
@@ -846,5 +894,62 @@ public class SystemValidator {
     /// Create a minimal snapshot used when a validation task is cancelled
     private static func makeCancelledSnapshot() -> SystemSnapshot {
         .unavailable(captureStatus: .cancelled, source: "cancelled")
+    }
+}
+
+private final class SystemCaptureCompletionState: @unchecked Sendable {
+    private struct State {
+        var result: SystemSnapshot?
+        var continuation: CheckedContinuation<SystemSnapshot, Never>?
+        var operationTask: Task<Void, Never>?
+        var timeoutTask: Task<Void, Never>?
+    }
+
+    private let state = OSAllocatedUnfairLock(initialState: State())
+
+    func setContinuation(_ continuation: CheckedContinuation<SystemSnapshot, Never>) {
+        let completedResult = state.withLock { state -> SystemSnapshot? in
+            if let result = state.result { return result }
+            state.continuation = continuation
+            return nil
+        }
+        if let completedResult {
+            continuation.resume(returning: completedResult)
+        }
+    }
+
+    func setOperationTask(_ task: Task<Void, Never>) {
+        let alreadyCompleted = state.withLock { state -> Bool in
+            state.operationTask = task
+            return state.result != nil
+        }
+        if alreadyCompleted { task.cancel() }
+    }
+
+    func setTimeoutTask(_ task: Task<Void, Never>) {
+        let alreadyCompleted = state.withLock { state -> Bool in
+            state.timeoutTask = task
+            return state.result != nil
+        }
+        if alreadyCompleted { task.cancel() }
+    }
+
+    func complete(with result: SystemSnapshot) -> Bool {
+        let completion = state.withLock { state -> (
+            CheckedContinuation<SystemSnapshot, Never>?,
+            Task<Void, Never>?,
+            Task<Void, Never>?
+        )? in
+            guard state.result == nil else { return nil }
+            state.result = result
+            let continuation = state.continuation
+            state.continuation = nil
+            return (continuation, state.operationTask, state.timeoutTask)
+        }
+        guard let completion else { return false }
+        completion.1?.cancel()
+        completion.2?.cancel()
+        completion.0?.resume(returning: result)
+        return true
     }
 }

--- a/Sources/KeyPathInstallationWizard/Core/WizardOperationsUIExtension.swift
+++ b/Sources/KeyPathInstallationWizard/Core/WizardOperationsUIExtension.swift
@@ -13,52 +13,14 @@ extension WizardOperations {
         freshness: WizardSystemSnapshotFreshness = .fresh,
         progressCallback: @escaping @Sendable (Double) -> Void = { _ in }
     ) -> AsyncOperation<SystemStateResult> {
-        enum StateDetectionError: Error {
-            case timeout
-        }
-
-        return AsyncOperation<SystemStateResult>(
+        AsyncOperation<SystemStateResult>(
             id: "state_detection",
             name: "System State Detection"
         ) { operationProgressCallback in
             // Forward progress from SystemValidator to the operation callback
             if let machine = stateMachine {
                 progressCallback(0.1)
-                do {
-                    try await withThrowingTaskGroup(of: Void.self) { group in
-                        group.addTask { await machine.refresh(freshness: freshness) }
-                        group.addTask {
-                            let clock = ContinuousClock()
-                            try await clock.sleep(for: .seconds(12))
-                            throw StateDetectionError.timeout
-                        }
-                        _ = try await group.next()
-                        group.cancelAll()
-                    }
-                } catch {
-                    AppLogger.shared.log("⚠️ [Wizard] State detection timed out: \(error)")
-                    progressCallback(1.0)
-                    operationProgressCallback(1.0)
-                    // machine.refresh() may have partially or fully completed
-                    // before the timeout. Use whatever state it stored.
-                    return await MainActor.run {
-                        let issues = machine.wizardIssues
-                        let captured = machine.lastWizardSnapshot
-                        if !issues.isEmpty {
-                            AppLogger.shared.log("⚠️ [Wizard] Using \(issues.count) issues from timed-out validation")
-                            return SystemStateResult(
-                                state: machine.wizardState,
-                                issues: issues,
-                                autoFixActions: [],
-                                detectionTimestamp: Date(),
-                                captureStatus: .timedOut,
-                                helperInstalled: captured?.helperInstalled ?? false,
-                                helperNeedsApproval: captured?.helperNeedsApproval ?? false
-                            )
-                        }
-                        return timeoutResult()
-                    }
-                }
+                await machine.refresh(freshness: freshness)
 
                 progressCallback(1.0)
                 operationProgressCallback(1.0)

--- a/Tests/KeyPathTests/Lint/SnapshotConsumerLintTests.swift
+++ b/Tests/KeyPathTests/Lint/SnapshotConsumerLintTests.swift
@@ -7,6 +7,31 @@ import Foundation
 /// It prevents new runtime/installer state caches outside the known provider-style
 /// owners while follow-up work shrinks the allowlist.
 final class SnapshotConsumerLintTests: XCTestCase {
+    func testCanonicalCaptureTimeoutIsOwnedBySystemValidator() throws {
+        let validatorURL = LintScanner.path(
+            "Sources/KeyPathAppKit/Services/System/SystemValidator.swift"
+        )
+        let validator = try String(contentsOf: validatorURL, encoding: .utf8)
+        XCTAssertTrue(validator.contains("canonicalCaptureTimeout"))
+        XCTAssertTrue(validator.contains("boundedCapture(timeout:"))
+
+        let mainControllerURL = LintScanner.path(
+            "Sources/KeyPathAppKit/Services/MainAppStateController.swift"
+        )
+        let mainController = try String(contentsOf: mainControllerURL, encoding: .utf8)
+        XCTAssertFalse(mainController.contains("ValidationError.timeout"))
+        XCTAssertFalse(mainController.contains("Validation run started (watchdog="))
+
+        let wizardURL = LintScanner.path(
+            "Sources/KeyPathInstallationWizard/Core/WizardOperationsUIExtension.swift"
+        )
+        let stateDetection = try LintScanner.functionBody(named: "stateDetection", in: wizardURL)
+        XCTAssertFalse(
+            stateDetection.contains("withThrowingTaskGroup"),
+            "Wizard state detection must consume SystemValidator timeout evidence, not race a client watchdog."
+        )
+    }
+
     func testFreshCaptureInvalidatesComponentFacts() throws {
         let validator = LintScanner.path(
             "Sources/KeyPathAppKit/Services/System/SystemValidator.swift"

--- a/Tests/KeyPathTests/MainAppStateControllerTests.swift
+++ b/Tests/KeyPathTests/MainAppStateControllerTests.swift
@@ -43,19 +43,6 @@ struct MainAppStateControllerTests {
         )
     }
 
-    @Test("Validation timeout issue is non-blocking")
-    func validationTimeoutIssueIsNonBlocking() {
-        let issue = MainAppStateController.validationTimeoutIssue()
-
-        #expect(issue.identifier == .validationTimeout)
-        #expect(issue.severity == .warning)
-        #expect(issue.autoFixAction == nil)
-        #expect(
-            MainAppStateController.ValidationState.failed(blockingCount: 0, totalCount: 1)
-                .hasCriticalIssues == false
-        )
-    }
-
     @Test("ValidationState equality works correctly")
     func validationStateEquality() {
         #expect(MainAppStateController.ValidationState.success == .success)

--- a/Tests/KeyPathTests/Services/SystemValidatorTests.swift
+++ b/Tests/KeyPathTests/Services/SystemValidatorTests.swift
@@ -257,4 +257,45 @@ struct SystemValidatorTests {
         #expect(SystemValidator.combinedCaptureStatus([.cancelled, .failed]) == .failed)
         #expect(SystemValidator.combinedCaptureStatus([.complete, .complete]) == .complete)
     }
+
+    @Test("Canonical capture timeout returns first-class timed-out evidence")
+    func canonicalCaptureTimeout() async {
+        let clock = ContinuousClock()
+        let started = clock.now
+        let snapshot = await SystemValidator.boundedCapture(timeout: 0.01) {
+            while !Task.isCancelled {
+                await Task.yield()
+            }
+            return .unavailable(captureStatus: .failed, source: "late-test-result")
+        }
+
+        #expect(snapshot.captureStatus == .timedOut)
+        #expect(started.duration(to: clock.now) < .milliseconds(250))
+    }
+
+    @Test("Canonical capture returns completed evidence before its deadline")
+    func canonicalCaptureCompletes() async {
+        let expected = SystemSnapshot.unavailable(captureStatus: .failed, source: "test-result")
+        let snapshot = await SystemValidator.boundedCapture(timeout: 1) { expected }
+
+        #expect(snapshot.id == expected.id)
+        #expect(snapshot.captureStatus == .failed)
+    }
+
+    @Test("Cancelling canonical capture returns cancelled evidence")
+    func canonicalCaptureCancellation() async {
+        let capture = Task { @MainActor in
+            await SystemValidator.boundedCapture(timeout: 1) {
+                while !Task.isCancelled {
+                    await Task.yield()
+                }
+                return .unavailable(captureStatus: .failed, source: "late-test-result")
+            }
+        }
+        await Task.yield()
+        capture.cancel()
+
+        let snapshot = await capture.value
+        #expect(snapshot.captureStatus == .cancelled)
+    }
 }

--- a/docs/bugs/2026-07-10-client-capture-timeout-divergence.md
+++ b/docs/bugs/2026-07-10-client-capture-timeout-divergence.md
@@ -1,0 +1,31 @@
+# Client capture timeout divergence
+
+## Symptom
+
+The main window and installation wizard each wrapped `SystemValidator` with a
+separate 12-second watchdog. A timeout therefore produced client-specific state:
+the main window preserved its previous context, while the wizard synthesized a
+new result from whichever fields happened to be available. Other consumers had
+no timeout at all.
+
+## Root cause
+
+Capture timeout policy lived in presentation clients instead of the canonical
+system-evidence owner. `SystemSnapshotCaptureStatus.timedOut` existed, but
+`SystemValidator` did not emit it for an overall capture deadline.
+
+## Fix
+
+- `SystemValidator.checkSystem()` now bounds every canonical capture and returns
+  an unavailable snapshot with `.timedOut` evidence when the deadline wins.
+- Cancellation returns the distinct `.cancelled` capture status.
+- The main window and wizard no longer race their own watchdogs; both project
+  the same snapshot and timeout issue through `SystemContext`/`SystemInspector`.
+- The race cancels its losing operation and resumes exactly once, including when
+  cancellation arrives before task setup completes.
+
+## Regression coverage
+
+`SystemValidatorTests` covers completion, timeout, cancellation, and prompt
+return at the deadline. `SnapshotConsumerLintTests` prevents presentation-layer
+capture watchdogs from being reintroduced.


### PR DESCRIPTION
SystemValidator now owns the canonical 12-second capture deadline and emits first-class timed-out evidence. The main UI and wizard consume that same snapshot instead of racing local watchdogs. Includes exactly-once timeout, completion and cancellation tests, a structural lint ratchet, and durable documentation. Validation: stable Xcode 26.6 build, 156 focused tests, and accessibility pass. Local review gate selected the enforced remote claude-review path; do not merge until it passes.