### PR TITLE
Fix stale uninstaller resource paths

### DIFF
--- a/Scripts/build-and-sign.sh
+++ b/Scripts/build-and-sign.sh
@@ -394,7 +394,7 @@ if [ -d "Sources/KeyPathApp/Resources" ]; then
     fi
     echo "✅ Copied app resources"
 else
-    echo "⚠️ WARNING: Sources/KeyPath/Resources directory not found"
+    echo "⚠️ WARNING: Sources/KeyPathApp/Resources directory not found"
 fi
 
 # Copy SwiftPM resource bundles (KeyPath_KeyPath.bundle, KeyPath_KeyPathAppKit.bundle, etc.)

--- a/Scripts/uninstall.sh
+++ b/Scripts/uninstall.sh
@@ -1,1 +1,1 @@
-../Sources/KeyPath/Resources/uninstall.sh
+../Sources/KeyPathApp/Resources/uninstall.sh

--- a/Sources/KeyPathAppKit/Managers/UninstallCoordinator.swift
+++ b/Sources/KeyPathAppKit/Managers/UninstallCoordinator.swift
@@ -532,7 +532,7 @@ public final class UninstallCoordinator {
 
         let workingDirectory = Foundation.ProcessInfo.processInfo.environment["PWD"] ?? "."
         let repoPath = URL(fileURLWithPath: workingDirectory)
-            .appendingPathComponent("Sources/KeyPath/Resources/uninstall.sh")
+            .appendingPathComponent("Sources/KeyPathApp/Resources/uninstall.sh")
         if Foundation.FileManager().isExecutableFile(atPath: repoPath.path) {
             return repoPath
         }

--- a/Tests/KeyPathTests/Lint/DeploymentScriptContractTests.swift
+++ b/Tests/KeyPathTests/Lint/DeploymentScriptContractTests.swift
@@ -2,6 +2,30 @@ import Foundation
 import XCTest
 
 final class DeploymentScriptContractTests: XCTestCase {
+    func testUninstallerPathsTrackAppResources() throws {
+        let root = repositoryRoot()
+        let entryPoint = root.appendingPathComponent("Scripts/uninstall.sh")
+        let expectedDestination = "../Sources/KeyPathApp/Resources/uninstall.sh"
+        let coordinator = try contents(
+            of: root.appendingPathComponent("Sources/KeyPathAppKit/Managers/UninstallCoordinator.swift")
+        )
+        let buildAndSign = try contents(of: root.appendingPathComponent("Scripts/build-and-sign.sh"))
+
+        XCTAssertEqual(
+            try FileManager.default.destinationOfSymbolicLink(atPath: entryPoint.path),
+            expectedDestination,
+            "Scripts/uninstall.sh must remain a relative link to the current app resource."
+        )
+        XCTAssertTrue(
+            FileManager.default.isExecutableFile(atPath: entryPoint.path),
+            "Scripts/uninstall.sh must resolve to an executable file."
+        )
+        XCTAssertTrue(coordinator.contains("Sources/KeyPathApp/Resources/uninstall.sh"))
+        XCTAssertFalse(coordinator.contains("Sources/KeyPath/Resources/uninstall.sh"))
+        XCTAssertTrue(buildAndSign.contains("Sources/KeyPathApp/Resources directory not found"))
+        XCTAssertFalse(buildAndSign.contains("Sources/KeyPath/Resources directory not found"))
+    }
+
     func testCanonicalBuildScriptsUseStableXcodeContract() throws {
         let root = repositoryRoot()
         let xcodeContract = try contents(of: root.appendingPathComponent("Scripts/lib/xcode.sh"))


### PR DESCRIPTION
## Summary

- repair the `Scripts/uninstall.sh` relative symlink after the app source move
- update the development uninstaller fallback and build warning to `Sources/KeyPathApp/Resources`
- add a deployment contract test covering the symlink target, executable resolution, coordinator fallback, and warning text

## Root cause

The app resources moved from `Sources/KeyPath` to `Sources/KeyPathApp`, but three uninstaller references were left behind. The dangling script symlink caused repository rsync traversal to fail before CrabBox could run.

## Validation

- `TEST_FILTER=DeploymentScriptContractTests ./Scripts/run-tests-safe.sh` — passed, 5 XCTest cases
- `./Scripts/test-full.sh` — passed, 4,733 tests
- `mise exec -- swiftformat --lint Tests/KeyPathTests/Lint/DeploymentScriptContractTests.swift Sources/KeyPathAppKit/Managers/UninstallCoordinator.swift` — passed
- `python3 Scripts/check-accessibility.py` — passed
- `bash -n Scripts/build-and-sign.sh` — passed
- repository `rsync -a --dry-run` traversal excluding `.git` and `.build` — passed
- symlink resolves to an executable file — verified
- `git diff --check` — passed
- `./Scripts/review-gate.sh` — remote review gate selected; GitHub `claude-review` must pass before merge

## Installer matrix

Affected row: uninstall completion and failure. This patch restores resource discovery only; it does not change uninstall behavior or lifecycle semantics.