### PR TITLE
Clean interrupted VM admission waits

### DIFF
--- a/Scripts/lab/remote.sh
+++ b/Scripts/lab/remote.sh
@@ -30,6 +30,7 @@ LOGS="$STATE_ROOT/logs"
 OPERATIONS="$STATE_ROOT/operations"
 HELD_ADMISSION_LOCK=
 HELD_ADMISSION_OWNER=
+PENDING_ADMISSION_OWNER=
 
 die() { print -u2 "keypath-lab(remote): $*"; exit 1; }
 now_epoch() { date +%s; }
@@ -101,6 +102,14 @@ provider_capacity() {
   esac
 }
 
+cleanup_pending_admission_owner_and_exit() {
+  local exit_code=$1
+  trap - INT TERM HUP
+  [[ -n "$PENDING_ADMISSION_OWNER" ]] && rm -f "$PENDING_ADMISSION_OWNER"
+  PENDING_ADMISSION_OWNER=
+  exit "$exit_code"
+}
+
 acquire_admission_lock() {
   local provider=$1 attempt=0 owner owner_pid stale lock_age lock_mtime lock="$STATE_ROOT/provider-admission-$provider.lock"
   local owner_record="$STATE_ROOT/.provider-admission-$provider.owner.$$"
@@ -113,8 +122,14 @@ acquire_admission_lock() {
     print "provider\t$provider"
     print "created_at\t$(utc_now)"
   } > "$owner_record"
+  PENDING_ADMISSION_OWNER="$owner_record"
+  trap 'cleanup_pending_admission_owner_and_exit 130' INT
+  trap 'cleanup_pending_admission_owner_and_exit 143' TERM
+  trap 'cleanup_pending_admission_owner_and_exit 129' HUP
   while ((attempt < max_attempts)); do
     if ln "$owner_record" "$lock" 2>/dev/null; then
+      trap - INT TERM HUP
+      PENDING_ADMISSION_OWNER=
       HELD_ADMISSION_LOCK="$lock"
       HELD_ADMISSION_OWNER="$owner_record"
       return
@@ -139,8 +154,14 @@ acquire_admission_lock() {
     ((attempt += 1))
     sleep 0.1
   done
+  trap - INT TERM HUP
   rm -f "$owner_record"
-  owner=$([[ -d "$lock" ]] && cat "$lock/owner.tsv" 2>/dev/null || cat "$lock" 2>/dev/null || print unavailable)
+  PENDING_ADMISSION_OWNER=
+  if [[ -d "$lock" ]]; then
+    owner=$(cat "$lock/owner.tsv" 2>/dev/null || print unavailable)
+  else
+    owner=$(cat "$lock" 2>/dev/null || print unavailable)
+  fi
   print -u2 "admission_lock_busy"
   print -u2 -- "$owner"
   return 75

--- a/Scripts/lab/remote.sh
+++ b/Scripts/lab/remote.sh
@@ -102,14 +102,6 @@ provider_capacity() {
   esac
 }
 
-cleanup_pending_admission_owner_and_exit() {
-  local exit_code=$1
-  trap - INT TERM HUP
-  [[ -n "$PENDING_ADMISSION_OWNER" ]] && rm -f "$PENDING_ADMISSION_OWNER"
-  PENDING_ADMISSION_OWNER=
-  exit "$exit_code"
-}
-
 acquire_admission_lock() {
   local provider=$1 attempt=0 owner owner_pid stale lock_age lock_mtime lock="$STATE_ROOT/provider-admission-$provider.lock"
   local owner_record="$STATE_ROOT/.provider-admission-$provider.owner.$$"
@@ -117,18 +109,14 @@ acquire_admission_lock() {
   local incomplete_grace=${KEYPATH_LAB_INCOMPLETE_LOCK_GRACE_SECONDS:-5}
   [[ "$max_attempts" == <-> && "$max_attempts" -gt 0 ]] || die "invalid admission wait attempts: $max_attempts"
   [[ "$incomplete_grace" == <-> ]] || die "invalid incomplete lock grace: $incomplete_grace"
+  PENDING_ADMISSION_OWNER="$owner_record"
   {
     print "pid\t$$"
     print "provider\t$provider"
     print "created_at\t$(utc_now)"
   } > "$owner_record"
-  PENDING_ADMISSION_OWNER="$owner_record"
-  trap 'cleanup_pending_admission_owner_and_exit 130' INT
-  trap 'cleanup_pending_admission_owner_and_exit 143' TERM
-  trap 'cleanup_pending_admission_owner_and_exit 129' HUP
   while ((attempt < max_attempts)); do
     if ln "$owner_record" "$lock" 2>/dev/null; then
-      trap - INT TERM HUP
       PENDING_ADMISSION_OWNER=
       HELD_ADMISSION_LOCK="$lock"
       HELD_ADMISSION_OWNER="$owner_record"
@@ -154,7 +142,6 @@ acquire_admission_lock() {
     ((attempt += 1))
     sleep 0.1
   done
-  trap - INT TERM HUP
   rm -f "$owner_record"
   PENDING_ADMISSION_OWNER=
   if [[ -d "$lock" ]]; then
@@ -168,6 +155,8 @@ acquire_admission_lock() {
 }
 
 release_admission_lock() {
+  [[ -n "$PENDING_ADMISSION_OWNER" ]] && rm -f "$PENDING_ADMISSION_OWNER"
+  PENDING_ADMISSION_OWNER=
   if [[ -n "$HELD_ADMISSION_LOCK" && -n "$HELD_ADMISSION_OWNER" &&
         -f "$HELD_ADMISSION_LOCK" && "$HELD_ADMISSION_LOCK" -ef "$HELD_ADMISSION_OWNER" ]]; then
     rm -f "$HELD_ADMISSION_LOCK"
@@ -363,7 +352,7 @@ install_archive() {
 
 create_lease() {
   local macos=$1 archive_key=$2 commit=$3 installer_sha=$4 installer_name=$5 ttl=$6 desktop=$7
-  local launcher provider archive repo slug output lease created expires manifest guest_output product build operation ttl_seconds provider_resource
+  local launcher provider archive repo slug output lease created expires manifest guest_output product build operation ttl_seconds provider_resource exit_code
   launcher=$(launcher_for "$macos")
   provider=$(provider_for "$macos")
   valid_id "$archive_key"
@@ -371,11 +360,15 @@ create_lease() {
   [[ -f "$archive/ready.tsv" && -d "$archive/repo/.git" ]] || die "prepared archive not found: $archive_key"
   ttl_seconds=$(duration_seconds "$ttl")
   (( ttl_seconds > 0 && ttl_seconds <= 7200 )) || die "TTL must be between 1 second and 2 hours"
-  acquire_admission_lock "$provider" || return $?
   trap 'release_admission_lock' EXIT
   trap 'release_admission_lock_and_exit 130' INT
   trap 'release_admission_lock_and_exit 143' TERM
   trap 'release_admission_lock_and_exit 129' HUP
+  acquire_admission_lock "$provider" || {
+    exit_code=$?
+    trap - EXIT INT TERM HUP
+    return "$exit_code"
+  }
   if [[ "${KEYPATH_LAB_TESTING:-0}" == "1" && -n "${KEYPATH_LAB_TEST_PAUSE_AFTER_ADMISSION_LOCK:-}" ]]; then
     sleep "$KEYPATH_LAB_TEST_PAUSE_AFTER_ADMISSION_LOCK"
   fi

--- a/Scripts/lab/tests/keypath-lab-tests.sh
+++ b/Scripts/lab/tests/keypath-lab-tests.sh
@@ -219,6 +219,36 @@ lock_exit=$?
 set -e
 [[ $lock_exit -eq 75 ]] || { echo "expected admission-lock contention to exit 75, got $lock_exit" >&2; exit 1; }
 assert_contains "$lock_output" admission_lock_busy
+
+env \
+    KEYPATH_LAB_TESTING=1 \
+    KEYPATH_LAB_TEST_ROOT="$ROOT" \
+    KEYPATH_LAB_LAUNCHER_15="$ROOT/bin/launcher15" \
+    KEYPATH_LAB_LAUNCHER_26="$ROOT/bin/launcher26" \
+    KEYPATH_LAB_LAUNCHER_27="$ROOT/bin/launcher27" \
+    KEYPATH_LAB_CRABBOX="$ROOT/bin/crabbox" \
+    KEYPATH_LAB_TART="$ROOT/bin/tart" \
+    KEYPATH_LAB_GUEST_SSH="$ROOT/bin/guest-ssh" \
+    KEYPATH_LAB_TEST_SSH_KEY="$TMP/id_ed25519" \
+    KEYPATH_LAB_TEST_SECRET_FILE="$TMP/secure-input" \
+    KEYPATH_LAB_ADMISSION_WAIT_ATTEMPTS=3000 \
+    /bin/zsh "$REMOTE" create 15 "$archive_key" "$commit" "$checksum" KeyPath.zip 2h 0 >"$TMP/interrupted-wait.log" 2>&1 &
+interrupted_wait_pid=$!
+for _ in {1..100}; do
+    compgen -G "$ROOT/KeyPathInstallerLab/.provider-admission-tart.owner.*" >/dev/null && break
+    sleep 0.05
+done
+compgen -G "$ROOT/KeyPathInstallerLab/.provider-admission-tart.owner.*" >/dev/null || { echo "contending create did not write pending owner record" >&2; exit 1; }
+kill -TERM "$interrupted_wait_pid"
+set +e
+wait "$interrupted_wait_pid"
+interrupted_wait_exit=$?
+set -e
+[[ $interrupted_wait_exit -eq 143 ]] || { cat "$TMP/interrupted-wait.log" >&2; echo "expected interrupted lock wait to exit 143, got $interrupted_wait_exit" >&2; exit 1; }
+if compgen -G "$ROOT/KeyPathInstallerLab/.provider-admission-tart.owner.*" >/dev/null; then
+    echo "interrupted lock wait left a pending owner record" >&2
+    exit 1
+fi
 rm -rf "$ROOT/KeyPathInstallerLab/provider-admission-tart.lock"
 
 env \


### PR DESCRIPTION
## Summary
- remove prewritten VM admission owner records when a waiting process receives INT, TERM, or HUP
- preserve signal-derived exit codes while contending for a live provider lock
- make busy-lock owner diagnostics explicit for file and legacy-directory locks
- add a regression test for cancellation while waiting behind a live lock

## Root cause
The atomic claim added in #1127 writes its owner record before polling the fixed lock path. The holding-process traps are installed only after acquisition, so cancellation during the wait could leave the unlinked owner record behind.

## Validation
- `/bin/zsh -n Scripts/lab/remote.sh`
- `/bin/bash -n Scripts/lab/tests/keypath-lab-tests.sh`
- `Scripts/lab/tests/keypath-lab-tests.sh`
- #1127 full safe suite: 4,743 tests passed

Follow-up to the final review comment on #1127, which auto-merged before that comment became actionable.