### PR TITLE
[1.1] Add reverse prerequisite disable flow

### DIFF
--- a/Sources/KeyPathAppKit/Managers/RuntimeCoordinator.swift
+++ b/Sources/KeyPathAppKit/Managers/RuntimeCoordinator.swift
@@ -120,6 +120,11 @@ public class RuntimeCoordinator: SaveCoordinatorDelegate {
     var prerequisiteResolutionContinuation:
         CheckedContinuation<RulePrerequisiteResolutionChoice?, Never>?
 
+    // Reverse dependent resolution state (#868)
+    var pendingDependentResolution: RuleDependentResolutionDialogModel?
+    var dependentResolutionContinuation:
+        CheckedContinuation<RuleDependentResolutionChoice?, Never>?
+
     /// Rule collections are now managed by RuleCollectionsCoordinator
     var ruleCollections: [RuleCollection] {
         get { ruleCollectionsCoordinator.ruleCollections }
@@ -454,6 +459,9 @@ public class RuntimeCoordinator: SaveCoordinatorDelegate {
         }
         ruleCollectionsManager.onPrerequisiteResolution = { [weak self] context in
             await self?.promptForPrerequisiteResolution(context)
+        }
+        ruleCollectionsManager.onDependentResolution = { [weak self] context in
+            await self?.promptForDependentResolution(context)
         }
         // Note: onActionURI callback not needed - RuleCollectionsManager.handleActionURI()
         // already dispatches to ActionDispatcher. Setting this would cause double dispatch.
@@ -1123,7 +1131,8 @@ public class RuntimeCoordinator: SaveCoordinatorDelegate {
             // Rule conflict resolution
             pendingRuleConflict: pendingRuleConflict,
             pendingMappingConflict: pendingMappingConflict,
-            pendingPrerequisiteResolution: pendingPrerequisiteResolution
+            pendingPrerequisiteResolution: pendingPrerequisiteResolution,
+            pendingDependentResolution: pendingDependentResolution
         )
     }
 
@@ -1578,6 +1587,43 @@ public class RuntimeCoordinator: SaveCoordinatorDelegate {
         pendingPrerequisiteResolution = nil
         prerequisiteResolutionContinuation?.resume(returning: choice)
         prerequisiteResolutionContinuation = nil
+        notifyStateChanged()
+    }
+
+    /// Prompts before disabling a provider that is still required by enabled rules.
+    @MainActor
+    func promptForDependentResolution(
+        _ context: RuleDependentResolutionContext
+    ) async -> RuleDependentResolutionChoice? {
+        dependentResolutionContinuation?.resume(returning: nil)
+        dependentResolutionContinuation = nil
+
+        pendingDependentResolution = RuleDependentResolutionDialogModel(
+            context: context
+        )
+        notifyStateChanged()
+        openPreferencesTab(.openSettingsRules)
+
+        return await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                dependentResolutionContinuation = continuation
+            }
+        } onCancel: {
+            Task { @MainActor in
+                self.dependentResolutionContinuation?.resume(returning: nil)
+                self.dependentResolutionContinuation = nil
+                self.pendingDependentResolution = nil
+                self.notifyStateChanged()
+            }
+        }
+    }
+
+    func resolveDependentResolution(
+        with choice: RuleDependentResolutionChoice?
+    ) {
+        pendingDependentResolution = nil
+        dependentResolutionContinuation?.resume(returning: choice)
+        dependentResolutionContinuation = nil
         notifyStateChanged()
     }
 

