### PR TITLE
Make Kanata config checks asynchronous

### DIFF
--- a/Tests/KeyPathTests/Integration/ConfigValidationTests.swift
+++ b/Tests/KeyPathTests/Integration/ConfigValidationTests.swift
@@ -21,54 +21,10 @@ final class ConfigValidationTests: XCTestCase {
         continueAfterFailure = true
     }
 
-    private func findKanataBinary() -> String? {
-        let candidates: [String] = [
-            ProcessInfo.processInfo.environment["KEYPATH_KANATA_PATH"],
-            URL(fileURLWithPath: #filePath)
-                .deletingLastPathComponent() // Integration
-                .deletingLastPathComponent() // KeyPathTests
-                .deletingLastPathComponent() // Tests
-                .deletingLastPathComponent() // repo root
-                .appendingPathComponent("External/kanata/target/aarch64-apple-darwin/release/kanata")
-                .path,
-            "/Applications/KeyPath.app/Contents/Library/KeyPath/Kanata Engine.app/Contents/MacOS/kanata",
-            "/opt/homebrew/bin/kanata"
-        ].compactMap { $0 }
-
-        return candidates.first { FileManager.default.isExecutableFile(atPath: $0) }
-    }
-
     @MainActor
     private func validateWithKanata(_ config: String) async throws -> (isValid: Bool, errors: [String]) {
-        guard let binary = findKanataBinary() else {
-            throw XCTSkip("Kanata binary not found — skipping CLI validation")
-        }
-
-        let tempFile = FileManager.default.temporaryDirectory
-            .appendingPathComponent("kanata-test-\(UUID().uuidString).kbd")
-        try config.write(to: tempFile, atomically: true, encoding: .utf8)
-        defer { try? FileManager.default.removeItem(at: tempFile) }
-
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: binary)
-        process.arguments = ["--cfg", tempFile.path, "--check"]
-        let pipe = Pipe()
-        process.standardOutput = pipe
-        process.standardError = pipe
-
-        try process.run()
-        process.waitUntilExit()
-
-        let data = pipe.fileHandleForReading.readDataToEndOfFile()
-        let output = String(data: data, encoding: .utf8) ?? ""
-
-        if process.terminationStatus == 0 {
-            return (true, [])
-        } else {
-            let errors = output.components(separatedBy: .newlines)
-                .filter { $0.contains("[ERROR]") || $0.contains("help:") }
-            return (false, errors)
-        }
+        let result = try await KanataCheckHelper.runCheck(config)
+        return (result.isValid, result.errors)
     }
 
     // MARK: - Default Config Validation

