### PR TITLE
Define rule dependency graph model

### DIFF
--- a/Sources/KeyPathRulesCore/RuleDependencyGraph.swift
+++ b/Sources/KeyPathRulesCore/RuleDependencyGraph.swift
@@ -1,0 +1,261 @@
+import Foundation
+
+/// A canonical layer identifier used by rule dependency capabilities.
+///
+/// Layer names are open-ended because custom rules and packs can introduce
+/// them. Canonicalizing at this boundary prevents equivalent Kanata layer names
+/// such as `FUN` and ` fun ` from producing different graph nodes.
+public struct RuleLayerIdentifier: RawRepresentable, Hashable, Sendable {
+    public let rawValue: String
+
+    public init(rawValue: String) {
+        self.rawValue = rawValue
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+    }
+
+    public init(_ rawValue: String) {
+        self.init(rawValue: rawValue)
+    }
+
+    public init(_ layer: RuleCollectionLayer) {
+        self.init(rawValue: layer.kanataName)
+    }
+}
+
+/// Named aliases that one rule can expose for another rule to consume.
+public enum RuleKeyAlias: String, Hashable, Sendable {
+    case hyper
+}
+
+/// A typed unit of rule behavior that can be provided or required.
+public enum RuleCapability: Hashable, Sendable {
+    /// A layer contains useful mappings or generated behavior.
+    case layerContent(RuleLayerIdentifier)
+
+    /// A functional path reaches or activates a layer.
+    case layerActivation(RuleLayerIdentifier)
+
+    /// A named alias is defined with the expected behavior.
+    case keyAlias(RuleKeyAlias)
+}
+
+/// Structured context explaining why a rule requires a capability.
+///
+/// This is deliberately presentation-free. Later UI can format the same
+/// evidence differently for dialogs, accessibility, CLI output, or diagnostics.
+public enum RuleDependencyEvidence: Hashable, Sendable {
+    case keys([String])
+    case layerPath(source: RuleLayerIdentifier, target: RuleLayerIdentifier)
+    case configuration(field: String, value: String)
+    case mappingIDs([UUID])
+
+    fileprivate var normalized: Self {
+        switch self {
+        case let .keys(keys):
+            .keys(Array(Set(keys)).sorted())
+        case let .layerPath(source, target):
+            .layerPath(
+                source: RuleLayerIdentifier(source.rawValue),
+                target: RuleLayerIdentifier(target.rawValue)
+            )
+        case let .configuration(field, value):
+            .configuration(field: field, value: value)
+        case let .mappingIDs(ids):
+            .mappingIDs(Array(Set(ids)).sorted(by: Self.uuidLessThan))
+        }
+    }
+
+    fileprivate var stableSortKey: String {
+        switch self {
+        case let .keys(keys):
+            "0|\(keys.joined(separator: "\u{1F}"))"
+        case let .layerPath(source, target):
+            "1|\(source.rawValue)|\(target.rawValue)"
+        case let .configuration(field, value):
+            "2|\(field)|\(value)"
+        case let .mappingIDs(ids):
+            "3|\(ids.map(\.uuidString).joined(separator: "|"))"
+        }
+    }
+
+    private static func uuidLessThan(_ lhs: UUID, _ rhs: UUID) -> Bool {
+        lhs.uuidString < rhs.uuidString
+    }
+}
+
+/// A capability requirement plus the configuration evidence that created it.
+public struct RuleRequirement: Hashable, Sendable {
+    public let capability: RuleCapability
+    public let evidence: Set<RuleDependencyEvidence>
+
+    public init(
+        capability: RuleCapability,
+        evidence: Set<RuleDependencyEvidence> = []
+    ) {
+        self.capability = capability
+        self.evidence = evidence
+    }
+
+    /// Evidence in deterministic order for query and presentation adapters.
+    public var sortedEvidence: [RuleDependencyEvidence] {
+        evidence.sorted { $0.stableSortKey < $1.stableSortKey }
+    }
+
+    fileprivate var normalized: Self {
+        RuleRequirement(
+            capability: capability,
+            evidence: Set(evidence.map(\.normalized))
+        )
+    }
+
+    fileprivate var stableSortKey: String {
+        let evidenceKey = sortedEvidence
+            .map(\.stableSortKey)
+            .joined(separator: "\u{1E}")
+        return "\(capability.stableSortKey)|\(evidenceKey)"
+    }
+}
+
+/// One collection's dependency contribution to a graph snapshot.
+///
+/// Family-specific extraction from `RuleCollection` intentionally lives in
+/// issue #867. Keeping this input generic makes the graph independently
+/// testable and reusable by future import, pack, and CLI validation paths.
+public struct RuleDependencyContribution: Equatable, Sendable {
+    public let collectionID: UUID
+    public let isEnabled: Bool
+    public let provides: Set<RuleCapability>
+    public let requirements: Set<RuleRequirement>
+
+    public init(
+        collectionID: UUID,
+        isEnabled: Bool,
+        provides: Set<RuleCapability> = [],
+        requirements: Set<RuleRequirement> = []
+    ) {
+        self.collectionID = collectionID
+        self.isEnabled = isEnabled
+        self.provides = provides
+        self.requirements = requirements
+    }
+}
+
+/// A deterministic snapshot of capabilities across the known rule catalog.
+///
+/// Lookup indexes retain disabled providers so callers can distinguish
+/// "missing now" from "available to enable." The graph is derived data and
+/// should be rebuilt whenever the analyzed collection configuration changes.
+public struct RuleDependencyGraph: Equatable, Sendable {
+    public let enabledCollectionIDs: Set<UUID>
+    public let capabilitiesByCollection: [UUID: Set<RuleCapability>]
+    public let requirementsByCollection: [UUID: Set<RuleRequirement>]
+    public let providersByCapability: [RuleCapability: Set<UUID>]
+    public let activeProvidersByCapability: [RuleCapability: Set<UUID>]
+
+    private init(
+        enabledCollectionIDs: Set<UUID>,
+        capabilitiesByCollection: [UUID: Set<RuleCapability>],
+        requirementsByCollection: [UUID: Set<RuleRequirement>],
+        providersByCapability: [RuleCapability: Set<UUID>],
+        activeProvidersByCapability: [RuleCapability: Set<UUID>]
+    ) {
+        self.enabledCollectionIDs = enabledCollectionIDs
+        self.capabilitiesByCollection = capabilitiesByCollection
+        self.requirementsByCollection = requirementsByCollection
+        self.providersByCapability = providersByCapability
+        self.activeProvidersByCapability = activeProvidersByCapability
+    }
+
+    /// Builds a graph in linear time over the supplied contributions and edges.
+    ///
+    /// Multiple contributions for one collection are merged. This supports
+    /// independent extractors without making ordering part of graph semantics.
+    public static func build(from contributions: [RuleDependencyContribution]) -> Self {
+        var enabledCollectionIDs: Set<UUID> = []
+        var capabilitiesByCollection: [UUID: Set<RuleCapability>] = [:]
+        var requirementsByCollection: [UUID: Set<RuleRequirement>] = [:]
+        var providersByCapability: [RuleCapability: Set<UUID>] = [:]
+
+        for contribution in contributions {
+            if contribution.isEnabled {
+                enabledCollectionIDs.insert(contribution.collectionID)
+            }
+
+            capabilitiesByCollection[contribution.collectionID, default: []]
+                .formUnion(contribution.provides)
+            requirementsByCollection[contribution.collectionID, default: []]
+                .formUnion(contribution.requirements.map(\.normalized))
+
+            for capability in contribution.provides {
+                providersByCapability[capability, default: []]
+                    .insert(contribution.collectionID)
+            }
+        }
+
+        var activeProvidersByCapability: [RuleCapability: Set<UUID>] = [:]
+        activeProvidersByCapability.reserveCapacity(providersByCapability.count)
+        for (capability, providers) in providersByCapability {
+            let activeProviders = providers.intersection(enabledCollectionIDs)
+            if !activeProviders.isEmpty {
+                activeProvidersByCapability[capability] = activeProviders
+            }
+        }
+
+        return RuleDependencyGraph(
+            enabledCollectionIDs: enabledCollectionIDs,
+            capabilitiesByCollection: capabilitiesByCollection,
+            requirementsByCollection: requirementsByCollection,
+            providersByCapability: providersByCapability,
+            activeProvidersByCapability: activeProvidersByCapability
+        )
+    }
+
+    /// All known collections in deterministic UUID order.
+    public var collectionIDs: [UUID] {
+        Set(capabilitiesByCollection.keys)
+            .union(requirementsByCollection.keys)
+            .sorted(by: Self.uuidLessThan)
+    }
+
+    /// All known providers, including disabled collections.
+    public func knownProviders(for capability: RuleCapability) -> [UUID] {
+        providersByCapability[capability, default: []]
+            .sorted(by: Self.uuidLessThan)
+    }
+
+    /// Providers enabled in this graph snapshot.
+    public func activeProviders(for capability: RuleCapability) -> [UUID] {
+        activeProvidersByCapability[capability, default: []]
+            .sorted(by: Self.uuidLessThan)
+    }
+
+    /// Capabilities contributed by a collection in deterministic order.
+    public func capabilitiesProvided(by collectionID: UUID) -> [RuleCapability] {
+        capabilitiesByCollection[collectionID, default: []]
+            .sorted { $0.stableSortKey < $1.stableSortKey }
+    }
+
+    /// Requirements contributed by a collection in deterministic order.
+    public func requirements(for collectionID: UUID) -> [RuleRequirement] {
+        requirementsByCollection[collectionID, default: []]
+            .sorted { $0.stableSortKey < $1.stableSortKey }
+    }
+
+    private static func uuidLessThan(_ lhs: UUID, _ rhs: UUID) -> Bool {
+        lhs.uuidString < rhs.uuidString
+    }
+}
+
+private extension RuleCapability {
+    var stableSortKey: String {
+        switch self {
+        case let .layerContent(layer):
+            "0|\(layer.rawValue)"
+        case let .layerActivation(layer):
+            "1|\(layer.rawValue)"
+        case let .keyAlias(alias):
+            "2|\(alias.rawValue)"
+        }
+    }
+}

