### PR TITLE
Add issue type markers to dashboard

### DIFF
--- a/Scripts/lab/tests/issue-dashboard-tests.py
+++ b/Scripts/lab/tests/issue-dashboard-tests.py
@@ -37,6 +37,14 @@ class IssueDashboardTests(unittest.TestCase):
     def test_issue_limit_is_explicit(self) -> None:
         self.assertEqual(module.ISSUE_LIMIT, 200)
 
+    def test_issue_type_uses_stable_label_precedence(self) -> None:
+        self.assertEqual(module.issue_type(issue(1, "bug-risk", "upstream")), "bug")
+        self.assertEqual(module.issue_type(issue(2, "testing", "tech-debt")), "testing")
+        self.assertEqual(module.issue_type(issue(3, "refactor", "enhancement")), "debt")
+        self.assertEqual(module.issue_type(issue(4, "Feature", "upstream")), "feature")
+        self.assertEqual(module.issue_type(issue(5, "research", "devux")), "upstream")
+        self.assertEqual(module.issue_type(issue(6, "documentation")), "docs")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Scripts/lab/update-issue-dashboard
+++ b/Scripts/lab/update-issue-dashboard
@@ -30,6 +30,23 @@ def issue_status(issue: dict) -> str:
     return "deferred"
 
 
+def issue_type(issue: dict) -> str:
+    labels = {label["name"].lower() for label in issue.get("labels", [])}
+    if labels & {"bug", "bug-risk"}:
+        return "bug"
+    if labels & {"testing", "reliability"}:
+        return "testing"
+    if labels & {"tech-debt", "refactor"}:
+        return "debt"
+    if labels & {"feature", "enhancement", "feature-gap"}:
+        return "feature"
+    if labels & {"upstream", "research"}:
+        return "upstream"
+    if labels & {"documentation", "design", "devux"}:
+        return "docs"
+    return "other"
+
+
 def priority(issue: dict) -> tuple:
     order = {"active": 0, "next": 1, "queued": 2, "human": 3, "feature": 4, "deferred": 5}
     return (order[issue["dashboardStatus"]], -issue["number"])
@@ -68,6 +85,7 @@ def main() -> None:
     issues = json.loads(result.stdout)
     for issue in issues:
         issue["dashboardStatus"] = issue_status(issue)
+        issue["dashboardType"] = issue_type(issue)
         issue["labels"] = [label["name"] for label in issue.get("labels", [])]
     issues.sort(key=priority)
     counts = {}

--- a/docs/testing/keypath-github-issues-dashboard.fragment.html
+++ b/docs/testing/keypath-github-issues-dashboard.fragment.html
@@ -17,6 +17,9 @@
     #keypath-issue-board .queued-mark { background:var(--viz-series-1); }
     #keypath-issue-board .human-mark { background:var(--viz-series-5); }
     #keypath-issue-board .feature-mark { background:var(--muted); border:1px solid var(--border); }
+    #keypath-issue-board .type-key { display:flex; flex-wrap:wrap; align-items:center; gap:11px; margin:-5px 0 14px; color:var(--muted-foreground); font:10px system-ui,sans-serif; }
+    #keypath-issue-board .type-key .key-label { text-transform:uppercase; letter-spacing:.06em; }
+    #keypath-issue-board .type-key span { display:inline-flex; align-items:center; gap:5px; }
     #keypath-issue-board .summary { display:grid; grid-template-columns:repeat(4,minmax(0,1fr)); gap:1px; margin-bottom:14px; overflow:hidden; background:var(--border); border:1px solid var(--border); border-radius:8px; }
     #keypath-issue-board .metric { padding:11px 13px; background:color-mix(in srgb,var(--card) 88%,var(--background)); }
     #keypath-issue-board .metric strong { display:block; font-size:20px; font-weight:500; }
@@ -26,6 +29,13 @@
     #keypath-issue-board .track { display:grid; grid-template-columns:repeat(12,minmax(0,1fr)); gap:5px; }
     #keypath-issue-board .issue { appearance:none; position:relative; min-height:44px; padding:6px 2px; border:1px solid transparent; border-radius:6px; color:var(--foreground); font:500 10px ui-monospace,SFMono-Regular,Menlo,monospace; cursor:pointer; transition:transform 120ms ease,filter 120ms ease; }
     #keypath-issue-board .issue::before { content:""; position:absolute; top:5px; right:5px; width:5px; height:5px; border-radius:50%; background:currentColor; opacity:.65; }
+    #keypath-issue-board .type-marker { display:inline-block; width:7px; height:7px; margin-right:4px; background:var(--muted-foreground); vertical-align:1px; }
+    #keypath-issue-board [data-type="bug"] .type-marker { border-radius:50%; background:var(--viz-series-2); }
+    #keypath-issue-board [data-type="testing"] .type-marker { background:var(--viz-series-1); transform:rotate(45deg) scale(.78); }
+    #keypath-issue-board [data-type="debt"] .type-marker { border-radius:1px; background:var(--muted-foreground); }
+    #keypath-issue-board [data-type="feature"] .type-marker { background:var(--viz-series-5); clip-path:polygon(50% 0,100% 100%,0 100%); }
+    #keypath-issue-board [data-type="upstream"] .type-marker { border:1px solid var(--viz-series-6); border-radius:50%; background:transparent; }
+    #keypath-issue-board [data-type="docs"] .type-marker { width:8px; height:2px; background:var(--viz-series-2); }
     #keypath-issue-board .issue[data-status="active"] { background:color-mix(in srgb,var(--viz-series-2) 64%,var(--card)); }
     #keypath-issue-board .issue[data-status="next"] { background:color-mix(in srgb,var(--viz-series-3) 55%,var(--card)); }
     #keypath-issue-board .issue[data-status="queued"] { background:color-mix(in srgb,var(--viz-series-1) 38%,var(--card)); }
@@ -75,6 +85,15 @@
     <span><i class="swatch human-mark"></i>Human / external gate</span>
     <span><i class="swatch feature-mark"></i>Feature or deferred</span>
   </div>
+  <div class="type-key" aria-label="Issue type legend">
+    <span class="key-label">Type</span>
+    <span data-type="bug"><i class="type-marker"></i>Bug</span>
+    <span data-type="testing"><i class="type-marker"></i>Test</span>
+    <span data-type="debt"><i class="type-marker"></i>Debt</span>
+    <span data-type="feature"><i class="type-marker"></i>Feature</span>
+    <span data-type="upstream"><i class="type-marker"></i>Upstream</span>
+    <span data-type="docs"><i class="type-marker"></i>Docs</span>
+  </div>
 
   <section class="summary" aria-label="Open issue summary">
     <div class="metric"><strong id="metric-open">—</strong><span>Open issues</span></div>
