### PR TITLE
Route CLI service control through helper

### DIFF
--- a/Sources/KeyPathAppKit/CLI/SystemFacade.swift
+++ b/Sources/KeyPathAppKit/CLI/SystemFacade.swift
@@ -10,7 +10,9 @@ import KeyPathWizardCore
 public struct SystemFacade: Sendable {
     typealias RuntimeSnapshot = ServiceHealthChecker.KanataServiceRuntimeSnapshot
 
-    private let subprocessRunner: any SubprocessRunning
+    private let startServiceOperation: @Sendable () async throws -> Void
+    private let stopServiceOperation: @Sendable () async throws -> Void
+    private let runtimeCacheInvalidator: @Sendable () async -> Void
     private let runtimeSnapshotProvider: @Sendable () async -> RuntimeSnapshot
     private let runtimeTransitionTimeoutSeconds: TimeInterval
     private let pollDelayNanoseconds: UInt64
@@ -18,21 +20,45 @@ public struct SystemFacade: Sendable {
 
     public init() {
         self.init(
-            subprocessRunner: SubprocessRunner.shared,
+            startServiceOperation: {
+                try await HelperManager.shared.startKanataService()
+            },
+            stopServiceOperation: {
+                try await HelperManager.shared.stopKanataService()
+            },
+            runtimeCacheInvalidator: {
+                await MainActor.run {
+                    ServiceHealthChecker.shared.invalidateHealthCache()
+                }
+            },
             runtimeSnapshotProvider: {
-                await ServiceHealthChecker.shared.checkKanataServiceRuntimeSnapshot()
+                await ServiceHealthChecker.shared.checkKanataServiceRuntimeSnapshotFresh()
             }
         )
     }
 
     init(
-        subprocessRunner: any SubprocessRunning,
+        startServiceOperation: @escaping @Sendable () async throws -> Void = {
+            try await HelperManager.shared.startKanataService()
+        },
+        stopServiceOperation: @escaping @Sendable () async throws -> Void = {
+            try await HelperManager.shared.stopKanataService()
+        },
+        runtimeCacheInvalidator: @escaping @Sendable () async -> Void = {
+            await MainActor.run {
+                ServiceHealthChecker.shared.invalidateHealthCache()
+            }
+        },
         runtimeSnapshotProvider: @escaping @Sendable () async -> RuntimeSnapshot,
-        runtimeTransitionTimeoutSeconds: TimeInterval = 5,
+        // The Kanata LaunchDaemon has a 10-second ThrottleInterval. A restart
+        // can legitimately remain stopped for that long before launchd starts it.
+        runtimeTransitionTimeoutSeconds: TimeInterval = 20,
         pollDelayNanoseconds: UInt64 = 200_000_000,
         restartDelayNanoseconds: UInt64 = 500_000_000
     ) {
-        self.subprocessRunner = subprocessRunner
+        self.startServiceOperation = startServiceOperation
+        self.stopServiceOperation = stopServiceOperation
+        self.runtimeCacheInvalidator = runtimeCacheInvalidator
         self.runtimeSnapshotProvider = runtimeSnapshotProvider
         self.runtimeTransitionTimeoutSeconds = runtimeTransitionTimeoutSeconds
         self.pollDelayNanoseconds = pollDelayNanoseconds
@@ -42,9 +68,12 @@ public struct SystemFacade: Sendable {
     // MARK: - Service Lifecycle
 
     public func startService() async -> Bool {
+        await MainActor.run {
+            CLIRuntimeBootstrap.ensureConfigured()
+        }
         do {
-            let result = try await subprocessRunner.launchctl("kickstart", ["system/com.keypath.kanata"])
-            guard result.exitCode == 0 else { return false }
+            try await startServiceOperation()
+            await runtimeCacheInvalidator()
             return await waitForRuntime(timeoutSeconds: runtimeTransitionTimeoutSeconds) { snapshot in
                 snapshot.isRunning && snapshot.isResponding
             }
@@ -54,9 +83,12 @@ public struct SystemFacade: Sendable {
     }
 
     public func stopService() async -> Bool {
+        await MainActor.run {
+            CLIRuntimeBootstrap.ensureConfigured()
+        }
         do {
-            let result = try await subprocessRunner.launchctl("kill", ["SIGTERM", "system/com.keypath.kanata"])
-            guard result.exitCode == 0 else { return false }
+            try await stopServiceOperation()
+            await runtimeCacheInvalidator()
             return await waitForRuntime(timeoutSeconds: runtimeTransitionTimeoutSeconds) { snapshot in
                 !snapshot.isRunning && !snapshot.isResponding
             }

--- a/Sources/KeyPathAppKit/Core/HelperManager+RequestHandlers.swift
+++ b/Sources/KeyPathAppKit/Core/HelperManager+RequestHandlers.swift
@@ -252,6 +252,18 @@ extension HelperManager {
         }
     }
 
+    func startKanataService() async throws {
+        try await executeXPCCall("startKanataService") { proxy, reply in
+            proxy.startKanataService(reply: reply)
+        }
+    }
+
+    func stopKanataService() async throws {
+        try await executeXPCCall("stopKanataService") { proxy, reply in
+            proxy.stopKanataService(reply: reply)
+        }
+    }
+
     // MARK: - VirtualHID Operations
 
     func activateVirtualHIDManager() async throws {

--- a/Sources/KeyPathAppKit/Core/HelperProtocol.swift
+++ b/Sources/KeyPathAppKit/Core/HelperProtocol.swift
@@ -37,6 +37,14 @@ import Foundation
     /// - Parameter reply: Completion handler with (success, errorMessage)
     func installRequiredRuntimeServices(reply: @escaping (Bool, String?) -> Void)
 
+    /// Start the fixed KeyPath Kanata LaunchDaemon.
+    /// - Parameter reply: Completion handler with (success, errorMessage)
+    func startKanataService(reply: @escaping (Bool, String?) -> Void)
+
+    /// Stop the fixed KeyPath Kanata LaunchDaemon.
+    /// - Parameter reply: Completion handler with (success, errorMessage)
+    func stopKanataService(reply: @escaping (Bool, String?) -> Void)
+
     // MARK: - VirtualHID Operations
 
     /// Activate the VirtualHID Manager service

--- a/Sources/KeyPathCore/KeyPathHelperContract.swift
+++ b/Sources/KeyPathCore/KeyPathHelperContract.swift
@@ -1,5 +1,5 @@
 /// Shared identity and compatibility contract for the privileged helper.
 public enum KeyPathHelperContract {
     /// Version returned by the helper XPC service and packaged in its Info.plist.
-    public static let version = "1.1.0"
+    public static let version = "1.2.0"
 }

--- a/Sources/KeyPathHelper/HelperProtocol.swift
+++ b/Sources/KeyPathHelper/HelperProtocol.swift
@@ -37,6 +37,14 @@ import Foundation
     /// - Parameter reply: Completion handler with (success, errorMessage)
     func installRequiredRuntimeServices(reply: @escaping (Bool, String?) -> Void)
 
+    /// Start the fixed KeyPath Kanata LaunchDaemon.
+    /// - Parameter reply: Completion handler with (success, errorMessage)
+    func startKanataService(reply: @escaping (Bool, String?) -> Void)
+
+    /// Stop the fixed KeyPath Kanata LaunchDaemon.
+    /// - Parameter reply: Completion handler with (success, errorMessage)
+    func stopKanataService(reply: @escaping (Bool, String?) -> Void)
+
     // MARK: - VirtualHID Operations
 
     /// Activate the VirtualHID Manager service

--- a/Sources/KeyPathHelper/HelperService.swift
+++ b/Sources/KeyPathHelper/HelperService.swift
@@ -13,6 +13,7 @@ class HelperService: NSObject, HelperProtocol {
 
     /// Helper version shared with the app and wizard for compatibility checks.
     private static let version = KeyPathHelperContract.version
+    private static let kanataServiceTarget = "system/com.keypath.kanata"
     private static let vhidRootOnlyDirectory = "/Library/Application Support/org.pqrs/tmp/rootonly"
     private let logger = Logger(subsystem: "com.keypath.helper", category: "service")
 
@@ -130,6 +131,46 @@ class HelperService: NSObject, HelperProtocol {
             operation: {
                 NSLog("[KeyPathHelper] Kanata is SMAppService-managed by KeyPath.app; repairing VHID services only")
                 try Self.installOrRepairVHIDServices()
+            },
+            reply: reply
+        )
+    }
+
+    func startKanataService(reply: @escaping (Bool, String?) -> Void) {
+        NSLog("[KeyPathHelper] startKanataService requested")
+        executePrivilegedOperation(
+            name: "startKanataService",
+            operation: {
+                let result = Self.run(
+                    "/bin/launchctl",
+                    ["kickstart", Self.kanataServiceTarget],
+                    timeout: 15
+                )
+                guard result.status == 0 else {
+                    throw HelperError.operationFailed(
+                        "Failed to start KeyPath Kanata service: \(result.out)"
+                    )
+                }
+            },
+            reply: reply
+        )
+    }
+
+    func stopKanataService(reply: @escaping (Bool, String?) -> Void) {
+        NSLog("[KeyPathHelper] stopKanataService requested")
+        executePrivilegedOperation(
+            name: "stopKanataService",
+            operation: {
+                let result = Self.run(
+                    "/bin/launchctl",
+                    ["kill", "SIGTERM", Self.kanataServiceTarget],
+                    timeout: 15
+                )
+                guard result.status == 0 else {
+                    throw HelperError.operationFailed(
+                        "Failed to stop KeyPath Kanata service: \(result.out)"
+                    )
+                }
             },
             reply: reply
         )

--- a/Sources/KeyPathHelper/Info.plist
+++ b/Sources/KeyPathHelper/Info.plist
@@ -12,10 +12,10 @@
 
     <!-- Version (should match main app) -->
     <key>CFBundleShortVersionString</key>
-    <string>1.1.0</string>
+	<string>1.2.0</string>
 
     <key>CFBundleVersion</key>
-    <string>2</string>
+	<string>3</string>
 
     <!-- Info dictionary version -->
     <key>CFBundleInfoDictionaryVersion</key>

--- a/Sources/KeyPathInstallationWizard/Core/ServiceHealthChecker.swift
+++ b/Sources/KeyPathInstallationWizard/Core/ServiceHealthChecker.swift
@@ -630,6 +630,18 @@ public final class ServiceHealthChecker: @unchecked Sendable {
         return await checkKanataServiceRuntimeSnapshotUncached(tcpPort: tcpPort, timeoutMs: timeoutMs)
     }
 
+    /// Fresh runtime evidence for lifecycle transition postconditions.
+    ///
+    /// Tight start/stop polling must not reuse the normal two-second snapshot
+    /// cache: a cached pre-transition result can otherwise make a successful
+    /// launchd mutation look like a failure.
+    public nonisolated func checkKanataServiceRuntimeSnapshotFresh(
+        tcpPort: Int = KeyPathConstants.Networking.defaultTCPPort,
+        timeoutMs: Int = 300
+    ) async -> KanataServiceRuntimeSnapshot {
+        await checkKanataServiceRuntimeSnapshotUncached(tcpPort: tcpPort, timeoutMs: timeoutMs)
+    }
+
     private nonisolated func checkKanataServiceRuntimeSnapshotUncached(
         tcpPort: Int,
         timeoutMs: Int

--- a/Tests/KeyPathTests/CLI/CLIServiceTests.swift
+++ b/Tests/KeyPathTests/CLI/CLIServiceTests.swift
@@ -28,20 +28,9 @@ final class CLIServiceTests: XCTestCase {
 
     // MARK: - service lifecycle
 
-    func testStopServiceReturnsFalseWhenLaunchctlExitsNonZero() async {
-        let fakeRunner = SubprocessRunnerFake.shared
-        await fakeRunner.reset()
-        await fakeRunner.configureLaunchctlResult { _, _ in
-            ProcessResult(
-                exitCode: 112,
-                stdout: "",
-                stderr: "Not privileged to signal service.",
-                duration: 0.1
-            )
-        }
-
+    func testStopServiceReturnsFalseWhenPrivilegedHelperFails() async {
         let facade = SystemFacade(
-            subprocessRunner: fakeRunner,
+            stopServiceOperation: { throw ServiceOperationError.failed },
             runtimeSnapshotProvider: { Self.runtimeSnapshot(running: true, responding: true) },
             runtimeTransitionTimeoutSeconds: 0.05,
             pollDelayNanoseconds: 0
@@ -52,40 +41,33 @@ final class CLIServiceTests: XCTestCase {
         XCTAssertFalse(stopped)
     }
 
-    func testStopServiceWaitsForStoppedRuntimeAfterLaunchctlSuccess() async {
-        let fakeRunner = SubprocessRunnerFake.shared
-        await fakeRunner.reset()
+    func testStopServiceWaitsForStoppedRuntimeAfterHelperSuccess() async {
         let snapshots = RuntimeSnapshotSequence([
             Self.runtimeSnapshot(running: true, responding: true),
             Self.runtimeSnapshot(running: false, responding: false)
         ])
+        let operations = ServiceOperationRecorder()
 
         let facade = SystemFacade(
-            subprocessRunner: fakeRunner,
+            stopServiceOperation: { await operations.recordStop() },
             runtimeSnapshotProvider: { await snapshots.next() },
             runtimeTransitionTimeoutSeconds: 0.05,
             pollDelayNanoseconds: 0
         )
 
         let stopped = await facade.stopService()
+        let stopCount = await operations.stopCount
 
         XCTAssertTrue(stopped)
+        XCTAssertEqual(stopCount, 1)
     }
 
     func testRestartServiceDoesNotReportSuccessWhenStopFails() async {
-        let fakeRunner = SubprocessRunnerFake.shared
-        await fakeRunner.reset()
-        await fakeRunner.configureLaunchctlResult { subcommand, _ in
-            ProcessResult(
-                exitCode: subcommand == "kill" ? 112 : 0,
-                stdout: "",
-                stderr: subcommand == "kill" ? "Not privileged to signal service." : "",
-                duration: 0.1
-            )
-        }
+        let operations = ServiceOperationRecorder()
 
         let facade = SystemFacade(
-            subprocessRunner: fakeRunner,
+            startServiceOperation: { await operations.recordStart() },
+            stopServiceOperation: { throw ServiceOperationError.failed },
             runtimeSnapshotProvider: { Self.runtimeSnapshot(running: true, responding: true) },
             runtimeTransitionTimeoutSeconds: 0.05,
             pollDelayNanoseconds: 0,
@@ -93,18 +75,15 @@ final class CLIServiceTests: XCTestCase {
         )
 
         let restarted = await facade.restartService()
-        let commands = await fakeRunner.executedCommands
+        let startCount = await operations.startCount
 
         XCTAssertFalse(restarted)
-        XCTAssertEqual(commands.compactMap(\.args.first), ["kill"])
+        XCTAssertEqual(startCount, 0)
     }
 
     func testStartServiceReturnsFalseWhenRuntimeNeverBecomesHealthy() async {
-        let fakeRunner = SubprocessRunnerFake.shared
-        await fakeRunner.reset()
-
         let facade = SystemFacade(
-            subprocessRunner: fakeRunner,
+            startServiceOperation: {},
             runtimeSnapshotProvider: { Self.runtimeSnapshot(running: true, responding: false) },
             runtimeTransitionTimeoutSeconds: 0.05,
             pollDelayNanoseconds: 0
@@ -113,6 +92,51 @@ final class CLIServiceTests: XCTestCase {
         let started = await facade.startService()
 
         XCTAssertFalse(started)
+    }
+
+    func testStartServiceWaitsForHealthyRuntimeAfterHelperSuccess() async {
+        let snapshots = RuntimeSnapshotSequence([
+            Self.runtimeSnapshot(running: false, responding: false),
+            Self.runtimeSnapshot(running: true, responding: true)
+        ])
+        let operations = ServiceOperationRecorder()
+        let facade = SystemFacade(
+            startServiceOperation: { await operations.recordStart() },
+            runtimeSnapshotProvider: { await snapshots.next() },
+            runtimeTransitionTimeoutSeconds: 0.05,
+            pollDelayNanoseconds: 0
+        )
+
+        let started = await facade.startService()
+        let startCount = await operations.startCount
+
+        XCTAssertTrue(started)
+        XCTAssertEqual(startCount, 1)
+    }
+
+    func testServiceOperationsInvalidateRuntimeHealthCacheBeforePolling() async {
+        let invalidations = SynchronousCallRecorder()
+        let stoppedFacade = SystemFacade(
+            stopServiceOperation: {},
+            runtimeCacheInvalidator: { invalidations.record() },
+            runtimeSnapshotProvider: { Self.runtimeSnapshot(running: false, responding: false) },
+            runtimeTransitionTimeoutSeconds: 0.05,
+            pollDelayNanoseconds: 0
+        )
+        let startedFacade = SystemFacade(
+            startServiceOperation: {},
+            runtimeCacheInvalidator: { invalidations.record() },
+            runtimeSnapshotProvider: { Self.runtimeSnapshot(running: true, responding: true) },
+            runtimeTransitionTimeoutSeconds: 0.05,
+            pollDelayNanoseconds: 0
+        )
+
+        let stopped = await stoppedFacade.stopService()
+        let started = await startedFacade.startService()
+
+        XCTAssertTrue(stopped)
+        XCTAssertTrue(started)
+        XCTAssertEqual(invalidations.count, 2)
     }
 
     private nonisolated static func runtimeSnapshot(
@@ -129,6 +153,36 @@ final class CLIServiceTests: XCTestCase {
             staleEnabledRegistration: false,
             recentlyRestarted: false
         )
+    }
+}
+
+private enum ServiceOperationError: Error {
+    case failed
+}
+
+private actor ServiceOperationRecorder {
+    private(set) var startCount = 0
+    private(set) var stopCount = 0
+
+    func recordStart() {
+        startCount += 1
+    }
+
+    func recordStop() {
+        stopCount += 1
+    }
+}
+
+private final class SynchronousCallRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var recordedCount = 0
+
+    var count: Int {
+        lock.withLock { recordedCount }
+    }
+
+    func record() {
+        lock.withLock { recordedCount += 1 }
     }
 }
 

--- a/Tests/KeyPathTests/Lint/CLIPrivilegeBoundaryLintTests.swift
+++ b/Tests/KeyPathTests/Lint/CLIPrivilegeBoundaryLintTests.swift
@@ -1,0 +1,69 @@
+import Foundation
+@preconcurrency import XCTest
+
+/// The CLI is an authorized client of KeyPath's narrowly scoped XPC helper.
+/// It must not grow a second privileged execution path through launchctl, sudo,
+/// osascript, or the generic admin-command executor.
+final class CLIPrivilegeBoundaryLintTests: KeyPathTestCase {
+    func testCLIUsesBrokeredOrHelperBackedPrivilegedOperations() throws {
+        let root = cliPrivilegeBoundaryRepositoryRoot()
+        let sourceRoots = [
+            "Sources/KeyPathCLI",
+            "Sources/KeyPathCLISupport",
+            "Sources/KeyPathAppKit/CLI",
+        ]
+        let forbidden = [
+            ".launchctl(",
+            "/bin/launchctl",
+            "/usr/bin/sudo",
+            "/usr/bin/osascript",
+            "AdminCommandExecutor",
+            "PrivilegedCommandRunner",
+        ]
+        var violations: [String] = []
+
+        for relativeRoot in sourceRoots {
+            let directory = root.appendingPathComponent(relativeRoot)
+            guard let enumerator = FileManager.default.enumerator(
+                at: directory,
+                includingPropertiesForKeys: nil
+            ) else {
+                XCTFail("Could not enumerate \(relativeRoot)")
+                continue
+            }
+
+            for case let file as URL in enumerator where file.pathExtension == "swift" {
+                let source = try String(contentsOf: file, encoding: .utf8)
+                for (lineIndex, line) in source
+                    .split(separator: "\n", omittingEmptySubsequences: false)
+                    .enumerated()
+                {
+                    for token in forbidden where line.contains(token) {
+                        let relativePath = file.path.replacingOccurrences(
+                            of: root.path + "/",
+                            with: ""
+                        )
+                        violations.append("\(relativePath):\(lineIndex + 1): \(token)")
+                    }
+                }
+            }
+        }
+
+        XCTAssertTrue(
+            violations.isEmpty,
+            """
+            CLI privileged operations must use the explicit helper API or the
+            installer privilege broker. Direct privileged execution found:
+            \(violations.joined(separator: "\n"))
+            """
+        )
+    }
+}
+
+private func cliPrivilegeBoundaryRepositoryRoot(file: StaticString = #filePath) -> URL {
+    URL(fileURLWithPath: "\(file)")
+        .deletingLastPathComponent() // Lint
+        .deletingLastPathComponent() // KeyPathTests
+        .deletingLastPathComponent() // Tests
+        .deletingLastPathComponent() // repository root
+}

--- a/docs/bugs/cli-service-control-helper-bypass.md
+++ b/docs/bugs/cli-service-control-helper-bypass.md
@@ -1,0 +1,39 @@
+# CLI service control bypassed the privileged helper
+
+## Symptom
+
+`keypath-cli service stop` failed for a normal user with `Not privileged to signal service`.
+`service start` had the same authorization defect, and `service restart` composed both paths.
+
+## Root cause
+
+`SystemFacade` invoked `launchctl kill` and `launchctl kickstart` directly even though the
+bundled CLI is an explicitly trusted client of KeyPath's privileged XPC helper. The commands
+therefore depended on the caller already being root instead of using KeyPath's authorization
+boundary.
+
+## Resolution
+
+The helper protocol now exposes narrowly scoped start and stop operations for the fixed
+`system/com.keypath.kanata` service target. `SystemFacade` calls those operations and retains
+its independent runtime postcondition checks. The helper contract version was advanced so an
+older helper cannot be mistaken for a compatible one.
+
+Lifecycle commands now bootstrap the same runtime dependencies as `service status`, invalidate
+pre-transition health evidence, and poll fresh snapshots. Startup verification allows for the
+LaunchDaemon's 10-second throttle interval. Without those pieces, the privileged operation could
+succeed while the CLI falsely reported failure because it had no launchctl targets or reused a
+pre-transition snapshot.
+
+`CLIPrivilegeBoundaryLintTests` scans the CLI source surfaces for direct `launchctl`, `sudo`,
+`osascript`, and generic privileged-command execution. Installer, repair, and uninstall remain
+on the existing installer privilege broker.
+
+## Verification
+
+- The supported CLI lifecycle suite passes.
+- The privilege-boundary lint passes.
+- The installed normal-user CLI completes `service restart --json` without `sudo` and reports
+  `{"restarted": true}`.
+- The installed app returns to an operational state with a fresh helper, running Kanata, and
+  healthy VirtualHID.


### PR DESCRIPTION
## What changed

- route CLI Kanata start and stop operations through narrowly scoped privileged-helper methods
- bump the helper compatibility contract to 1.2.0
- bootstrap lifecycle dependencies and verify transitions with fresh runtime evidence
- account for the LaunchDaemon throttle window during startup verification
- add focused lifecycle coverage and a lint preventing future direct privileged CLI execution

## Why

`keypath-cli service stop`, `start`, and `restart` invoked `launchctl` directly. Normal users therefore received an authorization failure even though the bundled CLI is an authorized client of KeyPath's helper. Live deployment also exposed false-negative postconditions caused by missing CLI bootstrap state and cached pre-transition snapshots.

## Impact

Normal-user CLI service control now uses KeyPath's existing privilege boundary without `sudo` or an administrator password. Lifecycle commands report success only after observing the requested runtime state.

## Validation

- `TEST_FILTER=CLIServiceTests TIMEOUT_SECONDS=180 ./Scripts/run-tests-safe.sh`
- `TEST_FILTER=CLIPrivilegeBoundaryLintTests TIMEOUT_SECONDS=120 ./Scripts/run-tests-safe.sh`
- installed `/Applications/KeyPath.app/Contents/MacOS/keypath-cli service restart --json` returned `{"restarted": true}`
- final installed state: helper 1.2.0 fresh, Kanata running, VirtualHID healthy, app signature valid
