### PR TITLE
Preserve USB Tart path during lab warmup

### DIFF
--- a/Scripts/lab/remote.sh
+++ b/Scripts/lab/remote.sh
@@ -57,6 +57,14 @@ provider_for() {
   case "$1" in 15) print tart ;; 26|27) print parallels ;; *) die "unsupported macOS lane: $1" ;; esac
 }
 
+configure_tart_path() {
+  local usb_prefix=
+  if [[ "${CRABBOX_TART_USB_PASSTHROUGH:-false}" == "true" ]]; then
+    usb_prefix="$TART_USB_TOOL_ROOT/bin:"
+  fi
+  export PATH="${usb_prefix}$LAB_ROOT/CompatTools/bin:$LAB_ROOT/SharedTools/bin:/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+}
+
 base_for() {
   local macos=$1 lane=$2
   if [[ "$macos" == "15" ]]; then
@@ -473,7 +481,7 @@ warmup_desktop() {
     "$CRABBOX" warmup --provider "$(provider_for "$macos")" --target macos --desktop --slug "$slug" --ttl 2h
   elif [[ "$macos" == "15" ]]; then
     if [[ "${USER:-}" == "clawd" ]]; then export TART_HOME="$LAB_ROOT/TartHome-clawd"; else export TART_HOME="$LAB_ROOT/TartHome"; fi
-    export PATH="$LAB_ROOT/CompatTools/bin:$LAB_ROOT/SharedTools/bin:/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+    configure_tart_path
     "$CRABBOX" warmup --provider tart --target macos --desktop \
       --tart-image "$(base_for "$macos" "$lane")" \
       --tart-user admin --tart-cpu 4 --tart-memory 8192 --tart-random-serial --ssh-port 22 \
@@ -495,7 +503,7 @@ warmup_lease() {
     "$(launcher_for "$macos")" warmup "$slug"
   elif [[ "$macos" == "15" ]]; then
     if [[ "${USER:-}" == "clawd" ]]; then export TART_HOME="$LAB_ROOT/TartHome-clawd"; else export TART_HOME="$LAB_ROOT/TartHome"; fi
-    export PATH="$LAB_ROOT/CompatTools/bin:$LAB_ROOT/SharedTools/bin:/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+    configure_tart_path
     "$CRABBOX" warmup --provider tart --target macos \
       --tart-image "$(base_for "$macos" "$lane")" \
       --tart-user admin --tart-cpu 4 --tart-memory 8192 --tart-random-serial --ssh-port 22 \

--- a/Scripts/lab/tests/keypath-lab-tests.sh
+++ b/Scripts/lab/tests/keypath-lab-tests.sh
@@ -194,6 +194,7 @@ grep -Fq 'exec 3<> \"\$fifo\"; KEYPATH_GUEST_PASSWORD=; IFS= read -r -t $credent
 grep -Fq 'IFS= read -r secret_value || [[ -n "$secret_value" ]]' "$REMOTE"
 grep -Fq 'managed_clone_enrollment\talready-enrolled' "$REMOTE"
 grep -Fq 'window.subrole() === "AXSystemDialog"' "$REMOTE"
+grep -Fq 'usb_prefix="$TART_USB_TOOL_ROOT/bin:"' "$REMOTE"
 if grep -Fq 'peekaboo see --app "System Settings"' "$REMOTE"; then
     echo "capture prompt guard must not create a new capture request" >&2
     exit 1


### PR DESCRIPTION
## What changed

- centralizes the Tart PATH used by owned lab warmups
- keeps the signed USB Tart directory first only when the guarded USB passthrough mode is active
- preserves the existing standard Tart path for every ordinary lease
- adds a contract assertion for the USB path prefix

## Root cause

The USB lane selected the signed CrabBox binary correctly, but the desktop warmup function then replaced PATH and caused CrabBox to invoke the shared Tart binary, which does not have `--usb-passthrough`.

## Validation

- `Scripts/lab/tests/keypath-lab-tests.sh`
- `zsh -n Scripts/lab/remote.sh`
- `git diff --check`

The failed live attempt reported no lease ID, no matching Tart process, and no matching Tart inventory entry.