### PR TITLE
Make home row timing mode-aware

### DIFF
--- a/Sources/KeyPathAppKit/UI/Rules/HomeRowLayerTogglesCollectionView.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/HomeRowLayerTogglesCollectionView.swift
@@ -104,6 +104,30 @@ struct HomeRowLayerTogglesCollectionView: View {
                 Text(config.toggleMode.description)
                     .font(.caption)
                     .foregroundColor(.secondary)
+
+                HStack(spacing: 4) {
+                    Text("Opposite-hand activation")
+                    Spacer()
+                    Picker("Opposite-hand activation", selection: Binding(
+                        get: { config.oppositeHandMode },
+                        set: { newValue in
+                            config.oppositeHandMode = newValue
+                            updateConfig()
+                        }
+                    )) {
+                        Text(OppositeHandMode.off.displayName).tag(OppositeHandMode.off)
+                        Text(OppositeHandMode.press.displayName).tag(OppositeHandMode.press)
+                        Text(OppositeHandMode.release.displayName).tag(OppositeHandMode.release)
+                    }
+                    .pickerStyle(.segmented)
+                    .frame(maxWidth: 240)
+                    .accessibilityIdentifier("home-row-layer-toggles-opposite-hand-picker")
+                    .accessibilityLabel("Opposite-hand activation mode")
+                }
+
+                Text(oppositeHandHelperText)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
             }
 
             // Key selection
