### PR TITLE
Prevent false VirtualHID safety stops

### DIFF
--- a/Sources/KeyPathAppKit/Services/MainAppStateController.swift
+++ b/Sources/KeyPathAppKit/Services/MainAppStateController.swift
@@ -62,6 +62,7 @@ class MainAppStateController {
     @ObservationIgnored private weak var serviceLifecycle: ServiceLifecycleCoordinator?
     @ObservationIgnored private var onSystemHealthy: (() -> Void)?
     @ObservationIgnored private var hasRunInitialValidation = false
+    @ObservationIgnored private var vhidConfirmedFailureCount = 0
 
     /// Returns true if configure() has been called.
     /// Use this to assert initialization order invariants.
@@ -299,17 +300,23 @@ class MainAppStateController {
                 // W3 safety exception: this background mutation only stops remapping
                 // to prevent unsafe keyboard capture; it must not perform repair.
                 if isHealthy {
-                    let vhidHealthy = await ServiceHealthChecker.shared.isServiceHealthy(
-                        serviceID: ServiceHealthChecker.vhidDaemonServiceID
+                    let vhidStatus = await ServiceHealthChecker.shared.vhidSafetyStatus()
+                    vhidConfirmedFailureCount = VHIDSafetyCheck.confirmedFailureCount(
+                        after: vhidStatus,
+                        previousCount: vhidConfirmedFailureCount
                     )
                     if VHIDSafetyCheck.shouldEmergencyStop(
-                        kanataRunning: true, vhidDaemonHealthy: vhidHealthy
+                        kanataRunning: true,
+                        confirmedFailureCount: vhidConfirmedFailureCount
                     ) {
                         AppLogger.shared.error(
-                            "🚨 [MainAppStateController] SAFETY: Kanata running without VirtualHID daemon — emergency stop"
+                            "🚨 [MainAppStateController] SAFETY: Kanata running after repeated confirmed VirtualHID failures — emergency stop"
                         )
                         await serviceLifecycle.stopKanata(reason: "Emergency: VirtualHID not running")
+                        vhidConfirmedFailureCount = 0
                     }
+                } else {
+                    vhidConfirmedFailureCount = 0
                 }
 
                 try? await Task.sleep(for: .seconds(2))

--- a/Sources/KeyPathAppKit/Services/System/VHIDSafetyCheck.swift
+++ b/Sources/KeyPathAppKit/Services/System/VHIDSafetyCheck.swift
@@ -1,4 +1,5 @@
 import Foundation
+import KeyPathInstallationWizard
 
 /// Pure-function safety logic for the VirtualHID daemon invariant:
 /// Kanata must never run without a healthy VirtualHID daemon, because kanata
@@ -7,10 +8,36 @@ import Foundation
 /// Extracted as a value type so the decision logic is unit-testable without
 /// instantiating singletons or hitting real system services.
 enum VHIDSafetyCheck {
+    static let requiredConfirmedFailures = 2
+
     /// Returns `true` when kanata is running but the VirtualHID daemon is not healthy.
     /// Callers should emergency-stop kanata when this returns `true`.
     static func shouldEmergencyStop(kanataRunning: Bool, vhidDaemonHealthy: Bool) -> Bool {
         kanataRunning && !vhidDaemonHealthy
+    }
+
+    /// A safety shutdown requires repeated, affirmative evidence. Unknown
+    /// observations (timeouts, command failures) neither advance nor erase
+    /// confirmation. Healthy evidence resets the sequence.
+    static func confirmedFailureCount(
+        after status: ServiceHealthChecker.VHIDSafetyStatus,
+        previousCount: Int
+    ) -> Int {
+        switch status {
+        case .healthy:
+            0
+        case .confirmedUnhealthy:
+            previousCount + 1
+        case .unknown:
+            previousCount
+        }
+    }
+
+    static func shouldEmergencyStop(
+        kanataRunning: Bool,
+        confirmedFailureCount: Int
+    ) -> Bool {
+        kanataRunning && confirmedFailureCount >= requiredConfirmedFailures
     }
 
     /// Returns `true` when VirtualHID is healthy enough to allow kanata to start.

--- a/Sources/KeyPathInstallationWizard/Core/ServiceHealthChecker.swift
+++ b/Sources/KeyPathInstallationWizard/Core/ServiceHealthChecker.swift
@@ -174,6 +174,16 @@ public final class ServiceHealthChecker: @unchecked Sendable {
         case unknown
     }
 
+    /// Evidence used by the runtime's emergency-stop invariant.
+    /// `unknown` is deliberately distinct from confirmed failure: inability to
+    /// inspect macOS system-extension or launchd state must fail safe without
+    /// turning a transient probe failure into a runtime shutdown.
+    public enum VHIDSafetyStatus: Sendable, Equatable {
+        case healthy
+        case confirmedUnhealthy
+        case unknown
+    }
+
     /// Unified diagnosis from a single read of the kanata daemon stderr log.
     /// Replaces the separate `checkDaemonStderrForPermissionFailure()` and
     /// `checkKanataInputCaptureStatus()` parsers that read the same file
@@ -685,6 +695,57 @@ public final class ServiceHealthChecker: @unchecked Sendable {
 
     public nonisolated func isVHIDDriverExtensionEnabled() async -> Bool {
         await vhidDriverExtensionStatus() == .enabled
+    }
+
+    /// Captures the two pieces of evidence required by the runtime safety path:
+    /// an enabled DriverKit extension and a live VirtualHID launch daemon.
+    /// Probe failures remain `.unknown` rather than being collapsed to `false`.
+    public nonisolated func vhidSafetyStatus() async -> VHIDSafetyStatus {
+        let driverStatus = await vhidDriverExtensionStatus()
+        switch driverStatus {
+        case .installedButNotEnabled, .missing:
+            return .confirmedUnhealthy
+        case .enabled, .unknown:
+            break
+        }
+
+        let evidence = await systemStateProvider.launchctlPrint(
+            target: "system/\(Self.vhidDaemonServiceID)"
+        )
+        guard let exitCode = evidence.exitCode else {
+            AppLogger.shared.log(
+                "⚠️ [ServiceHealthChecker] Unable to confirm VHID launchd health: \(evidence.stderr)"
+            )
+            return .unknown
+        }
+        if exitCode == Self.launchctlNotFoundExitCode {
+            return .confirmedUnhealthy
+        }
+        guard exitCode == 0 else {
+            AppLogger.shared.log(
+                "⚠️ [ServiceHealthChecker] Inconclusive VHID launchd probe (exit \(exitCode)): \(evidence.stderr)"
+            )
+            return .unknown
+        }
+
+        let state = evidence.stdout
+            .firstMatchString(pattern: #"(?m)^\s*state\s*=\s*([^\r\n]+)"#)?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        let pid = evidence.stdout.firstMatchInt(pattern: #"\bpid\s*=\s*([0-9]+)"#)
+        if state == "running" || state == "launching" || pid != nil {
+            return driverStatus == .enabled ? .healthy : .unknown
+        }
+
+        switch state {
+        case "exited", "not running", "stopped", "waiting":
+            return .confirmedUnhealthy
+        default:
+            AppLogger.shared.log(
+                "⚠️ [ServiceHealthChecker] Unrecognized VHID launchd state; preserving unknown: \(state ?? "missing")"
+            )
+            return .unknown
+        }
     }
 
     public nonisolated func vhidDriverExtensionStatus() async -> VHIDDriverExtensionStatus {

--- a/Tests/KeyPathTests/Services/ServiceHealthCheckerTests.swift
+++ b/Tests/KeyPathTests/Services/ServiceHealthCheckerTests.swift
@@ -141,6 +141,40 @@ final class ServiceHealthCheckerTests: XCTestCase {
         try data.write(to: url)
     }
 
+    private func makeVHIDSafetyChecker(
+        extensionStatus: ServiceHealthChecker.VHIDDriverExtensionStatus = .enabled,
+        exitCode: Int32?,
+        stdout: String = "",
+        stderr: String = ""
+    ) async -> ServiceHealthChecker {
+        #if DEBUG
+            ServiceHealthChecker.vhidDriverExtensionStatusOverride = { extensionStatus }
+        #endif
+
+        let probes = SystemProbeClient(
+            processIDs: { _ in [] },
+            processMatches: { _ in [] },
+            launchctlPrint: { target in
+                LaunchctlPrintEvidence(
+                    target: target,
+                    exitCode: exitCode,
+                    stdout: stdout,
+                    stderr: stderr
+                )
+            },
+            processIDsSynchronously: { _ in [] },
+            isProcessAlive: { _ in false },
+            probeTCPPort: { _, _ in false }
+        )
+        let provider = SystemStateProvider(probes: probes)
+        return await MainActor.run {
+            ServiceHealthChecker(
+                subprocessRunner: SubprocessRunnerFake.shared,
+                systemStateProvider: provider
+            )
+        }
+    }
+
     func testServiceIdentifiers() {
         XCTAssertEqual(ServiceHealthChecker.kanataServiceID, "com.keypath.kanata")
         XCTAssertEqual(ServiceHealthChecker.vhidDaemonServiceID, "com.keypath.karabiner-vhiddaemon")
@@ -255,6 +289,120 @@ final class ServiceHealthCheckerTests: XCTestCase {
     func testIsServiceHealthyReturnsFalseForInvalidServiceID() async {
         let healthy = await checker.isServiceHealthy(serviceID: "com.keypath.invalid-service")
         XCTAssertFalse(healthy)
+    }
+
+    func testVHIDSafetyStatusClassifiesRunningLaunchdEvidenceAsHealthy() async {
+        let checker = await makeVHIDSafetyChecker(
+            exitCode: 0,
+            stdout: "state = running\npid = 4242"
+        )
+
+        let status = await checker.vhidSafetyStatus()
+        XCTAssertEqual(status, .healthy)
+    }
+
+    func testVHIDSafetyStatusClassifiesMissingLaunchdJobAsConfirmedUnhealthy() async {
+        let checker = await makeVHIDSafetyChecker(
+            exitCode: 113,
+            stderr: "Could not find service"
+        )
+
+        let status = await checker.vhidSafetyStatus()
+        XCTAssertEqual(status, .confirmedUnhealthy)
+    }
+
+    func testVHIDSafetyStatusPreservesProbeFailureAsUnknown() async {
+        let checker = await makeVHIDSafetyChecker(
+            exitCode: nil,
+            stderr: "timed out"
+        )
+
+        let status = await checker.vhidSafetyStatus()
+        XCTAssertEqual(status, .unknown)
+    }
+
+    func testVHIDSafetyStatusPreservesUnrecognizedLaunchdStateAsUnknown() async {
+        let checker = await makeVHIDSafetyChecker(
+            exitCode: 0,
+            stdout: "state = future-transitional-state"
+        )
+
+        let status = await checker.vhidSafetyStatus()
+        XCTAssertEqual(status, .unknown)
+    }
+
+    func testVHIDSafetyStatusClassifiesExitedLaunchdJobAsConfirmedUnhealthy() async {
+        let checker = await makeVHIDSafetyChecker(
+            exitCode: 0,
+            stdout: "state = exited\nlast exit status = 1"
+        )
+
+        let status = await checker.vhidSafetyStatus()
+        XCTAssertEqual(status, .confirmedUnhealthy)
+    }
+
+    func testVHIDSafetyStatusClassifiesMultiwordNotRunningStateAsConfirmedUnhealthy() async {
+        let checker = await makeVHIDSafetyChecker(
+            exitCode: 0,
+            stdout: "state = not running"
+        )
+
+        let status = await checker.vhidSafetyStatus()
+        XCTAssertEqual(status, .confirmedUnhealthy)
+    }
+
+    func testVHIDSafetyStatusClassifiesMissingDriverExtensionAsConfirmedUnhealthy() async {
+        let checker = await makeVHIDSafetyChecker(
+            extensionStatus: .missing,
+            exitCode: 0,
+            stdout: "state = running\npid = 4242"
+        )
+
+        let status = await checker.vhidSafetyStatus()
+        XCTAssertEqual(status, .confirmedUnhealthy)
+    }
+
+    func testVHIDSafetyStatusClassifiesDisabledDriverExtensionAsConfirmedUnhealthy() async {
+        let checker = await makeVHIDSafetyChecker(
+            extensionStatus: .installedButNotEnabled,
+            exitCode: 0,
+            stdout: "state = running\npid = 4242"
+        )
+
+        let status = await checker.vhidSafetyStatus()
+        XCTAssertEqual(status, .confirmedUnhealthy)
+    }
+
+    func testVHIDSafetyStatusPreservesUnknownDriverExtensionAsUnknown() async {
+        let checker = await makeVHIDSafetyChecker(
+            extensionStatus: .unknown,
+            exitCode: 0,
+            stdout: "state = running\npid = 4242"
+        )
+
+        let status = await checker.vhidSafetyStatus()
+        XCTAssertEqual(status, .unknown)
+    }
+
+    func testVHIDSafetyStatusStillDetectsMissingLaunchdJobWhenDriverProbeIsUnknown() async {
+        let checker = await makeVHIDSafetyChecker(
+            extensionStatus: .unknown,
+            exitCode: 113,
+            stderr: "Could not find service"
+        )
+
+        let status = await checker.vhidSafetyStatus()
+        XCTAssertEqual(status, .confirmedUnhealthy)
+    }
+
+    func testVHIDSafetyStatusPreservesInconclusiveLaunchctlExitAsUnknown() async {
+        let checker = await makeVHIDSafetyChecker(
+            exitCode: 5,
+            stderr: "I/O error"
+        )
+
+        let status = await checker.vhidSafetyStatus()
+        XCTAssertEqual(status, .unknown)
     }
 
     func testCheckKanataServiceHealthDoesNotProbeSystemInTestMode() async {

--- a/Tests/KeyPathTests/Services/VHIDSafetyInvariantTests.swift
+++ b/Tests/KeyPathTests/Services/VHIDSafetyInvariantTests.swift
@@ -42,6 +42,53 @@ final class VHIDSafetyInvariantTests: KeyPathTestCase {
         XCTAssertFalse(healthy, "Should NOT trigger emergency stop when kanata is not running (VHID healthy)")
     }
 
+    func test_unknownVHIDObservationPreservesButDoesNotAdvanceConfirmation() {
+        let count = VHIDSafetyCheck.confirmedFailureCount(
+            after: .unknown,
+            previousCount: VHIDSafetyCheck.requiredConfirmedFailures - 1
+        )
+
+        XCTAssertEqual(count, 1)
+        XCTAssertFalse(
+            VHIDSafetyCheck.shouldEmergencyStop(
+                kanataRunning: true,
+                confirmedFailureCount: count
+            )
+        )
+    }
+
+    func test_emergencyStopRequiresTwoConfirmedFailures() {
+        let first = VHIDSafetyCheck.confirmedFailureCount(
+            after: .confirmedUnhealthy,
+            previousCount: 0
+        )
+        XCTAssertFalse(
+            VHIDSafetyCheck.shouldEmergencyStop(
+                kanataRunning: true,
+                confirmedFailureCount: first
+            )
+        )
+
+        let second = VHIDSafetyCheck.confirmedFailureCount(
+            after: .confirmedUnhealthy,
+            previousCount: first
+        )
+        XCTAssertTrue(
+            VHIDSafetyCheck.shouldEmergencyStop(
+                kanataRunning: true,
+                confirmedFailureCount: second
+            )
+        )
+    }
+
+    func test_healthyObservationResetsConfirmedFailureSequence() {
+        let count = VHIDSafetyCheck.confirmedFailureCount(
+            after: .healthy,
+            previousCount: 1
+        )
+        XCTAssertEqual(count, 0)
+    }
+
     // MARK: - Start Gate Decision
 
     func test_startKanata_refusesWhenVHIDUnhealthy() {

--- a/docs/bugs/2026-07-27-vhid-probe-timeout-false-emergency-stop.md
+++ b/docs/bugs/2026-07-27-vhid-probe-timeout-false-emergency-stop.md
@@ -1,0 +1,42 @@
+# VHID probe timeouts caused false emergency stops
+
+## Symptom
+
+KeyPath could stop an otherwise healthy Kanata runtime while the VirtualHID
+daemon and DriverKit extension remained available. The debug log showed the
+safety monitor treating a timed-out `systemextensionsctl list` probe as proof
+that VirtualHID was unhealthy.
+
+## Root cause
+
+The runtime safety path reused a Boolean health API. That API intentionally
+collapsed an inconclusive system-extension query to `false`, which is useful
+for ordinary status display but unsafe as destructive evidence. On macOS 27,
+`systemextensionsctl list` can outlive KeyPath's subprocess timeout and ignore
+the initial termination signal, making the inconclusive state reproducible
+under system load.
+
+The safety monitor then converted the single `false` observation directly into
+an emergency stop. It did not distinguish a missing service from a failed
+probe, and it did not require confirmation.
+
+## Durable rule
+
+Runtime safety decisions use tri-state evidence:
+
+- `healthy` means the DriverKit extension is enabled and launchd reports a live
+  VirtualHID daemon;
+- `confirmedUnhealthy` means current evidence affirmatively shows the extension
+  or daemon is absent or in a recognized stopped state;
+- `unknown` preserves timeouts, command failures, and malformed responses.
+
+Only two `confirmedUnhealthy` observations may stop Kanata. `unknown` neither
+advances nor erases that evidence; only `healthy` resets the confirmation
+sequence. This keeps the fail-safe invariant while preventing an observability
+failure from becoming a service mutation.
+
+An unknown system-extension result does not short-circuit the independent
+launchd probe. A missing or recognized stopped daemon can therefore still be
+confirmed during a `systemextensionsctl` outage. If both evidence sources are
+inconclusive, KeyPath deliberately leaves the result `unknown` rather than
+turning loss of observability into a destructive action.


### PR DESCRIPTION
## Summary

- preserve `unknown` when the macOS system-extension or launchd probes are inconclusive
- require two confirmed VirtualHID failures before emergency-stopping Kanata
- reset failure confirmation only after healthy evidence; unknown neither advances nor erases it
- document the timeout-to-false-stop bug and add focused invariant tests

## Root cause

The runtime safety path consumed a Boolean health result. A timed-out
`systemextensionsctl list` probe was collapsed to `false`, and one false value
immediately stopped a healthy Kanata runtime. On macOS 27 the command can outlive
the subprocess timeout under load, so an observability failure became a service
mutation.

## Impact

KeyPath still stops Kanata when VirtualHID is affirmatively unavailable, but a
timeout or malformed probe can no longer trigger a false emergency stop.

## Installer/repair state matrix

Affected row: `VHID services missing/unhealthy`. The runtime safety monitor now
requires affirmative, repeated current evidence before acting; installer and
repair routing are unchanged.

## Validation

- `swift build --target KeyPathAppKit --jobs 4`
- `TEST_FILTER=VHIDSafetyInvariantTests ./Scripts/run-tests-safe.sh` — 8 tests, 0 failures
- `TEST_FILTER=ServiceHealthCheckerTests ./Scripts/run-tests-safe.sh` — 43 tests, 0 failures
- `python3 Scripts/check-accessibility.py`
- `git diff --check`
- `./Scripts/test-full.sh` — default 240s watchdog expired during unchanged snapshots, with no failures observed before timeout
- `TIMEOUT_SECONDS=900 ./Scripts/test-full.sh` — exceeded the extended watchdog on the loaded machine; the only observed failures were three unchanged Home Row Timing snapshots rendering at 1300x586 vs stored 1300x638. All 15 hard-view snapshots passed, and no non-snapshot failures were observed before timeout.

Review gate: `remote review gate selected`; do not merge until GitHub
`claude-review` passes.

Remote review feedback addressed: unfamiliar launchd state is preserved as
`unknown`, and direct evidence-classification tests now cover running, missing,
timed-out, inconclusive, unrecognized, exited, and extension-state results.
Unknown observations preserve but never advance confirmed-failure evidence;
healthy evidence resets it.
An unknown extension probe no longer short-circuits launchd evidence, so a
missing/stopped daemon is still confirmed during a `systemextensionsctl` outage.
Multi-word launchd states such as `not running` are parsed and classified in
full rather than truncated to the first token.

CI follow-up addressed: expected inconclusive-probe telemetry is informational,
and the focused runner reports 0 app warnings and 0 app errors.

Related: #919
