### PR TITLE
Show recommended issues in dashboard queue

### DIFF
--- a/Scripts/lab/tests/issue-dashboard-tests.py
+++ b/Scripts/lab/tests/issue-dashboard-tests.py
@@ -34,6 +34,12 @@ class IssueDashboardTests(unittest.TestCase):
         self.assertIn("id=\"metric-hold\"", fragment)
         self.assertIn("hold:'On hold'", fragment)
 
+    def test_recommended_next_is_a_distinct_visible_dashboard_state(self) -> None:
+        fragment = (REPO_ROOT / "docs/testing/keypath-github-issues-dashboard.fragment.html").read_text()
+        self.assertIn("data-status=\"next\"", fragment)
+        self.assertIn("next-mark", fragment)
+        self.assertIn("next:'Recommended next'", fragment)
+
     def test_topic_labels_do_not_imply_execution_state(self) -> None:
         self.assertEqual(module.issue_status(issue(912, "wwdc26", "enhancement")), "feature")
         self.assertEqual(module.issue_status(issue(919, "wwdc26", "human-in-loop")), "human")
@@ -49,6 +55,14 @@ class IssueDashboardTests(unittest.TestCase):
     def test_recommended_next_overrides_feature_classification(self) -> None:
         self.assertEqual(
             module.issue_status(issue(870, "enhancement", "agent-ok", "recommended-next")),
+            "next",
+        )
+        self.assertEqual(
+            module.issue_status(issue(870, "recommended-next", "human-in-loop")),
+            "human",
+        )
+        self.assertEqual(
+            module.issue_status(issue(870, "recommended-next", "large-refactor")),
             "next",
         )
 

--- a/Scripts/lab/tests/issue-dashboard-tests.py
+++ b/Scripts/lab/tests/issue-dashboard-tests.py
@@ -26,6 +26,7 @@ class IssueDashboardTests(unittest.TestCase):
         self.assertEqual(module.issue_status(issue(982, "human-in-loop", "on-hold")), "hold")
         self.assertEqual(module.issue_status(issue(604, "testing", "tracking-only")), "deferred")
         self.assertEqual(module.issue_status(issue(865, "enhancement", "tracking-only", "on-hold")), "hold")
+        self.assertEqual(module.issue_status(issue(870, "recommended-next", "on-hold")), "hold")
 
     def test_on_hold_is_a_distinct_visible_dashboard_state(self) -> None:
         fragment = (REPO_ROOT / "docs/testing/keypath-github-issues-dashboard.fragment.html").read_text()
@@ -44,6 +45,12 @@ class IssueDashboardTests(unittest.TestCase):
         self.assertEqual(module.issue_status(issue(1, "bug")), "queued")
         self.assertEqual(module.issue_status(issue(2, "testing")), "queued")
         self.assertEqual(module.issue_status(issue(3, "tech-debt")), "queued")
+
+    def test_recommended_next_overrides_feature_classification(self) -> None:
+        self.assertEqual(
+            module.issue_status(issue(870, "enhancement", "agent-ok", "recommended-next")),
+            "next",
+        )
 
     def test_issue_limit_is_explicit(self) -> None:
         self.assertEqual(module.ISSUE_LIMIT, 200)

--- a/Scripts/lab/update-issue-dashboard
+++ b/Scripts/lab/update-issue-dashboard
@@ -23,6 +23,8 @@ def issue_status(issue: dict) -> str:
         return "deferred"
     if "human-in-loop" in labels:
         return "human"
+    if "recommended-next" in labels:
+        return "next"
     if "large-refactor" in labels:
         return "deferred"
     if labels & {"Feature", "feature-gap", "enhancement"}:


### PR DESCRIPTION
## What changed

- classify open issues carrying `recommended-next` as the dashboard's existing `next` state
- preserve explicit `on-hold`, tracking, and human-gated precedence
- add focused coverage for both the recommendation and hold-precedence cases

## Why

The issue dashboard already rendered a `Recommended next` state, and #870, #867, and #866 already carry that label, but the feed generator classified them as ordinary deferred feature work. That left the visible agent queue at zero and hid the intended work sequence.

## Impact

After the feed refreshes, the dashboard reports the three labeled issues as recommended next while continuing to keep held issues paused.

## Validation

- `python3 Scripts/lab/tests/issue-dashboard-tests.py` — 12 tests passed
- live feed generation to a temporary file — counts `next: 3`; #870, #867, and #866 classified as `next`
- `python3 Scripts/check-accessibility.py` — all 354 checked files passed
- `git diff --check`

## Review gate

Local review tooling selected the remote review gate. Do not merge until GitHub `claude-review` passes.