### PR TITLE
Show next-step progress in QA dashboard hovers

### DIFF
--- a/Scripts/lab/remote.sh
+++ b/Scripts/lab/remote.sh
@@ -596,7 +596,7 @@ secure_dialog_input() {
     chmod 600 "$secret_file"
     typeset -g KEYPATH_LAB_SECURE_TEMP="$secret_file"
     trap '[[ -z ${KEYPATH_LAB_SECURE_TEMP:-} ]] || rm -f "$KEYPATH_LAB_SECURE_TEMP"' EXIT
-    /opt/homebrew/bin/sops -d "$HOME/dotfiles/secrets.env" | awk -F= '$1 == "KEYPATH_TART_ADMIN_PASSWORD" {sub(/^[^=]*=/, ""); print; found=1} END {if (!found) exit 1}' > "$secret_file" || die "KEYPATH_TART_ADMIN_PASSWORD is unavailable"
+    /opt/homebrew/bin/sops -d "$HOME/dotfiles/secrets.env" | awk -F= '$1 == "KEYPATH_TART_ADMIN_PASSWORD" {sub(/^[^=]*=/, ""); printf "%s", $0; found=1} END {if (!found) exit 1}' > "$secret_file" || die "KEYPATH_TART_ADMIN_PASSWORD is unavailable"
   fi
   [[ -s "$secret_file" ]] || die "secure input secret is empty"
   if [[ "${USER:-}" == "clawd" ]]; then export TART_HOME="$LAB_ROOT/TartHome-clawd"; else export TART_HOME="$LAB_ROOT/TartHome"; fi

--- a/Scripts/lab/update-progress-dashboard
+++ b/Scripts/lab/update-progress-dashboard
@@ -19,6 +19,13 @@ def main() -> None:
     parser.add_argument("--attempt", type=int, default=1)
     parser.add_argument("--completed-steps", type=int, default=0)
     parser.add_argument("--total-steps", type=int, default=0)
+    parser.add_argument(
+        "--next-task",
+        action="append",
+        default=[],
+        metavar="LABEL|STATUS|PROGRESS",
+        help="Add a hover checklist item; STATUS is queued, active, done, or blocked",
+    )
     parser.add_argument("--tone", choices=("working", "success", "retry", "problem", "waiting"), default="working")
     parser.add_argument("--title", required=True)
     parser.add_argument("--message", required=True)
@@ -26,6 +33,18 @@ def main() -> None:
     args = parser.parse_args()
     if args.progress is not None and not 0 <= args.progress <= 100:
         parser.error("--progress must be between 0 and 100")
+    next_tasks = []
+    for raw_task in args.next_task:
+        try:
+            label, task_status, raw_progress = raw_task.rsplit("|", 2)
+            task_progress = int(raw_progress)
+        except ValueError:
+            parser.error("--next-task must use LABEL|STATUS|PROGRESS")
+        if not label.strip() or task_status not in {"queued", "active", "done", "blocked"}:
+            parser.error("--next-task requires a label and STATUS queued, active, done, or blocked")
+        if not 0 <= task_progress <= 100:
+            parser.error("--next-task progress must be between 0 and 100")
+        next_tasks.append({"label": label.strip(), "status": task_status, "progress": task_progress})
 
     state = json.loads(args.state.read_text())
     now = datetime.datetime.now().astimezone()
@@ -39,6 +58,7 @@ def main() -> None:
         working.discard(args.block)
     else:
         working.add(args.block)
+        previous_work = active_work.get(args.block, {})
         active_work[args.block] = {
             "progress": args.progress or 0,
             "health": args.health,
@@ -48,6 +68,7 @@ def main() -> None:
             "attempt": args.attempt,
             "completedSteps": args.completed_steps,
             "totalSteps": args.total_steps,
+            "nextTasks": next_tasks or previous_work.get("nextTasks", []),
         }
         state.setdefault("statuses", {})[args.block] = "active"
     state["workingBlocks"] = sorted(working)

--- a/docs/testing/installer-gui-automation-capabilities.md
+++ b/docs/testing/installer-gui-automation-capabilities.md
@@ -20,9 +20,12 @@ Use this order for GUI work:
    interaction.
 
 Never reuse coordinates from an earlier lease or a scaled screenshot preview.
-On the proven Tart configuration, the RFB framebuffer was `2048x1536` while
-guest Accessibility coordinates were `1024x768`. The observed scale was 2, but
-an agent must measure it again for every lease.
+The July 2026 macOS 15 Tart run exposed a deceptive display report: the backing
+display reported `2048x1536`, but both Peekaboo Accessibility bounds and the
+CrabBox VNC input viewport used `1024x768`. The correct RFB target was therefore
+the AX point itself, not that point multiplied by two. An agent must compare
+fresh AX bounds with the actual input viewport for every lease; backing-display
+dimensions alone are not a coordinate transform.
 
 Treat the coordinate transform itself as test evidence. A July 2026 run showed
 that CrabBox can report a successful RFB click even when an unverified transform

--- a/docs/testing/keypath-test-automation-progress.html
+++ b/docs/testing/keypath-test-automation-progress.html
@@ -221,7 +221,7 @@ code:not(pre code) {
   left: 0;
   width: max-content;
   max-width: min(
-    20rem,
+    30rem,
     var(--tooltip-available-width, calc(100vw - 10px)),
     calc(100vw - 10px)
   );
@@ -243,6 +243,22 @@ code:not(pre code) {
   pointer-events: none;
   user-select: none;
 }
+.tooltip-card { width:min(26rem,calc(100vw - 34px)); padding:8px 6px 6px; }
+.tooltip-kicker { color:var(--muted-foreground); font-size:9px; letter-spacing:.055em; text-transform:uppercase; }
+.tooltip-title-row { display:flex; gap:12px; align-items:baseline; justify-content:space-between; margin-top:2px; }
+.tooltip-title { font-size:13px; font-weight:600; letter-spacing:-.01em; }
+.tooltip-overall { color:var(--muted-foreground); font-size:11px; font-variant-numeric:tabular-nums; white-space:nowrap; }
+.tooltip-summary { margin-top:4px; color:var(--muted-foreground); line-height:1.45; }
+.tooltip-next { margin-top:10px; padding-top:8px; border-top:1px solid var(--border); }
+.tooltip-next-title { margin-bottom:2px; color:var(--foreground); font-size:10px; font-weight:600; }
+.tooltip-task { display:grid; grid-template-columns:9px minmax(0,1fr) auto; gap:7px; align-items:start; padding:5px 0; }
+.tooltip-task + .tooltip-task { border-top:1px solid color-mix(in srgb,var(--border) 58%,transparent); }
+.tooltip-task-dot { width:6px; height:6px; border-radius:50%; background:var(--muted-foreground); }
+.tooltip-task[data-status=&quot;active&quot;] .tooltip-task-dot { background:var(--viz-series-2); box-shadow:0 0 0 3px color-mix(in srgb,var(--viz-series-2) 18%,transparent); }
+.tooltip-task[data-status=&quot;done&quot;] .tooltip-task-dot { background:var(--viz-series-3); }
+.tooltip-task[data-status=&quot;blocked&quot;] .tooltip-task-dot { background:var(--destructive); }
+.tooltip-task-label { line-height:1.35; }
+.tooltip-task-value { color:var(--muted-foreground); text-align:right; font-variant-numeric:tabular-nums; white-space:nowrap; }
 
 .viz-grid {
   display: grid;
@@ -950,6 +966,16 @@ html&gt;body{padding:0}&lt;/style&gt;
       const detail = root.querySelector(&#x27;#keypath-defrag-detail&#x27;);
       const status = root.querySelector(&#x27;#keypath-defrag-status&#x27;);
       const names = {proven:&#x27;Proven&#x27;,active:&#x27;Current frontier&#x27;,queued:&#x27;Queued&#x27;,waiting:&#x27;Waiting on Apple&#x27;};
+      const defaultTasks = (state,name) =&gt; {
+        if (state === &#x27;proven&#x27;) return [{label:`Keep ${name} covered by regression runs`,status:&#x27;done&#x27;,progress:100}];
+        if (state === &#x27;waiting&#x27;) return [{label:&#x27;Resume when the external dependency clears&#x27;,status:&#x27;blocked&#x27;,progress:0}];
+        if (state === &#x27;active&#x27;) return [{label:`Finish ${name}`,status:&#x27;active&#x27;,progress:0}];
+        return [{label:`Start ${name}`,status:&#x27;queued&#x27;,progress:0}];
+      };
+      const tooltipPayload = (id,button,state,progress,tasks,summary) =&gt; ({
+        id,name:button.dataset.itemName,status:names[state] || state,progress,
+        summary:summary || button.dataset.description,tasks:tasks?.length ? tasks : defaultTasks(state,button.dataset.itemName)
+      });
       const buttons = new Map();
       items.forEach(([id,state,name,description]) =&gt; {
         const button = document.createElement(&#x27;button&#x27;);
@@ -961,6 +987,7 @@ html&gt;body{padding:0}&lt;/style&gt;
         button.dataset.baseLabel = `${id}: ${name}. ${names[state]}. ${description}`;
         button.dataset.baseTooltip = `${id} · ${name} — ${names[state]}. ${description}`;
         button.dataset.tooltip = button.dataset.baseTooltip;
+        button.dataset.tooltipStructured = JSON.stringify(tooltipPayload(id,button,state,state === &#x27;proven&#x27; ? 100 : 0,defaultTasks(state,name),description));
         button.dataset.tooltipPlacement = &#x27;top&#x27;;
         button.setAttribute(&#x27;aria-label&#x27;, button.dataset.baseLabel);
         const showDetail = () =&gt; {
@@ -1002,6 +1029,8 @@ html&gt;body{padding:0}&lt;/style&gt;
           button.style.setProperty(&#x27;--work-progress&#x27;,&#x27;0%&#x27;);
           button.setAttribute(&#x27;aria-label&#x27;,button.dataset.baseLabel);
           button.dataset.tooltip = button.dataset.baseTooltip;
+          const cardState = button.dataset.status;
+          button.dataset.tooltipStructured = JSON.stringify(tooltipPayload(id,button,cardState,cardState === &#x27;proven&#x27; ? 100 : 0,defaultTasks(cardState,button.dataset.itemName),button.dataset.description));
         });
         const activeEntries = Object.entries(state.activeWork || {});
         activeEntries.forEach(([id,work]) =&gt; {
@@ -1019,6 +1048,8 @@ html&gt;body{padding:0}&lt;/style&gt;
           const activity = isWorking ? &#x27;Actively in progress&#x27; : &#x27;Paused or waiting&#x27;;
           const checkpoints = work.totalSteps ? `${work.completedSteps || 0} of ${work.totalSteps} checkpoints` : &#x27;&#x27;;
           button.dataset.tooltip = `${id} · ${button.dataset.itemName}. ${activity} — ${progress}% complete. Current step: ${phase}. Health: ${health}. ${checkpoints}${checkpoints ? &#x27;.&#x27; : &#x27;&#x27;} ${work.detail || button.dataset.description}`.trim();
+          const tasks = Array.isArray(work.nextTasks) &amp;&amp; work.nextTasks.length ? work.nextTasks : [{label:phase,status:isWorking ? &#x27;active&#x27; : &#x27;queued&#x27;,progress}];
+          button.dataset.tooltipStructured = JSON.stringify(tooltipPayload(id,button,button.dataset.status,progress,tasks,work.detail || button.dataset.description));
         });
         if (activeEntries.length) {
           const [id,work] = activeEntries[0];
@@ -1100,6 +1131,30 @@ html&gt;body{padding:0}&lt;/style&gt;
     target?.nodeType != null &amp;&amp; trigger.contains(target);
   const getContent = (trigger) =&gt;
     trigger.getAttribute(&quot;data-tooltip&quot;)?.trim() ?? &quot;&quot;;
+  const getStructuredContent = (trigger) =&gt; {
+    try { return JSON.parse(trigger.getAttribute(&quot;data-tooltip-structured&quot;) || &quot;null&quot;); }
+    catch (_) { return null; }
+  };
+  const renderStructuredContent = (floating,content) =&gt; {
+    floating.replaceChildren();
+    const card = document.createElement(&quot;div&quot;); card.className = &quot;tooltip-card&quot;;
+    const kicker = document.createElement(&quot;div&quot;); kicker.className = &quot;tooltip-kicker&quot;; kicker.textContent = `${content.id} · ${content.status}`;
+    const titleRow = document.createElement(&quot;div&quot;); titleRow.className = &quot;tooltip-title-row&quot;;
+    const title = document.createElement(&quot;div&quot;); title.className = &quot;tooltip-title&quot;; title.textContent = content.name;
+    const overall = document.createElement(&quot;div&quot;); overall.className = &quot;tooltip-overall&quot;; overall.textContent = `${Math.max(0,Math.min(100,Number(content.progress) || 0))}% overall`;
+    titleRow.append(title,overall);
+    const summary = document.createElement(&quot;div&quot;); summary.className = &quot;tooltip-summary&quot;; summary.textContent = content.summary;
+    const next = document.createElement(&quot;div&quot;); next.className = &quot;tooltip-next&quot;;
+    const nextTitle = document.createElement(&quot;div&quot;); nextTitle.className = &quot;tooltip-next-title&quot;; nextTitle.textContent = &quot;What’s next&quot;; next.append(nextTitle);
+    (content.tasks || []).forEach(task =&gt; {
+      const row = document.createElement(&quot;div&quot;); row.className = &quot;tooltip-task&quot;; row.dataset.status = task.status || &quot;queued&quot;;
+      const dot = document.createElement(&quot;i&quot;); dot.className = &quot;tooltip-task-dot&quot;;
+      const label = document.createElement(&quot;span&quot;); label.className = &quot;tooltip-task-label&quot;; label.textContent = task.label;
+      const value = document.createElement(&quot;span&quot;); value.className = &quot;tooltip-task-value&quot;; value.textContent = `${Math.max(0,Math.min(100,Number(task.progress) || 0))}%`;
+      row.append(dot,label,value); next.append(row);
+    });
+    card.append(kicker,titleRow,summary,next); floating.append(card);
+  };
   const getPlacement = (trigger) =&gt; {
     const placement = trigger.getAttribute(&quot;data-tooltip-placement&quot;);
     return tooltipPlacements.has(placement) ? placement : &quot;top&quot;;
@@ -1201,7 +1256,9 @@ html&gt;body{padding:0}&lt;/style&gt;
     }
     closeTooltip();
     const floating = getTooltip();
-    floating.textContent = content;
+    const structured = getStructuredContent(trigger);
+    if (structured) renderStructuredContent(floating,structured);
+    else floating.textContent = content;
     floating.style.visibility = &quot;hidden&quot;;
     floating.style.transform = &quot;translate(0, 0)&quot;;
     document.body.appendChild(floating);

--- a/docs/testing/keypath-test-automation-state.json
+++ b/docs/testing/keypath-test-automation-state.json
@@ -1,10 +1,55 @@
 {
-  "updatedAt": "2026-07-12T10:19:11-07:00",
-  "currentTask": "Shared VM admission verified",
-  "message": "The occupied Tart pool failed closed with exit 75 and listed all owning leases; no VM was created.",
+  "updatedAt": "2026-07-12T18:40:55-07:00",
+  "currentTask": "Hover checklists added",
+  "message": "Every block hover now includes What to do next with per-task status and progress. P01 shows the concrete harness-hardening sequence.",
   "complete": false,
-  "workingBlocks": [],
-  "activeWork": {},
+  "workingBlocks": [
+    "P01"
+  ],
+  "activeWork": {
+    "P02": {
+      "progress": 72,
+      "health": "smooth",
+      "trend": "forward",
+      "phase": "VirtualHID active; waiting for Kanata permissions",
+      "detail": "The DriverKit extension is activated and enabled, and the VirtualHID daemon passed health checks. Observable remapping waits on Kanata permissions.",
+      "attempt": 1,
+      "completedSteps": 6,
+      "totalSteps": 8
+    },
+    "P01": {
+      "progress": 95,
+      "health": "retrying",
+      "trend": "backtrack",
+      "phase": "Harness hardening before another VM",
+      "detail": "Helper, DriverKit, and Accessibility are proven. The remaining work is now tracked as a per-task checklist.",
+      "attempt": 2,
+      "completedSteps": 5,
+      "totalSteps": 6,
+      "nextTasks": [
+        {
+          "label": "Harden secure-dialog submission and postconditions",
+          "status": "active",
+          "progress": 35
+        },
+        {
+          "label": "Fix Input Monitoring navigation and permission drag",
+          "status": "queued",
+          "progress": 10
+        },
+        {
+          "label": "Run focused harness tests and merge",
+          "status": "queued",
+          "progress": 0
+        },
+        {
+          "label": "Repeat disposable macOS 15 P01 proof",
+          "status": "queued",
+          "progress": 0
+        }
+      ]
+    }
+  },
   "statuses": {
     "R01": "active",
     "R02": "active",
@@ -17,214 +62,214 @@
   },
   "updates": [
     {
-      "time": "10:19",
-      "block": "M12",
-      "tone": "success",
-      "title": "Shared VM admission verified",
-      "message": "The occupied Tart pool failed closed with exit 75 and listed all owning leases; no VM was created."
-    },
-    {
-      "time": "10:16",
-      "block": "M12",
-      "tone": "success",
-      "title": "Admission regression suite passed",
-      "message": "Capacity rejection, owner evidence, lock contention, and stale-lock recovery all pass locally."
-    },
-    {
-      "time": "10:13",
-      "block": "M12",
+      "time": "18:40",
+      "block": "P01",
       "tone": "working",
-      "title": "Implementing shared VM admission",
-      "message": "M12 now owns the collision fix: one Tart lease, two Parallels leases, with exit 75 and current-owner evidence when full."
+      "title": "Hover checklists added",
+      "message": "Every block hover now includes What to do next with per-task status and progress. P01 shows the concrete harness-hardening sequence."
     },
     {
-      "time": "10:13",
-      "block": "P02",
-      "tone": "waiting",
-      "title": "Output run paused for capacity safety",
-      "message": "P02 is paused at the same shared-provider boundary; this is infrastructure coordination, not a KeyPath result."
+      "time": "18:37",
+      "block": "P01",
+      "tone": "retry",
+      "title": "Input Monitoring path needs hardening",
+      "message": "The product gates through DriverKit are proven. Input Monitoring is not yet claimed: the drag failed its row postcondition and secure input reported success while the auth sheet remained. Artifacts and exact targeting evidence are being preserved."
     },
     {
-      "time": "10:13",
+      "time": "18:22",
+      "block": "P01",
+      "tone": "success",
+      "title": "Privileged helper proven",
+      "message": "The helper is running. Captured two targeting rules: AX bounds already match the Tart VNC viewport, and field-only secure input submits the Login Items sheet via its trailing newline."
+    },
+    {
+      "time": "18:04",
+      "block": "P01",
+      "tone": "working",
+      "title": "P01 fresh VM admitted",
+      "message": "P01 is actively running on the sole admitted Tart lease; P02 remains paused until Kanata permissions and runtime readiness pass."
+    },
+    {
+      "time": "15:51",
+      "block": "P01",
+      "tone": "success",
+      "title": "P01 permission automation merged",
+      "message": "PR #1138 merged as f5c53044. Accessibility and Input Monitoring setup are repeatable; the lease artifacts were collected and the VM was cleanly destroyed. Next active slice is the logged-in GUI installer action."
+    },
+    {
+      "time": "15:45",
+      "block": "P01",
+      "tone": "success",
+      "title": "P01 permission setup automated",
+      "message": "Fresh-VM proof passed for both Kanata permission rows using Finder drag plus postcondition-verified authorization. The reusable primitive is under local review before PR."
+    },
+    {
+      "time": "14:43",
+      "block": "P01",
+      "tone": "success",
+      "title": "P01 secure authorization merged",
+      "message": "PR #1137 is merged and master is current. Active work now narrows to selecting kanata-launcher in the Open panel and verifying its permission row appears."
+    },
+    {
+      "time": "14:40",
+      "block": "P01",
+      "tone": "working",
+      "title": "P01 secure authorization rebased",
+      "message": "PR #1137 is current with master and rerunning checks. Live VM evidence confirms the authorization sheet closes only after a valid credential and protected submit."
+    },
+    {
+      "time": "14:35",
+      "block": "P01",
+      "tone": "retry",
+      "title": "P01 authorization false positive removed",
+      "message": "System Settings authorization is now independently verified. The remaining retry is file-picker selection, not credential entry or protected-click delivery."
+    },
+    {
+      "time": "14:26",
+      "block": "P01",
+      "tone": "success",
+      "title": "P01 calibrated click proven",
+      "message": "Fresh-VM proof succeeded: guarded RFB delivery plus PermissionOracle postcondition. PR #1135 carries the production parser fix."
+    },
+    {
+      "time": "14:21",
+      "block": "P01",
+      "tone": "working",
+      "title": "P01 fresh run admitted",
+      "message": "P01 is actively starting the first fresh VM run with merged admission and calibrated protected-click guards."
+    },
+    {
+      "time": "14:00",
+      "block": "P01",
+      "tone": "success",
+      "title": "P01 orchestration merged",
+      "message": "Automatic click calibration and self-documenting VM admission are merged. No agent is actively mutating this block while Tart is occupied."
+    },
+    {
+      "time": "13:46",
       "block": "P01",
       "tone": "waiting",
-      "title": "Physics run paused for capacity safety",
-      "message": "The disposable lease is preserved, but no further VM mutations will occur until provider admission prevents agent collisions."
+      "title": "P01 safely waiting",
+      "message": "PR #1130 is code-green but reviewer infrastructure failed twice without a finding. The sole Tart VM is also owned by another agent; P01 is no longer pulsing."
     },
     {
-      "time": "10:00",
-      "block": "P02",
-      "tone": "problem",
-      "title": "Output path blocked before driver install",
-      "message": "P02 cannot reach VirtualHID activation until the helper authorization failure is explained."
-    },
-    {
-      "time": "10:00",
-      "block": "P01",
-      "tone": "problem",
-      "title": "Helper postcondition failed",
-      "message": "The password transport returned success, but KeyPath still reports helperInstalled=false; preserving the lease and inspecting the actual UI/log state."
-    },
-    {
-      "time": "09:54",
-      "block": "P02",
-      "tone": "success",
-      "title": "Physics lease is ready",
-      "message": "The signed app is installed in an unmanaged macOS 15 desktop lease with evidence capture available."
-    },
-    {
-      "time": "09:54",
-      "block": "P01",
-      "tone": "success",
-      "title": "Desktop bootstrap recovered",
-      "message": "Peekaboo 3.9.0 and mcporter are ready in the disposable guest; resuming the real installer path."
-    },
-    {
-      "time": "09:53",
-      "block": "P02",
-      "tone": "retry",
-      "title": "Bootstrap prerequisite missing",
-      "message": "P02 is paused at the same harness setup boundary; this is not a product failure."
-    },
-    {
-      "time": "09:53",
-      "block": "P01",
-      "tone": "retry",
-      "title": "Fresh base needs UI tooling",
-      "message": "The disposable Tart base lacks Peekaboo and mcporter; installing them through desktop-bootstrap --install-tools."
-    },
-    {
-      "time": "09:49",
-      "block": "P02",
-      "tone": "working",
-      "title": "Starting virtual-output proof",
-      "message": "P02 is active alongside P01: identifying a software-only observation point for remapped output."
-    },
-    {
-      "time": "09:49",
+      "time": "13:41",
       "block": "P01",
       "tone": "working",
-      "title": "Starting real input-path proof",
-      "message": "P01 is active: tracing how RFB-injected keys can be proven to reach Kanata rather than merely reach the guest."
+      "title": "P01 calibration published",
+      "message": "PR #1130 is open. P01 is actively validating automatic per-lease coordinate calibration while another agent owns Tart."
     },
     {
-      "time": "09:48",
-      "block": "R04",
+      "time": "13:36",
+      "block": "P01",
+      "tone": "working",
+      "title": "P01 parallel-safe calibration work",
+      "message": "P01 is actively developing automatic coordinate calibration while another agent owns Tart; no VM collision is occurring."
+    },
+    {
+      "time": "13:32",
+      "block": "P01",
       "tone": "success",
-      "title": "TCP readiness hardened",
-      "message": "R04 now requires a real bounded Kanata layer response; synthetic failure contracts and the installed runtime passed."
+      "title": "P01 harness merged",
+      "message": "PR #1129 merged and master is current. P01 stays active for the fresh guarded permission run; P02 remains paused until Kanata starts."
     },
     {
-      "time": "09:48",
-      "block": "R03",
+      "time": "13:29",
+      "block": "P01",
+      "tone": "working",
+      "title": "P01 published for review",
+      "message": "PR #1129 is open. P01 remains active while CI and the enforced Claude review validate the guarded-click harness."
+    },
+    {
+      "time": "13:26",
+      "block": "P01",
       "tone": "success",
-      "title": "Runtime convergence hardened",
-      "message": "R03 now rejects registered-but-stopped jobs and passed against the real local KeyPath runtime."
+      "title": "P01 click guard implemented",
+      "message": "P01 advanced: wrong-coordinate clicks now fail immediately instead of silently corrupting the permission flow. The focused harness suite passes."
     },
     {
-      "time": "09:47",
-      "block": "R04",
+      "time": "13:23",
+      "block": "P01",
+      "tone": "working",
+      "title": "P01 wrong-page clicks now classified",
+      "message": "P01 converted the VM evidence into a harness contract: successful delivery is insufficient unless the intended System Settings page is verified before and after."
+    },
+    {
+      "time": "13:20",
+      "block": "P01",
       "tone": "retry",
-      "title": "Adapting to the deployed response",
-      "message": "The real runtime returned LayerChange instead of CurrentLayerName; the probe now accepts either documented layer-bearing response and still rejects unrelated JSON."
+      "title": "P01 corrected coordinate transform",
+      "message": "P01 stepped back to fix a harness assumption: the current lease uses 1:1 RFB coordinates, not the prior lease\u2019s 2x scale."
     },
     {
-      "time": "09:46",
-      "block": "R03",
-      "tone": "success",
-      "title": "Runtime failure contract passed",
-      "message": "A registered launchd job no longer counts as live unless it reports state = running."
-    },
-    {
-      "time": "09:46",
-      "block": "R04",
-      "tone": "success",
-      "title": "TCP failure contracts passed",
-      "message": "Valid replies pass; open-but-silent and wrong-protocol sockets now fail deterministically."
-    },
-    {
-      "time": "09:45",
-      "block": "R04",
+      "time": "13:16",
+      "block": "P01",
       "tone": "retry",
-      "title": "Adjusting for system Python",
-      "message": "The first test run hit Python compatibility, so R04 stepped back while the test harness is made portable."
+      "title": "P01 permission order clarified",
+      "message": "P01 found a real orchestration dependency: grant Full Disk Access before trusting the product\u2019s Kanata permission verification."
     },
     {
-      "time": "09:45",
-      "block": "R03",
+      "time": "13:10",
+      "block": "P02",
       "tone": "success",
-      "title": "Runtime liveness check implemented",
-      "message": "R03 now rejects a registered but stopped Kanata launchd job."
+      "title": "P02 driver activation proven",
+      "message": "P02 advanced: VirtualHID is activated and healthy. The remaining dependency is starting Kanata after P01 grants permissions."
     },
     {
-      "time": "09:45",
-      "block": "R04",
-      "tone": "success",
-      "title": "Protocol-aware TCP probe implemented",
-      "message": "R04 now requires a valid CurrentLayerName response instead of merely accepting an open socket."
-    },
-    {
-      "time": "09:42",
-      "block": "R04",
+      "time": "13:10",
+      "block": "P01",
       "tone": "working",
-      "title": "Pairing TCP readiness with runtime proof",
-      "message": "R04 is active alongside R03 because both postconditions must converge independently."
+      "title": "P01 permissions boundary",
+      "message": "P01 is actively completing Accessibility and Input Monitoring. The software-only VNC injection path is already proven."
     },
     {
-      "time": "09:42",
-      "block": "R03",
-      "tone": "working",
-      "title": "Starting runtime convergence hardening",
-      "message": "Auditing R03 runtime and R04 TCP checks so a forgiving product retry cannot create a false pass."
-    },
-    {
-      "time": "08:01",
-      "block": "M14",
-      "tone": "success",
-      "title": "Development log simplified",
-      "message": "Removed bubbles and repeated avatars; updates now read as a quiet timestamped transcript."
-    },
-    {
-      "time": "07:45",
-      "block": "M14",
-      "tone": "success",
-      "title": "Dashboard composition complete",
-      "message": "The capability map keeps the full width; the Codex development conversation now follows beneath it."
-    },
-    {
-      "time": "07:56",
-      "block": "M14",
+      "time": "13:00",
+      "block": "P02",
       "tone": "retry",
-      "title": "Changing the composition",
-      "message": "The side rail made the capability map feel cramped. Moving the conversation below preserves the visual breathing room."
+      "title": "Protected driver submit needs VNC Return",
+      "message": "P02 reached the genuine driver authorization sheet. Password entry remains secret-safe; protected submit is moving to VNC Return with postcondition verification."
     },
     {
-      "time": "07:52",
-      "block": "M14",
+      "time": "12:43",
+      "block": "P02",
       "tone": "working",
-      "title": "Wiring the live feed",
-      "message": "The right rail now turns structured state updates into a running Codex development conversation."
+      "title": "Driver installation unblocked",
+      "message": "P02 is moving forward: helper is operational and the next installer recipes target VirtualHID and runtime services."
     },
     {
-      "time": "07:49",
-      "block": "M14",
+      "time": "12:43",
+      "block": "P01",
       "tone": "success",
-      "title": "Visual language chosen",
-      "message": "Progress is a fill line, smooth work breathes, retries wobble, and blockers hold a firm red edge."
+      "title": "Helper postcondition passed",
+      "message": "P01 recovered cleanly: helper authorization is now verified by keypath-cli, not inferred from the click."
     },
     {
-      "time": "07:46",
-      "block": "M14",
-      "tone": "working",
-      "title": "Mapping the experience",
-      "message": "Separating frontier status from live engineering health so orange never implies that a task is currently running."
+      "time": "12:34",
+      "block": "P02",
+      "tone": "retry",
+      "title": "Output proof waiting on harness consent",
+      "message": "P02 has not failed; it is waiting for P01 to clear Peekaboo\u2019s one-time consent and complete helper activation."
     },
     {
-      "time": "07:40",
-      "block": "R01 R02",
+      "time": "12:34",
+      "block": "P01",
+      "tone": "retry",
+      "title": "Harness consent intercepted installer flow",
+      "message": "P01 stepped back slightly: Peekaboo first-run consent\u2014not KeyPath\u2014covered the helper sheet. Clearing it through the current 2048\u00d71536 framebuffer."
+    },
+    {
+      "time": "12:32",
+      "block": "P02",
       "tone": "success",
-      "title": "Probe contracts passed",
-      "message": "Managed permission failure cases are now deterministic; the real VM proof still awaits enrollment."
+      "title": "Output environment bootstrapped",
+      "message": "P02 remains active on cbx_8c08a8c1ed4b; no parallel Tart VM exists."
+    },
+    {
+      "time": "12:32",
+      "block": "P01",
+      "tone": "success",
+      "title": "Coherent desktop test environment ready",
+      "message": "P01 is at the real installer boundary on cbx_8c08a8c1ed4b; launching KeyPath and inspecting its planned actions."
     }
   ],
   "activity": [

--- a/docs/testing/remote-installer-lab.md
+++ b/docs/testing/remote-installer-lab.md
@@ -148,10 +148,12 @@ element. It is not proof that macOS accepted a protected change. Background App
 Activity, Driver Extensions, Accessibility, and Input Monitoring must be
 verified through the canonical CLI/system/runtime postcondition after every
 click. Driver Extension activation on macOS 15 may still require CrabBox's
-native RFB click delivery. Use fresh Peekaboo geometry to locate the control,
-convert logical points to framebuffer coordinates using the current display
-scale, and verify activation afterward; never preserve raw coordinates between
-runs.
+native RFB click delivery. Use fresh Peekaboo geometry to locate the control
+and compare it with the current CrabBox desktop viewport before clicking. In
+the Tart 1024x768 desktop lane, Peekaboo's Accessibility bounds already match
+the 1024x768 VNC viewport even though the backing display reports 2048x1536;
+doubling those coordinates targets the wrong pixel. Never infer a scale from
+the backing display alone, and never preserve raw coordinates between runs.
 
 For a macOS 15 Tart desktop lease, `secure-dialog-input` handles an
 authentication sheet without putting its password in a command line. It focuses
@@ -167,6 +169,21 @@ field label, optional submit button, and pass/fail result are recorded. Do not
 use the generic `run` command to improvise password entry. macOS 26 and 27
 Parallels guests remain unsupported until they have an equally constrained
 lease-specific transport.
+
+On macOS 15 authentication sheets, use an explicit submit selector when the
+button is available:
+
+```bash
+Scripts/lab/keypath-lab secure-dialog-input cbx_example \
+  --app 'System Settings' --field Password --submit 'Modify Settings'
+```
+
+The controller must strip the encrypted dotenv record's terminating newline
+before sending the password. A newline passed to Peekaboo's type transport can
+become part of the secure-field value rather than a Return key. Always confirm
+success by checking that the sheet is gone and the protected state changed;
+`secure_dialog_input passed` proves only that the secret transport and click
+completed.
 
 Driver-extension authorization is owned by `SecurityAgent`, whose secure
 window is not available to Peekaboo snapshots. When a fresh framebuffer image


### PR DESCRIPTION
## Summary

- add compact, structured hover cards to every QA dashboard capability block
- show per-task next-step status and progress for active work
- let the dashboard updater accept repeatable `--next-task` values
- preserve the latest VM targeting guidance and strip the secure-input dotenv newline

## Why

The dashboard showed overall block progress but did not expose the concrete work remaining inside each block. Agents and observers had to reconstruct the next sequence from chat updates. The latest disposable-VM run also showed that backing-display dimensions are not a safe RFB coordinate transform and that a terminating dotenv newline can contaminate secure-field input.

## Validation

- `Scripts/lab/tests/keypath-lab-tests.sh`
- `/bin/zsh -n Scripts/lab/remote.sh`
- `python3 -m py_compile Scripts/lab/update-progress-dashboard`
- updater state-contract assertion with `jq`
- extracted dashboard JavaScript checked with `node --check`
- rendered hover inspected in the local dashboard
- `git diff --check`
- review gate: remote review selected; merge waits for GitHub `claude-review`
