### PR TITLE
Add secure Tart dialog input

### DIFF
--- a/Scripts/lab/keypath-lab
+++ b/Scripts/lab/keypath-lab
@@ -14,6 +14,7 @@ Commands:
   preflight
   create --macos 15|26|27 --commit SHA --installer PATH [--ttl 2h] [--desktop]
   install-app LEASE_ID
+  secure-dialog-input LEASE_ID --app APP --field LABEL [--submit BUTTON]
   run LEASE_ID -- COMMAND [ARG...]
   status LEASE_ID
   list
@@ -111,6 +112,25 @@ EOF
         [[ $# -eq 1 ]] || usage
         require_lease_id "$1"
         remote install-app "$1"
+        ;;
+    secure-dialog-input)
+        lease=${1:-}
+        [[ -n $lease ]] || usage
+        require_lease_id "$lease"
+        shift
+        app=
+        field=
+        submit=
+        while [[ $# -gt 0 ]]; do
+            case "$1" in
+                --app) app=${2:-}; shift 2 ;;
+                --field) field=${2:-}; shift 2 ;;
+                --submit) submit=${2:-}; shift 2 ;;
+                *) usage ;;
+            esac
+        done
+        [[ -n $app && -n $field ]] || usage
+        remote secure-dialog-input "$lease" "$app" "$field" "$submit"
         ;;
     run)
         lease=${1:-}

--- a/Scripts/lab/remote.sh
+++ b/Scripts/lab/remote.sh
@@ -10,12 +10,16 @@ if [[ "${KEYPATH_LAB_TESTING:-0}" == "1" ]]; then
   LAUNCHER_26="${KEYPATH_LAB_LAUNCHER_26:?test launcher 26 is required}"
   LAUNCHER_27="${KEYPATH_LAB_LAUNCHER_27:?test launcher 27 is required}"
   CRABBOX="${KEYPATH_LAB_CRABBOX:?test CrabBox is required}"
+  TART="${KEYPATH_LAB_TART:?test Tart is required}"
+  GUEST_SSH="${KEYPATH_LAB_GUEST_SSH:?test guest SSH is required}"
 else
   LAB_ROOT="$PRODUCTION_ROOT"
   LAUNCHER_15="$LAB_ROOT/keypath15"
   LAUNCHER_26="$LAB_ROOT/keypath26"
   LAUNCHER_27="$LAB_ROOT/keypath27"
   CRABBOX="$LAB_ROOT/SharedTools/bin/crabbox"
+  TART="${KEYPATH_LAB_TART:-$LAB_ROOT/CompatTools/bin/tart}"
+  GUEST_SSH="${KEYPATH_LAB_GUEST_SSH:-/usr/bin/ssh}"
 fi
 
 STATE_ROOT="$LAB_ROOT/KeyPathInstallerLab"
@@ -353,6 +357,55 @@ run_command() {
   return "$exit_code"
 }
 
