### PR TITLE
Encode per-family rule dependencies

### DIFF
--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionDependencyExtractor.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionDependencyExtractor.swift
@@ -26,13 +26,15 @@ struct RuleCollectionDependencyExtractor {
                 requirements: &requirements
             )
 
-        case let .homeRowMods(config) where config.holdMode == .layers:
-            addLayerAssignments(
-                enabledKeys: config.enabledKeys,
-                assignments: config.layerAssignments,
-                provides: &provides,
-                requirements: &requirements
-            )
+        case let .homeRowMods(config):
+            if config.holdMode == .layers {
+                addLayerAssignments(
+                    enabledKeys: config.enabledKeys,
+                    assignments: config.layerAssignments,
+                    provides: &provides,
+                    requirements: &requirements
+                )
+            }
 
         case let .launcherGrid(config):
             addLauncherContribution(
@@ -49,12 +51,17 @@ struct RuleCollectionDependencyExtractor {
                 }
             }
 
-        case let .tapHoldPicker(config)
-            where collection.id == RuleCollectionIdentifier.capsLockRemap
-            && config.selectedHoldOutput == "hyper":
-            provides.insert(.keyAlias(.hyper))
+        case let .tapHoldPicker(config):
+            if collection.id == RuleCollectionIdentifier.capsLockRemap,
+               config.selectedHoldOutput == "hyper"
+            {
+                provides.insert(.keyAlias(.hyper))
+            }
 
-        default:
+        // Keep dependency-free families explicit so a new configuration case
+        // produces a compiler error until its dependency semantics are chosen.
+        case .list, .table, .singleKeyPicker, .chordGroups,
+             .layerPresetPicker, .autoShiftSymbols, .keyRepeatControl:
             break
         }
 
@@ -64,6 +71,9 @@ struct RuleCollectionDependencyExtractor {
             provides.insert(.layerActivation(RuleLayerIdentifier(.navigation)))
         }
 
+        // Launcher configuration is the activation source of truth. The
+        // persisted momentary activator is a legacy Hyper-link representation;
+        // its source layer is not consulted by config generation.
         let usesConfigurationDefinedLauncherActivation =
             collection.configuration.launcherGridConfig != nil
 
