### PR TITLE
Highlight issue cards by label

### DIFF
--- a/docs/testing/keypath-github-issues-dashboard.fragment.html
+++ b/docs/testing/keypath-github-issues-dashboard.fragment.html
@@ -17,9 +17,10 @@
     #keypath-issue-board .queued-mark { background:var(--viz-series-1); }
     #keypath-issue-board .human-mark { background:var(--viz-series-5); }
     #keypath-issue-board .feature-mark { background:var(--muted); border:1px solid var(--border); }
-    #keypath-issue-board .type-key { display:flex; flex-wrap:wrap; align-items:center; gap:11px; margin:-5px 0 14px; color:var(--muted-foreground); font:10px system-ui,sans-serif; }
+    #keypath-issue-board .type-key { display:flex; flex-wrap:wrap; align-items:center; gap:14px; margin:-5px 0 14px; color:var(--muted-foreground); font:10px system-ui,sans-serif; }
     #keypath-issue-board .type-key .key-label { text-transform:uppercase; letter-spacing:.06em; }
-    #keypath-issue-board .type-key span { display:inline-flex; align-items:center; gap:5px; }
+    #keypath-issue-board .type-filter { appearance:none; padding:2px 0; border:0; border-bottom:1px solid transparent; color:inherit; background:transparent; font:inherit; cursor:default; }
+    #keypath-issue-board .type-filter:hover,#keypath-issue-board .type-filter:focus-visible { color:var(--foreground); border-bottom-color:var(--foreground); }
     #keypath-issue-board .summary { display:grid; grid-template-columns:repeat(4,minmax(0,1fr)); gap:1px; margin-bottom:14px; overflow:hidden; background:var(--border); border:1px solid var(--border); border-radius:8px; }
     #keypath-issue-board .metric { padding:11px 13px; background:color-mix(in srgb,var(--card) 88%,var(--background)); }
     #keypath-issue-board .metric strong { display:block; font-size:20px; font-weight:500; }
@@ -29,13 +30,13 @@
     #keypath-issue-board .track { display:grid; grid-template-columns:repeat(12,minmax(0,1fr)); gap:5px; }
     #keypath-issue-board .issue { appearance:none; position:relative; min-height:44px; padding:6px 2px; border:1px solid transparent; border-radius:6px; color:var(--foreground); font:500 10px ui-monospace,SFMono-Regular,Menlo,monospace; cursor:pointer; transition:transform 120ms ease,filter 120ms ease; }
     #keypath-issue-board .issue::before { content:""; position:absolute; top:5px; right:5px; width:5px; height:5px; border-radius:50%; background:currentColor; opacity:.65; }
-    #keypath-issue-board .type-marker { display:inline-block; width:7px; height:7px; margin-right:4px; background:var(--muted-foreground); vertical-align:1px; }
-    #keypath-issue-board [data-type="bug"] .type-marker { border-radius:50%; background:var(--viz-series-2); }
-    #keypath-issue-board [data-type="testing"] .type-marker { background:var(--viz-series-1); transform:rotate(45deg) scale(.78); }
-    #keypath-issue-board [data-type="debt"] .type-marker { border-radius:1px; background:var(--muted-foreground); }
-    #keypath-issue-board [data-type="feature"] .type-marker { background:var(--viz-series-5); clip-path:polygon(50% 0,100% 100%,0 100%); }
-    #keypath-issue-board [data-type="upstream"] .type-marker { border:1px solid var(--viz-series-6); border-radius:50%; background:transparent; }
-    #keypath-issue-board [data-type="docs"] .type-marker { width:8px; height:2px; background:var(--viz-series-2); }
+    #keypath-issue-board .track[data-highlight-type] .issue { opacity:.25; }
+    #keypath-issue-board .track[data-highlight-type="bug"] .issue[data-type="bug"],
+    #keypath-issue-board .track[data-highlight-type="testing"] .issue[data-type="testing"],
+    #keypath-issue-board .track[data-highlight-type="debt"] .issue[data-type="debt"],
+    #keypath-issue-board .track[data-highlight-type="feature"] .issue[data-type="feature"],
+    #keypath-issue-board .track[data-highlight-type="upstream"] .issue[data-type="upstream"],
+    #keypath-issue-board .track[data-highlight-type="docs"] .issue[data-type="docs"] { opacity:1; transform:translateY(-1px); box-shadow:0 0 0 2px var(--ring); }
     #keypath-issue-board .issue[data-status="active"] { background:color-mix(in srgb,var(--viz-series-2) 64%,var(--card)); }
     #keypath-issue-board .issue[data-status="next"] { background:color-mix(in srgb,var(--viz-series-3) 55%,var(--card)); }
     #keypath-issue-board .issue[data-status="queued"] { background:color-mix(in srgb,var(--viz-series-1) 38%,var(--card)); }
