### PR TITLE
Fix macOS 27 lab console session delivery

### DIFF
--- a/Scripts/lab/keypath-lab
+++ b/Scripts/lab/keypath-lab
@@ -14,6 +14,8 @@ Commands:
   preflight
   create --macos 15|26|27 --lane managed-functional|unmanaged-ui --commit SHA --installer PATH [--ttl 2h] [--desktop]
   install-app LEASE_ID
+  console-login LEASE_ID
+  rfb-pointer-probe LEASE_ID --x X --y Y
   desktop-bootstrap LEASE_ID [--install-tools]
   nameplate LEASE_ID enable|show|hide|status
   protected-click LEASE_ID --app APP --window TITLE (--x X --y Y | --ax-x X --ax-y Y) [--after-window TITLE]
@@ -125,6 +127,28 @@ EOF
         [[ $# -eq 1 ]] || usage
         require_lease_id "$1"
         remote install-app "$1"
+        ;;
+    console-login)
+        [[ $# -eq 1 ]] || usage
+        require_lease_id "$1"
+        remote console-login "$1"
+        ;;
+    rfb-pointer-probe)
+        lease=${1:-}
+        [[ -n $lease ]] || usage
+        require_lease_id "$lease"
+        shift
+        x=
+        y=
+        while [[ $# -gt 0 ]]; do
+            case "$1" in
+                --x) x=${2:-}; shift 2 ;;
+                --y) y=${2:-}; shift 2 ;;
+                *) usage ;;
+            esac
+        done
+        [[ $x =~ ^[0-9]+$ && $y =~ ^[0-9]+$ ]] || usage
+        remote rfb-pointer-probe "$lease" "$x" "$y"
         ;;
     desktop-bootstrap)
         lease=${1:-}

--- a/Scripts/lab/remote.sh
+++ b/Scripts/lab/remote.sh
@@ -923,6 +923,195 @@ desktop_bootstrap() {
   set_field "$manifest" desktop_bootstrap_status passed
 }
 
