### PR TITLE
Guard release host bridge artifacts

### DIFF
--- a/Scripts/build-kanata-host-bridge.sh
+++ b/Scripts/build-kanata-host-bridge.sh
@@ -16,6 +16,8 @@ BRIDGE_ROOT="$PROJECT_ROOT/Rust/KeyPathKanataHostBridge"
 BUILD_DIR="$PROJECT_ROOT/build/kanata-host-bridge"
 CACHE_INFO="$BUILD_DIR/host-bridge-cache.info"
 BRIDGE_FEATURES="${KEYPATH_KANATA_HOST_BRIDGE_FEATURES:-passthru-output-spike}"
+BRIDGE_TARGET="aarch64-apple-darwin"
+BRIDGE_VERIFY_SCRIPT="$SCRIPT_DIR/verify-kanata-host-bridge.py"
 
 echo "🧩 Building KeyPath Kanata host bridge..."
 
@@ -40,40 +42,75 @@ calculate_source_hash() {
         -exec shasum -a 256 {} + 2>/dev/null | shasum -a 256 | cut -d' ' -f1
 }
 
-CURRENT_HASH=$(calculate_source_hash)
-CACHED_HASH=$(cat "$CACHE_INFO" 2>/dev/null || echo "")
+calculate_build_fingerprint() {
+    {
+        printf 'source=%s\n' "$(calculate_source_hash)"
+        printf 'features=%s\n' "$BRIDGE_FEATURES"
+        printf 'target=%s\n' "$BRIDGE_TARGET"
+        printf 'developer_dir=%s\n' "${DEVELOPER_DIR:-<unset>}"
+        rustc --version --verbose
+        cargo --version
+        xcrun ld -v 2>&1 || true
+    } | shasum -a 256 | cut -d' ' -f1
+}
 
-if [ "$CURRENT_HASH" = "$CACHED_HASH" ] && \
+verify_bridge() {
+    python3 "$BRIDGE_VERIFY_SCRIPT" "$BUILD_DIR/libkeypath_kanata_host_bridge.dylib"
+}
+
+CURRENT_FINGERPRINT=$(calculate_build_fingerprint)
+CACHED_FINGERPRINT=$(cat "$CACHE_INFO" 2>/dev/null || echo "")
+
+if [ "$CURRENT_FINGERPRINT" = "$CACHED_FINGERPRINT" ] && \
    [ -f "$BUILD_DIR/libkeypath_kanata_host_bridge.dylib" ] && \
    [ -f "$BUILD_DIR/libkeypath_kanata_host_bridge.a" ]; then
-    echo "🎯 Cache HIT: Host bridge source unchanged, using existing artifacts"
-    echo "✅ Host bridge ready"
-    exit 0
+    echo "🎯 Cache HIT: Host bridge inputs unchanged, verifying existing artifacts"
+    if verify_bridge; then
+        echo "✅ Host bridge ready"
+        exit 0
+    fi
+    echo "⚠️  Cached host bridge failed its load check; rebuilding" >&2
 fi
 
 echo "🔨 Cache miss, compiling host bridge..."
+
+# The outer cache tracks linker/toolchain identity, but Cargo has its own target
+# cache and does not reliably treat a DEVELOPER_DIR/linker change as a relink
+# input. Remove only this package's release outputs so dependencies stay warm
+# while the final Mach-O artifact is guaranteed to use the current toolchain.
+cargo clean \
+    --manifest-path "$BRIDGE_ROOT/Cargo.toml" \
+    --release \
+    --target "$BRIDGE_TARGET" \
+    --package keypath-kanata-host-bridge
 
 if [ -n "$BRIDGE_FEATURES" ]; then
     cargo build \
         --manifest-path "$BRIDGE_ROOT/Cargo.toml" \
         --release \
         --features "$BRIDGE_FEATURES" \
-        --target aarch64-apple-darwin
+        --target "$BRIDGE_TARGET"
 else
     cargo build \
         --manifest-path "$BRIDGE_ROOT/Cargo.toml" \
         --release \
-        --target aarch64-apple-darwin
+        --target "$BRIDGE_TARGET"
 fi
 
-cp "$BRIDGE_ROOT/target/aarch64-apple-darwin/release/libkeypath_kanata_host_bridge.a" \
+cp "$BRIDGE_ROOT/target/$BRIDGE_TARGET/release/libkeypath_kanata_host_bridge.a" \
    "$BUILD_DIR/libkeypath_kanata_host_bridge.a"
-cp "$BRIDGE_ROOT/target/aarch64-apple-darwin/release/libkeypath_kanata_host_bridge.dylib" \
+cp "$BRIDGE_ROOT/target/$BRIDGE_TARGET/release/libkeypath_kanata_host_bridge.dylib" \
    "$BUILD_DIR/libkeypath_kanata_host_bridge.dylib"
 cp "$BRIDGE_ROOT/include/keypath_kanata_host_bridge.h" \
    "$BUILD_DIR/include/keypath_kanata_host_bridge.h"
 
-echo "$CURRENT_HASH" > "$CACHE_INFO"
+echo "🧪 Verifying host bridge can be loaded by the release runtime..."
+if ! verify_bridge; then
+    echo "❌ Host bridge failed its load check; refusing to cache or package it" >&2
+    exit 1
+fi
+
+echo "$CURRENT_FINGERPRINT" > "$CACHE_INFO"
 
 echo "✅ Host bridge built"
 if [ -n "$BRIDGE_FEATURES" ]; then

