### PR TITLE
Fix legacy runner agent cleanup

### DIFF
--- a/Scripts/install-ci-runner-service.sh
+++ b/Scripts/install-ci-runner-service.sh
@@ -74,7 +74,11 @@ remove_legacy_runner_agent() {
     local runner_name legacy_dir legacy_plist legacy_label
 
     [[ -n "$RUNNER_UID" ]] || return 0
-    runner_name="$(/usr/libexec/PlistBuddy -c 'Print :agentName' "$RUNNER_DIR/.runner" 2>/dev/null || true)"
+    # GitHub stores runner registration metadata as JSON, not a property list.
+    # macOS plutil reads JSON and avoids adding a jq dependency to this boot-time
+    # installer.  A plist-only parser silently returns no name and leaves the
+    # conflicting LaunchAgent loaded.
+    runner_name="$(/usr/bin/plutil -extract agentName raw -o - "$RUNNER_DIR/.runner" 2>/dev/null || true)"
     [[ -n "$runner_name" ]] || return 0
 
     legacy_dir="/Users/$RUNNER_USER/Library/LaunchAgents"

--- a/Tests/KeyPathTests/Lint/DeploymentScriptContractTests.swift
+++ b/Tests/KeyPathTests/Lint/DeploymentScriptContractTests.swift
@@ -193,6 +193,20 @@ final class DeploymentScriptContractTests: XCTestCase {
             "Every build, timeout, crash, parsed-failure, and unexplained nonzero exit must print artifact paths."
         )
     }
+
+    func testCIRunnerInstallerReadsGitHubJSONRegistration() throws {
+        let root = repositoryRoot()
+        let installer = try contents(of: root.appendingPathComponent("Scripts/install-ci-runner-service.sh"))
+
+        XCTAssertTrue(
+            installer.contains("/usr/bin/plutil -extract agentName raw -o - \"$RUNNER_DIR/.runner\""),
+            "The runner installer must read agentName from GitHub's JSON .runner metadata."
+        )
+        XCTAssertFalse(
+            installer.contains("PlistBuddy -c 'Print :agentName' \"$RUNNER_DIR/.runner\""),
+            "PlistBuddy cannot read GitHub's JSON .runner file and leaves a duplicate LaunchAgent loaded."
+        )
+    }
 }
 
 // MARK: - Helpers


### PR DESCRIPTION
## Summary
- read the GitHub runner registration from its JSON `.runner` file with macOS `plutil`
- preserve removal of only the matching legacy LaunchAgent
- add a contract regression test for the metadata parser

## Root cause
The installer used `PlistBuddy` to read `.runner`, but GitHub stores that file as JSON. Parsing silently returned an empty runner name, so the old per-user LaunchAgent stayed loaded and competed with the new system LaunchDaemon for one runner session.

## Validation
- production Mini: removed the duplicate agent, system daemon reconnected, and a forced Runner Health Check passed on `keypath-mini`
- `bash -n Scripts/install-ci-runner-service.sh`
- targeted `DeploymentScriptContractTests/testCIRunnerInstallerReadsGitHubJSONRegistration`
- `./Scripts/test-fast.sh --changed` (full safe fallback: 4,742 tests passed)
- `./Scripts/review-gate.sh` → remote review gate selected; GitHub `claude-review` required