### PR TITLE
Bound notarization waits and preserve recovery evidence

### DIFF
--- a/Scripts/lib/signing.sh
+++ b/Scripts/lib/signing.sh
@@ -10,6 +10,7 @@ KP_STAPLER_CMD=${KP_STAPLER_CMD:-xcrun stapler}
 KP_SPCTL_CMD=${KP_SPCTL_CMD:-spctl}
 KP_VERIFY_CMD=${KP_VERIFY_CMD:-codesign}
 KP_SIGN_DRY_RUN=${KP_SIGN_DRY_RUN:-0}
+KP_NOTARY_WAIT_TIMEOUT=${KP_NOTARY_WAIT_TIMEOUT:-15m}
 
 kp_run() {
     if [ "$KP_SIGN_DRY_RUN" = "1" ]; then
@@ -31,24 +32,173 @@ kp_verify_signature() {
     kp_run "$KP_VERIFY_CMD" -dvvv "$target" "$@"
 }
 
+kp_write_notary_state() {
+    local state_file=$1
+    local submission_id=$2
+    local archive_path=$3
+    local archive_sha256=$4
+    local profile=$5
+    local status=$6
+
+    /usr/bin/python3 - "$state_file" "$submission_id" "$archive_path" "$archive_sha256" "$profile" "$status" <<'PY'
+import datetime
+import json
+import os
+import sys
+
+state_file, submission_id, archive_path, archive_sha256, profile, status = sys.argv[1:]
+directory = os.path.dirname(state_file)
+if directory:
+    os.makedirs(directory, exist_ok=True)
+
+payload = {
+    "schemaVersion": 1,
+    "submissionId": submission_id,
+    "archivePath": archive_path,
+    "archiveSHA256": archive_sha256,
+    "profile": profile,
+    "status": status,
+    "updatedAt": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+}
+temporary_file = f"{state_file}.tmp"
+with open(temporary_file, "w", encoding="utf-8") as handle:
+    json.dump(payload, handle, indent=2, sort_keys=True)
+    handle.write("\n")
+os.replace(temporary_file, state_file)
+PY
+}
+
+kp_notary_json_field() {
+    local field=$1
+    /usr/bin/python3 -c '
+import json
+import sys
+
+payload = json.load(sys.stdin)
+value = payload.get(sys.argv[1])
+if value is None:
+    raise SystemExit(1)
+print(value)
+' "$field"
+}
+
+kp_print_notary_recovery() {
+    local submission_id=$1
+    local archive_path=$2
+    local archive_sha256=$3
+    local profile=$4
+    local state_file=$5
+
+    echo "⚠️  Notarization did not reach Accepted within ${KP_NOTARY_WAIT_TIMEOUT}."
+    echo "   Submission ID: $submission_id"
+    echo "   Archive SHA-256: $archive_sha256"
+    echo "   Recovery state: $state_file"
+    echo ""
+    echo "   Check the existing submission before considering a retry:"
+    if [ -n "${KP_NOTARY_KEYCHAIN:-}" ]; then
+        echo "   xcrun notarytool info \"$submission_id\" --keychain-profile \"$profile\" --keychain \"$KP_NOTARY_KEYCHAIN\""
+    else
+        echo "   xcrun notarytool info \"$submission_id\" --keychain-profile \"$profile\""
+    fi
+    echo ""
+    echo "   Do not submit another archive automatically. If one explicit retry is"
+    echo "   necessary, first verify the archive still has this exact checksum:"
+    echo "   shasum -a 256 \"$archive_path\""
+    if [ -n "${KP_NOTARY_KEYCHAIN:-}" ]; then
+        echo "   xcrun notarytool submit \"$archive_path\" --keychain-profile \"$profile\" --keychain \"$KP_NOTARY_KEYCHAIN\" --no-wait --output-format json --no-progress"
+    else
+        echo "   xcrun notarytool submit \"$archive_path\" --keychain-profile \"$profile\" --no-wait --output-format json --no-progress"
+    fi
+}
+
 kp_notarize_zip() {
     local zip_path=$1
     local profile=$2
     shift 2
+    local state_file=${KP_NOTARY_STATE_FILE:-"${zip_path%.zip}.notary-submission.json"}
+
     if [ "$KP_SIGN_DRY_RUN" = "1" ]; then
         if [ -n "${KP_NOTARY_KEYCHAIN:-}" ]; then
-            echo "[DRY RUN] $KP_NOTARY_CMD submit $zip_path --keychain-profile $profile --keychain $KP_NOTARY_KEYCHAIN --wait $*"
+            echo "[DRY RUN] $KP_NOTARY_CMD submit $zip_path --keychain-profile $profile --keychain $KP_NOTARY_KEYCHAIN --no-wait --output-format json --no-progress $*"
+            echo "[DRY RUN] $KP_NOTARY_CMD wait <submission-id> --keychain-profile $profile --keychain $KP_NOTARY_KEYCHAIN --timeout $KP_NOTARY_WAIT_TIMEOUT"
         else
-            echo "[DRY RUN] $KP_NOTARY_CMD submit $zip_path --keychain-profile $profile --wait $*"
+            echo "[DRY RUN] $KP_NOTARY_CMD submit $zip_path --keychain-profile $profile --no-wait --output-format json --no-progress $*"
+            echo "[DRY RUN] $KP_NOTARY_CMD wait <submission-id> --keychain-profile $profile --timeout $KP_NOTARY_WAIT_TIMEOUT"
         fi
+        echo "[DRY RUN] persist submission evidence to $state_file"
         return 0
     fi
-    # Use word-splitting for multi-word command (xcrun notarytool)
+
+    local archive_path
+    archive_path=$(cd "$(dirname "$zip_path")" >/dev/null && pwd -P)/$(basename "$zip_path")
+    local archive_sha256
+    archive_sha256=$(/usr/bin/shasum -a 256 "$archive_path" | /usr/bin/awk '{print $1}')
+
+    local submit_output
     if [ -n "${KP_NOTARY_KEYCHAIN:-}" ]; then
-        $KP_NOTARY_CMD submit "$zip_path" --keychain-profile "$profile" --keychain "$KP_NOTARY_KEYCHAIN" --wait "$@"
+        if ! submit_output=$($KP_NOTARY_CMD submit "$archive_path" --keychain-profile "$profile" --keychain "$KP_NOTARY_KEYCHAIN" --no-wait --output-format json --no-progress "$@"); then
+            echo "❌ Notarization upload failed before a submission ID was recorded." >&2
+            return 1
+        fi
     else
-        $KP_NOTARY_CMD submit "$zip_path" --keychain-profile "$profile" --wait "$@"
+        if ! submit_output=$($KP_NOTARY_CMD submit "$archive_path" --keychain-profile "$profile" --no-wait --output-format json --no-progress "$@"); then
+            echo "❌ Notarization upload failed before a submission ID was recorded." >&2
+            return 1
+        fi
     fi
+
+    local submission_id
+    if ! submission_id=$(printf '%s' "$submit_output" | kp_notary_json_field id); then
+        echo "❌ Notarization upload returned no parseable submission ID." >&2
+        echo "$submit_output" >&2
+        return 1
+    fi
+
+    kp_write_notary_state "$state_file" "$submission_id" "$archive_path" "$archive_sha256" "$profile" "submitted"
+    echo "✅ Notarization upload recorded"
+    echo "   Submission ID: $submission_id"
+    echo "   Archive SHA-256: $archive_sha256"
+    echo "   Recovery state: $state_file"
+    echo "⏳ Waiting up to $KP_NOTARY_WAIT_TIMEOUT for Apple notarization..."
+
+    local wait_exit=0
+    if [ -n "${KP_NOTARY_KEYCHAIN:-}" ]; then
+        $KP_NOTARY_CMD wait "$submission_id" --keychain-profile "$profile" --keychain "$KP_NOTARY_KEYCHAIN" --timeout "$KP_NOTARY_WAIT_TIMEOUT" || wait_exit=$?
+    else
+        $KP_NOTARY_CMD wait "$submission_id" --keychain-profile "$profile" --timeout "$KP_NOTARY_WAIT_TIMEOUT" || wait_exit=$?
+    fi
+
+    local info_output=""
+    if [ -n "${KP_NOTARY_KEYCHAIN:-}" ]; then
+        info_output=$($KP_NOTARY_CMD info "$submission_id" --keychain-profile "$profile" --keychain "$KP_NOTARY_KEYCHAIN" --output-format json 2>/dev/null) || true
+    else
+        info_output=$($KP_NOTARY_CMD info "$submission_id" --keychain-profile "$profile" --output-format json 2>/dev/null) || true
+    fi
+
+    local final_status=""
+    final_status=$(printf '%s' "$info_output" | kp_notary_json_field status 2>/dev/null) || true
+    if [ "$final_status" = "Accepted" ]; then
+        kp_write_notary_state "$state_file" "$submission_id" "$archive_path" "$archive_sha256" "$profile" "accepted"
+        echo "✅ Apple notarization accepted submission $submission_id"
+        return 0
+    fi
+
+    local recorded_status="unknown"
+    if [ -n "$final_status" ]; then
+        recorded_status=$(printf '%s' "$final_status" | /usr/bin/tr '[:upper:] ' '[:lower:]-')
+    elif [ "$wait_exit" -ne 0 ]; then
+        recorded_status="wait-failed"
+    fi
+    kp_write_notary_state "$state_file" "$submission_id" "$archive_path" "$archive_sha256" "$profile" "$recorded_status"
+    kp_print_notary_recovery "$submission_id" "$archive_path" "$archive_sha256" "$profile" "$state_file"
+
+    if [ "$final_status" = "In Progress" ]; then
+        return 75
+    fi
+    if [ "$wait_exit" -ne 0 ]; then
+        return "$wait_exit"
+    fi
+    return 1
 }
 
 kp_staple() {

--- a/Scripts/lib/signing.sh
+++ b/Scripts/lib/signing.sh
@@ -120,10 +120,10 @@ kp_notarize_zip() {
     if [ "$KP_SIGN_DRY_RUN" = "1" ]; then
         if [ -n "${KP_NOTARY_KEYCHAIN:-}" ]; then
             echo "[DRY RUN] $KP_NOTARY_CMD submit $zip_path --keychain-profile $profile --keychain $KP_NOTARY_KEYCHAIN --no-wait --output-format json --no-progress $*"
-            echo "[DRY RUN] $KP_NOTARY_CMD wait <submission-id> --keychain-profile $profile --keychain $KP_NOTARY_KEYCHAIN --timeout $KP_NOTARY_WAIT_TIMEOUT"
+            echo "[DRY RUN] $KP_NOTARY_CMD wait <submission-id> --keychain-profile $profile --keychain $KP_NOTARY_KEYCHAIN --timeout $KP_NOTARY_WAIT_TIMEOUT --output-format json --no-progress"
         else
             echo "[DRY RUN] $KP_NOTARY_CMD submit $zip_path --keychain-profile $profile --no-wait --output-format json --no-progress $*"
-            echo "[DRY RUN] $KP_NOTARY_CMD wait <submission-id> --keychain-profile $profile --timeout $KP_NOTARY_WAIT_TIMEOUT"
+            echo "[DRY RUN] $KP_NOTARY_CMD wait <submission-id> --keychain-profile $profile --timeout $KP_NOTARY_WAIT_TIMEOUT --output-format json --no-progress"
         fi
         echo "[DRY RUN] persist submission evidence to $state_file"
         return 0
@@ -161,22 +161,29 @@ kp_notarize_zip() {
     echo "   Recovery state: $state_file"
     echo "⏳ Waiting up to $KP_NOTARY_WAIT_TIMEOUT for Apple notarization..."
 
+    local wait_output=""
     local wait_exit=0
     if [ -n "${KP_NOTARY_KEYCHAIN:-}" ]; then
-        $KP_NOTARY_CMD wait "$submission_id" --keychain-profile "$profile" --keychain "$KP_NOTARY_KEYCHAIN" --timeout "$KP_NOTARY_WAIT_TIMEOUT" || wait_exit=$?
+        wait_output=$($KP_NOTARY_CMD wait "$submission_id" --keychain-profile "$profile" --keychain "$KP_NOTARY_KEYCHAIN" --timeout "$KP_NOTARY_WAIT_TIMEOUT" --output-format json --no-progress) || wait_exit=$?
     else
-        $KP_NOTARY_CMD wait "$submission_id" --keychain-profile "$profile" --timeout "$KP_NOTARY_WAIT_TIMEOUT" || wait_exit=$?
-    fi
-
-    local info_output=""
-    if [ -n "${KP_NOTARY_KEYCHAIN:-}" ]; then
-        info_output=$($KP_NOTARY_CMD info "$submission_id" --keychain-profile "$profile" --keychain "$KP_NOTARY_KEYCHAIN" --output-format json 2>/dev/null) || true
-    else
-        info_output=$($KP_NOTARY_CMD info "$submission_id" --keychain-profile "$profile" --output-format json 2>/dev/null) || true
+        wait_output=$($KP_NOTARY_CMD wait "$submission_id" --keychain-profile "$profile" --timeout "$KP_NOTARY_WAIT_TIMEOUT" --output-format json --no-progress) || wait_exit=$?
     fi
 
     local final_status=""
-    final_status=$(printf '%s' "$info_output" | kp_notary_json_field status 2>/dev/null) || true
+    final_status=$(printf '%s' "$wait_output" | kp_notary_json_field status 2>/dev/null) || true
+    if [ "$wait_exit" -ne 0 ] || [ -z "$final_status" ]; then
+        local info_output=""
+        if [ -n "${KP_NOTARY_KEYCHAIN:-}" ]; then
+            info_output=$($KP_NOTARY_CMD info "$submission_id" --keychain-profile "$profile" --keychain "$KP_NOTARY_KEYCHAIN" --output-format json 2>/dev/null) || true
+        else
+            info_output=$($KP_NOTARY_CMD info "$submission_id" --keychain-profile "$profile" --output-format json 2>/dev/null) || true
+        fi
+        local info_status=""
+        info_status=$(printf '%s' "$info_output" | kp_notary_json_field status 2>/dev/null) || true
+        if [ -n "$info_status" ]; then
+            final_status=$info_status
+        fi
+    fi
     if [ "$final_status" = "Accepted" ]; then
         kp_write_notary_state "$state_file" "$submission_id" "$archive_path" "$archive_sha256" "$profile" "accepted"
         echo "✅ Apple notarization accepted submission $submission_id"

--- a/Scripts/lib/signing.sh
+++ b/Scripts/lib/signing.sh
@@ -129,8 +129,16 @@ kp_notarize_zip() {
         return 0
     fi
 
-    local archive_path
-    archive_path=$(cd "$(dirname "$zip_path")" >/dev/null && pwd -P)/$(basename "$zip_path")
+    local archive_directory
+    if ! archive_directory=$(cd "$(dirname "$zip_path")" >/dev/null && pwd -P); then
+        echo "❌ Notarization archive directory does not exist or is inaccessible: $(dirname "$zip_path")" >&2
+        return 1
+    fi
+    local archive_path="$archive_directory/$(basename "$zip_path")"
+    if [ ! -f "$archive_path" ]; then
+        echo "❌ Notarization archive does not exist: $archive_path" >&2
+        return 1
+    fi
     local archive_sha256
     archive_sha256=$(/usr/bin/shasum -a 256 "$archive_path" | /usr/bin/awk '{print $1}')
 
@@ -148,7 +156,8 @@ kp_notarize_zip() {
     fi
 
     local submission_id
-    if ! submission_id=$(printf '%s' "$submit_output" | kp_notary_json_field id); then
+    submission_id=$(printf '%s' "$submit_output" | kp_notary_json_field id 2>/dev/null) || true
+    if [ -z "$submission_id" ]; then
         echo "❌ Notarization upload returned no parseable submission ID." >&2
         echo "$submit_output" >&2
         return 1

--- a/Scripts/release-candidate.sh
+++ b/Scripts/release-candidate.sh
@@ -34,6 +34,11 @@ Options:
 Environment:
   CODESIGN_IDENTITY   Developer ID Application identity override.
   NOTARY_PROFILE      notarytool keychain profile override.
+  KP_NOTARY_WAIT_TIMEOUT
+                      Maximum Apple processing wait before preserving recovery
+                      evidence and stopping (default: 15m).
+  KP_NOTARY_STATE_FILE
+                      Optional notarization recovery-state file override.
 EOF
 }
 

--- a/Tests/KeyPathTests/BuildScripts/SigningPipelineTests.swift
+++ b/Tests/KeyPathTests/BuildScripts/SigningPipelineTests.swift
@@ -76,7 +76,7 @@ final class SigningPipelineTests: XCTestCase {
     }
 
     func testNotaryWrapperRecordsSubmissionBeforeBoundedWait() throws {
-        let fixture = try makeNotaryFixture(waitExit: 0, infoStatus: "Accepted")
+        let fixture = try makeNotaryFixture(waitExit: 0, waitStatus: "Accepted", infoStatus: nil)
         let script = """
         unset KP_SIGN_DRY_RUN
         source \(signingLibPath)
@@ -97,8 +97,9 @@ final class SigningPipelineTests: XCTestCase {
         XCTAssertFalse(invocations.contains("submit \(recordedArchivePath) --keychain-profile KeyPath-Profile --keychain /tmp/keypath-notary.keychain-db --wait"))
         XCTAssertTrue(invocations.contains("wait \(submissionID)"))
         XCTAssertTrue(invocations.contains("--timeout 15m"))
-        XCTAssertTrue(invocations.contains("info \(submissionID)"))
-        XCTAssertEqual(invocations.components(separatedBy: "--keychain /tmp/keypath-notary.keychain-db").count - 1, 3)
+        XCTAssertTrue(invocations.contains("--output-format json --no-progress"))
+        XCTAssertFalse(invocations.contains("info \(submissionID)"))
+        XCTAssertEqual(invocations.components(separatedBy: "--keychain /tmp/keypath-notary.keychain-db").count - 1, 2)
 
         XCTAssertEqual(state["submissionId"] as? String, submissionID)
         XCTAssertTrue(recordedArchivePath.hasSuffix("/KeyPath.zip"))
@@ -166,9 +167,17 @@ final class SigningPipelineTests: XCTestCase {
         XCTAssertTrue(result.stdout.contains("persist submission evidence to /tmp/KeyPath.notary-submission.json"))
     }
 
+    func testPinnedNotarytoolSupportsExplicitNoWait() {
+        let result = runScript("xcrun notarytool submit --help")
+
+        XCTAssertEqual(result.code, 0, result.stderr)
+        XCTAssertTrue(result.stdout.contains("--wait/--no-wait"))
+    }
+
     private func makeNotaryFixture(
         waitExit: Int32,
-        infoStatus: String
+        waitStatus: String? = nil,
+        infoStatus: String?
     ) throws -> (archive: URL, stub: URL, log: URL, state: URL) {
         let directory = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
@@ -179,18 +188,29 @@ final class SigningPipelineTests: XCTestCase {
         let log = directory.appendingPathComponent("notary-invocations.log")
         let state = directory.appendingPathComponent("KeyPath.notary-submission.json")
         let stub = directory.appendingPathComponent("notarytool-stub")
+        let waitResponse = waitStatus.map {
+            "printf '%s\\n' '{\"id\":\"\(submissionID)\",\"status\":\"\($0)\"}'"
+        } ?? ":"
+        let infoResponse = infoStatus.map {
+            "printf '%s\\n' '{\"id\":\"\(submissionID)\",\"status\":\"\($0)\"}'"
+        } ?? "exit 69"
         let stubSource = """
         #!/bin/bash
         printf '%s\\n' "$*" >> "$KP_NOTARY_TEST_LOG"
         case "$1" in
             submit)
+                case " $* " in
+                    *" --no-wait "*) ;;
+                    *) exit 64 ;;
+                esac
                 printf '%s\\n' '{"id":"\(submissionID)","message":"Successfully uploaded file"}'
                 ;;
             wait)
+                \(waitResponse)
                 exit \(waitExit)
                 ;;
             info)
-                printf '%s\\n' '{"id":"\(submissionID)","status":"\(infoStatus)"}'
+                \(infoResponse)
                 ;;
             *)
                 exit 2

