### PR TITLE
Add disposable macOS 27 lab lane

### DIFF
--- a/Scripts/lab/keypath-lab
+++ b/Scripts/lab/keypath-lab
@@ -12,7 +12,7 @@ Usage: Scripts/lab/keypath-lab [--host HOST] <command> [options]
 
 Commands:
   preflight
-  create --macos 15|26 --commit SHA --installer PATH [--ttl 2h] [--desktop]
+  create --macos 15|26|27 --commit SHA --installer PATH [--ttl 2h] [--desktop]
   install-app LEASE_ID
   run LEASE_ID -- COMMAND [ARG...]
   status LEASE_ID
@@ -79,7 +79,7 @@ case "$command" in
                 *) usage ;;
             esac
         done
-        [[ $macos == "15" || $macos == "26" ]] || die "--macos must be 15 or 26"
+        [[ $macos == "15" || $macos == "26" || $macos == "27" ]] || die "--macos must be 15, 26, or 27"
         [[ $commit =~ ^[0-9a-fA-F]{40}$ ]] || die "--commit must be a full 40-character SHA"
         [[ -f $installer ]] || die "installer not found: $installer"
         resolved=$(git -C "$REPO_ROOT" rev-parse --verify "$commit^{commit}")

--- a/Scripts/lab/remote.sh
+++ b/Scripts/lab/remote.sh
@@ -8,11 +8,13 @@ if [[ "${KEYPATH_LAB_TESTING:-0}" == "1" ]]; then
   LAB_ROOT="${KEYPATH_LAB_TEST_ROOT:?KEYPATH_LAB_TEST_ROOT is required in test mode}"
   LAUNCHER_15="${KEYPATH_LAB_LAUNCHER_15:?test launcher 15 is required}"
   LAUNCHER_26="${KEYPATH_LAB_LAUNCHER_26:?test launcher 26 is required}"
+  LAUNCHER_27="${KEYPATH_LAB_LAUNCHER_27:?test launcher 27 is required}"
   CRABBOX="${KEYPATH_LAB_CRABBOX:?test CrabBox is required}"
 else
   LAB_ROOT="$PRODUCTION_ROOT"
   LAUNCHER_15="$LAB_ROOT/keypath15"
   LAUNCHER_26="$LAB_ROOT/keypath26"
+  LAUNCHER_27="$LAB_ROOT/keypath27"
   CRABBOX="$LAB_ROOT/SharedTools/bin/crabbox"
 fi
 
@@ -35,12 +37,13 @@ launcher_for() {
   case "$1" in
     15) print -r -- "$LAUNCHER_15" ;;
     26) print -r -- "$LAUNCHER_26" ;;
+    27) print -r -- "$LAUNCHER_27" ;;
     *) die "unsupported macOS lane: $1" ;;
   esac
 }
 
 provider_for() {
-  case "$1" in 15) print tart ;; 26) print parallels ;; *) die "unsupported macOS lane: $1" ;; esac
+  case "$1" in 15) print tart ;; 26|27) print parallels ;; *) die "unsupported macOS lane: $1" ;; esac
 }
 
 manifest_path() { print -r -- "$LEASES/$1/manifest.tsv"; }
@@ -135,7 +138,7 @@ warmup_desktop() {
   else
     export PATH="$LAB_ROOT/SharedTools/bin:/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin"
     "$CRABBOX" warmup --provider parallels --target macos --desktop \
-      --parallels-template keypath-macos-26 --parallels-user keypathqa \
+      --parallels-template "keypath-macos-$macos" --parallels-user keypathqa \
       --parallels-work-root /Users/keypathqa/crabbox --ssh-port 22 \
       --slug "$slug" --ttl 2h
   fi
@@ -145,7 +148,7 @@ preflight() {
   local mount_point
   [[ "$LAB_ROOT" == "$PRODUCTION_ROOT" || "${KEYPATH_LAB_TESTING:-0}" == "1" ]] || die "unsafe lab root"
   [[ -d "$LAB_ROOT" ]] || die "lab root is not mounted: $LAB_ROOT"
-  [[ -x "$LAUNCHER_15" && -x "$LAUNCHER_26" && -x "$CRABBOX" ]] || die "lab launchers or CrabBox are unavailable"
+  [[ -x "$LAUNCHER_15" && -x "$LAUNCHER_26" && -x "$LAUNCHER_27" && -x "$CRABBOX" ]] || die "lab launchers or CrabBox are unavailable"
   if [[ "${KEYPATH_LAB_TESTING:-0}" != "1" ]]; then
     mount_point=$(df -P "$LAB_ROOT" | awk 'NR == 2 {for (i=6; i<=NF; i++) printf "%s%s", (i == 6 ? "" : " "), $i; print ""}')
     [[ "$mount_point" == "/Volumes/KeyPath Lab" ]] || die "lab root is not on the expected external volume"
@@ -153,6 +156,7 @@ preflight() {
   ensure_roots
   "$LAUNCHER_15" doctor
   "$LAUNCHER_26" doctor
+  "$LAUNCHER_27" doctor
   print "host_os\t$(sw_vers -productVersion 2>/dev/null || print unknown)"
   print "host_build\t$(sw_vers -buildVersion 2>/dev/null || print unknown)"
   print "lab_root\t$LAB_ROOT"

--- a/Scripts/lab/tests/keypath-lab-tests.sh
+++ b/Scripts/lab/tests/keypath-lab-tests.sh
@@ -31,6 +31,16 @@ case "\$1" in
  list) echo cbx_test26 ;;
 esac
 EOF
+cat > "$ROOT/bin/launcher27" <<EOF
+#!/bin/bash
+case "\$1" in
+ doctor) echo doctor-27 ;;
+ warmup) echo cbx_test27 ;;
+ run) echo product=27.0; echo build=26A5378j ;;
+ stop) echo "stop-27 \$2" >> "$CALLS" ;;
+ list) echo cbx_test27 ;;
+esac
+EOF
 cat > "$ROOT/bin/crabbox" <<EOF
 #!/bin/bash
 echo "crabbox \$*" >> "$CALLS"
