### PR TITLE
Keep blocked dashboard work from pulsing

### DIFF
--- a/Scripts/lab/tests/update-progress-dashboard-tests.py
+++ b/Scripts/lab/tests/update-progress-dashboard-tests.py
@@ -63,6 +63,18 @@ class UpdateProgressDashboardTests(unittest.TestCase):
         self.assertNotIn("P01", state["activeWork"])
         self.assertNotIn("P01", state["workingBlocks"])
 
+    def test_blocked_keeps_evidence_without_marking_work_active(self) -> None:
+        self.run_updater("--progress", "62", "--health", "blocked", "--blocked")
+        state = json.loads(self.state.read_text())
+        self.assertEqual(state["statuses"]["P01"], "blocked")
+        self.assertIn("P01", state["activeWork"])
+        self.assertNotIn("P01", state["workingBlocks"])
+
+    def test_rejects_finish_and_blocked_together(self) -> None:
+        result = self.run_updater("--finish", "--blocked", check=False)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("cannot be combined", result.stderr)
+
     def test_embedded_dashboard_script_parses_after_srcdoc_decoding(self) -> None:
         source = DASHBOARD.read_text()
         srcdoc = re.search(r'srcdoc="(.*?)">\s*</iframe>', source, re.DOTALL)

--- a/Scripts/lab/update-progress-dashboard
+++ b/Scripts/lab/update-progress-dashboard
@@ -44,7 +44,14 @@ def main() -> None:
     parser.add_argument("--title", required=True)
     parser.add_argument("--message", required=True)
     parser.add_argument("--finish", action="store_true")
+    parser.add_argument(
+        "--blocked",
+        action="store_true",
+        help="Keep block progress and evidence visible without marking it as actively worked",
+    )
     args = parser.parse_args()
+    if args.finish and args.blocked:
+        parser.error("--finish and --blocked cannot be combined")
     if args.progress is not None and not 0 <= args.progress <= 100:
         parser.error("--progress must be between 0 and 100")
     next_tasks = []
@@ -72,7 +79,10 @@ def main() -> None:
         working.discard(args.block)
         state.setdefault("statuses", {})[args.block] = "proven"
     else:
-        working.add(args.block)
+        if args.blocked:
+            working.discard(args.block)
+        else:
+            working.add(args.block)
         previous_work = active_work.get(args.block, {})
         active_work[args.block] = {
             "progress": args.progress or 0,
@@ -92,7 +102,7 @@ def main() -> None:
             ),
             "unlocks": args.unlocks or previous_work.get("unlocks", []),
         }
