### PR TITLE
Migrate legacy SwiftPM cache paths

### DIFF
--- a/Scripts/lib/build-cache.sh
+++ b/Scripts/lib/build-cache.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+# Prepare a worktree-local SwiftPM cache for canonical path reuse.
+#
+# Older quick-deploy versions derived PROJECT_DIR as `Scripts/..`. Swift embeds
+# the Clang module-cache path in compiled modules, so artifacts produced by that
+# spelling cannot be safely reused with the canonical path even though both
+# resolve to the same directory. Clean build products once, keep dependency
+# checkouts, and mark the migration complete.
+keypath_prepare_build_cache() {
+    local project_dir="$1"
+    local scratch_path="$2"
+    local canonical_scratch="$project_dir/.build"
+    local migration_marker="$scratch_path/.keypath-canonical-module-cache-v1"
+
+    mkdir -p "$scratch_path"
+
+    if [[ "$scratch_path" == "$canonical_scratch" && ! -f "$migration_marker" ]]; then
+        if [[ -f "$scratch_path/build.db" || -d "$scratch_path/arm64-apple-macosx" || -d "$scratch_path/out" ]]; then
+            echo "🧹 Migrating legacy SwiftPM artifacts to canonical cache paths (one time)"
+            (cd "$project_dir" && swift package clean)
+        fi
+        rm -rf "$scratch_path/ModuleCache.noindex"
+        mkdir -p "$scratch_path"
+        touch "$migration_marker"
+    fi
+
+    # SwiftPM's stable and beta build systems use different generated `debug`
+    # symlink targets. Remove only generated metadata and let this invocation
+    # recreate the target appropriate for its toolchain.
+    if [[ -L "$scratch_path/debug" ]]; then
+        echo "🧹 Refreshing generated $scratch_path/debug symlink"
+        rm "$scratch_path/debug"
+    fi
+}

--- a/Scripts/quick-deploy.sh
+++ b/Scripts/quick-deploy.sh
@@ -17,6 +17,7 @@ SCRIPT_DIR=$(cd "$(dirname "$0")" >/dev/null && pwd)
 PROJECT_DIR=$(cd "$SCRIPT_DIR/.." >/dev/null && pwd -P)
 source "$SCRIPT_DIR/lib/xcode.sh"
 source "$SCRIPT_DIR/lib/deploy-lock.sh"
+source "$SCRIPT_DIR/lib/build-cache.sh"
 keypath_use_stable_xcode
 APP_NAME="KeyPath"
 APP_BUNDLE="/Applications/${APP_NAME}.app"
@@ -64,16 +65,8 @@ cd "$PROJECT_DIR"
 
 # Ensure .build directory exists for stats
 mkdir -p "$PROJECT_DIR/.build" "$MODULE_CACHE" "$BUILD_LOG_DIR"
-
-# SwiftPM's stable and beta build systems use different generated `debug`
-# symlink targets. A worktree previously built by another toolchain can retain
-# the other target, causing SwiftPM to warn instead of refreshing the link.
-# The link is generated metadata, so remove only symlinks and let this build
-# recreate the target appropriate for the pinned stable Xcode.
-if [[ -L "$PROJECT_DIR/.build/debug" ]]; then
-    echo "🧹 Refreshing generated .build/debug symlink"
-    rm "$PROJECT_DIR/.build/debug"
-fi
+keypath_prepare_build_cache "$PROJECT_DIR" "$PROJECT_DIR/.build"
+mkdir -p "$MODULE_CACHE" "$BUILD_LOG_DIR"
 
 # --- Instrumentation Functions ---
 

--- a/Scripts/run-tests-safe.sh
+++ b/Scripts/run-tests-safe.sh
@@ -9,6 +9,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd -P)"
 source "$SCRIPT_DIR/lib/xcode.sh"
+source "$SCRIPT_DIR/lib/build-cache.sh"
 keypath_use_stable_xcode
 TIMEOUT_SECONDS=${TIMEOUT_SECONDS:-240}
 ALLOW_RUNNER_CRASH_SUCCESS=${KEYPATH_ALLOW_TEST_RUNNER_CRASH_SUCCESS:-0}
@@ -386,6 +387,7 @@ fi
 export HOME=${TEST_HOME:-$(mktemp -d 2>/dev/null || mktemp -d -t keypath-tests)}
 SCRATCH_PATH="$(absolute_dir "$SCRATCH_PATH")"
 MODULE_CACHE="$SCRATCH_PATH/ModuleCache.noindex"
