### PR TITLE
Add forward prerequisite resolution flow

### DIFF
--- a/Sources/KeyPathAppKit/Managers/RuntimeCoordinator.swift
+++ b/Sources/KeyPathAppKit/Managers/RuntimeCoordinator.swift
@@ -115,6 +115,11 @@ public class RuntimeCoordinator: SaveCoordinatorDelegate {
     var pendingMappingConflict: MappingConflictContext?
     var mappingConflictContinuation: CheckedContinuation<UUID?, Never>?
 
+    // Forward prerequisite resolution state (#869)
+    var pendingPrerequisiteResolution: RulePrerequisiteDialogModel?
+    var prerequisiteResolutionContinuation:
+        CheckedContinuation<RulePrerequisiteResolutionChoice?, Never>?
+
     /// Rule collections are now managed by RuleCollectionsCoordinator
     var ruleCollections: [RuleCollection] {
         get { ruleCollectionsCoordinator.ruleCollections }
@@ -446,6 +451,9 @@ public class RuntimeCoordinator: SaveCoordinatorDelegate {
         }
         ruleCollectionsManager.onMappingConflictResolution = { [weak self] context in
             await self?.promptForMappingConflict(context)
+        }
+        ruleCollectionsManager.onPrerequisiteResolution = { [weak self] context in
+            await self?.promptForPrerequisiteResolution(context)
         }
         // Note: onActionURI callback not needed - RuleCollectionsManager.handleActionURI()
         // already dispatches to ActionDispatcher. Setting this would cause double dispatch.
@@ -1114,7 +1122,8 @@ public class RuntimeCoordinator: SaveCoordinatorDelegate {
 
             // Rule conflict resolution
             pendingRuleConflict: pendingRuleConflict,
-            pendingMappingConflict: pendingMappingConflict
+            pendingMappingConflict: pendingMappingConflict,
+            pendingPrerequisiteResolution: pendingPrerequisiteResolution
         )
     }
 
@@ -1533,6 +1542,42 @@ public class RuntimeCoordinator: SaveCoordinatorDelegate {
         pendingMappingConflict = nil
         mappingConflictContinuation?.resume(returning: collectionID)
         mappingConflictContinuation = nil
+        notifyStateChanged()
+    }
+
+    /// Prompts before applying an enable or save that introduces an unmet
+    /// requirement. The dialog receives a prepared presentation snapshot.
+    @MainActor
+    func promptForPrerequisiteResolution(
+        _ context: RulePrerequisiteResolutionContext
+    ) async -> RulePrerequisiteResolutionChoice? {
+        prerequisiteResolutionContinuation?.resume(returning: nil)
+        prerequisiteResolutionContinuation = nil
+
+        pendingPrerequisiteResolution = RulePrerequisiteDialogModel(context: context)
+        notifyStateChanged()
+        openPreferencesTab(.openSettingsRules)
+
+        return await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                prerequisiteResolutionContinuation = continuation
+            }
+        } onCancel: {
+            Task { @MainActor in
+                self.prerequisiteResolutionContinuation?.resume(returning: nil)
+                self.prerequisiteResolutionContinuation = nil
+                self.pendingPrerequisiteResolution = nil
+                self.notifyStateChanged()
+            }
+        }
+    }
+
+    func resolvePrerequisiteResolution(
+        with choice: RulePrerequisiteResolutionChoice?
+    ) {
+        pendingPrerequisiteResolution = nil
+        prerequisiteResolutionContinuation?.resume(returning: choice)
+        prerequisiteResolutionContinuation = nil
         notifyStateChanged()
     }
 

