### PR TITLE
Isolate lab operation repositories from archives

### DIFF
--- a/Scripts/lab/remote.sh
+++ b/Scripts/lab/remote.sh
@@ -698,7 +698,7 @@ create_lease() {
   slug="keypath${macos}-$(print -r -- "$commit" | cut -c1-8)-$(date -u +%Y%m%d%H%M%S)-$$"
   operation="$OPERATIONS/$slug"
   mkdir -p "$operation"
-  git clone -q --local "$archive/repo" "$operation/repo"
+  git clone -q --local --no-hardlinks "$archive/repo" "$operation/repo"
   repo="$operation/repo"
   prepare_worktree "$repo"
   create_log="$operation/create.log"

--- a/Scripts/lab/tests/keypath-lab-tests.sh
+++ b/Scripts/lab/tests/keypath-lab-tests.sh
@@ -330,10 +330,19 @@ assert_contains "$disk_output" $'disk_reserve_busy\tfree_gib=99\tminimum_gib=100
 create=$(run_remote create 15 unmanaged-ui "$archive_key" "$commit" "$checksum" KeyPath.zip 2h 0)
 assert_contains "$create" $'lease_id\tcbx_test15'
 manifest="$ROOT/KeyPathInstallerLab/leases/cbx_test15/manifest.tsv"
+operation_repo="$ROOT/KeyPathInstallerLab/operations/$(grep $'^slug\t' "$manifest" | cut -f2)/repo"
 grep -q $'owner\tkeypath-installer-lab-v1' "$manifest"
 grep -q $'macos_build\t24G720' "$manifest"
 grep -q $'test_lane\tunmanaged-ui' "$manifest"
 grep -q $'base_name\tghcr.io/cirruslabs/macos-sequoia-base:latest' "$manifest"
+archive_object=$(find "$repo/.git/objects" -type f -print -quit)
+object_relative_path=${archive_object#"$repo/.git/objects/"}
+operation_object="$operation_repo/.git/objects/$object_relative_path"
+[[ -f "$operation_object" ]]
+if [[ $(stat -f %i "$archive_object") == "$(stat -f %i "$operation_object")" ]]; then
+    echo "operation repository must not hard-link archive Git objects" >&2
+    exit 1
+fi
 
 set +e
 capacity_output=$(run_remote create 15 unmanaged-ui "$archive_key" "$commit" "$checksum" KeyPath.zip 2h 0 2>&1)
@@ -373,7 +382,6 @@ if run_remote nameplate cbx_test15 enable >/dev/null 2>&1; then
     exit 1
 fi
 
-operation_repo="$ROOT/KeyPathInstallerLab/operations/$(grep $'^slug\t' "$manifest" | cut -f2)/repo"
 mkdir -p "$operation_repo/.crabbox/captures"
 echo failure-evidence > "$operation_repo/.crabbox/captures/failure.tar.gz"
 run_remote run cbx_test15 echo generated-output-is-safe >/dev/null


### PR DESCRIPTION
## What changed

- clone each lab operation repository with `--no-hardlinks`
- add a regression assertion proving archive and operation Git objects have different inodes

## Why

The immutable uploaded archive is the source for multiple disposable lab operations. A local clone may otherwise hard-link Git objects back to that archive, coupling mutable operation cleanup and maintenance to the reusable source bundle.

## Impact

Disposable VM operations now receive independent Git object storage. The change does not alter lease admission, VM creation, or artifact behavior.

## Validation

- `bash Scripts/lab/tests/keypath-lab-tests.sh`
- `/bin/zsh -n Scripts/lab/remote.sh`
- `bash -n Scripts/lab/tests/keypath-lab-tests.sh`
- `git diff --check`
- local review gate selected the enforced remote `claude-review`
