### PR TITLE
Fix CLI tri-mode permission reporting

### DIFF
--- a/Sources/KeyPathAppKit/CLI/SystemFacade.swift
+++ b/Sources/KeyPathAppKit/CLI/SystemFacade.swift
@@ -421,6 +421,7 @@ public struct SystemFacade: Sendable {
             permission: "Input Monitoring",
             deniedAction: "Open KeyPath.app and grant Input Monitoring in System Settings > Privacy & Security > Input Monitoring",
             remediationURL: WizardSystemPaths.inputMonitoringSettings,
+            isBlocking: false,
             to: &issues
         )
         appendPermissionIssue(
@@ -464,6 +465,7 @@ public struct SystemFacade: Sendable {
         permission: String,
         deniedAction: String,
         remediationURL: String,
+        isBlocking: Bool = true,
         to issues: inout [CLISystemIssue]
     ) {
         switch status {
@@ -475,7 +477,8 @@ public struct SystemFacade: Sendable {
                 category: "permissions",
                 action: deniedAction,
                 canAutoFix: false,
-                remediationURL: remediationURL
+                remediationURL: remediationURL,
+                severity: isBlocking ? .error : .warning
             ))
         case .unknown:
             issues.append(.init(
@@ -484,7 +487,7 @@ public struct SystemFacade: Sendable {
                 action: "Grant Full Disk Access to KeyPath to verify this permission",
                 canAutoFix: false,
                 remediationURL: WizardSystemPaths.fullDiskAccessSettings,
-                severity: "warning"
+                severity: .warning
             ))
         }
     }

--- a/Sources/KeyPathAppKit/CLI/SystemFacade.swift
+++ b/Sources/KeyPathAppKit/CLI/SystemFacade.swift
@@ -4,6 +4,7 @@ import KeyPathCLISupport
 import KeyPathCore
 import KeyPathDaemonLifecycle
 import KeyPathInstallationWizard
+import KeyPathPermissions
 import KeyPathWizardCore
 
 public struct SystemFacade: Sendable {
@@ -108,11 +109,7 @@ public struct SystemFacade: Sendable {
         let context = await engine.inspectSystem()
 
         return CLIStatusResult(
-            isOperational: context.permissions.isSystemReady
-                && context.helper.isReady
-                && context.components.hasAllRequired
-                && context.services.isHealthy
-                && !context.conflicts.hasConflicts,
+            isOperational: Self.isOperational(context),
             helperInstalled: context.helper.isInstalled,
             helperWorking: context.helper.isWorking,
             helperVersion: context.helper.version,
@@ -180,7 +177,7 @@ public struct SystemFacade: Sendable {
         }
 
         let initialIssues = Self.issues(from: context)
-        let initialUserActionIssues = initialIssues.filter { !$0.canAutoFix }
+        let initialUserActionIssues = initialIssues.filter(\.requiresUserAction)
         if !initialUserActionIssues.isEmpty, plan.recipes.isEmpty {
             return CLIInstallerReport(
                 success: false,
@@ -258,7 +255,7 @@ public struct SystemFacade: Sendable {
             plannedRecipes: plan.recipes.map { "\($0.id) (\($0.type))" },
             planIntent: "\(planIntent)",
             isOperational: Self.isOperational(context),
-            userActionRequired: Self.issues(from: context).contains { !$0.canAutoFix },
+            userActionRequired: Self.issues(from: context).contains(where: \.requiresUserAction),
             promptsNeeded: plan.metadata.promptsNeeded,
             issues: Self.issues(from: context),
             stateMatrixRow: plan.metadata.stateMatrixRow,
@@ -276,8 +273,10 @@ public struct SystemFacade: Sendable {
         return NSWorkspace.shared.open(url)
     }
 
-    fileprivate static func isOperational(_ context: SystemContext) -> Bool {
-        context.permissions.isSystemReady
+    static func isOperational(_ context: SystemContext) -> Bool {
+        !context.permissions.keyPath.accessibility.isBlocking
+            && !context.permissions.kanata.accessibility.isBlocking
+            && !context.permissions.kanata.inputMonitoring.isBlocking
             && context.helper.isReady
             && context.components.hasAllRequired
             && context.services.isHealthy
@@ -305,7 +304,7 @@ public struct SystemFacade: Sendable {
         )
     }
 
-    fileprivate static func issues(from context: SystemContext) -> [CLISystemIssue] {
+    static func issues(from context: SystemContext) -> [CLISystemIssue] {
         var issues: [CLISystemIssue] = []
 
         if !context.helper.isInstalled {
@@ -408,42 +407,38 @@ public struct SystemFacade: Sendable {
     }
 
     private static func appendPermissionIssues(from context: SystemContext, to issues: inout [CLISystemIssue]) {
-        if !context.permissions.keyPath.accessibility.isReady {
-            issues.append(.init(
-                title: "KeyPath needs Accessibility permission",
-                category: "permissions",
-                action: "Open KeyPath.app and grant Accessibility in System Settings > Privacy & Security > Accessibility",
-                canAutoFix: false,
-                remediationURL: WizardSystemPaths.accessibilitySettings
-            ))
-        }
-        if !context.permissions.keyPath.inputMonitoring.isReady {
-            issues.append(.init(
-                title: "KeyPath needs Input Monitoring permission",
-                category: "permissions",
-                action: "Open KeyPath.app and grant Input Monitoring in System Settings > Privacy & Security > Input Monitoring",
-                canAutoFix: false,
-                remediationURL: WizardSystemPaths.inputMonitoringSettings
-            ))
-        }
-        if !context.permissions.kanata.accessibility.isReady {
-            issues.append(.init(
-                title: "Kanata needs Accessibility permission",
-                category: "permissions",
-                action: "Open the KeyPath Installation Wizard to grant Kanata Engine Accessibility",
-                canAutoFix: false,
-                remediationURL: WizardSystemPaths.accessibilitySettings
-            ))
-        }
-        if !context.permissions.kanata.inputMonitoring.isReady {
-            issues.append(.init(
-                title: "Kanata needs Input Monitoring permission",
-                category: "permissions",
-                action: "Open the KeyPath Installation Wizard to grant Kanata Engine Input Monitoring",
-                canAutoFix: false,
-                remediationURL: WizardSystemPaths.inputMonitoringSettings
-            ))
-        }
+        appendPermissionIssue(
+            status: context.permissions.keyPath.accessibility,
+            subject: "KeyPath",
+            permission: "Accessibility",
+            deniedAction: "Open KeyPath.app and grant Accessibility in System Settings > Privacy & Security > Accessibility",
+            remediationURL: WizardSystemPaths.accessibilitySettings,
+            to: &issues
+        )
+        appendPermissionIssue(
+            status: context.permissions.keyPath.inputMonitoring,
+            subject: "KeyPath",
+            permission: "Input Monitoring",
+            deniedAction: "Open KeyPath.app and grant Input Monitoring in System Settings > Privacy & Security > Input Monitoring",
+            remediationURL: WizardSystemPaths.inputMonitoringSettings,
+            to: &issues
+        )
+        appendPermissionIssue(
+            status: context.permissions.kanata.accessibility,
+            subject: "Kanata",
+            permission: "Accessibility",
+            deniedAction: "Open the KeyPath Installation Wizard to grant Kanata Engine Accessibility",
+            remediationURL: WizardSystemPaths.accessibilitySettings,
+            to: &issues
+        )
+        appendPermissionIssue(
+            status: context.permissions.kanata.inputMonitoring,
+            subject: "Kanata",
+            permission: "Input Monitoring",
+            deniedAction: "Open the KeyPath Installation Wizard to grant Kanata Engine Input Monitoring",
+            remediationURL: WizardSystemPaths.inputMonitoringSettings,
+            to: &issues
+        )
         if !context.services.kanataInputCaptureReady {
             let needsManualVHIDApproval = context.requiresManualVHIDDriverApproval
             issues.append(.init(
@@ -459,6 +454,37 @@ public struct SystemFacade: Sendable {
                 remediationURL: needsManualVHIDApproval
                     ? WizardSystemPaths.loginItemsSettings
                     : KeyPathConstants.URLs.terminalInputCaptureTroubleshooting
+            ))
+        }
+    }
+
+    private static func appendPermissionIssue(
+        status: PermissionOracle.Status,
+        subject: String,
+        permission: String,
+        deniedAction: String,
+        remediationURL: String,
+        to issues: inout [CLISystemIssue]
+    ) {
+        switch status {
+        case .granted:
+            return
+        case .denied, .error:
+            issues.append(.init(
+                title: "\(subject) needs \(permission) permission",
+                category: "permissions",
+                action: deniedAction,
+                canAutoFix: false,
+                remediationURL: remediationURL
+            ))
+        case .unknown:
+            issues.append(.init(
+                title: "\(subject) \(permission) permission not verified",
+                category: "permissions",
+                action: "Grant Full Disk Access to KeyPath to verify this permission",
+                canAutoFix: false,
+                remediationURL: WizardSystemPaths.fullDiskAccessSettings,
+                severity: "warning"
             ))
         }
     }
@@ -499,7 +525,7 @@ public extension CLIInstallerReport {
         title: String
     ) {
         let finalIssues = SystemFacade.issues(from: finalContext ?? initialContext)
-        let finalUserActionIssues = finalIssues.filter { !$0.canAutoFix }
+        let finalUserActionIssues = finalIssues.filter(\.requiresUserAction)
         let finalOperational = finalContext.map(SystemFacade.isOperational) ?? false
         let completedButStillBlocked = report.success
             && report.completionState != .awaitingApproval
@@ -548,7 +574,7 @@ public extension CLIInstallerReport {
 
     init(dryRunPlan plan: InstallPlan, context: SystemContext, title: String) {
         let contextIssues = SystemFacade.issues(from: context)
-        let userActionIssues = contextIssues.filter { !$0.canAutoFix }
+        let userActionIssues = contextIssues.filter(\.requiresUserAction)
         let blockedBy = plan.blockedBy.map { [$0.name] } ?? []
 
         let failureReason: String? = if !blockedBy.isEmpty {

--- a/Sources/KeyPathCLISupport/CLIReportModels.swift
+++ b/Sources/KeyPathCLISupport/CLIReportModels.swift
@@ -291,16 +291,21 @@ public struct CLIInspectResult: Codable, Sendable {
     }
 }
 
+public enum CLISystemIssueSeverity: String, Codable, Sendable {
+    case error
+    case warning
+}
+
 public struct CLISystemIssue: Codable, Sendable {
     public let title: String
     public let category: String
     public let action: String
     public let canAutoFix: Bool
     public let remediationURL: String?
-    public let severity: String?
+    public let severity: CLISystemIssueSeverity?
 
     public var requiresUserAction: Bool {
-        severity != "warning" && !canAutoFix
+        severity != .warning && !canAutoFix
     }
 
     public init(
@@ -309,7 +314,7 @@ public struct CLISystemIssue: Codable, Sendable {
         action: String,
         canAutoFix: Bool,
         remediationURL: String? = nil,
-        severity: String = "error"
+        severity: CLISystemIssueSeverity = .error
     ) {
         self.title = title
         self.category = category

--- a/Sources/KeyPathCLISupport/CLIReportModels.swift
+++ b/Sources/KeyPathCLISupport/CLIReportModels.swift
@@ -297,18 +297,25 @@ public struct CLISystemIssue: Codable, Sendable {
     public let action: String
     public let canAutoFix: Bool
     public let remediationURL: String?
+    public let severity: String?
+
+    public var requiresUserAction: Bool {
+        severity != "warning" && !canAutoFix
+    }
 
     public init(
         title: String,
         category: String,
         action: String,
         canAutoFix: Bool,
-        remediationURL: String? = nil
+        remediationURL: String? = nil,
+        severity: String = "error"
     ) {
         self.title = title
         self.category = category
         self.action = action
         self.canAutoFix = canAutoFix
         self.remediationURL = remediationURL
+        self.severity = severity
     }
 }

--- a/Tests/KeyPathTests/CLI/CLIOutputContractTests.swift
+++ b/Tests/KeyPathTests/CLI/CLIOutputContractTests.swift
@@ -286,6 +286,42 @@ final class CLIOutputContractTests: XCTestCase {
         XCTAssertEqual(decoded.stateMatrixPlan, [InstallerStateMatrixAction.installHelper.rawValue])
     }
 
+    func testPermissionIssuesPreserveTriModeSemantics() {
+        let granted = SystemContextBuilder(
+            permissionsStatus: .granted,
+            helperReady: true,
+            servicesHealthy: true,
+            componentsInstalled: true
+        ).build()
+        XCTAssertFalse(SystemFacade.issues(from: granted).contains { $0.category == "permissions" })
+        XCTAssertTrue(SystemFacade.isOperational(granted))
+
+        let denied = SystemContextBuilder(
+            permissionsStatus: .denied,
+            helperReady: true,
+            servicesHealthy: true,
+            componentsInstalled: true
+        ).build()
+        let deniedIssues = SystemFacade.issues(from: denied).filter { $0.category == "permissions" }
+        XCTAssertTrue(deniedIssues.allSatisfy { $0.severity == "error" })
+        XCTAssertTrue(deniedIssues.allSatisfy(\.requiresUserAction))
+        XCTAssertTrue(deniedIssues.contains { $0.title == "Kanata needs Input Monitoring permission" })
+        XCTAssertFalse(SystemFacade.isOperational(denied))
+
+        let unknown = SystemContextBuilder(
+            permissionsStatus: .unknown,
+            helperReady: true,
+            servicesHealthy: true,
+            componentsInstalled: true
+        ).build()
+        let unknownIssues = SystemFacade.issues(from: unknown).filter { $0.category == "permissions" }
+        XCTAssertTrue(unknownIssues.allSatisfy { $0.severity == "warning" })
+        XCTAssertFalse(unknownIssues.contains(where: \.requiresUserAction))
+        XCTAssertTrue(unknownIssues.contains { $0.title == "Kanata Input Monitoring permission not verified" })
+        XCTAssertFalse(unknownIssues.contains { $0.title.contains(" needs ") })
+        XCTAssertTrue(SystemFacade.isOperational(unknown))
+    }
+
     func testJSONRoundTripsPreserveKeys() throws {
         let changeset = CLIApplyChangeset(enabledCollections: ["A"], disabledCollections: ["B"], customRules: ["caps → esc"])
         let result = CLIApplyResult(collectionsCount: 5, enabledCount: 3, customRulesCount: 2, reloadSuccess: true, changeset: changeset)

--- a/Tests/KeyPathTests/CLI/CLIOutputContractTests.swift
+++ b/Tests/KeyPathTests/CLI/CLIOutputContractTests.swift
@@ -2,6 +2,7 @@
 import KeyPathCLISupport
 import KeyPathCore
 @testable import KeyPathInstallationWizard
+import KeyPathPermissions
 import KeyPathWizardCore
 import XCTest
 
@@ -303,8 +304,8 @@ final class CLIOutputContractTests: XCTestCase {
             componentsInstalled: true
         ).build()
         let deniedIssues = SystemFacade.issues(from: denied).filter { $0.category == "permissions" }
-        XCTAssertTrue(deniedIssues.allSatisfy { $0.severity == "error" })
-        XCTAssertTrue(deniedIssues.allSatisfy(\.requiresUserAction))
+        XCTAssertTrue(deniedIssues.contains { $0.severity == .error })
+        XCTAssertTrue(deniedIssues.contains(where: \.requiresUserAction))
         XCTAssertTrue(deniedIssues.contains { $0.title == "Kanata needs Input Monitoring permission" })
         XCTAssertFalse(SystemFacade.isOperational(denied))
 
@@ -315,11 +316,22 @@ final class CLIOutputContractTests: XCTestCase {
             componentsInstalled: true
         ).build()
         let unknownIssues = SystemFacade.issues(from: unknown).filter { $0.category == "permissions" }
-        XCTAssertTrue(unknownIssues.allSatisfy { $0.severity == "warning" })
+        XCTAssertTrue(unknownIssues.allSatisfy { $0.severity == .warning })
         XCTAssertFalse(unknownIssues.contains(where: \.requiresUserAction))
         XCTAssertTrue(unknownIssues.contains { $0.title == "Kanata Input Monitoring permission not verified" })
         XCTAssertFalse(unknownIssues.contains { $0.title.contains(" needs ") })
         XCTAssertTrue(SystemFacade.isOperational(unknown))
+    }
+
+    func testKeyPathInputMonitoringDenialIsSoftForCoreOperation() {
+        let context = contextWithKeyPathInputMonitoring(.denied)
+
+        let issue = SystemFacade.issues(from: context).first {
+            $0.title == "KeyPath needs Input Monitoring permission"
+        }
+        XCTAssertEqual(issue?.severity, .warning)
+        XCTAssertEqual(issue?.requiresUserAction, false)
+        XCTAssertTrue(SystemFacade.isOperational(context))
     }
 
     func testJSONRoundTripsPreserveKeys() throws {
@@ -341,5 +353,37 @@ final class CLIOutputContractTests: XCTestCase {
         let data = try encoder.encode(value)
         let dict = try JSONSerialization.jsonObject(with: data) as! [String: Any]
         return Set(dict.keys)
+    }
+
+    private func contextWithKeyPathInputMonitoring(_ status: PermissionOracle.Status) -> SystemContext {
+        let context = SystemContextBuilder(
+            permissionsStatus: .granted,
+            helperReady: true,
+            servicesHealthy: true,
+            componentsInstalled: true
+        ).build()
+        let keyPathPermissions = PermissionOracle.PermissionSet(
+            accessibility: .granted,
+            inputMonitoring: status,
+            source: "test",
+            confidence: .high,
+            timestamp: context.timestamp
+        )
+        let permissions = PermissionOracle.Snapshot(
+            keyPath: keyPathPermissions,
+            kanata: context.permissions.kanata,
+            timestamp: context.timestamp
+        )
+        return SystemContext(
+            snapshotID: context.snapshotID,
+            permissions: permissions,
+            services: context.services,
+            conflicts: context.conflicts,
+            components: context.components,
+            helper: context.helper,
+            system: context.system,
+            timestamp: context.timestamp,
+            captureStatus: context.captureStatus
+        )
     }
 }


### PR DESCRIPTION
## Summary
- preserve granted, denied/error, and unknown permission states in CLI diagnostics
- report unverifiable permissions as non-blocking warnings instead of missing permissions
- keep CLI operational and installer user-action results consistent with tri-mode semantics
- add CLI contract coverage for all three states

## Validation
- `swift test --filter CLIOutputContractTests --jobs 4`
- `./Scripts/test-full.sh` (4,739 passed)
- `python3 Scripts/check-accessibility.py`
- `git diff --check`

## Review gate
- Local review tooling selected the remote review gate; do not merge until `claude-review` passes.