### PR TITLE
Capture TCP configuration in system snapshot

### DIFF
--- a/Sources/KeyPathAppKit/Services/MainAppStateController.swift
+++ b/Sources/KeyPathAppKit/Services/MainAppStateController.swift
@@ -268,62 +268,6 @@ class MainAppStateController {
         )
     }
 
-    // MARK: - TCP Configuration Check
-
-    /// Check if TCP communication is properly configured
-    /// Matches wizard logic from WizardSystemStatusOverview.getCommunicationServerStatus()
-    ///
-    /// **SECURITY NOTE (ADR-013):** No authentication check needed.
-    /// Kanata v1.9.0 TCP server does not support authentication.
-    /// We only verify: (1) plist exists, (2) plist has --port argument
-    private func checkTCPConfiguration() async -> Bool {
-        // NOTE: Kanata v1.9.0 TCP does NOT require authentication
-        // No token check needed - just verify service has TCP configuration
-
-        // In tests, Bundle.main resolves to the Xcode toolchain — plist path is meaningless
-        if TestEnvironment.isRunningTests { return true }
-
-        // Check SMAppService plist first if active, otherwise fall back to legacy plist
-        let plistPath = KanataDaemonManager.getActivePlistPath()
-
-        let plistExists = Foundation.FileManager().fileExists(atPath: plistPath)
-
-        guard plistExists else {
-            AppLogger.shared.warn(
-                "⚠️ [MainAppStateController] TCP check failed: Service plist doesn't exist at \(plistPath)"
-            )
-            return false
-        }
-
-        // Verify plist has TCP port argument
-        do {
-            let plistData = try Data(contentsOf: URL(fileURLWithPath: plistPath))
-            guard let plist = try PropertyListSerialization.propertyList(
-                from: plistData, options: [], format: nil
-            ) as? [String: Any],
-                let args = plist["ProgramArguments"] as? [String]
-            else {
-                AppLogger.shared.warn("⚠️ [MainAppStateController] Failed to parse plist structure")
-                return false
-            }
-            let hasTCPPort = args.contains("--port")
-            guard hasTCPPort else {
-                AppLogger.shared.warn(
-                    "⚠️ [MainAppStateController] TCP check failed: Service missing --port argument"
-                )
-                return false
-            }
-        } catch {
-            AppLogger.shared.warn(
-                "⚠️ [MainAppStateController] Failed to read daemon plist at \(plistPath): \(error.localizedDescription)"
-            )
-            return false
-        }
-
-        AppLogger.shared.info("✅ [MainAppStateController] TCP configuration verified: plist has --port")
-        return true
-    }
-
     // MARK: - Service Health Monitoring
 
     /// Subscribe to runtime state changes to trigger revalidation when runtime health changes.
