### PR TITLE
Make key repeat speed direction predictable

### DIFF
--- a/Sources/KeyPathAppKit/UI/Rules/KeyRepeatControlView.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/KeyRepeatControlView.swift
@@ -196,6 +196,13 @@ struct KeyRepeatControlView: View {
 
             ScrollView {
                 VStack(alignment: .leading, spacing: 20) {
+                    Text(
+                        "Repeat start delay is how long you hold a key before it begins repeating. Repeat speed is how quickly it continues.",
+                        bundle: #bundle
+                    )
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
                     allKeysSection
                     arrowSection
                     HStack(alignment: .top, spacing: 12) {
@@ -235,12 +242,23 @@ struct KeyRepeatControlView: View {
                     .font(.subheadline.weight(.semibold))
                     .foregroundStyle(.secondary)
                 Spacer()
-                Text("\(globalDelayMs)ms delay · \(KeyRepeatControlConfig.keysPerSecond(fromIntervalMs: globalIntervalMs))")
-                    .font(.caption.monospaced())
-                    .foregroundStyle(.tertiary)
+                KeyRepeatTimingSummary(
+                    delayMs: globalDelayMs,
+                    intervalMs: globalIntervalMs,
+                    speedScale: KeyRepeatControlConfig.globalSpeedScale
+                )
             }
-            cleanSlider(label: "Delay", value: $globalDelayMs, range: 50 ... 2000, snap: 10, id: "global-delay")
-            cleanSlider(label: "Speed", value: $globalIntervalMs, range: 5 ... 200, snap: 5, id: "global-speed")
+            RepeatStartDelaySliderRow(
+                delayMs: $globalDelayMs,
+                range: 50 ... 2000,
+                step: 10,
+                accessibilityID: "key-repeat-slider-global-delay"
+            )
+            RepeatSpeedSliderRow(
+                intervalMs: $globalIntervalMs,
+                scale: KeyRepeatControlConfig.globalSpeedScale,
+                accessibilityID: "key-repeat-slider-global-speed"
+            )
         }
     }
 
@@ -253,14 +271,25 @@ struct KeyRepeatControlView: View {
                     .accessibilityIdentifier("key-repeat-arrow-toggle")
                 Spacer()
                 if arrowEnabled {
-                    Text("\(arrowDelayMs)ms · \(KeyRepeatControlConfig.keysPerSecond(fromIntervalMs: arrowIntervalMs))")
-                        .font(.caption.monospaced())
-                        .foregroundStyle(.tertiary)
+                    KeyRepeatTimingSummary(
+                        delayMs: arrowDelayMs,
+                        intervalMs: arrowIntervalMs,
+                        speedScale: KeyRepeatControlConfig.overrideSpeedScale
+                    )
                 }
             }
             if arrowEnabled {
-                cleanSlider(label: "Delay", value: $arrowDelayMs, range: 50 ... 1000, snap: 10, id: "arrow-delay")
-                cleanSlider(label: "Speed", value: $arrowIntervalMs, range: 5 ... 100, snap: 5, id: "arrow-speed")
+                RepeatStartDelaySliderRow(
+                    delayMs: $arrowDelayMs,
+                    range: 50 ... 1000,
+                    step: 10,
+                    accessibilityID: "key-repeat-slider-arrow-delay"
+                )
+                RepeatSpeedSliderRow(
+                    intervalMs: $arrowIntervalMs,
+                    scale: KeyRepeatControlConfig.overrideSpeedScale,
+                    accessibilityID: "key-repeat-slider-arrow-speed"
+                )
             }
         }
     }
