### PR TITLE
Handle KeepAlive service restart race

### DIFF
--- a/Sources/KeyPathAppKit/CLI/SystemFacade.swift
+++ b/Sources/KeyPathAppKit/CLI/SystemFacade.swift
@@ -98,11 +98,27 @@ public struct SystemFacade: Sendable {
     }
 
     public func restartService() async -> Bool {
-        guard await stopService() else { return false }
-        if restartDelayNanoseconds > 0 {
-            try? await Task.sleep(nanoseconds: restartDelayNanoseconds)
+        await MainActor.run {
+            CLIRuntimeBootstrap.ensureConfigured()
         }
-        return await startService()
+        do {
+            try await stopServiceOperation()
+            await runtimeCacheInvalidator()
+            if restartDelayNanoseconds > 0 {
+                try? await Task.sleep(nanoseconds: restartDelayNanoseconds)
+            }
+            try await startServiceOperation()
+            await runtimeCacheInvalidator()
+
+            // The SMAppService job is KeepAlive. launchd may relaunch it before
+            // polling can observe a stopped snapshot, so restart success is the
+            // final healthy runtime—not a transient stopped state.
+            return await waitForRuntime(timeoutSeconds: runtimeTransitionTimeoutSeconds) { snapshot in
+                snapshot.isRunning && snapshot.isResponding
+            }
+        } catch {
+            return false
+        }
     }
 
     private func waitForRuntime(

--- a/Tests/KeyPathTests/CLI/CLIServiceTests.swift
+++ b/Tests/KeyPathTests/CLI/CLIServiceTests.swift
@@ -81,6 +81,29 @@ final class CLIServiceTests: XCTestCase {
         XCTAssertEqual(startCount, 0)
     }
 
+    func testRestartServiceAcceptsKeepAliveRelaunchBeforeStoppedSnapshot() async {
+        let operations = ServiceOperationRecorder()
+        let invalidations = SynchronousCallRecorder()
+        let facade = SystemFacade(
+            startServiceOperation: { await operations.recordStart() },
+            stopServiceOperation: { await operations.recordStop() },
+            runtimeCacheInvalidator: { invalidations.record() },
+            runtimeSnapshotProvider: { Self.runtimeSnapshot(running: true, responding: true) },
+            runtimeTransitionTimeoutSeconds: 0.05,
+            pollDelayNanoseconds: 0,
+            restartDelayNanoseconds: 0
+        )
+
+        let restarted = await facade.restartService()
+        let startCount = await operations.startCount
+        let stopCount = await operations.stopCount
+
+        XCTAssertTrue(restarted)
+        XCTAssertEqual(stopCount, 1)
+        XCTAssertEqual(startCount, 1)
+        XCTAssertEqual(invalidations.count, 2)
+    }
+
     func testStartServiceReturnsFalseWhenRuntimeNeverBecomesHealthy() async {
         let facade = SystemFacade(
             startServiceOperation: {},

--- a/Tests/KeyPathTests/CLI/CLIServiceTests.swift
+++ b/Tests/KeyPathTests/CLI/CLIServiceTests.swift
@@ -104,6 +104,24 @@ final class CLIServiceTests: XCTestCase {
         XCTAssertEqual(invalidations.count, 2)
     }
 
+    func testRestartServiceDoesNotReportSuccessWhenStartFails() async {
+        let operations = ServiceOperationRecorder()
+        let facade = SystemFacade(
+            startServiceOperation: { throw ServiceOperationError.failed },
+            stopServiceOperation: { await operations.recordStop() },
+            runtimeSnapshotProvider: { Self.runtimeSnapshot(running: true, responding: true) },
+            runtimeTransitionTimeoutSeconds: 0.05,
+            pollDelayNanoseconds: 0,
+            restartDelayNanoseconds: 0
+        )
+
+        let restarted = await facade.restartService()
+        let stopCount = await operations.stopCount
+
+        XCTAssertFalse(restarted)
+        XCTAssertEqual(stopCount, 1)
+    }
+
     func testStartServiceReturnsFalseWhenRuntimeNeverBecomesHealthy() async {
         let facade = SystemFacade(
             startServiceOperation: {},


### PR DESCRIPTION
## Summary
- make CLI restart verify the final healthy runtime instead of requiring a transient stopped snapshot
- continue requiring both privileged helper stop and start calls to succeed
- add regression coverage for launchd KeepAlive relaunching before the CLI observes stopped state

## Why
Installed verification after #1233 reproduced a false failure: `service restart --json` returned code 6 while launchd had already relaunched Kanata and the service became fully operational moments later. The SMAppService job is KeepAlive, so an intermediate stopped snapshot is not a reliable restart postcondition.

## Validation
- `TEST_FILTER=CLIServiceTests TIMEOUT_SECONDS=180 ./Scripts/run-tests-safe.sh` (10 XCTest cases, 0 failures; runner reports 11 passed)
- live reproduction on the installed merged #1233 build
- final installed status recovered to `isOperational: true`, helper 1.2.0 fresh, Kanata/VHID healthy
