### PR TITLE
Preserve release build metadata

### DIFF
--- a/Scripts/build-and-sign.sh
+++ b/Scripts/build-and-sign.sh
@@ -27,9 +27,9 @@ create_sparkle_archive() {
 
     # Extract version from Info.plist
     local VERSION
-    VERSION=$(defaults read "$CONTENTS/Info" CFBundleShortVersionString 2>/dev/null || echo "1.0.0")
+    VERSION=$(/usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" "$CONTENTS/Info.plist" 2>/dev/null || echo "1.0.0")
     local BUILD
-    BUILD=$(defaults read "$CONTENTS/Info" CFBundleVersion 2>/dev/null || echo "1")
+    BUILD=$(/usr/libexec/PlistBuddy -c "Print :CFBundleVersion" "$CONTENTS/Info.plist" 2>/dev/null || echo "1")
     local ARCHIVE_NAME="KeyPath-${VERSION}.zip"
     local SPARKLE_DIR="${DIST_DIR}/sparkle"
 
@@ -279,7 +279,7 @@ MACOS="${CONTENTS}/MacOS"
 	# Inject the main app's version into "Kanata Engine.app" so the bundle version
 	# stays in sync across releases (the source plist uses placeholder values).
 	_MAIN_VER=$(defaults read "$SCRIPT_DIR/../Sources/KeyPathApp/Info" CFBundleShortVersionString 2>/dev/null || echo "1.0")
-	_MAIN_BUILD=$(defaults read "$SCRIPT_DIR/../Sources/KeyPathApp/Info" CFBundleVersion 2>/dev/null || echo "1")
+	_MAIN_BUILD=$(/usr/libexec/PlistBuddy -c "Print :CFBundleVersion" "$SCRIPT_DIR/../Sources/KeyPathApp/Info.plist" 2>/dev/null || echo "1")
 	/usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $_MAIN_VER" "$KANATA_ENGINE_CONTENTS/Info.plist"
 	/usr/libexec/PlistBuddy -c "Set :CFBundleVersion $_MAIN_BUILD" "$KANATA_ENGINE_CONTENTS/Info.plist"
 
@@ -413,8 +413,8 @@ echo "APPL????" > "$CONTENTS/PkgInfo"
 echo "🧾 Writing BuildInfo.plist..."
 GIT_HASH=$(git rev-parse --short HEAD 2>/dev/null || echo unknown)
 BUILD_DATE=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
-CFVER=$(defaults read "$CONTENTS/Info" CFBundleShortVersionString 2>/dev/null || echo "1.0.0")
-CFBUILD=$(defaults read "$CONTENTS/Info" CFBundleVersion 2>/dev/null || echo "0")
+CFVER=$(/usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" "$CONTENTS/Info.plist" 2>/dev/null || echo "1.0.0")
+CFBUILD=$(/usr/libexec/PlistBuddy -c "Print :CFBundleVersion" "$CONTENTS/Info.plist" 2>/dev/null || echo "0")
 cat > "$RESOURCES/BuildInfo.plist" <<EOF
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">

--- a/Tests/KeyPathTests/Lint/DeploymentScriptContractTests.swift
+++ b/Tests/KeyPathTests/Lint/DeploymentScriptContractTests.swift
@@ -92,6 +92,20 @@ final class DeploymentScriptContractTests: XCTestCase {
         )
     }
 
+    func testReleaseBuildReadsVersionMetadataFromPlistPaths() throws {
+        let root = repositoryRoot()
+        let buildAndSign = try contents(of: root.appendingPathComponent("Scripts/build-and-sign.sh"))
+
+        XCTAssertTrue(
+            buildAndSign.contains(#"PlistBuddy -c "Print :CFBundleVersion" "$CONTENTS/Info.plist""#),
+            "Release metadata must read the assembled app plist as a file path."
+        )
+        XCTAssertFalse(
+            buildAndSign.contains(#"defaults read "$CONTENTS/Info""#),
+            "A relative path passed to defaults is interpreted as a preferences domain and falls back to build 0."
+        )
+    }
+
     func testQuickDeployPreservesBuildFailureDiagnostics() throws {
         let root = repositoryRoot()
         let quickDeploy = try contents(of: root.appendingPathComponent("Scripts/quick-deploy.sh"))

--- a/docs/testing/keypath-github-issues-state.json
+++ b/docs/testing/keypath-github-issues-state.json
@@ -1,6 +1,6 @@
 {
   "repository": "malpern/KeyPath",
-  "updatedAt": "2026-07-13T02:59:22.967285+00:00",
+  "updatedAt": "2026-07-13T03:16:24.461587+00:00",
   "issueLimit": 200,
   "truncated": false,
   "counts": {
@@ -19,7 +19,7 @@
       ],
       "number": 748,
       "title": "Post-1.0: report helper and service freshness explicitly",
-      "updatedAt": "2026-07-13T02:59:21Z",
+      "updatedAt": "2026-07-13T03:16:22Z",
       "url": "https://github.com/malpern/KeyPath/issues/748",
       "dashboardStatus": "active",
       "dashboardType": "debt",


### PR DESCRIPTION
## Summary
- read assembled release plist values with `PlistBuddy` using explicit file paths
- preserve the real app build in generated `BuildInfo.plist`, Kanata Engine metadata, and Sparkle archive naming
- add a release-script contract test preventing relative `defaults read` paths
- keep #748 active on the issue dashboard through installed verification

## Root cause
Signed validation after #1151 still reported expected build `0` while launchd reported the installed app as build `4`. `Scripts/build-and-sign.sh` passed relative plist paths to `defaults read`; macOS interpreted those strings as preferences domains, the reads failed, and the script silently wrote fallback build `0` into `BuildInfo.plist`.

## Validation
- `bash -n Scripts/build-and-sign.sh`
- `TEST_FILTER=DeploymentScriptContractTests ./Scripts/run-tests-safe.sh` (8 passed)
- direct extraction from the assembled release app: `release_metadata=1.0.0 build=4`
- `./Scripts/test-fast.sh --changed` (4,763 passed)
- `python3 Scripts/check-accessibility.py`
- `./Scripts/review-gate.sh` → remote review gate selected

After merge, I will rebuild and deploy a signed release candidate and require `kanataExpectedIdentity` build `4` plus `kanataServiceFreshness: fresh` before closing #748.

Closes #748
