### PR TITLE
Document desktop base admission requirements

### DIFF
--- a/docs/testing/remote-installer-lab.md
+++ b/docs/testing/remote-installer-lab.md
@@ -120,6 +120,23 @@ CrabBox's desktop capability; ordinary creation continues to use the launchers
 unchanged. Artifact collection captures a screenshot for desktop leases and
 records an explicit unavailable status otherwise.
 
+### Desktop-base admission
+
+`--desktop` reserves a display-capable lease; it does not by itself prove that
+the guest is ready for semantic UI automation. Before a scenario relies on
+System Settings, admit the base through these postconditions:
+
+- a real console user is logged in (not merely an SSH account);
+- the guest has a Python runtime for the scenario drivers; and
+- `Scripts/lab/peekaboo-ui preflight` succeeds for that console session.
+
+If any condition is absent, record an `environment-precondition-failure`,
+collect artifacts, and destroy the lease. Do not fall back to raw provider
+commands or treat the result as a KeyPath failure. The macOS 26 Parallels base
+observed on July 13, 2026 was SSH-ready but had no logged-in console user and
+no Python runtime; it needs a new clean base checkpoint after automatic login
+and desktop-tool provisioning before selector scenarios can run.
+
 ### Semantic UI automation with Peekaboo 3
 
 For the current capability matrix, security boundaries, and agent handoff


### PR DESCRIPTION
Record the macOS 26 selector-lane evidence and the required console-login, Python, and Peekaboo preflight contract.

Validation: `git diff --check`; review gate selected the required remote reviewer.