@@ -272,8 +301,17 @@ struct KeyRepeatControlView: View {
                 .toggleStyle(.checkbox)
                 .accessibilityIdentifier("key-repeat-delete-toggle")
             if deleteEnabled {
-                cleanSlider(label: "Delay", value: $deleteDelayMs, range: 50 ... 1000, snap: 10, id: "delete-delay")
-                cleanSlider(label: "Speed", value: $deleteIntervalMs, range: 5 ... 100, snap: 5, id: "delete-speed")
+                RepeatStartDelaySliderRow(
+                    delayMs: $deleteDelayMs,
+                    range: 50 ... 1000,
+                    step: 10,
+                    accessibilityID: "key-repeat-slider-delete-delay"
+                )
+                RepeatSpeedSliderRow(
+                    intervalMs: $deleteIntervalMs,
+                    scale: KeyRepeatControlConfig.overrideSpeedScale,
+                    accessibilityID: "key-repeat-slider-delete-speed"
+                )
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -286,8 +324,17 @@ struct KeyRepeatControlView: View {
                 .toggleStyle(.checkbox)
                 .accessibilityIdentifier("key-repeat-fwd-delete-toggle")
             if fwdDeleteEnabled {
-                cleanSlider(label: "Delay", value: $fwdDeleteDelayMs, range: 50 ... 1000, snap: 10, id: "fwd-delete-delay")
-                cleanSlider(label: "Speed", value: $fwdDeleteIntervalMs, range: 5 ... 100, snap: 5, id: "fwd-delete-speed")
+                RepeatStartDelaySliderRow(
+                    delayMs: $fwdDeleteDelayMs,
+                    range: 50 ... 1000,
+                    step: 10,
+                    accessibilityID: "key-repeat-slider-fwd-delete-delay"
+                )
+                RepeatSpeedSliderRow(
+                    intervalMs: $fwdDeleteIntervalMs,
+                    scale: KeyRepeatControlConfig.overrideSpeedScale,
+                    accessibilityID: "key-repeat-slider-fwd-delete-speed"
+                )
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -306,14 +353,39 @@ struct KeyRepeatControlView: View {
                         .foregroundStyle(Color.accentColor)
 
                     VStack(spacing: 4) {
-                        cleanSlider(label: "Delay", value: Binding(
-                            get: { customOverrides.indices.contains(index) ? customOverrides[index].delayMs : entry.delayMs },
-                            set: { if customOverrides.indices.contains(index) { customOverrides[index].delayMs = $0 } }
-                        ), range: 50 ... 2000, snap: 10)
-                        cleanSlider(label: "Speed", value: Binding(
-                            get: { customOverrides.indices.contains(index) ? customOverrides[index].intervalMs : entry.intervalMs },
-                            set: { if customOverrides.indices.contains(index) { customOverrides[index].intervalMs = $0 } }
-                        ), range: 5 ... 200, snap: 5)
+                        RepeatStartDelaySliderRow(
+                            delayMs: Binding(
+                                get: {
+                                    customOverrides.indices.contains(index)
+                                        ? customOverrides[index].delayMs
+                                        : entry.delayMs
+                                },
+                                set: {
+                                    if customOverrides.indices.contains(index) {
+                                        customOverrides[index].delayMs = $0
+                                    }
+                                }
+                            ),
+                            range: 50 ... 2000,
+                            step: 10,
+                            accessibilityID: "key-repeat-slider-custom-\(entry.key)-delay"
+                        )
+                        RepeatSpeedSliderRow(
+                            intervalMs: Binding(
+                                get: {
+                                    customOverrides.indices.contains(index)
+                                        ? customOverrides[index].intervalMs
+                                        : entry.intervalMs
+                                },
+                                set: {
+                                    if customOverrides.indices.contains(index) {
+                                        customOverrides[index].intervalMs = $0
+                                    }
+                                }
+                            ),
+                            scale: KeyRepeatControlConfig.globalSpeedScale,
+                            accessibilityID: "key-repeat-slider-custom-\(entry.key)-speed"
+                        )
                     }
 
                     Button { customOverrides.remove(at: index) } label: {
@@ -377,28 +449,6 @@ struct KeyRepeatControlView: View {
         }
     }
 
-    // MARK: - Clean Slider
-
-    private func cleanSlider(label: String, value: Binding<Int>, range: ClosedRange<Int>, snap: Int, id: String = "") -> some View {
-        let unit = label == "Delay" ? "ms" : "keys/sec"
-        let displayValue = label == "Speed"
-            ? KeyRepeatControlConfig.keysPerSecond(fromIntervalMs: value.wrappedValue)
-            : "\(value.wrappedValue) \(unit)"
-        return HStack(spacing: 8) {
-            Text(label)
-                .font(.caption)
-                .foregroundStyle(.tertiary)
-                .frame(width: 36, alignment: .trailing)
-            Slider(value: Binding(
-                get: { Double(value.wrappedValue) },
-                set: { value.wrappedValue = Int(($0 / Double(snap)).rounded() * Double(snap)) }
-            ), in: Double(range.lowerBound) ... Double(range.upperBound))
-                .controlSize(.small)
-                .accessibilityIdentifier(id.isEmpty ? "key-repeat-slider-\(label.lowercased())" : "key-repeat-slider-\(id)")
-                .accessibilityValue(displayValue)
-        }
-    }
-
     // MARK: - State
 
     private func applyPreset(_ preset: KeyRepeatControlConfig.Preset) {
@@ -444,4 +494,167 @@ struct KeyRepeatControlView: View {
     private static func matchPreset(_ config: KeyRepeatControlConfig) -> KeyRepeatControlConfig.Preset? {
         KeyRepeatControlConfig.Preset.allCases.first { $0.config == config }
     }
+}
+
+private struct KeyRepeatTimingSummary: View {
+    let delayMs: Int
+    let intervalMs: Int
+    let speedScale: KeyRepeatSpeedScale
+
+    private var repeatsPerSecond: Double {
+        speedScale.repeatsPerSecond(forIntervalMs: intervalMs)
+    }
+
+    var body: some View {
+        VStack(alignment: .trailing, spacing: 1) {
+            Text(
+                "\(repeatsPerSecond, format: repeatSpeedFormat(repeatsPerSecond)) repeats/sec",
+                bundle: #bundle,
+                comment: "Primary summary of a keyboard key's automatic repeat speed."
+            )
+            .font(.caption.monospaced().weight(.medium))
+
+            Text(
+                "\(delayMs) ms start · \(intervalMs) ms interval",
+                bundle: #bundle,
+                comment: "Secondary technical summary: repeat start delay followed by the interval between repeats."
+            )
+            .font(.caption2.monospaced())
+            .foregroundStyle(.tertiary)
+        }
+    }
+}
+
+private struct RepeatStartDelaySliderRow: View {
+    @Binding var delayMs: Int
+    let range: ClosedRange<Int>
+    let step: Int
+    let accessibilityID: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Text(
+                    "Repeat start delay",
+                    bundle: #bundle,
+                    comment: "Label for how long a key must be held before automatic repetition begins."
+                )
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                Spacer()
+                Text(
+                    "\(delayMs) ms",
+                    bundle: #bundle,
+                    comment: "Current keyboard repeat start delay in milliseconds."
+                )
+                .font(.caption.monospaced().weight(.medium))
+            }
+
+            Slider(
+                value: $delayMs.snappedDouble(step: step),
+                in: Double(range.lowerBound) ... Double(range.upperBound)
+            )
+            .controlSize(.small)
+            .accessibilityIdentifier(accessibilityID)
+            .accessibilityLabel(Text("Repeat start delay", bundle: #bundle))
+            .accessibilityValue(Text("\(delayMs) milliseconds", bundle: #bundle))
+
+            HStack {
+                Text("Starts sooner", bundle: #bundle)
+                Spacer()
+                Text("Starts later", bundle: #bundle)
+            }
+            .font(.caption2)
+            .foregroundStyle(.tertiary)
+        }
+    }
+}
+
+private struct RepeatSpeedSliderRow: View {
+    @Binding var intervalMs: Int
+    let scale: KeyRepeatSpeedScale
+    let accessibilityID: String
+
+    private var repeatsPerSecond: Double {
+        scale.repeatsPerSecond(forIntervalMs: intervalMs)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Text(
+                    "Repeat speed",
+                    bundle: #bundle,
+                    comment: "Label for how quickly a held key repeats after its start delay."
+                )
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                Spacer()
+                VStack(alignment: .trailing, spacing: 1) {
+                    Text(
+                        "\(repeatsPerSecond, format: repeatSpeedFormat(repeatsPerSecond)) repeats/sec",
+                        bundle: #bundle,
+                        comment: "Primary value for a keyboard key's automatic repeat speed."
+                    )
+                    .font(.caption.monospaced().weight(.medium))
+                    Text(
+                        "\(intervalMs) ms interval",
+                        bundle: #bundle,
+                        comment: "Secondary technical value for the interval between keyboard repeats."
+                    )
+                    .font(.caption2.monospaced())
+                    .foregroundStyle(.tertiary)
+                }
+            }
+
+            Slider(
+                value: $intervalMs.repeatsPerSecond(scale: scale),
+                in: scale.repeatsPerSecondRange
+            )
+            .controlSize(.small)
+            .accessibilityIdentifier(accessibilityID)
+            .accessibilityLabel(Text("Repeat speed", bundle: #bundle))
+            .accessibilityValue(
+                Text(
+                    "\(repeatsPerSecond, format: repeatSpeedFormat(repeatsPerSecond)) repeats per second",
+                    bundle: #bundle,
+                    comment: "Accessibility value for a keyboard key's automatic repeat speed."
+                )
+            )
+            .accessibilityHint(
+                Text(
+                    "The equivalent interval is \(intervalMs) milliseconds. Moving right repeats faster.",
+                    bundle: #bundle
+                )
+            )
+
+            HStack {
+                Text("Slower", bundle: #bundle)
+                Spacer()
+                Text("Faster", bundle: #bundle)
+            }
+            .font(.caption2)
+            .foregroundStyle(.tertiary)
+        }
+    }
+}
+
+private extension Binding where Value == Int {
+    func snappedDouble(step: Int) -> Binding<Double> {
+        Binding<Double>(
+            get: { Double(wrappedValue) },
+            set: { wrappedValue = Int(($0 / Double(step)).rounded()) * step }
+        )
+    }
+
+    func repeatsPerSecond(scale: KeyRepeatSpeedScale) -> Binding<Double> {
+        Binding<Double>(
+            get: { scale.repeatsPerSecond(forIntervalMs: wrappedValue) },
+            set: { wrappedValue = scale.intervalMs(forRepeatsPerSecond: $0) }
+        )
+    }
+}
+
+private func repeatSpeedFormat(_ repeatsPerSecond: Double) -> FloatingPointFormatStyle<Double> {
+    .number.precision(.fractionLength(repeatsPerSecond < 10 ? 1 : 0))
 }

--- a/Sources/KeyPathRulesCore/RuleCollectionConfiguration.swift
+++ b/Sources/KeyPathRulesCore/RuleCollectionConfiguration.swift
@@ -799,6 +799,51 @@ public struct AutoShiftSymbolsConfig: Codable, Equatable, Sendable {
 
 // MARK: - Key Repeat Control Configuration
 
+/// Converts between KeyPath's user-facing repeat speed and Kanata's interval.
+///
+/// Kanata persists milliseconds between repeats, where smaller values are
+/// faster. The UI presents repeats per second, where larger values are faster.
+public struct KeyRepeatSpeedScale: Equatable, Sendable {
+    public let intervalRange: ClosedRange<Int>
+    public let intervalStep: Int
+
+    public init(intervalRange: ClosedRange<Int>, intervalStep: Int) {
+        precondition(intervalStep > 0, "Key repeat interval step must be positive")
+        self.intervalRange = intervalRange
+        self.intervalStep = intervalStep
+    }
+
+    public var repeatsPerSecondRange: ClosedRange<Double> {
+        repeatsPerSecond(forIntervalMs: intervalRange.upperBound) ... repeatsPerSecond(forIntervalMs: intervalRange.lowerBound)
+    }
+
+    public func repeatsPerSecond(forIntervalMs intervalMs: Int) -> Double {
+        let clampedInterval = min(max(intervalMs, intervalRange.lowerBound), intervalRange.upperBound)
+        return 1000.0 / Double(clampedInterval)
+    }
+
+    /// Converts a user-facing speed to the nearest supported interval.
+    ///
+    /// Supported values are multiples of `intervalStep` within
+    /// `intervalRange`. Midpoints round away from zero before clamping.
+    public func intervalMs(forRepeatsPerSecond repeatsPerSecond: Double) -> Int {
+        if repeatsPerSecond.isNaN || repeatsPerSecond <= 0 {
+            return intervalRange.upperBound
+        }
+        if repeatsPerSecond == .infinity {
+            return intervalRange.lowerBound
+        }
+
+        let clampedSpeed = min(
+            max(repeatsPerSecond, repeatsPerSecondRange.lowerBound),
+            repeatsPerSecondRange.upperBound
+        )
+        let rawInterval = 1000.0 / clampedSpeed
+        let snappedInterval = Int((rawInterval / Double(intervalStep)).rounded()) * intervalStep
+        return min(max(snappedInterval, intervalRange.lowerBound), intervalRange.upperBound)
+    }
+}
+
 /// A per-key repeat rate override within the managed-repeat system.
 public struct KeyRepeatOverride: Codable, Equatable, Sendable, Identifiable {
     public var id: String {
@@ -843,6 +888,8 @@ public struct KeyRepeatControlConfig: Codable, Equatable, Sendable {
 
     public static let defaultGlobalDelayMs = 500
     public static let defaultGlobalIntervalMs = 30
+    public static let globalSpeedScale = KeyRepeatSpeedScale(intervalRange: 5 ... 200, intervalStep: 5)
+    public static let overrideSpeedScale = KeyRepeatSpeedScale(intervalRange: 5 ... 100, intervalStep: 5)
 
     public static let defaultPerKeyOverrides: [KeyRepeatOverride] = [
         KeyRepeatOverride(key: "left", delayMs: 150, intervalMs: 20),
@@ -863,14 +910,6 @@ public struct KeyRepeatControlConfig: Codable, Equatable, Sendable {
         self.globalDelayMs = globalDelayMs
         self.globalIntervalMs = globalIntervalMs
         self.perKeyOverrides = perKeyOverrides
-    }
-
-    /// Human-readable repeat speed (keys per second) from interval in ms
-    public static func keysPerSecond(fromIntervalMs ms: Int) -> String {
-        guard ms > 0 else { return "—" }
-        let kps = 1000.0 / Double(ms)
-        if kps >= 10 { return "\(Int(kps))/sec" }
-        return String(format: "%.1f/sec", kps)
     }
 
     /// Named presets for common configurations

--- a/Tests/KeyPathTests/Infrastructure/KanataConfigurationGeneratorSnapshotTests.swift
+++ b/Tests/KeyPathTests/Infrastructure/KanataConfigurationGeneratorSnapshotTests.swift
@@ -33,6 +33,34 @@ final class KanataConfigurationGeneratorSnapshotTests: XCTestCase {
         )
     }
 
+    func testConvertedRepeatSpeedEmitsRoundedKanataInterval() throws {
+        let scale = KeyRepeatControlConfig.globalSpeedScale
+        let intervalMs = scale.intervalMs(forRepeatsPerSecond: 58)
+        let repeatConfig = KeyRepeatControlConfig(
+            globalDelayMs: 450,
+            globalIntervalMs: intervalMs,
+            perKeyOverrides: [
+                KeyRepeatOverride(key: "left", delayMs: 120, intervalMs: intervalMs),
+            ]
+        )
+        let repeatCollection = try makeCollection(
+            id: XCTUnwrap(UUID(uuidString: "44444444-4444-4444-4444-444444444444")),
+            name: "Key Repeat Control",
+            summary: "Repeat",
+            category: .custom,
+            mappings: [],
+            targetLayer: .base,
+            momentaryActivator: nil,
+            configuration: .keyRepeatControl(repeatConfig)
+        )
+
+        let config = KanataConfiguration.generateFromCollections([repeatCollection])
+
+        XCTAssertEqual(intervalMs, 15)
+        assertContains(config, "managed-repeat-interval 15")
+        assertContains(config, "(left  120 15)")
+    }
+
     func testNavigationActivatorUsesOneShotAndWrapsMappings() throws {
         let navCollection = try makeCollection(
             id: XCTUnwrap(UUID(uuidString: "11111111-1111-1111-1111-111111111111")),

--- a/Tests/KeyPathTests/Models/KeyRepeatSpeedScaleTests.swift
+++ b/Tests/KeyPathTests/Models/KeyRepeatSpeedScaleTests.swift
@@ -1,0 +1,74 @@
+import Foundation
+import KeyPathRulesCore
+@preconcurrency import XCTest
+
+final class KeyRepeatSpeedScaleTests: XCTestCase {
+    func testMovingTowardHigherRatesAlwaysReducesInterval() {
+        let scale = KeyRepeatControlConfig.globalSpeedScale
+
+        XCTAssertGreaterThan(
+            scale.repeatsPerSecond(forIntervalMs: 20),
+            scale.repeatsPerSecond(forIntervalMs: 30)
+        )
+        XCTAssertLessThan(
+            scale.intervalMs(forRepeatsPerSecond: 50),
+            scale.intervalMs(forRepeatsPerSecond: 25)
+        )
+    }
+
+    func testSupportedIntervalsRoundTripExactly() {
+        for scale in [
+            KeyRepeatControlConfig.globalSpeedScale,
+            KeyRepeatControlConfig.overrideSpeedScale,
+        ] {
+            for interval in stride(
+                from: scale.intervalRange.lowerBound,
+                through: scale.intervalRange.upperBound,
+                by: scale.intervalStep
+            ) {
+                let repeatsPerSecond = scale.repeatsPerSecond(forIntervalMs: interval)
+                XCTAssertEqual(
+                    scale.intervalMs(forRepeatsPerSecond: repeatsPerSecond),
+                    interval,
+                    "Expected \(interval) ms to round-trip"
+                )
+            }
+        }
+    }
+
+    func testArbitraryRatesRoundToNearestSupportedInterval() {
+        let scale = KeyRepeatControlConfig.globalSpeedScale
+
+        XCTAssertEqual(scale.intervalMs(forRepeatsPerSecond: 58), 15)
+        XCTAssertEqual(scale.intervalMs(forRepeatsPerSecond: 45), 20)
+        XCTAssertEqual(scale.intervalMs(forRepeatsPerSecond: 40), 25)
+    }
+
+    func testRatesClampToSupportedRange() {
+        let scale = KeyRepeatControlConfig.globalSpeedScale
+
+        XCTAssertEqual(scale.intervalMs(forRepeatsPerSecond: 1), 200)
+        XCTAssertEqual(scale.intervalMs(forRepeatsPerSecond: 1000), 5)
+        XCTAssertEqual(scale.intervalMs(forRepeatsPerSecond: 0), 200)
+        XCTAssertEqual(scale.intervalMs(forRepeatsPerSecond: .nan), 200)
+        XCTAssertEqual(scale.intervalMs(forRepeatsPerSecond: .infinity), 5)
+    }
+
+    func testConfigurationPersistsConvertedIntervalWithoutUnitDrift() throws {
+        let interval = KeyRepeatControlConfig.globalSpeedScale.intervalMs(forRepeatsPerSecond: 50)
+        let original = KeyRepeatControlConfig(
+            globalDelayMs: 450,
+            globalIntervalMs: interval,
+            perKeyOverrides: [
+                KeyRepeatOverride(key: "left", delayMs: 120, intervalMs: interval),
+            ]
+        )
+
+        let data = try JSONEncoder().encode(original)
+        let restored = try JSONDecoder().decode(KeyRepeatControlConfig.self, from: data)
+
+        XCTAssertEqual(restored, original)
+        XCTAssertEqual(restored.globalIntervalMs, 20)
+        XCTAssertEqual(restored.perKeyOverrides.first?.intervalMs, 20)
+    }
+}

--- a/guides/key-repeat-control.md
+++ b/guides/key-repeat-control.md
@@ -16,12 +16,13 @@ Your arrow keys move through text at the same sluggish speed as every other key.
 
 ## What You Get
 
-Enable **Fast Navigation** and you get per-key repeat speed control:
+Enable **Fast Navigation** and you get per-key repeat speed control. KeyPath
+describes speed in repeats per second, so higher values always feel faster:
 
-- **Arrow keys** (←→↑↓) — start repeating in 150ms, repeat every 20ms (~50 keys/sec)
-- **Delete** (⌫) — starts in 210ms, repeats every 20ms
-- **Forward Delete** — starts in 210ms, repeats every 20ms
-- **Regular keys** (letters, numbers) — unchanged at system defaults (500ms delay, 30ms interval)
+- **Arrow keys** (←→↑↓) — start repeating in 150 ms, then repeat 50 times per second (20 ms interval)
+- **Delete** (⌫) — starts in 210 ms, then repeats 50 times per second
+- **Forward Delete** — starts in 210 ms, then repeats 50 times per second
+- **Regular keys** (letters, numbers) — start after 500 ms, then repeat about 33 times per second (30 ms interval)
 
 The result: hold an arrow key and it flies. Hold a letter and it stays steady.
 
@@ -42,11 +43,11 @@ Fast Navigation is **enabled by default** for new installations. To check or tog
 
 Three named presets to get started quickly:
 
-| Preset | Arrow delay | Arrow interval | Feel |
-|--------|-------------|----------------|------|
-| **Balanced** (default) | 150ms | 20ms (50/sec) | Fast arrows, steady text |
-| **Fast Navigation** | 120ms | 15ms (67/sec) | Maximum speed for power users |
-| **Careful** | 250ms | 35ms (29/sec) | Slower, fewer accidental repeats |
+| Preset | Repeat start delay | Repeat speed | Feel |
+|--------|--------------------|--------------|------|
+| **Balanced** (default) | 150 ms | 50 repeats/sec (20 ms interval) | Fast arrows, steady text |
+| **Fast Navigation** | 120 ms | 67 repeats/sec (15 ms interval) | Maximum speed for power users |
+| **Careful** | 300 ms | 40 repeats/sec (25 ms interval) | Slower, fewer accidental repeats |
 
 Select a preset card in the pack detail view. You can further customize in Settings.
 
@@ -57,14 +58,20 @@ Select a preset card in the pack detail view. You can further customize in Setti
 Click **Settings…** in the pack detail view to fine-tune:
 
 ### Global defaults
-- **Delay** — how long to hold before repeating starts (default: 500ms)
-- **Interval** — time between repeats once started (default: 30ms)
+- **Repeat start delay** — how long you hold a key before repeating starts. Moving right starts later.
+- **Repeat speed** — how quickly the key repeats after it starts. Moving right is always faster.
+- **Interval** — the equivalent milliseconds between repeats, shown as a secondary technical detail.
 
 ### Per-key overrides
-- **Arrow keys** — toggle fast arrows on/off, adjust delay and interval independently
+- **Arrow keys** — toggle fast arrows on/off, then adjust start delay and repeat speed independently
 - **Delete** — toggle fast delete, adjust separately
 - **Forward Delete** — toggle and adjust
 - **Custom keys** — add any key to the override list with its own speed settings
+
+For example, **50 repeats/sec** and a **20 ms interval** describe the same
+setting. KeyPath stores the interval because that is what the keyboard engine
+uses, while the main control shows repeats per second because it matches the
+way speed feels.
 
 ---
 
@@ -88,7 +95,7 @@ This is not a hack — it's using the keyboard firmware's built-in repeat contro
 ## Tips
 
 - **Pair with Vim Navigation** — fast arrow keys make the H/J/K/L navigation layer even snappier for long-distance moves
-- **Adjust delete carefully** — too fast and you'll overshoot. The 210ms delay gives you time to lift your finger.
+- **Adjust delete carefully** — too fast and you'll overshoot. The 210 ms start delay gives you time to lift your finger.
 - **The test area is your friend** — adjust values, then immediately feel the result in the test text field
 - Works standalone — no dependency on any other pack
 
@@ -104,9 +111,9 @@ This is not a hack — it's using the keyboard firmware's built-in repeat contro
 
 ### I'm getting accidental repeated characters when typing
 
-The global default delay (500ms) should prevent this. If you've lowered it:
+The global repeat start delay (500 ms) should prevent this. If you've lowered it:
 1. Go to Settings in the pack detail
-2. Increase the global delay back toward 500ms
+2. Increase the global repeat start delay back toward 500 ms
 3. Only lower the per-key overrides for arrow/delete keys
 
 ### I want different speeds for up/down vs. left/right


### PR DESCRIPTION
Closes #1213

## What changed
- present repeat speed in repeats/sec while preserving Kanata millisecond intervals
- make moving the speed slider right consistently faster
- distinguish repeat start delay from repeat speed in labels, summaries, and accessibility values
- document the unit conversion and update preset examples
- cover conversion, clamping, rounding, persistence, and generated Kanata output

## Validation
- KeyRepeatSpeedScaleTests: 5 passed
- KanataConfigurationGeneratorSnapshotTests: 17 passed
- accessibility identifier scan: passed across 356 files
- live UI: verified labels, values, direction, 33 to 50 repeats/sec mapping, and restored original 30 ms setting
- full safe suite: 4,839 passed; one unrelated SystemValidator timing assertion missed its 250 ms budget under full snapshot load, then passed alone in 20 ms
- review gate: remote review selected; do not merge until claude-review passes