--- a/Sources/KeyPathAppKit/Models/KanataUIState.swift
+++ b/Sources/KeyPathAppKit/Models/KanataUIState.swift
@@ -57,6 +57,9 @@ struct KanataUIState: Sendable {
     /// Enable/save prerequisite resolution (#869)
     let pendingPrerequisiteResolution: RulePrerequisiteDialogModel?
 
+    /// Disable-time dependent resolution (#868)
+    let pendingDependentResolution: RuleDependentResolutionDialogModel?
+
     /// Empty state for initialization fallback
     static let empty = KanataUIState(
         lastError: nil,
@@ -74,7 +77,8 @@ struct KanataUIState: Sendable {
         saveStatus: .idle,
         pendingRuleConflict: nil,
         pendingMappingConflict: nil,
-        pendingPrerequisiteResolution: nil
+        pendingPrerequisiteResolution: nil,
+        pendingDependentResolution: nil
     )
 }
 

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+DependentResolution.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+DependentResolution.swift
@@ -1,0 +1,73 @@
+import Foundation
+import KeyPathRulesCore
+
+/// A presentation-neutral snapshot of the enabled rules that would lose a
+/// required capability if a provider were disabled.
+struct RuleDependentResolutionContext: Equatable, Sendable {
+    let providerID: UUID
+    let providerName: String
+    let dependents: [RuleDependentMapping]
+    let affectedConsumers: [RuleCollection]
+    let availableProviders: [RuleCollection]
+}
+
+enum RuleDependentResolutionChoice: Equatable, Sendable {
+    case disableAnyway
+}
+
+extension RuleCollectionsManager {
+    /// Confirms a proposed disable before any mutation occurs.
+    ///
+    /// Interactive app callers receive the reverse-dependency dialog.
+    /// Headless callers preserve the existing direct-disable behavior.
+    func confirmedDisableOfProvider(
+        id providerID: UUID,
+        name providerName: String
+    ) async -> Bool {
+        let dependentMappings = dependents(ifDisabling: providerID)
+        guard !dependentMappings.isEmpty else { return true }
+
+        guard let onDependentResolution else {
+            return true
+        }
+
+        let context = dependentResolutionContext(
+            providerID: providerID,
+            providerName: providerName,
+            dependents: dependentMappings
+        )
+        return await onDependentResolution(context) == .disableAnyway
+    }
+
+    private func dependentResolutionContext(
+        providerID: UUID,
+        providerName: String,
+        dependents: [RuleDependentMapping]
+    ) -> RuleDependentResolutionContext {
+        var knownCollections = ruleCollections
+        knownCollections.append(contentsOf: customRules.asRuleCollections())
+
+        let existingIDs = Set(knownCollections.map(\.id))
+        knownCollections.append(contentsOf:
+            RuleCollectionCatalog().defaultCollections().filter {
+                !existingIDs.contains($0.id)
+            })
+
+        let consumerIDs = Set(dependents.map(\.dependentCollectionID))
+        let providerIDs = Set(
+            dependents.flatMap(\.remainingAvailableProviderCollectionIDs)
+        )
+
+        return RuleDependentResolutionContext(
+            providerID: providerID,
+            providerName: providerName,
+            dependents: dependents,
+            affectedConsumers: knownCollections.filter {
+                consumerIDs.contains($0.id)
+            },
+            availableProviders: knownCollections.filter {
+                providerIDs.contains($0.id)
+            }
+        )
+    }
+}

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+PublicAPI.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+PublicAPI.swift
@@ -52,6 +52,15 @@ extension RuleCollectionsManager {
         }
         candidate.isEnabled = isEnabled
 
+        if !isEnabled {
+            guard await confirmedDisableOfProvider(
+                id: candidate.id,
+                name: candidate.name
+            ) else {
+                return false
+            }
+        }
+
         // Ensure home row mods config exists if this is a home row mods collection.
         if candidate.displayStyle == .homeRowMods,
            case .homeRowMods = candidate.configuration
@@ -901,6 +910,15 @@ extension RuleCollectionsManager {
     func toggleCustomRule(id: UUID, isEnabled: Bool) async {
         let snapshot = snapshotRuleState()
         guard let existing = customRules.first(where: { $0.id == id }) else { return }
+
+        if !isEnabled {
+            guard await confirmedDisableOfProvider(
+                id: existing.id,
+                name: existing.displayTitle
+            ) else {
+                return
+            }
+        }
 
         if isEnabled,
            let conflict = conflictInfo(for: existing)

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager.swift
@@ -95,6 +95,11 @@ final class RuleCollectionsManager {
     var onPrerequisiteResolution:
         ((RulePrerequisiteResolutionContext) async -> RulePrerequisiteResolutionChoice?)?
 
+    /// Callback for confirming a disable that would orphan enabled dependents.
+    /// Returns `.disableAnyway`, or nil to keep the provider enabled.
+    var onDependentResolution:
+        ((RuleDependentResolutionContext) async -> RuleDependentResolutionChoice?)?
+
     /// Callback to suppress file watcher before internal saves (prevents double-reload beep)
     var onBeforeSave: (() -> Void)?
 

--- a/Sources/KeyPathAppKit/UI/Rules/RuleDependentResolutionDialog.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/RuleDependentResolutionDialog.swift
@@ -1,0 +1,319 @@
+import KeyPathRulesCore
+import SwiftUI
+
+struct RuleDependentDialogRowID: Hashable, Sendable {
+    let dependentID: UUID
+    let capability: RuleCapability
+}
+
+struct RuleDependentDialogRow: Equatable, Identifiable, Sendable {
+    let id: RuleDependentDialogRowID
+    let usageSummary: String
+    let evidence: [String]
+    let alternativeProviderNames: [String]
+}
+
+/// A prepared presentation snapshot for the reverse dependency dialog.
+///
+/// Collection lookup and evidence formatting happen once when the request
+/// arrives rather than inside SwiftUI's repeatedly evaluated body.
+struct RuleDependentResolutionDialogModel: Equatable, Sendable {
+    let providerName: String
+    let rows: [RuleDependentDialogRow]
+    let dependentCount: Int
+    let collapseDetails: Bool
+
+    init(context: RuleDependentResolutionContext) {
+        providerName = context.providerName
+
+        let consumersByID = Dictionary(
+            context.affectedConsumers.map { ($0.id, $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+        let providersByID = Dictionary(
+            context.availableProviders.map { ($0.id, $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+
+        rows = context.dependents.map { dependent in
+            let consumerName = consumersByID[dependent.dependentCollectionID]?.name
+                ?? "Another enabled rule"
+            return RuleDependentDialogRow(
+                id: RuleDependentDialogRowID(
+                    dependentID: dependent.dependentCollectionID,
+                    capability: dependent.newlyUnsatisfiedCapability
+                ),
+                usageSummary: Self.usageSummary(
+                    consumerName: consumerName,
+                    providerName: context.providerName,
+                    capability: dependent.newlyUnsatisfiedCapability
+                ),
+                evidence: RulePrerequisiteDialogModel.evidenceDescriptions(
+                    dependent.requirement.sortedEvidence
+                ),
+                alternativeProviderNames:
+                dependent.remainingAvailableProviderCollectionIDs.compactMap {
+                    providersByID[$0]?.name
+                }
+            )
+        }
+
+        dependentCount = Set(context.dependents.map(\.dependentCollectionID)).count
+        collapseDetails = rows.count > 3
+    }
+
+    private static func usageSummary(
+        consumerName: String,
+        providerName: String,
+        capability: RuleCapability
+    ) -> String {
+        switch capability {
+        case let .layerContent(layer):
+            "\(consumerName) uses \(providerName) for the \(RulePrerequisiteDialogModel.displayName(layer.rawValue)) layer."
+        case let .layerActivation(layer):
+            "\(consumerName) uses \(providerName) to enter the \(RulePrerequisiteDialogModel.displayName(layer.rawValue)) layer."
+        case let .keyAlias(alias):
+            switch alias {
+            case .hyper:
+                "\(consumerName) uses \(providerName) for the Hyper key."
+            }
+        }
+    }
+}
+
+struct RuleDependentResolutionDialog: View {
+    let model: RuleDependentResolutionDialogModel
+    let onKeepEnabled: () -> Void
+    let onDisableAnyway: () -> Void
+
+    var body: some View {
+        VStack(spacing: 0) {
+            RuleDependentDialogHeader(
+                providerName: model.providerName,
+                dependentCount: model.dependentCount,
+                onKeepEnabled: onKeepEnabled
+            )
+
+            Divider()
+
+            RuleDependentRulesSection(
+                rows: model.rows,
+                collapseDetails: model.collapseDetails
+            )
+
+            Divider()
+
+            RuleDependentActionsSection(
+                providerName: model.providerName,
+                onKeepEnabled: onKeepEnabled,
+                onDisableAnyway: onDisableAnyway
+            )
+        }
+        .frame(width: 500)
+        .background(Color(NSColor.windowBackgroundColor))
+    }
+}
+
+private struct RuleDependentDialogHeader: View {
+    let providerName: String
+    let dependentCount: Int
+    let onKeepEnabled: () -> Void
+
+    var body: some View {
+        ZStack(alignment: .topTrailing) {
+            VStack(spacing: 8) {
+                if dependentCount == 1 {
+                    Text("\(providerName) is still used by another rule")
+                        .font(.title2.weight(.semibold))
+                } else {
+                    Text("\(providerName) is still used by other rules")
+                        .font(.title2.weight(.semibold))
+                }
+
+                if dependentCount == 1 {
+                    Text("Disabling \(providerName) would leave one enabled rule without behavior it uses.")
+                        .font(.body)
+                        .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.center)
+                        .fixedSize(horizontal: false, vertical: true)
+                } else {
+                    Text("Disabling \(providerName) would leave \(dependentCount) enabled rules without behavior they use.")
+                        .font(.body)
+                        .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.center)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+            .padding(.horizontal, 24)
+
+            Button(action: onKeepEnabled) {
+                Image(systemName: "xmark")
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 22, height: 22)
+                    .background(Circle().fill(Color.secondary.opacity(0.16)))
+            }
+            .buttonStyle(.plain)
+            .keyboardShortcut(.cancelAction)
+            .accessibilityIdentifier("rule-dependent-close-button")
+            .accessibilityLabel("Keep \(providerName) enabled")
+        }
+        .padding(20)
+    }
+}
+
+private struct RuleDependentRulesSection: View {
+    let rows: [RuleDependentDialogRow]
+    let collapseDetails: Bool
+
+    var body: some View {
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: 12) {
+                ForEach(rows) { row in
+                    RuleDependentRuleRow(
+                        row: row,
+                        collapseDetails: collapseDetails
+                    )
+                }
+            }
+            .padding(20)
+        }
+        .frame(maxHeight: 360)
+    }
+}
+
+private struct RuleDependentRuleRow: View {
+    let row: RuleDependentDialogRow
+    let collapseDetails: Bool
+    @State private var isExpanded = false
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: "exclamationmark.link")
+                .foregroundStyle(.secondary)
+                .frame(width: 20)
+
+            VStack(alignment: .leading, spacing: 5) {
+                Text(row.usageSummary)
+                    .font(.body.weight(.medium))
+
+                Text("Its affected keys or actions may do nothing.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                if collapseDetails, !details.isEmpty {
+                    DisclosureGroup(isExpanded: $isExpanded) {
+                        RuleDependentDetailList(details: details)
+                            .padding(.top, 4)
+                    } label: {
+                        Text("Show \(details.count) \(details.count == 1 ? "detail" : "details")")
+                            .font(.caption)
+                    }
+                    .accessibilityIdentifier(
+                        "rule-dependent-details-\(row.id.dependentID.uuidString)"
+                    )
+                } else {
+                    RuleDependentDetailList(details: details)
+                }
+            }
+            .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    private var details: [String] {
+        var values = row.evidence
+        if !row.alternativeProviderNames.isEmpty {
+            values.append(
+                "Other matching rules are currently off: "
+                    + row.alternativeProviderNames.joined(separator: ", ")
+            )
+        }
+        return values
+    }
+}
+
+private struct RuleDependentDetailList: View {
+    let details: [String]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 3) {
+            ForEach(details, id: \.self) { detail in
+                Text(detail)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+}
+
+private struct RuleDependentActionsSection: View {
+    let providerName: String
+    let onKeepEnabled: () -> Void
+    let onDisableAnyway: () -> Void
+
+    var body: some View {
+        ViewThatFits {
+            HStack(spacing: 12) {
+                RuleDependentActionButtons(
+                    providerName: providerName,
+                    onKeepEnabled: onKeepEnabled,
+                    onDisableAnyway: onDisableAnyway
+                )
+            }
+
+            VStack(spacing: 10) {
+                RuleDependentActionButtons(
+                    providerName: providerName,
+                    onKeepEnabled: onKeepEnabled,
+                    onDisableAnyway: onDisableAnyway
+                )
+            }
+        }
+        .padding(20)
+    }
+}
+
+private struct RuleDependentActionButtons: View {
+    let providerName: String
+    let onKeepEnabled: () -> Void
+    let onDisableAnyway: () -> Void
+
+    var body: some View {
+        Button(role: .destructive, action: onDisableAnyway) {
+            Text("Disable Anyway")
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 6)
+        }
+        .buttonStyle(.bordered)
+        .accessibilityIdentifier("rule-dependent-disable-anyway-button")
+
+        Button(action: onKeepEnabled) {
+            Text("Keep \(providerName) Enabled")
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 6)
+        }
+        .buttonStyle(.borderedProminent)
+        .keyboardShortcut(.defaultAction)
+        .accessibilityIdentifier("rule-dependent-keep-enabled-button")
+    }
+}
+
+#if DEBUG
+    struct RuleDependentResolutionDialog_Previews: PreviewProvider {
+        static var previews: some View {
+            RuleDependentResolutionDialog(
+                model: RuleDependentResolutionDialogModel(
+                    context: RuleDependentResolutionContext(
+                        providerID: UUID(),
+                        providerName: "Function",
+                        dependents: [],
+                        affectedConsumers: [],
+                        availableProviders: []
+                    )
+                ),
+                onKeepEnabled: {},
+                onDisableAnyway: {}
+            )
+        }
+    }
+#endif

--- a/Sources/KeyPathAppKit/UI/Rules/RulePrerequisiteResolutionDialog.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/RulePrerequisiteResolutionDialog.swift
@@ -116,7 +116,7 @@ struct RulePrerequisiteDialogModel: Equatable, Sendable {
         }
     }
 
-    private static func evidenceDescriptions(
+    static func evidenceDescriptions(
         _ evidence: [RuleDependencyEvidence]
     ) -> [String] {
         evidence.map { item in
@@ -148,7 +148,7 @@ struct RulePrerequisiteDialogModel: Equatable, Sendable {
         }
     }
 
-    private static func displayName(_ rawValue: String) -> String {
+    static func displayName(_ rawValue: String) -> String {
         rawValue
             .replacingOccurrences(of: "_", with: " ")
             .replacingOccurrences(of: "-", with: " ")

--- a/Sources/KeyPathAppKit/UI/Settings/SettingsContainerView.swift
+++ b/Sources/KeyPathAppKit/UI/Settings/SettingsContainerView.swift
@@ -92,6 +92,22 @@ struct SettingsContainerView: View {
                 .interactiveDismissDisabled()
             }
         }
+        .sheet(isPresented: $kanataManager.showDependentResolutionDialog) {
+            if let model = kanataManager.pendingDependentResolution {
+                RuleDependentResolutionDialog(
+                    model: model,
+                    onKeepEnabled: {
+                        kanataManager.resolveDependentResolution(with: nil)
+                    },
+                    onDisableAnyway: {
+                        kanataManager.resolveDependentResolution(
+                            with: .disableAnyway
+                        )
+                    }
+                )
+                .interactiveDismissDisabled()
+            }
+        }
         .frame(
             minWidth: 680,
             idealWidth: 680,

--- a/Sources/KeyPathAppKit/UI/ViewModels/KanataViewModel.swift
+++ b/Sources/KeyPathAppKit/UI/ViewModels/KanataViewModel.swift
@@ -65,6 +65,10 @@ class KanataViewModel {
     var showPrerequisiteResolutionDialog = false
     var pendingPrerequisiteResolution: RulePrerequisiteDialogModel?
 
+    // Disable-time dependent resolution (#868)
+    var showDependentResolutionDialog = false
+    var pendingDependentResolution: RuleDependentResolutionDialogModel?
+
     enum ToastType {
         case success
         case error
@@ -152,6 +156,9 @@ class KanataViewModel {
 
         pendingPrerequisiteResolution = state.pendingPrerequisiteResolution
         showPrerequisiteResolutionDialog = state.pendingPrerequisiteResolution != nil
+
+        pendingDependentResolution = state.pendingDependentResolution
+        showDependentResolutionDialog = state.pendingDependentResolution != nil
 
         // Map validation error to alert properties
         if let error = state.validationError {
@@ -577,6 +584,13 @@ class KanataViewModel {
     ) {
         showPrerequisiteResolutionDialog = false
         manager.resolvePrerequisiteResolution(with: choice)
+    }
+
+    func resolveDependentResolution(
+        with choice: RuleDependentResolutionChoice?
+    ) {
+        showDependentResolutionDialog = false
+        manager.resolveDependentResolution(with: choice)
     }
 }
 

--- a/Tests/KeyPathTests/RuleCollections/RuleCollectionsManagerDependentResolutionTests.swift
+++ b/Tests/KeyPathTests/RuleCollections/RuleCollectionsManagerDependentResolutionTests.swift
@@ -1,0 +1,371 @@
+@testable import KeyPathAppKit
+import KeyPathCore
+import KeyPathRulesCore
+import XCTest
+
+@MainActor
+final class RuleCollectionsManagerDependentResolutionTests: XCTestCase {
+    func testKeepEnabledAppliesNothing() async throws {
+        let manager = try makeManager()
+        defer { TestEnvironment.forceTestMode = false }
+        let provider = layerContentProvider(
+            id: uuid(1),
+            name: "Function",
+            enabled: true
+        )
+        let consumer = homeRowToggles(
+            id: uuid(2),
+            name: "Home Row Layer Toggles",
+            enabled: true,
+            assignments: ["a": "fun", ";": "fun"]
+        )
+        manager.ruleCollections = [provider, consumer]
+
+        var receivedContext: RuleDependentResolutionContext?
+        manager.onDependentResolution = { context in
+            receivedContext = context
+            return nil
+        }
+        var regenerationCount = 0
+        manager.onBeforeSave = { regenerationCount += 1 }
+
+        let applied = await manager.toggleCollection(
+            id: provider.id,
+            isEnabled: false,
+            bypassOwnershipCheck: true
+        )
+
+        XCTAssertFalse(applied)
+        XCTAssertEqual(regenerationCount, 0)
+        XCTAssertTrue(manager.ruleCollections[id: provider.id]?.isEnabled == true)
+        XCTAssertTrue(manager.ruleCollections[id: consumer.id]?.isEnabled == true)
+
+        let context = try XCTUnwrap(receivedContext)
+        XCTAssertEqual(context.providerID, provider.id)
+        XCTAssertEqual(context.providerName, "Function")
+        XCTAssertEqual(context.affectedConsumers.map(\.id), [consumer.id])
+        XCTAssertEqual(context.dependents.map(\.dependentCollectionID), [
+            consumer.id,
+        ])
+
+        let model = RuleDependentResolutionDialogModel(context: context)
+        XCTAssertEqual(model.providerName, "Function")
+        XCTAssertEqual(model.dependentCount, 1)
+        XCTAssertFalse(model.collapseDetails)
+        XCTAssertEqual(model.rows.map(\.usageSummary), [
+            "Home Row Layer Toggles uses Function for the Fun layer.",
+        ])
+        XCTAssertEqual(model.rows.flatMap(\.evidence), [
+            "2 affected keys: ; and A",
+        ])
+    }
+
+    func testDisableAnywayAppliesOnlyProviderDisableOnce() async throws {
+        let manager = try makeManager()
+        defer { TestEnvironment.forceTestMode = false }
+        let provider = layerContentProvider(
+            id: uuid(10),
+            name: "Function",
+            enabled: true
+        )
+        let consumer = homeRowToggles(
+            id: uuid(11),
+            name: "Home Row Layer Toggles",
+            enabled: true,
+            assignments: ["a": "fun"]
+        )
+        manager.ruleCollections = [provider, consumer]
+        manager.onDependentResolution = { _ in .disableAnyway }
+
+        var regenerationCount = 0
+        manager.onBeforeSave = { regenerationCount += 1 }
+
+        let applied = await manager.toggleCollection(
+            id: provider.id,
+            isEnabled: false,
+            bypassOwnershipCheck: true
+        )
+
+        XCTAssertTrue(applied)
+        XCTAssertEqual(regenerationCount, 1)
+        XCTAssertTrue(manager.ruleCollections[id: provider.id]?.isEnabled == false)
+        XCTAssertTrue(manager.ruleCollections[id: consumer.id]?.isEnabled == true)
+    }
+
+    func testAlternateActiveProviderSuppressesDialog() async throws {
+        let manager = try makeManager()
+        defer { TestEnvironment.forceTestMode = false }
+        let first = layerContentProvider(
+            id: uuid(20),
+            name: "Function",
+            enabled: true,
+            input: "x"
+        )
+        let second = layerContentProvider(
+            id: uuid(21),
+            name: "Custom Function",
+            enabled: true,
+            input: "z"
+        )
+        let consumer = homeRowToggles(
+            id: uuid(22),
+            name: "Home Row Layer Toggles",
+            enabled: true,
+            assignments: ["a": "fun"]
+        )
+        manager.ruleCollections = [first, second, consumer]
+
+        var didPrompt = false
+        manager.onDependentResolution = { _ in
+            didPrompt = true
+            return nil
+        }
+
+        let applied = await manager.toggleCollection(
+            id: first.id,
+            isEnabled: false,
+            bypassOwnershipCheck: true
+        )
+
+        XCTAssertTrue(applied)
+        XCTAssertFalse(didPrompt)
+        XCTAssertTrue(manager.ruleCollections[id: first.id]?.isEnabled == false)
+        XCTAssertTrue(manager.ruleCollections[id: second.id]?.isEnabled == true)
+    }
+
+    func testManyDependentsProduceDeterministicCollapsedRows() async throws {
+        let manager = try makeManager()
+        defer { TestEnvironment.forceTestMode = false }
+        let provider = layerContentProvider(
+            id: uuid(30),
+            name: "Function",
+            enabled: true
+        )
+        let consumers = [
+            homeRowToggles(
+                id: uuid(31),
+                name: "Alpha",
+                enabled: true,
+                assignments: ["a": "fun"]
+            ),
+            homeRowToggles(
+                id: uuid(32),
+                name: "Bravo",
+                enabled: true,
+                assignments: ["s": "fun"]
+            ),
+            homeRowToggles(
+                id: uuid(33),
+                name: "Charlie",
+                enabled: true,
+                assignments: ["d": "fun"]
+            ),
+            homeRowToggles(
+                id: uuid(34),
+                name: "Delta",
+                enabled: true,
+                assignments: ["f": "fun"]
+            ),
+        ]
+        manager.ruleCollections = [provider] + consumers
+
+        var receivedContext: RuleDependentResolutionContext?
+        manager.onDependentResolution = { context in
+            receivedContext = context
+            return nil
+        }
+
+        _ = await manager.toggleCollection(
+            id: provider.id,
+            isEnabled: false,
+            bypassOwnershipCheck: true
+        )
+
+        let model = try XCTUnwrap(receivedContext.map(
+            RuleDependentResolutionDialogModel.init(context:)
+        ))
+        XCTAssertEqual(model.dependentCount, 4)
+        XCTAssertTrue(model.collapseDetails)
+        XCTAssertEqual(model.rows.map(\.usageSummary), [
+            "Alpha uses Function for the Fun layer.",
+            "Bravo uses Function for the Fun layer.",
+            "Charlie uses Function for the Fun layer.",
+            "Delta uses Function for the Fun layer.",
+        ])
+    }
+
+    func testCustomRuleProviderUsesSameReverseConfirmation() async throws {
+        let manager = try makeManager()
+        defer { TestEnvironment.forceTestMode = false }
+        let provider = CustomRule(
+            id: uuid(40),
+            title: "My Function Layer",
+            input: "x",
+            action: .keystroke(key: "y"),
+            isEnabled: true,
+            targetLayer: .custom("fun")
+        )
+        let consumer = homeRowToggles(
+            id: uuid(41),
+            name: "Home Row Layer Toggles",
+            enabled: true,
+            assignments: ["a": "fun"]
+        )
+        manager.customRules = [provider]
+        manager.ruleCollections = [consumer]
+
+        var receivedProviderName: String?
+        manager.onDependentResolution = { context in
+            receivedProviderName = context.providerName
+            return nil
+        }
+
+        await manager.toggleCustomRule(id: provider.id, isEnabled: false)
+
+        XCTAssertEqual(receivedProviderName, "My Function Layer")
+        XCTAssertTrue(manager.customRules.first?.isEnabled == true)
+    }
+
+    func testFailedDisableRestoresProviderAndDependentState() async throws {
+        let manager = try makeManager()
+        defer { TestEnvironment.forceTestMode = false }
+
+        var leader = try XCTUnwrap(
+            RuleCollectionCatalog().defaultCollections().first {
+                $0.id == RuleCollectionIdentifier.leaderKey
+            }
+        )
+        leader.isEnabled = true
+
+        let dependent = RuleCollection(
+            id: uuid(50),
+            name: "Navigation Consumer",
+            summary: "Test",
+            category: .custom,
+            mappings: [
+                KeyMapping(input: "x", action: .keystroke(key: "y")),
+            ],
+            isEnabled: true,
+            targetLayer: .custom("fun"),
+            momentaryActivator: MomentaryActivator(
+                input: "f",
+                targetLayer: .custom("fun"),
+                sourceLayer: .navigation
+            ),
+            configuration: .list
+        )
+        let navigationMapping = RuleCollection(
+            id: uuid(51),
+            name: "Navigation Space Mapping",
+            summary: "Test",
+            category: .custom,
+            mappings: [
+                KeyMapping(input: "space", action: .keystroke(key: "q")),
+            ],
+            isEnabled: true,
+            targetLayer: .navigation,
+            configuration: .list
+        )
+        manager.ruleCollections = [leader, dependent, navigationMapping]
+        manager.onDependentResolution = { _ in .disableAnyway }
+
+        var regenerationCount = 0
+        manager.onBeforeSave = { regenerationCount += 1 }
+
+        let applied = await manager.toggleCollection(
+            id: leader.id,
+            isEnabled: false,
+            bypassOwnershipCheck: true
+        )
+
+        XCTAssertFalse(applied)
+        XCTAssertEqual(
+            regenerationCount,
+            2,
+            "The failed disable and rollback should each regenerate once"
+        )
+        XCTAssertTrue(manager.ruleCollections[id: leader.id]?.isEnabled == true)
+        XCTAssertEqual(
+            manager.ruleCollections[id: dependent.id]?.momentaryActivator?.input,
+            "f"
+        )
+        XCTAssertTrue(
+            manager.ruleCollections[id: navigationMapping.id]?.isEnabled == true
+        )
+    }
+
+    private func makeManager() throws -> RuleCollectionsManager {
+        TestEnvironment.forceTestMode = true
+        let directory = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("dependent-resolution-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true
+        )
+
+        return RuleCollectionsManager(
+            ruleCollectionStore: RuleCollectionStore(
+                fileURL: directory.appendingPathComponent("RuleCollections.json")
+            ),
+            customRulesStore: CustomRulesStore(
+                fileURL: directory.appendingPathComponent("CustomRules.json")
+            ),
+            configurationService: ConfigurationService(
+                configDirectory: directory.path
+            )
+        )
+    }
+
+    private func homeRowToggles(
+        id: UUID,
+        name: String,
+        enabled: Bool,
+        assignments: [String: String]
+    ) -> RuleCollection {
+        RuleCollection(
+            id: id,
+            name: name,
+            summary: "Test",
+            category: .custom,
+            mappings: [],
+            isEnabled: enabled,
+            configuration: .homeRowLayerToggles(HomeRowLayerTogglesConfig(
+                enabledKeys: Set(assignments.keys),
+                layerAssignments: assignments
+            ))
+        )
+    }
+
+    private func layerContentProvider(
+        id: UUID,
+        name: String,
+        enabled: Bool,
+        input: String = "x"
+    ) -> RuleCollection {
+        RuleCollection(
+            id: id,
+            name: name,
+            summary: "Test",
+            category: .custom,
+            mappings: [
+                KeyMapping(input: input, action: .keystroke(key: "y")),
+            ],
+            isEnabled: enabled,
+            targetLayer: .custom("fun"),
+            configuration: .list
+        )
+    }
+
+    private func uuid(_ value: Int) -> UUID {
+        UUID(uuidString: String(
+            format: "00000000-0000-0000-0000-%012d",
+            value
+        ))!
+    }
+}
+
+private extension [RuleCollection] {
+    subscript(id id: UUID) -> RuleCollection? {
+        first { $0.id == id }
+    }
+}


### PR DESCRIPTION
Closes #868

## Summary
- analyze reverse dependencies before disabling built-in or custom rule providers
- keep the safe action primary and make closing the dialog equivalent to keeping the provider enabled
- apply only the requested disable, regenerate once, and restore the prior rule state when apply fails
- group deterministic dependent rows and collapse details when more than three rows are present
- format provider usage, affected keys or mappings, and alternate providers from structured dependency evidence

## Validation
- RuleCollectionsManagerDependentResolutionTests: 6 passed
- RuleCollectionsManagerPrerequisiteResolutionTests: 9 passed
- RuleCollectionsManagerPrerequisiteDetectionTests: 16 passed
- accessibility identifier audit: passed
- installed app verification: signature valid, runtime running, TCP ready
- installed walkthrough: Function / Home Row Layer Toggles safe close and destructive disable paths passed
- installed walkthrough: Leader Key / Delete Enhancement navigation-activation warning passed
- changed-files full gate reached the existing slow screenshot suite and timed out after 240 seconds in MediumViewSnapshotTests.testKeyRepeatControlView; no failures were reported before the timeout

## Review gates
- remote review gate selected; GitHub claude-review must pass before merge
- human UX review requested before merge: copy clarity, safe/destructive hierarchy, and grouped-detail density

The installed debug build on this Mac matches this branch. Original user rule JSON was restored byte-for-byte after the walkthrough.