--- a/Tests/KeyPathTests/Integration/KanataCheckHelper.swift
+++ b/Tests/KeyPathTests/Integration/KanataCheckHelper.swift
@@ -1,0 +1,125 @@
+import Foundation
+import XCTest
+
+enum KanataCheckHelper {
+    struct Result: Sendable {
+        let exitCode: Int32
+        let errors: [String]
+
+        var isValid: Bool {
+            exitCode == 0
+        }
+    }
+
+    static func runCheck(_ config: String) async throws -> Result {
+        guard let binary = findKanataBinary() else {
+            throw XCTSkip("Kanata binary not found — skipping CLI validation")
+        }
+
+        return try await runCheck(config, binary: binary)
+    }
+
+    static func runCheck(_ config: String, binary: String) async throws -> Result {
+        let tempFile = FileManager.default.temporaryDirectory
+            .appendingPathComponent("kanata-test-\(UUID().uuidString).kbd")
+        try config.write(to: tempFile, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: tempFile) }
+
+        let process = Process()
+        let pipe = Pipe()
+        process.executableURL = URL(fileURLWithPath: binary)
+        process.arguments = ["--cfg", tempFile.path, "--check"]
+        process.standardOutput = pipe
+        process.standardError = pipe
+
+        return try await withCheckedThrowingContinuation { continuation in
+            let context = CheckRunContext(continuation: continuation)
+
+            process.terminationHandler = { completedProcess in
+                context.setExitCode(completedProcess.terminationStatus)
+            }
+
+            do {
+                try process.run()
+                DispatchQueue.global(qos: .utility).async {
+                    context.setOutput(pipe.fileHandleForReading.readDataToEndOfFile())
+                }
+            } catch {
+                context.fail(error)
+            }
+        }
+    }
+
+    private static func findKanataBinary() -> String? {
+        let candidates: [String] = [
+            ProcessInfo.processInfo.environment["KEYPATH_KANATA_PATH"],
+            URL(fileURLWithPath: #filePath)
+                .deletingLastPathComponent() // Integration
+                .deletingLastPathComponent() // KeyPathTests
+                .deletingLastPathComponent() // Tests
+                .deletingLastPathComponent() // repo root
+                .appendingPathComponent("External/kanata/target/aarch64-apple-darwin/release/kanata")
+                .path,
+            "/Applications/KeyPath.app/Contents/Library/KeyPath/Kanata Engine.app/Contents/MacOS/kanata",
+            "/opt/homebrew/bin/kanata",
+        ].compactMap { $0 }
+
+        return candidates.first { FileManager.default.isExecutableFile(atPath: $0) }
+    }
+}
+
+private final class CheckRunContext: @unchecked Sendable {
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<KanataCheckHelper.Result, Error>?
+    private var exitCode: Int32?
+    private var output: Data?
+
+    init(continuation: CheckedContinuation<KanataCheckHelper.Result, Error>) {
+        self.continuation = continuation
+    }
+
+    func setExitCode(_ exitCode: Int32) {
+        let completion = lock.withLock { () -> Completion? in
+            self.exitCode = exitCode
+            return takeCompletionIfReady()
+        }
+        completion?.resume()
+    }
+
+    func setOutput(_ output: Data) {
+        let completion = lock.withLock { () -> Completion? in
+            self.output = output
+            return takeCompletionIfReady()
+        }
+        completion?.resume()
+    }
+
+    func fail(_ error: Error) {
+        let continuation = lock.withLock { () -> CheckedContinuation<KanataCheckHelper.Result, Error>? in
+            defer { self.continuation = nil }
+            return self.continuation
+        }
+        continuation?.resume(throwing: error)
+    }
+
+    private func takeCompletionIfReady() -> Completion? {
+        guard let continuation, let exitCode, let output else { return nil }
+        self.continuation = nil
+        let text = String(decoding: output, as: UTF8.self)
+        let errors = text.components(separatedBy: .newlines)
+            .filter { $0.contains("[ERROR]") || $0.contains("help:") }
+        return Completion(
+            continuation: continuation,
+            result: KanataCheckHelper.Result(exitCode: exitCode, errors: errors)
+        )
+    }
+
+    private struct Completion {
+        let continuation: CheckedContinuation<KanataCheckHelper.Result, Error>
+        let result: KanataCheckHelper.Result
+
+        func resume() {
+            continuation.resume(returning: result)
+        }
+    }
+}

--- a/Tests/KeyPathTests/Integration/KanataCheckHelperTests.swift
+++ b/Tests/KeyPathTests/Integration/KanataCheckHelperTests.swift
@@ -1,0 +1,25 @@
+import Foundation
+import XCTest
+
+final class KanataCheckHelperTests: XCTestCase {
+    func testDrainsOutputWhileProcessIsRunning() async throws {
+        let script = FileManager.default.temporaryDirectory
+            .appendingPathComponent("kanata-check-fake-\(UUID().uuidString).sh")
+        try """
+        #!/bin/bash
+        /usr/bin/yes x | /usr/bin/head -c 1048576
+        echo '[ERROR] synthetic large-output failure'
+        exit 1
+        """.write(to: script, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755],
+            ofItemAtPath: script.path
+        )
+        defer { try? FileManager.default.removeItem(at: script) }
+
+        let result = try await KanataCheckHelper.runCheck("(defcfg)", binary: script.path)
+
+        XCTAssertEqual(result.exitCode, 1)
+        XCTAssertEqual(result.errors, ["[ERROR] synthetic large-output failure"])
+    }
+}

--- a/Tests/KeyPathTests/Integration/PerOptionMatrixTests.swift
+++ b/Tests/KeyPathTests/Integration/PerOptionMatrixTests.swift
@@ -20,52 +20,11 @@ final class PerOptionMatrixTests: XCTestCase {
         continueAfterFailure = true
     }
 
