### PR TITLE
Decouple Auto Shift fast-typing protection

### DIFF
--- a/Sources/KeyPathAppKit/Infrastructure/Config/KanataConfiguration+MappingGenerators.swift
+++ b/Sources/KeyPathAppKit/Infrastructure/Config/KanataConfiguration+MappingGenerators.swift
@@ -172,7 +172,8 @@ extension KanataConfiguration {
                 holdTimeout: config.timeoutMs,
                 activateHoldOnOtherKey: false,
                 quickTap: false,
-                customTapKeys: []
+                customTapKeys: [],
+                requirePriorIdleOverrideMs: config.protectFastTyping ? config.fastTypingProtectionWindowMs : nil
             )
 
             let mapping = KeyMapping(

--- a/Sources/KeyPathAppKit/Infrastructure/Config/KanataConfiguration+MappingGenerators.swift
+++ b/Sources/KeyPathAppKit/Infrastructure/Config/KanataConfiguration+MappingGenerators.swift
@@ -173,7 +173,9 @@ extension KanataConfiguration {
                 activateHoldOnOtherKey: false,
                 quickTap: false,
                 customTapKeys: [],
-                requirePriorIdleOverrideMs: config.protectFastTyping ? config.fastTypingProtectionWindowMs : nil
+                // A zero override is deliberate when protection is off: it keeps
+                // Auto Shift independent from any nonzero global home-row setting.
+                requirePriorIdleOverrideMs: config.protectFastTyping ? config.fastTypingProtectionWindowMs : 0
             )
 
             let mapping = KeyMapping(

--- a/Sources/KeyPathAppKit/Infrastructure/Config/KanataConfigurationGenerator.swift
+++ b/Sources/KeyPathAppKit/Infrastructure/Config/KanataConfigurationGenerator.swift
@@ -62,11 +62,12 @@ public struct KanataConfiguration: Sendable {
 
         AppLogger.shared.log("📚 [KanataConfig] Enabled collections: \(enabledCollections.map { "\($0.name) (enabled: \($0.isEnabled))" }.joined(separator: ", "))")
 
-        // Extract max tap-hold-require-prior-idle value from enabled collections (defcfg-level option).
-        // This is a GLOBAL kanata setting — the highest value from any enabled collection wins.
-        // When active, ALL tap-hold actions (HRM, auto-shift, leader keys, etc.) require the
-        // specified idle gap before hold detection activates. Leader/nav keys get per-action
-        // (require-prior-idle 0) overrides so they still activate immediately during fast typing.
+        // Extract max tap-hold-require-prior-idle value from the collections that intentionally
+        // use a shared defcfg-level setting. When active, ALL un-overridden tap-hold actions
+        // require the specified idle gap. Auto Shift is deliberately excluded: it renders a
+        // per-action override so its fast-typing protection cannot affect other collections.
+        // Leader/nav keys get per-action (require-prior-idle 0) overrides so they still
+        // activate immediately during fast typing.
         // Computed before buildCollectionBlocks so leader key can use per-action override when active.
         let requirePriorIdleMs = enabledCollections.compactMap { collection -> Int? in
             switch collection.configuration {
@@ -74,8 +75,6 @@ public struct KanataConfiguration: Sendable {
                 config.timing.requirePriorIdleMs
             case let .homeRowLayerToggles(config):
                 config.timing.requirePriorIdleMs
-            case let .autoShiftSymbols(config):
-                config.protectFastTyping ? config.timeoutMs : nil
             default:
                 nil
             }

--- a/Sources/KeyPathAppKit/UI/Rules/AutoShiftCollectionView.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/AutoShiftCollectionView.swift
@@ -21,6 +21,7 @@ struct AutoShiftCollectionView: View {
     @State private var enabledKeys: Set<String>
     @State private var timeoutMs: Int
     @State private var protectFastTyping: Bool
+    @State private var fastTypingProtectionWindowMs: Int
     @State private var hoveredKey: String?
     @State private var flashedKey: String?
     @State private var eventMonitor: Any?
@@ -54,6 +55,7 @@ struct AutoShiftCollectionView: View {
         _enabledKeys = State(initialValue: config.enabledKeys)
         _timeoutMs = State(initialValue: config.timeoutMs)
         _protectFastTyping = State(initialValue: config.protectFastTyping)
+        _fastTypingProtectionWindowMs = State(initialValue: config.fastTypingProtectionWindowMs)
     }
 
     // MARK: - Body
@@ -70,6 +72,7 @@ struct AutoShiftCollectionView: View {
         .onChange(of: enabledKeys) { _, _ in emitConfig() }
         .onChange(of: timeoutMs) { _, _ in emitConfig() }
         .onChange(of: protectFastTyping) { _, _ in emitConfig() }
+        .onChange(of: fastTypingProtectionWindowMs) { _, _ in emitConfig() }
     }
 
     // MARK: - Experimental Badge
@@ -266,7 +269,7 @@ struct AutoShiftCollectionView: View {
     private var timeoutSection: some View {
         VStack(alignment: .leading, spacing: 6) {
             HStack {
-                Text("Timeout")
+                Text("Shift hold delay")
                     .font(.subheadline.weight(.medium))
                     .foregroundColor(.primary)
 
@@ -277,6 +280,10 @@ struct AutoShiftCollectionView: View {
                     .foregroundColor(.secondary)
             }
 
+            Text("Hold a symbol key this long to type its shifted character.")
+                .font(.caption)
+                .foregroundColor(.secondary)
+
             Slider(
                 value: Binding(
                     get: { Double(timeoutMs) },
@@ -286,7 +293,7 @@ struct AutoShiftCollectionView: View {
                 step: 10
             )
             .accessibilityIdentifier("autoshift-timeout-slider")
-            .accessibilityLabel("Auto shift timeout")
+            .accessibilityLabel("Shift hold delay")
             .accessibilityValue("\(timeoutMs) milliseconds")
         }
         .padding(12)
@@ -303,18 +310,60 @@ struct AutoShiftCollectionView: View {
     // MARK: - Fast Typing Toggle
 
     private var fastTypingToggle: some View {
-        Toggle(isOn: $protectFastTyping) {
-            VStack(alignment: .leading, spacing: 2) {
-                Text("Protect fast typing")
-                    .font(.subheadline.weight(.medium))
-                Text("Ignore holds when another key was pressed recently")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
+        VStack(alignment: .leading, spacing: 10) {
+            Toggle(isOn: $protectFastTyping) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Fast-typing protection")
+                        .font(.subheadline.weight(.medium))
+                    Text("Force the unshifted symbol when you pressed another key recently.")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+            }
+            .toggleStyle(.checkbox)
+            .accessibilityIdentifier("autoshift-protect-fast-typing")
+            .accessibilityLabel("Fast-typing protection")
+
+            if protectFastTyping {
+                VStack(alignment: .leading, spacing: 6) {
+                    HStack {
+                        Text("Fast-typing protection window")
+                            .font(.subheadline.weight(.medium))
+
+                        Spacer()
+
+                        Text("\(fastTypingProtectionWindowMs) ms")
+                            .font(.subheadline.monospacedDigit())
+                            .foregroundColor(.secondary)
+                    }
+
+                    Text("Look backward from this symbol key press by this amount of time.")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+
+                    Slider(
+                        value: Binding(
+                            get: { Double(fastTypingProtectionWindowMs) },
+                            set: { fastTypingProtectionWindowMs = Int($0) }
+                        ),
+                        in: 50 ... 400,
+                        step: 10
+                    )
+                    .accessibilityIdentifier("autoshift-fast-typing-window-slider")
+                    .accessibilityLabel("Fast-typing protection window")
+                    .accessibilityValue("\(fastTypingProtectionWindowMs) milliseconds")
+                }
             }
         }
-        .toggleStyle(.checkbox)
-        .accessibilityIdentifier("autoshift-protect-fast-typing")
-        .accessibilityLabel("Protect fast typing")
+        .padding(12)
+        .background(
+            RoundedRectangle(cornerRadius: 10)
+                .fill(Color(NSColor.controlBackgroundColor).opacity(0.35))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 10)
+                .stroke(Color.white.opacity(0.08), lineWidth: 1)
+        )
     }
 
     // MARK: - Actions
@@ -332,6 +381,7 @@ struct AutoShiftCollectionView: View {
         updated.enabledKeys = enabledKeys
         updated.timeoutMs = timeoutMs
         updated.protectFastTyping = protectFastTyping
+        updated.fastTypingProtectionWindowMs = fastTypingProtectionWindowMs
         onConfigChanged(updated)
     }
 

--- a/Sources/KeyPathRulesCore/RuleCollectionConfiguration.swift
+++ b/Sources/KeyPathRulesCore/RuleCollectionConfiguration.swift
@@ -757,14 +757,24 @@ public struct AutoShiftSymbolsConfig: Codable, Equatable, Sendable {
     /// Timeout in milliseconds — hold longer than this to get shifted output
     public var timeoutMs: Int
 
-    /// When true, contributes to global require-prior-idle to prevent accidental shifts during fast typing
+    /// When true, symbol keys skip hold detection after recent typing.
     public var protectFastTyping: Bool
+
+    /// How recently another key may have been pressed before Auto Shift forces a tap.
+    ///
+    /// This is intentionally independent from ``timeoutMs``. It is rendered as a
+    /// per-action Kanata override so Auto Shift does not change timing for other
+    /// tap-hold collections.
+    public var fastTypingProtectionWindowMs: Int
 
     /// Which keys are enabled for auto-shift behavior
     public var enabledKeys: Set<String>
 
     /// Default timeout for auto-shift (milliseconds)
     public static let defaultTimeoutMs = 180
+
+    /// Default fast-typing protection window for newly created configurations.
+    public static let defaultFastTypingProtectionWindowMs = 180
 
     /// The full set of symbol keys eligible for auto-shift
     public static let allSymbolKeys: [String] = [
@@ -789,11 +799,40 @@ public struct AutoShiftSymbolsConfig: Codable, Equatable, Sendable {
     public init(
         timeoutMs: Int = AutoShiftSymbolsConfig.defaultTimeoutMs,
         protectFastTyping: Bool = true,
+        fastTypingProtectionWindowMs: Int? = nil,
         enabledKeys: Set<String>? = nil
     ) {
         self.timeoutMs = timeoutMs
         self.protectFastTyping = protectFastTyping
+        // Preserve the pre-#1210 behavior for existing call sites that only
+        // supplied a timeout: that timeout was also the protection window.
+        self.fastTypingProtectionWindowMs = fastTypingProtectionWindowMs ?? timeoutMs
         self.enabledKeys = enabledKeys ?? Set(AutoShiftSymbolsConfig.allSymbolKeys)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case timeoutMs
+        case protectFastTyping
+        case fastTypingProtectionWindowMs
+        case enabledKeys
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        timeoutMs = try container.decodeIfPresent(Int.self, forKey: .timeoutMs) ?? Self.defaultTimeoutMs
+        protectFastTyping = try container.decodeIfPresent(Bool.self, forKey: .protectFastTyping) ?? true
+        // Older saved configurations used timeoutMs as the global protection
+        // window. Retain that exact behavior when the new field is absent.
+        fastTypingProtectionWindowMs = try container.decodeIfPresent(Int.self, forKey: .fastTypingProtectionWindowMs) ?? timeoutMs
+        enabledKeys = try container.decodeIfPresent(Set<String>.self, forKey: .enabledKeys) ?? Set(Self.allSymbolKeys)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(timeoutMs, forKey: .timeoutMs)
+        try container.encode(protectFastTyping, forKey: .protectFastTyping)
+        try container.encode(fastTypingProtectionWindowMs, forKey: .fastTypingProtectionWindowMs)
+        try container.encode(enabledKeys, forKey: .enabledKeys)
     }
 }
 

--- a/Tests/KeyPathTests/Infrastructure/KanataConfigMappingGeneratorTests.swift
+++ b/Tests/KeyPathTests/Infrastructure/KanataConfigMappingGeneratorTests.swift
@@ -215,6 +215,7 @@ final class KanataConfigMappingGeneratorTests: XCTestCase {
         var config = AutoShiftSymbolsConfig()
         config.enabledKeys = Set(["min", "eql"])
         config.timeoutMs = 180
+        config.fastTypingProtectionWindowMs = 120
 
         let mappings = KanataConfiguration.generateAutoShiftSymbolsMappings(from: config)
         XCTAssertEqual(mappings.count, 2)
@@ -225,6 +226,7 @@ final class KanataConfigMappingGeneratorTests: XCTestCase {
             XCTAssertEqual(dr.holdTimeout, 180)
             XCTAssertEqual(dr.tapAction, .keystroke(key: "min"))
             XCTAssertEqual(dr.holdAction, .keystroke(key: "S-min"))
+            XCTAssertEqual(dr.requirePriorIdleOverrideMs, 120)
         } else {
             XCTFail("Expected dualRole behavior for auto-shift")
         }

--- a/Tests/KeyPathTests/Integration/PerOptionMatrixTests.swift
+++ b/Tests/KeyPathTests/Integration/PerOptionMatrixTests.swift
@@ -224,7 +224,7 @@ final class PerOptionMatrixTests: XCTestCase {
     // MARK: - Auto Shift Symbols
 
     @MainActor
-    func testAutoShift_ProtectFastTyping_True_EmitsRequirePriorIdle() async throws {
+    func testAutoShift_ProtectFastTyping_True_EmitsPerActionRequirePriorIdle() async throws {
         let config = MatrixTestHelpers.enabledCollectionConfig(RuleCollectionIdentifier.autoShiftSymbols) { coll in
             if case var .autoShiftSymbols(cfg) = coll.configuration {
                 cfg.protectFastTyping = true
@@ -232,10 +232,9 @@ final class PerOptionMatrixTests: XCTestCase {
             }
         }
 
-        XCTAssertTrue(
-            config.contains("require-prior-idle"),
-            "Auto Shift with protectFastTyping=true should emit require-prior-idle"
-        )
+        XCTAssertTrue(config.contains("beh_base_dot (tap-hold") && config.contains("(require-prior-idle 180)"))
+        XCTAssertFalse(config.contains("tap-hold-require-prior-idle"),
+                       "Auto Shift must not change the global timing used by other tap-hold collections")
         try await assertKanataValid(config, "Auto Shift protectFastTyping=true")
     }
 
@@ -248,11 +247,9 @@ final class PerOptionMatrixTests: XCTestCase {
             }
         }
 
-        // Other rules may still emit require-prior-idle globally; the assertion
-        // is specifically that this family's contribution is gone.
         XCTAssertFalse(
-            config.contains("require-prior-idle \(AutoShiftSymbolsConfig.defaultTimeoutMs)"),
-            "Auto Shift with protectFastTyping=false should not contribute its idle term"
+            config.contains("(require-prior-idle \(AutoShiftSymbolsConfig.defaultFastTypingProtectionWindowMs))"),
+            "Auto Shift with protectFastTyping=false should not emit a per-action idle term"
         )
         try await assertKanataValid(config, "Auto Shift protectFastTyping=false")
     }

--- a/Tests/KeyPathTests/Integration/PerRuleOptionCoverageTests.swift
+++ b/Tests/KeyPathTests/Integration/PerRuleOptionCoverageTests.swift
@@ -196,14 +196,40 @@ final class PerRuleOptionCoverageTests: XCTestCase {
         autoShift.enabledKeys = ["min"]
         autoShift.timeoutMs = 175
         autoShift.protectFastTyping = true
+        autoShift.fastTypingProtectionWindowMs = 120
         let autoShiftCollection = collection(
             id: RuleCollectionIdentifier.autoShiftSymbols,
             name: "Auto Shift Symbols",
             configuration: .autoShiftSymbols(autoShift)
         )
         let autoShiftConfig = KanataConfiguration.generateFromCollections([autoShiftCollection])
-        assertContains(autoShiftConfig, "tap-hold-require-prior-idle 175", "auto-shift protect typing")
-        assertContains(autoShiftConfig, "beh_base_min (tap-hold 175 175 min S-min)", "auto-shift output")
+        XCTAssertFalse(autoShiftConfig.contains("tap-hold-require-prior-idle"),
+                       "Auto Shift must not set a global prior-idle value")
+        assertContains(autoShiftConfig, "beh_base_min (tap-hold 175 175 min S-min (require-prior-idle 120))", "auto-shift protection")
+
+        var homeRowMods = HomeRowModsConfig()
+        homeRowMods.enabledKeys = ["a"]
+        homeRowMods.timing.requirePriorIdleMs = 210
+        let homeRowModsCollection = collection(
+            id: RuleCollectionIdentifier.homeRowMods,
+            name: "Home Row Mods",
+            configuration: .homeRowMods(homeRowMods)
+        )
+        let autoShiftWithMods = KanataConfiguration.generateFromCollections([homeRowModsCollection, autoShiftCollection])
+        assertContains(autoShiftWithMods, "tap-hold-require-prior-idle 210", "home row mods global protection")
+        assertContains(autoShiftWithMods, "beh_base_min (tap-hold 175 175 min S-min (require-prior-idle 120))", "auto-shift override with home row mods")
+
+        var homeRowLayers = HomeRowLayerTogglesConfig()
+        homeRowLayers.enabledKeys = ["a"]
+        homeRowLayers.timing.requirePriorIdleMs = 230
+        let homeRowLayersCollection = collection(
+            id: RuleCollectionIdentifier.homeRowLayerToggles,
+            name: "Home Row Layer Toggles",
+            configuration: .homeRowLayerToggles(homeRowLayers)
+        )
+        let autoShiftWithLayers = KanataConfiguration.generateFromCollections([homeRowLayersCollection, autoShiftCollection])
+        assertContains(autoShiftWithLayers, "tap-hold-require-prior-idle 230", "home row layer toggles global protection")
+        assertContains(autoShiftWithLayers, "beh_base_min (tap-hold 175 175 min S-min (require-prior-idle 120))", "auto-shift override with home row layer toggles")
 
         var repeatConfig = KeyRepeatControlConfig()
         repeatConfig.isEnabled = true

--- a/Tests/KeyPathTests/Integration/PerRuleOptionCoverageTests.swift
+++ b/Tests/KeyPathTests/Integration/PerRuleOptionCoverageTests.swift
@@ -231,6 +231,20 @@ final class PerRuleOptionCoverageTests: XCTestCase {
         assertContains(autoShiftWithLayers, "tap-hold-require-prior-idle 230", "home row layer toggles global protection")
         assertContains(autoShiftWithLayers, "beh_base_min (tap-hold 175 175 min S-min (require-prior-idle 120))", "auto-shift override with home row layer toggles")
 
+        autoShift.protectFastTyping = false
+        let unprotectedAutoShiftCollection = collection(
+            id: RuleCollectionIdentifier.autoShiftSymbols,
+            name: "Auto Shift Symbols",
+            configuration: .autoShiftSymbols(autoShift)
+        )
+        let unprotectedAutoShiftWithMods = KanataConfiguration.generateFromCollections([homeRowModsCollection, unprotectedAutoShiftCollection])
+        assertContains(unprotectedAutoShiftWithMods, "tap-hold-require-prior-idle 210", "home row mods global protection remains enabled")
+        assertContains(unprotectedAutoShiftWithMods, "beh_base_min (tap-hold 175 175 min S-min (require-prior-idle 0))", "unprotected auto-shift bypasses home row mods protection")
+
+        let unprotectedAutoShiftWithLayers = KanataConfiguration.generateFromCollections([homeRowLayersCollection, unprotectedAutoShiftCollection])
+        assertContains(unprotectedAutoShiftWithLayers, "tap-hold-require-prior-idle 230", "home row layer toggles global protection remains enabled")
+        assertContains(unprotectedAutoShiftWithLayers, "beh_base_min (tap-hold 175 175 min S-min (require-prior-idle 0))", "unprotected auto-shift bypasses home row layer toggles protection")
+
         var repeatConfig = KeyRepeatControlConfig()
         repeatConfig.isEnabled = true
         repeatConfig.globalDelayMs = 175

--- a/Tests/KeyPathTests/Services/AutoShiftSymbolsTests.swift
+++ b/Tests/KeyPathTests/Services/AutoShiftSymbolsTests.swift
@@ -196,8 +196,8 @@ struct AutoShiftKanataRenderingTests {
         #expect(output.contains("require-prior-idle 180"))
     }
 
-    @Test("No require-prior-idle when protectFastTyping is false")
-    func noRequirePriorIdleWhenDisabled() {
+    @Test("Zero require-prior-idle override when protectFastTyping is false")
+    func zeroRequirePriorIdleOverrideWhenDisabled() {
         let config = AutoShiftSymbolsConfig(timeoutMs: 180, protectFastTyping: false, enabledKeys: Set(["dot"]))
         let collection = RuleCollection(
             id: RuleCollectionIdentifier.autoShiftSymbols,
@@ -210,7 +210,7 @@ struct AutoShiftKanataRenderingTests {
         )
 
         let output = KanataConfiguration.generateFromCollections([collection])
-        #expect(!output.contains("require-prior-idle"))
+        #expect(output.contains("(require-prior-idle 0)"))
     }
 }
 

--- a/Tests/KeyPathTests/Services/AutoShiftSymbolsTests.swift
+++ b/Tests/KeyPathTests/Services/AutoShiftSymbolsTests.swift
@@ -15,18 +15,30 @@ struct AutoShiftSymbolsConfigCodableTests {
         #expect(decoded == config)
     }
 
-    @Test("Round-trip encodes custom timeout and key set")
+    @Test("Round-trip encodes independent timing values and key set")
     func roundTripCustom() throws {
         let config = AutoShiftSymbolsConfig(
             timeoutMs: 250,
             protectFastTyping: false,
+            fastTypingProtectionWindowMs: 120,
             enabledKeys: Set(["grv", "min", "dot"])
         )
         let data = try JSONEncoder().encode(config)
         let decoded = try JSONDecoder().decode(AutoShiftSymbolsConfig.self, from: data)
         #expect(decoded.timeoutMs == 250)
         #expect(decoded.protectFastTyping == false)
+        #expect(decoded.fastTypingProtectionWindowMs == 120)
         #expect(decoded.enabledKeys == Set(["grv", "min", "dot"]))
+    }
+
+    @Test("Decoding a pre-window configuration preserves its protection behavior")
+    func decodingLegacyConfigurationUsesTimeoutAsProtectionWindow() throws {
+        let legacy = #"{"timeoutMs":250,"protectFastTyping":true,"enabledKeys":["dot"]}"#
+
+        let decoded = try JSONDecoder().decode(AutoShiftSymbolsConfig.self, from: Data(legacy.utf8))
+
+        #expect(decoded.timeoutMs == 250)
+        #expect(decoded.fastTypingProtectionWindowMs == 250)
     }
 
     @Test("Default config has all symbol keys enabled")
@@ -39,6 +51,7 @@ struct AutoShiftSymbolsConfigCodableTests {
     func defaultTimeout() {
         let config = AutoShiftSymbolsConfig()
         #expect(config.timeoutMs == 180)
+        #expect(config.fastTypingProtectionWindowMs == 180)
     }
 
     @Test("Default protectFastTyping is true")
@@ -110,6 +123,26 @@ struct AutoShiftMappingGenerationTests {
         #expect(behavior.activateHoldOnOtherKey == false)
         #expect(behavior.quickTap == false)
         #expect(behavior.useOppositeHand == false)
+        #expect(behavior.requirePriorIdleOverrideMs == 200)
+    }
+
+    @Test("Fast-typing protection can be disabled without changing hold delay")
+    func disablesProtectionOverride() {
+        let config = AutoShiftSymbolsConfig(
+            timeoutMs: 200,
+            protectFastTyping: false,
+            fastTypingProtectionWindowMs: 90,
+            enabledKeys: Set(["dot"])
+        )
+
+        let mappings = KanataConfiguration.generateAutoShiftSymbolsMappings(from: config)
+
+        guard case let .dualRole(behavior) = mappings.first?.behavior else {
+            Issue.record("Expected dualRole behavior")
+            return
+        }
+        #expect(behavior.tapTimeout == 200)
+        #expect(behavior.requirePriorIdleOverrideMs == nil)
     }
 
     @Test("Empty enabled keys produces no mappings")

--- a/Tests/KeyPathTests/Services/AutoShiftSymbolsTests.swift
+++ b/Tests/KeyPathTests/Services/AutoShiftSymbolsTests.swift
@@ -127,7 +127,7 @@ struct AutoShiftMappingGenerationTests {
     }
 
     @Test("Fast-typing protection can be disabled without changing hold delay")
-    func disablesProtectionOverride() {
+    func disablesProtectionWithZeroOverride() {
         let config = AutoShiftSymbolsConfig(
             timeoutMs: 200,
             protectFastTyping: false,
@@ -142,7 +142,7 @@ struct AutoShiftMappingGenerationTests {
             return
         }
         #expect(behavior.tapTimeout == 200)
-        #expect(behavior.requirePriorIdleOverrideMs == nil)
+        #expect(behavior.requirePriorIdleOverrideMs == 0)
     }
 
     @Test("Empty enabled keys produces no mappings")

--- a/guides/auto-shift.md
+++ b/guides/auto-shift.md
@@ -52,24 +52,24 @@ The configuration panel shows all 11 keys as toggleable chips — click any to d
 
 ---
 
-## Timing
+## Shift Hold Delay
 
-The **timeout** controls how long you hold before the shifted version fires:
+The **Shift hold delay** controls how long you hold before the shifted version fires:
 
 - **Default: 180ms** — fast enough that normal typing isn't affected, long enough that deliberate holds register
 - **Range: 100–400ms** — use the slider to adjust
 
 **Finding your sweet spot:**
-- If you accidentally get shifted symbols while typing fast → increase the timeout
-- If you have to hold too long to trigger shifts → decrease the timeout
+- If you accidentally get shifted symbols while deliberately holding a key → increase the shift hold delay
+- If you have to hold too long to trigger shifts → decrease the Shift hold delay
 
 ---
 
 ## Protect Fast Typing
 
-When enabled (default: ON), this prevents accidental shifts during fast typing. If you just pressed another key recently, the hold won't trigger — only deliberate pauses followed by a hold fire the shifted output.
+When enabled (default: ON), this prevents accidental shifts during fast typing. The **Fast-typing protection window** looks backward from the moment you press a symbol key. If another key was pressed within that window, Auto Shift forces the unshifted symbol instead of treating the key as a hold.
 
-This uses Kanata's `tap-hold-require-prior-idle` setting under the hood.
+This setting is separate from Shift hold delay: one controls how long you hold, while the other decides whether a recent keystroke should suppress hold detection.
 
 ---
 
@@ -83,11 +83,11 @@ This uses Kanata's `tap-hold-require-prior-idle` setting under the hood.
 
 ## Interaction with Home Row Mods
 
-Auto-Shift and [home row mods]({{ '/guides/home-row-mods/' | relative_url }}) both use tap-hold behavior. They coexist well because they apply to different keys (HRM applies to letters, Auto-Shift to symbols). The "Protect Fast Typing" setting is shared — whichever feature sets a higher idle threshold wins.
+Auto-Shift and [home row mods]({{ '/guides/home-row-mods/' | relative_url }}) both use tap-hold behavior. They coexist well because they apply to different keys (HRM applies to letters, Auto-Shift to symbols). Auto Shift's Fast-typing protection window applies only to Auto Shift symbol keys; it does not change the timing you configured for Home Row Mods or Home Row Layer Toggles.
 
 If you notice interactions between the two, try:
-1. Increasing the auto-shift timeout slightly (200–250ms)
-2. Keeping "Protect Fast Typing" on
+1. Increasing the Fast-typing protection window slightly (200–250ms)
+2. Keeping Fast-typing protection on
 
 ---
 
@@ -95,13 +95,13 @@ If you notice interactions between the two, try:
 
 ### I get shifted symbols when I don't want them
 
-- Increase the timeout (try 250ms)
-- Enable "Protect Fast Typing" if it's off
+- Increase the Fast-typing protection window (try 250ms)
+- Enable Fast-typing protection if it's off
 - Disable specific keys that misfire for you (click their chips to toggle off)
 
 ### The shifted symbol takes too long to appear
 
-- Decrease the timeout (try 150ms)
+- Decrease the Shift hold delay (try 150ms)
 - Note: there's inherent latency because the engine waits to see if you'll hold long enough
 
 ### Semicolons/commas feel laggy


### PR DESCRIPTION
Closes #1210

## What changed
- give Auto Shift a dedicated fast-typing protection window, independent of Shift hold delay
- render protection as a per-action `require-prior-idle` override so Auto Shift cannot change Home Row Mods or Home Row Layer Toggles timing
- preserve the old behavior when decoding existing configurations
- add generated-config regressions for Auto Shift alone and with each home-row feature
- update the Auto Shift UI and guide with the new terms and behavior

## Validation
- `mise exec -- swiftformat --lint` on changed Swift files
- `python3 Scripts/check-accessibility.py`
- `./Scripts/review-gate.sh` selected the required remote `claude-review` gate
- Local Swift test attempts were stopped at the five-minute cap while cold-compiling unrelated app targets; CI is the remaining runtime validation.