### PR TITLE
Move issue updates below visualization

### DIFF
--- a/docs/testing/keypath-github-issues-dashboard.fragment.html
+++ b/docs/testing/keypath-github-issues-dashboard.fragment.html
@@ -21,7 +21,7 @@
     #keypath-issue-board .metric { padding:11px 13px; background:color-mix(in srgb,var(--card) 88%,var(--background)); }
     #keypath-issue-board .metric strong { display:block; font-size:20px; font-weight:500; }
     #keypath-issue-board .metric span { color:var(--muted-foreground); font:11px system-ui,sans-serif; text-transform:uppercase; letter-spacing:.06em; }
-    #keypath-issue-board .workspace { display:grid; grid-template-columns:minmax(0,1fr) 300px; gap:18px; align-items:start; }
+    #keypath-issue-board .workspace { display:block; }
     #keypath-issue-board .board { padding:14px; background:color-mix(in srgb,var(--card) 82%,var(--background)); border:1px solid var(--border); border-radius:8px; }
     #keypath-issue-board .track { display:grid; grid-template-columns:repeat(12,minmax(0,1fr)); gap:5px; }
     #keypath-issue-board .issue { appearance:none; position:relative; min-height:44px; padding:6px 2px; border:1px solid transparent; border-radius:6px; color:var(--foreground); font:500 10px ui-monospace,SFMono-Regular,Menlo,monospace; cursor:pointer; transition:transform 120ms ease,filter 120ms ease; }
@@ -47,9 +47,9 @@
     #keypath-issue-board .lane.active { border-color:var(--viz-series-2); }
     #keypath-issue-board .lane.next { border-color:var(--viz-series-3); }
     #keypath-issue-board .lane.human { border-color:var(--viz-series-5); }
-    #keypath-issue-board .activity { padding-left:14px; border-left:1px solid var(--border); }
+    #keypath-issue-board .activity { margin-top:18px; padding-top:14px; border-top:1px solid var(--border); }
     #keypath-issue-board .activity h2 { margin:0 0 8px; font:500 14px system-ui,sans-serif; }
-    #keypath-issue-board .activity-list { display:flex; flex-direction:column; }
+    #keypath-issue-board .activity-list { display:grid; grid-template-columns:repeat(2,minmax(0,1fr)); column-gap:22px; }
     #keypath-issue-board .activity-row { display:grid; grid-template-columns:8px minmax(0,1fr); gap:9px; padding:9px 0; border-top:1px solid var(--border); }
     #keypath-issue-board .activity-dot { width:7px; height:7px; margin-top:5px; border-radius:50%; background:var(--viz-series-1); }
     #keypath-issue-board .activity-row[data-status="active"] .activity-dot { background:var(--viz-series-2); }
