### PR TITLE
Add desktop installer lab support

### DIFF
--- a/Scripts/lab/keypath-lab
+++ b/Scripts/lab/keypath-lab
@@ -12,7 +12,8 @@ Usage: Scripts/lab/keypath-lab [--host HOST] <command> [options]
 
 Commands:
   preflight
-  create --macos 15|26 --commit SHA --installer PATH [--ttl 2h]
+  create --macos 15|26 --commit SHA --installer PATH [--ttl 2h] [--desktop]
+  install-app LEASE_ID
   run LEASE_ID -- COMMAND [ARG...]
   status LEASE_ID
   list
@@ -67,12 +68,14 @@ case "$command" in
         commit=
         installer=
         ttl=2h
+        desktop=0
         while [[ $# -gt 0 ]]; do
             case "$1" in
                 --macos) macos=${2:-}; shift 2 ;;
                 --commit) commit=${2:-}; shift 2 ;;
                 --installer) installer=${2:-}; shift 2 ;;
                 --ttl) ttl=${2:-}; shift 2 ;;
+                --desktop) desktop=1; shift ;;
                 *) usage ;;
             esac
         done
@@ -102,7 +105,12 @@ EOF
         [[ $upload_ticket == /tmp/keypath-lab.* ]] || die "host returned an invalid upload ticket"
         scp -q "$temp_dir/archive.tgz" "$host:$upload_ticket"
         remote install-archive "$upload_ticket" "$archive_key" "$commit" "$installer_sha" "$installer_name"
