### PR TITLE
Remove retired command actions preference

### DIFF
--- a/Sources/KeyPathAppKit/Services/Configuration/PreferencesService.swift
+++ b/Sources/KeyPathAppKit/Services/Configuration/PreferencesService.swift
@@ -453,6 +453,10 @@ final class PreferencesService: @unchecked Sendable {
     // MARK: - Initialization
 
     init() {
+        // The command-action feature was removed in #879. Clear its retired
+        // preference so older installs do not retain a misleading security flag.
+        UserDefaults.standard.removeObject(forKey: "KeyPath.Security.ConfigCommandActionsEnabled")
+
         // Load stored preferences or use defaults
         let protocolString =
             UserDefaults.standard.string(forKey: Keys.communicationProtocol)

--- a/Tests/KeyPathTests/Services/PreferencesServicePersistenceTests.swift
+++ b/Tests/KeyPathTests/Services/PreferencesServicePersistenceTests.swift
@@ -336,6 +336,22 @@ final class PreferencesServicePersistenceTests: XCTestCase {
 
     // MARK: - Legacy TCP Port Migration
 
+    func testRetiredCommandActionsPreferenceIsRemovedOnLoad() {
+        let key = "KeyPath.Security.ConfigCommandActionsEnabled"
+        let saved = UserDefaults.standard.object(forKey: key)
+        defer {
+            if let saved { UserDefaults.standard.set(saved, forKey: key) } else {
+                UserDefaults.standard.removeObject(forKey: key)
+            }
+        }
+
+        UserDefaults.standard.set(true, forKey: key)
+
+        _ = PreferencesService()
+
+        XCTAssertNil(UserDefaults.standard.object(forKey: key))
+    }
+
     /// An old install that still has the UDP-era port (54141) stored should be
     /// migrated to the current default (37001) on load, and the stale key
     /// cleared so it tracks the default going forward. This is the fix for the

--- a/Tests/KeyPathTests/Services/PreferencesServicePersistenceTests.swift
+++ b/Tests/KeyPathTests/Services/PreferencesServicePersistenceTests.swift
@@ -334,7 +334,7 @@ final class PreferencesServicePersistenceTests: XCTestCase {
         XCTAssertFalse(prefs.isValidPort(65536))
     }
 
-    // MARK: - Legacy TCP Port Migration
+    // MARK: - Retired Preference Cleanup
 
     func testRetiredCommandActionsPreferenceIsRemovedOnLoad() {
         let key = "KeyPath.Security.ConfigCommandActionsEnabled"
@@ -351,6 +351,8 @@ final class PreferencesServicePersistenceTests: XCTestCase {
 
         XCTAssertNil(UserDefaults.standard.object(forKey: key))
     }
+
+    // MARK: - Legacy TCP Port Migration
 
     /// An old install that still has the UDP-era port (54141) stored should be
     /// migrated to the current default (37001) on load, and the stale key


### PR DESCRIPTION
## Summary
- clear the retired `KeyPath.Security.ConfigCommandActionsEnabled` default when preferences load
- add regression coverage proving older persisted values are removed

## Why
#879 removed command actions and their policy, leaving this preference as benign but misleading residue on upgraded installs. This keeps the cleanup in the existing preference migration path without reintroducing a consumer for the retired key.

Closes #909.

## Validation
- `TEST_FILTER=PreferencesServicePersistenceTests/testRetiredCommandActionsPreferenceIsRemovedOnLoad ./Scripts/run-tests-safe.sh`
- `./Scripts/test-fast.sh --changed` — 4,744 tests passed
- `./Scripts/review-gate.sh` — remote review gate selected; GitHub `claude-review` required before merge