### PR TITLE
Detect stale VirtualHID minor versions

### DIFF
--- a/Sources/KeyPathInstallationWizard/Core/VHIDDeviceManager.swift
+++ b/Sources/KeyPathInstallationWizard/Core/VHIDDeviceManager.swift
@@ -74,7 +74,7 @@ public final class VHIDDeviceManager: @unchecked Sendable {
         WizardSystemPaths.bundledVHIDDriverVersion
     }
 
-    private static let currentKanataVersion = "1.10.0" // Current supported Kanata version
+    private static let currentKanataVersion = "1.12.0"
 
     // Driver DriverKit extension identifiers
     private static let driverTeamID = "G43BCU2T37" // pqrs.org team ID
@@ -417,21 +417,22 @@ public final class VHIDDeviceManager: @unchecked Sendable {
             return false
         }
 
-        // Parse major version
-        let versionComponents = installedVersion.split(separator: ".").compactMap { Int($0) }
-        guard let majorVersion = versionComponents.first else {
+        guard let installedComponents = Self.numericVersionComponents(installedVersion),
+              let requiredComponents = Self.numericVersionComponents(Self.requiredDriverVersionString)
+        else {
             AppLogger.shared.log("⚠️ [VHIDManager] Cannot parse version \(installedVersion)")
             return false
         }
 
-        let hasMismatch = majorVersion != Self.requiredDriverVersionMajor
+        let hasMismatch = installedComponents[0] != requiredComponents[0]
+            || installedComponents.lexicographicallyPrecedes(requiredComponents)
         if hasMismatch {
             AppLogger.shared.log("❌ [VHIDManager] Version mismatch detected:")
-            AppLogger.shared.log("  - Installed: v\(installedVersion) (major: \(majorVersion))")
+            AppLogger.shared.log("  - Installed: v\(installedVersion)")
+            AppLogger.shared.log("  - Minimum supported: v\(Self.requiredDriverVersionString)")
             AppLogger.shared.log(
-                "  - Required: v\(Self.requiredDriverVersionString) (major: \(Self.requiredDriverVersionMajor))"
+                "  - Kanata \(Self.currentKanataVersion) requires driver v\(Self.requiredDriverVersionString) or newer within major v\(Self.requiredDriverVersionMajor)"
             )
-            AppLogger.shared.log("  - Kanata \(Self.currentKanataVersion) requires driver v\(Self.requiredDriverVersionMajor).x")
         } else {
             AppLogger.shared.log("✅ [VHIDManager] Version compatible: v\(installedVersion)")
         }
@@ -440,7 +441,7 @@ public final class VHIDDeviceManager: @unchecked Sendable {
     }
 
     /// Requires readable installed-version evidence as well as compatibility
-    /// with the driver major version bundled with KeyPath.
+    /// with the minimum driver version bundled with KeyPath.
     public func hasRequiredDriverVersion() -> Bool {
         guard getInstalledVersion() != nil else { return false }
         return !hasVersionMismatch()
@@ -452,12 +453,15 @@ public final class VHIDDeviceManager: @unchecked Sendable {
             return nil
         }
 
-        let versionComponents = installedVersion.split(separator: ".").compactMap { Int($0) }
-        guard let majorVersion = versionComponents.first else {
+        guard let installedComponents = Self.numericVersionComponents(installedVersion),
+              let requiredComponents = Self.numericVersionComponents(Self.requiredDriverVersionString)
+        else {
             return nil
         }
 
-        if majorVersion != Self.requiredDriverVersionMajor {
+        if installedComponents[0] != requiredComponents[0]
+            || installedComponents.lexicographicallyPrecedes(requiredComponents)
+        {
             return """
             Version Compatibility Issue
 
@@ -468,6 +472,21 @@ public final class VHIDDeviceManager: @unchecked Sendable {
         }
 
         return nil
+    }
+
+    private static func numericVersionComponents(_ version: String) -> [Int]? {
+        let components = version.split(separator: ".", omittingEmptySubsequences: false)
+        guard !components.isEmpty,
+              components.allSatisfy({ !$0.isEmpty && $0.allSatisfy(\.isNumber) })
+        else {
+            return nil
+        }
+
+        var numeric = components.compactMap { Int($0) }
+        while numeric.count < 3 {
+            numeric.append(0)
+        }
+        return numeric
     }
 
     // MARK: - Activation Methods

--- a/Tests/KeyPathTests/Services/VHIDDeviceManagerTests.swift
+++ b/Tests/KeyPathTests/Services/VHIDDeviceManagerTests.swift
@@ -29,11 +29,22 @@ final class VHIDDeviceManagerTests: XCTestCase {
         XCTAssertFalse(mgr.hasVersionMismatch(), "v6 installed with v6 required should NOT be a mismatch")
     }
 
-    func testHasVersionMismatch_V6_1InstalledRequiresV6() {
-        // Simulate v6.1.0 installed - same major version should be compatible
+    func testHasVersionMismatch_V6_1InstalledRequiresV6_2() {
         VHIDDeviceManager.testInstalledVersionProvider = { "6.1.0" }
         let mgr = VHIDDeviceManager()
-        XCTAssertFalse(mgr.hasVersionMismatch(), "v6.1 installed with v6 required should NOT be a mismatch (same major)")
+        XCTAssertTrue(mgr.hasVersionMismatch(), "v6.1 installed with v6.2 required should be a mismatch")
+    }
+
+    func testHasVersionMismatch_V6_0InstalledRequiresV6_2() {
+        VHIDDeviceManager.testInstalledVersionProvider = { "6.0.0" }
+        let mgr = VHIDDeviceManager()
+        XCTAssertTrue(mgr.hasVersionMismatch(), "v6.0 installed with v6.2 required should be a mismatch")
+    }
+
+    func testHasVersionMismatch_NewerCompatibleV6Release() {
+        VHIDDeviceManager.testInstalledVersionProvider = { "6.14.0" }
+        let mgr = VHIDDeviceManager()
+        XCTAssertFalse(mgr.hasVersionMismatch(), "a newer v6 release should remain compatible")
     }
 
     func testHasVersionMismatch_NoVersionInstalled() {


### PR DESCRIPTION
## Summary
- treat VirtualHID 6.0 and 6.1 as stale now that KeyPath bundles the Kanata 1.12-supported 6.2 baseline
- accept 6.2 and newer compatible 6.x releases while rejecting older or different-major versions
- update stale Kanata version diagnostics from 1.10 to 1.12

This was found during installed release-candidate QA for #1107: the app bundled 6.2.0 but the system still had the 6.0.0 package receipt, and major-only comparison incorrectly reported it compatible.

## Validation
- TEST_FILTER=VHIDDeviceManagerTests ./Scripts/run-tests-safe.sh (25 passed)
- python3 Scripts/check-accessibility.py
- git diff --check

## Review gate
Local tooling selected the remote review gate; do not merge until GitHub claude-review passes.
