### PR TITLE
Persist issue type highlights

### DIFF
--- a/Scripts/lab/tests/issue-dashboard-tests.py
+++ b/Scripts/lab/tests/issue-dashboard-tests.py
@@ -64,6 +64,13 @@ class IssueDashboardTests(unittest.TestCase):
         self.assertTrue(excerpt.endswith("…"))
         self.assertNotIn("**", excerpt)
 
+    def test_type_highlight_can_be_persistently_toggled(self) -> None:
+        fragment = (REPO_ROOT / "docs/testing/keypath-github-issues-dashboard.fragment.html").read_text()
+        self.assertIn("selectedType === filter.dataset.type ? undefined", fragment)
+        self.assertIn("candidate.setAttribute('aria-pressed'", fragment)
+        self.assertIn("showType(selectedType)", fragment)
+        self.assertNotIn('.issue::before { content:"";', fragment)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/docs/testing/keypath-github-issues-dashboard.fragment.html
+++ b/docs/testing/keypath-github-issues-dashboard.fragment.html
@@ -19,8 +19,8 @@
     #keypath-issue-board .feature-mark { background:var(--muted); border:1px solid var(--border); }
     #keypath-issue-board .type-key { display:flex; flex-wrap:wrap; align-items:center; gap:14px; margin:-5px 0 14px; color:var(--muted-foreground); font:10px system-ui,sans-serif; }
     #keypath-issue-board .type-key .key-label { text-transform:uppercase; letter-spacing:.06em; }
-    #keypath-issue-board .type-filter { appearance:none; padding:2px 0; border:0; border-bottom:1px solid transparent; color:inherit; background:transparent; font:inherit; cursor:default; }
-    #keypath-issue-board .type-filter:hover,#keypath-issue-board .type-filter:focus-visible { color:var(--foreground); border-bottom-color:var(--foreground); }
+    #keypath-issue-board .type-filter { appearance:none; padding:2px 0; border:0; border-bottom:1px solid transparent; color:inherit; background:transparent; font:inherit; cursor:pointer; }
+    #keypath-issue-board .type-filter:hover,#keypath-issue-board .type-filter:focus-visible,#keypath-issue-board .type-filter[aria-pressed="true"] { color:var(--foreground); border-bottom-color:var(--foreground); }
     #keypath-issue-board .summary { display:grid; grid-template-columns:repeat(4,minmax(0,1fr)); gap:1px; margin-bottom:14px; overflow:hidden; background:var(--border); border:1px solid var(--border); border-radius:8px; }
     #keypath-issue-board .metric { padding:11px 13px; background:color-mix(in srgb,var(--card) 88%,var(--background)); }
     #keypath-issue-board .metric strong { display:block; font-size:20px; font-weight:500; }
@@ -29,7 +29,6 @@
     #keypath-issue-board .board { padding:14px; background:color-mix(in srgb,var(--card) 82%,var(--background)); border:1px solid var(--border); border-radius:8px; }
     #keypath-issue-board .track { display:grid; grid-template-columns:repeat(12,minmax(0,1fr)); gap:5px; }
     #keypath-issue-board .issue { appearance:none; position:relative; min-height:44px; padding:6px 2px; border:1px solid transparent; border-radius:6px; color:var(--foreground); font:500 10px ui-monospace,SFMono-Regular,Menlo,monospace; cursor:pointer; transition:transform 120ms ease,border-color 120ms ease; }
-    #keypath-issue-board .issue::before { content:""; position:absolute; top:5px; right:5px; width:5px; height:5px; border-radius:50%; background:currentColor; opacity:.65; }
     #keypath-issue-board .track[data-highlight-type] .issue { opacity:.25; }
     #keypath-issue-board .track[data-highlight-type="bug"] .issue[data-type="bug"],
     #keypath-issue-board .track[data-highlight-type="testing"] .issue[data-type="testing"],
@@ -95,12 +94,12 @@
   </div>
   <nav class="type-key" aria-label="Highlight issues by label">
     <span class="key-label">Type</span>
