### PR TITLE
Serialize shared VM provider admission

### DIFF
--- a/Scripts/lab/remote.sh
+++ b/Scripts/lab/remote.sh
@@ -28,6 +28,7 @@ LEASES="$STATE_ROOT/leases"
 ARTIFACTS="$STATE_ROOT/artifacts"
 LOGS="$STATE_ROOT/logs"
 OPERATIONS="$STATE_ROOT/operations"
+ADMISSION_LOCK="$STATE_ROOT/provider-admission.lock"
 
 die() { print -u2 "keypath-lab(remote): $*"; exit 1; }
 now_epoch() { date +%s; }
@@ -89,6 +90,74 @@ duration_seconds() {
 
 ensure_roots() {
   mkdir -p "$ARCHIVES" "$LEASES" "$ARTIFACTS" "$LOGS" "$OPERATIONS"
+}
+
+provider_capacity() {
+  case "$1" in
+    tart) print "${KEYPATH_LAB_CAPACITY_TART:-1}" ;;
+    parallels) print "${KEYPATH_LAB_CAPACITY_PARALLELS:-2}" ;;
+    *) die "unsupported provider capacity key: $1" ;;
+  esac
+}
+
+acquire_admission_lock() {
+  local provider=$1 attempt=0 owner owner_pid stale max_attempts=${KEYPATH_LAB_ADMISSION_WAIT_ATTEMPTS:-300}
+  [[ "$max_attempts" == <-> && "$max_attempts" -gt 0 ]] || die "invalid admission wait attempts: $max_attempts"
+  while ((attempt < max_attempts)); do
+    if mkdir "$ADMISSION_LOCK" 2>/dev/null; then
+      {
+        print "pid\t$$"
+        print "provider\t$provider"
+        print "created_at\t$(utc_now)"
+      } > "$ADMISSION_LOCK/owner.tsv"
+      return
+    fi
+    owner_pid=$(field "$ADMISSION_LOCK/owner.tsv" pid 2>/dev/null || true)
+    if [[ "$owner_pid" == <-> ]] && ! kill -0 "$owner_pid" 2>/dev/null; then
+      stale="$STATE_ROOT/provider-admission.stale.$$"
+      if mv "$ADMISSION_LOCK" "$stale" 2>/dev/null; then
+        rm -rf "$stale"
+        continue
+      fi
+    fi
+    ((attempt += 1))
+    sleep 0.1
+  done
+  owner=$(cat "$ADMISSION_LOCK/owner.tsv" 2>/dev/null || print unavailable)
+  print -u2 "admission_lock_busy"
+  print -u2 -- "$owner"
+  return 75
+}
+
+release_admission_lock() {
+  [[ -d "$ADMISSION_LOCK" ]] || return
+  rm -f "$ADMISSION_LOCK/owner.tsv"
+  rmdir "$ADMISSION_LOCK"
+}
+
+assert_provider_capacity() {
+  local provider=$1 capacity active=0 manifest lease expires cleanup lease_status commit macos lane slug
+  capacity=$(provider_capacity "$provider")
+  [[ "$capacity" == <-> && "$capacity" -gt 0 ]] || die "invalid $provider capacity: $capacity"
+  for manifest in "$LEASES"/*/manifest.tsv(N); do
+    [[ "$(field "$manifest" owner)" == "$OWNER" ]] || continue
+    [[ "$(field "$manifest" provider)" == "$provider" ]] || continue
+    cleanup=$(field "$manifest" cleanup_status)
+    lease_status=$(field "$manifest" status)
+    expires=$(field "$manifest" expires_epoch)
+    [[ "$cleanup" != complete && "$lease_status" != destroyed && "$expires" == <-> && "$expires" -gt "$(now_epoch)" ]] || continue
+    lease=$(field "$manifest" lease_id)
+    commit=$(field "$manifest" keypath_commit)
+    macos=$(field "$manifest" macos)
+    lane=$(field "$manifest" test_lane)
+    slug=$(field "$manifest" slug)
+    ((active += 1))
+    print -u2 "active_lease\t$lease\tprovider=$provider\tmacos=$macos\tlane=${lane:-legacy}\tstatus=$lease_status\texpires_epoch=$expires\tcommit=$commit\tslug=$slug"
+  done
+  if ((active >= capacity)); then
+    print -u2 "capacity_busy\tprovider=$provider\tactive=$active\tlimit=$capacity"
+    return 75
+  fi
 }
 
 record_command() {
@@ -164,6 +233,8 @@ preflight() {
   print "host_os\t$(sw_vers -productVersion 2>/dev/null || print unknown)"
   print "host_build\t$(sw_vers -buildVersion 2>/dev/null || print unknown)"
   print "lab_root\t$LAB_ROOT"
+  print "capacity_tart\t$(provider_capacity tart)"
+  print "capacity_parallels\t$(provider_capacity parallels)"
   print "safety\tdisposable-owned-leases-only"
 }
 
@@ -251,6 +322,9 @@ create_lease() {
   [[ -f "$archive/ready.tsv" && -d "$archive/repo/.git" ]] || die "prepared archive not found: $archive_key"
   ttl_seconds=$(duration_seconds "$ttl")
   (( ttl_seconds > 0 && ttl_seconds <= 7200 )) || die "TTL must be between 1 second and 2 hours"
+  acquire_admission_lock "$provider" || return $?
+  trap 'release_admission_lock' EXIT INT TERM HUP
+  assert_provider_capacity "$provider" || return $?
   slug="keypath${macos}-$(print -r -- "$commit" | cut -c1-8)-$(date -u +%Y%m%d%H%M%S)-$$"
   operation="$OPERATIONS/$slug"
   mkdir -p "$operation"
@@ -305,6 +379,8 @@ create_lease() {
   set_field "$manifest" macos_build "${build:-unknown}"
   set_field "$manifest" status ready
   record_command "$lease" passed sw_vers
+  release_admission_lock
+  trap - EXIT INT TERM HUP
   print "lease_id\t$lease"
   print "manifest\t$manifest"
 }

--- a/Scripts/lab/remote.sh
+++ b/Scripts/lab/remote.sh
@@ -28,7 +28,7 @@ LEASES="$STATE_ROOT/leases"
 ARTIFACTS="$STATE_ROOT/artifacts"
 LOGS="$STATE_ROOT/logs"
 OPERATIONS="$STATE_ROOT/operations"
-ADMISSION_LOCK="$STATE_ROOT/provider-admission.lock"
+HELD_ADMISSION_LOCK=
 
 die() { print -u2 "keypath-lab(remote): $*"; exit 1; }
 now_epoch() { date +%s; }
@@ -101,21 +101,23 @@ provider_capacity() {
 }
 
 acquire_admission_lock() {
-  local provider=$1 attempt=0 owner owner_pid stale max_attempts=${KEYPATH_LAB_ADMISSION_WAIT_ATTEMPTS:-300}
+  local provider=$1 attempt=0 owner owner_pid stale lock="$STATE_ROOT/provider-admission-$provider.lock"
+  local max_attempts=${KEYPATH_LAB_ADMISSION_WAIT_ATTEMPTS:-3000}
   [[ "$max_attempts" == <-> && "$max_attempts" -gt 0 ]] || die "invalid admission wait attempts: $max_attempts"
   while ((attempt < max_attempts)); do
-    if mkdir "$ADMISSION_LOCK" 2>/dev/null; then
+    if mkdir "$lock" 2>/dev/null; then
       {
         print "pid\t$$"
         print "provider\t$provider"
         print "created_at\t$(utc_now)"
-      } > "$ADMISSION_LOCK/owner.tsv"
+      } > "$lock/owner.tsv"
+      HELD_ADMISSION_LOCK="$lock"
       return
     fi
-    owner_pid=$(field "$ADMISSION_LOCK/owner.tsv" pid 2>/dev/null || true)
+    owner_pid=$(field "$lock/owner.tsv" pid 2>/dev/null || true)
     if [[ "$owner_pid" == <-> ]] && ! kill -0 "$owner_pid" 2>/dev/null; then
-      stale="$STATE_ROOT/provider-admission.stale.$$"
-      if mv "$ADMISSION_LOCK" "$stale" 2>/dev/null; then
+      stale="$STATE_ROOT/provider-admission-$provider.stale.$$"
+      if mv "$lock" "$stale" 2>/dev/null; then
         rm -rf "$stale"
         continue
       fi
@@ -123,16 +125,17 @@ acquire_admission_lock() {
     ((attempt += 1))
     sleep 0.1
   done
-  owner=$(cat "$ADMISSION_LOCK/owner.tsv" 2>/dev/null || print unavailable)
+  owner=$(cat "$lock/owner.tsv" 2>/dev/null || print unavailable)
   print -u2 "admission_lock_busy"
   print -u2 -- "$owner"
   return 75
 }
 
 release_admission_lock() {
-  [[ -d "$ADMISSION_LOCK" ]] || return
-  rm -f "$ADMISSION_LOCK/owner.tsv"
-  rmdir "$ADMISSION_LOCK"
+  [[ -n "$HELD_ADMISSION_LOCK" && -d "$HELD_ADMISSION_LOCK" ]] || return
+  rm -f "$HELD_ADMISSION_LOCK/owner.tsv"
+  rmdir "$HELD_ADMISSION_LOCK"
+  HELD_ADMISSION_LOCK=
 }
 
 assert_provider_capacity() {

--- a/Scripts/lab/tests/keypath-lab-tests.sh
+++ b/Scripts/lab/tests/keypath-lab-tests.sh
@@ -209,21 +209,24 @@ run_remote destroy cbx_test15 >/dev/null
 grep -q 'stop-15 cbx_test15' "$CALLS"
 grep -q $'cleanup_status\tcomplete' "$manifest"
 
-mkdir -p "$ROOT/KeyPathInstallerLab/provider-admission.lock"
-printf 'pid\t%s\nprovider\ttart\n' "$$" > "$ROOT/KeyPathInstallerLab/provider-admission.lock/owner.tsv"
+mkdir -p "$ROOT/KeyPathInstallerLab/provider-admission-tart.lock"
+printf 'pid\t%s\nprovider\ttart\n' "$$" > "$ROOT/KeyPathInstallerLab/provider-admission-tart.lock/owner.tsv"
+parallel_provider_create=$(run_remote create 26 "$archive_key" "$commit" "$checksum" KeyPath.zip 2h 0)
+assert_contains "$parallel_provider_create" $'lease_id\tcbx_test26'
+run_remote destroy cbx_test26 >/dev/null
 set +e
 lock_output=$(KEYPATH_LAB_ADMISSION_WAIT_ATTEMPTS=1 run_remote create 15 "$archive_key" "$commit" "$checksum" KeyPath.zip 2h 0 2>&1)
 lock_exit=$?
 set -e
 [[ $lock_exit -eq 75 ]] || { echo "expected admission-lock contention to exit 75, got $lock_exit" >&2; exit 1; }
 assert_contains "$lock_output" admission_lock_busy
-rm -rf "$ROOT/KeyPathInstallerLab/provider-admission.lock"
+rm -rf "$ROOT/KeyPathInstallerLab/provider-admission-tart.lock"
 
-mkdir -p "$ROOT/KeyPathInstallerLab/provider-admission.lock"
-printf 'pid\t99999999\nprovider\tparallels\n' > "$ROOT/KeyPathInstallerLab/provider-admission.lock/owner.tsv"
+mkdir -p "$ROOT/KeyPathInstallerLab/provider-admission-parallels.lock"
+printf 'pid\t99999999\nprovider\tparallels\n' > "$ROOT/KeyPathInstallerLab/provider-admission-parallels.lock/owner.tsv"
 create26=$(run_remote create 26 "$archive_key" "$commit" "$checksum" KeyPath.zip 2h 0)
 assert_contains "$create26" $'lease_id\tcbx_test26'
-[[ ! -e "$ROOT/KeyPathInstallerLab/provider-admission.lock" ]]
+[[ ! -e "$ROOT/KeyPathInstallerLab/provider-admission-parallels.lock" ]]
 artifacts26=$(run_remote artifacts cbx_test26)
 assert_contains "$artifacts26" $'download_status\t0'
 grep -q 'crabbox run --provider parallels --target macos --id cbx_test26 --stop-after never --download' "$CALLS"

--- a/Scripts/lab/tests/keypath-lab-tests.sh
+++ b/Scripts/lab/tests/keypath-lab-tests.sh
@@ -157,6 +157,14 @@ manifest="$ROOT/KeyPathInstallerLab/leases/cbx_test15/manifest.tsv"
 grep -q $'owner\tkeypath-installer-lab-v1' "$manifest"
 grep -q $'macos_build\t24G720' "$manifest"
 
+set +e
+capacity_output=$(run_remote create 15 "$archive_key" "$commit" "$checksum" KeyPath.zip 2h 0 2>&1)
+capacity_exit=$?
+set -e
+[[ $capacity_exit -eq 75 ]] || { echo "expected Tart capacity admission to exit 75, got $capacity_exit" >&2; exit 1; }
+assert_contains "$capacity_output" $'capacity_busy\tprovider=tart\tactive=1\tlimit=1'
+assert_contains "$capacity_output" $'active_lease\tcbx_test15'
+
 run_remote run cbx_test15 echo hello >/dev/null
 grep -q 'echo hello' "$ROOT/KeyPathInstallerLab/leases/cbx_test15/commands.tsv"
 run_remote scenario cbx_test15 clean-install >/dev/null
@@ -201,8 +209,21 @@ run_remote destroy cbx_test15 >/dev/null
 grep -q 'stop-15 cbx_test15' "$CALLS"
 grep -q $'cleanup_status\tcomplete' "$manifest"
 
+mkdir -p "$ROOT/KeyPathInstallerLab/provider-admission.lock"
+printf 'pid\t%s\nprovider\ttart\n' "$$" > "$ROOT/KeyPathInstallerLab/provider-admission.lock/owner.tsv"
+set +e
+lock_output=$(KEYPATH_LAB_ADMISSION_WAIT_ATTEMPTS=1 run_remote create 15 "$archive_key" "$commit" "$checksum" KeyPath.zip 2h 0 2>&1)
+lock_exit=$?
+set -e
+[[ $lock_exit -eq 75 ]] || { echo "expected admission-lock contention to exit 75, got $lock_exit" >&2; exit 1; }
+assert_contains "$lock_output" admission_lock_busy
+rm -rf "$ROOT/KeyPathInstallerLab/provider-admission.lock"
+
+mkdir -p "$ROOT/KeyPathInstallerLab/provider-admission.lock"
+printf 'pid\t99999999\nprovider\tparallels\n' > "$ROOT/KeyPathInstallerLab/provider-admission.lock/owner.tsv"
 create26=$(run_remote create 26 "$archive_key" "$commit" "$checksum" KeyPath.zip 2h 0)
 assert_contains "$create26" $'lease_id\tcbx_test26'
+[[ ! -e "$ROOT/KeyPathInstallerLab/provider-admission.lock" ]]
 artifacts26=$(run_remote artifacts cbx_test26)
 assert_contains "$artifacts26" $'download_status\t0'
 grep -q 'crabbox run --provider parallels --target macos --id cbx_test26 --stop-after never --download' "$CALLS"

--- a/docs/testing/remote-installer-lab.md
+++ b/docs/testing/remote-installer-lab.md
@@ -37,8 +37,9 @@ Scripts/lab/keypath-lab preflight
 Agents may prepare code, artifacts, and local contract tests concurrently, but
 VM creation is admitted centrally on the mini. The default host limits are one
 active Tart lease and two active Parallels leases. `create` takes an atomic
-host-side admission lock, counts unexpired owned lease manifests, and reserves
-capacity before another creator can enter. The lock is held only during
+provider-specific host-side admission lock, counts unexpired owned lease
+manifests, and reserves capacity before another creator for that provider can
+enter. Tart and Parallels provisioning can proceed in parallel. The lock is held only during
 provisioning; each resulting manifest remains the capacity reservation until
 the lease is destroyed or expires.
 
@@ -47,7 +48,7 @@ owning lease, OS, lane, expiry, commit, and slug. This is an infrastructure wait
 not a KeyPath failure. Agents should continue non-VM work or retry after the
 reported lease is destroyed; they must not stop or adopt that lease. A dead
 creator's admission lock is reclaimed automatically, while a live creator gets
-a short bounded window to finish provisioning.
+a five-minute bounded window to finish provisioning.
 
 The limits can be tuned on the mini with `KEYPATH_LAB_CAPACITY_TART` and
 `KEYPATH_LAB_CAPACITY_PARALLELS`. Keep Tart at one until repeated concurrent

--- a/docs/testing/remote-installer-lab.md
+++ b/docs/testing/remote-installer-lab.md
@@ -32,6 +32,27 @@ Check the non-mutating host/provider contract:
 Scripts/lab/keypath-lab preflight
 ```
 
+## Concurrent agents and provider admission
+
+Agents may prepare code, artifacts, and local contract tests concurrently, but
+VM creation is admitted centrally on the mini. The default host limits are one
+active Tart lease and two active Parallels leases. `create` takes an atomic
+host-side admission lock, counts unexpired owned lease manifests, and reserves
+capacity before another creator can enter. The lock is held only during
+provisioning; each resulting manifest remains the capacity reservation until
+the lease is destroyed or expires.
+
+When a pool is full, `create` exits 75 and prints `capacity_busy` plus every
+owning lease, OS, lane, expiry, commit, and slug. This is an infrastructure wait,
+not a KeyPath failure. Agents should continue non-VM work or retry after the
+reported lease is destroyed; they must not stop or adopt that lease. A dead
+creator's admission lock is reclaimed automatically, while a live creator gets
+a short bounded window to finish provisioning.
+
+The limits can be tuned on the mini with `KEYPATH_LAB_CAPACITY_TART` and
+`KEYPATH_LAB_CAPACITY_PARALLELS`. Keep Tart at one until repeated concurrent
+Tart runs prove that the host and provider inventory remain isolated.
+
 ## Lifecycle
 
 Creation never syncs the current worktree. It exports the explicit commit with


### PR DESCRIPTION
## Summary
- serialize shared Tart/Parallels VM acquisition with an atomic host-side admission lock
- enforce configurable provider capacity (Tart 1, Parallels 2 by default) and return exit 75 with owning lease evidence when full
- recover dead creator locks while refusing live lock contention
- document multi-agent admission behavior

## Validation
- `/bin/zsh -n Scripts/lab/remote.sh`
- `Scripts/lab/tests/keypath-lab-tests.sh`
- production fail-closed check against occupied Tart pool: exit 75, owner leases listed, no VM created

## Review gate
- remote review gate selected; GitHub `claude-review` must pass before merge

## State-matrix relevance
Harness infrastructure only; no KeyPath installer routing or product postconditions changed.