+keypath_prepare_build_cache "$PROJECT_DIR" "$SCRATCH_PATH"
 if [ "$TEST_RESET_MODULE_CACHE" = "1" ] && [ -d "$MODULE_CACHE" ]; then
   echo "🧹 Resetting generated module cache: $MODULE_CACHE"
   rm -rf "$MODULE_CACHE"
@@ -421,13 +423,6 @@ echo "📦 Scratch: $SCRATCH_PATH | HOME=$HOME"
 echo "🗂️  Module cache: $MODULE_CACHE"
 mkdir -p "$(dirname "$LOG")" "$(dirname "$BUILD_LOG")"
 rm -f "$LOG" "$BUILD_LOG"
-
-# Refresh generated metadata left by a different SwiftPM build system. Never
-# remove a real directory or file at this path.
-if [ -L "$SCRATCH_PATH/debug" ]; then
-  echo "🧹 Refreshing generated $SCRATCH_PATH/debug symlink"
-  rm "$SCRATCH_PATH/debug"
-fi
 
 # 1) Build tests first (doesn't count against watchdog timeout)
 echo "🔨 Building tests..."

--- a/Tests/KeyPathTests/Lint/DeploymentScriptContractTests.swift
+++ b/Tests/KeyPathTests/Lint/DeploymentScriptContractTests.swift
@@ -106,6 +106,7 @@ final class DeploymentScriptContractTests: XCTestCase {
         let root = repositoryRoot()
         let quickDeploy = try contents(of: root.appendingPathComponent("Scripts/quick-deploy.sh"))
         let safeTests = try contents(of: root.appendingPathComponent("Scripts/run-tests-safe.sh"))
+        let cacheContract = try contents(of: root.appendingPathComponent("Scripts/lib/build-cache.sh"))
 
         XCTAssertTrue(
             FileManager.default.fileExists(atPath: root.appendingPathComponent("Package.resolved").path),
@@ -125,13 +126,19 @@ final class DeploymentScriptContractTests: XCTestCase {
             "Routine build and test entry points must honor Package.resolved without re-resolving."
         )
         XCTAssertTrue(
-            quickDeploy.contains(#"if [[ -L "$PROJECT_DIR/.build/debug" ]]"#)
-                && safeTests.contains(#"if [ -L "$SCRATCH_PATH/debug" ]"#),
+            quickDeploy.contains(#"source "$SCRIPT_DIR/lib/build-cache.sh""#)
+                && safeTests.contains(#"source "$SCRIPT_DIR/lib/build-cache.sh""#)
+                && cacheContract.contains(#"if [[ -L "$scratch_path/debug" ]]"#),
             "Build entry points must safely refresh only generated debug symlinks."
         )
         XCTAssertTrue(
             quickDeploy.contains(#"PROJECT_DIR=$(cd "$SCRIPT_DIR/.." >/dev/null && pwd -P)"#),
             "quick-deploy must canonicalize PROJECT_DIR so Clang sees one module-cache path."
+        )
+        XCTAssertTrue(
+            cacheContract.contains(".keypath-canonical-module-cache-v1")
+                && cacheContract.contains("swift package clean"),
+            "Legacy noncanonical modules require one marker-gated artifact migration."
         )
     }
 }

--- a/docs/bugs/2026-07-10-worktree-build-cache-fragmentation.md
+++ b/docs/bugs/2026-07-10-worktree-build-cache-fragmentation.md
@@ -27,6 +27,9 @@ at the other layout.
 - Canonicalize the quick-deploy project path before deriving cache paths;
   spelling the same directory as both `.build` and `Scripts/../.build` makes
   Clang diagnose duplicate PCM modules and can crash `swift-frontend`.
+- Existing worktrees may already contain Swift modules embedding the legacy
+  spelling. A marker-gated, one-time `swift package clean` removes build
+  products while preserving dependency checkouts; later runs stay incremental.
 
 Each concurrent thread still has independent artifacts because repository
 policy gives every thread its own worktree.


### PR DESCRIPTION
## Summary
- add a shared build-cache preparation contract for quick deploy and safe tests
- perform a marker-gated one-time `swift package clean` for modules embedding the legacy `Scripts/../.build` cache spelling
- preserve dependency checkouts and keep all subsequent builds incremental
- retain safe generated-symlink refresh and add contract coverage

## Validation
- simulated legacy migration: one-time cleanup + successful rebuild/deploy (60.47s)
- immediate subsequent quick deploy: 3.27s total / 0.93s build
- `DeploymentScriptContractTests`: 4/4 passed; zero Swift/module-cache/app warnings or errors
- `bash -n Scripts/lib/build-cache.sh Scripts/quick-deploy.sh Scripts/run-tests-safe.sh`
- local review gate selected the enforced remote `claude-review` path