@@ -91,14 +101,10 @@ struct RuleCollectionDependencyExtractor {
            !hasOwnActivation
         {
             let target = RuleLayerIdentifier(collection.targetLayer)
-            var evidence: Set<RuleDependencyEvidence> = []
             let mappingIDs = effectiveMappings.map(\.id)
-            if !mappingIDs.isEmpty {
-                evidence.insert(.mappingIDs(mappingIDs))
-            }
             requirements.insert(RuleRequirement(
                 capability: .layerActivation(target),
-                evidence: evidence
+                evidence: [.mappingIDs(mappingIDs)]
             ))
         }
 

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionDependencyExtractor.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionDependencyExtractor.swift
@@ -93,7 +93,6 @@ struct RuleCollectionDependencyExtractor {
         }
 
         let hasOwnActivation = usesConfigurationDefinedLauncherActivation
-            || functionalActivator(in: collection) != nil
             || provides.contains(.layerActivation(RuleLayerIdentifier(collection.targetLayer)))
 
         if collection.targetLayer != .base,

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionDependencyExtractor.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionDependencyExtractor.swift
@@ -1,0 +1,210 @@
+import Foundation
+import KeyPathRulesCore
+
+/// Converts configured rule collections into the pure dependency graph inputs.
+///
+/// The extractor deliberately keeps each configuration family explicit. A
+/// collection's enabled state is not consulted here: disabled collections are
+/// still potential providers, and the graph adapter decides which providers
+/// are active in a particular snapshot.
+struct RuleCollectionDependencyExtractor {
+    func contribution(for collection: RuleCollection) -> RuleDependencyContribution {
+        let effectiveMappings = KanataConfiguration.effectiveMappings(for: collection)
+        var provides: Set<RuleCapability> = []
+        var requirements: Set<RuleRequirement> = []
+
+        if !effectiveMappings.isEmpty {
+            provides.insert(.layerContent(RuleLayerIdentifier(collection.targetLayer)))
+        }
+
+        switch collection.configuration {
+        case let .homeRowLayerToggles(config):
+            addLayerAssignments(
+                enabledKeys: config.enabledKeys,
+                assignments: config.layerAssignments,
+                provides: &provides,
+                requirements: &requirements
+            )
+
+        case let .homeRowMods(config) where config.holdMode == .layers:
+            addLayerAssignments(
+                enabledKeys: config.enabledKeys,
+                assignments: config.layerAssignments,
+                provides: &provides,
+                requirements: &requirements
+            )
+
+        case let .launcherGrid(config):
+            addLauncherContribution(
+                config: config,
+                targetLayer: collection.targetLayer,
+                provides: &provides,
+                requirements: &requirements
+            )
+
+        case let .sequences(config):
+            for sequence in config.sequences where sequence.isValid {
+                if case let .activateLayer(layer) = sequence.action {
+                    provides.insert(.layerActivation(RuleLayerIdentifier(layer)))
+                }
+            }
+
+        case let .tapHoldPicker(config)
+            where collection.id == RuleCollectionIdentifier.capsLockRemap
+            && config.selectedHoldOutput == "hyper":
+            provides.insert(.keyAlias(.hyper))
+
+        default:
+            break
+        }
+
+        if collection.id == RuleCollectionIdentifier.leaderKey,
+           configuredLeaderKey(in: collection) != nil
+        {
+            provides.insert(.layerActivation(RuleLayerIdentifier(.navigation)))
+        }
+
+        let usesConfigurationDefinedLauncherActivation =
+            collection.configuration.launcherGridConfig != nil
+
+        if !usesConfigurationDefinedLauncherActivation,
+           let activator = functionalActivator(in: collection)
+        {
+            let source = RuleLayerIdentifier(activator.sourceLayer)
+            let target = RuleLayerIdentifier(activator.targetLayer)
+            provides.insert(.layerActivation(target))
+
+            if activator.sourceLayer != .base {
+                requirements.insert(RuleRequirement(
+                    capability: .layerActivation(source),
+                    evidence: [.layerPath(source: source, target: target)]
+                ))
+            }
+        }
+
+        let hasOwnActivation = usesConfigurationDefinedLauncherActivation
+            || functionalActivator(in: collection) != nil
+            || provides.contains(.layerActivation(RuleLayerIdentifier(collection.targetLayer)))
+
+        if collection.targetLayer != .base,
+           !effectiveMappings.isEmpty,
+           !hasOwnActivation
+        {
+            let target = RuleLayerIdentifier(collection.targetLayer)
+            var evidence: Set<RuleDependencyEvidence> = []
+            let mappingIDs = effectiveMappings.map(\.id)
+            if !mappingIDs.isEmpty {
+                evidence.insert(.mappingIDs(mappingIDs))
+            }
+            requirements.insert(RuleRequirement(
+                capability: .layerActivation(target),
+                evidence: evidence
+            ))
+        }
+
+        return RuleDependencyContribution(
+            collectionID: collection.id,
+            provides: provides,
+            requirements: requirements
+        )
+    }
+
+    private func addLayerAssignments(
+        enabledKeys: Set<String>,
+        assignments: [String: String],
+        provides: inout Set<RuleCapability>,
+        requirements: inout Set<RuleRequirement>
+    ) {
+        let keysByLayer = Dictionary(grouping: enabledKeys.compactMap { key -> (String, String)? in
+            guard let layerName = assignments[key]?
+                .trimmingCharacters(in: .whitespacesAndNewlines),
+                !layerName.isEmpty
+            else {
+                return nil
+            }
+            return (layerName, key)
+        }, by: { RuleLayerIdentifier($0.0) })
+
+        for (layer, assignments) in keysByLayer {
+            provides.insert(.layerActivation(layer))
+            requirements.insert(RuleRequirement(
+                capability: .layerContent(layer),
+                evidence: [.keys(assignments.map(\.1).sorted())]
+            ))
+        }
+    }
+
+    private func addLauncherContribution(
+        config: LauncherGridConfig,
+        targetLayer: RuleCollectionLayer,
+        provides: inout Set<RuleCapability>,
+        requirements: inout Set<RuleRequirement>
+    ) {
+        let target = RuleLayerIdentifier(targetLayer)
+        provides.insert(.layerActivation(target))
+
+        switch config.activationMode {
+        case .holdHyper:
+            requirements.insert(RuleRequirement(
+                capability: .keyAlias(.hyper),
+                evidence: [
+                    .configuration(field: "activationMode", value: config.activationMode.rawValue),
+                    .configuration(field: "hyperTriggerMode", value: config.hyperTriggerMode.rawValue),
+                ]
+            ))
+
+        case .leaderSequence:
+            let navigation = RuleLayerIdentifier(.navigation)
+            requirements.insert(RuleRequirement(
+                capability: .layerActivation(navigation),
+                evidence: [
+                    .configuration(field: "activationMode", value: config.activationMode.rawValue),
+                    .layerPath(source: navigation, target: target),
+                ]
+            ))
+        }
+    }
+
+    private func functionalActivator(in collection: RuleCollection) -> MomentaryActivator? {
+        guard let activator = collection.momentaryActivator,
+              !activator.input.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              activator.targetLayer != .base
+        else {
+            return nil
+        }
+        return activator
+    }
+
+    private func configuredLeaderKey(in collection: RuleCollection) -> String? {
+        guard case let .singleKeyPicker(config) = collection.configuration else {
+            return nil
+        }
+        let output = config.selectedOutput ?? config.presetOptions.first?.output
+        guard let output = output?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !output.isEmpty
+        else {
+            return nil
+        }
+        return output
+    }
+}
+
+/// Builds a dependency graph from persisted collections and custom rules.
+///
+/// Custom rules use their existing `RuleCollection` adapter so custom and
+/// built-in mappings share exactly the same extraction rules.
+struct RuleCollectionDependencyGraphAdapter {
+    private let extractor = RuleCollectionDependencyExtractor()
+
+    func build(
+        collections: [RuleCollection],
+        customRules: [CustomRule] = []
+    ) -> RuleDependencyGraph {
+        let customCollections = customRules.asRuleCollections()
+        let allCollections = collections + customCollections
+        return RuleDependencyGraph.build(
+            from: allCollections.map(extractor.contribution(for:)),
+            enabledCollectionIDs: Set(allCollections.filter(\.isEnabled).map(\.id))
+        )
+    }
+}

--- a/Tests/KeyPathTests/RuleCollections/RuleCollectionDependencyExtractorTests.swift
+++ b/Tests/KeyPathTests/RuleCollections/RuleCollectionDependencyExtractorTests.swift
@@ -1,0 +1,474 @@
+@testable import KeyPathAppKit
+import KeyPathRulesCore
+import XCTest
+
+final class RuleCollectionDependencyExtractorTests: XCTestCase {
+    private let extractor = RuleCollectionDependencyExtractor()
+    private let adapter = RuleCollectionDependencyGraphAdapter()
+
+    func testUsefulMappingsProvideNormalizedLayerContentForDisabledCollection() {
+        let collection = makeCollection(
+            isEnabled: false,
+            mappings: [KeyMapping(input: "a", action: .keystroke(key: "b"))],
+            targetLayer: .custom(" FUN ")
+        )
+
+        let contribution = extractor.contribution(for: collection)
+
+        XCTAssertEqual(contribution.provides, [.layerContent(layer("fun"))])
+        let graph = adapter.build(collections: [collection])
+        XCTAssertEqual(
+            graph.knownProviders(for: .layerContent(layer("fun"))),
+            [collection.id]
+        )
+        XCTAssertTrue(
+            graph.activeProviders(for: .layerContent(layer("fun"))).isEmpty
+        )
+    }
+
+    func testBaseAndChainedActivatorsProvideTargetActivation() {
+        let baseProvider = makeCollection(
+            momentaryActivator: MomentaryActivator(
+                input: "space",
+                targetLayer: .custom(" FUN ")
+            )
+        )
+        let chainedProvider = makeCollection(
+            momentaryActivator: MomentaryActivator(
+                input: "f",
+                targetLayer: .custom("SYM"),
+                sourceLayer: .custom(" NAV ")
+            )
+        )
+
+        let baseContribution = extractor.contribution(for: baseProvider)
+        XCTAssertTrue(baseContribution.provides.contains(.layerActivation(layer("fun"))))
+        XCTAssertTrue(baseContribution.requirements.isEmpty)
+
+        let chainedContribution = extractor.contribution(for: chainedProvider)
+        XCTAssertTrue(chainedContribution.provides.contains(.layerActivation(layer("sym"))))
+        XCTAssertEqual(
+            chainedContribution.requirements,
+            [RuleRequirement(
+                capability: .layerActivation(layer("nav")),
+                evidence: [.layerPath(source: layer("nav"), target: layer("sym"))]
+            )]
+        )
+    }
+
+    func testNonBaseMappingsWithoutActivatorRequireTargetActivationWithMappingEvidence() {
+        let mappingID = uuid(20)
+        let collection = makeCollection(
+            mappings: [
+                KeyMapping(
+                    id: mappingID,
+                    input: "a",
+                    action: .keystroke(key: "b")
+                ),
+            ],
+            targetLayer: .custom(" Fun ")
+        )
+
+        let contribution = extractor.contribution(for: collection)
+
+        XCTAssertEqual(
+            contribution.requirements,
+            [RuleRequirement(
+                capability: .layerActivation(layer("fun")),
+                evidence: [.mappingIDs([mappingID])]
+            )]
+        )
+    }
+
+    func testCustomRulesUseCollectionExtractionAndPreserveEnabledState() {
+        let enabledRule = CustomRule(
+            id: uuid(21),
+            input: "a",
+            action: .keystroke(key: "b"),
+            isEnabled: true,
+            targetLayer: .custom(" NAV ")
+        )
+        let disabledRule = CustomRule(
+            id: uuid(22),
+            input: "c",
+            action: .keystroke(key: "d"),
+            isEnabled: false,
+            targetLayer: .custom(" NAV ")
+        )
+
+        let graph = adapter.build(collections: [], customRules: [enabledRule, disabledRule])
+        let navContent = RuleCapability.layerContent(layer("nav"))
+
+        XCTAssertEqual(graph.knownProviders(for: navContent), [enabledRule.id, disabledRule.id])
+        XCTAssertEqual(graph.activeProviders(for: navContent), [enabledRule.id])
+        XCTAssertEqual(
+            graph.requirements(for: enabledRule.id),
+            [RuleRequirement(
+                capability: .layerActivation(layer("nav")),
+                evidence: [.mappingIDs([enabledRule.id])]
+            )]
+        )
+    }
+
+    func testHomeRowLayerTogglesGroupEnabledKeysAndProvideActivationInBothModes() {
+        for toggleMode in [LayerToggleMode.whileHeld, .toggle] {
+            let config = HomeRowLayerTogglesConfig(
+                enabledKeys: ["a", "d", "f"],
+                layerAssignments: [
+                    "a": " FUN ",
+                    "d": "sym",
+                    "f": "FUN",
+                    "j": "nav",
+                ],
+                toggleMode: toggleMode
+            )
+            let collection = makeCollection(
+                id: RuleCollectionIdentifier.homeRowLayerToggles,
+                configuration: .homeRowLayerToggles(config)
+            )
+
+            let contribution = extractor.contribution(for: collection)
+
+            XCTAssertTrue(contribution.provides.contains(.layerActivation(layer("fun"))))
+            XCTAssertTrue(contribution.provides.contains(.layerActivation(layer("sym"))))
+            XCTAssertFalse(contribution.provides.contains(.layerActivation(layer("nav"))))
+            XCTAssertEqual(
+                requirement(in: contribution, for: .layerContent(layer("fun")))?.evidence,
+                [.keys(["a", "f"])]
+            )
+            XCTAssertEqual(
+                requirement(in: contribution, for: .layerContent(layer("sym")))?.evidence,
+                [.keys(["d"])]
+            )
+            XCTAssertNil(requirement(in: contribution, for: .layerContent(layer("nav"))))
+        }
+    }
+
+    func testHomeRowModsOnlyRequireLayerContentInLayerMode() {
+        var config = HomeRowModsConfig(
+            enabledKeys: ["a", "d"],
+            layerAssignments: ["a": "fun", "d": "sym"],
+            holdMode: .modifiers
+        )
+        let modifierCollection = makeCollection(
+            id: RuleCollectionIdentifier.homeRowMods,
+            configuration: .homeRowMods(config)
+        )
+
+        let modifierContribution = extractor.contribution(for: modifierCollection)
+        XCTAssertFalse(modifierContribution.provides.contains(.layerActivation(layer("fun"))))
+        XCTAssertTrue(modifierContribution.requirements.isEmpty)
+
+        config.holdMode = .layers
+        let layerCollection = makeCollection(
+            id: RuleCollectionIdentifier.homeRowMods,
+            configuration: .homeRowMods(config)
+        )
+        let layerContribution = extractor.contribution(for: layerCollection)
+
+        XCTAssertTrue(layerContribution.provides.contains(.layerActivation(layer("fun"))))
+        XCTAssertTrue(layerContribution.provides.contains(.layerActivation(layer("sym"))))
+        XCTAssertEqual(
+            requirement(in: layerContribution, for: .layerContent(layer("fun")))?.evidence,
+            [.keys(["a"])]
+        )
+    }
+
+    func testLauncherHyperAndLeaderModesHaveConfigurationSensitiveRequirements() {
+        let hyperConfig = LauncherGridConfig(
+            activationMode: .holdHyper,
+            hyperTriggerMode: .tap,
+            mappings: []
+        )
+        let hyperLauncher = makeCollection(
+            id: RuleCollectionIdentifier.launcher,
+            targetLayer: .custom(" LAUNCHER "),
+            momentaryActivator: MomentaryActivator(
+                input: "hyper",
+                targetLayer: .custom("launcher")
+            ),
+            configuration: .launcherGrid(hyperConfig)
+        )
+
+        let hyperContribution = extractor.contribution(for: hyperLauncher)
+        XCTAssertTrue(hyperContribution.provides.contains(.layerActivation(layer("launcher"))))
+        XCTAssertEqual(
+            requirement(in: hyperContribution, for: .keyAlias(.hyper))?.evidence,
+            [
+                .configuration(field: "activationMode", value: "holdHyper"),
+                .configuration(field: "hyperTriggerMode", value: "tap"),
+            ]
+        )
+        XCTAssertNil(
+            requirement(in: hyperContribution, for: .layerActivation(layer("nav")))
+        )
+
+        let leaderConfig = LauncherGridConfig(
+            activationMode: .leaderSequence,
+            hyperTriggerMode: .hold,
+            mappings: []
+        )
+        let leaderLauncher = makeCollection(
+            id: RuleCollectionIdentifier.launcher,
+            targetLayer: .custom("launcher"),
+            momentaryActivator: MomentaryActivator(
+                input: "hyper",
+                targetLayer: .custom("launcher")
+            ),
+            configuration: .launcherGrid(leaderConfig)
+        )
+
+        let leaderContribution = extractor.contribution(for: leaderLauncher)
+        XCTAssertNil(requirement(in: leaderContribution, for: .keyAlias(.hyper)))
+        XCTAssertEqual(
+            requirement(
+                in: leaderContribution,
+                for: .layerActivation(layer("nav"))
+            )?.evidence,
+            [
+                .configuration(field: "activationMode", value: "leaderSequence"),
+                .layerPath(source: layer("nav"), target: layer("launcher")),
+            ]
+        )
+    }
+
+    func testCapsLockRemapProvidesHyperOnlyForExactConfiguredHoldOutput() {
+        for (output, expected) in [
+            ("hyper", true),
+            ("Hyper", false),
+            ("meh", false),
+        ] {
+            let collection = makeCollection(
+                id: RuleCollectionIdentifier.capsLockRemap,
+                configuration: .tapHoldPicker(TapHoldPickerConfig(
+                    inputKey: "caps",
+                    tapOptions: [],
+                    holdOptions: [],
+                    selectedTapOutput: "esc",
+                    selectedHoldOutput: output
+                ))
+            )
+
+            XCTAssertEqual(
+                extractor.contribution(for: collection)
+                    .provides.contains(.keyAlias(.hyper)),
+                expected
+            )
+        }
+
+        let unrelated = makeCollection(
+            configuration: .tapHoldPicker(TapHoldPickerConfig(
+                inputKey: "caps",
+                tapOptions: [],
+                holdOptions: [],
+                selectedHoldOutput: "hyper"
+            ))
+        )
+        XCTAssertFalse(
+            extractor.contribution(for: unrelated)
+                .provides.contains(.keyAlias(.hyper))
+        )
+    }
+
+    func testConfiguredLeaderKeyProvidesNavigationActivation() {
+        let configured = makeCollection(
+            id: RuleCollectionIdentifier.leaderKey,
+            configuration: .singleKeyPicker(SingleKeyPickerConfig(
+                inputKey: "leader",
+                presetOptions: [],
+                selectedOutput: " space "
+            ))
+        )
+        let unconfigured = makeCollection(
+            id: RuleCollectionIdentifier.leaderKey,
+            configuration: .singleKeyPicker(SingleKeyPickerConfig(
+                inputKey: "leader",
+                presetOptions: [],
+                selectedOutput: " "
+            ))
+        )
+
+        XCTAssertTrue(
+            extractor.contribution(for: configured)
+                .provides.contains(.layerActivation(layer("nav")))
+        )
+        XCTAssertFalse(
+            extractor.contribution(for: unconfigured)
+                .provides.contains(.layerActivation(layer("nav")))
+        )
+    }
+
+    func testValidSequencesProvideCorrespondingActivationCapabilities() {
+        let valid = SequenceDefinition(
+            name: "Launcher",
+            keys: ["space", "l"],
+            action: .activateLayer(.custom(" LAUNCHER "))
+        )
+        let invalid = SequenceDefinition(
+            name: "",
+            keys: ["space", "n"],
+            action: .activateLayer(.navigation)
+        )
+        let collection = makeCollection(
+            id: RuleCollectionIdentifier.sequences,
+            configuration: .sequences(SequencesConfig(sequences: [valid, invalid]))
+        )
+
+        let contribution = extractor.contribution(for: collection)
+
+        XCTAssertTrue(contribution.provides.contains(.layerActivation(layer("launcher"))))
+        XCTAssertFalse(contribution.provides.contains(.layerActivation(layer("nav"))))
+    }
+
+    func testDefaultEffectiveCatalogHasNoMissingPrerequisites() {
+        let graph = adapter.build(collections: RuleCollectionCatalog().defaultCollections())
+
+        XCTAssertTrue(missingRequirements(in: graph).isEmpty)
+    }
+
+    func testHomeRowLayerTogglesSoloExposeFourMissingContentCapabilitiesWithKeyEvidence() {
+        let config = HomeRowLayerTogglesConfig()
+        let collection = makeCollection(
+            id: RuleCollectionIdentifier.homeRowLayerToggles,
+            configuration: .homeRowLayerToggles(config)
+        )
+        let graph = adapter.build(collections: [collection])
+
+        let missing = Set(missingRequirements(in: graph).map(\.requirement))
+
+        XCTAssertEqual(missing, [
+            RuleRequirement(
+                capability: .layerContent(layer("fun")),
+                evidence: [.keys([";", "a"])]
+            ),
+            RuleRequirement(
+                capability: .layerContent(layer("num")),
+                evidence: [.keys(["l", "s"])]
+            ),
+            RuleRequirement(
+                capability: .layerContent(layer("sym")),
+                evidence: [.keys(["d", "k"])]
+            ),
+            RuleRequirement(
+                capability: .layerContent(layer("nav")),
+                evidence: [.keys(["f", "j"])]
+            ),
+        ])
+    }
+
+    func testHomeRowLayerTogglesWithCompanionLayersHasNoMissingPrerequisites() {
+        let toggles = makeCollection(
+            id: RuleCollectionIdentifier.homeRowLayerToggles,
+            configuration: .homeRowLayerToggles(HomeRowLayerTogglesConfig())
+        )
+        let companions = ["fun", "num", "sym", "nav"].map { layerName in
+            makeCollection(
+                id: uuid(100 + stableIndex(for: layerName)),
+                mappings: [KeyMapping(input: "x", action: .keystroke(key: "y"))],
+                targetLayer: RuleCollectionLayer(kanataName: layerName)
+            )
+        }
+
+        let graph = adapter.build(collections: [toggles] + companions)
+
+        XCTAssertTrue(missingRequirements(in: graph).isEmpty)
+    }
+
+    func testAlternateActiveNavigationProviderPreventsOrphaningConsumer() {
+        let disabledProvider = makeCollection(
+            id: uuid(30),
+            isEnabled: false,
+            momentaryActivator: MomentaryActivator(
+                input: "space",
+                targetLayer: .navigation
+            )
+        )
+        let enabledProvider = makeCollection(
+            id: uuid(31),
+            momentaryActivator: MomentaryActivator(
+                input: "caps",
+                targetLayer: .navigation
+            )
+        )
+        let consumer = makeCollection(
+            id: uuid(32),
+            mappings: [KeyMapping(input: "x", action: .keystroke(key: "y"))],
+            targetLayer: .navigation
+        )
+
+        let graph = adapter.build(
+            collections: [disabledProvider, enabledProvider, consumer]
+        )
+
+        XCTAssertEqual(
+            graph.knownProviders(for: .layerActivation(layer("nav"))),
+            [disabledProvider.id, enabledProvider.id]
+        )
+        XCTAssertEqual(
+            graph.activeProviders(for: .layerActivation(layer("nav"))),
+            [enabledProvider.id]
+        )
+        XCTAssertTrue(missingRequirements(in: graph).isEmpty)
+    }
+
+    private func makeCollection(
+        id: UUID = UUID(),
+        isEnabled: Bool = true,
+        mappings: [KeyMapping] = [],
+        targetLayer: RuleCollectionLayer = .base,
+        momentaryActivator: MomentaryActivator? = nil,
+        configuration: RuleCollectionConfiguration = .list
+    ) -> RuleCollection {
+        RuleCollection(
+            id: id,
+            name: "Test",
+            summary: "Test",
+            category: .custom,
+            mappings: mappings,
+            isEnabled: isEnabled,
+            targetLayer: targetLayer,
+            momentaryActivator: momentaryActivator,
+            configuration: configuration
+        )
+    }
+
+    private func layer(_ name: String) -> RuleLayerIdentifier {
+        RuleLayerIdentifier(name)
+    }
+
+    private func requirement(
+        in contribution: RuleDependencyContribution,
+        for capability: RuleCapability
+    ) -> RuleRequirement? {
+        contribution.requirements.first { $0.capability == capability }
+    }
+
+    private func missingRequirements(
+        in graph: RuleDependencyGraph
+    ) -> [(collectionID: UUID, requirement: RuleRequirement)] {
+        graph.enabledCollectionIDs.flatMap { collectionID in
+            graph.requirements(for: collectionID).compactMap { requirement in
+                graph.activeProviders(for: requirement.capability).isEmpty
+                    ? (collectionID, requirement)
+                    : nil
+            }
+        }
+    }
+
+    private func uuid(_ value: Int) -> UUID {
+        UUID(uuidString: String(
+            format: "00000000-0000-0000-0000-%012d",
+            value
+        ))!
+    }
+
+    private func stableIndex(for layerName: String) -> Int {
+        switch layerName {
+        case "fun": 1
+        case "num": 2
+        case "sym": 3
+        case "nav": 4
+        default: 0
+        }
+    }
+}

--- a/Tests/KeyPathTests/RuleCollections/RuleCollectionDependencyExtractorTests.swift
+++ b/Tests/KeyPathTests/RuleCollections/RuleCollectionDependencyExtractorTests.swift
@@ -80,6 +80,35 @@ final class RuleCollectionDependencyExtractorTests: XCTestCase {
         )
     }
 
