### PR TITLE
Add owned Tart USB passthrough lab lane

### DIFF
--- a/Scripts/lab/keypath-lab
+++ b/Scripts/lab/keypath-lab
@@ -12,7 +12,7 @@ Usage: Scripts/lab/keypath-lab [--host HOST] <command> [options]
 
 Commands:
   preflight
-  create --macos 15|26|27 --lane managed-functional|unmanaged-ui --commit SHA --installer PATH [--ttl 2h] [--desktop]
+  create --macos 15|26|27 --lane managed-functional|unmanaged-ui --commit SHA --installer PATH [--ttl 2h] [--desktop] [--tart-usb-passthrough]
   install-app LEASE_ID
   console-login LEASE_ID
   reset-guest-password LEASE_ID
@@ -85,6 +85,7 @@ case "$command" in
         installer=
         ttl=2h
         desktop=0
+        tart_usb_passthrough=0
         while [[ $# -gt 0 ]]; do
             case "$1" in
                 --macos) macos=${2:-}; shift 2 ;;
@@ -93,12 +94,14 @@ case "$command" in
                 --installer) installer=${2:-}; shift 2 ;;
                 --ttl) ttl=${2:-}; shift 2 ;;
                 --desktop) desktop=1; shift ;;
+                --tart-usb-passthrough) tart_usb_passthrough=1; shift ;;
                 *) usage ;;
             esac
         done
         [[ $macos == "15" || $macos == "26" || $macos == "27" ]] || die "--macos must be 15, 26, or 27"
         [[ $lane == "managed-functional" || $lane == "unmanaged-ui" ]] || die "--lane must be managed-functional or unmanaged-ui"
         [[ ! ($macos == "27" && $lane == "managed-functional") ]] || die "managed-functional is not yet supported on macOS 27"
+        [[ $tart_usb_passthrough == "0" || $macos == "15" ]] || die "--tart-usb-passthrough requires --macos 15"
         [[ $commit =~ ^[0-9a-fA-F]{40}$ ]] || die "--commit must be a full 40-character SHA"
         [[ -f $installer ]] || die "installer not found: $installer"
         resolved=$(git -C "$REPO_ROOT" rev-parse --verify "$commit^{commit}")
@@ -132,7 +135,7 @@ EOF
         [[ $upload_ticket == /tmp/keypath-lab.* ]] || die "host returned an invalid upload ticket"
         scp -q "$temp_dir/archive.tgz" "$host:$upload_ticket"
         remote install-archive "$upload_ticket" "$archive_key" "$commit" "$installer_sha" "$installer_name"