+secure_dialog_input() {
+  local lease=$1 app=$2 field_label=$3 submit_button=$4
+  local manifest macos resource key ip secret_file guest_command exit_code
+  manifest=$(owned_manifest "$lease")
+  macos=$(field "$manifest" macos)
+  [[ "$macos" == "15" ]] || die "secure dialog input currently supports only the Tart macOS 15 lane"
+  [[ "$(field "$manifest" desktop_enabled)" == "true" ]] || die "secure dialog input requires a desktop-enabled lease"
+  resource=$(field "$manifest" provider_resource)
+  [[ "$resource" =~ '^[A-Za-z0-9._-]+$' && "$resource" != "unknown" ]] || die "invalid Tart resource id"
+  key="$HOME/Library/Application Support/crabbox/testboxes/$lease/id_ed25519"
+  if [[ "${KEYPATH_LAB_TESTING:-0}" == "1" ]]; then
+    key="${KEYPATH_LAB_TEST_SSH_KEY:?test SSH key is required}"
+    secret_file="${KEYPATH_LAB_TEST_SECRET_FILE:?test secret file is required}"
+  else
+    [[ -f "$key" && ! -L "$key" && -O "$key" ]] || die "owned CrabBox SSH key not found for lease"
+    secret_file=$(mktemp "$STATE_ROOT/.secure-input.XXXXXXXX")
+    chmod 600 "$secret_file"
+    trap 'rm -f "$secret_file"' EXIT
+    /opt/homebrew/bin/sops -d "$HOME/dotfiles/secrets.env" | awk -F= '$1 == "KEYPATH_TART_ADMIN_PASSWORD" {sub(/^[^=]*=/, ""); print; found=1} END {if (!found) exit 1}' > "$secret_file" || die "KEYPATH_TART_ADMIN_PASSWORD is unavailable"
+  fi
+  [[ -s "$secret_file" ]] || die "secure input secret is empty"
+  if [[ "${USER:-}" == "clawd" ]]; then export TART_HOME="$LAB_ROOT/TartHome-clawd"; else export TART_HOME="$LAB_ROOT/TartHome"; fi
+  ip=$($TART ip "$resource")
+  [[ "$ip" =~ '^[0-9A-Fa-f:.]+$' ]] || die "Tart returned an invalid guest address"
+
+  # Peekaboo's MCP type response contains the typed value. Suppress both output
+  # streams for that command so the secret cannot enter controller logs.
+  guest_command='set -euo pipefail; command -v /opt/homebrew/bin/peekaboo >/dev/null; command -v /opt/homebrew/bin/mcporter >/dev/null; '
+  printf -v guest_command '%s%q ' "$guest_command" /opt/homebrew/bin/peekaboo click --app "$app" --query "$field_label" --json
+  guest_command+=" >/dev/null; "
+  guest_command+='PEEKABOO_VISUALIZER_MASK_TYPED_TEXT=true /opt/homebrew/bin/mcporter call --stdio '\''peekaboo mcp serve --bridge-socket "$HOME/Library/Application Support/Peekaboo/daemon.sock"'\'' --env PEEKABOO_VISUALIZER_MASK_TYPED_TEXT=true type text=@/dev/stdin clear=true --output json --timeout 20000 >/dev/null 2>&1'
+  if [[ -n "$submit_button" ]]; then
+    printf -v guest_command '%s; %q ' "$guest_command" /opt/homebrew/bin/peekaboo click --app "$app" --query "$submit_button" --json
+    guest_command+=" >/dev/null"
+  fi
+  set +e
+  "$GUEST_SSH" -o BatchMode=yes -o StrictHostKeyChecking=accept-new -i "$key" "admin@$ip" "/bin/zsh -lc $(printf %q "$guest_command")" < "$secret_file"
+  exit_code=$?
+  set -e
+  [[ "${KEYPATH_LAB_TESTING:-0}" == "1" ]] || rm -f "$secret_file"
+  if (( exit_code == 0 )); then
+    record_command "$lease" passed secure-dialog-input --app "$app" --field "$field_label" ${submit_button:+--submit "$submit_button"}
+    print "secure_dialog_input\tpassed"
+  else
+    record_command "$lease" "failed:$exit_code" secure-dialog-input --app "$app" --field "$field_label" ${submit_button:+--submit "$submit_button"}
+    die "secure dialog input failed"
+  fi
+}
+
 print_status() {
   local lease=$1 manifest macos launcher
   manifest=$(owned_manifest "$lease")
@@ -484,6 +537,7 @@ case "$action" in
   install-archive) [[ $# -eq 5 ]] || die "install-archive requires ticket, key, commit, checksum, and name"; install_archive "$@" ;;
   create) [[ $# -eq 7 ]] || die "create requires lane, archive, commit, checksum, name, ttl, desktop"; create_lease "$@" ;;
   install-app) [[ $# -eq 1 ]] || die "install-app requires lease"; install_app "$1" ;;
+  secure-dialog-input) [[ $# -eq 4 ]] || die "secure-dialog-input requires lease, app, field, and optional submit value"; secure_dialog_input "$@" ;;
   run) [[ $# -ge 2 ]] || die "run requires lease and command"; run_command "$@" ;;
   status) [[ $# -eq 1 ]] || die "status requires lease"; print_status "$1" ;;
   list) [[ $# -eq 0 ]] || die "list takes no arguments"; list_leases ;;

--- a/Scripts/lab/tests/keypath-lab-tests.sh
+++ b/Scripts/lab/tests/keypath-lab-tests.sh
@@ -45,7 +45,7 @@ cat > "$ROOT/bin/crabbox" <<EOF
 #!/bin/bash
 echo "crabbox \$*" >> "$CALLS"
 if [[ \$1 == warmup ]]; then
-  if [[ " \$* " == *" --provider tart "* ]]; then echo cbx_desktop15; else echo cbx_desktop26; fi
+  if [[ " \$* " == *" --provider tart "* ]]; then echo 'warmup instance=test-resource cbx_desktop15'; else echo 'warmup vm=00000000-0000-0000-0000-000000000000 cbx_desktop26'; fi
   exit 0
 fi
 if [[ \$1 == screenshot ]]; then
@@ -72,6 +72,20 @@ exit 0
 EOF
 chmod +x "$ROOT/bin/launcher15" "$ROOT/bin/launcher26" "$ROOT/bin/launcher27" "$ROOT/bin/crabbox"
 
+echo 192.0.2.15 > "$TMP/tart-ip"
+cat > "$ROOT/bin/tart" <<EOF
+#!/bin/bash
+[[ \$1 == ip ]] && cat "$TMP/tart-ip"
+EOF
+cat > "$ROOT/bin/guest-ssh" <<EOF
+#!/bin/bash
+printf '%s\n' "\$*" > "$TMP/guest-ssh-args"
+cat > "$TMP/guest-ssh-stdin"
+EOF
+chmod +x "$ROOT/bin/tart" "$ROOT/bin/guest-ssh"
+echo test-private-key > "$TMP/id_ed25519"
+echo 'fixture-password-that-must-not-leak' > "$TMP/secure-input"
+
 /bin/bash -n "$LAB_DIR/../qa-macos-27-regression.sh"
 grep -q 'macos-27-regression)' "$LAB_DIR/scenarios/installer-scenario"
 
@@ -82,6 +96,10 @@ run_remote() {
     KEYPATH_LAB_LAUNCHER_26="$ROOT/bin/launcher26" \
     KEYPATH_LAB_LAUNCHER_27="$ROOT/bin/launcher27" \
     KEYPATH_LAB_CRABBOX="$ROOT/bin/crabbox" \
+    KEYPATH_LAB_TART="$ROOT/bin/tart" \
+    KEYPATH_LAB_GUEST_SSH="$ROOT/bin/guest-ssh" \
+    KEYPATH_LAB_TEST_SSH_KEY="$TMP/id_ed25519" \
+    KEYPATH_LAB_TEST_SECRET_FILE="$TMP/secure-input" \
         /bin/zsh "$REMOTE" "$@"
 }
 
@@ -206,6 +224,17 @@ desktop_artifacts=$(run_remote artifacts cbx_desktop15)
 assert_contains "$desktop_artifacts" $'screenshot_status\t0'
 desktop_artifact_dir=$(printf '%s\n' "$desktop_artifacts" | awk -F '\t' '$1 == "artifact_dir" {print $2}')
 [[ -f "$desktop_artifact_dir/screenshot.png" ]]
+secure_result=$(run_remote secure-dialog-input cbx_desktop15 'System Settings' Password 'Modify Settings')
+assert_contains "$secure_result" $'secure_dialog_input\tpassed'
+grep -q 'admin@192.0.2.15' "$TMP/guest-ssh-args"
+grep -q 'mcporter' "$TMP/guest-ssh-args"
+grep -q 'text=@/dev/stdin' "$TMP/guest-ssh-args"
+grep -q 'dev/null' "$TMP/guest-ssh-args"
+cmp -s "$TMP/secure-input" "$TMP/guest-ssh-stdin"
+if grep -R -F 'fixture-password-that-must-not-leak' "$ROOT/KeyPathInstallerLab" "$TMP/guest-ssh-args"; then
+    echo "secure dialog input leaked its secret into logs or arguments" >&2
+    exit 1
+fi
 run_remote destroy cbx_desktop15 >/dev/null
 
 if run_remote create 26 "$archive_key" "$commit" "$checksum" KeyPath.zip 3h 0 >/dev/null 2>&1; then

--- a/docs/testing/remote-installer-lab.md
+++ b/docs/testing/remote-installer-lab.md
@@ -61,6 +61,8 @@ Scripts/lab/keypath-lab list
 Scripts/lab/keypath-lab status cbx_example
 Scripts/lab/keypath-lab install-app cbx_example
 Scripts/lab/keypath-lab run cbx_example -- sw_vers
+Scripts/lab/keypath-lab secure-dialog-input cbx_example \
+  --app 'System Settings' --field Password --submit 'Modify Settings'
 Scripts/lab/keypath-lab artifacts cbx_example
 Scripts/lab/keypath-lab destroy cbx_example
 Scripts/lab/keypath-lab cleanup --dry-run
@@ -118,10 +120,20 @@ convert logical points to framebuffer coordinates using the current display
 scale, and verify activation afterward; never preserve raw coordinates between
 runs.
 
-The adapter deliberately has no password-input command. Do not put a lab
-password in a command line, workflow file, shell trace, or collected artifact.
-Authentication-sheet automation needs a separate secure credential-injection
-contract before it becomes part of the reusable workflow.
+For a macOS 15 Tart desktop lease, `secure-dialog-input` handles an
+authentication sheet without putting its password in a command line. It focuses
+the named field with Peekaboo, decrypts only `KEYPATH_TART_ADMIN_PASSWORD` on
+the mini, and streams it over the lease-specific CrabBox SSH connection to
+Peekaboo's supported MCP `type` tool. Peekaboo and `mcporter` must be installed
+in the guest (`brew install steipete/tap/peekaboo steipete/tap/mcporter`).
+
+The command suppresses the complete MCP response because Peekaboo's `type`
+result contains the value it typed. The secret is never an argument, never
+written to `commands.tsv`, and never retained as an artifact. Only the app,
+field label, optional submit button, and pass/fail result are recorded. Do not
+use the generic `run` command to improvise password entry. macOS 26 and 27
+Parallels guests remain unsupported until they have an equally constrained
+lease-specific transport.
 
 `install-app` expands the staged ZIP into `/Applications` on the disposable
 guest. Tart uses the base image's noninteractive sudo contract. Parallels uses


### PR DESCRIPTION
## Summary
- add a typed `keypath-lab secure-dialog-input` command for macOS 15 Tart desktop leases
- stream the dedicated Tart password over the lease-owned SSH channel into Peekaboo MCP without placing it in arguments or artifacts
- suppress MCP type output, document the threat boundary, and test that fixture secrets never enter logs

## Validation
- `./Scripts/test-full.sh`
- `Scripts/lab/tests/keypath-lab-tests.sh`
- `python3 Scripts/check-accessibility.py`
- `git diff --check`
- review gate: remote review gate selected; merge requires GitHub `claude-review`