@@ -58,7 +58,7 @@
     #keypath-issue-board .activity-row span { display:block; color:var(--muted-foreground); font:11px system-ui,sans-serif; }
     #keypath-issue-board .note { margin-top:11px; color:var(--muted-foreground); font:11px system-ui,sans-serif; }
     @media(prefers-reduced-motion:reduce) { #keypath-issue-board .issue[data-status="active"] { animation:none; } }
-    @media(max-width:820px) { #keypath-issue-board .workspace { grid-template-columns:1fr; } #keypath-issue-board .activity { padding:12px 0 0; border-left:0; border-top:1px solid var(--border); } }
+    @media(max-width:820px) { #keypath-issue-board .activity-list { grid-template-columns:1fr; } }
     @media(max-width:680px) { #keypath-issue-board .track { grid-template-columns:repeat(8,minmax(0,1fr)); } #keypath-issue-board .summary,#keypath-issue-board .lanes { grid-template-columns:1fr 1fr; } #keypath-issue-board .top { align-items:flex-start; flex-direction:column; } }
     @media(max-width:430px) { #keypath-issue-board .track { grid-template-columns:repeat(5,minmax(0,1fr)); } #keypath-issue-board .summary,#keypath-issue-board .lanes { grid-template-columns:1fr; } }
   </style>

--- a/docs/testing/keypath-github-issues-dashboard.html
+++ b/docs/testing/keypath-github-issues-dashboard.html
@@ -771,7 +771,7 @@ html&gt;body{padding:0}&lt;/style&gt;
     #keypath-issue-board .metric { padding:11px 13px; background:color-mix(in srgb,var(--card) 88%,var(--background)); }
     #keypath-issue-board .metric strong { display:block; font-size:20px; font-weight:500; }
     #keypath-issue-board .metric span { color:var(--muted-foreground); font:11px system-ui,sans-serif; text-transform:uppercase; letter-spacing:.06em; }
-    #keypath-issue-board .workspace { display:grid; grid-template-columns:minmax(0,1fr) 300px; gap:18px; align-items:start; }
+    #keypath-issue-board .workspace { display:block; }
     #keypath-issue-board .board { padding:14px; background:color-mix(in srgb,var(--card) 82%,var(--background)); border:1px solid var(--border); border-radius:8px; }
     #keypath-issue-board .track { display:grid; grid-template-columns:repeat(12,minmax(0,1fr)); gap:5px; }
     #keypath-issue-board .issue { appearance:none; position:relative; min-height:44px; padding:6px 2px; border:1px solid transparent; border-radius:6px; color:var(--foreground); font:500 10px ui-monospace,SFMono-Regular,Menlo,monospace; cursor:pointer; transition:transform 120ms ease,filter 120ms ease; }
@@ -797,9 +797,9 @@ html&gt;body{padding:0}&lt;/style&gt;
     #keypath-issue-board .lane.active { border-color:var(--viz-series-2); }
     #keypath-issue-board .lane.next { border-color:var(--viz-series-3); }
     #keypath-issue-board .lane.human { border-color:var(--viz-series-5); }
-    #keypath-issue-board .activity { padding-left:14px; border-left:1px solid var(--border); }
+    #keypath-issue-board .activity { margin-top:18px; padding-top:14px; border-top:1px solid var(--border); }
     #keypath-issue-board .activity h2 { margin:0 0 8px; font:500 14px system-ui,sans-serif; }
-    #keypath-issue-board .activity-list { display:flex; flex-direction:column; }
+    #keypath-issue-board .activity-list { display:grid; grid-template-columns:repeat(2,minmax(0,1fr)); column-gap:22px; }
     #keypath-issue-board .activity-row { display:grid; grid-template-columns:8px minmax(0,1fr); gap:9px; padding:9px 0; border-top:1px solid var(--border); }
     #keypath-issue-board .activity-dot { width:7px; height:7px; margin-top:5px; border-radius:50%; background:var(--viz-series-1); }
     #keypath-issue-board .activity-row[data-status=&quot;active&quot;] .activity-dot { background:var(--viz-series-2); }
@@ -808,7 +808,7 @@ html&gt;body{padding:0}&lt;/style&gt;
     #keypath-issue-board .activity-row span { display:block; color:var(--muted-foreground); font:11px system-ui,sans-serif; }
     #keypath-issue-board .note { margin-top:11px; color:var(--muted-foreground); font:11px system-ui,sans-serif; }
     @media(prefers-reduced-motion:reduce) { #keypath-issue-board .issue[data-status=&quot;active&quot;] { animation:none; } }
-    @media(max-width:820px) { #keypath-issue-board .workspace { grid-template-columns:1fr; } #keypath-issue-board .activity { padding:12px 0 0; border-left:0; border-top:1px solid var(--border); } }
+    @media(max-width:820px) { #keypath-issue-board .activity-list { grid-template-columns:1fr; } }
     @media(max-width:680px) { #keypath-issue-board .track { grid-template-columns:repeat(8,minmax(0,1fr)); } #keypath-issue-board .summary,#keypath-issue-board .lanes { grid-template-columns:1fr 1fr; } #keypath-issue-board .top { align-items:flex-start; flex-direction:column; } }
     @media(max-width:430px) { #keypath-issue-board .track { grid-template-columns:repeat(5,minmax(0,1fr)); } #keypath-issue-board .summary,#keypath-issue-board .lanes { grid-template-columns:1fr; } }
   &lt;/style&gt;


### PR DESCRIPTION
## Summary

- give the GitHub issue map the full dashboard width
- move the recently updated feed below the visualization and work-sequence row
- present recent updates in two columns, collapsing to one on narrower windows

## Validation

- `python3 Scripts/lab/tests/issue-dashboard-tests.py`
- `./Scripts/lab/render-issue-dashboard`
- `git diff --check`
- browser layout and semantic-order verification
- `./Scripts/review-gate.sh` (remote review gate selected)
