### PR TITLE
Build deterministic managed macOS lab lanes

### DIFF
--- a/Scripts/lab/keypath-lab
+++ b/Scripts/lab/keypath-lab
@@ -112,6 +112,14 @@ case "$command" in
         installer_name=$(basename "$installer")
         [[ $installer_name =~ ^[A-Za-z0-9._-]+$ ]] || die "installer filename must contain only letters, numbers, dots, underscores, and dashes"
         cp "$installer" "$temp_dir/repo/.keypath-lab/installer/$installer_name"
+        if [[ $lane == "managed-functional" ]]; then
+            mkdir -p "$temp_dir/installer-extract"
+            /usr/bin/ditto -x -k "$installer" "$temp_dir/installer-extract"
+            [[ -d $temp_dir/installer-extract/KeyPath.app ]] || die "managed installer must contain KeyPath.app at its root"
+            "$SCRIPT_DIR/mdm/generate-keypath-profiles" \
+                --app "$temp_dir/installer-extract/KeyPath.app" \
+                --output "$temp_dir/repo/.keypath-lab/managed-policy" >/dev/null
+        fi
         cat > "$temp_dir/repo/.keypath-lab/source.tsv" <<EOF
 keypath_commit	$commit
 installer_name	$installer_name

--- a/Scripts/lab/keypath-lab
+++ b/Scripts/lab/keypath-lab
@@ -15,6 +15,7 @@ Commands:
   create --macos 15|26|27 --lane managed-functional|unmanaged-ui --commit SHA --installer PATH [--ttl 2h] [--desktop]
   install-app LEASE_ID
   console-login LEASE_ID
+  reset-guest-password LEASE_ID
   secure-console-submit LEASE_ID
   rfb-pointer-probe LEASE_ID --x X --y Y
   desktop-bootstrap LEASE_ID [--install-tools]
