### PR TITLE
Show recent issue completions

### DIFF
--- a/Scripts/lab/update-issue-dashboard
+++ b/Scripts/lab/update-issue-dashboard
@@ -10,9 +10,10 @@ import subprocess
 
 
 EXCLUDED = {172, 740, 747, 919}
-ACTIVE = {748}
-NEXT = {848}
+ACTIVE = {848}
+NEXT = set()
 ISSUE_LIMIT = 200
+RECENTLY_CLOSED_LIMIT = 10
 
 
 def issue_status(issue: dict) -> str:
@@ -24,6 +25,8 @@ def issue_status(issue: dict) -> str:
         return "next"
     if number in EXCLUDED or "human-in-loop" in labels or "wwdc26" in labels:
         return "human"
+    if "large-refactor" in labels:
+        return "deferred"
     if labels & {"Feature", "feature-gap", "enhancement"}:
         return "feature"
     if labels & {"bug", "bug-risk", "testing", "tech-debt", "agent-ok"}:
@@ -74,32 +77,43 @@ def main() -> None:
     parser.add_argument("--repo", default="malpern/KeyPath")
     args = parser.parse_args()
     gh = shutil.which("gh") or "/opt/homebrew/bin/gh"
-    result = subprocess.run(
-        [
-            gh,
-            "issue",
-            "list",
-            "--repo",
-            args.repo,
-            "--state",
-            "open",
-            "--limit",
-            str(ISSUE_LIMIT),
-            "--json",
-            "number,title,body,labels,updatedAt,url",
-        ],
-        check=True,
-        capture_output=True,
-        text=True,
-        env={**os.environ, "PATH": f"/opt/homebrew/bin:/usr/local/bin:{os.environ.get('PATH', '')}"},
-    )
-    issues = json.loads(result.stdout)
+    def list_issues(state: str, limit: int) -> list[dict]:
+        result = subprocess.run(
+            [
+                gh,
+                "issue",
+                "list",
+                "--repo",
+                args.repo,
+                "--state",
+                state,
+                "--search",
+                "sort:updated-desc",
+                "--limit",
+                str(limit),
+                "--json",
+                "number,title,body,labels,updatedAt,url",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+            env={**os.environ, "PATH": f"/opt/homebrew/bin:/usr/local/bin:{os.environ.get('PATH', '')}"},
+        )
+        return json.loads(result.stdout)
+
+    issues = list_issues("open", ISSUE_LIMIT)
+    recently_closed = list_issues("closed", RECENTLY_CLOSED_LIMIT)
     for issue in issues:
         issue["dashboardStatus"] = issue_status(issue)
         issue["dashboardType"] = issue_type(issue)
         issue["descriptionExcerpt"] = description_excerpt(issue.pop("body", ""))
         issue["labels"] = [label["name"] for label in issue.get("labels", [])]
     issues.sort(key=priority)
+    for issue in recently_closed:
+        issue["dashboardStatus"] = "completed"
+        issue["dashboardType"] = issue_type(issue)
+        issue["descriptionExcerpt"] = description_excerpt(issue.pop("body", ""))
+        issue["labels"] = [label["name"] for label in issue.get("labels", [])]
     counts = {}
     for issue in issues:
         status = issue["dashboardStatus"]
@@ -111,6 +125,7 @@ def main() -> None:
         "truncated": len(issues) >= ISSUE_LIMIT,
         "counts": counts,
         "issues": issues,
+        "recentlyClosed": recently_closed,
     }
     args.output.parent.mkdir(parents=True, exist_ok=True)
     temporary = args.output.with_suffix(".tmp")

--- a/docs/testing/keypath-github-issues-dashboard.fragment.html
+++ b/docs/testing/keypath-github-issues-dashboard.fragment.html
@@ -71,6 +71,7 @@
     #keypath-issue-board .activity-dot { width:7px; height:7px; margin-top:5px; border-radius:50%; background:var(--viz-series-1); }
     #keypath-issue-board .activity-row[data-status="active"] .activity-dot { background:var(--viz-series-2); }
     #keypath-issue-board .activity-row[data-status="next"] .activity-dot { background:var(--viz-series-3); }
+    #keypath-issue-board .activity-row[data-status="completed"] .activity-dot { background:var(--viz-series-1); }
     #keypath-issue-board .activity-row strong { display:block; font:500 11px system-ui,sans-serif; }
     #keypath-issue-board .activity-row span { display:block; color:var(--muted-foreground); font:11px system-ui,sans-serif; }
     #keypath-issue-board .note { margin-top:11px; color:var(--muted-foreground); font:11px system-ui,sans-serif; }
