### PR TITLE
Allow CrabBox-generated lab output

### DIFF
--- a/Scripts/lab/remote.sh
+++ b/Scripts/lab/remote.sh
@@ -92,10 +92,14 @@ record_command() {
 }
 
 prepare_worktree() {
-  local repo=$1
+  local repo=$1 changes
   [[ "$repo" == "$OPERATIONS"/*/repo ]] || die "unsafe lease worktree path"
   [[ -d "$repo/.git" ]] || die "lease checkout is not a Git worktree"
-  [[ -z "$(git -C "$repo" status --porcelain --untracked-files=all)" ]] || die "refusing to sync a changing checkout"
+  changes=$(git -C "$repo" status --porcelain --untracked-files=all -- . \
+    ':(exclude).crabbox/logs/**' \
+    ':(exclude).crabbox/captures/**' \
+    ':(exclude).crabbox/runs/**')
+  [[ -z "$changes" ]] || die "refusing to sync a changing checkout"
 }
 
 run_with_download() {
@@ -323,6 +327,9 @@ collect_artifacts() {
   cp "$manifest" "$output/manifest.tsv"
   cp "$LEASES/$lease/commands.tsv" "$output/commands.tsv" 2>/dev/null || true
   cp -R "$LOGS/$lease" "$output/controller-logs"
+  if [[ -d "$repo/.crabbox/captures" ]]; then
+    cp -R "$repo/.crabbox/captures" "$output/controller-crabbox-captures"
+  fi
   archive="$output/scenario-output.tar.gz"
   set +e
   (cd "$repo" && run_with_download "$macos" "$lease" ".keypath-lab/scenario-output.tar.gz" "$archive" \

--- a/Scripts/lab/tests/keypath-lab-tests.sh
+++ b/Scripts/lab/tests/keypath-lab-tests.sh
@@ -129,12 +129,20 @@ if grep -q 'crabbox cp' "$CALLS"; then
 fi
 [[ -f "$(find "$ROOT/KeyPathInstallerLab/artifacts/cbx_test15" -path '*/scenario-output/controller-capture/sw-vers.txt' -print -quit)" ]]
 
-touch "$ROOT/KeyPathInstallerLab/operations/$(grep $'^slug\t' "$manifest" | cut -f2)/repo/changing-file"
+operation_repo="$ROOT/KeyPathInstallerLab/operations/$(grep $'^slug\t' "$manifest" | cut -f2)/repo"
+mkdir -p "$operation_repo/.crabbox/captures"
+echo failure-evidence > "$operation_repo/.crabbox/captures/failure.tar.gz"
+run_remote run cbx_test15 echo generated-output-is-safe >/dev/null
+artifacts_with_capture=$(run_remote artifacts cbx_test15)
+capture_dir=$(printf '%s\n' "$artifacts_with_capture" | awk -F '\t' '$1 == "artifact_dir" {print $2}')
+[[ -f "$capture_dir/controller-crabbox-captures/failure.tar.gz" ]]
+
+touch "$operation_repo/changing-file"
 if run_remote run cbx_test15 echo unsafe >/dev/null 2>&1; then
     echo "run accepted a changing checkout" >&2
     exit 1
 fi
-rm "$ROOT/KeyPathInstallerLab/operations/$(grep $'^slug\t' "$manifest" | cut -f2)/repo/changing-file"
+rm "$operation_repo/changing-file"
 
 mkdir -p "$ROOT/KeyPathInstallerLab/leases/not-owned"
 printf 'owner\tother\nlease_id\tnot-owned\n' > "$ROOT/KeyPathInstallerLab/leases/not-owned/manifest.tsv"


### PR DESCRIPTION
## Summary
- exempt only CrabBox's documented generated `logs`, `captures`, and `runs` directories from the immutable-checkout source-drift guard
- retain arbitrary tracked and nonignored untracked file rejection
- preserve local CrabBox failure bundles in collected external-volume artifacts
- add shell contract coverage for both the allowed generated output and rejected source drift

## Real behavior proof
The first macOS 15 installer-matrix run produced an expected CrabBox failure bundle after a root-context SMAppService rejection. The next lab command was incorrectly blocked because `.crabbox/captures` was classified as source drift. This change follows CrabBox's documented sync exclusions while retaining evidence.

## Validation
- `Scripts/lab/tests/keypath-lab-tests.sh`
- Bash/zsh syntax checks
- `git diff --check`
- `./Scripts/review-gate.sh` — remote review gate selected