@@ -614,7 +558,7 @@ class MainAppStateController {
         // Update published state
         lastValidatedSystemContext = context
         lastAdaptedState = adapted.state
-        lastTCPConfigured = await checkTCPConfiguration()
+        lastTCPConfigured = snapshot.health.kanataTCPConfigured ?? false
         let decision = InstallerDecisionPipeline.decide(for: .repair, context: context)
         lastInstallerStateMatrixRow = decision.assessment
         lastInstallerStateMatrixPlan = decision.matrixActions

--- a/Sources/KeyPathAppKit/Services/System/SystemValidator.swift
+++ b/Sources/KeyPathAppKit/Services/System/SystemValidator.swift
@@ -762,6 +762,7 @@ public class SystemValidator {
         let kanataRunning = kanataHealth.isRunning
             && kanataHealth.isResponding
             && kanataHealth.inputCaptureReady
+        let kanataTCPConfigured = checkTCPConfiguration()
         let stderrDiagnosis = await ServiceHealthChecker.shared.diagnoseDaemonStderr()
         let configParseError = Self.effectiveConfigParseError(
             stderrDiagnosis.configParseError,
@@ -816,6 +817,7 @@ public class SystemValidator {
                 (kanataHealth.launchctlExitCode == 0 || kanataHealth.isRunning),
             kanataProcessRunning: kanataHealth.isRunning,
             kanataTCPResponding: kanataHealth.isResponding,
+            kanataTCPConfigured: kanataTCPConfigured,
             kanataRunning: kanataRunning,
             karabinerDaemonRunning: karabinerDaemonRunning,
             vhidHealthy: vhidHealthy,
@@ -827,6 +829,44 @@ public class SystemValidator {
             kanataSMAppServiceRegistered: kanataSMAppServiceRegistered,
             loginItemsApprovalRequired: loginItemsApprovalRequired
         )
+    }
+
+    private func checkTCPConfiguration() -> Bool {
+        if TestEnvironment.isRunningTests { return true }
+
+        let plistPath = KanataDaemonManager.getActivePlistPath()
+        guard let plistData = FileManager.default.contents(atPath: plistPath) else {
+            AppLogger.shared.warn(
+                "⚠️ [SystemValidator] TCP configuration missing daemon plist at \(plistPath)"
+            )
+            return false
+        }
+
+        let configured = Self.plistHasTCPPortArgument(plistData)
+        if !configured {
+            AppLogger.shared.warn(
+                "⚠️ [SystemValidator] Daemon plist is missing a valid --port argument"
+            )
+        }
+        return configured
+    }
+
+    static func plistHasTCPPortArgument(_ data: Data) -> Bool {
+        guard
+            let plist = try? PropertyListSerialization.propertyList(
+                from: data,
+                options: [],
+                format: nil
+            ) as? [String: Any],
+            let arguments = plist["ProgramArguments"] as? [String],
+            let portIndex = arguments.firstIndex(of: "--port"),
+            arguments.indices.contains(arguments.index(after: portIndex))
+        else {
+            return false
+        }
+
+        let value = arguments[arguments.index(after: portIndex)]
+        return Int(value).map { (1 ... 65535).contains($0) } ?? false
     }
 
     static func effectiveConfigParseError(
@@ -880,7 +920,12 @@ public class SystemValidator {
                 vhidVersionMismatch: false
             ),
             conflicts: ConflictStatus(conflicts: [], canAutoResolve: false),
-            health: HealthStatus(kanataRunning: true, karabinerDaemonRunning: true, vhidHealthy: true),
+            health: HealthStatus(
+                kanataTCPConfigured: true,
+                kanataRunning: true,
+                karabinerDaemonRunning: true,
+                vhidHealthy: true
+            ),
             helper: HelperStatus(
                 isInstalled: true,
                 version: KeyPathHelperContract.version,

--- a/Sources/KeyPathWizardCore/SystemSnapshot.swift
+++ b/Sources/KeyPathWizardCore/SystemSnapshot.swift
@@ -355,6 +355,9 @@ public struct HealthStatus: Sendable {
     public let kanataProcessRunning: Bool?
     /// True when the Kanata TCP health endpoint responds.
     public let kanataTCPResponding: Bool?
+    /// True when the installed daemon plist declares the TCP server argument.
+    /// Nil means this older/fallback evidence did not capture configuration.
+    public let kanataTCPConfigured: Bool?
     public let kanataRunning: Bool
     public let karabinerDaemonRunning: Bool
     public let vhidHealthy: Bool
@@ -387,6 +390,7 @@ public struct HealthStatus: Sendable {
         kanataLaunchdLoaded: Bool? = nil,
         kanataProcessRunning: Bool? = nil,
         kanataTCPResponding: Bool? = nil,
+        kanataTCPConfigured: Bool? = nil,
         kanataRunning: Bool,
         karabinerDaemonRunning: Bool,
         vhidHealthy: Bool,
@@ -403,6 +407,7 @@ public struct HealthStatus: Sendable {
         self.kanataLaunchdLoaded = kanataLaunchdLoaded
         self.kanataProcessRunning = kanataProcessRunning
         self.kanataTCPResponding = kanataTCPResponding
+        self.kanataTCPConfigured = kanataTCPConfigured
         self.kanataRunning = kanataRunning
         self.karabinerDaemonRunning = karabinerDaemonRunning
         self.vhidHealthy = vhidHealthy
@@ -420,6 +425,7 @@ public struct HealthStatus: Sendable {
     /// Overall health (includes Kanata runtime)
     public var isHealthy: Bool {
         kanataRunning && karabinerDaemonRunning && vhidHealthy && kanataInputCaptureReady
+            && (kanataTCPConfigured ?? true)
     }
 
     /// Health of background services only (Karabiner daemon + VHID driver)

--- a/Tests/KeyPathTests/Lint/SnapshotConsumerLintTests.swift
+++ b/Tests/KeyPathTests/Lint/SnapshotConsumerLintTests.swift
@@ -32,6 +32,16 @@ final class SnapshotConsumerLintTests: XCTestCase {
         )
     }
 
+    func testTCPConfigurationEvidenceComesFromCanonicalSnapshot() throws {
+        let controllerURL = LintScanner.path(
+            "Sources/KeyPathAppKit/Services/MainAppStateController.swift"
+        )
+        let controller = try String(contentsOf: controllerURL, encoding: .utf8)
+        XCTAssertTrue(controller.contains("snapshot.health.kanataTCPConfigured"))
+        XCTAssertFalse(controller.contains("func checkTCPConfiguration"))
+        XCTAssertFalse(controller.contains("PropertyListSerialization.propertyList"))
+    }
+
     func testFreshCaptureInvalidatesComponentFacts() throws {
         let validator = LintScanner.path(
             "Sources/KeyPathAppKit/Services/System/SystemValidator.swift"

--- a/Tests/KeyPathTests/Services/SystemValidatorTests.swift
+++ b/Tests/KeyPathTests/Services/SystemValidatorTests.swift
@@ -250,6 +250,36 @@ struct SystemValidatorTests {
         #expect(error == "Duplicate alias: beh_base_a")
     }
 
+    @Test("Daemon plist TCP evidence requires a valid port value")
+    func daemonPlistTCPConfiguration() throws {
+        func plist(_ arguments: [String]) throws -> Data {
+            try PropertyListSerialization.data(
+                fromPropertyList: ["ProgramArguments": arguments],
+                format: .xml,
+                options: 0
+            )
+        }
+
+        #expect(try SystemValidator.plistHasTCPPortArgument(plist(["kanata", "--port", "37001"])))
+        #expect(try !SystemValidator.plistHasTCPPortArgument(plist(["kanata", "--port"])))
+        #expect(try !SystemValidator.plistHasTCPPortArgument(plist(["kanata", "--port", "invalid"])))
+        #expect(try !SystemValidator.plistHasTCPPortArgument(plist(["kanata", "--port", "0"])))
+        #expect(try !SystemValidator.plistHasTCPPortArgument(plist(["kanata", "--port", "70000"])))
+        #expect(try !SystemValidator.plistHasTCPPortArgument(plist(["kanata"])))
+    }
+
+    @Test("Captured missing TCP configuration makes health incomplete")
+    func missingTCPConfigurationIsUnhealthy() {
+        let health = HealthStatus(
+            kanataTCPConfigured: false,
+            kanataRunning: true,
+            karabinerDaemonRunning: true,
+            vhidHealthy: true
+        )
+
+        #expect(!health.isHealthy)
+    }
+
     @Test("Capture status keeps the most conservative probe result")
     func combinedCaptureStatusIsConservative() {
         #expect(SystemValidator.combinedCaptureStatus([.complete, .timedOut]) == .timedOut)

--- a/docs/bugs/2026-07-10-tcp-configuration-snapshot-leak.md
+++ b/docs/bugs/2026-07-10-tcp-configuration-snapshot-leak.md
@@ -1,0 +1,31 @@
+# TCP configuration snapshot leak
+
+## Symptom
+
+After receiving a canonical `SystemSnapshot`, `MainAppStateController` read and
+parsed the installed daemon plist again to decide whether the app was healthy.
+That second observation could disagree with the snapshot used by the wizard,
+installer planner, CLI, and menu surfaces.
+
+## Root cause
+
+`HealthStatus` captured TCP responsiveness but not whether the daemon was
+configured to launch Kanata with a valid TCP port. Presentation code filled the
+missing evidence with its own filesystem probe.
+
+## Fix
+
+- `HealthStatus.kanataTCPConfigured` now carries the raw optional fact.
+- `SystemValidator` reads the active bundled daemon plist during canonical
+  capture and validates that `--port` is followed by a numeric port in the
+  valid range.
+- Captured `false` configuration makes service health incomplete. Nil remains
+  backward-compatible for older fixtures and unavailable fallback snapshots.
+- `MainAppStateController` derives its published TCP status directly from the
+  snapshot and no longer reads or parses the plist.
+
+## Regression coverage
+
+`SystemValidatorTests` covers valid, missing, malformed, and out-of-range TCP
+arguments plus health classification. `SnapshotConsumerLintTests` prevents the
+controller-level plist probe from returning.


### PR DESCRIPTION
SystemValidator now captures daemon TCP configuration as canonical HealthStatus evidence, validates a real numeric port, and MainAppStateController derives readiness from that snapshot instead of reparsing the plist. Includes health and parser tests, a structural lint ratchet, and durable bug documentation. Validation: stable Xcode 26.6 build, 159 consumer tests, 25 focused snapshot tests, accessibility pass. Remote claude-review is required before merge.