@@ -85,15 +86,15 @@
     <span><i class="swatch human-mark"></i>Human / external gate</span>
     <span><i class="swatch feature-mark"></i>Feature or deferred</span>
   </div>
-  <div class="type-key" aria-label="Issue type legend">
+  <nav class="type-key" aria-label="Highlight issues by label">
     <span class="key-label">Type</span>
-    <span data-type="bug"><i class="type-marker"></i>Bug</span>
-    <span data-type="testing"><i class="type-marker"></i>Test</span>
-    <span data-type="debt"><i class="type-marker"></i>Debt</span>
-    <span data-type="feature"><i class="type-marker"></i>Feature</span>
-    <span data-type="upstream"><i class="type-marker"></i>Upstream</span>
-    <span data-type="docs"><i class="type-marker"></i>Docs</span>
-  </div>
+    <button class="type-filter" type="button" data-type="bug">Bug</button>
+    <button class="type-filter" type="button" data-type="testing">Test</button>
+    <button class="type-filter" type="button" data-type="debt">Debt</button>
+    <button class="type-filter" type="button" data-type="feature">Feature</button>
+    <button class="type-filter" type="button" data-type="upstream">Upstream</button>
+    <button class="type-filter" type="button" data-type="docs">Docs</button>
+  </nav>
 
   <section class="summary" aria-label="Open issue summary">
     <div class="metric"><strong id="metric-open">—</strong><span>Open issues</span></div>
@@ -137,6 +138,16 @@
       const detail = root.querySelector('#issue-detail');
       const labels = root.querySelector('#issue-labels');
       const link = root.querySelector('#issue-link');
+      let detailTimer;
+      let highlightTimer;
+      root.querySelectorAll('.type-filter').forEach(filter => {
+        const highlight = () => { clearTimeout(highlightTimer); highlightTimer = setTimeout(() => { grid.dataset.highlightType = filter.dataset.type; }, 120); };
+        const clearHighlight = () => { clearTimeout(highlightTimer); grid.removeAttribute('data-highlight-type'); };
+        filter.addEventListener('mouseenter',highlight);
+        filter.addEventListener('mouseleave',clearHighlight);
+        filter.addEventListener('focus',() => { clearTimeout(highlightTimer); grid.dataset.highlightType = filter.dataset.type; });
+        filter.addEventListener('blur',clearHighlight);
+      });
       const render = state => {
         root.querySelector('#issues-updated').textContent = state.truncated ? `Updated ${new Date(state.updatedAt).toLocaleTimeString()} · first ${state.issueLimit} shown` : `Updated ${new Date(state.updatedAt).toLocaleTimeString()}`;
         root.querySelector('#metric-open').textContent = `${state.issues.length}${state.truncated ? '+' : ''}`;
@@ -148,18 +159,17 @@
           button.className = 'issue';
           button.dataset.status = issue.dashboardStatus;
           button.dataset.type = issue.dashboardType || 'other';
-          const marker = document.createElement('i'); marker.className = 'type-marker'; marker.setAttribute('aria-hidden','true');
-          const number = document.createElement('span'); number.textContent = `#${issue.number}`;
-          button.append(marker,number);
-          button.dataset.tooltip = `#${issue.number} · ${typeNames[button.dataset.type]} · ${names[issue.dashboardStatus]} — ${issue.title}`;
-          button.setAttribute('aria-label',button.dataset.tooltip);
+          button.textContent = `#${issue.number}`;
+          button.setAttribute('aria-label',`#${issue.number} · ${typeNames[button.dataset.type]} · ${names[issue.dashboardStatus]} — ${issue.title}`);
           const select = () => {
             title.textContent = `#${issue.number} · ${issue.title}`;
             detail.textContent = names[issue.dashboardStatus];
             labels.replaceChildren(...issue.labels.map(value => { const badge=document.createElement('span'); badge.className='label'; badge.textContent=value; return badge; }));
             link.href = issue.url; link.textContent = `Open #${issue.number}`;
           };
-          button.addEventListener('mouseenter',select); button.addEventListener('focus',select); button.addEventListener('click',select);
+          button.addEventListener('mouseenter',() => { clearTimeout(detailTimer); detailTimer = setTimeout(select,280); });
+          button.addEventListener('mouseleave',() => clearTimeout(detailTimer));
+          button.addEventListener('focus',select); button.addEventListener('click',select);
           return button;
         }));
         const recent = [...state.issues].sort((a,b) => b.updatedAt.localeCompare(a.updatedAt)).slice(0,10);

