### PR TITLE
Guard KeyPath lab and CI against low disk space

### DIFF
--- a/.github/workflows/cache-warm.yml
+++ b/.github/workflows/cache-warm.yml
@@ -21,6 +21,9 @@ jobs:
         with:
           submodules: true
 
+      - name: Verify runner disk reserve
+        run: ./Scripts/lab/host-disk-reserve
+
       - name: Add Homebrew and Cargo to PATH
         run: |
           echo "/opt/homebrew/bin" >> $GITHUB_PATH

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,9 @@ jobs:
         submodules: true
         persist-credentials: false
 
+    - name: Verify runner disk reserve
+      run: ./Scripts/lab/host-disk-reserve
+
     - name: Add Homebrew and Cargo to PATH
       run: |
         echo "/opt/homebrew/bin" >> $GITHUB_PATH

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -29,6 +29,9 @@ jobs:
           submodules: true
           persist-credentials: false
 
+      - name: Verify runner disk reserve
+        run: ./Scripts/lab/host-disk-reserve
+
       - name: Add Homebrew to PATH
         run: echo "/opt/homebrew/bin" >> $GITHUB_PATH
 
@@ -113,6 +116,9 @@ jobs:
         with:
           submodules: true
           persist-credentials: false
+
+      - name: Verify runner disk reserve
+        run: ./Scripts/lab/host-disk-reserve
 
       - name: Add Homebrew to PATH
         run: echo "/opt/homebrew/bin" >> $GITHUB_PATH

--- a/Scripts/lab/host-disk-reserve
+++ b/Scripts/lab/host-disk-reserve
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -euo pipefail
+
+path=${KEYPATH_DISK_RESERVE_PATH:-/System/Volumes/Data}
+minimum_gib=${KEYPATH_MIN_FREE_DISK_GIB:-100}
+
+[[ "$minimum_gib" =~ ^[0-9]+$ && "$minimum_gib" -gt 0 ]] || {
+  echo "host-disk-reserve: KEYPATH_MIN_FREE_DISK_GIB must be a positive integer" >&2
+  exit 2
+}
+
+free_kib=$(df -Pk "$path" | awk 'NR == 2 {print $4}')
+[[ "$free_kib" =~ ^[0-9]+$ ]] || {
+  echo "host-disk-reserve: could not determine free space for $path" >&2
+  exit 2
+}
+
+minimum_kib=$((minimum_gib * 1024 * 1024))
+printf 'disk_reserve_path\t%s\n' "$path"
+printf 'disk_reserve_free_gib\t%d\n' "$((free_kib / 1024 / 1024))"
+printf 'disk_reserve_minimum_gib\t%s\n' "$minimum_gib"
+
+if (( free_kib < minimum_kib )); then
+  echo "disk_reserve_busy: free space is below the ${minimum_gib} GiB safety reserve" >&2
+  exit 75
+fi

--- a/Scripts/lab/remote.sh
+++ b/Scripts/lab/remote.sh
@@ -111,6 +111,27 @@ provider_capacity() {
   esac
 }
 
