### PR TITLE
Clarify community-derived rule names

### DIFF
--- a/Sources/KeyPathAppKit/CLI/PacksFacade.swift
+++ b/Sources/KeyPathAppKit/CLI/PacksFacade.swift
@@ -2,6 +2,13 @@ import Foundation
 import KeyPathCore
 
 public struct PacksFacade: Sendable {
+    /// Previous user-facing names that remain accepted by the CLI after a pack
+    /// receives a clearer display name. Pack IDs remain the durable identity.
+    private static let legacyNameAliases = [
+        "ben vallack nav": "com.keypath.pack.vallack-system",
+        "vallack": "com.keypath.pack.vallack-system"
+    ]
+
     /// Test seam: overrides the manager used by install/uninstall/configure so tests
     /// can inject temp-backed stores instead of the shared persistent ones (#953).
     private let managerFactory: (@Sendable @MainActor () async -> RuleCollectionsManager)?
@@ -215,6 +222,12 @@ public struct PacksFacade: Sendable {
         let allPacks = PackRegistry.starterKit
 
         if let pack = allPacks.first(where: { $0.id == nameOrId }) {
+            return pack
+        }
+
+        if let packID = Self.legacyNameAliases[nameOrId.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()],
+           let pack = allPacks.first(where: { $0.id == packID })
+        {
             return pack
         }
 

--- a/Sources/KeyPathAppKit/CLI/PacksFacade.swift
+++ b/Sources/KeyPathAppKit/CLI/PacksFacade.swift
@@ -224,20 +224,6 @@ public struct PacksFacade: Sendable {
             return pack
         }
 
-        let legacyNameMatches = allPacks.filter { pack in
-            Self.legacyNamesByPackID[pack.id, default: []].contains { legacyName in
-                legacyName.localizedCaseInsensitiveContains(nameOrId)
-            }
-        }
-        if legacyNameMatches.count == 1 { return legacyNameMatches[0] }
-        if legacyNameMatches.count > 1 {
-            throw AmbiguousPackMatch(
-                query: nameOrId,
-                matches: legacyNameMatches.map { .init(name: $0.name, id: $0.id) },
-                hint: "Multiple packs match this legacy name. Use the full ID to disambiguate."
-            )
-        }
-
         let prefix = "com.keypath.pack."
         let slugMatches = allPacks.filter { pack in
             guard pack.id.hasPrefix(prefix) else { return false }
@@ -265,8 +251,11 @@ public struct PacksFacade: Sendable {
             )
         }
 
-        let substringMatches = allPacks.filter {
-            $0.name.localizedCaseInsensitiveContains(nameOrId)
+        let substringMatches = allPacks.filter { pack in
+            pack.name.localizedCaseInsensitiveContains(nameOrId)
+                || Self.legacyNamesByPackID[pack.id, default: []].contains {
+                    $0.localizedCaseInsensitiveContains(nameOrId)
+                }
         }
         if substringMatches.count == 1 { return substringMatches[0] }
         if substringMatches.count > 1 {

--- a/Sources/KeyPathAppKit/CLI/PacksFacade.swift
+++ b/Sources/KeyPathAppKit/CLI/PacksFacade.swift
@@ -4,9 +4,8 @@ import KeyPathCore
 public struct PacksFacade: Sendable {
     /// Previous user-facing names that remain accepted by the CLI after a pack
     /// receives a clearer display name. Pack IDs remain the durable identity.
-    private static let legacyNameAliases = [
-        "ben vallack nav": "com.keypath.pack.vallack-system",
-        "vallack": "com.keypath.pack.vallack-system"
+    private static let legacyNamesByPackID = [
+        PackRegistry.vallackSystem.id: ["Ben Vallack Nav"]
     ]
 
     /// Test seam: overrides the manager used by install/uninstall/configure so tests
@@ -225,10 +224,18 @@ public struct PacksFacade: Sendable {
             return pack
         }
 
-        if let packID = Self.legacyNameAliases[nameOrId.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()],
-           let pack = allPacks.first(where: { $0.id == packID })
-        {
-            return pack
+        let legacyNameMatches = allPacks.filter { pack in
+            Self.legacyNamesByPackID[pack.id, default: []].contains { legacyName in
+                legacyName.localizedCaseInsensitiveContains(nameOrId)
+            }
+        }
+        if legacyNameMatches.count == 1 { return legacyNameMatches[0] }
+        if legacyNameMatches.count > 1 {
+            throw AmbiguousPackMatch(
+                query: nameOrId,
+                matches: legacyNameMatches.map { .init(name: $0.name, id: $0.id) },
+                hint: "Multiple packs match this legacy name. Use the full ID to disambiguate."
+            )
         }
 
         let prefix = "com.keypath.pack."

--- a/Sources/KeyPathAppKit/Resources/rule-collection-catalog.json
+++ b/Sources/KeyPathAppKit/Resources/rule-collection-catalog.json
@@ -1278,7 +1278,7 @@
 
     ],
     "name" : "Chord Groups",
-    "summary" : "Multi-key combinations (Ben Vallack style) for efficient navigation and editing",
+    "summary" : "Multi-key combinations for efficient navigation and editing, with an optional Ben Vallack-inspired preset",
     "tags" : [
       "chords",
       "defchords",
@@ -3188,7 +3188,7 @@
         "input" : ";"
       }
     ],
-    "name" : "Ben Vallack Nav",
+    "name" : "Home Row Navigation System",
     "summary" : "Hold F or J for arrows, clipboard, tab switching, and line navigation — fingers never leave the home row.",
     "tags" : [
       "vallack",

--- a/Sources/KeyPathAppKit/Services/Packs/PackRegistry.swift
+++ b/Sources/KeyPathAppKit/Services/Packs/PackRegistry.swift
@@ -657,7 +657,7 @@ public enum PackRegistry {
     public static let vallackSystem = Pack(
         id: "com.keypath.pack.vallack-system",
         version: "1.0.0",
-        name: "Ben Vallack Nav",
+        name: "Home Row Navigation System",
         tagline: "Your fingers stay put, the keyboard changes",
         shortDescription:
         "Navigate, copy, paste, and switch tabs without your fingers leaving the home row. Inspired by [Ben Vallack](https://www.youtube.com/@BenVallacksKeyboards) — hold an index finger to transform your keyboard into a navigation surface, with modifiers on the top row so nothing competes for space.",
@@ -670,12 +670,12 @@ public enum PackRegistry {
         managedDefaults: [
             ManagedCollectionDefault(
                 collectionID: RuleCollectionIdentifier.vallackNavigation,
-                displayName: "Vallack Navigation"
+                displayName: "Navigation Layer"
             ),
             ManagedCollectionDefault(
                 collectionID: RuleCollectionIdentifier.homeRowMods,
                 defaultConfiguration: .homeRowMods(HomeRowModsConfig.vallackDefault),
-                displayName: "Ben's Modifiers"
+                displayName: "Top-Row Modifiers"
             ),
             ManagedCollectionDefault(
                 collectionID: RuleCollectionIdentifier.homeRowLayerToggles,
@@ -686,7 +686,7 @@ public enum PackRegistry {
                     toggleMode: .whileHeld,
                     oppositeHandMode: .press
                 )),
-                displayName: "Vallack Layer Toggles"
+                displayName: "Index-Finger Layer Toggles"
             ),
             ManagedCollectionDefault(
                 collectionID: RuleCollectionIdentifier.homeRowArrows,

--- a/Sources/KeyPathAppKit/UI/Rules/ChordGroupsCollectionView.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/ChordGroupsCollectionView.swift
@@ -81,7 +81,7 @@ struct ChordGroupsCollectionView: View {
             }
         }
         .animation(.easeInOut(duration: 0.25), value: showDetails)
-        .alert("Load Ben Vallack Preset?", isPresented: $showPresetConfirmation) {
+        .alert("Load Home-Row Chords (Ben Vallack preset)?", isPresented: $showPresetConfirmation) {
             Button("Cancel", role: .cancel) {}
             Button("Load Preset") {
                 confirmLoadPreset()
@@ -123,7 +123,7 @@ struct ChordGroupsCollectionView: View {
             // Quick actions
             Menu {
                 Button(action: loadBenVallackPreset) {
-                    Label("Load Ben Vallack Preset", systemImage: "wand.and.stars")
+                    Label("Load Home-Row Chords (Ben Vallack preset)", systemImage: "wand.and.stars")
                 }
 
                 Button(action: addNewGroup) {
@@ -159,7 +159,7 @@ struct ChordGroupsCollectionView: View {
 
             HStack(spacing: 12) {
                 Button(action: loadBenVallackPreset) {
-                    Label("Load Ben Vallack Preset", systemImage: "wand.and.stars")
+                    Label("Load Home-Row Chords (Ben Vallack preset)", systemImage: "wand.and.stars")
                 }
                 .buttonStyle(.bordered)
                 .accessibilityIdentifier("chord-groups-load-preset-button")

--- a/Tests/KeyPathTests/CLI/PacksFacadeTests.swift
+++ b/Tests/KeyPathTests/CLI/PacksFacadeTests.swift
@@ -48,7 +48,13 @@ final class PacksFacadeTests: XCTestCase {
 
     func testResolvePack_LegacyDisplayName_ReturnsMatch() throws {
         let facade = PacksFacade()
-        let pack = try facade.resolvePack(nameOrId: "Vallack")
+        let pack = try facade.resolvePack(nameOrId: "Ben Vallack")
+        XCTAssertEqual(pack?.id, "com.keypath.pack.vallack-system")
+    }
+
+    func testResolvePack_FullLegacyDisplayName_ReturnsMatch() throws {
+        let facade = PacksFacade()
+        let pack = try facade.resolvePack(nameOrId: "Ben Vallack Nav")
         XCTAssertEqual(pack?.id, "com.keypath.pack.vallack-system")
     }
 

--- a/Tests/KeyPathTests/CLI/PacksFacadeTests.swift
+++ b/Tests/KeyPathTests/CLI/PacksFacadeTests.swift
@@ -185,7 +185,7 @@ final class PacksFacadeTests: XCTestCase {
             query: "Nav",
             matches: [
                 .init(name: "Vim Navigation", id: "com.keypath.pack.vim-navigation"),
-                .init(name: "Ben Vallack Nav", id: "com.keypath.pack.vallack-system")
+                .init(name: "Home Row Navigation System", id: "com.keypath.pack.vallack-system")
             ]
         )
         XCTAssertTrue(err.description.contains("2 packs"))

--- a/Tests/KeyPathTests/CLI/PacksFacadeTests.swift
+++ b/Tests/KeyPathTests/CLI/PacksFacadeTests.swift
@@ -46,9 +46,15 @@ final class PacksFacadeTests: XCTestCase {
 
     // MARK: - resolvePack: by substring
 
-    func testResolvePack_SubstringUnique_ReturnsMatch() throws {
+    func testResolvePack_LegacyDisplayName_ReturnsMatch() throws {
         let facade = PacksFacade()
         let pack = try facade.resolvePack(nameOrId: "Vallack")
+        XCTAssertEqual(pack?.id, "com.keypath.pack.vallack-system")
+    }
+
+    func testResolvePack_CurrentDisplayNameSubstring_ReturnsMatch() throws {
+        let facade = PacksFacade()
+        let pack = try facade.resolvePack(nameOrId: "Home Row Navigation System")
         XCTAssertEqual(pack?.id, "com.keypath.pack.vallack-system")
     }
 

--- a/Tests/KeyPathTests/Integration/ConfigValidationTests.swift
+++ b/Tests/KeyPathTests/Integration/ConfigValidationTests.swift
@@ -183,7 +183,7 @@ final class ConfigValidationTests: XCTestCase {
             ("Auto Shift Symbols", RuleCollectionIdentifier.autoShiftSymbols),
             ("Fast Navigation", RuleCollectionIdentifier.keyRepeatControl),
             ("Home Row Arrows", RuleCollectionIdentifier.homeRowArrows),
-            ("Ben Vallack Nav", RuleCollectionIdentifier.vallackNavigation),
+            ("Home Row Navigation System", RuleCollectionIdentifier.vallackNavigation),
             ("Quick Launcher", RuleCollectionIdentifier.launcher)
         ]
 

--- a/Tests/KeyPathTests/Integration/PerRuleOptionCoverageTests.swift
+++ b/Tests/KeyPathTests/Integration/PerRuleOptionCoverageTests.swift
@@ -27,7 +27,7 @@ final class PerRuleOptionCoverageTests: XCTestCase {
             RuleCollectionIdentifier.autoShiftSymbols: ("Auto Shift Symbols", .autoShiftSymbols),
             RuleCollectionIdentifier.keyRepeatControl: ("Fast Navigation", .keyRepeatControl),
             RuleCollectionIdentifier.homeRowArrows: ("Home Row Arrows", .layerPresetPicker),
-            RuleCollectionIdentifier.vallackNavigation: ("Ben Vallack Nav", .table),
+            RuleCollectionIdentifier.vallackNavigation: ("Home Row Navigation System", .table),
             RuleCollectionIdentifier.launcher: ("Quick Launcher", .launcherGrid)
         ]
 

--- a/Tests/KeyPathTests/PackOwnershipTests.swift
+++ b/Tests/KeyPathTests/PackOwnershipTests.swift
@@ -98,10 +98,10 @@ final class PackOwnershipTests: XCTestCase {
             RuleCollectionIdentifier.homeRowArrows
         )
 
-        XCTAssertEqual(navOwner?.packName, "Ben Vallack Nav")
-        XCTAssertEqual(hrmOwner?.packName, "Ben Vallack Nav")
-        XCTAssertEqual(togglesOwner?.packName, "Ben Vallack Nav")
-        XCTAssertEqual(arrowsOwner?.packName, "Ben Vallack Nav")
+        XCTAssertEqual(navOwner?.packName, "Home Row Navigation System")
+        XCTAssertEqual(hrmOwner?.packName, "Home Row Navigation System")
+        XCTAssertEqual(togglesOwner?.packName, "Home Row Navigation System")
+        XCTAssertEqual(arrowsOwner?.packName, "Home Row Navigation System")
     }
 
     // MARK: - Self-managed badge filtering

--- a/guides/chords.md
+++ b/guides/chords.md
@@ -21,7 +21,7 @@ This technique was popularized by [Ben Vallack](https://www.youtube.com/@BenVall
 1. Open KeyPath and click the gear icon to open the inspector panel
 2. Go to the **Rules** tab
 3. Find **Chord Groups** and toggle it **on**
-4. Choose **Load Ben Vallack Preset** for a ready-made starting point, or **Create Custom** to build your own
+4. Choose **Load Home-Row Chords (Ben Vallack preset)** for a ready-made starting point, or **Create Custom** to build your own
 
 The preset gives you:
 - `S + D` → Escape

--- a/guides/packs.md
+++ b/guides/packs.md
@@ -87,11 +87,11 @@ Even if you've never used Vim, the arrow key layout is worth learning. Your fing
 
 [Full guide &rarr;]({{ '/guides/vim-navigation/' | relative_url }})
 
-### Ben Vallack Nav
+### Home Row Navigation System
 
 A complete navigation system inspired by keyboard minimalist [Ben Vallack](https://www.youtube.com/@BenVallacksKeyboards). Hold an index finger key to transform your keyboard into a navigation surface, with modifiers on the top row so nothing competes for space.
 
-Installs three coordinated collections: Vallack Navigation, Ben's Modifiers, and Vallack Layer Toggles. This is an opinionated alternative to the default Vim Navigation — use one or the other, not both.
+Installs three coordinated collections: Navigation Layer, Top-Row Modifiers, and Index-Finger Layer Toggles. This is an opinionated alternative to the default Vim Navigation — use one or the other, not both.
 
 [Full guide &rarr;]({{ '/guides/vallack-nav/' | relative_url }})
 

--- a/guides/vallack-nav.md
+++ b/guides/vallack-nav.md
@@ -127,9 +127,9 @@ When you install the Home Row Navigation System pack, KeyPath sets up three coor
 
 | Collection | What it does |
 |-----------|-------------|
-| **Navigation Layer** | The layer mappings — arrows, clipboard, tab switching, line navigation |
-| **Top-Row Modifiers** | Top-row modifiers (Q/W/E and U/I/O) instead of standard home row mods |
-| **Index-Finger Layer Toggles** | F and J as hold-to-activate triggers for the navigation layer |
+| **Home Row Navigation System** | The layer mappings — arrows, clipboard, tab switching, line navigation |
+| **Top Row Mods** | Top-row modifiers (Q/W/E and U/I/O) instead of standard home row mods |
+| **Home Row Layer Toggles** | F and J as hold-to-activate triggers for the navigation layer |
 
 These three are designed to work as a system. Installing the pack enables all three and configures them to the Vallack defaults. You can adjust individual settings in each collection if you want to customize.
 

--- a/guides/vallack-nav.md
+++ b/guides/vallack-nav.md
@@ -1,13 +1,13 @@
 ---
 layout: default
-title: "Ben Vallack Navigation"
+title: "Home Row Navigation System"
 description: "A complete home row navigation system inspired by keyboard minimalist Ben Vallack"
 theme: parchment
 header_image: header-vallack-nav.png
 permalink: /guides/vallack-nav/
 ---
 
-# Ben Vallack Navigation
+# Home Row Navigation System
 
 This pack is a complete home row navigation system inspired by [Ben Vallack](https://www.youtube.com/@BenVallacksKeyboards), a keyboard designer and YouTuber known for pushing the limits of what a keyboard can do. His channel explores minimal keyboard layouts, custom firmware, and the idea that your fingers should never leave the home row — for anything.
 
@@ -123,13 +123,13 @@ This frees the entire home row for navigation and typing. No conflicts — modif
 
 ## Three collections working together
 
-When you install the Ben Vallack Nav pack, KeyPath sets up three coordinated collections:
+When you install the Home Row Navigation System pack, KeyPath sets up three coordinated collections. It is inspired by Ben Vallack's home-row layout:
 
 | Collection | What it does |
 |-----------|-------------|
-| **Vallack Navigation** | The layer mappings — arrows, clipboard, tab switching, line navigation |
-| **Ben's Modifiers** | Top-row modifiers (Q/W/E and U/I/O) instead of standard home row mods |
-| **Vallack Layer Toggles** | F and J as hold-to-activate triggers for the navigation layer |
+| **Navigation Layer** | The layer mappings — arrows, clipboard, tab switching, line navigation |
+| **Top-Row Modifiers** | Top-row modifiers (Q/W/E and U/I/O) instead of standard home row mods |
+| **Index-Finger Layer Toggles** | F and J as hold-to-activate triggers for the navigation layer |
 
 These three are designed to work as a system. Installing the pack enables all three and configures them to the Vallack defaults. You can adjust individual settings in each collection if you want to customize.
 
@@ -153,7 +153,7 @@ These three are designed to work as a system. Installing the pack enables all th
 ## Installing
 
 1. Open the **Pack Gallery**
-2. Find **Ben Vallack Nav** and click **Install**
+2. Find **Home Row Navigation System** and click **Install**
 3. KeyPath will ask about conflicts if you have Home Row Mods or Vim Navigation enabled — the Vallack system replaces both
 
 Or from the command line:


### PR DESCRIPTION
Closes #1227

## What changed
- Renamed the Vallack system pack and its managed collections around their behavior.
- Retained Ben Vallack attribution in supporting copy and the optional chord preset.
- Preserved pack IDs, collection IDs, and guide URLs; updated compatibility expectations.

## Validation
- `jq empty Sources/KeyPathAppKit/Resources/rule-collection-catalog.json`
- `python3 Scripts/check-accessibility.py`
- `git diff --check`
- `./Scripts/review-gate.sh` (remote review selected)
- Focused `PackOwnershipTests` is still compiling in the cold worktree; CI will run the full test lane.