@@ -133,6 +134,11 @@ EOF
         [[ $# -eq 1 ]] || usage
         require_lease_id "$1"
         remote console-login "$1"
+        ;;
+    reset-guest-password)
+        [[ $# -eq 1 ]] || usage
+        require_lease_id "$1"
+        remote reset-guest-password "$1"
         ;;
     secure-console-submit)
         [[ $# -eq 1 ]] || usage

--- a/Scripts/lab/mdm/Caddyfile.lab
+++ b/Scripts/lab/mdm/Caddyfile.lab
@@ -1,0 +1,9 @@
+https://192.168.1.162:8443 {
+    tls internal
+    reverse_proxy 127.0.0.1:8080
+}
+
+https://192.168.1.162:9443 {
+    tls internal
+    reverse_proxy 127.0.0.1:9000
+}

--- a/Scripts/lab/mdm/build-enrollment-profile.py
+++ b/Scripts/lab/mdm/build-enrollment-profile.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+
+import argparse
+import plistlib
+import uuid
+from pathlib import Path
+
+
+NAMESPACE = uuid.UUID("3f53bb0e-671a-48a6-b7ee-91480af3110e")
+
+
+def payload_uuid(name: str) -> str:
+    return str(uuid.uuid5(NAMESPACE, name)).upper()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Build the private KeyPath lab MDM enrollment profile."
+    )
+    parser.add_argument("--scep-url", required=True)
+    parser.add_argument("--mdm-url", required=True)
+    parser.add_argument("--challenge-file", required=True, type=Path)
+    parser.add_argument("--topic", required=True)
+    parser.add_argument("--tls-root-der", required=True, type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    args = parser.parse_args()
+
+    challenge = args.challenge_file.read_text().strip()
+    if not challenge:
+        raise SystemExit("SCEP challenge is empty")
+    if not args.topic.startswith("com.apple.mgmt."):
+        raise SystemExit("APNs topic must start with com.apple.mgmt.")
+
+    root_uuid = payload_uuid("https-root")
+    scep_uuid = payload_uuid("scep")
+    mdm_uuid = payload_uuid("mdm")
+
+    profile = {
+        "PayloadContent": [
+            {
+                "PayloadContent": args.tls_root_der.read_bytes(),
+                "PayloadDisplayName": "KeyPath Lab MDM HTTPS Root",
+                "PayloadIdentifier": "com.keypath.lab.mdm.https-root",
+                "PayloadType": "com.apple.security.root",
+                "PayloadUUID": root_uuid,
+                "PayloadVersion": 1,
+            },
+            {
+                "PayloadContent": {
+                    "Challenge": challenge,
+                    "Key Type": "RSA",
+                    "Key Usage": 5,
+                    "Keysize": 2048,
+                    "URL": args.scep_url,
+                },
+                "PayloadIdentifier": "com.keypath.lab.mdm.scep",
+                "PayloadType": "com.apple.security.scep",
+                "PayloadUUID": scep_uuid,
+                "PayloadVersion": 1,
+            },
+            {
+                "AccessRights": 8191,
+                "CheckInURL": args.mdm_url,
+                "CheckInURLPinningCertificateUUIDs": [root_uuid],
+                "CheckOutWhenRemoved": True,
+                "IdentityCertificateUUID": scep_uuid,
+                "PayloadIdentifier": "com.keypath.lab.mdm.enrollment",
+                "PayloadType": "com.apple.mdm",
+                "PayloadUUID": mdm_uuid,
+                "PayloadVersion": 1,
+                "ServerCapabilities": [
+                    "com.apple.mdm.per-user-connections",
+                    "com.apple.mdm.bootstraptoken",
+                    "com.apple.mdm.token",
+                ],
+                "ServerURL": args.mdm_url,
+                "ServerURLPinningCertificateUUIDs": [root_uuid],
+                "SignMessage": True,
+                "Topic": args.topic,
+                "UseDevelopmentAPNS": False,
+            },
+        ],
+        "PayloadDescription": "Enrolls a disposable KeyPath VM in the private test lab.",
+        "PayloadDisplayName": "KeyPath Lab MDM Enrollment",
+        "PayloadIdentifier": "com.keypath.lab.mdm",
+        "PayloadOrganization": "KeyPath",
+        "PayloadRemovalDisallowed": False,
+        "PayloadScope": "System",
+        "PayloadType": "Configuration",
+        "PayloadUUID": payload_uuid("profile"),
+        "PayloadVersion": 1,
+    }
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    with args.output.open("wb") as handle:
+        plistlib.dump(profile, handle, fmt=plistlib.FMT_XML, sort_keys=True)
+    args.output.chmod(0o600)
+    print(args.output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Scripts/lab/mdm/generate-keypath-profiles
+++ b/Scripts/lab/mdm/generate-keypath-profiles
@@ -113,22 +113,26 @@ def profile(identifier, display_name, payload_type, content):
         "PayloadContent": [payload],
     }
 
-def identity(identifier, identifier_type, requirement):
+def identity(identifier, identifier_type, requirement, authorization):
     return {
         "Identifier": identifier,
         "IdentifierType": identifier_type,
         "CodeRequirement": requirement,
         "StaticCode": False,
-        "Allowed": True,
+        "Authorization": authorization,
     }
 
-app = identity(app_id, "bundleID", app_req)
-launcher = identity(
-    "/Applications/KeyPath.app/Contents/Library/KeyPath/kanata-launcher",
-    "path",
-    launcher_req,
-)
-engine = identity(engine_id, "bundleID", engine_req)
+def identities(authorization):
+    return [
+        identity(app_id, "bundleID", app_req, authorization),
+        identity(
+            "/Applications/KeyPath.app/Contents/Library/KeyPath/kanata-launcher",
+            "path",
+            launcher_req,
+            authorization,
+        ),
+        identity(engine_id, "bundleID", engine_req, authorization),
+    ]
 
 profiles = {
     "keypath-pppc.mobileconfig": profile(
@@ -137,9 +141,13 @@ profiles = {
         "com.apple.TCC.configuration-profile-policy",
         {
             "Services": {
-                "Accessibility": [app, launcher, engine],
-                "ListenEvent": [app, launcher, engine],
-                "SystemPolicyAllFiles": [app],
+                "Accessibility": identities("Allow"),
+                # Apple does not permit MDM to grant ListenEvent directly.
+                # This makes the setting user-configurable without admin auth.
+                "ListenEvent": identities("AllowStandardUserToSetSystemService"),
+                "SystemPolicyAllFiles": [
+                    identity(app_id, "bundleID", app_req, "Allow")
+                ],
             }
         },
     ),

--- a/Scripts/lab/mdm/publish-managed-profiles
+++ b/Scripts/lab/mdm/publish-managed-profiles
@@ -1,0 +1,145 @@
+#!/bin/bash
+set -euo pipefail
+
+usage() {
+    echo "Usage: $0 --profile-dir DIR --evidence-dir DIR [--enrollment-id UUID]" >&2
+    exit 2
+}
+
+die() {
+    echo "publish-managed-profiles: $*" >&2
+    exit 1
+}
+
+profile_dir=
+evidence_dir=
+enrollment_id=
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --profile-dir) profile_dir=${2:-}; shift 2 ;;
+        --evidence-dir) evidence_dir=${2:-}; shift 2 ;;
+        --enrollment-id) enrollment_id=${2:-}; shift 2 ;;
+        *) usage ;;
+    esac
+done
+
+[[ -d $profile_dir && -n $evidence_dir ]] || usage
+
+base=${KEYPATH_LAB_MDM_HOME:-"$HOME/Library/Application Support/KeyPathLabMDM"}
+db="$base/state/nanomdm/dbkv"
+cmdr=${KEYPATH_LAB_MDM_CMDR:-"$base/bin/nanomdm-darwin-arm64-v0.9.0/cmdr.py"}
+curl_bin=${KEYPATH_LAB_MDM_CURL:-/usr/bin/curl}
+uuidgen_bin=${KEYPATH_LAB_MDM_UUIDGEN:-/usr/bin/uuidgen}
+python_bin=${PYTHON_BIN:-/usr/bin/python3}
+sleep_bin=${KEYPATH_LAB_MDM_SLEEP:-/bin/sleep}
+api_url=${KEYPATH_LAB_MDM_API_URL:-http://127.0.0.1:9000}
+netrc=${KEYPATH_LAB_MDM_NETRC:-"$base/secrets/nanomdm.netrc"}
+poll_attempts=${KEYPATH_LAB_MDM_POLL_ATTEMPTS:-20}
+
+[[ -d $db/enrollments && -d $db/queue ]] || die "NanoMDM filekv storage is unavailable"
+[[ -x $cmdr && -x $curl_bin && -x $uuidgen_bin && -x $python_bin ]] || die "NanoMDM command dependencies are unavailable"
+[[ -f $netrc && ! -L $netrc ]] || die "NanoMDM API credential file is unavailable"
+[[ $poll_attempts =~ ^[0-9]+$ && $poll_attempts -gt 0 ]] || die "invalid poll attempt count"
+
+profiles=(
+    "pppc:keypath-pppc.mobileconfig"
+    "system-extension:keypath-system-extension.mobileconfig"
+    "service-management:keypath-service-management.mobileconfig"
+)
+for entry in "${profiles[@]}"; do
+    filename=${entry#*:}
+    [[ -f $profile_dir/$filename && ! -L $profile_dir/$filename ]] || die "managed profile is unavailable: $filename"
+done
+[[ -f $profile_dir/manifest.json && ! -L $profile_dir/manifest.json ]] || die "managed policy manifest is unavailable"
+
+if [[ -z $enrollment_id ]]; then
+    enrollment_ids=()
+    while IFS= read -r type_file; do
+        enrollment_ids+=("$(basename "$type_file" .type)")
+    done < <(find "$db/enrollments" -type f -name '*.type' -print | sort)
+    [[ ${#enrollment_ids[@]} -eq 1 ]] || die "expected exactly one NanoMDM enrollment, found ${#enrollment_ids[@]}"
+    enrollment_id=${enrollment_ids[0]}
+fi
+[[ $enrollment_id =~ ^[A-Fa-f0-9-]{36}$ ]] || die "invalid enrollment id"
+
+mkdir -p "$evidence_dir/commands" "$evidence_dir/responses"
+
+wait_for_report() {
+    local uuid=$1 report= attempt=0
+    while ((attempt < poll_attempts)); do
+        report=$(find "$db/queue" -type f -name "$enrollment_id.$uuid.queueitem.report" -print -quit)
+        if [[ -n $report ]]; then
+            printf '%s' "$report"
+            return
+        fi
+        ((attempt += 1))
+        "$sleep_bin" 1
+    done
+    die "timed out waiting for command report: $uuid"
+}
+
+report_status() {
+    "$python_bin" - "$1" <<'PY'
+import plistlib
+import sys
+
+with open(sys.argv[1], "rb") as handle:
+    print(plistlib.load(handle).get("Status", ""))
+PY
+}
+
+for entry in "${profiles[@]}"; do
+    label=${entry%%:*}
+    filename=${entry#*:}
+    uuid=$("$uuidgen_bin")
+    [[ $uuid =~ ^[A-Fa-f0-9-]{36}$ ]] || die "UUID generator returned an invalid value"
+    "$cmdr" -u "$uuid" InstallProfile "$profile_dir/$filename" > "$evidence_dir/commands/$label.plist"
+    "$curl_bin" --silent --show-error --fail \
+        --netrc-file "$netrc" \
+        --data-binary @"$evidence_dir/commands/$label.plist" \
+        "$api_url/v1/enqueue/$enrollment_id" \
+        > "$evidence_dir/responses/enqueue-$label.json"
+    report=$(wait_for_report "$uuid")
+    cp "$report" "$evidence_dir/responses/$label-report.plist"
+    status=$(report_status "$report")
+    [[ $status == Acknowledged ]] || die "$label profile returned status: ${status:-missing}"
+    printf 'profile_acknowledged\t%s\t%s\n' "$label" "$uuid"
+done
+
+uuid=$("$uuidgen_bin")
+[[ $uuid =~ ^[A-Fa-f0-9-]{36}$ ]] || die "UUID generator returned an invalid value"
+"$cmdr" -u "$uuid" ProfileList > "$evidence_dir/commands/profile-list.plist"
+"$curl_bin" --silent --show-error --fail \
+    --netrc-file "$netrc" \
+    --data-binary @"$evidence_dir/commands/profile-list.plist" \
+    "$api_url/v1/enqueue/$enrollment_id" \
+    > "$evidence_dir/responses/enqueue-profile-list.json"
+report=$(wait_for_report "$uuid")
+cp "$report" "$evidence_dir/responses/profile-list-report.plist"
+"$python_bin" - "$report" <<'PY'
+import plistlib
+import sys
+
+expected = {
+    "com.keypath.lab.pppc",
+    "com.keypath.lab.system-extension",
+    "com.keypath.lab.service-management",
+}
+with open(sys.argv[1], "rb") as handle:
+    report = plistlib.load(handle)
+if report.get("Status") != "Acknowledged":
+    raise SystemExit("ProfileList was not acknowledged")
+actual = {
+    item.get("PayloadIdentifier")
+    for item in report.get("ProfileList", [])
+    if item.get("PayloadIdentifier")
+}
+missing = sorted(expected - actual)
+if missing:
+    raise SystemExit("ProfileList missing: " + ", ".join(missing))
+PY
+
+cp "$profile_dir/manifest.json" "$evidence_dir/manifest.json"
+printf 'enrollment_id\t%s\n' "$enrollment_id"
+printf 'profile_count\t3\n'
+printf 'verification\tpassed\n'

--- a/Scripts/lab/mdm/server-runner
+++ b/Scripts/lab/mdm/server-runner
@@ -1,0 +1,64 @@
+#!/bin/bash
+set -euo pipefail
+
+base=${KEYPATH_LAB_MDM_HOME:-"$HOME/Library/Application Support/KeyPathLabMDM"}
+mode=${1:-}
+
+read_secret() {
+    local path=$1
+    [[ -f $path ]] || {
+        echo "missing server secret: $path" >&2
+        exit 1
+    }
+    local value
+    IFS= read -r value < "$path"
+    [[ -n $value ]] || {
+        echo "empty server secret: $path" >&2
+        exit 1
+    }
+    printf '%s' "$value"
+}
+
+case $mode in
+    nanomdm)
+        nanomdm="$base/bin/nanomdm-darwin-arm64-v0.9.0/nanomdm-darwin-arm64"
+        [[ -x $nanomdm ]] || {
+            echo "NanoMDM binary is missing: $nanomdm" >&2
+            exit 1
+        }
+        export NANOMDM_API
+        NANOMDM_API=$(read_secret "$base/secrets/nanomdm-api")
+        exec "$nanomdm" \
+            -listen 127.0.0.1:9000 \
+            -ca "$base/state/scep/depot/ca.pem" \
+            -storage filekv \
+            -storage-dsn "$base/state/nanomdm/dbkv" \
+            -debug
+        ;;
+    proxy)
+        caddy="$base/bin/caddy"
+        [[ -x $caddy ]] || {
+            echo "Caddy binary is missing: $caddy" >&2
+            exit 1
+        }
+        exec "$caddy" run --config "$base/state/Caddyfile"
+        ;;
+    scep)
+        scep="$base/bin/scepserver-darwin-arm64"
+        [[ -x $scep ]] || {
+            echo "SCEP binary is missing: $scep" >&2
+            exit 1
+        }
+        challenge=$(read_secret "$base/secrets/scep-challenge")
+        exec "$scep" \
+            -http-addr 127.0.0.1:8080 \
+            -depot "$base/state/scep/depot" \
+            -challenge "$challenge" \
+            -allowrenew 0 \
+            -log-json
+        ;;
+    *)
+        echo "Usage: $0 nanomdm|proxy|scep" >&2
+        exit 2
+        ;;
+esac

--- a/Scripts/lab/mdm/tests/profile-generator-tests.sh
+++ b/Scripts/lab/mdm/tests/profile-generator-tests.sh
@@ -54,6 +54,10 @@ pppc = plistlib.load(open(root / "keypath-pppc.mobileconfig", "rb"))
 services = pppc["PayloadContent"][0]["Services"]
 assert {"Accessibility", "ListenEvent", "SystemPolicyAllFiles"} == set(services)
 assert [item["IdentifierType"] for item in services["Accessibility"]] == ["bundleID", "path", "bundleID"]
+assert {item["Authorization"] for item in services["Accessibility"]} == {"Allow"}
+assert {item["Authorization"] for item in services["ListenEvent"]} == {"AllowStandardUserToSetSystemService"}
+assert {item["Authorization"] for item in services["SystemPolicyAllFiles"]} == {"Allow"}
+assert all("Allowed" not in item for items in services.values() for item in items)
 
 system_extension = plistlib.load(open(root / "keypath-system-extension.mobileconfig", "rb"))
 payload = system_extension["PayloadContent"][0]

--- a/Scripts/lab/mdm/tests/publish-managed-profiles-tests.sh
+++ b/Scripts/lab/mdm/tests/publish-managed-profiles-tests.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" >/dev/null && pwd -P)
+MDM_DIR=$(cd "$SCRIPT_DIR/.." >/dev/null && pwd -P)
+TMP=$(mktemp -d "${TMPDIR:-/tmp}/keypath-publish-managed-tests.XXXXXX")
+trap 'rm -rf "$TMP"' EXIT
+
+base="$TMP/mdm"
+profiles="$TMP/profiles"
+evidence="$TMP/evidence"
+bin="$TMP/bin"
+enrollment_id=1DC7C8BB-5FCB-5ADC-8C8F-82A95ACAB35B
+uuids=(
+    11111111-1111-4111-8111-111111111111
+    22222222-2222-4222-8222-222222222222
+    33333333-3333-4333-8333-333333333333
+    44444444-4444-4444-8444-444444444444
+)
+
+mkdir -p \
+    "$base/state/nanomdm/dbkv/enrollments/1D/C7" \
+    "$base/state/nanomdm/dbkv/queue/1D/C7" \
+    "$base/secrets" \
+    "$profiles" \
+    "$bin"
+printf 'Device' > "$base/state/nanomdm/dbkv/enrollments/1D/C7/$enrollment_id.type"
+printf 'machine nanomdm login test password test\n' > "$base/secrets/nanomdm.netrc"
+for profile in keypath-pppc.mobileconfig keypath-system-extension.mobileconfig keypath-service-management.mobileconfig; do
+    printf '<plist version="1.0"><dict/></plist>\n' > "$profiles/$profile"
+done
+printf '{"lane":"managed-functional"}\n' > "$profiles/manifest.json"
+
+cat > "$bin/cmdr" <<'EOF'
+#!/bin/bash
+printf '<plist version="1.0"><dict><key>CommandUUID</key><string>%s</string></dict></plist>\n' "$2"
+EOF
+cat > "$bin/curl" <<'EOF'
+#!/bin/bash
+printf '{}\n'
+EOF
+cat > "$bin/uuidgen" <<EOF
+#!/bin/bash
+counter="$TMP/uuid-counter"
+index=0
+[[ ! -f "\$counter" ]] || index=\$(cat "\$counter")
+case \$index in
+  0) uuid=${uuids[0]} ;;
+  1) uuid=${uuids[1]} ;;
+  2) uuid=${uuids[2]} ;;
+  3) uuid=${uuids[3]} ;;
+  *) exit 9 ;;
+esac
+echo \$((index + 1)) > "\$counter"
+printf '%s\n' "\$uuid"
+EOF
+chmod +x "$bin/cmdr" "$bin/curl" "$bin/uuidgen"
+
+/usr/bin/python3 - "$base" "$enrollment_id" "${uuids[@]}" <<'PY'
+import plistlib
+import sys
+from pathlib import Path
+
+base = Path(sys.argv[1])
+enrollment = sys.argv[2]
+uuids = sys.argv[3:]
+queue = base / "state/nanomdm/dbkv/queue/1D/C7"
+for uuid in uuids[:3]:
+    report = {
+        "CommandUUID": uuid,
+        "Status": "Acknowledged",
+        "UDID": enrollment,
+    }
+    with (queue / f"{enrollment}.{uuid}.queueitem.report").open("wb") as handle:
+        plistlib.dump(report, handle)
+profile_list = {
+    "CommandUUID": uuids[3],
+    "Status": "Acknowledged",
+    "UDID": enrollment,
+    "ProfileList": [
+        {"PayloadIdentifier": "com.keypath.lab.pppc"},
+        {"PayloadIdentifier": "com.keypath.lab.system-extension"},
+        {"PayloadIdentifier": "com.keypath.lab.service-management"},
+    ],
+}
+with (queue / f"{enrollment}.{uuids[3]}.queueitem.report").open("wb") as handle:
+    plistlib.dump(profile_list, handle)
+PY
+
+result=$(
+    KEYPATH_LAB_MDM_HOME="$base" \
+    KEYPATH_LAB_MDM_CMDR="$bin/cmdr" \
+    KEYPATH_LAB_MDM_CURL="$bin/curl" \
+    KEYPATH_LAB_MDM_UUIDGEN="$bin/uuidgen" \
+    KEYPATH_LAB_MDM_SLEEP=/usr/bin/true \
+    "$MDM_DIR/publish-managed-profiles" \
+        --profile-dir "$profiles" \
+        --evidence-dir "$evidence"
+)
+[[ $result == *$'profile_count\t3'* ]]
+[[ $result == *$'verification\tpassed'* ]]
+[[ -f $evidence/responses/profile-list-report.plist ]]
+[[ -f $evidence/manifest.json ]]
+
+mkdir -p "$base/state/nanomdm/dbkv/enrollments/AA/BB"
+printf 'Device' > "$base/state/nanomdm/dbkv/enrollments/AA/BB/AAAAAAAA-BBBB-4CCC-8DDD-EEEEEEEEEEEE.type"
+if KEYPATH_LAB_MDM_HOME="$base" \
+    KEYPATH_LAB_MDM_CMDR="$bin/cmdr" \
+    KEYPATH_LAB_MDM_CURL="$bin/curl" \
+    KEYPATH_LAB_MDM_UUIDGEN="$bin/uuidgen" \
+    "$MDM_DIR/publish-managed-profiles" \
+        --profile-dir "$profiles" \
+        --evidence-dir "$TMP/ambiguous" >/dev/null 2>"$TMP/ambiguous.stderr"; then
+    echo "expected ambiguous enrollment discovery to fail" >&2
+    exit 1
+fi
+grep -Fq 'expected exactly one NanoMDM enrollment, found 2' "$TMP/ambiguous.stderr"
+
+echo "publish-managed-profiles-tests: passed"

