### PR TITLE
Unify worktree build caches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,6 @@ Temporary Items
 # Swift Package Manager
 .swiftpm/
 Packages/
-Package.resolved
 *.xcodeproj/
 target/
 **/target/

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,60 @@
+{
+  "originHash" : "5513bf21d79c2d0e2c5036d55205c5492baee3caa3246324bca559157d1e6433",
+  "pins" : [
+    {
+      "identity" : "sparkle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sparkle-project/Sparkle",
+      "state" : {
+        "revision" : "d46d456107feacc80711b21847b82b07bd9fb46e",
+        "version" : "2.9.3"
+      }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser",
+      "state" : {
+        "revision" : "6a52f3251125d74daf04fcbd5e6f08a75d074382",
+        "version" : "1.8.2"
+      }
+    },
+    {
+      "identity" : "swift-custom-dump",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-custom-dump",
+      "state" : {
+        "revision" : "a8cd6c976f335ed361dcecddb0dc39ebda51bc3e",
+        "version" : "1.6.1"
+      }
+    },
+    {
+      "identity" : "swift-snapshot-testing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-snapshot-testing",
+      "state" : {
+        "revision" : "ad5e3190cc63dc288f28546f9c6827efc1e9d495",
+        "version" : "1.19.2"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-syntax",
+      "state" : {
+        "revision" : "79e4b74a295b6eb74a8b585e3a39d29e70c1dbd1",
+        "version" : "603.0.2"
+      }
+    },
+    {
+      "identity" : "xctest-dynamic-overlay",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
+      "state" : {
+        "revision" : "401bf70d95bfe8db2a1dc619f9e175a85c089321",
+        "version" : "1.10.1"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Scripts/README.md
+++ b/Scripts/README.md
@@ -70,9 +70,11 @@
 - `./Scripts/run-tests-safe.sh` - CI-style safe test runner. Defaults to quiet
   app logs (`KEYPATH_LOG_LEVEL=3`) and prints build/test timing plus log size.
   Set `KEYPATH_TEST_VERBOSE_LOGS=1` for debug-level app diagnostics during a
-  noisy test investigation. Local named lanes reuse the normalized Swift module
-  cache by default; set `KEYPATH_TEST_RESET_MODULE_CACHE=1` when a narrow local
-  lane should intentionally reset it.
+  noisy test investigation. Local tests reuse the worktree's `.build` graph and
+  normalized Swift module cache by default; set
+  `KEYPATH_TEST_RESET_MODULE_CACHE=1` only when diagnosing cache/module state.
+  `Package.resolved` pins SwiftPM dependencies so fresh worktrees do not drift
+  to newer dependency releases during an ordinary build or test.
 - `./Scripts/measure-local-loop.sh --preset baseline` - Measure the standard
   MacBook Air local baseline (`smoke`, `core-isolated`, `unit`, `appkit`) and write
   `.build/local-loop-measurements/latest.md`.

--- a/Scripts/quick-deploy.sh
+++ b/Scripts/quick-deploy.sh
@@ -14,7 +14,7 @@
 set -euo pipefail
 
 SCRIPT_DIR=$(cd "$(dirname "$0")" >/dev/null && pwd)
-PROJECT_DIR="$SCRIPT_DIR/.."
+PROJECT_DIR=$(cd "$SCRIPT_DIR/.." >/dev/null && pwd -P)
 source "$SCRIPT_DIR/lib/xcode.sh"
 source "$SCRIPT_DIR/lib/deploy-lock.sh"
 keypath_use_stable_xcode
@@ -64,6 +64,16 @@ cd "$PROJECT_DIR"
 
 # Ensure .build directory exists for stats
 mkdir -p "$PROJECT_DIR/.build" "$MODULE_CACHE" "$BUILD_LOG_DIR"
+
+# SwiftPM's stable and beta build systems use different generated `debug`
+# symlink targets. A worktree previously built by another toolchain can retain
+# the other target, causing SwiftPM to warn instead of refreshing the link.
+# The link is generated metadata, so remove only symlinks and let this build
+# recreate the target appropriate for the pinned stable Xcode.
+if [[ -L "$PROJECT_DIR/.build/debug" ]]; then
+    echo "🧹 Refreshing generated .build/debug symlink"
+    rm "$PROJECT_DIR/.build/debug"
+fi
 
 # --- Instrumentation Functions ---
 
@@ -288,7 +298,7 @@ if [[ -n "${KEYPATH_BUILD_SYSTEM:-}" && "${KEYPATH_BUILD_SYSTEM:-}" != "native" 
     BUILD_SYSTEM_FLAGS=(--build-system "$KEYPATH_BUILD_SYSTEM")
 fi
 # ${arr[@]+...} guard: bash 3.2 under `set -u` treats expanding an empty array as unbound
-if ! swift build ${BUILD_SYSTEM_FLAGS[@]+"${BUILD_SYSTEM_FLAGS[@]}"} "${MODULE_CACHE_FLAGS[@]}" ${PRODUCT_FLAGS[@]+"${PRODUCT_FLAGS[@]}"} >> "$BUILD_LOG" 2>&1; then
+if ! swift build --disable-automatic-resolution ${BUILD_SYSTEM_FLAGS[@]+"${BUILD_SYSTEM_FLAGS[@]}"} "${MODULE_CACHE_FLAGS[@]}" ${PRODUCT_FLAGS[@]+"${PRODUCT_FLAGS[@]}"} >> "$BUILD_LOG" 2>&1; then
     BUILD_END_MS=$(get_time_ms)
     DURATION=$((BUILD_END_MS - BUILD_START_MS))
     print_build_failure_diagnostics "$BUILD_LOG"
@@ -296,7 +306,7 @@ if ! swift build ${BUILD_SYSTEM_FLAGS[@]+"${BUILD_SYSTEM_FLAGS[@]}"} "${MODULE_C
     exit 1
 fi
 
-if ! BIN_DIR_OUTPUT=$(swift build --show-bin-path ${BUILD_SYSTEM_FLAGS[@]+"${BUILD_SYSTEM_FLAGS[@]}"} "${MODULE_CACHE_FLAGS[@]}" 2>> "$BUILD_LOG"); then
+if ! BIN_DIR_OUTPUT=$(swift build --show-bin-path --disable-automatic-resolution ${BUILD_SYSTEM_FLAGS[@]+"${BUILD_SYSTEM_FLAGS[@]}"} "${MODULE_CACHE_FLAGS[@]}" 2>> "$BUILD_LOG"); then
     BUILD_END_MS=$(get_time_ms)
     DURATION=$((BUILD_END_MS - BUILD_START_MS))
     print_build_failure_diagnostics "$BUILD_LOG"

--- a/Scripts/run-tests-safe.sh
+++ b/Scripts/run-tests-safe.sh
@@ -27,7 +27,7 @@ TEST_FILTER="${KEYPATH_TEST_FILTER:-${TEST_FILTER:-}}"
 TEST_SKIP="${KEYPATH_TEST_SKIP:-${TEST_SKIP:-}}"
 TEST_PREBUILD="${KEYPATH_TEST_PREBUILD:-1}"
 TEST_DISABLE_XCTEST="${KEYPATH_TEST_DISABLE_XCTEST:-0}"
-TEST_RESET_MODULE_CACHE="${KEYPATH_TEST_RESET_MODULE_CACHE:-1}"
+TEST_RESET_MODULE_CACHE="${KEYPATH_TEST_RESET_MODULE_CACHE:-0}"
 LOG="${KEYPATH_TEST_LOG:-$PROJECT_DIR/test_output.safe.txt}"
 BUILD_LOG="${KEYPATH_TEST_BUILD_LOG:-$LOG.build}"
 EXTRA_SWIFT_TEST_ARGS="${SWIFT_TEST_ARGS:-}"
@@ -372,14 +372,16 @@ append_runner_crash_summary() {
     fi
 }
 
-# 0) Isolated build/test dirs and HOME to avoid parallel-agent collisions
-# In CI, reuse the default .build/ to avoid relinking the CLI executable
+# 0) Worktree-local build/test dir and isolated HOME.
+# One thread owns one worktree and one `.build`, so local tests reuse the app
+# build graph instead of compiling a duplicate `.build-ci` graph. CI also uses
+# `.build` to avoid relinking the CLI executable
 # (keypath depends on KeyPathAppKit → SwiftUI, which can fail to link from a
 # fresh scratch path on Xcode 16.4 due to SwiftUICore client restrictions).
 if [ "${CI_ENVIRONMENT}" = "true" ] || [ -n "${GITHUB_ACTIONS:-}" ]; then
     SCRATCH_PATH=${SCRATCH_PATH:-"$PROJECT_DIR/.build"}
 else
-    SCRATCH_PATH=${SCRATCH_PATH:-"$PROJECT_DIR/.build-ci"}
+    SCRATCH_PATH=${SCRATCH_PATH:-"$PROJECT_DIR/.build"}
 fi
 export HOME=${TEST_HOME:-$(mktemp -d 2>/dev/null || mktemp -d -t keypath-tests)}
 SCRATCH_PATH="$(absolute_dir "$SCRATCH_PATH")"
@@ -420,6 +422,13 @@ echo "🗂️  Module cache: $MODULE_CACHE"
 mkdir -p "$(dirname "$LOG")" "$(dirname "$BUILD_LOG")"
 rm -f "$LOG" "$BUILD_LOG"
 
+# Refresh generated metadata left by a different SwiftPM build system. Never
+# remove a real directory or file at this path.
+if [ -L "$SCRATCH_PATH/debug" ]; then
+  echo "🧹 Refreshing generated $SCRATCH_PATH/debug symlink"
+  rm "$SCRATCH_PATH/debug"
+fi
+
 # 1) Build tests first (doesn't count against watchdog timeout)
 echo "🔨 Building tests..."
 BUILD_START_SECONDS="$(date +%s)"
@@ -428,7 +437,7 @@ if [ "$TEST_PREBUILD" = "0" ]; then
   echo "⏭️  Skipping separate swift build --build-tests step"
   BUILD_EXIT_CODE=0
 else
-  swift build --build-tests --scratch-path "$SCRATCH_PATH" "${MODULE_CACHE_FLAGS[@]}" 2>&1 | tee "$BUILD_LOG"
+  swift build --disable-automatic-resolution --build-tests --scratch-path "$SCRATCH_PATH" "${MODULE_CACHE_FLAGS[@]}" 2>&1 | tee "$BUILD_LOG"
   BUILD_EXIT_CODE="${PIPESTATUS[0]}"
 fi
 set -e
@@ -462,7 +471,7 @@ TEST_START_SECONDS="$(date +%s)"
 (
   set +e
   set -o pipefail
-  SWIFT_TEST_COMMAND=(swift test --scratch-path "$SCRATCH_PATH" "${MODULE_CACHE_FLAGS[@]}")
+  SWIFT_TEST_COMMAND=(swift test --disable-automatic-resolution --scratch-path "$SCRATCH_PATH" "${MODULE_CACHE_FLAGS[@]}")
   if [ "$TEST_PREBUILD" != "0" ]; then
     SWIFT_TEST_COMMAND+=(--skip-build)
   fi

--- a/Tests/KeyPathTests/Lint/DeploymentScriptContractTests.swift
+++ b/Tests/KeyPathTests/Lint/DeploymentScriptContractTests.swift
@@ -101,6 +101,39 @@ final class DeploymentScriptContractTests: XCTestCase {
             "quick-deploy must not reduce failed build output to only the last three lines."
         )
     }
+
+    func testLocalBuildsSharePinnedWorktreeCache() throws {
+        let root = repositoryRoot()
+        let quickDeploy = try contents(of: root.appendingPathComponent("Scripts/quick-deploy.sh"))
+        let safeTests = try contents(of: root.appendingPathComponent("Scripts/run-tests-safe.sh"))
+
+        XCTAssertTrue(
+            FileManager.default.fileExists(atPath: root.appendingPathComponent("Package.resolved").path),
+            "SwiftPM dependencies must be pinned for repeatable fresh-worktree builds."
+        )
+        XCTAssertTrue(
+            safeTests.contains(#"SCRATCH_PATH=${SCRATCH_PATH:-"$PROJECT_DIR/.build"}"#),
+            "Local tests must reuse the worktree's canonical .build graph."
+        )
+        XCTAssertTrue(
+            safeTests.contains(#"TEST_RESET_MODULE_CACHE="${KEYPATH_TEST_RESET_MODULE_CACHE:-0}""#),
+            "The safe runner must preserve the module cache unless reset is explicitly requested."
+        )
+        XCTAssertTrue(
+            quickDeploy.contains("swift build --disable-automatic-resolution")
+                && safeTests.contains("swift build --disable-automatic-resolution"),
+            "Routine build and test entry points must honor Package.resolved without re-resolving."
+        )
+        XCTAssertTrue(
+            quickDeploy.contains(#"if [[ -L "$PROJECT_DIR/.build/debug" ]]"#)
+                && safeTests.contains(#"if [ -L "$SCRATCH_PATH/debug" ]"#),
+            "Build entry points must safely refresh only generated debug symlinks."
+        )
+        XCTAssertTrue(
+            quickDeploy.contains(#"PROJECT_DIR=$(cd "$SCRIPT_DIR/.." >/dev/null && pwd -P)"#),
+            "quick-deploy must canonicalize PROJECT_DIR so Clang sees one module-cache path."
+        )
+    }
 }
 
 // MARK: - Helpers

--- a/docs/bugs/2026-07-10-worktree-build-cache-fragmentation.md
+++ b/docs/bugs/2026-07-10-worktree-build-cache-fragmentation.md
@@ -1,0 +1,32 @@
+# Worktree build cache fragmentation
+
+## Symptom
+
+Fresh feature worktrees spent roughly 90–180 seconds resolving and rebuilding,
+then the safe test runner compiled a second graph under `.build-ci`. Repeated
+full runs deleted the module cache and sometimes emitted missing `.pcm`
+warnings. Quick deploy also warned that it could not recreate `.build/debug`.
+
+## Root cause
+
+The scripts predated the one-thread/one-worktree/one-`.build` rule. Local tests
+still isolated themselves in `.build-ci`, reset the module cache by default,
+and allowed SwiftPM to resolve unpinned dependency ranges. Switching between
+SwiftPM build-system layouts could also leave a generated `debug` symlink aimed
+at the other layout.
+
+## Fix
+
+- Commit `Package.resolved` at the dependency revisions already validated on
+  master and disable automatic resolution in routine build/test entry points.
+- Reuse the worktree's `.build` graph for local app builds and tests.
+- Preserve the module cache by default; cache reset remains an explicit
+  diagnostic opt-in.
+- Remove `.build/debug` only when it is a generated symlink, allowing the pinned
+  stable Xcode toolchain to recreate the correct target.
+- Canonicalize the quick-deploy project path before deriving cache paths;
+  spelling the same directory as both `.build` and `Scripts/../.build` makes
+  Clang diagnose duplicate PCM modules and can crash `swift-frontend`.
+
+Each concurrent thread still has independent artifacts because repository
+policy gives every thread its own worktree.


### PR DESCRIPTION
## Summary
- pin the SwiftPM graph with Package.resolved and disable automatic resolution in routine build/test paths
- reuse each worktree's `.build` graph for app builds and tests; preserve module caches by default
- safely refresh generated `.build/debug` symlinks across SwiftPM layouts
- canonicalize quick-deploy paths to prevent duplicate PCM module crashes
- document and ratchet the cache contract

## Validation
- cold app build with pinned dependencies: 49.93s (prior fresh-worktree observations were 90-180s)
- warm focused test rerun: 6s total / 4s build with zero warnings
- quick deploy: 10.55s after path fix, no stale-link warning
- `DEVELOPER_DIR=/Applications/Xcode-26.6.0.app/Contents/Developer ./Scripts/test-full.sh` (4,721 passed; 4s build, zero Swift/module-cache/app warnings or errors)
- `bash -n Scripts/quick-deploy.sh Scripts/run-tests-safe.sh`
- `python3 Scripts/check-accessibility.py`
- local review gate selected the enforced remote `claude-review` path