--- a/Tests/KeyPathTests/BuildScripts/HostBridgeBuildContractTests.swift
+++ b/Tests/KeyPathTests/BuildScripts/HostBridgeBuildContractTests.swift
@@ -1,0 +1,51 @@
+import Foundation
+@preconcurrency import XCTest
+
+final class HostBridgeBuildContractTests: XCTestCase {
+    func testHostBridgeCacheTracksReleaseToolchainAndRuntimeLoadability() throws {
+        let root = repositoryRoot()
+        let buildScript = try contents(of: root.appendingPathComponent("Scripts/build-kanata-host-bridge.sh"))
+        let releaseScript = try contents(of: root.appendingPathComponent("Scripts/build-and-sign.sh"))
+
+        XCTAssertTrue(buildScript.contains("calculate_build_fingerprint"))
+        XCTAssertTrue(buildScript.contains("rustc --version --verbose"))
+        XCTAssertTrue(buildScript.contains("cargo --version"))
+        XCTAssertTrue(buildScript.contains("xcrun ld -v"))
+        XCTAssertTrue(buildScript.contains(#"${DEVELOPER_DIR:-<unset>}"#))
+        XCTAssertTrue(buildScript.contains(#"features=%s\n"#))
+        XCTAssertTrue(buildScript.contains(#"target=%s\n"#))
+        XCTAssertTrue(
+            buildScript.contains("--package keypath-kanata-host-bridge"),
+            "A toolchain fingerprint miss must force Cargo to relink the final cdylib."
+        )
+
+        XCTAssertTrue(
+            buildScript.contains(#"python3 "$BRIDGE_VERIFY_SCRIPT""#),
+            "The cache and newly linked artifact must pass a real dlopen/API check."
+        )
+        XCTAssertTrue(
+            buildScript.contains("Cached host bridge failed its load check; rebuilding"),
+            "A corrupt cache entry must be rebuilt instead of entering a release bundle."
+        )
+        XCTAssertTrue(
+            buildScript.contains("Host bridge failed its load check; refusing to cache or package it"),
+            "A newly linked but unloadable bridge must stop release assembly explicitly."
+        )
+        XCTAssertTrue(
+            releaseScript.contains("./Scripts/build-kanata-host-bridge.sh &"),
+            "The guarded host-bridge builder must remain part of the signed release path."
+        )
+    }
+}
+
+private func repositoryRoot(file: StaticString = #filePath) -> URL {
+    URL(fileURLWithPath: file.description)
+        .deletingLastPathComponent() // BuildScripts
+        .deletingLastPathComponent() // KeyPathTests
+        .deletingLastPathComponent() // Tests
+        .deletingLastPathComponent() // repo root
+}
+
+private func contents(of url: URL) throws -> String {
+    try String(contentsOf: url, encoding: .utf8)
+}

--- a/docs/bugs/2026-07-12-host-bridge-toolchain-cache.md
+++ b/docs/bugs/2026-07-12-host-bridge-toolchain-cache.md
@@ -1,0 +1,28 @@
+# Host bridge cache reused an unloadable dylib
+
+**Status:** Fixed by #988
+
+## Symptom
+
+A signed, notarized release could start Kanata but log that
+`libkeypath_kanata_host_bridge.dylib` was unavailable because `dlopen` rejected
+its `__LINKEDIT` string pool as misaligned. The launcher fallback hid the loss
+of host-bridge validation and runtime integration from normal readiness checks.
+
+## Root cause
+
+The Rust host-bridge build cache was keyed only by source content. An artifact
+linked with a different Xcode linker could therefore be reused after the
+release workflow selected KeyPath's pinned stable Xcode. Copying, signing, and
+notarization preserved the already-invalid Mach-O file; they did not create the
+corruption.
+
+## Durable rule
+
+Native artifact caches must include every build input that can affect the
+binary format, including the selected developer directory, linker, Rust/Cargo
+toolchain, target, and feature set. A cache key is not sufficient proof that a
+native artifact is usable: the host bridge must also pass its real `dlopen` and
+C-ABI smoke check before the build script returns success. A failed cached
+check invalidates the hit and rebuilds; a failed newly built check stops the
+release before bundle assembly.


### PR DESCRIPTION
## Summary
- key the Rust host-bridge cache by source, feature set, target, Rust/Cargo versions, selected developer directory, and linker identity
- run the existing dlopen/C-ABI smoke check for both cache hits and newly built dylibs so unloadable artifacts cannot enter a signed release bundle
- document the release-only failure mode and add a release-path contract test

## Root cause
The bridge cache used only a source hash. A dylib linked under the active Xcode beta was reused after the release workflow selected pinned Xcode 26.6; copying and signing preserved the already-invalid Mach-O artifact.

## Test plan
- `bash -n Scripts/build-kanata-host-bridge.sh`
- `TEST_FILTER=HostBridgeBuildContractTests ./Scripts/run-tests-safe.sh`
- `./Scripts/test-fast.sh --changed` (full safe fallback; green)
- reproduced the beta-linked `mis-aligned LINKEDIT string pool` failure at the new load gate
- verified the same source rebuilds and loads under pinned Xcode 26.6
- `git diff --check`
- review gate: remote review gate selected

Fixes #988