@@ -60,7 +70,7 @@ while [[ \$# -gt 0 ]]; do
 done
 exit 0
 EOF
-chmod +x "$ROOT/bin/launcher15" "$ROOT/bin/launcher26" "$ROOT/bin/crabbox"
+chmod +x "$ROOT/bin/launcher15" "$ROOT/bin/launcher26" "$ROOT/bin/launcher27" "$ROOT/bin/crabbox"
 
 /bin/bash -n "$LAB_DIR/../qa-macos-27-regression.sh"
 grep -q 'macos-27-regression)' "$LAB_DIR/scenarios/installer-scenario"
@@ -70,6 +80,7 @@ run_remote() {
     KEYPATH_LAB_TEST_ROOT="$ROOT" \
     KEYPATH_LAB_LAUNCHER_15="$ROOT/bin/launcher15" \
     KEYPATH_LAB_LAUNCHER_26="$ROOT/bin/launcher26" \
+    KEYPATH_LAB_LAUNCHER_27="$ROOT/bin/launcher27" \
     KEYPATH_LAB_CRABBOX="$ROOT/bin/crabbox" \
         /bin/zsh "$REMOTE" "$@"
 }
@@ -81,6 +92,7 @@ assert_contains() {
 preflight=$(run_remote preflight)
 assert_contains "$preflight" doctor-15
 assert_contains "$preflight" doctor-26
+assert_contains "$preflight" doctor-27
 
 ticket_one=$(run_remote prepare-upload "$(printf 'a%.0s' {1..40})-$(printf 'b%.0s' {1..64})")
 ticket_two=$(run_remote prepare-upload "$(printf 'a%.0s' {1..40})-$(printf 'b%.0s' {1..64})")
@@ -177,6 +189,14 @@ artifacts26=$(run_remote artifacts cbx_test26)
 assert_contains "$artifacts26" $'download_status\t0'
 grep -q 'crabbox run --provider parallels --target macos --id cbx_test26 --stop-after never --download' "$CALLS"
 run_remote destroy cbx_test26 >/dev/null
+
+create27=$(run_remote create 27 "$archive_key" "$commit" "$checksum" KeyPath.zip 2h 0)
+assert_contains "$create27" $'lease_id\tcbx_test27'
+artifacts27=$(run_remote artifacts cbx_test27)
+assert_contains "$artifacts27" $'download_status\t0'
+grep -q 'crabbox run --provider parallels --target macos --id cbx_test27 --stop-after never --download' "$CALLS"
+run_remote destroy cbx_test27 >/dev/null
+grep -q 'stop-27 cbx_test27' "$CALLS"
 
 desktop_create=$(run_remote create 15 "$archive_key" "$commit" "$checksum" KeyPath.zip 2h 1)
 assert_contains "$desktop_create" $'lease_id\tcbx_desktop15'

--- a/docs/testing/remote-installer-lab.md
+++ b/docs/testing/remote-installer-lab.md
@@ -18,7 +18,7 @@ remain beneath `KeyPathInstallerLab` on the external volume after cleanup.
 ## Prerequisites
 
 - SSH access to `clawd@keypath-lab-mini` without an interactive password.
-- `/Volumes/KeyPath Lab/CrabBox/keypath15` and `keypath26` executable.
+- `/Volumes/KeyPath Lab/CrabBox/keypath15`, `keypath26`, and `keypath27` executable.
 - Shared CrabBox 0.36.0 tools beneath `CrabBox/SharedTools`.
 - A full 40-character KeyPath commit SHA present in the local repository.
 - A signed installer artifact whose SHA-256 checksum can be recorded.
@@ -51,7 +51,7 @@ the completed archive.
 ```bash
 SHA=$(git rev-parse HEAD)
 Scripts/lab/keypath-lab create \
-  --macos 15 \
+  --macos 27 \
   --commit "$SHA" \
   --installer dist/KeyPath.zip \
   --ttl 2h \


### PR DESCRIPTION
## Summary
- add macOS 27 to the installer-lab controller and remote routing
- require and validate the new `keypath27` launcher
- cover macOS 27 create, artifact, and destroy behavior in shell tests
- document macOS 27 as a supported disposable lane

## Validation
- `Scripts/lab/tests/keypath-lab-tests.sh`
- live CrabBox lifecycle: full clone from `KeyPath macOS 27 Base`, per-lease SSH key injection, `sw_vers` => macOS 27.0 / 26A5378j, destroy
- `git diff --check`

## Review gate
Local review tooling selected the remote review gate; do not merge until `claude-review` passes.