### PR TITLE
Add macOS 26 selector evidence driver

### DIFF
--- a/Scripts/lab/macos-26-selector-driver
+++ b/Scripts/lab/macos-26-selector-driver
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Capture and validate macOS 26 System Settings selector evidence."""
+
+import argparse
+import json
+import os
+import pathlib
+import subprocess
+import sys
+
+
+ROOT = pathlib.Path(__file__).resolve().parent
+PEEKABOO = pathlib.Path(os.environ.get("KEYPATH_SELECTOR_PEEKABOO", ROOT / "peekaboo-ui"))
+RESULT = pathlib.Path(os.environ.get("KEYPATH_SELECTOR_RESULT", ROOT / "scenario-result"))
+
+
+def run(command, output=None):
+    if output is None:
+        return subprocess.run(command, check=False, capture_output=True, text=True)
+    with output.open("w") as handle:
+        return subprocess.run(command, check=False, stdout=handle, stderr=subprocess.STDOUT, text=True)
+
+
+def macos_major() -> str:
+    result = run(["sw_vers", "-productVersion"])
+    if result.returncode != 0:
+        raise RuntimeError("could not read macOS version")
+    return result.stdout.strip().split(".")[0]
+
+
+def contains(value, expected: str) -> bool:
+    needle = expected.casefold()
+    if isinstance(value, str):
+        return needle in value.casefold()
+    if isinstance(value, dict):
+        return any(contains(item, expected) for item in value.values())
+    if isinstance(value, list):
+        return any(contains(item, expected) for item in value)
+    return False
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", required=True, type=pathlib.Path)
+    parser.add_argument("--expect", action="append", default=[], help="required text in fresh System Settings AX evidence")
+    parser.add_argument("--scenario", default="macos-26-selector-probe")
+    args = parser.parse_args()
+    args.output.mkdir(parents=True, exist_ok=True)
+    if macos_major() != "26":
+        subprocess.run([str(RESULT), "record", "--output", str(args.output / "result.json"), "--scenario", args.scenario,
+                        "--status", "blocked", "--summary", "macOS 26 selector driver requires a macOS 26 guest.",
+                        "--classification", "unsupported-os-selector", "--step", "os-admission"], check=True)
+        return 4
+    run(["sw_vers"], args.output / "sw-vers.txt")
+    snapshot = args.output / "system-settings-ax.json"
+    capture = run([str(PEEKABOO), "snapshot", "--app", "System Settings", "--output", str(snapshot)])
+    if capture.returncode != 0:
+        subprocess.run([str(RESULT), "record", "--output", str(args.output / "result.json"), "--scenario", args.scenario,
+                        "--status", "failed", "--summary", "Could not capture current System Settings selector evidence.",
+                        "--classification", "harness-transport-failure", "--step", "ax-snapshot"], check=True)
+        return capture.returncode
+    try:
+        evidence = json.loads(snapshot.read_text())
+    except json.JSONDecodeError:
+        subprocess.run([str(RESULT), "record", "--output", str(args.output / "result.json"), "--scenario", args.scenario,
+                        "--status", "failed", "--summary", "System Settings selector evidence was not valid JSON.",
+                        "--classification", "harness-transport-failure", "--step", "ax-snapshot"], check=True)
+        return 1
+    missing = [selector for selector in args.expect if not contains(evidence, selector)]
+    if missing:
+        subprocess.run([str(RESULT), "record", "--output", str(args.output / "result.json"), "--scenario", args.scenario,
+                        "--status", "blocked", "--summary", "macOS 26 System Settings surface did not expose the required selector evidence.",
+                        "--classification", "unsupported-os-selector", "--step", "selector-admission",
+                        "--message", "Missing selectors: " + ", ".join(missing), "--evidence", "system-settings-ax.json"], check=True)
+        return 4
+    (args.output / "selector-contract.json").write_text(json.dumps({"schemaVersion": 1, "macOSMajor": 26, "expected": args.expect, "evidence": "system-settings-ax.json"}, indent=2) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Scripts/lab/tests/macos-26-selector-driver-tests.py
+++ b/Scripts/lab/tests/macos-26-selector-driver-tests.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+import json
+import os
+import pathlib
+import subprocess
+import tempfile
+import unittest
+
+TOOL = pathlib.Path(__file__).resolve().parents[1] / "macos-26-selector-driver"
+
+class DriverTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory(); self.root = pathlib.Path(self.tmp.name)
+        self.bin = self.root / "bin"; self.bin.mkdir(); self.output = self.root / "out"
+        (self.bin / "sw_vers").write_text('#!/bin/sh\nversion=${MACOS_TEST_VERSION:-26.0}\nif [ "$1" = -productVersion ]; then echo "$version"; else echo "ProductVersion: $version"; fi\n')
+        (self.bin / "sw_vers").chmod(0o755)
+        self.peekaboo = self.root / "peekaboo-ui"; self.peekaboo.write_text('#!/bin/sh\nout=\nwhile [ $# -gt 0 ]; do [ "$1" = --output ] && out=$2; shift; done\nprintf \'{"data":{"ui_elements":[{"identifier":"InputMonitoring","label":"KeyPath"}]}}\' > "$out"\n')
+        self.peekaboo.chmod(0o755)
+        self.result = self.root / "scenario-result"; self.result.write_text((TOOL.parent / "scenario-result").read_text()); self.result.chmod(0o755)
+
+    def tearDown(self): self.tmp.cleanup()
+
+    def call(self, *extra, version="26.0"):
+        env = os.environ | {"PATH": str(self.bin) + ":" + os.environ["PATH"], "MACOS_TEST_VERSION": version, "KEYPATH_SELECTOR_PEEKABOO": str(self.peekaboo), "KEYPATH_SELECTOR_RESULT": str(self.result)}
+        return subprocess.run([str(TOOL), "--output", str(self.output), *extra], env=env, text=True, capture_output=True)
+
+    def test_accepts_fresh_macos_26_selector_evidence(self):
+        result = self.call("--expect", "InputMonitoring", "--expect", "KeyPath")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(json.loads((self.output / "selector-contract.json").read_text())["macOSMajor"], 26)
+
+    def test_rejects_another_macos_version_without_snapshot(self):
+        result = self.call("--expect", "KeyPath", version="15.7.7")
+        self.assertEqual(result.returncode, 4)
+        self.assertEqual(json.loads((self.output / "result.json").read_text())["failure"]["classification"], "unsupported-os-selector")
+
+    def test_missing_selector_is_explicitly_unsupported(self):
+        result = self.call("--expect", "Missing Control")
+        self.assertEqual(result.returncode, 4)
+        outcome = json.loads((self.output / "result.json").read_text())
+        self.assertEqual(outcome["failure"]["classification"], "unsupported-os-selector")
+
+if __name__ == "__main__": unittest.main()


### PR DESCRIPTION
## Summary
- add a macOS 26-only System Settings selector evidence driver
- capture fresh AX evidence and fail closed when declared selectors are absent
- classify wrong OS and unknown selectors as unsupported, not product failures

## Validation
- `python3 Scripts/lab/tests/macos-26-selector-driver-tests.py`
- `python3 Scripts/lab/tests/scenario-result-tests.py`