### PR TITLE
Centralize repeated Kanata test configs

### DIFF
--- a/Tests/KeyPathTests/Services/ConfigBackupManagerTests.swift
+++ b/Tests/KeyPathTests/Services/ConfigBackupManagerTests.swift
@@ -23,13 +23,7 @@ final class ConfigBackupManagerTests: XCTestCase {
     }
 
     private func writeValidConfig(_ content: String? = nil) throws {
-        let validConfig = content ?? """
-        (defcfg
-          process-unmapped-keys yes
-        )
-        (defsrc caps)
-        (deflayer base esc)
-        """
+        let validConfig = content ?? KanataConfigFixtures.capsToEscape
         try validConfig.write(toFile: configPath, atomically: true, encoding: .utf8)
     }
 

--- a/Tests/KeyPathTests/Services/ConfigHotReloadServiceTests.swift
+++ b/Tests/KeyPathTests/Services/ConfigHotReloadServiceTests.swift
@@ -80,11 +80,7 @@ final class ConfigHotReloadServiceTests: XCTestCase {
     // MARK: - Validation Tests
 
     func testHandleExternalChangeValidatesConfig() async {
-        let validConfig = """
-        (defcfg)
-        (defsrc caps)
-        (deflayer base esc)
-        """
+        let validConfig = KanataConfigFixtures.capsToEscapeBare
         let tempFile = createTempConfigFile(content: validConfig)
 
         let result = await service.handleExternalChange(configPath: tempFile.path)
@@ -108,11 +104,7 @@ final class ConfigHotReloadServiceTests: XCTestCase {
 
     func testHandleExternalChangeCallsReloadHandler() async {
         reloadHandlerResult = true
-        let validConfig = """
-        (defcfg)
-        (defsrc caps)
-        (deflayer base esc)
-        """
+        let validConfig = KanataConfigFixtures.capsToEscapeBare
         let tempFile = createTempConfigFile(content: validConfig)
 
         let result = await service.handleExternalChange(configPath: tempFile.path)
@@ -128,11 +120,7 @@ final class ConfigHotReloadServiceTests: XCTestCase {
         // we should return success:false + pendingReload:true because the config is valid
         // but was never applied to kanata.
         reloadHandlerResult = false
-        let validConfig = """
-        (defcfg)
-        (defsrc caps)
-        (deflayer base esc)
-        """
+        let validConfig = KanataConfigFixtures.capsToEscapeBare
         let tempFile = createTempConfigFile(content: validConfig)
 
         let result = await service.handleExternalChange(configPath: tempFile.path)
@@ -163,11 +151,7 @@ final class ConfigHotReloadServiceTests: XCTestCase {
             isKanataProcessRunningProvider: { true }
         )
 
-        let validConfig = """
-        (defcfg)
-        (defsrc caps)
-        (deflayer base esc)
-        """
+        let validConfig = KanataConfigFixtures.capsToEscapeBare
         let tempFile = createTempConfigFile(content: validConfig)
 
         let result = await service.handleExternalChange(configPath: tempFile.path)
@@ -181,11 +165,7 @@ final class ConfigHotReloadServiceTests: XCTestCase {
 
     func testCallbacksInvokedOnSuccess() async {
         reloadHandlerResult = true
-        let validConfig = """
-        (defcfg)
-        (defsrc caps)
-        (deflayer base esc)
-        """
+        let validConfig = KanataConfigFixtures.capsToEscapeBare
         let tempFile = createTempConfigFile(content: validConfig)
 
         var detectedCalled = false
@@ -211,11 +191,7 @@ final class ConfigHotReloadServiceTests: XCTestCase {
         // Force reload handler to fail - in test environment this triggers
         // "service unavailable" path (process not running) which calls onReset
         reloadHandlerResult = false
-        let validConfig = """
-        (defcfg)
-        (defsrc caps)
-        (deflayer base esc)
-        """
+        let validConfig = KanataConfigFixtures.capsToEscapeBare
         let tempFile = createTempConfigFile(content: validConfig)
 
         var detectedCalled = false

--- a/Tests/KeyPathTests/Services/ConfigurationServiceSavePipelineTests.swift
+++ b/Tests/KeyPathTests/Services/ConfigurationServiceSavePipelineTests.swift
@@ -338,11 +338,7 @@ final class ConfigurationServiceSavePipelineTests: KeyPathTestCase {
     }
 
     func testWriteFileAsync_AcceptsKbdWithDefsrc() async throws {
-        let validContent = """
-        (defcfg process-unmapped-keys yes)
-        (defsrc caps)
-        (deflayer base esc)
-        """
+        let validContent = KanataConfigFixtures.capsToEscapeInlineDefcfg
         try await configService.writeFileAsync(
             string: validContent,
             to: tempDirectory.appendingPathComponent("keypath.kbd").path
@@ -700,11 +696,7 @@ final class ConfigurationServiceSavePipelineTests: KeyPathTestCase {
     // MARK: - Validation Test Mode Tests
 
     func testValidationInTestMode_PassesValidConfig() async {
-        let validConfig = """
-        (defcfg process-unmapped-keys yes)
-        (defsrc caps)
-        (deflayer base esc)
-        """
+        let validConfig = KanataConfigFixtures.capsToEscapeInlineDefcfg
         let result = await configService.validateConfiguration(validConfig)
         XCTAssertTrue(result.isValid)
         XCTAssertTrue(result.errors.isEmpty)

--- a/Tests/KeyPathTests/Services/ConfigurationServiceTests.swift
+++ b/Tests/KeyPathTests/Services/ConfigurationServiceTests.swift
@@ -566,11 +566,7 @@ class ConfigurationServiceTests: XCTestCase {
     }
 
     func testBackupFailedConfigAppliesSafeDefaults() async throws {
-        let original = """
-        (defcfg)
-        (defsrc caps)
-        (deflayer base esc)
-        """
+        let original = KanataConfigFixtures.capsToEscapeBare
         let mappings = [KeyMapping(input: "caps", action: .keystroke(key: "esc"))]
 
         let backupPath = try await configService.backupFailedConfigAndApplySafe(
@@ -1580,13 +1576,7 @@ class ConfigurationServiceTests: XCTestCase {
 
     /// Test that writeConfigurationContent accepts valid content
     func testWriteConfigurationContent_AcceptsValidContent() async throws {
-        let validContent = """
-        (defcfg
-          process-unmapped-keys yes
-        )
-        (defsrc caps)
-        (deflayer base esc)
-        """
+        let validContent = KanataConfigFixtures.capsToEscape
 
         // Should not throw
         try await configService.writeConfigurationContent(validContent)
@@ -1630,14 +1620,7 @@ class ConfigurationServiceTests: XCTestCase {
     func testObserverFiresOnMainActor_OnReload() async throws {
         // First, write a valid config file so reload succeeds
         let configPath = tempDirectory.appendingPathComponent("keypath.kbd")
-        let content = """
-        (defcfg
-          process-unmapped-keys yes
-        )
-
-        (defsrc caps)
-        (deflayer base esc)
-        """
+        let content = KanataConfigFixtures.capsToEscape
         try content.write(to: configPath, atomically: true, encoding: .utf8)
 
         let exp = expectation(description: "Observer fired on reload")

--- a/Tests/KeyPathTests/Services/SimpleModsWriterTests.swift
+++ b/Tests/KeyPathTests/Services/SimpleModsWriterTests.swift
@@ -102,13 +102,7 @@ final class SimpleModsWriterTests: XCTestCase {
     /// Test that writeBlock adds mappings correctly
     func testWriteBlock_AddsMappingsCorrectly() throws {
         // Start with a valid base config
-        let baseConfig = """
-        (defcfg
-          process-unmapped-keys yes
-        )
-        (defsrc caps)
-        (deflayer base esc)
-        """
+        let baseConfig = KanataConfigFixtures.capsToEscape
 
         try baseConfig.write(toFile: configPath, atomically: true, encoding: .utf8)
 
@@ -136,13 +130,7 @@ final class SimpleModsWriterTests: XCTestCase {
 
     /// Test that writeBlock deduplicates mappings (keeps last per fromKey)
     func testWriteBlock_DeduplicatesMappings() throws {
-        let baseConfig = """
-        (defcfg
-          process-unmapped-keys yes
-        )
-        (defsrc caps)
-        (deflayer base esc)
-        """
+        let baseConfig = KanataConfigFixtures.capsToEscape
 
         try baseConfig.write(toFile: configPath, atomically: true, encoding: .utf8)
 

--- a/Tests/KeyPathTests/TestHelpers/KanataConfigFixtures.swift
+++ b/Tests/KeyPathTests/TestHelpers/KanataConfigFixtures.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+/// Shared, intentionally small Kanata configurations for tests that need valid
+/// syntax but are not testing the configuration text itself.
+enum KanataConfigFixtures {
+    static let capsToEscapeBare = """
+    (defcfg)
+    (defsrc caps)
+    (deflayer base esc)
+    """
+
+    static let capsToEscape = """
+    (defcfg
+      process-unmapped-keys yes
+    )
+    (defsrc caps)
+    (deflayer base esc)
+    """
+
+    static let capsToEscapeInlineDefcfg = """
+    (defcfg process-unmapped-keys yes)
+    (defsrc caps)
+    (deflayer base esc)
+    """
+}


### PR DESCRIPTION
Closes #848.

## What changed
- add three small shared Kanata fixtures for tests that only need valid configuration syntax
- replace 14 copies of the repeated caps-to-Escape configurations across five service test files
- keep behavior-specific and parser-edge-case configurations inline so each test remains self-describing

## Scope evidence
A fresh inventory found 42 multiline configurations containing `defsrc`, with 31 normalized shapes and 11 duplicate instances. After this change, the 28 remaining inline configurations have 28 distinct normalized shapes. A broader builder abstraction would no longer remove duplication.

## Validation
- targeted tests for all five affected test suites
- `./Scripts/test-fast.sh --changed` (full fallback): 4,751 passed
- `python3 Scripts/check-accessibility.py`: 354 files checked, clean
- `./Scripts/review-gate.sh`: remote review gate selected; GitHub `claude-review` required before merge
- branch current with `origin/master` before push (`0 1`)