### PR TITLE
Harden installer lab blocker orchestration

### DIFF
--- a/Scripts/lab/permission-drag
+++ b/Scripts/lab/permission-drag
@@ -30,11 +30,32 @@ done
 mkdir -p "${output:h}"
 
 tmp=$(mktemp -d /tmp/keypath-permission-drag.XXXXXX)
-trap 'rm -rf "$tmp"' EXIT
+finder_geometry=
+settings_geometry=
+
+window_geometry() {
+  "$osascript" -l JavaScript -e 'function run(argv) { var p = Application("System Events").processes.byName(argv[0]); if (!p.exists() || p.windows().length === 0) throw new Error("window unavailable"); var w = p.windows[0]; return w.position().concat(w.size()).join(","); }' "$1"
+}
+
+restore_window() {
+  [[ -n "$2" ]] || return 0
+  "$osascript" -l JavaScript -e 'function run(argv) { var values = argv[1].split(",").map(Number); if (values.length !== 4 || values.some(function (value) { return !Number.isFinite(value); })) throw new Error("invalid geometry"); var p = Application("System Events").processes.byName(argv[0]); if (!p.exists() || p.windows().length === 0) return; var w = p.windows[0]; w.position = values.slice(0, 2); w.size = values.slice(2, 4); }' "$1" "$2" >/dev/null 2>&1 || true
+}
+
+cleanup() {
+  restore_window Finder "$finder_geometry"
+  restore_window "System Settings" "$settings_geometry"
+  rm -rf "$tmp"
+}
+trap cleanup EXIT
 name=${file_path:t}
 
 "$open_bin" -R "$file_path"
 sleep ${KEYPATH_PERMISSION_DRAG_REVEAL_SECONDS:-2}
+finder_geometry=$(window_geometry Finder) || die "could not capture Finder window geometry"
+settings_geometry=$(window_geometry "System Settings") || die "could not capture System Settings window geometry"
+[[ "$finder_geometry" =~ '^-?[0-9]+,-?[0-9]+,[0-9]+,[0-9]+$' ]] || die "Finder returned invalid window geometry"
+[[ "$settings_geometry" =~ '^-?[0-9]+,-?[0-9]+,[0-9]+,[0-9]+$' ]] || die "System Settings returned invalid window geometry"
 "$osascript" -e 'tell application "System Events" to tell process "Finder" to tell window 1 to set {position, size} to {{0, 40}, {500, 700}}' >/dev/null
 "$osascript" -e 'tell application "System Events" to tell process "System Settings" to tell window 1 to set {position, size} to {{500, 40}, {524, 700}}' >/dev/null
 sleep ${KEYPATH_PERMISSION_DRAG_SETTLE_SECONDS:-1}

