### PR TITLE
Add repeatable macOS 27 regression capture

### DIFF
--- a/Scripts/lab/scenarios/installer-scenario
+++ b/Scripts/lab/scenarios/installer-scenario
@@ -65,9 +65,16 @@ case "$name" in
     "$installed_cli" system inspect --json > "$artifact_dir/system-inspect.json" 2>/dev/null || true
     print "Scenario artifacts written to $artifact_dir; follow with keypath-lab artifacts <lease-id>."
     ;;
+  macos-27-regression)
+    [[ -x "$installed_cli" ]] || { print -u2 "KeyPath CLI is not installed"; exit 3; }
+    product_major=$(sw_vers -productVersion | cut -d. -f1)
+    [[ "$product_major" == "27" ]] || { print -u2 "macOS 27 guest required"; exit 4; }
+    Scripts/qa-macos-27-regression.sh "$artifact_dir/evidence"
+    print "Complete the operator checklist in $artifact_dir/evidence/operator-checklist.md."
+    ;;
   *)
     print -u2 "Unknown scenario: $name"
-    print -u2 "Available: clean-install approvals helper-daemon-health launch repair-reinstall reboot-persistence-before reboot-persistence-after uninstall cancellation-failure artifact-capture"
+    print -u2 "Available: clean-install approvals helper-daemon-health launch repair-reinstall reboot-persistence-before reboot-persistence-after uninstall cancellation-failure artifact-capture macos-27-regression"
     exit 2
     ;;
 esac

--- a/Scripts/lab/tests/keypath-lab-tests.sh
+++ b/Scripts/lab/tests/keypath-lab-tests.sh
@@ -62,6 +62,9 @@ exit 0
 EOF
 chmod +x "$ROOT/bin/launcher15" "$ROOT/bin/launcher26" "$ROOT/bin/crabbox"
 