--- a/Scripts/lab/mdm/verify-lane
+++ b/Scripts/lab/mdm/verify-lane
@@ -16,7 +16,8 @@ elif [[ $# -ne 0 ]]; then
     usage
 fi
 
-profiles_output=$(/usr/bin/profiles show -type configuration 2>&1 || true)
+profiles_bin=${PROFILES_BIN:-/usr/bin/profiles}
+profiles_output=$("$profiles_bin" show -type=configuration 2>&1 || true)
 export KEYPATH_LAB_SW_VERS_BIN="${SW_VERS_BIN:-/usr/bin/sw_vers}"
 expected=(
     com.keypath.lab.pppc
@@ -36,7 +37,7 @@ if [[ $lane == managed-functional ]]; then
         echo "lane verification failed: managed-functional has $present/${#expected[@]} required profiles" >&2
         exit 1
     }
-    enrollment=$(/usr/bin/profiles status -type enrollment 2>&1 || true)
+    enrollment=$("$profiles_bin" status -type=enrollment 2>&1 || true)
     grep -Eiq 'MDM enrollment: (Yes|Enrolled)|Enrolled via DEP: Yes' <<<"$enrollment" || {
         echo "lane verification failed: device is not MDM enrolled" >&2
         printf '%s\n' "$enrollment" >&2

--- a/Scripts/lab/remote.sh
+++ b/Scripts/lab/remote.sh
@@ -562,7 +562,7 @@ install_app() {
   if [[ "$lane" == "managed-functional" ]]; then
     admission_command+=" --manifest /Library/KeyPathLab/managed-policy/manifest.json"
   fi
-  command="set -euo pipefail; $admission_command; rm -rf /tmp/keypath-install; mkdir -p /tmp/keypath-install; ditto -x -k '$guest_repo/.keypath-lab/installer/$installer_name' /tmp/keypath-install; cd '$guest_repo'; if [[ '$lane' == managed-functional ]]; then Scripts/lab/mdm/verify-artifact-policy --app /tmp/keypath-install/KeyPath.app --manifest /Library/KeyPathLab/managed-policy/manifest.json; fi; rm -rf /Applications/KeyPath.app; ditto /tmp/keypath-install/KeyPath.app /Applications/KeyPath.app"
+  command="setopt errexit nounset pipefail; $admission_command; rm -rf /tmp/keypath-install; mkdir -p /tmp/keypath-install; ditto -x -k '$guest_repo/.keypath-lab/installer/$installer_name' /tmp/keypath-install; cd '$guest_repo'; if [[ '$lane' == managed-functional ]]; then Scripts/lab/mdm/verify-artifact-policy --app /tmp/keypath-install/KeyPath.app --manifest /Library/KeyPathLab/managed-policy/manifest.json; fi; rm -rf /Applications/KeyPath.app; ditto /tmp/keypath-install/KeyPath.app /Applications/KeyPath.app"
   set +e
   if [[ "${KEYPATH_LAB_TESTING:-0}" == "1" ]]; then
     print "admission $lane" >> "$LOGS/$lease/install-app.log"
@@ -1090,7 +1090,7 @@ secure_console_submit() {
   local lease=$1 manifest macos resource parallels_cli secret_file
   manifest=$(owned_manifest "$lease")
   macos=$(field "$manifest" macos)
-  [[ "$macos" == "27" ]] || die "secure console submit currently supports only the macOS 27 Parallels lane"
+  [[ "$macos" == "26" || "$macos" == "27" ]] || die "secure console submit requires a macOS 26 or 27 Parallels lane"
   [[ "$(field "$manifest" provider)" == "parallels" ]] || die "secure console submit requires a Parallels lease"
   [[ "$(field "$manifest" desktop_enabled)" == "true" ]] || die "secure console submit requires a desktop-enabled lease"
   resource=$(field "$manifest" provider_resource)
@@ -1117,13 +1117,20 @@ secure_console_submit() {
 codes={"a":38,"b":56,"c":54,"d":40,"e":26,"f":41,"g":42,"h":43,"i":31,"j":44,"k":45,"l":46,"m":58,"n":57,"o":32,"p":33,"q":24,"r":27,"s":39,"t":28,"u":30,"v":55,"w":25,"x":53,"y":29,"z":52,"1":10,"2":11,"3":12,"4":13,"5":14,"6":15,"7":16,"8":17,"9":18,"0":19,"-":20}
 value=open(sys.argv[1],"r",encoding="utf-8").read()
 if not value or any(ch not in codes for ch in value): raise SystemExit(64)
-for ch in value: print(json.dumps([{"key":codes[ch]}],separators=(",",":")))' "$secret_file" | \
-    while IFS= read -r key_event; do
+for ch in value: print(json.dumps([{"key":codes[ch]}],separators=(",",":")))' "$secret_file" 3<&- | \
+    while IFS= read -r key_event <&3; do
       printf '%s\n' "$key_event" | "$parallels_cli" send-key-event "$resource" --json >/dev/null || exit 1
       sleep "${KEYPATH_LAB_SECURE_CONSOLE_KEY_DELAY_SECONDS:-0.2}"
-    done || die "failed to deliver the guest credential through Parallels key events"
+  done 3<&0 || die "failed to deliver the guest credential through Parallels key events"
   sleep "${KEYPATH_LAB_SECURE_CONSOLE_SETTLE_SECONDS:-0.25}"
-  "$parallels_cli" send-key-event "$resource" --key 36 >/dev/null
+  if [[ "$macos" == "26" ]]; then
+    # SecurityAgent accepts password text from the Parallels console but
+    # ignores synthetic application clicks. Leave the protected Enroll action
+    # to a real user click.
+    :
+  else
+    "$parallels_cli" send-key-event "$resource" --key 36 >/dev/null
+  fi
 
   if [[ "${KEYPATH_LAB_TESTING:-0}" != "1" ]]; then
     rm -f "$secret_file"
@@ -1133,6 +1140,74 @@ for ch in value: print(json.dumps([{"key":codes[ch]}],separators=(",",":")))' "$
   record_command "$lease" passed secure-console-submit
   print "secure_console_submit\tpassed"
   print "credential_transport\tparallels-key-events"
+}
+
+reset_guest_password() {
+  local lease=$1 manifest resource parallels_cli secret_file key known_hosts known_hosts_option guest_ip
+  local fifo account_file guest_command reset_pid fifo_ready attempt stream_exit reset_exit enrollment_account
+  manifest=$(owned_manifest "$lease")
+  [[ "$(field "$manifest" provider)" == "parallels" ]] || die "guest password reset requires a Parallels lease"
+  [[ "$(field "$manifest" desktop_enabled)" == "true" ]] || die "guest password reset requires a desktop-enabled lease"
+  resource=$(field "$manifest" provider_resource)
+  [[ "$resource" =~ '^[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}$' ]] || die "invalid Parallels resource id"
+  parallels_cli=${KEYPATH_LAB_PRLCTL:-"/Applications/Parallels Desktop.app/Contents/MacOS/prlctl"}
+  [[ -x "$parallels_cli" ]] || die "Parallels CLI is unavailable"
+
+  key="$HOME/Library/Application Support/crabbox/testboxes/$lease/id_ed25519"
+  [[ -f "$key" && ! -L "$key" && -O "$key" ]] || die "owned CrabBox SSH key not found for lease"
+  known_hosts="$HOME/Library/Application Support/crabbox/testboxes/$lease/known_hosts"
+  [[ -f "$known_hosts" && ! -L "$known_hosts" && -O "$known_hosts" ]] || die "owned CrabBox known-hosts file not found for lease"
+  known_hosts_option=${known_hosts// /\\ }
+  guest_ip=$("$parallels_cli" list -i -f -j "$resource" | python3 -c 'import json,sys; rows=json.load(sys.stdin); addresses=rows[0].get("Network",{}).get("ipAddresses",[]) if rows else []; print(next((item.get("ip","") for item in addresses if item.get("type")=="ipv4"),""),end="")')
+  [[ "$guest_ip" =~ '^[0-9A-Fa-f:.]+$' ]] || die "Parallels returned an invalid guest address"
+
+  secret_file=$(mktemp "$STATE_ROOT/.guest-password-reset.XXXXXXXX")
+  chmod 600 "$secret_file"
+  typeset -g KEYPATH_LAB_SECURE_TEMP="$secret_file"
+  trap '[[ -z ${KEYPATH_LAB_SECURE_TEMP:-} ]] || rm -f "$KEYPATH_LAB_SECURE_TEMP"' EXIT
+  /opt/homebrew/bin/sops -d "$HOME/dotfiles/secrets.env" | awk -F= '$1 == "KEYPATH_LAB_GUEST_PASSWORD" {sub(/^[^=]*=/, ""); printf "%s", $0; found=1} END {if (!found) exit 1}' > "$secret_file" || die "KEYPATH_LAB_GUEST_PASSWORD is unavailable"
+  [[ -s "$secret_file" ]] || die "guest password reset secret is empty"
+
+  fifo="/tmp/keypath-password-reset-$lease-$$.fifo"
+  account_file="/tmp/keypath-password-reset-$lease-$$.account"
+  guest_command="set -euo pipefail; fifo=$(printf %q "$fifo"); account_file=$(printf %q "$account_file"); rm -f \"\$fifo\" \"\$account_file\"; /usr/bin/mkfifo \"\$fifo\"; /usr/sbin/chown keypathqa:staff \"\$fifo\"; /bin/chmod 600 \"\$fifo\"; trap 'rm -f \"\$fifo\"' EXIT; password=; IFS= read -r password < \"\$fifo\"; if /usr/sbin/sysadminctl -resetPasswordFor keypathqa -newPassword \"\$password\" >/dev/null 2>&1 && /usr/bin/dscl . -authonly keypathqa \"\$password\"; then account=keypathqa; else /usr/sbin/sysadminctl -deleteUser keypathmdm >/dev/null 2>&1 || true; /usr/sbin/sysadminctl -addUser keypathmdm -fullName 'KeyPath MDM' -password \"\$password\" -admin >/dev/null; /usr/bin/dscl . -authonly keypathmdm \"\$password\"; /usr/sbin/dseditgroup -o checkmember -m keypathmdm admin | /usr/bin/grep -q 'yes'; account=keypathmdm; fi; printf '%s\n' \"\$account\" > \"\$account_file\"; /bin/chmod 600 \"\$account_file\"; unset password"
+  set +e
+  "$parallels_cli" exec "$resource" /bin/zsh -lc "$(printf %q "$guest_command")" >/dev/null 2>&1 &
+  reset_pid=$!
+  fifo_ready=0
+  for attempt in {1..300}; do
+    if "$GUEST_SSH" -o BatchMode=yes -o StrictHostKeyChecking=yes -o "UserKnownHostsFile=$known_hosts_option" -i "$key" "keypathqa@$guest_ip" \
+      "/bin/test -p $(printf %q "$fifo")" </dev/null >/dev/null 2>&1; then
+      fifo_ready=1
+      break
+    fi
+    sleep 0.1
+  done
+  if (( fifo_ready == 1 )); then
+    { /bin/cat "$secret_file"; printf '\n'; } | \
+      "$GUEST_SSH" -o BatchMode=yes -o StrictHostKeyChecking=yes -o "UserKnownHostsFile=$known_hosts_option" -i "$key" "keypathqa@$guest_ip" \
+        "/bin/zsh -c $(printf %q "/bin/cat > $(printf %q "$fifo")")" >/dev/null 2>&1
+    stream_exit=$?
+  else
+    stream_exit=76
+    kill "$reset_pid" 2>/dev/null || true
+  fi
+  wait "$reset_pid"
+  reset_exit=$?
+  set -e
+  "$parallels_cli" exec "$resource" /bin/rm -f "$fifo" >/dev/null 2>&1 || true
+  enrollment_account=$("$parallels_cli" exec "$resource" /bin/cat "$account_file" 2>/dev/null | tail -1 || true)
+  "$parallels_cli" exec "$resource" /bin/rm -f "$account_file" >/dev/null 2>&1 || true
+  rm -f "$secret_file"
+  KEYPATH_LAB_SECURE_TEMP=
+  trap - EXIT
+  (( stream_exit == 0 && reset_exit == 0 )) || die "failed to reset or provision and verify a disposable enrollment administrator"
+  [[ "$enrollment_account" == "keypathqa" || "$enrollment_account" == "keypathmdm" ]] || die "disposable enrollment administrator result was invalid"
+
+  record_command "$lease" passed reset-guest-password
+  print "guest_password_reset\tpassed"
+  print "credential_verification\tpassed"
+  print "enrollment_account\t$enrollment_account"
 }
 
 rfb_pointer_probe() {
@@ -1296,6 +1371,7 @@ case "$action" in
   scenario) [[ $# -eq 2 ]] || die "scenario requires lease and name"; scenario "$1" "$2" ;;
   desktop-bootstrap) [[ $# -eq 2 ]] || die "desktop-bootstrap requires lease and install-tools flag"; desktop_bootstrap "$@" ;;
   console-login) [[ $# -eq 1 ]] || die "console-login requires lease"; console_login "$1" ;;
+  reset-guest-password) [[ $# -eq 1 ]] || die "reset-guest-password requires lease"; reset_guest_password "$1" ;;
   secure-console-submit) [[ $# -eq 1 ]] || die "secure-console-submit requires lease"; secure_console_submit "$1" ;;
   rfb-pointer-probe) [[ $# -eq 3 ]] || die "rfb-pointer-probe requires lease, x, and y"; rfb_pointer_probe "$@" ;;
   nameplate) [[ $# -eq 2 ]] || die "nameplate requires lease and action"; nameplate_control "$@" ;;

--- a/Scripts/lab/remote.sh
+++ b/Scripts/lab/remote.sh
@@ -1286,10 +1286,12 @@ rfb_pointer_probe() {
   local lease=$1 x=$2 y=$3 manifest macos resource parallels_cli key known_hosts known_hosts_option guest_ip cursor_command before after
   manifest=$(owned_manifest "$lease")
   macos=$(field "$manifest" macos)
-  [[ "$macos" == "27" ]] || die "RFB pointer probe currently supports only the macOS 27 Parallels lane"
+  [[ "$macos" == "26" || "$macos" == "27" ]] || die "RFB pointer probe currently supports only the macOS 26 and 27 Parallels lanes"
   [[ "$(field "$manifest" provider)" == "parallels" ]] || die "RFB pointer probe requires a Parallels lease"
   [[ "$(field "$manifest" desktop_enabled)" == "true" ]] || die "RFB pointer probe requires a desktop-enabled lease"
-  [[ "$(field "$manifest" console_login_status)" == "passed" ]] || die "RFB pointer probe requires a verified console login"
+  if [[ "$macos" == "27" ]]; then
+    [[ "$(field "$manifest" console_login_status)" == "passed" ]] || die "RFB pointer probe requires a verified console login on macOS 27"
+  fi
   [[ "$x" == <-> && "$y" == <-> ]] || die "RFB pointer coordinates must be non-negative integers"
   resource=$(field "$manifest" provider_resource)
   [[ "$resource" =~ '^[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}$' ]] || die "invalid Parallels resource id"

--- a/Scripts/lab/remote.sh
+++ b/Scripts/lab/remote.sh
@@ -230,6 +230,22 @@ assert_provider_capacity() {
   fi
 }
 
+assert_managed_identity_available() {
+  local lane=$1 manifest cleanup lease_status expires existing_lease
+  [[ "$lane" == managed-functional ]] || return 0
+  for manifest in "$LEASES"/*/manifest.tsv(N); do
+    [[ "$(field "$manifest" owner)" == "$OWNER" ]] || continue
+    [[ "$(field "$manifest" test_lane)" == managed-functional ]] || continue
+    cleanup=$(field "$manifest" cleanup_status)
+    lease_status=$(field "$manifest" status)
+    expires=$(field "$manifest" expires_epoch)
+    [[ "$cleanup" != complete && "$lease_status" != destroyed && "$expires" == <-> && "$expires" -gt "$(now_epoch)" ]] || continue
+    existing_lease=$(field "$manifest" lease_id)
+    print -u2 "managed_identity_busy\tactive_lease=$existing_lease\tstatus=$lease_status\texpires_epoch=$expires"
+    return 75
+  done
+}
+
 record_command() {
   local lease=$1 result=$2; shift 2
   local command_text
@@ -246,6 +262,45 @@ prepare_worktree() {
     ':(exclude).crabbox/captures/**' \
     ':(exclude).crabbox/runs/**')
   [[ -z "$changes" ]] || die "refusing to sync a changing checkout"
+}
+
+rehydrate_managed_clone() {
+  local lease=$1 manifest repo provider_resource profile_dir guest_policy guest_repo parallels_cli evidence filename
+  manifest=$(owned_manifest "$lease")
+  repo=$(field "$manifest" worktree)
+  provider_resource=$(field "$manifest" provider_resource)
+  profile_dir="$repo/.keypath-lab/managed-policy"
+  guest_policy=/Library/KeyPathLab/managed-policy
+  guest_repo="/Users/keypathqa/crabbox/$lease/repo"
+  evidence="$ARTIFACTS/$lease/managed-policy"
+  for filename in keypath-pppc.mobileconfig keypath-system-extension.mobileconfig keypath-service-management.mobileconfig manifest.json; do
+    [[ -f "$profile_dir/$filename" && ! -L "$profile_dir/$filename" ]] || die "managed policy archive is missing: $filename"
+  done
+  if [[ "${KEYPATH_LAB_TESTING:-0}" == "1" ]]; then
+    mkdir -p "$evidence"
+    cp "$profile_dir/manifest.json" "$evidence/manifest.json"
+    print "managed_policy_rehydration\tpassed"
+    return
+  fi
+  [[ "$provider_resource" =~ '^[A-Fa-f0-9-]{36}$' ]] || die "invalid managed Parallels resource id"
+  parallels_cli=${KEYPATH_LAB_PRLCTL:-"/Applications/Parallels Desktop.app/Contents/MacOS/prlctl"}
+  [[ -x "$parallels_cli" ]] || die "Parallels CLI is unavailable"
+  "$parallels_cli" exec "$provider_resource" /bin/mkdir -p "$guest_policy"
+  for filename in keypath-pppc.mobileconfig keypath-system-extension.mobileconfig keypath-service-management.mobileconfig manifest.json; do
+    "$parallels_cli" exec "$provider_resource" /usr/bin/tee "$guest_policy/$filename" < "$profile_dir/$filename" >/dev/null
+  done
+  "$parallels_cli" exec "$provider_resource" /bin/chmod 444 \
+    "$guest_policy/keypath-pppc.mobileconfig" \
+    "$guest_policy/keypath-system-extension.mobileconfig" \
+    "$guest_policy/keypath-service-management.mobileconfig" \
+    "$guest_policy/manifest.json"
+  "$repo/Scripts/lab/mdm/publish-managed-profiles" \
+    --profile-dir "$profile_dir" \
+    --evidence-dir "$evidence"
+  "$parallels_cli" exec "$provider_resource" \
+    "$guest_repo/Scripts/lab/mdm/verify-lane" managed-functional \
+    --manifest "$guest_policy/manifest.json"
+  print "managed_policy_rehydration\tpassed"
 }
 
 run_with_download() {
@@ -445,7 +500,7 @@ lease_candidate_from_line() {
 
 create_lease() {
   local macos=$1 lane=$2 archive_key=$3 commit=$4 installer_sha=$5 installer_name=$6 ttl=$7 desktop=$8
-  local launcher provider archive repo slug output lease created expires manifest guest_output product build operation ttl_seconds provider_resource create_status candidate_file create_log exit_code
+  local launcher provider archive repo slug output lease created expires manifest guest_output product build operation ttl_seconds provider_resource create_status candidate_file create_log exit_code managed_policy_exit
   launcher=$(launcher_for "$macos")
   provider=$(provider_for "$macos")
   [[ "$lane" == "managed-functional" || "$lane" == "unmanaged-ui" ]] || die "invalid test lane: $lane"
@@ -468,6 +523,7 @@ create_lease() {
     sleep "$KEYPATH_LAB_TEST_PAUSE_AFTER_ADMISSION_LOCK"
   fi
   assert_provider_capacity "$provider" || return $?
+  assert_managed_identity_available "$lane" || return $?
   assert_internal_disk_reserve || return $?
   created=$(now_epoch)
   expires=$((created + ttl_seconds))
@@ -540,6 +596,22 @@ create_lease() {
   build=$(print -r -- "$guest_output" | sed -n 's/^build=//p' | tail -1)
   set_field "$manifest" macos_product_version "${product:-unknown}"
   set_field "$manifest" macos_build "${build:-unknown}"
+  if [[ "$lane" == managed-functional ]]; then
+    set +e
+    rehydrate_managed_clone "$lease" > "$LOGS/$lease/managed-policy.log" 2>&1
+    managed_policy_exit=$?
+    set -e
+    set_field "$manifest" managed_policy_result "$managed_policy_exit"
+    set_field "$manifest" managed_policy_at "$(utc_now)"
+    cat "$LOGS/$lease/managed-policy.log"
+    if ((managed_policy_exit != 0)); then
+      set_field "$manifest" status managed-policy-failed
+      release_admission_lock
+      trap - EXIT INT TERM HUP
+      return "$managed_policy_exit"
+    fi
+    record_command "$lease" passed managed-policy-rehydration
+  fi
   set_field "$manifest" status ready
   record_command "$lease" passed sw_vers
   release_admission_lock

--- a/Scripts/lab/tests/keypath-lab-tests.sh
+++ b/Scripts/lab/tests/keypath-lab-tests.sh
@@ -568,6 +568,11 @@ run_remote destroy cbx_desktop27 >/dev/null
 
 desktop26_create=$(run_remote create 26 unmanaged-ui "$archive_key" "$commit" "$checksum" KeyPath.zip 2h 1)
 assert_contains "$desktop26_create" $'lease_id\tcbx_desktop26'
+rfb_probe26=$(KEYPATH_LAB_TEST_SSH_KEY="$TMP/test-ssh-key" KEYPATH_LAB_TEST_CURSOR_BEFORE='10 10' KEYPATH_LAB_TEST_CURSOR_AFTER='170 130' KEYPATH_LAB_RFB_POINTER_SETTLE_SECONDS=0 run_remote rfb-pointer-probe cbx_desktop26 170 130)
+assert_contains "$rfb_probe26" $'rfb_pointer_probe\tpassed'
+assert_contains "$rfb_probe26" $'cursor_before\t10 10'
+assert_contains "$rfb_probe26" $'cursor_after\t170 130'
+grep -q 'crabbox desktop click --provider parallels --target macos --id cbx_desktop26 --x 170 --y 130' "$CALLS"
 desktop26_artifacts=$(run_remote artifacts cbx_desktop26)
 assert_contains "$desktop26_artifacts" $'screenshot_status\t0'
 grep -q 'prlctl capture 00000000-0000-0000-0000-000000000000 --file' "$CALLS"

--- a/Scripts/lab/tests/keypath-lab-tests.sh
+++ b/Scripts/lab/tests/keypath-lab-tests.sh
@@ -260,6 +260,11 @@ repo="$ROOT/KeyPathInstallerLab/archives/$archive_key/repo"
 mkdir -p "$repo/.keypath-lab/installer" "$repo/Scripts/lab/scenarios"
 cp "$LAB_DIR/scenarios/installer-scenario" "$repo/Scripts/lab/scenarios/installer-scenario"
 cp "$LAB_DIR/nameplate-instrumentation" "$repo/Scripts/lab/nameplate-instrumentation"
+mkdir -p "$repo/.keypath-lab/managed-policy"
+for profile in keypath-pppc.mobileconfig keypath-system-extension.mobileconfig keypath-service-management.mobileconfig; do
+    printf '<plist version="1.0"><dict/></plist>\n' > "$repo/.keypath-lab/managed-policy/$profile"
+done
+printf '{"lane":"managed-functional"}\n' > "$repo/.keypath-lab/managed-policy/manifest.json"
 chmod +x "$repo/Scripts/lab/scenarios/installer-scenario"
 chmod +x "$repo/Scripts/lab/nameplate-instrumentation"
 echo installer > "$repo/.keypath-lab/installer/KeyPath.zip"
@@ -357,6 +362,21 @@ printf 'pid\t%s\nprovider\ttart\n' "$$" > "$ROOT/KeyPathInstallerLab/provider-ad
 parallel_provider_create=$(run_remote create 26 unmanaged-ui "$archive_key" "$commit" "$checksum" KeyPath.zip 2h 0)
 assert_contains "$parallel_provider_create" $'lease_id\tcbx_test26'
 run_remote destroy cbx_test26 >/dev/null
+
+managed_create=$(run_remote create 26 managed-functional "$archive_key" "$commit" "$checksum" KeyPath.zip 2h 0)
+assert_contains "$managed_create" $'managed_policy_rehydration\tpassed'
+assert_contains "$managed_create" $'lease_id\tcbx_test26'
+managed_manifest="$ROOT/KeyPathInstallerLab/leases/cbx_test26/manifest.tsv"
+grep -q $'managed_policy_result\t0' "$managed_manifest"
+grep -q $'managed-policy-rehydration' "$ROOT/KeyPathInstallerLab/leases/cbx_test26/commands.tsv"
+set +e
+managed_busy_output=$(run_remote create 26 managed-functional "$archive_key" "$commit" "$checksum" KeyPath.zip 2h 0 2>&1)
+managed_busy_exit=$?
+set -e
+[[ $managed_busy_exit -eq 75 ]] || { echo "expected managed identity contention to exit 75, got $managed_busy_exit" >&2; exit 1; }
+assert_contains "$managed_busy_output" $'managed_identity_busy\tactive_lease=cbx_test26'
+run_remote destroy cbx_test26 >/dev/null
+
 set +e
 lock_output=$(KEYPATH_LAB_ADMISSION_WAIT_ATTEMPTS=1 run_remote create 15 unmanaged-ui "$archive_key" "$commit" "$checksum" KeyPath.zip 2h 0 2>&1)
 lock_exit=$?

--- a/docs/testing/installer-gui-automation-capabilities.md
+++ b/docs/testing/installer-gui-automation-capabilities.md
@@ -85,7 +85,9 @@ The remaining core capabilities are:
 5. Hardened macOS 26 and macOS 27 selectors before those OS versions can claim
    the same unattended UI coverage as macOS 15. The macOS 27 console session,
    secret-safe Remote Management authorization, and RFB event delivery are now
-   proven; selector capture and composition remain.
+   proven. The macOS 26 pointer probe is implemented and fails closed when RFB
+   authentication is not configured; selector capture, Remote Management base
+   setup, and composition remain.
 
 Clean install, repair, upgrade, reboot, uninstall, reinstall, cancellation,
 nightly, and pairwise entries are consumers of those foundations. They are

--- a/docs/testing/managed-vm-lanes.md
+++ b/docs/testing/managed-vm-lanes.md
@@ -120,8 +120,8 @@ macOS 26.2 and later, the managed Accessibility switches can appear enabled
 while the system has no corresponding TCC grant. Runtime admission must require
 KeyPath's independent permission result and must fail in that state.
 
-Apple's replacement is the declarative
-`com.apple.configuration.app-settings` configuration. Until the lab publishes
-and verifies that declaration, macOS 26.2 and later cannot claim a deterministic
-managed Accessibility lane. macOS 27 also removes the legacy PPPC behavior
-entirely.
+[Apple's replacement](https://developer.apple.com/documentation/devicemanagement/privacypreferencespolicycontrol/services-data.dictionary)
+is the declarative `com.apple.configuration.app-settings` configuration. Until
+the lab publishes and verifies that declaration, macOS 26.2 and later cannot
+claim a deterministic managed Accessibility lane. macOS 27 also removes the
+legacy PPPC behavior entirely.

--- a/docs/testing/managed-vm-lanes.md
+++ b/docs/testing/managed-vm-lanes.md
@@ -114,7 +114,14 @@ Scripts/lab/mdm/tests/managed-capability-probe-tests.sh
 
 ## OS boundary
 
-The generated PPPC profile is for macOS 15 and 26. Accessibility grants through
-PPPC are deprecated as of macOS 26.2, and macOS 27 removes the legacy managed
-privacy behavior. Until the macOS 27 spike passes, it must not claim the same
-managed permission lane.
+The generated legacy PPPC profile remains an admission input for macOS 15 and
+26, but its Accessibility grant is functional only before macOS 26.2. On
+macOS 26.2 and later, the managed Accessibility switches can appear enabled
+while the system has no corresponding TCC grant. Runtime admission must require
+KeyPath's independent permission result and must fail in that state.
+
+Apple's replacement is the declarative
+`com.apple.configuration.app-settings` configuration. Until the lab publishes
+and verifies that declaration, macOS 26.2 and later cannot claim a deterministic
+managed Accessibility lane. macOS 27 also removes the legacy PPPC behavior
+entirely.

--- a/docs/testing/managed-vm-lanes.md
+++ b/docs/testing/managed-vm-lanes.md
@@ -85,6 +85,14 @@ The lane is recorded in the lease manifest and determines the base name. It
 cannot be changed after creation. Managed macOS 27 creation is rejected until
 that policy has been proven.
 
+For a managed lease, `create` derives a fresh policy set from that exact signed
+installer, copies the manifest into the clone, publishes all three profiles,
+waits for NanoMDM acknowledgements, queries the installed profile inventory,
+and runs system-level lane admission before reporting the lease ready. Policy
+publication fails closed if NanoMDM has zero or multiple enrollment identities.
+Only one live managed-functional lease is admitted while clones share the base
+enrollment identity.
+
 After installation, managed tests must still verify behavior: KeyPath and the
 runtime report Accessibility and Input Monitoring, the VirtualHID extension is
 active, background services are approved, Kanata is running, and TCP readiness

--- a/docs/testing/managed-vm-lanes.md
+++ b/docs/testing/managed-vm-lanes.md
@@ -7,7 +7,7 @@ base image is cloned for a test and is never itself used as a test machine.
 
 | Lane | Base state | Purpose |
 | --- | --- | --- |
-| `managed-functional` | MDM enrolled; KeyPath PPPC, system-extension, and service-management profiles installed; KeyPath never installed | Deterministic install, use, repair, upgrade, and uninstall scenarios without testing Apple's approval UI |
+| `managed-functional` | MDM enrolled; KeyPath PPPC, system-extension, and service-management profiles installed; KeyPath never installed | Deterministic system-extension, service-management, install, repair, upgrade, and uninstall scenarios; Input Monitoring still uses Apple's approval UI |
 | `unmanaged-ui` | No MDM enrollment, lab profiles, KeyPath installation, or KeyPath TCC history | A small set of tests that verify KeyPath correctly explains and responds to real macOS approval prompts |
 
 Do not convert a clone from one lane into the other. Enrollment, TCC,
@@ -42,6 +42,12 @@ The generator derives PPPC designated requirements from the signed app. It
 fails if the expected KeyPath identifiers or team change, rather than silently
 creating an overly broad profile. The VirtualHID system extension remains
 restricted to its upstream team and extension identifier.
+
+Apple does not allow an MDM profile to grant `ListenEvent` (Input Monitoring).
+The PPPC payload therefore uses `AllowStandardUserToSetSystemService`, which
+lets a standard user make that choice without administrator authorization but
+does not make the choice for them. Managed functional tests must complete and
+verify the genuine Input Monitoring approval before claiming runtime readiness.
 
 ## Clone identity and MDM
 
@@ -100,6 +106,7 @@ Scripts/lab/mdm/tests/managed-capability-probe-tests.sh
 
 ## OS boundary
 
-The generated PPPC profile is for macOS 15 and 26. macOS 27 changes managed
-privacy consent and needs its own separately proven configuration. Until that
-spike passes, macOS 27 must not claim the same deterministic permission lane.
+The generated PPPC profile is for macOS 15 and 26. Accessibility grants through
+PPPC are deprecated as of macOS 26.2, and macOS 27 removes the legacy managed
+privacy behavior. Until the macOS 27 spike passes, it must not claim the same
+managed permission lane.

--- a/docs/testing/p01-unmanaged-input-monitoring-spike.md
+++ b/docs/testing/p01-unmanaged-input-monitoring-spike.md
@@ -76,9 +76,9 @@ Continue in this order:
 
 1. Use the proven KeyPath-owned input event as P02's input and observe the
    remapped VirtualHID output.
-2. Prove the managed-functional PPPC profile grants ListenEvent to the exact
-   signed launcher requirement. This is the preferred non-hardware functional
-   lane once the lab MDM path is available.
+2. Prove the managed-functional PPPC profile targets the exact signed launcher
+   requirement and allows a standard user to approve ListenEvent without admin
+   authorization. Apple does not permit MDM to grant ListenEvent directly.
 3. If PPPC cannot target this raw executable reliably, spike packaging the
    launcher as a properly signed app bundle or service whose designated
    requirement macOS can represent consistently in TCC and MDM.

--- a/docs/testing/p02-virtualhid-output-proof.md
+++ b/docs/testing/p02-virtualhid-output-proof.md
@@ -10,9 +10,9 @@ is Kanata Accessibility.
 The legacy PPPC payload draws the launcher and engine Accessibility switches as
 managed and enabled, but macOS 26.2 and later no longer honor an Accessibility
 grant from that payload. KeyPath's independent oracle correctly finds no
-Accessibility TCC record and refuses to call the runtime operational. Apple
-documents the replacement as the declarative
-`com.apple.configuration.app-settings` configuration.
+Accessibility TCC record and refuses to call the runtime operational.
+[Apple documents the replacement](https://developer.apple.com/documentation/devicemanagement/privacypreferencespolicycontrol/services-data.dictionary)
+as the declarative `com.apple.configuration.app-settings` configuration.
 
 The smaller alternative is a managed macOS 15 lane, where the legacy
 Accessibility grant remains supported and the lab already has native VNC input

--- a/docs/testing/p02-virtualhid-output-proof.md
+++ b/docs/testing/p02-virtualhid-output-proof.md
@@ -2,16 +2,53 @@
 
 ## Current result
 
-P02 is not yet proven. The unmanaged macOS 15 lane reaches the genuine
-VirtualHID Driver Extension control, but the operating system still reports the
-extension as `activated waiting for user` after the current supported UI-driven
-attempt. Until that becomes `activated enabled`, a `q` to `w` remapping result
-in a focused app would not be attributable to KeyPath's normal VirtualHID
-output path.
+P02 is not yet proven. A managed macOS 26.5.2 lease now proves the helper,
+DriverKit extension, VirtualHID daemon, exact installer-derived profile
+publication, and genuine Input Monitoring approval. The remaining runtime gate
+is Kanata Accessibility.
+
+The legacy PPPC payload draws the launcher and engine Accessibility switches as
+managed and enabled, but macOS 26.2 and later no longer honor an Accessibility
+grant from that payload. KeyPath's independent oracle correctly finds no
+Accessibility TCC record and refuses to call the runtime operational. Apple
+documents the replacement as the declarative
+`com.apple.configuration.app-settings` configuration.
+
+The smaller alternative is a managed macOS 15 lane, where the legacy
+Accessibility grant remains supported and the lab already has native VNC input
+and `desktop-type`. The controller correctly targets
+`keypath-macos-15-managed`, but that base does not exist yet.
 
 This is an approval-lane limitation, not a confirmed KeyPath remapping defect.
 Do not turn it into a product bug or bypass it by modifying system-extension or
 privacy databases.
+
+## Managed macOS 26 evidence on July 23, 2026
+
+Lease `cbx_30fc557d2c01` used macOS 26.5.2 (`25F84`), KeyPath commit
+`03b3858dd200c9645265f6e9bf519359c834d2e4`, and signed installer SHA-256
+`8dcbc201ce9333f5afff305fdd0956863613b45542556f81e6382fb772be87f4`.
+Final artifacts are retained at:
+
+`/Volumes/KeyPath Lab/CrabBox/KeyPathInstallerLab/artifacts/cbx_30fc557d2c01/20260724T003624Z`
+
+The lease proved:
+
+1. Automatic exact-policy publication, acknowledgement, ProfileList inventory,
+   and system-level managed admission.
+2. A fresh helper at version `1.1.0`.
+3. The VirtualHID system extension at `activated enabled`.
+4. A healthy VirtualHID daemon and device.
+5. Real console clicks enabling the `Kanata Engine` and `kanata-launcher`
+   Input Monitoring rows.
+6. A system TCC result of `2` (granted) for the launcher's
+   `kTCCServiceListenEvent` entry.
+
+The same log showed no user or system TCC entry for
+`kTCCServiceAccessibility`, despite the managed-on switch. Repair therefore
+failed closed with Kanata not running or TCP responsive. The lab also extended
+its Parallels RFB pointer probe to macOS 26; this clone rejected RFB
+authentication, so no native input assertion was claimed.
 
 ## Evidence captured on July 12, 2026
 
@@ -87,11 +124,17 @@ proof.
 
 ## Resume path
 
-Prefer the managed-functional lane once lab MDM/APNs enrollment is available.
-It can pre-approve the signed KeyPath PPPC, DriverKit, and service-management
-requirements without asking the test to exercise Apple's approval UI. Verify
-the lane admission contract before installation, then run the proof shape
-above.
+Choose one explicit path:
+
+1. Build and admit `keypath-macos-15-managed`, then run the proof shape above
+   with the existing Tart `protected-click` and `desktop-type` primitives.
+2. Add NanoMDM Declarative Device Management support and publish an
+   `com.apple.configuration.app-settings` Accessibility configuration for
+   macOS 26.2 and later.
+
+The macOS 15 base is the smaller route to P02. The declarative route is the
+durable macOS 26 and 27 investment. Do not continue treating successful
+installation of the legacy macOS 26 PPPC payload as an Accessibility grant.
 
 Keep the unmanaged lane for a small number of real approval-flow tests. If its
 DriverKit state remains `activated waiting for user`, preserve the command


### PR DESCRIPTION
## What changed

- adds a NanoMDM-backed managed-functional lane with exact installer-derived PPPC, system-extension, and service-management policy
- rehydrates managed policy automatically for each sequential disposable clone and fails closed on ambiguous enrollment identity or admission mismatch
- adds managed-capability probes, macOS 26 RFB probe coverage, and focused shell tests
- documents the macOS 26.2 Accessibility boundary and the two supported P02 continuation paths

## Why

The lab previously mixed managed preparation with runtime proof and could report a clone ready without proving that the exact policy for its installer was published and acknowledged. macOS 26.2 also presents legacy managed Accessibility switches as enabled while withholding the TCC grant, so that state must be recorded as an OS boundary rather than a KeyPath failure.

## Impact

Sequential managed clones now converge automatically and fail closed. P02 has reliable evidence for helper, DriverKit, VirtualHID, and Input Monitoring health, with Accessibility explicitly routed to either a macOS 15 legacy lane or declarative app-settings support.

## Validation

- `Scripts/lab/mdm/tests/profile-generator-tests.sh`
- `Scripts/lab/mdm/tests/publish-managed-profiles-tests.sh`
- `Scripts/lab/mdm/tests/managed-capability-probe-tests.sh`
- `Scripts/lab/tests/keypath-lab-tests.sh`
- fresh macOS 26.5.2 managed lease with retained artifacts

Local review gate selected the enforced remote `claude-review` path; this PR must not merge until that check passes.