--- a/Scripts/lab/remote.sh
+++ b/Scripts/lab/remote.sh
@@ -640,6 +640,7 @@ secure_dialog_input() {
       printf -v submit_command '%q ' "${submit_args[@]}"
       printf -v submit_label_quoted '%q' "$submit_button"
       guest_command+="; $refresh_command >/tmp/keypath-secure-submit.json || exit 44; if ! $submit_command >/dev/null; then $refresh_command >/tmp/keypath-secure-submit.json || exit 43; /usr/bin/python3 -c 'import json,sys; elements=json.load(open(sys.argv[1])).get(\"data\",{}).get(\"ui_elements\",[]); raise SystemExit(1 if any(e.get(\"label\")==sys.argv[2] for e in elements) else 0)' /tmp/keypath-secure-submit.json $submit_label_quoted || exit 43; fi"
+      guest_command+="; for attempt in {1..150}; do $refresh_command >/tmp/keypath-secure-postcondition.json || exit 44; /usr/bin/python3 -c 'import json,sys; elements=json.load(open(sys.argv[1])).get(\"data\",{}).get(\"ui_elements\",[]); labels={e.get(\"label\") for e in elements}; raise SystemExit(0 if sys.argv[2] not in labels and sys.argv[3] not in labels else 1)' /tmp/keypath-secure-postcondition.json $(printf %q "$field_label") $submit_label_quoted && break; sleep 0.1; done; /usr/bin/python3 -c 'import json,sys; elements=json.load(open(sys.argv[1])).get(\"data\",{}).get(\"ui_elements\",[]); labels={e.get(\"label\") for e in elements}; raise SystemExit(0 if sys.argv[2] not in labels and sys.argv[3] not in labels else 79)' /tmp/keypath-secure-postcondition.json $(printf %q "$field_label") $submit_label_quoted"
     fi
   fi
   if [[ "$field_label" == "AXSecureTextField" ]]; then
@@ -679,6 +680,9 @@ secure_dialog_input() {
   elif (( exit_code == 78 )); then
     record_command "$lease" "failed:$exit_code" secure-dialog-input --app "$app" --field "$field_label" ${submit_button:+--submit "$submit_button"}
     die "secure dialog input could not resolve valid SecurityAgent button geometry"
+  elif (( exit_code == 79 )); then
+    record_command "$lease" "failed:$exit_code" secure-dialog-input --app "$app" --field "$field_label" ${submit_button:+--submit "$submit_button"}
+    die "secure dialog input was submitted but the authentication sheet did not close"
   else
     record_command "$lease" "failed:$exit_code" secure-dialog-input --app "$app" --field "$field_label" ${submit_button:+--submit "$submit_button"}
     die "secure dialog input failed"

--- a/Scripts/lab/tests/keypath-lab-tests.sh
+++ b/Scripts/lab/tests/keypath-lab-tests.sh
@@ -332,6 +332,8 @@ grep -q 'text=@/dev/stdin' "$TMP/guest-ssh-args"
 grep -q 'dev/null' "$TMP/guest-ssh-args"
 grep -q 'peekaboo.*click.*Password.*--app.*System.*Settings' "$TMP/guest-ssh-args"
 grep -q 'peekaboo.*click.*Modify.*Settings.*--app.*System.*Settings' "$TMP/guest-ssh-args"
+grep -q 'keypath-secure-postcondition' "$TMP/guest-ssh-args"
+grep -q 'keypath-secure-postcondition.json.*79' "$TMP/guest-ssh-args"
 if grep -q -- '--query' "$TMP/guest-ssh-args"; then
     echo "secure dialog input passed the adapter-only --query option to Peekaboo" >&2
     exit 1

--- a/Scripts/lab/tests/peekaboo-ui-tests.sh
+++ b/Scripts/lab/tests/peekaboo-ui-tests.sh
@@ -81,10 +81,16 @@ export OPEN_CALLS="$TMP/open-calls"
 FAKE_OSASCRIPT="$TMP/osascript"
 cat > "$FAKE_OSASCRIPT" <<'EOF'
 #!/bin/bash
+printf '%s\n' "$*" >> "$OSASCRIPT_CALLS"
+if [[ "$*" == *'return w.position().concat(w.size()).join'* ]]; then
+  [[ "${*: -1}" == Finder ]] && echo '80,90,640,480' || echo '700,100,800,600'
+  exit 0
+fi
 [[ "$*" == *'AXSecureTextField'* ]] && echo secure
 exit 0
 EOF
 chmod +x "$FAKE_OSASCRIPT"
+export OSASCRIPT_CALLS="$TMP/osascript-calls"
 
 touch "$TMP/kanata-launcher"
 KEYPATH_PERMISSION_DRAG_REVEAL_SECONDS=0 KEYPATH_PERMISSION_DRAG_SETTLE_SECONDS=0 \
@@ -93,5 +99,7 @@ KEYPATH_PERMISSION_DRAG_REVEAL_SECONDS=0 KEYPATH_PERMISSION_DRAG_SETTLE_SECONDS=
 grep -q $'permission_drag\tauthorization-required' "$TMP/drag-result"
 grep -q -- '-R .*kanata-launcher' "$OPEN_CALLS"
 grep -q 'drag --from-coords 30,50 --to-coords 650,110 --duration 1500 --steps 30 --profile linear --json' "$PEEKABOO_CALLS"
+grep -q 'Finder 80,90,640,480' "$OSASCRIPT_CALLS"
+grep -q 'System Settings 700,100,800,600' "$OSASCRIPT_CALLS"
 
 echo 'peekaboo-ui shell tests passed'

--- a/Scripts/lab/tests/update-progress-dashboard-tests.py
+++ b/Scripts/lab/tests/update-progress-dashboard-tests.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+import json
+import pathlib
+import subprocess
+import tempfile
+import unittest
+
+
+UPDATER = pathlib.Path(__file__).resolve().parents[1] / "update-progress-dashboard"
+
+
+class UpdateProgressDashboardTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.state = pathlib.Path(self.temporary.name) / "state.json"
+        self.state.write_text('{"activeWork": {}, "workingBlocks": [], "statuses": {}, "updates": []}\n')
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def run_updater(self, *arguments: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [str(UPDATER), "--state", str(self.state), "--block", "P01", "--title", "Test", "--message", "Test", *arguments],
+            check=check,
+            capture_output=True,
+            text=True,
+        )
+
+    def test_records_and_preserves_blocker_metadata(self) -> None:
+        self.run_updater(
+            "--progress", "40",
+            "--next-task", "Prove input|active|25",
+            "--blocker", "Synthetic input is not trusted",
+            "--core-capability",
+            "--unlocks", "Scenario matrix",
+        )
+        work = json.loads(self.state.read_text())["activeWork"]["P01"]
+        self.assertEqual(work["nextTasks"], [{"label": "Prove input", "status": "active", "progress": 25}])
+        self.assertEqual(work["blocker"], "Synthetic input is not trusted")
+        self.assertTrue(work["coreCapability"])
+        self.assertEqual(work["unlocks"], ["Scenario matrix"])
+
+        self.run_updater("--progress", "50")
+        preserved = json.loads(self.state.read_text())["activeWork"]["P01"]
+        self.assertEqual(preserved["nextTasks"], work["nextTasks"])
+        self.assertEqual(preserved["blocker"], work["blocker"])
+        self.assertEqual(preserved["unlocks"], work["unlocks"])
+
+    def test_rejects_invalid_task_status(self) -> None:
+        result = self.run_updater("--next-task", "Bad task|unknown|10", check=False)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("STATUS queued, active, done, or blocked", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Scripts/lab/update-progress-dashboard
+++ b/Scripts/lab/update-progress-dashboard
@@ -26,6 +26,20 @@ def main() -> None:
         metavar="LABEL|STATUS|PROGRESS",
         help="Add a hover checklist item; STATUS is queued, active, done, or blocked",
     )
+    parser.add_argument("--blocker", help="Describe the current limiting condition shown in the block hover")
+    parser.add_argument(
+        "--core-capability",
+        action="store_true",
+        default=None,
+        help="Mark this work as reusable infrastructure for downstream blocks",
+    )
+    parser.add_argument(
+        "--unlocks",
+        action="append",
+        default=[],
+        metavar="CAPABILITY",
+        help="Name a downstream capability this work unlocks",
+    )
     parser.add_argument("--tone", choices=("working", "success", "retry", "problem", "waiting"), default="working")
     parser.add_argument("--title", required=True)
     parser.add_argument("--message", required=True)
@@ -69,6 +83,13 @@ def main() -> None:
             "completedSteps": args.completed_steps,
             "totalSteps": args.total_steps,
             "nextTasks": next_tasks or previous_work.get("nextTasks", []),
+            "blocker": args.blocker or previous_work.get("blocker"),
+            "coreCapability": (
+                args.core_capability
+                if args.core_capability is not None
+                else previous_work.get("coreCapability", False)
+            ),
+            "unlocks": args.unlocks or previous_work.get("unlocks", []),
         }
         state.setdefault("statuses", {})[args.block] = "active"
     state["workingBlocks"] = sorted(working)

--- a/docs/testing/installer-gui-automation-capabilities.md
+++ b/docs/testing/installer-gui-automation-capabilities.md
@@ -86,7 +86,9 @@ Scripts/lab/keypath-lab secure-dialog-input "$LEASE" \
 ```
 
 Peekaboo's MCP `type` result echoes typed text. The secure command suppresses
-that entire response. Never reproduce the MCP call through `keypath-lab run`,
+that entire response. With `--submit`, the command also waits for both the named
+field and submit control to disappear; the protected setting still needs its
+canonical postcondition. Never reproduce the MCP call through `keypath-lab run`,
 put a password in an argument, or collect its output.
 
 For an AX-resistant control, take a fresh semantic snapshot, read the native

--- a/docs/testing/keypath-test-automation-progress.html
+++ b/docs/testing/keypath-test-automation-progress.html
@@ -249,6 +249,12 @@ code:not(pre code) {
 .tooltip-title { font-size:13px; font-weight:600; letter-spacing:-.01em; }
 .tooltip-overall { color:var(--muted-foreground); font-size:11px; font-variant-numeric:tabular-nums; white-space:nowrap; }
 .tooltip-summary { margin-top:4px; color:var(--muted-foreground); line-height:1.45; }
+.tooltip-health { margin-top:6px; color:var(--muted-foreground); font-size:10px; }
+.tooltip-health strong { color:var(--foreground); font-weight:600; }
+.tooltip-foundation { margin-top:9px; padding-left:8px; border-left:2px solid var(--viz-series-2); }
+.tooltip-foundation-label { color:var(--foreground); font-size:10px; font-weight:600; }
+.tooltip-foundation-copy { margin-top:2px; color:var(--muted-foreground); line-height:1.4; }
+.tooltip-unlocks { margin-top:5px; color:var(--muted-foreground); font-size:10px; line-height:1.4; }
 .tooltip-next { margin-top:10px; padding-top:8px; border-top:1px solid var(--border); }
 .tooltip-next-title { margin-bottom:2px; color:var(--foreground); font-size:10px; font-weight:600; }
 .tooltip-task { display:grid; grid-template-columns:9px minmax(0,1fr) auto; gap:7px; align-items:start; padding:5px 0; }
@@ -773,6 +779,7 @@ html&gt;body{padding:0}&lt;/style&gt;
     #keypath-defrag-progress .sub { color:var(--muted-foreground); max-width:700px; }
     #keypath-defrag-progress .date { color:var(--muted-foreground); font-size:12px; white-space:nowrap; }
     #keypath-defrag-progress .legend { display:flex; flex-wrap:wrap; gap:14px; margin:0 0 14px; font-size:12px; color:var(--muted-foreground); }
+    #keypath-defrag-progress .encoding { margin:-8px 0 14px; color:var(--muted-foreground); font-size:10px; }
     #keypath-defrag-progress .legend span { display:flex; align-items:center; gap:6px; }
     #keypath-defrag-progress .swatch { width:11px; height:11px; border-radius:2px; }
     #keypath-defrag-progress .proven-mark { background:var(--viz-series-3); }
@@ -789,12 +796,12 @@ html&gt;body{padding:0}&lt;/style&gt;
     #keypath-defrag-progress .block[data-status=&quot;queued&quot;] { background:var(--muted); color:var(--muted-foreground); }
     #keypath-defrag-progress .block[data-status=&quot;waiting&quot;] { background:repeating-linear-gradient(135deg,color-mix(in srgb,var(--viz-series-5) 86%,var(--card)) 0 8px,color-mix(in srgb,var(--viz-series-5) 58%,var(--card)) 8px 13px); color:var(--card-foreground); }
     #keypath-defrag-progress .block:hover, #keypath-defrag-progress .block:focus-visible { filter:brightness(1.1); transform:translateY(-2px) scale(1.04); box-shadow:0 0 0 2px var(--ring); z-index:1; }
-    #keypath-defrag-progress .block::after { content:&quot;&quot;; position:absolute; left:0; bottom:0; width:var(--work-progress,0%); height:4px; background:var(--viz-series-3); transition:width 420ms ease, background 180ms ease; }
+    #keypath-defrag-progress .block::after { content:&quot;&quot;; position:absolute; left:0; bottom:0; width:var(--work-progress,0%); height:4px; background:var(--viz-series-2); transition:width 420ms ease, background 180ms ease; }
+    #keypath-defrag-progress .block[data-health=&quot;retrying&quot;]::before { content:&quot;↻&quot;; position:absolute; top:1px; right:4px; font-size:10px; font-weight:700; color:color-mix(in srgb,var(--viz-series-2) 70%,black); }
     #keypath-defrag-progress .block[data-working=&quot;true&quot;] { animation:keypath-pulse 1.35s ease-in-out infinite; }
     #keypath-defrag-progress .block[data-health=&quot;retrying&quot;] { animation:keypath-retry 1.1s ease-in-out infinite; }
-    #keypath-defrag-progress .block[data-health=&quot;retrying&quot;]::after { background:var(--viz-series-2); }
     #keypath-defrag-progress .block[data-health=&quot;blocked&quot;] { animation:none; box-shadow:inset 0 0 0 2px var(--destructive); }
-    #keypath-defrag-progress .block[data-health=&quot;blocked&quot;]::after, #keypath-defrag-progress .block[data-trend=&quot;backtrack&quot;]::after { background:var(--destructive); }
+    #keypath-defrag-progress .block[data-health=&quot;blocked&quot;]::after { background:var(--destructive); }
     @keyframes keypath-pulse { 0%,100% { filter:brightness(1); box-shadow:0 0 0 0 transparent; } 50% { filter:brightness(1.16); box-shadow:0 0 0 2px var(--viz-series-2); } }
     @keyframes keypath-retry { 0%,100% { transform:translateX(0); } 35% { transform:translateX(-1px); } 65% { transform:translateX(1px); } }
     #keypath-defrag-progress .readout { min-height:42px; margin-top:12px; padding-top:11px; border-top:1px solid var(--border); display:flex; justify-content:space-between; gap:18px; align-items:flex-start; }
@@ -868,6 +875,7 @@ html&gt;body{padding:0}&lt;/style&gt;
     &lt;span&gt;&lt;i class=&quot;swatch queued-mark&quot;&gt;&lt;/i&gt;Queued work&lt;/span&gt;
     &lt;span&gt;&lt;i class=&quot;swatch waiting-mark&quot;&gt;&lt;/i&gt;Waiting on Apple&lt;/span&gt;
   &lt;/div&gt;
+  &lt;div class=&quot;encoding&quot;&gt;Block fill = completion state · bottom line = progress only · ↻ = retrying · red outline = blocked&lt;/div&gt;
 
   &lt;section class=&quot;card livebar&quot; aria-live=&quot;polite&quot;&gt;
     &lt;div class=&quot;live-main&quot;&gt;&lt;span class=&quot;live-dot&quot; id=&quot;keypath-live-dot&quot;&gt;&lt;/span&gt;&lt;div class=&quot;live-copy&quot;&gt;&lt;strong id=&quot;keypath-live-task&quot;&gt;Connecting to live progress…&lt;/strong&gt;&lt;small id=&quot;keypath-live-message&quot;&gt;Waiting for the local progress feed.&lt;/small&gt;&lt;/div&gt;&lt;/div&gt;
@@ -972,8 +980,10 @@ html&gt;body{padding:0}&lt;/style&gt;
         if (state === &#x27;active&#x27;) return [{label:`Finish ${name}`,status:&#x27;active&#x27;,progress:0}];
         return [{label:`Start ${name}`,status:&#x27;queued&#x27;,progress:0}];
       };
-      const tooltipPayload = (id,button,state,progress,tasks,summary) =&gt; ({
+      const tooltipPayload = (id,button,state,progress,tasks,summary,work={}) =&gt; ({
         id,name:button.dataset.itemName,status:names[state] || state,progress,
+        complete:state === &#x27;proven&#x27;,health:work.health,blocker:work.blocker,
+        coreCapability:Boolean(work.coreCapability),unlocks:Array.isArray(work.unlocks) ? work.unlocks : [],
         summary:summary || button.dataset.description,tasks:tasks?.length ? tasks : defaultTasks(state,button.dataset.itemName)
       });
       const buttons = new Map();
@@ -988,7 +998,7 @@ html&gt;body{padding:0}&lt;/style&gt;
         button.dataset.baseTooltip = `${id} · ${name} — ${names[state]}. ${description}`;
         button.dataset.tooltip = button.dataset.baseTooltip;
         button.dataset.tooltipStructured = JSON.stringify(tooltipPayload(id,button,state,state === &#x27;proven&#x27; ? 100 : 0,defaultTasks(state,name),description));
-        button.dataset.tooltipPlacement = &#x27;top&#x27;;
+        button.dataset.tooltipPlacement = &#x27;right&#x27;;
         button.setAttribute(&#x27;aria-label&#x27;, button.dataset.baseLabel);
         const showDetail = () =&gt; {
           title.textContent = `${id} · ${name}`;
@@ -1049,7 +1059,7 @@ html&gt;body{padding:0}&lt;/style&gt;
           const checkpoints = work.totalSteps ? `${work.completedSteps || 0} of ${work.totalSteps} checkpoints` : &#x27;&#x27;;
           button.dataset.tooltip = `${id} · ${button.dataset.itemName}. ${activity} — ${progress}% complete. Current step: ${phase}. Health: ${health}. ${checkpoints}${checkpoints ? &#x27;.&#x27; : &#x27;&#x27;} ${work.detail || button.dataset.description}`.trim();
           const tasks = Array.isArray(work.nextTasks) &amp;&amp; work.nextTasks.length ? work.nextTasks : [{label:phase,status:isWorking ? &#x27;active&#x27; : &#x27;queued&#x27;,progress}];
-          button.dataset.tooltipStructured = JSON.stringify(tooltipPayload(id,button,button.dataset.status,progress,tasks,work.detail || button.dataset.description));
+          button.dataset.tooltipStructured = JSON.stringify(tooltipPayload(id,button,button.dataset.status,progress,tasks,work.detail || button.dataset.description,work));
         });
         if (activeEntries.length) {
           const [id,work] = activeEntries[0];
@@ -1138,12 +1148,26 @@ html&gt;body{padding:0}&lt;/style&gt;
   const renderStructuredContent = (floating,content) =&gt; {
     floating.replaceChildren();
     const card = document.createElement(&quot;div&quot;); card.className = &quot;tooltip-card&quot;;
-    const kicker = document.createElement(&quot;div&quot;); kicker.className = &quot;tooltip-kicker&quot;; kicker.textContent = `${content.id} · ${content.status}`;
+    const kicker = document.createElement(&quot;div&quot;); kicker.className = &quot;tooltip-kicker&quot;; kicker.textContent = `${content.id} · ${content.status} · ${content.complete ? &quot;Complete&quot; : &quot;Not complete&quot;}`;
     const titleRow = document.createElement(&quot;div&quot;); titleRow.className = &quot;tooltip-title-row&quot;;
     const title = document.createElement(&quot;div&quot;); title.className = &quot;tooltip-title&quot;; title.textContent = content.name;
     const overall = document.createElement(&quot;div&quot;); overall.className = &quot;tooltip-overall&quot;; overall.textContent = `${Math.max(0,Math.min(100,Number(content.progress) || 0))}% overall`;
     titleRow.append(title,overall);
     const summary = document.createElement(&quot;div&quot;); summary.className = &quot;tooltip-summary&quot;; summary.textContent = content.summary;
+    const healthLabels = {smooth:&quot;Going smoothly&quot;,retrying:&quot;Retrying another approach&quot;,blocked:&quot;Blocked&quot;};
+    const health = document.createElement(&quot;div&quot;); health.className = &quot;tooltip-health&quot;;
+    const healthLabel = document.createElement(&quot;strong&quot;); healthLabel.textContent = &quot;Health: &quot;;
+    health.append(healthLabel,document.createTextNode(healthLabels[content.health] || (content.complete ? &quot;Proven&quot; : &quot;Not started&quot;)));
+    let foundation = null;
+    if (content.blocker || content.coreCapability) {
+      foundation = document.createElement(&quot;div&quot;); foundation.className = &quot;tooltip-foundation&quot;;
+      const foundationLabel = document.createElement(&quot;div&quot;); foundationLabel.className = &quot;tooltip-foundation-label&quot;; foundationLabel.textContent = content.coreCapability ? &quot;Core capability blocker&quot; : &quot;Current blocker&quot;;
+      const foundationCopy = document.createElement(&quot;div&quot;); foundationCopy.className = &quot;tooltip-foundation-copy&quot;; foundationCopy.textContent = content.blocker || &quot;Reusable infrastructure required by downstream work.&quot;;
+      foundation.append(foundationLabel,foundationCopy);
+      if (content.unlocks?.length) {
+        const unlocks = document.createElement(&quot;div&quot;); unlocks.className = &quot;tooltip-unlocks&quot;; unlocks.textContent = `Unlocks: ${content.unlocks.join(&quot; · &quot;)}`; foundation.append(unlocks);
+      }
+    }
     const next = document.createElement(&quot;div&quot;); next.className = &quot;tooltip-next&quot;;
     const nextTitle = document.createElement(&quot;div&quot;); nextTitle.className = &quot;tooltip-next-title&quot;; nextTitle.textContent = &quot;What’s next&quot;; next.append(nextTitle);
     (content.tasks || []).forEach(task =&gt; {
@@ -1153,7 +1177,9 @@ html&gt;body{padding:0}&lt;/style&gt;
       const value = document.createElement(&quot;span&quot;); value.className = &quot;tooltip-task-value&quot;; value.textContent = `${Math.max(0,Math.min(100,Number(task.progress) || 0))}%`;
       row.append(dot,label,value); next.append(row);
     });
-    card.append(kicker,titleRow,summary,next); floating.append(card);
+    card.append(kicker,titleRow,summary,health);
+    if (foundation) card.append(foundation);
+    card.append(next); floating.append(card);
   };
   const getPlacement = (trigger) =&gt; {
     const placement = trigger.getAttribute(&quot;data-tooltip-placement&quot;);

--- a/docs/testing/keypath-test-automation-state.json
+++ b/docs/testing/keypath-test-automation-state.json
@@ -1,7 +1,7 @@
 {
-  "updatedAt": "2026-07-12T18:40:55-07:00",
-  "currentTask": "Hover checklists added",
-  "message": "Every block hover now includes What to do next with per-task status and progress. P01 shows the concrete harness-hardening sequence.",
+  "updatedAt": "2026-07-12T19:05:12-07:00",
+  "currentTask": "P01 harness guardrails pass",
+  "message": "Secure approval now has a real dismissal postcondition; permission targeting is reversible. Focused lab tests pass. Next: disposable-VM proof.",
   "complete": false,
   "workingBlocks": [
     "P01"
@@ -15,30 +15,54 @@
       "detail": "The DriverKit extension is activated and enabled, and the VirtualHID daemon passed health checks. Observable remapping waits on Kanata permissions.",
       "attempt": 1,
       "completedSteps": 6,
-      "totalSteps": 8
+      "totalSteps": 8,
+      "nextTasks": [
+        {
+          "label": "Receive trusted captured input from P01",
+          "status": "blocked",
+          "progress": 0
+        },
+        {
+          "label": "Observe the remapped VirtualHID output",
+          "status": "queued",
+          "progress": 0
+        },
+        {
+          "label": "Package output observation as a reusable assertion",
+          "status": "queued",
+          "progress": 0
+        }
+      ],
+      "blocker": "VirtualHID is healthy, but output cannot be attributed to KeyPath until P01 supplies a trusted captured-input event.",
+      "coreCapability": true,
+      "unlocks": [
+        "End-to-end remap assertions",
+        "Repair and reboot validation",
+        "Scenario-matrix pass/fail evidence"
+      ]
     },
     "P01": {
       "progress": 95,
       "health": "retrying",
-      "trend": "backtrack",
-      "phase": "Harness hardening before another VM",
-      "detail": "Helper, DriverKit, and Accessibility are proven. The remaining work is now tracked as a per-task checklist.",
-      "attempt": 2,
+      "trend": "forward",
+      "phase": "Harness hardening validated; next proof is inside a disposable VM",
+      "detail": "Secure-dialog handling now requires the sheet controls to disappear, and permission drag restores Finder and System Settings geometry on every exit. Focused contract tests pass.",
+      "attempt": 3,
       "completedSteps": 5,
       "totalSteps": 6,
       "nextTasks": [
         {
-          "label": "Harden secure-dialog submission and postconditions",
+          "label": "Verify secure-dialog dismissal and protected state",
+          "status": "done",
+          "progress": 100
+        },
+        {
+          "label": "Make Input Monitoring targeting deterministic",
           "status": "active",
-          "progress": 35
+          "progress": 65
         },
         {
-          "label": "Fix Input Monitoring navigation and permission drag",
-          "status": "queued",
-          "progress": 10
-        },
-        {
-          "label": "Run focused harness tests and merge",
+          "label": "Prove a non-hardware input path reaches Kanata HID capture",
           "status": "queued",
           "progress": 0
         },
@@ -47,6 +71,13 @@
           "status": "queued",
           "progress": 0
         }
+      ],
+      "blocker": "Input Monitoring approval still needs a disposable-VM proof, and RFB key delivery may bypass the HID path Kanata observes.",
+      "coreCapability": true,
+      "unlocks": [
+        "Runtime and remap proof",
+        "Overlay and reboot verification",
+        "Install, repair, and upgrade matrix"
       ]
     }
   },
@@ -61,6 +92,27 @@
     "M12": "active"
   },
   "updates": [
+    {
+      "time": "19:05",
+      "block": "P01",
+      "tone": "success",
+      "title": "P01 harness guardrails pass",
+      "message": "Secure approval now has a real dismissal postcondition; permission targeting is reversible. Focused lab tests pass. Next: disposable-VM proof."
+    },
+    {
+      "time": "19:02",
+      "block": "P01",
+      "tone": "working",
+      "title": "Hardening permission orchestration",
+      "message": "Implementing sheet-dismissal verification and reversible System Settings geometry before the next VM proof."
+    },
+    {
+      "time": "18:58",
+      "block": "P01",
+      "tone": "working",
+      "title": "Clarified completion and blocker semantics",
+      "message": "Green block fill now means proven only. Progress lines are amber, retrying uses \u21bb, and P01/P02 hovers identify reusable blockers and downstream work they unlock."
+    },
     {
       "time": "18:40",
       "block": "P01",
@@ -249,27 +301,6 @@
       "tone": "retry",
       "title": "Output proof waiting on harness consent",
       "message": "P02 has not failed; it is waiting for P01 to clear Peekaboo\u2019s one-time consent and complete helper activation."
-    },
-    {
-      "time": "12:34",
-      "block": "P01",
-      "tone": "retry",
-      "title": "Harness consent intercepted installer flow",
-      "message": "P01 stepped back slightly: Peekaboo first-run consent\u2014not KeyPath\u2014covered the helper sheet. Clearing it through the current 2048\u00d71536 framebuffer."
-    },
-    {
-      "time": "12:32",
-      "block": "P02",
-      "tone": "success",
-      "title": "Output environment bootstrapped",
-      "message": "P02 remains active on cbx_8c08a8c1ed4b; no parallel Tart VM exists."
-    },
-    {
-      "time": "12:32",
-      "block": "P01",
-      "tone": "success",
-      "title": "Coherent desktop test environment ready",
-      "message": "P01 is at the real installer boundary on cbx_8c08a8c1ed4b; launching KeyPath and inspecting its planned actions."
     }
   ],
   "activity": [

--- a/docs/testing/remote-installer-lab.md
+++ b/docs/testing/remote-installer-lab.md
@@ -141,7 +141,9 @@ the current source and permission-list target geometry from fresh AX snapshots,
 and drag between the two arranged windows. It succeeds only when macOS presents
 an authorization sheet or the expected permission row appears. If authorization
 is requested, follow it with `secure-dialog-input` and verify the new
-`kanata-launcher_Title` row before continuing.
+`kanata-launcher_Title` row before continuing. The adapter records both windows'
+original geometry and restores it on every exit path, so a failed attempt does
+not leave later UI targeting in a modified coordinate space.
 
 Peekaboo click success means that it delivered an action to the selected UI
 element. It is not proof that macOS accepted a protected change. Background App
@@ -181,9 +183,10 @@ Scripts/lab/keypath-lab secure-dialog-input cbx_example \
 The controller must strip the encrypted dotenv record's terminating newline
 before sending the password. A newline passed to Peekaboo's type transport can
 become part of the secure-field value rather than a Return key. Always confirm
-success by checking that the sheet is gone and the protected state changed;
-`secure_dialog_input passed` proves only that the secret transport and click
-completed.
+success by checking that the protected state changed. When `--submit` is used,
+`secure_dialog_input passed` proves the secret transport completed and both the
+named password field and submit control disappeared; it still does not prove
+that macOS accepted the underlying protected-state change.
 
 Driver-extension authorization is owned by `SecurityAgent`, whose secure
 window is not available to Peekaboo snapshots. When a fresh framebuffer image


### PR DESCRIPTION
## Summary
- make dashboard completion, active progress, retries, and reusable blockers visually unambiguous
- require submitted authentication sheets to actually dismiss before reporting secure input success
- restore Finder and System Settings geometry after permission drag attempts
- document and test the new postconditions

## Validation
- `Scripts/lab/tests/keypath-lab-tests.sh`
- `Scripts/lab/tests/peekaboo-ui-tests.sh`
- `python3 Scripts/lab/tests/update-progress-dashboard-tests.py`
- `/bin/zsh -n Scripts/lab/remote.sh`
- `/bin/zsh -n Scripts/lab/permission-drag`
- `python3 -m py_compile Scripts/lab/update-progress-dashboard`
- `git diff --check`

## Review gate
Local gate selected remote review; do not merge until GitHub `claude-review` passes.