### PR TITLE
Fix Parallels artifact screenshots

### DIFF
--- a/Scripts/lab/remote.sh
+++ b/Scripts/lab/remote.sh
@@ -821,7 +821,7 @@ list_leases() {
 }
 
 collect_artifacts() {
-  local lease=$1 manifest output exit_code macos repo archive
+  local lease=$1 manifest output exit_code macos repo archive provider_resource parallels_cli
   local nameplate_restore=0 nameplate_hide_status=not-needed nameplate_restore_status=not-needed
   manifest=$(owned_manifest "$lease")
   macos=$(field "$manifest" macos)
@@ -863,7 +863,11 @@ collect_artifacts() {
       export PATH="$LAB_ROOT/CompatTools/bin:$LAB_ROOT/SharedTools/bin:/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin"
       (cd "$repo" && "$CRABBOX" screenshot --provider tart --target macos --id "$lease" --output "$output/screenshot.png") >> "$output/download.log" 2>&1
     else
-      (cd "$repo" && "$CRABBOX" screenshot --provider parallels --target macos --id "$lease" --parallels-user keypathqa --parallels-work-root /Users/keypathqa/crabbox --output "$output/screenshot.png") >> "$output/download.log" 2>&1
+      provider_resource=$(field "$manifest" provider_resource)
+      [[ "$provider_resource" =~ '^[A-Fa-f0-9-]+$' && "$provider_resource" != "unknown" ]] || die "invalid Parallels resource id"
+      parallels_cli=${KEYPATH_LAB_PRLCTL:-"/Applications/Parallels Desktop.app/Contents/MacOS/prlctl"}
+      [[ -x "$parallels_cli" ]] || die "Parallels CLI is unavailable"
+      "$parallels_cli" capture "$provider_resource" --file "$output/screenshot.png" >> "$output/download.log" 2>&1
     fi
     screenshot_exit=$?
     set -e

--- a/Scripts/lab/remote.sh
+++ b/Scripts/lab/remote.sh
@@ -822,6 +822,7 @@ list_leases() {
 
 collect_artifacts() {
   local lease=$1 manifest output exit_code macos repo archive provider_resource parallels_cli
+  local parallels_resource_pattern='^[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}$'
   local nameplate_restore=0 nameplate_hide_status=not-needed nameplate_restore_status=not-needed
   manifest=$(owned_manifest "$lease")
   macos=$(field "$manifest" macos)
@@ -864,7 +865,7 @@ collect_artifacts() {
       (cd "$repo" && "$CRABBOX" screenshot --provider tart --target macos --id "$lease" --output "$output/screenshot.png") >> "$output/download.log" 2>&1
     else
       provider_resource=$(field "$manifest" provider_resource)
-      [[ "$provider_resource" =~ '^[A-Fa-f0-9-]+$' && "$provider_resource" != "unknown" ]] || die "invalid Parallels resource id"
+      [[ "$provider_resource" =~ $parallels_resource_pattern ]] || die "invalid Parallels resource id"
       parallels_cli=${KEYPATH_LAB_PRLCTL:-"/Applications/Parallels Desktop.app/Contents/MacOS/prlctl"}
       [[ -x "$parallels_cli" ]] || die "Parallels CLI is unavailable"
       "$parallels_cli" capture "$provider_resource" --file "$output/screenshot.png" >> "$output/download.log" 2>&1

--- a/Scripts/lab/tests/keypath-lab-tests.sh
+++ b/Scripts/lab/tests/keypath-lab-tests.sh
@@ -113,6 +113,15 @@ printf '%s\n' "\$*" > "$TMP/guest-ssh-args"
 cat > "$TMP/guest-ssh-stdin"
 EOF
 chmod +x "$ROOT/bin/tart" "$ROOT/bin/guest-ssh"
+cat > "$ROOT/bin/prlctl" <<EOF
+#!/bin/bash
+echo "prlctl \$*" >> "$CALLS"
+if [[ \$1 == capture && \$3 == --file ]]; then
+  mkdir -p "\$(dirname "\$4")"
+  echo png > "\$4"
+fi
+EOF
+chmod +x "$ROOT/bin/prlctl"
 echo test-private-key > "$TMP/id_ed25519"
 echo 'fixture-password-that-must-not-leak' > "$TMP/secure-input"
 
@@ -131,6 +140,7 @@ run_remote() {
     KEYPATH_LAB_CRABBOX="$ROOT/bin/crabbox" \
     KEYPATH_LAB_TART="$ROOT/bin/tart" \
     KEYPATH_LAB_GUEST_SSH="$ROOT/bin/guest-ssh" \
+    KEYPATH_LAB_PRLCTL="$ROOT/bin/prlctl" \
     KEYPATH_LAB_TEST_SSH_KEY="$TMP/id_ed25519" \
     KEYPATH_LAB_TEST_SECRET_FILE="$TMP/secure-input" \
         /bin/zsh "$REMOTE" "$@"
@@ -364,6 +374,13 @@ assert_contains "$artifacts27" $'download_status\t0'
 grep -q 'crabbox run --provider parallels --target macos --id cbx_test27 --stop-after never --download' "$CALLS"
 run_remote destroy cbx_test27 >/dev/null
 grep -q 'stop-27 cbx_test27' "$CALLS"
+
+desktop26_create=$(run_remote create 26 unmanaged-ui "$archive_key" "$commit" "$checksum" KeyPath.zip 2h 1)
+assert_contains "$desktop26_create" $'lease_id\tcbx_desktop26'
+desktop26_artifacts=$(run_remote artifacts cbx_desktop26)
+assert_contains "$desktop26_artifacts" $'screenshot_status\t0'
+grep -q 'prlctl capture 00000000-0000-0000-0000-000000000000 --file' "$CALLS"
+run_remote destroy cbx_desktop26 >/dev/null
 
 desktop_create=$(run_remote create 15 unmanaged-ui "$archive_key" "$commit" "$checksum" KeyPath.zip 2h 1)
 assert_contains "$desktop_create" $'lease_id\tcbx_desktop15'

--- a/Scripts/lab/tests/keypath-lab-tests.sh
+++ b/Scripts/lab/tests/keypath-lab-tests.sh
@@ -380,6 +380,17 @@ assert_contains "$desktop26_create" $'lease_id\tcbx_desktop26'
 desktop26_artifacts=$(run_remote artifacts cbx_desktop26)
 assert_contains "$desktop26_artifacts" $'screenshot_status\t0'
 grep -q 'prlctl capture 00000000-0000-0000-0000-000000000000 --file' "$CALLS"
+desktop26_manifest="$ROOT/KeyPathInstallerLab/leases/cbx_desktop26/manifest.tsv"
+awk -F '\t' 'BEGIN {OFS="\t"} $1 == "provider_resource" {$2="-option-like-id"} {print}' "$desktop26_manifest" > "$desktop26_manifest.tmp"
+mv "$desktop26_manifest.tmp" "$desktop26_manifest"
+prlctl_calls_before=$(grep -c '^prlctl capture ' "$CALLS")
+set +e
+invalid_resource_output=$(run_remote artifacts cbx_desktop26 2>&1)
+invalid_resource_exit=$?
+set -e
+[[ $invalid_resource_exit -eq 1 ]]
+assert_contains "$invalid_resource_output" 'invalid Parallels resource id'
+[[ $(grep -c '^prlctl capture ' "$CALLS") -eq $prlctl_calls_before ]]
 run_remote destroy cbx_desktop26 >/dev/null
 
 desktop_create=$(run_remote create 15 unmanaged-ui "$archive_key" "$commit" "$checksum" KeyPath.zip 2h 1)

--- a/docs/testing/remote-installer-lab.md
+++ b/docs/testing/remote-installer-lab.md
@@ -113,7 +113,10 @@ Artifact collection packages scenario output inside the guest and retrieves the
 single archive with CrabBox's native, owner-only `run --download` path. It does
 not parse private SSH-key locations or invoke `scp`. CrabBox 0.36's provider
 `cp` command is not supported by these providers, and its aggregate desktop
-artifact workflow requires a desktop-enabled lease.
+artifact workflow requires a desktop-enabled lease. Controller screenshots use
+CrabBox for Tart leases and Parallels' read-only `prlctl capture` for Parallels
+leases; CrabBox's generic screenshot command expects a VNC endpoint that the
+Parallels desktop base intentionally does not expose.
 
 Pass `--desktop` when approval interaction or screenshots are required. The
 controller mirrors the existing provider launcher configuration while adding


### PR DESCRIPTION
## What changed

- capture Parallels desktop artifacts with native `prlctl capture`
- retain CrabBox screenshot capture for Tart leases
- cover the provider-specific path in the lab controller shell tests
- document why Parallels does not use CrabBox's VNC-based screenshot command

## Root cause

The controller routed both providers through CrabBox's generic screenshot command. That path expects a VNC endpoint, but the managed Parallels desktop base intentionally does not expose one. Artifact downloads succeeded while the final desktop screenshot failed.

## Validation

- `./Scripts/lab/tests/keypath-lab-tests.sh`
- `./Scripts/test-fast.sh --changed` — full safe suite, 4,746 tests passed
- `./Scripts/review-gate.sh` — remote review gate selected
- disposable macOS 26 Parallels lease `cbx_3abd819fab2e`: artifact download status 0, screenshot status 0, 2040x1280 PNG captured, lease destroyed

