### PR TITLE
Remove unsafe wizard dependency state

### DIFF
--- a/Sources/KeyPathAppKit/WizardProtocolConformances.swift
+++ b/Sources/KeyPathAppKit/WizardProtocolConformances.swift
@@ -137,9 +137,6 @@ public func configureWizardDependencies(runtimeCoordinator: RuntimeCoordinator) 
     WizardDependencies.permissionRequestService = PermissionRequestService.shared
     WizardDependencies.privilegedOperations = PrivilegedOperationsRouter.shared
 
-    WizardDependencies.smServiceFactory = { plistName in
-        HelperManager.smServiceFactory(plistName)
-    }
     WizardDependencies.helperNeedsApproval = {
         HelperManager.shared.helperNeedsLoginItemsApproval()
     }
@@ -167,11 +164,6 @@ public func configureWizardDependencies(runtimeCoordinator: RuntimeCoordinator) 
     }
     WizardDependencies.hasExternalKanataRunning = {
         ExternalKanataService.hasExternalKanataRunning()
-    }
-
-    // TCP readiness probe
-    WizardDependencies.tcpProbe = { port, timeoutMs in
-        SystemStateProvider.probeTCPPort(port: port, timeoutMs: timeoutMs)
     }
 
     // Page view factories for pages that live in KeyPathAppKit
@@ -208,9 +200,6 @@ func configureCLIWizardDependencies(systemValidator: SystemValidator) {
     WizardDependencies.permissionRequestService = PermissionRequestService.shared
     WizardDependencies.privilegedOperations = PrivilegedOperationsRouter.shared
 
-    WizardDependencies.smServiceFactory = { plistName in
-        HelperManager.smServiceFactory(plistName)
-    }
     WizardDependencies.helperNeedsApproval = {
         HelperManager.shared.helperNeedsLoginItemsApproval()
     }
@@ -247,8 +236,5 @@ func configureCLIWizardDependencies(systemValidator: SystemValidator) {
     }
     WizardDependencies.hasExternalKanataRunning = {
         ExternalKanataService.hasExternalKanataRunning()
-    }
-    WizardDependencies.tcpProbe = { port, timeoutMs in
-        SystemStateProvider.probeTCPPort(port: port, timeoutMs: timeoutMs)
     }
 }

