### PR TITLE
Add scenario failure ownership contract

### DIFF
--- a/Scripts/lab/scenario-result
+++ b/Scripts/lab/scenario-result
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Write validated, machine-readable outcomes for KeyPath lab scenarios."""
+
+import argparse
+import datetime
+import json
+import pathlib
+import sys
+
+
+CLASSIFICATIONS = (
+    "keypath-product-failure",
+    "harness-selector-failure",
+    "harness-transport-failure",
+    "provider-failure",
+    "unsupported-os-selector",
+    "environment-precondition-failure",
+)
+
+
+def write_result(args: argparse.Namespace) -> None:
+    if args.status == "passed" and args.classification:
+        raise ValueError("a passed result cannot have a failure classification")
+    if args.status != "passed" and not args.classification:
+        raise ValueError("a non-passing result requires --classification")
+    if args.status != "passed" and not args.step:
+        raise ValueError("a non-passing result requires --step")
+
+    result = {
+        "schemaVersion": 1,
+        "scenario": args.scenario,
+        "status": args.status,
+        "summary": args.summary,
+        "recordedAt": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        "evidence": args.evidence,
+    }
+    if args.classification:
+        result["failure"] = {
+            "classification": args.classification,
+            "step": args.step,
+            "message": args.message or args.summary,
+        }
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(result, indent=2) + "\n")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest="command", required=True)
+
+    record = commands.add_parser("record", help="record one validated scenario outcome")
+    record.add_argument("--output", required=True, type=pathlib.Path)
+    record.add_argument("--scenario", required=True)
+    record.add_argument("--status", required=True, choices=("passed", "failed", "blocked"))
+    record.add_argument("--summary", required=True)
+    record.add_argument("--classification", choices=CLASSIFICATIONS)
+    record.add_argument("--step")
+    record.add_argument("--message")
+    record.add_argument("--evidence", action="append", default=[])
+
+    selector = commands.add_parser(
+        "selector-self-test",
+        help="record a deliberate selector mismatch as a harness failure",
+    )
+    selector.add_argument("--output", required=True, type=pathlib.Path)
+    selector.add_argument("--scenario", default="failure-ownership-self-test")
+
+    args = parser.parse_args()
+    try:
+        if args.command == "selector-self-test":
+            args.status = "failed"
+            args.summary = "Deliberate missing selector was classified as a harness failure."
+            args.classification = "harness-selector-failure"
+            args.step = "intentional-selector-mismatch"
+            args.message = "The target accessibility identifier was intentionally absent."
+            args.evidence = []
+        write_result(args)
+    except ValueError as error:
+        parser.error(str(error))
+
+
+if __name__ == "__main__":
+    main()

--- a/Scripts/lab/scenarios/installer-scenario
+++ b/Scripts/lab/scenarios/installer-scenario
@@ -6,6 +6,18 @@ lane=${2:-}
 installer_dir="$PWD/.keypath-lab/installer"
 artifact_dir="$PWD/.keypath-lab/scenario-output/$name"
 mkdir -p "$artifact_dir"
+result_tool="$PWD/Scripts/lab/scenario-result"
+
+require_installed_cli() {
+  if [[ -x "$installed_cli" ]]; then
+    return
+  fi
+  "$result_tool" record --output "$artifact_dir/result.json" --scenario "$name" \
+    --status failed --summary "KeyPath CLI is not installed." \
+    --classification environment-precondition-failure --step installed-cli
+  print -u2 "KeyPath CLI is not installed"
+  exit 3
+}
 
 record_system() {
   sw_vers > "$artifact_dir/sw-vers.txt"
@@ -27,13 +39,19 @@ case "$name" in
     print "Capture each prompt before and after approval; never copy TCC databases into artifacts."
     ;;
   helper-daemon-health)
-    [[ -x "$installed_cli" ]] || { print -u2 "KeyPath CLI is not installed"; exit 3; }
+    require_installed_cli
     "$installed_cli" system inspect --json | tee "$artifact_dir/system-inspect.json"
     Scripts/lab/probe-kanata-tcp 2> "$artifact_dir/tcp-readiness.stderr" | tee "$artifact_dir/tcp-readiness.json"
     ;;
   managed-capabilities)
-    [[ "$lane" == "managed-functional" ]] || { print -u2 "managed-functional lease required"; exit 4; }
-    [[ -x "$installed_cli" ]] || { print -u2 "KeyPath CLI is not installed"; exit 3; }
+    if [[ "$lane" != "managed-functional" ]]; then
+      "$result_tool" record --output "$artifact_dir/result.json" --scenario "$name" \
+        --status blocked --summary "Managed-functional lease required." \
+        --classification environment-precondition-failure --step lane-admission
+      print -u2 "managed-functional lease required"
+      exit 4
+    fi
+    require_installed_cli
     Scripts/lab/mdm/probe-managed-capabilities --output "$artifact_dir"
     ;;
   launch)
@@ -42,28 +60,31 @@ case "$name" in
     pgrep -fl '/Applications/KeyPath.app/Contents/MacOS/KeyPath' | tee "$artifact_dir/processes.txt"
     ;;
   repair-reinstall)
-    [[ -x "$installed_cli" ]] || { print -u2 "KeyPath CLI is not installed"; exit 3; }
+    require_installed_cli
     "$installed_cli" system repair --json | tee "$artifact_dir/repair.json"
     "$installed_cli" system inspect --json | tee "$artifact_dir/post-repair.json"
     ;;
   reboot-persistence-before)
-    [[ -x "$installed_cli" ]] || { print -u2 "KeyPath CLI is not installed"; exit 3; }
+    require_installed_cli
     "$installed_cli" system inspect --json > "$artifact_dir/before-reboot.json"
     print "Run the host-approved guest reboot, then execute reboot-persistence-after on the same lease."
     ;;
   reboot-persistence-after)
-    [[ -x "$installed_cli" ]] || { print -u2 "KeyPath CLI is not installed"; exit 3; }
+    require_installed_cli
     "$installed_cli" system inspect --json | tee "$artifact_dir/after-reboot.json"
     Scripts/lab/probe-kanata-tcp 2> "$artifact_dir/tcp-readiness.stderr" | tee "$artifact_dir/tcp-readiness.json"
     ;;
   uninstall)
-    [[ -x "$installed_cli" ]] || { print -u2 "KeyPath CLI is not installed"; exit 3; }
+    require_installed_cli
     "$installed_cli" system uninstall --json | tee "$artifact_dir/uninstall.json"
     test ! -e /Applications/KeyPath.app
     ;;
   cancellation-failure)
     print "Use a disposable lease to cancel one approval flow and inject one non-destructive failure."
     print "Record the visible recovery action, CLI result, and KeyPath logs; do not corrupt the base image."
+    ;;
+  failure-ownership-self-test)
+    "$result_tool" selector-self-test --output "$artifact_dir/result.json" --scenario "$name"
     ;;
   artifact-capture)
     mkdir -p "$artifact_dir/logs"
@@ -72,7 +93,7 @@ case "$name" in
     print "Scenario artifacts written to $artifact_dir; follow with keypath-lab artifacts <lease-id>."
     ;;
   macos-27-regression)
-    [[ -x "$installed_cli" ]] || { print -u2 "KeyPath CLI is not installed"; exit 3; }
+    require_installed_cli
     product_major=$(sw_vers -productVersion | cut -d. -f1)
     [[ "$product_major" == "27" ]] || { print -u2 "macOS 27 guest required"; exit 4; }
     Scripts/qa-macos-27-regression.sh "$artifact_dir/evidence"
@@ -80,7 +101,7 @@ case "$name" in
     ;;
   *)
     print -u2 "Unknown scenario: $name"
-    print -u2 "Available: clean-install approvals helper-daemon-health managed-capabilities launch repair-reinstall reboot-persistence-before reboot-persistence-after uninstall cancellation-failure artifact-capture macos-27-regression"
+    print -u2 "Available: clean-install approvals helper-daemon-health managed-capabilities launch repair-reinstall reboot-persistence-before reboot-persistence-after uninstall cancellation-failure failure-ownership-self-test artifact-capture macos-27-regression"
     exit 2
     ;;
 esac

--- a/Scripts/lab/tests/scenario-result-tests.py
+++ b/Scripts/lab/tests/scenario-result-tests.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+import json
+import pathlib
+import subprocess
+import tempfile
+import unittest
+
+
+TOOL = pathlib.Path(__file__).resolve().parents[1] / "scenario-result"
+
+
+class ScenarioResultTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.output = pathlib.Path(self.temporary.name) / "result.json"
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def run_tool(self, *arguments: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+        return subprocess.run([str(TOOL), *arguments], check=check, capture_output=True, text=True)
+
+    def test_records_a_product_failure_with_evidence(self) -> None:
+        self.run_tool(
+            "record", "--output", str(self.output), "--scenario", "repair-reinstall",
+            "--status", "failed", "--summary", "Repair reported success without TCP readiness.",
+            "--classification", "keypath-product-failure", "--step", "postcondition",
+            "--evidence", "system-inspect.json", "--evidence", "tcp-readiness.json",
+        )
+        result = json.loads(self.output.read_text())
+        self.assertEqual(result["failure"]["classification"], "keypath-product-failure")
+        self.assertEqual(result["evidence"], ["system-inspect.json", "tcp-readiness.json"])
+
+    def test_selector_self_test_is_never_a_product_failure(self) -> None:
+        self.run_tool("selector-self-test", "--output", str(self.output))
+        result = json.loads(self.output.read_text())
+        self.assertEqual(result["status"], "failed")
+        self.assertEqual(result["failure"]["classification"], "harness-selector-failure")
+
+    def test_rejects_unclassified_failure(self) -> None:
+        result = self.run_tool(
+            "record", "--output", str(self.output), "--scenario", "repair-reinstall",
+            "--status", "failed", "--summary", "Unknown failure.", "--step", "repair",
+            check=False,
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("requires --classification", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/testing/installer-gui-automation-capabilities.md
+++ b/docs/testing/installer-gui-automation-capabilities.md
@@ -183,6 +183,9 @@ Every failed step must use one of these top-level classifications:
 A self-test with a deliberately incorrect selector must prove that it produces
 `harness-selector-failure`, never a KeyPath failure.
 
+The executable schema, classification contract, and selector self-test are in
+[Scenario Failure Ownership](scenario-failure-ownership.md).
+
 ### Fixtures reproduce reality when possible
 
 Create starting states through the path that produces them in real use: install

--- a/docs/testing/scenario-failure-ownership.md
+++ b/docs/testing/scenario-failure-ownership.md
@@ -1,0 +1,42 @@
+# Scenario Failure Ownership
+
+Every non-passing lab scenario writes `result.json` with one failure owner. The
+classification prevents a selector, transport, provider, or environment problem
+from being reported as a KeyPath defect.
+
+## Contract
+
+Use `Scripts/lab/scenario-result record` to write a result. A passing result has
+no classification. A failed or blocked result requires a classification and the
+step where it occurred.
+
+The supported classifications are:
+
+- `keypath-product-failure`: KeyPath claimed a completed action, but its
+  independently observed postcondition is absent or disagrees.
+- `harness-selector-failure`: the harness selected the wrong UI element or
+  interpreted a valid UI state incorrectly.
+- `harness-transport-failure`: delivery, screenshot, SSH, or RFB transport
+  failed before the expected product action could be observed.
+- `provider-failure`: the virtualization provider failed after a lease was
+  admitted.
+- `unsupported-os-selector`: a known OS-specific UI is not yet supported by
+  the harness.
+- `environment-precondition-failure`: a required lane, policy, account,
+  capacity reservation, or other external prerequisite is absent.
+
+Attach only sanitized artifact-relative evidence paths. Do not put secrets,
+credentials, or raw tool responses in `result.json`.
+
+## Selector self-test
+
+Run this in every runner test suite:
+
+```bash
+Scripts/lab/scenario-result selector-self-test \
+  --output .keypath-lab/scenario-output/failure-ownership/result.json
+```
+
+It intentionally records a missing selector as
+`harness-selector-failure`. This is the regression guard: a deliberate harness
+mistake must never become a `keypath-product-failure`.


### PR DESCRIPTION
## Summary
- add validated machine-readable scenario outcomes and the six ownership classes
- classify known scenario preconditions instead of emitting only text errors
- add a deliberate selector self-test that cannot be reported as a product failure

## Validation
- `python3 Scripts/lab/tests/scenario-result-tests.py`
- `Scripts/lab/tests/keypath-lab-tests.sh`
- `/bin/zsh -n Scripts/lab/scenarios/installer-scenario`
- `git diff --check`
- `./Scripts/review-gate.sh` (remote review gate selected; GitHub `claude-review` required before merge)