### PR TITLE
Improve safe test failure summaries

### DIFF
--- a/Scripts/run-tests-safe.sh
+++ b/Scripts/run-tests-safe.sh
@@ -219,6 +219,11 @@ print_run_summary() {
   SUMMARY_PRINTED=1
 }
 
+print_failure_log_paths() {
+  echo "🪵 Full test log: ${LOG:-not-created}"
+  echo "🪵 Full build log: ${BUILD_LOG:-not-created}"
+}
+
 kill_process_tree() {
   local pid="${1:-}"
   local child
@@ -440,6 +445,7 @@ BUILD_DURATION_SECONDS=$(($(date +%s) - BUILD_START_SECONDS))
 if [ "$BUILD_EXIT_CODE" != "0" ]; then
   echo "❌ Test build failed (exit $BUILD_EXIT_CODE)"
   print_run_summary "$BUILD_EXIT_CODE"
+  print_failure_log_paths
   exit "$BUILD_EXIT_CODE"
 fi
 
@@ -542,6 +548,7 @@ fi
 if [ "$EXIT_CODE" = "124" ]; then
   echo "⚠️  Tests timed out; see $LOG"
   print_run_summary "$EXIT_CODE"
+  print_failure_log_paths
   exit 124
 fi
 
@@ -565,6 +572,7 @@ if [ "$IS_SIGNAL_CRASH" = true ]; then
 
   echo "❌ Treating test runner signal crash as failure"
   print_run_summary "$EXIT_CODE"
+  print_failure_log_paths
   exit "$EXIT_CODE"
 fi
 
@@ -586,6 +594,7 @@ if [ "$LOG_SIGNAL_CRASH" = true ]; then
 
   echo "❌ Treating test runner signal crash as failure"
   print_run_summary "$EXIT_CODE"
+  print_failure_log_paths
   exit "$EXIT_CODE"
 fi
 
@@ -594,6 +603,7 @@ if [ "$FAIL_COUNT" -gt 0 ]; then
   echo "❌ $FAIL_COUNT test(s) failed ($PASS_COUNT passed)"
   grep -E "Test Case '.*' failed|Test .* failed after" "$LOG" || true
   print_run_summary "$EXIT_CODE"
+  print_failure_log_paths
   exit 1
 fi
 
@@ -611,4 +621,5 @@ else
   echo "❌ Test run failed (exit $EXIT_CODE, no test output found)"
 fi
 print_run_summary "$EXIT_CODE"
+print_failure_log_paths
 exit $EXIT_CODE

--- a/Tests/KeyPathTests/Lint/DeploymentScriptContractTests.swift
+++ b/Tests/KeyPathTests/Lint/DeploymentScriptContractTests.swift
@@ -165,6 +165,20 @@ final class DeploymentScriptContractTests: XCTestCase {
             "Legacy noncanonical modules require one marker-gated artifact migration."
         )
     }
+
+    func testSafeTestFailuresAlwaysPrintArtifactPaths() throws {
+        let root = repositoryRoot()
+        let safeTests = try contents(of: root.appendingPathComponent("Scripts/run-tests-safe.sh"))
+
+        XCTAssertTrue(safeTests.contains("print_failure_log_paths()"))
+        XCTAssertTrue(safeTests.contains(#"Full test log: ${LOG:-not-created}"#))
+        XCTAssertTrue(safeTests.contains(#"Full build log: ${BUILD_LOG:-not-created}"#))
+        XCTAssertEqual(
+            safeTests.components(separatedBy: "print_failure_log_paths\n").count - 1,
+            6,
+            "Every build, timeout, crash, parsed-failure, and unexplained nonzero exit must print artifact paths."
+        )
+    }
 }
 
 // MARK: - Helpers


### PR DESCRIPTION
Fixes #826

## Summary
- print full test and build log paths on every non-success exit from the safe test runner
- cover build failures, timeouts, signal crashes, parsed test failures, and unexplained nonzero exits
- add a deployment-script contract test that keeps every failure branch aligned

## Root cause
The safe runner captured full artifacts, but several ordinary failure branches ended after the compact runner summary without repeating their paths. That made the last CI lines less actionable even though the logs existed.

## Validation
- `bash -n Scripts/run-tests-safe.sh`
- forced failure: `KEYPATH_TEST_PREBUILD=0 SWIFT_TEST_ARGS=--not-a-real-option ./Scripts/run-tests-safe.sh` (exit 64; both absolute paths printed at the end)
- `TEST_FILTER=DeploymentScriptContractTests ./Scripts/run-tests-safe.sh` (6 passed)
- `./Scripts/test-fast.sh --changed` (4,743 passed)
- `./Scripts/review-gate.sh` (remote review gate selected; claude-review required before merge)