--- a/docs/testing/keypath-github-issues-dashboard.html
+++ b/docs/testing/keypath-github-issues-dashboard.html
@@ -767,9 +767,10 @@ html&gt;body{padding:0}&lt;/style&gt;
     #keypath-issue-board .queued-mark { background:var(--viz-series-1); }
     #keypath-issue-board .human-mark { background:var(--viz-series-5); }
     #keypath-issue-board .feature-mark { background:var(--muted); border:1px solid var(--border); }
-    #keypath-issue-board .type-key { display:flex; flex-wrap:wrap; align-items:center; gap:11px; margin:-5px 0 14px; color:var(--muted-foreground); font:10px system-ui,sans-serif; }
+    #keypath-issue-board .type-key { display:flex; flex-wrap:wrap; align-items:center; gap:14px; margin:-5px 0 14px; color:var(--muted-foreground); font:10px system-ui,sans-serif; }
     #keypath-issue-board .type-key .key-label { text-transform:uppercase; letter-spacing:.06em; }
-    #keypath-issue-board .type-key span { display:inline-flex; align-items:center; gap:5px; }
+    #keypath-issue-board .type-filter { appearance:none; padding:2px 0; border:0; border-bottom:1px solid transparent; color:inherit; background:transparent; font:inherit; cursor:default; }
+    #keypath-issue-board .type-filter:hover,#keypath-issue-board .type-filter:focus-visible { color:var(--foreground); border-bottom-color:var(--foreground); }
     #keypath-issue-board .summary { display:grid; grid-template-columns:repeat(4,minmax(0,1fr)); gap:1px; margin-bottom:14px; overflow:hidden; background:var(--border); border:1px solid var(--border); border-radius:8px; }
     #keypath-issue-board .metric { padding:11px 13px; background:color-mix(in srgb,var(--card) 88%,var(--background)); }
     #keypath-issue-board .metric strong { display:block; font-size:20px; font-weight:500; }
@@ -779,13 +780,13 @@ html&gt;body{padding:0}&lt;/style&gt;
     #keypath-issue-board .track { display:grid; grid-template-columns:repeat(12,minmax(0,1fr)); gap:5px; }
     #keypath-issue-board .issue { appearance:none; position:relative; min-height:44px; padding:6px 2px; border:1px solid transparent; border-radius:6px; color:var(--foreground); font:500 10px ui-monospace,SFMono-Regular,Menlo,monospace; cursor:pointer; transition:transform 120ms ease,filter 120ms ease; }
     #keypath-issue-board .issue::before { content:&quot;&quot;; position:absolute; top:5px; right:5px; width:5px; height:5px; border-radius:50%; background:currentColor; opacity:.65; }
-    #keypath-issue-board .type-marker { display:inline-block; width:7px; height:7px; margin-right:4px; background:var(--muted-foreground); vertical-align:1px; }
-    #keypath-issue-board [data-type=&quot;bug&quot;] .type-marker { border-radius:50%; background:var(--viz-series-2); }
-    #keypath-issue-board [data-type=&quot;testing&quot;] .type-marker { background:var(--viz-series-1); transform:rotate(45deg) scale(.78); }
-    #keypath-issue-board [data-type=&quot;debt&quot;] .type-marker { border-radius:1px; background:var(--muted-foreground); }
-    #keypath-issue-board [data-type=&quot;feature&quot;] .type-marker { background:var(--viz-series-5); clip-path:polygon(50% 0,100% 100%,0 100%); }
-    #keypath-issue-board [data-type=&quot;upstream&quot;] .type-marker { border:1px solid var(--viz-series-6); border-radius:50%; background:transparent; }
-    #keypath-issue-board [data-type=&quot;docs&quot;] .type-marker { width:8px; height:2px; background:var(--viz-series-2); }
+    #keypath-issue-board .track[data-highlight-type] .issue { opacity:.25; }
+    #keypath-issue-board .track[data-highlight-type=&quot;bug&quot;] .issue[data-type=&quot;bug&quot;],
+    #keypath-issue-board .track[data-highlight-type=&quot;testing&quot;] .issue[data-type=&quot;testing&quot;],
+    #keypath-issue-board .track[data-highlight-type=&quot;debt&quot;] .issue[data-type=&quot;debt&quot;],
+    #keypath-issue-board .track[data-highlight-type=&quot;feature&quot;] .issue[data-type=&quot;feature&quot;],
+    #keypath-issue-board .track[data-highlight-type=&quot;upstream&quot;] .issue[data-type=&quot;upstream&quot;],
+    #keypath-issue-board .track[data-highlight-type=&quot;docs&quot;] .issue[data-type=&quot;docs&quot;] { opacity:1; transform:translateY(-1px); box-shadow:0 0 0 2px var(--ring); }
     #keypath-issue-board .issue[data-status=&quot;active&quot;] { background:color-mix(in srgb,var(--viz-series-2) 64%,var(--card)); }
     #keypath-issue-board .issue[data-status=&quot;next&quot;] { background:color-mix(in srgb,var(--viz-series-3) 55%,var(--card)); }
     #keypath-issue-board .issue[data-status=&quot;queued&quot;] { background:color-mix(in srgb,var(--viz-series-1) 38%,var(--card)); }
