### PR TITLE
Add resumable lab scenario runner

### DIFF
--- a/Scripts/lab/scenario-runner
+++ b/Scripts/lab/scenario-runner
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""Run a checkpointed lab scenario without replaying uncertain mutations."""
+
+import argparse
+import datetime
+import hashlib
+import json
+import os
+import pathlib
+import re
+import subprocess
+import sys
+import tempfile
+from typing import Any
+
+
+STEP_ID = re.compile(r"^[a-z0-9][a-z0-9-]*$")
+STATE_VERSION = 1
+
+
+class PlanError(ValueError):
+    pass
+
+
+def now() -> str:
+    return datetime.datetime.now(datetime.timezone.utc).isoformat()
+
+
+def canonical_digest(plan: dict[str, Any]) -> str:
+    payload = json.dumps(plan, sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.sha256(payload).hexdigest()
+
+
+def command(value: Any, field: str, step_id: str) -> list[str]:
+    if not isinstance(value, list) or not value or not all(isinstance(part, str) and part for part in value):
+        raise PlanError(f"step {step_id} requires a non-empty {field} command array")
+    return value
+
+
+def validate_plan(plan: Any) -> dict[str, Any]:
+    if not isinstance(plan, dict) or plan.get("schemaVersion") != 1:
+        raise PlanError("plan requires schemaVersion 1")
+    if not isinstance(plan.get("scenario"), str) or not plan["scenario"]:
+        raise PlanError("plan requires a scenario name")
+    steps = plan.get("steps")
+    if not isinstance(steps, list) or not steps:
+        raise PlanError("plan requires one or more steps")
+
+    seen: set[str] = set()
+    for step in steps:
+        if not isinstance(step, dict):
+            raise PlanError("each step must be an object")
+        step_id = step.get("id")
+        if not isinstance(step_id, str) or not STEP_ID.fullmatch(step_id):
+            raise PlanError("step ids must use lowercase letters, numbers, and dashes")
+        if step_id in seen:
+            raise PlanError(f"duplicate step id: {step_id}")
+        seen.add(step_id)
+        command(step.get("verify"), "verify", step_id)
+        command(step.get("action"), "action", step_id)
+        has_recovery = "recovery" in step or "recoveryVerify" in step
+        if has_recovery:
+            command(step.get("recovery"), "recovery", step_id)
+            command(step.get("recoveryVerify"), "recoveryVerify", step_id)
+    return plan
+
+
+def write_json(path: pathlib.Path, value: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    try:
+        with os.fdopen(fd, "w") as handle:
+            json.dump(value, handle, indent=2)
+            handle.write("\n")
+        os.chmod(temporary_name, 0o600)
+        os.replace(temporary_name, path)
+    except BaseException:
+        os.unlink(temporary_name)
+        raise
+
+
+def initial_state(plan: dict[str, Any], digest: str) -> dict[str, Any]:
+    return {
+        "schemaVersion": STATE_VERSION,
+        "scenario": plan["scenario"],
+        "planDigest": digest,
+        "status": "running",
+        "updatedAt": now(),
+        "steps": [
+            {"id": step["id"], "status": "pending", "attempts": 0}
+            for step in plan["steps"]
+        ],
+    }
+
+
+def load_state(path: pathlib.Path, plan: dict[str, Any], digest: str) -> dict[str, Any]:
+    if not path.exists():
+        return initial_state(plan, digest)
+    try:
+        state = json.loads(path.read_text())
+    except json.JSONDecodeError as error:
+        raise PlanError(f"state file is not valid JSON: {error}") from error
+    expected_steps = [step["id"] for step in plan["steps"]]
+    actual_steps = [step.get("id") for step in state.get("steps", [])]
+    if state.get("schemaVersion") != STATE_VERSION or state.get("scenario") != plan["scenario"]:
+        raise PlanError("state belongs to a different scenario")
+    if state.get("planDigest") != digest:
+        raise PlanError("plan changed after checkpoints were recorded; use a new state path")
+    if actual_steps != expected_steps:
+        raise PlanError("state step order does not match the plan")
+    return state
+
+
+def save_state(path: pathlib.Path, state: dict[str, Any]) -> None:
+    state["updatedAt"] = now()
+    write_json(path, state)
+
+
+def run_command(command_value: list[str], log: pathlib.Path, cwd: pathlib.Path) -> int:
+    log.parent.mkdir(parents=True, exist_ok=True)
+    with log.open("w") as handle:
+        return subprocess.run(command_value, cwd=cwd, stdout=handle, stderr=subprocess.STDOUT).returncode
+
+
+def record_blocked(result_tool: pathlib.Path, result: pathlib.Path, scenario: str, step: str, summary: str) -> None:
+    subprocess.run(
+        [
+            str(result_tool), "record", "--output", str(result), "--scenario", scenario,
+            "--status", "blocked", "--summary", summary,
+            "--classification", "harness-transport-failure", "--step", step,
+            "--message", "Runner interruption left this mutation uncertain; a recovery path is required.",
+        ],
+        check=True,
+    )
+
+
+def record_product_failure(result_tool: pathlib.Path, result: pathlib.Path, scenario: str, step: str, evidence: str) -> None:
+    subprocess.run(
+        [
+            str(result_tool), "record", "--output", str(result), "--scenario", scenario,
+            "--status", "failed", "--summary", "Scenario action completed without its required postcondition.",
+            "--classification", "keypath-product-failure", "--step", step,
+            "--evidence", evidence,
+        ],
+        check=True,
+    )
+
+
+def transition(state: dict[str, Any], step_state: dict[str, Any], status: str, path: pathlib.Path) -> None:
+    step_state["status"] = status
+    step_state["updatedAt"] = now()
+    state["currentStep"] = step_state["id"]
+    save_state(path, state)
+
+
+def complete(state: dict[str, Any], step_state: dict[str, Any], path: pathlib.Path) -> None:
+    step_state["status"] = "verified"
+    step_state["verifiedAt"] = now()
+    step_state.pop("uncertainSince", None)
+    state.pop("currentStep", None)
+    save_state(path, state)
+
+
+def recover_uncertain_step(
+    plan_step: dict[str, Any], state: dict[str, Any], step_state: dict[str, Any], state_path: pathlib.Path,
+    workdir: pathlib.Path, result_tool: pathlib.Path, result_path: pathlib.Path,
+) -> bool:
+    step_id = plan_step["id"]
+    attempt = step_state["attempts"]
+    if run_command(plan_step["verify"], workdir / f"{step_id}.resume-verify-{attempt}.log", workdir) == 0:
+        complete(state, step_state, state_path)
+        return True
+    if "recovery" not in plan_step:
+        state["status"] = "blocked"
+        step_state["blocker"] = "interrupted mutation has no declared recovery path"
+        save_state(state_path, state)
+        record_blocked(
+            result_tool, result_path, state["scenario"], step_id,
+            f"Interrupted {step_id} could not be verified and has no recovery path.",
+        )
+        return False
+    transition(state, step_state, "recovering", state_path)
+    if run_command(plan_step["recovery"], workdir / f"{step_id}.recovery-{attempt}.log", workdir) != 0:
+        state["status"] = "blocked"
+        step_state["blocker"] = "declared recovery command failed"
+        save_state(state_path, state)
+        record_blocked(result_tool, result_path, state["scenario"], step_id, f"Recovery for interrupted {step_id} failed.")
+        return False
+    if run_command(plan_step["recoveryVerify"], workdir / f"{step_id}.recovery-verify-{attempt}.log", workdir) != 0:
+        state["status"] = "blocked"
+        step_state["blocker"] = "declared recovery did not reach its safe postcondition"
+        save_state(state_path, state)
+        record_blocked(result_tool, result_path, state["scenario"], step_id, f"Recovery for interrupted {step_id} was not verified.")
+        return False
+    transition(state, step_state, "pending", state_path)
+    return True
+
+
+def run(plan_path: pathlib.Path, state_path: pathlib.Path, result_path: pathlib.Path) -> int:
+    try:
+        plan = validate_plan(json.loads(plan_path.read_text()))
+        digest = canonical_digest(plan)
+        state = load_state(state_path, plan, digest)
+    except (OSError, json.JSONDecodeError, PlanError) as error:
+        print(f"scenario-runner: {error}", file=sys.stderr)
+        return 2
+
+    if state.get("status") in ("passed", "failed", "blocked"):
+        print(f"scenario-runner: existing run is {state['status']}; use a new state path", file=sys.stderr)
+        return 3
+
+    workdir = state_path.parent / "logs"
+    result_tool = pathlib.Path(__file__).with_name("scenario-result")
+    by_id = {step["id"]: step for step in plan["steps"]}
+    for step_state in state["steps"]:
+        plan_step = by_id[step_state["id"]]
+        if step_state["status"] == "verified":
+            continue
+        if step_state["status"] in ("in-flight", "recovering"):
+            if not recover_uncertain_step(plan_step, state, step_state, state_path, workdir, result_tool, result_path):
+                return 3
+            if step_state["status"] == "verified":
+                continue
+
+        attempt = step_state["attempts"] + 1
+        transition(state, step_state, "verifying", state_path)
+        if run_command(plan_step["verify"], workdir / f"{plan_step['id']}.verify-{attempt}.log", workdir) == 0:
+            complete(state, step_state, state_path)
+            continue
+
+        step_state["attempts"] = attempt
+        step_state["uncertainSince"] = now()
+        transition(state, step_state, "in-flight", state_path)
+        action_exit = run_command(plan_step["action"], workdir / f"{plan_step['id']}.action-{attempt}.log", workdir)
+        if action_exit != 0:
+            if not recover_uncertain_step(plan_step, state, step_state, state_path, workdir, result_tool, result_path):
+                return 3
+            continue
+        evidence = str((workdir / f"{plan_step['id']}.verify-after-{attempt}.log").relative_to(state_path.parent))
+        if run_command(plan_step["verify"], workdir / f"{plan_step['id']}.verify-after-{attempt}.log", workdir) != 0:
+            state["status"] = "failed"
+            step_state["blocker"] = "action exited successfully but its postcondition was absent"
+            save_state(state_path, state)
+            record_product_failure(result_tool, result_path, state["scenario"], plan_step["id"], evidence)
+            return 1
+        complete(state, step_state, state_path)
+
+    state["status"] = "passed"
+    state.pop("currentStep", None)
+    save_state(state_path, state)
+    return 0
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--plan", required=True, type=pathlib.Path)
+    parser.add_argument("--state", required=True, type=pathlib.Path)
+    parser.add_argument("--result", required=True, type=pathlib.Path)
+    args = parser.parse_args()
+    raise SystemExit(run(args.plan, args.state, args.result))
+
+
+if __name__ == "__main__":
+    main()

--- a/Scripts/lab/tests/scenario-runner-tests.py
+++ b/Scripts/lab/tests/scenario-runner-tests.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+import json
+import os
+import pathlib
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+
+
+RUNNER = pathlib.Path(__file__).resolve().parents[1] / "scenario-runner"
+
+
+class ScenarioRunnerTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = pathlib.Path(self.temporary.name)
+        self.plan = self.root / "plan.json"
+        self.state = self.root / "state.json"
+        self.result = self.root / "result.json"
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def command(self, code: str) -> list[str]:
+        return [sys.executable, "-c", code]
+
+    def write_plan(self, steps: list[dict]) -> None:
+        self.plan.write_text(json.dumps({"schemaVersion": 1, "scenario": "resume-test", "steps": steps}))
+
+    def invoke(self, check: bool = True) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [str(RUNNER), "--plan", str(self.plan), "--state", str(self.state), "--result", str(self.result)],
+            capture_output=True, text=True, check=check,
+        )
+
+    def test_resume_accepts_postcondition_without_replaying_interrupted_action(self) -> None:
+        effect = self.root / "effect"
+        started = self.root / "started"
+        self.write_plan([{
+            "id": "install", "verify": self.command(f"import pathlib, sys; sys.exit(not pathlib.Path({str(effect)!r}).exists())"),
+            "action": self.command(f"import pathlib, time; pathlib.Path({str(effect)!r}).touch(); pathlib.Path({str(started)!r}).touch(); time.sleep(30)"),
+        }])
+        process = subprocess.Popen(
+            [str(RUNNER), "--plan", str(self.plan), "--state", str(self.state), "--result", str(self.result)],
+            start_new_session=True,
+        )
+        for _ in range(100):
+            if started.exists():
+                break
+            time.sleep(0.02)
+        self.assertTrue(started.exists(), "action did not begin")
+        os.killpg(process.pid, signal.SIGTERM)
+        process.wait(timeout=5)
+
+        resumed = self.invoke(check=False)
+        self.assertEqual(resumed.returncode, 0, resumed.stderr)
+        state = json.loads(self.state.read_text())
+        self.assertEqual(state["status"], "passed")
+        self.assertEqual(state["steps"][0]["attempts"], 1)
+
+    def test_unverified_interrupted_mutation_blocks_without_replay(self) -> None:
+        count = self.root / "action-count"
+        started = self.root / "started"
+        self.write_plan([{
+            "id": "repair", "verify": self.command("import sys; sys.exit(1)"),
+            "action": self.command(
+                f"import pathlib, time; p=pathlib.Path({str(count)!r}); p.write_text(str(int(p.read_text()) + 1) if p.exists() else '1'); pathlib.Path({str(started)!r}).touch(); time.sleep(30)"
+            ),
+        }])
+        process = subprocess.Popen(
+            [str(RUNNER), "--plan", str(self.plan), "--state", str(self.state), "--result", str(self.result)],
+            start_new_session=True,
+        )
+        for _ in range(100):
+            if started.exists():
+                break
+            time.sleep(0.02)
+        self.assertTrue(started.exists(), "action did not begin")
+        os.killpg(process.pid, signal.SIGTERM)
+        process.wait(timeout=5)
+
+        resumed = self.invoke(check=False)
+        self.assertEqual(resumed.returncode, 3)
+        self.assertEqual(count.read_text(), "1")
+        state = json.loads(self.state.read_text())
+        self.assertEqual(state["status"], "blocked")
+        result = json.loads(self.result.read_text())
+        self.assertEqual(result["failure"]["classification"], "harness-transport-failure")
+
+    def test_completed_checkpoint_is_not_replayed(self) -> None:
+        first = self.root / "first"
+        second = self.root / "second"
+        self.write_plan([
+            {
+                "id": "first", "verify": self.command(f"import pathlib, sys; sys.exit(not pathlib.Path({str(first)!r}).exists())"),
+                "action": self.command(f"import pathlib; pathlib.Path({str(first)!r}).touch()"),
+            },
+            {
+                "id": "second", "verify": self.command(f"import pathlib, sys; sys.exit(not pathlib.Path({str(second)!r}).exists())"),
+                "action": self.command(f"import pathlib; pathlib.Path({str(second)!r}).touch()"),
+            },
+        ])
+        self.invoke()
+        self.assertEqual(self.invoke(check=False).returncode, 3)
+        self.assertTrue(first.exists())
+        self.assertTrue(second.exists())
+
+    def test_plan_digest_change_is_rejected(self) -> None:
+        target = self.root / "target"
+        self.write_plan([{
+            "id": "install", "verify": self.command(f"import pathlib, sys; sys.exit(not pathlib.Path({str(target)!r}).exists())"),
+            "action": self.command(f"import pathlib; pathlib.Path({str(target)!r}).touch()"),
+        }])
+        self.invoke()
+        plan = json.loads(self.plan.read_text())
+        plan["steps"][0]["id"] = "install-changed"
+        self.plan.write_text(json.dumps(plan))
+        changed = self.invoke(check=False)
+        self.assertEqual(changed.returncode, 2)
+        self.assertIn("plan changed", changed.stderr)
+
+    def test_successful_action_without_postcondition_is_product_failure(self) -> None:
+        self.write_plan([{
+            "id": "verify-runtime", "verify": self.command("import sys; sys.exit(1)"),
+            "action": self.command("pass"),
+        }])
+        run = self.invoke(check=False)
+        self.assertEqual(run.returncode, 1)
+        result = json.loads(self.result.read_text())
+        self.assertEqual(result["failure"]["classification"], "keypath-product-failure")
+
+    def test_verified_recovery_allows_an_interrupted_step_to_restart(self) -> None:
+        count = self.root / "action-count"
+        started = self.root / "started"
+        recovered = self.root / "recovered"
+        effect = self.root / "effect"
+        action = (
+            f"import pathlib, time; p=pathlib.Path({str(count)!r}); n=int(p.read_text()) + 1 if p.exists() else 1; "
+            f"p.write_text(str(n)); pathlib.Path({str(started)!r}).touch(); "
+            f"time.sleep(30) if n == 1 else None; pathlib.Path({str(effect)!r}).touch()"
+        )
+        self.write_plan([{
+            "id": "repair", "verify": self.command(f"import pathlib, sys; sys.exit(not pathlib.Path({str(effect)!r}).exists())"),
+            "action": self.command(action),
+            "recovery": self.command(f"import pathlib; pathlib.Path({str(recovered)!r}).touch()"),
+            "recoveryVerify": self.command(f"import pathlib, sys; sys.exit(not pathlib.Path({str(recovered)!r}).exists())"),
+        }])
+        process = subprocess.Popen(
+            [str(RUNNER), "--plan", str(self.plan), "--state", str(self.state), "--result", str(self.result)],
+            start_new_session=True,
+        )
+        for _ in range(100):
+            if started.exists():
+                break
+            time.sleep(0.02)
+        self.assertTrue(started.exists(), "action did not begin")
+        os.killpg(process.pid, signal.SIGTERM)
+        process.wait(timeout=5)
+
+        resumed = self.invoke(check=False)
+        self.assertEqual(resumed.returncode, 0, resumed.stderr)
+        self.assertTrue(recovered.exists())
+        self.assertEqual(count.read_text(), "2")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/testing/installer-gui-automation-capabilities.md
+++ b/docs/testing/installer-gui-automation-capabilities.md
@@ -186,6 +186,10 @@ A self-test with a deliberately incorrect selector must prove that it produces
 The executable schema, classification contract, and selector self-test are in
 [Scenario Failure Ownership](scenario-failure-ownership.md).
 
+Interrupted scenarios use the [Resumable Scenario Runner](resumable-scenario-runner.md).
+It checkpoints only independently verified postconditions, so a restarted
+controller never blindly repeats an uncertain installer mutation.
+
 ### Fixtures reproduce reality when possible
 
 Create starting states through the path that produces them in real use: install

--- a/docs/testing/resumable-scenario-runner.md
+++ b/docs/testing/resumable-scenario-runner.md
@@ -1,0 +1,71 @@
+# Resumable Scenario Runner
+
+`Scripts/lab/scenario-runner` executes a scenario plan through verified,
+durable checkpoints. It is the runner contract for scenarios that include an
+installer action, approval, reboot, or other mutation that cannot be safely
+repeated merely because the controller was interrupted.
+
+## Plan contract
+
+Each plan has a stable scenario name and ordered steps. Every step needs an
+`action` command and a `verify` command. `verify` is the independently observed
+postcondition, not a process-exit check from the action.
+
+```json
+{
+  "schemaVersion": 1,
+  "scenario": "repair-reinstall",
+  "steps": [
+    {
+      "id": "repair-runtime",
+      "action": ["/Applications/KeyPath.app/Contents/MacOS/keypath-cli", "system", "repair", "--json"],
+      "verify": ["Scripts/lab/assert-runtime-ready"]
+    }
+  ]
+}
+```
+
+Run it with lease-local artifact paths:
+
+```bash
+Scripts/lab/scenario-runner \
+  --plan .keypath-lab/scenarios/repair-reinstall.json \
+  --state .keypath-lab/scenario-output/repair-reinstall/run-state.json \
+  --result .keypath-lab/scenario-output/repair-reinstall/result.json
+```
+
+The state file is atomically replaced after every transition. It records the
+canonical digest of the plan, ordered step IDs, attempts, the current step, and
+only verified checkpoints. A changed plan must use a new state path; it cannot
+reuse an earlier checkpoint ledger.
+
+## Resume behavior
+
+The runner first executes the step's postcondition probe. If it passes, that
+step is checkpointed and its action is not replayed.
+
+If an earlier process died while an action was in flight, resume probes the
+postcondition before doing anything else:
+
+- If it now passes, the step is checkpointed as complete.
+- If it is absent and the plan has no recovery path, the run becomes blocked.
+  It writes a `harness-transport-failure` result explaining that the mutation
+  is uncertain. It never replays the action.
+- A plan may declare both `recovery` and `recoveryVerify`. Only after that
+  recovery has reached its declared safe postcondition may the original action
+  be tried again.
+
+When an action exits successfully but its verified postcondition remains
+absent, the runner records `keypath-product-failure`; product success is never
+inferred from an action exit code.
+
+The runner keeps command output under a `logs/` sibling of the state file. Plan
+authors must keep commands and logs secret-safe: use `secure-dialog-input` for
+password sheets and do not put credentials in a plan or command output.
+
+## Integration rule
+
+Scenario drivers own the product plan and postconditions. The runner owns only
+checkpoint durability and failure ownership. A scenario must obtain approval
+actions from `keypath-cli system inspect --json` `plannedRecipes` and
+`userActionRequired`; it must not invent a second installer planner.


### PR DESCRIPTION
## Summary
- add an atomically checkpointed scenario runner with plan digests
- resume only from independently verified postconditions
- block uncertain mutations unless a declared recovery path is verified
- classify missing postconditions as product failures and interrupted transport as harness evidence

## Validation
- `python3 Scripts/lab/tests/scenario-runner-tests.py`
- `python3 Scripts/lab/tests/scenario-result-tests.py`
- `Scripts/lab/tests/keypath-lab-tests.sh`
- `./Scripts/review-gate.sh` (remote review gate selected)