-    // MARK: - Kanata Validation (shared)
-
-    private func findKanataBinary() -> String? {
-        let candidates: [String] = [
-            ProcessInfo.processInfo.environment["KEYPATH_KANATA_PATH"],
-            URL(fileURLWithPath: #filePath)
-                .deletingLastPathComponent() // Integration
-                .deletingLastPathComponent() // KeyPathTests
-                .deletingLastPathComponent() // Tests
-                .deletingLastPathComponent() // repo root
-                .appendingPathComponent("External/kanata/target/aarch64-apple-darwin/release/kanata")
-                .path,
-            "/Applications/KeyPath.app/Contents/Library/KeyPath/Kanata Engine.app/Contents/MacOS/kanata",
-            "/opt/homebrew/bin/kanata"
-        ].compactMap { $0 }
-
-        return candidates.first { FileManager.default.isExecutableFile(atPath: $0) }
-    }
-
     @MainActor
     private func assertKanataValid(_ config: String, _ label: String, file: StaticString = #filePath, line: UInt = #line) async throws {
-        guard let binary = findKanataBinary() else {
-            throw XCTSkip("Kanata binary not found — skipping CLI validation")
-        }
-
-        let tempFile = FileManager.default.temporaryDirectory
-            .appendingPathComponent("kanata-test-\(UUID().uuidString).kbd")
-        try config.write(to: tempFile, atomically: true, encoding: .utf8)
-        defer { try? FileManager.default.removeItem(at: tempFile) }
-
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: binary)
-        process.arguments = ["--cfg", tempFile.path, "--check"]
-        let pipe = Pipe()
-        process.standardOutput = pipe
-        process.standardError = pipe
-
-        try process.run()
-        process.waitUntilExit()
-
-        if process.terminationStatus != 0 {
-            let data = pipe.fileHandleForReading.readDataToEndOfFile()
-            let output = String(data: data, encoding: .utf8) ?? ""
-            let errors = output.components(separatedBy: .newlines)
-                .filter { $0.contains("[ERROR]") || $0.contains("help:") }
-            XCTFail("\(label) produced invalid kanata. Errors: \(errors)", file: file, line: line)
+        let result = try await KanataCheckHelper.runCheck(config)
+        if !result.isValid {
+            XCTFail("\(label) produced invalid kanata. Errors: \(result.errors)", file: file, line: line)
         }
     }
 

--- a/Tests/KeyPathTests/Integration/StubDeflayerSafetyNetTests.swift
+++ b/Tests/KeyPathTests/Integration/StubDeflayerSafetyNetTests.swift
@@ -24,50 +24,10 @@ final class StubDeflayerSafetyNetTests: XCTestCase {
         continueAfterFailure = true
     }
 
-    private func findKanataBinary() -> String? {
-        let candidates: [String] = [
-            ProcessInfo.processInfo.environment["KEYPATH_KANATA_PATH"],
-            URL(fileURLWithPath: #filePath)
-                .deletingLastPathComponent() // Integration
-                .deletingLastPathComponent() // KeyPathTests
-                .deletingLastPathComponent() // Tests
-                .deletingLastPathComponent() // repo root
-                .appendingPathComponent("External/kanata/target/aarch64-apple-darwin/release/kanata")
-                .path,
-            "/Applications/KeyPath.app/Contents/Library/KeyPath/Kanata Engine.app/Contents/MacOS/kanata",
-            "/opt/homebrew/bin/kanata"
-        ].compactMap { $0 }
-        return candidates.first { FileManager.default.isExecutableFile(atPath: $0) }
-    }
-
     @MainActor
     private func validateWithKanata(_ config: String) async throws -> (isValid: Bool, errors: [String]) {
-        guard let binary = findKanataBinary() else {
-            throw XCTSkip("Kanata binary not found — skipping CLI validation")
-        }
-        let tempFile = FileManager.default.temporaryDirectory
-            .appendingPathComponent("stub-deflayer-\(UUID().uuidString).kbd")
-        try config.write(to: tempFile, atomically: true, encoding: .utf8)
-        defer { try? FileManager.default.removeItem(at: tempFile) }
-
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: binary)
-        process.arguments = ["--cfg", tempFile.path, "--check"]
-        let pipe = Pipe()
-        process.standardOutput = pipe
-        process.standardError = pipe
-        try process.run()
-        process.waitUntilExit()
-
-        if process.terminationStatus == 0 {
-            return (true, [])
-        } else {
-            let data = pipe.fileHandleForReading.readDataToEndOfFile()
-            let output = String(data: data, encoding: .utf8) ?? ""
-            let errors = output.components(separatedBy: .newlines)
-                .filter { $0.contains("[ERROR]") || $0.contains("help:") }
-            return (false, errors)
-        }
+        let result = try await KanataCheckHelper.runCheck(config)
+        return (result.isValid, result.errors)
     }
 
     // MARK: - HRL Toggles toggle mode (the case that surfaced this fix)


### PR DESCRIPTION
## Summary
- replace three duplicated `kanata --check` subprocess helpers with one async test helper
- drain combined stdout/stderr while Kanata runs so pipe capacity cannot deadlock the child
- centralize binary discovery, temporary config handling, exit status, and error parsing
- add a regression that writes 1 MiB before exit to prove concurrent draining

## Test plan
- `TEST_FILTER="KanataCheckHelperTests|ConfigValidationTests|PerOptionMatrixTests|StubDeflayerSafetyNetTests" ./Scripts/run-tests-safe.sh` (29 parsed passes)
- `./Scripts/test-fast.sh --changed` (full safe fallback: 4,742 passes)
- SwiftFormat 0.61.1
- `git diff --check`
- review gate: remote review gate selected

Fixes #873