### PR TITLE
docs: record VirtualHID output approval gate

### DIFF
--- a/docs/testing/installer-gui-automation-capabilities.md
+++ b/docs/testing/installer-gui-automation-capabilities.md
@@ -203,6 +203,9 @@ recovery runtime.
 P02 remains: activate the complete runtime path and prove that the healthy
 VirtualHID Driver Extension produces observable remapped output from that
 captured input, not merely an installed, enabled, or device-healthy status.
+The first unmanaged macOS 15 attempt reached the genuine Driver Extensions
+control but remained `activated waiting for user`; its evidence and managed-lane
+resume criteria are in [P02 VirtualHID output proof](p02-virtualhid-output-proof.md).
 
 If virtual output cannot be observed in the VM, retain the VM lane for
 installer, repair, and state testing and add an explicitly separate

--- a/docs/testing/keypath-test-automation-state.json
+++ b/docs/testing/keypath-test-automation-state.json
@@ -1,17 +1,19 @@
 {
-  "updatedAt": "2026-07-12T19:49:14-07:00",
-  "currentTask": "P01 RFB capture proven",
-  "message": "KeyPath captured a real CrabBox VNC key event in its user-session input host. P01 is complete and the lease-owned input path is reusable.",
+  "updatedAt": "2026-07-12T21:27:05-07:00",
+  "currentTask": "P02 has a platform gate",
+  "message": "The VM reached the real VirtualHID approval control, but macOS has not transitioned the driver out of waiting-for-user. Captured RFB input is ready; remapped-output proof waits on a deterministic approval lane.",
   "complete": false,
-  "workingBlocks": [],
+  "workingBlocks": [
+    "P02"
+  ],
   "activeWork": {
     "P02": {
-      "progress": 75,
-      "health": "smooth",
-      "trend": "forward",
-      "phase": "VirtualHID active; captured-input dependency cleared",
-      "detail": "The DriverKit extension and VirtualHID daemon are healthy, and P01 now supplies a trusted RFB-captured input event. The next proof is observable remapped output.",
-      "attempt": 1,
+      "progress": 82,
+      "health": "blocked",
+      "trend": "backtrack",
+      "phase": "Awaiting a deterministic VirtualHID approval lane",
+      "detail": "The real macOS 15 driver extension is installed and exposed in System Settings. Its approval toggle was driven through the lease-owned UI, but systemextensionsctl still reports activated waiting for user; a focused-app output assertion cannot be honestly run until this state changes.",
+      "attempt": 3,
       "completedSteps": 6,
       "totalSteps": 8,
       "nextTasks": [
@@ -21,7 +23,17 @@
           "progress": 100
         },
         {
-          "label": "Observe the remapped VirtualHID output",
+          "label": "Install a deterministic q-to-w mapping",
+          "status": "active",
+          "progress": 30
+        },
+        {
+          "label": "Activate VirtualHID in a deterministic lane",
+          "status": "blocked",
+          "progress": 0
+        },
+        {
+          "label": "Observe focused-app output through RFB",
           "status": "queued",
           "progress": 0
         },
@@ -31,7 +43,7 @@
           "progress": 0
         }
       ],
-      "blocker": "No upstream dependency remains; P02 must now observe and attribute the remapped VirtualHID output.",
+      "blocker": "Unmanaged macOS leaves the DriverKit extension at activated waiting for user after current UI automation; this is a platform-approval gap, not evidence of a KeyPath remapping defect.",
       "coreCapability": true,
       "unlocks": [
         "End-to-end remap assertions",
@@ -51,6 +63,20 @@
     "M12": "active"
   },
   "updates": [
+    {
+      "time": "21:27",
+      "block": "P02",
+      "tone": "problem",
+      "title": "P02 has a platform gate",
+      "message": "The VM reached the real VirtualHID approval control, but macOS has not transitioned the driver out of waiting-for-user. Captured RFB input is ready; remapped-output proof waits on a deterministic approval lane."
+    },
+    {
+      "time": "20:29",
+      "block": "P02",
+      "tone": "working",
+      "title": "P02 output proof starting",
+      "message": "Composing a software-only q-to-w proof: known RFB input, healthy runtime, and independently observed focused-app output."
+    },
     {
       "time": "19:49",
       "block": "P01",
@@ -246,20 +272,6 @@
       "tone": "success",
       "title": "P01 click guard implemented",
       "message": "P01 advanced: wrong-coordinate clicks now fail immediately instead of silently corrupting the permission flow. The focused harness suite passes."
-    },
-    {
-      "time": "13:23",
-      "block": "P01",
-      "tone": "working",
-      "title": "P01 wrong-page clicks now classified",
-      "message": "P01 converted the VM evidence into a harness contract: successful delivery is insufficient unless the intended System Settings page is verified before and after."
-    },
-    {
-      "time": "13:20",
-      "block": "P01",
-      "tone": "retry",
-      "title": "P01 corrected coordinate transform",
-      "message": "P01 stepped back to fix a harness assumption: the current lease uses 1:1 RFB coordinates, not the prior lease\u2019s 2x scale."
     }
   ],
   "activity": [

--- a/docs/testing/p02-virtualhid-output-proof.md
+++ b/docs/testing/p02-virtualhid-output-proof.md
@@ -1,0 +1,75 @@
+# P02 VirtualHID output proof
+
+## Current result
+
+P02 is not yet proven. The unmanaged macOS 15 lane reaches the genuine
+VirtualHID Driver Extension control, but the operating system still reports the
+extension as `activated waiting for user` after the current supported UI-driven
+attempt. Until that becomes `activated enabled`, a `q` to `w` remapping result
+in a focused app would not be attributable to KeyPath's normal VirtualHID
+output path.
+
+This is an approval-lane limitation, not a confirmed KeyPath remapping defect.
+Do not turn it into a product bug or bypass it by modifying system-extension or
+privacy databases.
+
+## Evidence captured on July 12, 2026
+
+The disposable unmanaged proof used lease `cbx_1b376f03fbb6`, macOS 15.7.7
+(`24G720`), KeyPath commit
+`ccbb4d2c1ef3ecbff02a96a8ae517258e5555cb2`, and signed installer SHA-256
+`8dcbc201ce9333f5afff305fdd0956863613b45542556f81e6382fb772be87f4`.
+Artifacts are retained on the lab host at:
+
+`/Volumes/KeyPath Lab/CrabBox/KeyPathInstallerLab/artifacts/cbx_1b376f03fbb6/20260713T042245Z`
+
+Before the DriverKit attempt, this same lease had completed the installer-side
+preconditions required for P02:
+
+1. KeyPath Input Monitoring was approved through its real macOS UI.
+2. The KeyPath helper and background item were enabled through the real macOS
+   UI with secret-safe password entry.
+3. KeyPath Accessibility was enabled through the real macOS UI.
+4. The P01 `desktop-type` primitive had already proven that a CrabBox VNC/RFB
+   key reaches KeyPath's user-session input host.
+
+The KeyPath wizard opened the real Login Items & Extensions surface. The
+VirtualHID detail sheet exposed `.Karabiner-VirtualHIDDevice-Manager` and
+`org.pqrs.Karabiner-DriverKit-VirtualHIDDevice`, including its approval toggle.
+The harness drove that toggle with the current lease-owned UI state, then
+checked the OS rather than treating the click as a pass. The authoritative
+postcondition remained:
+
+```text
+org.pqrs.Karabiner-DriverKit-VirtualHIDDevice [activated waiting for user]
+```
+
+## Required proof shape
+
+P02 passes only when all of the following are true in one disposable lease:
+
+1. The approved, normal KeyPath runtime is healthy: Driver Extension enabled,
+   VirtualHID daemon running, Kanata running, and TCP readiness responding.
+2. A deterministic configuration maps physical `q` to virtual `w`.
+3. The harness focuses an independent target app with an observable text value.
+4. `keypath-lab desktop-type LEASE --text q` reports the native `vnc-key`
+   delivery method.
+5. The target app's accessibility value changes to `w`, not `q`.
+
+Step 5 is the functional assertion. Driver metadata, a successful click, and a
+KeyPath-local input monitor are useful preparation evidence but are not output
+proof.
+
+## Resume path
+
+Prefer the managed-functional lane once lab MDM/APNs enrollment is available.
+It can pre-approve the signed KeyPath PPPC, DriverKit, and service-management
+requirements without asking the test to exercise Apple's approval UI. Verify
+the lane admission contract before installation, then run the proof shape
+above.
+
+Keep the unmanaged lane for a small number of real approval-flow tests. If its
+DriverKit state remains `activated waiting for user`, preserve the command
+output and artifacts, mark the test infrastructure-blocked, and continue
+functional remap proof in the managed lane. Never infer a KeyPath product
+failure from this state alone.


### PR DESCRIPTION
## Summary
- record the real unmanaged macOS 15 VirtualHID approval result and artifact location
- define the P02 q-to-w focused-app proof contract
- mark the dashboard with the platform gate and managed-lane resume path

## Validation
- `python3 Scripts/lab/tests/update-progress-dashboard-tests.py`
- `python3 -m json.tool docs/testing/keypath-test-automation-state.json`
- `git diff --check`

Remote review gate selected; waiting for `claude-review`.