### PR TITLE
Add remote installer lab interface

### DIFF
--- a/Scripts/lab/keypath-lab
+++ b/Scripts/lab/keypath-lab
@@ -98,9 +98,10 @@ installer_sha256	$installer_sha
 EOF
         tar -czf "$temp_dir/archive.tgz" -C "$temp_dir" repo
 
-        remote prepare-upload "$archive_key"
-        scp -q "$temp_dir/archive.tgz" "$host:/tmp/keypath-lab-${archive_key}.tgz"
-        remote install-archive "$archive_key" "$commit" "$installer_sha" "$installer_name"
+        upload_ticket=$(remote prepare-upload "$archive_key")
+        [[ $upload_ticket == /tmp/keypath-lab.* ]] || die "host returned an invalid upload ticket"
+        scp -q "$temp_dir/archive.tgz" "$host:$upload_ticket"
+        remote install-archive "$upload_ticket" "$archive_key" "$commit" "$installer_sha" "$installer_name"
         remote create "$macos" "$archive_key" "$commit" "$installer_sha" "$installer_name" "$ttl"
         ;;
     run)

--- a/Scripts/lab/keypath-lab
+++ b/Scripts/lab/keypath-lab
@@ -1,0 +1,151 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" >/dev/null && pwd -P)
+REPO_ROOT=$(cd "$SCRIPT_DIR/../.." >/dev/null && pwd -P)
+REMOTE_SCRIPT="$SCRIPT_DIR/remote.sh"
+DEFAULT_HOST="clawd@keypath-lab-mini"
+
+usage() {
+    cat >&2 <<'EOF'
+Usage: Scripts/lab/keypath-lab [--host HOST] <command> [options]
+
+Commands:
+  preflight
+  create --macos 15|26 --commit SHA --installer PATH [--ttl 2h]
+  run LEASE_ID -- COMMAND [ARG...]
+  status LEASE_ID
+  list
+  artifacts LEASE_ID
+  scenario LEASE_ID NAME
+  destroy LEASE_ID
+  cleanup [--dry-run]
+
+The default host is clawd@keypath-lab-mini. Set KEYPATH_LAB_HOST or pass
+--host to override it. Creation always requires an explicit full commit SHA and
+an installer artifact. No command embeds or prompts for credentials.
+EOF
+    exit 2
+}
+
+die() {
+    echo "keypath-lab: $*" >&2
+    exit 1
+}
+
+host=${KEYPATH_LAB_HOST:-$DEFAULT_HOST}
+if [[ ${1:-} == "--host" ]]; then
+    [[ -n ${2:-} ]] || usage
+    host=$2
+    shift 2
+fi
+
+command=${1:-}
+[[ -n $command ]] || usage
+shift
+
+remote() {
+    local remote_command="/bin/zsh -s --" argument quoted
+    for argument in "$@"; do
+        printf -v quoted '%q' "$argument"
+        remote_command="$remote_command $quoted"
+    done
+    ssh -o BatchMode=yes "$host" "$remote_command" < "$REMOTE_SCRIPT"
+}
+
+require_lease_id() {
+    [[ $1 =~ ^[A-Za-z0-9._-]+$ ]] || die "invalid lease id: $1"
+}
+
+case "$command" in
+    preflight)
+        [[ $# -eq 0 ]] || usage
+        remote preflight
+        ;;
+    create)
+        macos=
+        commit=
+        installer=
+        ttl=2h
+        while [[ $# -gt 0 ]]; do
+            case "$1" in
+                --macos) macos=${2:-}; shift 2 ;;
+                --commit) commit=${2:-}; shift 2 ;;
+                --installer) installer=${2:-}; shift 2 ;;
+                --ttl) ttl=${2:-}; shift 2 ;;
+                *) usage ;;
+            esac
+        done
+        [[ $macos == "15" || $macos == "26" ]] || die "--macos must be 15 or 26"
+        [[ $commit =~ ^[0-9a-fA-F]{40}$ ]] || die "--commit must be a full 40-character SHA"
+        [[ -f $installer ]] || die "installer not found: $installer"
+        resolved=$(git -C "$REPO_ROOT" rev-parse --verify "$commit^{commit}")
+        [[ $resolved == "$commit" ]] || die "commit does not resolve exactly: $commit"
+
+        installer_sha=$(shasum -a 256 "$installer" | awk '{print $1}')
+        archive_key="${commit}-${installer_sha}"
+        temp_dir=$(mktemp -d "${TMPDIR:-/tmp}/keypath-lab.XXXXXX")
+        trap 'rm -rf "$temp_dir"' EXIT
+        mkdir -p "$temp_dir/repo/.keypath-lab/installer"
+        git -C "$REPO_ROOT" archive "$commit" | tar -x -C "$temp_dir/repo"
+        installer_name=$(basename "$installer")
+        [[ $installer_name =~ ^[A-Za-z0-9._-]+$ ]] || die "installer filename must contain only letters, numbers, dots, underscores, and dashes"
+        cp "$installer" "$temp_dir/repo/.keypath-lab/installer/$installer_name"
+        cat > "$temp_dir/repo/.keypath-lab/source.tsv" <<EOF
+keypath_commit	$commit
+installer_name	$installer_name
+installer_sha256	$installer_sha
+EOF
+        tar -czf "$temp_dir/archive.tgz" -C "$temp_dir" repo
+
+        remote prepare-upload "$archive_key"
+        scp -q "$temp_dir/archive.tgz" "$host:/tmp/keypath-lab-${archive_key}.tgz"
+        remote install-archive "$archive_key" "$commit" "$installer_sha" "$installer_name"
+        remote create "$macos" "$archive_key" "$commit" "$installer_sha" "$installer_name" "$ttl"
+        ;;
+    run)
+        lease=${1:-}
+        [[ -n $lease ]] || usage
+        require_lease_id "$lease"
+        shift
+        [[ ${1:-} == "--" ]] || usage
+        shift
+        [[ $# -gt 0 ]] || usage
+        remote run "$lease" "$@"
+        ;;
+    status)
+        [[ $# -eq 1 ]] || usage
+        require_lease_id "$1"
+        remote status "$1"
+        ;;
+    list)
+        [[ $# -eq 0 ]] || usage
+        remote list
+        ;;
+    artifacts)
+        [[ $# -eq 1 ]] || usage
+        require_lease_id "$1"
+        remote artifacts "$1"
+        ;;
+    scenario)
+        [[ $# -eq 2 ]] || usage
+        require_lease_id "$1"
+        [[ $2 =~ ^[a-z0-9-]+$ ]] || die "invalid scenario name: $2"
+        remote scenario "$1" "$2"
+        ;;
+    destroy)
+        [[ $# -eq 1 ]] || usage
+        require_lease_id "$1"
+        remote destroy "$1"
+        ;;
+    cleanup)
+        if [[ ${1:-} == "--dry-run" && $# -eq 1 ]]; then
+            remote cleanup --dry-run
+        elif [[ $# -eq 0 ]]; then
+            remote cleanup
+        else
+            usage
+        fi
+        ;;
+    *) usage ;;
+esac

--- a/Scripts/lab/remote.sh
+++ b/Scripts/lab/remote.sh
@@ -138,18 +138,19 @@ preflight() {
 prepare_upload() {
   valid_id "$1"
   [[ "$1" =~ '^[0-9a-f]{40}-[0-9a-f]{64}$' ]] || die "invalid archive key"
-  rm -f "/tmp/keypath-lab-$1.tgz"
+  mktemp "/tmp/keypath-lab.XXXXXXXX"
 }
 
 install_archive() {
-  local key=$1 commit=$2 installer_sha=$3 installer_name=$4
+  local source=$1 key=$2 commit=$3 installer_sha=$4 installer_name=$5
+  [[ "$source" =~ '^/tmp/keypath-lab\.[A-Za-z0-9]+$' ]] || die "invalid upload ticket"
+  [[ -f "$source" && ! -L "$source" && -O "$source" ]] || die "upload ticket is not an owned regular file"
   valid_id "$key"
   [[ "$commit" =~ '^[0-9a-f]{40}$' ]] || die "invalid commit SHA"
   [[ "$installer_sha" =~ '^[0-9a-f]{64}$' ]] || die "invalid installer checksum"
   [[ "$installer_name" =~ '^[A-Za-z0-9._-]+$' ]] || die "invalid installer name"
   ensure_roots
-  local source="/tmp/keypath-lab-$key.tgz" destination="$ARCHIVES/$key" staging="$ARCHIVES/.staging-$key-$$"
-  [[ -f "$source" ]] || die "uploaded archive missing"
+  local destination="$ARCHIVES/$key" staging="$ARCHIVES/.staging-$key-$$" lock="$ARCHIVES/.lock-$key" attempt
   if [[ -f "$destination/ready.tsv" ]]; then
     [[ "$(field "$destination/ready.tsv" owner)" == "$OWNER" ]] || die "archive ownership mismatch"
     [[ "$(field "$destination/ready.tsv" keypath_commit)" == "$commit" ]] || die "archive commit mismatch"
@@ -178,7 +179,33 @@ install_archive() {
     print "installer_name\t$installer_name"
     print "created_at\t$(utc_now)"
   } > "$staging/ready.tsv"
+  if ! mkdir "$lock" 2>/dev/null; then
+    rm -rf "$staging"
+    for attempt in {1..100}; do
+      if [[ -f "$destination/ready.tsv" ]]; then
+        [[ "$(field "$destination/ready.tsv" owner)" == "$OWNER" ]] || die "archive ownership mismatch after concurrent publish"
+        [[ "$(field "$destination/ready.tsv" keypath_commit)" == "$commit" ]] || die "archive commit mismatch after concurrent publish"
+        [[ "$(field "$destination/ready.tsv" installer_sha256)" == "$installer_sha" ]] || die "archive checksum mismatch after concurrent publish"
+        print "archive\treused\t$key"
+        return
+      fi
+      sleep 0.1
+    done
+    die "timed out waiting for concurrent archive publish: $key"
+  fi
+  if [[ -f "$destination/ready.tsv" ]]; then
+    rm -rf "$staging"
+    rmdir "$lock"
+    print "archive\treused\t$key"
+    return
+  fi
+  if [[ -e "$destination" ]]; then
+    rm -rf "$staging"
+    rmdir "$lock"
+    die "archive destination exists without a ready marker: $key"
+  fi
   mv "$staging" "$destination"
+  rmdir "$lock"
   print "archive\tcreated\t$key"
 }
 
@@ -373,7 +400,7 @@ shift || true
 case "$action" in
   preflight) [[ $# -eq 0 ]] || die "preflight takes no arguments"; preflight ;;
   prepare-upload) [[ $# -eq 1 ]] || die "prepare-upload requires archive key"; prepare_upload "$1" ;;
-  install-archive) [[ $# -eq 4 ]] || die "install-archive requires key, commit, checksum, and name"; install_archive "$@" ;;
+  install-archive) [[ $# -eq 5 ]] || die "install-archive requires ticket, key, commit, checksum, and name"; install_archive "$@" ;;
   create) [[ $# -eq 6 ]] || die "create requires lane, archive, commit, checksum, name, ttl"; create_lease "$@" ;;
   run) [[ $# -ge 2 ]] || die "run requires lease and command"; run_command "$@" ;;
   status) [[ $# -eq 1 ]] || die "status requires lease"; print_status "$1" ;;

--- a/Scripts/lab/remote.sh
+++ b/Scripts/lab/remote.sh
@@ -1,0 +1,386 @@
+#!/bin/zsh
+set -euo pipefail
+
+PRODUCTION_ROOT="/Volumes/KeyPath Lab/CrabBox"
+OWNER="keypath-installer-lab-v1"
+
+if [[ "${KEYPATH_LAB_TESTING:-0}" == "1" ]]; then
+  LAB_ROOT="${KEYPATH_LAB_TEST_ROOT:?KEYPATH_LAB_TEST_ROOT is required in test mode}"
+  LAUNCHER_15="${KEYPATH_LAB_LAUNCHER_15:?test launcher 15 is required}"
+  LAUNCHER_26="${KEYPATH_LAB_LAUNCHER_26:?test launcher 26 is required}"
+  CRABBOX="${KEYPATH_LAB_CRABBOX:?test CrabBox is required}"
+else
+  LAB_ROOT="$PRODUCTION_ROOT"
+  LAUNCHER_15="$LAB_ROOT/keypath15"
+  LAUNCHER_26="$LAB_ROOT/keypath26"
+  CRABBOX="$LAB_ROOT/SharedTools/bin/crabbox"
+fi
+
+STATE_ROOT="$LAB_ROOT/KeyPathInstallerLab"
+ARCHIVES="$STATE_ROOT/archives"
+LEASES="$STATE_ROOT/leases"
+ARTIFACTS="$STATE_ROOT/artifacts"
+LOGS="$STATE_ROOT/logs"
+OPERATIONS="$STATE_ROOT/operations"
+
+die() { print -u2 "keypath-lab(remote): $*"; exit 1; }
+now_epoch() { date +%s; }
+utc_now() { date -u +%Y-%m-%dT%H:%M:%SZ; }
+
+valid_id() {
+  [[ "$1" =~ '^[A-Za-z0-9._-]+$' ]] || die "invalid identifier: $1"
+}
+
+launcher_for() {
+  case "$1" in
+    15) print -r -- "$LAUNCHER_15" ;;
+    26) print -r -- "$LAUNCHER_26" ;;
+    *) die "unsupported macOS lane: $1" ;;
+  esac
+}
+
+provider_for() {
+  case "$1" in 15) print tart ;; 26) print parallels ;; *) die "unsupported macOS lane: $1" ;; esac
+}
+
+manifest_path() { print -r -- "$LEASES/$1/manifest.tsv"; }
+
+field() {
+  local manifest=$1 key=$2
+  awk -F '\t' -v key="$key" '$1 == key {sub(/^[^\t]*\t/, ""); print; exit}' "$manifest"
+}
+
+set_field() {
+  local manifest=$1 key=$2 value=$3 temp="${manifest}.tmp.$$"
+  awk -F '\t' -v key="$key" -v value="$value" 'BEGIN {OFS="\t"} $1 == key {$0=key OFS value; found=1} {print} END {if (!found) print key, value}' "$manifest" > "$temp"
+  mv "$temp" "$manifest"
+}
+
+owned_manifest() {
+  local lease=$1 manifest
+  valid_id "$lease"
+  manifest=$(manifest_path "$lease")
+  [[ -f "$manifest" ]] || die "lease is not owned by this interface: $lease"
+  [[ "$(field "$manifest" owner)" == "$OWNER" ]] || die "ownership marker mismatch for lease: $lease"
+  [[ "$(field "$manifest" lease_id)" == "$lease" ]] || die "lease manifest id mismatch: $lease"
+  print -r -- "$manifest"
+}
+
+duration_seconds() {
+  local value=$1 number unit
+  if [[ "$value" == <-> ]]; then print "$value"; return; fi
+  number=${value[1,-2]}
+  unit=${value[-1]}
+  [[ "$number" == <-> ]] || die "invalid duration: $value"
+  case "$unit" in
+    m) print $((number * 60)) ;;
+    h) print $((number * 3600)) ;;
+    d) print $((number * 86400)) ;;
+    *) die "invalid duration: $value" ;;
+  esac
+}
+
+ensure_roots() {
+  mkdir -p "$ARCHIVES" "$LEASES" "$ARTIFACTS" "$LOGS" "$OPERATIONS"
+}
+
+record_command() {
+  local lease=$1 result=$2; shift 2
+  local command_text
+  command_text=$(printf '%q ' "$@")
+  print -r -- "$(utc_now)\t$result\t$command_text" >> "$LEASES/$lease/commands.tsv"
+}
+
+prepare_worktree() {
+  local repo=$1
+  [[ "$repo" == "$OPERATIONS"/*/repo ]] || die "unsafe lease worktree path"
+  [[ -d "$repo/.git" ]] || die "lease checkout is not a Git worktree"
+  [[ -z "$(git -C "$repo" status --porcelain --untracked-files=all)" ]] || die "refusing to sync a changing checkout"
+}
+
+run_with_download() {
+  local macos=$1 lease=$2 remote_file=$3 local_file=$4; shift 4
+  if [[ "${KEYPATH_LAB_TESTING:-0}" == "1" ]]; then
+    "$CRABBOX" run --provider "$(provider_for "$macos")" --target macos --id "$lease" \
+      --stop-after never --download "$remote_file=$local_file" -- "$@"
+  elif [[ "$macos" == "15" ]]; then
+    if [[ "${USER:-}" == "clawd" ]]; then export TART_HOME="$LAB_ROOT/TartHome-clawd"; else export TART_HOME="$LAB_ROOT/TartHome"; fi
+    export PATH="$LAB_ROOT/CompatTools/bin:$LAB_ROOT/SharedTools/bin:/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+    "$CRABBOX" run --provider tart --target macos --id "$lease" \
+      --tart-user admin --ssh-port 22 --stop-after never \
+      --download "$remote_file=$local_file" -- "$@"
+  else
+    export PATH="$LAB_ROOT/SharedTools/bin:/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+    "$CRABBOX" run --provider parallels --target macos --id "$lease" \
+      --parallels-user keypathqa --parallels-work-root /Users/keypathqa/crabbox \
+      --ssh-port 22 --stop-after never --download "$remote_file=$local_file" -- "$@"
+  fi
+}
+
+preflight() {
+  local mount_point
+  [[ "$LAB_ROOT" == "$PRODUCTION_ROOT" || "${KEYPATH_LAB_TESTING:-0}" == "1" ]] || die "unsafe lab root"
+  [[ -d "$LAB_ROOT" ]] || die "lab root is not mounted: $LAB_ROOT"
+  [[ -x "$LAUNCHER_15" && -x "$LAUNCHER_26" && -x "$CRABBOX" ]] || die "lab launchers or CrabBox are unavailable"
+  if [[ "${KEYPATH_LAB_TESTING:-0}" != "1" ]]; then
+    mount_point=$(df -P "$LAB_ROOT" | awk 'NR == 2 {for (i=6; i<=NF; i++) printf "%s%s", (i == 6 ? "" : " "), $i; print ""}')
+    [[ "$mount_point" == "/Volumes/KeyPath Lab" ]] || die "lab root is not on the expected external volume"
+  fi
+  ensure_roots
+  "$LAUNCHER_15" doctor
+  "$LAUNCHER_26" doctor
+  print "host_os\t$(sw_vers -productVersion 2>/dev/null || print unknown)"
+  print "host_build\t$(sw_vers -buildVersion 2>/dev/null || print unknown)"
+  print "lab_root\t$LAB_ROOT"
+  print "safety\tdisposable-owned-leases-only"
+}
+
+prepare_upload() {
+  valid_id "$1"
+  [[ "$1" =~ '^[0-9a-f]{40}-[0-9a-f]{64}$' ]] || die "invalid archive key"
+  rm -f "/tmp/keypath-lab-$1.tgz"
+}
+
+install_archive() {
+  local key=$1 commit=$2 installer_sha=$3 installer_name=$4
+  valid_id "$key"
+  [[ "$commit" =~ '^[0-9a-f]{40}$' ]] || die "invalid commit SHA"
+  [[ "$installer_sha" =~ '^[0-9a-f]{64}$' ]] || die "invalid installer checksum"
+  [[ "$installer_name" =~ '^[A-Za-z0-9._-]+$' ]] || die "invalid installer name"
+  ensure_roots
+  local source="/tmp/keypath-lab-$key.tgz" destination="$ARCHIVES/$key" staging="$ARCHIVES/.staging-$key-$$"
+  [[ -f "$source" ]] || die "uploaded archive missing"
+  if [[ -f "$destination/ready.tsv" ]]; then
+    [[ "$(field "$destination/ready.tsv" owner)" == "$OWNER" ]] || die "archive ownership mismatch"
+    [[ "$(field "$destination/ready.tsv" keypath_commit)" == "$commit" ]] || die "archive commit mismatch"
+    [[ "$(field "$destination/ready.tsv" installer_sha256)" == "$installer_sha" ]] || die "archive installer checksum mismatch"
+    rm -f "$source"
+    print "archive\treused\t$key"
+    return
+  fi
+  mkdir -p "$staging"
+  tar -xzf "$source" -C "$staging"
+  rm -f "$source"
+  [[ -d "$staging/repo" && ! -e "$staging/repo/.git" ]] || die "uploaded payload must contain exported content without Git state"
+  local actual_sha
+  actual_sha=$(shasum -a 256 "$staging/repo/.keypath-lab/installer/$installer_name" | awk '{print $1}')
+  [[ "$actual_sha" == "$installer_sha" ]] || die "installer checksum mismatch"
+  git -C "$staging/repo" init -q
+  git -C "$staging/repo" config user.name "KeyPath Lab"
+  git -C "$staging/repo" config user.email "keypath-lab@localhost"
+  git -C "$staging/repo" add -A
+  GIT_AUTHOR_DATE=2000-01-01T00:00:00Z GIT_COMMITTER_DATE=2000-01-01T00:00:00Z git -C "$staging/repo" commit -q -m "KeyPath lab archive $commit"
+  [[ -z "$(git -C "$staging/repo" status --porcelain)" ]] || die "archive checkout is dirty"
+  {
+    print "owner\t$OWNER"
+    print "keypath_commit\t$commit"
+    print "installer_sha256\t$installer_sha"
+    print "installer_name\t$installer_name"
+    print "created_at\t$(utc_now)"
+  } > "$staging/ready.tsv"
+  mv "$staging" "$destination"
+  print "archive\tcreated\t$key"
+}
+
+create_lease() {
+  local macos=$1 archive_key=$2 commit=$3 installer_sha=$4 installer_name=$5 ttl=$6
+  local launcher provider archive repo slug output lease created expires manifest guest_output product build operation ttl_seconds
+  launcher=$(launcher_for "$macos")
+  provider=$(provider_for "$macos")
+  valid_id "$archive_key"
+  archive="$ARCHIVES/$archive_key"
+  [[ -f "$archive/ready.tsv" && -d "$archive/repo/.git" ]] || die "prepared archive not found: $archive_key"
+  ttl_seconds=$(duration_seconds "$ttl")
+  (( ttl_seconds > 0 && ttl_seconds <= 7200 )) || die "TTL must be between 1 second and 2 hours"
+  slug="keypath${macos}-$(print -r -- "$commit" | cut -c1-8)-$(date -u +%Y%m%d%H%M%S)-$$"
+  operation="$OPERATIONS/$slug"
+  mkdir -p "$operation"
+  git clone -q --local "$archive/repo" "$operation/repo"
+  repo="$operation/repo"
+  prepare_worktree "$repo"
+  output=$(cd "$repo" && "$launcher" warmup "$slug" 2>&1)
+  print -r -- "$output"
+  print -r -- "$output" > "$operation/create.log"
+  lease=$(print -r -- "$output" | grep -Eo 'cbx_[A-Za-z0-9]+' | tail -1 || true)
+  [[ -n "$lease" ]] || die "CrabBox did not report a lease id; inspect provider inventory before cleanup"
+  valid_id "$lease"
+  created=$(now_epoch)
+  expires=$((created + ttl_seconds))
+  mkdir -p "$LEASES/$lease" "$LOGS/$lease" "$ARTIFACTS/$lease"
+  manifest=$(manifest_path "$lease")
+  {
+    print "owner\t$OWNER"
+    print "lease_id\t$lease"
+    print "slug\t$slug"
+    print "macos\t$macos"
+    print "provider\t$provider"
+    print "archive_key\t$archive_key"
+    print "keypath_commit\t$commit"
+    print "installer_sha256\t$installer_sha"
+    print "installer_name\t$installer_name"
+    print "worktree\t$repo"
+    print "created_epoch\t$created"
+    print "created_at\t$(utc_now)"
+    print "expires_epoch\t$expires"
+    print "status\tcreated"
+    print "cleanup_status\tpending"
+    print "desktop_enabled\tfalse"
+  } > "$manifest"
+  print -r -- "$output" > "$LOGS/$lease/create.log"
+  guest_output=$(cd "$repo" && "$launcher" run "$lease" -- /bin/zsh -lc 'printf "product=%s\n" "$(sw_vers -productVersion)"; printf "build=%s\n" "$(sw_vers -buildVersion)"' 2>&1) || {
+    record_command "$lease" failed sw_vers
+    set_field "$manifest" status verification-failed
+    print -r -- "$guest_output" > "$LOGS/$lease/guest-version.log"
+    die "lease created but guest verification failed: $lease"
+  }
+  print -r -- "$guest_output" > "$LOGS/$lease/guest-version.log"
+  product=$(print -r -- "$guest_output" | sed -n 's/^product=//p' | tail -1)
+  build=$(print -r -- "$guest_output" | sed -n 's/^build=//p' | tail -1)
+  set_field "$manifest" macos_product_version "${product:-unknown}"
+  set_field "$manifest" macos_build "${build:-unknown}"
+  set_field "$manifest" status ready
+  record_command "$lease" passed sw_vers
+  print "lease_id\t$lease"
+  print "manifest\t$manifest"
+}
+
+run_command() {
+  local lease=$1; shift
+  local manifest macos launcher repo log exit_code
+  manifest=$(owned_manifest "$lease")
+  macos=$(field "$manifest" macos)
+  launcher=$(launcher_for "$macos")
+  repo=$(field "$manifest" worktree)
+  prepare_worktree "$repo"
+  log="$LOGS/$lease/run-$(date -u +%Y%m%dT%H%M%SZ).log"
+  set +e
+  (cd "$repo" && "$launcher" run "$lease" -- "$@") 2>&1 | tee "$log"
+  exit_code=${pipestatus[1]}
+  set -e
+  if (( exit_code == 0 )); then record_command "$lease" passed "$@"; else record_command "$lease" "failed:$exit_code" "$@"; fi
+  set_field "$manifest" last_result "$exit_code"
+  set_field "$manifest" last_run_at "$(utc_now)"
+  return "$exit_code"
+}
+
+print_status() {
+  local lease=$1 manifest macos launcher
+  manifest=$(owned_manifest "$lease")
+  cat "$manifest"
+  macos=$(field "$manifest" macos)
+  launcher=$(launcher_for "$macos")
+  print "provider_inventory_begin"
+  "$launcher" list || true
+  print "provider_inventory_end"
+}
+
+list_leases() {
+  ensure_roots
+  print "lease_id\tmacos\tprovider\tstatus\texpires_epoch\tcommit\tcleanup"
+  local manifest lease
+  for manifest in "$LEASES"/*/manifest.tsv(N); do
+    [[ "$(field "$manifest" owner)" == "$OWNER" ]] || continue
+    lease=$(field "$manifest" lease_id)
+    print "$lease\t$(field "$manifest" macos)\t$(field "$manifest" provider)\t$(field "$manifest" status)\t$(field "$manifest" expires_epoch)\t$(field "$manifest" keypath_commit)\t$(field "$manifest" cleanup_status)"
+  done
+}
+
+collect_artifacts() {
+  local lease=$1 manifest output exit_code macos repo archive
+  manifest=$(owned_manifest "$lease")
+  macos=$(field "$manifest" macos)
+  repo=$(field "$manifest" worktree)
+  prepare_worktree "$repo"
+  output="$ARTIFACTS/$lease/$(date -u +%Y%m%dT%H%M%SZ)"
+  mkdir -p "$output"
+  cp "$manifest" "$output/manifest.tsv"
+  cp "$LEASES/$lease/commands.tsv" "$output/commands.tsv" 2>/dev/null || true
+  cp -R "$LOGS/$lease" "$output/controller-logs"
+  archive="$output/scenario-output.tar.gz"
+  set +e
+  (cd "$repo" && run_with_download "$macos" "$lease" ".keypath-lab/scenario-output.tar.gz" "$archive" \
+    /bin/zsh -lc 'set -e; out=.keypath-lab/scenario-output/controller-capture; mkdir -p "$out/logs"; sw_vers > "$out/sw-vers.txt"; date -u +%Y-%m-%dT%H:%M:%SZ > "$out/captured-at.txt"; cp -R "$HOME/Library/Logs/KeyPath/." "$out/logs/" 2>/dev/null || true; /Applications/KeyPath.app/Contents/MacOS/keypath-cli system inspect --json > "$out/system-inspect.json" 2>/dev/null || true; tar -czf .keypath-lab/scenario-output.tar.gz -C .keypath-lab scenario-output') > "$output/download.log" 2>&1
+  exit_code=$?
+  set -e
+  if (( exit_code == 0 )); then
+    tar -xzf "$archive" -C "$output"
+  fi
+  set_field "$manifest" artifacts_status "$exit_code"
+  set_field "$manifest" artifacts_last_collected_at "$(utc_now)"
+  set_field "$manifest" screenshot_status "unavailable:lease-not-created-with-desktop"
+  print "artifact_dir\t$output"
+  print "download_status\t$exit_code"
+  print "screenshot_status\tunavailable:lease-not-created-with-desktop"
+  return "$exit_code"
+}
+
+scenario() {
+  local lease=$1 name=$2 manifest repo scenario_script
+  manifest=$(owned_manifest "$lease")
+  repo=$(field "$manifest" worktree)
+  prepare_worktree "$repo"
+  scenario_script="Scripts/lab/scenarios/installer-scenario"
+  [[ -x "$repo/$scenario_script" ]] || die "scenario runner missing from archived commit"
+  run_command "$lease" "/bin/zsh" "$scenario_script" "$name"
+}
+
+destroy_lease() {
+  local lease=$1 manifest macos launcher exit_code repo
+  manifest=$(owned_manifest "$lease")
+  [[ "$(field "$manifest" cleanup_status)" != "complete" ]] || { print "already_clean\t$lease"; return; }
+  macos=$(field "$manifest" macos)
+  launcher=$(launcher_for "$macos")
+  repo=$(field "$manifest" worktree)
+  prepare_worktree "$repo"
+  mkdir -p "$LOGS/$lease"
+  set +e
+  (cd "$repo" && "$launcher" stop "$lease") > "$LOGS/$lease/destroy.log" 2>&1
+  exit_code=$?
+  set -e
+  set_field "$manifest" cleanup_attempted_at "$(utc_now)"
+  set_field "$manifest" cleanup_result "$exit_code"
+  if (( exit_code == 0 )); then
+    set_field "$manifest" cleanup_status complete
+    set_field "$manifest" status destroyed
+  else
+    set_field "$manifest" cleanup_status failed
+    set_field "$manifest" status cleanup-failed
+  fi
+  cat "$LOGS/$lease/destroy.log"
+  return "$exit_code"
+}
+
+cleanup_expired() {
+  local dry_run=${1:-} current manifest lease expires cleanup
+  [[ -z "$dry_run" || "$dry_run" == "--dry-run" ]] || die "invalid cleanup option"
+  current=$(now_epoch)
+  for manifest in "$LEASES"/*/manifest.tsv(N); do
+    [[ "$(field "$manifest" owner)" == "$OWNER" ]] || continue
+    lease=$(field "$manifest" lease_id)
+    expires=$(field "$manifest" expires_epoch)
+    cleanup=$(field "$manifest" cleanup_status)
+    [[ "$expires" == <-> && "$expires" -le "$current" && "$cleanup" != "complete" ]] || continue
+    if [[ "$dry_run" == "--dry-run" ]]; then
+      print "would_destroy\t$lease"
+    else
+      destroy_lease "$lease" || true
+    fi
+  done
+}
+
+action=${1:-}
+shift || true
+case "$action" in
+  preflight) [[ $# -eq 0 ]] || die "preflight takes no arguments"; preflight ;;
+  prepare-upload) [[ $# -eq 1 ]] || die "prepare-upload requires archive key"; prepare_upload "$1" ;;
+  install-archive) [[ $# -eq 4 ]] || die "install-archive requires key, commit, checksum, and name"; install_archive "$@" ;;
+  create) [[ $# -eq 6 ]] || die "create requires lane, archive, commit, checksum, name, ttl"; create_lease "$@" ;;
+  run) [[ $# -ge 2 ]] || die "run requires lease and command"; run_command "$@" ;;
+  status) [[ $# -eq 1 ]] || die "status requires lease"; print_status "$1" ;;
+  list) [[ $# -eq 0 ]] || die "list takes no arguments"; list_leases ;;
+  artifacts) [[ $# -eq 1 ]] || die "artifacts requires lease"; collect_artifacts "$1" ;;
+  scenario) [[ $# -eq 2 ]] || die "scenario requires lease and name"; scenario "$1" "$2" ;;
+  destroy) [[ $# -eq 1 ]] || die "destroy requires lease"; destroy_lease "$1" ;;
+  cleanup) cleanup_expired "${1:-}" ;;
+  *) die "unknown action: $action" ;;
+esac

--- a/Scripts/lab/scenarios/installer-scenario
+++ b/Scripts/lab/scenarios/installer-scenario
@@ -1,0 +1,73 @@
+#!/bin/zsh
+set -euo pipefail
+
+name=${1:-}
+installer_dir="$PWD/.keypath-lab/installer"
+artifact_dir="$PWD/.keypath-lab/scenario-output/$name"
+mkdir -p "$artifact_dir"
+
+record_system() {
+  sw_vers > "$artifact_dir/sw-vers.txt"
+  system_profiler SPSoftwareDataType > "$artifact_dir/software.txt"
+  date -u +%Y-%m-%dT%H:%M:%SZ > "$artifact_dir/captured-at.txt"
+}
+
+installed_cli="/Applications/KeyPath.app/Contents/MacOS/keypath-cli"
+record_system
+
+case "$name" in
+  clean-install)
+    find "$installer_dir" -maxdepth 1 -type f -print > "$artifact_dir/installer-files.txt"
+    print "Install the staged artifact from $installer_dir into this disposable guest."
+    print "Capture Gatekeeper output and the first visible installer screen before granting approvals."
+    ;;
+  approvals)
+    print "Exercise Login Items/Background App Activity, DriverKit, Accessibility, and Input Monitoring approvals."
+    print "Capture each prompt before and after approval; never copy TCC databases into artifacts."
+    ;;
+  helper-daemon-health)
+    [[ -x "$installed_cli" ]] || { print -u2 "KeyPath CLI is not installed"; exit 3; }
+    "$installed_cli" system inspect --json | tee "$artifact_dir/system-inspect.json"
+    nc -vz 127.0.0.1 37001 2>&1 | tee "$artifact_dir/tcp-readiness.txt"
+    ;;
+  launch)
+    open -a KeyPath
+    sleep 3
+    pgrep -fl '/Applications/KeyPath.app/Contents/MacOS/KeyPath' | tee "$artifact_dir/processes.txt"
+    ;;
+  repair-reinstall)
+    [[ -x "$installed_cli" ]] || { print -u2 "KeyPath CLI is not installed"; exit 3; }
+    "$installed_cli" system repair --json | tee "$artifact_dir/repair.json"
+    "$installed_cli" system inspect --json | tee "$artifact_dir/post-repair.json"
+    ;;
+  reboot-persistence-before)
+    [[ -x "$installed_cli" ]] || { print -u2 "KeyPath CLI is not installed"; exit 3; }
+    "$installed_cli" system inspect --json > "$artifact_dir/before-reboot.json"
+    print "Run the host-approved guest reboot, then execute reboot-persistence-after on the same lease."
+    ;;
+  reboot-persistence-after)
+    [[ -x "$installed_cli" ]] || { print -u2 "KeyPath CLI is not installed"; exit 3; }
+    "$installed_cli" system inspect --json | tee "$artifact_dir/after-reboot.json"
+    nc -vz 127.0.0.1 37001 2>&1 | tee "$artifact_dir/tcp-readiness.txt"
+    ;;
+  uninstall)
+    [[ -x "$installed_cli" ]] || { print -u2 "KeyPath CLI is not installed"; exit 3; }
+    "$installed_cli" system uninstall --json | tee "$artifact_dir/uninstall.json"
+    test ! -e /Applications/KeyPath.app
+    ;;
+  cancellation-failure)
+    print "Use a disposable lease to cancel one approval flow and inject one non-destructive failure."
+    print "Record the visible recovery action, CLI result, and KeyPath logs; do not corrupt the base image."
+    ;;
+  artifact-capture)
+    mkdir -p "$artifact_dir/logs"
+    cp -R "$HOME/Library/Logs/KeyPath/." "$artifact_dir/logs/" 2>/dev/null || true
+    "$installed_cli" system inspect --json > "$artifact_dir/system-inspect.json" 2>/dev/null || true
+    print "Scenario artifacts written to $artifact_dir; follow with keypath-lab artifacts <lease-id>."
+    ;;
+  *)
+    print -u2 "Unknown scenario: $name"
+    print -u2 "Available: clean-install approvals helper-daemon-health launch repair-reinstall reboot-persistence-before reboot-persistence-after uninstall cancellation-failure artifact-capture"
+    exit 2
+    ;;
+esac

--- a/Scripts/lab/tests/keypath-lab-tests.sh
+++ b/Scripts/lab/tests/keypath-lab-tests.sh
@@ -1,0 +1,174 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" >/dev/null && pwd -P)
+LAB_DIR=$(cd "$SCRIPT_DIR/.." >/dev/null && pwd -P)
+REMOTE="$LAB_DIR/remote.sh"
+TMP=$(mktemp -d "${TMPDIR:-/tmp}/keypath-lab-tests.XXXXXX")
+trap 'rm -rf "$TMP"' EXIT
+
+ROOT="$TMP/CrabBox"
+mkdir -p "$ROOT/bin" "$ROOT/KeyPathInstallerLab/archives"
+CALLS="$TMP/calls.log"
+
+cat > "$ROOT/bin/launcher15" <<EOF
+#!/bin/bash
+case "\$1" in
+ doctor) echo doctor-15 ;;
+ warmup) echo cbx_test15 ;;
+ run) echo product=15.7.7; echo build=24G720 ;;
+ stop) echo "stop-15 \$2" >> "$CALLS" ;;
+ list) echo cbx_test15 ;;
+esac
+EOF
+cat > "$ROOT/bin/launcher26" <<EOF
+#!/bin/bash
+case "\$1" in
+ doctor) echo doctor-26 ;;
+ warmup) echo cbx_test26 ;;
+ run) echo product=26.5.2; echo build=25F84 ;;
+ stop) echo "stop-26 \$2" >> "$CALLS" ;;
+ list) echo cbx_test26 ;;
+esac
+EOF
+cat > "$ROOT/bin/crabbox" <<EOF
+#!/bin/bash
+echo "crabbox \$*" >> "$CALLS"
+while [[ \$# -gt 0 ]]; do
+  if [[ \$1 == --download ]]; then
+    target=\${2#*=}
+    mkdir -p "\$(dirname "\$target")"
+    fixture="\$(mktemp -d)"
+    mkdir -p "\$fixture/scenario-output/controller-capture"
+    echo test > "\$fixture/scenario-output/controller-capture/sw-vers.txt"
+    tar -czf "\$target" -C "\$fixture" scenario-output
+    rm -rf "\$fixture"
+    break
+  fi
+  shift
+done
+exit 0
+EOF
+chmod +x "$ROOT/bin/launcher15" "$ROOT/bin/launcher26" "$ROOT/bin/crabbox"
+
+run_remote() {
+    KEYPATH_LAB_TESTING=1 \
+    KEYPATH_LAB_TEST_ROOT="$ROOT" \
+    KEYPATH_LAB_LAUNCHER_15="$ROOT/bin/launcher15" \
+    KEYPATH_LAB_LAUNCHER_26="$ROOT/bin/launcher26" \
+    KEYPATH_LAB_CRABBOX="$ROOT/bin/crabbox" \
+        /bin/zsh "$REMOTE" "$@"
+}
+
+assert_contains() {
+    [[ $1 == *"$2"* ]] || { echo "expected '$2' in: $1" >&2; exit 1; }
+}
+
+preflight=$(run_remote preflight)
+assert_contains "$preflight" doctor-15
+assert_contains "$preflight" doctor-26
+
+archive_key="$(printf 'a%.0s' {1..40})-$(printf 'b%.0s' {1..64})"
+repo="$ROOT/KeyPathInstallerLab/archives/$archive_key/repo"
+mkdir -p "$repo/.keypath-lab/installer" "$repo/Scripts/lab/scenarios"
+cp "$LAB_DIR/scenarios/installer-scenario" "$repo/Scripts/lab/scenarios/installer-scenario"
+chmod +x "$repo/Scripts/lab/scenarios/installer-scenario"
+echo installer > "$repo/.keypath-lab/installer/KeyPath.zip"
+git -C "$repo" init -q
+git -C "$repo" config user.name test
+git -C "$repo" config user.email test@example.com
+git -C "$repo" add -A
+git -C "$repo" commit -qm fixture
+cat > "$ROOT/KeyPathInstallerLab/archives/$archive_key/ready.tsv" <<EOF
+owner	keypath-installer-lab-v1
+EOF
+
+commit=$(printf 'a%.0s' {1..40})
+checksum=$(printf 'b%.0s' {1..64})
+create=$(run_remote create 15 "$archive_key" "$commit" "$checksum" KeyPath.zip 2h)
+assert_contains "$create" $'lease_id\tcbx_test15'
+manifest="$ROOT/KeyPathInstallerLab/leases/cbx_test15/manifest.tsv"
+grep -q $'owner\tkeypath-installer-lab-v1' "$manifest"
+grep -q $'macos_build\t24G720' "$manifest"
+
+run_remote run cbx_test15 echo hello >/dev/null
+grep -q 'echo hello' "$ROOT/KeyPathInstallerLab/leases/cbx_test15/commands.tsv"
+run_remote scenario cbx_test15 clean-install >/dev/null
+grep -q 'installer-scenario clean-install' "$ROOT/KeyPathInstallerLab/leases/cbx_test15/commands.tsv"
+
+artifacts=$(run_remote artifacts cbx_test15)
+assert_contains "$artifacts" $'download_status\t0'
+assert_contains "$artifacts" $'screenshot_status\tunavailable:lease-not-created-with-desktop'
+grep -q -- '--download' "$CALLS"
+grep -q 'crabbox run --provider tart --target macos --id cbx_test15 --stop-after never --download' "$CALLS"
+if grep -q 'crabbox cp' "$CALLS"; then
+    echo "artifact collection used unsupported crabbox cp" >&2
+    exit 1
+fi
+[[ -f "$(find "$ROOT/KeyPathInstallerLab/artifacts/cbx_test15" -path '*/scenario-output/controller-capture/sw-vers.txt' -print -quit)" ]]
+
+touch "$ROOT/KeyPathInstallerLab/operations/$(grep $'^slug\t' "$manifest" | cut -f2)/repo/changing-file"
+if run_remote run cbx_test15 echo unsafe >/dev/null 2>&1; then
+    echo "run accepted a changing checkout" >&2
+    exit 1
+fi
+rm "$ROOT/KeyPathInstallerLab/operations/$(grep $'^slug\t' "$manifest" | cut -f2)/repo/changing-file"
+
+mkdir -p "$ROOT/KeyPathInstallerLab/leases/not-owned"
+printf 'owner\tother\nlease_id\tnot-owned\n' > "$ROOT/KeyPathInstallerLab/leases/not-owned/manifest.tsv"
+if run_remote destroy not-owned >/dev/null 2>&1; then
+    echo "destroy accepted an unowned lease" >&2
+    exit 1
+fi
+
+run_remote destroy cbx_test15 >/dev/null
+grep -q 'stop-15 cbx_test15' "$CALLS"
+grep -q $'cleanup_status\tcomplete' "$manifest"
+
+create26=$(run_remote create 26 "$archive_key" "$commit" "$checksum" KeyPath.zip 2h)
+assert_contains "$create26" $'lease_id\tcbx_test26'
+artifacts26=$(run_remote artifacts cbx_test26)
+assert_contains "$artifacts26" $'download_status\t0'
+grep -q 'crabbox run --provider parallels --target macos --id cbx_test26 --stop-after never --download' "$CALLS"
+run_remote destroy cbx_test26 >/dev/null
+
+if run_remote create 26 "$archive_key" "$commit" "$checksum" KeyPath.zip 3h >/dev/null 2>&1; then
+    echo "create accepted a TTL longer than the launchers support" >&2
+    exit 1
+fi
+
+cp -R "$ROOT/KeyPathInstallerLab/leases/cbx_test15" "$ROOT/KeyPathInstallerLab/leases/cbx_expired"
+expired="$ROOT/KeyPathInstallerLab/leases/cbx_expired/manifest.tsv"
+sed -i '' 's/cbx_test15/cbx_expired/g; s/^expires_epoch.*/expires_epoch\t1/; s/^cleanup_status.*/cleanup_status\tpending/' "$expired"
+dry_run=$(run_remote cleanup --dry-run)
+assert_contains "$dry_run" $'would_destroy\tcbx_expired'
+if grep -q 'stop-15 cbx_expired' "$CALLS"; then
+    echo "dry-run destroyed a lease" >&2
+    exit 1
+fi
+run_remote cleanup >/dev/null
+grep -q 'stop-15 cbx_expired' "$CALLS"
+
+touch "$ROOT/base-image-must-survive"
+run_remote cleanup >/dev/null
+[[ -f "$ROOT/base-image-must-survive" ]]
+
+mkdir -p "$TMP/fake-bin"
+cat > "$TMP/fake-bin/ssh" <<EOF
+#!/bin/bash
+echo "\$*" > "$TMP/ssh-args"
+cat >/dev/null
+echo controller-preflight
+EOF
+chmod +x "$TMP/fake-bin/ssh"
+controller=$(PATH="$TMP/fake-bin:$PATH" KEYPATH_LAB_HOST=tester@test-host "$LAB_DIR/keypath-lab" preflight)
+assert_contains "$controller" controller-preflight
+grep -q 'tester@test-host' "$TMP/ssh-args"
+
+echo fake-installer > "$TMP/KeyPath.zip"
+if PATH="$TMP/fake-bin:$PATH" "$LAB_DIR/keypath-lab" create --macos 15 --commit abc --installer "$TMP/KeyPath.zip" >/dev/null 2>&1; then
+    echo "controller accepted a non-explicit commit SHA" >&2
+    exit 1
+fi
+
+echo "keypath-lab shell tests passed"

--- a/Scripts/lab/tests/keypath-lab-tests.sh
+++ b/Scripts/lab/tests/keypath-lab-tests.sh
@@ -68,6 +68,28 @@ preflight=$(run_remote preflight)
 assert_contains "$preflight" doctor-15
 assert_contains "$preflight" doctor-26
 
+ticket_one=$(run_remote prepare-upload "$(printf 'a%.0s' {1..40})-$(printf 'b%.0s' {1..64})")
+ticket_two=$(run_remote prepare-upload "$(printf 'a%.0s' {1..40})-$(printf 'b%.0s' {1..64})")
+[[ "$ticket_one" == /tmp/keypath-lab.* && "$ticket_two" == /tmp/keypath-lab.* ]]
+[[ "$ticket_one" != "$ticket_two" && -f "$ticket_one" && -f "$ticket_two" ]]
+rm -f "$ticket_one" "$ticket_two"
+
+publish_commit=$(printf 'c%.0s' {1..40})
+publish_checksum=$(shasum -a 256 "$LAB_DIR/scenarios/installer-scenario" | awk '{print $1}')
+publish_key="$publish_commit-$publish_checksum"
+mkdir -p "$TMP/upload/repo/.keypath-lab/installer"
+cp "$LAB_DIR/scenarios/installer-scenario" "$TMP/upload/repo/.keypath-lab/installer/installer.zip"
+for pass in 1 2; do
+    ticket=$(run_remote prepare-upload "$publish_key")
+    tar -czf "$ticket" -C "$TMP/upload" repo
+    published=$(run_remote install-archive "$ticket" "$publish_key" "$publish_commit" "$publish_checksum" installer.zip)
+    if [[ $pass == 1 ]]; then assert_contains "$published" $'archive\tcreated'; else assert_contains "$published" $'archive\treused'; fi
+done
+if find "$ROOT/KeyPathInstallerLab/archives" -maxdepth 1 -name ".staging-$publish_key-*" | grep -q .; then
+    echo "archive publish left a staging directory" >&2
+    exit 1
+fi
+
 archive_key="$(printf 'a%.0s' {1..40})-$(printf 'b%.0s' {1..64})"
 repo="$ROOT/KeyPathInstallerLab/archives/$archive_key/repo"
 mkdir -p "$repo/.keypath-lab/installer" "$repo/Scripts/lab/scenarios"

--- a/docs/testing/remote-installer-lab.md
+++ b/docs/testing/remote-installer-lab.md
@@ -1,0 +1,127 @@
+# Remote KeyPath Installer Lab
+
+`Scripts/lab/keypath-lab` is the supported controller for disposable installer
+testing on the existing Mac mini lab. It defaults to
+`clawd@keypath-lab-mini`; use `--host` or `KEYPATH_LAB_HOST` for another SSH
+alias that exposes the same lab contract.
+
+The controller does not modify disk layout, the host's main drive, the stopped
+Parallels base VM, or the Tart OCI base image. Destructive commands require an
+exact `keypath-installer-lab-v1` ownership manifest under:
+
+`/Volumes/KeyPath Lab/CrabBox/KeyPathInstallerLab/leases/<lease-id>/`
+
+Only disposable leases created by this interface can be destroyed or swept.
+Logs, manifests, commands, results, screenshots, and collected test artifacts
+remain beneath `KeyPathInstallerLab` on the external volume after cleanup.
+
+## Prerequisites
+
+- SSH access to `clawd@keypath-lab-mini` without an interactive password.
+- `/Volumes/KeyPath Lab/CrabBox/keypath15` and `keypath26` executable.
+- Shared CrabBox 0.36.0 tools beneath `CrabBox/SharedTools`.
+- A full 40-character KeyPath commit SHA present in the local repository.
+- A signed installer artifact whose SHA-256 checksum can be recorded.
+
+`--ttl` defaults to `2h` and accepts values from one second through two hours,
+matching the maximum lifecycle exposed by the existing launchers.
+
+Check the non-mutating host/provider contract:
+
+```bash
+Scripts/lab/keypath-lab preflight
+```
+
+## Lifecycle
+
+Creation never syncs the current worktree. It exports the explicit commit with
+`git archive`, adds the installer and source metadata, uploads that immutable
+payload, and atomically initializes a clean synthetic archive on the external
+lab volume. Each lease receives its own clean checkout cloned from that archive.
+CrabBox's claim therefore binds one disposable lease to one stable repository
+root, and every run, download, and destructive stop executes from that exact
+claimed checkout. The interface refuses to sync if Git reports tracked or
+nonignored untracked changes.
+
+```bash
+SHA=$(git rev-parse HEAD)
+Scripts/lab/keypath-lab create \
+  --macos 15 \
+  --commit "$SHA" \
+  --installer dist/KeyPath.zip \
+  --ttl 2h
+
+Scripts/lab/keypath-lab list
+Scripts/lab/keypath-lab status cbx_example
+Scripts/lab/keypath-lab run cbx_example -- sw_vers
+Scripts/lab/keypath-lab artifacts cbx_example
+Scripts/lab/keypath-lab destroy cbx_example
+Scripts/lab/keypath-lab cleanup --dry-run
+Scripts/lab/keypath-lab cleanup
+```
+
+Every manifest records the source commit, macOS product version and build,
+provider, installer name and checksum, expiration, commands/results, artifact
+collection, and cleanup state. `destroy` is idempotent after successful cleanup.
+Artifact collection packages scenario output inside the guest and retrieves the
+single archive with CrabBox's native, owner-only `run --download` path. It does
+not parse private SSH-key locations or invoke `scp`. CrabBox 0.36's provider
+`cp` command is not supported by these providers, and its aggregate desktop
+artifact workflow requires a desktop-enabled lease.
+
+The existing `keypath15` and `keypath26` launchers do not create leases with
+CrabBox's `--desktop` capability. Artifact collection therefore records
+`screenshot_status=unavailable:lease-not-created-with-desktop` instead of
+attempting an unsupported screenshot. Adding screenshots requires an explicit,
+separately validated desktop-capable launcher contract.
+
+## Installer scenarios
+
+Run a named scenario after creating a lease:
+
+```bash
+Scripts/lab/keypath-lab scenario cbx_example clean-install
+Scripts/lab/keypath-lab scenario cbx_example approvals
+Scripts/lab/keypath-lab scenario cbx_example helper-daemon-health
+Scripts/lab/keypath-lab scenario cbx_example launch
+Scripts/lab/keypath-lab scenario cbx_example repair-reinstall
+Scripts/lab/keypath-lab scenario cbx_example reboot-persistence-before
+# Reboot the disposable guest through the approved lab workflow.
+Scripts/lab/keypath-lab scenario cbx_example reboot-persistence-after
+Scripts/lab/keypath-lab scenario cbx_example uninstall
+Scripts/lab/keypath-lab scenario cbx_example cancellation-failure
+Scripts/lab/keypath-lab scenario cbx_example artifact-capture
+Scripts/lab/keypath-lab artifacts cbx_example
+```
+
+The scenario set covers clean installation, every macOS approval gate,
+helper/daemon and TCP health, launch, repair/reinstall, reboot persistence,
+uninstall, cancellation/failure rendering, and final artifact capture. Approval
+and cancellation cases intentionally give an operator a controlled observation
+point rather than attempting to bypass macOS security UI. Never place Apple IDs,
+passwords, private keys, TCC databases, or other credentials in a scenario or
+artifact bundle. CrabBox does not redact collected files automatically; inspect
+every bundle before sharing or publishing it.
+
+## Failure and recovery
+
+- If creation reports a lease but guest verification fails, preserve the lease
+  ID and logs, inspect it with `status`, collect artifacts, then `destroy` it.
+- If cleanup fails, the manifest remains `cleanup-failed`; the interface does
+  not discard evidence or pretend the provider object was deleted.
+- `cleanup` considers only expired manifests owned by this interface. It never
+  invokes a provider-wide cleanup and never deletes archive caches or base
+  images. The final `crabbox stop` runs from the exact checkout recorded in the
+  lease manifest so CrabBox's own repository claim remains an additional
+  destructive-operation guard.
+- To test a different SSH endpoint, pass `--host user@host`; do not edit the
+  launchers or embed host credentials in the repository.
+
+## Local contract tests
+
+The shell tests use fake launchers and a temporary lab root; they never contact
+the mini or provision a VM:
+
+```bash
+Scripts/lab/tests/keypath-lab-tests.sh
+```

--- a/docs/testing/remote-installer-lab.md
+++ b/docs/testing/remote-installer-lab.md
@@ -43,6 +43,11 @@ root, and every run, download, and destructive stop executes from that exact
 claimed checkout. The interface refuses to sync if Git reports tracked or
 nonignored untracked changes.
 
+Uploads use a host-generated, owner-only `mktemp` ticket rather than a
+commit-derived `/tmp` filename. Publishing the immutable archive is protected by
+a per-key lock, so concurrent requests either publish once or validate and reuse
+the completed archive.
+
 ```bash
 SHA=$(git rev-parse HEAD)
 Scripts/lab/keypath-lab create \


### PR DESCRIPTION
## Summary
- add a `Scripts/lab/keypath-lab` controller for macOS 15 Tart and macOS 26 Parallels disposable installer leases
- stage an explicit KeyPath commit and installer checksum into an immutable archive, with one clean CrabBox-claimed checkout per lease
- record lifecycle metadata, commands, results, artifacts, and cleanup status under the external KeyPath Lab volume
- add installer scenario definitions and fake-provider shell contract tests
- document setup, safety boundaries, lifecycle examples, artifact handling, and screenshot capability limits

## Real behavior proof
- `Scripts/lab/keypath-lab preflight` passed against `clawd@keypath-lab-mini`; both existing provider doctors passed
- created and verified Tart lease `cbx_a7ef3e1fbc6b` as macOS 15.7.7 build 24G720 from KeyPath commit `36f883a505f2071586e4a473c85d73ed6310432b`
- arbitrary argv execution returned exit 0 on that lease
- revised artifact collection used CrabBox `run --download`, skipped sync through the clean-checkout fingerprint, and retained the downloaded archive and controller evidence under `/Volumes/KeyPath Lab/CrabBox/KeyPathInstallerLab/artifacts`
- screenshot capture is explicitly reported unavailable because the current launchers do not create desktop-capable leases

## Validation
- `Scripts/lab/tests/keypath-lab-tests.sh`
- Bash and zsh syntax checks
- `git diff --check`
- `./Scripts/test-full.sh` — 4,733 passed, 0 failed
- `./Scripts/review-gate.sh` — exit 2, remote review gate selected; GitHub `claude-review` required before merge

## Safety
- no host disk/APFS changes
- no provider-wide cleanup
- no direct Tart/Parallels deletion
- destructive operations require an exact interface ownership manifest and execute from the exact CrabBox-claimed checkout
- base VM and Tart OCI base image are never deletion targets