--- a/Tests/KeyPathTests/BuildScripts/SigningPipelineTests.swift
+++ b/Tests/KeyPathTests/BuildScripts/SigningPipelineTests.swift
@@ -218,7 +218,12 @@ final class SigningPipelineTests: XCTestCase {
     }
 
     func testPinnedNotarytoolSupportsExplicitNoWait() {
-        let result = runScript("xcrun notarytool submit --help")
+        let script = """
+        source Scripts/lib/xcode.sh
+        keypath_use_stable_xcode
+        xcrun notarytool submit --help
+        """
+        let result = runScript(script)
 
         XCTAssertEqual(result.code, 0, result.stderr)
         XCTAssertTrue(result.stdout.contains("--wait/--no-wait"))
@@ -233,6 +238,9 @@ final class SigningPipelineTests: XCTestCase {
         let directory = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        addTeardownBlock {
+            try? FileManager.default.removeItem(at: directory)
+        }
 
         let archive = directory.appendingPathComponent("KeyPath.zip")
         try Data("signed KeyPath archive".utf8).write(to: archive)

--- a/Tests/KeyPathTests/BuildScripts/SigningPipelineTests.swift
+++ b/Tests/KeyPathTests/BuildScripts/SigningPipelineTests.swift
@@ -1,7 +1,9 @@
+import Foundation
 @preconcurrency import XCTest
 
 final class SigningPipelineTests: XCTestCase {
     private let signingLibPath = "Scripts/lib/signing.sh"
+    private let submissionID = "68348f8a-cb0e-49ad-b130-8e071eb3c0f4"
 
     /// Simple helper to run a bash snippet and capture its exit code.
     private func runScript(_ script: String, env: [String: String] = [:]) -> (code: Int32, stdout: String, stderr: String) {
@@ -71,5 +73,138 @@ final class SigningPipelineTests: XCTestCase {
         """
         let result = runScript(script)
         XCTAssertNotEqual(result.code, 0, "notary wrapper should bubble up failures")
+    }
+
+    func testNotaryWrapperRecordsSubmissionBeforeBoundedWait() throws {
+        let fixture = try makeNotaryFixture(waitExit: 0, infoStatus: "Accepted")
+        let script = """
+        unset KP_SIGN_DRY_RUN
+        source \(signingLibPath)
+        KP_NOTARY_CMD="\(fixture.stub.path)"
+        KP_NOTARY_STATE_FILE="\(fixture.state.path)"
+        KP_NOTARY_KEYCHAIN="/tmp/keypath-notary.keychain-db"
+        KP_NOTARY_WAIT_TIMEOUT="15m"
+        kp_notarize_zip "\(fixture.archive.path)" "KeyPath-Profile"
+        """
+        let result = runScript(script, env: ["KP_NOTARY_TEST_LOG": fixture.log.path])
+
+        XCTAssertEqual(result.code, 0, result.stderr)
+        let state = try notaryState(at: fixture.state)
+        let recordedArchivePath = try XCTUnwrap(state["archivePath"] as? String)
+        let invocations = try String(contentsOf: fixture.log, encoding: .utf8)
+        XCTAssertTrue(invocations.contains("submit \(recordedArchivePath)"))
+        XCTAssertTrue(invocations.contains("--no-wait --output-format json --no-progress"))
+        XCTAssertFalse(invocations.contains("submit \(recordedArchivePath) --keychain-profile KeyPath-Profile --keychain /tmp/keypath-notary.keychain-db --wait"))
+        XCTAssertTrue(invocations.contains("wait \(submissionID)"))
+        XCTAssertTrue(invocations.contains("--timeout 15m"))
+        XCTAssertTrue(invocations.contains("info \(submissionID)"))
+        XCTAssertEqual(invocations.components(separatedBy: "--keychain /tmp/keypath-notary.keychain-db").count - 1, 3)
+
+        XCTAssertEqual(state["submissionId"] as? String, submissionID)
+        XCTAssertTrue(recordedArchivePath.hasSuffix("/KeyPath.zip"))
+        XCTAssertEqual(state["status"] as? String, "accepted")
+        XCTAssertEqual((state["archiveSHA256"] as? String)?.count, 64)
+    }
+
+    func testNotaryWrapperPreservesRecoveryEvidenceOnTimeout() throws {
+        let fixture = try makeNotaryFixture(waitExit: 124, infoStatus: "In Progress")
+        let script = """
+        unset KP_SIGN_DRY_RUN
+        source \(signingLibPath)
+        KP_NOTARY_CMD="\(fixture.stub.path)"
+        KP_NOTARY_STATE_FILE="\(fixture.state.path)"
+        KP_NOTARY_WAIT_TIMEOUT="15m"
+        kp_notarize_zip "\(fixture.archive.path)" "KeyPath-Profile"
+        """
+        let result = runScript(script, env: ["KP_NOTARY_TEST_LOG": fixture.log.path])
+
+        let state = try notaryState(at: fixture.state)
+        let recordedArchivePath = try XCTUnwrap(state["archivePath"] as? String)
+        XCTAssertEqual(result.code, 75)
+        XCTAssertTrue(result.stdout.contains("Submission ID: \(submissionID)"))
+        XCTAssertTrue(result.stdout.contains("Recovery state: \(fixture.state.path)"))
+        XCTAssertTrue(result.stdout.contains("Check the existing submission before considering a retry"))
+        XCTAssertTrue(result.stdout.contains("Do not submit another archive automatically"))
+        XCTAssertTrue(result.stdout.contains("shasum -a 256 \"\(recordedArchivePath)\""))
+
+        XCTAssertEqual(state["status"] as? String, "in-progress")
+        XCTAssertEqual(state["submissionId"] as? String, submissionID)
+    }
+
+    func testNotaryWrapperRecoversWhenWaitClientFailsAfterAcceptance() throws {
+        let fixture = try makeNotaryFixture(waitExit: 138, infoStatus: "Accepted")
+        let script = """
+        unset KP_SIGN_DRY_RUN
+        source \(signingLibPath)
+        KP_NOTARY_CMD="\(fixture.stub.path)"
+        KP_NOTARY_STATE_FILE="\(fixture.state.path)"
+        kp_notarize_zip "\(fixture.archive.path)" "KeyPath-Profile"
+        """
+        let result = runScript(script, env: ["KP_NOTARY_TEST_LOG": fixture.log.path])
+
+        XCTAssertEqual(result.code, 0, result.stderr)
+        XCTAssertTrue(result.stdout.contains("Apple notarization accepted submission \(submissionID)"))
+        let state = try notaryState(at: fixture.state)
+        XCTAssertEqual(state["status"] as? String, "accepted")
+    }
+
+    func testNotaryWrapperDryRunShowsBoundedTwoPhaseFlow() {
+        let script = """
+        source \(signingLibPath)
+        KP_SIGN_DRY_RUN=1
+        KP_NOTARY_WAIT_TIMEOUT=15m
+        KP_NOTARY_STATE_FILE=/tmp/KeyPath.notary-submission.json
+        kp_notarize_zip "/tmp/KeyPath.zip" "KeyPath-Profile"
+        """
+        let result = runScript(script)
+
+        XCTAssertEqual(result.code, 0, result.stderr)
+        XCTAssertTrue(result.stdout.contains("submit /tmp/KeyPath.zip"))
+        XCTAssertTrue(result.stdout.contains("--no-wait --output-format json --no-progress"))
+        XCTAssertTrue(result.stdout.contains("wait <submission-id>"))
+        XCTAssertTrue(result.stdout.contains("--timeout 15m"))
+        XCTAssertTrue(result.stdout.contains("persist submission evidence to /tmp/KeyPath.notary-submission.json"))
+    }
+
+    private func makeNotaryFixture(
+        waitExit: Int32,
+        infoStatus: String
+    ) throws -> (archive: URL, stub: URL, log: URL, state: URL) {
+        let directory = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+
+        let archive = directory.appendingPathComponent("KeyPath.zip")
+        try Data("signed KeyPath archive".utf8).write(to: archive)
+        let log = directory.appendingPathComponent("notary-invocations.log")
+        let state = directory.appendingPathComponent("KeyPath.notary-submission.json")
+        let stub = directory.appendingPathComponent("notarytool-stub")
+        let stubSource = """
+        #!/bin/bash
+        printf '%s\\n' "$*" >> "$KP_NOTARY_TEST_LOG"
+        case "$1" in
+            submit)
+                printf '%s\\n' '{"id":"\(submissionID)","message":"Successfully uploaded file"}'
+                ;;
+            wait)
+                exit \(waitExit)
+                ;;
+            info)
+                printf '%s\\n' '{"id":"\(submissionID)","status":"\(infoStatus)"}'
+                ;;
+            *)
+                exit 2
+                ;;
+        esac
+        """
+        try stubSource.write(to: stub, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: stub.path)
+
+        return (archive, stub, log, state)
+    }
+
+    private func notaryState(at url: URL) throws -> [String: Any] {
+        let data = try Data(contentsOf: url)
+        return try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
     }
 }

--- a/Tests/KeyPathTests/BuildScripts/SigningPipelineTests.swift
+++ b/Tests/KeyPathTests/BuildScripts/SigningPipelineTests.swift
@@ -75,6 +75,38 @@ final class SigningPipelineTests: XCTestCase {
         XCTAssertNotEqual(result.code, 0, "notary wrapper should bubble up failures")
     }
 
+    func testNotaryWrapperRejectsInaccessibleArchiveDirectory() {
+        let script = """
+        unset KP_SIGN_DRY_RUN
+        source \(signingLibPath)
+        KP_NOTARY_CMD=/bin/false kp_notarize_zip "/path/that/does/not/exist/KeyPath.zip" "NoProfile"
+        """
+        let result = runScript(script)
+
+        XCTAssertNotEqual(result.code, 0)
+        XCTAssertTrue(result.stderr.contains("archive directory does not exist or is inaccessible"))
+    }
+
+    func testNotaryWrapperRejectsEmptySubmissionID() throws {
+        let fixture = try makeNotaryFixture(
+            waitExit: 0,
+            infoStatus: nil,
+            submitID: ""
+        )
+        let script = """
+        unset KP_SIGN_DRY_RUN
+        source \(signingLibPath)
+        KP_NOTARY_CMD="\(fixture.stub.path)"
+        KP_NOTARY_STATE_FILE="\(fixture.state.path)"
+        kp_notarize_zip "\(fixture.archive.path)" "KeyPath-Profile"
+        """
+        let result = runScript(script, env: ["KP_NOTARY_TEST_LOG": fixture.log.path])
+
+        XCTAssertNotEqual(result.code, 0)
+        XCTAssertTrue(result.stderr.contains("no parseable submission ID"))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: fixture.state.path))
+    }
+
     func testNotaryWrapperRecordsSubmissionBeforeBoundedWait() throws {
         let fixture = try makeNotaryFixture(waitExit: 0, waitStatus: "Accepted", infoStatus: nil)
         let script = """
@@ -177,7 +209,8 @@ final class SigningPipelineTests: XCTestCase {
     private func makeNotaryFixture(
         waitExit: Int32,
         waitStatus: String? = nil,
-        infoStatus: String?
+        infoStatus: String?,
+        submitID: String? = nil
     ) throws -> (archive: URL, stub: URL, log: URL, state: URL) {
         let directory = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
@@ -194,6 +227,7 @@ final class SigningPipelineTests: XCTestCase {
         let infoResponse = infoStatus.map {
             "printf '%s\\n' '{\"id\":\"\(submissionID)\",\"status\":\"\($0)\"}'"
         } ?? "exit 69"
+        let resolvedSubmitID = submitID ?? submissionID
         let stubSource = """
         #!/bin/bash
         printf '%s\\n' "$*" >> "$KP_NOTARY_TEST_LOG"
@@ -203,7 +237,7 @@ final class SigningPipelineTests: XCTestCase {
                     *" --no-wait "*) ;;
                     *) exit 64 ;;
                 esac
-                printf '%s\\n' '{"id":"\(submissionID)","message":"Successfully uploaded file"}'
+                printf '%s\\n' '{"id":"\(resolvedSubmitID)","message":"Successfully uploaded file"}'
                 ;;
             wait)
                 \(waitResponse)

--- a/Tests/KeyPathTests/BuildScripts/SigningPipelineTests.swift
+++ b/Tests/KeyPathTests/BuildScripts/SigningPipelineTests.swift
@@ -181,6 +181,24 @@ final class SigningPipelineTests: XCTestCase {
         XCTAssertEqual(state["status"] as? String, "accepted")
     }
 
+    func testNotaryWrapperRecordsPermanentInvalidStatus() throws {
+        let fixture = try makeNotaryFixture(waitExit: 0, waitStatus: "Invalid", infoStatus: nil)
+        let script = """
+        unset KP_SIGN_DRY_RUN
+        source \(signingLibPath)
+        KP_NOTARY_CMD="\(fixture.stub.path)"
+        KP_NOTARY_STATE_FILE="\(fixture.state.path)"
+        kp_notarize_zip "\(fixture.archive.path)" "KeyPath-Profile"
+        """
+        let result = runScript(script, env: ["KP_NOTARY_TEST_LOG": fixture.log.path])
+
+        XCTAssertEqual(result.code, 1)
+        let state = try notaryState(at: fixture.state)
+        XCTAssertEqual(state["status"] as? String, "invalid")
+        let invocations = try String(contentsOf: fixture.log, encoding: .utf8)
+        XCTAssertFalse(invocations.contains("info \(submissionID)"))
+    }
+
     func testNotaryWrapperDryRunShowsBoundedTwoPhaseFlow() {
         let script = """
         source \(signingLibPath)

--- a/docs/process/release-process.md
+++ b/docs/process/release-process.md
@@ -80,7 +80,10 @@ inspection and retry commands. Check the existing submission first. Apple does
 not expose a cancel command, and the release scripts never create a duplicate
 submission automatically. If one explicit retry is justified, verify that the
 archive still has the recorded checksum and submit that exact archive once with
-`--no-wait`; do not stack additional submissions.
+`--no-wait`; do not stack additional submissions. The script returns exit 75
+when Apple still reports `In Progress`, reserving a distinct transient result
+for automation even though the current release entry points stop on any
+nonzero result. Permanent statuses such as `Invalid` return exit 1.
 
 Opt into slower work only when needed:
 

--- a/docs/process/release-process.md
+++ b/docs/process/release-process.md
@@ -65,6 +65,23 @@ whole build/sign/notarize/deploy flow. Update old worktrees before running
 `quick-deploy.sh`; older scripts that do not use this lock can still overwrite
 the installed app and invalidate the running process.
 
+Notarization upload and waiting are separate operations. After upload,
+`build-and-sign.sh` records the submission ID, archive SHA-256, profile, and
+status beside the archive, then waits up to 15 minutes by default. Override the
+limit only for an intentional longer watch:
+
+```bash
+KP_NOTARY_WAIT_TIMEOUT=30m ./Scripts/release-candidate.sh
+```
+
+If Apple is still processing, or the local wait client fails, the release stops
+before stapling or deployment and prints the recovery-state path plus exact
+inspection and retry commands. Check the existing submission first. Apple does
+not expose a cancel command, and the release scripts never create a duplicate
+submission automatically. If one explicit retry is justified, verify that the
+archive still has the recorded checksum and submit that exact archive once with
+`--no-wait`; do not stack additional submissions.
+
 Opt into slower work only when needed:
 
 ```bash


### PR DESCRIPTION
Closes #1217

## What changed
- split notarization upload from a bounded status wait (15 minutes by default)
- persist the submission ID, archive path and SHA-256, profile, and current status before waiting
- re-check Apple independently after the wait so a local client failure cannot hide an accepted submission
- stop before stapling or deployment when processing remains incomplete, with exact inspection and one-retry guidance
- document the recovery contract and expose timeout/state-file overrides

## Validation
- `TEST_FILTER=SigningPipelineTests ./Scripts/run-tests-safe.sh` (8 passed)
- `./Scripts/verify-release-signing-contract.sh --source`
- `python3 Scripts/check-accessibility.py`
- `bash -n Scripts/lib/signing.sh Scripts/release-candidate.sh Scripts/build-and-sign.sh`
- `git diff --check`

Local review gate selected the enforced remote `claude-review`; do not merge until that check passes.