### PR TITLE
Add issue dashboard hover details

### DIFF
--- a/Scripts/lab/tests/issue-dashboard-tests.py
+++ b/Scripts/lab/tests/issue-dashboard-tests.py
@@ -56,6 +56,14 @@ class IssueDashboardTests(unittest.TestCase):
         self.assertIn("event.source!==dashboardFrame.contentWindow", tab_renderer)
         self.assertIn(r"github\\.com\\/malpern\\/KeyPath\\/issues", tab_renderer)
 
+    def test_description_excerpt_is_plain_bounded_text(self) -> None:
+        body = "## Context\n\n**Important** `detail` " + ("word " * 80)
+        excerpt = module.description_excerpt(body)
+        self.assertTrue(excerpt.startswith("Context Important detail"))
+        self.assertLessEqual(len(excerpt), 261)
+        self.assertTrue(excerpt.endswith("…"))
+        self.assertNotIn("**", excerpt)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Scripts/lab/update-issue-dashboard
+++ b/Scripts/lab/update-issue-dashboard
@@ -4,6 +4,7 @@ import datetime as dt
 import json
 import os
 import pathlib
+import re
 import shutil
 import subprocess
 
@@ -47,6 +48,16 @@ def issue_type(issue: dict) -> str:
     return "other"
 
 
+def description_excerpt(body: str, limit: int = 260) -> str:
+    text = re.sub(r"(?m)^\s{0,3}#{1,6}\s*", "", body or "")
+    text = re.sub(r"[`*_>]", "", text)
+    text = re.sub(r"\s+", " ", text).strip()
+    if len(text) <= limit:
+        return text
+    clipped = text[:limit].rsplit(" ", 1)[0].rstrip(" ,.;:-")
+    return f"{clipped}…"
+
+
 def priority(issue: dict) -> tuple:
     order = {"active": 0, "next": 1, "queued": 2, "human": 3, "feature": 4, "deferred": 5}
     return (order[issue["dashboardStatus"]], -issue["number"])
@@ -75,7 +86,7 @@ def main() -> None:
             "--limit",
             str(ISSUE_LIMIT),
             "--json",
-            "number,title,labels,updatedAt,url",
+            "number,title,body,labels,updatedAt,url",
         ],
         check=True,
         capture_output=True,
@@ -86,6 +97,7 @@ def main() -> None:
     for issue in issues:
         issue["dashboardStatus"] = issue_status(issue)
         issue["dashboardType"] = issue_type(issue)
+        issue["descriptionExcerpt"] = description_excerpt(issue.pop("body", ""))
         issue["labels"] = [label["name"] for label in issue.get("labels", [])]
     issues.sort(key=priority)
     counts = {}

--- a/docs/testing/keypath-github-issues-dashboard.fragment.html
+++ b/docs/testing/keypath-github-issues-dashboard.fragment.html
@@ -28,7 +28,7 @@
     #keypath-issue-board .workspace { display:block; }
     #keypath-issue-board .board { padding:14px; background:color-mix(in srgb,var(--card) 82%,var(--background)); border:1px solid var(--border); border-radius:8px; }
     #keypath-issue-board .track { display:grid; grid-template-columns:repeat(12,minmax(0,1fr)); gap:5px; }
-    #keypath-issue-board .issue { appearance:none; position:relative; min-height:44px; padding:6px 2px; border:1px solid transparent; border-radius:6px; color:var(--foreground); font:500 10px ui-monospace,SFMono-Regular,Menlo,monospace; cursor:pointer; transition:transform 120ms ease,filter 120ms ease; }
+    #keypath-issue-board .issue { appearance:none; position:relative; min-height:44px; padding:6px 2px; border:1px solid transparent; border-radius:6px; color:var(--foreground); font:500 10px ui-monospace,SFMono-Regular,Menlo,monospace; cursor:pointer; transition:transform 120ms ease,border-color 120ms ease; }
     #keypath-issue-board .issue::before { content:""; position:absolute; top:5px; right:5px; width:5px; height:5px; border-radius:50%; background:currentColor; opacity:.65; }
     #keypath-issue-board .track[data-highlight-type] .issue { opacity:.25; }
     #keypath-issue-board .track[data-highlight-type="bug"] .issue[data-type="bug"],
@@ -42,7 +42,7 @@
     #keypath-issue-board .issue[data-status="queued"] { background:color-mix(in srgb,var(--viz-series-1) 38%,var(--card)); }
     #keypath-issue-board .issue[data-status="human"] { background:repeating-linear-gradient(135deg,color-mix(in srgb,var(--viz-series-5) 55%,var(--card)) 0 7px,color-mix(in srgb,var(--viz-series-5) 35%,var(--card)) 7px 11px); }
     #keypath-issue-board .issue[data-status="feature"],#keypath-issue-board .issue[data-status="deferred"] { background:var(--muted); color:var(--muted-foreground); }
-    #keypath-issue-board .issue:hover,#keypath-issue-board .issue:focus-visible { filter:brightness(1.15); transform:translateY(-2px); border-color:var(--ring); z-index:1; }
+    #keypath-issue-board .issue:hover,#keypath-issue-board .issue:focus-visible { transform:translateY(-2px); border-color:var(--ring); z-index:1; }
     #keypath-issue-board .issue.is-selected { border-color:var(--foreground); box-shadow:inset 0 0 0 1px var(--foreground); transform:translateY(-1px); }
     #keypath-issue-board .issue.is-selected[data-status="active"] { animation:none; }
     #keypath-issue-board .issue[data-status="active"] { animation:issue-pulse 1.6s ease-in-out infinite; }
@@ -53,6 +53,11 @@
     #keypath-issue-board .readout a { align-self:start; color:var(--viz-series-1); font:500 12px system-ui,sans-serif; }
     #keypath-issue-board .labels { display:flex; flex-wrap:wrap; gap:5px; margin-top:7px; }
     #keypath-issue-board .label { padding:1px 6px; border:1px solid var(--border); border-radius:999px; color:var(--muted-foreground); font-size:10px; }
+    #keypath-issue-board .issue-hover-card { display:none; position:fixed; z-index:40; width:min(390px,calc(100vw - 24px)); padding:14px; border:1px solid var(--border); border-radius:10px; color:var(--popover-foreground); background:var(--popover); font-family:system-ui,sans-serif; pointer-events:none; }
+    #keypath-issue-board .issue-hover-card.is-visible { display:block; }
+    #keypath-issue-board .issue-hover-card strong { display:block; margin-bottom:8px; font-size:14px; font-weight:500; line-height:1.35; }
+    #keypath-issue-board .issue-hover-card p { margin:9px 0 0; color:var(--muted-foreground); font-size:12px; line-height:1.45; }
+    #keypath-issue-board .issue-hover-card .labels { margin-top:0; }
     #keypath-issue-board .lanes { display:grid; grid-template-columns:repeat(4,minmax(0,1fr)); gap:8px; margin-top:12px; }
     #keypath-issue-board .lane { padding:11px; border-top:2px solid var(--border); }
     #keypath-issue-board .lane strong { display:block; font:500 12px system-ui,sans-serif; }
@@ -129,6 +134,11 @@
     </aside>
   </div>
   <div class="note">Dashboard priority is an operating view, not a replacement for GitHub labels. Refreshes from the local GitHub CLI every 60 seconds.</div>
