### PR TITLE
Unblock macOS 27 Remote Management input

### DIFF
--- a/Scripts/lab/keypath-lab
+++ b/Scripts/lab/keypath-lab
@@ -15,6 +15,7 @@ Commands:
   create --macos 15|26|27 --lane managed-functional|unmanaged-ui --commit SHA --installer PATH [--ttl 2h] [--desktop]
   install-app LEASE_ID
   console-login LEASE_ID
+  secure-console-submit LEASE_ID
   rfb-pointer-probe LEASE_ID --x X --y Y
   desktop-bootstrap LEASE_ID [--install-tools]
   nameplate LEASE_ID enable|show|hide|status
@@ -132,6 +133,11 @@ EOF
         [[ $# -eq 1 ]] || usage
         require_lease_id "$1"
         remote console-login "$1"
+        ;;
+    secure-console-submit)
+        [[ $# -eq 1 ]] || usage
+        require_lease_id "$1"
+        remote secure-console-submit "$1"
         ;;
     rfb-pointer-probe)
         lease=${1:-}

--- a/Scripts/lab/remote.sh
+++ b/Scripts/lab/remote.sh
@@ -952,7 +952,7 @@ console_login() {
   if [[ "${KEYPATH_LAB_TESTING:-0}" == "1" ]]; then
     secret_file="${KEYPATH_LAB_TEST_SECRET_FILE:?test secret file is required}"
     key="${KEYPATH_LAB_TEST_SSH_KEY:?test SSH key is required}"
-    known_hosts=/dev/null
+    known_hosts="${KEYPATH_LAB_TEST_KNOWN_HOSTS:-/dev/null}"
     guest_ip=192.0.2.27
   else
     key="$HOME/Library/Application Support/crabbox/testboxes/$lease/id_ed25519"
@@ -968,6 +968,8 @@ console_login() {
     /opt/homebrew/bin/sops -d "$HOME/dotfiles/secrets.env" | awk -F= '$1 == "KEYPATH_LAB_GUEST_PASSWORD" {sub(/^[^=]*=/, ""); printf "%s", $0; found=1} END {if (!found) exit 1}' > "$secret_file" || die "KEYPATH_LAB_GUEST_PASSWORD is unavailable"
   fi
   [[ -s "$secret_file" ]] || die "console login secret is empty"
+  # OpenSSH parses -o values a second time, so spaces in this path must remain
+  # escaped even though the complete option is already one shell argument.
   known_hosts_option=${known_hosts// /\\ }
   credential_timeout=${KEYPATH_LAB_CONSOLE_CREDENTIAL_TIMEOUT_SECONDS:-30}
   [[ "$credential_timeout" == <-> && "$credential_timeout" -gt 0 ]] || die "console login credential timeout must be a positive integer"
@@ -1002,9 +1004,13 @@ console_login() {
     sleep 0.1
   done
   if (( fifo_ready == 1 )); then
-    /usr/bin/perl -e 'my $timeout = shift; alarm $timeout; exec @ARGV or exit 127' "$credential_timeout" \
-      "$GUEST_SSH" -o BatchMode=yes -o StrictHostKeyChecking=yes -o "UserKnownHostsFile=$known_hosts_option" -i "$key" "keypathqa@$guest_ip" \
-      "/bin/zsh -c $(printf %q "/bin/cat > $(printf %q "$fifo")")" < "$secret_file" >/dev/null 2>&1
+    # The decrypted dotenv value intentionally has no trailing newline. Frame
+    # it as one record so the guest's `read` completes immediately instead of
+    # waiting indefinitely after receiving a partial line from the FIFO.
+    { /bin/cat "$secret_file"; printf '\n'; } | \
+      /usr/bin/perl -e 'my $timeout = shift; alarm $timeout; exec @ARGV or exit 127' "$credential_timeout" \
+        "$GUEST_SSH" -o BatchMode=yes -o StrictHostKeyChecking=yes -o "UserKnownHostsFile=$known_hosts_option" -i "$key" "keypathqa@$guest_ip" \
+        "/bin/zsh -c $(printf %q "/bin/cat > $(printf %q "$fifo")")" >/dev/null 2>&1
     stream_exit=$?
     (( stream_exit == 0 )) || kill "$configure_pid" 2>/dev/null || true
   else
@@ -1078,6 +1084,55 @@ console_login() {
   record_command "$lease" passed console-login
   print "console_login\tpassed"
   print "console_user\t$console_user"
+}
+
+secure_console_submit() {
+  local lease=$1 manifest macos resource parallels_cli secret_file
+  manifest=$(owned_manifest "$lease")
+  macos=$(field "$manifest" macos)
+  [[ "$macos" == "27" ]] || die "secure console submit currently supports only the macOS 27 Parallels lane"
+  [[ "$(field "$manifest" provider)" == "parallels" ]] || die "secure console submit requires a Parallels lease"
+  [[ "$(field "$manifest" desktop_enabled)" == "true" ]] || die "secure console submit requires a desktop-enabled lease"
+  resource=$(field "$manifest" provider_resource)
+  [[ "$resource" =~ '^[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}$' ]] || die "invalid Parallels resource id"
+  parallels_cli=${KEYPATH_LAB_PRLCTL:-"/Applications/Parallels Desktop.app/Contents/MacOS/prlctl"}
+  [[ -x "$parallels_cli" ]] || die "Parallels CLI is unavailable"
+
+  if [[ "${KEYPATH_LAB_TESTING:-0}" == "1" ]]; then
+    secret_file="${KEYPATH_LAB_TEST_SECRET_FILE:?test secret file is required}"
+  else
+    secret_file=$(mktemp "$STATE_ROOT/.secure-console.XXXXXXXX")
+    chmod 600 "$secret_file"
+    typeset -g KEYPATH_LAB_SECURE_TEMP="$secret_file"
+    trap '[[ -z ${KEYPATH_LAB_SECURE_TEMP:-} ]] || rm -f "$KEYPATH_LAB_SECURE_TEMP"' EXIT
+    /opt/homebrew/bin/sops -d "$HOME/dotfiles/secrets.env" | awk -F= '$1 == "KEYPATH_LAB_GUEST_PASSWORD" {sub(/^[^=]*=/, ""); printf "%s", $0; found=1} END {if (!found) exit 1}' > "$secret_file" || die "KEYPATH_LAB_GUEST_PASSWORD is unavailable"
+  fi
+  [[ -s "$secret_file" ]] || die "secure console secret is empty"
+
+  # Convert the credential to Parallels key codes in a pipe. The plaintext is
+  # read only from the owner-only temp file and never enters argv, logs, the
+  # guest pasteboard, or an artifact. Keep the accepted alphabet deliberately
+  # narrow; expanding it requires an explicit key-map review.
+  python3 -c 'import json,sys
+codes={"a":38,"b":56,"c":54,"d":40,"e":26,"f":41,"g":42,"h":43,"i":31,"j":44,"k":45,"l":46,"m":58,"n":57,"o":32,"p":33,"q":24,"r":27,"s":39,"t":28,"u":30,"v":55,"w":25,"x":53,"y":29,"z":52,"1":10,"2":11,"3":12,"4":13,"5":14,"6":15,"7":16,"8":17,"9":18,"0":19,"-":20}
+value=open(sys.argv[1],"r",encoding="utf-8").read()
+if not value or any(ch not in codes for ch in value): raise SystemExit(64)
+for ch in value: print(json.dumps([{"key":codes[ch]}],separators=(",",":")))' "$secret_file" | \
+    while IFS= read -r key_event; do
+      printf '%s\n' "$key_event" | "$parallels_cli" send-key-event "$resource" --json >/dev/null || exit 1
+      sleep "${KEYPATH_LAB_SECURE_CONSOLE_KEY_DELAY_SECONDS:-0.2}"
+    done || die "failed to deliver the guest credential through Parallels key events"
+  sleep "${KEYPATH_LAB_SECURE_CONSOLE_SETTLE_SECONDS:-0.25}"
+  "$parallels_cli" send-key-event "$resource" --key 36 >/dev/null
+
+  if [[ "${KEYPATH_LAB_TESTING:-0}" != "1" ]]; then
+    rm -f "$secret_file"
+    KEYPATH_LAB_SECURE_TEMP=
+    trap - EXIT
+  fi
+  record_command "$lease" passed secure-console-submit
+  print "secure_console_submit\tpassed"
+  print "credential_transport\tparallels-key-events"
 }
 
 rfb_pointer_probe() {
@@ -1241,6 +1296,7 @@ case "$action" in
   scenario) [[ $# -eq 2 ]] || die "scenario requires lease and name"; scenario "$1" "$2" ;;
   desktop-bootstrap) [[ $# -eq 2 ]] || die "desktop-bootstrap requires lease and install-tools flag"; desktop_bootstrap "$@" ;;
   console-login) [[ $# -eq 1 ]] || die "console-login requires lease"; console_login "$1" ;;
+  secure-console-submit) [[ $# -eq 1 ]] || die "secure-console-submit requires lease"; secure_console_submit "$1" ;;
   rfb-pointer-probe) [[ $# -eq 3 ]] || die "rfb-pointer-probe requires lease, x, and y"; rfb_pointer_probe "$@" ;;
   nameplate) [[ $# -eq 2 ]] || die "nameplate requires lease and action"; nameplate_control "$@" ;;
   destroy) [[ $# -eq 1 ]] || die "destroy requires lease"; destroy_lease "$1" ;;

--- a/Scripts/lab/tests/keypath-lab-tests.sh
+++ b/Scripts/lab/tests/keypath-lab-tests.sh
@@ -153,6 +153,9 @@ fi
 if [[ \$1 == exec && " \$* " == *" /usr/bin/test -p /tmp/keypath-console-login-"* ]]; then
   [[ -f "$TMP/console-fifo-ready" ]]
 fi
+if [[ \$1 == send-key-event && " \$* " == *" --json "* ]]; then
+  cat >> "$TMP/secure-console-key-events.jsonl"
+fi
 if [[ \$1 == exec && " \$* " == *" /usr/sbin/sysadminctl -autologin status "* ]]; then
   echo 'Automatic login is ON.'
 fi
@@ -438,10 +441,44 @@ grep -q 'stop-27 cbx_test27' "$CALLS"
 
 desktop27_create=$(run_remote create 27 unmanaged-ui "$archive_key" "$commit" "$checksum" KeyPath.zip 2h 1)
 assert_contains "$desktop27_create" $'lease_id\tcbx_desktop27'
-console_login=$(KEYPATH_LAB_CONSOLE_LOGIN_POLL_SECONDS=0 run_remote console-login cbx_desktop27)
+test_known_hosts="$TMP/known hosts/known_hosts"
+mkdir -p "$(dirname "$test_known_hosts")"
+touch "$test_known_hosts"
+console_login=$(KEYPATH_LAB_TEST_KNOWN_HOSTS="$test_known_hosts" KEYPATH_LAB_CONSOLE_LOGIN_POLL_SECONDS=0 run_remote console-login cbx_desktop27)
 assert_contains "$console_login" $'console_login\tpassed'
 assert_contains "$console_login" $'console_user\tkeypathqa'
 [[ "$(cat "$TMP/guest-ssh-stdin")" == "$(cat "$TMP/secure-input")" ]] || { echo "console login streamed the wrong credential" >&2; exit 1; }
+{ cat "$TMP/secure-input"; printf '\n'; } | cmp -s - "$TMP/guest-ssh-stdin" || { echo "console login did not frame the credential as one FIFO record" >&2; exit 1; }
+escaped_test_known_hosts=${test_known_hosts// /\\ }
+grep -Fq "UserKnownHostsFile=$escaped_test_known_hosts" "$TMP/guest-ssh-args"
+secure_console_submit=$(KEYPATH_LAB_SECURE_CONSOLE_KEY_DELAY_SECONDS=0 KEYPATH_LAB_SECURE_CONSOLE_SETTLE_SECONDS=0 run_remote secure-console-submit cbx_desktop27)
+assert_contains "$secure_console_submit" $'secure_console_submit\tpassed'
+assert_contains "$secure_console_submit" $'credential_transport\tparallels-key-events'
+python3 -c 'import json,sys
+codes={"a":38,"b":56,"c":54,"d":40,"e":26,"f":41,"g":42,"h":43,"i":31,"j":44,"k":45,"l":46,"m":58,"n":57,"o":32,"p":33,"q":24,"r":27,"s":39,"t":28,"u":30,"v":55,"w":25,"x":53,"y":29,"z":52,"1":10,"2":11,"3":12,"4":13,"5":14,"6":15,"7":16,"8":17,"9":18,"0":19,"-":20}
+events=[json.loads(line) for line in open(sys.argv[1]) if line.strip()]
+expected=[[{"key":codes[ch]}] for ch in open(sys.argv[2]).read()]
+assert events == expected' "$TMP/secure-console-key-events.jsonl" "$TMP/secure-input"
+! grep -Fq 'fixture-password-that-must-not-leak' "$TMP/secure-console-key-events.jsonl"
+grep -q 'prlctl send-key-event 11111111-1111-1111-1111-111111111111 --key 36' "$CALLS"
+if grep -R -F 'fixture-password-that-must-not-leak' "$ROOT/KeyPathInstallerLab" "$CALLS" "$TMP/guest-ssh-args"; then
+    echo "secure console submit leaked its secret into controller logs or arguments" >&2
+    exit 1
+fi
+cp "$TMP/secure-input" "$TMP/secure-input.valid"
+printf 'Unsupported-credential' > "$TMP/secure-input"
+secure_console_calls_before=$(wc -l < "$CALLS")
+set +e
+secure_console_rejected=$(KEYPATH_LAB_SECURE_CONSOLE_KEY_DELAY_SECONDS=0 KEYPATH_LAB_SECURE_CONSOLE_SETTLE_SECONDS=0 run_remote secure-console-submit cbx_desktop27 2>&1)
+secure_console_rejected_status=$?
+set -e
+mv "$TMP/secure-input.valid" "$TMP/secure-input"
+[[ $secure_console_rejected_status -ne 0 ]] || { echo "unsupported secure console credential unexpectedly passed" >&2; exit 1; }
+assert_contains "$secure_console_rejected" 'failed to deliver the guest credential through Parallels key events'
+if tail -n "+$((secure_console_calls_before + 1))" "$CALLS" | grep -q 'send-key-event'; then
+    echo "unsupported secure console credential sent a key event" >&2
+    exit 1
+fi
 grep -q 'prlctl exec 11111111-1111-1111-1111-111111111111 /bin/zsh -lc' "$CALLS"
 grep -q 'sysadminctl.*autologin.*set.*userName.*keypathqa.*password' "$CALLS"
 grep -q 'prlctl restart 11111111-1111-1111-1111-111111111111' "$CALLS"

--- a/docs/testing/installer-gui-automation-capabilities.md
+++ b/docs/testing/installer-gui-automation-capabilities.md
@@ -51,7 +51,8 @@ for diagnostics where the native framebuffer point is already known.
 | Full Disk Access | No inherent human requirement | Same real-UI path, including file selection when the app must be added. | KeyPath's canonical FDA check after relaunch if required |
 | Driver/System Extension | No inherent human requirement | Open Login Items & Extensions semantically, locate the current row, then use fresh native RFB coordinates when the switch ignores semantic input. | VirtualHID extension state and functional device readiness |
 | Login Items/Background Activity | No inherent human requirement | Operate the actual Login Items UI with Peekaboo or RFB. | Current `SMAppService` status plus launchd, process, and TCP evidence |
-| Authentication/keychain sheet | No | `keypath-lab secure-dialog-input` streams `KEYPATH_TART_ADMIN_PASSWORD` through the lease-owned SSH channel into Peekaboo's MCP `type` tool. | Sheet closes and the protected setting changes |
+| Authentication/keychain sheet | No | On Tart, `keypath-lab secure-dialog-input` streams `KEYPATH_TART_ADMIN_PASSWORD` through the lease-owned SSH channel into Peekaboo's MCP `type` tool. On the macOS 27 Parallels lane, focus the secure field in the real console and use `secure-console-submit`; it sends the encrypted guest credential as paced Parallels key events. | Sheet closes and the protected setting changes; credential transport success alone is insufficient |
+| macOS 27 Remote Management input | No inherent human requirement | Enable Remote Management and VNC control in the disposable clone's real System Settings UI. The command-line setup is view-only. Submit the focused authorization sheet with `secure-console-submit`. | `rfb-pointer-probe` observes the guest cursor move; build `26A5378j` passed after the supported UI approval |
 | KeyPath GUI installer | No, once a desktop session exists | Launch and operate KeyPath inside the logged-in console session. Root may install files, but headless root cannot perform the app-owned `SMAppService` registration flow. | Installer state matrix and runtime postconditions |
 | Overlay and keyboard behavior | Partly | Capture screenshots, inspect AX state, send test input, and verify runtime events automatically. Human review remains useful for subjective visual quality. | Screenshot/evidence plus observed input and overlay state |
 | Reboot, services, trust, logs, artifacts, cleanup | No | Existing lab commands and scenarios | Post-reboot CLI inspection, signature/Gatekeeper results, logs, artifact manifest, and destroyed lease |
@@ -82,7 +83,9 @@ The remaining core capabilities are:
 4. A resumable scenario runner with differential assertions, explicit failure
    ownership, sanitized artifacts, and consolidated machine-readable results.
 5. Hardened macOS 26 and macOS 27 selectors before those OS versions can claim
-   the same unattended UI coverage as macOS 15.
+   the same unattended UI coverage as macOS 15. The macOS 27 console session,
+   secret-safe Remote Management authorization, and RFB event delivery are now
+   proven; selector capture and composition remain.
 
 Clean install, repair, upgrade, reboot, uninstall, reinstall, cancellation,
 nightly, and pairwise entries are consumers of those foundations. They are

--- a/docs/testing/keypath-test-automation-state.json
+++ b/docs/testing/keypath-test-automation-state.json
@@ -1,9 +1,10 @@
 {
-  "updatedAt": "2026-07-12T21:27:05-07:00",
-  "currentTask": "P02 has a platform gate",
-  "message": "The VM reached the real VirtualHID approval control, but macOS has not transitioned the driver out of waiting-for-user. Captured RFB input is ready; remapped-output proof waits on a deterministic approval lane.",
+  "updatedAt": "2026-07-16T10:17:39-07:00",
+  "currentTask": "M11 Remote Management delivery proven",
+  "message": "Supported-UI approval plus paced secure input enabled Remote Management; the independent RFB probe now delivers events on macOS 27 build 26A5378j.",
   "complete": false,
   "workingBlocks": [
+    "M11",
     "P02"
   ],
   "activeWork": {
@@ -50,6 +51,59 @@
         "Repair and reboot validation",
         "Scenario-matrix pass/fail evidence"
       ]
+    },
+    "M11": {
+      "progress": 71,
+      "health": "smooth",
+      "trend": "forward",
+      "phase": "Remote Management input delivery proven",
+      "detail": "A disposable macOS 27 build 26A5378j clone now has a verified keypathqa console session, supported-UI Remote Management approval, paced secret-safe credential transport, and independently observed RFB cursor delivery. Selector capture and driver composition remain.",
+      "attempt": 1,
+      "completedSteps": 5,
+      "totalSteps": 7,
+      "nextTasks": [
+        {
+          "label": "Create and reserve fresh macOS 27 desktop lease",
+          "status": "done",
+          "progress": 100
+        },
+        {
+          "label": "Verify encrypted QA account credential",
+          "status": "done",
+          "progress": 100
+        },
+        {
+          "label": "Establish logged-in console session",
+          "status": "done",
+          "progress": 100
+        },
+        {
+          "label": "Enable Remote Management through supported UI",
+          "status": "done",
+          "progress": 100
+        },
+        {
+          "label": "Prove RFB event posting with cursor postcondition",
+          "status": "done",
+          "progress": 100
+        },
+        {
+          "label": "Capture macOS 27 semantic selectors",
+          "status": "active",
+          "progress": 10
+        },
+        {
+          "label": "Compose self-verifying macOS 27 approval driver",
+          "status": "queued",
+          "progress": 0
+        }
+      ],
+      "blocker": null,
+      "coreCapability": true,
+      "unlocks": [
+        "macOS 27 agent-driven System Settings automation",
+        "macOS 27 installer scenarios"
+      ]
     }
   },
   "statuses": {
@@ -60,9 +114,17 @@
     "P01": "proven",
     "P02": "active",
     "M14": "active",
-    "M12": "active"
+    "M12": "active",
+    "M11": "active"
   },
   "updates": [
+    {
+      "time": "10:17",
+      "block": "M11",
+      "tone": "success",
+      "title": "M11 Remote Management delivery proven",
+      "message": "Supported-UI approval plus paced secure input enabled Remote Management; the independent RFB probe now delivers events on macOS 27 build 26A5378j."
+    },
     {
       "time": "21:27",
       "block": "P02",
@@ -265,13 +327,6 @@
       "tone": "working",
       "title": "P01 published for review",
       "message": "PR #1129 is open. P01 remains active while CI and the enforced Claude review validate the guarded-click harness."
-    },
-    {
-      "time": "13:26",
-      "block": "P01",
-      "tone": "success",
-      "title": "P01 click guard implemented",
-      "message": "P01 advanced: wrong-coordinate clicks now fail immediately instead of silently corrupting the permission flow. The focused harness suite passes."
     }
   ],
   "activity": [

--- a/docs/testing/remote-installer-lab.md
+++ b/docs/testing/remote-installer-lab.md
@@ -198,15 +198,32 @@ The probe reads the guest cursor location, sends one CrabBox RFB click, and
 requires the cursor location to change. It refuses to run until
 `console-login` has established and verified the `keypathqa` console session.
 
-On macOS 27 build `26A5378j`, this probe currently reports that authenticated
-RFB input is acknowledged but not delivered. Unified logs show the console
-agent checking in with event posting disabled. This is a distinct platform
-permission boundary, not a console-login failure: Apple's supported
-command-line Remote Management setup is view-only, and toggling ordinary
-Screen Sharing off and on did not grant event posting in this build. Full
-control therefore remains gated on enabling Remote Management control through
-System Settings or an MDM profile. Keep the failed probe as evidence and do not
-classify an installer scenario as agent-drivable until the probe passes.
+On macOS 27 build `26A5378j`, ordinary Screen Sharing initially acknowledges
+RFB input without delivering it. Unified logs report that the console agent has
+event posting disabled. Apple's supported command-line setup is view-only, so
+enable Remote Management control through the real logged-in System Settings UI
+before classifying the lease as agent-drivable.
+
+For the Parallels lane, operate that one-time prerequisite through the lease's
+real Parallels console. When the authorization sheet has its password field
+focused, submit the encrypted guest credential without exposing it to argv,
+logs, screenshots, or the pasteboard:
+
+```bash
+Scripts/lab/keypath-lab secure-console-submit cbx_example
+Scripts/lab/keypath-lab rfb-pointer-probe cbx_example --x 160 --y 120
+```
+
+`secure-console-submit` emits one Parallels key event at a time with a bounded
+inter-key delay. Parallels can drop characters when a complete credential is
+sent as one unpaced event batch. The command deliberately reports credential
+transport only; the RFB probe is the required independent postcondition.
+
+On July 16, 2026, the supported UI flow enabled Remote Management and VNC
+control for `keypathqa`, and the probe moved the guest cursor from
+`684.703125 141.1875` to `80 60`. That proves event posting for this disposable
+clone and OS build. Repeat the UI approval and probe for a fresh clone or beta
+seed; do not infer delivery from the visible toggle alone.
 
 For a console-ready candidate base, run `desktop-bootstrap --install-tools`
 once before capturing its checkpoint. It installs Python 3 as well as


### PR DESCRIPTION
## Summary

- frame the encrypted QA credential as a complete console-login record
- add a secret-safe, paced Parallels key-event path for focused authorization sheets
- require an independent RFB cursor postcondition and record the proven macOS 27 capability in the lab dashboard

## Root cause

The decrypted dotenv value has no trailing newline, so the guest FIFO reader could wait indefinitely for a complete record. Separately, Parallels drops characters when a full credential is sent as one unpaced key-event batch. Sending one event at a time with a short delay reliably completes the supported Remote Management authorization flow.

## Validation

- live disposable macOS 27 build `26A5378j`: Remote Management enabled through System Settings and RFB cursor delivery independently observed
- `Scripts/lab/tests/keypath-lab-tests.sh`
- `python3 Scripts/lab/tests/update-progress-dashboard-tests.py`
- `python3 Scripts/lab/tests/issue-dashboard-tests.py`
- `./Scripts/test-fast.sh --changed` (full safe fallback: 4,746 tests passed)
- `./Scripts/review-gate.sh` (remote review gate selected; GitHub `claude-review` required)

Related to #919; this does not complete the full macOS 27 regression lane.