-    <button class="type-filter" type="button" data-type="bug">Bug</button>
-    <button class="type-filter" type="button" data-type="testing">Test</button>
-    <button class="type-filter" type="button" data-type="debt">Debt</button>
-    <button class="type-filter" type="button" data-type="feature">Feature</button>
-    <button class="type-filter" type="button" data-type="upstream">Upstream</button>
-    <button class="type-filter" type="button" data-type="docs">Docs</button>
+    <button class="type-filter" type="button" data-type="bug" aria-pressed="false">Bug</button>
+    <button class="type-filter" type="button" data-type="testing" aria-pressed="false">Test</button>
+    <button class="type-filter" type="button" data-type="debt" aria-pressed="false">Debt</button>
+    <button class="type-filter" type="button" data-type="feature" aria-pressed="false">Feature</button>
+    <button class="type-filter" type="button" data-type="upstream" aria-pressed="false">Upstream</button>
+    <button class="type-filter" type="button" data-type="docs" aria-pressed="false">Docs</button>
   </nav>
 
   <section class="summary" aria-label="Open issue summary">
@@ -160,6 +159,7 @@
       let clickTimer;
       let selectedButton;
       let selectedIssue;
+      let selectedType;
       const resetReadout = () => {
         title.textContent = 'Select an issue';
         detail.textContent = 'The map is ordered active → next → agent queue → human-gated → features and deferred work.';
@@ -196,13 +196,20 @@
         hoverCard.style.visibility = '';
         hoverCard.setAttribute('aria-hidden','false');
       };
