### PR TITLE
Fix VM admission lock interruption cleanup

### DIFF
--- a/Scripts/lab/remote.sh
+++ b/Scripts/lab/remote.sh
@@ -29,6 +29,7 @@ ARTIFACTS="$STATE_ROOT/artifacts"
 LOGS="$STATE_ROOT/logs"
 OPERATIONS="$STATE_ROOT/operations"
 HELD_ADMISSION_LOCK=
+HELD_ADMISSION_OWNER=
 
 die() { print -u2 "keypath-lab(remote): $*"; exit 1; }
 now_epoch() { date +%s; }
@@ -102,27 +103,33 @@ provider_capacity() {
 
 acquire_admission_lock() {
   local provider=$1 attempt=0 owner owner_pid stale lock_age lock_mtime lock="$STATE_ROOT/provider-admission-$provider.lock"
+  local owner_record="$STATE_ROOT/.provider-admission-$provider.owner.$$"
   local max_attempts=${KEYPATH_LAB_ADMISSION_WAIT_ATTEMPTS:-3000}
   local incomplete_grace=${KEYPATH_LAB_INCOMPLETE_LOCK_GRACE_SECONDS:-5}
   [[ "$max_attempts" == <-> && "$max_attempts" -gt 0 ]] || die "invalid admission wait attempts: $max_attempts"
   [[ "$incomplete_grace" == <-> ]] || die "invalid incomplete lock grace: $incomplete_grace"
+  {
+    print "pid\t$$"
+    print "provider\t$provider"
+    print "created_at\t$(utc_now)"
+  } > "$owner_record"
   while ((attempt < max_attempts)); do
-    if mkdir "$lock" 2>/dev/null; then
-      {
-        print "pid\t$$"
-        print "provider\t$provider"
-        print "created_at\t$(utc_now)"
-      } > "$lock/owner.tsv"
+    if ln "$owner_record" "$lock" 2>/dev/null; then
       HELD_ADMISSION_LOCK="$lock"
+      HELD_ADMISSION_OWNER="$owner_record"
       return
     fi
-    owner_pid=$(field "$lock/owner.tsv" pid 2>/dev/null || true)
-    # Owner metadata is written immediately after mkdir; an older empty lock means
-    # its creator died in that narrow window rather than merely running slowly.
-    lock_mtime=$(stat -f %m "$lock" 2>/dev/null || stat -c %Y "$lock" 2>/dev/null || print 0)
-    lock_age=$(( $(now_epoch) - lock_mtime ))
+    if [[ -d "$lock" ]]; then
+      # Recover directory locks created by the initial implementation of this protocol.
+      owner_pid=$(field "$lock/owner.tsv" pid 2>/dev/null || true)
+      lock_mtime=$(stat -f %m "$lock" 2>/dev/null || stat -c %Y "$lock" 2>/dev/null || print 0)
+      lock_age=$(( $(now_epoch) - lock_mtime ))
+    else
+      owner_pid=$(field "$lock" pid 2>/dev/null || true)
+      lock_age=0
+    fi
     if { [[ "$owner_pid" == <-> ]] && ! kill -0 "$owner_pid" 2>/dev/null; } ||
-       { [[ -z "$owner_pid" && "$lock_age" -ge "$incomplete_grace" ]]; }; then
+       { [[ -d "$lock" && -z "$owner_pid" && "$lock_age" -ge "$incomplete_grace" ]]; }; then
       stale="$STATE_ROOT/provider-admission-$provider.stale.$$"
       if mv "$lock" "$stale" 2>/dev/null; then
         rm -rf "$stale"
@@ -132,17 +139,21 @@ acquire_admission_lock() {
     ((attempt += 1))
     sleep 0.1
   done
-  owner=$(cat "$lock/owner.tsv" 2>/dev/null || print unavailable)
+  rm -f "$owner_record"
+  owner=$([[ -d "$lock" ]] && cat "$lock/owner.tsv" 2>/dev/null || cat "$lock" 2>/dev/null || print unavailable)
   print -u2 "admission_lock_busy"
   print -u2 -- "$owner"
   return 75
 }
 
 release_admission_lock() {
-  [[ -n "$HELD_ADMISSION_LOCK" && -d "$HELD_ADMISSION_LOCK" ]] || return
-  rm -f "$HELD_ADMISSION_LOCK/owner.tsv"
-  rmdir "$HELD_ADMISSION_LOCK"
+  if [[ -n "$HELD_ADMISSION_LOCK" && -n "$HELD_ADMISSION_OWNER" &&
+        -f "$HELD_ADMISSION_LOCK" && "$HELD_ADMISSION_LOCK" -ef "$HELD_ADMISSION_OWNER" ]]; then
+    rm -f "$HELD_ADMISSION_LOCK"
+  fi
+  [[ -n "$HELD_ADMISSION_OWNER" ]] && rm -f "$HELD_ADMISSION_OWNER"
   HELD_ADMISSION_LOCK=
+  HELD_ADMISSION_OWNER=
 }
 
 release_admission_lock_and_exit() {

--- a/Scripts/lab/remote.sh
+++ b/Scripts/lab/remote.sh
@@ -101,9 +101,11 @@ provider_capacity() {
 }
 
 acquire_admission_lock() {
-  local provider=$1 attempt=0 owner owner_pid stale lock="$STATE_ROOT/provider-admission-$provider.lock"
+  local provider=$1 attempt=0 owner owner_pid stale lock_age lock_mtime lock="$STATE_ROOT/provider-admission-$provider.lock"
   local max_attempts=${KEYPATH_LAB_ADMISSION_WAIT_ATTEMPTS:-3000}
+  local incomplete_grace=${KEYPATH_LAB_INCOMPLETE_LOCK_GRACE_SECONDS:-5}
   [[ "$max_attempts" == <-> && "$max_attempts" -gt 0 ]] || die "invalid admission wait attempts: $max_attempts"
+  [[ "$incomplete_grace" == <-> ]] || die "invalid incomplete lock grace: $incomplete_grace"
   while ((attempt < max_attempts)); do
     if mkdir "$lock" 2>/dev/null; then
       {
@@ -115,7 +117,10 @@ acquire_admission_lock() {
       return
     fi
     owner_pid=$(field "$lock/owner.tsv" pid 2>/dev/null || true)
-    if [[ "$owner_pid" == <-> ]] && ! kill -0 "$owner_pid" 2>/dev/null; then
+    lock_mtime=$(stat -f %m "$lock" 2>/dev/null || stat -c %Y "$lock" 2>/dev/null || print 0)
+    lock_age=$(( $(now_epoch) - lock_mtime ))
+    if { [[ "$owner_pid" == <-> ]] && ! kill -0 "$owner_pid" 2>/dev/null; } ||
+       { [[ -z "$owner_pid" && "$lock_age" -ge "$incomplete_grace" ]]; }; then
       stale="$STATE_ROOT/provider-admission-$provider.stale.$$"
       if mv "$lock" "$stale" 2>/dev/null; then
         rm -rf "$stale"
@@ -136,6 +141,13 @@ release_admission_lock() {
   rm -f "$HELD_ADMISSION_LOCK/owner.tsv"
   rmdir "$HELD_ADMISSION_LOCK"
   HELD_ADMISSION_LOCK=
+}
+
+release_admission_lock_and_exit() {
+  local exit_code=$1
+  trap - EXIT INT TERM HUP
+  release_admission_lock || true
+  exit "$exit_code"
 }
 
 assert_provider_capacity() {
@@ -326,7 +338,13 @@ create_lease() {
   ttl_seconds=$(duration_seconds "$ttl")
   (( ttl_seconds > 0 && ttl_seconds <= 7200 )) || die "TTL must be between 1 second and 2 hours"
   acquire_admission_lock "$provider" || return $?
-  trap 'release_admission_lock' EXIT INT TERM HUP
+  trap 'release_admission_lock' EXIT
+  trap 'release_admission_lock_and_exit 130' INT
+  trap 'release_admission_lock_and_exit 143' TERM
+  trap 'release_admission_lock_and_exit 129' HUP
+  if [[ "${KEYPATH_LAB_TESTING:-0}" == "1" && -n "${KEYPATH_LAB_TEST_PAUSE_AFTER_ADMISSION_LOCK:-}" ]]; then
+    sleep "$KEYPATH_LAB_TEST_PAUSE_AFTER_ADMISSION_LOCK"
+  fi
   assert_provider_capacity "$provider" || return $?
   slug="keypath${macos}-$(print -r -- "$commit" | cut -c1-8)-$(date -u +%Y%m%d%H%M%S)-$$"
   operation="$OPERATIONS/$slug"

--- a/Scripts/lab/remote.sh
+++ b/Scripts/lab/remote.sh
@@ -117,6 +117,8 @@ acquire_admission_lock() {
       return
     fi
     owner_pid=$(field "$lock/owner.tsv" pid 2>/dev/null || true)
+    # Owner metadata is written immediately after mkdir; an older empty lock means
+    # its creator died in that narrow window rather than merely running slowly.
     lock_mtime=$(stat -f %m "$lock" 2>/dev/null || stat -c %Y "$lock" 2>/dev/null || print 0)
     lock_age=$(( $(now_epoch) - lock_mtime ))
     if { [[ "$owner_pid" == <-> ]] && ! kill -0 "$owner_pid" 2>/dev/null; } ||

--- a/Scripts/lab/tests/keypath-lab-tests.sh
+++ b/Scripts/lab/tests/keypath-lab-tests.sh
@@ -209,8 +209,7 @@ run_remote destroy cbx_test15 >/dev/null
 grep -q 'stop-15 cbx_test15' "$CALLS"
 grep -q $'cleanup_status\tcomplete' "$manifest"
 
-mkdir -p "$ROOT/KeyPathInstallerLab/provider-admission-tart.lock"
-printf 'pid\t%s\nprovider\ttart\n' "$$" > "$ROOT/KeyPathInstallerLab/provider-admission-tart.lock/owner.tsv"
+printf 'pid\t%s\nprovider\ttart\n' "$$" > "$ROOT/KeyPathInstallerLab/provider-admission-tart.lock"
 parallel_provider_create=$(run_remote create 26 "$archive_key" "$commit" "$checksum" KeyPath.zip 2h 0)
 assert_contains "$parallel_provider_create" $'lease_id\tcbx_test26'
 run_remote destroy cbx_test26 >/dev/null
@@ -237,10 +236,10 @@ env \
     /bin/zsh "$REMOTE" create 15 "$archive_key" "$commit" "$checksum" KeyPath.zip 2h 0 >"$TMP/interrupted-create.log" 2>&1 &
 interrupted_pid=$!
 for _ in {1..100}; do
-    [[ -f "$ROOT/KeyPathInstallerLab/provider-admission-tart.lock/owner.tsv" ]] && break
+    grep -q $'^pid\t' "$ROOT/KeyPathInstallerLab/provider-admission-tart.lock" 2>/dev/null && break
     sleep 0.05
 done
-[[ -f "$ROOT/KeyPathInstallerLab/provider-admission-tart.lock/owner.tsv" ]] || { echo "interrupted create never acquired admission lock" >&2; exit 1; }
+[[ -f "$ROOT/KeyPathInstallerLab/provider-admission-tart.lock" ]] || { echo "interrupted create never acquired admission lock" >&2; exit 1; }
 kill -TERM "$interrupted_pid"
 set +e
 wait "$interrupted_pid"
@@ -249,18 +248,10 @@ set -e
 [[ $interrupted_exit -eq 143 ]] || { cat "$TMP/interrupted-create.log" >&2; echo "expected interrupted create to exit 143, got $interrupted_exit" >&2; exit 1; }
 [[ ! -e "$ROOT/KeyPathInstallerLab/provider-admission-tart.lock" ]] || { echo "interrupted create left admission lock" >&2; exit 1; }
 
-mkdir -p "$ROOT/KeyPathInstallerLab/provider-admission-tart.lock"
-touch -t 202001010000 "$ROOT/KeyPathInstallerLab/provider-admission-tart.lock"
-create15_after_incomplete_lock=$(KEYPATH_LAB_INCOMPLETE_LOCK_GRACE_SECONDS=1 run_remote create 15 "$archive_key" "$commit" "$checksum" KeyPath.zip 2h 0)
-assert_contains "$create15_after_incomplete_lock" $'lease_id\tcbx_test15'
-run_remote destroy cbx_test15 >/dev/null
-[[ ! -e "$ROOT/KeyPathInstallerLab/provider-admission-tart.lock" ]]
-
-mkdir -p "$ROOT/KeyPathInstallerLab/provider-admission-parallels.lock"
-printf 'pid\t99999999\nprovider\tparallels\n' > "$ROOT/KeyPathInstallerLab/provider-admission-parallels.lock/owner.tsv"
+printf 'pid\t99999999\nprovider\tparallels\n' > "$ROOT/KeyPathInstallerLab/provider-admission-parallels.lock"
 create26=$(run_remote create 26 "$archive_key" "$commit" "$checksum" KeyPath.zip 2h 0)
 assert_contains "$create26" $'lease_id\tcbx_test26'
-[[ ! -e "$ROOT/KeyPathInstallerLab/provider-admission-parallels.lock" ]]
+[[ ! -e "$ROOT/KeyPathInstallerLab/provider-admission-parallels.lock" ]] || { echo "stale Parallels admission lock was not reclaimed" >&2; exit 1; }
 artifacts26=$(run_remote artifacts cbx_test26)
 assert_contains "$artifacts26" $'download_status\t0'
 grep -q 'crabbox run --provider parallels --target macos --id cbx_test26 --stop-after never --download' "$CALLS"

--- a/Scripts/lab/tests/keypath-lab-tests.sh
+++ b/Scripts/lab/tests/keypath-lab-tests.sh
@@ -222,6 +222,40 @@ set -e
 assert_contains "$lock_output" admission_lock_busy
 rm -rf "$ROOT/KeyPathInstallerLab/provider-admission-tart.lock"
 
+env \
+    KEYPATH_LAB_TESTING=1 \
+    KEYPATH_LAB_TEST_ROOT="$ROOT" \
+    KEYPATH_LAB_LAUNCHER_15="$ROOT/bin/launcher15" \
+    KEYPATH_LAB_LAUNCHER_26="$ROOT/bin/launcher26" \
+    KEYPATH_LAB_LAUNCHER_27="$ROOT/bin/launcher27" \
+    KEYPATH_LAB_CRABBOX="$ROOT/bin/crabbox" \
+    KEYPATH_LAB_TART="$ROOT/bin/tart" \
+    KEYPATH_LAB_GUEST_SSH="$ROOT/bin/guest-ssh" \
+    KEYPATH_LAB_TEST_SSH_KEY="$TMP/id_ed25519" \
+    KEYPATH_LAB_TEST_SECRET_FILE="$TMP/secure-input" \
+    KEYPATH_LAB_TEST_PAUSE_AFTER_ADMISSION_LOCK=1 \
+    /bin/zsh "$REMOTE" create 15 "$archive_key" "$commit" "$checksum" KeyPath.zip 2h 0 >"$TMP/interrupted-create.log" 2>&1 &
+interrupted_pid=$!
+for _ in {1..100}; do
+    [[ -f "$ROOT/KeyPathInstallerLab/provider-admission-tart.lock/owner.tsv" ]] && break
+    sleep 0.05
+done
+[[ -f "$ROOT/KeyPathInstallerLab/provider-admission-tart.lock/owner.tsv" ]] || { echo "interrupted create never acquired admission lock" >&2; exit 1; }
+kill -TERM "$interrupted_pid"
+set +e
+wait "$interrupted_pid"
+interrupted_exit=$?
+set -e
+[[ $interrupted_exit -eq 143 ]] || { cat "$TMP/interrupted-create.log" >&2; echo "expected interrupted create to exit 143, got $interrupted_exit" >&2; exit 1; }
+[[ ! -e "$ROOT/KeyPathInstallerLab/provider-admission-tart.lock" ]] || { echo "interrupted create left admission lock" >&2; exit 1; }
+
+mkdir -p "$ROOT/KeyPathInstallerLab/provider-admission-tart.lock"
+touch -t 202001010000 "$ROOT/KeyPathInstallerLab/provider-admission-tart.lock"
+create15_after_incomplete_lock=$(KEYPATH_LAB_INCOMPLETE_LOCK_GRACE_SECONDS=1 run_remote create 15 "$archive_key" "$commit" "$checksum" KeyPath.zip 2h 0)
+assert_contains "$create15_after_incomplete_lock" $'lease_id\tcbx_test15'
+run_remote destroy cbx_test15 >/dev/null
+[[ ! -e "$ROOT/KeyPathInstallerLab/provider-admission-tart.lock" ]]
+
 mkdir -p "$ROOT/KeyPathInstallerLab/provider-admission-parallels.lock"
 printf 'pid\t99999999\nprovider\tparallels\n' > "$ROOT/KeyPathInstallerLab/provider-admission-parallels.lock/owner.tsv"
 create26=$(run_remote create 26 "$archive_key" "$commit" "$checksum" KeyPath.zip 2h 0)


### PR DESCRIPTION
## Summary
- terminate VM provisioning after INT, TERM, or HUP while releasing the provider admission lock
- recover aged incomplete admission locks whose creator died before writing owner metadata
- cover signal exit/cleanup and incomplete-lock recovery in the lab shell suite

## Root cause
PR #1126 used the same non-terminating trap for `EXIT`, `INT`, `TERM`, and `HUP`. A real signal therefore released the lock but allowed provisioning to resume. A hard kill between lock-directory creation and owner-file creation could also leave an unrecoverable lock.

## Validation
- `/bin/zsh -n Scripts/lab/remote.sh`
- `/bin/bash -n Scripts/lab/tests/keypath-lab-tests.sh`
- `Scripts/lab/tests/keypath-lab-tests.sh`
- `./Scripts/test-fast.sh --changed` (full safe suite: 4,743 tests passed)
- `./Scripts/review-gate.sh` (`remote review gate selected`)

Follow-up to the actionable review feedback on merged PR #1126.