### PR TITLE
Calibrate protected RFB click coordinates

### DIFF
--- a/Scripts/lab/keypath-lab
+++ b/Scripts/lab/keypath-lab
@@ -15,7 +15,7 @@ Commands:
   create --macos 15|26|27 --lane managed-functional|unmanaged-ui --commit SHA --installer PATH [--ttl 2h] [--desktop]
   install-app LEASE_ID
   desktop-bootstrap LEASE_ID [--install-tools]
-  protected-click LEASE_ID --app APP --window TITLE --x X --y Y [--after-window TITLE]
+  protected-click LEASE_ID --app APP --window TITLE (--x X --y Y | --ax-x X --ax-y Y) [--after-window TITLE]
   secure-dialog-input LEASE_ID --app APP --field LABEL [--submit BUTTON] [--already-focused]
   run LEASE_ID -- COMMAND [ARG...]
   status LEASE_ID
@@ -139,6 +139,7 @@ EOF
         after_window=
         x=
         y=
+        coordinate_space=native
         while [[ $# -gt 0 ]]; do
             case "$1" in
                 --app) app=${2:-}; shift 2 ;;
@@ -146,12 +147,14 @@ EOF
                 --after-window) after_window=${2:-}; shift 2 ;;
                 --x) x=${2:-}; shift 2 ;;
                 --y) y=${2:-}; shift 2 ;;
+                --ax-x) x=${2:-}; coordinate_space=ax; shift 2 ;;
+                --ax-y) y=${2:-}; coordinate_space=ax; shift 2 ;;
                 *) usage ;;
             esac
         done
         [[ -n $app && -n $window && $x =~ ^[0-9]+$ && $y =~ ^[0-9]+$ ]] || usage
         [[ -n $after_window ]] || after_window=$window
-        remote protected-click "$lease" "$app" "$window" "$after_window" "$x" "$y"
+        remote protected-click "$lease" "$app" "$window" "$after_window" "$coordinate_space" "$x" "$y"
         ;;
     secure-dialog-input)
         lease=${1:-}

