### PR TITLE
Unify Kanata runtime readiness evidence

### DIFF
--- a/Sources/KeyPathAppKit/App.swift
+++ b/Sources/KeyPathAppKit/App.swift
@@ -353,7 +353,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             return false
         }
         let health = await ServiceHealthChecker.shared.checkKanataServiceHealth()
-        let completed = health.isRunning && health.isResponding
+        let completed = health.isReady
         LiveKeyboardOverlayController.shared.setOnboardingCompleted(completed)
         return completed
     }

--- a/Sources/KeyPathAppKit/Core/PrivilegedOperationsRouter.swift
+++ b/Sources/KeyPathAppKit/Core/PrivilegedOperationsRouter.swift
@@ -949,7 +949,7 @@ public final class PrivilegedOperationsRouter {
                 timeoutMs: timeoutMs
             )
 
-            if snapshot.isRunning, snapshot.isResponding, snapshot.inputCaptureReady {
+            if snapshot.readiness.isReady {
                 return .ready
             }
 

--- a/Sources/KeyPathAppKit/Managers/ServiceLifecycleCoordinator.swift
+++ b/Sources/KeyPathAppKit/Managers/ServiceLifecycleCoordinator.swift
@@ -360,7 +360,7 @@ final class ServiceLifecycleCoordinator {
             lastSummary =
                 "state=\(managementState.description), running=\(snapshot.isRunning), tcp=\(snapshot.isResponding), inputCapture=\(snapshot.inputCaptureReady), decision=\(decision)"
 
-            if snapshot.isRunning, snapshot.isResponding, snapshot.inputCaptureReady, !snapshot.staleEnabledRegistration {
+            if Self.shouldAcceptPostStartRuntime(snapshot) {
                 AppLogger.shared.log("✅ [Service] Runtime readiness verified after start (\(reason)): \(lastSummary)")
                 return .ready
             }
@@ -371,6 +371,12 @@ final class ServiceLifecycleCoordinator {
         }
 
         return .failed("Kanata start did not reach runtime readiness after \(RuntimeReadinessTiming.timeoutMs)ms (\(lastSummary))")
+    }
+
+    static func shouldAcceptPostStartRuntime(
+        _ snapshot: ServiceHealthChecker.KanataServiceRuntimeSnapshot
+    ) -> Bool {
+        snapshot.readiness.isReady
     }
 
     private func sleepForReadinessPoll() async {

--- a/Sources/KeyPathAppKit/Services/MainAppStateController.swift
+++ b/Sources/KeyPathAppKit/Services/MainAppStateController.swift
@@ -128,14 +128,14 @@ class MainAppStateController {
 
     #if DEBUG
         @ObservationIgnored private var startupGateHealthOverride:
-            (() async -> KanataHealthSnapshot)?
+            (() async -> KanataRuntimeReadiness)?
         @ObservationIgnored private var startupGateTransientWindowOverride:
             (() async -> Bool)?
         @ObservationIgnored private var startupGateTimingOverride:
             (definitiveGrace: TimeInterval, transientGrace: TimeInterval, checkInterval: TimeInterval)?
 
         func configureStartupGateTestingState(
-            healthOverride: (() async -> KanataHealthSnapshot)? = nil,
+            healthOverride: (() async -> KanataRuntimeReadiness)? = nil,
             transientWindowOverride: (() async -> Bool)? = nil,
             timingOverride: (
                 definitiveGrace: TimeInterval,
@@ -777,7 +777,7 @@ class MainAppStateController {
         )
     }
 
-    private func currentKanataStartupHealth() async -> KanataHealthSnapshot {
+    private func currentKanataStartupHealth() async -> KanataRuntimeReadiness {
         #if DEBUG
             if let override = startupGateHealthOverride {
                 return await override()

--- a/Sources/KeyPathAppKit/Services/System/SystemValidator.swift
+++ b/Sources/KeyPathAppKit/Services/System/SystemValidator.swift
@@ -769,9 +769,7 @@ public class SystemValidator {
         let kanataHealth = await ServiceHealthChecker.shared.checkKanataServiceRuntimeSnapshot(
             tcpPort: PreferencesService.shared.tcpServerPort
         )
-        let kanataRunning = kanataHealth.isRunning
-            && kanataHealth.isResponding
-            && kanataHealth.inputCaptureReady
+        let kanataRunning = kanataHealth.readiness.isReady
         let kanataTCPConfigured = checkTCPConfiguration()
         let stderrDiagnosis = await ServiceHealthChecker.shared.diagnoseDaemonStderr()
         let configParseError = Self.effectiveConfigParseError(

--- a/Sources/KeyPathAppKit/UI/Overlay/LiveKeyboardOverlayController.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/LiveKeyboardOverlayController.swift
@@ -179,7 +179,7 @@ final class LiveKeyboardOverlayController: NSObject, NSWindowDelegate {
         // Only restore if system is healthy
         Task { @MainActor in
             let health = await ServiceHealthChecker.shared.checkKanataServiceHealth()
-            if health.isRunning, health.isResponding {
+            if health.isReady {
                 isVisible = true
             } else {
                 AppLogger.shared.log("⚠️ [OverlayController] Skipping overlay restore - Kanata not ready")

--- a/Sources/KeyPathInstallationWizard/Core/InstallerEngine.swift
+++ b/Sources/KeyPathInstallationWizard/Core/InstallerEngine.swift
@@ -878,15 +878,11 @@ public final class InstallerEngine {
     }
 
     /// Check Kanata service health (running + TCP responsive)
-    public func checkKanataServiceHealth(tcpPort: Int = KeyPathConstants.Networking.defaultTCPPort) async -> KanataHealthSnapshot {
+    public func checkKanataServiceHealth(tcpPort: Int = KeyPathConstants.Networking.defaultTCPPort) async -> KanataRuntimeReadiness {
         let runtimeSnapshot = await ServiceHealthChecker.shared.checkKanataServiceRuntimeSnapshot(
             tcpPort: tcpPort
         )
-        return KanataHealthSnapshot(
-            isRunning: runtimeSnapshot.isRunning,
-            isResponding: runtimeSnapshot.isResponding,
-            inputCaptureReady: runtimeSnapshot.inputCaptureReady
-        )
+        return runtimeSnapshot.readiness
     }
 
     /// Convenience wrapper that chains inspectSystem() → makePlan() → execute() internally.

--- a/Sources/KeyPathInstallationWizard/Core/InstallerEngineTypes.swift
+++ b/Sources/KeyPathInstallationWizard/Core/InstallerEngineTypes.swift
@@ -232,9 +232,7 @@ public enum InstallerPostcondition: String, Codable, Sendable, Equatable, CaseIt
 
         switch self {
         case .runtimeReadyOrApprovalPending:
-            let processRunning = context.services.kanataProcessRunning ?? context.services.kanataRunning
-            let tcpResponding = context.services.kanataTCPResponding ?? context.services.kanataRunning
-            return (processRunning && tcpResponding && context.services.kanataInputCaptureReady)
+            return context.services.kanataRuntimeReadiness.isReady
                 || context.services.loginItemsApprovalRequired == true
         case .vhidServicesHealthy:
             return context.components.vhidServicesHealthy && context.services.vhidHealthy
@@ -583,28 +581,6 @@ public struct InstallerReport: Sendable {
         self.recommendedRecovery = recommendedRecovery
         self.recoveryPlan = recoveryPlan
         self.failedPostconditions = failedPostconditions
-    }
-}
-
-// MARK: - Service Health Types
-
-/// Health status of the Kanata service (running + TCP responsive)
-public struct KanataHealthSnapshot: Sendable {
-    /// Whether the service process is running (launchctl PID check)
-    public let isRunning: Bool
-    /// Whether the service is responding to TCP health checks
-    public let isResponding: Bool
-    /// Whether Kanata can actually capture input from the active keyboard devices.
-    public let inputCaptureReady: Bool
-
-    public init(isRunning: Bool, isResponding: Bool, inputCaptureReady: Bool = true) {
-        self.isRunning = isRunning
-        self.isResponding = isResponding
-        self.inputCaptureReady = inputCaptureReady
-    }
-
-    public var isReady: Bool {
-        isRunning && isResponding && inputCaptureReady
     }
 }
 

--- a/Sources/KeyPathInstallationWizard/Core/ServiceHealthChecker.swift
+++ b/Sources/KeyPathInstallationWizard/Core/ServiceHealthChecker.swift
@@ -144,6 +144,14 @@ public final class ServiceHealthChecker: @unchecked Sendable {
             self.recentlyRestarted = recentlyRestarted
             self.activeProgramIdentity = activeProgramIdentity
         }
+
+        public var readiness: KanataRuntimeReadiness {
+            KanataRuntimeReadiness(
+                isRunning: isRunning,
+                isResponding: isResponding,
+                inputCaptureReady: inputCaptureReady
+            )
+        }
     }
 
     public struct LaunchctlProgramIdentity: Sendable, Equatable {
@@ -543,39 +551,30 @@ public final class ServiceHealthChecker: @unchecked Sendable {
 
     // MARK: - Kanata-Specific Health Check
 
-    /// Unified Kanata service health check: launchctl PID check + TCP probe.
+    /// Lightweight Kanata process + TCP readiness probe.
     ///
-    /// This provides a comprehensive health check that verifies both:
-    /// 1. The process is running (via launchctl print)
-    /// 2. The TCP server is responding (via socket connection)
-    ///
-    /// - Parameters:
-    ///   - tcpPort: TCP port to probe (default: 37001)
-    ///   - timeoutMs: TCP connection timeout in milliseconds (default: 300)
-    /// - Returns: `KanataHealthSnapshot` with running and responding status
+    /// This method does not inspect input capture; its returned
+    /// `inputCaptureReady` value preserves the legacy process/TCP-only contract.
+    /// Call `checkKanataServiceRuntimeSnapshot` when input-capture evidence is required.
     public nonisolated func checkKanataServiceHealth(
         tcpPort: Int = KeyPathConstants.Networking.defaultTCPPort,
         timeoutMs: Int = 300
-    ) async -> KanataHealthSnapshot {
+    ) async -> KanataRuntimeReadiness {
         if TestEnvironment.shouldSkipAdminOperations {
-            // Keep tests hermetic: avoid probing launchctl and real TCP sockets.
-            return KanataHealthSnapshot(isRunning: false, isResponding: false)
+            return KanataRuntimeReadiness(isRunning: false, isResponding: false)
         }
 
         let managementState = await getDaemonManager()?.refreshManagementState() ?? Self.fallbackManagementState
         let targets = await getDaemonManager()?.preferredLaunchctlTargets(for: managementState) ?? []
-
-        // 1) launchctl check for PID using SubprocessRunner
-        let runningState = await evaluateKanataLaunchctlRunningState(managementState: managementState, launchctlTargets: targets)
-        let isRunning = runningState.isRunning
-
-        // 2) TCP readiness through the shared system-state provider.
+        let runningState = await evaluateKanataLaunchctlRunningState(
+            managementState: managementState,
+            launchctlTargets: targets
+        )
         let tcpOK = await probeConfiguredTCPPort(defaultPort: tcpPort, timeoutMs: timeoutMs)
 
-        return KanataHealthSnapshot(
-            isRunning: isRunning,
-            isResponding: tcpOK
-        )
+        // Preserve this API's intentionally narrow process + TCP probe. Input-capture
+        // evidence belongs to the richer runtime snapshot used by installer/lifecycle paths.
+        return KanataRuntimeReadiness(isRunning: runningState.isRunning, isResponding: tcpOK)
     }
 
     public nonisolated func checkKanataServiceRuntimeSnapshot(
@@ -826,7 +825,7 @@ public final class ServiceHealthChecker: @unchecked Sendable {
             return .unhealthy(reason: runtimeSnapshot.inputCaptureIssue ?? "input-capture-not-ready")
         }
 
-        if runtimeSnapshot.isRunning, runtimeSnapshot.isResponding {
+        if runtimeSnapshot.readiness.isReady {
             return .healthy
         }
 

--- a/Sources/KeyPathWizardCore/SystemSnapshot.swift
+++ b/Sources/KeyPathWizardCore/SystemSnapshot.swift
@@ -383,6 +383,28 @@ public struct ConflictStatus: Sendable {
     }
 }
 
+// MARK: - Runtime Readiness
+
+/// Canonical evidence that the Kanata runtime can currently remap input.
+///
+/// Registration and startup grace periods are deliberately not represented here:
+/// they are lifecycle policy, not proof that the runtime is ready.
+public struct KanataRuntimeReadiness: Sendable, Equatable {
+    public let isRunning: Bool
+    public let isResponding: Bool
+    public let inputCaptureReady: Bool
+
+    public init(isRunning: Bool, isResponding: Bool, inputCaptureReady: Bool = true) {
+        self.isRunning = isRunning
+        self.isResponding = isResponding
+        self.inputCaptureReady = inputCaptureReady
+    }
+
+    public var isReady: Bool {
+        isRunning && isResponding && inputCaptureReady
+    }
+}
+
 // MARK: - Health Status
 
 public struct HealthStatus: Sendable {
@@ -467,8 +489,19 @@ public struct HealthStatus: Sendable {
 
     /// Overall health (includes Kanata runtime)
     public var isHealthy: Bool {
-        kanataRunning && karabinerDaemonRunning && vhidHealthy && kanataInputCaptureReady
+        kanataRuntimeReadiness.isReady && karabinerDaemonRunning && vhidHealthy
             && (kanataTCPConfigured ?? true)
+    }
+
+    /// Project the broader system snapshot onto the canonical runtime-readiness contract.
+    /// Older snapshots that lack explicit process/TCP evidence retain their historical
+    /// `kanataRunning` fallback instead of becoming false negatives.
+    public var kanataRuntimeReadiness: KanataRuntimeReadiness {
+        KanataRuntimeReadiness(
+            isRunning: kanataProcessRunning ?? kanataRunning,
+            isResponding: kanataTCPResponding ?? kanataRunning,
+            inputCaptureReady: kanataInputCaptureReady
+        )
     }
 
     /// Health of background services only (Karabiner daemon + VHID driver)

--- a/Tests/KeyPathTests/InstallationEngine/InstallerEngineFailurePathTests.swift
+++ b/Tests/KeyPathTests/InstallationEngine/InstallerEngineFailurePathTests.swift
@@ -549,8 +549,8 @@ final class InstallerEngineFailurePathTests: KeyPathAsyncTestCase {
 
     // MARK: - Health Check Types
 
-    func testKanataHealthSnapshot_AllHealthy() {
-        let snapshot = KanataHealthSnapshot(
+    func testKanataRuntimeReadiness_AllEvidenceReady() {
+        let snapshot = KanataRuntimeReadiness(
             isRunning: true,
             isResponding: true,
             inputCaptureReady: true
@@ -558,10 +558,11 @@ final class InstallerEngineFailurePathTests: KeyPathAsyncTestCase {
         XCTAssertTrue(snapshot.isRunning)
         XCTAssertTrue(snapshot.isResponding)
         XCTAssertTrue(snapshot.inputCaptureReady)
+        XCTAssertTrue(snapshot.isReady)
     }
 
-    func testKanataHealthSnapshot_PartialFailure() {
-        let snapshot = KanataHealthSnapshot(
+    func testKanataRuntimeReadiness_RequiresEverySignal() {
+        let snapshot = KanataRuntimeReadiness(
             isRunning: true,
             isResponding: false,
             inputCaptureReady: false
@@ -569,6 +570,30 @@ final class InstallerEngineFailurePathTests: KeyPathAsyncTestCase {
         XCTAssertTrue(snapshot.isRunning)
         XCTAssertFalse(snapshot.isResponding)
         XCTAssertFalse(snapshot.inputCaptureReady)
+        XCTAssertFalse(snapshot.isReady)
+    }
+
+    func testHealthStatusProjectsExplicitRuntimeEvidenceBeforeLegacySummary() {
+        let health = HealthStatus(
+            kanataProcessRunning: true,
+            kanataTCPResponding: false,
+            kanataRunning: true,
+            karabinerDaemonRunning: true,
+            vhidHealthy: true
+        )
+
+        XCTAssertFalse(health.kanataRuntimeReadiness.isReady)
+        XCTAssertFalse(health.isHealthy, "A running process without TCP readiness is not system healthy")
+    }
+
+    func testHealthStatusRetainsLegacyRuntimeSummaryFallback() {
+        let health = HealthStatus(
+            kanataRunning: true,
+            karabinerDaemonRunning: true,
+            vhidHealthy: true
+        )
+
+        XCTAssertTrue(health.kanataRuntimeReadiness.isReady)
     }
 
     // MARK: - Stub Coordinator Tests

--- a/Tests/KeyPathTests/InstallationEngine/InstallerEngineHealthCheckTests.swift
+++ b/Tests/KeyPathTests/InstallationEngine/InstallerEngineHealthCheckTests.swift
@@ -89,7 +89,7 @@ final class InstallerEngineHealthCheckTests: KeyPathAsyncTestCase {
         let health = await engine.checkKanataServiceHealth()
 
         // Verify structure
-        XCTAssertNotNil(health, "checkKanataServiceHealth() should return a KanataHealthSnapshot")
+        XCTAssertNotNil(health, "checkKanataServiceHealth() should return runtime readiness evidence")
 
         // isRunning and isResponding should be booleans
         _ = health.isRunning

--- a/Tests/KeyPathTests/MainAppStateControllerTests.swift
+++ b/Tests/KeyPathTests/MainAppStateControllerTests.swift
@@ -356,7 +356,7 @@ struct MainAppStateControllerBehaviorTests {
                     if !isResponding {
                         observedNonRespondingProbe = true
                     }
-                    return KanataHealthSnapshot(
+                    return KanataRuntimeReadiness(
                         isRunning: true,
                         isResponding: isResponding
                     )
@@ -385,7 +385,7 @@ struct MainAppStateControllerBehaviorTests {
         #if DEBUG
             controller.configureStartupGateTestingState(
                 healthOverride: {
-                    KanataHealthSnapshot(isRunning: false, isResponding: false)
+                    KanataRuntimeReadiness(isRunning: false, isResponding: false)
                 },
                 transientWindowOverride: { false },
                 timingOverride: (
@@ -407,7 +407,7 @@ struct MainAppStateControllerBehaviorTests {
         #if DEBUG
             controller.configureStartupGateTestingState(
                 healthOverride: {
-                    KanataHealthSnapshot(isRunning: false, isResponding: false)
+                    KanataRuntimeReadiness(isRunning: false, isResponding: false)
                 },
                 transientWindowOverride: { true },
                 timingOverride: (
@@ -534,7 +534,7 @@ struct MainAppStateControllerBehaviorTests {
         #if DEBUG
             controller.configureStartupGateTestingState(
                 healthOverride: {
-                    KanataHealthSnapshot(isRunning: true, isResponding: true)
+                    KanataRuntimeReadiness(isRunning: true, isResponding: true)
                 },
                 transientWindowOverride: { false },
                 timingOverride: (
@@ -556,7 +556,7 @@ struct MainAppStateControllerBehaviorTests {
         #if DEBUG
             controller.configureStartupGateTestingState(
                 healthOverride: {
-                    KanataHealthSnapshot(isRunning: true, isResponding: true)
+                    KanataRuntimeReadiness(isRunning: true, isResponding: true)
                 },
                 transientWindowOverride: { false }
             )

--- a/Tests/KeyPathTests/Services/ServiceHealthCheckerTests.swift
+++ b/Tests/KeyPathTests/Services/ServiceHealthCheckerTests.swift
@@ -437,6 +437,7 @@ final class ServiceHealthCheckerTests: XCTestCase {
         let decision = ServiceHealthChecker.decideKanataHealth(for: snapshot)
         XCTAssertEqual(decision, .healthy)
         XCTAssertTrue(decision.isHealthy)
+        XCTAssertTrue(snapshot.readiness.isReady, "Live runtime evidence must outrank stale registration metadata")
     }
 
     func testLaunchctlProgramIdentityExtractsSMAppServiceSource() {

--- a/Tests/KeyPathTests/Services/ServiceLifecycleCoordinatorTests.swift
+++ b/Tests/KeyPathTests/Services/ServiceLifecycleCoordinatorTests.swift
@@ -173,6 +173,24 @@ final class ServiceLifecycleCoordinatorTests: KeyPathTestCase {
         )
     }
 
+    func testPostStartReadinessAcceptsLiveRuntimeDespiteStaleRegistrationMetadata() {
+        let snapshot = ServiceHealthChecker.KanataServiceRuntimeSnapshot(
+            managementState: .smappserviceActive,
+            isRunning: true,
+            isResponding: true,
+            inputCaptureReady: true,
+            inputCaptureIssue: nil,
+            launchctlExitCode: 0,
+            staleEnabledRegistration: true,
+            recentlyRestarted: false
+        )
+
+        XCTAssertTrue(
+            ServiceLifecycleCoordinator.shouldAcceptPostStartRuntime(snapshot),
+            "Current process, TCP, and input-capture evidence must outrank stale registration metadata"
+        )
+    }
+
     // MARK: - Restart
 
     func testRestartCallsStopThenStart() async {

--- a/docs/architecture/service-readiness-contract.md
+++ b/docs/architecture/service-readiness-contract.md
@@ -1,0 +1,46 @@
+# Service Readiness Contract
+
+KeyPath uses one evidence contract when deciding whether the Kanata runtime can
+currently remap input: `KanataRuntimeReadiness` in `KeyPathWizardCore`.
+
+Runtime readiness requires all three current observations:
+
+1. the Kanata process is running;
+2. its TCP endpoint responds; and
+3. input capture is active.
+
+Registration is not liveness. An enabled `SMAppService`, a loaded launchd job,
+or a startup grace period can explain why readiness is not available yet, but
+none of them proves readiness.
+
+## Current ownership
+
+| Type | Responsibility | Relationship to readiness |
+| --- | --- | --- |
+| `KanataRuntimeReadiness` | Process, TCP, and input-capture evidence | Canonical readiness decision |
+| `ServiceHealthChecker.KanataServiceRuntimeSnapshot` | Collects readiness plus launchctl, registration, freshness, and diagnosis metadata | Projects `readiness` |
+| `HealthStatus` | Broader system snapshot used by wizard, UI, and CLI | Projects `kanataRuntimeReadiness`; preserves the legacy summary fallback only when explicit process/TCP evidence is absent |
+| `ServiceHealthChecker.KanataHealthDecision` | Monitoring policy, including restart warm-up as transiently healthy | Not a readiness result; `.transient` must not satisfy postconditions |
+| `ServiceHealthMonitor` | Time-based monitoring, cooldown, and recovery policy | Consumes health observations; does not redefine readiness |
+| `ServiceLifecycleCoordinator` | Start, stop, and restart orchestration | A start succeeds only after canonical readiness or explicit pending approval |
+| `InstallerPostcondition.runtimeReadyOrApprovalPending` | Installer transaction verification | Uses canonical readiness, with pending approval as a separate terminal state |
+
+## Decision rules
+
+- Current process + TCP + input-capture evidence outranks stale registration
+  metadata. This avoids treating an actually running runtime as unavailable
+  because an earlier registration probe was stale.
+- Pending Login Items approval is an explicit lifecycle result, not runtime
+  readiness.
+- A TCP warm-up grace period may suppress premature recovery, but it does not
+  make a start or installer postcondition successful.
+- Input-capture failures are degraded runtime failures even when process and TCP
+  checks pass.
+
+## Consolidation boundary
+
+Do not merge `ServiceHealthChecker` and `ServiceHealthMonitor` solely to share
+this decision. They live on opposite sides of the installation/AppKit module
+boundary and have different jobs: evidence collection versus time-based
+recovery policy. Consolidate those types only when a concrete behavior change
+requires moving the module boundary.


### PR DESCRIPTION
## Summary
- define one immutable Kanata runtime-readiness contract: process running, TCP responding, and input capture ready
- project existing service/system snapshots onto that contract and use it for lifecycle, installer, UI, and health decisions
- keep registration, pending approval, startup grace, and recovery policy separate from readiness
- document current ownership; no manager/service merge

## Root cause
Readiness was recomputed as local Boolean expressions across app, wizard, installer, and privileged paths. Those copies drifted: post-start verification rejected live runtime evidence when stale registration metadata remained, even though the shared health decision correctly let current evidence win.

## Intentional behavior change
Post-start lifecycle verification now accepts contemporaneous process, TCP, and input-capture evidence even when registration metadata says the enabled job was not loaded. That registration value is treated as stale negative metadata once the same snapshot proves the runtime is live and usable. When live evidence is absent, stale registration remains an unhealthy state and continues to trigger recovery.

The lightweight UI probe remains process + TCP only and is explicitly documented not to provide real input-capture evidence. Installer and lifecycle decisions use the full runtime snapshot.

## Validation
- stable Xcode 26.6 `swift build --jobs 4`
- focused readiness suites: 123 tests passed
- `ServiceHealthCheckerTests`: 32 tests passed
- `ServiceLifecycleCoordinatorTests`: 24 tests passed
- `InstallerEngineFailurePathTests`: 37 tests passed
- `./Scripts/test-fast.sh --changed`: 4,738 passed; one load-sensitive, unrelated timeout assertion failed
- isolated `SystemValidatorTests`: 16 passed, including that timeout scenario in 0.017s
- `python3 Scripts/check-accessibility.py`
- review gate: remote review gate selected; GitHub `claude-review` is required

Closes #735