-        state.setdefault("statuses", {})[args.block] = "active"
+        state.setdefault("statuses", {})[args.block] = "blocked" if args.blocked else "active"
     state["workingBlocks"] = sorted(working)
     updates = state.setdefault("updates", [])
     updates.insert(0, {

--- a/docs/testing/keypath-test-automation-progress.html
+++ b/docs/testing/keypath-test-automation-progress.html
@@ -784,6 +784,7 @@ html&gt;body{padding:0}&lt;/style&gt;
     #keypath-defrag-progress .swatch { width:11px; height:11px; border-radius:2px; }
     #keypath-defrag-progress .proven-mark { background:var(--viz-series-3); }
     #keypath-defrag-progress .active-mark { background:var(--viz-series-2); }
+    #keypath-defrag-progress .blocked-mark { background:var(--destructive); }
     #keypath-defrag-progress .queued-mark { background:var(--muted); border:1px solid var(--border); }
     #keypath-defrag-progress .waiting-mark { background:var(--viz-series-5); }
     #keypath-defrag-progress .workspace { display:block; }
@@ -793,6 +794,7 @@ html&gt;body{padding:0}&lt;/style&gt;
     #keypath-defrag-progress .block { appearance:none; position:relative; overflow:hidden; border:0; border-radius:3px; min-height:42px; padding:5px 3px 8px; font:inherit; font-size:10px; font-weight:500; cursor:pointer; color:var(--foreground); outline-offset:2px; transition:transform 120ms ease, filter 120ms ease, box-shadow 120ms ease; }
     #keypath-defrag-progress .block[data-status=&quot;proven&quot;] { background:color-mix(in srgb,var(--viz-series-3) 78%,var(--card)); color:var(--card-foreground); }
     #keypath-defrag-progress .block[data-status=&quot;active&quot;] { background:color-mix(in srgb,var(--viz-series-2) 72%,var(--card)); color:var(--card-foreground); }
+    #keypath-defrag-progress .block[data-status=&quot;blocked&quot;] { background:color-mix(in srgb,var(--destructive) 62%,var(--card)); color:var(--card-foreground); }
     #keypath-defrag-progress .block[data-status=&quot;queued&quot;] { background:var(--muted); color:var(--muted-foreground); }
     #keypath-defrag-progress .block[data-status=&quot;waiting&quot;] { background:repeating-linear-gradient(135deg,color-mix(in srgb,var(--viz-series-5) 86%,var(--card)) 0 8px,color-mix(in srgb,var(--viz-series-5) 58%,var(--card)) 8px 13px); color:var(--card-foreground); }
     #keypath-defrag-progress .block:hover, #keypath-defrag-progress .block:focus-visible { filter:brightness(1.1); transform:translateY(-2px) scale(1.04); box-shadow:0 0 0 2px var(--ring); z-index:1; }
@@ -872,6 +874,7 @@ html&gt;body{padding:0}&lt;/style&gt;
   &lt;div class=&quot;legend&quot; aria-label=&quot;Status legend&quot;&gt;
     &lt;span&gt;&lt;i class=&quot;swatch proven-mark&quot;&gt;&lt;/i&gt;Proven in a disposable VM&lt;/span&gt;
     &lt;span&gt;&lt;i class=&quot;swatch active-mark&quot;&gt;&lt;/i&gt;Current frontier&lt;/span&gt;
+    &lt;span&gt;&lt;i class=&quot;swatch blocked-mark&quot;&gt;&lt;/i&gt;Platform blocked&lt;/span&gt;
     &lt;span&gt;&lt;i class=&quot;swatch queued-mark&quot;&gt;&lt;/i&gt;Queued work&lt;/span&gt;
     &lt;span&gt;&lt;i class=&quot;swatch waiting-mark&quot;&gt;&lt;/i&gt;Waiting on Apple&lt;/span&gt;
   &lt;/div&gt;
@@ -980,10 +983,11 @@ html&gt;body{padding:0}&lt;/style&gt;
       const title = root.querySelector(&#x27;#keypath-defrag-title&#x27;);
       const detail = root.querySelector(&#x27;#keypath-defrag-detail&#x27;);
       const status = root.querySelector(&#x27;#keypath-defrag-status&#x27;);
-      const names = {proven:&#x27;Proven&#x27;,active:&#x27;Current frontier&#x27;,queued:&#x27;Queued&#x27;,waiting:&#x27;Waiting on Apple&#x27;};
+      const names = {proven:&#x27;Proven&#x27;,active:&#x27;Current frontier&#x27;,blocked:&#x27;Platform blocked&#x27;,queued:&#x27;Queued&#x27;,waiting:&#x27;Waiting on Apple&#x27;};
       const defaultTasks = (state,name) =&gt; {
         if (state === &#x27;proven&#x27;) return [{label:`Keep ${name} covered by regression runs`,status:&#x27;done&#x27;,progress:100}];
         if (state === &#x27;waiting&#x27;) return [{label:&#x27;Resume when the external dependency clears&#x27;,status:&#x27;blocked&#x27;,progress:0}];
+        if (state === &#x27;blocked&#x27;) return [{label:&#x27;Resume when the platform prerequisite is available&#x27;,status:&#x27;blocked&#x27;,progress:0}];
         if (state === &#x27;active&#x27;) return [{label:`Finish ${name}`,status:&#x27;active&#x27;,progress:0}];
         return [{label:`Start ${name}`,status:&#x27;queued&#x27;,progress:0}];
       };


### PR DESCRIPTION
## Summary
- add a durable blocked state to the progress dashboard writer
- show blocked work in red without the active pulse
- preserve progress, hover evidence, and recent status updates

## Validation
- `python3 Scripts/lab/tests/update-progress-dashboard-tests.py`
- `git diff --check`
- `./Scripts/review-gate.sh` (remote review gate selected; GitHub `claude-review` required before merge)