### PR TITLE
Honor backlog status labels in issue dashboard

### DIFF
--- a/Scripts/lab/tests/issue-dashboard-tests.py
+++ b/Scripts/lab/tests/issue-dashboard-tests.py
@@ -19,17 +19,17 @@ def issue(number: int, *labels: str) -> dict:
 
 
 class IssueDashboardTests(unittest.TestCase):
-    def test_active_and_next_override_general_labels(self) -> None:
-        self.assertEqual(module.issue_status(issue(748, "tech-debt")), "active")
-        self.assertEqual(module.issue_status(issue(848, "testing", "agent-ok")), "next")
-
     def test_upstream_release_wait_is_human_gated(self) -> None:
         self.assertEqual(module.issue_status(issue(982, "bug-risk", "human-in-loop")), "human")
 
-    def test_explicitly_deferred_issues_are_human_gated(self) -> None:
-        for number in (172, 740, 747, 919):
-            with self.subTest(number=number):
-                self.assertEqual(module.issue_status(issue(number, "agent-ok")), "human")
+    def test_on_hold_and_tracking_labels_override_work_type(self) -> None:
+        self.assertEqual(module.issue_status(issue(982, "human-in-loop", "on-hold")), "deferred")
+        self.assertEqual(module.issue_status(issue(604, "testing", "tracking-only")), "deferred")
+        self.assertEqual(module.issue_status(issue(865, "enhancement", "tracking-only", "on-hold")), "deferred")
+
+    def test_topic_labels_do_not_imply_execution_state(self) -> None:
+        self.assertEqual(module.issue_status(issue(912, "wwdc26", "enhancement")), "feature")
+        self.assertEqual(module.issue_status(issue(919, "wwdc26", "human-in-loop")), "human")
 
     def test_features_do_not_enter_agent_bug_queue(self) -> None:
         self.assertEqual(module.issue_status(issue(870, "Feature", "agent-ok")), "feature")

--- a/Scripts/lab/update-issue-dashboard
+++ b/Scripts/lab/update-issue-dashboard
@@ -9,21 +9,17 @@ import shutil
 import subprocess
 
 
-EXCLUDED = {172, 740, 747, 919}
-ACTIVE = {848}
-NEXT = set()
 ISSUE_LIMIT = 200
 RECENTLY_CLOSED_LIMIT = 10
 
 
 def issue_status(issue: dict) -> str:
-    number = issue["number"]
     labels = {label["name"] for label in issue.get("labels", [])}
-    if number in ACTIVE:
-        return "active"
-    if number in NEXT:
-        return "next"
-    if number in EXCLUDED or "human-in-loop" in labels or "wwdc26" in labels:
+    # Explicit execution state outranks work type and required operator. Topic
+    # labels such as `wwdc26` do not imply that an issue is active or human-gated.
+    if labels & {"on-hold", "tracking-only"}:
+        return "deferred"
+    if "human-in-loop" in labels:
         return "human"
     if "large-refactor" in labels:
         return "deferred"


### PR DESCRIPTION
## Summary
- derive issue-dashboard execution state from `on-hold` and `tracking-only` labels
- remove stale hard-coded issue-number priority overrides
- add focused precedence tests for held and tracking issues

## Why
The backlog now uses explicit GitHub labels as its source of truth. The dashboard still classified held feature ideas as queued, feature, or human work because it ignored those labels and carried obsolete issue-number exceptions.

## Validation
- `python3 Scripts/lab/tests/issue-dashboard-tests.py`
- generated a fresh state file: 1 queued, 2 human-led, 74 deferred
- `git diff --check`
- review gate: remote review gate selected; GitHub `claude-review` required