@@ -835,15 +836,15 @@ html&gt;body{padding:0}&lt;/style&gt;
     &lt;span&gt;&lt;i class=&quot;swatch human-mark&quot;&gt;&lt;/i&gt;Human / external gate&lt;/span&gt;
     &lt;span&gt;&lt;i class=&quot;swatch feature-mark&quot;&gt;&lt;/i&gt;Feature or deferred&lt;/span&gt;
   &lt;/div&gt;
-  &lt;div class=&quot;type-key&quot; aria-label=&quot;Issue type legend&quot;&gt;
+  &lt;nav class=&quot;type-key&quot; aria-label=&quot;Highlight issues by label&quot;&gt;
     &lt;span class=&quot;key-label&quot;&gt;Type&lt;/span&gt;
-    &lt;span data-type=&quot;bug&quot;&gt;&lt;i class=&quot;type-marker&quot;&gt;&lt;/i&gt;Bug&lt;/span&gt;
-    &lt;span data-type=&quot;testing&quot;&gt;&lt;i class=&quot;type-marker&quot;&gt;&lt;/i&gt;Test&lt;/span&gt;
-    &lt;span data-type=&quot;debt&quot;&gt;&lt;i class=&quot;type-marker&quot;&gt;&lt;/i&gt;Debt&lt;/span&gt;
-    &lt;span data-type=&quot;feature&quot;&gt;&lt;i class=&quot;type-marker&quot;&gt;&lt;/i&gt;Feature&lt;/span&gt;
-    &lt;span data-type=&quot;upstream&quot;&gt;&lt;i class=&quot;type-marker&quot;&gt;&lt;/i&gt;Upstream&lt;/span&gt;
-    &lt;span data-type=&quot;docs&quot;&gt;&lt;i class=&quot;type-marker&quot;&gt;&lt;/i&gt;Docs&lt;/span&gt;
-  &lt;/div&gt;
+    &lt;button class=&quot;type-filter&quot; type=&quot;button&quot; data-type=&quot;bug&quot;&gt;Bug&lt;/button&gt;
+    &lt;button class=&quot;type-filter&quot; type=&quot;button&quot; data-type=&quot;testing&quot;&gt;Test&lt;/button&gt;
+    &lt;button class=&quot;type-filter&quot; type=&quot;button&quot; data-type=&quot;debt&quot;&gt;Debt&lt;/button&gt;
+    &lt;button class=&quot;type-filter&quot; type=&quot;button&quot; data-type=&quot;feature&quot;&gt;Feature&lt;/button&gt;
+    &lt;button class=&quot;type-filter&quot; type=&quot;button&quot; data-type=&quot;upstream&quot;&gt;Upstream&lt;/button&gt;
+    &lt;button class=&quot;type-filter&quot; type=&quot;button&quot; data-type=&quot;docs&quot;&gt;Docs&lt;/button&gt;
+  &lt;/nav&gt;
 
   &lt;section class=&quot;summary&quot; aria-label=&quot;Open issue summary&quot;&gt;
     &lt;div class=&quot;metric&quot;&gt;&lt;strong id=&quot;metric-open&quot;&gt;—&lt;/strong&gt;&lt;span&gt;Open issues&lt;/span&gt;&lt;/div&gt;
