### PR TITLE
Explain the Chord press window and fallback tradeoff

### DIFF
--- a/Sources/KeyPathAppKit/Models/ChordPressWindowCopy.swift
+++ b/Sources/KeyPathAppKit/Models/ChordPressWindowCopy.swift
@@ -25,6 +25,13 @@ enum ChordPressWindowCopy {
         )
     }
 
+    static func compactSummary(milliseconds: Int) -> String {
+        String(
+            localized: "\(milliseconds) ms window",
+            comment: "Short chord press window value for repeated sidebar rows. The variable is milliseconds."
+        )
+    }
+
     static func accessibilityValue(milliseconds: Int, speed: ChordSpeed) -> String {
         String(
             localized: "\(milliseconds) milliseconds, \(speed.rawValue). Lower values give faster fallback; higher values give an easier chord.",

--- a/Sources/KeyPathAppKit/Models/ChordPressWindowCopy.swift
+++ b/Sources/KeyPathAppKit/Models/ChordPressWindowCopy.swift
@@ -1,0 +1,34 @@
+import Foundation
+import KeyPathRulesCore
+
+/// Canonical user-facing explanations for a chord group's timing control.
+enum ChordPressWindowCopy {
+    static let title = LocalizedStringResource(
+        "Chord press window",
+        comment: "Name of the timing control that determines how quickly all keys in a chord must be pressed."
+    )
+
+    static let explanation = LocalizedStringResource(
+        "The window starts when you press the first chord key. Press the last required key before it expires; otherwise, the keys use their normal layer actions.",
+        comment: "Explains when chord timing starts, what completes a chord, and what happens when time expires."
+    )
+
+    static let tradeoff = LocalizedStringResource(
+        "Lower values make normal actions respond sooner but require a more precise chord. Higher values make chords easier but delay normal-action fallback.",
+        comment: "Explains the physical effect of changing the chord press window."
+    )
+
+    static func summary(milliseconds: Int) -> String {
+        String(
+            localized: "Chord press window: \(milliseconds) ms",
+            comment: "Compact chord group summary. The variable is the timing window in milliseconds."
+        )
+    }
+
+    static func accessibilityValue(milliseconds: Int, speed: ChordSpeed) -> String {
+        String(
+            localized: "\(milliseconds) milliseconds, \(speed.rawValue). Lower values give faster fallback; higher values give an easier chord.",
+            comment: "Accessibility value for the chord press window. The first variable is milliseconds; the second is the preset name."
+        )
+    }
+}

--- a/Sources/KeyPathAppKit/UI/Rules/ChordGroupsCollectionView.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/ChordGroupsCollectionView.swift
@@ -112,7 +112,7 @@ struct ChordGroupsCollectionView: View {
                     .fontWeight(.medium)
 
                 if let group = selectedGroup {
-                    Text("\(group.name): \(group.chords.count) chords • \(ChordPressWindowCopy.summary(milliseconds: group.timeout))")
+                    Text("\(group.name): \(group.chords.count) chords • \(ChordPressWindowCopy.compactSummary(milliseconds: group.timeout))")
                         .font(.caption)
                         .foregroundColor(.secondary)
                 }

--- a/Sources/KeyPathAppKit/UI/Rules/ChordGroupsCollectionView.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/ChordGroupsCollectionView.swift
@@ -90,8 +90,8 @@ struct ChordGroupsCollectionView: View {
             Text("""
             This will load 2 chord groups with 7 total chords:
 
-            • Navigation (250ms): s+d → Esc, d+f → Enter, j+k → Up, k+l → Down
-            • Editing (400ms): a+s → Backspace, s+d+f → Cut, e+r → Undo
+            • Navigation (250 ms): s+d → Esc, d+f → Enter, j+k → Up, k+l → Down
+            • Editing (400 ms): a+s → Backspace, s+d+f → Cut, e+r → Undo
 
             These are Ben Vallack's home row chord combinations for fast navigation and editing.
             """)
@@ -112,7 +112,7 @@ struct ChordGroupsCollectionView: View {
                     .fontWeight(.medium)
 
                 if let group = selectedGroup {
-                    Text("\(group.name): \(group.chords.count) chords @ \(group.timeout)ms")
+                    Text("\(group.name): \(group.chords.count) chords • \(ChordPressWindowCopy.summary(milliseconds: group.timeout))")
                         .font(.caption)
                         .foregroundColor(.secondary)
                 }
@@ -243,7 +243,7 @@ struct ChordGroupsCollectionView: View {
                 VStack(alignment: .leading, spacing: 2) {
                     Text(group.name)
                         .font(.headline)
-                    Text("\(group.category.displayName) • \(group.timeout)ms timeout")
+                    Text("\(group.category.displayName) • \(ChordPressWindowCopy.summary(milliseconds: group.timeout))")
                         .font(.caption)
                         .foregroundColor(.secondary)
                 }

--- a/Sources/KeyPathAppKit/UI/Rules/ChordGroupsModalView.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/ChordGroupsModalView.swift
@@ -236,12 +236,12 @@ struct ChordGroupsModalView: View {
                     )
                     .accessibilityIdentifier("chord-press-window-slider")
                     .accessibilityLabel(Text(ChordPressWindowCopy.title))
-                    .accessibilityValue(
+                    .accessibilityValue(Text(
                         ChordPressWindowCopy.accessibilityValue(
                             milliseconds: group.timeout,
                             speed: ChordSpeed.nearest(to: group.timeout)
                         )
-                    )
+                    ))
 
                     // Speed preset buttons
                     HStack(spacing: 8) {
@@ -447,7 +447,7 @@ private struct GroupRowView: View {
                         .fontWeight(isSelected ? .semibold : .regular)
                         .foregroundColor(isSelected ? .white : .primary)
 
-                    Text("\(group.chords.count) chords • \(ChordPressWindowCopy.summary(milliseconds: group.timeout))")
+                    Text("\(group.chords.count) chords • \(ChordPressWindowCopy.compactSummary(milliseconds: group.timeout))")
                         .font(.caption)
                         .foregroundColor(isSelected ? .white.opacity(0.8) : .secondary)
                 }

--- a/Sources/KeyPathAppKit/UI/Rules/ChordGroupsModalView.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/ChordGroupsModalView.swift
@@ -196,7 +196,7 @@ struct ChordGroupsModalView: View {
                         get: { group.category },
                         set: { newCategory in
                             localConfig.groups[index].category = newCategory
-                            // Update timeout to category's suggested value
+                            // Update the chord press window to the category's suggested value.
                             localConfig.groups[index].timeout = newCategory.suggestedTimeout
                         }
                     )) {
@@ -212,13 +212,13 @@ struct ChordGroupsModalView: View {
                     .accessibilityIdentifier("chord-group-category-picker")
                 }
 
-                // Timeout slider
+                // Chord press window slider
                 VStack(alignment: .leading, spacing: 8) {
                     HStack {
-                        Text("Timeout")
+                        Text(ChordPressWindowCopy.title)
                             .font(.headline)
                         Spacer()
-                        Text("\(group.timeout)ms")
+                        Text("\(group.timeout) ms")
                             .font(.subheadline)
                             .foregroundColor(.secondary)
                         Text("(\(ChordSpeed.nearest(to: group.timeout).rawValue))")
@@ -234,8 +234,14 @@ struct ChordGroupsModalView: View {
                         in: 100 ... 800,
                         step: 50
                     )
-                    .accessibilityLabel("Chord timeout")
-                    .accessibilityValue("\(group.timeout) ms, \(ChordSpeed.nearest(to: group.timeout).rawValue)")
+                    .accessibilityIdentifier("chord-press-window-slider")
+                    .accessibilityLabel(Text(ChordPressWindowCopy.title))
+                    .accessibilityValue(
+                        ChordPressWindowCopy.accessibilityValue(
+                            milliseconds: group.timeout,
+                            speed: ChordSpeed.nearest(to: group.timeout)
+                        )
+                    )
 
                     // Speed preset buttons
                     HStack(spacing: 8) {
@@ -250,6 +256,14 @@ struct ChordGroupsModalView: View {
                     }
 
                     Text(ChordSpeed.nearest(to: group.timeout).description)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+
+                    Text(ChordPressWindowCopy.explanation)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+
+                    Text(ChordPressWindowCopy.tradeoff)
                         .font(.caption)
                         .foregroundColor(.secondary)
                 }
@@ -433,7 +447,7 @@ private struct GroupRowView: View {
                         .fontWeight(isSelected ? .semibold : .regular)
                         .foregroundColor(isSelected ? .white : .primary)
 
-                    Text("\(group.chords.count) chords • \(group.timeout)ms")
+                    Text("\(group.chords.count) chords • \(ChordPressWindowCopy.summary(milliseconds: group.timeout))")
                         .font(.caption)
                         .foregroundColor(isSelected ? .white.opacity(0.8) : .secondary)
                 }

--- a/Sources/KeyPathRulesCore/ChordGroupsConfig.swift
+++ b/Sources/KeyPathRulesCore/ChordGroupsConfig.swift
@@ -441,7 +441,7 @@ public enum ChordCategory: String, Codable, Sendable, CaseIterable {
     }
 }
 
-/// Preset timeout speeds with descriptions.
+/// Preset chord press windows with descriptions.
 public enum ChordSpeed: String, CaseIterable, Codable, Sendable {
     case lightning = "Lightning Fast"
     case fast = "Fast"
@@ -460,13 +460,13 @@ public enum ChordSpeed: String, CaseIterable, Codable, Sendable {
     public var description: String {
         switch self {
         case .lightning:
-            "For experts (150ms) - requires precise timing"
+            "150 ms · Fastest fallback; requires the most precise press"
         case .fast:
-            "For experienced users (250ms) - Ben Vallack's preferred speed"
+            "250 ms · Quick fallback with a tight, practiced press"
         case .moderate:
-            "Balanced (400ms) - good for learning"
+            "400 ms · More time to finish the chord; fallback waits longer"
         case .deliberate:
-            "Relaxed (600ms) - easiest to trigger reliably"
+            "600 ms · Most forgiving press; fallback waits longest"
         }
     }
 

--- a/Tests/KeyPathRulesCoreTests/ChordGroupsConfigTests.swift
+++ b/Tests/KeyPathRulesCoreTests/ChordGroupsConfigTests.swift
@@ -285,6 +285,23 @@ final class ChordGroupsConfigTests: XCTestCase {
         XCTAssertEqual(ChordSpeed.deliberate.milliseconds, 600)
     }
 
+    func testChordSpeedDescriptionsMatchMillisecondsAndFallbackTradeoff() {
+        for speed in ChordSpeed.allCases {
+            XCTAssertTrue(
+                speed.description.contains("\(speed.milliseconds) ms"),
+                "\(speed.rawValue) should describe its actual millisecond value"
+            )
+            XCTAssertTrue(
+                speed.description.localizedCaseInsensitiveContains("fallback"),
+                "\(speed.rawValue) should describe the normal-action fallback tradeoff"
+            )
+        }
+
+        XCTAssertTrue(ChordSpeed.lightning.description.contains("most precise"))
+        XCTAssertTrue(ChordSpeed.deliberate.description.contains("Most forgiving"))
+        XCTAssertTrue(ChordSpeed.deliberate.description.contains("waits longest"))
+    }
+
     func testChordSpeedNearest() {
         XCTAssertEqual(ChordSpeed.nearest(to: 140), .lightning)
         XCTAssertEqual(ChordSpeed.nearest(to: 200), .lightning) // Tie, picks first (lightning)

--- a/Tests/KeyPathTests/UI/ChordPressWindowCopyTests.swift
+++ b/Tests/KeyPathTests/UI/ChordPressWindowCopyTests.swift
@@ -31,4 +31,11 @@ final class ChordPressWindowCopyTests: XCTestCase {
         XCTAssertTrue(value.contains("faster fallback"))
         XCTAssertTrue(value.contains("easier chord"))
     }
+
+    func testCompactSummaryAvoidsRepeatingTheFullControlName() {
+        let summary = ChordPressWindowCopy.compactSummary(milliseconds: 250)
+
+        XCTAssertEqual(summary, "250 ms window")
+        XCTAssertFalse(summary.contains("Chord press window"))
+    }
 }

--- a/Tests/KeyPathTests/UI/ChordPressWindowCopyTests.swift
+++ b/Tests/KeyPathTests/UI/ChordPressWindowCopyTests.swift
@@ -31,5 +31,4 @@ final class ChordPressWindowCopyTests: XCTestCase {
         XCTAssertTrue(value.contains("faster fallback"))
         XCTAssertTrue(value.contains("easier chord"))
     }
-
 }

--- a/Tests/KeyPathTests/UI/ChordPressWindowCopyTests.swift
+++ b/Tests/KeyPathTests/UI/ChordPressWindowCopyTests.swift
@@ -32,24 +32,4 @@ final class ChordPressWindowCopyTests: XCTestCase {
         XCTAssertTrue(value.contains("easier chord"))
     }
 
-    func testSliderUsesCanonicalLabelAndStableIdentifier() throws {
-        let source = try String(
-            contentsOf: repositoryRoot()
-                .appendingPathComponent("Sources/KeyPathAppKit/UI/Rules/ChordGroupsModalView.swift"),
-            encoding: .utf8
-        )
-
-        XCTAssertTrue(source.contains(".accessibilityIdentifier(\"chord-press-window-slider\")"))
-        XCTAssertTrue(source.contains(".accessibilityLabel(Text(ChordPressWindowCopy.title))"))
-        XCTAssertFalse(source.contains("Text(\"Timeout\")"))
-        XCTAssertFalse(source.contains(".accessibilityLabel(\"Chord timeout\")"))
-    }
-}
-
-private func repositoryRoot(file: StaticString = #filePath) -> URL {
-    URL(fileURLWithPath: file.description)
-        .deletingLastPathComponent() // UI
-        .deletingLastPathComponent() // KeyPathTests
-        .deletingLastPathComponent() // Tests
-        .deletingLastPathComponent() // repository root
 }

--- a/Tests/KeyPathTests/UI/ChordPressWindowCopyTests.swift
+++ b/Tests/KeyPathTests/UI/ChordPressWindowCopyTests.swift
@@ -1,0 +1,55 @@
+import Foundation
+@testable import KeyPathAppKit
+import XCTest
+
+final class ChordPressWindowCopyTests: XCTestCase {
+    func testExplanationDefinesStartCompletionAndFallback() {
+        let explanation = String(localized: ChordPressWindowCopy.explanation)
+
+        XCTAssertTrue(explanation.contains("press the first chord key"))
+        XCTAssertTrue(explanation.contains("last required key"))
+        XCTAssertTrue(explanation.contains("expires"))
+        XCTAssertTrue(explanation.contains("normal layer actions"))
+    }
+
+    func testTradeoffExplainsLowerAndHigherValuesInFeltTerms() {
+        let tradeoff = String(localized: ChordPressWindowCopy.tradeoff)
+
+        XCTAssertTrue(tradeoff.contains("Lower values"))
+        XCTAssertTrue(tradeoff.contains("respond sooner"))
+        XCTAssertTrue(tradeoff.contains("more precise"))
+        XCTAssertTrue(tradeoff.contains("Higher values"))
+        XCTAssertTrue(tradeoff.contains("easier"))
+        XCTAssertTrue(tradeoff.contains("delay"))
+    }
+
+    func testAccessibilityValueIncludesTimingPresetAndTradeoff() {
+        let value = ChordPressWindowCopy.accessibilityValue(milliseconds: 250, speed: .fast)
+
+        XCTAssertTrue(value.contains("250 milliseconds"))
+        XCTAssertTrue(value.contains("Fast"))
+        XCTAssertTrue(value.contains("faster fallback"))
+        XCTAssertTrue(value.contains("easier chord"))
+    }
+
+    func testSliderUsesCanonicalLabelAndStableIdentifier() throws {
+        let source = try String(
+            contentsOf: repositoryRoot()
+                .appendingPathComponent("Sources/KeyPathAppKit/UI/Rules/ChordGroupsModalView.swift"),
+            encoding: .utf8
+        )
+
+        XCTAssertTrue(source.contains(".accessibilityIdentifier(\"chord-press-window-slider\")"))
+        XCTAssertTrue(source.contains(".accessibilityLabel(Text(ChordPressWindowCopy.title))"))
+        XCTAssertFalse(source.contains("Text(\"Timeout\")"))
+        XCTAssertFalse(source.contains(".accessibilityLabel(\"Chord timeout\")"))
+    }
+}
+
+private func repositoryRoot(file: StaticString = #filePath) -> URL {
+    URL(fileURLWithPath: file.description)
+        .deletingLastPathComponent() // UI
+        .deletingLastPathComponent() // KeyPathTests
+        .deletingLastPathComponent() // Tests
+        .deletingLastPathComponent() // repository root
+}

--- a/guides/chords.md
+++ b/guides/chords.md
@@ -37,15 +37,15 @@ The preset gives you:
 
 ## How Chords Work
 
-A chord detects when you press two (or more) keys within a short time window — the **timeout**. If both keys land within that window, the chord fires. If only one key lands, it types normally.
+The **Chord press window** starts when you press the first participating key. Press the last required key before that window expires and the chord fires. If the window expires first, those keys use their normal layer actions.
 
 ```
   Press S alone → types "s"
   Press D alone → types "d"
-  Press S + D together (within 250ms) → fires Escape
+  Press S + D together (within 250 ms) → fires Escape
 ```
 
-Order doesn't matter — pressing S then D, or D then S, both trigger the same chord as long as they're within the timeout window.
+Order doesn't matter — pressing S then D, or D then S, both trigger the same chord as long as the last key arrives before the Chord press window closes.
 
 ---
 
@@ -58,19 +58,19 @@ Click **Open Full Editor** to configure your chords in detail:
 **Right panel** — The selected group's settings:
 - **Group name** — identifier (letters, numbers, hyphens only)
 - **Category** — Navigation, Editing, Symbols, Modifiers, or Custom
-- **Timeout** — how quickly both keys must be pressed
+- **Chord press window** — the maximum time from the first chord key to the last required key
 - **Chord list** — each chord showing its keys, output, and an ergonomic score
 
 ### Speed presets
 
-| Preset | Timeout | Best for |
-|--------|---------|----------|
-| Lightning | 150ms | Experts with precise timing |
-| Fast | 250ms | Most users (Ben Vallack's preference) |
-| Moderate | 400ms | Learning chords |
-| Deliberate | 600ms | Easiest to trigger reliably |
+| Preset | Chord press window | Felt effect |
+|--------|--------------------|-------------|
+| Lightning Fast | 150 ms | Fastest normal-action fallback; requires the most precise press |
+| Fast | 250 ms | Quick fallback with a tight, practiced press |
+| Moderate | 400 ms | More time to finish the chord; fallback waits longer |
+| Deliberate | 600 ms | Most forgiving press; normal-action fallback waits longest |
 
-Start with **Fast** (250ms) and adjust once you develop muscle memory.
+Start with **Fast** (250 ms) and adjust once you develop muscle memory.
 
 ---
 
@@ -90,12 +90,12 @@ Stick to adjacent home row pairs for your most-used chords.
 
 ## Organizing with Groups
 
-Chord groups let you organize chords by purpose and set different timeouts per group:
+Chord groups let you organize chords by purpose and set a different Chord press window for each group:
 
-- **Navigation** (250ms) — arrows, page up/down, home/end
-- **Editing** (400ms) — backspace, delete, cut, undo
-- **Symbols** (150ms) — quick symbol access
-- **Modifiers** (600ms) — deliberate modifier combos
+- **Navigation** (250 ms) — arrows, page up/down, home/end
+- **Editing** (400 ms) — backspace, delete, cut, undo
+- **Symbols** (150 ms) — quick symbol access
+- **Modifiers** (600 ms) — deliberate modifier combos
 
 Each group generates its own detection window, so navigation chords can be fast while editing chords give you more time.
 
@@ -125,15 +125,15 @@ Orange warning indicators appear in the editor when conflicts are detected.
 
 ### Chord fires when I'm just typing fast
 
-Lower the timeout (try 150ms), or choose key pairs that aren't common bigrams in English.
+Lower the Chord press window (try 150 ms), or choose key pairs that aren't common bigrams in English.
 
 ### Chord doesn't fire reliably
 
-Increase the timeout (try 400ms), or practice pressing both keys more simultaneously.
+Increase the Chord press window (try 400 ms), or practice pressing both keys more simultaneously.
 
 ### Individual keys feel delayed
 
-This is the tradeoff: the engine waits the timeout duration to see if a second key arrives. Shorter timeouts reduce the delay but require more precise timing. 250ms is the sweet spot for most users.
+This is the tradeoff: after the first chord key, KeyPath waits through the Chord press window for the remaining keys. A lower value returns to normal actions sooner but requires a more precise chord. A higher value makes chords easier but delays normal-action fallback. Start at 250 ms and adjust for how you type.
 
 ---
 


### PR DESCRIPTION
Closes #1212

## What changed

- rename the Chord Groups timing control to **Chord press window** across the editor and summaries
- explain that timing starts with the first chord key, completes with the last required key, and falls back to normal layer actions on expiry
- rewrite every speed preset around the precision-versus-fallback tradeoff while keeping the existing millisecond values
- add a stable slider accessibility identifier plus an informative spoken label/value
- update the Chords user guide and add focused copy/accessibility contract tests

## User impact

Users can now tell what the timing value measures and what they will feel when they move it lower or higher. No chord-recognition behavior or stored configuration changes.

## Validation

- `ChordGroupsConfigTests|ChordPressWindowCopyTests`: 32 passed
- accessibility identifier audit: passed across 356 UI files
- full safe suite: 4,825 tests passed; one unrelated load-sensitive `SystemValidatorTests` duration assertion exceeded 250 ms under the full-suite load
- isolated `SystemValidatorTests` rerun: 17 passed
- pre-PR review: remote review gate selected; wait for GitHub `claude-review` before merge