@@ -142,7 +143,7 @@
   <script>
     (() => {
       const root = document.getElementById('keypath-issue-board');
-      const names = {active:'Active',next:'Recommended next',queued:'Agent queue',human:'Human / external gate',feature:'Feature deferred',deferred:'Deferred'};
+      const names = {active:'Active',next:'Recommended next',queued:'Agent queue',human:'Human / external gate',feature:'Feature deferred',deferred:'Deferred',completed:'Completed'};
       const typeNames = {bug:'Bug',testing:'Testing',debt:'Technical debt',feature:'Feature',upstream:'Upstream / research',docs:'Documentation / design',other:'Other'};
       const grid = root.querySelector('#issue-grid');
       const title = root.querySelector('#issue-title');
@@ -263,7 +264,8 @@
           });
           return button;
         }));
-        const recent = [...state.issues].sort((a,b) => b.updatedAt.localeCompare(a.updatedAt)).slice(0,10);
+        const recent = [...state.issues, ...(state.recentlyClosed || [])]
+          .sort((a,b) => b.updatedAt.localeCompare(a.updatedAt)).slice(0,10);
         root.querySelector('#issue-activity').replaceChildren(...recent.map(issue => {
           const row=document.createElement('div'); row.className='activity-row'; row.dataset.status=issue.dashboardStatus;
           const dot=document.createElement('span'); dot.className='activity-dot';

--- a/docs/testing/keypath-github-issues-dashboard.html
+++ b/docs/testing/keypath-github-issues-dashboard.html
@@ -821,6 +821,7 @@ html&gt;body{padding:0}&lt;/style&gt;
     #keypath-issue-board .activity-dot { width:7px; height:7px; margin-top:5px; border-radius:50%; background:var(--viz-series-1); }
     #keypath-issue-board .activity-row[data-status=&quot;active&quot;] .activity-dot { background:var(--viz-series-2); }
     #keypath-issue-board .activity-row[data-status=&quot;next&quot;] .activity-dot { background:var(--viz-series-3); }
+    #keypath-issue-board .activity-row[data-status=&quot;completed&quot;] .activity-dot { background:var(--viz-series-1); }
     #keypath-issue-board .activity-row strong { display:block; font:500 11px system-ui,sans-serif; }
     #keypath-issue-board .activity-row span { display:block; color:var(--muted-foreground); font:11px system-ui,sans-serif; }
     #keypath-issue-board .note { margin-top:11px; color:var(--muted-foreground); font:11px system-ui,sans-serif; }
@@ -892,7 +893,7 @@ html&gt;body{padding:0}&lt;/style&gt;
   &lt;script&gt;
     (() =&gt; {
       const root = document.getElementById(&#x27;keypath-issue-board&#x27;);
-      const names = {active:&#x27;Active&#x27;,next:&#x27;Recommended next&#x27;,queued:&#x27;Agent queue&#x27;,human:&#x27;Human / external gate&#x27;,feature:&#x27;Feature deferred&#x27;,deferred:&#x27;Deferred&#x27;};
+      const names = {active:&#x27;Active&#x27;,next:&#x27;Recommended next&#x27;,queued:&#x27;Agent queue&#x27;,human:&#x27;Human / external gate&#x27;,feature:&#x27;Feature deferred&#x27;,deferred:&#x27;Deferred&#x27;,completed:&#x27;Completed&#x27;};
       const typeNames = {bug:&#x27;Bug&#x27;,testing:&#x27;Testing&#x27;,debt:&#x27;Technical debt&#x27;,feature:&#x27;Feature&#x27;,upstream:&#x27;Upstream / research&#x27;,docs:&#x27;Documentation / design&#x27;,other:&#x27;Other&#x27;};
       const grid = root.querySelector(&#x27;#issue-grid&#x27;);
       const title = root.querySelector(&#x27;#issue-title&#x27;);
@@ -1013,7 +1014,8 @@ html&gt;body{padding:0}&lt;/style&gt;
           });
           return button;
         }));
-        const recent = [...state.issues].sort((a,b) =&gt; b.updatedAt.localeCompare(a.updatedAt)).slice(0,10);
+        const recent = [...state.issues, ...(state.recentlyClosed || [])]
+          .sort((a,b) =&gt; b.updatedAt.localeCompare(a.updatedAt)).slice(0,10);
         root.querySelector(&#x27;#issue-activity&#x27;).replaceChildren(...recent.map(issue =&gt; {
           const row=document.createElement(&#x27;div&#x27;); row.className=&#x27;activity-row&#x27;; row.dataset.status=issue.dashboardStatus;
           const dot=document.createElement(&#x27;span&#x27;); dot.className=&#x27;activity-dot&#x27;;


### PR DESCRIPTION
## Summary
- keep the issue card board focused on open work
- include the ten most recently updated closed issues in the activity feed
- show completed activity explicitly, including #748
- classify broad `large-refactor` issues such as #855 as deferred

## Why
The open-only updater made completed work disappear from the dashboard. It also treated every `tech-debt` issue as agent-queued even when a `large-refactor` label intentionally lowers its priority.

## Validation
- `python3 -m py_compile Scripts/lab/update-issue-dashboard`
- rendered the dashboard from live GitHub data
- verified #748 appears in `recentlyClosed`
- verified #855 renders as `deferred`
- `./Scripts/review-gate.sh` → remote review gate selected
