### PR TITLE
Provision Python in desktop base bootstrap

### DIFF
--- a/Scripts/lab/desktop-bootstrap
+++ b/Scripts/lab/desktop-bootstrap
@@ -26,10 +26,13 @@ console_user=$(stat -f '%Su' /dev/console)
 
 if (( install_tools )); then
   command -v brew >/dev/null || die "Homebrew is required to install desktop tools"
+  command -v python3 >/dev/null || brew install python
   command -v peekaboo >/dev/null || brew install steipete/tap/peekaboo
   command -v mcporter >/dev/null || brew install steipete/tap/mcporter
 fi
 
+python_bin=$(command -v python3 || true)
+[[ -x "$python_bin" ]] || die "Python 3 is required"
 peekaboo_bin=$(command -v peekaboo || true)
 mcporter_bin=$(command -v mcporter || true)
 [[ -x "$peekaboo_bin" && -x "$mcporter_bin" ]] || die "Peekaboo 3 and mcporter are required"
@@ -44,7 +47,7 @@ sleep 2
 $peekaboo_bin see --app "System Settings" --json > "$output/initial-desktop.json" || true
 $peekaboo_bin see --app UserNotificationCenter --json > "$output/user-notification-center.json" || true
 
-consent=$(python3 - "$output/user-notification-center.json" <<'PY'
+consent=$($python_bin - "$output/user-notification-center.json" <<'PY'
 import json, sys
 try:
     data = json.load(open(sys.argv[1])).get("data", {})
@@ -67,7 +70,7 @@ fi
 $peekaboo_bin see --app "System Settings" --json > "$output/desktop-ready.json"
 $peekaboo_bin permissions status --json > "$output/peekaboo-permissions-after.json"
 
-python3 - "$output/bootstrap.json" "$console_user" "$($peekaboo_bin --version | head -1)" <<'PY'
+$python_bin - "$output/bootstrap.json" "$console_user" "$($peekaboo_bin --version | head -1)" <<'PY'
 import json, platform, sys
 path, user, version = sys.argv[1:]
 with open(path, "w") as f:

--- a/Scripts/lab/desktop-bootstrap
+++ b/Scripts/lab/desktop-bootstrap
@@ -36,18 +36,18 @@ python_bin=$(command -v python3 || true)
 peekaboo_bin=$(command -v peekaboo || true)
 mcporter_bin=$(command -v mcporter || true)
 [[ -x "$peekaboo_bin" && -x "$mcporter_bin" ]] || die "Peekaboo 3 and mcporter are required"
-[[ "$($peekaboo_bin --version | head -1)" == Peekaboo\ 3.* ]] || die "Peekaboo 3 is required"
+[[ "$("$peekaboo_bin" --version | head -1)" == Peekaboo\ 3.* ]] || die "Peekaboo 3 is required"
 
-$peekaboo_bin permissions status --json > "$output/peekaboo-permissions-before.json" || true
+"$peekaboo_bin" permissions status --json > "$output/peekaboo-permissions-before.json" || true
 # Ensure there is a normal shareable window. A bare Finder desktop has no
 # eligible window, so it cannot trigger or verify capture consent.
 open -a "System Settings"
 sleep 2
 # The first capture can display macOS's private-picker bypass consent sheet.
-$peekaboo_bin see --app "System Settings" --json > "$output/initial-desktop.json" || true
-$peekaboo_bin see --app UserNotificationCenter --json > "$output/user-notification-center.json" || true
+"$peekaboo_bin" see --app "System Settings" --json > "$output/initial-desktop.json" || true
+"$peekaboo_bin" see --app UserNotificationCenter --json > "$output/user-notification-center.json" || true
 
-consent=$($python_bin - "$output/user-notification-center.json" <<'PY'
+consent=$("$python_bin" - "$output/user-notification-center.json" <<'PY'
 import json, sys
 try:
     data = json.load(open(sys.argv[1])).get("data", {})
@@ -63,14 +63,14 @@ PY
 if [[ -n "$consent" ]]; then
   snapshot=${consent%%$'\t'*}
   element=${consent#*$'\t'}
-  $peekaboo_bin click --on "$element" --snapshot "$snapshot" --no-auto-focus --json \
+  "$peekaboo_bin" click --on "$element" --snapshot "$snapshot" --no-auto-focus --json \
     > "$output/peekaboo-consent-click.json"
 fi
 
-$peekaboo_bin see --app "System Settings" --json > "$output/desktop-ready.json"
-$peekaboo_bin permissions status --json > "$output/peekaboo-permissions-after.json"
+"$peekaboo_bin" see --app "System Settings" --json > "$output/desktop-ready.json"
+"$peekaboo_bin" permissions status --json > "$output/peekaboo-permissions-after.json"
 
-$python_bin - "$output/bootstrap.json" "$console_user" "$($peekaboo_bin --version | head -1)" <<'PY'
+"$python_bin" - "$output/bootstrap.json" "$console_user" "$("$peekaboo_bin" --version | head -1)" <<'PY'
 import json, platform, sys
 path, user, version = sys.argv[1:]
 with open(path, "w") as f:

--- a/Scripts/lab/permission-drag
+++ b/Scripts/lab/permission-drag
@@ -11,6 +11,7 @@ usage() {
 peekaboo=${PEEKABOO_BIN:-/opt/homebrew/bin/peekaboo}
 open_bin=${OPEN_BIN:-/usr/bin/open}
 osascript=${OSASCRIPT_BIN:-/usr/bin/osascript}
+python_bin=$(command -v python3 || true)
 file_path=
 target_identifier=
 output=
@@ -27,6 +28,7 @@ done
 [[ "$file_path" == /* && -f "$file_path" ]] || die "--path must identify an existing absolute file"
 [[ -n "$target_identifier" ]] || die "--target-identifier is required"
 [[ -n "$output" && "$output" != -* ]] || die "--output is required"
+[[ -x "$python_bin" ]] || die "Python 3 is required"
 mkdir -p "${output:h}"
 
 tmp=$(mktemp -d /tmp/keypath-permission-drag.XXXXXX)
@@ -63,7 +65,7 @@ sleep ${KEYPATH_PERMISSION_DRAG_SETTLE_SECONDS:-1}
 "$peekaboo" see --app Finder --json > "$tmp/source.json"
 "$peekaboo" see --app "System Settings" --json > "$tmp/target.json"
 
-coords=$(/usr/bin/python3 - "$tmp/source.json" "$tmp/target.json" "$name" "$target_identifier" <<'PY'
+coords=$("$python_bin" - "$tmp/source.json" "$tmp/target.json" "$name" "$target_identifier" <<'PY'
 import json, sys
 
 source = json.load(open(sys.argv[1])).get("data", {}).get("ui_elements", [])
@@ -97,7 +99,7 @@ if "$osascript" -l JavaScript -e 'var p=Application("System Events").processes.b
 fi
 
 "$peekaboo" see --app "System Settings" --json > "$tmp/after.json"
-/usr/bin/python3 - "$tmp/after.json" "${name}_Title" <<'PY' || die "drag delivery had no authorization sheet or permission-row postcondition"
+"$python_bin" - "$tmp/after.json" "${name}_Title" <<'PY' || die "drag delivery had no authorization sheet or permission-row postcondition"
 import json, sys
 elements = json.load(open(sys.argv[1])).get("data", {}).get("ui_elements", [])
 raise SystemExit(0 if any(e.get("identifier") == sys.argv[2] for e in elements) else 1)

--- a/Scripts/lab/remote.sh
+++ b/Scripts/lab/remote.sh
@@ -665,8 +665,8 @@ secure_dialog_input() {
       submit_args=(/opt/homebrew/bin/peekaboo click "$submit_button" --app "$app" --foreground --json)
       printf -v submit_command '%q ' "${submit_args[@]}"
       printf -v submit_label_quoted '%q' "$submit_button"
-      guest_command+="; $refresh_command >/tmp/keypath-secure-submit.json || exit 44; if ! $submit_command >/dev/null; then $refresh_command >/tmp/keypath-secure-submit.json || exit 43; /usr/bin/python3 -c 'import json,sys; elements=json.load(open(sys.argv[1])).get(\"data\",{}).get(\"ui_elements\",[]); raise SystemExit(1 if any(e.get(\"label\")==sys.argv[2] for e in elements) else 0)' /tmp/keypath-secure-submit.json $submit_label_quoted || exit 43; fi"
-      guest_command+="; for attempt in {1..150}; do $refresh_command >/tmp/keypath-secure-postcondition.json || exit 44; /usr/bin/python3 -c 'import json,sys; elements=json.load(open(sys.argv[1])).get(\"data\",{}).get(\"ui_elements\",[]); labels={e.get(\"label\") for e in elements}; raise SystemExit(0 if sys.argv[2] not in labels and sys.argv[3] not in labels else 1)' /tmp/keypath-secure-postcondition.json $(printf %q "$field_label") $submit_label_quoted && break; sleep 0.1; done; /usr/bin/python3 -c 'import json,sys; elements=json.load(open(sys.argv[1])).get(\"data\",{}).get(\"ui_elements\",[]); labels={e.get(\"label\") for e in elements}; raise SystemExit(0 if sys.argv[2] not in labels and sys.argv[3] not in labels else 79)' /tmp/keypath-secure-postcondition.json $(printf %q "$field_label") $submit_label_quoted"
+      guest_command+="; $refresh_command >/tmp/keypath-secure-submit.json || exit 44; if ! $submit_command >/dev/null; then $refresh_command >/tmp/keypath-secure-submit.json || exit 43; /usr/bin/env python3 -c 'import json,sys; elements=json.load(open(sys.argv[1])).get(\"data\",{}).get(\"ui_elements\",[]); raise SystemExit(1 if any(e.get(\"label\")==sys.argv[2] for e in elements) else 0)' /tmp/keypath-secure-submit.json $submit_label_quoted || exit 43; fi"
+      guest_command+="; for attempt in {1..150}; do $refresh_command >/tmp/keypath-secure-postcondition.json || exit 44; /usr/bin/env python3 -c 'import json,sys; elements=json.load(open(sys.argv[1])).get(\"data\",{}).get(\"ui_elements\",[]); labels={e.get(\"label\") for e in elements}; raise SystemExit(0 if sys.argv[2] not in labels and sys.argv[3] not in labels else 1)' /tmp/keypath-secure-postcondition.json $(printf %q "$field_label") $submit_label_quoted && break; sleep 0.1; done; /usr/bin/env python3 -c 'import json,sys; elements=json.load(open(sys.argv[1])).get(\"data\",{}).get(\"ui_elements\",[]); labels={e.get(\"label\") for e in elements}; raise SystemExit(0 if sys.argv[2] not in labels and sys.argv[3] not in labels else 79)' /tmp/keypath-secure-postcondition.json $(printf %q "$field_label") $submit_label_quoted"
     fi
   fi
   if [[ "$field_label" == "AXSecureTextField" ]]; then
@@ -738,7 +738,7 @@ protected_click() {
     ip=$($TART ip "$resource")
     [[ "$ip" =~ '^[0-9A-Fa-f:.]+$' ]] || die "Tart returned an invalid guest address"
     printf -v guest_command '%q ' /opt/homebrew/bin/peekaboo see --app "$app" --json
-    guest_command+="| /usr/bin/python3 -c 'import json,sys; print(json.load(sys.stdin).get(\"data\",{}).get(\"window_title\",\"\"))'"
+    guest_command+="| /usr/bin/env python3 -c 'import json,sys; print(json.load(sys.stdin).get(\"data\",{}).get(\"window_title\",\"\"))'"
     before=$("$GUEST_SSH" -o BatchMode=yes -o StrictHostKeyChecking=accept-new -i "$key" "admin@$ip" "/bin/zsh -lc $(printf %q "$guest_command")")
   fi
   [[ "$before" == "$expected_before" ]] || {
@@ -750,7 +750,7 @@ protected_click() {
     if [[ "${KEYPATH_LAB_TESTING:-0}" == "1" ]]; then
       geometry=${KEYPATH_LAB_TEST_DISPLAY_GEOMETRY:-'2048 1536 1024 768'}
     else
-      geometry_command='/opt/homebrew/bin/peekaboo list windows --app '$(printf %q "$app")' --json | /usr/bin/python3 -c '\''import json,re,sys; data=json.load(sys.stdin).get("data",{}); windows=data.get("windows",data if isinstance(data,list) else []); names=[w.get("screenName","") for w in windows if isinstance(w,dict)]; m=next((re.search(r"([0-9]+)×([0-9]+)",n) for n in names if re.search(r"([0-9]+)×([0-9]+)",n)),None); print(f"{m.group(1)} {m.group(2)}" if m else "",end="")'\''; printf " "; /usr/bin/osascript -l JavaScript -e '\''ObjC.import("AppKit"); var s=$.NSScreen.mainScreen.frame.size; s.width+" "+s.height'\'''
+      geometry_command='/opt/homebrew/bin/peekaboo list windows --app '$(printf %q "$app")' --json | /usr/bin/env python3 -c '\''import json,re,sys; data=json.load(sys.stdin).get("data",{}); windows=data.get("windows",data if isinstance(data,list) else []); names=[w.get("screenName","") for w in windows if isinstance(w,dict)]; m=next((re.search(r"([0-9]+)×([0-9]+)",n) for n in names if re.search(r"([0-9]+)×([0-9]+)",n)),None); print(f"{m.group(1)} {m.group(2)}" if m else "",end="")'\''; printf " "; /usr/bin/osascript -l JavaScript -e '\''ObjC.import("AppKit"); var s=$.NSScreen.mainScreen.frame.size; s.width+" "+s.height'\'''
       geometry=$("$GUEST_SSH" -o BatchMode=yes -o StrictHostKeyChecking=accept-new -i "$key" "admin@$ip" "/bin/zsh -lc $(printf %q "$geometry_command")")
     fi
     IFS=' ' read -r native_width native_height logical_width logical_height <<< "$geometry"

--- a/Scripts/lab/tests/peekaboo-ui-tests.sh
+++ b/Scripts/lab/tests/peekaboo-ui-tests.sh
@@ -102,4 +102,9 @@ grep -q 'drag --from-coords 30,50 --to-coords 650,110 --duration 1500 --steps 30
 grep -q 'Finder 80,90,640,480' "$OSASCRIPT_CALLS"
 grep -q 'System Settings 700,100,800,600' "$OSASCRIPT_CALLS"
 
+if grep -q '/usr/bin/python3' "$LAB_DIR/permission-drag" "$LAB_DIR/remote.sh"; then
+  echo 'desktop QA helper bypassed the provisioned Python 3 on PATH' >&2
+  exit 1
+fi
+
 echo 'peekaboo-ui shell tests passed'

--- a/docs/testing/remote-installer-lab.md
+++ b/docs/testing/remote-installer-lab.md
@@ -137,6 +137,11 @@ observed on July 13, 2026 was SSH-ready but had no logged-in console user and
 no Python runtime; it needs a new clean base checkpoint after automatic login
 and desktop-tool provisioning before selector scenarios can run.
 
+For a console-ready candidate base, run `desktop-bootstrap --install-tools`
+once before capturing its checkpoint. It installs Python 3 as well as
+Peekaboo and mcporter, then records the console-user and Peekaboo evidence.
+This is base provisioning, not a per-scenario setup step.
+
 ### Semantic UI automation with Peekaboo 3
 
 For the current capability matrix, security boundaries, and agent handoff


### PR DESCRIPTION
## What changed

- Install Python 3 when `desktop-bootstrap --install-tools` provisions a candidate desktop base.
- Resolve and reuse the verified Python executable for bootstrap evidence.
- Document that this is a one-time base-provisioning step.

## Why

The macOS 26 desktop base lacked Python, so selector and Peekaboo evidence could not start even after a console session is available.

## Validation

- `./Scripts/lab/tests/keypath-lab-tests.sh`
- `./Scripts/lab/tests/peekaboo-ui-tests.sh`
- `git diff --check`

Remote review gate selected; GitHub `claude-review` is required before merge.