@@ -112,6 +131,7 @@
     (() => {
       const root = document.getElementById('keypath-issue-board');
       const names = {active:'Active upstream',next:'Recommended next',queued:'Agent queue',human:'Human / external gate',feature:'Feature deferred',deferred:'Deferred'};
+      const typeNames = {bug:'Bug',testing:'Testing',debt:'Technical debt',feature:'Feature',upstream:'Upstream / research',docs:'Documentation / design',other:'Other'};
       const grid = root.querySelector('#issue-grid');
       const title = root.querySelector('#issue-title');
       const detail = root.querySelector('#issue-detail');
@@ -127,8 +147,11 @@
           const button = document.createElement('button');
           button.className = 'issue';
           button.dataset.status = issue.dashboardStatus;
-          button.textContent = `#${issue.number}`;
-          button.dataset.tooltip = `#${issue.number} · ${names[issue.dashboardStatus]} — ${issue.title}`;
+          button.dataset.type = issue.dashboardType || 'other';
+          const marker = document.createElement('i'); marker.className = 'type-marker'; marker.setAttribute('aria-hidden','true');
+          const number = document.createElement('span'); number.textContent = `#${issue.number}`;
+          button.append(marker,number);
+          button.dataset.tooltip = `#${issue.number} · ${typeNames[button.dataset.type]} · ${names[issue.dashboardStatus]} — ${issue.title}`;
           button.setAttribute('aria-label',button.dataset.tooltip);
           const select = () => {
             title.textContent = `#${issue.number} · ${issue.title}`;

--- a/docs/testing/keypath-github-issues-dashboard.html
+++ b/docs/testing/keypath-github-issues-dashboard.html
@@ -767,6 +767,9 @@ html&gt;body{padding:0}&lt;/style&gt;
     #keypath-issue-board .queued-mark { background:var(--viz-series-1); }
     #keypath-issue-board .human-mark { background:var(--viz-series-5); }
     #keypath-issue-board .feature-mark { background:var(--muted); border:1px solid var(--border); }
+    #keypath-issue-board .type-key { display:flex; flex-wrap:wrap; align-items:center; gap:11px; margin:-5px 0 14px; color:var(--muted-foreground); font:10px system-ui,sans-serif; }
+    #keypath-issue-board .type-key .key-label { text-transform:uppercase; letter-spacing:.06em; }
+    #keypath-issue-board .type-key span { display:inline-flex; align-items:center; gap:5px; }
     #keypath-issue-board .summary { display:grid; grid-template-columns:repeat(4,minmax(0,1fr)); gap:1px; margin-bottom:14px; overflow:hidden; background:var(--border); border:1px solid var(--border); border-radius:8px; }
     #keypath-issue-board .metric { padding:11px 13px; background:color-mix(in srgb,var(--card) 88%,var(--background)); }
     #keypath-issue-board .metric strong { display:block; font-size:20px; font-weight:500; }
@@ -776,6 +779,13 @@ html&gt;body{padding:0}&lt;/style&gt;
     #keypath-issue-board .track { display:grid; grid-template-columns:repeat(12,minmax(0,1fr)); gap:5px; }
     #keypath-issue-board .issue { appearance:none; position:relative; min-height:44px; padding:6px 2px; border:1px solid transparent; border-radius:6px; color:var(--foreground); font:500 10px ui-monospace,SFMono-Regular,Menlo,monospace; cursor:pointer; transition:transform 120ms ease,filter 120ms ease; }
     #keypath-issue-board .issue::before { content:&quot;&quot;; position:absolute; top:5px; right:5px; width:5px; height:5px; border-radius:50%; background:currentColor; opacity:.65; }
+    #keypath-issue-board .type-marker { display:inline-block; width:7px; height:7px; margin-right:4px; background:var(--muted-foreground); vertical-align:1px; }
+    #keypath-issue-board [data-type=&quot;bug&quot;] .type-marker { border-radius:50%; background:var(--viz-series-2); }
+    #keypath-issue-board [data-type=&quot;testing&quot;] .type-marker { background:var(--viz-series-1); transform:rotate(45deg) scale(.78); }
+    #keypath-issue-board [data-type=&quot;debt&quot;] .type-marker { border-radius:1px; background:var(--muted-foreground); }
+    #keypath-issue-board [data-type=&quot;feature&quot;] .type-marker { background:var(--viz-series-5); clip-path:polygon(50% 0,100% 100%,0 100%); }
+    #keypath-issue-board [data-type=&quot;upstream&quot;] .type-marker { border:1px solid var(--viz-series-6); border-radius:50%; background:transparent; }
+    #keypath-issue-board [data-type=&quot;docs&quot;] .type-marker { width:8px; height:2px; background:var(--viz-series-2); }
     #keypath-issue-board .issue[data-status=&quot;active&quot;] { background:color-mix(in srgb,var(--viz-series-2) 64%,var(--card)); }
     #keypath-issue-board .issue[data-status=&quot;next&quot;] { background:color-mix(in srgb,var(--viz-series-3) 55%,var(--card)); }
     #keypath-issue-board .issue[data-status=&quot;queued&quot;] { background:color-mix(in srgb,var(--viz-series-1) 38%,var(--card)); }
@@ -825,6 +835,15 @@ html&gt;body{padding:0}&lt;/style&gt;
     &lt;span&gt;&lt;i class=&quot;swatch human-mark&quot;&gt;&lt;/i&gt;Human / external gate&lt;/span&gt;
     &lt;span&gt;&lt;i class=&quot;swatch feature-mark&quot;&gt;&lt;/i&gt;Feature or deferred&lt;/span&gt;
   &lt;/div&gt;
+  &lt;div class=&quot;type-key&quot; aria-label=&quot;Issue type legend&quot;&gt;
+    &lt;span class=&quot;key-label&quot;&gt;Type&lt;/span&gt;
+    &lt;span data-type=&quot;bug&quot;&gt;&lt;i class=&quot;type-marker&quot;&gt;&lt;/i&gt;Bug&lt;/span&gt;
+    &lt;span data-type=&quot;testing&quot;&gt;&lt;i class=&quot;type-marker&quot;&gt;&lt;/i&gt;Test&lt;/span&gt;
+    &lt;span data-type=&quot;debt&quot;&gt;&lt;i class=&quot;type-marker&quot;&gt;&lt;/i&gt;Debt&lt;/span&gt;
+    &lt;span data-type=&quot;feature&quot;&gt;&lt;i class=&quot;type-marker&quot;&gt;&lt;/i&gt;Feature&lt;/span&gt;
+    &lt;span data-type=&quot;upstream&quot;&gt;&lt;i class=&quot;type-marker&quot;&gt;&lt;/i&gt;Upstream&lt;/span&gt;
+    &lt;span data-type=&quot;docs&quot;&gt;&lt;i class=&quot;type-marker&quot;&gt;&lt;/i&gt;Docs&lt;/span&gt;
+  &lt;/div&gt;
 
   &lt;section class=&quot;summary&quot; aria-label=&quot;Open issue summary&quot;&gt;
     &lt;div class=&quot;metric&quot;&gt;&lt;strong id=&quot;metric-open&quot;&gt;—&lt;/strong&gt;&lt;span&gt;Open issues&lt;/span&gt;&lt;/div&gt;
@@ -862,6 +881,7 @@ html&gt;body{padding:0}&lt;/style&gt;
     (() =&gt; {
       const root = document.getElementById(&#x27;keypath-issue-board&#x27;);
       const names = {active:&#x27;Active upstream&#x27;,next:&#x27;Recommended next&#x27;,queued:&#x27;Agent queue&#x27;,human:&#x27;Human / external gate&#x27;,feature:&#x27;Feature deferred&#x27;,deferred:&#x27;Deferred&#x27;};
+      const typeNames = {bug:&#x27;Bug&#x27;,testing:&#x27;Testing&#x27;,debt:&#x27;Technical debt&#x27;,feature:&#x27;Feature&#x27;,upstream:&#x27;Upstream / research&#x27;,docs:&#x27;Documentation / design&#x27;,other:&#x27;Other&#x27;};
       const grid = root.querySelector(&#x27;#issue-grid&#x27;);
       const title = root.querySelector(&#x27;#issue-title&#x27;);
       const detail = root.querySelector(&#x27;#issue-detail&#x27;);
@@ -877,8 +897,11 @@ html&gt;body{padding:0}&lt;/style&gt;
           const button = document.createElement(&#x27;button&#x27;);
           button.className = &#x27;issue&#x27;;
           button.dataset.status = issue.dashboardStatus;
-          button.textContent = `#${issue.number}`;
-          button.dataset.tooltip = `#${issue.number} · ${names[issue.dashboardStatus]} — ${issue.title}`;
+          button.dataset.type = issue.dashboardType || &#x27;other&#x27;;
+          const marker = document.createElement(&#x27;i&#x27;); marker.className = &#x27;type-marker&#x27;; marker.setAttribute(&#x27;aria-hidden&#x27;,&#x27;true&#x27;);
+          const number = document.createElement(&#x27;span&#x27;); number.textContent = `#${issue.number}`;
+          button.append(marker,number);
+          button.dataset.tooltip = `#${issue.number} · ${typeNames[button.dataset.type]} · ${names[issue.dashboardStatus]} — ${issue.title}`;
           button.setAttribute(&#x27;aria-label&#x27;,button.dataset.tooltip);
           const select = () =&gt; {
             title.textContent = `#${issue.number} · ${issue.title}`;

--- a/docs/testing/keypath-github-issues-state.json
+++ b/docs/testing/keypath-github-issues-state.json
@@ -26,7 +26,8 @@
       "title": "Upstream: migrate Kanata to the current VirtualHIDDevice protocol",
       "updatedAt": "2026-07-12T14:38:58Z",
       "url": "https://github.com/malpern/KeyPath/issues/982",
-      "dashboardStatus": "active"
+      "dashboardStatus": "active",
+      "dashboardType": "bug"
     },
     {
       "labels": [
@@ -37,7 +38,8 @@
       "title": "Post-1.0: report helper and service freshness explicitly",
       "updatedAt": "2026-06-06T19:09:37Z",
       "url": "https://github.com/malpern/KeyPath/issues/748",
-      "dashboardStatus": "next"
+      "dashboardStatus": "next",
+      "dashboardType": "debt"
     },
     {
       "labels": [
@@ -51,7 +53,8 @@
       "title": "InstallerEngine conflates provision and diagnose responsibilities",
       "updatedAt": "2026-07-04T13:30:28Z",
       "url": "https://github.com/malpern/KeyPath/issues/855",
-      "dashboardStatus": "queued"
+      "dashboardStatus": "queued",
+      "dashboardType": "debt"
     },
     {
       "labels": [
@@ -65,7 +68,8 @@
       "title": "App.swift / AppDelegate is overloaded (879 lines, 16 MARK sections)",
       "updatedAt": "2026-07-04T13:30:27Z",
       "url": "https://github.com/malpern/KeyPath/issues/852",
-      "dashboardStatus": "queued"
+      "dashboardStatus": "queued",
+      "dashboardType": "debt"
     },
     {
       "labels": [
@@ -78,7 +82,8 @@
       "title": "Centralize Kanata test fixtures (~350 inline config strings duplicated across tests)",
       "updatedAt": "2026-07-04T13:30:24Z",
       "url": "https://github.com/malpern/KeyPath/issues/848",
-      "dashboardStatus": "queued"
+      "dashboardStatus": "queued",
+      "dashboardType": "testing"
     },
     {
       "labels": [
@@ -90,7 +95,8 @@
       "title": "Post-1.0: clean up Swift 6 concurrency and compiler warnings",
       "updatedAt": "2026-06-06T19:10:00Z",
       "url": "https://github.com/malpern/KeyPath/issues/750",
-      "dashboardStatus": "queued"
+      "dashboardStatus": "queued",
+      "dashboardType": "debt"
     },
     {
       "labels": [
@@ -102,7 +108,8 @@
       "title": "Post-1.0: move shipping mapper code out of UI/Experimental",
       "updatedAt": "2026-07-04T13:30:08Z",
       "url": "https://github.com/malpern/KeyPath/issues/737",
-      "dashboardStatus": "queued"
+      "dashboardStatus": "queued",
+      "dashboardType": "other"
     },
     {
       "labels": [
@@ -114,7 +121,8 @@
       "title": "Post-1.0: consolidate configuration save/write/validate pipeline",
       "updatedAt": "2026-07-04T13:30:07Z",
       "url": "https://github.com/malpern/KeyPath/issues/736",
-      "dashboardStatus": "queued"
+      "dashboardStatus": "queued",
+      "dashboardType": "other"
     },
     {
       "labels": [
@@ -125,7 +133,8 @@
       "title": "Post-1.0: unify service health and lifecycle readiness contracts",
       "updatedAt": "2026-06-06T19:10:11Z",
       "url": "https://github.com/malpern/KeyPath/issues/735",
-      "dashboardStatus": "queued"
+      "dashboardStatus": "queued",
+      "dashboardType": "debt"
     },
     {
       "labels": [
@@ -136,7 +145,8 @@
       "title": "Test improvement roadmap: remaining coverage and integration work",
       "updatedAt": "2026-07-12T00:09:33Z",
       "url": "https://github.com/malpern/KeyPath/issues/604",
-      "dashboardStatus": "queued"
+      "dashboardStatus": "queued",
+      "dashboardType": "testing"
     },
     {
       "labels": [
@@ -147,7 +157,8 @@
       "title": "nonisolated(unsafe) dependency container in WizardDependencies (audit \u00a73.5)",
       "updatedAt": "2026-06-06T16:54:28Z",
       "url": "https://github.com/malpern/KeyPath/issues/496",
-      "dashboardStatus": "queued"
+      "dashboardStatus": "queued",
+      "dashboardType": "debt"
     },
     {
       "labels": [
@@ -159,7 +170,8 @@
       "title": "Large files could benefit from splitting (audit \u00a79.7)",
       "updatedAt": "2026-06-06T17:09:55Z",
       "url": "https://github.com/malpern/KeyPath/issues/495",
-      "dashboardStatus": "queued"
+      "dashboardStatus": "queued",
+      "dashboardType": "debt"
     },
     {
       "labels": [
@@ -171,7 +183,8 @@
       "title": "RulesSummaryView state management cleanup (audit \u00a78.3, \u00a78.5)",
       "updatedAt": "2026-06-06T17:09:56Z",
       "url": "https://github.com/malpern/KeyPath/issues/494",
-      "dashboardStatus": "queued"
+      "dashboardStatus": "queued",
+      "dashboardType": "debt"
     },
     {
       "labels": [
@@ -182,7 +195,8 @@
       "title": "DispatchQueue.main.async in async contexts (audit \u00a73.2)",
       "updatedAt": "2026-06-06T17:09:58Z",
       "url": "https://github.com/malpern/KeyPath/issues/490",
-      "dashboardStatus": "queued"
+      "dashboardStatus": "queued",
+      "dashboardType": "debt"
     },
     {
       "labels": [
@@ -193,7 +207,8 @@
       "title": "Hardcoded keyboard layout dimensions (audit \u00a78.6)",
       "updatedAt": "2026-06-06T17:09:59Z",
       "url": "https://github.com/malpern/KeyPath/issues/488",
-      "dashboardStatus": "queued"
+      "dashboardStatus": "queued",
+      "dashboardType": "debt"
     },
     {
       "labels": [
@@ -205,7 +220,8 @@
       "title": "Large modifier chains in OverlayMapperSection (audit \u00a78.4)",
       "updatedAt": "2026-06-06T17:10:01Z",
       "url": "https://github.com/malpern/KeyPath/issues/487",
-      "dashboardStatus": "queued"
+      "dashboardStatus": "queued",
+      "dashboardType": "debt"
     },
     {
       "labels": [
@@ -216,7 +232,8 @@
       "title": "Large computed property chains in RulesSummaryView (audit \u00a77.3)",
       "updatedAt": "2026-06-06T17:10:04Z",
       "url": "https://github.com/malpern/KeyPath/issues/484",
-      "dashboardStatus": "queued"
+      "dashboardStatus": "queued",
+      "dashboardType": "debt"
     },
     {
       "labels": [
@@ -227,7 +244,8 @@
       "title": "Gradually migrate XCTest tests to Swift Testing",
       "updatedAt": "2026-06-06T17:11:50Z",
       "url": "https://github.com/malpern/KeyPath/issues/365",
-      "dashboardStatus": "queued"
+      "dashboardStatus": "queued",
+      "dashboardType": "testing"
     },
     {
       "labels": [
@@ -238,7 +256,8 @@
       "title": "Test KeyPathInsights feature end-to-end",
       "updatedAt": "2026-06-06T17:11:52Z",
       "url": "https://github.com/malpern/KeyPath/issues/204",
-      "dashboardStatus": "queued"
+      "dashboardStatus": "queued",
+      "dashboardType": "testing"
     },
     {
       "labels": [
@@ -252,7 +271,8 @@
       "title": "Wizard polish batch: restart messaging, prompt wording, progress indicator, completion moment, error recovery, misc",
       "updatedAt": "2026-07-12T00:09:46Z",
       "url": "https://github.com/malpern/KeyPath/issues/934",
-      "dashboardStatus": "human"
+      "dashboardStatus": "human",
+      "dashboardType": "feature"
     },
     {
       "labels": [
@@ -265,7 +285,8 @@
       "title": "[1.1 docs] Capture the 26 placeholder screenshots stripped for 1.0 ship",
       "updatedAt": "2026-07-04T13:29:50Z",
       "url": "https://github.com/malpern/KeyPath/issues/920",
-      "dashboardStatus": "human"
+      "dashboardStatus": "human",
+      "dashboardType": "docs"
     },
     {
       "labels": [
@@ -279,7 +300,8 @@
       "title": "Regression-test permissions, daemon, and TCC behavior on macOS 27 betas",
       "updatedAt": "2026-07-12T00:38:35Z",
       "url": "https://github.com/malpern/KeyPath/issues/919",
-      "dashboardStatus": "human"
+      "dashboardStatus": "human",
+      "dashboardType": "bug"
     },
     {
       "labels": [
@@ -292,7 +314,8 @@
       "title": "Swift Testing migration policy: use XCTest interop, port KeyPathTestCase guards to a trait",
       "updatedAt": "2026-06-12T16:40:48Z",
       "url": "https://github.com/malpern/KeyPath/issues/918",
-      "dashboardStatus": "human"
+      "dashboardStatus": "human",
+      "dashboardType": "testing"
     },
     {
       "labels": [
@@ -305,7 +328,8 @@
       "title": "Build an eval suite for AI config repair using Apple's Evaluations framework",
       "updatedAt": "2026-06-12T16:40:40Z",
       "url": "https://github.com/malpern/KeyPath/issues/917",
-      "dashboardStatus": "human"
+      "dashboardStatus": "human",
+      "dashboardType": "testing"
     },
     {
       "labels": [
@@ -318,7 +342,8 @@
       "title": "Upgrade toolchain to Xcode 27 / Swift 6.4",
       "updatedAt": "2026-06-12T16:40:35Z",
       "url": "https://github.com/malpern/KeyPath/issues/916",
-      "dashboardStatus": "human"
+      "dashboardStatus": "human",
+      "dashboardType": "feature"
     },
     {
       "labels": [
@@ -330,7 +355,8 @@
       "title": "Adopt AppKit automatic @Observable tracking in draw/layout (back-deploys to macOS 15)",
       "updatedAt": "2026-06-12T16:40:27Z",
       "url": "https://github.com/malpern/KeyPath/issues/915",
-      "dashboardStatus": "human"
+      "dashboardStatus": "human",
+      "dashboardType": "feature"
     },
     {
       "labels": [
@@ -343,7 +369,8 @@
       "title": "Adopt App Intents Testing Framework for intent coverage (macOS 27)",
       "updatedAt": "2026-06-12T16:40:21Z",
       "url": "https://github.com/malpern/KeyPath/issues/914",
-      "dashboardStatus": "human"
+      "dashboardStatus": "human",
+      "dashboardType": "testing"
     },
     {
       "labels": [
@@ -355,7 +382,8 @@
       "title": "Expose rules/packs/layers as App Intents Entity Schemas for Siri AI & Spotlight (macOS 27)",
       "updatedAt": "2026-06-12T16:40:15Z",
       "url": "https://github.com/malpern/KeyPath/issues/913",
-      "dashboardStatus": "human"
+      "dashboardStatus": "human",
+      "dashboardType": "feature"
     },
     {
       "labels": [
@@ -367,7 +395,8 @@
       "title": "Adopt Foundation Models framework for AI config repair (on-device + Claude via LanguageModel protocol)",
       "updatedAt": "2026-06-12T16:39:56Z",
       "url": "https://github.com/malpern/KeyPath/issues/912",
-      "dashboardStatus": "human"
+      "dashboardStatus": "human",
+      "dashboardType": "feature"
     },
     {
       "labels": [
@@ -379,7 +408,8 @@
       "title": "[Design] Post-1.0 copy + terminology cleanup across rule editors",
       "updatedAt": "2026-07-04T13:29:48Z",
       "url": "https://github.com/malpern/KeyPath/issues/888",
-      "dashboardStatus": "human"
+      "dashboardStatus": "human",
+      "dashboardType": "docs"
     },
     {
       "labels": [
@@ -393,7 +423,8 @@
       "title": "[1.1] Reverse prerequisite dialog: disable user flow",
       "updatedAt": "2026-07-04T13:29:47Z",
       "url": "https://github.com/malpern/KeyPath/issues/868",
-      "dashboardStatus": "human"
+      "dashboardStatus": "human",
+      "dashboardType": "feature"
     },
     {
       "labels": [
@@ -407,7 +438,8 @@
       "title": "[Sprint 1.1] Rule dependency awareness: bidirectional prerequisite detection",
       "updatedAt": "2026-07-12T14:00:23Z",
       "url": "https://github.com/malpern/KeyPath/issues/865",
-      "dashboardStatus": "human"
+      "dashboardStatus": "human",
+      "dashboardType": "feature"
     },
     {
       "labels": [
@@ -421,7 +453,8 @@
       "title": "Verify permission and setup UX on clean accounts and signed releases",
       "updatedAt": "2026-07-12T00:09:34Z",
       "url": "https://github.com/malpern/KeyPath/issues/747",
-      "dashboardStatus": "human"
+      "dashboardStatus": "human",
+      "dashboardType": "testing"
     },
     {
       "labels": [
@@ -433,7 +466,8 @@
       "title": "Post-1.0: audit design-system token/style consolidation",
       "updatedAt": "2026-07-04T13:29:49Z",
       "url": "https://github.com/malpern/KeyPath/issues/741",
-      "dashboardStatus": "human"
+      "dashboardStatus": "human",
+      "dashboardType": "other"
     },
     {
       "labels": [
@@ -445,7 +479,8 @@
       "title": "Post-1.0: continue targeted error taxonomy cleanup",
       "updatedAt": "2026-07-04T13:30:10Z",
       "url": "https://github.com/malpern/KeyPath/issues/740",
-      "dashboardStatus": "human"
+      "dashboardStatus": "human",
+      "dashboardType": "other"
     },
     {
       "labels": [
@@ -459,7 +494,8 @@
       "title": "Upstream: Option key stops working as shortcut modifier after sleep",
       "updatedAt": "2026-07-12T14:15:25Z",
       "url": "https://github.com/malpern/KeyPath/issues/177",
-      "dashboardStatus": "human"
+      "dashboardStatus": "human",
+      "dashboardType": "upstream"
     },
     {
       "labels": [
@@ -474,7 +510,8 @@
       "title": "Upstream: Bluetooth and Logitech mice disabled or stuck when Kanata runs",
       "updatedAt": "2026-07-12T14:15:23Z",
       "url": "https://github.com/malpern/KeyPath/issues/176",
-      "dashboardStatus": "human"
+      "dashboardStatus": "human",
+      "dashboardType": "upstream"
     },
     {
       "labels": [
@@ -488,7 +525,8 @@
       "title": "Upstream: Sidecar/external displays crash Kanata (null pointer in driverkit)",
       "updatedAt": "2026-07-12T14:15:22Z",
       "url": "https://github.com/malpern/KeyPath/issues/175",
-      "dashboardStatus": "human"
+      "dashboardStatus": "human",
+      "dashboardType": "testing"
     },
     {
       "labels": [
@@ -503,7 +541,8 @@
       "title": "Upstream: Kanata crashes or loses config after MacBook sleep/lid close",
       "updatedAt": "2026-07-12T14:15:20Z",
       "url": "https://github.com/malpern/KeyPath/issues/174",
-      "dashboardStatus": "human"
+      "dashboardStatus": "human",
+      "dashboardType": "bug"
     },
     {
       "labels": [
@@ -519,7 +558,8 @@
       "title": "Upstream: Virtual HID keyboard doesn't emit native media key usage pages (F-row)",
       "updatedAt": "2026-07-12T14:15:15Z",
       "url": "https://github.com/malpern/KeyPath/issues/172",
-      "dashboardStatus": "human"
+      "dashboardStatus": "human",
+      "dashboardType": "bug"
     },
     {
       "labels": [
@@ -535,7 +575,8 @@
       "title": "Upstream: Kanata drops mouse events from composite HID devices on macOS",
       "updatedAt": "2026-07-12T14:15:14Z",
       "url": "https://github.com/malpern/KeyPath/issues/171",
-      "dashboardStatus": "human"
+      "dashboardStatus": "human",
+      "dashboardType": "bug"
     },
     {
       "labels": [
@@ -549,7 +590,8 @@
       "title": "Onboarding: post-setup first-success moment \u2014 starter collection + panel tour",
       "updatedAt": "2026-07-04T13:29:57Z",
       "url": "https://github.com/malpern/KeyPath/issues/954",
-      "dashboardStatus": "feature"
+      "dashboardStatus": "feature",
+      "dashboardType": "feature"
     },
     {
       "labels": [
@@ -563,7 +605,8 @@
       "title": "[1.1] Define rule dependency graph data model and builder",
       "updatedAt": "2026-07-04T13:30:06Z",
       "url": "https://github.com/malpern/KeyPath/issues/870",
-      "dashboardStatus": "feature"
+      "dashboardStatus": "feature",
+      "dashboardType": "feature"
     },
     {
       "labels": [
@@ -577,7 +620,8 @@
       "title": "[1.1] Forward prerequisite dialog: enable / config-edit user flow",
       "updatedAt": "2026-07-04T13:30:04Z",
       "url": "https://github.com/malpern/KeyPath/issues/869",
-      "dashboardStatus": "feature"
+      "dashboardStatus": "feature",
+      "dashboardType": "feature"
     },
     {
       "labels": [
@@ -591,7 +635,8 @@
       "title": "[1.1] Encode per-family dependencies (HRL Toggles, Launcher, Leader-based, Custom)",
       "updatedAt": "2026-07-04T13:30:03Z",
       "url": "https://github.com/malpern/KeyPath/issues/867",
-      "dashboardStatus": "feature"
+      "dashboardStatus": "feature",
+      "dashboardType": "feature"
     },
     {
       "labels": [
@@ -605,7 +650,8 @@
       "title": "[1.1] Implement Prerequisite detector: forward + reverse queries on RuleCollectionsManager",
       "updatedAt": "2026-07-04T13:30:01Z",
       "url": "https://github.com/malpern/KeyPath/issues/866",
-      "dashboardStatus": "feature"
+      "dashboardStatus": "feature",
+      "dashboardType": "feature"
     },
     {
       "labels": [
@@ -617,7 +663,8 @@
       "title": "Post-1.0: harden permission and installer UX",
       "updatedAt": "2026-06-06T19:09:49Z",
       "url": "https://github.com/malpern/KeyPath/issues/749",
-      "dashboardStatus": "feature"
+      "dashboardStatus": "feature",
+      "dashboardType": "debt"
     },
     {
       "labels": [
@@ -632,7 +679,8 @@
       "title": "Deferred TODOs: QMK HID-descriptor mapping (unused) + device-enumeration workaround (#254)",
       "updatedAt": "2026-07-04T13:30:33Z",
       "url": "https://github.com/malpern/KeyPath/issues/694",
-      "dashboardStatus": "feature"
+      "dashboardStatus": "feature",
+      "dashboardType": "feature"
     },
     {
       "labels": [
@@ -647,7 +695,8 @@
       "title": "Unimplemented feature flags present but not built (JIT permissions, optional wizard)",
       "updatedAt": "2026-07-04T13:30:32Z",
       "url": "https://github.com/malpern/KeyPath/issues/688",
-      "dashboardStatus": "feature"
+      "dashboardStatus": "feature",
+      "dashboardType": "feature"
     },
     {
       "labels": [
@@ -658,7 +707,8 @@
       "title": "Multi-pack collection ownership conflict resolution",
       "updatedAt": "2026-06-06T17:10:05Z",
       "url": "https://github.com/malpern/KeyPath/issues/468",
-      "dashboardStatus": "feature"
+      "dashboardStatus": "feature",
+      "dashboardType": "feature"
     },
     {
       "labels": [
@@ -669,7 +719,8 @@
       "title": "Pack conflict detection and resolution for multi-mechanism packs",
       "updatedAt": "2026-06-06T17:10:10Z",
       "url": "https://github.com/malpern/KeyPath/issues/375",
-      "dashboardStatus": "feature"
+      "dashboardStatus": "feature",
+      "dashboardType": "feature"
     },
     {
       "labels": [
@@ -681,7 +732,8 @@
       "title": "Research: host-to-keyboard display protocol for screen-equipped keyboards (Work Louder, etc.)",
       "updatedAt": "2026-06-06T17:11:53Z",
       "url": "https://github.com/malpern/KeyPath/issues/299",
-      "dashboardStatus": "feature"
+      "dashboardStatus": "feature",
+      "dashboardType": "feature"
     },
     {
       "labels": [
@@ -692,7 +744,8 @@
       "title": "feat: Option/AltGr layer labels in overlay",
       "updatedAt": "2026-06-06T17:10:14Z",
       "url": "https://github.com/malpern/KeyPath/issues/293",
-      "dashboardStatus": "feature"
+      "dashboardStatus": "feature",
+      "dashboardType": "feature"
     },
     {
       "labels": [
@@ -703,7 +756,8 @@
       "title": "Karabiner parity: mouse-to-scroll (mouse_motion_to_scroll)",
       "updatedAt": "2026-06-06T17:10:17Z",
       "url": "https://github.com/malpern/KeyPath/issues/216",
-      "dashboardStatus": "feature"
+      "dashboardStatus": "feature",
+      "dashboardType": "feature"
     },
     {
       "labels": [
@@ -714,7 +768,8 @@
       "title": "Karabiner parity: mouse axis manipulation (mouse_basic)",
       "updatedAt": "2026-06-06T17:10:18Z",
       "url": "https://github.com/malpern/KeyPath/issues/215",
-      "dashboardStatus": "feature"
+      "dashboardStatus": "feature",
+      "dashboardType": "feature"
     },
     {
       "labels": [
@@ -725,7 +780,8 @@
       "title": "Karabiner parity: input source switching (select_input_source)",
       "updatedAt": "2026-06-06T17:10:20Z",
       "url": "https://github.com/malpern/KeyPath/issues/214",
-      "dashboardStatus": "feature"
+      "dashboardStatus": "feature",
+      "dashboardType": "feature"
     },
     {
       "labels": [
@@ -736,7 +792,8 @@
       "title": "Tracking: 100% Karabiner conversion fidelity roadmap",
       "updatedAt": "2026-06-06T17:10:22Z",
       "url": "https://github.com/malpern/KeyPath/issues/213",
-      "dashboardStatus": "feature"
+      "dashboardStatus": "feature",
+      "dashboardType": "feature"
     },
     {
       "labels": [
@@ -747,7 +804,8 @@
       "title": "Karabiner converter: support GokuRakuJoudo (Goku) EDN format import",
       "updatedAt": "2026-06-06T17:10:23Z",
       "url": "https://github.com/malpern/KeyPath/issues/212",
-      "dashboardStatus": "feature"
+      "dashboardStatus": "feature",
+      "dashboardType": "feature"
     },
     {
       "labels": [
@@ -758,7 +816,8 @@
       "title": "Karabiner converter: AI-assisted Tier 2+ conversion for complex rules",
       "updatedAt": "2026-06-06T17:10:25Z",
       "url": "https://github.com/malpern/KeyPath/issues/211",
-      "dashboardStatus": "feature"
+      "dashboardStatus": "feature",
+      "dashboardType": "feature"
     },
     {
       "labels": [
@@ -771,7 +830,8 @@
       "title": "Kanata: Add hidden sequence input modes",
       "updatedAt": "2026-06-06T17:10:31Z",
       "url": "https://github.com/malpern/KeyPath/issues/197",
-      "dashboardStatus": "feature"
+      "dashboardStatus": "feature",
+      "dashboardType": "feature"
     },
     {
       "labels": [
@@ -784,7 +844,8 @@
       "title": "Kanata: Add unmod/unshift modifier suppression",
       "updatedAt": "2026-06-06T17:10:32Z",
       "url": "https://github.com/malpern/KeyPath/issues/196",
-      "dashboardStatus": "feature"
+      "dashboardStatus": "feature",
+      "dashboardType": "feature"
     },
     {
       "labels": [
@@ -797,7 +858,8 @@
       "title": "Kanata: Add movemouse-speed dynamic adjustment",
       "updatedAt": "2026-06-06T17:10:34Z",
       "url": "https://github.com/malpern/KeyPath/issues/195",
-      "dashboardStatus": "feature"
+      "dashboardStatus": "feature",
+      "dashboardType": "feature"
     },
     {
       "labels": [
@@ -810,7 +872,8 @@
       "title": "Kanata: Add arbitrary-code keycode output",
       "updatedAt": "2026-06-06T17:10:35Z",
       "url": "https://github.com/malpern/KeyPath/issues/194",
-      "dashboardStatus": "feature"
+      "dashboardStatus": "feature",
+      "dashboardType": "feature"
     },
     {
       "labels": [
@@ -823,7 +886,8 @@
       "title": "Kanata: Add environment-conditional config support",
       "updatedAt": "2026-06-06T17:10:37Z",
       "url": "https://github.com/malpern/KeyPath/issues/193",
-      "dashboardStatus": "feature"
+      "dashboardStatus": "feature",
+      "dashboardType": "feature"
     },
     {
       "labels": [
@@ -836,7 +900,8 @@
       "title": "Kanata: Expose include directives for user config composition",
       "updatedAt": "2026-06-06T17:10:38Z",
       "url": "https://github.com/malpern/KeyPath/issues/192",
-      "dashboardStatus": "feature"
+      "dashboardStatus": "feature",
+      "dashboardType": "feature"
     },
     {
       "labels": [
@@ -849,7 +914,8 @@
       "title": "Kanata: Add hold-for-duration behavior",
       "updatedAt": "2026-06-06T17:10:40Z",
       "url": "https://github.com/malpern/KeyPath/issues/191",
-      "dashboardStatus": "feature"
+      "dashboardStatus": "feature",
+      "dashboardType": "feature"
     },
     {
       "labels": [
@@ -862,7 +928,8 @@
       "title": "Kanata: Add repeat key (rpt/rpt-any) support",
       "updatedAt": "2026-06-06T17:10:42Z",
       "url": "https://github.com/malpern/KeyPath/issues/190",
-      "dashboardStatus": "feature"
+      "dashboardStatus": "feature",
+      "dashboardType": "feature"
     },
     {
       "labels": [
@@ -875,7 +942,8 @@
       "title": "Kanata: Add clipboard actions (save/restore/swap)",
       "updatedAt": "2026-06-06T17:10:43Z",
       "url": "https://github.com/malpern/KeyPath/issues/189",
-      "dashboardStatus": "feature"
+      "dashboardStatus": "feature",
+      "dashboardType": "feature"
     },
     {
       "labels": [
@@ -888,7 +956,8 @@
       "title": "Kanata: Add ZippyChord text expansion support",
       "updatedAt": "2026-06-06T17:10:45Z",
       "url": "https://github.com/malpern/KeyPath/issues/188",
-      "dashboardStatus": "feature"
+      "dashboardStatus": "feature",
+      "dashboardType": "feature"
     },
     {
       "labels": [
@@ -901,7 +970,8 @@
       "title": "Kanata: Add config cycling (lrld-next/lrld-prev) support",
       "updatedAt": "2026-06-06T17:10:46Z",
       "url": "https://github.com/malpern/KeyPath/issues/187",
-      "dashboardStatus": "feature"
+      "dashboardStatus": "feature",
+      "dashboardType": "feature"
     },
     {
       "labels": [
@@ -914,7 +984,8 @@
       "title": "Kanata: Add arbitrary command execution (cmd) to UI",
       "updatedAt": "2026-06-06T17:10:48Z",
       "url": "https://github.com/malpern/KeyPath/issues/186",
-      "dashboardStatus": "feature"
+      "dashboardStatus": "feature",
+      "dashboardType": "feature"
     },
     {
       "labels": [
@@ -927,7 +998,8 @@
       "title": "Kanata: Expose user-authored fork actions in UI",
       "updatedAt": "2026-06-06T17:10:49Z",
       "url": "https://github.com/malpern/KeyPath/issues/185",
-      "dashboardStatus": "feature"
+      "dashboardStatus": "feature",
+      "dashboardType": "feature"
     },
     {
       "labels": [
@@ -940,7 +1012,8 @@
       "title": "Kanata: Add switch conditional action support",
       "updatedAt": "2026-06-06T17:10:50Z",
       "url": "https://github.com/malpern/KeyPath/issues/184",
-      "dashboardStatus": "feature"
+      "dashboardStatus": "feature",
+      "dashboardType": "feature"
     },
     {
       "labels": [
@@ -953,7 +1026,8 @@
       "title": "Kanata: Add unicode character output support",
       "updatedAt": "2026-06-06T17:10:52Z",
       "url": "https://github.com/malpern/KeyPath/issues/183",
-      "dashboardStatus": "feature"
+      "dashboardStatus": "feature",
+      "dashboardType": "feature"
     },
     {
       "labels": [
@@ -966,7 +1040,8 @@
       "title": "Kanata: Add dynamic macro support (record/playback)",
       "updatedAt": "2026-06-06T17:10:53Z",
       "url": "https://github.com/malpern/KeyPath/issues/182",
-      "dashboardStatus": "feature"
+      "dashboardStatus": "feature",
+      "dashboardType": "feature"
     },
     {
       "labels": [
@@ -978,7 +1053,8 @@
       "title": "Kanata: Add mouse key support (movement, clicks, scrolling)",
       "updatedAt": "2026-06-06T17:10:55Z",
       "url": "https://github.com/malpern/KeyPath/issues/181",
-      "dashboardStatus": "feature"
+      "dashboardStatus": "feature",
+      "dashboardType": "feature"
     },
     {
       "labels": [
@@ -991,7 +1067,8 @@
       "title": "Kanata: Add defoverrides support",
       "updatedAt": "2026-06-06T17:10:56Z",
       "url": "https://github.com/malpern/KeyPath/issues/180",
-      "dashboardStatus": "feature"
+      "dashboardStatus": "feature",
+      "dashboardType": "feature"
     },
     {
       "labels": [
@@ -1004,7 +1081,8 @@
       "title": "Kanata: Expose one-shot modifiers as standalone UI behavior",
       "updatedAt": "2026-06-06T17:10:58Z",
       "url": "https://github.com/malpern/KeyPath/issues/179",
-      "dashboardStatus": "feature"
+      "dashboardStatus": "feature",
+      "dashboardType": "feature"
     },
     {
       "labels": [
@@ -1017,7 +1095,8 @@
       "title": "Kanata: Add caps-word support",
       "updatedAt": "2026-06-06T17:11:00Z",
       "url": "https://github.com/malpern/KeyPath/issues/178",
-      "dashboardStatus": "feature"
+      "dashboardStatus": "feature",
+      "dashboardType": "feature"
     },
     {
       "labels": [
@@ -1028,7 +1107,8 @@
       "title": "Phase 3: Add chord/macro/sequence suppression to keyboard overlay",
       "updatedAt": "2026-06-06T17:11:23Z",
       "url": "https://github.com/malpern/KeyPath/issues/77",
-      "dashboardStatus": "feature"
+      "dashboardStatus": "feature",
+      "dashboardType": "feature"
     },
     {
       "labels": [
@@ -1041,7 +1121,8 @@
       "title": "Implement keyberon emission points for OneShotActivated, ChordResolved, TapDanceResolved",
       "updatedAt": "2026-06-06T17:12:05Z",
       "url": "https://github.com/malpern/KeyPath/issues/68",
-      "dashboardStatus": "feature"
+      "dashboardStatus": "feature",
+      "dashboardType": "feature"
     },
     {
       "labels": [
@@ -1052,7 +1133,8 @@
       "title": "Retrospective: stale-kanata detection (#638) reverted \u2014 revisit only via authoritative HelloOk build-stamp, else let go",
       "updatedAt": "2026-06-06T17:11:55Z",
       "url": "https://github.com/malpern/KeyPath/issues/641",
-      "dashboardStatus": "deferred"
+      "dashboardStatus": "deferred",
+      "dashboardType": "upstream"
     },
     {
       "labels": [
@@ -1063,7 +1145,8 @@
       "title": "Extract shared CollectionEditorView for rule collection UIs",
       "updatedAt": "2026-06-06T17:11:58Z",
       "url": "https://github.com/malpern/KeyPath/issues/602",
-      "dashboardStatus": "deferred"
+      "dashboardStatus": "deferred",
+      "dashboardType": "debt"
     },
     {
       "labels": [
@@ -1074,7 +1157,8 @@
       "title": "Shared keycap rendering + unified hero component across packs and collections",
       "updatedAt": "2026-06-06T17:11:59Z",
       "url": "https://github.com/malpern/KeyPath/issues/388",
-      "dashboardStatus": "deferred"
+      "dashboardStatus": "deferred",
+      "dashboardType": "debt"
     },
     {
       "labels": [
@@ -1086,7 +1170,8 @@
       "title": "Implement alternative keyboard layouts in kanata base deflayer",
       "updatedAt": "2026-06-06T17:12:01Z",
       "url": "https://github.com/malpern/KeyPath/issues/377",
-      "dashboardStatus": "deferred"
+      "dashboardStatus": "deferred",
+      "dashboardType": "other"
     },
     {
       "labels": [
@@ -1099,7 +1184,8 @@
       "title": "Remove fake device fixtures once macOS multi-device support lands",
       "updatedAt": "2026-06-06T17:12:03Z",
       "url": "https://github.com/malpern/KeyPath/issues/254",
-      "dashboardStatus": "deferred"
+      "dashboardStatus": "deferred",
+      "dashboardType": "upstream"
     },
     {
       "labels": [
@@ -1112,7 +1198,8 @@
       "title": "Eliminate fake key layer notifications via native Kanata LayerChange",
       "updatedAt": "2026-06-06T17:10:29Z",
       "url": "https://github.com/malpern/KeyPath/issues/198",
-      "dashboardStatus": "deferred"
+      "dashboardStatus": "deferred",
+      "dashboardType": "debt"
     },
     {
       "labels": [
@@ -1123,7 +1210,8 @@
       "title": "Define module boundaries and extraction plan for KeyPathAppKit",
       "updatedAt": "2026-06-06T17:11:12Z",
       "url": "https://github.com/malpern/KeyPath/issues/149",
-      "dashboardStatus": "deferred"
+      "dashboardStatus": "deferred",
+      "dashboardType": "debt"
     },
     {
       "labels": [
@@ -1135,7 +1223,8 @@
       "title": "Protocol: make TCP Hello framing deterministic (low priority)",
       "updatedAt": "2026-06-06T17:12:06Z",
       "url": "https://github.com/malpern/KeyPath/issues/121",
-      "dashboardStatus": "deferred"
+      "dashboardStatus": "deferred",
+      "dashboardType": "upstream"
     },
     {
       "labels": [
@@ -1146,7 +1235,8 @@
       "title": "Kanata: Add virtual key press/release variants",
       "updatedAt": "2026-06-06T17:11:15Z",
       "url": "https://github.com/malpern/KeyPath/issues/114",
-      "dashboardStatus": "deferred"
+      "dashboardStatus": "deferred",
+      "dashboardType": "other"
     },
     {
       "labels": [
@@ -1157,7 +1247,8 @@
       "title": "Kanata: Add advanced one-shot variants support",
       "updatedAt": "2026-06-06T17:11:16Z",
       "url": "https://github.com/malpern/KeyPath/issues/113",
-      "dashboardStatus": "deferred"
+      "dashboardStatus": "deferred",
+      "dashboardType": "other"
     },
     {
       "labels": [
@@ -1168,7 +1259,8 @@
       "title": "Kanata: Add advanced macro timing and macro-repeat",
       "updatedAt": "2026-06-06T17:11:18Z",
       "url": "https://github.com/malpern/KeyPath/issues/110",
-      "dashboardStatus": "deferred"
+      "dashboardStatus": "deferred",
+      "dashboardType": "other"
     },
     {
       "labels": [
@@ -1179,7 +1271,8 @@
       "title": "Kanata: Add deftemplate and deflayermap support",
       "updatedAt": "2026-06-06T17:11:19Z",
       "url": "https://github.com/malpern/KeyPath/issues/109",
-      "dashboardStatus": "deferred"
+      "dashboardStatus": "deferred",
+      "dashboardType": "other"
     },
     {
       "labels": [
@@ -1190,7 +1283,8 @@
       "title": "TCP: Handle chord/tap-dance resolution events",
       "updatedAt": "2026-06-06T17:11:21Z",
       "url": "https://github.com/malpern/KeyPath/issues/107",
-      "dashboardStatus": "deferred"
+      "dashboardStatus": "deferred",
+      "dashboardType": "other"
     },
     {
       "labels": [
@@ -1201,7 +1295,8 @@
       "title": "Kanata: Add sequences (defseq) UI support",
       "updatedAt": "2026-06-06T17:11:22Z",
       "url": "https://github.com/malpern/KeyPath/issues/105",
-      "dashboardStatus": "deferred"
+      "dashboardStatus": "deferred",
+      "dashboardType": "other"
     },
     {
       "labels": [
@@ -1212,7 +1307,8 @@
       "title": "Per-keyboard rule targeting (Karabiner-like) \u2014 device-aware predicates for switch/actions",
       "updatedAt": "2026-06-06T17:11:57Z",
       "url": "https://github.com/malpern/KeyPath/issues/63",
-      "dashboardStatus": "deferred"
+      "dashboardStatus": "deferred",
+      "dashboardType": "upstream"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- derive one stable issue type from GitHub labels using bug-first precedence
- add subtle shape and color markers to issue tiles
- add a compact type key without changing workflow-status backgrounds
- include issue type in accessible names and hover details

## Validation

- `python3 Scripts/lab/tests/issue-dashboard-tests.py`
- `./Scripts/lab/tests/keypath-lab-tests.sh`
- rendered dashboard and browser visual/DOM verification
- `git diff --check`
- `./Scripts/review-gate.sh` (remote review gate selected)
