### PR TITLE
Route SwiftPM CI away from macOS 27 headless AppSSO trap

### DIFF
--- a/.github/workflows/cache-warm.yml
+++ b/.github/workflows/cache-warm.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   warm-cache:
-    runs-on: [self-hosted, macOS, keypath]
+    runs-on: [self-hosted, macOS, keypath, swiftpm-safe]
     timeout-minutes: 5
     steps:
       - name: Checkout code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,9 @@ concurrency:
 
 jobs:
   build-and-test:
-    runs-on: [self-hosted, macOS, keypath]
+    # macOS 27 AppSSO traps SwiftPM binary-artifact requests from a headless
+    # LaunchDaemon. Only the interactive runner carries swiftpm-safe.
+    runs-on: [self-hosted, macOS, keypath, swiftpm-safe]
     # Warm runs normally finish in 2-3 minutes. A measured cold run spent about
     # 3 minutes on setup/Kanata and was still compiling Swift tests after another
     # 12 minutes, before test execution. Keep a finite bound with real headroom.

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   narrow-coverage:
-    runs-on: [self-hosted, macOS, keypath]
+    runs-on: [self-hosted, macOS, keypath, swiftpm-safe]
     timeout-minutes: 10
     env:
       COVERAGE_BASELINE_PERCENT: "0.27"
@@ -96,7 +96,7 @@ jobs:
   # enforce a floor yet — the narrow lane above is the only gate. Once these
   # numbers are trusted, a realistic per-file floor can be added here.
   full-coverage:
-    runs-on: [self-hosted, macOS, keypath]
+    runs-on: [self-hosted, macOS, keypath, swiftpm-safe]
     # Sequence after the narrow lane: the two jobs share the self-hosted runner's
     # workspace/.build, so running them in parallel risks clobbering each other's
     # default.profdata (CLAUDE.md: avoid concurrent broad Swift builds). `needs`

--- a/.github/workflows/runner-health.yml
+++ b/.github/workflows/runner-health.yml
@@ -21,17 +21,24 @@ jobs:
       - name: Verify SwiftPM label boundary
         run: |
           export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
