### PR TITLE
Clarify Leader timing terminology

### DIFF
--- a/Sources/KeyPathAppKit/Resources/Localizable.xcstrings
+++ b/Sources/KeyPathAppKit/Resources/Localizable.xcstrings
@@ -2146,6 +2146,22 @@
         }
       }
     },
+    "How long to hold the Leader key before KeyPath shows the Shortcut List.": {
+      "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "KeyPathがショートカットリストを表示するまでLeaderキーを押し続ける時間。"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "How long to hold the Leader key before KeyPath shows the Shortcut List."
+          }
+        }
+      }
+    },
     "How to Clean Up:": {
       "localizations": {
         "ja": {
@@ -2766,6 +2782,22 @@
           "stringUnit": {
             "state": "translated",
             "value": "Layer Changes"
+          }
+        }
+      }
+    },
+    "Leader hold delay": {
+      "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Leaderホールド遅延"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Leader hold delay"
           }
         }
       }

--- a/Sources/KeyPathAppKit/Resources/Localizable.xcstrings
+++ b/Sources/KeyPathAppKit/Resources/Localizable.xcstrings
@@ -2146,18 +2146,34 @@
         }
       }
     },
-    "How long to hold the Leader key before KeyPath shows the Shortcut List.": {
+    "Custom Leader hold delay in milliseconds": {
       "localizations": {
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "KeyPathがショートカットリストを表示するまでLeaderキーを押し続ける時間。"
+            "value": "カスタムLeaderホールド遅延（ミリ秒）"
           }
         },
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "How long to hold the Leader key before KeyPath shows the Shortcut List."
+            "value": "Custom Leader hold delay in milliseconds"
+          }
+        }
+      }
+    },
+    "How long to hold the Leader key before KeyPath shows the Shortcut List. Default is Long (300 ms). Medium (200 ms) matches previous behavior.": {
+      "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "KeyPathがショートカットリストを表示するまでLeaderキーを押し続ける時間。デフォルトは長め（300ミリ秒）です。標準（200ミリ秒）は以前の動作と同じです。"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "How long to hold the Leader key before KeyPath shows the Shortcut List. Default is Long (300 ms). Medium (200 ms) matches previous behavior."
           }
         }
       }

--- a/Sources/KeyPathAppKit/UI/Components/TimingCopy.swift
+++ b/Sources/KeyPathAppKit/UI/Components/TimingCopy.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 /// Shared, user-facing language for timing controls.
 ///
 /// Keep this focused on what a person experiences rather than the renderer's
@@ -43,6 +45,16 @@ enum TimingCopy {
 
     static let holdActivationDelay = "Hold activation delay"
     static let holdActivationDelayExplanation = "How long to hold this key before its hold action activates."
+    static let leaderHoldDelay = LocalizedStringResource(
+        "Leader hold delay",
+        bundle: #bundle,
+        comment: "Label for the setting that controls how long the Leader key must be held."
+    )
+    static let leaderHoldDelayExplanation = LocalizedStringResource(
+        "How long to hold the Leader key before KeyPath shows the Shortcut List.",
+        bundle: #bundle,
+        comment: "Explains that the Leader hold delay controls when the Shortcut List appears."
+    )
     static let multiTapWindow = "Multi-tap window"
     static let multiTapWindowExplanation = "After every tap, the window starts again. When it expires, KeyPath resolves the tap count."
     static let activateHoldOnOtherKeyPress = "Activate hold when another key is pressed"

--- a/Sources/KeyPathAppKit/UI/Components/TimingCopy.swift
+++ b/Sources/KeyPathAppKit/UI/Components/TimingCopy.swift
@@ -51,9 +51,14 @@ enum TimingCopy {
         comment: "Label for the setting that controls how long the Leader key must be held."
     )
     static let leaderHoldDelayExplanation = LocalizedStringResource(
-        "How long to hold the Leader key before KeyPath shows the Shortcut List.",
+        "How long to hold the Leader key before KeyPath shows the Shortcut List. Default is Long (300 ms). Medium (200 ms) matches previous behavior.",
         bundle: #bundle,
-        comment: "Explains that the Leader hold delay controls when the Shortcut List appears."
+        comment: "Explains the Leader hold delay and its default and compatibility presets."
+    )
+    static let customLeaderHoldDelayAccessibilityLabel = LocalizedStringResource(
+        "Custom Leader hold delay in milliseconds",
+        bundle: #bundle,
+        comment: "Accessibility label for the custom Leader hold delay field."
     )
     static let multiTapWindow = "Multi-tap window"
     static let multiTapWindowExplanation = "After every tap, the window starts again. When it expires, KeyPath resolves the tap count."

--- a/Sources/KeyPathAppKit/UI/ContextHUD/ContextHUDSettingsSection.swift
+++ b/Sources/KeyPathAppKit/UI/ContextHUD/ContextHUDSettingsSection.swift
@@ -85,18 +85,20 @@ struct ContextHUDSettingsSection: View {
                 VStack(alignment: .leading, spacing: 10) {
                     HStack {
                         HStack(spacing: 4) {
-                            Text("Hold Delay")
+                            Text(TimingCopy.leaderHoldDelay)
                                 .font(.subheadline)
                                 .foregroundColor(.secondary)
-                            InfoTip("Default is Long. Medium matches previous behavior.")
+                            InfoTip(String(localized: TimingCopy.leaderHoldDelayExplanation))
                         }
 
                         Spacer()
 
-                        Picker("Hold Delay", selection: $holdDelayPreset) {
+                        Picker(selection: $holdDelayPreset) {
                             ForEach(ContextHUDHoldDelayPreset.allCases, id: \.self) { preset in
                                 Text(preset.displayName).tag(preset)
                             }
+                        } label: {
+                            Text(TimingCopy.leaderHoldDelay)
                         }
                         .pickerStyle(.menu)
                         .labelsHidden()
@@ -106,7 +108,7 @@ struct ContextHUDSettingsSection: View {
                             customHoldDelayMs = services.preferences.contextHUDHoldDelayCustomMs
                         }
                         .accessibilityIdentifier("settings-context-hud-hold-delay-preset")
-                        .accessibilityLabel("Shortcut List hold delay preset")
+                        .accessibilityLabel(Text(TimingCopy.leaderHoldDelay))
                     }
 
                     if holdDelayPreset == .custom {
@@ -129,7 +131,7 @@ struct ContextHUDSettingsSection: View {
                                 customHoldDelayMs = services.preferences.contextHUDHoldDelayCustomMs
                             }
                             .accessibilityIdentifier("settings-context-hud-hold-delay-custom")
-                            .accessibilityLabel("Custom Shortcut List hold delay in milliseconds")
+                            .accessibilityLabel("Custom Leader hold delay in milliseconds")
                         }
                     }
                 }

--- a/Sources/KeyPathAppKit/UI/ContextHUD/ContextHUDSettingsSection.swift
+++ b/Sources/KeyPathAppKit/UI/ContextHUD/ContextHUDSettingsSection.swift
@@ -131,7 +131,7 @@ struct ContextHUDSettingsSection: View {
                                 customHoldDelayMs = services.preferences.contextHUDHoldDelayCustomMs
                             }
                             .accessibilityIdentifier("settings-context-hud-hold-delay-custom")
-                            .accessibilityLabel("Custom Leader hold delay in milliseconds")
+                            .accessibilityLabel(Text(TimingCopy.customLeaderHoldDelayAccessibilityLabel))
                         }
                     }
                 }