+    func testMismatchedActivatorTargetDoesNotSatisfyCollectionLayerActivation() {
+        let mappingID = uuid(23)
+        let collection = makeCollection(
+            mappings: [
+                KeyMapping(
+                    id: mappingID,
+                    input: "a",
+                    action: .keystroke(key: "b")
+                ),
+            ],
+            targetLayer: .custom("fun"),
+            momentaryActivator: MomentaryActivator(
+                input: "space",
+                targetLayer: .custom("other")
+            )
+        )
+
+        let contribution = extractor.contribution(for: collection)
+
+        XCTAssertTrue(contribution.provides.contains(.layerActivation(layer("other"))))
+        XCTAssertEqual(
+            requirement(in: contribution, for: .layerActivation(layer("fun"))),
+            RuleRequirement(
+                capability: .layerActivation(layer("fun")),
+                evidence: [.mappingIDs([mappingID])]
+            )
+        )
+    }
+
     func testCustomRulesUseCollectionExtractionAndPreserveEnabledState() {
         let enabledRule = CustomRule(
             id: uuid(21),

--- a/Tests/KeyPathTests/RuleCollections/RuleCollectionDependencyExtractorTests.swift
+++ b/Tests/KeyPathTests/RuleCollections/RuleCollectionDependencyExtractorTests.swift
@@ -232,6 +232,32 @@ final class RuleCollectionDependencyExtractorTests: XCTestCase {
         )
     }
 
+    func testLauncherConfigurationOverridesLegacyMomentaryActivatorSource() {
+        let launcher = makeCollection(
+            id: RuleCollectionIdentifier.launcher,
+            targetLayer: .custom("launcher"),
+            momentaryActivator: MomentaryActivator(
+                input: "hyper",
+                targetLayer: .custom("launcher"),
+                sourceLayer: .custom("legacy-source")
+            ),
+            configuration: .launcherGrid(LauncherGridConfig(
+                activationMode: .holdHyper,
+                mappings: []
+            ))
+        )
+
+        let contribution = extractor.contribution(for: launcher)
+
+        XCTAssertNotNil(requirement(in: contribution, for: .keyAlias(.hyper)))
+        XCTAssertNil(
+            requirement(
+                in: contribution,
+                for: .layerActivation(layer("legacy-source"))
+            )
+        )
+    }
+
     func testCapsLockRemapProvidesHyperOnlyForExactConfiguredHoldOutput() {
         for (output, expected) in [
             ("hyper", true),


### PR DESCRIPTION
## Summary

- add an explicit collection-facing dependency contribution extractor for mapped content, layer activators, Hyper aliases, HRL/Home Row Mods, Launcher, Leader Key, sequences, and custom mappings
- add a graph adapter that combines persisted collections and custom rules while preserving disabled collections as potential providers
- attach structured key, mapping, configuration, and layer-path evidence for later query and UI work
- keep the configuration-family switch exhaustive so future rule families must declare dependency semantics
- treat mismatched legacy activator targets as insufficient evidence that a collection layer is reachable
- cover the default catalog and the dependency scenarios from #867 with a focused matrix

## Why

#870 introduced the pure capability graph model. This PR connects real RuleCollection configuration to that model so #866 can query prerequisites without duplicating per-family product logic.

## Impact

No UI or mutation behavior changes. This adds derived dependency analysis only.

## Checks

- `TEST_FILTER=RuleCollectionDependencyExtractorTests ./Scripts/run-tests-safe.sh` — 16 focused tests passed
- `./Scripts/test-fast.sh --changed` — 389 tests passed, 4 skipped
- `./Scripts/test-full.sh` — 4,775 tests passed
- `python3 Scripts/check-accessibility.py` — passed
- SwiftFormat 0.61.1 and `git diff --check` — passed
- local review gate selected the required remote review path; `claude-review` must pass before merge

Closes #867