### PR TITLE
Update Karabiner 16 compatibility checks

### DIFF
--- a/Sources/KeyPathCore/WizardSystemPaths.swift
+++ b/Sources/KeyPathCore/WizardSystemPaths.swift
@@ -211,10 +211,6 @@ public enum WizardSystemPaths {
     public static let karabinerVHIDDevice =
         "/Applications/Karabiner-Elements.app/Contents/Library/bin/karabiner_grabber"
 
-    /// Karabiner-Elements daemon path
-    public static let karabinerDaemon =
-        "/Library/Application Support/org.pqrs.Karabiner-Elements/bin/karabiner_session_monitor"
-
     /// Karabiner-Elements user configuration file
     public static var karabinerConfigPath: String {
         "\(userHomeDirectory)/.config/karabiner/karabiner.json"

--- a/Tests/KeyPathTests/Lint/KarabinerCompatibilityLintTests.swift
+++ b/Tests/KeyPathTests/Lint/KarabinerCompatibilityLintTests.swift
@@ -1,0 +1,33 @@
+import Foundation
+import Testing
+
+@Suite("Karabiner compatibility lint")
+struct KarabinerCompatibilityLintTests {
+    @Test("Removed Karabiner session monitor does not become a health signal again")
+    func removedSessionMonitorDoesNotRegrow() throws {
+        let roots = ["Sources", "Tests", "docs", "guides"]
+        let obsoleteName = "karabiner_" + "session_monitor"
+
+        for root in roots {
+            let rootURL = LintScanner.path(root)
+            guard let enumerator = FileManager.default.enumerator(
+                at: rootURL,
+                includingPropertiesForKeys: nil
+            ) else {
+                Issue.record("Could not enumerate \(root)")
+                continue
+            }
+            let files = enumerator.compactMap { item -> URL? in
+                guard let file = item as? URL else { return nil }
+                return ["swift", "md"].contains(file.pathExtension) ? file : nil
+            }
+            for file in files where !file.path.contains("KarabinerCompatibilityLintTests.swift") {
+                let contents = try String(contentsOf: file, encoding: .utf8)
+                #expect(
+                    !contents.contains(obsoleteName),
+                    "Karabiner 16.1 removed the session monitor; use driver extension state, KeyPath launchd jobs, or karabiner_grabber conflict evidence instead: \(file.path)"
+                )
+            }
+        }
+    }
+}

--- a/Tests/KeyPathTests/Services/KarabinerConflictServiceTests.swift
+++ b/Tests/KeyPathTests/Services/KarabinerConflictServiceTests.swift
@@ -29,6 +29,31 @@ struct KarabinerConflictServiceTests {
         )
     }
 
+    @Test("Karabiner 16 installed without grabber is not a conflict")
+    func karabiner16WithoutGrabberIsNotAConflict() async {
+        TestSingletonReset.resetAll()
+        let runner = SubprocessRunnerFake.shared
+        await runner.reset()
+        await runner.configurePgrepResult { pattern in
+            // Modern Karabiner releases may run harmless supporting agents,
+            // but only the input grabber competes with Kanata for exclusive
+            // keyboard access.
+            pattern == "karabiner_console_user_server" ? [4444] : []
+        }
+
+        let provider = SystemStateProvider(probes: runner.systemProbeClient())
+        let service = KarabinerConflictService(systemStateProvider: provider)
+
+        let isRunning = await service.isKarabinerElementsRunning()
+        let commands = await runner.executedCommands
+
+        #expect(!isRunning)
+        #expect(
+            commands.filter { $0.executable == "/usr/bin/pgrep" }.map(\.args) == [["-f", "karabiner_grabber"]],
+            "Harmless Karabiner agents and app presence must not be treated as an input conflict"
+        )
+    }
+
     @Test("VirtualHID daemon detection uses injected SystemStateProvider")
     func virtualHIDDaemonDetectionUsesInjectedSystemStateProvider() async {
         TestSingletonReset.resetAll()

--- a/docs/troubleshooting/debugging-kanata.md
+++ b/docs/troubleshooting/debugging-kanata.md
@@ -630,7 +630,6 @@ launchctl list | grep -i karabiner
 # 10916	0	org.pqrs.service.agent.Karabiner-Menu
 # 10919	0	org.pqrs.service.agent.Karabiner-NotificationWindow
 # 10221	0	org.pqrs.service.agent.karabiner_console_user_server
-# 10223	0	org.pqrs.service.agent.karabiner_session_monitor
 ```
 
 **Common Issues**:


### PR DESCRIPTION
## Summary

- remove the obsolete Karabiner session-monitor path removed in Karabiner-Elements 16.1
- codify that harmless Karabiner agents or app presence are not conflicts; only the active `karabiner_grabber` competes with Kanata
- add a repository lint guard so the removed process assumption cannot become a health signal again
- remove the stale session-monitor example from troubleshooting documentation

## Root cause

The runtime conflict model already used current evidence (`karabiner_grabber`, VirtualHID extension state, and KeyPath-owned launchd jobs), but a shared path constant and troubleshooting example still described a process removed in Karabiner 16.1. That stale breadcrumb could invite future diagnostics to depend on an invalid signal.

Closes #983.

## Validation

- `TEST_FILTER=KarabinerConflictServiceTests ./Scripts/run-tests-safe.sh` (4 passed)
- `TEST_FILTER=KarabinerCompatibilityLintTests ./Scripts/run-tests-safe.sh` (1 passed)
- `./Scripts/test-fast.sh --changed` (selected the full safe suite)
- `python3 Scripts/check-accessibility.py`
- `git diff --check`
- `./Scripts/review-gate.sh` selected the remote review gate; do not merge until GitHub `claude-review` passes