### PR TITLE
Wire Sequence pause limit into generated configuration

### DIFF
--- a/Sources/KeyPathAppKit/Infrastructure/Config/KanataConfigurationGenerator.swift
+++ b/Sources/KeyPathAppKit/Infrastructure/Config/KanataConfigurationGenerator.swift
@@ -100,6 +100,10 @@ public struct KanataConfiguration: Sendable {
         let keyRepeatConfig = enabledCollections
             .compactMap(\.configuration.keyRepeatControlConfig)
             .first
+        let sequencePauseLimitMs = enabledCollections
+            .compactMap(\.configuration.sequencesConfig)
+            .first?
+            .globalTimeout
 
         // All defcfg header construction flows through KanataDefcfg (single source of truth).
         // `concurrent-tap-hold` is required by kanata whenever defchordsv2 is emitted, which
@@ -111,6 +115,7 @@ public struct KanataConfiguration: Sendable {
         let defcfg = KanataDefcfg.standard(
             managedRepeatTiming: repeatTiming,
             requirePriorIdleMs: requirePriorIdleMs > 0 ? requirePriorIdleMs : nil,
+            sequenceTimeoutMs: sequencePauseLimitMs,
             hasChords: !chordMappings.isEmpty,
             deviceTargeting: macosDeviceTargeting
         )

--- a/Sources/KeyPathAppKit/Infrastructure/Config/KanataConfigurationGenerator.swift
+++ b/Sources/KeyPathAppKit/Infrastructure/Config/KanataConfigurationGenerator.swift
@@ -100,10 +100,11 @@ public struct KanataConfiguration: Sendable {
         let keyRepeatConfig = enabledCollections
             .compactMap(\.configuration.keyRepeatControlConfig)
             .first
-        let sequencePauseLimitMs = enabledCollections
+        let sequencesConfig = enabledCollections
             .compactMap(\.configuration.sequencesConfig)
-            .first?
-            .clampedPauseLimitMs
+            .first
+        let hasSequences = !sequences.isEmpty || !(sequencesConfig?.sequences.isEmpty ?? true)
+        let sequencePauseLimitMs = hasSequences ? sequencesConfig?.clampedPauseLimitMs : nil
 
         // All defcfg header construction flows through KanataDefcfg (single source of truth).
         // `concurrent-tap-hold` is required by kanata whenever defchordsv2 is emitted, which

--- a/Sources/KeyPathAppKit/Infrastructure/Config/KanataConfigurationGenerator.swift
+++ b/Sources/KeyPathAppKit/Infrastructure/Config/KanataConfigurationGenerator.swift
@@ -103,7 +103,7 @@ public struct KanataConfiguration: Sendable {
         let sequencePauseLimitMs = enabledCollections
             .compactMap(\.configuration.sequencesConfig)
             .first?
-            .globalTimeout
+            .clampedPauseLimitMs
 
         // All defcfg header construction flows through KanataDefcfg (single source of truth).
         // `concurrent-tap-hold` is required by kanata whenever defchordsv2 is emitted, which

--- a/Sources/KeyPathAppKit/Infrastructure/Config/KanataDefcfg.swift
+++ b/Sources/KeyPathAppKit/Infrastructure/Config/KanataDefcfg.swift
@@ -28,6 +28,8 @@ public struct KanataDefcfg: Sendable, Equatable {
     public var managedRepeatIntervalMs: Int?
     /// `tap-hold-require-prior-idle <ms>` — omitted when nil.
     public var tapHoldRequirePriorIdleMs: Int?
+    /// `sequence-timeout <ms>` — omitted when nil.
+    public var sequenceTimeoutMs: Int?
     /// Emits `concurrent-tap-hold yes` when true. Kanata requires this whenever a
     /// `defchordsv2` block is present, otherwise it rejects the config.
     public var concurrentTapHold: Bool
@@ -43,6 +45,7 @@ public struct KanataDefcfg: Sendable, Equatable {
         managedRepeatDelayMs: Int? = nil,
         managedRepeatIntervalMs: Int? = nil,
         tapHoldRequirePriorIdleMs: Int? = nil,
+        sequenceTimeoutMs: Int? = nil,
         concurrentTapHold: Bool = false,
         trailer: String = ""
     ) {
@@ -52,6 +55,7 @@ public struct KanataDefcfg: Sendable, Equatable {
         self.managedRepeatDelayMs = managedRepeatDelayMs
         self.managedRepeatIntervalMs = managedRepeatIntervalMs
         self.tapHoldRequirePriorIdleMs = tapHoldRequirePriorIdleMs
+        self.sequenceTimeoutMs = sequenceTimeoutMs
         self.concurrentTapHold = concurrentTapHold
         self.trailer = trailer
     }
@@ -86,6 +90,9 @@ public struct KanataDefcfg: Sendable, Equatable {
         if let tapHoldRequirePriorIdleMs {
             lines.append("  tap-hold-require-prior-idle \(tapHoldRequirePriorIdleMs)")
         }
+        if let sequenceTimeoutMs {
+            lines.append("  sequence-timeout \(sequenceTimeoutMs)")
+        }
         if concurrentTapHold {
             lines.append("  concurrent-tap-hold yes")
         }
@@ -102,6 +109,8 @@ public extension KanataDefcfg {
     ///     entry point (the `render()` assert backstops the internal `init`).
     ///   - requirePriorIdleMs: `tap-hold-require-prior-idle` value, or nil to omit.
     ///     The caller maps its "0 means disabled" sentinel to nil.
+    ///   - sequenceTimeoutMs: `sequence-timeout` value from an enabled Sequences
+    ///     collection, or nil to use Kanata's default.
     ///   - hasChords: emits `concurrent-tap-hold yes` (required by `defchordsv2`).
     ///   - deviceTargeting: verbatim macOS device-targeting trailer ("" when none).
     ///
@@ -110,6 +119,7 @@ public extension KanataDefcfg {
     static func standard(
         managedRepeatTiming: (delayMs: Int, intervalMs: Int)?,
         requirePriorIdleMs: Int?,
+        sequenceTimeoutMs: Int? = nil,
         hasChords: Bool,
         deviceTargeting: String
     ) -> KanataDefcfg {
@@ -120,6 +130,7 @@ public extension KanataDefcfg {
             managedRepeatDelayMs: managedRepeatTiming?.delayMs,
             managedRepeatIntervalMs: managedRepeatTiming?.intervalMs,
             tapHoldRequirePriorIdleMs: requirePriorIdleMs,
+            sequenceTimeoutMs: sequenceTimeoutMs,
             concurrentTapHold: hasChords,
             trailer: deviceTargeting
         )

--- a/Sources/KeyPathAppKit/UI/Rules/SequencesModalView.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/SequencesModalView.swift
@@ -16,7 +16,7 @@ import SwiftUI
 /// - Visual key sequence builder with dropdowns
 /// - Preset sequences for quick setup
 /// - Conflict detection with warnings
-/// - Global timeout configuration
+/// - Sequence pause limit configuration
 struct SequencesModalView: View {
     // MARK: - State
 
@@ -227,7 +227,7 @@ struct SequencesModalView: View {
                     // Description
                     descriptionSection(for: sequence)
 
-                    // Global Timeout
+                    // Sequence pause limit
                     timeoutSection
 
                     // Conflicts
@@ -384,11 +384,11 @@ struct SequencesModalView: View {
         }
     }
 
-    // MARK: - Timeout Section
+    // MARK: - Sequence Pause Limit
 
     private var timeoutSection: some View {
         VStack(alignment: .leading, spacing: 12) {
-            Text("Global Timeout")
+            Text("Sequence pause limit")
                 .font(.headline)
 
             VStack(alignment: .leading, spacing: 8) {
@@ -396,28 +396,36 @@ struct SequencesModalView: View {
                     Slider(value: Binding(
                         get: { Double(localConfig.globalTimeout) },
                         set: { localConfig.globalTimeout = Int($0) }
-                    ), in: 300 ... 1000, step: 50)
+                    ), in: Double(SequencesConfig.minimumPauseLimitMs) ... Double(SequencesConfig.maximumPauseLimitMs),
+                    step: Double(SequencesConfig.pauseLimitStepMs))
                         .accessibilityIdentifier("sequences-modal-timeout-slider")
-                        .accessibilityLabel("Global timeout")
+                        .accessibilityLabel("Sequence pause limit")
                         .accessibilityValue("\(localConfig.globalTimeout) ms")
 
-                    Text("\(localConfig.globalTimeout)ms")
+                    Text("\(localConfig.globalTimeout) ms")
                         .font(.system(.body, design: .monospaced))
                         .frame(width: 70, alignment: .trailing)
                 }
 
-                Text(timeoutPreset.description)
+                Text(pauseLimitDescription)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+
+                Text("The timer restarts after each matching key. If you pause longer than this, KeyPath clears the incomplete sequence.")
                     .font(.caption)
                     .foregroundColor(.secondary)
             }
         }
     }
 
-    private var timeoutPreset: SequenceTimeout {
+    private var pauseLimitDescription: LocalizedStringKey {
         switch localConfig.globalTimeout {
-        case ..<400: .fast
-        case 400 ..< 800: .moderate
-        default: .relaxed
+        case ..<400:
+            "Requires a quick rhythm and clears incomplete sequences sooner."
+        case 400 ..< 800:
+            "Balances comfortable entry with a short wait after incomplete sequences."
+        default:
+            "Allows longer pauses while learning, but incomplete sequences stay pending longer."
         }
     }
 

--- a/Sources/KeyPathRulesCore/SequencesConfig.swift
+++ b/Sources/KeyPathRulesCore/SequencesConfig.swift
@@ -41,6 +41,11 @@ public struct SequencesConfig: Codable, Equatable, Sendable {
             && globalTimeout <= Self.maximumPauseLimitMs
     }
 
+    /// Safe value for runtime generation when persisted or imported data predates validation.
+    public var clampedPauseLimitMs: Int {
+        min(max(globalTimeout, Self.minimumPauseLimitMs), Self.maximumPauseLimitMs)
+    }
+
     // MARK: - Preset Factory
 
     /// Default preset sequences (Window Management, App Launcher, Navigation)

--- a/Sources/KeyPathRulesCore/SequencesConfig.swift
+++ b/Sources/KeyPathRulesCore/SequencesConfig.swift
@@ -11,20 +11,22 @@ import KeyPathCore
 
 /// Configuration for key sequences (defseq)
 public struct SequencesConfig: Codable, Equatable, Sendable {
+    public static let minimumPauseLimitMs = 300
+    public static let maximumPauseLimitMs = 2000
+    public static let defaultPauseLimitMs = 500
+    public static let pauseLimitStepMs = 50
+
     public var sequences: [SequenceDefinition]
     public var activeSequenceID: UUID?
 
-    /// Global timeout in milliseconds for all sequences.
-    /// Valid range: 300-2000ms (enforced by UI slider).
-    /// - 300ms: Fast (experienced users)
-    /// - 500ms: Moderate (default, recommended)
-    /// - 1000ms: Relaxed (learning mode)
+    /// Maximum pause in milliseconds after the most recent sequence key.
+    /// The persisted name is retained for configuration compatibility.
     public var globalTimeout: Int
 
     public init(
         sequences: [SequenceDefinition] = [],
         activeSequenceID: UUID? = nil,
-        globalTimeout: Int = 500
+        globalTimeout: Int = Self.defaultPauseLimitMs
     ) {
         self.sequences = sequences
         self.activeSequenceID = activeSequenceID
@@ -33,10 +35,10 @@ public struct SequencesConfig: Codable, Equatable, Sendable {
 
     // MARK: - Validation
 
-    /// Validates whether the global timeout is within acceptable bounds.
-    /// Recommended range: 300-2000ms
+    /// Validates whether the sequence pause limit is within the supported range.
     public var isValidTimeout: Bool {
-        globalTimeout >= 300 && globalTimeout <= 2000
+        globalTimeout >= Self.minimumPauseLimitMs
+            && globalTimeout <= Self.maximumPauseLimitMs
     }
 
     // MARK: - Preset Factory
@@ -49,7 +51,7 @@ public struct SequencesConfig: Codable, Equatable, Sendable {
                 .appLauncherPreset,
                 .navigationPreset
             ],
-            globalTimeout: 500
+            globalTimeout: defaultPauseLimitMs
         )
     }
 

--- a/Sources/KeyPathRulesCore/SequencesConfig.swift
+++ b/Sources/KeyPathRulesCore/SequencesConfig.swift
@@ -210,30 +210,3 @@ public struct SequenceConflict: Identifiable {
         }
     }
 }
-
-// MARK: - SequenceTimeout
-
-/// Timeout presets for sequence completion
-public enum SequenceTimeout: Int, CaseIterable, Codable, Sendable {
-    case fast = 300 // Experienced users
-    case moderate = 500 // Default
-    case relaxed = 1000 // Learning mode
-
-    /// Display name (e.g., "Fast (300ms)")
-    public var displayName: String {
-        switch self {
-        case .fast: "Fast (300ms)"
-        case .moderate: "Moderate (500ms)"
-        case .relaxed: "Relaxed (1000ms)"
-        }
-    }
-
-    /// Description of timeout behavior
-    public var description: String {
-        switch self {
-        case .fast: "For experienced users - requires quick key presses"
-        case .moderate: "Balanced timeout - works for most users"
-        case .relaxed: "Longer timeout - ideal for learning sequences"
-        }
-    }
-}

--- a/Tests/KeyPathRulesCoreTests/SequencesConfigTests.swift
+++ b/Tests/KeyPathRulesCoreTests/SequencesConfigTests.swift
@@ -17,7 +17,11 @@ final class SequencesConfigTests: XCTestCase {
 
         XCTAssertEqual(config.sequences.count, 0, "Default config should have no sequences")
         XCTAssertNil(config.activeSequenceID, "Default config should have no active sequence")
-        XCTAssertEqual(config.globalTimeout, 500, "Default timeout should be 500ms")
+        XCTAssertEqual(
+            config.globalTimeout,
+            SequencesConfig.defaultPauseLimitMs,
+            "Default pause limit should use the shared model default"
+        )
     }
 
     func testPresets() {
@@ -128,6 +132,16 @@ final class SequencesConfigTests: XCTestCase {
     }
 
     // MARK: - Validation Tests
+
+    func testPauseLimitRangeIncludesSupportedBoundaries() {
+        XCTAssertEqual(SequencesConfig.minimumPauseLimitMs, 300)
+        XCTAssertEqual(SequencesConfig.maximumPauseLimitMs, 2000)
+        XCTAssertEqual(SequencesConfig.pauseLimitStepMs, 50)
+        XCTAssertTrue(SequencesConfig(globalTimeout: 300).isValidTimeout)
+        XCTAssertTrue(SequencesConfig(globalTimeout: 2000).isValidTimeout)
+        XCTAssertFalse(SequencesConfig(globalTimeout: 299).isValidTimeout)
+        XCTAssertFalse(SequencesConfig(globalTimeout: 2001).isValidTimeout)
+    }
 
     func testSequenceValidation_Valid() {
         let valid = SequenceDefinition(

--- a/Tests/KeyPathRulesCoreTests/SequencesConfigTests.swift
+++ b/Tests/KeyPathRulesCoreTests/SequencesConfigTests.swift
@@ -249,16 +249,4 @@ final class SequencesConfigTests: XCTestCase {
         XCTAssertEqual(decoded.keys, original.keys, "Should preserve keys")
         XCTAssertEqual(decoded.description, original.description, "Should preserve description")
     }
-
-    // MARK: - Timeout Presets Tests
-
-    func testTimeoutPresets() {
-        XCTAssertEqual(SequenceTimeout.fast.rawValue, 300, "Fast should be 300ms")
-        XCTAssertEqual(SequenceTimeout.moderate.rawValue, 500, "Moderate should be 500ms")
-        XCTAssertEqual(SequenceTimeout.relaxed.rawValue, 1000, "Relaxed should be 1000ms")
-
-        XCTAssertEqual(SequenceTimeout.fast.displayName, "Fast (300ms)")
-        XCTAssertEqual(SequenceTimeout.moderate.displayName, "Moderate (500ms)")
-        XCTAssertEqual(SequenceTimeout.relaxed.displayName, "Relaxed (1000ms)")
-    }
 }

--- a/Tests/KeyPathRulesCoreTests/SequencesConfigTests.swift
+++ b/Tests/KeyPathRulesCoreTests/SequencesConfigTests.swift
@@ -141,6 +141,8 @@ final class SequencesConfigTests: XCTestCase {
         XCTAssertTrue(SequencesConfig(globalTimeout: 2000).isValidTimeout)
         XCTAssertFalse(SequencesConfig(globalTimeout: 299).isValidTimeout)
         XCTAssertFalse(SequencesConfig(globalTimeout: 2001).isValidTimeout)
+        XCTAssertEqual(SequencesConfig(globalTimeout: 299).clampedPauseLimitMs, 300)
+        XCTAssertEqual(SequencesConfig(globalTimeout: 2001).clampedPauseLimitMs, 2000)
     }
 
     func testSequenceValidation_Valid() {

--- a/Tests/KeyPathTests/CLI/CLIExportImportTests.swift
+++ b/Tests/KeyPathTests/CLI/CLIExportImportTests.swift
@@ -199,4 +199,36 @@ final class CLIExportImportTests: XCTestCase {
         XCTAssertEqual(restoredConfig.layerAssignments["f"], "nav")
         XCTAssertEqual(restoredConfig.timing.holdDelay, 260)
     }
+
+    func testExportImportRoundTripPreservesSequencePauseLimit() throws {
+        let sequence = SequenceDefinition(
+            name: "Window",
+            keys: ["space", "w"],
+            action: .activateLayer(.custom("window"))
+        )
+        let collection = RuleCollection(
+            name: "Round Trip Sequences",
+            summary: "Config-backed",
+            category: .productivity,
+            mappings: [],
+            configuration: .sequences(SequencesConfig(
+                sequences: [sequence],
+                activeSequenceID: sequence.id,
+                globalTimeout: 1750
+            ))
+        )
+
+        let exported = CLIExportedCollection(from: collection)
+        let data = try JSONEncoder().encode(exported)
+        let decoded = try JSONDecoder().decode(CLIExportedCollection.self, from: data)
+        let restored = decoded.toRuleCollection()
+
+        guard case let .sequences(restoredConfig) = restored.configuration else {
+            XCTFail("Expected Sequences configuration after round trip")
+            return
+        }
+        XCTAssertEqual(restoredConfig.sequences, [sequence])
+        XCTAssertEqual(restoredConfig.activeSequenceID, sequence.id)
+        XCTAssertEqual(restoredConfig.globalTimeout, 1750)
+    }
 }

--- a/Tests/KeyPathTests/Infrastructure/Config/KanataDefcfgTests.swift
+++ b/Tests/KeyPathTests/Infrastructure/Config/KanataDefcfgTests.swift
@@ -66,6 +66,24 @@ final class KanataDefcfgTests: XCTestCase {
         """)
     }
 
+    func testStandardWithSequencePauseLimit() {
+        let defcfg = KanataDefcfg.standard(
+            managedRepeatTiming: nil,
+            requirePriorIdleMs: nil,
+            sequenceTimeoutMs: 750,
+            hasChords: false,
+            deviceTargeting: ""
+        )
+        XCTAssertEqual(defcfg.render(), """
+        (defcfg
+          process-unmapped-keys yes
+          managed-repeat yes
+          managed-repeat-unlisted no
+          sequence-timeout 750
+        )
+        """)
+    }
+
     func testStandardAppendsDeviceTargetingTrailerVerbatim() {
         // The trailer carries its own leading newline/indentation and lands before the
         // closing paren — exactly how renderMacOSDeviceTargetingForDefcfg() is spliced.

--- a/Tests/KeyPathTests/Integration/PerRuleOptionCoverageTests.swift
+++ b/Tests/KeyPathTests/Integration/PerRuleOptionCoverageTests.swift
@@ -340,10 +340,17 @@ final class PerRuleOptionCoverageTests: XCTestCase {
             configuration: .sequences(SequencesConfig(globalTimeout: 750))
         )
         sequencesCollection.isEnabled = false
+        let preserved = KanataDefseqParser.parseSequences(
+            from: "(defseq window-leader (space w))"
+        )
 
-        let config = KanataConfiguration.generateFromCollections([sequencesCollection])
+        let config = KanataConfiguration.generateFromCollections(
+            [sequencesCollection],
+            sequences: preserved
+        )
 
         XCTAssertFalse(config.contains("sequence-timeout"))
+        assertContains(config, "window-leader (space w)", "preserved manual sequence")
     }
 
     func testEnabledSequenceCollectionWithoutSequencesOmitsPauseLimit() {

--- a/Tests/KeyPathTests/Integration/PerRuleOptionCoverageTests.swift
+++ b/Tests/KeyPathTests/Integration/PerRuleOptionCoverageTests.swift
@@ -346,6 +346,24 @@ final class PerRuleOptionCoverageTests: XCTestCase {
         XCTAssertFalse(config.contains("sequence-timeout"))
     }
 
+    func testSequencePauseLimitClampsOutOfRangeStoredValues() {
+        for (stored, expected) in [
+            (SequencesConfig.minimumPauseLimitMs - 1, SequencesConfig.minimumPauseLimitMs),
+            (SequencesConfig.maximumPauseLimitMs + 1, SequencesConfig.maximumPauseLimitMs)
+        ] {
+            let sequencesCollection = collection(
+                id: RuleCollectionIdentifier.sequences,
+                name: "Sequences",
+                configuration: .sequences(SequencesConfig(globalTimeout: stored))
+            )
+
+            let config = KanataConfiguration.generateFromCollections([sequencesCollection])
+
+            assertContains(config, "sequence-timeout \(expected)", "clamped sequence pause limit")
+            XCTAssertFalse(config.contains("sequence-timeout \(stored)"))
+        }
+    }
+
     private func catalogCollection(_ id: UUID) throws -> RuleCollection {
         try XCTUnwrap(
             RuleCollectionCatalog().defaultCollections().first { $0.id == id },

--- a/Tests/KeyPathTests/Integration/PerRuleOptionCoverageTests.swift
+++ b/Tests/KeyPathTests/Integration/PerRuleOptionCoverageTests.swift
@@ -346,7 +346,23 @@ final class PerRuleOptionCoverageTests: XCTestCase {
         XCTAssertFalse(config.contains("sequence-timeout"))
     }
 
+    func testEnabledSequenceCollectionWithoutSequencesOmitsPauseLimit() {
+        let sequencesCollection = collection(
+            id: RuleCollectionIdentifier.sequences,
+            name: "Sequences",
+            configuration: .sequences(SequencesConfig(globalTimeout: 750))
+        )
+
+        let config = KanataConfiguration.generateFromCollections([sequencesCollection])
+
+        XCTAssertFalse(config.contains("sequence-timeout"))
+    }
+
     func testSequencePauseLimitClampsOutOfRangeStoredValues() {
+        let preserved = KanataDefseqParser.parseSequences(
+            from: "(defseq window-leader (space w))"
+        )
+
         for (stored, expected) in [
             (SequencesConfig.minimumPauseLimitMs - 1, SequencesConfig.minimumPauseLimitMs),
             (SequencesConfig.maximumPauseLimitMs + 1, SequencesConfig.maximumPauseLimitMs)
@@ -357,7 +373,10 @@ final class PerRuleOptionCoverageTests: XCTestCase {
                 configuration: .sequences(SequencesConfig(globalTimeout: stored))
             )
 
-            let config = KanataConfiguration.generateFromCollections([sequencesCollection])
+            let config = KanataConfiguration.generateFromCollections(
+                [sequencesCollection],
+                sequences: preserved
+            )
 
             assertContains(config, "sequence-timeout \(expected)", "clamped sequence pause limit")
             XCTAssertFalse(config.contains("sequence-timeout \(stored)"))

--- a/Tests/KeyPathTests/Integration/PerRuleOptionCoverageTests.swift
+++ b/Tests/KeyPathTests/Integration/PerRuleOptionCoverageTests.swift
@@ -306,6 +306,46 @@ final class PerRuleOptionCoverageTests: XCTestCase {
         assertContains(sequenceConfig, "window-leader (space w)", "preserved sequence")
     }
 
+    func testSequencePauseLimitEmitsSupportedValuesAndPreservesManualSequences() {
+        let preserved = KanataDefseqParser.parseSequences(
+            from: "(defseq window-leader (space w))"
+        )
+
+        for value in [
+            SequencesConfig.minimumPauseLimitMs,
+            SequencesConfig.defaultPauseLimitMs,
+            750,
+            SequencesConfig.maximumPauseLimitMs
+        ] {
+            let sequencesCollection = collection(
+                id: RuleCollectionIdentifier.sequences,
+                name: "Sequences",
+                configuration: .sequences(SequencesConfig(globalTimeout: value))
+            )
+
+            let config = KanataConfiguration.generateFromCollections(
+                [sequencesCollection],
+                sequences: preserved
+            )
+
+            assertContains(config, "sequence-timeout \(value)", "sequence pause limit \(value)")
+            assertContains(config, "window-leader (space w)", "preserved manual sequence")
+        }
+    }
+
+    func testDisabledSequenceCollectionOmitsPauseLimit() {
+        var sequencesCollection = collection(
+            id: RuleCollectionIdentifier.sequences,
+            name: "Sequences",
+            configuration: .sequences(SequencesConfig(globalTimeout: 750))
+        )
+        sequencesCollection.isEnabled = false
+
+        let config = KanataConfiguration.generateFromCollections([sequencesCollection])
+
+        XCTAssertFalse(config.contains("sequence-timeout"))
+    }
+
     private func catalogCollection(_ id: UUID) throws -> RuleCollection {
         try XCTUnwrap(
             RuleCollectionCatalog().defaultCollections().first { $0.id == id },

--- a/docs.md
+++ b/docs.md
@@ -57,6 +57,7 @@ theme: parchment
 <li><a href="{{ '/guides/quick-launcher/' | relative_url }}">Quick Launcher</a></li>
 <li><a href="{{ '/guides/action-uri/' | relative_url }}">Launching Apps</a></li>
 <li><a href="{{ '/guides/chords/' | relative_url }}">Chords</a></li>
+<li><a href="{{ '/guides/sequences/' | relative_url }}">Memorable Shortcut Paths</a></li>
 <li><a href="{{ '/guides/auto-shift/' | relative_url }}">Auto-Shift Symbols</a></li>
 <li><a href="{{ '/guides/alternative-layouts/' | relative_url }}">Alternative Layouts</a></li>
 <li><a href="{{ '/guides/keyboard-layouts/' | relative_url }}">Works With Your Keyboard</a></li>

--- a/guides/sequences.md
+++ b/guides/sequences.md
@@ -1,0 +1,98 @@
+---
+layout: default
+title: "Type Memorable Shortcut Paths"
+description: "Create short key sequences for actions you can remember, then tune how long KeyPath waits between keys"
+theme: parchment
+header_image: header-leader-key.png
+permalink: /guides/sequences/
+---
+
+
+# Type Memorable Shortcut Paths
+
+Shortcut combinations are easy to exhaust and hard to remember. Sequences let
+you type a short path instead: `Leader → W → L` for window left, or
+`Leader → S → M` for Messages. Each key narrows the path until the action is
+unambiguous.
+
+---
+
+## Create a Sequence
+
+1. Open KeyPath and click the gear icon.
+2. Go to the **Rules** tab.
+3. Find **Sequences** and turn it on.
+4. Click **Customize…**.
+5. Add a sequence, choose its keys in order, and select the layer it activates.
+6. Click **Save**.
+
+Screenshot — the timing control in the Sequences editor:
+
+```
+┌─ Sequences ────────────────────────────────────────────┐
+│ Key Sequence     Leader  →  W  →  L                   │
+│ Action           Activate Window                      │
+│                                                        │
+│ Sequence pause limit                    500 ms          │
+│ ├──────────────●──────────────────────────────┤         │
+│ The timer restarts after each matching key.            │
+└────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Tune the Pause Between Keys
+
+**Sequence pause limit** is the longest pause allowed after the most recent
+matching key. The timer restarts every time you enter the next correct key.
+
+```
+Leader pressed
+    │
+    ├── W pressed after 300 ms  → timer restarts
+    │
+    ├── L pressed after 400 ms  → sequence completes
+    │
+    └── pause longer than the limit → incomplete sequence clears
+```
+
+A larger value gives you more time between keys, which is helpful while
+learning. It also leaves an incomplete sequence pending longer. A smaller value
+clears mistakes sooner but requires a tighter rhythm.
+
+Start with **500 ms**. Increase it if sequences clear before you finish; reduce
+it if an incomplete sequence feels slow to get out of the way. KeyPath supports
+values from **300 to 2000 ms**.
+
+---
+
+## What Happens When a Sequence Fails?
+
+KeyPath clears the pending path when you pause longer than the Sequence pause
+limit or press a key that cannot complete any configured sequence. Start the
+path again from your Leader key.
+
+If two sequences overlap—such as `Leader → W` and `Leader → W → L`—the editor
+warns you because the shorter path can make the longer one ambiguous.
+
+---
+
+## Tips
+
+- Use two or three keys after Leader; short paths become muscle memory quickly.
+- Choose mnemonic letters, such as `W → L` for “window left.”
+- Keep related actions under the same first key.
+- Raise the pause limit temporarily while learning, then tighten it later.
+
+---
+
+## Next Steps
+
+- **[Choose Your Leader Key]({{ '/guides/leader-key/' | relative_url }})** — Pick the key that starts your shortcut paths
+- **[Press Two Keys at Once]({{ '/guides/chords/' | relative_url }})** — Use simultaneous keys instead of an ordered path
+- **[What You Can Build]({{ '/guides/use-cases/' | relative_url }})** — See sequences in a complete keyboard workflow
+- **[Back to Docs](https://malpern.github.io/KeyPath/docs)**
+
+## External resources
+
+- **[Kanata sequence documentation](https://github.com/jtroo/kanata/blob/main/docs/config.adoc#sequences)** — Engine-level details for advanced configurations ↗

--- a/guides/use-cases.md
+++ b/guides/use-cases.md
@@ -111,7 +111,9 @@ Run out of shortcut combinations? Type short mnemonics instead. Press a leader k
 
 Easy to remember, impossible to run out of.
 
-**How to set it up:** Create sequence rules in the **Custom Rules** tab.
+**How to set it up:** Turn on **Sequences** in the **Rules** tab, then click
+**Customize…**. See [Type Memorable Shortcut Paths]({{ '/guides/sequences/' |
+relative_url }}) for setup and timing guidance.
 
 ---
 


### PR DESCRIPTION
## What changed

- emit the enabled Sequences collection's pause limit as Kanata's `sequence-timeout`
- give the timing control one shared 300–2000 ms range, 500 ms default, and clearer reset/clear copy
- preserve manually authored `defseq` blocks while generating the timing setting
- cover default, minimum, maximum, changed, disabled, and export/import behavior
- add a user guide for creating sequences and tuning the pause limit

## Why

The Sequences editor persisted a timeout value, but the generated Kanata configuration never consumed it. Changing the slider therefore had no effect on runtime behavior, and the UI slider exposed only part of the model's supported range.

## Validation

- `TEST_FILTER=SequencesConfigTests ./Scripts/run-tests-safe.sh` — passed
- `TEST_FILTER='KanataDefcfgTests|PerRuleOptionCoverageTests|CLIExportImportTests' ./Scripts/run-tests-safe.sh` — passed
- `TEST_FILTER=RuleCollectionKanataValidationTests ./Scripts/run-tests-safe.sh` — passed against bundled Kanata
- `python3 Scripts/check-accessibility.py` — passed
- `./Scripts/test-fast.sh --changed` — fell back to the full suite; hundreds of tests passed with no failures before the repository's 240-second runner timeout
- `./Scripts/review-gate.sh` — remote review gate selected; merge awaits GitHub `claude-review`

Closes #1209