@@ -887,6 +888,16 @@ html&gt;body{padding:0}&lt;/style&gt;
       const detail = root.querySelector(&#x27;#issue-detail&#x27;);
       const labels = root.querySelector(&#x27;#issue-labels&#x27;);
       const link = root.querySelector(&#x27;#issue-link&#x27;);
+      let detailTimer;
+      let highlightTimer;
+      root.querySelectorAll(&#x27;.type-filter&#x27;).forEach(filter =&gt; {
+        const highlight = () =&gt; { clearTimeout(highlightTimer); highlightTimer = setTimeout(() =&gt; { grid.dataset.highlightType = filter.dataset.type; }, 120); };
+        const clearHighlight = () =&gt; { clearTimeout(highlightTimer); grid.removeAttribute(&#x27;data-highlight-type&#x27;); };
+        filter.addEventListener(&#x27;mouseenter&#x27;,highlight);
+        filter.addEventListener(&#x27;mouseleave&#x27;,clearHighlight);
+        filter.addEventListener(&#x27;focus&#x27;,() =&gt; { clearTimeout(highlightTimer); grid.dataset.highlightType = filter.dataset.type; });
+        filter.addEventListener(&#x27;blur&#x27;,clearHighlight);
+      });
       const render = state =&gt; {
         root.querySelector(&#x27;#issues-updated&#x27;).textContent = state.truncated ? `Updated ${new Date(state.updatedAt).toLocaleTimeString()} · first ${state.issueLimit} shown` : `Updated ${new Date(state.updatedAt).toLocaleTimeString()}`;
         root.querySelector(&#x27;#metric-open&#x27;).textContent = `${state.issues.length}${state.truncated ? &#x27;+&#x27; : &#x27;&#x27;}`;
@@ -898,18 +909,17 @@ html&gt;body{padding:0}&lt;/style&gt;
           button.className = &#x27;issue&#x27;;
           button.dataset.status = issue.dashboardStatus;
           button.dataset.type = issue.dashboardType || &#x27;other&#x27;;
-          const marker = document.createElement(&#x27;i&#x27;); marker.className = &#x27;type-marker&#x27;; marker.setAttribute(&#x27;aria-hidden&#x27;,&#x27;true&#x27;);
-          const number = document.createElement(&#x27;span&#x27;); number.textContent = `#${issue.number}`;
-          button.append(marker,number);
-          button.dataset.tooltip = `#${issue.number} · ${typeNames[button.dataset.type]} · ${names[issue.dashboardStatus]} — ${issue.title}`;
-          button.setAttribute(&#x27;aria-label&#x27;,button.dataset.tooltip);
+          button.textContent = `#${issue.number}`;
+          button.setAttribute(&#x27;aria-label&#x27;,`#${issue.number} · ${typeNames[button.dataset.type]} · ${names[issue.dashboardStatus]} — ${issue.title}`);
           const select = () =&gt; {
             title.textContent = `#${issue.number} · ${issue.title}`;
             detail.textContent = names[issue.dashboardStatus];
             labels.replaceChildren(...issue.labels.map(value =&gt; { const badge=document.createElement(&#x27;span&#x27;); badge.className=&#x27;label&#x27;; badge.textContent=value; return badge; }));
             link.href = issue.url; link.textContent = `Open #${issue.number}`;
           };
-          button.addEventListener(&#x27;mouseenter&#x27;,select); button.addEventListener(&#x27;focus&#x27;,select); button.addEventListener(&#x27;click&#x27;,select);
+          button.addEventListener(&#x27;mouseenter&#x27;,() =&gt; { clearTimeout(detailTimer); detailTimer = setTimeout(select,280); });
+          button.addEventListener(&#x27;mouseleave&#x27;,() =&gt; clearTimeout(detailTimer));
+          button.addEventListener(&#x27;focus&#x27;,select); button.addEventListener(&#x27;click&#x27;,select);
           return button;
         }));
         const recent = [...state.issues].sort((a,b) =&gt; b.updatedAt.localeCompare(a.updatedAt)).slice(0,10);


### PR DESCRIPTION
## Summary

- remove type icons from individual issue cards
- replace the icon key with a clean text-only label rail
- softly highlight matching cards when a label is hovered or focused
- delay mouse-hover card details by 280 ms while keeping focus and click immediate

## Validation

- `python3 Scripts/lab/tests/issue-dashboard-tests.py`
- `./Scripts/lab/tests/keypath-lab-tests.sh`
- rendered dashboard and browser visual/interaction verification
- `git diff --check`
- `./Scripts/review-gate.sh` (remote review gate selected)