-        remote create "$macos" "$archive_key" "$commit" "$installer_sha" "$installer_name" "$ttl"
+        remote create "$macos" "$archive_key" "$commit" "$installer_sha" "$installer_name" "$ttl" "$desktop"
+        ;;
+    install-app)
+        [[ $# -eq 1 ]] || usage
+        require_lease_id "$1"
+        remote install-app "$1"
         ;;
     run)
         lease=${1:-}

--- a/Scripts/lab/remote.sh
+++ b/Scripts/lab/remote.sh
@@ -121,6 +121,26 @@ run_with_download() {
   fi
 }
 
+warmup_desktop() {
+  local macos=$1 slug=$2
+  if [[ "${KEYPATH_LAB_TESTING:-0}" == "1" ]]; then
+    "$CRABBOX" warmup --provider "$(provider_for "$macos")" --target macos --desktop --slug "$slug" --ttl 2h
+  elif [[ "$macos" == "15" ]]; then
+    if [[ "${USER:-}" == "clawd" ]]; then export TART_HOME="$LAB_ROOT/TartHome-clawd"; else export TART_HOME="$LAB_ROOT/TartHome"; fi
+    export PATH="$LAB_ROOT/CompatTools/bin:$LAB_ROOT/SharedTools/bin:/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+    "$CRABBOX" warmup --provider tart --target macos --desktop \
+      --tart-image ghcr.io/cirruslabs/macos-sequoia-base:latest \
+      --tart-user admin --tart-cpu 4 --tart-memory 8192 --ssh-port 22 \
+      --slug "$slug" --ttl 2h
+  else
+    export PATH="$LAB_ROOT/SharedTools/bin:/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+    "$CRABBOX" warmup --provider parallels --target macos --desktop \
+      --parallels-template keypath-macos-26 --parallels-user keypathqa \
+      --parallels-work-root /Users/keypathqa/crabbox --ssh-port 22 \
+      --slug "$slug" --ttl 2h
+  fi
+}
+
 preflight() {
   local mount_point
   [[ "$LAB_ROOT" == "$PRODUCTION_ROOT" || "${KEYPATH_LAB_TESTING:-0}" == "1" ]] || die "unsafe lab root"
@@ -214,8 +234,8 @@ install_archive() {
 }
 
 create_lease() {
-  local macos=$1 archive_key=$2 commit=$3 installer_sha=$4 installer_name=$5 ttl=$6
-  local launcher provider archive repo slug output lease created expires manifest guest_output product build operation ttl_seconds
+  local macos=$1 archive_key=$2 commit=$3 installer_sha=$4 installer_name=$5 ttl=$6 desktop=$7
+  local launcher provider archive repo slug output lease created expires manifest guest_output product build operation ttl_seconds provider_resource
   launcher=$(launcher_for "$macos")
   provider=$(provider_for "$macos")
   valid_id "$archive_key"
@@ -229,12 +249,17 @@ create_lease() {
   git clone -q --local "$archive/repo" "$operation/repo"
   repo="$operation/repo"
   prepare_worktree "$repo"
-  output=$(cd "$repo" && "$launcher" warmup "$slug" 2>&1)
+  if [[ "$desktop" == "1" ]]; then
+    output=$(cd "$repo" && warmup_desktop "$macos" "$slug" 2>&1)
+  else
+    output=$(cd "$repo" && "$launcher" warmup "$slug" 2>&1)
+  fi
   print -r -- "$output"
   print -r -- "$output" > "$operation/create.log"
   lease=$(print -r -- "$output" | grep -Eo 'cbx_[A-Za-z0-9]+' | tail -1 || true)
   [[ -n "$lease" ]] || die "CrabBox did not report a lease id; inspect provider inventory before cleanup"
   valid_id "$lease"
+  provider_resource=$(print -r -- "$output" | sed -nE 's/.* (vm|instance)=([^ ]+).*/\2/p' | tail -1)
   created=$(now_epoch)
   expires=$((created + ttl_seconds))
   mkdir -p "$LEASES/$lease" "$LOGS/$lease" "$ARTIFACTS/$lease"
@@ -255,7 +280,8 @@ create_lease() {
     print "expires_epoch\t$expires"
     print "status\tcreated"
     print "cleanup_status\tpending"
-    print "desktop_enabled\tfalse"
+    print "desktop_enabled\t$([[ "$desktop" == "1" ]] && print true || print false)"
+    print "provider_resource\t${provider_resource:-unknown}"
   } > "$manifest"
   print -r -- "$output" > "$LOGS/$lease/create.log"
   guest_output=$(cd "$repo" && "$launcher" run "$lease" -- /bin/zsh -lc 'printf "product=%s\n" "$(sw_vers -productVersion)"; printf "build=%s\n" "$(sw_vers -buildVersion)"' 2>&1) || {
@@ -273,6 +299,35 @@ create_lease() {
   record_command "$lease" passed sw_vers
   print "lease_id\t$lease"
   print "manifest\t$manifest"
+}
+
+install_app() {
+  local lease=$1 manifest macos repo installer_name provider_resource guest_repo command exit_code
+  manifest=$(owned_manifest "$lease")
+  macos=$(field "$manifest" macos)
+  repo=$(field "$manifest" worktree)
+  installer_name=$(field "$manifest" installer_name)
+  provider_resource=$(field "$manifest" provider_resource)
+  prepare_worktree "$repo"
+  guest_repo="/Users/$([[ "$macos" == "15" ]] && print admin || print keypathqa)/crabbox/$lease/repo"
+  command="set -euo pipefail; rm -rf /tmp/keypath-install; mkdir -p /tmp/keypath-install; ditto -x -k '$guest_repo/.keypath-lab/installer/$installer_name' /tmp/keypath-install; rm -rf /Applications/KeyPath.app; ditto /tmp/keypath-install/KeyPath.app /Applications/KeyPath.app"
+  set +e
+  if [[ "${KEYPATH_LAB_TESTING:-0}" == "1" ]]; then
+    print "install-app $macos $lease $provider_resource" >> "$LOGS/$lease/install-app.log"
+    exit_code=0
+  elif [[ "$macos" == "15" ]]; then
+    (cd "$repo" && "$(launcher_for "$macos")" run "$lease" -- /bin/zsh -lc "sudo -n /bin/zsh -lc $(printf %q "$command")") > "$LOGS/$lease/install-app.log" 2>&1
+    exit_code=$?
+  else
+    [[ "$provider_resource" =~ '^[A-Fa-f0-9-]+$' && "$provider_resource" != "unknown" ]] || die "invalid Parallels resource id"
+    "/Applications/Parallels Desktop.app/Contents/MacOS/prlctl" exec "$provider_resource" /bin/zsh -lc "$command" > "$LOGS/$lease/install-app.log" 2>&1
+    exit_code=$?
+  fi
+  set -e
+  set_field "$manifest" install_app_result "$exit_code"
+  set_field "$manifest" install_app_at "$(utc_now)"
+  cat "$LOGS/$lease/install-app.log"
+  return "$exit_code"
 }
 
 run_command() {
@@ -339,12 +394,27 @@ collect_artifacts() {
   if (( exit_code == 0 )); then
     tar -xzf "$archive" -C "$output"
   fi
+  if [[ "$(field "$manifest" desktop_enabled)" == "true" ]]; then
+    set +e
+    if [[ "$macos" == "15" ]]; then
+      if [[ "${USER:-}" == "clawd" ]]; then export TART_HOME="$LAB_ROOT/TartHome-clawd"; else export TART_HOME="$LAB_ROOT/TartHome"; fi
+      export PATH="$LAB_ROOT/CompatTools/bin:$LAB_ROOT/SharedTools/bin:/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+      (cd "$repo" && "$CRABBOX" screenshot --provider tart --target macos --id "$lease" --output "$output/screenshot.png") >> "$output/download.log" 2>&1
+    else
+      (cd "$repo" && "$CRABBOX" screenshot --provider parallels --target macos --id "$lease" --parallels-user keypathqa --parallels-work-root /Users/keypathqa/crabbox --output "$output/screenshot.png") >> "$output/download.log" 2>&1
+    fi
+    screenshot_exit=$?
+    set -e
+    set_field "$manifest" screenshot_status "$screenshot_exit"
+  else
+    screenshot_exit=unavailable:lease-not-created-with-desktop
+    set_field "$manifest" screenshot_status "$screenshot_exit"
+  fi
   set_field "$manifest" artifacts_status "$exit_code"
   set_field "$manifest" artifacts_last_collected_at "$(utc_now)"
-  set_field "$manifest" screenshot_status "unavailable:lease-not-created-with-desktop"
   print "artifact_dir\t$output"
   print "download_status\t$exit_code"
-  print "screenshot_status\tunavailable:lease-not-created-with-desktop"
+  print "screenshot_status\t$screenshot_exit"
   return "$exit_code"
 }
 
@@ -408,7 +478,8 @@ case "$action" in
   preflight) [[ $# -eq 0 ]] || die "preflight takes no arguments"; preflight ;;
   prepare-upload) [[ $# -eq 1 ]] || die "prepare-upload requires archive key"; prepare_upload "$1" ;;
   install-archive) [[ $# -eq 5 ]] || die "install-archive requires ticket, key, commit, checksum, and name"; install_archive "$@" ;;
-  create) [[ $# -eq 6 ]] || die "create requires lane, archive, commit, checksum, name, ttl"; create_lease "$@" ;;
+  create) [[ $# -eq 7 ]] || die "create requires lane, archive, commit, checksum, name, ttl, desktop"; create_lease "$@" ;;
+  install-app) [[ $# -eq 1 ]] || die "install-app requires lease"; install_app "$1" ;;
   run) [[ $# -ge 2 ]] || die "run requires lease and command"; run_command "$@" ;;
   status) [[ $# -eq 1 ]] || die "status requires lease"; print_status "$1" ;;
   list) [[ $# -eq 0 ]] || die "list takes no arguments"; list_leases ;;

--- a/Scripts/lab/tests/keypath-lab-tests.sh
+++ b/Scripts/lab/tests/keypath-lab-tests.sh
@@ -34,6 +34,17 @@ EOF
 cat > "$ROOT/bin/crabbox" <<EOF
 #!/bin/bash
 echo "crabbox \$*" >> "$CALLS"
+if [[ \$1 == warmup ]]; then
+  if [[ " \$* " == *" --provider tart "* ]]; then echo cbx_desktop15; else echo cbx_desktop26; fi
+  exit 0
+fi
+if [[ \$1 == screenshot ]]; then
+  while [[ \$# -gt 0 ]]; do
+    if [[ \$1 == --output ]]; then mkdir -p "\$(dirname "\$2")"; echo png > "\$2"; break; fi
+    shift
+  done
+  exit 0
+fi
 while [[ \$# -gt 0 ]]; do
   if [[ \$1 == --download ]]; then
     target=\${2#*=}
@@ -107,7 +118,7 @@ EOF
 
 commit=$(printf 'a%.0s' {1..40})
 checksum=$(printf 'b%.0s' {1..64})
-create=$(run_remote create 15 "$archive_key" "$commit" "$checksum" KeyPath.zip 2h)
+create=$(run_remote create 15 "$archive_key" "$commit" "$checksum" KeyPath.zip 2h 0)
 assert_contains "$create" $'lease_id\tcbx_test15'
 manifest="$ROOT/KeyPathInstallerLab/leases/cbx_test15/manifest.tsv"
 grep -q $'owner\tkeypath-installer-lab-v1' "$manifest"
@@ -117,6 +128,8 @@ run_remote run cbx_test15 echo hello >/dev/null
 grep -q 'echo hello' "$ROOT/KeyPathInstallerLab/leases/cbx_test15/commands.tsv"
 run_remote scenario cbx_test15 clean-install >/dev/null
 grep -q 'installer-scenario clean-install' "$ROOT/KeyPathInstallerLab/leases/cbx_test15/commands.tsv"
+run_remote install-app cbx_test15 >/dev/null
+grep -q 'install-app 15 cbx_test15' "$ROOT/KeyPathInstallerLab/logs/cbx_test15/install-app.log"
 
 artifacts=$(run_remote artifacts cbx_test15)
 assert_contains "$artifacts" $'download_status\t0'
@@ -155,14 +168,24 @@ run_remote destroy cbx_test15 >/dev/null
 grep -q 'stop-15 cbx_test15' "$CALLS"
 grep -q $'cleanup_status\tcomplete' "$manifest"
 
-create26=$(run_remote create 26 "$archive_key" "$commit" "$checksum" KeyPath.zip 2h)
+create26=$(run_remote create 26 "$archive_key" "$commit" "$checksum" KeyPath.zip 2h 0)
 assert_contains "$create26" $'lease_id\tcbx_test26'
 artifacts26=$(run_remote artifacts cbx_test26)
 assert_contains "$artifacts26" $'download_status\t0'
 grep -q 'crabbox run --provider parallels --target macos --id cbx_test26 --stop-after never --download' "$CALLS"
 run_remote destroy cbx_test26 >/dev/null
 
-if run_remote create 26 "$archive_key" "$commit" "$checksum" KeyPath.zip 3h >/dev/null 2>&1; then
+desktop_create=$(run_remote create 15 "$archive_key" "$commit" "$checksum" KeyPath.zip 2h 1)
+assert_contains "$desktop_create" $'lease_id\tcbx_desktop15'
+desktop_manifest="$ROOT/KeyPathInstallerLab/leases/cbx_desktop15/manifest.tsv"
+grep -q $'desktop_enabled\ttrue' "$desktop_manifest"
+desktop_artifacts=$(run_remote artifacts cbx_desktop15)
+assert_contains "$desktop_artifacts" $'screenshot_status\t0'
+desktop_artifact_dir=$(printf '%s\n' "$desktop_artifacts" | awk -F '\t' '$1 == "artifact_dir" {print $2}')
+[[ -f "$desktop_artifact_dir/screenshot.png" ]]
+run_remote destroy cbx_desktop15 >/dev/null
+
+if run_remote create 26 "$archive_key" "$commit" "$checksum" KeyPath.zip 3h 0 >/dev/null 2>&1; then
     echo "create accepted a TTL longer than the launchers support" >&2
     exit 1
 fi

--- a/docs/testing/remote-installer-lab.md
+++ b/docs/testing/remote-installer-lab.md
@@ -54,10 +54,12 @@ Scripts/lab/keypath-lab create \
   --macos 15 \
   --commit "$SHA" \
   --installer dist/KeyPath.zip \
-  --ttl 2h
+  --ttl 2h \
+  --desktop
 
 Scripts/lab/keypath-lab list
 Scripts/lab/keypath-lab status cbx_example
+Scripts/lab/keypath-lab install-app cbx_example
 Scripts/lab/keypath-lab run cbx_example -- sw_vers
 Scripts/lab/keypath-lab artifacts cbx_example
 Scripts/lab/keypath-lab destroy cbx_example
@@ -74,11 +76,18 @@ not parse private SSH-key locations or invoke `scp`. CrabBox 0.36's provider
 `cp` command is not supported by these providers, and its aggregate desktop
 artifact workflow requires a desktop-enabled lease.
 
-The existing `keypath15` and `keypath26` launchers do not create leases with
-CrabBox's `--desktop` capability. Artifact collection therefore records
-`screenshot_status=unavailable:lease-not-created-with-desktop` instead of
-attempting an unsupported screenshot. Adding screenshots requires an explicit,
-separately validated desktop-capable launcher contract.
+Pass `--desktop` when approval interaction or screenshots are required. The
+controller mirrors the existing provider launcher configuration while adding
+CrabBox's desktop capability; ordinary creation continues to use the launchers
+unchanged. Artifact collection captures a screenshot for desktop leases and
+records an explicit unavailable status otherwise.
+
+`install-app` expands the staged ZIP into `/Applications` on the disposable
+guest. Tart uses the base image's noninteractive sudo contract. Parallels uses
+the same passwordless `prlctl exec` guest-control channel CrabBox already uses
+to prepare the disposable clone, scoped to the exact provider resource recorded
+in the owned lease manifest. Neither path changes the base image or stores a
+guest password.
 
 ## Installer scenarios
 


### PR DESCRIPTION
## Summary
- add opt-in `create --desktop` using CrabBox's native macOS desktop capability
- capture real screenshots for desktop-enabled Tart and Parallels leases
- add `install-app` for the staged artifact using passwordless sudo on Tart and CrabBox's existing passwordless `prlctl exec` guest-control channel on the exact owned Parallels clone
- retain the existing launchers unchanged for non-desktop leases
- document the credential and base-image safety boundaries

## Real behavior proof
- created desktop Tart lease `cbx_e470cb6cb888`; CrabBox verified VNC readiness on port 5900
- installed the notarized KeyPath ZIP through `install-app`
- launched KeyPath and captured repeated 2048x1536 framebuffer screenshots under the external KeyPath Lab artifact root
- captured the Login Items & Extensions approval surface and KeyPath background-item notification
- destroyed the disposable clone; base OCI image remained untouched

## Findings from the live proof
- clean launch currently triggers KeyPath's orphan-cleanup alert because the app creates Application Support, Logs, and Preferences before `OrphanDetector` evaluates those same paths
- CrabBox macOS click delivery did not reliably toggle the protected Login Items switch on the Retina framebuffer; this PR does not claim protected approval automation

## Validation
- `Scripts/lab/tests/keypath-lab-tests.sh`
- Bash/zsh syntax checks
- `git diff --check`
- `./Scripts/review-gate.sh` — remote review gate selected