+/bin/bash -n "$LAB_DIR/../qa-macos-27-regression.sh"
+grep -q 'macos-27-regression)' "$LAB_DIR/scenarios/installer-scenario"
+
 run_remote() {
     KEYPATH_LAB_TESTING=1 \
     KEYPATH_LAB_TEST_ROOT="$ROOT" \

--- a/Scripts/qa-macos-27-regression.sh
+++ b/Scripts/qa-macos-27-regression.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+set -euo pipefail
+
+APP_PATH=${KEYPATH_MACOS27_QA_APP_PATH:-/Applications/KeyPath.app}
+CLI="$APP_PATH/Contents/MacOS/keypath-cli"
+OUTPUT_ROOT=${1:-"${TMPDIR:-/tmp}/keypath-macos27-qa-$(date -u +%Y%m%dT%H%M%SZ)"}
+
+die() {
+    echo "qa-macos-27-regression: $*" >&2
+    exit 1
+}
+
+product_version=$(sw_vers -productVersion)
+product_major=${product_version%%.*}
+if [[ $product_major != 27 && ${KEYPATH_MACOS27_QA_ALLOW_OTHER_OS:-0} != 1 ]]; then
+    die "requires macOS 27 (found $product_version)"
+fi
+[[ -d $APP_PATH ]] || die "installed app not found: $APP_PATH"
+[[ -x $CLI ]] || die "installed CLI not found: $CLI"
+
+mkdir -p "$OUTPUT_ROOT"
+sw_vers > "$OUTPUT_ROOT/sw-vers.txt"
+date -u +%Y-%m-%dT%H:%M:%SZ > "$OUTPUT_ROOT/captured-at.txt"
+
+"$CLI" system inspect --json > "$OUTPUT_ROOT/system-inspect.json"
+systemextensionsctl list > "$OUTPUT_ROOT/system-extensions.txt" 2>&1 || true
+launchctl print system/com.keypath.kanata > "$OUTPUT_ROOT/kanata-launchd.txt" 2>&1 || true
+launchctl print system/com.keypath.karabiner-vhiddaemon > "$OUTPUT_ROOT/vhid-daemon-launchd.txt" 2>&1 || true
+launchctl print system/com.keypath.karabiner-vhidmanager > "$OUTPUT_ROOT/vhid-manager-launchd.txt" 2>&1 || true
+
+codesign --verify --deep --strict --verbose=2 "$APP_PATH" > "$OUTPUT_ROOT/codesign.txt" 2>&1
+if [[ ${KEYPATH_MACOS27_QA_REQUIRE_DISTRIBUTION_TRUST:-1} == 1 ]]; then
+    spctl --assess --type execute --verbose=2 "$APP_PATH" > "$OUTPUT_ROOT/gatekeeper.txt" 2>&1
+    xcrun stapler validate "$APP_PATH" > "$OUTPUT_ROOT/stapler.txt" 2>&1
+else
+    echo "skipped: KEYPATH_MACOS27_QA_REQUIRE_DISTRIBUTION_TRUST=0" > "$OUTPUT_ROOT/gatekeeper.txt"
+    echo "skipped: KEYPATH_MACOS27_QA_REQUIRE_DISTRIBUTION_TRUST=0" > "$OUTPUT_ROOT/stapler.txt"
+fi
+
+pgrep -fl "$APP_PATH/Contents/MacOS/KeyPath" > "$OUTPUT_ROOT/keypath-process.txt" || true
+pgrep -fl "$APP_PATH/Contents/Library/KeyPath/Kanata Engine.app/Contents/MacOS/kanata" \
+    > "$OUTPUT_ROOT/kanata-process.txt" || true
+nc -vz 127.0.0.1 37001 > "$OUTPUT_ROOT/tcp-readiness.txt" 2>&1
+
+mkdir -p "$OUTPUT_ROOT/logs"
+cp "$HOME/Library/Logs/KeyPath/keypath-debug.log" "$OUTPUT_ROOT/logs/" 2>/dev/null || true
+cp /var/log/com.keypath.kanata.stdout.log "$OUTPUT_ROOT/logs/" 2>/dev/null || true
+cp /var/log/com.keypath.kanata.stderr.log "$OUTPUT_ROOT/logs/" 2>/dev/null || true
+
+cat > "$OUTPUT_ROOT/operator-checklist.md" <<'EOF'
+# macOS 27 operator checkpoints
+
+- [ ] In a disposable or clean account, capture the setup summary before granting permissions.
+- [ ] Grant and revoke Accessibility; confirm KeyPath reports the current state and recovery action.
+- [ ] Grant and revoke Input Monitoring; confirm PermissionOracle follows the current IOHID result.
+- [ ] Exercise Background App Activity/Login Items approval and distinguish pending approval from failure.
+- [ ] Confirm the VirtualHID Driver Extension approval opens the correct macOS 27 System Settings surface.
+- [ ] Type through Kanata and confirm the live overlay renders physical key down/up state correctly.
+- [ ] Restart the guest and rerun this capture to verify helper, daemon, and permission persistence.
+
+Do not copy TCC databases, credentials, Apple IDs, or private keys into this artifact directory.
+EOF
+
+echo "macOS 27 regression evidence: $OUTPUT_ROOT"

--- a/docs/testing/macos-27-regression.md
+++ b/docs/testing/macos-27-regression.md
@@ -1,0 +1,65 @@
+# macOS 27 Regression Matrix
+
+Run this matrix on every significant macOS 27 beta seed and again on the GM.
+Keep automated evidence separate from approval interactions that require a clean
+or disposable account.
+
+## Automated capture
+
+```bash
+Scripts/qa-macos-27-regression.sh
+```
+
+The capture fails unless the host is running macOS 27 and the installed app
+passes code-signature, Gatekeeper, stapling, and TCP-readiness checks. It records
+the canonical `keypath-cli system inspect --json` snapshot rather than reading
+TCC databases directly.
+
+| Area | Evidence |
+| --- | --- |
+| Exact beta seed | `sw-vers.txt`, `captured-at.txt` |
+| Permission/runtime state | `system-inspect.json` |
+| Driver approval | `system-extensions.txt` |
+| SMAppService/runtime jobs | `kanata-launchd.txt`, `vhid-*-launchd.txt` |
+| XPC and bundle signing | `codesign.txt` |
+| Distribution trust | `gatekeeper.txt`, `stapler.txt` |
+| Keyboard runtime | process files, `tcp-readiness.txt`, logs |
+
+## Operator matrix
+
+Use a disposable desktop VM or clean local account. Capture screenshots before
+and after each approval, then rerun the automated capture after reboot.
+
+| State | Expected KeyPath result |
+| --- | --- |
+| Accessibility denied | Exact Accessibility action; no false runtime success |
+| Accessibility newly granted | Current state appears after the supported refresh/relaunch path |
+| Input Monitoring denied | `PermissionOracle` reports denial and identifies KeyPath precisely |
+| Input Monitoring newly granted | Current IOHID result wins over stale fallback evidence |
+| Background App Activity pending | Pending approval is distinct from installation/runtime failure |
+| VirtualHID extension disabled | Driver Extension action opens the macOS 27 settings surface |
+| Karabiner app installed, grabber stopped | No conflict is reported |
+| `karabiner_grabber` running | A specific conflict and recovery action are reported |
+| All approvals granted | `planStatus=ready`, `isOperational=true`, TCP responding |
+| Reboot after healthy setup | Helper, daemon, permissions, and TCP readiness persist |
+
+Do not reset or copy TCC databases as part of artifact collection. Do not store
+credentials, Apple IDs, private keys, or passwords in the evidence bundle.
+
+## Current beta checkpoint
+
+On 2026-07-11, the non-destructive capture ran on macOS 27.0 build `26A5378j`
+against the installed local build. With distribution-trust checks explicitly
+disabled for harness development, it reported:
+
+- `planStatus=ready`
+- `driverCompatible=true`
+- `isOperational=true`
+- VirtualHID `[activated enabled]`
+- KeyPath and Kanata processes present
+- TCP ready on `127.0.0.1:37001`
+- bundle code signature valid
+
+This checkpoint validates the harness and current healthy-runtime path. It does
+not satisfy the clean-account approval matrix or the signed/notarized trust
+gate; those require a release-candidate artifact with the default strict mode.

--- a/docs/testing/remote-installer-lab.md
+++ b/docs/testing/remote-installer-lab.md
@@ -105,6 +105,7 @@ Scripts/lab/keypath-lab scenario cbx_example reboot-persistence-after
 Scripts/lab/keypath-lab scenario cbx_example uninstall
 Scripts/lab/keypath-lab scenario cbx_example cancellation-failure
 Scripts/lab/keypath-lab scenario cbx_example artifact-capture
+Scripts/lab/keypath-lab scenario cbx_example macos-27-regression
 Scripts/lab/keypath-lab artifacts cbx_example
 ```
 
@@ -116,6 +117,36 @@ point rather than attempting to bypass macOS security UI. Never place Apple IDs,
 passwords, private keys, TCC databases, or other credentials in a scenario or
 artifact bundle. CrabBox does not redact collected files automatically; inspect
 every bundle before sharing or publishing it.
+
+### macOS 27 beta regression capture
+
+On every significant macOS 27 beta seed, run the non-destructive evidence
+capture on an installed signed and notarized build:
+
+```bash
+Scripts/qa-macos-27-regression.sh
+```
+
+For a disposable macOS 27 desktop lease, run the same capture after installing
+the app:
+
+```bash
+Scripts/lab/keypath-lab scenario cbx_example macos-27-regression
+Scripts/lab/keypath-lab artifacts cbx_example
+```
+
+The command records the exact OS build, canonical CLI system snapshot,
+VirtualHID extension state, KeyPath-owned launchd jobs, signatures, Gatekeeper
+and stapling results, processes, TCP readiness, and relevant logs. It also emits
+an operator checklist for Accessibility, Input Monitoring, Background App
+Activity, Driver Extension approval, overlay behavior, and reboot persistence.
+Those interactions remain manual because programmatically modifying TCC or
+bypassing macOS approval UI would invalidate the regression test.
+
+Distribution trust checks are required by default. For harness development
+against a locally signed debug deployment only, set
+`KEYPATH_MACOS27_QA_REQUIRE_DISTRIBUTION_TRUST=0`; never use that override for a
+release or beta-seed result.
 
 ## Failure and recovery
 


### PR DESCRIPTION
## Summary

- add a non-destructive macOS 27 evidence capture for canonical system state, DriverKit, launchd, signing, Gatekeeper, stapling, processes, TCP readiness, and logs
- add a disposable-lab scenario that runs the same capture inside a macOS 27 desktop lease
- document the per-beta automated evidence and operator-only permission matrix
- record the first healthy-path harness checkpoint on macOS 27.0 build 26A5378j

## Safety and scope

The harness never reads, copies, or modifies TCC databases and never bypasses macOS approval UI. Accessibility, Input Monitoring, Background App Activity, Driver Extension approval, overlay behavior, and reboot persistence remain explicit operator checkpoints. Distribution trust is required by default; the override is documented as harness-development-only and is not valid release evidence.

Related to #919. This PR makes the matrix repeatable but does not close #919 until the clean-account approval path and strict signed/notarized capture are completed.

## Validation

- `bash -n Scripts/qa-macos-27-regression.sh`
- `zsh -n Scripts/lab/scenarios/installer-scenario`
- `Scripts/lab/tests/keypath-lab-tests.sh`
- live macOS 27 capture with development-only trust override
- canonical snapshot reported ready/operational/driver-compatible and TCP ready
- `python3 Scripts/check-accessibility.py`
- `git diff --check`
- `./Scripts/review-gate.sh` selected remote review; do not merge until `claude-review` passes