### PR TITLE
Add semantic Peekaboo installer lab adapter

### DIFF
--- a/Scripts/lab/peekaboo-ui
+++ b/Scripts/lab/peekaboo-ui
@@ -1,0 +1,106 @@
+#!/bin/zsh
+set -euo pipefail
+
+die() { print -u2 "peekaboo-ui: $*"; exit 1; }
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: Scripts/lab/peekaboo-ui <command> [options]
+
+Commands:
+  preflight
+  snapshot --app APP --output FILE
+  click --app APP --query QUERY --output FILE [--foreground]
+  dialogs --app APP --output FILE
+  file --app APP --path PATH --output FILE [--select BUTTON]
+  screenshot --app APP --output FILE [--retina]
+
+This command runs inside a desktop-enabled disposable guest. Every operation
+writes Peekaboo's JSON result to FILE. It never accepts credentials. A
+successful click proves delivery only; protected System Settings controls must
+also be checked with an independent system/runtime postcondition.
+EOF
+  exit 2
+}
+
+require_value() {
+  [[ -n "${2:-}" ]] || die "$1 requires a value"
+}
+
+require_output_path() {
+  local output=$1 parent
+  [[ -n "$output" && "$output" != -* ]] || die "invalid output path"
+  parent=${output:h}
+  mkdir -p "$parent"
+}
+
+peekaboo_bin=${PEEKABOO_BIN:-$(command -v peekaboo || true)}
+
+command=${1:-}
+[[ -n "$command" ]] || usage
+shift
+
+if [[ "$command" == preflight ]]; then
+  [[ $# -eq 0 ]] || usage
+  [[ -x "$peekaboo_bin" ]] || die "Peekaboo 3.x is required (brew install steipete/tap/peekaboo)"
+  version=$($peekaboo_bin --version 2>/dev/null | head -1)
+  [[ "$version" =~ '^Peekaboo[[:space:]]+3\.' ]] || die "Peekaboo 3.x is required; found: ${version:-unknown}"
+  $peekaboo_bin permissions status --json
+  exit
+fi
+
+[[ -x "$peekaboo_bin" ]] || die "Peekaboo 3.x is required (brew install steipete/tap/peekaboo)"
+
+app=
+output=
+query=
+file_path=
+select_button=Open
+foreground=0
+retina=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --app) require_value "$1" "${2:-}"; app=$2; shift 2 ;;
+    --output) require_value "$1" "${2:-}"; output=$2; shift 2 ;;
+    --query) require_value "$1" "${2:-}"; query=$2; shift 2 ;;
+    --path) require_value "$1" "${2:-}"; file_path=$2; shift 2 ;;
+    --select) require_value "$1" "${2:-}"; select_button=$2; shift 2 ;;
+    --foreground) foreground=1; shift ;;
+    --retina) retina=1; shift ;;
+    *) usage ;;
+  esac
+done
+
+[[ -n "$app" ]] || die "--app is required"
+[[ -n "$output" ]] || die "--output is required"
+require_output_path "$output"
+
+case "$command" in
+  snapshot)
+    $peekaboo_bin see --app "$app" --json > "$output"
+    ;;
+  click)
+    [[ -n "$query" ]] || die "--query is required"
+    args=(click "$query" --app "$app" --json)
+    (( foreground )) && args+=(--foreground)
+    $peekaboo_bin "${args[@]}" > "$output"
+    ;;
+  dialogs)
+    $peekaboo_bin dialog list --app "$app" --json > "$output"
+    ;;
+  file)
+    [[ -n "$file_path" && "$file_path" == /* ]] || die "--path must be absolute"
+    file_directory=${file_path:h}
+    file_name=${file_path:t}
+    [[ -n "$file_name" ]] || die "--path must identify a file"
+    $peekaboo_bin dialog file --app "$app" --path "$file_directory" --name "$file_name" --select "$select_button" --json > "$output"
+    ;;
+  screenshot)
+    args=(image --app "$app" --mode window --path "$output" --json)
+    (( retina )) && args+=(--retina)
+    result="${output}.json"
+    $peekaboo_bin "${args[@]}" > "$result"
+    ;;
+  *) usage ;;
+esac

--- a/Scripts/lab/tests/keypath-lab-tests.sh
+++ b/Scripts/lab/tests/keypath-lab-tests.sh
@@ -227,4 +227,6 @@ if PATH="$TMP/fake-bin:$PATH" "$LAB_DIR/keypath-lab" create --macos 15 --commit 
     exit 1
 fi
 
+"$LAB_DIR/tests/peekaboo-ui-tests.sh"
+
 echo "keypath-lab shell tests passed"

--- a/Scripts/lab/tests/peekaboo-ui-tests.sh
+++ b/Scripts/lab/tests/peekaboo-ui-tests.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" >/dev/null && pwd -P)
+LAB_DIR=$(cd "$SCRIPT_DIR/.." >/dev/null && pwd -P)
+TMP=$(mktemp -d "${TMPDIR:-/tmp}/peekaboo-ui-tests.XXXXXX")
+trap 'rm -rf "$TMP"' EXIT
+
+FAKE="$TMP/peekaboo"
+cat > "$FAKE" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$PEEKABOO_CALLS"
+if [[ ${1:-} == --version ]]; then
+  echo "${PEEKABOO_TEST_VERSION:-Peekaboo 3.9.0}"
+else
+  printf '{"success":true}\n'
+fi
+EOF
+chmod +x "$FAKE"
+export PEEKABOO_BIN="$FAKE"
+export PEEKABOO_CALLS="$TMP/calls"
+
+"$LAB_DIR/peekaboo-ui" preflight > "$TMP/preflight.json"
+grep -q 'permissions status --json' "$PEEKABOO_CALLS"
+
+for unsupported in 'Peekaboo 2.3.0' 'Peekaboo 13.0.0'; do
+  if PEEKABOO_TEST_VERSION="$unsupported" "$LAB_DIR/peekaboo-ui" preflight >/dev/null 2>&1; then
+    echo "expected unsupported version to fail: $unsupported" >&2
+    exit 1
+  fi
+done
+
+"$LAB_DIR/peekaboo-ui" snapshot --app 'System Settings' --output "$TMP/out/snapshot.json"
+grep -q 'see --app System Settings --json' "$PEEKABOO_CALLS"
+grep -q '"success":true' "$TMP/out/snapshot.json"
+
+"$LAB_DIR/peekaboo-ui" click --app KeyPath --query 'Get Started' --foreground --output "$TMP/out/click.json"
+grep -q 'click Get Started --app KeyPath --json --foreground' "$PEEKABOO_CALLS"
+
+"$LAB_DIR/peekaboo-ui" dialogs --app 'System Settings' --output "$TMP/out/dialogs.json"
+grep -q 'dialog list --app System Settings --json' "$PEEKABOO_CALLS"
+
+"$LAB_DIR/peekaboo-ui" file --app 'System Settings' --path /Applications/KeyPath.app --select Open --output "$TMP/out/file.json"
+grep -q 'dialog file --app System Settings --path /Applications --name KeyPath.app --select Open --json' "$PEEKABOO_CALLS"
+
+"$LAB_DIR/peekaboo-ui" screenshot --app KeyPath --retina --output "$TMP/out/keypath.png"
+grep -q 'image --app KeyPath --mode window --path .*keypath.png --json --retina' "$PEEKABOO_CALLS"
+grep -q '"success":true' "$TMP/out/keypath.png.json"
+
+if "$LAB_DIR/peekaboo-ui" file --app KeyPath --path relative --output "$TMP/out/bad.json" >/dev/null 2>&1; then
+  echo 'expected relative file path to fail' >&2
+  exit 1
+fi
+
+if "$LAB_DIR/peekaboo-ui" click --app KeyPath --output "$TMP/out/bad.json" >/dev/null 2>&1; then
+  echo 'expected missing query to fail' >&2
+  exit 1
+fi
+
+echo 'peekaboo-ui shell tests passed'

--- a/docs/testing/remote-installer-lab.md
+++ b/docs/testing/remote-installer-lab.md
@@ -82,6 +82,47 @@ CrabBox's desktop capability; ordinary creation continues to use the launchers
 unchanged. Artifact collection captures a screenshot for desktop leases and
 records an explicit unavailable status otherwise.
 
+### Semantic UI automation with Peekaboo 3
+
+Desktop guests can use `Scripts/lab/peekaboo-ui` to discover and operate
+KeyPath and System Settings without framebuffer coordinate assumptions. The
+adapter provides typed commands for snapshots, semantic clicks, dialog
+inspection, file selection, and Retina screenshots. Every command writes JSON
+evidence alongside the scenario output so it is included by `artifacts`.
+
+```bash
+OUT=.keypath-lab/scenario-output/approvals/peekaboo
+
+Scripts/lab/keypath-lab run cbx_example -- \
+  Scripts/lab/peekaboo-ui preflight
+Scripts/lab/keypath-lab run cbx_example -- \
+  Scripts/lab/peekaboo-ui snapshot \
+  --app 'System Settings' --output "$OUT/input-monitoring.json"
+Scripts/lab/keypath-lab run cbx_example -- \
+  Scripts/lab/peekaboo-ui click \
+  --app 'System Settings' --query Add --output "$OUT/add-click.json"
+Scripts/lab/keypath-lab run cbx_example -- \
+  Scripts/lab/peekaboo-ui file \
+  --app 'System Settings' \
+  --path /Applications/KeyPath.app/Contents/Library/KeyPath/kanata-launcher \
+  --output "$OUT/file-dialog.json"
+```
+
+Peekaboo click success means that it delivered an action to the selected UI
+element. It is not proof that macOS accepted a protected change. Background App
+Activity, Driver Extensions, Accessibility, and Input Monitoring must be
+verified through the canonical CLI/system/runtime postcondition after every
+click. Driver Extension activation on macOS 15 may still require CrabBox's
+native RFB click delivery. Use fresh Peekaboo geometry to locate the control,
+convert logical points to framebuffer coordinates using the current display
+scale, and verify activation afterward; never preserve raw coordinates between
+runs.
+
+The adapter deliberately has no password-input command. Do not put a lab
+password in a command line, workflow file, shell trace, or collected artifact.
+Authentication-sheet automation needs a separate secure credential-injection
+contract before it becomes part of the reusable workflow.
+
 `install-app` expands the staged ZIP into `/Applications` on the disposable
 guest. Tart uses the base image's noninteractive sudo contract. Parallels uses
 the same passwordless `prlctl exec` guest-control channel CrabBox already uses


### PR DESCRIPTION
## Summary
- add a guest-side Peekaboo 3 adapter for semantic snapshots, clicks, dialog inspection, file selection, and Retina screenshots
- require JSON evidence output and reject unsafe or missing arguments
- document independent postcondition checks and the narrow RFB fallback for protected Driver Extension controls
- keep credentials out of the reusable command contract
- add shell contract coverage and wire it into the existing lab test suite

## Validation
- Scripts/lab/tests/keypath-lab-tests.sh
- ./Scripts/test-full.sh (4,740 tests passed)
- git diff --check
- review gate: remote review gate selected; GitHub claude-review must pass before merge
