### PR TITLE
Fix Tart protected-click coordinate mapping

### DIFF
--- a/Scripts/lab/remote.sh
+++ b/Scripts/lab/remote.sh
@@ -691,8 +691,7 @@ secure_dialog_input() {
 
 protected_click() {
   local lease=$1 app=$2 expected_before=$3 expected_after=$4 coordinate_space=$5 x=$6 y=$7
-  local manifest macos resource key ip before after guest_command geometry_command geometry
-  local native_width native_height logical_width logical_height scale_x scale_y
+  local manifest macos resource key ip before after guest_command
   manifest=$(owned_manifest "$lease")
   macos=$(field "$manifest" macos)
   [[ "$macos" == "15" ]] || die "protected click currently supports only the Tart macOS 15 lane"
@@ -720,22 +719,11 @@ protected_click() {
     die "protected click precondition failed: expected window '$expected_before', found '${before:-unknown}'"
   }
 
-  if [[ "$coordinate_space" == "ax" ]]; then
-    if [[ "${KEYPATH_LAB_TESTING:-0}" == "1" ]]; then
-      geometry=${KEYPATH_LAB_TEST_DISPLAY_GEOMETRY:-'2048 1536 1024 768'}
-    else
-      geometry_command='/opt/homebrew/bin/peekaboo list windows --app '$(printf %q "$app")' --json | /usr/bin/python3 -c '\''import json,re,sys; data=json.load(sys.stdin).get("data",{}); windows=data.get("windows",data if isinstance(data,list) else []); names=[w.get("screenName","") for w in windows if isinstance(w,dict)]; m=next((re.search(r"([0-9]+)×([0-9]+)",n) for n in names if re.search(r"([0-9]+)×([0-9]+)",n)),None); print(f"{m.group(1)} {m.group(2)}" if m else "",end="")'\''; printf " "; /usr/bin/osascript -l JavaScript -e '\''ObjC.import("AppKit"); var s=$.NSScreen.mainScreen.frame.size; s.width+" "+s.height'\'''
-      geometry=$("$GUEST_SSH" -o BatchMode=yes -o StrictHostKeyChecking=accept-new -i "$key" "admin@$ip" "/bin/zsh -lc $(printf %q "$geometry_command")")
-    fi
-    IFS=' ' read -r native_width native_height logical_width logical_height <<< "$geometry"
-    [[ "$native_width" == <-> && "$native_height" == <-> && "$logical_width" == <-> && "$logical_height" == <-> && "$logical_width" -gt 0 && "$logical_height" -gt 0 ]] || die "protected click could not measure display geometry"
-    (( native_width % logical_width == 0 && native_height % logical_height == 0 )) || die "protected click measured a non-integral display scale"
-    scale_x=$((native_width / logical_width))
-    scale_y=$((native_height / logical_height))
-    (( scale_x == scale_y && scale_x > 0 )) || die "protected click measured inconsistent display scales"
-    x=$((x * scale_x))
-    y=$((y * scale_y))
-  fi
+  # Tart's VNC/RFB viewport uses the same 1024x768 logical coordinate space
+  # exposed by Accessibility. NSScreen's 2x backing dimensions are not input
+  # coordinates, so multiplying fresh AX bounds targets a different control.
+  # `native` remains an explicit escape hatch for a caller that already has a
+  # verified framebuffer point.
 
   "$CRABBOX" desktop click --provider tart --target macos --id "$resource" --x "$x" --y "$y" >/dev/null
   sleep "${KEYPATH_LAB_PROTECTED_CLICK_SETTLE_SECONDS:-1}"
@@ -754,7 +742,7 @@ protected_click() {
   print "window_after\t$after"
   print "coordinate_space\t$coordinate_space"
   if [[ "$coordinate_space" == "ax" ]]; then
-    print "display_scale\t$scale_x"
+    print "input_mapping\tax-direct"
   fi
 }
 

--- a/Scripts/lab/tests/keypath-lab-tests.sh
+++ b/Scripts/lab/tests/keypath-lab-tests.sh
@@ -380,8 +380,8 @@ set -e
 [[ $protected_wrong_page_exit -ne 0 ]] || { echo "protected click accepted the wrong destination page" >&2; exit 1; }
 assert_contains "$protected_wrong_page" "protected click postcondition failed"
 protected_ax_result=$(KEYPATH_LAB_PROTECTED_CLICK_SETTLE_SECONDS=0 run_remote protected-click cbx_desktop15 'System Settings' Accessibility Accessibility ax 402 247)
-assert_contains "$protected_ax_result" $'display_scale\t2'
-grep -q 'crabbox desktop click --provider tart --target macos --id test-resource --x 804 --y 494' "$CALLS"
+assert_contains "$protected_ax_result" $'input_mapping\tax-direct'
+grep -q 'crabbox desktop click --provider tart --target macos --id test-resource --x 402 --y 247' "$CALLS"
 run_remote desktop-type cbx_desktop15 q >/dev/null
 grep -q 'crabbox desktop type --provider tart --target macos --id test-resource --text q' "$CALLS"
 run_remote destroy cbx_desktop15 >/dev/null

--- a/docs/testing/installer-gui-automation-capabilities.md
+++ b/docs/testing/installer-gui-automation-capabilities.md
@@ -36,10 +36,11 @@ expected page (or explicitly expected dialog) immediately afterward. A changed
 page is a harness failure; never continue to password entry or report the
 permission as granted.
 
-Pass Accessibility coordinates to `keypath-lab protected-click` with `--ax-x`
-and `--ax-y`. The controller measures the guest's native and logical display
-dimensions and applies the scale itself. Reserve raw `--x` and `--y` coordinates
-for diagnostics where the native framebuffer point is already known.
+Pass fresh Accessibility coordinates to `keypath-lab protected-click` with
+`--ax-x` and `--ax-y`. On the Tart macOS 15 lane the controller sends those
+points unchanged because the VNC viewport is already in logical coordinates;
+the backing-display scale must not be applied. Reserve raw `--x` and `--y`
+coordinates for diagnostics where the native framebuffer point is already known.
 
 ## Current capability matrix
 

--- a/docs/testing/remote-installer-lab.md
+++ b/docs/testing/remote-installer-lab.md
@@ -230,11 +230,13 @@ Scripts/lab/keypath-lab protected-click cbx_example \
   --ax-x 402 --ax-y 247
 ```
 
-With `--ax-x` and `--ax-y`, the command measures the current display's logical
-and native dimensions and converts Accessibility coordinates to framebuffer
-coordinates. Raw native coordinates remain available as `--x` and `--y` for
-diagnostics. The command snapshots the named app before and after delivery and fails
-if either window title differs from the declared page. When the click is
+With `--ax-x` and `--ax-y`, the command delivers the fresh Accessibility point
+unchanged. On the Tart macOS 15 lane, the VNC input viewport matches that
+logical coordinate space even though the backing display reports a 2x Retina
+size. Raw native coordinates remain available as `--x` and `--y` for
+diagnostics where a framebuffer point has been independently verified. The
+command snapshots the named app before and after delivery and fails if either
+window title differs from the declared page. When the click is
 expected to open another page or dialog, declare that explicitly with
 `--after-window`. This guard detects a delivered click that landed on the wrong
 System Settings surface; it does not replace the permission's canonical product


### PR DESCRIPTION
## Summary
- deliver fresh Accessibility points directly to the Tart VNC viewport
- keep raw framebuffer coordinates explicit for diagnostics
- align shell coverage and lab documentation with the verified mapping

## Validation
- `Scripts/lab/tests/keypath-lab-tests.sh`
- `zsh -n Scripts/lab/keypath-lab Scripts/lab/remote.sh`
- `./Scripts/review-gate.sh` (remote review gate selected)