--- a/Sources/KeyPathAppKit/UI/Rules/HomeRowLayerTogglesModalView.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/HomeRowLayerTogglesModalView.swift
@@ -176,7 +176,7 @@ struct HomeRowLayerTogglesModalView: View {
                             }
 
                             VStack(alignment: .leading, spacing: 4) {
-                                Text("Hold delay")
+                                Text(localConfig.oppositeHandMode.decisionWindowLabel)
                                     .font(.subheadline)
                                     .foregroundColor(.secondary)
                                 HStack {
@@ -187,7 +187,7 @@ struct HomeRowLayerTogglesModalView: View {
                                             set: { localConfig.timing.holdDelay = $0 }
                                         ),
                                         accessibilityIdentifier: "home-row-layer-toggles-modal-hold-delay-field",
-                                        accessibilityLabel: "Hold delay"
+                                        accessibilityLabel: localConfig.oppositeHandMode.decisionWindowLabel
                                     )
                                     Text("ms")
                                         .font(.subheadline)
@@ -271,7 +271,7 @@ struct HomeRowLayerTogglesModalView: View {
 
                                 Divider().padding(.vertical, 4)
 
-                                Text("Per-Key Hold Offsets")
+                                Text("Per-key \(localConfig.oppositeHandMode.decisionWindowLabel.lowercased()) offsets")
                                     .font(.subheadline)
                                     .fontWeight(.bold)
 
@@ -295,14 +295,14 @@ struct HomeRowLayerTogglesModalView: View {
                                                         }
                                                     ),
                                                     accessibilityIdentifier: "home-row-layer-toggles-modal-hold-offset-\(key)-field",
-                                                    accessibilityLabel: "\(displayLabel(forCanonicalKey: key)) hold offset"
+                                                    accessibilityLabel: "\(displayLabel(forCanonicalKey: key)) \(localConfig.oppositeHandMode.decisionWindowLabel.lowercased()) offset"
                                                 )
                                             }
                                         }
                                         Spacer()
                                     }
                                 }
-                                Text("Extends hold delay for a key (e.g., `50` makes it easier to hold). Leave blank or `0` for default.")
+                                Text("Extends the \(localConfig.oppositeHandMode.decisionWindowLabel.lowercased()) for a key (e.g., `50` makes it easier to hold). Leave blank or `0` for default.")
                                     .font(.caption)
                                     .foregroundColor(.secondary)
                             }

--- a/Tests/KeyPathTests/UI/TimingCopyTests.swift
+++ b/Tests/KeyPathTests/UI/TimingCopyTests.swift
@@ -41,4 +41,12 @@ final class TimingCopyTests: XCTestCase {
         XCTAssertFalse(TimingCopy.showsHoldActivationDelay(for: .basic, isEditingTapDance: true))
         XCTAssertTrue(TimingCopy.showsHoldActivationDelay(for: .basic, isEditingTapDance: false))
     }