-        remote create "$macos" "$lane" "$archive_key" "$commit" "$installer_sha" "$installer_name" "$ttl" "$desktop"
+        remote create "$macos" "$lane" "$archive_key" "$commit" "$installer_sha" "$installer_name" "$ttl" "$desktop" "$tart_usb_passthrough"
         ;;
     install-app)
         [[ $# -eq 1 ]] || usage

--- a/Scripts/lab/remote.sh
+++ b/Scripts/lab/remote.sh
@@ -24,6 +24,8 @@ else
   GUEST_SSH="${KEYPATH_LAB_GUEST_SSH:-/usr/bin/ssh}"
 fi
 
+TART_USB_TOOL_ROOT="${KEYPATH_LAB_TART_USB_TOOL_ROOT:-$LAB_ROOT/CompatTools/KeyPathUSB}"
+
 STATE_ROOT="$LAB_ROOT/KeyPathInstallerLab"
 ARCHIVES="$STATE_ROOT/archives"
 LEASES="$STATE_ROOT/leases"
@@ -644,13 +646,22 @@ lease_candidate_from_line() {
 }
 
 create_lease() {
-  local macos=$1 lane=$2 archive_key=$3 commit=$4 installer_sha=$5 installer_name=$6 ttl=$7 desktop=$8
+  local macos=$1 lane=$2 archive_key=$3 commit=$4 installer_sha=$5 installer_name=$6 ttl=$7 desktop=$8 tart_usb_passthrough=${9:-0}
   local launcher provider archive repo slug output lease created expires manifest guest_output product build operation ttl_seconds
   local provider_resource create_status candidate_file create_log exit_code managed_policy_exit identity_scope
   launcher=$(launcher_for "$macos")
   provider=$(provider_for "$macos")
   [[ "$lane" == "managed-functional" || "$lane" == "unmanaged-ui" ]] || die "invalid test lane: $lane"
   [[ ! ("$macos" == "27" && "$lane" == "managed-functional") ]] || die "managed-functional is not yet supported on macOS 27"
+  [[ "$tart_usb_passthrough" == "0" || "$tart_usb_passthrough" == "1" ]] || die "invalid Tart USB passthrough setting"
+  [[ "$tart_usb_passthrough" == "0" || "$macos" == "15" ]] || die "Tart USB passthrough requires macOS 15"
+  if [[ "$tart_usb_passthrough" == "1" ]]; then
+    [[ -x "$TART_USB_TOOL_ROOT/bin/crabbox-usb" ]] || die "USB-enabled CrabBox is unavailable"
+    [[ -x "$TART_USB_TOOL_ROOT/tart-usb.app/Contents/MacOS/tart" ]] || die "signed USB-enabled Tart is unavailable"
+    CRABBOX="$TART_USB_TOOL_ROOT/bin/crabbox-usb"
+    export CRABBOX_TART_USB_PASSTHROUGH=true
+    export PATH="$TART_USB_TOOL_ROOT/bin:$PATH"
+  fi
   if [[ "${KEYPATH_LAB_TESTING:-0}" != "1" && "$macos" == "15" && "$lane" == "managed-functional" ]]; then
     desktop=1
   fi
@@ -726,6 +737,7 @@ create_lease() {
     print "status\tcreated"
     print "cleanup_status\tpending"
     print "desktop_enabled\t$([[ "$desktop" == "1" ]] && print true || print false)"
+    print "tart_usb_passthrough\t$([[ "$tart_usb_passthrough" == "1" ]] && print true || print false)"
     print "provider_resource\t${provider_resource:-unknown}"
   } > "$manifest"
   if (( create_status != 0 )); then
@@ -1597,7 +1609,7 @@ case "$action" in
   preflight) [[ $# -eq 0 ]] || die "preflight takes no arguments"; preflight ;;
   prepare-upload) [[ $# -eq 1 ]] || die "prepare-upload requires archive key"; prepare_upload "$1" ;;
   install-archive) [[ $# -eq 5 ]] || die "install-archive requires ticket, key, commit, checksum, and name"; install_archive "$@" ;;
-  create) [[ $# -eq 8 ]] || die "create requires macOS, test lane, archive, commit, checksum, name, ttl, desktop"; create_lease "$@" ;;
+  create) [[ $# -eq 8 || $# -eq 9 ]] || die "create requires macOS, test lane, archive, commit, checksum, name, ttl, desktop, and optional Tart USB passthrough"; create_lease "$@" ;;
   install-app) [[ $# -eq 1 ]] || die "install-app requires lease"; install_app "$1" ;;
   secure-dialog-input) [[ $# -eq 5 ]] || die "secure-dialog-input requires lease, app, field, optional submit value, and focus mode"; secure_dialog_input "$@" ;;
   resume-managed-policy) [[ $# -eq 1 ]] || die "resume-managed-policy requires a lease"; resume_managed_policy "$1" ;;

--- a/Scripts/lab/tests/keypath-lab-tests.sh
+++ b/Scripts/lab/tests/keypath-lab-tests.sh
@@ -136,6 +136,9 @@ else
 fi
 EOF
 chmod +x "$ROOT/bin/tart" "$ROOT/bin/guest-ssh"
+mkdir -p "$ROOT/CompatTools/KeyPathUSB/bin" "$ROOT/CompatTools/KeyPathUSB/tart-usb.app/Contents/MacOS"
+cp "$ROOT/bin/crabbox" "$ROOT/CompatTools/KeyPathUSB/bin/crabbox-usb"
+cp "$ROOT/bin/tart" "$ROOT/CompatTools/KeyPathUSB/tart-usb.app/Contents/MacOS/tart"
 cat > "$ROOT/bin/prlctl" <<EOF
 #!/bin/bash
 echo "prlctl \$*" >> "$CALLS"
@@ -394,6 +397,12 @@ fi
 run_remote destroy cbx_test15 >/dev/null
 grep -q 'stop-15 cbx_test15' "$CALLS"
 grep -q $'cleanup_status\tcomplete' "$manifest"
+
+usb_create=$(run_remote create 15 unmanaged-ui "$archive_key" "$commit" "$checksum" KeyPath.zip 2h 0 1)
+assert_contains "$usb_create" $'lease_id\tcbx_test15'
+usb_manifest="$ROOT/KeyPathInstallerLab/leases/cbx_test15/manifest.tsv"
+grep -q $'tart_usb_passthrough\ttrue' "$usb_manifest"
+run_remote destroy cbx_test15 >/dev/null
 
 printf 'pid\t%s\nprovider\ttart\n' "$$" > "$ROOT/KeyPathInstallerLab/provider-admission-tart.lock"
 parallel_provider_create=$(run_remote create 26 unmanaged-ui "$archive_key" "$commit" "$checksum" KeyPath.zip 2h 0)


### PR DESCRIPTION
## What changed

- adds `--tart-usb-passthrough` to the owned KeyPath lab controller
- restricts the option to the macOS 15 Tart provider
- selects the separately deployed, signed USB-enabled Tart and matching CrabBox binary only for that lease creation
- records the USB passthrough state in the lease manifest
- adds a shell regression covering the USB-enabled creation path

## Why

P02 needs a guest-visible physical USB keyboard input source. The lab must launch the entitled Dock-visible Tart build through the same admission, ownership, evidence, and cleanup contract as every other disposable test VM.

## Validation

- `Scripts/lab/tests/keypath-lab-tests.sh`
- `bash -n Scripts/lab/keypath-lab`
- `zsh -n Scripts/lab/remote.sh`
- `git diff --check`

Local review gate selected the required remote GitHub `claude-review` path.