### PR TITLE
Clarify rule activation hints

### DIFF
--- a/Sources/KeyPathAppKit/Models/KeyboardConceptCopy.swift
+++ b/Sources/KeyPathAppKit/Models/KeyboardConceptCopy.swift
@@ -5,6 +5,14 @@ import KeyPathRulesCore
 /// Keep first-use UI copy based on these definitions so Leader and Hyper do not
 /// acquire different meanings in the catalog, editors, and onboarding.
 enum KeyboardConceptCopy {
+    /// Formats the primary instruction shown on a rule card.
+    ///
+    /// Keep activation separate from counts, delays, and prerequisites: those
+    /// describe a rule, but do not tell someone what to physically do.
+    static func activationHint(_ instruction: String) -> String {
+        "Use: \(instruction)"
+    }
+
     static let leaderMeaning =
         "Your Leader key is the starting key for KeyPath layers and sequences."
 

--- a/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView+CollectionRow.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView+CollectionRow.swift
@@ -282,7 +282,6 @@ struct ExpandableCollectionRow: View {
                             Label(hint, systemImage: "hand.point.up.left")
                                 .font(.caption)
                                 .foregroundColor(.accentColor)
-                                .accessibilityLabel(hint)
                             if let activationDetail {
                                 Text(activationDetail)
                                     .font(.caption)
@@ -303,6 +302,7 @@ struct ExpandableCollectionRow: View {
             .frame(maxWidth: .infinity, alignment: .leading)
             .accessibilityIdentifier("rules-summary-expand-button-\(collectionId)")
             .accessibilityLabel(isExpanded ? "Collapse \(name)" : "Expand \(name)")
+            .accessibilityHint(activationAccessibilityHint)
             .accessibilityValue(effectiveEnabled ? "on" : "off")
 
             // Help button (only for collections that provide one)
@@ -357,6 +357,13 @@ struct ExpandableCollectionRow: View {
             }
         }
         .padding(12)
+    }
+
+    private var activationAccessibilityHint: String? {
+        let hint = [activationHint, activationDetail]
+            .compactMap { $0 }
+            .joined(separator: ". ")
+        return hint.isEmpty ? nil : hint
     }
 
     @ViewBuilder

--- a/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView+CollectionRow.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView+CollectionRow.swift
@@ -42,7 +42,7 @@ struct ExpandableCollectionRow: View {
     /// Optional activation hint from collection (overrides default formatting)
     var activationHint: String?
     /// Supporting activation metadata, kept separate from the physical instruction.
-    var activationDetail: String? = nil
+    var activationDetail: String?
     var managingPackName: String?
     var onManagedToggleTapped: (() -> Void)?
     var defaultExpanded: Bool = false

--- a/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView+CollectionRow.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView+CollectionRow.swift
@@ -41,6 +41,8 @@ struct ExpandableCollectionRow: View {
     var leaderKeyDisplay: String = "␣ Space"
     /// Optional activation hint from collection (overrides default formatting)
     var activationHint: String?
+    /// Supporting activation metadata, kept separate from the physical instruction.
+    var activationDetail: String? = nil
     var managingPackName: String?
     var onManagedToggleTapped: (() -> Void)?
     var defaultExpanded: Bool = false
@@ -280,6 +282,12 @@ struct ExpandableCollectionRow: View {
                             Label(hint, systemImage: "hand.point.up.left")
                                 .font(.caption)
                                 .foregroundColor(.accentColor)
+                                .accessibilityLabel(hint)
+                            if let activationDetail {
+                                Text(activationDetail)
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                            }
                         } else if layerActivator != nil {
                             Label("Hold \(leaderKeyDisplay)", systemImage: "hand.point.up.left")
                                 .font(.caption)

--- a/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView+CollectionRow.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView+CollectionRow.swift
@@ -302,7 +302,7 @@ struct ExpandableCollectionRow: View {
             .frame(maxWidth: .infinity, alignment: .leading)
             .accessibilityIdentifier("rules-summary-expand-button-\(collectionId)")
             .accessibilityLabel(isExpanded ? "Collapse \(name)" : "Expand \(name)")
-            .accessibilityHint(activationAccessibilityHint)
+            .accessibilityHint(activationAccessibilityHint ?? "")
             .accessibilityValue(effectiveEnabled ? "on" : "off")
 
             // Help button (only for collections that provide one)

--- a/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView+DynamicDisplay.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView+DynamicDisplay.swift
@@ -47,7 +47,7 @@ extension RulesTabView {
         let tapLabel = config.tapOptions.first { $0.output == tapOutput }?.label ?? tapOutput
         let holdLabel = config.holdOptions.first { $0.output == holdOutput }?.label ?? holdOutput
 
-        return "Tap: \(tapLabel), Hold: \(holdLabel)"
+        return KeyboardConceptCopy.activationHint("Tap for \(tapLabel), or hold for \(holdLabel)")
     }
 
     /// Generate a dynamic description for launcher collections
@@ -74,19 +74,20 @@ extension RulesTabView {
     /// Generate a dynamic activation hint for launcher collections
     func dynamicLauncherActivationHint(for collection: RuleCollection) -> String {
         guard case let .launcherGrid(config) = collection.configuration else {
-            return collection.activationHint ?? "Hold Hyper key"
+            return collection.activationHint.map(KeyboardConceptCopy.activationHint)
+                ?? KeyboardConceptCopy.activationHint("Hold Hyper, then press a shortcut key")
         }
 
         switch config.activationMode {
         case .holdHyper:
             switch config.hyperTriggerMode {
             case .hold:
-                return "Hold Hyper key"
+                return KeyboardConceptCopy.activationHint("Hold Hyper, then press a shortcut key")
             case .tap:
-                return "Tap Hyper key"
+                return KeyboardConceptCopy.activationHint("Tap Hyper to turn the launcher on or off, then press a shortcut key")
             }
         case .leaderSequence:
-            return "\(currentLeaderKeyDisplay) → L"
+            return KeyboardConceptCopy.activationHint("Hold \(currentLeaderKeyDisplay), then press L, then a shortcut key")
         }
     }
 
@@ -98,16 +99,27 @@ extension RulesTabView {
         if case .tapHoldPicker = collection.configuration {
             return dynamicTapHoldActivationHint(for: collection)
         }
-        if case let .autoShiftSymbols(config) = collection.configuration {
-            return "\(config.enabledKeys.count) keys \u{00B7} \(config.timeoutMs)ms hold"
+        if case .autoShiftSymbols = collection.configuration {
+            return KeyboardConceptCopy.activationHint("Hold a supported key to type its shifted symbol")
         }
         if let wsMode = collection.windowSnappingActivationMode {
             switch wsMode {
-            case .leader: return "\(currentLeaderKeyDisplay) → w → action key"
-            case .quickLauncher: return "Hyper + w → action key"
+            case .leader:
+                return KeyboardConceptCopy.activationHint("Hold \(currentLeaderKeyDisplay), then press W, then an action key")
+            case .quickLauncher:
+                return KeyboardConceptCopy.activationHint("Hold Hyper, then press W, then an action key")
             }
         }
-        return collection.activationHint
+        return collection.activationHint.map(KeyboardConceptCopy.activationHint)
+    }
+
+    /// Returns tunable activation metadata without competing with the action-first hint.
+    func dynamicActivationDetail(for collection: RuleCollection) -> String? {
+        guard case let .autoShiftSymbols(config) = collection.configuration else {
+            return nil
+        }
+
+        return "\(config.enabledKeys.count) supported keys · Hold delay \(config.timeoutMs) ms"
     }
 
     /// Generate a dynamic name for picker-style collections

--- a/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView+RowBuilder.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView+RowBuilder.swift
@@ -44,6 +44,7 @@ extension RulesTabView {
             layerActivator: collection.momentaryActivator,
             leaderKeyDisplay: currentLeaderKeyDisplay,
             activationHint: dynamicActivationHint(for: collection),
+            activationDetail: dynamicActivationDetail(for: collection),
             managingPackName: collectionOwnershipMap[collection.id]?.packName,
             onManagedToggleTapped: collectionOwnershipMap[collection.id] != nil ? {
                 managedToggleCollection = collection

--- a/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView.swift
@@ -70,11 +70,15 @@ struct RulesTabView: View {
         let catalog = RuleCollectionCatalog()
         return catalog.defaultCollections().compactMap { catalogCollection in
             // Hide pack-internal collections from the Rules tab
-            if catalogCollection.owningPackID != nil { return nil }
+            if catalogCollection.owningPackID != nil {
+                return nil
+            }
             // Find matching collection from kanataManager to preserve enabled state
             if var existing = kanataManager.ruleCollections.first(where: { $0.id == catalogCollection.id }) {
                 // Also hide if the persisted copy gained an owningPackID
-                if existing.owningPackID != nil { return nil }
+                if existing.owningPackID != nil {
+                    return nil
+                }
                 // Always use catalog category (user data may have stale values)
                 existing.category = catalogCollection.category
                 return existing
@@ -355,6 +359,7 @@ struct RulesTabView: View {
                                     NotificationCenter.default.post(name: .openOverlayWithMapper, object: nil)
                                 },
                                 description: isSearching ? "Filtered custom rules" : "Remap any key combination or sequence",
+                                activationDetail: nil,
                                 defaultExpanded: !hasAnyCustomRules,
                                 scrollID: "custom-rules",
                                 scrollProxy: scrollProxy
@@ -574,7 +579,11 @@ struct RulesTabView: View {
         // Dependency: config mismatch dialog (can't auto-resolve)
         .alert("Missing Configuration", isPresented: Binding(
             get: { pendingEnablePack != nil },
-            set: { if !$0 { pendingEnablePack = nil; pendingEnableUnmetDeps = [] } }
+            set: {
+                if !$0 {
+                    pendingEnablePack = nil; pendingEnableUnmetDeps = []
+                }
+            }
         )) {
             if let depPackID = pendingEnableUnmetDeps.first?.dependency.packID,
                let depPack = PackRegistry.pack(id: depPackID)
@@ -597,7 +606,11 @@ struct RulesTabView: View {
         // Dependency: disable warning dialog
         .alert("Other Rules Depend on This", isPresented: Binding(
             get: { pendingDisablePack != nil },
-            set: { if !$0 { pendingDisablePack = nil; pendingDisableDependents = [] } }
+            set: {
+                if !$0 {
+                    pendingDisablePack = nil; pendingDisableDependents = []
+                }
+            }
         )) {
             Button("Disable Anyway", role: .destructive) {
                 if let pack = pendingDisablePack,
@@ -623,7 +636,11 @@ struct RulesTabView: View {
         }
         .alert("Part of a Pack", isPresented: Binding(
             get: { managedToggleCollection != nil },
-            set: { if !$0 { managedToggleCollection = nil } }
+            set: {
+                if !$0 {
+                    managedToggleCollection = nil
+                }
+            }
         )) {
             if let collection = managedToggleCollection,
                let owner = collectionOwnershipMap[collection.id]

--- a/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView.swift
@@ -630,6 +630,7 @@ struct RulesTabView: View {
                 pendingDisablePack = nil
                 pendingDisableDependents = []
             }
+            .accessibilityIdentifier("rules-summary-cancel-disable-pack")
         } message: {
             let names = pendingDisableDependents.map(\.name).joined(separator: ", ")
             Text("Disabling \(pendingDisablePack?.name ?? "") will affect: \(names)")
@@ -658,6 +659,7 @@ struct RulesTabView: View {
             Button("Cancel", role: .cancel) {
                 managedToggleCollection = nil
             }
+            .accessibilityIdentifier("rules-summary-cancel-managed-pack-toggle")
         } message: {
             if let collection = managedToggleCollection,
                let owner = collectionOwnershipMap[collection.id]

--- a/Tests/KeyPathTests/KeyboardConceptCopyTests.swift
+++ b/Tests/KeyPathTests/KeyboardConceptCopyTests.swift
@@ -3,6 +3,13 @@ import KeyPathRulesCore
 import XCTest
 
 final class KeyboardConceptCopyTests: XCTestCase {
+    func testActivationHintUsesActionFirstPrefix() {
+        XCTAssertEqual(
+            KeyboardConceptCopy.activationHint("Hold Hyper, then press a shortcut key"),
+            "Use: Hold Hyper, then press a shortcut key"
+        )
+    }
+
     func testDefinitionsDistinguishLeaderFromHyper() {
         XCTAssertTrue(KeyboardConceptCopy.leaderDefinition.contains("starting key"))
         XCTAssertTrue(KeyboardConceptCopy.leaderDefinition.contains("Space by default"))


### PR DESCRIPTION
Closes #1226

## What changed
- Standardized dynamic rule-card activation copy around an action-first `Use:` instruction.
- Added a separate Auto Shift detail line for key count and hold delay.
- Exposed the same action text to VoiceOver.

## Why
Bare key paths and timing values did not consistently answer what someone should physically do to use a rule.

## Validation
- `swift build --target KeyPathAppKit --jobs 4`
- `python3 Scripts/check-accessibility.py`
- `git diff --check`
- `./Scripts/review-gate.sh` (remote review gate selected)

The focused `KeyboardConceptCopyTests` run was stopped after exceeding the five-minute local cap in a cold worktree; CI will run the full test lane.