### PR TITLE
Fix false orphan cleanup prompt on clean install

### DIFF
--- a/Sources/KeyPathAppKit/Services/Monitoring/OrphanDetector.swift
+++ b/Sources/KeyPathAppKit/Services/Monitoring/OrphanDetector.swift
@@ -11,6 +11,9 @@ final class OrphanDetector {
 
     private let engineFactory: () -> (any InstallerEnginePrivilegedRouting)
     private let brokerFactory: () -> PrivilegeBroker
+    private let homeDirectory: URL
+    private let creationDate: (URL) -> Date?
+    private let launchDate: () -> Date
 
     // MARK: - Singleton
 
@@ -18,10 +21,19 @@ final class OrphanDetector {
 
     init(
         engineFactory: @escaping () -> (any InstallerEnginePrivilegedRouting) = { InstallerEngine() },
-        brokerFactory: @escaping () -> PrivilegeBroker = { PrivilegeBroker() }
+        brokerFactory: @escaping () -> PrivilegeBroker = { PrivilegeBroker() },
+        homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser,
+        creationDate: @escaping (URL) -> Date? = { url in
+            guard FileManager.default.fileExists(atPath: url.path) else { return nil }
+            return try? url.resourceValues(forKeys: [.creationDateKey]).creationDate
+        },
+        launchDate: @escaping () -> Date = { NSRunningApplication.current.launchDate ?? Date() }
     ) {
         self.engineFactory = engineFactory
         self.brokerFactory = brokerFactory
+        self.homeDirectory = homeDirectory
+        self.creationDate = creationDate
+        self.launchDate = launchDate
     }
 
     /// User defaults key to track if we've shown the orphan cleanup alert
@@ -37,18 +49,21 @@ final class OrphanDetector {
     func detectOrphanedInstall() -> Bool {
         // Check for leftover files from manual app deletion
         let orphanedPaths = [
-            Foundation.FileManager().homeDirectoryForCurrentUser
+            homeDirectory
                 .appendingPathComponent("Library/Application Support/KeyPath"),
-            Foundation.FileManager().homeDirectoryForCurrentUser
+            homeDirectory
                 .appendingPathComponent("Library/Logs/KeyPath"),
-            Foundation.FileManager().homeDirectoryForCurrentUser
+            homeDirectory
                 .appendingPathComponent("Library/Preferences")
                 .appendingPathComponent("com.keypath.KeyPath.plist")
         ]
 
-        // Count how many orphaned paths exist
-        let orphanCount = orphanedPaths.filter {
-            Foundation.FileManager().fileExists(atPath: $0.path)
+        // Startup creates these same paths on a genuinely clean install. Only
+        // paths that predate this process are evidence of an earlier install.
+        let currentLaunchDate = launchDate()
+        let orphanCount = orphanedPaths.filter { path in
+            guard let createdAt = creationDate(path) else { return false }
+            return createdAt < currentLaunchDate
         }.count
 
         // If 2 or more paths exist, this is likely an orphaned install

--- a/Tests/KeyPathTests/Services/OrphanDetectorTests.swift
+++ b/Tests/KeyPathTests/Services/OrphanDetectorTests.swift
@@ -1,0 +1,48 @@
+import Foundation
+@testable import KeyPathAppKit
+@preconcurrency import XCTest
+
+@MainActor
+final class OrphanDetectorTests: XCTestCase {
+    private let home = URL(fileURLWithPath: "/test-home", isDirectory: true)
+    private let launch = Date(timeIntervalSince1970: 1_000)
+
+    func testCurrentLaunchPathsDoNotLookLikeOrphans() {
+        let detector = makeDetector(dates: [
+            "Library/Application Support/KeyPath": launch.addingTimeInterval(1),
+            "Library/Logs/KeyPath": launch.addingTimeInterval(2),
+            "Library/Preferences/com.keypath.KeyPath.plist": launch.addingTimeInterval(3)
+        ])
+
+        XCTAssertFalse(detector.detectOrphanedInstall())
+    }
+
+    func testTwoPathsPredatingLaunchAreAnOrphanedInstall() {
+        let detector = makeDetector(dates: [
+            "Library/Application Support/KeyPath": launch.addingTimeInterval(-100),
+            "Library/Logs/KeyPath": launch.addingTimeInterval(-90)
+        ])
+
+        XCTAssertTrue(detector.detectOrphanedInstall())
+    }
+
+    func testOneOldPathAndCurrentLaunchOutputIsNotEnough() {
+        let detector = makeDetector(dates: [
+            "Library/Application Support/KeyPath": launch.addingTimeInterval(-100),
+            "Library/Logs/KeyPath": launch.addingTimeInterval(1),
+            "Library/Preferences/com.keypath.KeyPath.plist": launch.addingTimeInterval(2)
+        ])
+
+        XCTAssertFalse(detector.detectOrphanedInstall())
+    }
+
+    private func makeDetector(dates: [String: Date]) -> OrphanDetector {
+        OrphanDetector(
+            homeDirectory: home,
+            creationDate: { [home] url in
+                dates[url.path.replacingOccurrences(of: home.path + "/", with: "")]
+            },
+            launchDate: { [launch] in launch }
+        )
+    }
+}

--- a/Tests/KeyPathTests/Services/OrphanDetectorTests.swift
+++ b/Tests/KeyPathTests/Services/OrphanDetectorTests.swift
@@ -5,7 +5,7 @@ import Foundation
 @MainActor
 final class OrphanDetectorTests: XCTestCase {
     private let home = URL(fileURLWithPath: "/test-home", isDirectory: true)
-    private let launch = Date(timeIntervalSince1970: 1_000)
+    private let launch = Date(timeIntervalSince1970: 1000)
 
     func testCurrentLaunchPathsDoNotLookLikeOrphans() {
         let detector = makeDetector(dates: [


### PR DESCRIPTION
## Summary
- ignore files created during the current app launch when detecting an orphaned installation
- preserve detection for leftover paths that predate the current process
- add focused regression coverage for clean and genuinely orphaned states

## Verification
- `TEST_FILTER=OrphanDetectorTests ./Scripts/run-tests-safe.sh` (3 focused tests passed)
- `./Scripts/test-full.sh` (4,736 tests passed)
- `git diff --check`
- `./Scripts/review-gate.sh` selected the remote review gate (exit 2); do not merge until GitHub `claude-review` passes

## Live evidence
A clean CrabBox macOS 15 desktop lease reproduced the false “Clean Up Leftover Files?” prompt before this fix. After CI/review, the merged build will be rerun through the same clean-install desktop scenario.