### PR TITLE
Automate permission binary drag flow

### DIFF
--- a/Scripts/lab/permission-drag
+++ b/Scripts/lab/permission-drag
@@ -1,0 +1,84 @@
+#!/bin/zsh
+set -euo pipefail
+
+die() { print -u2 "permission-drag: $*"; exit 1; }
+
+usage() {
+  print -u2 "Usage: Scripts/lab/permission-drag --path FILE --target-identifier IDENTIFIER --output FILE"
+  exit 2
+}
+
+peekaboo=${PEEKABOO_BIN:-/opt/homebrew/bin/peekaboo}
+open_bin=${OPEN_BIN:-/usr/bin/open}
+osascript=${OSASCRIPT_BIN:-/usr/bin/osascript}
+file_path=
+target_identifier=
+output=
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --path) file_path=${2:-}; shift 2 ;;
+    --target-identifier) target_identifier=${2:-}; shift 2 ;;
+    --output) output=${2:-}; shift 2 ;;
+    *) usage ;;
+  esac
+done
+
+[[ "$file_path" == /* && -f "$file_path" ]] || die "--path must identify an existing absolute file"
+[[ -n "$target_identifier" ]] || die "--target-identifier is required"
+[[ -n "$output" && "$output" != -* ]] || die "--output is required"
+mkdir -p "${output:h}"
+
+tmp=$(mktemp -d /tmp/keypath-permission-drag.XXXXXX)
+trap 'rm -rf "$tmp"' EXIT
+name=${file_path:t}
+
+"$open_bin" -R "$file_path"
+sleep ${KEYPATH_PERMISSION_DRAG_REVEAL_SECONDS:-2}
+"$osascript" -e 'tell application "System Events" to tell process "Finder" to tell window 1 to set {position, size} to {{0, 40}, {500, 700}}' >/dev/null
+"$osascript" -e 'tell application "System Events" to tell process "System Settings" to tell window 1 to set {position, size} to {{500, 40}, {524, 700}}' >/dev/null
+sleep ${KEYPATH_PERMISSION_DRAG_SETTLE_SECONDS:-1}
+
+"$peekaboo" see --app Finder --json > "$tmp/source.json"
+"$peekaboo" see --app "System Settings" --json > "$tmp/target.json"
+
+coords=$(/usr/bin/python3 - "$tmp/source.json" "$tmp/target.json" "$name" "$target_identifier" <<'PY'
+import json, sys
+
+source = json.load(open(sys.argv[1])).get("data", {}).get("ui_elements", [])
+target = json.load(open(sys.argv[2])).get("data", {}).get("ui_elements", [])
+source_name, target_identifier = sys.argv[3], sys.argv[4]
+
+def center(element):
+    bounds = element.get("bounds") or {}
+    return round(bounds["x"] + bounds["width"] / 2), round(bounds["y"] + bounds["height"] / 2)
+
+source_element = next((e for e in source if e.get("label") == source_name and e.get("is_actionable")), None)
+target_element = next((e for e in target if e.get("identifier") == target_identifier), None)
+if source_element is None or target_element is None:
+    raise SystemExit(1)
+sx, sy = center(source_element)
+tx, ty = center(target_element)
+print(f"{sx},{sy} {tx},{ty}")
+PY
+) || die "could not resolve source or permission-list target"
+
+source_coords=${coords%% *}
+target_coords=${coords##* }
+"$peekaboo" drag --from-coords "$source_coords" --to-coords "$target_coords" --duration 1500 --steps 30 --profile linear --json > "$output"
+sleep ${KEYPATH_PERMISSION_DRAG_SETTLE_SECONDS:-1}
+
+# Delivery is not success. Require either the expected authorization sheet or
+# the newly-added permission row before returning.
+if "$osascript" -l JavaScript -e 'var p=Application("System Events").processes.byName("System Settings"); function all(e){var o=[];try{var x=e.uiElements();for(var i=0;i<x.length;i++){o.push(x[i]);o=o.concat(all(x[i]));}}catch(_){}return o;} all(p.windows[0]).some(function(e){try{return e.subrole()==="AXSecureTextField"}catch(_){return false}}) ? "secure" : "absent"' 2>/dev/null | grep -q secure; then
+  print "permission_drag\tauthorization-required"
+  exit 0
+fi
+
+"$peekaboo" see --app "System Settings" --json > "$tmp/after.json"
+/usr/bin/python3 - "$tmp/after.json" "${name}_Title" <<'PY' || die "drag delivery had no authorization sheet or permission-row postcondition"
+import json, sys
+elements = json.load(open(sys.argv[1])).get("data", {}).get("ui_elements", [])
+raise SystemExit(0 if any(e.get("identifier") == sys.argv[2] for e in elements) else 1)
+PY
+print "permission_drag\tadded"

--- a/Scripts/lab/tests/peekaboo-ui-tests.sh
+++ b/Scripts/lab/tests/peekaboo-ui-tests.sh
@@ -58,4 +58,40 @@ if "$LAB_DIR/peekaboo-ui" click --app KeyPath --output "$TMP/out/bad.json" >/dev
   exit 1
 fi
 
+DRAG_PEEKABOO="$TMP/drag-peekaboo"
+cat > "$DRAG_PEEKABOO" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$PEEKABOO_CALLS"
+if [[ ${1:-} == see && "$*" == *"--app Finder"* ]]; then
+  printf '{"data":{"ui_elements":[{"label":"kanata-launcher","is_actionable":true,"bounds":{"x":10,"y":20,"width":40,"height":60}}]}}\n'
+elif [[ ${1:-} == see ]]; then
+  printf '{"data":{"ui_elements":[{"identifier":"KeyPath_Title","bounds":{"x":600,"y":100,"width":100,"height":20}}]}}\n'
+else
+  printf '{"success":true}\n'
+fi
+EOF
+chmod +x "$DRAG_PEEKABOO"
+
+FAKE_OPEN="$TMP/open"
+printf '#!/bin/bash\nprintf "%%s\\n" "$*" >> "$OPEN_CALLS"\n' > "$FAKE_OPEN"
+chmod +x "$FAKE_OPEN"
+export OPEN_CALLS="$TMP/open-calls"
+
+FAKE_OSASCRIPT="$TMP/osascript"
+cat > "$FAKE_OSASCRIPT" <<'EOF'
+#!/bin/bash
+[[ "$*" == *'AXSecureTextField'* ]] && echo secure
+exit 0
+EOF
+chmod +x "$FAKE_OSASCRIPT"
+
+touch "$TMP/kanata-launcher"
+KEYPATH_PERMISSION_DRAG_REVEAL_SECONDS=0 KEYPATH_PERMISSION_DRAG_SETTLE_SECONDS=0 \
+  PEEKABOO_BIN="$DRAG_PEEKABOO" OPEN_BIN="$FAKE_OPEN" OSASCRIPT_BIN="$FAKE_OSASCRIPT" \
+  "$LAB_DIR/permission-drag" --path "$TMP/kanata-launcher" --target-identifier KeyPath_Title --output "$TMP/out/drag.json" > "$TMP/drag-result"
+grep -q $'permission_drag\tauthorization-required' "$TMP/drag-result"
+grep -q -- '-R .*kanata-launcher' "$OPEN_CALLS"
+grep -q 'drag --from-coords 30,50 --to-coords 650,110 --duration 1500 --steps 30 --profile linear --json' "$PEEKABOO_CALLS"
+
 echo 'peekaboo-ui shell tests passed'

--- a/docs/testing/remote-installer-lab.md
+++ b/docs/testing/remote-installer-lab.md
@@ -128,14 +128,20 @@ Scripts/lab/keypath-lab run cbx_example -- \
   Scripts/lab/peekaboo-ui snapshot \
   --app 'System Settings' --output "$OUT/input-monitoring.json"
 Scripts/lab/keypath-lab run cbx_example -- \
-  Scripts/lab/peekaboo-ui click \
-  --app 'System Settings' --query Add --output "$OUT/add-click.json"
-Scripts/lab/keypath-lab run cbx_example -- \
-  Scripts/lab/peekaboo-ui file \
-  --app 'System Settings' \
+  Scripts/lab/permission-drag \
   --path /Applications/KeyPath.app/Contents/Library/KeyPath/kanata-launcher \
-  --output "$OUT/file-dialog.json"
+  --target-identifier KeyPath_Title \
+  --output "$OUT/permission-drag.json"
 ```
+
+The Accessibility and Input Monitoring plus-button panels filter the raw
+`kanata-launcher` executable and leave Open disabled. `permission-drag` uses
+the supported KeyPath flow instead: reveal the exact binary in Finder, derive
+the current source and permission-list target geometry from fresh AX snapshots,
+and drag between the two arranged windows. It succeeds only when macOS presents
+an authorization sheet or the expected permission row appears. If authorization
+is requested, follow it with `secure-dialog-input` and verify the new
+`kanata-launcher_Title` row before continuing.
 
 Peekaboo click success means that it delivered an action to the selected UI
 element. It is not proof that macOS accepted a protected change. Background App
@@ -177,15 +183,16 @@ transport. It is valid only after current visual evidence shows the focused
 secure field, and success still requires the corresponding system-extension
 postcondition.
 
-When the SecurityAgent sheet exposes its unnamed `AXSecureTextField`, prefer
-the stricter role-based path with a submit label. The controller writes the
+When an authorization sheet exposes an `AXSecureTextField`, prefer the stricter
+role-based path with a submit label. This covers both standalone SecurityAgent
+windows and sheets hosted by System Settings. The controller writes the
 streamed password to a mode-0600 guest temporary file long enough for
-AppleScript to set the protected field directly, derives the submit button's
+AppleScript to set the protected field in the named app, derives the submit button's
 current center from AX geometry, and delivers a synthesized foreground pointer
 click. The file is removed by an exit trap, the clipboard is never used, and
-the helper succeeds only after the SecurityAgent sheet closes. It does not use
+the helper succeeds only after that secure field disappears. It does not use
 `sudo` as a password oracle because the disposable Tart image intentionally has
-passwordless sudo. Do not generalize this role-based path to other apps.
+passwordless sudo.
 
 For a protected control that requires native RFB delivery, use the lease-owned
 guard instead of invoking CrabBox directly:


### PR DESCRIPTION
## Summary
- add a reusable Finder-to-System-Settings permission drag primitive
- derive source and target coordinates from fresh accessibility snapshots
- require an authorization-sheet or permission-row postcondition
- document why the plus-button Open panel cannot select the raw launcher binary

## Validation
- `Scripts/lab/tests/peekaboo-ui-tests.sh`
- `Scripts/lab/tests/keypath-lab-tests.sh`
- live disposable macOS 15 unmanaged VM: Accessibility and Input Monitoring both gained `kanata-launcher_Title` after encrypted, postcondition-verified authorization

## Review gate
- local review gate selected remote review; merge waits for GitHub `claude-review`