### PR TITLE
Allow cold CI builds to complete

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,10 @@ concurrency:
 jobs:
   build-and-test:
     runs-on: [self-hosted, macOS, keypath]
-    timeout-minutes: 10
+    # Warm runs normally finish in 2-3 minutes, but a cold Kanata + Swift test
+    # rebuild has exceeded 10 minutes while still compiling. Keep a finite
+    # bound with enough room for the measured cold path.
+    timeout-minutes: 15
     # Separate from the workflow-level concurrency group above (which cancels
     # stale runs of the *same* PR): this queues jobs from *different* PRs onto
     # the single physical runner instead of letting them execute in parallel.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,10 @@ concurrency:
 jobs:
   build-and-test:
     runs-on: [self-hosted, macOS, keypath]
-    # Warm runs normally finish in 2-3 minutes, but a cold Kanata + Swift test
-    # rebuild has exceeded 10 minutes while still compiling. Keep a finite
-    # bound with enough room for the measured cold path.
-    timeout-minutes: 15
+    # Warm runs normally finish in 2-3 minutes. A measured cold run spent about
+    # 3 minutes on setup/Kanata and was still compiling Swift tests after another
+    # 12 minutes, before test execution. Keep a finite bound with real headroom.
+    timeout-minutes: 25
     # Separate from the workflow-level concurrency group above (which cancels
     # stale runs of the *same* PR): this queues jobs from *different* PRs onto
     # the single physical runner instead of letting them execute in parallel.

--- a/docs/planning/todo-self-hosted-ci-runner.md
+++ b/docs/planning/todo-self-hosted-ci-runner.md
@@ -39,6 +39,12 @@ A persistent Mac Mini cuts CI wall time to ~2-3min and enables the full test sui
 - [x] `code-quality`: Removed SwiftLint/SwiftFormat install step
 - [x] `code-quality`: SwiftLint/SwiftFormat now only lint changed files (not entire codebase)
 
+The build-and-test timeout was raised from 10 to 15 minutes on July 15, 2026.
+Warm runs still complete in roughly 2-3 minutes, but a cold Kanata rebuild plus
+Swift test compilation twice reached the old 10-minute cap while compilers were
+actively making progress. Fifteen minutes preserves a failure bound without
+misclassifying a healthy cold rebuild as a test failure.
+
 ### Security
 - [x] Fork PR approval set to "Require approval for all external contributors"
 - [x] Zero existing forks on the repo

--- a/docs/planning/todo-self-hosted-ci-runner.md
+++ b/docs/planning/todo-self-hosted-ci-runner.md
@@ -39,11 +39,13 @@ A persistent Mac Mini cuts CI wall time to ~2-3min and enables the full test sui
 - [x] `code-quality`: Removed SwiftLint/SwiftFormat install step
 - [x] `code-quality`: SwiftLint/SwiftFormat now only lint changed files (not entire codebase)
 
-The build-and-test timeout was raised from 10 to 15 minutes on July 15, 2026.
-Warm runs still complete in roughly 2-3 minutes, but a cold Kanata rebuild plus
-Swift test compilation twice reached the old 10-minute cap while compilers were
-actively making progress. Fifteen minutes preserves a failure bound without
-misclassifying a healthy cold rebuild as a test failure.
+The build-and-test timeout was raised from 10 to 25 minutes on July 15, 2026.
+Warm runs still complete in roughly 2-3 minutes, but cold Kanata and Swift test
+rebuilds reached both the 10- and 15-minute caps while compilers were actively
+making progress. In the measured 15-minute run, setup and Kanata took about 3
+minutes and Swift had compiled 1,380 of 1,457 test-build steps when GitHub
+cancelled it. Twenty-five minutes preserves a finite failure bound while leaving
+room to link and execute the tests after a healthy cold rebuild.
 
 ### Security
 - [x] Fork PR approval set to "Require approval for all external contributors"


### PR DESCRIPTION
## Summary
- raise the self-hosted `build-and-test` job timeout from 10 to 25 minutes
- document the measured cold-build behavior behind that limit

## Evidence
PR #1185's final head hit the 10-minute job cap twice while the Mini was actively compiling Swift test modules. The 25-minute proof run completed the previously truncated cold path:

- setup and the cold Kanata build used about 3 minutes
- the cold Swift test build completed instead of being cancelled
- the full job reached a real test result in about 19 minutes
- 4,682 parsed checks passed; the only failure was an unrelated load-sensitive wall-clock assertion in `SystemValidatorTests` (100 ms timeout expected within 250 ms, observed at 1.11 s under the cold compile load)
- an unchanged warm rerun passed the complete job in 2m45s

Twenty-five minutes keeps a finite failure bound while providing measured headroom for a genuinely cold build. This PR intentionally does not change test selection, cache architecture, the unrelated timing assertion, or #1185's lab implementation.

## Validation
- workflow YAML parsed with Ruby Psych
- `git diff --check`
- branch behind count: `0`
- review gate: `remote review gate selected`
- GitHub `claude-review`: passed
- cold-build path completed within the new limit
- unchanged warm rerun: passed in 2m45s
