### PR TITLE
Fix repeated health status presentation

### DIFF
--- a/Sources/KeyPathAppKit/Services/MainAppStateController.swift
+++ b/Sources/KeyPathAppKit/Services/MainAppStateController.swift
@@ -57,7 +57,8 @@ class MainAppStateController {
 
     // MARK: - Dependencies
 
-    @ObservationIgnored private var validator: SystemValidator?
+    @ObservationIgnored private var validator: (any WizardSystemValidating)?
+    @ObservationIgnored private var inProgressValidation: Task<Void, Never>?
     @ObservationIgnored private weak var serviceLifecycle: ServiceLifecycleCoordinator?
     @ObservationIgnored private var onSystemHealthy: (() -> Void)?
     @ObservationIgnored private var hasRunInitialValidation = false
@@ -165,7 +166,7 @@ class MainAppStateController {
     // MainActor-isolated properties like task handles.
 
     /// Inject the shared SystemValidator instance (called from configureWizardDependencies).
-    func setValidator(_ shared: SystemValidator) {
+    func setValidator(_ shared: any WizardSystemValidating) {
         validator = shared
     }
 
@@ -457,6 +458,24 @@ class MainAppStateController {
     }
 
     private func performValidation() async {
+        if let inProgressValidation {
+            AppLogger.shared.log(
+                "🔍 [MainAppStateController] Validation already in progress - waiting for published result"
+            )
+            await inProgressValidation.value
+            return
+        }
+
+        let task = Task<Void, Never> { @MainActor [weak self] in
+            guard let self else { return }
+            await performValidationBody()
+        }
+        inProgressValidation = task
+        await task.value
+        inProgressValidation = nil
+    }
+
+    private func performValidationBody() async {
         guard let validator else {
             AppLogger.shared.warnUnlessQuietTest("⚠️ [MainAppStateController] Cannot validate - validator not configured")
             validationState = .checking
@@ -558,7 +577,9 @@ class MainAppStateController {
         // Update published state
         lastValidatedSystemContext = context
         lastAdaptedState = adapted.state
-        lastTCPConfigured = snapshot.health.kanataTCPConfigured ?? false
+        // Preserve missing evidence as unknown. An incomplete/fallback capture
+        // must not become a proven TCP configuration failure in presentation.
+        lastTCPConfigured = snapshot.health.kanataTCPConfigured
         let decision = InstallerDecisionPipeline.decide(for: .repair, context: context)
         lastInstallerStateMatrixRow = decision.assessment
         lastInstallerStateMatrixPlan = decision.matrixActions
@@ -590,7 +611,13 @@ class MainAppStateController {
         switch adapted.state {
         case .active:
             // Kanata is running - but check if there are blocking issues that prevent proper operation
-            let tcpConfigured = lastTCPConfigured ?? false
+            guard let tcpConfigured = lastTCPConfigured else {
+                validationState = .checking
+                AppLogger.shared.info(
+                    "⏳ [MainAppStateController] Validation inconclusive - TCP configuration evidence unavailable"
+                )
+                return
+            }
 
             if blockingIssues.isEmpty, tcpConfigured {
                 validationState = .success

--- a/Sources/KeyPathAppKit/Services/MainAppStateController.swift
+++ b/Sources/KeyPathAppKit/Services/MainAppStateController.swift
@@ -642,7 +642,7 @@ class MainAppStateController {
                 )
                 let signature = "active:\(reasons.joined(separator: ",")):\(blockingIssues.map(\.title).joined(separator: ","))"
                 if shouldLogValidationFailureInDetail(site: .validationFailure, signature: signature) {
-                    AppLogger.shared.error(
+                    AppLogger.shared.errorUnlessQuietTest(
                         "❌ [MainAppStateController] Validation FAILED - \(reasons.joined(separator: ", "))"
                     )
                     for (index, issue) in blockingIssues.enumerated() {

--- a/Sources/KeyPathAppKit/UI/Overlay/OverlayHealthIndicatorObserver.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/OverlayHealthIndicatorObserver.swift
@@ -13,6 +13,7 @@ final class OverlayHealthIndicatorObserver {
     private var dismissTask: Task<Void, Never>?
     private var checkingDebounceTask: Task<Void, Never>?
     private var currentState: HealthIndicatorState = .dismissed
+    private var lastSemanticHealth: Bool?
     private var isObserving = false
 
     /// Debounce duration for showing "checking" state (prevents brief flashes)
@@ -140,18 +141,24 @@ final class OverlayHealthIndicatorObserver {
         case .success:
             checkingDebounceTask?.cancel()
             checkingDebounceTask = nil
-            setState(.healthy)
-            scheduleDismiss()
+            presentHealthyTransitionIfNeeded()
         case .failed:
             checkingDebounceTask?.cancel()
             checkingDebounceTask = nil
             if blockingIssues.isEmpty {
-                setState(.healthy)
-                scheduleDismiss()
+                presentHealthyTransitionIfNeeded()
             } else {
+                lastSemanticHealth = false
                 setState(.unhealthy(issueCount: blockingIssues.count))
             }
         }
+    }
+
+    private func presentHealthyTransitionIfNeeded() {
+        guard lastSemanticHealth != true else { return }
+        lastSemanticHealth = true
+        setState(.healthy)
+        scheduleDismiss()
     }
 
     /// Schedule showing the "checking" state after a debounce period

--- a/Sources/KeyPathAppKit/UI/Settings/SettingsView.swift
+++ b/Sources/KeyPathAppKit/UI/Settings/SettingsView.swift
@@ -324,9 +324,7 @@ struct StatusSettingsTabView: View {
         // triggers a revalidation, this ensures the Settings tab updates automatically
         // instead of showing stale data from the initial .task fetch.
         .onChange(of: MainAppStateController.shared.lastValidationDate) { _, _ in
-            Task {
-                await refreshStatus()
-            }
+            copyPublishedStatus()
         }
         // Removed legacy onReceive(currentState)
         .onReceive(NotificationCenter.default.publisher(for: .wizardClosed)) { _ in
@@ -485,9 +483,17 @@ struct StatusSettingsTabView: View {
         // Trigger a revalidation if stale, then read the published state.
         await controller.revalidate()
 
+        copyPublishedStatus()
+    }
+
+    /// Copy the controller's latest published evidence without triggering a
+    /// second validation. This is used by the validation-date subscription so
+    /// observing a completed validation cannot feed back into another capture.
+    private func copyPublishedStatus() {
+        let controller = MainAppStateController.shared
+
         let context = controller.lastValidatedSystemContext ?? .empty
         let duplicates = HelperMaintenance.shared.detectDuplicateAppCopies()
-        let tcpOk = controller.lastTCPConfigured ?? false
 
         permissionSnapshot = context.permissions
         systemContext = context
@@ -496,7 +502,7 @@ struct StatusSettingsTabView: View {
         tcpConfigured = controller.lastTCPConfigured
         showSetupBanner = !(context.permissions.isSystemReady && context.services.isHealthy)
             || duplicates.count > 1
-            || (context.services.kanataRunning && !tcpOk)
+            || (context.services.kanataRunning && controller.lastTCPConfigured == false)
         duplicateAppCopies = duplicates
     }
 

--- a/Tests/KeyPathTests/Lint/SettingsStatusValidationLintTests.swift
+++ b/Tests/KeyPathTests/Lint/SettingsStatusValidationLintTests.swift
@@ -1,0 +1,22 @@
+import Foundation
+@preconcurrency import XCTest
+
+/// Prevents the status view from turning validation publication into a new
+/// validation request, which previously produced repeated startup captures.
+final class SettingsStatusValidationLintTests: XCTestCase {
+    func testValidationDateObserverOnlyCopiesPublishedStatus() throws {
+        let source = try String(
+            contentsOf: LintScanner.path("Sources/KeyPathAppKit/UI/Settings/SettingsView.swift"),
+            encoding: .utf8
+        )
+        let observerPattern = #"\.onChange\(of: MainAppStateController\.shared\.lastValidationDate\)[\s\S]*?\n        \}"#
+        let observer = try XCTUnwrap(source.range(of: observerPattern, options: .regularExpression))
+        let body = String(source[observer])
+
+        XCTAssertTrue(body.contains("copyPublishedStatus()"))
+        XCTAssertFalse(
+            body.contains("refreshStatus()"),
+            "Observing validation completion must not request another validation"
+        )
+    }
+}

--- a/Tests/KeyPathTests/MainAppStateControllerTests.swift
+++ b/Tests/KeyPathTests/MainAppStateControllerTests.swift
@@ -453,6 +453,57 @@ struct MainAppStateControllerBehaviorTests {
         #expect(controller.issues.isEmpty)
     }
 
+    @Test("Unknown TCP configuration remains inconclusive")
+    func unknownTCPConfigurationRemainsInconclusive() async {
+        let context = SystemContextBuilder(
+            servicesHealthy: true,
+            kanataTCPConfigured: nil,
+            componentsInstalled: true
+        ).build()
+        let controller = configuredController(validator: StubSystemValidator(context: context))
+
+        await controller.refreshValidation()
+
+        #expect(controller.lastTCPConfigured == nil)
+        #expect(controller.validationState == .checking)
+    }
+
+    @Test("Explicit missing TCP configuration remains a failure")
+    func explicitMissingTCPConfigurationRemainsFailure() async {
+        let context = SystemContextBuilder(
+            servicesHealthy: true,
+            kanataTCPConfigured: false,
+            componentsInstalled: true
+        ).build()
+        let controller = configuredController(validator: StubSystemValidator(context: context))
+
+        await controller.refreshValidation()
+
+        #expect(controller.lastTCPConfigured == false)
+        #expect(controller.validationState?.hasCriticalIssues == true)
+    }
+
+    @Test("Concurrent refreshes publish one validation result")
+    func concurrentRefreshesPublishOneValidationResult() async {
+        let context = SystemContextBuilder(
+            servicesHealthy: true,
+            kanataTCPConfigured: true,
+            componentsInstalled: true
+        ).build()
+        let validator = GatedCountingValidator(context: context)
+        let controller = configuredController(validator: validator)
+
+        async let first: Void = controller.refreshValidation()
+        await Task.yield()
+        async let second: Void = controller.refreshValidation()
+        await Task.yield()
+        validator.open()
+        _ = await (first, second)
+
+        #expect(validator.checkCount == 1)
+        #expect(controller.validationState == .success)
+    }
+
     @Test("startup gate with immediately-healthy service reports ready")
     func startupGateWithImmediatelyHealthyServiceReportsReady() async {
         let controller = MainAppStateController()
@@ -473,5 +524,55 @@ struct MainAppStateControllerBehaviorTests {
 
         let ready = await controller.evaluateKanataStartupGateForTesting()
         #expect(ready == true)
+    }
+
+    private func configuredController(validator: any WizardSystemValidating) -> MainAppStateController {
+        let controller = MainAppStateController()
+        controller.setValidator(validator)
+        #if DEBUG
+            controller.configureStartupGateTestingState(
+                healthOverride: {
+                    KanataHealthSnapshot(isRunning: true, isResponding: true)
+                },
+                transientWindowOverride: { false }
+            )
+        #endif
+        return controller
+    }
+}
+
+@MainActor
+private final class GatedCountingValidator: WizardSystemValidating {
+    private let snapshot: SystemSnapshot
+    private var isOpen = false
+    private(set) var checkCount = 0
+
+    init(context: SystemContext) {
+        snapshot = SystemSnapshot(
+            id: context.snapshotID,
+            permissions: context.permissions,
+            components: context.components,
+            conflicts: context.conflicts,
+            health: context.services,
+            helper: context.helper,
+            compatibility: SystemCompatibilityStatus(
+                macOSVersion: context.system.macOSVersion,
+                driverCompatible: context.system.driverCompatible
+            ),
+            timestamp: context.timestamp,
+            captureStatus: context.captureStatus
+        )
+    }
+
+    func checkSystem() async -> SystemSnapshot {
+        checkCount += 1
+        while !isOpen, !Task.isCancelled {
+            await Task.yield()
+        }
+        return snapshot
+    }
+
+    func open() {
+        isOpen = true
     }
 }

--- a/Tests/KeyPathTests/MainAppStateControllerTests.swift
+++ b/Tests/KeyPathTests/MainAppStateControllerTests.swift
@@ -468,6 +468,30 @@ struct MainAppStateControllerBehaviorTests {
         #expect(controller.validationState == .checking)
     }
 
+    @Test("A later complete capture resolves unknown TCP configuration")
+    func laterCaptureResolvesUnknownTCPConfiguration() async {
+        let unknown = SystemContextBuilder(
+            servicesHealthy: true,
+            kanataTCPConfigured: nil,
+            componentsInstalled: true
+        ).build()
+        let healthy = SystemContextBuilder(
+            servicesHealthy: true,
+            kanataTCPConfigured: true,
+            componentsInstalled: true
+        ).build()
+        let validator = SequenceSystemValidator(contexts: [unknown, healthy])
+        let controller = configuredController(validator: validator)
+
+        await controller.refreshValidation()
+        #expect(controller.validationState == .checking)
+
+        await controller.revalidate()
+        #expect(controller.lastTCPConfigured == true)
+        #expect(controller.validationState == .success)
+        #expect(validator.checkCount == 2)
+    }
+
     @Test("Explicit missing TCP configuration remains a failure")
     func explicitMissingTCPConfigurationRemainsFailure() async {
         let context = SystemContextBuilder(
@@ -574,5 +598,38 @@ private final class GatedCountingValidator: WizardSystemValidating {
 
     func open() {
         isOpen = true
+    }
+}
+
+@MainActor
+private final class SequenceSystemValidator: WizardSystemValidating {
+    private var snapshots: [SystemSnapshot]
+    private(set) var checkCount = 0
+
+    init(contexts: [SystemContext]) {
+        snapshots = contexts.map { context in
+            SystemSnapshot(
+                id: context.snapshotID,
+                permissions: context.permissions,
+                components: context.components,
+                conflicts: context.conflicts,
+                health: context.services,
+                helper: context.helper,
+                compatibility: SystemCompatibilityStatus(
+                    macOSVersion: context.system.macOSVersion,
+                    driverCompatible: context.system.driverCompatible
+                ),
+                timestamp: context.timestamp,
+                captureStatus: context.captureStatus
+            )
+        }
+    }
+
+    func checkSystem() async -> SystemSnapshot {
+        checkCount += 1
+        if snapshots.count > 1 {
+            return snapshots.removeFirst()
+        }
+        return snapshots[0]
     }
 }

--- a/Tests/KeyPathTests/TestSupport/SystemContextBuilder.swift
+++ b/Tests/KeyPathTests/TestSupport/SystemContextBuilder.swift
@@ -14,6 +14,7 @@ struct SystemContextBuilder {
     var kanataLaunchdLoaded: Bool?
     var kanataProcessRunning: Bool?
     var kanataTCPResponding: Bool?
+    var kanataTCPConfigured: Bool?
     var kanataSMAppServiceRegistered: Bool?
     var kanataRunning: Bool?
     var karabinerDaemonRunning: Bool?
@@ -68,6 +69,7 @@ struct SystemContextBuilder {
             kanataLaunchdLoaded: kanataLaunchdLoaded,
             kanataProcessRunning: kanataProcessRunning,
             kanataTCPResponding: kanataTCPResponding,
+            kanataTCPConfigured: kanataTCPConfigured,
             kanataRunning: kanataRunning ?? servicesHealthy,
             karabinerDaemonRunning: karabinerDaemonRunning ?? servicesHealthy,
             vhidHealthy: vhidHealthy ?? servicesHealthy,

--- a/Tests/KeyPathTests/UI/OverlayHealthIndicatorObserverTests.swift
+++ b/Tests/KeyPathTests/UI/OverlayHealthIndicatorObserverTests.swift
@@ -198,6 +198,43 @@ final class OverlayHealthIndicatorObserverTests: KeyPathTestCase {
             states.contains(.checking),
             "Should not flash 'checking' during periodic revalidation when already healthy"
         )
+        XCTAssertFalse(
+            states.contains(.healthy),
+            "Should not re-announce Ready when semantic health did not change"
+        )
+    }
+
+    @MainActor
+    func testRecoveryReannouncesHealthyAfterUnhealthyState() async {
+        var states: [HealthIndicatorState] = []
+        let observer = OverlayHealthIndicatorObserver(
+            onStateChange: { states.append($0) },
+            onDismiss: {},
+            sleep: { _ in }
+        )
+        let controller = MainAppStateController()
+        controller.issues = [
+            WizardIssue(
+                identifier: .daemon,
+                severity: .error,
+                category: .daemon,
+                title: "Daemon Error",
+                description: "Blocking issue",
+                autoFixAction: nil,
+                userAction: nil
+            ),
+        ]
+        controller.validationState = .failed(blockingCount: 1, totalCount: 1)
+        observer.startObserving(controller: controller)
+        await flushObserverTasks()
+
+        states.removeAll()
+        controller.issues = []
+        controller.validationState = .success
+        observer.refreshForTesting(controller: controller)
+        await flushObserverTasks()
+
+        XCTAssertEqual(states.first, .healthy)
     }
 
     private func flushObserverTasks() async {

--- a/docs/bugs/2026-07-10-health-indicator-churn.md
+++ b/docs/bugs/2026-07-10-health-indicator-churn.md
@@ -1,0 +1,36 @@
+# Health indicator churn during startup
+
+## Symptom
+
+After launch, the overlay could show **Ready**, dismiss it, and show it again
+several times. A TCP warning could also appear briefly before the system settled.
+
+## Root causes
+
+Three independent publication problems amplified normal health refreshes:
+
+1. Every successful validation was rendered as a new healthy transition, even
+   when the previous semantic state was already healthy.
+2. The Settings status view observed `lastValidationDate` and responded by
+   requesting another validation, creating a publication feedback loop.
+3. Missing TCP configuration evidence was collapsed from `nil` (not captured)
+   to `false` (known misconfiguration), allowing incomplete snapshots to render
+   a warning.
+
+Concurrent controller callers could also await the same validator capture and
+then publish the shared result more than once.
+
+## Fix and invariant
+
+- Render **Ready** only when health transitions from unhealthy or unknown to
+  healthy. Periodic healthy-to-healthy refreshes are silent.
+- A view observing validation publication may copy published evidence, but must
+  not request validation from that observation callback.
+- Preserve optional health evidence. `nil` is inconclusive and must not be
+  rendered as an explicit failure.
+- Coalesce validation at the state-controller publication boundary, not only at
+  the underlying snapshot capture boundary.
+
+Tests cover stable healthy refreshes, unhealthy-to-healthy recovery, unknown and
+explicitly false TCP evidence, concurrent refresh publication, and the Settings
+observer invariant.


### PR DESCRIPTION
## Summary
- coalesce validation publication in MainAppStateController
- make healthy-to-healthy overlay refreshes silent while preserving recovery feedback
- remove the Settings validation feedback loop and preserve unknown TCP evidence
- document the root cause and add regression coverage

## Validation
- `TEST_FILTER="MainAppStateControllerTests|MainAppStateControllerBehaviorTests|OverlayHealthIndicatorObserverTests" ./Scripts/run-tests-safe.sh` (36 passed)
- `TEST_FILTER=SettingsStatusValidationLintTests ./Scripts/run-tests-safe.sh` (2 passed)
- `./Scripts/test-fast.sh ui` (328 passed)
- `python3 Scripts/check-accessibility.py`
- `./Scripts/test-full.sh` (4,726 passed)
- live quick-deploy: initial recovery published healthy once; scheduled healthy refresh remained silent and TCP stayed connected

## Review gate
Local review tooling selected the remote gate. Do not merge until `claude-review` passes.