### PR TITLE
Unify editor timing language

### DIFF
--- a/Sources/KeyPathAppKit/UI/Components/TimingCopy.swift
+++ b/Sources/KeyPathAppKit/UI/Components/TimingCopy.swift
@@ -1,0 +1,70 @@
+/// Shared, user-facing language for timing controls.
+///
+/// Keep this focused on what a person experiences rather than the renderer's
+/// serialized field names. The same stored timeout can have a different clock
+/// and outcome in another dual-role variant.
+enum TimingCopy {
+    enum DualRoleVariant: CaseIterable {
+        case basic
+        case holdOnOtherKeyPress
+        case holdOnOtherKeyRelease
+        case customTapKeys
+        case releaseOrder
+        case oppositeHandPress
+        case oppositeHandRelease
+
+        var primaryWindowLabel: String {
+            switch self {
+            case .releaseOrder:
+                "Typing grace period"
+            default:
+                "Repeat-tap window"
+            }
+        }
+
+        var primaryWindowExplanation: String {
+            switch self {
+            case .releaseOrder:
+                "After you press this key, another key released during this period makes it a hold."
+            default:
+                "After you press this key, another key can still change how it resolves during this period."
+            }
+        }
+
+        var usesHoldActivationDelay: Bool {
+            switch self {
+            case .releaseOrder, .oppositeHandPress, .oppositeHandRelease:
+                false
+            default:
+                true
+            }
+        }
+    }
+
+    static let holdActivationDelay = "Hold activation delay"
+    static let holdActivationDelayExplanation = "How long to hold this key before its hold action activates."
+    static let multiTapWindow = "Multi-tap window"
+    static let multiTapWindowExplanation = "After every tap, the window starts again. When it expires, KeyPath resolves the tap count."
+    static let activateHoldOnOtherKeyPress = "Activate hold when another key is pressed"
+    static let activateHoldOnOtherKeyRelease = "Activate hold after another key is released"
+
+    static func dualRoleVariant(
+        activateHoldOnOtherKey: Bool,
+        quickTap: Bool,
+        useReleaseOrder: Bool
+    ) -> DualRoleVariant {
+        if useReleaseOrder { return .releaseOrder }
+        if activateHoldOnOtherKey { return .holdOnOtherKeyPress }
+        if quickTap { return .holdOnOtherKeyRelease }
+        return .basic
+    }
+
+    static func dualRoleVariant(for holdBehavior: AdvancedBehaviorManager.HoldBehaviorType) -> DualRoleVariant {
+        switch holdBehavior {
+        case .basic: .basic
+        case .triggerEarly: .holdOnOtherKeyPress
+        case .quickTap: .holdOnOtherKeyRelease
+        case .customKeys: .customTapKeys
+        }
+    }
+}

--- a/Sources/KeyPathAppKit/UI/Components/TimingCopy.swift
+++ b/Sources/KeyPathAppKit/UI/Components/TimingCopy.swift
@@ -67,4 +67,11 @@ enum TimingCopy {
         case .customKeys: .customTapKeys
         }
     }
+
+    static func showsHoldActivationDelay(
+        for variant: DualRoleVariant,
+        isEditingTapDance: Bool
+    ) -> Bool {
+        !isEditingTapDance && variant.usesHoldActivationDelay
+    }
 }