+
+    func testLeaderHoldDelayNamesTheKeyAndShortcutListOutcome() {
+        XCTAssertEqual(String(localized: TimingCopy.leaderHoldDelay), "Leader hold delay")
+        XCTAssertEqual(
+            String(localized: TimingCopy.leaderHoldDelayExplanation),
+            "How long to hold the Leader key before KeyPath shows the Shortcut List."
+        )
+    }
 }

--- a/Tests/KeyPathTests/UI/TimingCopyTests.swift
+++ b/Tests/KeyPathTests/UI/TimingCopyTests.swift
@@ -46,7 +46,11 @@ final class TimingCopyTests: XCTestCase {
         XCTAssertEqual(String(localized: TimingCopy.leaderHoldDelay), "Leader hold delay")
         XCTAssertEqual(
             String(localized: TimingCopy.leaderHoldDelayExplanation),
-            "How long to hold the Leader key before KeyPath shows the Shortcut List."
+            "How long to hold the Leader key before KeyPath shows the Shortcut List. Default is Long (300 ms). Medium (200 ms) matches previous behavior."
+        )
+        XCTAssertEqual(
+            String(localized: TimingCopy.customLeaderHoldDelayAccessibilityLabel),
+            "Custom Leader hold delay in milliseconds"
         )
     }
 }

--- a/guides/leader-key.md
+++ b/guides/leader-key.md
@@ -116,7 +116,7 @@ This is the "Caps Lock does everything" setup that many keyboard enthusiasts use
 
 ### Space feels laggy after enabling
 
-The tap/hold threshold (default 180ms) determines how long you must hold before it's a "hold" vs. a "tap." If typing feels sluggish:
+The **Leader hold delay** (default 180ms) determines how long you must hold before KeyPath treats the key as your Leader. If typing feels sluggish:
 - Practice releasing Space quickly between words
 - The threshold is tuned for most typists — give it a day before adjusting
 
@@ -130,5 +130,6 @@ Currently the four options (Space, Caps Lock, Tab, Backtick) are the supported l
 
 - **[Navigate Text Like a Keyboard Ninja]({{ '/guides/vim-navigation/' | relative_url }})** — The foundation layer that Leader activates
 - **[Shortcuts Without Reaching]({{ '/guides/home-row-mods/' | relative_url }})** — Combine Leader layers with home row modifiers
+- **[One Key, Multiple Actions]({{ '/guides/tap-hold/' | relative_url }})** — A glossary of KeyPath timing controls
 - **[Keyboard Concepts]({{ '/guides/concepts/' | relative_url }})** — Background on layers and momentary activation
 - **[Back to Docs](https://malpern.github.io/KeyPath/docs)**

--- a/guides/leader-key.md
+++ b/guides/leader-key.md
@@ -116,7 +116,7 @@ This is the "Caps Lock does everything" setup that many keyboard enthusiasts use
 
 ### Space feels laggy after enabling
 
-The **Leader hold delay** (default 180ms) determines how long you must hold before KeyPath treats the key as your Leader. If typing feels sluggish:
+The **Leader hold delay** (default: Long, 300 ms) determines how long you must hold before KeyPath treats the key as your Leader. The Medium preset (200 ms) matches previous behavior. If typing feels sluggish:
 - Practice releasing Space quickly between words
 - The threshold is tuned for most typists — give it a day before adjusting
 

--- a/guides/tap-hold.md
+++ b/guides/tap-hold.md
@@ -196,6 +196,7 @@ The editors use the same names wherever the underlying clock and outcome match:
 
 - **Repeat-tap window**: after you press the key, another key can still change how it resolves during this period.
 - **Hold activation delay**: how long to hold the key before its hold action activates.
+- **Leader hold delay**: how long to hold the Leader key before KeyPath shows the Shortcut List. This controls the Leader shortcut reference, not the timing of your other tap-hold rules.
 - **Typing grace period**: the release-order variant's short buffer; another key released during it makes this key a hold. It does not use a separate hold delay.
 - **Multi-tap window**: tap-dance's window for another tap. The clock starts again after every tap; when it expires, KeyPath resolves the tap count.
 


### PR DESCRIPTION
## What changed
- Rename the Shortcut List setting to **Leader hold delay** and explain its concrete outcome.
- Add localized shared timing copy and match the accessibility label.
- Make Home Row Layer Toggles use its mode-specific timing label instead of a generic hold delay.
- Add the Leader term to the tap-hold glossary and Leader-key guide.

## Why
The setting was labelled only “Hold Delay,” which did not say that it controls the Leader hold used to show the Shortcut List. The affected editor also retained generic timing wording when its activation model changed.

## Validation
- `python3 Scripts/check-accessibility.py` passed.
- Localization catalog parsed successfully with `jq` and the diff passed whitespace checks.
- The focused `TimingCopyTests` run was stopped at the five-minute cold-build cutoff before tests executed; CI should run the test suite.

Closes #1214.