@@ -163,28 +187,30 @@ struct HomeRowLayerTogglesCollectionView: View {
                     .font(.body)
 
                 HStack(spacing: 16) {
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text("Tap window")
-                            .font(.subheadline)
-                            .foregroundColor(.secondary)
-                        HStack {
-                            automationIntegerField(
-                                placeholder: "",
-                                value: Binding(
-                                    get: { config.timing.tapWindow },
-                                    set: { config.timing.tapWindow = $0 }
-                                ),
-                                accessibilityIdentifier: "home-row-layer-toggles-tap-window-field",
-                                accessibilityLabel: "Tap window"
-                            )
-                            Text("ms")
+                    if usesTapWindow {
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text("Tap window")
                                 .font(.subheadline)
                                 .foregroundColor(.secondary)
+                            HStack {
+                                automationIntegerField(
+                                    placeholder: "",
+                                    value: Binding(
+                                        get: { config.timing.tapWindow },
+                                        set: { config.timing.tapWindow = $0 }
+                                    ),
+                                    accessibilityIdentifier: "home-row-layer-toggles-tap-window-field",
+                                    accessibilityLabel: "Tap window"
+                                )
+                                Text("ms")
+                                    .font(.subheadline)
+                                    .foregroundColor(.secondary)
+                            }
                         }
                     }
 
                     VStack(alignment: .leading, spacing: 4) {
-                        Text("Hold delay")
+                        Text(config.oppositeHandMode.decisionWindowLabel)
                             .font(.subheadline)
                             .foregroundColor(.secondary)
                         HStack {
@@ -195,7 +221,7 @@ struct HomeRowLayerTogglesCollectionView: View {
                                     set: { config.timing.holdDelay = $0 }
                                 ),
                                 accessibilityIdentifier: "home-row-layer-toggles-hold-delay-field",
-                                accessibilityLabel: "Hold delay"
+                                accessibilityLabel: config.oppositeHandMode.decisionWindowLabel
                             )
                             Text("ms")
                                 .font(.subheadline)
@@ -204,87 +230,109 @@ struct HomeRowLayerTogglesCollectionView: View {
                     }
                 }
 
-                Toggle("Favor tap when another key is pressed (quick tap)", isOn: Binding(
-                    get: { config.timing.quickTapEnabled },
-                    set: { newValue in
-                        config.timing.quickTapEnabled = newValue
-                        updateConfig()
-                    }
-                ))
-                .toggleStyle(.checkbox)
-                .accessibilityIdentifier("home-row-layer-toggles-quick-tap-toggle")
-                .accessibilityLabel("Favor tap when another key is pressed")
-
-                HStack {
-                    Text("Quick tap term")
-                        .font(.subheadline)
-                        .foregroundColor(.secondary)
-                    Slider(value: Binding(
-                        get: { Double(config.timing.quickTapTermMs) },
+                if usesTapWindow {
+                    Toggle("Favor tap when another key is pressed (quick tap)", isOn: Binding(
+                        get: { config.timing.quickTapEnabled },
                         set: { newValue in
-                            config.timing.quickTapTermMs = Int(newValue)
+                            config.timing.quickTapEnabled = newValue
                             updateConfig()
                         }
-                    ), in: 0 ... 80, step: 5)
-                        .accessibilityIdentifier("home-row-layer-toggles-quick-tap-term-slider")
-                        .accessibilityLabel("Quick tap term")
-                        .accessibilityValue("\(config.timing.quickTapTermMs) ms")
-                    Text(String(localized: "\(config.timing.quickTapTermMs) ms"))
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                        .frame(width: 60, alignment: .trailing)
-                }
-                .disabled(!config.timing.quickTapEnabled)
+                    ))
+                    .toggleStyle(.checkbox)
+                    .accessibilityIdentifier("home-row-layer-toggles-quick-tap-toggle")
+                    .accessibilityLabel("Favor tap when another key is pressed")
 
-                Toggle("Show per-key tap offsets", isOn: Binding(
-                    get: { config.showAdvanced },
+                    if config.timing.quickTapEnabled {
+                        HStack {
+                            Text("Quick tap term")
+                                .font(.subheadline)
+                                .foregroundColor(.secondary)
+                            Slider(value: Binding(
+                                get: { Double(config.timing.quickTapTermMs) },
+                                set: { newValue in
+                                    config.timing.quickTapTermMs = Int(newValue)
+                                    updateConfig()
+                                }
+                            ), in: 0 ... 80, step: 5)
+                                .accessibilityIdentifier("home-row-layer-toggles-quick-tap-term-slider")
+                                .accessibilityLabel("Quick tap term")
+                                .accessibilityValue("\(config.timing.quickTapTermMs) ms")
+                            Text(String(localized: "\(config.timing.quickTapTermMs) ms"))
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                                .frame(width: 60, alignment: .trailing)
+                        }
+                    }
+                }
+
+                if usesTapWindow {
+                    Toggle("Show per-key tap offsets", isOn: Binding(
+                        get: { config.showAdvanced },
+                        set: { newValue in
+                            config.showAdvanced = newValue
+                            updateConfig()
+                        }
+                    ))
+                    .toggleStyle(.checkbox)
+                    .accessibilityIdentifier("home-row-layer-toggles-show-advanced-toggle")
+                    .accessibilityLabel("Show per-key tap offsets")
+
+                    if config.showAdvanced {
+                        VStack(alignment: .leading, spacing: 6) {
+                            Text("Per-key tap offsets (ms)")
+                                .font(.subheadline)
+                                .foregroundColor(.secondary)
+
+                            ForEach(chunks(of: HomeRowLayerTogglesConfig.allKeys, size: 4), id: \.self) { row in
+                                HStack(spacing: 12) {
+                                    ForEach(row, id: \.self) { key in
+                                        VStack(alignment: .leading, spacing: 4) {
+                                            Text(displayLabel(forCanonicalKey: key))
+                                                .font(.caption)
+                                                .foregroundColor(.secondary)
+                                            automationIntegerField(
+                                                placeholder: "0",
+                                                value: Binding(
+                                                    get: { config.timing.tapOffsets[key] ?? 0 },
+                                                    set: { newValue in
+                                                        if newValue == 0 {
+                                                            config.timing.tapOffsets.removeValue(forKey: key)
+                                                        } else {
+                                                            config.timing.tapOffsets[key] = newValue
+                                                        }
+                                                    }
+                                                ),
+                                                accessibilityIdentifier: "home-row-layer-toggles-tap-offset-\(key)-field",
+                                                accessibilityLabel: "\(displayLabel(forCanonicalKey: key)) tap offset"
+                                            )
+                                        }
+                                    }
+                                    Spacer()
+                                }
+                            }
+                            Text("Positive values extend the tap window per key; leave 0 for default.")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        }
+                        .transition(.opacity.combined(with: .move(edge: .top)))
+                    }
+                }
+
+                Toggle("Fast typing protection", isOn: Binding(
+                    get: { config.timing.requirePriorIdleMs > 0 },
                     set: { newValue in
-                        config.showAdvanced = newValue
+                        config.timing.requirePriorIdleMs = newValue ? TimingConfig.defaultPriorIdleMs : 0
                         updateConfig()
                     }
                 ))
                 .toggleStyle(.checkbox)
-                .accessibilityIdentifier("home-row-layer-toggles-show-advanced-toggle")
-                .accessibilityLabel("Show per-key tap offsets")
+                .accessibilityIdentifier("home-row-layer-toggles-fast-typing-protection-toggle")
+                .accessibilityLabel("Fast typing protection")
 
-                if config.showAdvanced {
-                    VStack(alignment: .leading, spacing: 6) {
-                        Text("Per-key tap offsets (ms)")
-                            .font(.subheadline)
-                            .foregroundColor(.secondary)
-
-                        ForEach(chunks(of: HomeRowLayerTogglesConfig.allKeys, size: 4), id: \.self) { row in
-                            HStack(spacing: 12) {
-                                ForEach(row, id: \.self) { key in
-                                    VStack(alignment: .leading, spacing: 4) {
-                                        Text(displayLabel(forCanonicalKey: key))
-                                            .font(.caption)
-                                            .foregroundColor(.secondary)
-                                        automationIntegerField(
-                                            placeholder: "0",
-                                            value: Binding(
-                                                get: { config.timing.tapOffsets[key] ?? 0 },
-                                                set: { newValue in
-                                                    if newValue == 0 {
-                                                        config.timing.tapOffsets.removeValue(forKey: key)
-                                                    } else {
-                                                        config.timing.tapOffsets[key] = newValue
-                                                    }
-                                                }
-                                            ),
-                                            accessibilityIdentifier: "home-row-layer-toggles-tap-offset-\(key)-field",
-                                            accessibilityLabel: "\(displayLabel(forCanonicalKey: key)) tap offset"
-                                        )
-                                    }
-                                }
-                                Spacer()
-                            }
-                        }
-                        Text("Positive values extend the tap window per key; leave 0 for default.")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                    }
-                    .transition(.opacity.combined(with: .move(edge: .top)))
+                if config.timing.requirePriorIdleMs > 0 {
+                    Text("Keys pressed soon after typing stay letters instead of activating a layer.")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
                 }
             }
 
@@ -436,6 +484,16 @@ struct HomeRowLayerTogglesCollectionView: View {
 
     private func updateConfig() {
         onConfigChanged(config)
+    }
+
+    private var usesTapWindow: Bool {
+        config.oppositeHandMode.usesTapWindow
+    }
+
+    private var oppositeHandHelperText: String {
+        usesTapWindow
+            ? "Tap and hold use separate timers."
+            : "The decision window determines when another-hand input activates the layer."
     }
 
     private func displayLabel(forCanonicalKey key: String) -> String {

--- a/Sources/KeyPathAppKit/UI/Rules/HomeRowTimingSection.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/HomeRowTimingSection.swift
@@ -172,10 +172,10 @@ struct HomeRowTimingSection: View {
                     // Hold duration
                     VStack(alignment: .leading, spacing: 4) {
                         HStack(spacing: 4) {
-                            Text("Hold duration")
+                            Text(config.oppositeHandMode.decisionWindowLabel)
                                 .font(.subheadline)
                                 .foregroundColor(.secondary)
-                            InfoTip("How long you hold a key before the modifier activates.")
+                            InfoTip("How long KeyPath waits before activating the hold action in this mode.")
                         }
                         if config.showExpertTiming {
                             HStack(spacing: 16) {
@@ -198,7 +198,7 @@ struct HomeRowTimingSection: View {
                                     }
                                 }
                                 VStack(alignment: .leading, spacing: 4) {
-                                    Text("Hold delay").font(.caption).foregroundColor(.secondary)
+                                    Text(config.oppositeHandMode.decisionWindowLabel).font(.caption).foregroundColor(.secondary)
                                     HStack(spacing: 4) {
                                         automationIntegerField(
                                             placeholder: "",
@@ -208,7 +208,7 @@ struct HomeRowTimingSection: View {
                                             ),
                                             range: 80 ... 350,
                                             accessibilityIdentifier: "home-row-mods-hold-delay-field",
-                                            accessibilityLabel: "Hold delay"
+                                            accessibilityLabel: config.oppositeHandMode.decisionWindowLabel
                                         )
                                         Text("ms").font(.caption).foregroundColor(.secondary)
                                     }
@@ -321,59 +321,61 @@ struct HomeRowTimingSection: View {
 
             // MARK: - Quick Tap
 
-            Toggle("Favor tap when another key is pressed (quick tap)", isOn: Binding(
-                get: { config.timing.quickTapEnabled },
-                set: { newValue in
-                    config.timing.quickTapEnabled = newValue
-                    updateConfig()
-                }
-            ))
-            .toggleStyle(.checkbox)
-            .accessibilityIdentifier("home-row-mods-quick-tap-toggle")
-            .accessibilityLabel("Favor tap when another key is pressed (quick tap)")
-            .accessibilityValue(config.timing.quickTapEnabled ? "on" : "off")
+            if usesTimedTapWindow {
+                Toggle("Favor tap when another key is pressed (quick tap)", isOn: Binding(
+                    get: { config.timing.quickTapEnabled },
+                    set: { newValue in
+                        config.timing.quickTapEnabled = newValue
+                        updateConfig()
+                    }
+                ))
+                .toggleStyle(.checkbox)
+                .accessibilityIdentifier("home-row-mods-quick-tap-toggle")
+                .accessibilityLabel("Favor tap when another key is pressed (quick tap)")
+                .accessibilityValue(config.timing.quickTapEnabled ? "on" : "off")
 
-            if config.timing.quickTapEnabled {
-                HStack(spacing: 8) {
-                    Text("Faster modifiers")
-                        .font(.caption2)
-                        .foregroundStyle(.secondary)
-                        .frame(width: 90, alignment: .trailing)
+                if config.timing.quickTapEnabled {
+                    HStack(spacing: 8) {
+                        Text("Faster modifiers")
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                            .frame(width: 90, alignment: .trailing)
 
-                    if config.showExpertTiming {
-                        automationIntegerField(
-                            placeholder: "",
-                            value: Binding(
-                                get: { config.timing.quickTapTermMs },
-                                set: { config.timing.quickTapTermMs = $0 }
-                            ),
-                            range: 0 ... 120,
-                            accessibilityIdentifier: "home-row-mods-quick-tap-term-field",
-                            accessibilityLabel: "Quick tap extra time"
-                        )
-                    } else {
-                        Slider(value: Binding(
-                            get: { Double(config.timing.quickTapTermMs) },
-                            set: { newValue in
-                                config.timing.quickTapTermMs = Int(newValue)
-                                debouncedUpdateConfig()
-                            }
-                        ), in: 0 ... 80, step: 5)
-                            .accessibilityIdentifier("home-row-mods-quick-tap-term-slider")
-                            .accessibilityLabel("Quick tap extra time")
-                            .accessibilityValue("\(config.timing.quickTapTermMs) ms")
+                        if config.showExpertTiming {
+                            automationIntegerField(
+                                placeholder: "",
+                                value: Binding(
+                                    get: { config.timing.quickTapTermMs },
+                                    set: { config.timing.quickTapTermMs = $0 }
+                                ),
+                                range: 0 ... 120,
+                                accessibilityIdentifier: "home-row-mods-quick-tap-term-field",
+                                accessibilityLabel: "Quick tap extra time"
+                            )
+                        } else {
+                            Slider(value: Binding(
+                                get: { Double(config.timing.quickTapTermMs) },
+                                set: { newValue in
+                                    config.timing.quickTapTermMs = Int(newValue)
+                                    debouncedUpdateConfig()
+                                }
+                            ), in: 0 ... 80, step: 5)
+                                .accessibilityIdentifier("home-row-mods-quick-tap-term-slider")
+                                .accessibilityLabel("Quick tap extra time")
+                                .accessibilityValue("\(config.timing.quickTapTermMs) ms")
+                        }
+
+                        Text("Fewer misfires")
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                            .frame(width: 90, alignment: .leading)
                     }
 
-                    Text("Fewer misfires")
-                        .font(.caption2)
+                    Text(quickTapHelperText)
+                        .font(.caption)
                         .foregroundStyle(.secondary)
-                        .frame(width: 90, alignment: .leading)
+                        .padding(.leading, 88)
                 }
-
-                Text(quickTapHelperText)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .padding(.leading, 88)
             }
 
             // MARK: - Per-Finger Sensitivity
@@ -385,7 +387,7 @@ struct HomeRowTimingSection: View {
                 Text("Per-finger sensitivity")
                     .font(.body)
 
-                InfoTip("Add extra delay for slower fingers to prevent accidental holds.")
+                InfoTip("Add extra delay for slower fingers to the \(config.oppositeHandMode.decisionWindowLabel.lowercased()).")
             }
 
             VStack(alignment: .leading, spacing: 6) {
@@ -489,42 +491,44 @@ struct HomeRowTimingSection: View {
 
     private var perKeyOffsetFields: some View {
         VStack(alignment: .leading, spacing: 8) {
-            Text("Per-key tap offsets (ms)")
-                .font(.subheadline)
-                .foregroundColor(.secondary)
+            if usesTimedTapWindow {
+                Text("Per-key tap offsets (ms)")
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
 
-            ForEach(chunks(of: HomeRowModsConfig.allKeys, size: 4), id: \.self) { row in
-                HStack(spacing: 12) {
-                    ForEach(row, id: \.self) { key in
-                        VStack(alignment: .leading, spacing: 4) {
-                            Text(key.uppercased())
-                                .font(.caption)
-                                .foregroundColor(.secondary)
-                            automationIntegerField(
-                                placeholder: "0",
-                                value: Binding(
-                                    get: { config.timing.tapOffsets[key] ?? 0 },
-                                    set: { newValue in
-                                        if newValue == 0 {
-                                            config.timing.tapOffsets.removeValue(forKey: key)
-                                        } else {
-                                            config.timing.tapOffsets[key] = newValue
+                ForEach(chunks(of: HomeRowModsConfig.allKeys, size: 4), id: \.self) { row in
+                    HStack(spacing: 12) {
+                        ForEach(row, id: \.self) { key in
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text(key.uppercased())
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                                automationIntegerField(
+                                    placeholder: "0",
+                                    value: Binding(
+                                        get: { config.timing.tapOffsets[key] ?? 0 },
+                                        set: { newValue in
+                                            if newValue == 0 {
+                                                config.timing.tapOffsets.removeValue(forKey: key)
+                                            } else {
+                                                config.timing.tapOffsets[key] = newValue
+                                            }
                                         }
-                                    }
-                                ),
-                                range: -100 ... 200,
-                                accessibilityIdentifier: "home-row-mods-tap-offset-\(key)-field",
-                                accessibilityLabel: "\(key.uppercased()) tap offset"
-                            )
+                                    ),
+                                    range: -100 ... 200,
+                                    accessibilityIdentifier: "home-row-mods-tap-offset-\(key)-field",
+                                    accessibilityLabel: "\(key.uppercased()) tap offset"
+                                )
+                            }
                         }
+                        Spacer()
                     }
-                    Spacer()
                 }
+
+                Divider()
             }
 
-            Divider()
-
-            Text("Per-key hold offsets (ms)")
+            Text("Per-key \(config.oppositeHandMode.decisionWindowLabel.lowercased()) offsets (ms)")
                 .font(.subheadline)
                 .foregroundColor(.secondary)
 
@@ -549,7 +553,7 @@ struct HomeRowTimingSection: View {
                                 ),
                                 range: -100 ... 200,
                                 accessibilityIdentifier: "home-row-mods-hold-offset-\(key)-field",
-                                accessibilityLabel: "\(key.uppercased()) hold offset"
+                                accessibilityLabel: "\(key.uppercased()) \(config.oppositeHandMode.decisionWindowLabel.lowercased()) offset"
                             )
                         }
                     }
@@ -767,7 +771,7 @@ struct HomeRowTimingSection: View {
     }
 
     private var usesTimedTapWindow: Bool {
-        !config.oppositeHandMode.isEnabled
+        config.oppositeHandMode.usesTapWindow
     }
 
     private var timingSliderAccessibilityValue: String {

--- a/Sources/KeyPathRulesCore/HomeRowModsConfig.swift
+++ b/Sources/KeyPathRulesCore/HomeRowModsConfig.swift
@@ -20,6 +20,17 @@ public enum OppositeHandMode: String, Codable, Sendable {
     public var isEnabled: Bool {
         self != .off
     }
+
+    /// Whether the rendered tap-hold behavior uses a separate tap timeout.
+    /// Opposite-hand variants use only their decision timeout.
+    public var usesTapWindow: Bool {
+        !isEnabled
+    }
+
+    /// The user-facing name for the timer that decides when the hold action starts.
+    public var decisionWindowLabel: String {
+        usesTapWindow ? "Hold activation delay" : "Opposite-hand decision window"
+    }
 }
 
 /// Timing UI complexity level for home row mods

--- a/Tests/KeyPathTests/HomeRowModsConfigTests.swift
+++ b/Tests/KeyPathTests/HomeRowModsConfigTests.swift
@@ -23,6 +23,16 @@ final class HomeRowModsConfigTests: XCTestCase {
         XCTAssertEqual(timing.quickTapTermMs, 0)
     }
 
+    func testOppositeHandModesDescribeTheTimerTheyRender() {
+        XCTAssertTrue(OppositeHandMode.off.usesTapWindow)
+        XCTAssertEqual(OppositeHandMode.off.decisionWindowLabel, "Hold activation delay")
+
+        for mode in [OppositeHandMode.press, .release] {
+            XCTAssertFalse(mode.usesTapWindow)
+            XCTAssertEqual(mode.decisionWindowLabel, "Opposite-hand decision window")
+        }
+    }
+
     func testLegacyDecodingDefaultsNewFields() throws {
         let legacyJSON = """
         {

--- a/Tests/KeyPathTests/Infrastructure/HomeRowModsMappingGeneratorTests.swift
+++ b/Tests/KeyPathTests/Infrastructure/HomeRowModsMappingGeneratorTests.swift
@@ -102,6 +102,30 @@ final class HomeRowModsMappingGeneratorTests: XCTestCase {
         XCTAssertEqual(behavior.tapTimeout, 220) // 200 + 20
         XCTAssertEqual(behavior.holdTimeout, 160) // 150 + 10
         XCTAssertTrue(behavior.useOppositeHand)
+
+        let rendered = KanataBehaviorRenderer.render(mappings[0])
+        XCTAssertEqual(rendered, "(tap-hold-opposite-hand 160 a lsft)")
+        XCTAssertFalse(rendered.contains("220"), "Opposite-hand rendering uses its decision window, not the tap window")
+    }
+
+    func testOppositeHandReleaseUsesDecisionWindowInsteadOfTapOrQuickTapTiming() {
+        var timing = TimingConfig(tapWindow: 275, holdDelay: 145)
+        timing.tapOffsets = ["a": 40]
+        timing.holdOffsets = ["a": 15]
+        timing.quickTapEnabled = true
+        timing.quickTapTermMs = 60
+        let config = HomeRowModsConfig(
+            enabledKeys: ["a"],
+            modifierAssignments: ["a": "lsft"],
+            timing: timing,
+            oppositeHandMode: .release
+        )
+
+        let mappings = KanataConfiguration.generateHomeRowModsMappings(from: config)
+        let rendered = KanataBehaviorRenderer.render(mappings[0])
+
+        XCTAssertEqual(rendered, "(tap-hold-opposite-hand-release 160 a lsft)")
+        XCTAssertFalse(rendered.contains("375"), "Quick tap and tap offsets are not part of opposite-hand rendering")
     }
 
     func testOppositeHandActivation_LayerToggleMode() {
@@ -157,6 +181,24 @@ final class HomeRowModsMappingGeneratorTests: XCTestCase {
             XCTAssertTrue(behavior.useOppositeHand)
             XCTAssertTrue(behavior.customTapKeys.isEmpty)
         }
+    }
+
+    func testLayerToggleWithoutOppositeHandUsesTapAndHoldTimers() {
+        var timing = TimingConfig(tapWindow: 180, holdDelay: 140)
+        timing.quickTapEnabled = true
+        timing.quickTapTermMs = 40
+        let config = HomeRowLayerTogglesConfig(
+            enabledKeys: ["a"],
+            layerAssignments: ["a": "nav"],
+            timing: timing,
+            oppositeHandMode: .off
+        )
+
+        let mappings = KanataConfiguration.generateHomeRowLayerTogglesMappings(from: config)
+        XCTAssertEqual(
+            KanataBehaviorRenderer.render(mappings[0]),
+            "(tap-hold-press 220 140 a (layer-while-held nav))"
+        )
     }
 
     // MARK: - Full Round-Trip Tests

--- a/guides/home-row-mods.md
+++ b/guides/home-row-mods.md
@@ -88,8 +88,10 @@ Screenshot — Typing Feel slider in rule settings:
   └─────────────────────────────────────────────────────┘
 ```
 
-- Slide toward **"More Letters"** for a longer tap window (fewer accidental modifiers)
-- Slide toward **"More Modifiers"** for quicker modifier activation
+- With **Opposite-hand activation** off, slide toward **"More Letters"** for a longer tap window (fewer accidental modifiers), or toward **"More Modifiers"** for quicker modifier activation.
+- With **Opposite-hand activation** on, the same control changes the **Opposite-hand decision window** instead. That is the one timer Kanata uses in this mode: shorter feels more immediate; longer gives you more time before a cross-hand press becomes a modifier.
+
+The rule settings name the active timer so you can tell what you are adjusting: **Hold activation delay** for ordinary tap-hold behavior, or **Opposite-hand decision window** for opposite-hand behavior. Controls that do not affect the selected mode, including Quick tap, stay out of the way.
 
 ### Per-finger sensitivity
 
@@ -115,6 +117,8 @@ Screenshot — Per-finger sensitivity sliders:
 ### Quick tap
 
 When enabled, a quick tap-and-release always produces the letter, even if another key was pressed during the tap window. This is especially helpful for fast typists.
+
+Quick tap is available only when opposite-hand activation is off. Opposite-hand behavior has its own decision rule and does not use the tap window or Quick tap term.
 
 *Start with defaults, then adjust one parameter at a time.*
 
@@ -165,6 +169,8 @@ Screenshot — Fast typing protection in rule settings:
 ```
 
 This is enabled by default at 150ms. Adjust the slider to match your typing speed — faster typists may want a lower value (strict), while slower typists can use a higher value (forgiving).
+
+The same **Fast typing protection** is available for Home Row Layer Toggles. It keeps a key pressed shortly after normal typing as its letter, rather than unexpectedly activating its layer.
 
 ### Per-finger timing
 


### PR DESCRIPTION
Closes #1208

## Summary
- Show only timing controls that affect the selected home-row mode.
- Name the active timer: Hold activation delay or Opposite-hand decision window.
- Add opposite-hand and fast-typing guidance to Layer Toggles.
- Document the mode-specific behavior.

## Why
Opposite-hand Kanata variants use only their decision timeout, but the UI previously exposed tap-window and Quick tap controls that had no effect.

## Validation
- Direct XCTest: `HomeRowModsConfigTests` and `HomeRowModsMappingGeneratorTests` (23 tests, passing).
- Accessibility identifier check passed.
- Live UI check: Off restores Quick tap; On Press hides it and exposes the decision-window wording.
- `Scripts/review-gate.sh` selected remote `claude-review`.