### PR TITLE
Close final installer hardening gaps

### DIFF
--- a/Sources/KeyPathAppKit/Core/PrivilegedOperationsRouter.swift
+++ b/Sources/KeyPathAppKit/Core/PrivilegedOperationsRouter.swift
@@ -843,10 +843,23 @@ public final class PrivilegedOperationsRouter {
             }
         #endif
 
+        let hasRequiredVersion = VHIDDeviceManager().hasRequiredDriverVersion()
         switch await serviceHealthChecker.vhidDriverExtensionStatus() {
         case .enabled:
+            guard hasRequiredVersion else {
+                AppLogger.shared.warnUnlessQuietTest(
+                    "⚠️ [PrivilegedOperationsRouter] VHID driver version is wrong or unknown after \(context)"
+                )
+                return false
+            }
             return true
         case .installedButNotEnabled:
+            guard hasRequiredVersion else {
+                AppLogger.shared.warnUnlessQuietTest(
+                    "⚠️ [PrivilegedOperationsRouter] VHID driver version is wrong or unknown after \(context)"
+                )
+                return false
+            }
             AppLogger.shared.warnUnlessQuietTest(
                 "⚠️ [PrivilegedOperationsRouter] VHID driver installed but not enabled after \(context); user approval may be required"
             )

--- a/Sources/KeyPathAppKit/Managers/UninstallCoordinator.swift
+++ b/Sources/KeyPathAppKit/Managers/UninstallCoordinator.swift
@@ -17,7 +17,7 @@ public final class UninstallCoordinator {
 
     @ObservationIgnored private let resolveUninstallerURLClosure: () -> URL?
     @ObservationIgnored private let runWithAdminPrivilegesClosure: (URL, Bool, Bool) async -> AppleScriptResult
-    @ObservationIgnored private let uninstallPostconditionsSatisfiedClosure: () -> Bool
+    @ObservationIgnored private let uninstallPostconditionsSatisfiedClosure: (Bool) -> Bool
     @ObservationIgnored private let helperInstalledClosure: () async -> Bool
     @ObservationIgnored private let helperFunctionalClosure: () async -> Bool
     @ObservationIgnored private let repairHelperClosure: () async -> Bool
@@ -30,7 +30,7 @@ public final class UninstallCoordinator {
     init(
         resolveUninstallerURL: @escaping () -> URL?,
         runWithAdminPrivileges: @escaping (URL, Bool, Bool) async -> AppleScriptResult,
-        uninstallPostconditionsSatisfied: (() -> Bool)? = nil,
+        uninstallPostconditionsSatisfied: ((Bool) -> Bool)? = nil,
         helperInstalled: (() async -> Bool)? = nil,
         helperFunctional: (() async -> Bool)? = nil,
         repairHelper: (() async -> Bool)? = nil,
@@ -42,8 +42,8 @@ public final class UninstallCoordinator {
     ) {
         resolveUninstallerURLClosure = resolveUninstallerURL
         runWithAdminPrivilegesClosure = runWithAdminPrivileges
-        uninstallPostconditionsSatisfiedClosure = uninstallPostconditionsSatisfied ?? {
-            UninstallCoordinator.defaultUninstallPostconditionsSatisfied()
+        uninstallPostconditionsSatisfiedClosure = uninstallPostconditionsSatisfied ?? { deleteConfig in
+            UninstallCoordinator.defaultUninstallPostconditionsSatisfied(deleteConfig: deleteConfig)
         }
         helperInstalledClosure = helperInstalled ?? {
             await HelperManager.shared.isHelperInstalled()
@@ -121,7 +121,7 @@ public final class UninstallCoordinator {
         // This clears the internal registration database that helper/script can't access
         await unregisterRuntimeServicesClosure()
 
-        if uninstallPostconditionsSatisfiedClosure() {
+        if uninstallPostconditionsSatisfiedClosure(deleteConfig) {
             if removeVirtualHID, await !virtualHIDRemovedClosure() {
                 let message = "KeyPath is removed, but the virtual keyboard driver remains registered with macOS."
                 steps.append(WizardUninstallStepResult(
@@ -216,7 +216,7 @@ public final class UninstallCoordinator {
                     error: helperUnregistered ? nil : "The system helper registration remains active."
                 ))
 
-                let verified = await waitForUninstallPostconditions()
+                let verified = await waitForUninstallPostconditions(deleteConfig: deleteConfig)
                 steps.append(WizardUninstallStepResult(
                     id: "verify-uninstall",
                     success: verified,
@@ -252,7 +252,7 @@ public final class UninstallCoordinator {
         // requested components. Only tear down helper registration after the
         // filesystem postcondition proves the uninstall completed.
         let filesRemovedAfterHelperError = helperReplyFailed
-            ? await waitForUninstallPostconditions()
+            ? await waitForUninstallPostconditions(deleteConfig: deleteConfig)
             : false
         if filesRemovedAfterHelperError {
             let driverRemoved: Bool = if removeVirtualHID {
@@ -312,10 +312,10 @@ public final class UninstallCoordinator {
         return result
     }
 
-    private func waitForUninstallPostconditions() async -> Bool {
+    private func waitForUninstallPostconditions(deleteConfig: Bool) async -> Bool {
         let clock = ContinuousClock()
         for attempt in 1 ... 8 {
-            if uninstallPostconditionsSatisfiedClosure() {
+            if uninstallPostconditionsSatisfiedClosure(deleteConfig) {
                 return true
             }
             if attempt < 8 {
@@ -381,7 +381,7 @@ public final class UninstallCoordinator {
                 logLines.append(contentsOf: output.components(separatedBy: "\n"))
             }
 
-            let filesRemoved = await waitForUninstallPostconditions()
+            let filesRemoved = await waitForUninstallPostconditions(deleteConfig: deleteConfig)
             var driverRemoved = !removeVirtualHID
             if removeVirtualHID {
                 driverRemoved = await waitForVirtualHIDRemoval()
@@ -540,8 +540,8 @@ public final class UninstallCoordinator {
         return nil
     }
 
-    private static func defaultUninstallPostconditionsSatisfied() -> Bool {
-        let paths = [
+    private static func defaultUninstallPostconditionsSatisfied(deleteConfig: Bool) -> Bool {
+        var paths = [
             "/Applications/KeyPath.app",
             "/Library/PrivilegedHelperTools/com.keypath.helper",
             "/Library/LaunchDaemons/com.keypath.kanata.plist",
@@ -549,6 +549,10 @@ public final class UninstallCoordinator {
             "/Library/LaunchDaemons/com.keypath.karabiner-vhidmanager.plist",
             "/Library/LaunchDaemons/com.keypath.helper.plist"
         ]
+        if deleteConfig {
+            paths.append(FileManager.default.homeDirectoryForCurrentUser
+                .appendingPathComponent(".config/keypath").path)
+        }
         return paths.allSatisfy { !FileManager.default.fileExists(atPath: $0) }
     }
 

--- a/Sources/KeyPathInstallationWizard/Core/InstallerEngine.swift
+++ b/Sources/KeyPathInstallationWizard/Core/InstallerEngine.swift
@@ -1059,14 +1059,32 @@ public final class InstallerEngine {
                 finalRecipes = [directRecipe]
             } else {
                 AppLogger.shared.log("⚠️ [InstallerEngine] No recipe available for action: \(action)")
+                let runID = UUID()
+                let error = "No recipe available for action: \(action)"
+                let telemetry = InstallerRepairTelemetryEvent(
+                    runID: runID,
+                    planID: basePlan.id,
+                    beforeSnapshotID: context.snapshotID,
+                    trigger: .singleAction,
+                    intent: basePlan.intent.telemetryValue,
+                    stateMatrixRow: basePlan.metadata.stateMatrixRow,
+                    stateMatrixPlan: basePlan.metadata.stateMatrixPlan,
+                    action: String(describing: action),
+                    recipeID: nil,
+                    recipeType: nil,
+                    postconditionResult: .failed,
+                    error: error
+                )
                 return InstallerReport(
+                    runID: runID,
                     planID: basePlan.id,
                     beforeSnapshotID: context.snapshotID,
                     success: false,
                     completionState: .executionFailed,
-                    failureReason: "No recipe available for action: \(action)",
+                    failureReason: error,
                     executedRecipes: [],
-                    logs: []
+                    logs: [],
+                    repairTelemetry: [telemetry]
                 )
             }
         } else {

--- a/Sources/KeyPathInstallationWizard/Core/VHIDDeviceManager.swift
+++ b/Sources/KeyPathInstallationWizard/Core/VHIDDeviceManager.swift
@@ -439,6 +439,13 @@ public final class VHIDDeviceManager: @unchecked Sendable {
         return hasMismatch
     }
 
+    /// Requires readable installed-version evidence as well as compatibility
+    /// with the driver major version bundled with KeyPath.
+    public func hasRequiredDriverVersion() -> Bool {
+        guard getInstalledVersion() != nil else { return false }
+        return !hasVersionMismatch()
+    }
+
     /// Gets a user-friendly message about version compatibility
     public func getVersionMismatchMessage() -> String? {
         guard let installedVersion = getInstalledVersion() else {

--- a/Sources/KeyPathInstallationWizard/Core/WizardOperationsUIExtension.swift
+++ b/Sources/KeyPathInstallationWizard/Core/WizardOperationsUIExtension.swift
@@ -27,16 +27,18 @@ extension WizardOperations {
                 // machine.refresh() completed — read state it stored
                 return await MainActor.run {
                     let issues = machine.wizardIssues
-                    let captured = machine.lastWizardSnapshot
+                    guard let captured = machine.lastWizardSnapshot else {
+                        return timeoutResult()
+                    }
                     if !issues.isEmpty || machine.wizardState == .active {
                         return SystemStateResult(
                             state: machine.wizardState,
                             issues: issues,
                             autoFixActions: [],
                             detectionTimestamp: Date(),
-                            captureStatus: captured?.captureStatus ?? .complete,
-                            helperInstalled: captured?.helperInstalled ?? false,
-                            helperNeedsApproval: captured?.helperNeedsApproval ?? false
+                            captureStatus: captured.captureStatus,
+                            helperInstalled: captured.helperInstalled,
+                            helperNeedsApproval: captured.helperNeedsApproval
                         )
                     }
                     return timeoutResult()

--- a/Tests/KeyPathTests/Core/PrivilegedOperationsCoordinatorTests.swift
+++ b/Tests/KeyPathTests/Core/PrivilegedOperationsCoordinatorTests.swift
@@ -616,6 +616,10 @@ final class PrivilegedOperationsRouterTests: XCTestCase {
                 installCalls += 1
             }
             ServiceHealthChecker.vhidDriverExtensionStatusOverride = { .installedButNotEnabled }
+            VHIDDeviceManager.testInstalledVersionProvider = {
+                VHIDDeviceManager.requiredDriverVersionString
+            }
+            defer { VHIDDeviceManager.testInstalledVersionProvider = nil }
         #else
             throw XCTSkip("Uses DEBUG-only PrivilegedOperationsRouter test overrides")
         #endif
@@ -626,6 +630,25 @@ final class PrivilegedOperationsRouterTests: XCTestCase {
         #if DEBUG
             XCTAssertEqual(installCalls, 1)
         #endif
+    }
+
+    func testDownloadAndInstallCorrectVHIDDriverRejectsWrongInstalledVersion() async throws {
+        #if DEBUG
+            PrivilegedOperationsRouter.resetTestingState()
+            PrivilegedOperationsRouter.downloadAndInstallCorrectVHIDDriverOverride = {}
+            ServiceHealthChecker.vhidDriverExtensionStatusOverride = { .enabled }
+            VHIDDeviceManager.testInstalledVersionProvider = { "999.0.0" }
+            defer { VHIDDeviceManager.testInstalledVersionProvider = nil }
+        #else
+            throw XCTSkip("Uses DEBUG-only PrivilegedOperationsRouter test overrides")
+        #endif
+
+        do {
+            try await PrivilegedOperationsRouter.shared.downloadAndInstallCorrectVHIDDriver()
+            XCTFail("Expected the wrong installed driver version to fail verification")
+        } catch let PrivilegedOperationError.operationFailed(message) {
+            XCTAssertTrue(message.contains("VHID driver postcondition failed"))
+        }
     }
 
     func testTerminateProcessFailsWhenPostconditionFails() async throws {

--- a/Tests/KeyPathTests/Lint/HelperOperationGateWiringLintTests.swift
+++ b/Tests/KeyPathTests/Lint/HelperOperationGateWiringLintTests.swift
@@ -1,0 +1,35 @@
+import Foundation
+@preconcurrency import XCTest
+
+/// Pins the production XPC entry points to the shared helper-operation gate.
+final class HelperOperationGateWiringLintTests: XCTestCase {
+    func testEveryHelperXPCEntryPointUsesOperationPermit() throws {
+        let requestHandlers = try String(
+            contentsOf: LintScanner.path("Sources/KeyPathAppKit/Core/HelperManager+RequestHandlers.swift"),
+            encoding: .utf8
+        )
+        let status = try String(
+            contentsOf: LintScanner.path("Sources/KeyPathAppKit/Core/HelperManager+Status.swift"),
+            encoding: .utf8
+        )
+
+        XCTAssertTrue(body(of: "executeXPCCall", in: requestHandlers).contains("withHelperOperationPermit"))
+        XCTAssertTrue(body(of: "executeValueXPCCall", in: requestHandlers).contains("withHelperOperationPermit"))
+        XCTAssertTrue(body(of: "getHelperVersion", in: status).contains("withHelperOperationPermit"))
+    }
+
+    private func body(of function: String, in source: String) -> String {
+        guard let start = source.range(of: "func \(function)")?.lowerBound,
+              let opening = source[start...].firstIndex(of: "{")
+        else { return "" }
+        var depth = 0
+        for index in source.indices[opening...].dropFirst() {
+            if source[index] == "{" { depth += 1 }
+            if source[index] == "}" {
+                if depth == 0 { return String(source[opening ... index]) }
+                depth -= 1
+            }
+        }
+        return ""
+    }
+}

--- a/Tests/KeyPathTests/Managers/UninstallCoordinatorTests.swift
+++ b/Tests/KeyPathTests/Managers/UninstallCoordinatorTests.swift
@@ -14,7 +14,7 @@ final class UninstallCoordinatorTests: XCTestCase {
                 adminFallbackCalls += 1
                 return .failure("Admin fallback should not run")
             },
-            postconditionsSatisfied: { postconditionsSatisfied },
+            postconditionsSatisfied: { _ in postconditionsSatisfied },
             helperInstalled: { true },
             helperFunctional: { true },
             repairHelper: { XCTFail("Healthy helper should not be repaired"); return false },
@@ -40,7 +40,7 @@ final class UninstallCoordinatorTests: XCTestCase {
         var repairCalls = 0
         var helperUninstallCalls = 0
         let coordinator = makeCoordinator(
-            postconditionsSatisfied: { postconditionsSatisfied },
+            postconditionsSatisfied: { _ in postconditionsSatisfied },
             helperInstalled: { false },
             helperFunctional: { helperReady },
             repairHelper: {
@@ -69,7 +69,7 @@ final class UninstallCoordinatorTests: XCTestCase {
                 adminFallbackCalls += 1
                 return .success
             },
-            postconditionsSatisfied: { false },
+            postconditionsSatisfied: { _ in false },
             helperInstalled: { false },
             helperFunctional: { false },
             repairHelper: { false }
@@ -88,7 +88,7 @@ final class UninstallCoordinatorTests: XCTestCase {
         var postconditionsSatisfied = false
         var events: [String] = []
         let coordinator = makeCoordinator(
-            postconditionsSatisfied: { postconditionsSatisfied },
+            postconditionsSatisfied: { _ in postconditionsSatisfied },
             uninstallViaHelper: { _ in
                 events.append("uninstall-keypath")
                 postconditionsSatisfied = true
@@ -109,7 +109,7 @@ final class UninstallCoordinatorTests: XCTestCase {
     func testVirtualHIDFailureStopsBeforeRemovingKeyPath() async {
         var helperUninstallCalls = 0
         let coordinator = makeCoordinator(
-            postconditionsSatisfied: { false },
+            postconditionsSatisfied: { _ in false },
             uninstallViaHelper: { _ in helperUninstallCalls += 1 },
             uninstallVirtualHID: {
                 throw NSError(domain: "UninstallTests", code: 7)
@@ -136,7 +136,7 @@ final class UninstallCoordinatorTests: XCTestCase {
                 postconditionsSatisfied = true
                 return .success
             },
-            postconditionsSatisfied: { postconditionsSatisfied },
+            postconditionsSatisfied: { _ in postconditionsSatisfied },
             helperInstalled: { false },
             helperFunctional: { false },
             repairHelper: { false }
@@ -153,7 +153,7 @@ final class UninstallCoordinatorTests: XCTestCase {
     func testEmergencyCleanupFailsWhenScriptIsMissing() async {
         let coordinator = makeCoordinator(
             resolveUninstallerURL: { nil },
-            postconditionsSatisfied: { false },
+            postconditionsSatisfied: { _ in false },
             helperInstalled: { false },
             helperFunctional: { false },
             repairHelper: { false }
@@ -169,7 +169,7 @@ final class UninstallCoordinatorTests: XCTestCase {
     func testEmergencyCleanupDoesNotTrustCommandSuccessWithoutPostconditions() async {
         let coordinator = makeCoordinator(
             runWithAdminPrivileges: { _, _, _ in .success },
-            postconditionsSatisfied: { false },
+            postconditionsSatisfied: { _ in false },
             helperInstalled: { false },
             helperFunctional: { false },
             repairHelper: { false }
@@ -192,7 +192,7 @@ final class UninstallCoordinatorTests: XCTestCase {
                 adminFallbackCalls += 1
                 return .failure("Should not run")
             },
-            postconditionsSatisfied: { true },
+            postconditionsSatisfied: { _ in true },
             helperInstalled: {
                 helperChecked = true
                 return false
@@ -215,7 +215,7 @@ final class UninstallCoordinatorTests: XCTestCase {
                 adminFallbackCalls += 1
                 return .failure("Emergency Cleanup should not run")
             },
-            postconditionsSatisfied: { helperAttempted },
+            postconditionsSatisfied: { _ in helperAttempted },
             uninstallViaHelper: { _ in
                 helperAttempted = true
                 throw HelperManagerError.ambiguousOutcome("reply lost")
@@ -231,11 +231,38 @@ final class UninstallCoordinatorTests: XCTestCase {
         XCTAssertTrue(coordinator.logLines.contains { $0.contains("skipping Emergency Cleanup") })
     }
 
+    func testDeleteConfigIntentDoesNotAcceptSystemOnlyPostconditions() async {
+        var helperAttempted = false
+        var adminFallbackCalls = 0
+        let coordinator = makeCoordinator(
+            runWithAdminPrivileges: { _, deleteConfig, _ in
+                XCTAssertTrue(deleteConfig)
+                adminFallbackCalls += 1
+                return .success
+            },
+            postconditionsSatisfied: { deleteConfig in
+                helperAttempted && !deleteConfig
+            },
+            uninstallViaHelper: { _ in
+                helperAttempted = true
+                throw HelperManagerError.ambiguousOutcome("reply lost")
+            }
+        )
+
+        let result = await coordinator.performUninstall(
+            deleteConfig: true,
+            allowAdminFallback: true
+        )
+
+        XCTAssertFalse(result.success)
+        XCTAssertEqual(adminFallbackCalls, 1)
+    }
+
     func testCompletedHelperReplyDoesNotDuplicateStepsWhenEmergencyCleanupRuns() async {
         var postconditionChecks = 0
         let coordinator = makeCoordinator(
             runWithAdminPrivileges: { _, _, _ in .success },
-            postconditionsSatisfied: {
+            postconditionsSatisfied: { _ in
                 postconditionChecks += 1
                 return postconditionChecks > 9
             },
@@ -258,7 +285,7 @@ final class UninstallCoordinatorTests: XCTestCase {
         runWithAdminPrivileges: @escaping (URL, Bool, Bool) async -> AppleScriptResult = { _, _, _ in
             .failure("Admin fallback should not run")
         },
-        postconditionsSatisfied: @escaping () -> Bool,
+        postconditionsSatisfied: @escaping (Bool) -> Bool,
         helperInstalled: @escaping () async -> Bool = { true },
         helperFunctional: @escaping () async -> Bool = { true },
         repairHelper: @escaping () async -> Bool = { true },

--- a/docs/bugs/2026-07-10-helper-timeout-probe-starvation.md
+++ b/docs/bugs/2026-07-10-helper-timeout-probe-starvation.md
@@ -32,3 +32,7 @@ the connection generation that installed them.
 `HelperManagerTests` covers cancellation-safe gate acquisition, XPC interruption
 normalization, the bounded recovery window, and rejection of stale connection-end
 callbacks. `SystemValidatorTests` covers conservative capture-status aggregation.
+
+`HelperOperationGateWiringLintTests` separately pins the production
+`executeXPCCall`, `executeValueXPCCall`, and `getHelperVersion` entry points to
+`withHelperOperationPermit`; the gate tests alone only cover the primitive.


### PR DESCRIPTION
## Summary
- require the installed VHID driver to match KeyPath’s bundled major version before treating replacement as successful
- include `deleteConfig` in uninstall postcondition verification
- pin production helper XPC entry points to the shared helper-operation gate
- emit correlated telemetry for the single-action no-recipe exit
- remove the unreachable `.complete` capture fallback and update regression docs

## Validation
- focused router/uninstall/wiring/single-action suites: 55 tests passed
- `./Scripts/test-full.sh`: 4,730 tests passed; all warning/error guardrails zero
- `python3 Scripts/check-accessibility.py`

## Explicit deferrals
- installer-gate cancellation remains deferred pending caller-specific policy for background work (drop-after-acquire vs fresh re-inspection)
- extended per-probe capture degradation remains optional/deferred

## Review gate
Local review tooling selected the remote gate. Do not merge until `claude-review` passes.