--- a/Sources/KeyPathRulesCore/RuleDependencyGraph.swift
+++ b/Sources/KeyPathRulesCore/RuleDependencyGraph.swift
@@ -124,8 +124,8 @@ public struct RuleRequirement: Hashable, Sendable {
 
 /// One collection's dependency contribution to a graph snapshot.
 ///
-/// Family-specific extraction from `RuleCollection` intentionally lives in
-/// issue #867. Keeping this input generic makes the graph independently
+/// Family-specific extraction from `RuleCollection` intentionally lives in an
+/// app-layer adapter. Keeping this input generic makes the graph independently
 /// testable and reusable by future import, pack, and CLI validation paths.
 ///
 /// Enabled state is intentionally not part of a contribution. Independent

--- a/Sources/KeyPathRulesCore/RuleDependencyGraph.swift
+++ b/Sources/KeyPathRulesCore/RuleDependencyGraph.swift
@@ -185,19 +185,33 @@ public struct RuleDependencyGraph: Equatable, Sendable {
         enabledCollectionIDs: Set<UUID> = []
     ) -> Self {
         var capabilitiesByCollection: [UUID: Set<RuleCapability>] = [:]
-        var requirementsByCollection: [UUID: Set<RuleRequirement>] = [:]
+        var requirementEvidenceByCollection:
+            [UUID: [RuleCapability: Set<RuleDependencyEvidence>]] = [:]
         var providersByCapability: [RuleCapability: Set<UUID>] = [:]
 
         for contribution in contributions {
             capabilitiesByCollection[contribution.collectionID, default: []]
                 .formUnion(contribution.provides)
-            requirementsByCollection[contribution.collectionID, default: []]
-                .formUnion(contribution.requirements.map(\.normalized))
+            _ = requirementEvidenceByCollection[contribution.collectionID, default: [:]]
+
+            for requirement in contribution.requirements.map(\.normalized) {
+                requirementEvidenceByCollection[
+                    contribution.collectionID,
+                    default: [:]
+                ][requirement.capability, default: []]
+                    .formUnion(requirement.evidence)
+            }
 
             for capability in contribution.provides {
                 providersByCapability[capability, default: []]
                     .insert(contribution.collectionID)
             }
+        }
+
+        let requirementsByCollection = requirementEvidenceByCollection.mapValues { requirements in
+            Set(requirements.map { capability, evidence in
+                RuleRequirement(capability: capability, evidence: evidence)
+            })
         }
 
         var activeProvidersByCapability: [RuleCapability: Set<UUID>] = [:]
@@ -245,6 +259,9 @@ public struct RuleDependencyGraph: Equatable, Sendable {
     }
 
     /// Requirements contributed by a collection in deterministic order.
+    ///
+    /// Contributions requiring the same capability are represented once with
+    /// their normalized evidence combined.
     public func requirements(for collectionID: UUID) -> [RuleRequirement] {
         requirementsByCollection[collectionID, default: []]
             .sorted { $0.stableSortKey < $1.stableSortKey }

--- a/Sources/KeyPathRulesCore/RuleDependencyGraph.swift
+++ b/Sources/KeyPathRulesCore/RuleDependencyGraph.swift
@@ -5,6 +5,11 @@ import Foundation
 /// Layer names are open-ended because custom rules and packs can introduce
 /// them. Canonicalizing at this boundary prevents equivalent Kanata layer names
 /// such as `FUN` and ` fun ` from producing different graph nodes.
+///
+/// Raw Kanata syntax is case-sensitive, but KeyPath's `RuleCollectionLayer`
+/// model and layer-creation path lowercase custom layer names before config
+/// generation. This type represents those canonical KeyPath layer names, not
+/// arbitrary identifiers parsed from an external Kanata configuration.
 public struct RuleLayerIdentifier: RawRepresentable, Hashable, Sendable {
     public let rawValue: String
 

--- a/Sources/KeyPathRulesCore/RuleDependencyGraph.swift
+++ b/Sources/KeyPathRulesCore/RuleDependencyGraph.swift
@@ -122,20 +122,22 @@ public struct RuleRequirement: Hashable, Sendable {
 /// Family-specific extraction from `RuleCollection` intentionally lives in
 /// issue #867. Keeping this input generic makes the graph independently
 /// testable and reusable by future import, pack, and CLI validation paths.
+///
+/// Enabled state is intentionally not part of a contribution. Independent
+/// extractors may emit multiple contributions for one collection, while
+/// enabled state has exactly one collection-wide source of truth supplied to
+/// the graph builder.
 public struct RuleDependencyContribution: Equatable, Sendable {
     public let collectionID: UUID
-    public let isEnabled: Bool
     public let provides: Set<RuleCapability>
     public let requirements: Set<RuleRequirement>
 
     public init(
         collectionID: UUID,
-        isEnabled: Bool,
         provides: Set<RuleCapability> = [],
         requirements: Set<RuleRequirement> = []
     ) {
         self.collectionID = collectionID
-        self.isEnabled = isEnabled
         self.provides = provides
         self.requirements = requirements
     }
@@ -171,17 +173,17 @@ public struct RuleDependencyGraph: Equatable, Sendable {
     ///
     /// Multiple contributions for one collection are merged. This supports
     /// independent extractors without making ordering part of graph semantics.
-    public static func build(from contributions: [RuleDependencyContribution]) -> Self {
-        var enabledCollectionIDs: Set<UUID> = []
+    /// Enabled state is supplied once per graph snapshot so extractors cannot
+    /// disagree about a collection's state.
+    public static func build(
+        from contributions: [RuleDependencyContribution],
+        enabledCollectionIDs: Set<UUID> = []
+    ) -> Self {
         var capabilitiesByCollection: [UUID: Set<RuleCapability>] = [:]
         var requirementsByCollection: [UUID: Set<RuleRequirement>] = [:]
         var providersByCapability: [RuleCapability: Set<UUID>] = [:]
 
         for contribution in contributions {
-            if contribution.isEnabled {
-                enabledCollectionIDs.insert(contribution.collectionID)
-            }
-
             capabilitiesByCollection[contribution.collectionID, default: []]
                 .formUnion(contribution.provides)
             requirementsByCollection[contribution.collectionID, default: []]
@@ -213,7 +215,8 @@ public struct RuleDependencyGraph: Equatable, Sendable {
 
     /// All known collections in deterministic UUID order.
     public var collectionIDs: [UUID] {
-        Set(capabilitiesByCollection.keys)
+        enabledCollectionIDs
+            .union(capabilitiesByCollection.keys)
             .union(requirementsByCollection.keys)
             .sorted(by: Self.uuidLessThan)
     }

--- a/Sources/KeyPathRulesCore/RuleDependencyGraph.swift
+++ b/Sources/KeyPathRulesCore/RuleDependencyGraph.swift
@@ -192,7 +192,6 @@ public struct RuleDependencyGraph: Equatable, Sendable {
         for contribution in contributions {
             capabilitiesByCollection[contribution.collectionID, default: []]
                 .formUnion(contribution.provides)
-            _ = requirementEvidenceByCollection[contribution.collectionID, default: [:]]
 
             for requirement in contribution.requirements.map(\.normalized) {
                 requirementEvidenceByCollection[

--- a/Tests/KeyPathRulesCoreTests/RuleDependencyGraphTests.swift
+++ b/Tests/KeyPathRulesCoreTests/RuleDependencyGraphTests.swift
@@ -29,6 +29,23 @@ final class RuleDependencyGraphTests: XCTestCase {
         XCTAssertEqual(graph.capabilitiesProvided(by: providerID), [functionContent])
     }
 
+    func testHyperAliasCapabilityCanBeProvidedAndRequired() {
+        let providerID = uuid(1)
+        let consumerID = uuid(2)
+        let hyperAlias = RuleCapability.keyAlias(.hyper)
+        let requirement = RuleRequirement(
+            capability: hyperAlias,
+            evidence: [.configuration(field: "modifier", value: "hyper")]
+        )
+        let graph = RuleDependencyGraph.build(from: [
+            contribution(providerID, provides: [hyperAlias]),
+            contribution(consumerID, requirements: [requirement]),
+        ], enabledCollectionIDs: [providerID, consumerID])
+
+        XCTAssertEqual(graph.activeProviders(for: hyperAlias), [providerID])
+        XCTAssertEqual(graph.requirements(for: consumerID), [requirement])
+    }
+
     func testDisabledProviderIsKnownButNotActive() {
         let providerID = uuid(1)
         let functionContent = layerContent("fun")
@@ -209,6 +226,77 @@ final class RuleDependencyGraphTests: XCTestCase {
 
         XCTAssertEqual(graph.enabledCollectionIDs, [collectionID])
         XCTAssertEqual(graph.collectionIDs, [collectionID])
+    }
+
+    func testEquivalentRequirementEvidenceAcrossContributionsIsDeduplicated() {
+        let collectionID = uuid(1)
+        let graph = RuleDependencyGraph.build(from: [
+            contribution(
+                collectionID,
+                requirements: [
+                    RuleRequirement(
+                        capability: layerContent("fun"),
+                        evidence: [.keys(["a", "b"])]
+                    ),
+                ]
+            ),
+            contribution(
+                collectionID,
+                requirements: [
+                    RuleRequirement(
+                        capability: layerContent("fun"),
+                        evidence: [.keys(["b", "a"])]
+                    ),
+                ]
+            ),
+        ])
+
+        XCTAssertEqual(
+            graph.requirements(for: collectionID),
+            [
+                RuleRequirement(
+                    capability: layerContent("fun"),
+                    evidence: [.keys(["a", "b"])]
+                ),
+            ]
+        )
+    }
+
+    func testDifferentEvidenceForOneCapabilityIsCombined() {
+        let collectionID = uuid(1)
+        let graph = RuleDependencyGraph.build(from: [
+            contribution(
+                collectionID,
+                requirements: [
+                    RuleRequirement(
+                        capability: layerContent("fun"),
+                        evidence: [.keys(["a"])]
+                    ),
+                ]
+            ),
+            contribution(
+                collectionID,
+                requirements: [
+                    RuleRequirement(
+                        capability: layerContent("fun"),
+                        evidence: [.configuration(field: "mode", value: "toggle")]
+                    ),
+                ]
+            ),
+        ])
+
+        XCTAssertEqual(
+            graph.requirements(for: collectionID),
+            [
+                RuleRequirement(
+                    capability: layerContent("fun"),
+                    evidence: [
+                        .keys(["a"]),
+                        .configuration(field: "mode", value: "toggle"),
+                    ]
+                ),
+            ]
+        )
     }
 
     private func contribution(

--- a/Tests/KeyPathRulesCoreTests/RuleDependencyGraphTests.swift
+++ b/Tests/KeyPathRulesCoreTests/RuleDependencyGraphTests.swift
@@ -20,10 +20,9 @@ final class RuleDependencyGraphTests: XCTestCase {
         let graph = RuleDependencyGraph.build(from: [
             contribution(
                 providerID,
-                isEnabled: true,
                 provides: [functionContent]
             ),
-        ])
+        ], enabledCollectionIDs: [providerID])
 
         XCTAssertEqual(graph.knownProviders(for: functionContent), [providerID])
         XCTAssertEqual(graph.activeProviders(for: functionContent), [providerID])
@@ -36,7 +35,6 @@ final class RuleDependencyGraphTests: XCTestCase {
         let graph = RuleDependencyGraph.build(from: [
             contribution(
                 providerID,
-                isEnabled: false,
                 provides: [functionContent]
             ),
         ])
@@ -52,15 +50,13 @@ final class RuleDependencyGraphTests: XCTestCase {
         let graph = RuleDependencyGraph.build(from: [
             contribution(
                 secondProviderID,
-                isEnabled: false,
                 provides: [navigationActivation]
             ),
             contribution(
                 firstProviderID,
-                isEnabled: true,
                 provides: [navigationActivation]
             ),
-        ])
+        ], enabledCollectionIDs: [firstProviderID])
 
         XCTAssertEqual(
             graph.knownProviders(for: navigationActivation),
@@ -78,10 +74,9 @@ final class RuleDependencyGraphTests: XCTestCase {
         let graph = RuleDependencyGraph.build(from: [
             contribution(
                 consumerID,
-                isEnabled: true,
                 requirements: [requirement]
             ),
-        ])
+        ], enabledCollectionIDs: [consumerID])
 
         XCTAssertEqual(graph.requirements(for: consumerID), [requirement])
         XCTAssertTrue(graph.knownProviders(for: requirement.capability).isEmpty)
@@ -94,10 +89,9 @@ final class RuleDependencyGraphTests: XCTestCase {
         let graph = RuleDependencyGraph.build(from: [
             contribution(
                 providerID,
-                isEnabled: true,
                 provides: [layerContent("  FUN\n")]
             ),
-        ])
+        ], enabledCollectionIDs: [providerID])
 
         XCTAssertEqual(
             graph.knownProviders(for: normalizedCapability),
@@ -128,10 +122,9 @@ final class RuleDependencyGraphTests: XCTestCase {
         let graph = RuleDependencyGraph.build(from: [
             contribution(
                 consumerID,
-                isEnabled: true,
                 requirements: [requirement]
             ),
-        ])
+        ], enabledCollectionIDs: [consumerID])
 
         let storedRequirement = try XCTUnwrap(
             graph.requirements(for: consumerID).first
@@ -151,23 +144,21 @@ final class RuleDependencyGraphTests: XCTestCase {
         )
     }
 
-    func testContributionsForOneCollectionAreMerged() {
+    func testContributionsForOneCollectionShareOneAuthoritativeEnabledState() {
         let collectionID = uuid(1)
         let graph = RuleDependencyGraph.build(from: [
             contribution(
                 collectionID,
-                isEnabled: false,
                 provides: [layerContent("fun")]
             ),
             contribution(
                 collectionID,
-                isEnabled: true,
                 provides: [layerActivation("fun")],
                 requirements: [
                     RuleRequirement(capability: layerActivation("nav")),
                 ]
             ),
-        ])
+        ], enabledCollectionIDs: [collectionID])
 
         XCTAssertEqual(graph.collectionIDs, [collectionID])
         XCTAssertEqual(
@@ -182,17 +173,30 @@ final class RuleDependencyGraphTests: XCTestCase {
             graph.activeProviders(for: layerContent("fun")),
             [collectionID]
         )
+        XCTAssertEqual(
+            graph.activeProviders(for: layerActivation("fun")),
+            [collectionID]
+        )
+    }
+
+    func testEnabledCollectionWithoutDependencyContributionIsRetained() {
+        let collectionID = uuid(1)
+        let graph = RuleDependencyGraph.build(
+            from: [],
+            enabledCollectionIDs: [collectionID]
+        )
+
+        XCTAssertEqual(graph.enabledCollectionIDs, [collectionID])
+        XCTAssertEqual(graph.collectionIDs, [collectionID])
     }
 
     private func contribution(
         _ collectionID: UUID,
-        isEnabled: Bool,
         provides: Set<RuleCapability> = [],
         requirements: Set<RuleRequirement> = []
     ) -> RuleDependencyContribution {
         RuleDependencyContribution(
             collectionID: collectionID,
-            isEnabled: isEnabled,
             provides: provides,
             requirements: requirements
         )

--- a/Tests/KeyPathRulesCoreTests/RuleDependencyGraphTests.swift
+++ b/Tests/KeyPathRulesCoreTests/RuleDependencyGraphTests.swift
@@ -141,6 +141,15 @@ final class RuleDependencyGraphTests: XCTestCase {
         )
     }
 
+    func testRuleCollectionLayerBridgeUsesCanonicalKanataName() {
+        let layer = RuleCollectionLayer.custom("MiXeD")
+
+        XCTAssertEqual(
+            RuleLayerIdentifier(layer),
+            RuleLayerIdentifier("mixed")
+        )
+    }
+
     func testEvidenceIsPreservedAndNormalizedForStableQueries() throws {
         let consumerID = uuid(1)
         let firstMappingID = uuid(10)

--- a/Tests/KeyPathRulesCoreTests/RuleDependencyGraphTests.swift
+++ b/Tests/KeyPathRulesCoreTests/RuleDependencyGraphTests.swift
@@ -1,0 +1,212 @@
+import Foundation
+@testable import KeyPathRulesCore
+import XCTest
+
+final class RuleDependencyGraphTests: XCTestCase {
+    func testEmptyGraph() {
+        let graph = RuleDependencyGraph.build(from: [])
+
+        XCTAssertTrue(graph.enabledCollectionIDs.isEmpty)
+        XCTAssertTrue(graph.capabilitiesByCollection.isEmpty)
+        XCTAssertTrue(graph.requirementsByCollection.isEmpty)
+        XCTAssertTrue(graph.providersByCapability.isEmpty)
+        XCTAssertTrue(graph.activeProvidersByCapability.isEmpty)
+        XCTAssertTrue(graph.collectionIDs.isEmpty)
+    }
+
+    func testActiveProviderIsKnownAndActive() {
+        let providerID = uuid(1)
+        let functionContent = layerContent("fun")
+        let graph = RuleDependencyGraph.build(from: [
+            contribution(
+                providerID,
+                isEnabled: true,
+                provides: [functionContent]
+            ),
+        ])
+
+        XCTAssertEqual(graph.knownProviders(for: functionContent), [providerID])
+        XCTAssertEqual(graph.activeProviders(for: functionContent), [providerID])
+        XCTAssertEqual(graph.capabilitiesProvided(by: providerID), [functionContent])
+    }
+
+    func testDisabledProviderIsKnownButNotActive() {
+        let providerID = uuid(1)
+        let functionContent = layerContent("fun")
+        let graph = RuleDependencyGraph.build(from: [
+            contribution(
+                providerID,
+                isEnabled: false,
+                provides: [functionContent]
+            ),
+        ])
+
+        XCTAssertEqual(graph.knownProviders(for: functionContent), [providerID])
+        XCTAssertTrue(graph.activeProviders(for: functionContent).isEmpty)
+    }
+
+    func testMultipleProvidersHaveStableOrdering() {
+        let firstProviderID = uuid(1)
+        let secondProviderID = uuid(2)
+        let navigationActivation = layerActivation("nav")
+        let graph = RuleDependencyGraph.build(from: [
+            contribution(
+                secondProviderID,
+                isEnabled: false,
+                provides: [navigationActivation]
+            ),
+            contribution(
+                firstProviderID,
+                isEnabled: true,
+                provides: [navigationActivation]
+            ),
+        ])
+
+        XCTAssertEqual(
+            graph.knownProviders(for: navigationActivation),
+            [firstProviderID, secondProviderID]
+        )
+        XCTAssertEqual(
+            graph.activeProviders(for: navigationActivation),
+            [firstProviderID]
+        )
+    }
+
+    func testRequirementCanBeMissingWithNoKnownProvider() {
+        let consumerID = uuid(1)
+        let requirement = RuleRequirement(capability: layerContent("sym"))
+        let graph = RuleDependencyGraph.build(from: [
+            contribution(
+                consumerID,
+                isEnabled: true,
+                requirements: [requirement]
+            ),
+        ])
+
+        XCTAssertEqual(graph.requirements(for: consumerID), [requirement])
+        XCTAssertTrue(graph.knownProviders(for: requirement.capability).isEmpty)
+        XCTAssertTrue(graph.activeProviders(for: requirement.capability).isEmpty)
+    }
+
+    func testLayerNamesAreNormalizedAtTheCapabilityBoundary() {
+        let providerID = uuid(1)
+        let normalizedCapability = layerContent("fun")
+        let graph = RuleDependencyGraph.build(from: [
+            contribution(
+                providerID,
+                isEnabled: true,
+                provides: [layerContent("  FUN\n")]
+            ),
+        ])
+
+        XCTAssertEqual(
+            graph.knownProviders(for: normalizedCapability),
+            [providerID]
+        )
+        XCTAssertEqual(
+            graph.capabilitiesProvided(by: providerID),
+            [normalizedCapability]
+        )
+    }
+
+    func testEvidenceIsPreservedAndNormalizedForStableQueries() throws {
+        let consumerID = uuid(1)
+        let firstMappingID = uuid(10)
+        let secondMappingID = uuid(20)
+        let requirement = RuleRequirement(
+            capability: layerContent("fun"),
+            evidence: [
+                .keys([";", "a", "a"]),
+                .layerPath(
+                    source: RuleLayerIdentifier(" NAV "),
+                    target: RuleLayerIdentifier(" FUN ")
+                ),
+                .configuration(field: "toggleMode", value: "toggle"),
+                .mappingIDs([secondMappingID, firstMappingID, secondMappingID]),
+            ]
+        )
+        let graph = RuleDependencyGraph.build(from: [
+            contribution(
+                consumerID,
+                isEnabled: true,
+                requirements: [requirement]
+            ),
+        ])
+
+        let storedRequirement = try XCTUnwrap(
+            graph.requirements(for: consumerID).first
+        )
+        XCTAssertEqual(storedRequirement.capability, layerContent("fun"))
+        XCTAssertEqual(
+            storedRequirement.sortedEvidence,
+            [
+                .keys([";", "a"]),
+                .layerPath(
+                    source: RuleLayerIdentifier("nav"),
+                    target: RuleLayerIdentifier("fun")
+                ),
+                .configuration(field: "toggleMode", value: "toggle"),
+                .mappingIDs([firstMappingID, secondMappingID]),
+            ]
+        )
+    }
+
+    func testContributionsForOneCollectionAreMerged() {
+        let collectionID = uuid(1)
+        let graph = RuleDependencyGraph.build(from: [
+            contribution(
+                collectionID,
+                isEnabled: false,
+                provides: [layerContent("fun")]
+            ),
+            contribution(
+                collectionID,
+                isEnabled: true,
+                provides: [layerActivation("fun")],
+                requirements: [
+                    RuleRequirement(capability: layerActivation("nav")),
+                ]
+            ),
+        ])
+
+        XCTAssertEqual(graph.collectionIDs, [collectionID])
+        XCTAssertEqual(
+            graph.capabilitiesProvided(by: collectionID),
+            [layerContent("fun"), layerActivation("fun")]
+        )
+        XCTAssertEqual(
+            graph.requirements(for: collectionID),
+            [RuleRequirement(capability: layerActivation("nav"))]
+        )
+        XCTAssertEqual(
+            graph.activeProviders(for: layerContent("fun")),
+            [collectionID]
+        )
+    }
+
+    private func contribution(
+        _ collectionID: UUID,
+        isEnabled: Bool,
+        provides: Set<RuleCapability> = [],
+        requirements: Set<RuleRequirement> = []
+    ) -> RuleDependencyContribution {
+        RuleDependencyContribution(
+            collectionID: collectionID,
+            isEnabled: isEnabled,
+            provides: provides,
+            requirements: requirements
+        )
+    }
+
+    private func layerContent(_ name: String) -> RuleCapability {
+        .layerContent(RuleLayerIdentifier(name))
+    }
+
+    private func layerActivation(_ name: String) -> RuleCapability {
+        .layerActivation(RuleLayerIdentifier(name))
+    }
+
+    private func uuid(_ suffix: Int) -> UUID {
+        UUID(uuidString: String(format: "00000000-0000-0000-0000-%012d", suffix))!
+    }
+}

--- a/Tests/KeyPathRulesCoreTests/RuleDependencyGraphTests.swift
+++ b/Tests/KeyPathRulesCoreTests/RuleDependencyGraphTests.swift
@@ -68,6 +68,27 @@ final class RuleDependencyGraphTests: XCTestCase {
         )
     }
 
+    func testMultipleActiveProvidersHaveStableOrdering() {
+        let firstProviderID = uuid(1)
+        let secondProviderID = uuid(2)
+        let navigationActivation = layerActivation("nav")
+        let graph = RuleDependencyGraph.build(from: [
+            contribution(
+                secondProviderID,
+                provides: [navigationActivation]
+            ),
+            contribution(
+                firstProviderID,
+                provides: [navigationActivation]
+            ),
+        ], enabledCollectionIDs: [secondProviderID, firstProviderID])
+
+        XCTAssertEqual(
+            graph.activeProviders(for: navigationActivation),
+            [firstProviderID, secondProviderID]
+        )
+    }
+
     func testRequirementCanBeMissingWithNoKnownProvider() {
         let consumerID = uuid(1)
         let requirement = RuleRequirement(capability: layerContent("sym"))


### PR DESCRIPTION
Closes #870

## What changed

- added a pure `RuleDependencyGraph` model in `KeyPathRulesCore`;
- introduced normalized layer identifiers and typed layer-content, layer-activation, and key-alias capabilities;
- separated structured requirement evidence from capability identity and merged evidence for the same requirement;
- made enabled collection IDs one authoritative graph input so independent extractors cannot disagree;
- distinguished all known providers from providers active in the analyzed snapshot;
- added deterministic query methods for collections, capabilities, providers, requirements, and evidence;
- added focused tests for empty graphs, active and disabled providers, multiple active providers, missing providers, layer and evidence normalization, Hyper aliases, evidence aggregation, ordering, merged contributions, and the production collection-layer bridge.

## Why

The later dependency-detection work needs a presentation-free vocabulary that can explain both what the enabled rule set currently provides and what disabled rules could provide as a confirmed fix. Building from generic contributions keeps family-specific extraction in the app-layer adapter and prevents #870 from coupling the graph to catalog or UI logic.

## Validation

- stable Xcode 26.6 Swift build;
- `RuleDependencyGraphTests`: 14 passed;
- repository fast lane: 611 passed, 5 skipped, 0 failed;
- GitHub build-and-test passed;
- GitHub code-quality passed;
- GitHub `claude-review` passed on final head `f8eb555b`;
- SwiftFormat 0.61.1;
- accessibility identifier check passed;
- `git diff --check` passed.

## Review follow-through

Review feedback was incorporated for authoritative enabled state, canonical KeyPath layer naming, multi-provider coverage, evidence deduplication and aggregation, Hyper alias coverage, the production layer bridge, and removal of a no-op statement.