--- a/Sources/KeyPathAppKit/Models/KanataUIState.swift
+++ b/Sources/KeyPathAppKit/Models/KanataUIState.swift
@@ -54,6 +54,9 @@ struct KanataUIState: Sendable {
     /// Save-time mapping conflict resolution (#460)
     let pendingMappingConflict: MappingConflictContext?
 
+    /// Enable/save prerequisite resolution (#869)
+    let pendingPrerequisiteResolution: RulePrerequisiteDialogModel?
+
     /// Empty state for initialization fallback
     static let empty = KanataUIState(
         lastError: nil,
@@ -70,7 +73,8 @@ struct KanataUIState: Sendable {
         validationError: nil,
         saveStatus: .idle,
         pendingRuleConflict: nil,
-        pendingMappingConflict: nil
+        pendingMappingConflict: nil,
+        pendingPrerequisiteResolution: nil
     )
 }
 

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+PrerequisiteResolution.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+PrerequisiteResolution.swift
@@ -1,0 +1,165 @@
+import Foundation
+import KeyPathCore
+import KeyPathRulesCore
+
+/// The user action that introduced a proposed prerequisite change.
+enum RulePrerequisiteOperation: Equatable, Sendable {
+    case enable
+    case save
+}
+
+/// A presentation-neutral snapshot for the prerequisite confirmation UI.
+struct RulePrerequisiteResolutionContext: Equatable, Sendable {
+    let operation: RulePrerequisiteOperation
+    let candidate: RuleCollection
+    let prerequisites: [RulePrerequisite]
+    let affectedConsumers: [RuleCollection]
+    let availableProviders: [RuleCollection]
+
+    /// Provider IDs are returned in prerequisite order with duplicates removed.
+    /// `nil` means at least one requirement does not have one unambiguous provider.
+    var recommendedProviderIDs: [UUID]? {
+        var seen: Set<UUID> = []
+        var result: [UUID] = []
+
+        for prerequisite in prerequisites {
+            guard let providerID = prerequisite.recommendedProviderCollectionID else {
+                return nil
+            }
+            if seen.insert(providerID).inserted {
+                result.append(providerID)
+            }
+        }
+
+        return result
+    }
+}
+
+enum RulePrerequisiteResolutionChoice: Equatable, Sendable {
+    case enableRequiredProvidersAndApply
+    case applyWithoutProviders
+}
+
+extension RuleCollectionsManager {
+    /// Resolves the proposed prerequisite consequences before any mutation.
+    ///
+    /// An empty array means the candidate should be applied alone. A non-empty
+    /// array contains provider IDs that should be enabled in the same change.
+    /// `nil` means the user cancelled and nothing should be applied.
+    func confirmedPrerequisiteProviderIDs(
+        for candidate: RuleCollection,
+        operation: RulePrerequisiteOperation
+    ) async -> [UUID]? {
+        let missing = prerequisites(for: candidate)
+        guard !missing.isEmpty else { return [] }
+
+        // Non-interactive clients preserve the established behavior: apply the
+        // candidate while leaving missing providers disabled.
+        guard let onPrerequisiteResolution else { return [] }
+
+        let context = prerequisiteResolutionContext(
+            operation: operation,
+            candidate: candidate,
+            prerequisites: missing
+        )
+        guard let choice = await onPrerequisiteResolution(context) else {
+            return nil
+        }
+
+        switch choice {
+        case .applyWithoutProviders:
+            return []
+        case .enableRequiredProvidersAndApply:
+            return context.recommendedProviderIDs
+        }
+    }
+
+    /// Replaces or appends the candidate and enables confirmed providers
+    /// in memory. The caller owns the single regeneration and rollback.
+    func applyPrerequisiteChangeInMemory(
+        candidate: RuleCollection,
+        providerIDs: [UUID]
+    ) {
+        if let index = ruleCollections.firstIndex(where: { $0.id == candidate.id }) {
+            ruleCollections[index] = candidate
+        } else {
+            ruleCollections.append(candidate)
+        }
+
+        let catalog = RuleCollectionCatalog().defaultCollections()
+        for providerID in providerIDs {
+            if let index = ruleCollections.firstIndex(where: { $0.id == providerID }) {
+                ruleCollections[index].isEnabled = true
+            } else if let index = customRules.firstIndex(where: { $0.id == providerID }) {
+                customRules[index].isEnabled = true
+            } else if var provider = catalog.first(where: { $0.id == providerID }) {
+                provider.isEnabled = true
+                ruleCollections.append(provider)
+            }
+        }
+
+        dedupeRuleCollectionsInPlace()
+        refreshLayerIndicatorState()
+    }
+
+    /// Applies one proposed save plus its confirmed provider enables as a
+    /// single mutation and regeneration, restoring the full snapshot on failure.
+    func applyProposedCollectionWithPrerequisites(
+        _ candidate: RuleCollection,
+        rollbackMessage: String
+    ) async -> [UUID]? {
+        let snapshot = snapshotRuleState()
+        guard let providerIDs = await confirmedPrerequisiteProviderIDs(
+            for: candidate,
+            operation: .save
+        ) else {
+            return nil
+        }
+
+        applyPrerequisiteChangeInMemory(
+            candidate: candidate,
+            providerIDs: providerIDs
+        )
+
+        guard await regenerateConfigFromCollections() else {
+            AppLogger.shared.log(
+                "↩️ [RuleCollections] Prerequisite-aware save failed; rolling back"
+            )
+            await rollbackToSnapshot(snapshot, userMessage: rollbackMessage)
+            return nil
+        }
+
+        return providerIDs
+    }
+
+    private func prerequisiteResolutionContext(
+        operation: RulePrerequisiteOperation,
+        candidate: RuleCollection,
+        prerequisites: [RulePrerequisite]
+    ) -> RulePrerequisiteResolutionContext {
+        var knownCollections = [candidate]
+        knownCollections.append(contentsOf: ruleCollections.filter { $0.id != candidate.id })
+        knownCollections.append(contentsOf: customRules.asRuleCollections())
+
+        let existingIDs = Set(knownCollections.map(\.id))
+        knownCollections.append(contentsOf:
+            RuleCollectionCatalog().defaultCollections().filter {
+                !existingIDs.contains($0.id)
+            })
+
+        let providerIDs = Set(
+            prerequisites.flatMap(\.availableProviderCollectionIDs)
+        )
+        let consumerIDs = Set(prerequisites.map(\.consumerCollectionID))
+        let consumers = knownCollections.filter { consumerIDs.contains($0.id) }
+        let providers = knownCollections.filter { providerIDs.contains($0.id) }
+
+        return RulePrerequisiteResolutionContext(
+            operation: operation,
+            candidate: candidate,
+            prerequisites: prerequisites,
+            affectedConsumers: consumers,
+            availableProviders: providers
+        )
+    }
+}

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+PrerequisiteResolution.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+PrerequisiteResolution.swift
@@ -48,29 +48,35 @@ extension RuleCollectionsManager {
     /// `nil` means the user cancelled and nothing should be applied.
     func confirmedPrerequisiteProviderIDs(
         for candidate: RuleCollection,
-        operation: RulePrerequisiteOperation
+        operation: RulePrerequisiteOperation,
+        nonInteractiveChoice: RulePrerequisiteResolutionChoice = .applyWithoutProviders
     ) async -> [UUID]? {
         let missing = prerequisites(for: candidate)
         guard !missing.isEmpty else { return [] }
-
-        // Non-interactive clients preserve the established behavior: apply the
-        // candidate while leaving missing providers disabled.
-        guard let onPrerequisiteResolution else { return [] }
 
         let context = prerequisiteResolutionContext(
             operation: operation,
             candidate: candidate,
             prerequisites: missing
         )
-        guard let choice = await onPrerequisiteResolution(context) else {
-            return nil
+        let choice: RulePrerequisiteResolutionChoice
+        if let onPrerequisiteResolution {
+            guard let confirmedChoice = await onPrerequisiteResolution(context) else {
+                return nil
+            }
+            choice = confirmedChoice
+        } else {
+            choice = nonInteractiveChoice
         }
 
         switch choice {
         case .applyWithoutProviders:
             return []
         case .enableRequiredProvidersAndApply:
-            return context.recommendedProviderIDs
+            // Ambiguous graphs cannot be auto-fixed safely. Interactive callers
+            // hide the action; non-interactive callers fall back to applying
+            // without providers.
+            return context.recommendedProviderIDs ?? []
         }
     }
 
@@ -106,12 +112,14 @@ extension RuleCollectionsManager {
     /// single mutation and regeneration, restoring the full snapshot on failure.
     func applyProposedCollectionWithPrerequisites(
         _ candidate: RuleCollection,
-        rollbackMessage: String
+        rollbackMessage: String,
+        nonInteractiveChoice: RulePrerequisiteResolutionChoice = .applyWithoutProviders
     ) async -> [UUID]? {
         let snapshot = snapshotRuleState()
         guard let providerIDs = await confirmedPrerequisiteProviderIDs(
             for: candidate,
-            operation: .save
+            operation: .save,
+            nonInteractiveChoice: nonInteractiveChoice
         ) else {
             return nil
         }

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+PrerequisiteResolution.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+PrerequisiteResolution.swift
@@ -73,10 +73,13 @@ extension RuleCollectionsManager {
         case .applyWithoutProviders:
             return []
         case .enableRequiredProvidersAndApply:
-            // Ambiguous graphs cannot be auto-fixed safely. Interactive callers
-            // hide the action; non-interactive callers fall back to applying
-            // without providers.
-            return context.recommendedProviderIDs ?? []
+            guard let providerIDs = context.recommendedProviderIDs else {
+                AppLogger.shared.log(
+                    "⚠️ [RuleCollections] Automatic prerequisite resolution aborted because a requirement has multiple providers"
+                )
+                return nil
+            }
+            return providerIDs
         }
     }
 

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+PublicAPI.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+PublicAPI.swift
@@ -656,7 +656,8 @@ extension RuleCollectionsManager {
         guard let enabledProviderIDs = await applyProposedCollectionWithPrerequisites(
             candidate,
             rollbackMessage:
-            "Could not save Window Snapping. Your previous rule state was restored."
+            "Could not save Window Snapping. Your previous rule state was restored.",
+            nonInteractiveChoice: .enableRequiredProvidersAndApply
         ) else {
             return nil
         }

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+PublicAPI.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+PublicAPI.swift
@@ -47,10 +47,30 @@ extension RuleCollectionsManager {
 
         let catalogMatch = RuleCollectionCatalog().defaultCollections().first { $0.id == id }
         AppLogger.shared.log("🔀 [RuleCollections] catalogMatch=\(catalogMatch?.name ?? "nil")")
-        let candidate = ruleCollections.first(where: { $0.id == id }) ?? catalogMatch
+        guard var candidate = ruleCollections.first(where: { $0.id == id }) ?? catalogMatch else {
+            return false
+        }
+        candidate.isEnabled = isEnabled
 
-        if var candidate, isEnabled {
-            candidate.isEnabled = true
+        // Ensure home row mods config exists if this is a home row mods collection.
+        if candidate.displayStyle == .homeRowMods,
+           case .homeRowMods = candidate.configuration
+        {
+            // Already configured.
+        } else if candidate.displayStyle == .homeRowMods {
+            candidate.configuration = .homeRowMods(HomeRowModsConfig())
+        }
+
+        var prerequisiteProviderIDs: [UUID] = []
+        if isEnabled {
+            guard let confirmedProviderIDs = await confirmedPrerequisiteProviderIDs(
+                for: candidate,
+                operation: .enable
+            ) else {
+                return false
+            }
+            prerequisiteProviderIDs = confirmedProviderIDs
+
             if let conflict = conflictInfo(for: candidate) {
                 if autoResolveConflicts {
                     AppLogger.shared.log(
@@ -82,38 +102,17 @@ extension RuleCollectionsManager {
             }
         }
 
-        guard let resolvedCandidate = candidate else { return false }
-
-        if let index = ruleCollections.firstIndex(where: { $0.id == id }) {
-            ruleCollections[index].isEnabled = isEnabled
-            // Ensure home row mods config exists if this is a home row mods collection
-            if case .homeRowMods = ruleCollections[index].configuration {
-                // Already has config, nothing to do
-            } else if resolvedCandidate.displayStyle == .homeRowMods {
-                ruleCollections[index].configuration = .homeRowMods(HomeRowModsConfig())
-            }
-        } else {
-            var newCollection = resolvedCandidate
-            newCollection.isEnabled = isEnabled
-            // Ensure home row mods config exists if this is a home row mods collection
-            if newCollection.displayStyle == .homeRowMods {
-                if case .homeRowMods = newCollection.configuration {
-                    // Already has config
-                } else {
-                    newCollection.configuration = .homeRowMods(HomeRowModsConfig())
-                }
-            }
-            ruleCollections.append(newCollection)
-        }
-
-        dedupeRuleCollectionsInPlace()
+        applyPrerequisiteChangeInMemory(
+            candidate: candidate,
+            providerIDs: prerequisiteProviderIDs
+        )
 
         AppLogger.shared.log("🔀 [RuleCollections] After toggle - collections: \(ruleCollections.map { "\($0.name) (enabled: \($0.isEnabled))" }.joined(separator: ", "))")
 
         // Special handling: If Leader Key collection is toggled off, reset all momentary activators to default (space)
         if id == RuleCollectionIdentifier.leaderKey {
             if isEnabled {
-                let key = leaderKeyOutput(from: resolvedCandidate) ?? leaderPreferenceSnapshot.key
+                let key = leaderKeyOutput(from: candidate) ?? leaderPreferenceSnapshot.key
                 syncLeaderKeyPreference(key: key, enabled: true)
             } else {
                 syncLeaderKeyPreference(enabled: false)
@@ -121,7 +120,6 @@ extension RuleCollectionsManager {
             }
         }
 
-        refreshLayerIndicatorState()
         AppLogger.shared.log("🔀 [RuleCollections] Calling regenerateConfigFromCollections...")
         let applied = await regenerateConfigFromCollections()
         guard applied else {
@@ -466,58 +464,44 @@ extension RuleCollectionsManager {
     /// - Returns: `true` if the collection was newly enabled (was disabled before this call)
     @discardableResult
     func updateHomeRowModsConfig(id: UUID, config: HomeRowModsConfig) async -> Bool {
-        guard let index = ruleCollections.firstIndex(where: { $0.id == id }) else {
-            // Try to find in catalog and add it
-            let catalog = RuleCollectionCatalog()
-            if var catalogCollection = catalog.defaultCollections().first(where: { $0.id == id }) {
-                catalogCollection.configuration.updateHomeRowModsConfig(config)
-                catalogCollection.isEnabled = true
-                ruleCollections.append(catalogCollection)
-                dedupeRuleCollectionsInPlace()
-                refreshLayerIndicatorState()
-                await regenerateConfigFromCollections()
-                return true
-            }
+        guard var candidate = ruleCollections.first(where: { $0.id == id })
+            ?? RuleCollectionCatalog().defaultCollections().first(where: { $0.id == id })
+        else {
             return false
         }
 
-        let wasNewlyEnabled = !ruleCollections[index].isEnabled
-        ruleCollections[index].configuration.updateHomeRowModsConfig(config)
-        ruleCollections[index].isEnabled = true
+        let wasNewlyEnabled = !candidate.isEnabled
+        candidate.configuration.updateHomeRowModsConfig(config)
+        candidate.isEnabled = true
 
-        dedupeRuleCollectionsInPlace()
-        refreshLayerIndicatorState()
-        await regenerateConfigFromCollections()
-        return wasNewlyEnabled
+        let appliedProviderIDs = await applyProposedCollectionWithPrerequisites(
+            candidate,
+            rollbackMessage:
+            "Could not save Home Row Mods. Your previous rule state was restored."
+        )
+        return appliedProviderIDs != nil && wasNewlyEnabled
     }
 
     /// Update home row layer toggles configuration
     /// - Returns: `true` if the collection was newly enabled (was disabled before this call)
     @discardableResult
     func updateHomeRowLayerTogglesConfig(id: UUID, config: HomeRowLayerTogglesConfig) async -> Bool {
-        guard let index = ruleCollections.firstIndex(where: { $0.id == id }) else {
-            // Try to find in catalog and add it
-            let catalog = RuleCollectionCatalog()
-            if var catalogCollection = catalog.defaultCollections().first(where: { $0.id == id }) {
-                catalogCollection.configuration.updateHomeRowLayerTogglesConfig(config)
-                catalogCollection.isEnabled = true
-                ruleCollections.append(catalogCollection)
-                dedupeRuleCollectionsInPlace()
-                refreshLayerIndicatorState()
-                await regenerateConfigFromCollections()
-                return true
-            }
+        guard var candidate = ruleCollections.first(where: { $0.id == id })
+            ?? RuleCollectionCatalog().defaultCollections().first(where: { $0.id == id })
+        else {
             return false
         }
 
-        let wasNewlyEnabled = !ruleCollections[index].isEnabled
-        ruleCollections[index].configuration.updateHomeRowLayerTogglesConfig(config)
-        ruleCollections[index].isEnabled = true
+        let wasNewlyEnabled = !candidate.isEnabled
+        candidate.configuration.updateHomeRowLayerTogglesConfig(config)
+        candidate.isEnabled = true
 
-        dedupeRuleCollectionsInPlace()
-        refreshLayerIndicatorState()
-        await regenerateConfigFromCollections()
-        return wasNewlyEnabled
+        let appliedProviderIDs = await applyProposedCollectionWithPrerequisites(
+            candidate,
+            rollbackMessage:
+            "Could not save Home Row Layer Toggles. Your previous rule state was restored."
+        )
+        return appliedProviderIDs != nil && wasNewlyEnabled
     }
 
     /// Update chord groups configuration
@@ -582,34 +566,25 @@ extension RuleCollectionsManager {
     /// - Returns: `true` if the collection was newly enabled (was disabled before this call)
     @discardableResult
     func updateLauncherConfig(id: UUID, config: LauncherGridConfig) async -> Bool {
-        guard let index = ruleCollections.firstIndex(where: { $0.id == id }) else {
-            // Try to find in catalog and add it
-            let catalog = RuleCollectionCatalog()
-            if var catalogCollection = catalog.defaultCollections().first(where: { $0.id == id }) {
-                catalogCollection.configuration.updateLauncherGridConfig(config)
-                catalogCollection.isEnabled = true
-                ruleCollections.append(catalogCollection)
-                dedupeRuleCollectionsInPlace()
-                refreshLayerIndicatorState()
-                await regenerateConfigFromCollections()
-                // Cache warm new launcher icons
-                await warmLauncherIconCache(for: config)
-                return true
-            }
+        guard var candidate = ruleCollections.first(where: { $0.id == id })
+            ?? RuleCollectionCatalog().defaultCollections().first(where: { $0.id == id })
+        else {
             return false
         }
 
-        let wasNewlyEnabled = !ruleCollections[index].isEnabled
-        ruleCollections[index].configuration.updateLauncherGridConfig(config)
-        ruleCollections[index].isEnabled = true
+        let wasNewlyEnabled = !candidate.isEnabled
+        candidate.configuration.updateLauncherGridConfig(config)
+        candidate.isEnabled = true
 
-        dedupeRuleCollectionsInPlace()
-        refreshLayerIndicatorState()
-        await regenerateConfigFromCollections()
-
-        // Cache warm new launcher icons
-        await warmLauncherIconCache(for: config)
-        return wasNewlyEnabled
+        let appliedProviderIDs = await applyProposedCollectionWithPrerequisites(
+            candidate,
+            rollbackMessage:
+            "Could not save Launcher. Your previous rule state was restored."
+        )
+        if appliedProviderIDs != nil {
+            await warmLauncherIconCache(for: config)
+        }
+        return appliedProviderIDs != nil && wasNewlyEnabled
     }
 
     /// Update auto shift symbols configuration
@@ -670,17 +645,25 @@ extension RuleCollectionsManager {
     /// Update window snapping activation mode
     /// - Returns: name of auto-enabled dependency, or nil
     func updateWindowSnappingActivationMode(id: UUID, mode: WindowSnappingActivationMode) async -> String? {
-        guard let index = ruleCollections.firstIndex(where: { $0.id == id }) else { return nil }
+        guard var candidate = ruleCollections.first(where: { $0.id == id }) else {
+            return nil
+        }
 
-        ruleCollections[index].windowSnappingActivationMode = mode
-        ruleCollections[index].momentaryActivator = Self.momentaryActivatorForWindowSnapping(mode)
-        ruleCollections[index].activationHint = Self.activationHintForWindowSnapping(mode)
+        candidate.windowSnappingActivationMode = mode
+        candidate.momentaryActivator = Self.momentaryActivatorForWindowSnapping(mode)
+        candidate.activationHint = Self.activationHintForWindowSnapping(mode)
 
-        let autoEnabled = autoEnableWindowSnappingDependency(mode)
-        dedupeRuleCollectionsInPlace()
-        refreshLayerIndicatorState()
-        await regenerateConfigFromCollections()
-        return autoEnabled
+        guard let enabledProviderIDs = await applyProposedCollectionWithPrerequisites(
+            candidate,
+            rollbackMessage:
+            "Could not save Window Snapping. Your previous rule state was restored."
+        ) else {
+            return nil
+        }
+
+        return enabledProviderIDs.compactMap { providerID in
+            ruleCollections.first(where: { $0.id == providerID })?.name
+        }.first
     }
 
     private static func momentaryActivatorForWindowSnapping(_ mode: WindowSnappingActivationMode) -> MomentaryActivator {
@@ -696,29 +679,6 @@ extension RuleCollectionsManager {
         switch mode {
         case .leader: "Leader → w → action key"
         case .quickLauncher: "Hyper + w → action key"
-        }
-    }
-
-    private func autoEnableWindowSnappingDependency(_ mode: WindowSnappingActivationMode) -> String? {
-        switch mode {
-        case .leader:
-            let navID = RuleCollectionIdentifier.leaderKey
-            if !ruleCollections.contains(where: { $0.id == navID && $0.isEnabled }) {
-                if let idx = ruleCollections.firstIndex(where: { $0.id == navID }) {
-                    ruleCollections[idx].isEnabled = true
-                    return "Leader Key"
-                }
-            }
-            return nil
-        case .quickLauncher:
-            let launcherID = RuleCollectionIdentifier.launcher
-            if !ruleCollections.contains(where: { $0.id == launcherID && $0.isEnabled }) {
-                if let idx = ruleCollections.firstIndex(where: { $0.id == launcherID }) {
-                    ruleCollections[idx].isEnabled = true
-                    return "Quick Launcher"
-                }
-            }
-            return nil
         }
     }
 

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager.swift
@@ -90,6 +90,11 @@ final class RuleCollectionsManager {
     /// Returns the id of the collection to disable, or nil if cancelled.
     var onMappingConflictResolution: ((MappingConflictContext) async -> UUID?)?
 
+    /// Callback for resolving newly introduced rule prerequisites.
+    /// Returns the user's confirmed apply choice, or nil if cancelled.
+    var onPrerequisiteResolution:
+        ((RulePrerequisiteResolutionContext) async -> RulePrerequisiteResolutionChoice?)?
+
     /// Callback to suppress file watcher before internal saves (prevents double-reload beep)
     var onBeforeSave: (() -> Void)?
 

--- a/Sources/KeyPathAppKit/UI/Gallery/PackDetailView+BindingRows.swift
+++ b/Sources/KeyPathAppKit/UI/Gallery/PackDetailView+BindingRows.swift
@@ -42,9 +42,6 @@ extension PackDetailView {
                             await kanataManager.underlyingManager.rulesManager.createLayer(name)
                         }
                     },
-                    onEnableLayerCollections: { collectionIds in
-                        await kanataManager.batchEnableCollections(collectionIds)
-                    },
                     holdTimingBinding: holdTimingQuickSetting != nil ? sliderBinding(for: "holdTimeout") : nil,
                     holdTimingValue: quickSettingValues["holdTimeout"] ?? holdTimingDefaultValue,
                     holdTimingDefault: holdTimingDefaultValue,

--- a/Sources/KeyPathAppKit/UI/Gallery/PackDetailView+PackActions.swift
+++ b/Sources/KeyPathAppKit/UI/Gallery/PackDetailView+PackActions.swift
@@ -186,10 +186,13 @@ extension PackDetailView {
         // VM method returns Void (it's the manager layer underneath that
         // returns Bool-for-newly-enabled). Mirrors Rules' call site. If we
         // want surfaced error toasts here later, call the manager directly.
-        await kanataManager.updateHomeRowModsConfig(
+        let persistedConfig = await kanataManager.updateHomeRowModsConfig(
             collectionId: collectionID,
             config: newConfig
         )
+        await MainActor.run {
+            homeRowModsConfig = persistedConfig
+        }
     }
 
     /// Mirror of `applyHomeRowEdit` for Auto Shift Symbols.

--- a/Sources/KeyPathAppKit/UI/Rules/HomeRowModsCollectionView+Configuration.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/HomeRowModsCollectionView+Configuration.swift
@@ -177,11 +177,6 @@ extension HomeRowModsCollectionView {
         let isHovered = hoveredHoldBehavior == mode
 
         Button {
-            if mode == .layers {
-                config.layerAssignments = recommendedLayerAssignments
-                applyHoldMode(.layers)
-                return
-            }
             applyHoldMode(mode)
         } label: {
             HStack(spacing: 10) {
@@ -230,10 +225,15 @@ extension HomeRowModsCollectionView {
     }
 
     func applyHoldMode(_ mode: HomeRowHoldMode) {
-        config.holdMode = mode
-        config.hasUserSelectedHoldMode = true
+        var updatedConfig = config
+        if mode == .layers {
+            updatedConfig.layerAssignments = recommendedLayerAssignments
+        }
+        updatedConfig.holdMode = mode
+        updatedConfig.hasUserSelectedHoldMode = true
+        config = updatedConfig
         selectedKey = nil
-        updateConfig()
+        updateConfig(updatedConfig)
     }
 
     var holdBehaviorExplanationText: String {

--- a/Sources/KeyPathAppKit/UI/Rules/HomeRowModsCollectionView+Configuration.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/HomeRowModsCollectionView+Configuration.swift
@@ -178,17 +178,8 @@ extension HomeRowModsCollectionView {
 
         Button {
             if mode == .layers {
-                Task {
-                    let ids = [
-                        RuleCollectionIdentifier.vimNavigation,
-                        RuleCollectionIdentifier.symbolLayer,
-                        RuleCollectionIdentifier.numpadLayer,
-                        RuleCollectionIdentifier.funLayer
-                    ]
-                    await onEnableLayerCollections?(ids)
-                    config.layerAssignments = recommendedLayerAssignments
-                    applyHoldMode(.layers)
-                }
+                config.layerAssignments = recommendedLayerAssignments
+                applyHoldMode(.layers)
                 return
             }
             applyHoldMode(mode)

--- a/Sources/KeyPathAppKit/UI/Rules/HomeRowModsCollectionView.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/HomeRowModsCollectionView.swift
@@ -11,7 +11,6 @@ struct HomeRowModsCollectionView: View {
     let availableLayers: [String]
     let onConfigChanged: (HomeRowModsConfig) -> Void
     let onEnsureLayersExist: ([String]) async -> Void
-    let onEnableLayerCollections: (([UUID]) async -> Void)?
     var holdTimingBinding: Binding<Double>?
     var holdTimingValue: Int = 180
     var holdTimingDefault: Int = 180

--- a/Sources/KeyPathAppKit/UI/Rules/HomeRowModsCollectionView.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/HomeRowModsCollectionView.swift
@@ -182,8 +182,12 @@ struct HomeRowModsCollectionView: View {
     // MARK: - Helpers
 
     func updateConfig() {
+        updateConfig(config)
+    }
+
+    func updateConfig(_ updatedConfig: HomeRowModsConfig) {
         AppLogger.shared.log("🧪 [QA] Home Row Mods config changed: \(homeRowModsAccessibilityValue)")
-        onConfigChanged(config)
+        onConfigChanged(updatedConfig)
     }
 
     var activeHoldAssignments: [String: String] {

--- a/Sources/KeyPathAppKit/UI/Rules/RulePrerequisiteResolutionDialog.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/RulePrerequisiteResolutionDialog.swift
@@ -1,0 +1,346 @@
+import KeyPathRulesCore
+import SwiftUI
+
+struct RulePrerequisiteDialogRowID: Hashable, Sendable {
+    let consumerID: UUID
+    let capability: RuleCapability
+}
+
+struct RulePrerequisiteDialogRow: Equatable, Identifiable, Sendable {
+    let id: RulePrerequisiteDialogRowID
+    let consumerName: String
+    let capabilityName: String
+    let providerSummary: String
+    let evidence: [String]
+}
+
+/// A prepared, presentation-only snapshot for the prerequisite dialog.
+///
+/// Building this once when the request arrives keeps graph and collection
+/// transformations out of SwiftUI's repeatedly evaluated view body.
+struct RulePrerequisiteDialogModel: Equatable, Sendable {
+    let operation: RulePrerequisiteOperation
+    let candidateName: String
+    let rows: [RulePrerequisiteDialogRow]
+    let recommendedProviderNames: [String]
+    let canEnableAll: Bool
+
+    init(context: RulePrerequisiteResolutionContext) {
+        operation = context.operation
+        candidateName = context.candidate.name
+
+        let consumersByID = Dictionary(
+            context.affectedConsumers.map { ($0.id, $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+        let providersByID = Dictionary(
+            context.availableProviders.map { ($0.id, $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+
+        rows = context.prerequisites.map { prerequisite in
+            let providerNames = prerequisite.availableProviderCollectionIDs.compactMap {
+                providersByID[$0]?.name
+            }
+            return RulePrerequisiteDialogRow(
+                id: RulePrerequisiteDialogRowID(
+                    consumerID: prerequisite.consumerCollectionID,
+                    capability: prerequisite.missingCapability
+                ),
+                consumerName: consumersByID[prerequisite.consumerCollectionID]?.name
+                    ?? context.candidate.name,
+                capabilityName: Self.capabilityName(prerequisite.missingCapability),
+                providerSummary: Self.providerSummary(providerNames),
+                evidence: Self.evidenceDescriptions(prerequisite.requirement.sortedEvidence)
+            )
+        }
+
+        if let providerIDs = context.recommendedProviderIDs {
+            canEnableAll = true
+            recommendedProviderNames = providerIDs.compactMap { providersByID[$0]?.name }
+        } else {
+            canEnableAll = false
+            recommendedProviderNames = []
+        }
+    }
+
+    var primaryActionTitle: String {
+        switch operation {
+        case .enable:
+            "Enable Required Rules & Turn On"
+        case .save:
+            "Enable Required Rules & Save"
+        }
+    }
+
+    var secondaryActionTitle: String {
+        switch operation {
+        case .enable:
+            "Turn On Without Them"
+        case .save:
+            "Save Without Them"
+        }
+    }
+
+    var consequenceSummary: String {
+        switch operation {
+        case .enable:
+            "Turning on \(candidateName) introduces requirements that are not active."
+        case .save:
+            "Saving \(candidateName) introduces requirements that are not active."
+        }
+    }
+
+    private static func capabilityName(_ capability: RuleCapability) -> String {
+        switch capability {
+        case let .layerContent(layer):
+            "\(displayName(layer.rawValue)) layer content"
+        case let .layerActivation(layer):
+            "a way to enter the \(displayName(layer.rawValue)) layer"
+        case let .keyAlias(alias):
+            switch alias {
+            case .hyper:
+                "the Hyper key"
+            }
+        }
+    }
+
+    private static func providerSummary(_ providerNames: [String]) -> String {
+        switch providerNames.count {
+        case 0:
+            "No matching rule is currently available."
+        case 1:
+            "Provided by \(providerNames[0])."
+        default:
+            "Available from \(joinedList(providerNames))."
+        }
+    }
+
+    private static func evidenceDescriptions(
+        _ evidence: [RuleDependencyEvidence]
+    ) -> [String] {
+        evidence.map { item in
+            switch item {
+            case let .keys(keys):
+                let noun = keys.count == 1 ? "key" : "keys"
+                return "\(keys.count) affected \(noun): \(joinedList(keys.map(displayName)))"
+            case let .mappingIDs(ids):
+                let noun = ids.count == 1 ? "mapping" : "mappings"
+                return "\(ids.count) affected \(noun)"
+            case let .layerPath(source, target):
+                return "Layer path: \(displayName(source.rawValue)) to \(displayName(target.rawValue))"
+            case let .configuration(field, value):
+                return "\(displayName(field)): \(displayName(value))"
+            }
+        }
+    }
+
+    private static func joinedList(_ values: [String]) -> String {
+        switch values.count {
+        case 0:
+            ""
+        case 1:
+            values[0]
+        case 2:
+            "\(values[0]) and \(values[1])"
+        default:
+            "\(values.dropLast().joined(separator: ", ")), and \(values.last ?? "")"
+        }
+    }
+
+    private static func displayName(_ rawValue: String) -> String {
+        rawValue
+            .replacingOccurrences(of: "_", with: " ")
+            .replacingOccurrences(of: "-", with: " ")
+            .split(separator: " ")
+            .map(\.capitalized)
+            .joined(separator: " ")
+    }
+}
+
+struct RulePrerequisiteResolutionDialog: View {
+    let model: RulePrerequisiteDialogModel
+    let onChoice: (RulePrerequisiteResolutionChoice) -> Void
+    let onCancel: () -> Void
+
+    var body: some View {
+        VStack(spacing: 0) {
+            RulePrerequisiteDialogHeader(
+                consequenceSummary: model.consequenceSummary,
+                onCancel: onCancel
+            )
+
+            Divider()
+
+            RulePrerequisiteRequirementsSection(rows: model.rows)
+
+            Divider()
+
+            RulePrerequisiteActionsSection(
+                model: model,
+                onChoice: onChoice
+            )
+        }
+        .frame(width: 500)
+        .background(Color(NSColor.windowBackgroundColor))
+    }
+}
+
+private struct RulePrerequisiteDialogHeader: View {
+    let consequenceSummary: String
+    let onCancel: () -> Void
+
+    var body: some View {
+        ZStack(alignment: .topTrailing) {
+            VStack(spacing: 8) {
+                Text("Enable the rules this change needs?")
+                    .font(.title2.weight(.semibold))
+
+                Text(consequenceSummary)
+                    .font(.body)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                Text("Without them, the affected keys or actions may do nothing.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            .padding(.horizontal, 24)
+
+            Button(action: onCancel) {
+                Image(systemName: "xmark")
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 22, height: 22)
+                    .background(Circle().fill(Color.secondary.opacity(0.16)))
+            }
+            .buttonStyle(.plain)
+            .keyboardShortcut(.cancelAction)
+            .accessibilityIdentifier("rule-prerequisite-close-button")
+            .accessibilityLabel("Cancel")
+        }
+        .padding(20)
+    }
+}
+
+private struct RulePrerequisiteRequirementsSection: View {
+    let rows: [RulePrerequisiteDialogRow]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            ForEach(rows) { row in
+                RulePrerequisiteRequirementRow(row: row)
+            }
+        }
+        .padding(20)
+    }
+}
+
+private struct RulePrerequisiteRequirementRow: View {
+    let row: RulePrerequisiteDialogRow
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: "link")
+                .foregroundStyle(.secondary)
+                .frame(width: 20)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text("\(row.consumerName) needs \(row.capabilityName).")
+                    .font(.body.weight(.medium))
+
+                Text(row.providerSummary)
+                    .foregroundStyle(.secondary)
+
+                ForEach(row.evidence, id: \.self) { evidence in
+                    Text(evidence)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .fixedSize(horizontal: false, vertical: true)
+        }
+        .accessibilityElement(children: .combine)
+    }
+}
+
+private struct RulePrerequisiteActionsSection: View {
+    let model: RulePrerequisiteDialogModel
+    let onChoice: (RulePrerequisiteResolutionChoice) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            if !model.canEnableAll {
+                Text("KeyPath found more than one possible provider for at least one requirement. Choose one manually later, or continue without it.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            ViewThatFits {
+                HStack(spacing: 12) {
+                    actionButtons
+                }
+
+                VStack(spacing: 10) {
+                    actionButtons
+                }
+            }
+        }
+        .padding(20)
+    }
+
+    @ViewBuilder
+    private var actionButtons: some View {
+        Button {
+            onChoice(.applyWithoutProviders)
+        } label: {
+            Text(model.secondaryActionTitle)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 6)
+        }
+        .buttonStyle(.bordered)
+        .accessibilityIdentifier("rule-prerequisite-apply-without-button")
+
+        if model.canEnableAll {
+            Button {
+                onChoice(.enableRequiredProvidersAndApply)
+            } label: {
+                Text(model.primaryActionTitle)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 6)
+            }
+            .buttonStyle(.borderedProminent)
+            .keyboardShortcut(.defaultAction)
+            .accessibilityIdentifier("rule-prerequisite-enable-required-button")
+        }
+    }
+}
+
+#if DEBUG
+    struct RulePrerequisiteResolutionDialog_Previews: PreviewProvider {
+        static var previews: some View {
+            RulePrerequisiteResolutionDialog(
+                model: RulePrerequisiteDialogModel(
+                    context: RulePrerequisiteResolutionContext(
+                        operation: .save,
+                        candidate: RuleCollection(
+                            id: UUID(),
+                            name: "Home Row Layer Toggles",
+                            summary: "Hold a home-row key to enter a layer",
+                            category: .layers,
+                            mappings: [],
+                            isEnabled: true
+                        ),
+                        prerequisites: [],
+                        affectedConsumers: [],
+                        availableProviders: []
+                    )
+                ),
+                onChoice: { _ in },
+                onCancel: {}
+            )
+        }
+    }
+#endif

--- a/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView+CollectionRow.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView+CollectionRow.swift
@@ -53,13 +53,11 @@ struct ExpandableCollectionRow: View {
     /// For tapHoldPicker style: callback to select hold output
     var onSelectHoldOutput: ((String) -> Void)?
     /// For homeRowMods style: callback to update config
-    var onUpdateHomeRowModsConfig: ((HomeRowModsConfig) -> Void)?
+    var onUpdateHomeRowModsConfig: ((HomeRowModsConfig, @escaping (HomeRowModsConfig) -> Void) -> Void)?
     /// For homeRowMods style: existing layer names to offer in layer-mode popover
     var homeRowAvailableLayers: [String] = []
     /// For homeRowMods style: create any missing layers before enabling layer mode
     var onEnsureHomeRowLayersExist: (([String]) async -> Void)?
-    /// For homeRowMods style: enable catalog layer collections when switching to layer mode
-    var onEnableLayerCollections: (([UUID]) async -> Void)?
     /// For homeRowMods style: callback to open modal
     var onOpenHomeRowModsModal: (() -> Void)?
     /// For homeRowMods style: callback to open modal with a specific key selected
@@ -429,18 +427,18 @@ struct ExpandableCollectionRow: View {
                             get: { effectiveHomeRowModsConfig },
                             set: { newConfig in
                                 localHomeRowModsConfig = newConfig
-                                onUpdateHomeRowModsConfig?(newConfig)
                             }
                         ),
                         availableLayers: homeRowAvailableLayers,
                         onConfigChanged: { newConfig in
                             localHomeRowModsConfig = newConfig
-                            onUpdateHomeRowModsConfig?(newConfig)
+                            onUpdateHomeRowModsConfig?(newConfig) { persistedConfig in
+                                localHomeRowModsConfig = persistedConfig
+                            }
                         },
                         onEnsureLayersExist: { layerNames in
                             await onEnsureHomeRowLayersExist?(layerNames)
-                        },
-                        onEnableLayerCollections: onEnableLayerCollections
+                        }
                     )
                     .padding(.top, 8)
                     .padding(.bottom, 12)

--- a/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView+RowBuilder.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView+RowBuilder.swift
@@ -61,18 +61,23 @@ extension RulesTabView {
             onSelectHoldOutput: style == .tapHoldPicker ? { hold in
                 Task { await kanataManager.updateCollectionHoldOutput(collection.id, holdOutput: hold) }
             } : nil,
-            onUpdateHomeRowModsConfig: style == .homeRowMods ? { config in
+            onUpdateHomeRowModsConfig: style == .homeRowMods ? { config, completion in
                 pendingToggles[collection.id] = true
-                Task { await kanataManager.updateHomeRowModsConfig(collectionId: collection.id, config: config) }
+                Task {
+                    let persistedConfig = await kanataManager.updateHomeRowModsConfig(
+                        collectionId: collection.id,
+                        config: config
+                    )
+                    await MainActor.run {
+                        completion(persistedConfig)
+                    }
+                }
             } : nil,
             homeRowAvailableLayers: style == .homeRowMods ? availableHomeRowLayers(for: collection) : [],
             onEnsureHomeRowLayersExist: style == .homeRowMods ? { layerNames in
                 for layerName in layerNames {
                     await kanataManager.underlyingManager.rulesManager.createLayer(layerName)
                 }
-            } : nil,
-            onEnableLayerCollections: style == .homeRowMods ? { collectionIds in
-                await kanataManager.batchEnableCollections(collectionIds)
             } : nil,
             onOpenHomeRowModsModal: style == .homeRowMods ? {
                 homeRowModsEditState = HomeRowModsEditState(collection: collection, selectedKey: nil)

--- a/Sources/KeyPathAppKit/UI/Settings/SettingsContainerView.swift
+++ b/Sources/KeyPathAppKit/UI/Settings/SettingsContainerView.swift
@@ -39,6 +39,8 @@ struct SettingsContainerView: View {
     @State private var canManageRules: Bool = true
 
     var body: some View {
+        @Bindable var kanataManager = kanataManager
+
         TabView(selection: $selection) {
             StatusSettingsTabView()
                 .tabItem {
@@ -76,6 +78,20 @@ struct SettingsContainerView: View {
         }
         .accessibilityIdentifier("settings-window")
         .background(tabShortcutHandlers)
+        .sheet(isPresented: $kanataManager.showPrerequisiteResolutionDialog) {
+            if let model = kanataManager.pendingPrerequisiteResolution {
+                RulePrerequisiteResolutionDialog(
+                    model: model,
+                    onChoice: { choice in
+                        kanataManager.resolvePrerequisiteResolution(with: choice)
+                    },
+                    onCancel: {
+                        kanataManager.resolvePrerequisiteResolution(with: nil)
+                    }
+                )
+                .interactiveDismissDisabled()
+            }
+        }
         .frame(
             minWidth: 680,
             idealWidth: 680,

--- a/Sources/KeyPathAppKit/UI/ViewModels/KanataViewModel.swift
+++ b/Sources/KeyPathAppKit/UI/ViewModels/KanataViewModel.swift
@@ -368,9 +368,10 @@ class KanataViewModel {
     func updateHomeRowModsConfig(collectionId: UUID, config: HomeRowModsConfig) async -> HomeRowModsConfig {
         let wasNewlyEnabled = await manager.updateHomeRowModsConfig(collectionId: collectionId, config: config)
         ruleCollections = manager.rulesManager.ruleCollections
-        let persistedConfig = ruleCollections
-            .first(where: { $0.id == collectionId })?
-            .configuration.homeRowModsConfig ?? config
+        let persistedConfig = Self.persistedHomeRowModsConfig(
+            collectionId: collectionId,
+            collections: ruleCollections
+        )
         AppLogger.shared.log(
             "🧪 [QA] Persisted Home Row Mods config collection=\(collectionId.uuidString) mode=\(config.holdMode.rawValue) keys=\(config.enabledKeys.sorted().joined(separator: ",")) tapWindow=\(config.timing.tapWindow) holdDelay=\(config.timing.holdDelay)"
         )
@@ -379,6 +380,19 @@ class KanataViewModel {
             showToast("Turned on \(name)", type: .success)
         }
         return persistedConfig
+    }
+
+    static func persistedHomeRowModsConfig(
+        collectionId: UUID,
+        collections: [RuleCollection]
+    ) -> HomeRowModsConfig {
+        collections
+            .first(where: { $0.id == collectionId })?
+            .configuration.homeRowModsConfig
+            ?? RuleCollectionCatalog().defaultCollections()
+            .first(where: { $0.id == collectionId })?
+            .configuration.homeRowModsConfig
+            ?? HomeRowModsConfig()
     }
 
     func updateHomeRowLayerTogglesConfig(collectionId: UUID, config: HomeRowLayerTogglesConfig) async {

--- a/Sources/KeyPathAppKit/UI/ViewModels/KanataViewModel.swift
+++ b/Sources/KeyPathAppKit/UI/ViewModels/KanataViewModel.swift
@@ -61,6 +61,10 @@ class KanataViewModel {
     var showMappingConflictDialog = false
     var pendingMappingConflict: MappingConflictContext?
 
+    // Enable/save prerequisite resolution (#869)
+    var showPrerequisiteResolutionDialog = false
+    var pendingPrerequisiteResolution: RulePrerequisiteDialogModel?
+
     enum ToastType {
         case success
         case error
@@ -145,6 +149,9 @@ class KanataViewModel {
         // Handle save-time mapping conflict resolution dialog (#460)
         pendingMappingConflict = state.pendingMappingConflict
         showMappingConflictDialog = state.pendingMappingConflict != nil
+
+        pendingPrerequisiteResolution = state.pendingPrerequisiteResolution
+        showPrerequisiteResolutionDialog = state.pendingPrerequisiteResolution != nil
 
         // Map validation error to alert properties
         if let error = state.validationError {
@@ -357,9 +364,13 @@ class KanataViewModel {
         ruleCollections = manager.rulesManager.ruleCollections
     }
 
-    func updateHomeRowModsConfig(collectionId: UUID, config: HomeRowModsConfig) async {
+    @discardableResult
+    func updateHomeRowModsConfig(collectionId: UUID, config: HomeRowModsConfig) async -> HomeRowModsConfig {
         let wasNewlyEnabled = await manager.updateHomeRowModsConfig(collectionId: collectionId, config: config)
         ruleCollections = manager.rulesManager.ruleCollections
+        let persistedConfig = ruleCollections
+            .first(where: { $0.id == collectionId })?
+            .configuration.homeRowModsConfig ?? config
         AppLogger.shared.log(
             "🧪 [QA] Persisted Home Row Mods config collection=\(collectionId.uuidString) mode=\(config.holdMode.rawValue) keys=\(config.enabledKeys.sorted().joined(separator: ",")) tapWindow=\(config.timing.tapWindow) holdDelay=\(config.timing.holdDelay)"
         )
@@ -367,6 +378,7 @@ class KanataViewModel {
             let name = ruleCollections.first(where: { $0.id == collectionId })?.name ?? "Collection"
             showToast("Turned on \(name)", type: .success)
         }
+        return persistedConfig
     }
 
     func updateHomeRowLayerTogglesConfig(collectionId: UUID, config: HomeRowLayerTogglesConfig) async {
@@ -544,6 +556,13 @@ class KanataViewModel {
     func resolveMappingConflict(disabling collectionID: UUID?) {
         showMappingConflictDialog = false
         manager.resolveMappingConflict(disabling: collectionID)
+    }
+
+    func resolvePrerequisiteResolution(
+        with choice: RulePrerequisiteResolutionChoice?
+    ) {
+        showPrerequisiteResolutionDialog = false
+        manager.resolvePrerequisiteResolution(with: choice)
     }
 }
 

--- a/Tests/KeyPathTests/RuleCollections/RuleCollectionsManagerPrerequisiteResolutionTests.swift
+++ b/Tests/KeyPathTests/RuleCollections/RuleCollectionsManagerPrerequisiteResolutionTests.swift
@@ -1,0 +1,453 @@
+@testable import KeyPathAppKit
+import KeyPathCore
+import KeyPathRulesCore
+import XCTest
+
+@MainActor
+final class RuleCollectionsManagerPrerequisiteResolutionTests: XCTestCase {
+    func testEnableRequiredProvidersAppliesOneAtomicRegeneration() async throws {
+        let manager = try makeManager()
+        defer { TestEnvironment.forceTestMode = false }
+        let provider = layerContentProvider(
+            id: uuid(1),
+            name: "Function",
+            enabled: false
+        )
+        let candidate = homeRowToggles(
+            id: uuid(2),
+            enabled: false,
+            assignments: ["a": "fun"]
+        )
+        manager.ruleCollections = [provider, candidate]
+
+        var receivedContext: RulePrerequisiteResolutionContext?
+        manager.onPrerequisiteResolution = { context in
+            receivedContext = context
+            return .enableRequiredProvidersAndApply
+        }
+        var regenerationCount = 0
+        manager.onBeforeSave = { regenerationCount += 1 }
+
+        let applied = await manager.toggleCollection(
+            id: candidate.id,
+            isEnabled: true,
+            bypassOwnershipCheck: true
+        )
+
+        XCTAssertTrue(applied)
+        XCTAssertEqual(receivedContext?.operation, .enable)
+        XCTAssertEqual(receivedContext?.candidate.id, candidate.id)
+        XCTAssertEqual(receivedContext?.recommendedProviderIDs, [provider.id])
+        XCTAssertEqual(receivedContext?.availableProviders.map(\.id), [provider.id])
+        XCTAssertEqual(receivedContext?.affectedConsumers.map(\.id), [candidate.id])
+
+        let dialogModel = try XCTUnwrap(receivedContext.map(
+            RulePrerequisiteDialogModel.init(context:)
+        ))
+        XCTAssertTrue(dialogModel.canEnableAll)
+        XCTAssertEqual(dialogModel.candidateName, "Home Row Layer Toggles")
+        XCTAssertEqual(dialogModel.recommendedProviderNames, ["Function"])
+        XCTAssertEqual(
+            dialogModel.primaryActionTitle,
+            "Enable Required Rules & Turn On"
+        )
+        XCTAssertEqual(dialogModel.secondaryActionTitle, "Turn On Without Them")
+        XCTAssertEqual(dialogModel.rows.map(\.consumerName), [
+            "Home Row Layer Toggles",
+        ])
+        XCTAssertEqual(dialogModel.rows.map(\.capabilityName), [
+            "Fun layer content",
+        ])
+        XCTAssertEqual(dialogModel.rows.map(\.providerSummary), [
+            "Provided by Function.",
+        ])
+        XCTAssertEqual(dialogModel.rows.flatMap(\.evidence), [
+            "1 affected key: A",
+        ])
+        XCTAssertEqual(regenerationCount, 1)
+        XCTAssertTrue(manager.ruleCollections[id: candidate.id]?.isEnabled == true)
+        XCTAssertTrue(manager.ruleCollections[id: provider.id]?.isEnabled == true)
+    }
+
+    func testCancelAppliesNothing() async throws {
+        let manager = try makeManager()
+        defer { TestEnvironment.forceTestMode = false }
+        let provider = layerContentProvider(
+            id: uuid(10),
+            name: "Function",
+            enabled: false
+        )
+        let candidate = homeRowToggles(
+            id: uuid(11),
+            enabled: false,
+            assignments: ["a": "fun"]
+        )
+        manager.ruleCollections = [provider, candidate]
+        manager.onPrerequisiteResolution = { _ in nil }
+
+        var regenerationCount = 0
+        manager.onBeforeSave = { regenerationCount += 1 }
+
+        let applied = await manager.toggleCollection(
+            id: candidate.id,
+            isEnabled: true,
+            bypassOwnershipCheck: true
+        )
+
+        XCTAssertFalse(applied)
+        XCTAssertEqual(regenerationCount, 0)
+        XCTAssertTrue(manager.ruleCollections[id: candidate.id]?.isEnabled == false)
+        XCTAssertTrue(manager.ruleCollections[id: provider.id]?.isEnabled == false)
+    }
+
+    func testSaveWithoutProvidersAppliesOnlyCandidateEdit() async throws {
+        let manager = try makeManager()
+        defer { TestEnvironment.forceTestMode = false }
+        let provider = layerContentProvider(
+            id: uuid(20),
+            name: "Function",
+            enabled: false
+        )
+        let candidate = homeRowToggles(
+            id: uuid(21),
+            enabled: false,
+            assignments: [:]
+        )
+        manager.ruleCollections = [provider, candidate]
+
+        var receivedContext: RulePrerequisiteResolutionContext?
+        manager.onPrerequisiteResolution = { context in
+            receivedContext = context
+            return .applyWithoutProviders
+        }
+        var regenerationCount = 0
+        manager.onBeforeSave = { regenerationCount += 1 }
+
+        let newlyEnabled = await manager.updateHomeRowLayerTogglesConfig(
+            id: candidate.id,
+            config: HomeRowLayerTogglesConfig(
+                enabledKeys: ["a"],
+                layerAssignments: ["a": "fun"]
+            )
+        )
+
+        XCTAssertTrue(newlyEnabled)
+        XCTAssertEqual(receivedContext?.operation, .save)
+        XCTAssertEqual(regenerationCount, 1)
+        XCTAssertTrue(manager.ruleCollections[id: candidate.id]?.isEnabled == true)
+        XCTAssertTrue(manager.ruleCollections[id: provider.id]?.isEnabled == false)
+        XCTAssertEqual(
+            manager.ruleCollections[id: candidate.id]?
+                .configuration.homeRowLayerTogglesConfig?.layerAssignments,
+            ["a": "fun"]
+        )
+    }
+
+    func testConfigurationEditAnalyzesProposedStateBeforeMutation() async throws {
+        let manager = try makeManager()
+        defer { TestEnvironment.forceTestMode = false }
+        let provider = layerContentProvider(
+            id: uuid(30),
+            name: "Function",
+            enabled: false
+        )
+        let candidate = homeRowToggles(
+            id: uuid(31),
+            enabled: true,
+            assignments: [:]
+        )
+        manager.ruleCollections = [provider, candidate]
+
+        var receivedContext: RulePrerequisiteResolutionContext?
+        manager.onPrerequisiteResolution = { context in
+            receivedContext = context
+            return nil
+        }
+
+        _ = await manager.updateHomeRowLayerTogglesConfig(
+            id: candidate.id,
+            config: HomeRowLayerTogglesConfig(
+                enabledKeys: ["a", ";"],
+                layerAssignments: ["a": "fun", ";": "fun"]
+            )
+        )
+
+        XCTAssertEqual(
+            receivedContext?.prerequisites.first?.requirement.evidence,
+            [.keys([";", "a"])]
+        )
+        XCTAssertEqual(
+            manager.ruleCollections[id: candidate.id]?
+                .configuration.homeRowLayerTogglesConfig?.layerAssignments,
+            [:],
+            "Cancelling must leave the stored configuration untouched"
+        )
+    }
+
+    func testHomeRowModsLayerEditDerivesAllProvidersFromGraph() async throws {
+        let manager = try makeManager()
+        defer { TestEnvironment.forceTestMode = false }
+        let function = layerContentProvider(
+            id: uuid(35),
+            name: "Function",
+            enabled: false,
+            layerName: "fun"
+        )
+        let numpad = layerContentProvider(
+            id: uuid(36),
+            name: "Numpad",
+            enabled: false,
+            layerName: "num"
+        )
+        let symbols = layerContentProvider(
+            id: uuid(37),
+            name: "Symbol",
+            enabled: false,
+            layerName: "sym"
+        )
+        let navigation = layerContentProvider(
+            id: uuid(39),
+            name: "Navigation",
+            enabled: false,
+            layerName: "nav"
+        )
+        let candidate = RuleCollection(
+            id: uuid(38),
+            name: "Home Row Mods",
+            summary: "Test",
+            category: .custom,
+            mappings: [],
+            isEnabled: false,
+            configuration: .homeRowMods(HomeRowModsConfig())
+        )
+        manager.ruleCollections = [
+            function,
+            numpad,
+            symbols,
+            navigation,
+            candidate,
+        ]
+
+        var receivedContext: RulePrerequisiteResolutionContext?
+        manager.onPrerequisiteResolution = { context in
+            receivedContext = context
+            return .enableRequiredProvidersAndApply
+        }
+        var regenerationCount = 0
+        manager.onBeforeSave = { regenerationCount += 1 }
+
+        var layerConfig = HomeRowModsConfig()
+        layerConfig.holdMode = .layers
+        let newlyEnabled = await manager.updateHomeRowModsConfig(
+            id: candidate.id,
+            config: layerConfig
+        )
+
+        XCTAssertTrue(newlyEnabled)
+        XCTAssertEqual(regenerationCount, 1)
+        XCTAssertEqual(
+            Set(receivedContext?.recommendedProviderIDs ?? []),
+            Set([function.id, numpad.id, symbols.id, navigation.id])
+        )
+        XCTAssertTrue(manager.ruleCollections[id: function.id]?.isEnabled == true)
+        XCTAssertTrue(manager.ruleCollections[id: numpad.id]?.isEnabled == true)
+        XCTAssertTrue(manager.ruleCollections[id: symbols.id]?.isEnabled == true)
+        XCTAssertTrue(manager.ruleCollections[id: navigation.id]?.isEnabled == true)
+        XCTAssertTrue(manager.ruleCollections[id: candidate.id]?.isEnabled == true)
+    }
+
+    func testMultipleProvidersDisableAutomaticFix() async throws {
+        let manager = try makeManager()
+        defer { TestEnvironment.forceTestMode = false }
+        let first = layerContentProvider(
+            id: uuid(40),
+            name: "First Function",
+            enabled: false
+        )
+        let second = layerContentProvider(
+            id: uuid(41),
+            name: "Second Function",
+            enabled: false
+        )
+        let candidate = homeRowToggles(
+            id: uuid(42),
+            enabled: false,
+            assignments: ["a": "fun"]
+        )
+        manager.ruleCollections = [first, second, candidate]
+
+        var recommendedProviderIDs: [UUID]?
+        var didReceiveContext = false
+        var receivedContext: RulePrerequisiteResolutionContext?
+        manager.onPrerequisiteResolution = { context in
+            didReceiveContext = true
+            receivedContext = context
+            recommendedProviderIDs = context.recommendedProviderIDs
+            return .applyWithoutProviders
+        }
+
+        _ = await manager.toggleCollection(
+            id: candidate.id,
+            isEnabled: true,
+            bypassOwnershipCheck: true
+        )
+
+        XCTAssertTrue(didReceiveContext)
+        XCTAssertNil(recommendedProviderIDs)
+        let context = try XCTUnwrap(receivedContext)
+        let dialogModel = RulePrerequisiteDialogModel(context: context)
+        XCTAssertFalse(dialogModel.canEnableAll)
+        XCTAssertEqual(dialogModel.rows.map(\.providerSummary), [
+            "Available from First Function and Second Function.",
+        ])
+        XCTAssertTrue(manager.ruleCollections[id: first.id]?.isEnabled == false)
+        XCTAssertTrue(manager.ruleCollections[id: second.id]?.isEnabled == false)
+    }
+
+    func testFailedAtomicSaveRestoresCandidateAndProvider() async throws {
+        let manager = try makeManager()
+        defer { TestEnvironment.forceTestMode = false }
+        let provider = layerContentProvider(
+            id: uuid(50),
+            name: "Function",
+            enabled: false,
+            input: "x",
+            output: "y",
+            activatorKey: "f"
+        )
+        let conflicting = RuleCollection(
+            id: uuid(51),
+            name: "Existing Function",
+            summary: "Test",
+            category: .custom,
+            mappings: [
+                KeyMapping(input: "z", action: .keystroke(key: "q")),
+            ],
+            isEnabled: true,
+            targetLayer: .custom("sym"),
+            momentaryActivator: MomentaryActivator(
+                input: "f",
+                targetLayer: .custom("sym")
+            ),
+            configuration: .list
+        )
+        let candidate = homeRowToggles(
+            id: uuid(52),
+            enabled: false,
+            assignments: [:]
+        )
+        manager.ruleCollections = [provider, conflicting, candidate]
+        manager.onPrerequisiteResolution = { _ in
+            .enableRequiredProvidersAndApply
+        }
+
+        var regenerationCount = 0
+        manager.onBeforeSave = { regenerationCount += 1 }
+
+        let newlyEnabled = await manager.updateHomeRowLayerTogglesConfig(
+            id: candidate.id,
+            config: HomeRowLayerTogglesConfig(
+                enabledKeys: ["a"],
+                layerAssignments: ["a": "fun"]
+            )
+        )
+
+        XCTAssertFalse(newlyEnabled)
+        XCTAssertEqual(
+            regenerationCount,
+            2,
+            "The failed apply and rollback should each regenerate exactly once"
+        )
+        XCTAssertTrue(manager.ruleCollections[id: candidate.id]?.isEnabled == false)
+        XCTAssertTrue(manager.ruleCollections[id: provider.id]?.isEnabled == false)
+        XCTAssertTrue(manager.ruleCollections[id: conflicting.id]?.isEnabled == true)
+        XCTAssertEqual(
+            manager.ruleCollections[id: candidate.id]?
+                .configuration.homeRowLayerTogglesConfig?.layerAssignments,
+            [:]
+        )
+    }
+
+    private func makeManager() throws -> RuleCollectionsManager {
+        TestEnvironment.forceTestMode = true
+        let directory = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("prerequisite-resolution-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true
+        )
+
+        return RuleCollectionsManager(
+            ruleCollectionStore: RuleCollectionStore(
+                fileURL: directory.appendingPathComponent("RuleCollections.json")
+            ),
+            customRulesStore: CustomRulesStore(
+                fileURL: directory.appendingPathComponent("CustomRules.json")
+            ),
+            configurationService: ConfigurationService(
+                configDirectory: directory.path
+            )
+        )
+    }
+
+    private func homeRowToggles(
+        id: UUID,
+        enabled: Bool,
+        assignments: [String: String]
+    ) -> RuleCollection {
+        RuleCollection(
+            id: id,
+            name: "Home Row Layer Toggles",
+            summary: "Test",
+            category: .custom,
+            mappings: [],
+            isEnabled: enabled,
+            configuration: .homeRowLayerToggles(HomeRowLayerTogglesConfig(
+                enabledKeys: Set(assignments.keys),
+                layerAssignments: assignments
+            ))
+        )
+    }
+
+    private func layerContentProvider(
+        id: UUID,
+        name: String,
+        enabled: Bool,
+        input: String = "x",
+        output: String = "y",
+        activatorKey: String? = nil,
+        layerName: String = "fun"
+    ) -> RuleCollection {
+        RuleCollection(
+            id: id,
+            name: name,
+            summary: "Test",
+            category: .custom,
+            mappings: [
+                KeyMapping(input: input, action: .keystroke(key: output)),
+            ],
+            isEnabled: enabled,
+            targetLayer: .custom(layerName),
+            momentaryActivator: activatorKey.map {
+                MomentaryActivator(
+                    input: $0,
+                    targetLayer: .custom(layerName)
+                )
+            },
+            configuration: .list
+        )
+    }
+
+    private func uuid(_ value: Int) -> UUID {
+        UUID(uuidString: String(
+            format: "00000000-0000-0000-0000-%012d",
+            value
+        ))!
+    }
+}
+
+private extension [RuleCollection] {
+    subscript(id id: UUID) -> RuleCollection? {
+        first { $0.id == id }
+    }
+}

--- a/Tests/KeyPathTests/RuleCollections/RuleCollectionsManagerPrerequisiteResolutionTests.swift
+++ b/Tests/KeyPathTests/RuleCollections/RuleCollectionsManagerPrerequisiteResolutionTests.swift
@@ -100,6 +100,29 @@ final class RuleCollectionsManagerPrerequisiteResolutionTests: XCTestCase {
         XCTAssertTrue(manager.ruleCollections[id: provider.id]?.isEnabled == false)
     }
 
+    func testCancelCatalogOnlyCandidateDoesNotInsertAttemptedConfig() async throws {
+        let manager = try makeManager()
+        defer { TestEnvironment.forceTestMode = false }
+        manager.ruleCollections = RuleCollectionCatalog().defaultCollections()
+            .filter { $0.id != RuleCollectionIdentifier.homeRowMods }
+        manager.onPrerequisiteResolution = { _ in nil }
+
+        var attempted = HomeRowModsConfig()
+        attempted.holdMode = .layers
+
+        _ = await manager.updateHomeRowModsConfig(
+            id: RuleCollectionIdentifier.homeRowMods,
+            config: attempted
+        )
+
+        XCTAssertNil(
+            manager.ruleCollections.first {
+                $0.id == RuleCollectionIdentifier.homeRowMods
+            },
+            "Cancelling a catalog-only edit must not insert its attempted config"
+        )
+    }
+
     func testSaveWithoutProvidersAppliesOnlyCandidateEdit() async throws {
         let manager = try makeManager()
         defer { TestEnvironment.forceTestMode = false }

--- a/Tests/KeyPathTests/RuleCollections/RuleCollectionsManagerPrerequisiteResolutionTests.swift
+++ b/Tests/KeyPathTests/RuleCollections/RuleCollectionsManagerPrerequisiteResolutionTests.swift
@@ -327,6 +327,42 @@ final class RuleCollectionsManagerPrerequisiteResolutionTests: XCTestCase {
         XCTAssertTrue(manager.ruleCollections[id: second.id]?.isEnabled == false)
     }
 
+    func testNonInteractiveAutomaticFixAbortsWhenProvidersAreAmbiguous() async throws {
+        let manager = try makeManager()
+        defer { TestEnvironment.forceTestMode = false }
+        let first = layerContentProvider(
+            id: uuid(43),
+            name: "First Function",
+            enabled: false
+        )
+        let second = layerContentProvider(
+            id: uuid(44),
+            name: "Second Function",
+            enabled: false
+        )
+        let candidate = homeRowToggles(
+            id: uuid(45),
+            enabled: false,
+            assignments: ["a": "fun"]
+        )
+        manager.ruleCollections = [first, second, candidate]
+
+        var regenerationCount = 0
+        manager.onBeforeSave = { regenerationCount += 1 }
+
+        let appliedProviderIDs = await manager.applyProposedCollectionWithPrerequisites(
+            candidate,
+            rollbackMessage: "Test rollback",
+            nonInteractiveChoice: .enableRequiredProvidersAndApply
+        )
+
+        XCTAssertNil(appliedProviderIDs)
+        XCTAssertEqual(regenerationCount, 0)
+        XCTAssertTrue(manager.ruleCollections[id: candidate.id]?.isEnabled == false)
+        XCTAssertTrue(manager.ruleCollections[id: first.id]?.isEnabled == false)
+        XCTAssertTrue(manager.ruleCollections[id: second.id]?.isEnabled == false)
+    }
+
     func testFailedAtomicSaveRestoresCandidateAndProvider() async throws {
         let manager = try makeManager()
         defer { TestEnvironment.forceTestMode = false }

--- a/Tests/KeyPathTests/ViewModelSyncTests.swift
+++ b/Tests/KeyPathTests/ViewModelSyncTests.swift
@@ -77,9 +77,6 @@ struct WindowSnappingActivationModeTests {
         if let idx = manager.ruleCollections.firstIndex(where: { $0.id == RuleCollectionIdentifier.launcher }) {
             manager.ruleCollections[idx].isEnabled = false
         }
-        manager.onPrerequisiteResolution = { _ in
-            .enableRequiredProvidersAndApply
-        }
 
         let autoEnabled = await manager.updateWindowSnappingActivationMode(
             id: RuleCollectionIdentifier.windowSnapping,
@@ -89,6 +86,20 @@ struct WindowSnappingActivationModeTests {
         #expect(autoEnabled == "Quick Launcher")
         let launcher = manager.ruleCollections.first { $0.id == RuleCollectionIdentifier.launcher }
         #expect(launcher?.isEnabled == true)
+    }
+
+    @Test("Catalog-only cancelled Home Row Mods edits resolve to catalog state")
+    func catalogOnlyHomeRowModsFallback() {
+        var attempted = HomeRowModsConfig()
+        attempted.holdMode = .layers
+
+        let persisted = KanataViewModel.persistedHomeRowModsConfig(
+            collectionId: RuleCollectionIdentifier.homeRowMods,
+            collections: []
+        )
+
+        #expect(persisted.holdMode == .modifiers)
+        #expect(persisted != attempted)
     }
 
     @Test("Activation mode updates activation hint")

--- a/Tests/KeyPathTests/ViewModelSyncTests.swift
+++ b/Tests/KeyPathTests/ViewModelSyncTests.swift
@@ -77,6 +77,9 @@ struct WindowSnappingActivationModeTests {
         if let idx = manager.ruleCollections.firstIndex(where: { $0.id == RuleCollectionIdentifier.launcher }) {
             manager.ruleCollections[idx].isEnabled = false
         }
+        manager.onPrerequisiteResolution = { _ in
+            .enableRequiredProvidersAndApply
+        }
 
         let autoEnabled = await manager.updateWindowSnappingActivationMode(
             id: RuleCollectionIdentifier.windowSnapping,


### PR DESCRIPTION
## What changed

- analyze proposed rule enables and configuration edits before mutating stored state
- present a prerequisite dialog with affected rules, missing capabilities, provider alternatives, and concrete evidence
- support Enable Required Rules & Apply, Apply Without Them, and Cancel
- apply the candidate plus selected providers atomically with one regeneration and full rollback on failure
- replace Home Row Mods and Window Snapping hard-coded provider enabling with graph-derived recommendations
- restore both persisted and visible editor state after cancellation

## Why

Issue #869 needs the prerequisite graph from #866/#870 to become an actionable user flow. Previously some editors silently enabled hard-coded companion rules, while other changes could leave unmet requirements without explaining the consequence.

## User impact

Users see exactly what a rule change needs before it is applied. They can accept the safe graph-derived fix, continue intentionally without providers, or cancel without any saved or visible partial change. New rules can participate by declaring graph capabilities and evidence rather than adding UI-specific rule-name logic.

## Validation

- prerequisite resolution tests: 7 passed
- Window Snapping activation tests: 9 passed
- accessibility identifier scan: passed across 355 files
- installed-app walkthrough: enable, apply, cancel, config-edit rollback, and provider state restoration verified
- broad safe suite: 4,798 passed; one unrelated wall-clock timing assertion failed under parallel load, then its complete 16-test `SystemValidatorTests` suite passed in isolation
- review gate: remote review selected; `claude-review` must pass before merge

Closes #869