### PR TITLE
Add consolidated lab scenario report

### DIFF
--- a/Scripts/lab/scenario-report
+++ b/Scripts/lab/scenario-report
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Consolidate validated KeyPath lab scenario results into one safe report."""
+
+import argparse
+import datetime
+import json
+import pathlib
+import sys
+
+
+STATUSES = ("passed", "failed", "blocked")
+CLASSIFICATIONS = (
+    "keypath-product-failure",
+    "harness-selector-failure",
+    "harness-transport-failure",
+    "provider-failure",
+    "unsupported-os-selector",
+    "environment-precondition-failure",
+)
+
+
+class ReportError(ValueError):
+    pass
+
+
+def safe_relative(path: pathlib.Path, root: pathlib.Path, label: str) -> pathlib.Path:
+    if path.is_absolute() or ".." in path.parts:
+        raise ReportError(f"{label} must be an artifact-relative path")
+    resolved = (root / path).resolve()
+    try:
+        return resolved.relative_to(root.resolve())
+    except ValueError as error:
+        raise ReportError(f"{label} escapes the artifact root") from error
+
+
+def load_result(path: pathlib.Path, root: pathlib.Path) -> dict:
+    if path.is_symlink():
+        raise ReportError(f"{path.relative_to(root)} must not be a symlink")
+    try:
+        result = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError) as error:
+        raise ReportError(f"cannot read {path.relative_to(root)}: {error}") from error
+    if result.get("schemaVersion") != 1:
+        raise ReportError(f"{path.relative_to(root)} has an unsupported schemaVersion")
+    scenario = result.get("scenario")
+    status = result.get("status")
+    summary = result.get("summary")
+    evidence = result.get("evidence")
+    if not isinstance(scenario, str) or not scenario:
+        raise ReportError(f"{path.relative_to(root)} has no scenario")
+    if status not in STATUSES:
+        raise ReportError(f"{path.relative_to(root)} has an invalid status")
+    if not isinstance(summary, str) or not summary:
+        raise ReportError(f"{path.relative_to(root)} has no summary")
+    if not isinstance(evidence, list) or not all(isinstance(item, str) for item in evidence):
+        raise ReportError(f"{path.relative_to(root)} has invalid evidence")
+
+    entry = {
+        "scenario": scenario,
+        "status": status,
+        "summary": summary,
+        "result": str(path.relative_to(root)),
+        "evidence": [],
+    }
+    for value in evidence:
+        if not value:
+            raise ReportError(f"evidence in {path.relative_to(root)} must not be empty")
+        relative = safe_relative(pathlib.Path(value), path.parent, f"evidence in {path.relative_to(root)}")
+        target = path.parent / relative
+        entry["evidence"].append({
+            "path": str(target.resolve().relative_to(root.resolve())),
+            "exists": target.is_file(),
+        })
+    if status != "passed":
+        failure = result.get("failure")
+        if not isinstance(failure, dict) or failure.get("classification") not in CLASSIFICATIONS or not failure.get("step"):
+            raise ReportError(f"{path.relative_to(root)} has no classified failure")
+        entry["failure"] = {
+            "classification": failure["classification"],
+            "step": failure["step"],
+        }
+    elif "failure" in result:
+        raise ReportError(f"{path.relative_to(root)} attaches a failure to a passing result")
+    return entry
+
+
+def build_report(root: pathlib.Path) -> dict:
+    root = root.resolve()
+    if not root.is_dir():
+        raise ReportError(f"input is not a directory: {root}")
+    paths = sorted(path for path in root.rglob("result.json") if path.is_file())
+    entries = [load_result(path, root) for path in paths]
+    status_counts = {status: 0 for status in STATUSES}
+    classification_counts: dict[str, int] = {}
+    for entry in entries:
+        status_counts[entry["status"]] += 1
+        if "failure" in entry:
+            classification = entry["failure"]["classification"]
+            classification_counts[classification] = classification_counts.get(classification, 0) + 1
+    return {
+        "schemaVersion": 1,
+        "generatedAt": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        "artifactRoot": ".",
+        "summary": {
+            "total": len(entries),
+            "statuses": status_counts,
+            "failureClassifications": dict(sorted(classification_counts.items())),
+        },
+        "results": entries,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", required=True, type=pathlib.Path, help="artifact root to scan")
+    parser.add_argument("--output", required=True, type=pathlib.Path, help="report JSON path")
+    args = parser.parse_args()
+    try:
+        report = build_report(args.input)
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(json.dumps(report, indent=2) + "\n")
+    except (OSError, ReportError) as error:
+        print(f"scenario-report: {error}", file=sys.stderr)
+        raise SystemExit(2)
+
+
+if __name__ == "__main__":
+    main()

--- a/Scripts/lab/tests/scenario-report-tests.py
+++ b/Scripts/lab/tests/scenario-report-tests.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+import json
+import pathlib
+import subprocess
+import tempfile
+import unittest
+
+
+TOOL = pathlib.Path(__file__).resolve().parents[1] / "scenario-report"
+
+
+class ScenarioReportTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = pathlib.Path(self.temporary.name) / "artifacts"
+        self.root.mkdir()
+        self.output = pathlib.Path(self.temporary.name) / "report.json"
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def write_result(self, directory: str, result: dict) -> pathlib.Path:
+        target = self.root / directory
+        target.mkdir(parents=True)
+        path = target / "result.json"
+        path.write_text(json.dumps(result))
+        return path
+
+    def invoke(self, check: bool = True) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [str(TOOL), "--input", str(self.root), "--output", str(self.output)],
+            capture_output=True, text=True, check=check,
+        )
+
+    def test_aggregates_results_and_sanitized_evidence_links(self) -> None:
+        passed = {
+            "schemaVersion": 1, "scenario": "clean-install", "status": "passed",
+            "summary": "Install reached its postcondition.", "evidence": ["inspect.json"],
+        }
+        failed = {
+            "schemaVersion": 1, "scenario": "repair", "status": "failed",
+            "summary": "Runtime postcondition was absent.", "evidence": ["logs/tcp.json"],
+            "failure": {"classification": "keypath-product-failure", "step": "verify", "message": "raw detail omitted"},
+        }
+        self.write_result("b", failed)
+        self.write_result("a", passed)
+        (self.root / "a/inspect.json").write_text("{}")
+        (self.root / "b/logs").mkdir()
+        (self.root / "b/logs/tcp.json").write_text("{}")
+
+        self.invoke()
+        report = json.loads(self.output.read_text())
+        self.assertEqual(report["summary"]["total"], 2)
+        self.assertEqual(report["summary"]["statuses"], {"passed": 1, "failed": 1, "blocked": 0})
+        self.assertEqual(report["summary"]["failureClassifications"], {"keypath-product-failure": 1})
+        self.assertEqual([entry["scenario"] for entry in report["results"]], ["clean-install", "repair"])
+        self.assertEqual(report["results"][0]["evidence"], [{"path": "a/inspect.json", "exists": True}])
+        self.assertNotIn("message", report["results"][1]["failure"])
+
+    def test_reports_missing_relative_evidence_without_inventing_success(self) -> None:
+        self.write_result("run", {
+            "schemaVersion": 1, "scenario": "selector", "status": "passed",
+            "summary": "Selector resolved.", "evidence": ["snapshot.json"],
+        })
+        self.invoke()
+        report = json.loads(self.output.read_text())
+        self.assertEqual(report["results"][0]["evidence"], [{"path": "run/snapshot.json", "exists": False}])
+
+    def test_rejects_evidence_path_traversal(self) -> None:
+        self.write_result("run", {
+            "schemaVersion": 1, "scenario": "selector", "status": "passed",
+            "summary": "Unsafe fixture.", "evidence": ["../secret.txt"],
+        })
+        result = self.invoke(check=False)
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("artifact-relative", result.stderr)
+        self.assertFalse(self.output.exists())
+
+    def test_rejects_unclassified_non_passing_result(self) -> None:
+        self.write_result("run", {
+            "schemaVersion": 1, "scenario": "selector", "status": "blocked",
+            "summary": "Missing prerequisite.", "evidence": [],
+        })
+        result = self.invoke(check=False)
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("no classified failure", result.stderr)
+
+    def test_rejects_result_symlink(self) -> None:
+        outside = pathlib.Path(self.temporary.name) / "outside.json"
+        outside.write_text(json.dumps({
+            "schemaVersion": 1, "scenario": "outside", "status": "passed",
+            "summary": "Outside artifact.", "evidence": [],
+        }))
+        run = self.root / "run"
+        run.mkdir()
+        (run / "result.json").symlink_to(outside)
+        result = self.invoke(check=False)
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("must not be a symlink", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/testing/scenario-failure-ownership.md
+++ b/docs/testing/scenario-failure-ownership.md
@@ -28,6 +28,25 @@ The supported classifications are:
 Attach only sanitized artifact-relative evidence paths. Do not put secrets,
 credentials, or raw tool responses in `result.json`.
 
+## Consolidated report
+
+After collecting scenario artifacts under one directory, build the
+machine-readable evidence index with:
+
+```bash
+Scripts/lab/scenario-report \
+  --input .keypath-lab/scenario-output \
+  --output .keypath-lab/scenario-report.json
+```
+
+The report recursively discovers `result.json` files, validates their outcome
+contract, and counts statuses and failure owners. Evidence links are rewritten
+relative to the supplied artifact root and include an `exists` flag. Absolute
+paths, parent traversal, symlink escapes, malformed results, and unclassified
+non-passing outcomes fail the report instead of being published. Failure
+messages are intentionally omitted from the consolidated report so raw tool
+details cannot spread beyond the individual sanitized result.
+
 ## Selector self-test
 
 Run this in every runner test suite:


### PR DESCRIPTION
## What changed

- add `Scripts/lab/scenario-report` to consolidate recursively collected `result.json` files
- validate scenario status and failure ownership before publishing the report
- rewrite evidence links relative to the artifact root and reject traversal or symlink escapes
- report missing evidence explicitly instead of inventing success
- document the M14 report workflow and add focused regression tests

## Why

The lab already emits one machine-readable result per scenario, but lacked the M14 consolidated evidence index. This keeps aggregation narrow: it does not add scheduling or expand the scenario matrix.

## Validation

- `python3 Scripts/lab/tests/scenario-report-tests.py`
- `python3 Scripts/lab/tests/scenario-result-tests.py`
- end-to-end two-result CLI report smoke test
- `./Scripts/test-fast.sh --changed` (full safe suite: 4,746 passed)
- `./Scripts/review-gate.sh` (`remote review gate selected`; merge waits for GitHub `claude-review`)
