### PR TITLE
Report helper and Kanata runtime freshness

### DIFF
--- a/Scripts/lab/tests/issue-dashboard-tests.py
+++ b/Scripts/lab/tests/issue-dashboard-tests.py
@@ -20,8 +20,11 @@ def issue(number: int, *labels: str) -> dict:
 
 class IssueDashboardTests(unittest.TestCase):
     def test_active_and_next_override_general_labels(self) -> None:
-        self.assertEqual(module.issue_status(issue(982, "bug-risk", "agent-ok")), "active")
-        self.assertEqual(module.issue_status(issue(748, "tech-debt")), "next")
+        self.assertEqual(module.issue_status(issue(748, "tech-debt")), "active")
+        self.assertEqual(module.issue_status(issue(848, "testing", "agent-ok")), "next")
+
+    def test_upstream_release_wait_is_human_gated(self) -> None:
+        self.assertEqual(module.issue_status(issue(982, "bug-risk", "human-in-loop")), "human")
 
     def test_explicitly_deferred_issues_are_human_gated(self) -> None:
         for number in (172, 740, 747, 919):

--- a/Scripts/lab/update-issue-dashboard
+++ b/Scripts/lab/update-issue-dashboard
@@ -10,8 +10,8 @@ import subprocess
 
 
 EXCLUDED = {172, 740, 747, 919}
-ACTIVE = {982}
-NEXT = {748}
+ACTIVE = {748}
+NEXT = {848}
 ISSUE_LIMIT = 200
 
 