--- a/Scripts/lab/remote.sh
+++ b/Scripts/lab/remote.sh
@@ -604,13 +604,15 @@ secure_dialog_input() {
 }
 
 protected_click() {
-  local lease=$1 app=$2 expected_before=$3 expected_after=$4 x=$5 y=$6
-  local manifest macos resource key ip before after guest_command
+  local lease=$1 app=$2 expected_before=$3 expected_after=$4 coordinate_space=$5 x=$6 y=$7
+  local manifest macos resource key ip before after guest_command geometry_command geometry
+  local native_width native_height logical_width logical_height scale_x scale_y
   manifest=$(owned_manifest "$lease")
   macos=$(field "$manifest" macos)
   [[ "$macos" == "15" ]] || die "protected click currently supports only the Tart macOS 15 lane"
   [[ "$(field "$manifest" desktop_enabled)" == "true" ]] || die "protected click requires a desktop-enabled lease"
   [[ "$x" == <-> && "$y" == <-> ]] || die "protected click coordinates must be non-negative integers"
+  [[ "$coordinate_space" == "native" || "$coordinate_space" == "ax" ]] || die "invalid protected click coordinate space"
   resource=$(field "$manifest" provider_resource)
   [[ "$resource" =~ '^[A-Za-z0-9._-]+$' && "$resource" != "unknown" ]] || die "invalid Tart resource id"
 
@@ -631,6 +633,23 @@ protected_click() {
     die "protected click precondition failed: expected window '$expected_before', found '${before:-unknown}'"
   }
 
+  if [[ "$coordinate_space" == "ax" ]]; then
+    if [[ "${KEYPATH_LAB_TESTING:-0}" == "1" ]]; then
+      geometry=${KEYPATH_LAB_TEST_DISPLAY_GEOMETRY:-$'2048\t1536\t1024\t768'}
+    else
+      geometry_command='/opt/homebrew/bin/peekaboo list windows --app '$(printf %q "$app")' --json | /usr/bin/python3 -c '\''import json,re,sys; data=json.load(sys.stdin).get("data",{}); windows=data.get("windows",data if isinstance(data,list) else []); names=[w.get("screenName","") for w in windows if isinstance(w,dict)]; m=next((re.search(r"([0-9]+)×([0-9]+)",n) for n in names if re.search(r"([0-9]+)×([0-9]+)",n)),None); print(f"{m.group(1)}\\t{m.group(2)}" if m else "")'\''; printf "\\t"; /usr/bin/osascript -l JavaScript -e '\''ObjC.import("AppKit"); var s=$.NSScreen.mainScreen.frame.size; s.width+"\\t"+s.height'\'''
+      geometry=$("$GUEST_SSH" -o BatchMode=yes -o StrictHostKeyChecking=accept-new -i "$key" "admin@$ip" "/bin/zsh -lc $(printf %q "$geometry_command")")
+    fi
+    IFS=$'\t' read -r native_width native_height logical_width logical_height <<< "$geometry"
+    [[ "$native_width" == <-> && "$native_height" == <-> && "$logical_width" == <-> && "$logical_height" == <-> && "$logical_width" -gt 0 && "$logical_height" -gt 0 ]] || die "protected click could not measure display geometry"
+    (( native_width % logical_width == 0 && native_height % logical_height == 0 )) || die "protected click measured a non-integral display scale"
+    scale_x=$((native_width / logical_width))
+    scale_y=$((native_height / logical_height))
+    (( scale_x == scale_y && scale_x > 0 )) || die "protected click measured inconsistent display scales"
+    x=$((x * scale_x))
+    y=$((y * scale_y))
+  fi
+
   "$CRABBOX" desktop click --provider tart --target macos --id "$resource" --x "$x" --y "$y" >/dev/null
   sleep "${KEYPATH_LAB_PROTECTED_CLICK_SETTLE_SECONDS:-1}"
   if [[ "${KEYPATH_LAB_TESTING:-0}" == "1" ]]; then
@@ -646,6 +665,10 @@ protected_click() {
   print "protected_click\tpassed"
   print "window_before\t$before"
   print "window_after\t$after"
+  print "coordinate_space\t$coordinate_space"
+  if [[ "$coordinate_space" == "ax" ]]; then
+    print "display_scale\t$scale_x"
+  fi
 }
 
 print_status() {
@@ -796,7 +819,7 @@ case "$action" in
   create) [[ $# -eq 8 ]] || die "create requires macOS, test lane, archive, commit, checksum, name, ttl, desktop"; create_lease "$@" ;;
   install-app) [[ $# -eq 1 ]] || die "install-app requires lease"; install_app "$1" ;;
   secure-dialog-input) [[ $# -eq 5 ]] || die "secure-dialog-input requires lease, app, field, optional submit value, and focus mode"; secure_dialog_input "$@" ;;
-  protected-click) [[ $# -eq 6 ]] || die "protected-click requires lease, app, before window, after window, x, and y"; protected_click "$@" ;;
+  protected-click) [[ $# -eq 7 ]] || die "protected-click requires lease, app, before window, after window, coordinate space, x, and y"; protected_click "$@" ;;
   run) [[ $# -ge 2 ]] || die "run requires lease and command"; run_command "$@" ;;
   status) [[ $# -eq 1 ]] || die "status requires lease"; print_status "$1" ;;
   list) [[ $# -eq 0 ]] || die "list takes no arguments"; list_leases ;;

--- a/Scripts/lab/tests/keypath-lab-tests.sh
+++ b/Scripts/lab/tests/keypath-lab-tests.sh
@@ -341,15 +341,18 @@ if grep -q 'peekaboo.*see\|peekaboo.*click' "$TMP/guest-ssh-args"; then
     echo "already-focused secure input attempted inaccessible AX discovery" >&2
     exit 1
 fi
-protected_result=$(KEYPATH_LAB_PROTECTED_CLICK_SETTLE_SECONDS=0 run_remote protected-click cbx_desktop15 'System Settings' Accessibility Accessibility 402 247)
+protected_result=$(KEYPATH_LAB_PROTECTED_CLICK_SETTLE_SECONDS=0 run_remote protected-click cbx_desktop15 'System Settings' Accessibility Accessibility native 402 247)
 assert_contains "$protected_result" $'protected_click\tpassed'
 grep -q 'crabbox desktop click --provider tart --target macos --id test-resource --x 402 --y 247' "$CALLS"
 set +e
-protected_wrong_page=$(KEYPATH_LAB_TEST_WINDOW_AFTER=Network KEYPATH_LAB_PROTECTED_CLICK_SETTLE_SECONDS=0 run_remote protected-click cbx_desktop15 'System Settings' Accessibility Accessibility 402 247 2>&1)
+protected_wrong_page=$(KEYPATH_LAB_TEST_WINDOW_AFTER=Network KEYPATH_LAB_PROTECTED_CLICK_SETTLE_SECONDS=0 run_remote protected-click cbx_desktop15 'System Settings' Accessibility Accessibility native 402 247 2>&1)
 protected_wrong_page_exit=$?
 set -e
 [[ $protected_wrong_page_exit -ne 0 ]] || { echo "protected click accepted the wrong destination page" >&2; exit 1; }
 assert_contains "$protected_wrong_page" "protected click postcondition failed"
+protected_ax_result=$(KEYPATH_LAB_PROTECTED_CLICK_SETTLE_SECONDS=0 run_remote protected-click cbx_desktop15 'System Settings' Accessibility Accessibility ax 402 247)
+assert_contains "$protected_ax_result" $'display_scale\t2'
+grep -q 'crabbox desktop click --provider tart --target macos --id test-resource --x 804 --y 494' "$CALLS"
 run_remote destroy cbx_desktop15 >/dev/null
 
 if run_remote create 26 unmanaged-ui "$archive_key" "$commit" "$checksum" KeyPath.zip 3h 0 >/dev/null 2>&1; then

--- a/docs/testing/installer-gui-automation-capabilities.md
+++ b/docs/testing/installer-gui-automation-capabilities.md
@@ -33,6 +33,11 @@ expected page (or explicitly expected dialog) immediately afterward. A changed
 page is a harness failure; never continue to password entry or report the
 permission as granted.
 
+Pass Accessibility coordinates to `keypath-lab protected-click` with `--ax-x`
+and `--ax-y`. The controller measures the guest's native and logical display
+dimensions and applies the scale itself. Reserve raw `--x` and `--y` coordinates
+for diagnostics where the native framebuffer point is already known.
+
 ## Current capability matrix
 
 | Gate | Human required? | Current automation path | Required proof |

--- a/docs/testing/remote-installer-lab.md
+++ b/docs/testing/remote-installer-lab.md
@@ -184,11 +184,13 @@ guard instead of invoking CrabBox directly:
 Scripts/lab/keypath-lab protected-click cbx_example \
   --app 'System Settings' \
   --window Accessibility \
-  --x 804 --y 494
+  --ax-x 402 --ax-y 247
 ```
 
-The coordinates are native framebuffer coordinates measured for the current
-lease. The command snapshots the named app before and after delivery and fails
+With `--ax-x` and `--ax-y`, the command measures the current display's logical
+and native dimensions and converts Accessibility coordinates to framebuffer
+coordinates. Raw native coordinates remain available as `--x` and `--y` for
+diagnostics. The command snapshots the named app before and after delivery and fails
 if either window title differs from the declared page. When the click is
 expected to open another page or dialog, declare that explicitly with
 `--after-window`. This guard detects a delivered click that landed on the wrong


### PR DESCRIPTION
## Summary
- accept Accessibility-space coordinates for protected VM clicks
- measure native and logical display dimensions inside the current guest
- convert to framebuffer coordinates and retain before/after page assertions

## Validation
- `Scripts/lab/tests/keypath-lab-tests.sh`
- verifies AX `(402,247)` becomes native `(804,494)` for a measured 2x display
- `./Scripts/review-gate.sh` selected the enforced remote review gate