+host_free_kib() {
+  if [[ -n "${KEYPATH_LAB_TEST_FREE_KIB:-}" ]]; then
+    print -r -- "$KEYPATH_LAB_TEST_FREE_KIB"
+  else
+    df -Pk /System/Volumes/Data | awk 'NR == 2 {print $4}'
+  fi
+}
+
+assert_internal_disk_reserve() {
+  local minimum_gib=${KEYPATH_LAB_MIN_FREE_DISK_GIB:-100} free_kib minimum_kib
+  [[ "$minimum_gib" == <-> && "$minimum_gib" -gt 0 ]] || die "invalid disk reserve: $minimum_gib GiB"
+  free_kib=$(host_free_kib)
+  [[ "$free_kib" == <-> ]] || die "could not determine internal free space"
+  minimum_kib=$((minimum_gib * 1024 * 1024))
+  print -u2 "disk_reserve\tfree_gib=$((free_kib / 1024 / 1024))\tminimum_gib=$minimum_gib"
+  if (( free_kib < minimum_kib )); then
+    print -u2 "disk_reserve_busy\tfree_gib=$((free_kib / 1024 / 1024))\tminimum_gib=$minimum_gib"
+    return 75
+  fi
+}
+
 acquire_admission_lock() {
   local provider=$1 attempt=0 owner owner_pid stale lock_age lock_mtime lock="$STATE_ROOT/provider-admission-$provider.lock"
   local owner_record="$STATE_ROOT/.provider-admission-$provider.owner.$$"
@@ -304,6 +325,8 @@ preflight() {
   print "lab_root\t$LAB_ROOT"
   print "capacity_tart\t$(provider_capacity tart)"
   print "capacity_parallels\t$(provider_capacity parallels)"
+  print "disk_reserve_minimum_gib\t${KEYPATH_LAB_MIN_FREE_DISK_GIB:-100}"
+  print "disk_reserve_free_gib\t$(( $(host_free_kib) / 1024 / 1024 ))"
   print "safety\tdisposable-owned-leases-only"
 }
 
@@ -443,6 +466,7 @@ create_lease() {
     sleep "$KEYPATH_LAB_TEST_PAUSE_AFTER_ADMISSION_LOCK"
   fi
   assert_provider_capacity "$provider" || return $?
+  assert_internal_disk_reserve || return $?
   created=$(now_epoch)
   expires=$((created + ttl_seconds))
   slug="keypath${macos}-$(print -r -- "$commit" | cut -c1-8)-$(date -u +%Y%m%d%H%M%S)-$$"

--- a/Scripts/lab/tests/keypath-lab-tests.sh
+++ b/Scripts/lab/tests/keypath-lab-tests.sh
@@ -120,6 +120,7 @@ preflight=$(run_remote preflight)
 assert_contains "$preflight" doctor-15
 assert_contains "$preflight" doctor-26
 assert_contains "$preflight" doctor-27
+assert_contains "$preflight" $'disk_reserve_minimum_gib\t100'
 
 ticket_one=$(run_remote prepare-upload "$(printf 'a%.0s' {1..40})-$(printf 'b%.0s' {1..64})")
 ticket_two=$(run_remote prepare-upload "$(printf 'a%.0s' {1..40})-$(printf 'b%.0s' {1..64})")
@@ -160,6 +161,13 @@ EOF
 
 commit=$(printf 'a%.0s' {1..40})
 checksum=$(printf 'b%.0s' {1..64})
+set +e
+disk_output=$(KEYPATH_LAB_TEST_FREE_KIB=104857599 run_remote create 15 unmanaged-ui "$archive_key" "$commit" "$checksum" KeyPath.zip 2h 0 2>&1)
+disk_exit=$?
+set -e
+[[ $disk_exit -eq 75 ]] || { echo "expected disk reserve admission to exit 75, got $disk_exit" >&2; exit 1; }
+assert_contains "$disk_output" $'disk_reserve_busy\tfree_gib=99\tminimum_gib=100'
+
 create=$(run_remote create 15 unmanaged-ui "$archive_key" "$commit" "$checksum" KeyPath.zip 2h 0)
 assert_contains "$create" $'lease_id\tcbx_test15'
 manifest="$ROOT/KeyPathInstallerLab/leases/cbx_test15/manifest.tsv"

--- a/docs/testing/remote-installer-lab.md
+++ b/docs/testing/remote-installer-lab.md
@@ -26,6 +26,19 @@ remain beneath `KeyPathInstallerLab` on the external volume after cleanup.
 `--ttl` defaults to `2h` and accepts values from one second through two hours,
 matching the maximum lifecycle exposed by the existing launchers.
 
+## Host disk reserve
+
+The Mini keeps a 100 GiB internal-data-volume reserve for runner builds,
+indexing, and host OS work. `create` checks this reserve after taking the
+provider admission lock and exits 75 with `disk_reserve_busy` when admitting a
+new lease would be unsafe. It is an infrastructure wait, not a product failure.
+`preflight` reports the current reserve evidence. Set
+`KEYPATH_LAB_MIN_FREE_DISK_GIB` only for a deliberately different host policy.
+
+The primary self-hosted CI and cache-warm workflows run
+`Scripts/lab/host-disk-reserve` before expensive compilation. It exits 75 when
+the same 100 GiB threshold is not met.
+
 Check the non-mutating host/provider contract:
 
 ```bash


### PR DESCRIPTION
## Summary
- reject new disposable VM leases below a 100 GiB internal-data reserve
- fail self-hosted CI, cache warming, and coverage before expensive compilation when the reserve is unavailable
- document the reserve contract and cover the low-space path

## Validation
- `Scripts/lab/tests/keypath-lab-tests.sh`
- YAML parse for updated workflows
- `Scripts/lab/host-disk-reserve` success and exit-75 paths
- `Scripts/lab/keypath-lab preflight` on the Mini (`disk_reserve_free_gib=232`)
- `./Scripts/review-gate.sh` (remote review selected)