--- a/Sources/KeyPathAppKit/CLI/SystemFacade.swift
+++ b/Sources/KeyPathAppKit/CLI/SystemFacade.swift
@@ -113,6 +113,8 @@ public struct SystemFacade: Sendable {
             helperInstalled: context.helper.isInstalled,
             helperWorking: context.helper.isWorking,
             helperVersion: context.helper.version,
+            helperExpectedVersion: KeyPathHelperContract.version,
+            helperFreshness: context.helper.freshness(expectedVersion: KeyPathHelperContract.version).rawValue,
             keyPathAccessibility: context.permissions.keyPath.accessibility.isReady,
             keyPathInputMonitoring: context.permissions.keyPath.inputMonitoring.isReady,
             kanataAccessibility: context.permissions.kanata.accessibility.isReady,
@@ -125,6 +127,8 @@ public struct SystemFacade: Sendable {
             vhidHealthy: context.services.vhidHealthy,
             activeRuntimePathTitle: context.services.activeRuntimePathTitle,
             activeRuntimePathDetail: context.services.activeRuntimePathDetail,
+            kanataServiceFreshness: context.services.kanataServiceFreshness.rawValue,
+            kanataExpectedIdentity: RuntimeIdentity.expectedKeyPathKanata().diagnosticDescription,
             hasConflicts: context.conflicts.hasConflicts,
             timestamp: context.timestamp
         )

--- a/Sources/KeyPathAppKit/Services/System/SystemValidator.swift
+++ b/Sources/KeyPathAppKit/Services/System/SystemValidator.swift
@@ -7,6 +7,16 @@ import KeyPathWizardCore
 import os.lock
 import ServiceManagement
 
+extension RuntimeIdentity {
+    static func expectedKeyPathKanata(buildVersion: String = BuildInfo.current().build) -> RuntimeIdentity {
+        RuntimeIdentity(
+            programIdentifier: KanataRuntimeHost.launcherBundleRelativePath,
+            parentBundleIdentifier: KeyPathConstants.Bundle.bundleID,
+            parentBundleVersion: buildVersion
+        )
+    }
+}
+
 /// Stateless system validation service
 ///
 /// This replaces StartupValidator + SystemStatusChecker with a single, simple validator.
@@ -811,6 +821,22 @@ public class SystemValidator {
         let (kanataSMStatus, helperSMStatus) = await (kanataSMAppServiceStatus, helperSMAppServiceStatus)
         let kanataSMAppServiceRegistered = kanataSMStatus == .enabled || kanataSMStatus == .requiresApproval
         let loginItemsApprovalRequired = kanataSMStatus == .requiresApproval || helperSMStatus == .requiresApproval
+        let expectedRuntimeIdentity = RuntimeIdentity.expectedKeyPathKanata()
+        let activeRuntimeIdentity = kanataHealth.activeProgramIdentity.map {
+            RuntimeIdentity(
+                programIdentifier: $0.programIdentifier,
+                parentBundleIdentifier: $0.parentBundleIdentifier,
+                parentBundleVersion: $0.parentBundleVersion
+            )
+        }
+        let kanataServiceFreshness = kanataRunning
+            ? RuntimeFreshness.classify(actual: activeRuntimeIdentity, expected: expectedRuntimeIdentity)
+            : .unknown
+        let activeRuntimePathTitle: String? = switch kanataServiceFreshness {
+        case .fresh: "Bundled runtime"
+        case .stale: "Stale runtime"
+        case .unknown: nil
+        }
 
         return HealthStatus(
             kanataLaunchdLoaded: !kanataHealth.staleEnabledRegistration &&
@@ -823,6 +849,9 @@ public class SystemValidator {
             vhidHealthy: vhidHealthy,
             kanataInputCaptureReady: kanataHealth.inputCaptureReady,
             kanataInputCaptureIssue: kanataHealth.inputCaptureIssue,
+            activeRuntimePathTitle: activeRuntimePathTitle,
+            activeRuntimePathDetail: activeRuntimeIdentity?.diagnosticDescription,
+            kanataServiceFreshness: kanataServiceFreshness,
             kanataPermissionRejected: stderrDiagnosis.permissionRejected,
             configParseError: configParseError,
             staleEnabledRegistration: kanataHealth.staleEnabledRegistration,

--- a/Sources/KeyPathCLI/Commands/Service/ServiceStatusCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Service/ServiceStatusCommand.swift
@@ -71,6 +71,7 @@ private func formatHumanReadable(_ status: CLIStatusResult, noColor: Bool) -> St
     if let version = status.helperVersion {
         lines.append("Version: \(version)")
     }
+    lines.append("Freshness: \(status.helperFreshness) (expected \(status.helperExpectedVersion))")
     lines.append("")
     lines.append("--- Permissions ---")
     lines.append("KeyPath:")
@@ -87,6 +88,11 @@ private func formatHumanReadable(_ status: CLIStatusResult, noColor: Bool) -> St
     lines.append("")
     lines.append("--- Services ---")
     lines.append("Kanata Running: \(check(status.kanataRunning))")
+    lines.append("Kanata Freshness: \(status.kanataServiceFreshness)")
+    if let activeRuntimeIdentity = status.activeRuntimePathDetail {
+        lines.append("Kanata Runtime: \(activeRuntimeIdentity)")
+    }
+    lines.append("Expected Runtime: \(status.kanataExpectedIdentity)")
     lines.append("Karabiner Daemon: \(check(status.karabinerDaemonRunning))")
     lines.append("VHID Healthy: \(check(status.vhidHealthy))")
 

--- a/Sources/KeyPathCLISupport/CLIReportModels.swift
+++ b/Sources/KeyPathCLISupport/CLIReportModels.swift
@@ -6,6 +6,8 @@ public struct CLIStatusResult: Codable, Sendable {
     public let helperInstalled: Bool
     public let helperWorking: Bool
     public let helperVersion: String?
+    public let helperExpectedVersion: String
+    public let helperFreshness: String
     public let keyPathAccessibility: Bool
     public let keyPathInputMonitoring: Bool
     public let kanataAccessibility: Bool
@@ -18,6 +20,8 @@ public struct CLIStatusResult: Codable, Sendable {
     public let vhidHealthy: Bool
     public let activeRuntimePathTitle: String?
     public let activeRuntimePathDetail: String?
+    public let kanataServiceFreshness: String
+    public let kanataExpectedIdentity: String
     public let hasConflicts: Bool
     public let timestamp: Date
 
@@ -26,6 +30,8 @@ public struct CLIStatusResult: Codable, Sendable {
         helperInstalled: Bool,
         helperWorking: Bool,
         helperVersion: String?,
+        helperExpectedVersion: String,
+        helperFreshness: String,
         keyPathAccessibility: Bool,
         keyPathInputMonitoring: Bool,
         kanataAccessibility: Bool,
@@ -38,6 +44,8 @@ public struct CLIStatusResult: Codable, Sendable {
         vhidHealthy: Bool,
         activeRuntimePathTitle: String?,
         activeRuntimePathDetail: String?,
+        kanataServiceFreshness: String,
+        kanataExpectedIdentity: String,
         hasConflicts: Bool,
         timestamp: Date
     ) {
@@ -45,6 +53,8 @@ public struct CLIStatusResult: Codable, Sendable {
         self.helperInstalled = helperInstalled
         self.helperWorking = helperWorking
         self.helperVersion = helperVersion
+        self.helperExpectedVersion = helperExpectedVersion
+        self.helperFreshness = helperFreshness
         self.keyPathAccessibility = keyPathAccessibility
         self.keyPathInputMonitoring = keyPathInputMonitoring
         self.kanataAccessibility = kanataAccessibility
@@ -57,6 +67,8 @@ public struct CLIStatusResult: Codable, Sendable {
         self.vhidHealthy = vhidHealthy
         self.activeRuntimePathTitle = activeRuntimePathTitle
         self.activeRuntimePathDetail = activeRuntimePathDetail
+        self.kanataServiceFreshness = kanataServiceFreshness
+        self.kanataExpectedIdentity = kanataExpectedIdentity
         self.hasConflicts = hasConflicts
         self.timestamp = timestamp
     }

--- a/Sources/KeyPathCore/KanataRuntimeHost.swift
+++ b/Sources/KeyPathCore/KanataRuntimeHost.swift
@@ -8,6 +8,8 @@ import Foundation
 /// those paths independently so the eventual in-process host migration only
 /// needs to change this model.
 public struct KanataRuntimeHost: Sendable, Equatable {
+    public static let launcherBundleRelativePath = "Contents/Library/KeyPath/kanata-launcher"
+
     public let launcherPath: String
     public let bridgeLibraryPath: String
     public let bundledCorePath: String
@@ -45,7 +47,7 @@ public struct KanataRuntimeHost: Sendable, Equatable {
         let resolvedBundlePath = resolveAppBundlePath(from: bundlePath)
         let engineBundlePath = "\(resolvedBundlePath)/Contents/Library/KeyPath/Kanata Engine.app"
         return KanataRuntimeHost(
-            launcherPath: "\(resolvedBundlePath)/Contents/Library/KeyPath/kanata-launcher",
+            launcherPath: "\(resolvedBundlePath)/\(launcherBundleRelativePath)",
             bridgeLibraryPath: "\(resolvedBundlePath)/Contents/Library/KeyPath/libkeypath_kanata_host_bridge.dylib",
             bundledCorePath: "\(engineBundlePath)/Contents/MacOS/kanata",
             kanataEngineBundlePath: engineBundlePath

--- a/Sources/KeyPathInstallationWizard/Core/ServiceHealthChecker.swift
+++ b/Sources/KeyPathInstallationWizard/Core/ServiceHealthChecker.swift
@@ -121,6 +121,35 @@ public final class ServiceHealthChecker: @unchecked Sendable {
         public let launchctlExitCode: Int32?
         public let staleEnabledRegistration: Bool
         public let recentlyRestarted: Bool
+        public let activeProgramIdentity: LaunchctlProgramIdentity?
+
+        public init(
+            managementState: WizardServiceManagementState,
+            isRunning: Bool,
+            isResponding: Bool,
+            inputCaptureReady: Bool,
+            inputCaptureIssue: String?,
+            launchctlExitCode: Int32?,
+            staleEnabledRegistration: Bool,
+            recentlyRestarted: Bool,
+            activeProgramIdentity: LaunchctlProgramIdentity? = nil
+        ) {
+            self.managementState = managementState
+            self.isRunning = isRunning
+            self.isResponding = isResponding
+            self.inputCaptureReady = inputCaptureReady
+            self.inputCaptureIssue = inputCaptureIssue
+            self.launchctlExitCode = launchctlExitCode
+            self.staleEnabledRegistration = staleEnabledRegistration
+            self.recentlyRestarted = recentlyRestarted
+            self.activeProgramIdentity = activeProgramIdentity
+        }
+    }
+
+    public struct LaunchctlProgramIdentity: Sendable, Equatable {
+        public let programIdentifier: String
+        public let parentBundleIdentifier: String
+        public let parentBundleVersion: String
     }
 
     public struct KanataInputCaptureStatus: Sendable, Equatable {
@@ -650,7 +679,8 @@ public final class ServiceHealthChecker: @unchecked Sendable {
             recentlyRestarted: Self.wasRecentlyRestarted(
                 Self.kanataServiceID,
                 within: Self.kanataRestartGraceWindow
-            )
+            ),
+            activeProgramIdentity: runningState.programIdentity
         )
     }
 
@@ -709,7 +739,7 @@ public final class ServiceHealthChecker: @unchecked Sendable {
         managementState _: WizardServiceManagementState,
         launchctlTargets: [String]
     ) async
-        -> (isRunning: Bool, exitCode: Int32?)
+        -> (isRunning: Bool, exitCode: Int32?, programIdentity: LaunchctlProgramIdentity?)
     {
         var lastExitCode: Int32?
         for target in launchctlTargets {
@@ -722,16 +752,40 @@ public final class ServiceHealthChecker: @unchecked Sendable {
                 continue
             }
 
+            let programIdentity = Self.launchctlProgramIdentity(from: evidence.stdout)
             for line in evidence.stdout.components(separatedBy: "\n") where line.contains("pid =") {
                 let components = line.components(separatedBy: "=")
                 if components.count == 2,
                    Int(components[1].trimmingCharacters(in: .whitespaces)) != nil
                 {
-                    return (true, evidence.exitCode)
+                    return (true, evidence.exitCode, programIdentity)
                 }
             }
         }
-        return (false, lastExitCode)
+        return (false, lastExitCode, nil)
+    }
+
+    public nonisolated static func launchctlProgramIdentity(from output: String) -> LaunchctlProgramIdentity? {
+        func value(for key: String) -> String? {
+            let prefix = "\(key) = "
+            return output.components(separatedBy: "\n")
+                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                .first { $0.hasPrefix(prefix) }
+                .map { String($0.dropFirst(prefix.count)) }
+        }
+
+        guard let rawProgramIdentifier = value(for: "program identifier"),
+              let parentBundleIdentifier = value(for: "parent bundle identifier"),
+              let parentBundleVersion = value(for: "parent bundle version")
+        else { return nil }
+
+        let programIdentifier = rawProgramIdentifier.components(separatedBy: " (mode:").first
+            ?? rawProgramIdentifier
+        return LaunchctlProgramIdentity(
+            programIdentifier: programIdentifier,
+            parentBundleIdentifier: parentBundleIdentifier,
+            parentBundleVersion: parentBundleVersion
+        )
     }
 
     /// Resolve the input-capture status, layering kanata's authoritative

--- a/Sources/KeyPathWizardCore/SystemSnapshot.swift
+++ b/Sources/KeyPathWizardCore/SystemSnapshot.swift
@@ -29,6 +29,46 @@ public struct SystemCompatibilityStatus: Sendable, Equatable {
     )
 }
 
+/// Whether live runtime identity evidence matches the currently installed app.
+/// Freshness is diagnostic only: a stale but working process remains operational.
+public enum RuntimeFreshness: String, Codable, Sendable, Equatable {
+    case fresh
+    case stale
+    case unknown
+
+    public static func classify(actual: String?, expected: String) -> RuntimeFreshness {
+        guard let actual, !actual.isEmpty, !expected.isEmpty else { return .unknown }
+        return actual == expected ? .fresh : .stale
+    }
+}
+
+public struct RuntimeIdentity: Sendable, Equatable {
+    public let programIdentifier: String
+    public let parentBundleIdentifier: String
+    public let parentBundleVersion: String
+
+    public init(
+        programIdentifier: String,
+        parentBundleIdentifier: String,
+        parentBundleVersion: String
+    ) {
+        self.programIdentifier = programIdentifier
+        self.parentBundleIdentifier = parentBundleIdentifier
+        self.parentBundleVersion = parentBundleVersion
+    }
+
+    public var diagnosticDescription: String {
+        "\(parentBundleIdentifier) build \(parentBundleVersion) · \(programIdentifier)"
+    }
+}
+
+public extension RuntimeFreshness {
+    static func classify(actual: RuntimeIdentity?, expected: RuntimeIdentity) -> RuntimeFreshness {
+        guard let actual else { return .unknown }
+        return actual == expected ? .fresh : .stale
+    }
+}
+
 /// Complete snapshot of system state at a point in time
 /// This is a pure data structure with no side effects - just state and computed properties
 public struct SystemSnapshot: Sendable {
@@ -365,6 +405,7 @@ public struct HealthStatus: Sendable {
     public let kanataInputCaptureIssue: String?
     public let activeRuntimePathTitle: String?
     public let activeRuntimePathDetail: String?
+    public let kanataServiceFreshness: RuntimeFreshness
     /// True when the daemon stderr log shows kanata was rejected by macOS
     /// at runtime despite the TCC database reporting permissions as granted
     /// (stale grant after a rebuild/move/upgrade).
@@ -398,6 +439,7 @@ public struct HealthStatus: Sendable {
         kanataInputCaptureIssue: String? = nil,
         activeRuntimePathTitle: String? = nil,
         activeRuntimePathDetail: String? = nil,
+        kanataServiceFreshness: RuntimeFreshness = .unknown,
         kanataPermissionRejected: Bool = false,
         configParseError: String? = nil,
         staleEnabledRegistration: Bool = false,
@@ -415,6 +457,7 @@ public struct HealthStatus: Sendable {
         self.kanataInputCaptureIssue = kanataInputCaptureIssue
         self.activeRuntimePathTitle = activeRuntimePathTitle
         self.activeRuntimePathDetail = activeRuntimePathDetail
+        self.kanataServiceFreshness = kanataServiceFreshness
         self.kanataPermissionRejected = kanataPermissionRejected
         self.configParseError = configParseError
         self.staleEnabledRegistration = staleEnabledRegistration
@@ -468,6 +511,11 @@ public struct HelperStatus: Sendable {
 
     public var displayVersion: String {
         version ?? "Unknown"
+    }
+
+    public func freshness(expectedVersion: String) -> RuntimeFreshness {
+        guard isInstalled, isWorking else { return .unknown }
+        return RuntimeFreshness.classify(actual: version, expected: expectedVersion)
     }
 
     /// Convenience factory for empty/fallback state

--- a/Tests/KeyPathCLISupportTests/CLIReportModelsTests.swift
+++ b/Tests/KeyPathCLISupportTests/CLIReportModelsTests.swift
@@ -19,6 +19,8 @@ final class CLIReportModelsTests: XCTestCase {
             helperInstalled: true,
             helperWorking: true,
             helperVersion: "1.0",
+            helperExpectedVersion: "1.1.0",
+            helperFreshness: "stale",
             keyPathAccessibility: true,
             keyPathInputMonitoring: true,
             kanataAccessibility: true,
@@ -31,16 +33,20 @@ final class CLIReportModelsTests: XCTestCase {
             vhidHealthy: true,
             activeRuntimePathTitle: "test",
             activeRuntimePathDetail: "detail",
+            kanataServiceFreshness: "stale",
+            kanataExpectedIdentity: "com.keypath.KeyPath build 4 · Contents/Library/KeyPath/kanata-launcher",
             hasConflicts: false,
             timestamp: Date()
         )
         let keys = try jsonKeys(status)
         let required: Set = [
             "isOperational", "helperInstalled", "helperWorking",
+            "helperExpectedVersion", "helperFreshness",
             "keyPathAccessibility", "keyPathInputMonitoring",
             "kanataAccessibility", "kanataInputMonitoring",
             "kanataBinaryInstalled", "karabinerDriverInstalled", "vhidDeviceHealthy",
             "kanataRunning", "karabinerDaemonRunning", "vhidHealthy",
+            "kanataServiceFreshness", "kanataExpectedIdentity",
             "hasConflicts", "timestamp",
         ]
         XCTAssertTrue(required.isSubset(of: keys), "Missing required keys: \(required.subtracting(keys))")

--- a/Tests/KeyPathTests/CLI/CLIOutputSnapshotTests.swift
+++ b/Tests/KeyPathTests/CLI/CLIOutputSnapshotTests.swift
@@ -229,6 +229,8 @@ final class CLIOutputSnapshotTests: XCTestCase {
             helperInstalled: true,
             helperWorking: true,
             helperVersion: "1.0",
+            helperExpectedVersion: "1.1.0",
+            helperFreshness: "stale",
             keyPathAccessibility: true,
             keyPathInputMonitoring: true,
             kanataAccessibility: true,
@@ -241,6 +243,8 @@ final class CLIOutputSnapshotTests: XCTestCase {
             vhidHealthy: true,
             activeRuntimePathTitle: "LaunchDaemon",
             activeRuntimePathDetail: "Running",
+            kanataServiceFreshness: "stale",
+            kanataExpectedIdentity: "com.keypath.KeyPath build 4 · Contents/Library/KeyPath/kanata-launcher",
             hasConflicts: false,
             timestamp: fixedDate
         )
@@ -248,11 +252,13 @@ final class CLIOutputSnapshotTests: XCTestCase {
         let dict = try JSONSerialization.jsonObject(with: Data(json.utf8)) as! [String: Any]
         let expectedKeys: Set = [
             "isOperational", "helperInstalled", "helperWorking", "helperVersion",
+            "helperExpectedVersion", "helperFreshness",
             "keyPathAccessibility", "keyPathInputMonitoring",
             "kanataAccessibility", "kanataInputMonitoring",
             "kanataBinaryInstalled", "karabinerDriverInstalled", "vhidDeviceHealthy",
             "kanataRunning", "karabinerDaemonRunning", "vhidHealthy",
             "activeRuntimePathTitle", "activeRuntimePathDetail",
+            "kanataServiceFreshness", "kanataExpectedIdentity",
             "hasConflicts", "timestamp",
         ]
         XCTAssertEqual(Set(dict.keys), expectedKeys, "Status result key set changed — this breaks agent contracts")

--- a/Tests/KeyPathTests/Services/RuntimeFreshnessTests.swift
+++ b/Tests/KeyPathTests/Services/RuntimeFreshnessTests.swift
@@ -1,0 +1,56 @@
+import KeyPathWizardCore
+import XCTest
+
+final class RuntimeFreshnessTests: XCTestCase {
+    func testRuntimeFreshnessClassifiesMatchingMismatchedAndMissingEvidence() {
+        XCTAssertEqual(RuntimeFreshness.classify(actual: "1.1.0", expected: "1.1.0"), .fresh)
+        XCTAssertEqual(RuntimeFreshness.classify(actual: "1.0.0", expected: "1.1.0"), .stale)
+        XCTAssertEqual(RuntimeFreshness.classify(actual: nil, expected: "1.1.0"), .unknown)
+    }
+
+    func testHelperFreshnessRequiresAWorkingInstalledHelper() {
+        XCTAssertEqual(
+            HelperStatus(isInstalled: true, version: "1.1.0", isWorking: true)
+                .freshness(expectedVersion: "1.1.0"),
+            .fresh
+        )
+        XCTAssertEqual(
+            HelperStatus(isInstalled: true, version: "1.0.0", isWorking: true)
+                .freshness(expectedVersion: "1.1.0"),
+            .stale
+        )
+        XCTAssertEqual(
+            HelperStatus(isInstalled: true, version: "1.1.0", isWorking: false)
+                .freshness(expectedVersion: "1.1.0"),
+            .unknown
+        )
+    }
+
+    func testKanataFreshnessIsDiagnosticAndUsesLiveServiceIdentity() {
+        let health = HealthStatus(
+            kanataRunning: true,
+            karabinerDaemonRunning: true,
+            vhidHealthy: true,
+            activeRuntimePathDetail: "com.keypath.KeyPath build 3 · Contents/Library/KeyPath/kanata-launcher",
+            kanataServiceFreshness: .stale
+        )
+
+        XCTAssertTrue(health.isHealthy)
+        XCTAssertEqual(health.kanataServiceFreshness, .stale)
+        XCTAssertEqual(
+            RuntimeFreshness.classify(
+                actual: RuntimeIdentity(
+                    programIdentifier: "Contents/Library/KeyPath/kanata-launcher",
+                    parentBundleIdentifier: "com.keypath.KeyPath",
+                    parentBundleVersion: "3"
+                ),
+                expected: RuntimeIdentity(
+                    programIdentifier: "Contents/Library/KeyPath/kanata-launcher",
+                    parentBundleIdentifier: "com.keypath.KeyPath",
+                    parentBundleVersion: "4"
+                )
+            ),
+            .stale
+        )
+    }
+}

--- a/Tests/KeyPathTests/Services/ServiceHealthCheckerTests.swift
+++ b/Tests/KeyPathTests/Services/ServiceHealthCheckerTests.swift
@@ -439,6 +439,27 @@ final class ServiceHealthCheckerTests: XCTestCase {
         XCTAssertTrue(decision.isHealthy)
     }
 
+    func testLaunchctlProgramIdentityExtractsSMAppServiceSource() {
+        let output = """
+        system/com.keypath.kanata = {
+            program identifier = Contents/Library/KeyPath/kanata-launcher (mode: 2)
+            parent bundle identifier = com.keypath.KeyPath
+            parent bundle version = 4
+            pid = 123
+        }
+        """
+
+        XCTAssertEqual(
+            ServiceHealthChecker.launchctlProgramIdentity(from: output),
+            ServiceHealthChecker.LaunchctlProgramIdentity(
+                programIdentifier: "Contents/Library/KeyPath/kanata-launcher",
+                parentBundleIdentifier: "com.keypath.KeyPath",
+                parentBundleVersion: "4"
+            )
+        )
+        XCTAssertNil(ServiceHealthChecker.launchctlProgramIdentity(from: "pid = 123"))
+    }
+
     func testDiagnoseDaemonStderrReturnsInputCaptureFailureForBuiltInKeyboard() async throws {
         let stderrURL = tempLaunchDaemonsDir.appendingPathComponent("kanata-stderr.log")
         try """

--- a/docs/bugs/2026-07-12-runtime-freshness-needs-identity-evidence.md
+++ b/docs/bugs/2026-07-12-runtime-freshness-needs-identity-evidence.md
@@ -1,0 +1,34 @@
+# Runtime health does not prove runtime freshness
+
+## Symptom
+
+KeyPath could report a responsive helper and a running, TCP-responsive Kanata
+service without saying whether those live processes matched the currently
+installed app. A healthy process left running across an app replacement was
+therefore ambiguous in diagnostics.
+
+## Root cause
+
+The helper already returned its shared compatibility version over XPC, but
+status exposed only the raw value. Kanata health read `launchctl print` output
+only for PID evidence and discarded the SMAppService identity fields:
+
+- `program identifier`
+- `parent bundle identifier`
+- `parent bundle version`
+
+SMAppService does not expose the absolute executable path in this output. Path
+fixtures are therefore not reliable freshness evidence for this service.
+
+## Durable rule
+
+Keep liveness and freshness separate. Runtime readiness continues to depend on
+process, TCP, and input-capture evidence. Freshness is a non-blocking diagnostic
+classification:
+
+- helper: compare the XPC-reported compatibility version with the shared helper
+  contract;
+- Kanata: compare the live SMAppService identity tuple with the current app's
+  expected program identifier, bundle identifier, and build version;
+- missing or incomplete identity evidence is `unknown`, never inferred from
+  registration or liveness alone.

--- a/docs/testing/keypath-github-issues-dashboard.fragment.html
+++ b/docs/testing/keypath-github-issues-dashboard.fragment.html
@@ -86,7 +86,7 @@
   </header>
 
   <div class="legend" aria-label="Issue status legend">
-    <span><i class="swatch active-mark"></i>Active upstream</span>
+    <span><i class="swatch active-mark"></i>Active</span>
     <span><i class="swatch next-mark"></i>Recommended next</span>
     <span><i class="swatch queued-mark"></i>Agent queue</span>
     <span><i class="swatch human-mark"></i>Human / external gate</span>
@@ -120,8 +120,8 @@
       </section>
 
       <section class="lanes" aria-label="Work sequence">
-        <div class="lane active"><strong>Active</strong><span>#982 upstream protocol migration</span></div>
-        <div class="lane next"><strong>Next if waiting</strong><span>#748 runtime freshness diagnostics</span></div>
+        <div class="lane active"><strong>Active</strong><span>#748 runtime freshness diagnostics</span></div>
+        <div class="lane next"><strong>Next</strong><span>#848 centralized Kanata test fixtures</span></div>
         <div class="lane"><strong>Bug-first queue</strong><span>Reliability and test debt before features</span></div>
         <div class="lane human"><strong>Explicitly deferred</strong><span>#172, #740, #747, #919 and human lanes</span></div>
       </section>
@@ -142,7 +142,7 @@
   <script>
     (() => {
       const root = document.getElementById('keypath-issue-board');
-      const names = {active:'Active upstream',next:'Recommended next',queued:'Agent queue',human:'Human / external gate',feature:'Feature deferred',deferred:'Deferred'};
+      const names = {active:'Active',next:'Recommended next',queued:'Agent queue',human:'Human / external gate',feature:'Feature deferred',deferred:'Deferred'};
       const typeNames = {bug:'Bug',testing:'Testing',debt:'Technical debt',feature:'Feature',upstream:'Upstream / research',docs:'Documentation / design',other:'Other'};
       const grid = root.querySelector('#issue-grid');
       const title = root.querySelector('#issue-title');

--- a/docs/testing/keypath-github-issues-dashboard.html
+++ b/docs/testing/keypath-github-issues-dashboard.html
@@ -836,7 +836,7 @@ html&gt;body{padding:0}&lt;/style&gt;
   &lt;/header&gt;
 
   &lt;div class=&quot;legend&quot; aria-label=&quot;Issue status legend&quot;&gt;
-    &lt;span&gt;&lt;i class=&quot;swatch active-mark&quot;&gt;&lt;/i&gt;Active upstream&lt;/span&gt;
+    &lt;span&gt;&lt;i class=&quot;swatch active-mark&quot;&gt;&lt;/i&gt;Active&lt;/span&gt;
     &lt;span&gt;&lt;i class=&quot;swatch next-mark&quot;&gt;&lt;/i&gt;Recommended next&lt;/span&gt;
     &lt;span&gt;&lt;i class=&quot;swatch queued-mark&quot;&gt;&lt;/i&gt;Agent queue&lt;/span&gt;
     &lt;span&gt;&lt;i class=&quot;swatch human-mark&quot;&gt;&lt;/i&gt;Human / external gate&lt;/span&gt;
@@ -870,8 +870,8 @@ html&gt;body{padding:0}&lt;/style&gt;
       &lt;/section&gt;
 
       &lt;section class=&quot;lanes&quot; aria-label=&quot;Work sequence&quot;&gt;
-        &lt;div class=&quot;lane active&quot;&gt;&lt;strong&gt;Active&lt;/strong&gt;&lt;span&gt;#982 upstream protocol migration&lt;/span&gt;&lt;/div&gt;
-        &lt;div class=&quot;lane next&quot;&gt;&lt;strong&gt;Next if waiting&lt;/strong&gt;&lt;span&gt;#748 runtime freshness diagnostics&lt;/span&gt;&lt;/div&gt;
+        &lt;div class=&quot;lane active&quot;&gt;&lt;strong&gt;Active&lt;/strong&gt;&lt;span&gt;#748 runtime freshness diagnostics&lt;/span&gt;&lt;/div&gt;
+        &lt;div class=&quot;lane next&quot;&gt;&lt;strong&gt;Next&lt;/strong&gt;&lt;span&gt;#848 centralized Kanata test fixtures&lt;/span&gt;&lt;/div&gt;
         &lt;div class=&quot;lane&quot;&gt;&lt;strong&gt;Bug-first queue&lt;/strong&gt;&lt;span&gt;Reliability and test debt before features&lt;/span&gt;&lt;/div&gt;
         &lt;div class=&quot;lane human&quot;&gt;&lt;strong&gt;Explicitly deferred&lt;/strong&gt;&lt;span&gt;#172, #740, #747, #919 and human lanes&lt;/span&gt;&lt;/div&gt;
       &lt;/section&gt;
@@ -892,7 +892,7 @@ html&gt;body{padding:0}&lt;/style&gt;
   &lt;script&gt;
     (() =&gt; {
       const root = document.getElementById(&#x27;keypath-issue-board&#x27;);
-      const names = {active:&#x27;Active upstream&#x27;,next:&#x27;Recommended next&#x27;,queued:&#x27;Agent queue&#x27;,human:&#x27;Human / external gate&#x27;,feature:&#x27;Feature deferred&#x27;,deferred:&#x27;Deferred&#x27;};
+      const names = {active:&#x27;Active&#x27;,next:&#x27;Recommended next&#x27;,queued:&#x27;Agent queue&#x27;,human:&#x27;Human / external gate&#x27;,feature:&#x27;Feature deferred&#x27;,deferred:&#x27;Deferred&#x27;};
       const typeNames = {bug:&#x27;Bug&#x27;,testing:&#x27;Testing&#x27;,debt:&#x27;Technical debt&#x27;,feature:&#x27;Feature&#x27;,upstream:&#x27;Upstream / research&#x27;,docs:&#x27;Documentation / design&#x27;,other:&#x27;Other&#x27;};
       const grid = root.querySelector(&#x27;#issue-grid&#x27;);
       const title = root.querySelector(&#x27;#issue-title&#x27;);

--- a/docs/testing/keypath-github-issues-state.json
+++ b/docs/testing/keypath-github-issues-state.json
@@ -1,35 +1,17 @@
 {
   "repository": "malpern/KeyPath",
-  "updatedAt": "2026-07-13T01:16:17.171211+00:00",
+  "updatedAt": "2026-07-13T02:42:51.277060+00:00",
   "issueLimit": 200,
   "truncated": false,
   "counts": {
     "active": 1,
     "next": 1,
-    "queued": 17,
-    "human": 22,
+    "queued": 16,
+    "human": 23,
     "feature": 40,
     "deferred": 15
   },
   "issues": [
-    {
-      "labels": [
-        "kanata",
-        "driver-kit",
-        "upstream",
-        "research",
-        "bug-risk",
-        "model:sonnet",
-        "agent-ok"
-      ],
-      "number": 982,
-      "title": "Upstream: migrate Kanata to the current VirtualHIDDevice protocol",
-      "updatedAt": "2026-07-12T14:38:58Z",
-      "url": "https://github.com/malpern/KeyPath/issues/982",
-      "dashboardStatus": "active",
-      "dashboardType": "bug",
-      "descriptionExcerpt": "Direction Treat this as an upstream-first Kanata compatibility project, independent of KeyPath integration. The immediate goal is to make the latest upstream Kanata compatible with the current Karabiner-DriverKit-VirtualHIDDevice protocol, validate the result\u2026"
-    },
     {
       "labels": [
         "tech-debt",
@@ -37,11 +19,26 @@
       ],
       "number": 748,
       "title": "Post-1.0: report helper and service freshness explicitly",
-      "updatedAt": "2026-06-06T19:09:37Z",
+      "updatedAt": "2026-07-13T02:36:57Z",
       "url": "https://github.com/malpern/KeyPath/issues/748",
-      "dashboardStatus": "next",
+      "dashboardStatus": "active",
       "dashboardType": "debt",
       "descriptionExcerpt": "Context Recent release-blocker work fixed stale SMAppService recovery for Kanata and the privileged helper. Runtime is healthy after the final signed/notarized build, but one observation remains ambiguous: launchd may keep an existing helper process alive\u2026"
+    },
+    {
+      "labels": [
+        "tech-debt",
+        "testing",
+        "model:sonnet",
+        "agent-ok"
+      ],
+      "number": 848,
+      "title": "Centralize Kanata test fixtures (~350 inline config strings duplicated across tests)",
+      "updatedAt": "2026-07-04T13:30:24Z",
+      "url": "https://github.com/malpern/KeyPath/issues/848",
+      "dashboardStatus": "next",
+      "dashboardType": "testing",
+      "descriptionExcerpt": "Problem Roughly 350 ad-hoc Kanata config string literals (defcfg, defsrc, deflayer, defvar) are inlined across Tests/KeyPathTests/. There is no shared fixture/builder library. Tests/TestSupport/ exists but contains only SystemContextBuilder.swift and\u2026"
     },
     {
       "labels": [
@@ -74,21 +71,6 @@
       "dashboardStatus": "queued",
       "dashboardType": "debt",
       "descriptionExcerpt": "Problem App.swift owns: window creation, wizard presentation, keyboard-layout detection, emergency-stop handling, headless auto-start, first-activation flow, fresh-install detection, menu bar setup, and SMAppService dev utilities. The first-activation block\u2026"
-    },
-    {
-      "labels": [
-        "tech-debt",
-        "testing",
-        "model:sonnet",
-        "agent-ok"
-      ],
-      "number": 848,
-      "title": "Centralize Kanata test fixtures (~350 inline config strings duplicated across tests)",
-      "updatedAt": "2026-07-04T13:30:24Z",
-      "url": "https://github.com/malpern/KeyPath/issues/848",
-      "dashboardStatus": "queued",
-      "dashboardType": "testing",
-      "descriptionExcerpt": "Problem Roughly 350 ad-hoc Kanata config string literals (defcfg, defsrc, deflayer, defvar) are inlined across Tests/KeyPathTests/. There is no shared fixture/builder library. Tests/TestSupport/ exists but contains only SystemContextBuilder.swift and\u2026"
     },
     {
       "labels": [
@@ -277,6 +259,24 @@
       "dashboardStatus": "queued",
       "dashboardType": "testing",
       "descriptionExcerpt": "Goal Validate the KeyPathInsights feature works correctly in a production-signed app build. Test checklist - [ ] Confirm KeyPathInsights plugin loads at app startup - [ ] Verify opt-in/consent flow appears and persists correctly - [ ] Generate sample activity\u2026"
+    },
+    {
+      "labels": [
+        "kanata",
+        "driver-kit",
+        "upstream",
+        "research",
+        "bug-risk",
+        "model:sonnet",
+        "human-in-loop"
+      ],
+      "number": 982,
+      "title": "Upstream: migrate Kanata to the current VirtualHIDDevice protocol",
+      "updatedAt": "2026-07-13T02:28:52Z",
+      "url": "https://github.com/malpern/KeyPath/issues/982",
+      "dashboardStatus": "human",
+      "dashboardType": "bug",
+      "descriptionExcerpt": "Direction Treat this as an upstream-first Kanata compatibility project, independent of KeyPath integration. The immediate goal is to make the latest upstream Kanata compatible with the current Karabiner-DriverKit-VirtualHIDDevice protocol, validate the result\u2026"
     },
     {
       "labels": [


### PR DESCRIPTION
## Summary
- classify the live helper as fresh, stale, or unknown from its XPC version contract
- retain the SMAppService program identity from `launchctl print` and compare its program, parent bundle, and build identity with the installed app
- expose actual/expected runtime identity and freshness through `keypath-cli service status` and JSON output
- keep stale-but-functional processes operational; freshness remains diagnostic only
- move #982 to the external gate and show #748 as active on the issue dashboard

## Root cause
Runtime inspection proved helper responsiveness and Kanata process/TCP readiness, but discarded the service identity fields and presented the helper version without classifying it. Liveness therefore could not answer whether the running instances matched the installed app.

## Validation
- `./Scripts/test-fast.sh --changed` — 4,748 tests passed
- focused runtime freshness, live launchctl-format parsing, CLI JSON contract, and runtime-host tests
- `python3 Scripts/lab/tests/issue-dashboard-tests.py`
- `python3 Scripts/check-accessibility.py`
- `git diff --check`
- live `launchctl print system/com.keypath.kanata` format verification
- review gate: remote review gate selected; GitHub `claude-review` required before merge

Closes #748