### PR TITLE
Prove P01 RFB input capture

### DIFF
--- a/Scripts/lab/keypath-lab
+++ b/Scripts/lab/keypath-lab
@@ -16,6 +16,7 @@ Commands:
   install-app LEASE_ID
   desktop-bootstrap LEASE_ID [--install-tools]
   protected-click LEASE_ID --app APP --window TITLE (--x X --y Y | --ax-x X --ax-y Y) [--after-window TITLE]
+  desktop-type LEASE_ID --text TEXT
   secure-dialog-input LEASE_ID --app APP --field LABEL [--submit BUTTON] [--already-focused]
   run LEASE_ID -- COMMAND [ARG...]
   status LEASE_ID
@@ -160,6 +161,14 @@ EOF
         [[ -n $app && -n $window && $x =~ ^[0-9]+$ && $y =~ ^[0-9]+$ ]] || usage
         [[ -n $after_window ]] || after_window=$window
         remote protected-click "$lease" "$app" "$window" "$after_window" "$coordinate_space" "$x" "$y"
+        ;;
+    desktop-type)
+        lease=${1:-}
+        [[ -n $lease ]] || usage
+        require_lease_id "$lease"
+        shift
+        [[ ${1:-} == "--text" && $# -eq 2 ]] || usage
+        remote desktop-type "$lease" "$2"
         ;;
     secure-dialog-input)
         lease=${1:-}

--- a/Scripts/lab/remote.sh
+++ b/Scripts/lab/remote.sh
@@ -758,6 +758,20 @@ protected_click() {
   fi
 }
 
+desktop_type() {
+  local lease=$1 text=$2 manifest macos resource
+  manifest=$(owned_manifest "$lease")
+  macos=$(field "$manifest" macos)
+  [[ "$macos" == "15" ]] || die "desktop type currently supports only the Tart macOS 15 lane"
+  [[ "$(field "$manifest" desktop_enabled)" == "true" ]] || die "desktop type requires a desktop-enabled lease"
+  resource=$(field "$manifest" provider_resource)
+  [[ "$resource" =~ '^[A-Za-z0-9._-]+$' && "$resource" != "unknown" ]] || die "invalid Tart resource id"
+  if [[ "${USER:-}" == "clawd" ]]; then export TART_HOME="$LAB_ROOT/TartHome-clawd"; else export TART_HOME="$LAB_ROOT/TartHome"; fi
+  export PATH="$LAB_ROOT/CompatTools/bin:$LAB_ROOT/SharedTools/bin:/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+  "$CRABBOX" desktop type --provider tart --target macos --id "$resource" --text "$text"
+  record_command "$lease" passed desktop-type --bytes "${#text}"
+}
+
 print_status() {
   local lease=$1 manifest macos launcher
   manifest=$(owned_manifest "$lease")
@@ -920,6 +934,7 @@ case "$action" in
   install-app) [[ $# -eq 1 ]] || die "install-app requires lease"; install_app "$1" ;;
   secure-dialog-input) [[ $# -eq 5 ]] || die "secure-dialog-input requires lease, app, field, optional submit value, and focus mode"; secure_dialog_input "$@" ;;
   protected-click) [[ $# -eq 7 ]] || die "protected-click requires lease, app, before window, after window, coordinate space, x, and y"; protected_click "$@" ;;
+  desktop-type) [[ $# -eq 2 ]] || die "desktop-type requires lease and text"; desktop_type "$@" ;;
   run) [[ $# -ge 2 ]] || die "run requires lease and command"; run_command "$@" ;;
   status) [[ $# -eq 1 ]] || die "status requires lease"; print_status "$1" ;;
   list) [[ $# -eq 0 ]] || die "list takes no arguments"; list_leases ;;

--- a/Scripts/lab/tests/keypath-lab-tests.sh
+++ b/Scripts/lab/tests/keypath-lab-tests.sh
@@ -382,6 +382,8 @@ assert_contains "$protected_wrong_page" "protected click postcondition failed"
 protected_ax_result=$(KEYPATH_LAB_PROTECTED_CLICK_SETTLE_SECONDS=0 run_remote protected-click cbx_desktop15 'System Settings' Accessibility Accessibility ax 402 247)
 assert_contains "$protected_ax_result" $'display_scale\t2'
 grep -q 'crabbox desktop click --provider tart --target macos --id test-resource --x 804 --y 494' "$CALLS"
+run_remote desktop-type cbx_desktop15 q >/dev/null
+grep -q 'crabbox desktop type --provider tart --target macos --id test-resource --text q' "$CALLS"
 run_remote destroy cbx_desktop15 >/dev/null
 
 set +e

--- a/Scripts/lab/tests/update-progress-dashboard-tests.py
+++ b/Scripts/lab/tests/update-progress-dashboard-tests.py
@@ -51,6 +51,14 @@ class UpdateProgressDashboardTests(unittest.TestCase):
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("STATUS queued, active, done, or blocked", result.stderr)
 
+    def test_finish_marks_block_proven_and_stops_pulsing(self) -> None:
+        self.run_updater("--progress", "80")
+        self.run_updater("--finish")
+        state = json.loads(self.state.read_text())
+        self.assertEqual(state["statuses"]["P01"], "proven")
+        self.assertNotIn("P01", state["activeWork"])
+        self.assertNotIn("P01", state["workingBlocks"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Scripts/lab/update-progress-dashboard
+++ b/Scripts/lab/update-progress-dashboard
@@ -70,6 +70,7 @@ def main() -> None:
     if args.finish:
         active_work.pop(args.block, None)
         working.discard(args.block)
+        state.setdefault("statuses", {})[args.block] = "proven"
     else:
         working.add(args.block)
         previous_work = active_work.get(args.block, {})

--- a/docs/testing/keypath-test-automation-state.json
+++ b/docs/testing/keypath-test-automation-state.json
@@ -1,26 +1,24 @@
 {
-  "updatedAt": "2026-07-12T19:05:12-07:00",
-  "currentTask": "P01 harness guardrails pass",
-  "message": "Secure approval now has a real dismissal postcondition; permission targeting is reversible. Focused lab tests pass. Next: disposable-VM proof.",
+  "updatedAt": "2026-07-12T19:49:14-07:00",
+  "currentTask": "P01 RFB capture proven",
+  "message": "KeyPath captured a real CrabBox VNC key event in its user-session input host. P01 is complete and the lease-owned input path is reusable.",
   "complete": false,
-  "workingBlocks": [
-    "P01"
-  ],
+  "workingBlocks": [],
   "activeWork": {
     "P02": {
-      "progress": 72,
+      "progress": 75,
       "health": "smooth",
       "trend": "forward",
-      "phase": "VirtualHID active; waiting for Kanata permissions",
-      "detail": "The DriverKit extension is activated and enabled, and the VirtualHID daemon passed health checks. Observable remapping waits on Kanata permissions.",
+      "phase": "VirtualHID active; captured-input dependency cleared",
+      "detail": "The DriverKit extension and VirtualHID daemon are healthy, and P01 now supplies a trusted RFB-captured input event. The next proof is observable remapped output.",
       "attempt": 1,
       "completedSteps": 6,
       "totalSteps": 8,
       "nextTasks": [
         {
           "label": "Receive trusted captured input from P01",
-          "status": "blocked",
-          "progress": 0
+          "status": "done",
+          "progress": 100
         },
         {
           "label": "Observe the remapped VirtualHID output",
@@ -33,51 +31,12 @@
           "progress": 0
         }
       ],
-      "blocker": "VirtualHID is healthy, but output cannot be attributed to KeyPath until P01 supplies a trusted captured-input event.",
+      "blocker": "No upstream dependency remains; P02 must now observe and attribute the remapped VirtualHID output.",
       "coreCapability": true,
       "unlocks": [
         "End-to-end remap assertions",
         "Repair and reboot validation",
         "Scenario-matrix pass/fail evidence"
-      ]
-    },
-    "P01": {
-      "progress": 95,
-      "health": "retrying",
-      "trend": "forward",
-      "phase": "Harness hardening validated; next proof is inside a disposable VM",
-      "detail": "Secure-dialog handling now requires the sheet controls to disappear, and permission drag restores Finder and System Settings geometry on every exit. Focused contract tests pass.",
-      "attempt": 3,
-      "completedSteps": 5,
-      "totalSteps": 6,
-      "nextTasks": [
-        {
-          "label": "Verify secure-dialog dismissal and protected state",
-          "status": "done",
-          "progress": 100
-        },
-        {
-          "label": "Make Input Monitoring targeting deterministic",
-          "status": "active",
-          "progress": 65
-        },
-        {
-          "label": "Prove a non-hardware input path reaches Kanata HID capture",
-          "status": "queued",
-          "progress": 0
-        },
-        {
-          "label": "Repeat disposable macOS 15 P01 proof",
-          "status": "queued",
-          "progress": 0
-        }
-      ],
-      "blocker": "Input Monitoring approval still needs a disposable-VM proof, and RFB key delivery may bypass the HID path Kanata observes.",
-      "coreCapability": true,
-      "unlocks": [
-        "Runtime and remap proof",
-        "Overlay and reboot verification",
-        "Install, repair, and upgrade matrix"
       ]
     }
   },
@@ -86,12 +45,61 @@
     "R02": "active",
     "R03": "active",
     "R04": "active",
-    "P01": "active",
+    "P01": "proven",
     "P02": "active",
     "M14": "active",
     "M12": "active"
   },
   "updates": [
+    {
+      "time": "19:49",
+      "block": "P01",
+      "tone": "success",
+      "title": "P01 RFB capture proven",
+      "message": "KeyPath captured a real CrabBox VNC key event in its user-session input host. P01 is complete and the lease-owned input path is reusable."
+    },
+    {
+      "time": "19:39",
+      "block": "P01",
+      "tone": "working",
+      "title": "P01 retargeted to intended runtime",
+      "message": "ADR-032 makes KeyPath user-session capture the correct physics target. Starting a clean RFB capture proof."
+    },
+    {
+      "time": "19:37",
+      "block": "P01",
+      "tone": "problem",
+      "title": "P01 narrowed to raw-binary consent",
+      "message": "KeyPath IM is automated. Raw kanata-launcher registration remains blocked: file panel filters it and synthetic drag creates no row."
+    },
+    {
+      "time": "19:26",
+      "block": "P01",
+      "tone": "retry",
+      "title": "Kanata row postcondition missing",
+      "message": "Authentication passed, but the launcher row did not appear. Retrying on the unlocked page; no product failure claimed."
+    },
+    {
+      "time": "19:24",
+      "block": "P01",
+      "tone": "success",
+      "title": "KeyPath Input Monitoring enabled",
+      "message": "Supported UI path reached Input Monitoring; KeyPath_Toggle is 1 and the running app oracle logged AX and IM granted."
+    },
+    {
+      "time": "19:20",
+      "block": "P01",
+      "tone": "retry",
+      "title": "Wizard sequencing corrected",
+      "message": "Escape closed the wizard after validation. Retrying without destructive dismissal; this is harness sequencing, not a KeyPath failure."
+    },
+    {
+      "time": "19:13",
+      "block": "P01",
+      "tone": "working",
+      "title": "Fresh P01 VM proof starting",
+      "message": "Tart capacity is free. Creating a disposable unmanaged macOS 15 desktop from merged harness code."
+    },
     {
       "time": "19:05",
       "block": "P01",
@@ -252,55 +260,6 @@
       "tone": "retry",
       "title": "P01 corrected coordinate transform",
       "message": "P01 stepped back to fix a harness assumption: the current lease uses 1:1 RFB coordinates, not the prior lease\u2019s 2x scale."
-    },
-    {
-      "time": "13:16",
-      "block": "P01",
-      "tone": "retry",
-      "title": "P01 permission order clarified",
-      "message": "P01 found a real orchestration dependency: grant Full Disk Access before trusting the product\u2019s Kanata permission verification."
-    },
-    {
-      "time": "13:10",
-      "block": "P02",
-      "tone": "success",
-      "title": "P02 driver activation proven",
-      "message": "P02 advanced: VirtualHID is activated and healthy. The remaining dependency is starting Kanata after P01 grants permissions."
-    },
-    {
-      "time": "13:10",
-      "block": "P01",
-      "tone": "working",
-      "title": "P01 permissions boundary",
-      "message": "P01 is actively completing Accessibility and Input Monitoring. The software-only VNC injection path is already proven."
-    },
-    {
-      "time": "13:00",
-      "block": "P02",
-      "tone": "retry",
-      "title": "Protected driver submit needs VNC Return",
-      "message": "P02 reached the genuine driver authorization sheet. Password entry remains secret-safe; protected submit is moving to VNC Return with postcondition verification."
-    },
-    {
-      "time": "12:43",
-      "block": "P02",
-      "tone": "working",
-      "title": "Driver installation unblocked",
-      "message": "P02 is moving forward: helper is operational and the next installer recipes target VirtualHID and runtime services."
-    },
-    {
-      "time": "12:43",
-      "block": "P01",
-      "tone": "success",
-      "title": "Helper postcondition passed",
-      "message": "P01 recovered cleanly: helper authorization is now verified by keypath-cli, not inferred from the click."
-    },
-    {
-      "time": "12:34",
-      "block": "P02",
-      "tone": "retry",
-      "title": "Output proof waiting on harness consent",
-      "message": "P02 has not failed; it is waiting for P01 to clear Peekaboo\u2019s one-time consent and complete helper activation."
     }
   ],
   "activity": [

--- a/docs/testing/p01-unmanaged-input-monitoring-spike.md
+++ b/docs/testing/p01-unmanaged-input-monitoring-spike.md
@@ -1,0 +1,86 @@
+# P01 unmanaged Input Monitoring spike
+
+## Result
+
+The macOS 15 unmanaged UI lane can automate KeyPath's own Input Monitoring
+approval without mutating TCC, deliver a key through CrabBox's native VNC/RFB
+path, and observe that key in KeyPath's user-session input host. P01 is proven.
+
+The raw embedded `kanata-launcher` executable still could not be registered
+through the supported System Settings paths tested on July 12, 2026. ADR-032
+defines that executable as a legacy recovery runtime, so that result is a
+separate packaging/managed-lane investigation rather than a prerequisite for
+P01.
+
+The disposable proof used lease `cbx_a35298e9ffef`, macOS 15.7.7 (24G720),
+KeyPath commit `442f4c5c27c2a3b414486eaaa9c9104e28482d4a`, and signed installer SHA-256
+`5a4246cf624683d546cf10cbfb9a05e75943c9c9d98fef85866b1890c4c2a2f7`.
+Artifacts are retained on the lab host at:
+
+`/Volumes/KeyPath Lab/CrabBox/KeyPathInstallerLab/artifacts/cbx_a35298e9ffef/20260713T023731Z`
+
+The successful capture proof used lease `cbx_8262dcfb476b` with the same OS,
+commit, and installer. After `KeyPath_Toggle` reported `AXValue=1`, the harness
+opened Input Capture Experiment, started recording, and sent `q` with CrabBox
+`desktop type`. CrabBox reported `method=vnc-key`, and the experiment's AX tree
+contained the captured `Q` chip. The new lease-owned `desktop-type` wrapper then
+repeated delivery with `w`.
+
+Capture-proof artifacts are retained at:
+
+`/Volumes/KeyPath Lab/CrabBox/KeyPathInstallerLab/artifacts/cbx_8262dcfb476b/20260713T025018Z`
+
+## Proven behavior
+
+1. Peekaboo 3.9 could discover and invoke KeyPath's wizard controls with
+   `perform-action --action AXPress`. Its generic `click` command did not
+   reliably invoke the same SwiftUI button.
+2. The standard `universalAccessAuthWarn` prompt exposed a semantic
+   `Open System Settings` action and opened the correct Input Monitoring page.
+3. `KeyPath_Toggle` could be enabled through AXPress. System Settings then
+   required `Quit & Reopen`; after that action the running KeyPath process
+   reported Input Monitoring granted through `IOHIDCheckAccess`.
+4. Password entry for protected System Settings changes remained secret-safe.
+   `secure-dialog-input` required the Password and Modify Settings controls to
+   disappear before returning success.
+5. Finder and System Settings geometry returned to their original values after
+   every `permission-drag` attempt.
+6. A CrabBox VNC key event reached KeyPath's local `NSEvent` capture monitor and
+   appeared as a visible captured-key chip. This is input evidence, not merely
+   proof that an injection command returned success.
+
+## Separate legacy-runtime limitation
+
+The actual input consumer is
+`/Applications/KeyPath.app/Contents/Library/KeyPath/kanata-launcher`. The
+following supported unmanaged paths did not create its Input Monitoring row:
+
+- System Settings Add and the native open panel: the raw executable is filtered
+  and Open remains unavailable.
+- A fresh Finder-to-permission-list drag through Peekaboo: the first attempt
+  produced a legitimate authentication sheet, but no launcher row appeared
+  after authentication. A second authenticated attempt produced neither an
+  authorization sheet nor the required row postcondition.
+- Dropping on the Add control rather than the existing list row: no launcher row
+  appeared.
+
+Do not treat an authentication sheet, completed drag, or closed password sheet
+as permission success. Any future legacy-runtime test still requires a launcher
+row plus canonical permission and live input-capture evidence.
+
+## Decision boundary
+
+Continue in this order:
+
+1. Use the proven KeyPath-owned input event as P02's input and observe the
+   remapped VirtualHID output.
+2. Prove the managed-functional PPPC profile grants ListenEvent to the exact
+   signed launcher requirement. This is the preferred non-hardware functional
+   lane once the lab MDM path is available.
+3. If PPPC cannot target this raw executable reliably, spike packaging the
+   launcher as a properly signed app bundle or service whose designated
+   requirement macOS can represent consistently in TCC and MDM.
+4. Keep the unmanaged lane for genuine KeyPath approval-prompt and quit/reopen
+   behavior even if the managed lane owns deterministic functional testing.
+
+Never write the TCC database to make this spike pass.

--- a/docs/testing/remote-installer-lab.md
+++ b/docs/testing/remote-installer-lab.md
@@ -145,6 +145,12 @@ is requested, follow it with `secure-dialog-input` and verify the new
 original geometry and restores it on every exit path, so a failed attempt does
 not leave later UI targeting in a modified coordinate space.
 
+The July 12 macOS 15 unmanaged spike confirmed that the authenticated synthetic
+drag still did not create a `kanata-launcher` row. Treat the drag adapter as an
+evidence-producing experiment, not a solved registration path, until its row
+and canonical permission postconditions pass. See
+[`p01-unmanaged-input-monitoring-spike.md`](p01-unmanaged-input-monitoring-spike.md).
+
 Peekaboo click success means that it delivered an action to the selected UI
 element. It is not proof that macOS accepted a protected change. Background App
 Activity, Driver Extensions, Accessibility, and Input Monitoring must be
@@ -233,6 +239,20 @@ expected to open another page or dialog, declare that explicitly with
 `--after-window`. This guard detects a delivered click that landed on the wrong
 System Settings surface; it does not replace the permission's canonical product
 or system postcondition.
+
+For ordinary text or single-key input on a macOS 15 desktop lease, use the
+lease-owned VNC path rather than calling CrabBox directly:
+
+```bash
+Scripts/lab/keypath-lab desktop-type cbx_example --text q
+```
+
+The controller verifies ownership, desktop capability, OS lane, and the exact
+provider resource before invoking CrabBox `desktop type`. On macOS this is an
+RFB key event (`method=vnc-key`), not guest-side AppleScript or CGEvent
+injection. The command proves delivery only; the scenario must separately
+observe its expected application or runtime postcondition. P01 used a captured
+key chip in KeyPath's Input Capture Experiment as that postcondition.
 
 `install-app` expands the staged ZIP into `/Applications` on the disposable
 guest. Tart uses the base image's noninteractive sudo contract. Parallels uses


### PR DESCRIPTION
## Summary
- add a lease-owned macOS RFB typing command to the installer lab controller
- document the unmanaged Input Monitoring spike and successful KeyPath capture proof
- mark P01 proven in the live dashboard and fix completed blocks remaining visually active

## Validation
- `python3 Scripts/lab/tests/update-progress-dashboard-tests.py`
- `Scripts/lab/tests/keypath-lab-tests.sh`
- real macOS 15.7.7 Tart lease: CrabBox reported `method=vnc-key`; KeyPath Input Capture Experiment exposed captured `Q` and `W` chips
- artifacts: `/Volumes/KeyPath Lab/CrabBox/KeyPathInstallerLab/artifacts/cbx_8262dcfb476b/20260713T025018Z`
- `./Scripts/review-gate.sh` selected the remote review gate; do not merge until `claude-review` passes