--- a/Sources/KeyPathWizardCore/WizardDependencies.swift
+++ b/Sources/KeyPathWizardCore/WizardDependencies.swift
@@ -22,7 +22,7 @@ public enum WizardDependencies {
     public static var runtimeCoordinator: (any RuntimeCoordinating)?
 
     /// HelperManager instance
-    public nonisolated(unsafe) static var helperManager: (any WizardHelperManaging)?
+    public static var helperManager: (any WizardHelperManaging)?
 
     /// KanataDaemonManager instance
     public static var daemonManager: (any WizardDaemonManaging)?
@@ -36,10 +36,10 @@ public enum WizardDependencies {
     public static var helperMaintenance: (any WizardHelperMaintaining)?
 
     /// FullDiskAccessChecker instance
-    public nonisolated(unsafe) static var fullDiskAccessChecker: (any WizardFullDiskAccessChecking)?
+    public static var fullDiskAccessChecker: (any WizardFullDiskAccessChecking)?
 
     /// PermissionRequestService instance
-    public nonisolated(unsafe) static var permissionRequestService: (any WizardPermissionRequesting)?
+    public static var permissionRequestService: (any WizardPermissionRequesting)?
 
     /// PrivilegedOperationsCoordinator instance
     public static var privilegedOperations: (any WizardPrivilegedOperating)?
@@ -60,55 +60,40 @@ public enum WizardDependencies {
 
     // MARK: - Type-Erased Closures
 
-    /// SMAppService factory for helper plist (type-erased)
-    public nonisolated(unsafe) static var smServiceFactory: ((String) -> Any)?
-
     /// Check if the helper needs Login Items approval in System Settings
-    public nonisolated(unsafe) static var helperNeedsApproval: (() -> Bool)?
+    public static var helperNeedsApproval: (() -> Bool)?
 
     /// UninstallCoordinator factory (type-erased, creates new instance each call)
     public static var createUninstallCoordinator: (() -> any WizardUninstalling)?
 
     /// AdminCommandExecutor - execute(batch:) for privileged commands
-    public nonisolated(unsafe) static var executePrivilegedBatch: ((PrivilegedCommandRunner.Batch) async throws -> (exitCode: Int32, output: String))?
+    public static var executePrivilegedBatch: ((PrivilegedCommandRunner.Batch) async throws -> (exitCode: Int32, output: String))?
 
     /// KeyPathAppKitResources bundle accessor
-    public nonisolated(unsafe) static var resourceBundle: Bundle?
+    public static var resourceBundle: Bundle?
 
     // MARK: - ExternalKanataService (static methods)
 
     /// Get info about externally-running Kanata process
-    public nonisolated(unsafe) static var getExternalKanataInfo: (() -> WizardSystemPaths.RunningKanataInfo?)?
+    public static var getExternalKanataInfo: (() -> WizardSystemPaths.RunningKanataInfo?)?
 
     /// Stop an externally-running Kanata process
-    public nonisolated(unsafe) static var stopExternalKanata: ((WizardSystemPaths.RunningKanataInfo) async -> Result<Void, Error>)?
+    public static var stopExternalKanata: ((WizardSystemPaths.RunningKanataInfo) async -> Result<Void, Error>)?
 
     /// Check if external Kanata is running
-    public nonisolated(unsafe) static var hasExternalKanataRunning: (() -> Bool)?
-
-    // MARK: - TCP readiness probe
-
-    /// TCP connectivity probe
-    public nonisolated(unsafe) static var tcpProbe: ((Int, Int) -> Bool)?
-
-    // MARK: - NotificationObserverManager factory
-
-    /// Factory to create notification observer managers
-    public nonisolated(unsafe) static var createNotificationObserverManager: (() -> Any)?
+    public static var hasExternalKanataRunning: (() -> Bool)?
 
     // MARK: - Ad-hoc Signature Cache
 
     /// Whether the app is running ad-hoc signed (not notarized).
     /// Cached at startup by KeyPathAppKit to avoid blocking the main thread
     /// with a synchronous codesign subprocess call from SwiftUI views.
-    public nonisolated(unsafe) static var isRunningAdHoc: Bool = false
+    public static var isRunningAdHoc: Bool = false
 
     // MARK: - Test Support
 
     /// Reset all dependencies to nil/false for test teardown.
     /// Call from KeyPathTestCase.tearDown() within `MainActor.assumeIsolated` or `MainActor.run`.
-    /// The nonisolated(unsafe) properties are safe to clear here because XCTest runs tests
-    /// serially and wizard views are not active during teardown.
     public static func reset() {
         runtimeCoordinator = nil
         helperManager = nil
@@ -121,7 +106,6 @@ public enum WizardDependencies {
         makeKanataMigrationPage = nil
         makeKarabinerImportPage = nil
         makeCommunicationPage = nil
-        smServiceFactory = nil
         helperNeedsApproval = nil
         createUninstallCoordinator = nil
         executePrivilegedBatch = nil
@@ -129,8 +113,6 @@ public enum WizardDependencies {
         getExternalKanataInfo = nil
         stopExternalKanata = nil
         hasExternalKanataRunning = nil
-        tcpProbe = nil
-        createNotificationObserverManager = nil
         isRunningAdHoc = false
     }
 }

--- a/Tests/KeyPathTests/Lint/W6DeletionPassLintTests.swift
+++ b/Tests/KeyPathTests/Lint/W6DeletionPassLintTests.swift
@@ -138,6 +138,21 @@ final class W6DeletionPassLintTests: XCTestCase {
         )
     }
 
+    func testWizardDependenciesRemainMainActorIsolated() throws {
+        let dependencies = repositoryRoot()
+            .appendingPathComponent("Sources/KeyPathWizardCore/WizardDependencies.swift")
+
+        let violations = try matchingLines(
+            in: dependencies,
+            patterns: [#"nonisolated\s*\(unsafe\)"#]
+        )
+
+        XCTAssertTrue(
+            violations.isEmpty,
+            "WizardDependencies is @MainActor; do not bypass its isolation with unsafe global state:\n\(violations.joined(separator: "\n"))"
+        )
+    }
+
     func testDiagnosticsManagerSingleImplementationProtocolDoesNotRegrow() throws {
         let managerFile = repositoryRoot()
             .appendingPathComponent("Sources/KeyPathAppKit/Managers/Diagnostics/DiagnosticsManager.swift")


### PR DESCRIPTION
## Summary
- keep `WizardDependencies` fully `@MainActor` isolated instead of bypassing actor checks
- remove three unused dependency injection points and their composition-root wiring
- add a lint ratchet preventing `nonisolated(unsafe)` from returning to the container

## Root cause
The dependency container had acquired `nonisolated(unsafe)` annotations when its lifecycle assumptions were implicit. Its current consumers are main-actor isolated, so those escape hatches are no longer necessary. Three of the unsafe injection points had no consumers at all.

## Validation
- stable Xcode 26.6 `swift build --jobs 4`
- `TEST_FILTER=W6DeletionPassLintTests ./Scripts/run-tests-safe.sh` (13 tests)
- `./Scripts/test-fast.sh --changed` (full fallback: 4,738 passed)
- `python3 Scripts/check-accessibility.py`
- `./Scripts/review-gate.sh` (`remote review gate selected`; merge waits for GitHub `claude-review`)

Closes #496