+console_login() {
+  local lease=$1 manifest macos resource parallels_cli secret_file exit_code console_user attempt guest_command autologin_status guest_control_ready configure_stage
+  local guest_ip key known_hosts known_hosts_option fifo status_file configure_pid fifo_ready stream_exit
+  manifest=$(owned_manifest "$lease")
+  macos=$(field "$manifest" macos)
+  [[ "$macos" == "27" ]] || die "console login currently supports only the macOS 27 Parallels lane"
+  [[ "$(field "$manifest" provider)" == "parallels" ]] || die "console login requires a Parallels lease"
+  [[ "$(field "$manifest" desktop_enabled)" == "true" ]] || die "console login requires a desktop-enabled lease"
+  resource=$(field "$manifest" provider_resource)
+  [[ "$resource" =~ '^[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}$' ]] || die "invalid Parallels resource id"
+  parallels_cli=${KEYPATH_LAB_PRLCTL:-"/Applications/Parallels Desktop.app/Contents/MacOS/prlctl"}
+  [[ -x "$parallels_cli" ]] || die "Parallels CLI is unavailable"
+  if ! "$parallels_cli" status "$resource" 2>/dev/null | grep -q running; then
+    "$parallels_cli" start "$resource" > "$LOGS/$lease/console-login-start.log" 2>&1 || die "failed to start the disposable Parallels guest"
+  fi
+  guest_control_ready=0
+  for attempt in {1..90}; do
+    if "$parallels_cli" exec "$resource" /usr/bin/true >/dev/null 2>&1; then
+      guest_control_ready=1
+      break
+    fi
+    sleep "${KEYPATH_LAB_CONSOLE_LOGIN_POLL_SECONDS:-2}"
+  done
+  (( guest_control_ready == 1 )) || die "Parallels guest control did not become ready"
+
+  if [[ "${KEYPATH_LAB_TESTING:-0}" == "1" ]]; then
+    secret_file="${KEYPATH_LAB_TEST_SECRET_FILE:?test secret file is required}"
+    key="${KEYPATH_LAB_TEST_SSH_KEY:?test SSH key is required}"
+    known_hosts=/dev/null
+    guest_ip=192.0.2.27
+  else
+    key="$HOME/Library/Application Support/crabbox/testboxes/$lease/id_ed25519"
+    [[ -f "$key" && ! -L "$key" && -O "$key" ]] || die "owned CrabBox SSH key not found for lease"
+    known_hosts="$HOME/Library/Application Support/crabbox/testboxes/$lease/known_hosts"
+    [[ -f "$known_hosts" && ! -L "$known_hosts" && -O "$known_hosts" ]] || die "owned CrabBox known-hosts file not found for lease"
+    guest_ip=$("$parallels_cli" list -i -f -j "$resource" | python3 -c 'import json,sys; rows=json.load(sys.stdin); addresses=rows[0].get("Network",{}).get("ipAddresses",[]) if rows else []; print(next((item.get("ip","") for item in addresses if item.get("type")=="ipv4"),""),end="")')
+    [[ "$guest_ip" =~ '^[0-9A-Fa-f:.]+$' ]] || die "Parallels returned an invalid guest address"
+    secret_file=$(mktemp "$STATE_ROOT/.console-login.XXXXXXXX")
+    chmod 600 "$secret_file"
+    typeset -g KEYPATH_LAB_SECURE_TEMP="$secret_file"
+    trap '[[ -z ${KEYPATH_LAB_SECURE_TEMP:-} ]] || rm -f "$KEYPATH_LAB_SECURE_TEMP"' EXIT
+    /opt/homebrew/bin/sops -d "$HOME/dotfiles/secrets.env" | awk -F= '$1 == "KEYPATH_LAB_GUEST_PASSWORD" {sub(/^[^=]*=/, ""); printf "%s", $0; found=1} END {if (!found) exit 1}' > "$secret_file" || die "KEYPATH_LAB_GUEST_PASSWORD is unavailable"
+  fi
+  [[ -s "$secret_file" ]] || die "console login secret is empty"
+  known_hosts_option=${known_hosts// /\\ }
+
+  # Configure automatic login inside the disposable clone through Parallels'
+  # root guest-control channel. prlctl exec does not forward stdin, so the root
+  # process creates a lease-specific FIFO and the existing lease-owned SSH
+  # channel streams the password into it. The controller's short-lived,
+  # owner-only temp file is removed before the reboot; the value never appears
+  # in process arguments or logs.
+  # sysadminctl's protected prompt cannot be driven through prlctl because
+  # guest-control does not forward stdin. Expand the FIFO-fed value only inside
+  # the isolated guest process; the controller command contains the variable
+  # reference, never its value, and both output streams stay suppressed.
+  fifo="/tmp/keypath-console-login-$lease-$$.fifo"
+  status_file="/tmp/keypath-console-login-$lease-$$.status"
+  guest_command="set -euo pipefail; fifo=$(printf %q "$fifo"); status_file=$(printf %q "$status_file"); rm -f \"\$fifo\" \"\$status_file\"; print -r -- started > \"\$status_file\"; /usr/bin/mkfifo \"\$fifo\"; /usr/sbin/chown keypathqa:staff \"\$fifo\"; /bin/chmod 600 \"\$fifo\"; trap 'rm -f \"\$fifo\"' EXIT; KEYPATH_GUEST_PASSWORD=; IFS= read -r KEYPATH_GUEST_PASSWORD < \"\$fifo\" || [[ -n \"\$KEYPATH_GUEST_PASSWORD\" ]]; print -r -- credential-received >> \"\$status_file\"; /usr/bin/dscl . -authonly keypathqa \"\$KEYPATH_GUEST_PASSWORD\" || exit 91; print -r -- credential-valid >> \"\$status_file\"; set +e; /usr/sbin/sysadminctl -autologin set -userName keypathqa -password \"\$KEYPATH_GUEST_PASSWORD\"; sysadmin_result=\$?; set -e; autologin_status=\$(/usr/sbin/sysadminctl -autologin status 2>&1 || true); if [[ \"\$autologin_status\" != *'Automatic login is ON'* && \"\$autologin_status\" != *'Automatic login user: keypathqa'* ]]; then kcpassword_tmp=\$(/usr/bin/mktemp /etc/kcpassword.XXXXXXXX); trap 'rm -f \"\$fifo\" \"\$kcpassword_tmp\"' EXIT; printf %s \"\$KEYPATH_GUEST_PASSWORD\" | /usr/bin/perl -e 'binmode STDIN; binmode STDOUT; local \$/; my \$password = <STDIN>; my @key = (0x7d,0x89,0x52,0x23,0xd2,0xbc,0xdd,0xea,0xa3,0xb9,0x1f); \$password .= chr(0); \$password .= chr(0) while length(\$password) % 12; print pack(\"C*\", map { ord(substr(\$password, \$_, 1)) ^ \$key[\$_ % @key] } 0 .. length(\$password)-1);' > \"\$kcpassword_tmp\"; /usr/sbin/chown root:wheel \"\$kcpassword_tmp\"; /bin/chmod 600 \"\$kcpassword_tmp\"; /bin/mv -f \"\$kcpassword_tmp\" /etc/kcpassword; /usr/bin/defaults write /Library/Preferences/com.apple.loginwindow autoLoginUser -string keypathqa; print -r -- method:kcpassword-fallback >> \"\$status_file\"; fi; /bin/mkdir -p /var/db/crabbox; printf '%s\n' \"\$KEYPATH_GUEST_PASSWORD\" > /var/db/crabbox/vnc.password; /usr/sbin/chown root:wheel /var/db/crabbox/vnc.password; /bin/chmod 600 /var/db/crabbox/vnc.password; print -r -- rfb-credential:aligned >> \"\$status_file\"; unset KEYPATH_GUEST_PASSWORD; print -r -- sysadminctl-exit:\$sysadmin_result >> \"\$status_file\"; exit 0"
+  set +e
+  "$parallels_cli" exec "$resource" /bin/zsh -lc "$(printf %q "$guest_command")" \
+    > "$LOGS/$lease/console-login-configure.log" 2>&1 &
+  configure_pid=$!
+  fifo_ready=0
+  for attempt in {1..300}; do
+    if "$GUEST_SSH" -o BatchMode=yes -o StrictHostKeyChecking=yes -o "UserKnownHostsFile=$known_hosts_option" -i "$key" "keypathqa@$guest_ip" \
+      "/bin/test -p $(printf %q "$fifo")" </dev/null >/dev/null 2>&1; then
+      fifo_ready=1
+      break
+    fi
+    sleep 0.1
+  done
+  if (( fifo_ready == 1 )); then
+    "$GUEST_SSH" -o BatchMode=yes -o StrictHostKeyChecking=yes -o "UserKnownHostsFile=$known_hosts_option" -i "$key" "keypathqa@$guest_ip" \
+      "/bin/zsh -c $(printf %q "/bin/cat > $(printf %q "$fifo")")" < "$secret_file" >/dev/null 2>&1
+    stream_exit=$?
+  else
+    stream_exit=76
+    kill "$configure_pid" 2>/dev/null || true
+  fi
+  wait "$configure_pid"
+  exit_code=$?
+  "$parallels_cli" exec "$resource" /bin/cat "$status_file" >> "$LOGS/$lease/console-login-configure.log" 2>&1 || true
+  "$parallels_cli" exec "$resource" /bin/rm -f "$status_file" >/dev/null 2>&1 || true
+  configure_stage=$(< "$LOGS/$lease/console-login-configure.log")
+  (( stream_exit == 0 )) || exit_code=$stream_exit
+  if grep -Fq -f "$secret_file" "$LOGS/$lease/console-login-configure.log"; then
+    : > "$LOGS/$lease/console-login-configure.log"
+    exit_code=90
+  fi
+  set -e
+  if [[ "${KEYPATH_LAB_TESTING:-0}" != "1" ]]; then
+    rm -f "$secret_file"
+    KEYPATH_LAB_SECURE_TEMP=
+    trap - EXIT
+  fi
+  if (( exit_code != 0 )); then
+    if [[ "$configure_stage" != *credential-valid* ]]; then
+      set_field "$manifest" console_login_status credential-mismatch
+      record_command "$lease" failed:credential-mismatch console-login
+      die "KEYPATH_LAB_GUEST_PASSWORD does not authenticate the keypathqa guest account"
+    fi
+    set_field "$manifest" console_login_status "configure-failed:$exit_code"
+    record_command "$lease" "failed:$exit_code" console-login
+    die "failed to configure automatic login in the disposable guest"
+  fi
+  autologin_status=$("$parallels_cli" exec "$resource" /usr/sbin/sysadminctl -autologin status 2>&1 || true)
+  if [[ "$autologin_status" != *"Automatic login is ON"* && "$autologin_status" != *"Automatic login user: keypathqa"* ]]; then
+    set_field "$manifest" console_login_status "configure-postcondition-failed"
+    record_command "$lease" failed console-login
+    die "automatic login remained disabled after configuration"
+  fi
+
+  # A reboot is required because the source base is intentionally captured at
+  # loginwindow. Use the provider-owned restart so the clone cannot be stranded
+  # stopped when its guest-control connection closes during shutdown.
+  "$parallels_cli" restart "$resource" \
+    > "$LOGS/$lease/console-login-reboot.log" 2>&1 || die "failed to restart the disposable Parallels guest"
+  console_user=
+  for attempt in {1..90}; do
+    sleep "${KEYPATH_LAB_CONSOLE_LOGIN_POLL_SECONDS:-2}"
+    console_user=$("$parallels_cli" exec "$resource" /usr/bin/stat -f %Su /dev/console 2>/dev/null | tail -1 || true)
+    [[ "$console_user" == "keypathqa" ]] && break
+  done
+  if [[ "$console_user" != "keypathqa" ]]; then
+    set_field "$manifest" console_login_status "postcondition-failed"
+    record_command "$lease" failed console-login
+    die "automatic login did not establish the keypathqa console session"
+  fi
+
+  set_field "$manifest" console_login_status passed
+  set_field "$manifest" console_login_at "$(utc_now)"
+  record_command "$lease" passed console-login
+  print "console_login\tpassed"
+  print "console_user\t$console_user"
+}
+
+rfb_pointer_probe() {
+  local lease=$1 x=$2 y=$3 manifest macos resource parallels_cli key known_hosts known_hosts_option guest_ip cursor_command before after
+  manifest=$(owned_manifest "$lease")
+  macos=$(field "$manifest" macos)
+  [[ "$macos" == "27" ]] || die "RFB pointer probe currently supports only the macOS 27 Parallels lane"
+  [[ "$(field "$manifest" provider)" == "parallels" ]] || die "RFB pointer probe requires a Parallels lease"
+  [[ "$(field "$manifest" desktop_enabled)" == "true" ]] || die "RFB pointer probe requires a desktop-enabled lease"
+  [[ "$(field "$manifest" console_login_status)" == "passed" ]] || die "RFB pointer probe requires a verified console login"
+  [[ "$x" == <-> && "$y" == <-> ]] || die "RFB pointer coordinates must be non-negative integers"
+  resource=$(field "$manifest" provider_resource)
+  [[ "$resource" =~ '^[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}$' ]] || die "invalid Parallels resource id"
+
+  if [[ "${KEYPATH_LAB_TESTING:-0}" == "1" ]]; then
+    before=${KEYPATH_LAB_TEST_CURSOR_BEFORE:-"10 10"}
+    key=${KEYPATH_LAB_TEST_SSH_KEY:?test SSH key is required}
+  else
+    parallels_cli=${KEYPATH_LAB_PRLCTL:-"/Applications/Parallels Desktop.app/Contents/MacOS/prlctl"}
+    [[ -x "$parallels_cli" ]] || die "Parallels CLI is unavailable"
+    key="$HOME/Library/Application Support/crabbox/testboxes/$lease/id_ed25519"
+    [[ -f "$key" && ! -L "$key" && -O "$key" ]] || die "owned CrabBox SSH key not found for lease"
+    known_hosts="$HOME/Library/Application Support/crabbox/testboxes/$lease/known_hosts"
+    [[ -f "$known_hosts" && ! -L "$known_hosts" && -O "$known_hosts" ]] || die "owned CrabBox known-hosts file not found for lease"
+    known_hosts_option=${known_hosts// /\\ }
+    guest_ip=$("$parallels_cli" list -i -f -j "$resource" | python3 -c 'import json,sys; rows=json.load(sys.stdin); addresses=rows[0].get("Network",{}).get("ipAddresses",[]) if rows else []; print(next((item.get("ip","") for item in addresses if item.get("type")=="ipv4"),""),end="")')
+    [[ "$guest_ip" =~ '^[0-9A-Fa-f:.]+$' ]] || die "Parallels returned an invalid guest address"
+    cursor_command='/usr/bin/osascript -l JavaScript -e '\''ObjC.import("CoreGraphics"); p=$.CGEventGetLocation($.CGEventCreate(null)); p.x+" "+p.y'\'''
+    before=$("$GUEST_SSH" -o BatchMode=yes -o StrictHostKeyChecking=yes -o "UserKnownHostsFile=$known_hosts_option" -i "$key" "keypathqa@$guest_ip" "/bin/zsh -lc $(printf %q "$cursor_command")")
+  fi
+  [[ "$before" =~ '^[0-9]+(\.[0-9]+)? [0-9]+(\.[0-9]+)?$' ]] || die "RFB pointer probe could not read the initial guest cursor location"
+
+  if [[ "${KEYPATH_LAB_TESTING:-0}" != "1" ]]; then
+    export PATH="/Applications/Parallels Desktop.app/Contents/MacOS:$PATH"
+  fi
+  CRABBOX_PARALLELS_USER=keypathqa CRABBOX_SSH_USER=keypathqa CRABBOX_SSH_PORT=22 CRABBOX_SSH_KEY="$key" \
+    "$CRABBOX" desktop click --provider parallels --target macos --id "$lease" --x "$x" --y "$y" >/dev/null
+  sleep "${KEYPATH_LAB_RFB_POINTER_SETTLE_SECONDS:-1}"
+  if [[ "${KEYPATH_LAB_TESTING:-0}" == "1" ]]; then
+    after=${KEYPATH_LAB_TEST_CURSOR_AFTER:-"$x $y"}
+  else
+    after=$("$GUEST_SSH" -o BatchMode=yes -o StrictHostKeyChecking=yes -o "UserKnownHostsFile=$known_hosts_option" -i "$key" "keypathqa@$guest_ip" "/bin/zsh -lc $(printf %q "$cursor_command")")
+  fi
+  [[ "$after" =~ '^[0-9]+(\.[0-9]+)? [0-9]+(\.[0-9]+)?$' ]] || die "RFB pointer probe could not read the resulting guest cursor location"
+  if [[ "$after" == "$before" ]]; then
+    record_command "$lease" failed rfb-pointer-probe --x "$x" --y "$y"
+    die "CrabBox acknowledged the RFB click but the guest cursor did not move"
+  fi
+  record_command "$lease" passed rfb-pointer-probe --x "$x" --y "$y"
+  print "rfb_pointer_probe\tpassed"
+  print "cursor_before\t$before"
+  print "cursor_after\t$after"
+}
+
 nameplate_control() {
   local lease=$1 nameplate_action=$2 manifest macos lane provider repo script output version checksum state
   manifest=$(owned_manifest "$lease")
@@ -1031,6 +1220,8 @@ case "$action" in
   artifacts) [[ $# -eq 1 ]] || die "artifacts requires lease"; collect_artifacts "$1" ;;
   scenario) [[ $# -eq 2 ]] || die "scenario requires lease and name"; scenario "$1" "$2" ;;
   desktop-bootstrap) [[ $# -eq 2 ]] || die "desktop-bootstrap requires lease and install-tools flag"; desktop_bootstrap "$@" ;;
+  console-login) [[ $# -eq 1 ]] || die "console-login requires lease"; console_login "$1" ;;
+  rfb-pointer-probe) [[ $# -eq 3 ]] || die "rfb-pointer-probe requires lease, x, and y"; rfb_pointer_probe "$@" ;;
   nameplate) [[ $# -eq 2 ]] || die "nameplate requires lease and action"; nameplate_control "$@" ;;
   destroy) [[ $# -eq 1 ]] || die "destroy requires lease"; destroy_lease "$1" ;;
   cleanup) cleanup_expired "${1:-}" ;;

--- a/Scripts/lab/remote.sh
+++ b/Scripts/lab/remote.sh
@@ -925,7 +925,7 @@ desktop_bootstrap() {
 
 console_login() {
   local lease=$1 manifest macos resource parallels_cli secret_file exit_code console_user attempt guest_command autologin_status guest_control_ready configure_stage
-  local guest_ip key known_hosts known_hosts_option fifo status_file configure_pid fifo_ready stream_exit
+  local guest_ip key known_hosts known_hosts_option fifo status_file configure_pid fifo_ready stream_exit credential_timeout
   manifest=$(owned_manifest "$lease")
   macos=$(field "$manifest" macos)
   [[ "$macos" == "27" ]] || die "console login currently supports only the macOS 27 Parallels lane"
@@ -968,6 +968,8 @@ console_login() {
   fi
   [[ -s "$secret_file" ]] || die "console login secret is empty"
   known_hosts_option=${known_hosts// /\\ }
+  credential_timeout=${KEYPATH_LAB_CONSOLE_CREDENTIAL_TIMEOUT_SECONDS:-30}
+  [[ "$credential_timeout" == <-> && "$credential_timeout" -gt 0 ]] || die "console login credential timeout must be a positive integer"
 
   # Configure automatic login inside the disposable clone through Parallels'
   # root guest-control channel. prlctl exec does not forward stdin, so the root
@@ -984,7 +986,7 @@ console_login() {
   # confined to the leak-checked controller log.
   fifo="/tmp/keypath-console-login-$lease-$$.fifo"
   status_file="/tmp/keypath-console-login-$lease-$$.status"
-  guest_command="set -euo pipefail; fifo=$(printf %q "$fifo"); status_file=$(printf %q "$status_file"); rm -f \"\$fifo\" \"\$status_file\"; print -r -- started > \"\$status_file\"; /usr/bin/mkfifo \"\$fifo\"; /usr/sbin/chown keypathqa:staff \"\$fifo\"; /bin/chmod 600 \"\$fifo\"; trap 'rm -f \"\$fifo\"' EXIT; KEYPATH_GUEST_PASSWORD=; IFS= read -r KEYPATH_GUEST_PASSWORD < \"\$fifo\" || [[ -n \"\$KEYPATH_GUEST_PASSWORD\" ]]; print -r -- credential-received >> \"\$status_file\"; /usr/bin/dscl . -authonly keypathqa \"\$KEYPATH_GUEST_PASSWORD\" || exit 91; print -r -- credential-valid >> \"\$status_file\"; set +e; /usr/sbin/sysadminctl -autologin set -userName keypathqa -password \"\$KEYPATH_GUEST_PASSWORD\"; sysadmin_result=\$?; set -e; autologin_status=\$(/usr/sbin/sysadminctl -autologin status 2>&1 || true); if [[ \"\$autologin_status\" != *'Automatic login is ON'* && \"\$autologin_status\" != *'Automatic login user: keypathqa'* ]]; then kcpassword_tmp=\$(/usr/bin/mktemp /etc/kcpassword.XXXXXXXX); trap 'rm -f \"\$fifo\" \"\$kcpassword_tmp\"' EXIT; printf %s \"\$KEYPATH_GUEST_PASSWORD\" | /usr/bin/perl -e 'binmode STDIN; binmode STDOUT; local \$/; my \$password = <STDIN>; my @key = (0x7d,0x89,0x52,0x23,0xd2,0xbc,0xdd,0xea,0xa3,0xb9,0x1f); \$password .= chr(0); \$password .= chr(0) while length(\$password) % 12; print pack(\"C*\", map { ord(substr(\$password, \$_, 1)) ^ \$key[\$_ % @key] } 0 .. length(\$password)-1);' > \"\$kcpassword_tmp\"; /usr/sbin/chown root:wheel \"\$kcpassword_tmp\"; /bin/chmod 600 \"\$kcpassword_tmp\"; /bin/mv -f \"\$kcpassword_tmp\" /etc/kcpassword; /usr/bin/defaults write /Library/Preferences/com.apple.loginwindow autoLoginUser -string keypathqa; print -r -- method:kcpassword-fallback >> \"\$status_file\"; fi; /bin/mkdir -p /var/db/crabbox; printf '%s\n' \"\$KEYPATH_GUEST_PASSWORD\" > /var/db/crabbox/vnc.password; /usr/sbin/chown root:wheel /var/db/crabbox/vnc.password; /bin/chmod 600 /var/db/crabbox/vnc.password; print -r -- rfb-credential:aligned >> \"\$status_file\"; unset KEYPATH_GUEST_PASSWORD; print -r -- sysadminctl-exit:\$sysadmin_result >> \"\$status_file\"; exit 0"
+  guest_command="set -euo pipefail; fifo=$(printf %q "$fifo"); status_file=$(printf %q "$status_file"); rm -f \"\$fifo\" \"\$status_file\"; print -r -- started > \"\$status_file\"; /usr/bin/mkfifo \"\$fifo\"; /usr/sbin/chown keypathqa:staff \"\$fifo\"; /bin/chmod 600 \"\$fifo\"; trap 'rm -f \"\$fifo\"' EXIT; exec 3<> \"\$fifo\"; KEYPATH_GUEST_PASSWORD=; IFS= read -r -t $credential_timeout -u 3 KEYPATH_GUEST_PASSWORD || [[ -n \"\$KEYPATH_GUEST_PASSWORD\" ]]; print -r -- credential-received >> \"\$status_file\"; /usr/bin/dscl . -authonly keypathqa \"\$KEYPATH_GUEST_PASSWORD\" || exit 91; print -r -- credential-valid >> \"\$status_file\"; set +e; /usr/sbin/sysadminctl -autologin set -userName keypathqa -password \"\$KEYPATH_GUEST_PASSWORD\"; sysadmin_result=\$?; set -e; autologin_status=\$(/usr/sbin/sysadminctl -autologin status 2>&1 || true); if [[ \"\$autologin_status\" != *'Automatic login is ON'* && \"\$autologin_status\" != *'Automatic login user: keypathqa'* ]]; then kcpassword_tmp=\$(/usr/bin/mktemp /etc/kcpassword.XXXXXXXX); trap 'rm -f \"\$fifo\" \"\$kcpassword_tmp\"' EXIT; printf %s \"\$KEYPATH_GUEST_PASSWORD\" | /usr/bin/perl -e 'binmode STDIN; binmode STDOUT; local \$/; my \$password = <STDIN>; my @key = (0x7d,0x89,0x52,0x23,0xd2,0xbc,0xdd,0xea,0xa3,0xb9,0x1f); \$password .= chr(0); \$password .= chr(0) while length(\$password) % 12; print pack(\"C*\", map { ord(substr(\$password, \$_, 1)) ^ \$key[\$_ % @key] } 0 .. length(\$password)-1);' > \"\$kcpassword_tmp\"; /usr/sbin/chown root:wheel \"\$kcpassword_tmp\"; /bin/chmod 600 \"\$kcpassword_tmp\"; /bin/mv -f \"\$kcpassword_tmp\" /etc/kcpassword; /usr/bin/defaults write /Library/Preferences/com.apple.loginwindow autoLoginUser -string keypathqa; print -r -- method:kcpassword-fallback >> \"\$status_file\"; fi; /bin/mkdir -p /var/db/crabbox; printf '%s\n' \"\$KEYPATH_GUEST_PASSWORD\" > /var/db/crabbox/vnc.password; /usr/sbin/chown root:wheel /var/db/crabbox/vnc.password; /bin/chmod 600 /var/db/crabbox/vnc.password; print -r -- rfb-credential:aligned >> \"\$status_file\"; unset KEYPATH_GUEST_PASSWORD; print -r -- sysadminctl-exit:\$sysadmin_result >> \"\$status_file\"; exit 0"
   set +e
   "$parallels_cli" exec "$resource" /bin/zsh -lc "$(printf %q "$guest_command")" \
     > "$LOGS/$lease/console-login-configure.log" 2>&1 &
@@ -1002,6 +1004,7 @@ console_login() {
     "$GUEST_SSH" -o BatchMode=yes -o StrictHostKeyChecking=yes -o "UserKnownHostsFile=$known_hosts_option" -i "$key" "keypathqa@$guest_ip" \
       "/bin/zsh -c $(printf %q "/bin/cat > $(printf %q "$fifo")")" < "$secret_file" >/dev/null 2>&1
     stream_exit=$?
+    (( stream_exit == 0 )) || kill "$configure_pid" 2>/dev/null || true
   else
     stream_exit=76
     kill "$configure_pid" 2>/dev/null || true
@@ -1023,6 +1026,11 @@ console_login() {
     trap - EXIT
   fi
   if (( exit_code != 0 )); then
+    if (( stream_exit != 0 )); then
+      set_field "$manifest" console_login_status "credential-stream-failed:$stream_exit"
+      record_command "$lease" "failed:$stream_exit" console-login
+      die "failed to stream the guest credential into the disposable guest"
+    fi
     if [[ "$configure_stage" != *credential-valid* ]]; then
       set_field "$manifest" console_login_status credential-mismatch
       record_command "$lease" failed:credential-mismatch console-login

--- a/Scripts/lab/remote.sh
+++ b/Scripts/lab/remote.sh
@@ -926,6 +926,7 @@ desktop_bootstrap() {
 console_login() {
   local lease=$1 manifest macos resource parallels_cli secret_file exit_code console_user attempt guest_command autologin_status guest_control_ready configure_stage
   local guest_ip key known_hosts known_hosts_option fifo status_file configure_pid fifo_ready stream_exit credential_timeout
+  local secret_leak
   manifest=$(owned_manifest "$lease")
   macos=$(field "$manifest" macos)
   [[ "$macos" == "27" ]] || die "console login currently supports only the macOS 27 Parallels lane"
@@ -1001,7 +1002,8 @@ console_login() {
     sleep 0.1
   done
   if (( fifo_ready == 1 )); then
-    "$GUEST_SSH" -o BatchMode=yes -o StrictHostKeyChecking=yes -o "UserKnownHostsFile=$known_hosts_option" -i "$key" "keypathqa@$guest_ip" \
+    /usr/bin/perl -e 'my $timeout = shift; alarm $timeout; exec @ARGV or exit 127' "$credential_timeout" \
+      "$GUEST_SSH" -o BatchMode=yes -o StrictHostKeyChecking=yes -o "UserKnownHostsFile=$known_hosts_option" -i "$key" "keypathqa@$guest_ip" \
       "/bin/zsh -c $(printf %q "/bin/cat > $(printf %q "$fifo")")" < "$secret_file" >/dev/null 2>&1
     stream_exit=$?
     (( stream_exit == 0 )) || kill "$configure_pid" 2>/dev/null || true
@@ -1015,8 +1017,10 @@ console_login() {
   "$parallels_cli" exec "$resource" /bin/rm -f "$status_file" >/dev/null 2>&1 || true
   configure_stage=$(< "$LOGS/$lease/console-login-configure.log")
   (( stream_exit == 0 )) || exit_code=$stream_exit
+  secret_leak=0
   if grep -Fq -f "$secret_file" "$LOGS/$lease/console-login-configure.log"; then
     : > "$LOGS/$lease/console-login-configure.log"
+    secret_leak=1
     exit_code=90
   fi
   set -e
@@ -1026,6 +1030,11 @@ console_login() {
     trap - EXIT
   fi
   if (( exit_code != 0 )); then
+    if (( secret_leak == 1 )); then
+      set_field "$manifest" console_login_status credential-leak-detected
+      record_command "$lease" failed:credential-leak console-login
+      die "guest credential disclosure was detected and redacted from the controller log"
+    fi
     if (( stream_exit != 0 )); then
       set_field "$manifest" console_login_status "credential-stream-failed:$stream_exit"
       record_command "$lease" "failed:$stream_exit" console-login

--- a/Scripts/lab/remote.sh
+++ b/Scripts/lab/remote.sh
@@ -974,11 +974,14 @@ console_login() {
   # process creates a lease-specific FIFO and the existing lease-owned SSH
   # channel streams the password into it. The controller's short-lived,
   # owner-only temp file is removed before the reboot; the value never appears
-  # in process arguments or logs.
+  # in controller process arguments or logs. Inside the disposable guest,
+  # dscl and sysadminctl have no noninteractive stdin form and briefly receive
+  # the value in argv. Do not run process-argument capture during this action.
   # sysadminctl's protected prompt cannot be driven through prlctl because
   # guest-control does not forward stdin. Expand the FIFO-fed value only inside
   # the isolated guest process; the controller command contains the variable
-  # reference, never its value, and both output streams stay suppressed.
+  # reference, never its value, and both guest command output streams stay
+  # confined to the leak-checked controller log.
   fifo="/tmp/keypath-console-login-$lease-$$.fifo"
   status_file="/tmp/keypath-console-login-$lease-$$.status"
   guest_command="set -euo pipefail; fifo=$(printf %q "$fifo"); status_file=$(printf %q "$status_file"); rm -f \"\$fifo\" \"\$status_file\"; print -r -- started > \"\$status_file\"; /usr/bin/mkfifo \"\$fifo\"; /usr/sbin/chown keypathqa:staff \"\$fifo\"; /bin/chmod 600 \"\$fifo\"; trap 'rm -f \"\$fifo\"' EXIT; KEYPATH_GUEST_PASSWORD=; IFS= read -r KEYPATH_GUEST_PASSWORD < \"\$fifo\" || [[ -n \"\$KEYPATH_GUEST_PASSWORD\" ]]; print -r -- credential-received >> \"\$status_file\"; /usr/bin/dscl . -authonly keypathqa \"\$KEYPATH_GUEST_PASSWORD\" || exit 91; print -r -- credential-valid >> \"\$status_file\"; set +e; /usr/sbin/sysadminctl -autologin set -userName keypathqa -password \"\$KEYPATH_GUEST_PASSWORD\"; sysadmin_result=\$?; set -e; autologin_status=\$(/usr/sbin/sysadminctl -autologin status 2>&1 || true); if [[ \"\$autologin_status\" != *'Automatic login is ON'* && \"\$autologin_status\" != *'Automatic login user: keypathqa'* ]]; then kcpassword_tmp=\$(/usr/bin/mktemp /etc/kcpassword.XXXXXXXX); trap 'rm -f \"\$fifo\" \"\$kcpassword_tmp\"' EXIT; printf %s \"\$KEYPATH_GUEST_PASSWORD\" | /usr/bin/perl -e 'binmode STDIN; binmode STDOUT; local \$/; my \$password = <STDIN>; my @key = (0x7d,0x89,0x52,0x23,0xd2,0xbc,0xdd,0xea,0xa3,0xb9,0x1f); \$password .= chr(0); \$password .= chr(0) while length(\$password) % 12; print pack(\"C*\", map { ord(substr(\$password, \$_, 1)) ^ \$key[\$_ % @key] } 0 .. length(\$password)-1);' > \"\$kcpassword_tmp\"; /usr/sbin/chown root:wheel \"\$kcpassword_tmp\"; /bin/chmod 600 \"\$kcpassword_tmp\"; /bin/mv -f \"\$kcpassword_tmp\" /etc/kcpassword; /usr/bin/defaults write /Library/Preferences/com.apple.loginwindow autoLoginUser -string keypathqa; print -r -- method:kcpassword-fallback >> \"\$status_file\"; fi; /bin/mkdir -p /var/db/crabbox; printf '%s\n' \"\$KEYPATH_GUEST_PASSWORD\" > /var/db/crabbox/vnc.password; /usr/sbin/chown root:wheel /var/db/crabbox/vnc.password; /bin/chmod 600 /var/db/crabbox/vnc.password; print -r -- rfb-credential:aligned >> \"\$status_file\"; unset KEYPATH_GUEST_PASSWORD; print -r -- sysadminctl-exit:\$sysadmin_result >> \"\$status_file\"; exit 0"

--- a/Scripts/lab/tests/keypath-lab-tests.sh
+++ b/Scripts/lab/tests/keypath-lab-tests.sh
@@ -115,6 +115,9 @@ printf '%s\n' "\$*" > "$TMP/guest-ssh-args"
 if [[ " \$* " == *" /bin/test -p /tmp/keypath-console-login-"* ]]; then
   cat >/dev/null
 else
+  if [[ \${KEYPATH_LAB_TEST_STREAM_FAIL:-0} == 1 ]]; then
+    exit 17
+  fi
   cat > "$TMP/guest-ssh-stdin"
 fi
 EOF
@@ -156,7 +159,7 @@ EOF
 chmod +x "$ROOT/bin/prlctl"
 echo test-private-key > "$TMP/id_ed25519"
 printf 'fixture-password-that-must-not-leak' > "$TMP/secure-input"
-grep -Fq 'IFS= read -r KEYPATH_GUEST_PASSWORD < \"\$fifo\" || [[ -n \"\$KEYPATH_GUEST_PASSWORD\" ]]' "$REMOTE"
+grep -Fq 'exec 3<> \"\$fifo\"; KEYPATH_GUEST_PASSWORD=; IFS= read -r -t $credential_timeout -u 3 KEYPATH_GUEST_PASSWORD || [[ -n \"\$KEYPATH_GUEST_PASSWORD\" ]]' "$REMOTE"
 
 /bin/bash -n "$LAB_DIR/../qa-macos-27-regression.sh"
 /bin/zsh -n "$LAB_DIR/desktop-bootstrap"
@@ -177,6 +180,7 @@ run_remote() {
     KEYPATH_LAB_TEST_SSH_KEY="$TMP/id_ed25519" \
     KEYPATH_LAB_TEST_SECRET_FILE="$TMP/secure-input" \
     KEYPATH_LAB_TEST_CONSOLE_AUTH_FAIL="${KEYPATH_LAB_TEST_CONSOLE_AUTH_FAIL:-0}" \
+    KEYPATH_LAB_TEST_STREAM_FAIL="${KEYPATH_LAB_TEST_STREAM_FAIL:-0}" \
     KEYPATH_LAB_TEST_CURSOR_BEFORE="${KEYPATH_LAB_TEST_CURSOR_BEFORE:-10 10}" \
     KEYPATH_LAB_TEST_CURSOR_AFTER="${KEYPATH_LAB_TEST_CURSOR_AFTER:-160 120}" \
         /bin/zsh "$REMOTE" "$@"
@@ -432,6 +436,13 @@ rfb_probe_undelivered_status=$?
 set -e
 [[ $rfb_probe_undelivered_status -ne 0 ]]
 assert_contains "$rfb_probe_undelivered" 'CrabBox acknowledged the RFB click but the guest cursor did not move'
+set +e
+console_login_stream_failure=$(KEYPATH_LAB_TEST_STREAM_FAIL=1 KEYPATH_LAB_CONSOLE_CREDENTIAL_TIMEOUT_SECONDS=1 KEYPATH_LAB_CONSOLE_LOGIN_POLL_SECONDS=0 run_remote console-login cbx_desktop27 2>&1)
+console_login_stream_failure_status=$?
+set -e
+[[ $console_login_stream_failure_status -ne 0 ]]
+assert_contains "$console_login_stream_failure" 'failed to stream the guest credential into the disposable guest'
+grep -q $'console_login_status\tcredential-stream-failed:17' "$ROOT/KeyPathInstallerLab/leases/cbx_desktop27/manifest.tsv"
 if grep -R -F 'fixture-password-that-must-not-leak' "$ROOT/KeyPathInstallerLab" "$CALLS"; then
     echo "console login leaked its secret into controller logs or arguments" >&2
     exit 1

--- a/Scripts/lab/tests/keypath-lab-tests.sh
+++ b/Scripts/lab/tests/keypath-lab-tests.sh
@@ -125,6 +125,9 @@ chmod +x "$ROOT/bin/tart" "$ROOT/bin/guest-ssh"
 cat > "$ROOT/bin/prlctl" <<EOF
 #!/bin/bash
 echo "prlctl \$*" >> "$CALLS"
+if [[ \$1 == exec && \$3 == /usr/bin/true && \${KEYPATH_LAB_TEST_GUEST_CONTROL_FAIL:-0} == 1 ]]; then
+  exit 1
+fi
 if [[ \$1 == exec && " \$* " == *sysadminctl*autologin*set* ]]; then
   touch "$TMP/console-fifo-ready"
   for _ in {1..100}; do
@@ -146,7 +149,11 @@ if [[ \$1 == exec && " \$* " == *" /usr/sbin/sysadminctl -autologin status "* ]]
   echo 'Automatic login is ON.'
 fi
 if [[ \$1 == exec && " \$* " == *" /usr/bin/stat -f %Su /dev/console "* ]]; then
-  echo keypathqa
+  if [[ \${KEYPATH_LAB_TEST_CONSOLE_USER_FAIL:-0} == 1 ]]; then
+    echo loginwindow
+  else
+    echo keypathqa
+  fi
 fi
 if [[ \$1 == status ]]; then
   echo running
@@ -160,6 +167,8 @@ chmod +x "$ROOT/bin/prlctl"
 echo test-private-key > "$TMP/id_ed25519"
 printf 'fixture-password-that-must-not-leak' > "$TMP/secure-input"
 grep -Fq 'exec 3<> \"\$fifo\"; KEYPATH_GUEST_PASSWORD=; IFS= read -r -t $credential_timeout -u 3 KEYPATH_GUEST_PASSWORD || [[ -n \"\$KEYPATH_GUEST_PASSWORD\" ]]' "$REMOTE"
+grep -Fq '/usr/bin/mktemp /etc/kcpassword.XXXXXXXX' "$REMOTE"
+grep -Fq "Automatic login user: keypathqa" "$REMOTE"
 
 /bin/bash -n "$LAB_DIR/../qa-macos-27-regression.sh"
 /bin/zsh -n "$LAB_DIR/desktop-bootstrap"
@@ -181,6 +190,8 @@ run_remote() {
     KEYPATH_LAB_TEST_SECRET_FILE="$TMP/secure-input" \
     KEYPATH_LAB_TEST_CONSOLE_AUTH_FAIL="${KEYPATH_LAB_TEST_CONSOLE_AUTH_FAIL:-0}" \
     KEYPATH_LAB_TEST_STREAM_FAIL="${KEYPATH_LAB_TEST_STREAM_FAIL:-0}" \
+    KEYPATH_LAB_TEST_GUEST_CONTROL_FAIL="${KEYPATH_LAB_TEST_GUEST_CONTROL_FAIL:-0}" \
+    KEYPATH_LAB_TEST_CONSOLE_USER_FAIL="${KEYPATH_LAB_TEST_CONSOLE_USER_FAIL:-0}" \
     KEYPATH_LAB_TEST_CURSOR_BEFORE="${KEYPATH_LAB_TEST_CURSOR_BEFORE:-10 10}" \
     KEYPATH_LAB_TEST_CURSOR_AFTER="${KEYPATH_LAB_TEST_CURSOR_AFTER:-160 120}" \
         /bin/zsh "$REMOTE" "$@"
@@ -443,6 +454,19 @@ set -e
 [[ $console_login_stream_failure_status -ne 0 ]]
 assert_contains "$console_login_stream_failure" 'failed to stream the guest credential into the disposable guest'
 grep -q $'console_login_status\tcredential-stream-failed:17' "$ROOT/KeyPathInstallerLab/leases/cbx_desktop27/manifest.tsv"
+set +e
+console_login_guest_control_failure=$(KEYPATH_LAB_TEST_GUEST_CONTROL_FAIL=1 KEYPATH_LAB_CONSOLE_LOGIN_POLL_SECONDS=0 run_remote console-login cbx_desktop27 2>&1)
+console_login_guest_control_failure_status=$?
+set -e
+[[ $console_login_guest_control_failure_status -ne 0 ]]
+assert_contains "$console_login_guest_control_failure" 'Parallels guest control did not become ready'
+set +e
+console_login_console_user_failure=$(KEYPATH_LAB_TEST_CONSOLE_USER_FAIL=1 KEYPATH_LAB_CONSOLE_LOGIN_POLL_SECONDS=0 run_remote console-login cbx_desktop27 2>&1)
+console_login_console_user_failure_status=$?
+set -e
+[[ $console_login_console_user_failure_status -ne 0 ]]
+assert_contains "$console_login_console_user_failure" 'automatic login did not establish the keypathqa console session'
+grep -q $'console_login_status\tpostcondition-failed' "$ROOT/KeyPathInstallerLab/leases/cbx_desktop27/manifest.tsv"
 if grep -R -F 'fixture-password-that-must-not-leak' "$ROOT/KeyPathInstallerLab" "$CALLS"; then
     echo "console login leaked its secret into controller logs or arguments" >&2
     exit 1

--- a/Scripts/lab/tests/keypath-lab-tests.sh
+++ b/Scripts/lab/tests/keypath-lab-tests.sh
@@ -433,7 +433,7 @@ set -e
 [[ $rfb_probe_undelivered_status -ne 0 ]]
 assert_contains "$rfb_probe_undelivered" 'CrabBox acknowledged the RFB click but the guest cursor did not move'
 if grep -R -F 'fixture-password-that-must-not-leak' "$ROOT/KeyPathInstallerLab" "$CALLS"; then
-    echo "console login leaked its secret into logs or arguments" >&2
+    echo "console login leaked its secret into controller logs or arguments" >&2
     exit 1
 fi
 set +e

--- a/Scripts/lab/tests/keypath-lab-tests.sh
+++ b/Scripts/lab/tests/keypath-lab-tests.sh
@@ -118,6 +118,10 @@ else
   if [[ \${KEYPATH_LAB_TEST_STREAM_FAIL:-0} == 1 ]]; then
     exit 17
   fi
+  if [[ \${KEYPATH_LAB_TEST_STREAM_HANG:-0} == 1 ]]; then
+    sleep 10
+    exit 0
+  fi
   cat > "$TMP/guest-ssh-stdin"
 fi
 EOF
@@ -130,6 +134,10 @@ if [[ \$1 == exec && \$3 == /usr/bin/true && \${KEYPATH_LAB_TEST_GUEST_CONTROL_F
 fi
 if [[ \$1 == exec && " \$* " == *sysadminctl*autologin*set* ]]; then
   touch "$TMP/console-fifo-ready"
+  if [[ \${KEYPATH_LAB_TEST_SECRET_LEAK:-0} == 1 ]]; then
+    echo fixture-password-that-must-not-leak
+    exit 0
+  fi
   for _ in {1..100}; do
     if [[ -f "$TMP/guest-ssh-stdin" ]]; then
       if [[ \${KEYPATH_LAB_TEST_CONSOLE_AUTH_FAIL:-0} == 1 ]]; then
@@ -190,8 +198,10 @@ run_remote() {
     KEYPATH_LAB_TEST_SECRET_FILE="$TMP/secure-input" \
     KEYPATH_LAB_TEST_CONSOLE_AUTH_FAIL="${KEYPATH_LAB_TEST_CONSOLE_AUTH_FAIL:-0}" \
     KEYPATH_LAB_TEST_STREAM_FAIL="${KEYPATH_LAB_TEST_STREAM_FAIL:-0}" \
+    KEYPATH_LAB_TEST_STREAM_HANG="${KEYPATH_LAB_TEST_STREAM_HANG:-0}" \
     KEYPATH_LAB_TEST_GUEST_CONTROL_FAIL="${KEYPATH_LAB_TEST_GUEST_CONTROL_FAIL:-0}" \
     KEYPATH_LAB_TEST_CONSOLE_USER_FAIL="${KEYPATH_LAB_TEST_CONSOLE_USER_FAIL:-0}" \
+    KEYPATH_LAB_TEST_SECRET_LEAK="${KEYPATH_LAB_TEST_SECRET_LEAK:-0}" \
     KEYPATH_LAB_TEST_CURSOR_BEFORE="${KEYPATH_LAB_TEST_CURSOR_BEFORE:-10 10}" \
     KEYPATH_LAB_TEST_CURSOR_AFTER="${KEYPATH_LAB_TEST_CURSOR_AFTER:-160 120}" \
         /bin/zsh "$REMOTE" "$@"
@@ -454,6 +464,14 @@ set -e
 [[ $console_login_stream_failure_status -ne 0 ]]
 assert_contains "$console_login_stream_failure" 'failed to stream the guest credential into the disposable guest'
 grep -q $'console_login_status\tcredential-stream-failed:17' "$ROOT/KeyPathInstallerLab/leases/cbx_desktop27/manifest.tsv"
+SECONDS=0
+set +e
+console_login_stream_hang=$(KEYPATH_LAB_TEST_STREAM_HANG=1 KEYPATH_LAB_CONSOLE_CREDENTIAL_TIMEOUT_SECONDS=1 KEYPATH_LAB_CONSOLE_LOGIN_POLL_SECONDS=0 run_remote console-login cbx_desktop27 2>&1)
+console_login_stream_hang_status=$?
+set -e
+[[ $console_login_stream_hang_status -ne 0 ]]
+[[ $SECONDS -le 4 ]]
+assert_contains "$console_login_stream_hang" 'failed to stream the guest credential into the disposable guest'
 set +e
 console_login_guest_control_failure=$(KEYPATH_LAB_TEST_GUEST_CONTROL_FAIL=1 KEYPATH_LAB_CONSOLE_LOGIN_POLL_SECONDS=0 run_remote console-login cbx_desktop27 2>&1)
 console_login_guest_control_failure_status=$?
@@ -467,6 +485,17 @@ set -e
 [[ $console_login_console_user_failure_status -ne 0 ]]
 assert_contains "$console_login_console_user_failure" 'automatic login did not establish the keypathqa console session'
 grep -q $'console_login_status\tpostcondition-failed' "$ROOT/KeyPathInstallerLab/leases/cbx_desktop27/manifest.tsv"
+set +e
+console_login_leak=$(KEYPATH_LAB_TEST_SECRET_LEAK=1 KEYPATH_LAB_CONSOLE_CREDENTIAL_TIMEOUT_SECONDS=1 KEYPATH_LAB_CONSOLE_LOGIN_POLL_SECONDS=0 run_remote console-login cbx_desktop27 2>&1)
+console_login_leak_status=$?
+set -e
+[[ $console_login_leak_status -ne 0 ]]
+assert_contains "$console_login_leak" 'guest credential disclosure was detected and redacted from the controller log'
+grep -q $'console_login_status\tcredential-leak-detected' "$ROOT/KeyPathInstallerLab/leases/cbx_desktop27/manifest.tsv"
+if grep -R -F 'fixture-password-that-must-not-leak' "$ROOT/KeyPathInstallerLab"; then
+    echo "console login retained a disclosed credential after redaction" >&2
+    exit 1
+fi
 if grep -R -F 'fixture-password-that-must-not-leak' "$ROOT/KeyPathInstallerLab" "$CALLS"; then
     echo "console login leaked its secret into controller logs or arguments" >&2
     exit 1

--- a/Scripts/lab/tests/keypath-lab-tests.sh
+++ b/Scripts/lab/tests/keypath-lab-tests.sh
@@ -72,6 +72,8 @@ if [[ \$1 == warmup ]]; then
     echo 'leased cbx_stale instance=stale-resource'
     echo 'diagnostic previous=cbx_unrelated'
     printf 'leased cbx_desktop15 instance=test-resource'
+  elif [[ " \$* " == *"keypath27-"* ]]; then
+    printf 'leased cbx_desktop27 vm=11111111-1111-1111-1111-111111111111'
   else
     printf 'leased cbx_desktop26 vm=00000000-0000-0000-0000-000000000000'
   fi
@@ -110,12 +112,42 @@ EOF
 cat > "$ROOT/bin/guest-ssh" <<EOF
 #!/bin/bash
 printf '%s\n' "\$*" > "$TMP/guest-ssh-args"
-cat > "$TMP/guest-ssh-stdin"
+if [[ " \$* " == *" /bin/test -p /tmp/keypath-console-login-"* ]]; then
+  cat >/dev/null
+else
+  cat > "$TMP/guest-ssh-stdin"
+fi
 EOF
 chmod +x "$ROOT/bin/tart" "$ROOT/bin/guest-ssh"
 cat > "$ROOT/bin/prlctl" <<EOF
 #!/bin/bash
 echo "prlctl \$*" >> "$CALLS"
+if [[ \$1 == exec && " \$* " == *sysadminctl*autologin*set* ]]; then
+  touch "$TMP/console-fifo-ready"
+  for _ in {1..100}; do
+    if [[ -f "$TMP/guest-ssh-stdin" ]]; then
+      if [[ \${KEYPATH_LAB_TEST_CONSOLE_AUTH_FAIL:-0} == 1 ]]; then
+        echo started
+        exit 9
+      fi
+      exit 0
+    fi
+    sleep 0.01
+  done
+  exit 9
+fi
+if [[ \$1 == exec && " \$* " == *" /usr/bin/test -p /tmp/keypath-console-login-"* ]]; then
+  [[ -f "$TMP/console-fifo-ready" ]]
+fi
+if [[ \$1 == exec && " \$* " == *" /usr/sbin/sysadminctl -autologin status "* ]]; then
+  echo 'Automatic login is ON.'
+fi
+if [[ \$1 == exec && " \$* " == *" /usr/bin/stat -f %Su /dev/console "* ]]; then
+  echo keypathqa
+fi
+if [[ \$1 == status ]]; then
+  echo running
+fi
 if [[ \$1 == capture && \$3 == --file ]]; then
   mkdir -p "\$(dirname "\$4")"
   echo png > "\$4"
@@ -123,7 +155,8 @@ fi
 EOF
 chmod +x "$ROOT/bin/prlctl"
 echo test-private-key > "$TMP/id_ed25519"
-echo 'fixture-password-that-must-not-leak' > "$TMP/secure-input"
+printf 'fixture-password-that-must-not-leak' > "$TMP/secure-input"
+grep -Fq 'IFS= read -r KEYPATH_GUEST_PASSWORD < \"\$fifo\" || [[ -n \"\$KEYPATH_GUEST_PASSWORD\" ]]' "$REMOTE"
 
 /bin/bash -n "$LAB_DIR/../qa-macos-27-regression.sh"
 /bin/zsh -n "$LAB_DIR/desktop-bootstrap"
@@ -143,6 +176,9 @@ run_remote() {
     KEYPATH_LAB_PRLCTL="$ROOT/bin/prlctl" \
     KEYPATH_LAB_TEST_SSH_KEY="$TMP/id_ed25519" \
     KEYPATH_LAB_TEST_SECRET_FILE="$TMP/secure-input" \
+    KEYPATH_LAB_TEST_CONSOLE_AUTH_FAIL="${KEYPATH_LAB_TEST_CONSOLE_AUTH_FAIL:-0}" \
+    KEYPATH_LAB_TEST_CURSOR_BEFORE="${KEYPATH_LAB_TEST_CURSOR_BEFORE:-10 10}" \
+    KEYPATH_LAB_TEST_CURSOR_AFTER="${KEYPATH_LAB_TEST_CURSOR_AFTER:-160 120}" \
         /bin/zsh "$REMOTE" "$@"
 }
 
@@ -374,6 +410,40 @@ assert_contains "$artifacts27" $'download_status\t0'
 grep -q 'crabbox run --provider parallels --target macos --id cbx_test27 --stop-after never --download' "$CALLS"
 run_remote destroy cbx_test27 >/dev/null
 grep -q 'stop-27 cbx_test27' "$CALLS"
+
+desktop27_create=$(run_remote create 27 unmanaged-ui "$archive_key" "$commit" "$checksum" KeyPath.zip 2h 1)
+assert_contains "$desktop27_create" $'lease_id\tcbx_desktop27'
+console_login=$(KEYPATH_LAB_CONSOLE_LOGIN_POLL_SECONDS=0 run_remote console-login cbx_desktop27)
+assert_contains "$console_login" $'console_login\tpassed'
+assert_contains "$console_login" $'console_user\tkeypathqa'
+[[ "$(cat "$TMP/guest-ssh-stdin")" == "$(cat "$TMP/secure-input")" ]] || { echo "console login streamed the wrong credential" >&2; exit 1; }
+grep -q 'prlctl exec 11111111-1111-1111-1111-111111111111 /bin/zsh -lc' "$CALLS"
+grep -q 'sysadminctl.*autologin.*set.*userName.*keypathqa.*password' "$CALLS"
+grep -q 'prlctl restart 11111111-1111-1111-1111-111111111111' "$CALLS"
+grep -q $'console_login_status\tpassed' "$ROOT/KeyPathInstallerLab/leases/cbx_desktop27/manifest.tsv"
+rfb_probe=$(KEYPATH_LAB_RFB_POINTER_SETTLE_SECONDS=0 run_remote rfb-pointer-probe cbx_desktop27 160 120)
+assert_contains "$rfb_probe" $'rfb_pointer_probe\tpassed'
+assert_contains "$rfb_probe" $'cursor_before\t10 10'
+assert_contains "$rfb_probe" $'cursor_after\t160 120'
+grep -q 'crabbox desktop click --provider parallels --target macos --id cbx_desktop27 --x 160 --y 120' "$CALLS"
+set +e
+rfb_probe_undelivered=$(KEYPATH_LAB_TEST_CURSOR_AFTER='10 10' KEYPATH_LAB_RFB_POINTER_SETTLE_SECONDS=0 run_remote rfb-pointer-probe cbx_desktop27 160 120 2>&1)
+rfb_probe_undelivered_status=$?
+set -e
+[[ $rfb_probe_undelivered_status -ne 0 ]]
+assert_contains "$rfb_probe_undelivered" 'CrabBox acknowledged the RFB click but the guest cursor did not move'
+if grep -R -F 'fixture-password-that-must-not-leak' "$ROOT/KeyPathInstallerLab" "$CALLS"; then
+    echo "console login leaked its secret into logs or arguments" >&2
+    exit 1
+fi
+set +e
+console_login_bad_credential=$(KEYPATH_LAB_TEST_CONSOLE_AUTH_FAIL=1 KEYPATH_LAB_CONSOLE_LOGIN_POLL_SECONDS=0 run_remote console-login cbx_desktop27 2>&1)
+console_login_bad_credential_status=$?
+set -e
+[[ $console_login_bad_credential_status -ne 0 ]]
+assert_contains "$console_login_bad_credential" 'KEYPATH_LAB_GUEST_PASSWORD does not authenticate the keypathqa guest account'
+grep -q $'console_login_status\tcredential-mismatch' "$ROOT/KeyPathInstallerLab/leases/cbx_desktop27/manifest.tsv"
+run_remote destroy cbx_desktop27 >/dev/null
 
 desktop26_create=$(run_remote create 26 unmanaged-ui "$archive_key" "$commit" "$checksum" KeyPath.zip 2h 1)
 assert_contains "$desktop26_create" $'lease_id\tcbx_desktop26'

--- a/docs/testing/remote-installer-lab.md
+++ b/docs/testing/remote-installer-lab.md
@@ -164,9 +164,11 @@ during `console-login`; destroy the clone after collecting the normal lab
 artifacts.
 
 The guest opens the FIFO read/write and applies a bounded credential-read
-timeout, so a failed SSH stream cannot leave the root guest-control action
-blocked forever. Stream transport failures are reported separately from
-credential-authentication failures.
+timeout. The controller applies the same bound with a watchdog around the SSH
+writer, so a failed or stalled stream cannot leave either side blocked forever.
+Stream transport failures, credential-authentication failures, and detected
+credential disclosure have distinct fail-closed statuses. If disclosure is
+detected, the controller log is immediately redacted.
 
 The command asks `sysadminctl` to enable automatic login first. macOS 27 build
 `26A5378j` can return success while logging `SACSetAutoLoginPassword error:22`

--- a/docs/testing/remote-installer-lab.md
+++ b/docs/testing/remote-installer-lab.md
@@ -141,6 +141,61 @@ observed on July 13, 2026 was SSH-ready but had no logged-in console user and
 no Python runtime; it needs a new clean base checkpoint after automatic login
 and desktop-tool provisioning before selector scenarios can run.
 
+The macOS 27 Parallels base is intentionally preserved at `loginwindow`. Before
+running `desktop-bootstrap`, establish its disposable clone's console session
+through the owned controller:
+
+```bash
+Scripts/lab/keypath-lab console-login cbx_example
+```
+
+This command is macOS-27/Parallels-only. It streams
+`KEYPATH_LAB_GUEST_PASSWORD` from
+the encrypted host secrets over the lease-owned SSH channel into a root-owned
+FIFO in the disposable guest. The command first verifies that the credential
+authenticates the `keypathqa` account. The value is held briefly in an
+owner-only controller temp file so it can be streamed and checked for accidental
+log disclosure; that file is removed before the guest reboots. The value never
+appears in controller arguments or logs.
+
+The command asks `sysadminctl` to enable automatic login first. macOS 27 build
+`26A5378j` can return success while logging `SACSetAutoLoginPassword error:22`
+and leaving automatic login disabled. When the postcondition catches that
+false success, the disposable clone falls back to writing the same
+login-window state, including the reversible `/etc/kcpassword` representation.
+That credential-bearing file exists only inside the disposable clone and is
+removed with the lease. It also aligns CrabBox's mode-0600 guest credential
+file with the verified account password so ARD authentication uses the same
+known credential; that credential-bearing file is likewise confined to the
+disposable clone. The command then reboots and does not succeed until
+`/dev/console` is owned by `keypathqa`. This avoids relying on
+pre-login RFB delivery, which macOS 27 can acknowledge without applying the
+input, while preserving RFB for post-login UI interaction. The controller also
+checks that automatic login names `keypathqa` before it reboots; a zero exit
+from `sysadminctl` alone is not accepted as proof. A credential mismatch is
+reported explicitly and does not mutate the guest account.
+
+After console login, verify that the RFB path delivers input instead of merely
+acknowledging the protocol write:
+
+```bash
+Scripts/lab/keypath-lab rfb-pointer-probe cbx_example --x 160 --y 120
+```
+
+The probe reads the guest cursor location, sends one CrabBox RFB click, and
+requires the cursor location to change. It refuses to run until
+`console-login` has established and verified the `keypathqa` console session.
+
+On macOS 27 build `26A5378j`, this probe currently reports that authenticated
+RFB input is acknowledged but not delivered. Unified logs show the console
+agent checking in with event posting disabled. This is a distinct platform
+permission boundary, not a console-login failure: Apple's supported
+command-line Remote Management setup is view-only, and toggling ordinary
+Screen Sharing off and on did not grant event posting in this build. Full
+control therefore remains gated on enabling Remote Management control through
+System Settings or an MDM profile. Keep the failed probe as evidence and do not
+classify an installer scenario as agent-drivable until the probe passes.
+
 For a console-ready candidate base, run `desktop-bootstrap --install-tools`
 once before capturing its checkpoint. It installs Python 3 as well as
 Peekaboo and mcporter, then records the console-user and Peekaboo evidence.

--- a/docs/testing/remote-installer-lab.md
+++ b/docs/testing/remote-installer-lab.md
@@ -156,7 +156,12 @@ FIFO in the disposable guest. The command first verifies that the credential
 authenticates the `keypathqa` account. The value is held briefly in an
 owner-only controller temp file so it can be streamed and checked for accidental
 log disclosure; that file is removed before the guest reboots. The value never
-appears in controller arguments or logs.
+appears in controller arguments or logs. Inside the disposable guest, macOS's
+noninteractive `dscl` authentication and `sysadminctl` automatic-login commands
+briefly receive the value in their process arguments because neither command
+offers a noninteractive stdin form. Do not enable process-argument capture
+during `console-login`; destroy the clone after collecting the normal lab
+artifacts.
 
 The command asks `sysadminctl` to enable automatic login first. macOS 27 build
 `26A5378j` can return success while logging `SACSetAutoLoginPassword error:22`

--- a/docs/testing/remote-installer-lab.md
+++ b/docs/testing/remote-installer-lab.md
@@ -163,6 +163,11 @@ offers a noninteractive stdin form. Do not enable process-argument capture
 during `console-login`; destroy the clone after collecting the normal lab
 artifacts.
 
+The guest opens the FIFO read/write and applies a bounded credential-read
+timeout, so a failed SSH stream cannot leave the root guest-control action
+blocked forever. Stream transport failures are reported separately from
+credential-authentication failures.
+
 The command asks `sysadminctl` to enable automatic login first. macOS 27 build
 `26A5378j` can return success while logging `SACSetAutoLoginPassword error:22`
 and leaving automatic login disabled. When the postcondition catches that


### PR DESCRIPTION
## Summary
- add an owned `console-login` lab action for disposable macOS 27 Parallels leases
- verify the encrypted guest credential, catch `sysadminctl` false success, and require a real `keypathqa` console session after reboot
- add an RFB pointer-delivery probe that distinguishes protocol acknowledgement from delivered input
- document the remaining Apple Remote Management control prerequisite without treating it as a KeyPath failure

## Root cause
The base intentionally boots at `loginwindow`, while Parallels RFB acknowledges pre-login input without applying it. Two additional defects blocked autonomous recovery: the no-newline secret stream caused `read` under `set -e` to exit at EOF, and macOS 27 build `26A5378j` returned zero from `sysadminctl` while leaving automatic login disabled.

The new flow accepts neither transport acknowledgement nor a zero process exit as proof. It verifies account authentication, automatic-login state, `/dev/console` ownership, and cursor movement independently.

## Live validation
On an owned disposable macOS 27.0 (`26A5378j`) Parallels lease:
- `keypathqa` credential authentication passed
- the `sysadminctl` false-success path was detected
- the disposable-clone fallback established `keypathqa` as `/dev/console` owner after restart
- ARD/RFB authentication passed
- the pointer probe correctly failed because macOS reported event posting disabled and the cursor did not move
- artifacts were collected and the lease was destroyed

Apple's supported command-line Remote Management setup is view-only. Full RFB control remains gated on Remote Management approval through System Settings or MDM; ordinary Screen Sharing toggling was tested and was insufficient on this build.

## Validation
- `/bin/bash -n Scripts/lab/keypath-lab`
- `/bin/zsh -n Scripts/lab/remote.sh`
- `Scripts/lab/tests/keypath-lab-tests.sh`
- `git diff --check`
- branch behind count: `0`
- review gate: `remote review gate selected`
- GitHub `claude-review`: passed
- code quality and accessibility checks: passed
- cold CI path completed in 19m07s; the only failure was the unrelated load-sensitive `SystemValidatorTests` wall-clock assertion also observed on #1186
- unchanged warm rerun: full `build-and-test` passed in 2m47s