+  <aside class="issue-hover-card" id="issue-hover-card" aria-hidden="true">
+    <strong id="issue-hover-title"></strong>
+    <div class="labels" id="issue-hover-labels"></div>
+    <p id="issue-hover-description"></p>
+  </aside>
 
   <script>
     (() => {
@@ -140,7 +150,12 @@
       const detail = root.querySelector('#issue-detail');
       const labels = root.querySelector('#issue-labels');
       const link = root.querySelector('#issue-link');
+      const hoverCard = root.querySelector('#issue-hover-card');
+      const hoverTitle = root.querySelector('#issue-hover-title');
+      const hoverLabels = root.querySelector('#issue-hover-labels');
+      const hoverDescription = root.querySelector('#issue-hover-description');
       let detailTimer;
+      let hoverTimer;
       let highlightTimer;
       let clickTimer;
       let selectedButton;
@@ -157,6 +172,29 @@
         detail.textContent = names[issue.dashboardStatus];
         labels.replaceChildren(...issue.labels.map(value => { const badge=document.createElement('span'); badge.className='label'; badge.textContent=value; return badge; }));
         link.href = issue.url; link.textContent = `Open #${issue.number}`;
+      };
+      const hideHoverCard = () => {
+        clearTimeout(hoverTimer);
+        hoverCard.classList.remove('is-visible');
+        hoverCard.setAttribute('aria-hidden','true');
+      };
+      const showHoverCard = (issue,button) => {
+        hoverTitle.textContent = `#${issue.number} · ${issue.title}`;
+        hoverLabels.replaceChildren(...issue.labels.map(value => { const badge=document.createElement('span'); badge.className='label'; badge.textContent=value; return badge; }));
+        hoverDescription.textContent = issue.descriptionExcerpt || 'No description provided.';
+        hoverCard.style.left = '0px';
+        hoverCard.style.top = '0px';
+        hoverCard.style.visibility = 'hidden';
+        hoverCard.classList.add('is-visible');
+        const anchor = button.getBoundingClientRect();
+        const card = hoverCard.getBoundingClientRect();
+        const left = Math.max(10,Math.min(window.innerWidth-card.width-10,anchor.left+(anchor.width-card.width)/2));
+        const below = anchor.bottom+10;
+        const top = below+card.height <= window.innerHeight-10 ? below : Math.max(10,anchor.top-card.height-10);
+        hoverCard.style.left = `${left}px`;
+        hoverCard.style.top = `${top}px`;
+        hoverCard.style.visibility = '';
+        hoverCard.setAttribute('aria-hidden','false');
       };
       root.querySelectorAll('.type-filter').forEach(filter => {
         const highlight = () => { clearTimeout(highlightTimer); highlightTimer = setTimeout(() => { grid.dataset.highlightType = filter.dataset.type; }, 120); };
@@ -199,9 +237,14 @@
             button.setAttribute('aria-pressed','true');
             showIssue(issue);
           };
-          button.addEventListener('mouseenter',() => { clearTimeout(detailTimer); detailTimer = setTimeout(() => showIssue(issue),280); });
-          button.addEventListener('mouseleave',() => { clearTimeout(detailTimer); selectedIssue ? showIssue(selectedIssue) : resetReadout(); });
-          button.addEventListener('focus',() => showIssue(issue));
+          button.addEventListener('mouseenter',() => {
+            clearTimeout(detailTimer); clearTimeout(hoverTimer);
+            detailTimer = setTimeout(() => showIssue(issue),280);
+            hoverTimer = setTimeout(() => showHoverCard(issue,button),360);
+          });
+          button.addEventListener('mouseleave',() => { clearTimeout(detailTimer); hideHoverCard(); selectedIssue ? showIssue(selectedIssue) : resetReadout(); });
+          button.addEventListener('focus',() => { showIssue(issue); showHoverCard(issue,button); });
+          button.addEventListener('blur',hideHoverCard);
           button.addEventListener('click',event => {
             clearTimeout(clickTimer);
             if (event.detail === 0) toggleSelection();

--- a/docs/testing/keypath-github-issues-dashboard.html
+++ b/docs/testing/keypath-github-issues-dashboard.html
@@ -778,7 +778,7 @@ html&gt;body{padding:0}&lt;/style&gt;
     #keypath-issue-board .workspace { display:block; }
     #keypath-issue-board .board { padding:14px; background:color-mix(in srgb,var(--card) 82%,var(--background)); border:1px solid var(--border); border-radius:8px; }
     #keypath-issue-board .track { display:grid; grid-template-columns:repeat(12,minmax(0,1fr)); gap:5px; }
-    #keypath-issue-board .issue { appearance:none; position:relative; min-height:44px; padding:6px 2px; border:1px solid transparent; border-radius:6px; color:var(--foreground); font:500 10px ui-monospace,SFMono-Regular,Menlo,monospace; cursor:pointer; transition:transform 120ms ease,filter 120ms ease; }
+    #keypath-issue-board .issue { appearance:none; position:relative; min-height:44px; padding:6px 2px; border:1px solid transparent; border-radius:6px; color:var(--foreground); font:500 10px ui-monospace,SFMono-Regular,Menlo,monospace; cursor:pointer; transition:transform 120ms ease,border-color 120ms ease; }
     #keypath-issue-board .issue::before { content:&quot;&quot;; position:absolute; top:5px; right:5px; width:5px; height:5px; border-radius:50%; background:currentColor; opacity:.65; }
     #keypath-issue-board .track[data-highlight-type] .issue { opacity:.25; }
     #keypath-issue-board .track[data-highlight-type=&quot;bug&quot;] .issue[data-type=&quot;bug&quot;],
@@ -792,7 +792,7 @@ html&gt;body{padding:0}&lt;/style&gt;
     #keypath-issue-board .issue[data-status=&quot;queued&quot;] { background:color-mix(in srgb,var(--viz-series-1) 38%,var(--card)); }
     #keypath-issue-board .issue[data-status=&quot;human&quot;] { background:repeating-linear-gradient(135deg,color-mix(in srgb,var(--viz-series-5) 55%,var(--card)) 0 7px,color-mix(in srgb,var(--viz-series-5) 35%,var(--card)) 7px 11px); }
     #keypath-issue-board .issue[data-status=&quot;feature&quot;],#keypath-issue-board .issue[data-status=&quot;deferred&quot;] { background:var(--muted); color:var(--muted-foreground); }
-    #keypath-issue-board .issue:hover,#keypath-issue-board .issue:focus-visible { filter:brightness(1.15); transform:translateY(-2px); border-color:var(--ring); z-index:1; }
+    #keypath-issue-board .issue:hover,#keypath-issue-board .issue:focus-visible { transform:translateY(-2px); border-color:var(--ring); z-index:1; }
     #keypath-issue-board .issue.is-selected { border-color:var(--foreground); box-shadow:inset 0 0 0 1px var(--foreground); transform:translateY(-1px); }
     #keypath-issue-board .issue.is-selected[data-status=&quot;active&quot;] { animation:none; }
     #keypath-issue-board .issue[data-status=&quot;active&quot;] { animation:issue-pulse 1.6s ease-in-out infinite; }
@@ -803,6 +803,11 @@ html&gt;body{padding:0}&lt;/style&gt;
     #keypath-issue-board .readout a { align-self:start; color:var(--viz-series-1); font:500 12px system-ui,sans-serif; }
     #keypath-issue-board .labels { display:flex; flex-wrap:wrap; gap:5px; margin-top:7px; }
     #keypath-issue-board .label { padding:1px 6px; border:1px solid var(--border); border-radius:999px; color:var(--muted-foreground); font-size:10px; }
+    #keypath-issue-board .issue-hover-card { display:none; position:fixed; z-index:40; width:min(390px,calc(100vw - 24px)); padding:14px; border:1px solid var(--border); border-radius:10px; color:var(--popover-foreground); background:var(--popover); font-family:system-ui,sans-serif; pointer-events:none; }
+    #keypath-issue-board .issue-hover-card.is-visible { display:block; }
+    #keypath-issue-board .issue-hover-card strong { display:block; margin-bottom:8px; font-size:14px; font-weight:500; line-height:1.35; }
+    #keypath-issue-board .issue-hover-card p { margin:9px 0 0; color:var(--muted-foreground); font-size:12px; line-height:1.45; }
+    #keypath-issue-board .issue-hover-card .labels { margin-top:0; }
     #keypath-issue-board .lanes { display:grid; grid-template-columns:repeat(4,minmax(0,1fr)); gap:8px; margin-top:12px; }
     #keypath-issue-board .lane { padding:11px; border-top:2px solid var(--border); }
     #keypath-issue-board .lane strong { display:block; font:500 12px system-ui,sans-serif; }
@@ -879,6 +884,11 @@ html&gt;body{padding:0}&lt;/style&gt;
     &lt;/aside&gt;
   &lt;/div&gt;
   &lt;div class=&quot;note&quot;&gt;Dashboard priority is an operating view, not a replacement for GitHub labels. Refreshes from the local GitHub CLI every 60 seconds.&lt;/div&gt;
+  &lt;aside class=&quot;issue-hover-card&quot; id=&quot;issue-hover-card&quot; aria-hidden=&quot;true&quot;&gt;
+    &lt;strong id=&quot;issue-hover-title&quot;&gt;&lt;/strong&gt;
+    &lt;div class=&quot;labels&quot; id=&quot;issue-hover-labels&quot;&gt;&lt;/div&gt;
+    &lt;p id=&quot;issue-hover-description&quot;&gt;&lt;/p&gt;
+  &lt;/aside&gt;
 
   &lt;script&gt;
     (() =&gt; {
@@ -890,7 +900,12 @@ html&gt;body{padding:0}&lt;/style&gt;
       const detail = root.querySelector(&#x27;#issue-detail&#x27;);
       const labels = root.querySelector(&#x27;#issue-labels&#x27;);
       const link = root.querySelector(&#x27;#issue-link&#x27;);
+      const hoverCard = root.querySelector(&#x27;#issue-hover-card&#x27;);
+      const hoverTitle = root.querySelector(&#x27;#issue-hover-title&#x27;);
+      const hoverLabels = root.querySelector(&#x27;#issue-hover-labels&#x27;);
+      const hoverDescription = root.querySelector(&#x27;#issue-hover-description&#x27;);
       let detailTimer;
+      let hoverTimer;
       let highlightTimer;
       let clickTimer;
       let selectedButton;
@@ -907,6 +922,29 @@ html&gt;body{padding:0}&lt;/style&gt;
         detail.textContent = names[issue.dashboardStatus];
         labels.replaceChildren(...issue.labels.map(value =&gt; { const badge=document.createElement(&#x27;span&#x27;); badge.className=&#x27;label&#x27;; badge.textContent=value; return badge; }));
         link.href = issue.url; link.textContent = `Open #${issue.number}`;
+      };
+      const hideHoverCard = () =&gt; {
+        clearTimeout(hoverTimer);
+        hoverCard.classList.remove(&#x27;is-visible&#x27;);
+        hoverCard.setAttribute(&#x27;aria-hidden&#x27;,&#x27;true&#x27;);
+      };
+      const showHoverCard = (issue,button) =&gt; {
+        hoverTitle.textContent = `#${issue.number} · ${issue.title}`;
+        hoverLabels.replaceChildren(...issue.labels.map(value =&gt; { const badge=document.createElement(&#x27;span&#x27;); badge.className=&#x27;label&#x27;; badge.textContent=value; return badge; }));
+        hoverDescription.textContent = issue.descriptionExcerpt || &#x27;No description provided.&#x27;;
+        hoverCard.style.left = &#x27;0px&#x27;;
+        hoverCard.style.top = &#x27;0px&#x27;;
+        hoverCard.style.visibility = &#x27;hidden&#x27;;
+        hoverCard.classList.add(&#x27;is-visible&#x27;);
+        const anchor = button.getBoundingClientRect();
+        const card = hoverCard.getBoundingClientRect();
+        const left = Math.max(10,Math.min(window.innerWidth-card.width-10,anchor.left+(anchor.width-card.width)/2));
+        const below = anchor.bottom+10;
+        const top = below+card.height &lt;= window.innerHeight-10 ? below : Math.max(10,anchor.top-card.height-10);
+        hoverCard.style.left = `${left}px`;
+        hoverCard.style.top = `${top}px`;
+        hoverCard.style.visibility = &#x27;&#x27;;
+        hoverCard.setAttribute(&#x27;aria-hidden&#x27;,&#x27;false&#x27;);
       };
       root.querySelectorAll(&#x27;.type-filter&#x27;).forEach(filter =&gt; {
         const highlight = () =&gt; { clearTimeout(highlightTimer); highlightTimer = setTimeout(() =&gt; { grid.dataset.highlightType = filter.dataset.type; }, 120); };
@@ -949,9 +987,14 @@ html&gt;body{padding:0}&lt;/style&gt;
             button.setAttribute(&#x27;aria-pressed&#x27;,&#x27;true&#x27;);
             showIssue(issue);
           };
-          button.addEventListener(&#x27;mouseenter&#x27;,() =&gt; { clearTimeout(detailTimer); detailTimer = setTimeout(() =&gt; showIssue(issue),280); });
-          button.addEventListener(&#x27;mouseleave&#x27;,() =&gt; { clearTimeout(detailTimer); selectedIssue ? showIssue(selectedIssue) : resetReadout(); });
-          button.addEventListener(&#x27;focus&#x27;,() =&gt; showIssue(issue));
+          button.addEventListener(&#x27;mouseenter&#x27;,() =&gt; {
+            clearTimeout(detailTimer); clearTimeout(hoverTimer);
+            detailTimer = setTimeout(() =&gt; showIssue(issue),280);
+            hoverTimer = setTimeout(() =&gt; showHoverCard(issue,button),360);
+          });
+          button.addEventListener(&#x27;mouseleave&#x27;,() =&gt; { clearTimeout(detailTimer); hideHoverCard(); selectedIssue ? showIssue(selectedIssue) : resetReadout(); });
+          button.addEventListener(&#x27;focus&#x27;,() =&gt; { showIssue(issue); showHoverCard(issue,button); });
+          button.addEventListener(&#x27;blur&#x27;,hideHoverCard);
           button.addEventListener(&#x27;click&#x27;,event =&gt; {
             clearTimeout(clickTimer);
             if (event.detail === 0) toggleSelection();

--- a/docs/testing/keypath-github-issues-state.json
+++ b/docs/testing/keypath-github-issues-state.json
@@ -27,7 +27,8 @@
       "updatedAt": "2026-07-12T14:38:58Z",
       "url": "https://github.com/malpern/KeyPath/issues/982",
       "dashboardStatus": "active",
-      "dashboardType": "bug"
+      "dashboardType": "bug",
+      "descriptionExcerpt": "Direction Treat this as an upstream-first Kanata compatibility project, independent of KeyPath integration. The immediate goal is to make the latest upstream Kanata compatible with the current Karabiner-DriverKit-VirtualHIDDevice protocol, validate the result\u2026"
     },
     {
       "labels": [
@@ -39,7 +40,8 @@
       "updatedAt": "2026-06-06T19:09:37Z",
       "url": "https://github.com/malpern/KeyPath/issues/748",
       "dashboardStatus": "next",
-      "dashboardType": "debt"
+      "dashboardType": "debt",
+      "descriptionExcerpt": "Context Recent release-blocker work fixed stale SMAppService recovery for Kanata and the privileged helper. Runtime is healthy after the final signed/notarized build, but one observation remains ambiguous: launchd may keep an existing helper process alive\u2026"
     },
     {
       "labels": [
@@ -54,7 +56,8 @@
       "updatedAt": "2026-07-04T13:30:28Z",
       "url": "https://github.com/malpern/KeyPath/issues/855",
       "dashboardStatus": "queued",
-      "dashboardType": "debt"
+      "dashboardType": "debt",
+      "descriptionExcerpt": "Problem InstallerEngine is documented as the facade for install/repair/uninstall + system inspection (CLAUDE.md). At 779 lines it owns both provisioning (recipe execution, package install) and diagnosis (system validation, health checks, system requirements)\u2026"
     },
     {
       "labels": [
@@ -69,7 +72,8 @@
       "updatedAt": "2026-07-04T13:30:27Z",
       "url": "https://github.com/malpern/KeyPath/issues/852",
       "dashboardStatus": "queued",
-      "dashboardType": "debt"
+      "dashboardType": "debt",
+      "descriptionExcerpt": "Problem App.swift owns: window creation, wizard presentation, keyboard-layout detection, emergency-stop handling, headless auto-start, first-activation flow, fresh-install detection, menu bar setup, and SMAppService dev utilities. The first-activation block\u2026"
     },
     {
       "labels": [
@@ -83,7 +87,8 @@
       "updatedAt": "2026-07-04T13:30:24Z",
       "url": "https://github.com/malpern/KeyPath/issues/848",
       "dashboardStatus": "queued",
-      "dashboardType": "testing"
+      "dashboardType": "testing",
+      "descriptionExcerpt": "Problem Roughly 350 ad-hoc Kanata config string literals (defcfg, defsrc, deflayer, defvar) are inlined across Tests/KeyPathTests/. There is no shared fixture/builder library. Tests/TestSupport/ exists but contains only SystemContextBuilder.swift and\u2026"
     },
     {
       "labels": [
@@ -96,7 +101,8 @@
       "updatedAt": "2026-06-06T19:10:00Z",
       "url": "https://github.com/malpern/KeyPath/issues/750",
       "dashboardStatus": "queued",
-      "dashboardType": "debt"
+      "dashboardType": "debt",
+      "descriptionExcerpt": "Context The final signed 1.0 candidate builds successfully, but the release build still emits compiler warnings. The most important category is Swift 6 actor-isolation/concurrency warnings in UI and service observer code. These are not current release\u2026"
     },
     {
       "labels": [
@@ -109,7 +115,8 @@
       "updatedAt": "2026-07-04T13:30:08Z",
       "url": "https://github.com/malpern/KeyPath/issues/737",
       "dashboardStatus": "queued",
-      "dashboardType": "other"
+      "dashboardType": "other",
+      "descriptionExcerpt": "Context Split out from #731 after the stable-1.0 release blockers were fixed. The mapper is a shipping feature, but some mapper implementation still lives under UI/Experimental, which makes ownership and navigation misleading. Evidence From #731\u2026"
     },
     {
       "labels": [
@@ -122,7 +129,8 @@
       "updatedAt": "2026-07-04T13:30:07Z",
       "url": "https://github.com/malpern/KeyPath/issues/736",
       "dashboardStatus": "queued",
-      "dashboardType": "other"
+      "dashboardType": "other",
+      "descriptionExcerpt": "Context Split out from #731 after the stable-1.0 release blockers were fixed. The 1.0 blocker work clarified reload outcomes as applied/pending/rejected/failed, but the broader configuration ownership model still has overlapping responsibilities. Current\u2026"
     },
     {
       "labels": [
@@ -134,7 +142,8 @@
       "updatedAt": "2026-06-06T19:10:11Z",
       "url": "https://github.com/malpern/KeyPath/issues/735",
       "dashboardStatus": "queued",
-      "dashboardType": "debt"
+      "dashboardType": "debt",
+      "descriptionExcerpt": "Context Split out from #731 after the stable-1.0 release blockers were fixed. 731 intentionally avoided a broad daemon/lifecycle layer merge before 1.0. The release-blocker work made ServiceLifecycleCoordinator.startKanata() wait for runtime readiness or\u2026"
     },
     {
       "labels": [
@@ -146,7 +155,8 @@
       "updatedAt": "2026-07-12T00:09:33Z",
       "url": "https://github.com/malpern/KeyPath/issues/604",
       "dashboardStatus": "queued",
-      "dashboardType": "testing"
+      "dashboardType": "testing",
+      "descriptionExcerpt": "Summary KeyPath has ~3,615 tests but coverage is uneven. CLI, Packs, and RuleCollections are well-tested. UI views (10% coverage), Utilities (7%), Core (28%), and Managers (36%) have critical gaps. ~10 \"ghost test\" files totaling 3,000+ lines have zero or\u2026"
     },
     {
       "labels": [
@@ -158,7 +168,8 @@
       "updatedAt": "2026-06-06T16:54:28Z",
       "url": "https://github.com/malpern/KeyPath/issues/496",
       "dashboardStatus": "queued",
-      "dashboardType": "debt"
+      "dashboardType": "debt",
+      "descriptionExcerpt": "Code Audit Finding \u00a73.5 \u2014 Low Problem: 10+ \\nonisolated(unsafe) public static\\ properties serve as a dependency container accessed from multiple isolation contexts. Relies on implicit single-threaded wizard lifecycle without compiler enforcement. Location\u2026"
     },
     {
       "labels": [
@@ -171,7 +182,8 @@
       "updatedAt": "2026-06-06T17:09:55Z",
       "url": "https://github.com/malpern/KeyPath/issues/495",
       "dashboardStatus": "queued",
-      "dashboardType": "debt"
+      "dashboardType": "debt",
+      "descriptionExcerpt": "Code Audit Finding \u00a79.7 \u2014 Low Problem: 8 files exceed 1000 lines; several already use MARK sections indicating natural split points. Files: - \\RuntimeCoordinator.swift\\ (1487 lines) - \\WizardDesignSystem.swift\\ (1242) - \\LauncherCollectionView.swift\\ (1053)\u2026"
     },
     {
       "labels": [
@@ -184,7 +196,8 @@
       "updatedAt": "2026-06-06T17:09:56Z",
       "url": "https://github.com/malpern/KeyPath/issues/494",
       "dashboardStatus": "queued",
-      "dashboardType": "debt"
+      "dashboardType": "debt",
+      "descriptionExcerpt": "Code Audit Findings \u00a78.3 + \u00a78.5 \u2014 Low Problem: - \u00a78.3: 21 separate \\@State\\ declarations including dictionaries, optionals, and sets. Harder to reason about state coherence. - \u00a78.5: \\@Bindable var kanataManager = kanataManager\\ declared inside body, recreated\u2026"
     },
     {
       "labels": [
@@ -196,7 +209,8 @@
       "updatedAt": "2026-06-06T17:09:58Z",
       "url": "https://github.com/malpern/KeyPath/issues/490",
       "dashboardStatus": "queued",
-      "dashboardType": "debt"
+      "dashboardType": "debt",
+      "descriptionExcerpt": "Code Audit Finding \u00a73.2 \u2014 Low Problem: Legacy \\DispatchQueue.main.async\\ and \\.asyncAfter\\ used where structured concurrency equivalents exist. Bypasses typed MainActor isolation. Locations\u2026"
     },
     {
       "labels": [
@@ -208,7 +222,8 @@
       "updatedAt": "2026-06-06T17:09:59Z",
       "url": "https://github.com/malpern/KeyPath/issues/488",
       "dashboardStatus": "queued",
-      "dashboardType": "debt"
+      "dashboardType": "debt",
+      "descriptionExcerpt": "Code Audit Finding \u00a78.6 \u2014 Medium Problem: keyUnitSize: CGFloat = 32 and keyGap: CGFloat = 2 hardcoded; layout doesn't adapt to screen size or accessibility settings. Location: Sources/KeyPathAppKit/UI/Overlay/OverlayKeyboardView.swift:106 Action: Use\u2026"
     },
     {
       "labels": [
@@ -221,7 +236,8 @@
       "updatedAt": "2026-06-06T17:10:01Z",
       "url": "https://github.com/malpern/KeyPath/issues/487",
       "dashboardStatus": "queued",
-      "dashboardType": "debt"
+      "dashboardType": "debt",
+      "descriptionExcerpt": "Code Audit Finding \u00a78.4 \u2014 Medium Problem: Body view chains 16+ .onChange() modifiers using intermediate let bindings, spanning 750+ lines. Obscures core view hierarchy. Location: Sources/KeyPathAppKit/UI/Overlay/OverlayMapperSection.swift:62-120 Action\u2026"
     },
     {
       "labels": [
@@ -233,7 +249,8 @@
       "updatedAt": "2026-06-06T17:10:04Z",
       "url": "https://github.com/malpern/KeyPath/issues/484",
       "dashboardStatus": "queued",
-      "dashboardType": "debt"
+      "dashboardType": "debt",
+      "descriptionExcerpt": "Code Audit Finding \u00a77.3 \u2014 Medium Problem: Five computed properties chain filtering and sorting on every render: allCollections \u2192 sortedCollections \u2192 filteredCollections \u2192 filteredCustomRules \u2192 filteredAppKeymaps. Scales poorly with large rule sets. Location\u2026"
     },
     {
       "labels": [
@@ -245,7 +262,8 @@
       "updatedAt": "2026-06-06T17:11:50Z",
       "url": "https://github.com/malpern/KeyPath/issues/365",
       "dashboardStatus": "queued",
-      "dashboardType": "testing"
+      "dashboardType": "testing",
+      "descriptionExcerpt": "Summary We're currently running both XCTest (~1541 tests) and Swift Testing (~505 tests) frameworks. Swift Testing is the future \u2014 better diagnostics, parameterized tests, cleaner syntax. Approach - Write all new tests in Swift Testing (@Test, #expect)\u2026"
     },
     {
       "labels": [
@@ -257,7 +275,8 @@
       "updatedAt": "2026-06-06T17:11:52Z",
       "url": "https://github.com/malpern/KeyPath/issues/204",
       "dashboardStatus": "queued",
-      "dashboardType": "testing"
+      "dashboardType": "testing",
+      "descriptionExcerpt": "Goal Validate the KeyPathInsights feature works correctly in a production-signed app build. Test checklist - [ ] Confirm KeyPathInsights plugin loads at app startup - [ ] Verify opt-in/consent flow appears and persists correctly - [ ] Generate sample activity\u2026"
     },
     {
       "labels": [
@@ -272,7 +291,8 @@
       "updatedAt": "2026-07-12T00:09:46Z",
       "url": "https://github.com/malpern/KeyPath/issues/934",
       "dashboardStatus": "human",
-      "dashboardType": "feature"
+      "dashboardType": "feature",
+      "descriptionExcerpt": "Grouped polish items from the 2026-07-02 fresh-install QA review (log + code audit). Split out anything that grows. The moments that hurt (tier 1) - [ ] Restart-needed messaging: AX polled \"denied\" for 50s while the user was granting it; only read granted\u2026"
     },
     {
       "labels": [
@@ -286,7 +306,8 @@
       "updatedAt": "2026-07-04T13:29:50Z",
       "url": "https://github.com/malpern/KeyPath/issues/920",
       "dashboardStatus": "human",
-      "dashboardType": "docs"
+      "dashboardType": "docs",
+      "descriptionExcerpt": "Seven published guides reference placeholder-.png screenshots that were never captured. For the 1.0 public release these were stripped from the guide markdown (their ![...]() image lines removed) so they don't render as broken <img icons on the website \u2014 the\u2026"
     },
     {
       "labels": [
@@ -301,7 +322,8 @@
       "updatedAt": "2026-07-12T00:38:35Z",
       "url": "https://github.com/malpern/KeyPath/issues/919",
       "dashboardStatus": "human",
-      "dashboardType": "bug"
+      "dashboardType": "bug",
+      "descriptionExcerpt": "Post-1.0 tracking, but should happen during the macOS 27 beta cycle (public release expected September 2026). From the WWDC 2026 review \u2014 see docs/wwdc-2026-macos-27-opportunities.md (PR #911), \u00a710. Why Nothing announced at WWDC26 changes SMAppService, XPC\u2026"
     },
     {
       "labels": [
@@ -315,7 +337,8 @@
       "updatedAt": "2026-06-12T16:40:48Z",
       "url": "https://github.com/malpern/KeyPath/issues/918",
       "dashboardStatus": "human",
-      "dashboardType": "testing"
+      "dashboardType": "testing",
+      "descriptionExcerpt": "Post-1.0. Not for the 1.0 launch. From the WWDC 2026 review \u2014 see docs/wwdc-2026-macos-27-opportunities.md (PR #911), opportunity #7. Why The codebase is ~294 XCTest files vs ~48 Swift Testing files. WWDC26 shipped Swift Testing \u2194 XCTest interoperability\u2026"
     },
     {
       "labels": [
@@ -329,7 +352,8 @@
       "updatedAt": "2026-06-12T16:40:40Z",
       "url": "https://github.com/malpern/KeyPath/issues/917",
       "dashboardStatus": "human",
-      "dashboardType": "testing"
+      "dashboardType": "testing",
+      "descriptionExcerpt": "Post-1.0. Not for the 1.0 launch. From the WWDC 2026 review \u2014 see docs/wwdc-2026-macos-27-opportunities.md (PR #911), opportunity #6. Why KeyPath ships an LLM feature (AnthropicConfigRepairService) with no systematic quality measurement. WWDC26's Evaluations\u2026"
     },
     {
       "labels": [
@@ -343,7 +367,8 @@
       "updatedAt": "2026-06-12T16:40:35Z",
       "url": "https://github.com/malpern/KeyPath/issues/916",
       "dashboardStatus": "human",
-      "dashboardType": "feature"
+      "dashboardType": "feature",
+      "descriptionExcerpt": "Post-1.0. Not for the 1.0 launch. From the WWDC 2026 review \u2014 see docs/wwdc-2026-macos-27-opportunities.md (PR #911), opportunity #5. Why (near-free wins) - Significant ViewBuilder build-time improvements in Xcode 27 \u2014 real money across 23 targets and ~350\u2026"
     },
     {
       "labels": [
@@ -356,7 +381,8 @@
       "updatedAt": "2026-06-12T16:40:27Z",
       "url": "https://github.com/malpern/KeyPath/issues/915",
       "dashboardStatus": "human",
-      "dashboardType": "feature"
+      "dashboardType": "feature",
+      "descriptionExcerpt": "Post-1.0. Not for the 1.0 launch. From the WWDC 2026 review \u2014 see docs/wwdc-2026-macos-27-opportunities.md (PR #911), opportunity #4. Why WWDC26: AppKit now automatically tracks @Observable property reads in draw, layout, updateConstraints, updateLayer (and\u2026"
     },
     {
       "labels": [
@@ -370,7 +396,8 @@
       "updatedAt": "2026-06-12T16:40:21Z",
       "url": "https://github.com/malpern/KeyPath/issues/914",
       "dashboardStatus": "human",
-      "dashboardType": "testing"
+      "dashboardType": "testing",
+      "descriptionExcerpt": "Post-1.0. Not for the 1.0 launch. From the WWDC 2026 review \u2014 see docs/wwdc-2026-macos-27-opportunities.md (PR #911), opportunity #3. Why Intent QA currently leans on Computer Use UI automation, which is slow and flaky by nature. The new App Intents Testing\u2026"
     },
     {
       "labels": [
@@ -383,7 +410,8 @@
       "updatedAt": "2026-06-12T16:40:15Z",
       "url": "https://github.com/malpern/KeyPath/issues/913",
       "dashboardStatus": "human",
-      "dashboardType": "feature"
+      "dashboardType": "feature",
+      "descriptionExcerpt": "Post-1.0. Not for the 1.0 launch. From the WWDC 2026 review \u2014 see docs/wwdc-2026-macos-27-opportunities.md (PR #911), opportunity #2. Why On macOS 27, the rebuilt Siri AI lives in Spotlight, and the new App Intents Entity Schemas feed Spotlight's semantic\u2026"
     },
     {
       "labels": [
@@ -396,7 +424,8 @@
       "updatedAt": "2026-06-12T16:39:56Z",
       "url": "https://github.com/malpern/KeyPath/issues/912",
       "dashboardStatus": "human",
-      "dashboardType": "feature"
+      "dashboardType": "feature",
+      "descriptionExcerpt": "Post-1.0. Not for the 1.0 launch. From the WWDC 2026 review \u2014 see docs/wwdc-2026-macos-27-opportunities.md (PR #911), opportunity #1 (highest reward). Why The biggest UX barrier to the AI repair feature is \"bring your own Anthropic API key\" (Keychain\u2026"
     },
     {
       "labels": [
@@ -409,7 +438,8 @@
       "updatedAt": "2026-07-04T13:29:48Z",
       "url": "https://github.com/malpern/KeyPath/issues/888",
       "dashboardStatus": "human",
-      "dashboardType": "docs"
+      "dashboardType": "docs",
+      "descriptionExcerpt": "Output of the Thu 1.0 design-review pass (gate 5 of the release plan). None of these block 1.0; they're queued as a single backlog so the next design sprint can pick them up together. Full context in the RELEASE-READINESS working doc. Theme 1 \u2014 Timing\u2026"
     },
     {
       "labels": [
@@ -424,7 +454,8 @@
       "updatedAt": "2026-07-04T13:29:47Z",
       "url": "https://github.com/malpern/KeyPath/issues/868",
       "dashboardStatus": "human",
-      "dashboardType": "feature"
+      "dashboardType": "feature",
+      "descriptionExcerpt": "Part of [#865](https://github.com/malpern/KeyPath/issues/865). Depends on the detector sub-issue. Can run in parallel with the forward dialog sub-issue once the detector lands. Goal User-facing dialog that surfaces reverse-direction orphan warnings when a\u2026"
     },
     {
       "labels": [
@@ -439,7 +470,8 @@
       "updatedAt": "2026-07-12T14:00:23Z",
       "url": "https://github.com/malpern/KeyPath/issues/865",
       "dashboardStatus": "human",
-      "dashboardType": "feature"
+      "dashboardType": "feature",
+      "descriptionExcerpt": "Status: Sprint planning spike \u2014 high-level requirements only. Sub-issues fan out the work. Problem The existing conflict detector at\u2026"
     },
     {
       "labels": [
@@ -454,7 +486,8 @@
       "updatedAt": "2026-07-12T00:09:34Z",
       "url": "https://github.com/malpern/KeyPath/issues/747",
       "dashboardStatus": "human",
-      "dashboardType": "testing"
+      "dashboardType": "testing",
+      "descriptionExcerpt": "Context KeyPath depends on macOS permissions and service-management state that can be confusing during first run and upgrade: Accessibility, Input Monitoring, Full Disk Access, Login Items, privileged helper registration, and the Kanata launch daemon. The\u2026"
     },
     {
       "labels": [
@@ -467,7 +500,8 @@
       "updatedAt": "2026-07-04T13:29:49Z",
       "url": "https://github.com/malpern/KeyPath/issues/741",
       "dashboardStatus": "human",
-      "dashboardType": "other"
+      "dashboardType": "other",
+      "descriptionExcerpt": "Context Split out from #731 after the stable-1.0 release blockers were fixed. 731 noted multiple design token/style files may be noisy, but this was not a 1.0 stability issue unless it blocked specific UI fixes. Direction Audit design-system/style definitions\u2026"
     },
     {
       "labels": [
@@ -480,7 +514,8 @@
       "updatedAt": "2026-07-04T13:30:10Z",
       "url": "https://github.com/malpern/KeyPath/issues/740",
       "dashboardStatus": "human",
-      "dashboardType": "other"
+      "dashboardType": "other",
+      "descriptionExcerpt": "Context Split out from #731 after the stable-1.0 release blockers were fixed. The broad audit called out many local error enums. #731 corrected that not every local enum is bad: some are domain-specific and should stay local. Direction Do targeted cleanup\u2026"
     },
     {
       "labels": [
@@ -495,7 +530,8 @@
       "updatedAt": "2026-07-12T14:15:25Z",
       "url": "https://github.com/malpern/KeyPath/issues/177",
       "dashboardStatus": "human",
-      "dashboardType": "upstream"
+      "dashboardType": "upstream",
+      "descriptionExcerpt": "[!NOTE] Status: upstream watch item; not yet reproduced through KeyPath. The upstream report remains open, but it has no current KeyPath-specific reproduction, logs, or confirmed causal path. Preserve it because persistent modifier corruption would be serious\u2026"
     },
     {
       "labels": [
@@ -511,7 +547,8 @@
       "updatedAt": "2026-07-12T14:15:23Z",
       "url": "https://github.com/malpern/KeyPath/issues/176",
       "dashboardStatus": "human",
-      "dashboardType": "upstream"
+      "dashboardType": "upstream",
+      "descriptionExcerpt": "[!NOTE] Status: upstream hardware-compatibility watch item; no confirmed current KeyPath reproduction. The two referenced upstream reports are closed, and the bundled Kanata contains the related macOS mouse event-tap fix (29c9366). Some combined Bluetooth\u2026"
     },
     {
       "labels": [
@@ -526,7 +563,8 @@
       "updatedAt": "2026-07-12T14:15:22Z",
       "url": "https://github.com/malpern/KeyPath/issues/175",
       "dashboardStatus": "human",
-      "dashboardType": "testing"
+      "dashboardType": "testing",
+      "descriptionExcerpt": "[!NOTE] Status: upstream issue resolved and relevant fixes are bundled; no confirmed remaining KeyPath bug. The original null-product-string crash was fixed in the driverkit dependency, and the current bundled Kanata also contains later macOS\u2026"
     },
     {
       "labels": [
@@ -542,7 +580,8 @@
       "updatedAt": "2026-07-12T14:15:20Z",
       "url": "https://github.com/malpern/KeyPath/issues/174",
       "dashboardStatus": "human",
-      "dashboardType": "bug"
+      "dashboardType": "bug",
+      "descriptionExcerpt": "[!IMPORTANT] Status: plausible direct KeyPath reliability bug; current-stack reproduction required. Sleep and lid-close recovery are normal KeyPath user paths, and the upstream issue remains open. The bundled Kanata now includes output-loss recovery plus\u2026"
     },
     {
       "labels": [
@@ -559,7 +598,8 @@
       "updatedAt": "2026-07-12T14:15:15Z",
       "url": "https://github.com/malpern/KeyPath/issues/172",
       "dashboardStatus": "human",
-      "dashboardType": "bug"
+      "dashboardType": "bug",
+      "descriptionExcerpt": "[!IMPORTANT] Status: plausible direct KeyPath behavior; reproduction required on the current bundled stack. The upstream report includes current macOS 26 behavior where media keys work with Kanata disabled and fail with Kanata enabled. Because KeyPath routes\u2026"
     },
     {
       "labels": [
@@ -576,7 +616,8 @@
       "updatedAt": "2026-07-12T14:15:14Z",
       "url": "https://github.com/malpern/KeyPath/issues/171",
       "dashboardStatus": "human",
-      "dashboardType": "bug"
+      "dashboardType": "bug",
+      "descriptionExcerpt": "[!NOTE] Status: upstream watch item; no confirmed current KeyPath reproduction. This affects a niche class of composite keyboard/pointing devices represented by upstream Kanata issue #708. Keep it for provenance and future affected-user reports, but do not\u2026"
     },
     {
       "labels": [
@@ -591,7 +632,8 @@
       "updatedAt": "2026-07-04T13:29:57Z",
       "url": "https://github.com/malpern/KeyPath/issues/954",
       "dashboardStatus": "feature",
-      "dashboardType": "feature"
+      "dashboardType": "feature",
+      "descriptionExcerpt": "Second half of the onboarding arc started in #932 (welcome page before the permission gauntlet). Once enough permissions are in place and setup completes, the arc should end in a working mapping, not a closed wizard \u2014 teach the core panel interaction and get\u2026"
     },
     {
       "labels": [
@@ -606,7 +648,8 @@
       "updatedAt": "2026-07-04T13:30:06Z",
       "url": "https://github.com/malpern/KeyPath/issues/870",
       "dashboardStatus": "feature",
-      "dashboardType": "feature"
+      "dashboardType": "feature",
+      "descriptionExcerpt": "Part of [#865](https://github.com/malpern/KeyPath/issues/865) \u2014 the dependency-detection sprint epic. Start here; everything else in the sprint depends on this. Goal A pure-data RuleDependencyGraph value type that captures the provides and requires relations\u2026"
     },
     {
       "labels": [
@@ -621,7 +664,8 @@
       "updatedAt": "2026-07-04T13:30:04Z",
       "url": "https://github.com/malpern/KeyPath/issues/869",
       "dashboardStatus": "feature",
-      "dashboardType": "feature"
+      "dashboardType": "feature",
+      "descriptionExcerpt": "Part of [#865](https://github.com/malpern/KeyPath/issues/865). Depends on the detector sub-issue. Goal User-facing dialog that surfaces forward-direction missing prerequisites at save time, with a single-click \"fix it for me\" action. User scenario Alex\u2026"
     },
     {
       "labels": [
@@ -636,7 +680,8 @@
       "updatedAt": "2026-07-04T13:30:03Z",
       "url": "https://github.com/malpern/KeyPath/issues/867",
       "dashboardStatus": "feature",
-      "dashboardType": "feature"
+      "dashboardType": "feature",
+      "descriptionExcerpt": "Part of [#865](https://github.com/malpern/KeyPath/issues/865). Depends on the dependency-graph data model. Goal Concrete \"requires\" derivations for each family in the catalog. This is the per-family code that introspects a RuleCollectionConfiguration and\u2026"
     },
     {
       "labels": [
@@ -651,7 +696,8 @@
       "updatedAt": "2026-07-04T13:30:01Z",
       "url": "https://github.com/malpern/KeyPath/issues/866",
       "dashboardStatus": "feature",
-      "dashboardType": "feature"
+      "dashboardType": "feature",
+      "descriptionExcerpt": "Part of [#865](https://github.com/malpern/KeyPath/issues/865). Depends on the dependency-graph data model sub-issue. Goal Add RuleCollectionsManager+PrerequisiteDetection.swift as a sibling to the existing\u2026"
     },
     {
       "labels": [
@@ -664,7 +710,8 @@
       "updatedAt": "2026-06-06T19:09:49Z",
       "url": "https://github.com/malpern/KeyPath/issues/749",
       "dashboardStatus": "feature",
-      "dashboardType": "debt"
+      "dashboardType": "debt",
+      "descriptionExcerpt": "Context Stable 1.0 should ship once the signed release smoke tests pass, but the permission/setup flow remains an area where polish will pay off after launch. KeyPath has to explain macOS state across TCC permissions, Login Items approval, privileged helper\u2026"
     },
     {
       "labels": [
@@ -680,7 +727,8 @@
       "updatedAt": "2026-07-04T13:30:33Z",
       "url": "https://github.com/malpern/KeyPath/issues/694",
       "dashboardStatus": "feature",
-      "dashboardType": "feature"
+      "dashboardType": "feature",
+      "descriptionExcerpt": "Tier: 3 (minor / deferred-by-design) From the pre-release feature-gap audit. Two unrelated deferred TODOs tracked together for cleanup. Items 1. QMK HID-descriptor key identification \u2014 declared but not used by the current keymap-based flow\u2026"
     },
     {
       "labels": [
@@ -696,7 +744,8 @@
       "updatedAt": "2026-07-04T13:30:32Z",
       "url": "https://github.com/malpern/KeyPath/issues/688",
       "dashboardStatus": "feature",
-      "dashboardType": "feature"
+      "dashboardType": "feature",
+      "descriptionExcerpt": "Tier: 3 (minor / deferred-by-design) From the pre-release feature-gap audit. Problem Two feature flags are declared but explicitly not implemented (Phase 2/3). They default OFF and aren't exposed in UI; tracking so they aren't accidentally surfaced and to\u2026"
     },
     {
       "labels": [
@@ -708,7 +757,8 @@
       "updatedAt": "2026-06-06T17:10:05Z",
       "url": "https://github.com/malpern/KeyPath/issues/468",
       "dashboardStatus": "feature",
-      "dashboardType": "feature"
+      "dashboardType": "feature",
+      "descriptionExcerpt": "Context Currently InstalledPackTracker.packManagingCollection() returns the first installed pack that claims ownership of a given collection. This works because Ben Vallack Nav is the only multi-collection system pack today. What breaks If a second system\u2026"
     },
     {
       "labels": [
@@ -720,7 +770,8 @@
       "updatedAt": "2026-06-06T17:10:10Z",
       "url": "https://github.com/malpern/KeyPath/issues/375",
       "dashboardStatus": "feature",
-      "dashboardType": "feature"
+      "dashboardType": "feature",
+      "descriptionExcerpt": "Context As packs get richer \u2014 bundling layer toggles + key assignments + chords (see #374) \u2014 the conflict surface area grows. Currently, conflict resolution is simple: autoResolveConflicts: true means the new mapping silently wins. That's fine for single-key\u2026"
     },
     {
       "labels": [
@@ -733,7 +784,8 @@
       "updatedAt": "2026-06-06T17:11:53Z",
       "url": "https://github.com/malpern/KeyPath/issues/299",
       "dashboardStatus": "feature",
-      "dashboardType": "feature"
+      "dashboardType": "feature",
+      "descriptionExcerpt": "The Dream KeyPath knows what kanata layer you're on. Your keyboard has a screen. Connect the dots: - Switch to vim layer \u2192 keyboard screen shows vim shortcuts - Activate macro pad layer \u2192 screen updates with macro labels - HRM active \u2192 show which modifier is\u2026"
     },
     {
       "labels": [
@@ -745,7 +797,8 @@
       "updatedAt": "2026-06-06T17:10:14Z",
       "url": "https://github.com/malpern/KeyPath/issues/293",
       "dashboardStatus": "feature",
-      "dashboardType": "feature"
+      "dashboardType": "feature",
+      "descriptionExcerpt": "Problem UCKeyTranslate is currently called with no modifiers and Shift only. Many international layouts have important characters on Option (e.g., \u20ac on Option+2) or AltGr (European keyboards). These aren't shown anywhere in the overlay. Solution Add an Option\u2026"
     },
     {
       "labels": [
@@ -757,7 +810,8 @@
       "updatedAt": "2026-06-06T17:10:17Z",
       "url": "https://github.com/malpern/KeyPath/issues/216",
       "dashboardStatus": "feature",
-      "dashboardType": "feature"
+      "dashboardType": "feature",
+      "descriptionExcerpt": "Summary Karabiner-Elements supports mousemotiontoscroll manipulator type that converts mouse movement into scroll wheel events (e.g., hold a modifier and move mouse to scroll). Kanata has no equivalent. Karabiner Features - Converts mouse X/Y movement into\u2026"
     },
     {
       "labels": [
@@ -769,7 +823,8 @@
       "updatedAt": "2026-06-06T17:10:18Z",
       "url": "https://github.com/malpern/KeyPath/issues/215",
       "dashboardStatus": "feature",
-      "dashboardType": "feature"
+      "dashboardType": "feature",
+      "descriptionExcerpt": "Summary Karabiner-Elements supports mousebasic manipulator type for flipping, swapping, and discarding mouse axes (e.g., invert scroll direction, swap X/Y axes). Kanata has no equivalent. Karabiner Features - flip: Invert mouse X, Y, verticalwheel\u2026"
     },
     {
       "labels": [
@@ -781,7 +836,8 @@
       "updatedAt": "2026-06-06T17:10:20Z",
       "url": "https://github.com/malpern/KeyPath/issues/214",
       "dashboardStatus": "feature",
-      "dashboardType": "feature"
+      "dashboardType": "feature",
+      "descriptionExcerpt": "Summary Karabiner-Elements supports selectinputsource as an output action, allowing users to switch keyboard input methods (e.g., English \u2194 Japanese) as part of a key mapping rule. Kanata has no native equivalent. Current State - Kanata: No native input\u2026"
     },
     {
       "labels": [
@@ -793,7 +849,8 @@
       "updatedAt": "2026-06-06T17:10:22Z",
       "url": "https://github.com/malpern/KeyPath/issues/213",
       "dashboardStatus": "feature",
-      "dashboardType": "feature"
+      "dashboardType": "feature",
+      "descriptionExcerpt": "Summary Tracking issue for achieving 100% fidelity Karabiner \u2192 KeyPath conversion. This encompasses three categories of work: Category 1: KeyPath UI Gaps (Kanata supports, needs UI) These features can be converted to working Kanata .kbd config today, but\u2026"
     },
     {
       "labels": [
@@ -805,7 +862,8 @@
       "updatedAt": "2026-06-06T17:10:23Z",
       "url": "https://github.com/malpern/KeyPath/issues/212",
       "dashboardStatus": "feature",
-      "dashboardType": "feature"
+      "dashboardType": "feature",
+      "descriptionExcerpt": "Summary Add support for importing [GokuRakuJoudo](https://github.com/yqrashawn/GokuRakuJoudo) (Goku) EDN configs in addition to raw Karabiner JSON. Why Goku is a popular DSL that generates Karabiner JSON from a more concise EDN (Clojure data notation) format\u2026"
     },
     {
       "labels": [
@@ -817,7 +875,8 @@
       "updatedAt": "2026-06-06T17:10:25Z",
       "url": "https://github.com/malpern/KeyPath/issues/211",
       "dashboardStatus": "feature",
-      "dashboardType": "feature"
+      "dashboardType": "feature",
+      "descriptionExcerpt": "Summary After the MVP Karabiner converter ships (Tier 1: deterministic conversion of simple remaps, tap-hold, chords, macros, app rules, launchers), explore using AI to improve conversion fidelity for complex rules that resist mechanical translation. Tier 2+\u2026"
     },
     {
       "labels": [
@@ -831,7 +890,8 @@
       "updatedAt": "2026-06-06T17:10:31Z",
       "url": "https://github.com/malpern/KeyPath/issues/197",
       "dashboardStatus": "feature",
-      "dashboardType": "feature"
+      "dashboardType": "feature",
+      "descriptionExcerpt": "Summary Add support for alternative sequence-input-mode options beyond the default visible-backspaced. Kanata Modes visible-backspaced ;; (current) type keys visibly, backspace on match hidden-suppressed ;; suppress keys until match/timeout hidden-delay-type\u2026"
     },
     {
       "labels": [
@@ -845,7 +905,8 @@
       "updatedAt": "2026-06-06T17:10:32Z",
       "url": "https://github.com/malpern/KeyPath/issues/196",
       "dashboardStatus": "feature",
-      "dashboardType": "feature"
+      "dashboardType": "feature",
+      "descriptionExcerpt": "Summary Add support for unmod and unshift, which temporarily release modifiers while outputting a key. Kanata Syntax (unmod $key) ;; release all mods (unmod ($mods) $key) ;; release specific mods (unshift $key) ;; release only shift User Value Niche but\u2026"
     },
     {
       "labels": [
@@ -859,7 +920,8 @@
       "updatedAt": "2026-06-06T17:10:34Z",
       "url": "https://github.com/malpern/KeyPath/issues/195",
       "dashboardStatus": "feature",
-      "dashboardType": "feature"
+      "dashboardType": "feature",
+      "descriptionExcerpt": "Summary Add support for movemouse-speed to dynamically adjust mouse movement speed as a percentage. Depends on mouse keys support. Kanata Syntax (movemouse-speed $percentage) User Value Fine/coarse mouse control toggle. Hold a key to slow down mouse for\u2026"
     },
     {
       "labels": [
@@ -873,7 +935,8 @@
       "updatedAt": "2026-06-06T17:10:35Z",
       "url": "https://github.com/malpern/KeyPath/issues/194",
       "dashboardStatus": "feature",
-      "dashboardType": "feature"
+      "dashboardType": "feature",
+      "descriptionExcerpt": "Summary Add support for arbitrary-code to send raw OS-level keycodes that Kanata doesn't have named keys for. Kanata Syntax (arbitrary-code $number) User Value Escape hatch for obscure keys, vendor-specific keycodes, or keys not yet named in Kanata. Niche but\u2026"
     },
     {
       "labels": [
@@ -887,7 +950,8 @@
       "updatedAt": "2026-06-06T17:10:37Z",
       "url": "https://github.com/malpern/KeyPath/issues/193",
       "dashboardStatus": "feature",
-      "dashboardType": "feature"
+      "dashboardType": "feature",
+      "descriptionExcerpt": "Summary Add support for Kanata's environment and defaliasenvcond blocks, enabling different config based on environment variables. Kanata Syntax (environment (LOCATION work) (defalias ...work-specific aliases...) ) (environment (LOCATION home) (defalias\u2026"
     },
     {
       "labels": [
@@ -901,7 +965,8 @@
       "updatedAt": "2026-06-06T17:10:38Z",
       "url": "https://github.com/malpern/KeyPath/issues/192",
       "dashboardStatus": "feature",
-      "dashboardType": "feature"
+      "dashboardType": "feature",
+      "descriptionExcerpt": "Summary KeyPath uses include internally for app-specific configs but doesn't let users compose configs from multiple external .kbd files. Kanata Syntax (include path/to/file.kbd) User Value Advanced users can maintain hand-written Kanata config snippets and\u2026"
     },
     {
       "labels": [
@@ -915,7 +980,8 @@
       "updatedAt": "2026-06-06T17:10:40Z",
       "url": "https://github.com/malpern/KeyPath/issues/191",
       "dashboardStatus": "feature",
-      "dashboardType": "feature"
+      "dashboardType": "feature",
+      "descriptionExcerpt": "Summary Add support for hold-for-duration, which activates an action only after holding a key for a specific duration. Unlike tap-hold, there is no tap action. Kanata Syntax (hold-for-duration $ms $action) User Value Useful for \"safety\" keys that require\u2026"
     },
     {
       "labels": [
@@ -929,7 +995,8 @@
       "updatedAt": "2026-06-06T17:10:42Z",
       "url": "https://github.com/malpern/KeyPath/issues/190",
       "dashboardStatus": "feature",
-      "dashboardType": "feature"
+      "dashboardType": "feature",
+      "descriptionExcerpt": "Summary Add support for Kanata's rpt and rpt-any actions, which repeat the last key pressed or last action performed. Kanata Syntax rpt ;; repeat last key rpt-any ;; repeat last action (including chords/combos) User Value Simple but handy for Vim-style\u2026"
     },
     {
       "labels": [
@@ -943,7 +1010,8 @@
       "updatedAt": "2026-06-06T17:10:43Z",
       "url": "https://github.com/malpern/KeyPath/issues/189",
       "dashboardStatus": "feature",
-      "dashboardType": "feature"
+      "dashboardType": "feature",
+      "descriptionExcerpt": "Summary Add support for Kanata's clipboard management actions, enabling a multi-slot clipboard ring from keyboard shortcuts. Kanata Syntax (clipboard-set $text) (clipboard-save $id) (clipboard-restore $id) (clipboard-save-swap $id1 $id2) User Value\u2026"
     },
     {
       "labels": [
@@ -957,7 +1025,8 @@
       "updatedAt": "2026-06-06T17:10:45Z",
       "url": "https://github.com/malpern/KeyPath/issues/188",
       "dashboardStatus": "feature",
-      "dashboardType": "feature"
+      "dashboardType": "feature",
+      "descriptionExcerpt": "Summary Add support for Kanata's defzippy feature, which enables chord-triggered text expansion from an external dictionary file. Kanata Syntax (defzippy $filepath) External file format: chordkeys outputtext User Value Built-in text expansion (like\u2026"
     },
     {
       "labels": [
@@ -971,7 +1040,8 @@
       "updatedAt": "2026-06-06T17:10:46Z",
       "url": "https://github.com/malpern/KeyPath/issues/187",
       "dashboardStatus": "feature",
-      "dashboardType": "feature"
+      "dashboardType": "feature",
+      "descriptionExcerpt": "Summary Add support for cycling through multiple Kanata config files at runtime using lrld-next, lrld-prev, and lrld-num. Kanata Syntax lrld-next ;; load next config lrld-prev ;; load previous config (lrld-num 2) ;; load config #2 User Value Users who\u2026"
     },
     {
       "labels": [
@@ -985,7 +1055,8 @@
       "updatedAt": "2026-06-06T17:10:48Z",
       "url": "https://github.com/malpern/KeyPath/issues/186",
       "dashboardStatus": "feature",
-      "dashboardType": "feature"
+      "dashboardType": "feature",
+      "descriptionExcerpt": "Summary Expose Kanata's cmd action in the UI, allowing users to run shell commands from key presses. KeyPath already uses push-msg for app launching but doesn't expose raw command execution. Kanata Syntax (cmd $program $arg1 $arg2 ...) (cmd-log $log-level\u2026"
     },
     {
       "labels": [
@@ -999,7 +1070,8 @@
       "updatedAt": "2026-06-06T17:10:49Z",
       "url": "https://github.com/malpern/KeyPath/issues/185",
       "dashboardStatus": "feature",
-      "dashboardType": "feature"
+      "dashboardType": "feature",
+      "descriptionExcerpt": "Summary KeyPath auto-generates fork for shift/ctrl variants but doesn't let users author arbitrary forks. Users should be able to create \"if modifier X is held, do A; otherwise do B\" rules. Kanata Syntax (fork $action-if-not-triggered $action-if-triggered\u2026"
     },
     {
       "labels": [
@@ -1013,7 +1085,8 @@
       "updatedAt": "2026-06-06T17:10:50Z",
       "url": "https://github.com/malpern/KeyPath/issues/184",
       "dashboardStatus": "feature",
-      "dashboardType": "feature"
+      "dashboardType": "feature",
+      "descriptionExcerpt": "Summary Add support for Kanata's switch action, which enables complex conditional logic based on key history, timing, active layers, and input state. Kanata Syntax (switch ((key-history a 1)) a break ((key-timing 1 lt 200)) b break ((layer vim)) c break () d\u2026"
     },
     {
       "labels": [
@@ -1027,7 +1100,8 @@
       "updatedAt": "2026-06-06T17:10:52Z",
       "url": "https://github.com/malpern/KeyPath/issues/183",
       "dashboardStatus": "feature",
-      "dashboardType": "feature"
+      "dashboardType": "feature",
+      "descriptionExcerpt": "Summary Add UI support for outputting arbitrary Unicode characters via Kanata's unicode action. Kanata Syntax (unicode \u2014) ;; em-dash (unicode \u00e9) ;; accented e (unicode U+1F600) ;; emoji by codepoint User Value Writers and international users can output\u2026"
     },
     {
       "labels": [
@@ -1041,7 +1115,8 @@
       "updatedAt": "2026-06-06T17:10:53Z",
       "url": "https://github.com/malpern/KeyPath/issues/182",
       "dashboardStatus": "feature",
-      "dashboardType": "feature"
+      "dashboardType": "feature",
+      "descriptionExcerpt": "Summary Add support for Kanata's dynamic macros, which let users record and replay keystroke sequences at runtime without editing config. Kanata Syntax (dynamic-macro-record $id) ;; Start recording (dynamic-macro-play $id) ;; Play back\u2026"
     },
     {
       "labels": [
@@ -1054,7 +1129,8 @@
       "updatedAt": "2026-06-06T17:10:55Z",
       "url": "https://github.com/malpern/KeyPath/issues/181",
       "dashboardStatus": "feature",
-      "dashboardType": "feature"
+      "dashboardType": "feature",
+      "descriptionExcerpt": "Summary Add UI support for Kanata's mouse control features: mouse movement, button clicks, and scroll wheel emulation from the keyboard. Kanata Syntax Movement (movemouse-up $interval $distance) (movemouse-accel-up $interval $accel-time $min $max) Clicks\u2026"
     },
     {
       "labels": [
@@ -1068,7 +1144,8 @@
       "updatedAt": "2026-06-06T17:10:56Z",
       "url": "https://github.com/malpern/KeyPath/issues/180",
       "dashboardStatus": "feature",
-      "dashboardType": "feature"
+      "dashboardType": "feature",
+      "descriptionExcerpt": "Summary Add UI support for Kanata's defoverrides, which intercepts specific key+modifier combinations at a low level and replaces them. Kanata Syntax (defoverrides (lsft bspc) (del) ;; Shift+Backspace = Delete (lctl a) (home) ;; Ctrl+A = Home ) User Value\u2026"
     },
     {
       "labels": [
@@ -1082,7 +1159,8 @@
       "updatedAt": "2026-06-06T17:10:58Z",
       "url": "https://github.com/malpern/KeyPath/issues/179",
       "dashboardStatus": "feature",
-      "dashboardType": "feature"
+      "dashboardType": "feature",
+      "descriptionExcerpt": "Summary KeyPath uses one-shot-press internally for layer activation but doesn't expose one-shot modifiers as a user-configurable behavior in the mapper UI. Kanata Syntax (one-shot $timeout $action) (one-shot-press $timeout $action) (one-shot-release $timeout\u2026"
     },
     {
       "labels": [
@@ -1096,7 +1174,8 @@
       "updatedAt": "2026-06-06T17:11:00Z",
       "url": "https://github.com/malpern/KeyPath/issues/178",
       "dashboardStatus": "feature",
-      "dashboardType": "feature"
+      "dashboardType": "feature",
+      "descriptionExcerpt": "Summary Add UI support for Kanata's caps-word feature, which auto-shifts letters until a word boundary (space, punctuation, timeout). Kanata Syntax (caps-word $timeout) (caps-word-toggle $timeout) (caps-word-custom $timeout ($shifted-keys)\u2026"
     },
     {
       "labels": [
@@ -1108,7 +1187,8 @@
       "updatedAt": "2026-06-06T17:11:23Z",
       "url": "https://github.com/malpern/KeyPath/issues/77",
       "dashboardStatus": "feature",
-      "dashboardType": "feature"
+      "dashboardType": "feature",
+      "descriptionExcerpt": "Centralized suppression plan (authoritative) This issue is the authoritative source for finishing suppression in the keyboard overlay. The doc docs/central-suppression.md should mirror this issue, not diverge. Goal When Kanata transforms input (remaps\u2026"
     },
     {
       "labels": [
@@ -1122,7 +1202,8 @@
       "updatedAt": "2026-06-06T17:12:05Z",
       "url": "https://github.com/malpern/KeyPath/issues/68",
       "dashboardStatus": "feature",
-      "dashboardType": "feature"
+      "dashboardType": "feature",
+      "descriptionExcerpt": "Summary The TCP protocol types and Swift handlers are ready for three overlay events, but the keyberon emission points are not yet implemented: | Event | Protocol | Swift | Keyberon Emission | | -- | -- | -- | -- | | OneShotActivated | \u2705 | \u2705 | \u274c Not\u2026"
     },
     {
       "labels": [
@@ -1134,7 +1215,8 @@
       "updatedAt": "2026-06-06T17:11:55Z",
       "url": "https://github.com/malpern/KeyPath/issues/641",
       "dashboardStatus": "deferred",
-      "dashboardType": "upstream"
+      "dashboardType": "upstream",
+      "descriptionExcerpt": "Retrospective + go/no-go for #638 (KeyPath should detect a stale running kanata). We built it, found it doesn't work in practice, and reverted it (#640). Capturing why, and a recommendation. The goal (#638) A kanata daemon can outlive a KeyPath\u2026"
     },
     {
       "labels": [
@@ -1146,7 +1228,8 @@
       "updatedAt": "2026-06-06T17:11:58Z",
       "url": "https://github.com/malpern/KeyPath/issues/602",
       "dashboardStatus": "deferred",
-      "dashboardType": "debt"
+      "dashboardType": "debt",
+      "descriptionExcerpt": "Summary Several rule collection views follow the same pattern \u2014 a grid/list of configurable items with inline editing, preset selection, and save/cancel actions. Each is implemented independently, resulting in ~2-3K lines of duplicated structure across 4-5\u2026"
     },
     {
       "labels": [
@@ -1158,7 +1241,8 @@
       "updatedAt": "2026-06-06T17:11:59Z",
       "url": "https://github.com/malpern/KeyPath/issues/388",
       "dashboardStatus": "deferred",
-      "dashboardType": "debt"
+      "dashboardType": "debt",
+      "descriptionExcerpt": "Context The Vallack system pack and Quick Launcher both have custom \"hero\" keyboard diagrams in the gallery, but they use completely different rendering paths from the live overlay. This creates visual drift \u2014 labels, icons, and styling diverge because each\u2026"
     },
     {
       "labels": [
@@ -1171,7 +1255,8 @@
       "updatedAt": "2026-06-06T17:12:01Z",
       "url": "https://github.com/malpern/KeyPath/issues/377",
       "dashboardStatus": "deferred",
-      "dashboardType": "other"
+      "dashboardType": "other",
+      "descriptionExcerpt": "Context KeyPath currently supports 8+ logical keymaps (QWERTY, Colemak, Colemak-DH, Dvorak, Workman, Graphite, AZERTY, QWERTZ) but the support is display-only \u2014 the overlay shows correct labels for the selected keymap, but the generated kanata config always\u2026"
     },
     {
       "labels": [
@@ -1185,7 +1270,8 @@
       "updatedAt": "2026-06-06T17:12:03Z",
       "url": "https://github.com/malpern/KeyPath/issues/254",
       "dashboardStatus": "deferred",
-      "dashboardType": "upstream"
+      "dashboardType": "upstream",
+      "descriptionExcerpt": "Context PreviewFixtures.connectedDevices provides fake device data for UI development of per-device key mappings. This was added because macOS multi-device support is blocked upstream \u2014 real multi-device enumeration isn't available yet. Upstream Blockers\u2026"
     },
     {
       "labels": [
@@ -1199,7 +1285,8 @@
       "updatedAt": "2026-06-06T17:10:29Z",
       "url": "https://github.com/malpern/KeyPath/issues/198",
       "dashboardStatus": "deferred",
-      "dashboardType": "debt"
+      "dashboardType": "debt",
+      "descriptionExcerpt": "Summary Make Kanata's layer-while-held emit native LayerChange TCP broadcasts on activation and deactivation. This single upstream change enables eliminating the entire fake key layer notification system, the OneShotLayerOverrideState reconciliation\u2026"
     },
     {
       "labels": [
@@ -1211,7 +1298,8 @@
       "updatedAt": "2026-06-06T17:11:12Z",
       "url": "https://github.com/malpern/KeyPath/issues/149",
       "dashboardStatus": "deferred",
-      "dashboardType": "debt"
+      "dashboardType": "debt",
+      "descriptionExcerpt": "KeyPathAppKit is a monolithic target (\\~121k Swift LOC). Directory structure exists but compile-time boundaries do not, so layering can drift. Baseline Findings (2026-02-06) Initial build benchmark for swift build --product KeyPath (debug): clean: 74s noop\u2026"
     },
     {
       "labels": [
@@ -1224,7 +1312,8 @@
       "updatedAt": "2026-06-06T17:12:06Z",
       "url": "https://github.com/malpern/KeyPath/issues/121",
       "dashboardStatus": "deferred",
-      "dashboardType": "upstream"
+      "dashboardType": "upstream",
+      "descriptionExcerpt": "Follow-up to the current client-only TCP handshake fix in KeyPath (Hello parsing now uses the initial response and only reads more lines if needed). Problem: Hello() can fail when broadcast lines (e.g., KeyInput) interleave with the HelloOk response, causing\u2026"
     },
     {
       "labels": [
@@ -1236,7 +1325,8 @@
       "updatedAt": "2026-06-06T17:11:15Z",
       "url": "https://github.com/malpern/KeyPath/issues/114",
       "dashboardStatus": "deferred",
-      "dashboardType": "other"
+      "dashboardType": "other",
+      "descriptionExcerpt": "Problem Kanata supports virtual key press and release actions but KeyPath only models tap. Current State Virtual key tap only Missing Virtual key press Virtual key release Impact Users can't create hold-based virtual key actions. Fix 1. Model press/release\u2026"
     },
     {
       "labels": [
@@ -1248,7 +1338,8 @@
       "updatedAt": "2026-06-06T17:11:16Z",
       "url": "https://github.com/malpern/KeyPath/issues/113",
       "dashboardStatus": "deferred",
-      "dashboardType": "other"
+      "dashboardType": "other",
+      "descriptionExcerpt": "Problem Kanata supports 5 types of one-shot behavior but KeyPath only exposes 1 type. Current State Basic one-shot support only. Missing Variants one-shot-press one-shot-release one-shot-press-pcancel one-shot-release-pcancel Impact Power users can't\u2026"
     },
     {
       "labels": [
@@ -1260,7 +1351,8 @@
       "updatedAt": "2026-06-06T17:11:18Z",
       "url": "https://github.com/malpern/KeyPath/issues/110",
       "dashboardStatus": "deferred",
-      "dashboardType": "other"
+      "dashboardType": "other",
+      "descriptionExcerpt": "Problem Kanata supports advanced macro features but KeyPath only supports basic macros: Timed macros (delays between keys) Dynamic macros (record on-the-fly) Macro-repeat variants Current State Basic macro support only - simple key sequences without timing\u2026"
     },
     {
       "labels": [
@@ -1272,7 +1364,8 @@
       "updatedAt": "2026-06-06T17:11:19Z",
       "url": "https://github.com/malpern/KeyPath/issues/109",
       "dashboardStatus": "deferred",
-      "dashboardType": "other"
+      "dashboardType": "other",
+      "descriptionExcerpt": "Problem Kanata supports code generation (deftemplate) and pattern layers (deflayermap) but KeyPath doesn't expose these features. Missing Features deftemplate: Code generation for repetitive config deflayermap: Pattern-based layer syntax Dynamic conditionals\u2026"
     },
     {
       "labels": [
@@ -1284,7 +1377,8 @@
       "updatedAt": "2026-06-06T17:11:21Z",
       "url": "https://github.com/malpern/KeyPath/issues/107",
       "dashboardStatus": "deferred",
-      "dashboardType": "other"
+      "dashboardType": "other",
+      "descriptionExcerpt": "Problem Kanata TCP protocol sends ChordResolved and TapDanceResolved events but KeyPath doesn't handle them. This is tracked as MAL-10 for keyberon emission points. Currently Handled LayerChange ConfigFileReload Ready ConfigError MessagePush Not Handled\u2026"
     },
     {
       "labels": [
@@ -1296,7 +1390,8 @@
       "updatedAt": "2026-06-06T17:11:22Z",
       "url": "https://github.com/malpern/KeyPath/issues/105",
       "dashboardStatus": "deferred",
-      "dashboardType": "other"
+      "dashboardType": "other",
+      "descriptionExcerpt": "Problem Kanata supports sequences (defseq) for git shortcuts and Vim leader sequences, but KeyPath only parses them - users can't create/edit sequences via UI. Impact Can't create git shortcuts (e.g., \"gs\" \u2192 \"git status\") Can't create Vim leader sequences\u2026"
     },
     {
       "labels": [
@@ -1308,7 +1403,8 @@
       "updatedAt": "2026-06-06T17:11:57Z",
       "url": "https://github.com/malpern/KeyPath/issues/63",
       "dashboardStatus": "deferred",
-      "dashboardType": "upstream"
+      "dashboardType": "upstream",
+      "descriptionExcerpt": "Problem Kanata can only select devices at startup (macos-dev-names-, linux-dev-names-). Within a single process there\u2019s no way to target or exclude specific keyboards inside rules (layers, overrides, aliases, etc.). Users want Karabiner-style per-device\u2026"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- add a delayed, larger hover card to GitHub issue tiles
- show the issue title, labels, and a bounded plain-text description excerpt
- include issue-body excerpts in generated dashboard state with unit coverage

## Why
The compact map makes the queue easy to scan, but issue numbers alone do not provide enough context. A delayed detail card adds useful context without making the resting dashboard noisier.

## Validation
- `python3 Scripts/lab/tests/issue-dashboard-tests.py`
- `./Scripts/lab/tests/keypath-lab-tests.sh`
- `git diff --check`
- visual verification in the in-app browser
- review gate: remote review gate selected; GitHub `claude-review` required before merge