-      root.querySelectorAll('.type-filter').forEach(filter => {
+      const typeFilters = root.querySelectorAll('.type-filter');
+      typeFilters.forEach(filter => {
+        const showType = type => { type ? grid.dataset.highlightType = type : grid.removeAttribute('data-highlight-type'); };
         const highlight = () => { clearTimeout(highlightTimer); highlightTimer = setTimeout(() => { grid.dataset.highlightType = filter.dataset.type; }, 120); };
-        const clearHighlight = () => { clearTimeout(highlightTimer); grid.removeAttribute('data-highlight-type'); };
+        const restoreSelection = () => { clearTimeout(highlightTimer); showType(selectedType); };
         filter.addEventListener('mouseenter',highlight);
-        filter.addEventListener('mouseleave',clearHighlight);
+        filter.addEventListener('mouseleave',restoreSelection);
         filter.addEventListener('focus',() => { clearTimeout(highlightTimer); grid.dataset.highlightType = filter.dataset.type; });
-        filter.addEventListener('blur',clearHighlight);
+        filter.addEventListener('blur',restoreSelection);
+        filter.addEventListener('click',() => {
+          selectedType = selectedType === filter.dataset.type ? undefined : filter.dataset.type;
+          typeFilters.forEach(candidate => candidate.setAttribute('aria-pressed',String(candidate.dataset.type === selectedType)));
+          showType(selectedType);
+        });
       });
       const render = state => {
         root.querySelector('#issues-updated').textContent = state.truncated ? `Updated ${new Date(state.updatedAt).toLocaleTimeString()} · first ${state.issueLimit} shown` : `Updated ${new Date(state.updatedAt).toLocaleTimeString()}`;

--- a/docs/testing/keypath-github-issues-dashboard.html
+++ b/docs/testing/keypath-github-issues-dashboard.html
@@ -769,8 +769,8 @@ html&gt;body{padding:0}&lt;/style&gt;
     #keypath-issue-board .feature-mark { background:var(--muted); border:1px solid var(--border); }
     #keypath-issue-board .type-key { display:flex; flex-wrap:wrap; align-items:center; gap:14px; margin:-5px 0 14px; color:var(--muted-foreground); font:10px system-ui,sans-serif; }
     #keypath-issue-board .type-key .key-label { text-transform:uppercase; letter-spacing:.06em; }
-    #keypath-issue-board .type-filter { appearance:none; padding:2px 0; border:0; border-bottom:1px solid transparent; color:inherit; background:transparent; font:inherit; cursor:default; }
-    #keypath-issue-board .type-filter:hover,#keypath-issue-board .type-filter:focus-visible { color:var(--foreground); border-bottom-color:var(--foreground); }
+    #keypath-issue-board .type-filter { appearance:none; padding:2px 0; border:0; border-bottom:1px solid transparent; color:inherit; background:transparent; font:inherit; cursor:pointer; }
+    #keypath-issue-board .type-filter:hover,#keypath-issue-board .type-filter:focus-visible,#keypath-issue-board .type-filter[aria-pressed=&quot;true&quot;] { color:var(--foreground); border-bottom-color:var(--foreground); }
     #keypath-issue-board .summary { display:grid; grid-template-columns:repeat(4,minmax(0,1fr)); gap:1px; margin-bottom:14px; overflow:hidden; background:var(--border); border:1px solid var(--border); border-radius:8px; }
     #keypath-issue-board .metric { padding:11px 13px; background:color-mix(in srgb,var(--card) 88%,var(--background)); }
     #keypath-issue-board .metric strong { display:block; font-size:20px; font-weight:500; }
@@ -779,7 +779,6 @@ html&gt;body{padding:0}&lt;/style&gt;
     #keypath-issue-board .board { padding:14px; background:color-mix(in srgb,var(--card) 82%,var(--background)); border:1px solid var(--border); border-radius:8px; }
     #keypath-issue-board .track { display:grid; grid-template-columns:repeat(12,minmax(0,1fr)); gap:5px; }
     #keypath-issue-board .issue { appearance:none; position:relative; min-height:44px; padding:6px 2px; border:1px solid transparent; border-radius:6px; color:var(--foreground); font:500 10px ui-monospace,SFMono-Regular,Menlo,monospace; cursor:pointer; transition:transform 120ms ease,border-color 120ms ease; }
-    #keypath-issue-board .issue::before { content:&quot;&quot;; position:absolute; top:5px; right:5px; width:5px; height:5px; border-radius:50%; background:currentColor; opacity:.65; }
     #keypath-issue-board .track[data-highlight-type] .issue { opacity:.25; }
     #keypath-issue-board .track[data-highlight-type=&quot;bug&quot;] .issue[data-type=&quot;bug&quot;],
     #keypath-issue-board .track[data-highlight-type=&quot;testing&quot;] .issue[data-type=&quot;testing&quot;],
@@ -845,12 +844,12 @@ html&gt;body{padding:0}&lt;/style&gt;
   &lt;/div&gt;
   &lt;nav class=&quot;type-key&quot; aria-label=&quot;Highlight issues by label&quot;&gt;
     &lt;span class=&quot;key-label&quot;&gt;Type&lt;/span&gt;
-    &lt;button class=&quot;type-filter&quot; type=&quot;button&quot; data-type=&quot;bug&quot;&gt;Bug&lt;/button&gt;
-    &lt;button class=&quot;type-filter&quot; type=&quot;button&quot; data-type=&quot;testing&quot;&gt;Test&lt;/button&gt;
-    &lt;button class=&quot;type-filter&quot; type=&quot;button&quot; data-type=&quot;debt&quot;&gt;Debt&lt;/button&gt;
-    &lt;button class=&quot;type-filter&quot; type=&quot;button&quot; data-type=&quot;feature&quot;&gt;Feature&lt;/button&gt;
-    &lt;button class=&quot;type-filter&quot; type=&quot;button&quot; data-type=&quot;upstream&quot;&gt;Upstream&lt;/button&gt;
-    &lt;button class=&quot;type-filter&quot; type=&quot;button&quot; data-type=&quot;docs&quot;&gt;Docs&lt;/button&gt;
+    &lt;button class=&quot;type-filter&quot; type=&quot;button&quot; data-type=&quot;bug&quot; aria-pressed=&quot;false&quot;&gt;Bug&lt;/button&gt;
+    &lt;button class=&quot;type-filter&quot; type=&quot;button&quot; data-type=&quot;testing&quot; aria-pressed=&quot;false&quot;&gt;Test&lt;/button&gt;
+    &lt;button class=&quot;type-filter&quot; type=&quot;button&quot; data-type=&quot;debt&quot; aria-pressed=&quot;false&quot;&gt;Debt&lt;/button&gt;
+    &lt;button class=&quot;type-filter&quot; type=&quot;button&quot; data-type=&quot;feature&quot; aria-pressed=&quot;false&quot;&gt;Feature&lt;/button&gt;
+    &lt;button class=&quot;type-filter&quot; type=&quot;button&quot; data-type=&quot;upstream&quot; aria-pressed=&quot;false&quot;&gt;Upstream&lt;/button&gt;
+    &lt;button class=&quot;type-filter&quot; type=&quot;button&quot; data-type=&quot;docs&quot; aria-pressed=&quot;false&quot;&gt;Docs&lt;/button&gt;
   &lt;/nav&gt;
 
   &lt;section class=&quot;summary&quot; aria-label=&quot;Open issue summary&quot;&gt;
@@ -910,6 +909,7 @@ html&gt;body{padding:0}&lt;/style&gt;
       let clickTimer;
       let selectedButton;
       let selectedIssue;
+      let selectedType;
       const resetReadout = () =&gt; {
         title.textContent = &#x27;Select an issue&#x27;;
         detail.textContent = &#x27;The map is ordered active → next → agent queue → human-gated → features and deferred work.&#x27;;
@@ -946,13 +946,20 @@ html&gt;body{padding:0}&lt;/style&gt;
         hoverCard.style.visibility = &#x27;&#x27;;
         hoverCard.setAttribute(&#x27;aria-hidden&#x27;,&#x27;false&#x27;);
       };
-      root.querySelectorAll(&#x27;.type-filter&#x27;).forEach(filter =&gt; {
+      const typeFilters = root.querySelectorAll(&#x27;.type-filter&#x27;);
+      typeFilters.forEach(filter =&gt; {
+        const showType = type =&gt; { type ? grid.dataset.highlightType = type : grid.removeAttribute(&#x27;data-highlight-type&#x27;); };
         const highlight = () =&gt; { clearTimeout(highlightTimer); highlightTimer = setTimeout(() =&gt; { grid.dataset.highlightType = filter.dataset.type; }, 120); };
-        const clearHighlight = () =&gt; { clearTimeout(highlightTimer); grid.removeAttribute(&#x27;data-highlight-type&#x27;); };
+        const restoreSelection = () =&gt; { clearTimeout(highlightTimer); showType(selectedType); };
         filter.addEventListener(&#x27;mouseenter&#x27;,highlight);
-        filter.addEventListener(&#x27;mouseleave&#x27;,clearHighlight);
+        filter.addEventListener(&#x27;mouseleave&#x27;,restoreSelection);
         filter.addEventListener(&#x27;focus&#x27;,() =&gt; { clearTimeout(highlightTimer); grid.dataset.highlightType = filter.dataset.type; });
-        filter.addEventListener(&#x27;blur&#x27;,clearHighlight);
+        filter.addEventListener(&#x27;blur&#x27;,restoreSelection);
+        filter.addEventListener(&#x27;click&#x27;,() =&gt; {
+          selectedType = selectedType === filter.dataset.type ? undefined : filter.dataset.type;
+          typeFilters.forEach(candidate =&gt; candidate.setAttribute(&#x27;aria-pressed&#x27;,String(candidate.dataset.type === selectedType)));
+          showType(selectedType);
+        });
       });
       const render = state =&gt; {
         root.querySelector(&#x27;#issues-updated&#x27;).textContent = state.truncated ? `Updated ${new Date(state.updatedAt).toLocaleTimeString()} · first ${state.issueLimit} shown` : `Updated ${new Date(state.updatedAt).toLocaleTimeString()}`;


### PR DESCRIPTION
## Summary
- let issue Type controls retain their highlight after a click
- clear the retained Type highlight when the selected control is clicked again
- preserve temporary hover and keyboard-focus previews
- remove the redundant dot from every issue card

## Why
Type highlighting was only transient, which made it difficult to inspect a category. The per-card dot repeated status information already conveyed by the card fill and added visual noise.

## Validation
- `python3 Scripts/lab/tests/issue-dashboard-tests.py`
- `./Scripts/lab/tests/keypath-lab-tests.sh`
- `git diff --check`
- visual and interaction verification in the in-app browser
- review gate: remote review gate selected; GitHub `claude-review` required before merge