--- a/Sources/KeyPathAppKit/UI/Mapper/AdvancedBehaviorContent.swift
+++ b/Sources/KeyPathAppKit/UI/Mapper/AdvancedBehaviorContent.swift
@@ -261,20 +261,24 @@ struct AdvancedBehaviorContent: View {
                     VStack(alignment: .leading, spacing: 6) {
                         HStack(spacing: 8) {
                             VStack(alignment: .leading, spacing: 2) {
-                                Text("Tap")
+                                Text(activeTimingLabel)
                                     .font(.caption2)
                                     .foregroundColor(.secondary)
                                 TextField("", value: $viewModel.tapTimeout, format: .number)
                                     .textFieldStyle(.roundedBorder)
                                     .frame(width: 50)
+                                    .accessibilityLabel(activeTimingLabel)
                             }
-                            VStack(alignment: .leading, spacing: 2) {
-                                Text("Hold")
-                                    .font(.caption2)
-                                    .foregroundColor(.secondary)
-                                TextField("", value: $viewModel.holdTimeout, format: .number)
-                                    .textFieldStyle(.roundedBorder)
-                                    .frame(width: 50)
+                            if timingVariant.usesHoldActivationDelay {
+                                VStack(alignment: .leading, spacing: 2) {
+                                    Text(TimingCopy.holdActivationDelay)
+                                        .font(.caption2)
+                                        .foregroundColor(.secondary)
+                                    TextField("", value: $viewModel.holdTimeout, format: .number)
+                                        .textFieldStyle(.roundedBorder)
+                                        .frame(width: 50)
+                                        .accessibilityLabel(TimingCopy.holdActivationDelay)
+                                }
                             }
                             Text("ms")
                                 .font(.subheadline)
@@ -284,9 +288,13 @@ struct AdvancedBehaviorContent: View {
                 } else {
                     // Single timing value
                     HStack(spacing: 8) {
+                        Text(activeTimingLabel)
+                            .font(.caption)
+                            .foregroundColor(.secondary)
                         TextField("", value: $viewModel.tappingTerm, format: .number)
                             .textFieldStyle(.roundedBorder)
                             .frame(width: 60)
+                            .accessibilityLabel(activeTimingLabel)
 
                         Text("ms")
                             .font(.subheadline)
@@ -400,10 +408,10 @@ struct AdvancedBehaviorContent: View {
                             .foregroundColor(viewModel.holdBehavior == behaviorType ? .accentColor : .secondary)
                     }
                     .buttonStyle(.plain)
-                    .accessibilityLabel("Select \(behaviorType.rawValue)")
+                    .accessibilityLabel("Select \(behaviorType.displayName)")
 
                     VStack(alignment: .leading, spacing: 2) {
-                        Text(behaviorType.rawValue)
+                        Text(behaviorType.displayName)
                             .font(.subheadline)
                             .foregroundColor(.primary)
 
@@ -416,7 +424,7 @@ struct AdvancedBehaviorContent: View {
                     }
                 }
                 .accessibilityIdentifier("mapper-hold-behavior-\(behaviorType.rawValue.lowercased().replacingOccurrences(of: " ", with: "-"))")
-                .accessibilityLabel(behaviorType.rawValue)
+                .accessibilityLabel(behaviorType.displayName)
 
                 // Custom keys input (shown when Custom keys is selected)
                 if behaviorType == .customKeys, viewModel.holdBehavior == .customKeys {
@@ -438,6 +446,19 @@ struct AdvancedBehaviorContent: View {
         let index = viewModel.tapDanceSteps.count
         guard index < MapperViewModel.tapDanceLabels.count else { return "More Taps" }
         return MapperViewModel.tapDanceLabels[index]
+    }
+
+    private var timingVariant: TimingCopy.DualRoleVariant {
+        TimingCopy.dualRoleVariant(for: viewModel.holdBehavior)
+    }
+
+    private var isEditingTapDance: Bool {
+        viewModel.holdAction.isEmpty &&
+            (!viewModel.doubleTapAction.isEmpty || viewModel.tapDanceSteps.contains { !$0.action.isEmpty })
+    }
+
+    private var activeTimingLabel: String {
+        isEditingTapDance ? TimingCopy.multiTapWindow : timingVariant.primaryWindowLabel
     }
 
     private func formatKeyForDisplay(_ key: String) -> String {

--- a/Sources/KeyPathAppKit/UI/Mapper/AdvancedBehaviorContent.swift
+++ b/Sources/KeyPathAppKit/UI/Mapper/AdvancedBehaviorContent.swift
@@ -269,7 +269,7 @@ struct AdvancedBehaviorContent: View {
                                     .frame(width: 50)
                                     .accessibilityLabel(activeTimingLabel)
                             }
-                            if timingVariant.usesHoldActivationDelay {
+                            if showsHoldActivationDelay {
                                 VStack(alignment: .leading, spacing: 2) {
                                     Text(TimingCopy.holdActivationDelay)
                                         .font(.caption2)
@@ -459,6 +459,13 @@ struct AdvancedBehaviorContent: View {
 
     private var activeTimingLabel: String {
         isEditingTapDance ? TimingCopy.multiTapWindow : timingVariant.primaryWindowLabel
+    }
+
+    private var showsHoldActivationDelay: Bool {
+        TimingCopy.showsHoldActivationDelay(
+            for: timingVariant,
+            isEditingTapDance: isEditingTapDance
+        )
     }
 
     private func formatKeyForDisplay(_ key: String) -> String {

--- a/Sources/KeyPathAppKit/UI/Mapper/AdvancedBehaviorManager.swift
+++ b/Sources/KeyPathAppKit/UI/Mapper/AdvancedBehaviorManager.swift
@@ -29,11 +29,24 @@ public final class AdvancedBehaviorManager {
             case .basic:
                 "Hold activates after timeout"
             case .triggerEarly:
-                "Hold activates when another key is pressed (home-row mods)"
+                "The hold action activates when another key is pressed."
             case .quickTap:
-                "Fast taps always register as tap"
+                "The hold action activates after another key is released."
             case .customKeys:
                 "Only specific keys trigger early tap"
+            }
+        }
+
+        public var displayName: String {
+            switch self {
+            case .basic:
+                "Basic"
+            case .triggerEarly:
+                TimingCopy.activateHoldOnOtherKeyPress
+            case .quickTap:
+                TimingCopy.activateHoldOnOtherKeyRelease
+            case .customKeys:
+                "Custom keys"
             }
         }
     }

--- a/Sources/KeyPathAppKit/UI/Rules/MappingBehaviorEditor.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/MappingBehaviorEditor.swift
@@ -153,7 +153,7 @@ struct MappingBehaviorEditor: View {
             GroupBox("Timing") {
                 VStack(alignment: .leading, spacing: 8) {
                     HStack {
-                        Text("Tapping term")
+                        Text(dualRoleTimingVariant.primaryWindowLabel)
                             .foregroundColor(.secondary)
                         Spacer()
                         Stepper(
@@ -163,32 +163,42 @@ struct MappingBehaviorEditor: View {
                             step: 10
                         )
                         .accessibilityIdentifier("mapping-behavior-tap-timeout-stepper")
+                        .accessibilityLabel(dualRoleTimingVariant.primaryWindowLabel)
                         .accessibilityValue("\(tapTimeout) ms")
                         .onChange(of: tapTimeout) { _, _ in syncBehaviorFromState() }
                     }
+                    Text(dualRoleTimingVariant.primaryWindowExplanation)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
 
-                    DisclosureGroup("Per-state overrides", isExpanded: $showTimingOverrides) {
-                        VStack(alignment: .leading, spacing: 6) {
-                            HStack {
-                                Text("Hold timeout")
-                                    .font(.caption)
+                    if dualRoleTimingVariant.usesHoldActivationDelay {
+                        DisclosureGroup("Separate timing", isExpanded: $showTimingOverrides) {
+                            VStack(alignment: .leading, spacing: 6) {
+                                HStack {
+                                    Text(TimingCopy.holdActivationDelay)
+                                        .font(.caption)
+                                        .foregroundColor(.secondary)
+                                    Spacer()
+                                    Stepper(
+                                        "\(holdTimeout) ms",
+                                        value: $holdTimeout,
+                                        in: 50 ... 500,
+                                        step: 10
+                                    )
+                                    .controlSize(.small)
+                                    .accessibilityIdentifier("mapping-behavior-hold-timeout-stepper")
+                                    .accessibilityLabel(TimingCopy.holdActivationDelay)
+                                    .accessibilityValue("\(holdTimeout) ms")
+                                    .onChange(of: holdTimeout) { _, _ in syncBehaviorFromState() }
+                                }
+                                Text(TimingCopy.holdActivationDelayExplanation)
+                                    .font(.caption2)
                                     .foregroundColor(.secondary)
-                                Spacer()
-                                Stepper(
-                                    "\(holdTimeout) ms",
-                                    value: $holdTimeout,
-                                    in: 50 ... 500,
-                                    step: 10
-                                )
-                                .controlSize(.small)
-                                .accessibilityIdentifier("mapping-behavior-hold-timeout-stepper")
-                                .accessibilityValue("\(holdTimeout) ms")
-                                .onChange(of: holdTimeout) { _, _ in syncBehaviorFromState() }
                             }
+                            .padding(.top, 4)
                         }
-                        .padding(.top, 4)
+                        .font(.caption)
                     }
-                    .font(.caption)
                 }
                 .padding(.vertical, 4)
             }
@@ -197,19 +207,19 @@ struct MappingBehaviorEditor: View {
             GroupBox("Options") {
                 VStack(alignment: .leading, spacing: 6) {
                     HStack(spacing: 4) {
-                        Toggle("Activate hold on other key", isOn: $activateHoldOnOtherKey)
+                        Toggle(TimingCopy.activateHoldOnOtherKeyPress, isOn: $activateHoldOnOtherKey)
                             .onChange(of: activateHoldOnOtherKey) { _, _ in syncBehaviorFromState() }
                             .accessibilityIdentifier("mapping-behavior-activate-hold-toggle")
-                            .accessibilityLabel("Activate hold on other key")
-                        InfoTip("Hold triggers when you press another key")
+                            .accessibilityLabel(TimingCopy.activateHoldOnOtherKeyPress)
+                        InfoTip("Pressing another key activates the hold action.")
                     }
 
                     HStack(spacing: 4) {
-                        Toggle("Quick tap", isOn: $quickTap)
+                        Toggle(TimingCopy.activateHoldOnOtherKeyRelease, isOn: $quickTap)
                             .accessibilityIdentifier("mapping-behavior-quick-tap-toggle")
-                            .accessibilityLabel("Quick tap")
+                            .accessibilityLabel(TimingCopy.activateHoldOnOtherKeyRelease)
                             .onChange(of: quickTap) { _, _ in syncBehaviorFromState() }
-                        InfoTip("Fast taps always register as tap")
+                        InfoTip("Releasing another key activates the hold action.")
                     }
 
                     HStack(spacing: 4) {
@@ -232,20 +242,26 @@ struct MappingBehaviorEditor: View {
 
     private var tapDanceEditor: some View {
         VStack(alignment: .leading, spacing: 12) {
-            GroupBox("Pattern Window") {
-                HStack {
-                    Text("Time to register taps")
+            GroupBox(TimingCopy.multiTapWindow) {
+                VStack(alignment: .leading, spacing: 6) {
+                    HStack {
+                        Text(TimingCopy.multiTapWindow)
+                            .foregroundColor(.secondary)
+                        Spacer()
+                        Stepper(
+                            "\(tapDanceWindow) ms",
+                            value: $tapDanceWindow,
+                            in: 100 ... 500,
+                            step: 10
+                        )
+                        .accessibilityIdentifier("mapping-behavior-tap-dance-window-stepper")
+                        .accessibilityLabel(TimingCopy.multiTapWindow)
+                        .accessibilityValue("\(tapDanceWindow) ms")
+                        .onChange(of: tapDanceWindow) { _, _ in syncBehaviorFromState() }
+                    }
+                    Text(TimingCopy.multiTapWindowExplanation)
+                        .font(.caption)
                         .foregroundColor(.secondary)
-                    Spacer()
-                    Stepper(
-                        "\(tapDanceWindow) ms",
-                        value: $tapDanceWindow,
-                        in: 100 ... 500,
-                        step: 10
-                    )
-                    .accessibilityIdentifier("mapping-behavior-tap-dance-window-stepper")
-                    .accessibilityValue("\(tapDanceWindow) ms")
-                    .onChange(of: tapDanceWindow) { _, _ in syncBehaviorFromState() }
                 }
                 .padding(.vertical, 4)
             }
@@ -331,6 +347,14 @@ struct MappingBehaviorEditor: View {
     }
 
     // MARK: - State Sync
+
+    private var dualRoleTimingVariant: TimingCopy.DualRoleVariant {
+        TimingCopy.dualRoleVariant(
+            activateHoldOnOtherKey: activateHoldOnOtherKey,
+            quickTap: quickTap,
+            useReleaseOrder: useReleaseOrder
+        )
+    }
 
     private func initializeFromBehavior() {
         guard let behavior else {

--- a/Sources/KeyPathAppKit/UI/Rules/MappingBehaviorEditor.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/MappingBehaviorEditor.swift
@@ -245,8 +245,6 @@ struct MappingBehaviorEditor: View {
             GroupBox(TimingCopy.multiTapWindow) {
                 VStack(alignment: .leading, spacing: 6) {
                     HStack {
-                        Text(TimingCopy.multiTapWindow)
-                            .foregroundColor(.secondary)
                         Spacer()
                         Stepper(
                             "\(tapDanceWindow) ms",

--- a/Tests/KeyPathTests/UI/TimingCopyTests.swift
+++ b/Tests/KeyPathTests/UI/TimingCopyTests.swift
@@ -36,4 +36,9 @@ final class TimingCopyTests: XCTestCase {
         XCTAssertEqual(TimingCopy.activateHoldOnOtherKeyRelease, "Activate hold after another key is released")
         XCTAssertTrue(TimingCopy.multiTapWindowExplanation.contains("After every tap"))
     }
+
+    func testTapDanceNeverShowsAnUnrelatedHoldActivationDelay() {
+        XCTAssertFalse(TimingCopy.showsHoldActivationDelay(for: .basic, isEditingTapDance: true))
+        XCTAssertTrue(TimingCopy.showsHoldActivationDelay(for: .basic, isEditingTapDance: false))
+    }
 }

--- a/Tests/KeyPathTests/UI/TimingCopyTests.swift
+++ b/Tests/KeyPathTests/UI/TimingCopyTests.swift
@@ -1,0 +1,36 @@
+@testable import KeyPathAppKit
+import XCTest
+
+final class TimingCopyTests: XCTestCase {
+    func testDualRoleVariantsUseApprovedPrimaryTimingLabels() {
+        XCTAssertEqual(TimingCopy.DualRoleVariant.basic.primaryWindowLabel, "Repeat-tap window")
+        XCTAssertEqual(TimingCopy.DualRoleVariant.holdOnOtherKeyPress.primaryWindowLabel, "Repeat-tap window")
+        XCTAssertEqual(TimingCopy.DualRoleVariant.holdOnOtherKeyRelease.primaryWindowLabel, "Repeat-tap window")
+        XCTAssertEqual(TimingCopy.DualRoleVariant.customTapKeys.primaryWindowLabel, "Repeat-tap window")
+        XCTAssertEqual(TimingCopy.DualRoleVariant.releaseOrder.primaryWindowLabel, "Typing grace period")
+    }
+
+    func testOnlySingleClockVariantsHideHoldActivationDelay() {
+        XCTAssertTrue(TimingCopy.DualRoleVariant.basic.usesHoldActivationDelay)
+        XCTAssertFalse(TimingCopy.DualRoleVariant.releaseOrder.usesHoldActivationDelay)
+        XCTAssertFalse(TimingCopy.DualRoleVariant.oppositeHandPress.usesHoldActivationDelay)
+        XCTAssertFalse(TimingCopy.DualRoleVariant.oppositeHandRelease.usesHoldActivationDelay)
+    }
+
+    func testEditorStateResolvesToTheSameSharedVariants() {
+        XCTAssertEqual(
+            TimingCopy.dualRoleVariant(activateHoldOnOtherKey: false, quickTap: false, useReleaseOrder: false),
+            .basic
+        )
+        XCTAssertEqual(
+            TimingCopy.dualRoleVariant(activateHoldOnOtherKey: true, quickTap: true, useReleaseOrder: false),
+            .holdOnOtherKeyPress
+        )
+        XCTAssertEqual(
+            TimingCopy.dualRoleVariant(for: .quickTap),
+            .holdOnOtherKeyRelease
+        )
+        XCTAssertEqual(TimingCopy.activateHoldOnOtherKeyRelease, "Activate hold after another key is released")
+        XCTAssertTrue(TimingCopy.multiTapWindowExplanation.contains("After every tap"))
+    }
+}

--- a/Tests/KeyPathTests/UI/TimingCopyTests.swift
+++ b/Tests/KeyPathTests/UI/TimingCopyTests.swift
@@ -12,6 +12,9 @@ final class TimingCopyTests: XCTestCase {
 
     func testOnlySingleClockVariantsHideHoldActivationDelay() {
         XCTAssertTrue(TimingCopy.DualRoleVariant.basic.usesHoldActivationDelay)
+        XCTAssertTrue(TimingCopy.DualRoleVariant.holdOnOtherKeyPress.usesHoldActivationDelay)
+        XCTAssertTrue(TimingCopy.DualRoleVariant.holdOnOtherKeyRelease.usesHoldActivationDelay)
+        XCTAssertTrue(TimingCopy.DualRoleVariant.customTapKeys.usesHoldActivationDelay)
         XCTAssertFalse(TimingCopy.DualRoleVariant.releaseOrder.usesHoldActivationDelay)
         XCTAssertFalse(TimingCopy.DualRoleVariant.oppositeHandPress.usesHoldActivationDelay)
         XCTAssertFalse(TimingCopy.DualRoleVariant.oppositeHandRelease.usesHoldActivationDelay)

--- a/guides/tap-hold.md
+++ b/guides/tap-hold.md
@@ -78,13 +78,13 @@ Screenshot — Rule editor with hold behavior options:
   │  │  On Hold:   [ left_control   ▾ ]               │ │
   │  │                                                │ │
   │  │  Hold Behavior:                                │ │
-  │  │  ┌──────────┐ ┌──────────┐ ┌──────────┐       │ │
-  │  │  │  Basic   │ │ Trigger  │ │  Quick   │       │ │
-  │  │  │          │ │  early   │ │   tap    │       │ │
-  │  │  └──────────┘ └──────────┘ └──────────┘       │ │
+  │  │  ┌──────────┐ ┌──────────┐ ┌───────────────┐  │ │
+  │  │  │  Basic   │ │ Activate │ │ Activate hold │  │ │
+  │  │  │          │ │ on press │ │ after release │  │ │
+  │  │  └──────────┘ └──────────┘ └───────────────┘  │ │
   │  │                                                │ │
-  │  │  Tap timeout:   [ 200 ms ]                     │ │
-  │  │  Hold timeout:  [ 200 ms ]                     │ │
+  │  │  Repeat-tap window:     [ 200 ms ]             │ │
+  │  │  Hold activation delay: [ 200 ms ]             │ │
   │  └────────────────────────────────────────────────┘ │
   │                                                     │
   │                              [ Cancel ]  [ Save ]   │
@@ -111,8 +111,8 @@ Screenshot — Rule editor with hold behavior options:
 | Option | Description |
 |--------|-------------|
 | Basic | Hold activates after timeout |
-| Trigger early | Hold activates when another key is pressed |
-| Quick tap | Fast taps always register as tap |
+| Activate hold when another key is pressed | Pressing another key activates the hold action. |
+| Activate hold after another key is released | Releasing another key activates the hold action. |
 | Custom keys | Only specific keys trigger early tap |
 
 ---
@@ -131,9 +131,9 @@ f → f (tap) / Left Command (hold)
 ```
 
 **Settings:**
-- Hold behavior: **Trigger early**
-- Tap timeout: 200ms
-- Hold timeout: 200ms
+- Hold behavior: **Activate hold when another key is pressed**
+- Repeat-tap window: 200ms
+- Hold activation delay: 200ms
 
 This allows you to press `a` + `j` quickly and it triggers `Ctrl+J` instead of `aj`.
 
@@ -147,7 +147,7 @@ caps → esc (tap) / lctl (hold)
 
 **Settings:**
 - Hold behavior: **Basic**
-- Tap timeout: 200ms
+- Repeat-tap window: 200ms
 
 ### Space Cadet Shift
 
@@ -158,8 +158,8 @@ spc → spc (tap) / lsft (hold)
 ```
 
 **Settings:**
-- Hold behavior: **Quick tap**
-- Tap timeout: 200ms
+- Hold behavior: **Activate hold after another key is released**
+- Repeat-tap window: 200ms
 
 ---
 
@@ -186,16 +186,20 @@ f1 → f1 (single tap) / layer-toggle function (double tap)
 KeyPath generates the appropriate Kanata variant based on your settings:
 
 1. **`tap-hold-press`**: Hold triggers on other key press (`activateHoldOnOtherKey = true`)
-2. **`tap-hold-release`**: Quick-tap / permissive-hold (`quickTap = true`)
+2. **`tap-hold-release`**: Hold activates after another key is released (`quickTap = true` internally)
 3. **`tap-hold-release-keys`**: Early tap on specific keys (`customTapKeys` non-empty)
 4. **`tap-hold`**: Basic timeout-based (default)
 
-### Timeout Configuration
+### Timing controls
 
-- **Tap timeout**: Time (ms) before hold activates
-- **Hold timeout**: Time (ms) for hold to fully activate
+The editors use the same names wherever the underlying clock and outcome match:
 
-Default is 200ms for both, which works well for most users. Adjust based on your typing speed and preferences.
+- **Repeat-tap window**: after you press the key, another key can still change how it resolves during this period.
+- **Hold activation delay**: how long to hold the key before its hold action activates.
+- **Typing grace period**: the release-order variant's short buffer; another key released during it makes this key a hold. It does not use a separate hold delay.
+- **Multi-tap window**: tap-dance's window for another tap. The clock starts again after every tap; when it expires, KeyPath resolves the tap count.
+
+The value is always milliseconds. A longer window gives you more time to perform the required action, while a shorter one resolves sooner. Default dual-role timing is 200ms; adjust it to suit your typing speed.
 
 ---
 
@@ -220,7 +224,7 @@ This is great for keys you rarely use in their original form. Pack multiple func
 3. Enable **Hold, Double Tap, etc.**
 4. Set actions for single tap, double tap, and optionally triple tap
 
-The timing window between taps is configurable. A shorter window means you need to tap faster; a longer window gives you more time but adds a slight delay before the single-tap action fires (KeyPath has to wait to see if you'll tap again).
+The **Multi-tap window** starts again after every tap. A shorter window means you need to tap faster; a longer window gives you more time but adds a slight delay before the single-tap action fires (KeyPath has to wait to see if you'll tap again).
 
 ---
 


### PR DESCRIPTION
Closes #1211

## What changed
- Added one shared timing-copy source for the Custom Rule editor and Mapper.
- Renamed dual-role controls to Repeat-tap window, Hold activation delay, and Typing grace period when release-order behavior is selected.
- Replaced the ambiguous Quick tap label with the physical other-key-release action, and described multi-tap timing as a reset-after-each-tap window.
- Updated accessibility labels, focused copy tests, and the tap-hold guide.

## Validation
- `swift test --filter TimingCopyTests --jobs 4` (3 passing)
- `python3 Scripts/check-accessibility.py`
- `./Scripts/review-gate.sh` selected the required remote `claude-review` gate.

No renderer, serialized configuration, or rule behavior changes.