-          runner_json="$(env -u GH_TOKEN -u GITHUB_TOKEN gh api repos/malpern/KeyPath/actions/runners)" || {
+          runner_json="$(env -u GH_TOKEN -u GITHUB_TOKEN gh api "repos/${{ github.repository }}/actions/runners")" || {
             echo "Runner label audit requires the Mini's existing gh authentication." >&2
             exit 1
           }
-          headless_labels="$(jq -r '.runners[] | select(.name == "keypath-mini") | [.labels[].name] | join(",")' <<<"$runner_json")"
-          interactive_labels="$(jq -r '.runners[] | select(.name == "keypath-mini-2") | [.labels[].name] | join(",")' <<<"$runner_json")"
+          headless="$(jq -c '[.runners[] | select(.status == "online" and .name == "keypath-mini")]' <<<"$runner_json")"
+          interactive="$(jq -c '[.runners[] | select(.status == "online" and .name == "keypath-mini-2")]' <<<"$runner_json")"
 
-          [[ -n "$headless_labels" && -n "$interactive_labels" ]] || {
-            echo "Expected both keypath-mini runner registrations." >&2
+          [[ "$(jq 'length' <<<"$headless")" == "1" ]] || {
+            echo "Expected exactly one online keypath-mini registration." >&2
             exit 1
           }
+          [[ "$(jq 'length' <<<"$interactive")" == "1" ]] || {
+            echo "Expected exactly one online keypath-mini-2 registration." >&2
+            exit 1
+          }
+
+          headless_labels="$(jq -r '.[0] | [.labels[].name] | join(",")' <<<"$headless")"
+          interactive_labels="$(jq -r '.[0] | [.labels[].name] | join(",")' <<<"$interactive")"
           [[ ",$headless_labels," != *",swiftpm-safe,"* ]] || {
             echo "Headless keypath-mini must not carry swiftpm-safe." >&2
             exit 1

--- a/.github/workflows/runner-health.yml
+++ b/.github/workflows/runner-health.yml
@@ -17,3 +17,26 @@ jobs:
           echo "Disk: $(df -h /Users | tail -1)"
           echo "Swift: $(swift --version 2>&1 | head -1)"
           echo "Kanata: $(kanata --version 2>&1 || echo 'not found')"
+
+      - name: Verify SwiftPM label boundary
+        run: |
+          export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
+          runner_json="$(env -u GH_TOKEN -u GITHUB_TOKEN gh api repos/malpern/KeyPath/actions/runners)" || {
+            echo "Runner label audit requires the Mini's existing gh authentication." >&2
+            exit 1
+          }
+          headless_labels="$(jq -r '.runners[] | select(.name == "keypath-mini") | [.labels[].name] | join(",")' <<<"$runner_json")"
+          interactive_labels="$(jq -r '.runners[] | select(.name == "keypath-mini-2") | [.labels[].name] | join(",")' <<<"$runner_json")"
+
+          [[ -n "$headless_labels" && -n "$interactive_labels" ]] || {
+            echo "Expected both keypath-mini runner registrations." >&2
+            exit 1
+          }
+          [[ ",$headless_labels," != *",swiftpm-safe,"* ]] || {
+            echo "Headless keypath-mini must not carry swiftpm-safe." >&2
+            exit 1
+          }
+          [[ ",$interactive_labels," == *",swiftpm-safe,"* ]] || {
+            echo "Interactive keypath-mini-2 must carry swiftpm-safe." >&2
+            exit 1
+          }

--- a/Scripts/install-ci-runner-service.sh
+++ b/Scripts/install-ci-runner-service.sh
@@ -159,11 +159,11 @@ cat > "$PLIST" <<PLIST_EOF
     <key>ThrottleInterval</key>
     <integer>10</integer>
     <!--
-      CI is intentionally headless.  Do not create an artificial interactive
-      login session: on macOS 27 AppSSO attempts an invalid XPC target-UID
-      handoff from that session and traps SwiftPM while it resolves a binary
-      artifact.  A background service has the least privilege the build needs
-      and remains available before anyone logs in.
+      This runner is intentionally headless and boot-available. On macOS 27,
+      AppSSO traps SwiftPM binary-artifact requests from this system launch
+      domain. Do not assign this registration the swiftpm-safe label; route
+      SwiftPM jobs to a real logged-in LaunchAgent. This daemon remains useful
+      for lightweight jobs that do not resolve or build Swift packages.
     -->
     <key>ProcessType</key>
     <string>Background</string>

--- a/Tests/KeyPathTests/Lint/DeploymentScriptContractTests.swift
+++ b/Tests/KeyPathTests/Lint/DeploymentScriptContractTests.swift
@@ -233,6 +233,10 @@ final class DeploymentScriptContractTests: XCTestCase {
             "Runner health should still exercise either registered runner."
         )
         XCTAssertTrue(runnerHealth.contains("Verify SwiftPM label boundary"))
+        XCTAssertTrue(runnerHealth.contains(#"repos/${{ github.repository }}/actions/runners"#))
+        XCTAssertTrue(runnerHealth.contains(#"select(.status == "online" and .name == "keypath-mini")"#))
+        XCTAssertTrue(runnerHealth.contains("Expected exactly one online keypath-mini registration"))
+        XCTAssertTrue(runnerHealth.contains("Expected exactly one online keypath-mini-2 registration"))
         XCTAssertTrue(runnerHealth.contains("Headless keypath-mini must not carry swiftpm-safe"))
         XCTAssertTrue(runnerHealth.contains("Interactive keypath-mini-2 must carry swiftpm-safe"))
         XCTAssertTrue(

--- a/Tests/KeyPathTests/Lint/DeploymentScriptContractTests.swift
+++ b/Tests/KeyPathTests/Lint/DeploymentScriptContractTests.swift
@@ -207,6 +207,36 @@ final class DeploymentScriptContractTests: XCTestCase {
             "PlistBuddy cannot read GitHub's JSON .runner file and leaves a duplicate LaunchAgent loaded."
         )
     }
+
+    func testSwiftPMWorkflowsRequireInteractiveSafeRunner() throws {
+        let root = repositoryRoot()
+        let ci = try contents(of: root.appendingPathComponent(".github/workflows/ci.yml"))
+        let cacheWarm = try contents(of: root.appendingPathComponent(".github/workflows/cache-warm.yml"))
+        let coverage = try contents(of: root.appendingPathComponent(".github/workflows/coverage.yml"))
+        let runnerHealth = try contents(of: root.appendingPathComponent(".github/workflows/runner-health.yml"))
+        let installer = try contents(of: root.appendingPathComponent("Scripts/install-ci-runner-service.sh"))
+        let safeRunner = "runs-on: [self-hosted, macOS, keypath, swiftpm-safe]"
+
+        XCTAssertEqual(
+            ci.components(separatedBy: safeRunner).count - 1,
+            1,
+            "Only build-and-test should require the SwiftPM-safe interactive runner in ci.yml."
+        )
+        XCTAssertTrue(cacheWarm.contains(safeRunner))
+        XCTAssertEqual(
+            coverage.components(separatedBy: safeRunner).count - 1,
+            2,
+            "Every coverage job invokes SwiftPM and must use the safe runner."
+        )
+        XCTAssertFalse(
+            runnerHealth.contains(safeRunner),
+            "Runner health should still exercise either registered runner."
+        )
+        XCTAssertTrue(
+            installer.contains("Do not assign this registration the swiftpm-safe label"),
+            "The headless service installer must preserve the macOS 27 AppSSO routing boundary."
+        )
+    }
 }
 
 // MARK: - Helpers

--- a/Tests/KeyPathTests/Lint/DeploymentScriptContractTests.swift
+++ b/Tests/KeyPathTests/Lint/DeploymentScriptContractTests.swift
@@ -232,6 +232,9 @@ final class DeploymentScriptContractTests: XCTestCase {
             runnerHealth.contains(safeRunner),
             "Runner health should still exercise either registered runner."
         )
+        XCTAssertTrue(runnerHealth.contains("Verify SwiftPM label boundary"))
+        XCTAssertTrue(runnerHealth.contains("Headless keypath-mini must not carry swiftpm-safe"))
+        XCTAssertTrue(runnerHealth.contains("Interactive keypath-mini-2 must carry swiftpm-safe"))
         XCTAssertTrue(
             installer.contains("Do not assign this registration the swiftpm-safe label"),
             "The headless service installer must preserve the macOS 27 AppSSO routing boundary."

--- a/docs/bugs/2026-07-16-headless-swiftpm-appsso-trap.md
+++ b/docs/bugs/2026-07-16-headless-swiftpm-appsso-trap.md
@@ -43,9 +43,17 @@ interactive runner. The corresponding crash reports on the Mini are
   either runner.
 - The boot-available headless runner remains registered, but must not receive
   the `swiftpm-safe` label while this macOS behavior persists.
+- The scheduled runner-health workflow audits the live GitHub runner labels
+  every six hours and fails if that boundary drifts. Runner labels are GitHub
+  registration metadata, not local LaunchDaemon configuration, so the service
+  installer also preserves an explicit warning at the point of maintenance.
 
 This makes scheduling fail closed: if the logged-in runner is unavailable, a
 SwiftPM job queues instead of running in a context known to crash.
+
+Serializing SwiftPM work onto one runner is an accepted temporary capacity
+tradeoff. The second runner still handles lightweight work in parallel; adding
+`swiftpm-safe` to the headless runner merely to regain throughput is unsafe.
 
 ## Re-enable criteria
 

--- a/docs/bugs/2026-07-16-headless-swiftpm-appsso-trap.md
+++ b/docs/bugs/2026-07-16-headless-swiftpm-appsso-trap.md
@@ -1,0 +1,56 @@
+# Headless SwiftPM AppSSO trap on macOS 27
+
+## Symptom
+
+`swift build --build-tests` can exit 133 while SwiftPM materializes Sparkle's
+binary artifact on the macOS 27 Mini. No KeyPath source has compiled yet. The
+crash is `EXC_BREAKPOINT / SIGTRAP` in `swift-package`.
+
+## Root cause
+
+The failure follows the runner execution context, not the commit or hardware.
+Two failed PR attempts ran on `keypath-mini`, a system LaunchDaemon. The same
+commits passed unchanged when rerun on `keypath-mini-2`, a LaunchAgent in the
+logged-in `clawd` GUI session.
+
+The macOS crash reports show this stack on an `NSURLSession` worker:
+
+```text
+_xpc_api_misuse
+xpc_connection_set_target_uid
+SOServiceConnection
+SOConfigurationClient
+AppSSO::shouldManageURL
+NSURLSession
+```
+
+macOS 27 AppSSO is attempting an invalid target-UID handoff for the headless
+system launch domain. `libxpc` deliberately traps. Sparkle is only the trigger:
+its SwiftPM binary target causes the URLSession request that reaches AppSSO.
+
+The failing attempts were GitHub Actions run `29520333429` attempt 1 and run
+`29521172200` attempt 1. Their unchanged attempt 2 reruns passed on the
+interactive runner. The corresponding crash reports on the Mini are
+`swift-package-2026-07-16-103852.ips` and
+`swift-package-2026-07-16-105007.ips`.
+
+## Containment
+
+- Only the interactive `keypath-mini-2` registration carries the custom
+  `swiftpm-safe` label.
+- Workflows that invoke `swift build` or `swift test` require that label.
+- Lightweight jobs such as code quality and runner health remain eligible for
+  either runner.
+- The boot-available headless runner remains registered, but must not receive
+  the `swiftpm-safe` label while this macOS behavior persists.
+
+This makes scheduling fail closed: if the logged-in runner is unavailable, a
+SwiftPM job queues instead of running in a context known to crash.
+
+## Re-enable criteria
+
+Do not return SwiftPM jobs to the headless runner based on a warm-cache pass.
+On a newer macOS seed, run a cold probe that removes only the probe's disposable
+scratch directory and materializes Sparkle from `Package.resolved`. Re-enable
+the label only after that probe passes repeatedly without an AppSSO crash
+report. Preserve the crash reports for an Apple Feedback Assistant report.

--- a/docs/planning/ci-optimization-phases.md
+++ b/docs/planning/ci-optimization-phases.md
@@ -20,7 +20,7 @@
 ## Phase 2: Parallel CI ✅
 
 ### 2a. Register a second runner on the Mini ✅
-**Done:** `keypath-mini-2` installed at `~/actions-runner-2` with LaunchAgent. Both runners online with labels `self-hosted,macOS,ARM64,keypath`. Verified: `build-and-test` (2m7s) and `code-quality` (11s) run in parallel on separate runners.
+**Done:** `keypath-mini-2` installed at `~/actions-runner-2` with LaunchAgent. Both runners are online. On macOS 27, only the interactive runner carries `swiftpm-safe`; SwiftPM jobs require that label while lightweight jobs can still run in parallel on the headless runner.
 
 ### 2b. Add concurrency control to ci.yml ✅
 **Done:** Added `concurrency: group: ci-${{ github.event.pull_request.number || github.ref }}, cancel-in-progress: true`. Verified: stale runs get cancelled on rapid pushes.

--- a/docs/planning/todo-self-hosted-ci-runner.md
+++ b/docs/planning/todo-self-hosted-ci-runner.md
@@ -47,6 +47,13 @@ minutes and Swift had compiled 1,380 of 1,457 test-build steps when GitHub
 cancelled it. Twenty-five minutes preserves a finite failure bound while leaving
 room to link and execute the tests after a healthy cold rebuild.
 
+On macOS 27, SwiftPM binary-artifact requests crash in AppSSO when they run from
+the boot-available `keypath-mini` LaunchDaemon. The interactive
+`keypath-mini-2` LaunchAgent is the proven SwiftPM execution context and carries
+the `swiftpm-safe` label. Build, cache-warm, and coverage workflows require that
+label; code-quality and health checks may still use either runner. See
+`docs/bugs/2026-07-16-headless-swiftpm-appsso-trap.md`.
+
 ### Security
 - [x] Fork PR approval set to "Require approval for all external contributors"
 - [x] Zero existing forks on the repo


### PR DESCRIPTION
## Summary

- route SwiftPM build, cache-warm, and coverage jobs to the proven logged-in runner via a fail-closed `swiftpm-safe` label
- keep lightweight code-quality and runner-health jobs eligible for the boot-available headless runner
- add a workflow contract test and document the macOS 27 AppSSO/XPC root cause and re-enable criteria

## Root cause

The two failed attempts ran on the system LaunchDaemon runner (`keypath-mini`) and trapped in `_xpc_api_misuse -> AppSSO::shouldManageURL -> NSURLSession` while SwiftPM materialized Sparkle, before KeyPath compilation. The same commits passed unchanged on the logged-in LaunchAgent runner (`keypath-mini-2`). Only that runner now carries `swiftpm-safe`.

This is a macOS 27 AppSSO execution-context failure; Sparkle is the network-request trigger, not the defective component.

## Validation

- `TEST_FILTER=DeploymentScriptContractTests ./Scripts/run-tests-safe.sh` (10 passed)
- `./Scripts/test-fast.sh --changed` (4,747 passed)
- workflow YAML parse for CI, cache warm, coverage, and runner health
- `bash -n Scripts/install-ci-runner-service.sh`
- live runner labels verified through GitHub API
- `./Scripts/review-gate.sh` selected the remote review gate; `claude-review` must pass before merge

## Runtime proof required from this PR

The `build-and-test` job must report `keypath-mini-2` as its runner. A queued job is preferable to fallback onto the known-bad headless context.
