### PR TITLE
Make helper service lifecycle idempotent

### DIFF
--- a/Sources/KeyPathAppKit/CLI/SystemFacade.swift
+++ b/Sources/KeyPathAppKit/CLI/SystemFacade.swift
@@ -12,11 +12,11 @@ public struct SystemFacade: Sendable {
 
     private let startServiceOperation: @Sendable () async throws -> Void
     private let stopServiceOperation: @Sendable () async throws -> Void
+    private let restartServiceOperation: @Sendable () async throws -> Void
     private let runtimeCacheInvalidator: @Sendable () async -> Void
     private let runtimeSnapshotProvider: @Sendable () async -> RuntimeSnapshot
     private let runtimeTransitionTimeoutSeconds: TimeInterval
     private let pollDelayNanoseconds: UInt64
-    private let restartDelayNanoseconds: UInt64
 
     public init() {
         self.init(
@@ -25,6 +25,9 @@ public struct SystemFacade: Sendable {
             },
             stopServiceOperation: {
                 try await HelperManager.shared.stopKanataService()
+            },
+            restartServiceOperation: {
+                try await HelperManager.shared.restartKanataService()
             },
             runtimeCacheInvalidator: {
                 await MainActor.run {
@@ -44,6 +47,9 @@ public struct SystemFacade: Sendable {
         stopServiceOperation: @escaping @Sendable () async throws -> Void = {
             try await HelperManager.shared.stopKanataService()
         },
+        restartServiceOperation: @escaping @Sendable () async throws -> Void = {
+            try await HelperManager.shared.restartKanataService()
+        },
         runtimeCacheInvalidator: @escaping @Sendable () async -> Void = {
             await MainActor.run {
                 ServiceHealthChecker.shared.invalidateHealthCache()
@@ -53,16 +59,15 @@ public struct SystemFacade: Sendable {
         // The Kanata LaunchDaemon has a 10-second ThrottleInterval. A restart
         // can legitimately remain stopped for that long before launchd starts it.
         runtimeTransitionTimeoutSeconds: TimeInterval = 20,
-        pollDelayNanoseconds: UInt64 = 200_000_000,
-        restartDelayNanoseconds: UInt64 = 500_000_000
+        pollDelayNanoseconds: UInt64 = 200_000_000
     ) {
         self.startServiceOperation = startServiceOperation
         self.stopServiceOperation = stopServiceOperation
+        self.restartServiceOperation = restartServiceOperation
         self.runtimeCacheInvalidator = runtimeCacheInvalidator
         self.runtimeSnapshotProvider = runtimeSnapshotProvider
         self.runtimeTransitionTimeoutSeconds = runtimeTransitionTimeoutSeconds
         self.pollDelayNanoseconds = pollDelayNanoseconds
-        self.restartDelayNanoseconds = restartDelayNanoseconds
     }
 
     // MARK: - Service Lifecycle
@@ -102,17 +107,11 @@ public struct SystemFacade: Sendable {
             CLIRuntimeBootstrap.ensureConfigured()
         }
         do {
-            try await stopServiceOperation()
-            await runtimeCacheInvalidator()
-            if restartDelayNanoseconds > 0 {
-                try? await Task.sleep(nanoseconds: restartDelayNanoseconds)
-            }
-            try await startServiceOperation()
+            try await restartServiceOperation()
             await runtimeCacheInvalidator()
 
-            // The SMAppService job is KeepAlive. launchd may relaunch it before
-            // polling can observe a stopped snapshot, so restart success is the
-            // final healthy runtime—not a transient stopped state.
+            // The helper performs one launchctl kickstart -k against the fixed
+            // launchd job. Verify the final healthy runtime, not a transient gap.
             return await waitForRuntime(timeoutSeconds: runtimeTransitionTimeoutSeconds) { snapshot in
                 snapshot.isRunning && snapshot.isResponding
             }

--- a/Sources/KeyPathAppKit/Core/HelperManager+RequestHandlers.swift
+++ b/Sources/KeyPathAppKit/Core/HelperManager+RequestHandlers.swift
@@ -264,6 +264,12 @@ extension HelperManager {
         }
     }
 
+    func restartKanataService() async throws {
+        try await executeXPCCall("restartKanataService") { proxy, reply in
+            proxy.restartKanataService(reply: reply)
+        }
+    }
+
     // MARK: - VirtualHID Operations
 
     func activateVirtualHIDManager() async throws {

--- a/Sources/KeyPathAppKit/Core/HelperProtocol.swift
+++ b/Sources/KeyPathAppKit/Core/HelperProtocol.swift
@@ -45,6 +45,10 @@ import Foundation
     /// - Parameter reply: Completion handler with (success, errorMessage)
     func stopKanataService(reply: @escaping (Bool, String?) -> Void)
 
+    /// Atomically restart the fixed KeyPath Kanata LaunchDaemon.
+    /// - Parameter reply: Completion handler with (success, errorMessage)
+    func restartKanataService(reply: @escaping (Bool, String?) -> Void)
+
     // MARK: - VirtualHID Operations
 
     /// Activate the VirtualHID Manager service

--- a/Sources/KeyPathCore/KeyPathHelperContract.swift
+++ b/Sources/KeyPathCore/KeyPathHelperContract.swift
@@ -1,5 +1,5 @@
 /// Shared identity and compatibility contract for the privileged helper.
 public enum KeyPathHelperContract {
     /// Version returned by the helper XPC service and packaged in its Info.plist.
-    public static let version = "1.2.0"
+    public static let version = "1.3.0"
 }

--- a/Sources/KeyPathHelper/HelperProtocol.swift
+++ b/Sources/KeyPathHelper/HelperProtocol.swift
@@ -45,6 +45,10 @@ import Foundation
     /// - Parameter reply: Completion handler with (success, errorMessage)
     func stopKanataService(reply: @escaping (Bool, String?) -> Void)
 
+    /// Atomically restart the fixed KeyPath Kanata LaunchDaemon.
+    /// - Parameter reply: Completion handler with (success, errorMessage)
+    func restartKanataService(reply: @escaping (Bool, String?) -> Void)
+
     // MARK: - VirtualHID Operations
 
     /// Activate the VirtualHID Manager service

--- a/Sources/KeyPathHelper/HelperService.swift
+++ b/Sources/KeyPathHelper/HelperService.swift
@@ -166,9 +166,37 @@ class HelperService: NSObject, HelperProtocol {
                     ["kill", "SIGTERM", Self.kanataServiceTarget],
                     timeout: 15
                 )
+                if result.status != 0,
+                   result.out.localizedCaseInsensitiveContains("No process to signal"),
+                   !Self.isServiceHealthy(Self.kanataServiceID)
+                {
+                    // The registered KeepAlive job is already stopped or waiting
+                    // for launchd's throttle window. Stop is idempotently complete.
+                    return
+                }
                 guard result.status == 0 else {
                     throw HelperError.operationFailed(
                         "Failed to stop KeyPath Kanata service: \(result.out)"
+                    )
+                }
+            },
+            reply: reply
+        )
+    }
+
+    func restartKanataService(reply: @escaping (Bool, String?) -> Void) {
+        NSLog("[KeyPathHelper] restartKanataService requested")
+        executePrivilegedOperation(
+            name: "restartKanataService",
+            operation: {
+                let result = Self.run(
+                    "/bin/launchctl",
+                    ["kickstart", "-k", Self.kanataServiceTarget],
+                    timeout: 15
+                )
+                guard result.status == 0 else {
+                    throw HelperError.operationFailed(
+                        "Failed to restart KeyPath Kanata service: \(result.out)"
                     )
                 }
             },

--- a/Sources/KeyPathHelper/Info.plist
+++ b/Sources/KeyPathHelper/Info.plist
@@ -12,7 +12,7 @@
 
     <!-- Version (should match main app) -->
     <key>CFBundleShortVersionString</key>
-	<string>1.2.0</string>
+	<string>1.3.0</string>
 
     <key>CFBundleVersion</key>
 	<string>3</string>

--- a/Tests/KeyPathTests/CLI/CLIServiceTests.swift
+++ b/Tests/KeyPathTests/CLI/CLIServiceTests.swift
@@ -62,64 +62,46 @@ final class CLIServiceTests: XCTestCase {
         XCTAssertEqual(stopCount, 1)
     }
 
-    func testRestartServiceDoesNotReportSuccessWhenStopFails() async {
+    func testRestartServiceDoesNotReportSuccessWhenPrivilegedHelperFails() async {
         let operations = ServiceOperationRecorder()
-
         let facade = SystemFacade(
-            startServiceOperation: { await operations.recordStart() },
-            stopServiceOperation: { throw ServiceOperationError.failed },
+            restartServiceOperation: {
+                await operations.recordRestart()
+                throw ServiceOperationError.failed
+            },
             runtimeSnapshotProvider: { Self.runtimeSnapshot(running: true, responding: true) },
             runtimeTransitionTimeoutSeconds: 0.05,
-            pollDelayNanoseconds: 0,
-            restartDelayNanoseconds: 0
+            pollDelayNanoseconds: 0
         )
 
         let restarted = await facade.restartService()
-        let startCount = await operations.startCount
+        let restartCount = await operations.restartCount
 
         XCTAssertFalse(restarted)
-        XCTAssertEqual(startCount, 0)
+        XCTAssertEqual(restartCount, 1)
     }
 
-    func testRestartServiceAcceptsKeepAliveRelaunchBeforeStoppedSnapshot() async {
+    func testRestartServiceWaitsForHealthyRuntimeAfterHelperSuccess() async {
+        let snapshots = RuntimeSnapshotSequence([
+            Self.runtimeSnapshot(running: false, responding: false),
+            Self.runtimeSnapshot(running: true, responding: true)
+        ])
         let operations = ServiceOperationRecorder()
         let invalidations = SynchronousCallRecorder()
         let facade = SystemFacade(
-            startServiceOperation: { await operations.recordStart() },
-            stopServiceOperation: { await operations.recordStop() },
+            restartServiceOperation: { await operations.recordRestart() },
             runtimeCacheInvalidator: { invalidations.record() },
-            runtimeSnapshotProvider: { Self.runtimeSnapshot(running: true, responding: true) },
+            runtimeSnapshotProvider: { await snapshots.next() },
             runtimeTransitionTimeoutSeconds: 0.05,
-            pollDelayNanoseconds: 0,
-            restartDelayNanoseconds: 0
+            pollDelayNanoseconds: 0
         )
 
         let restarted = await facade.restartService()
-        let startCount = await operations.startCount
-        let stopCount = await operations.stopCount
+        let restartCount = await operations.restartCount
 
         XCTAssertTrue(restarted)
-        XCTAssertEqual(stopCount, 1)
-        XCTAssertEqual(startCount, 1)
-        XCTAssertEqual(invalidations.count, 2)
-    }
-
-    func testRestartServiceDoesNotReportSuccessWhenStartFails() async {
-        let operations = ServiceOperationRecorder()
-        let facade = SystemFacade(
-            startServiceOperation: { throw ServiceOperationError.failed },
-            stopServiceOperation: { await operations.recordStop() },
-            runtimeSnapshotProvider: { Self.runtimeSnapshot(running: true, responding: true) },
-            runtimeTransitionTimeoutSeconds: 0.05,
-            pollDelayNanoseconds: 0,
-            restartDelayNanoseconds: 0
-        )
-
-        let restarted = await facade.restartService()
-        let stopCount = await operations.stopCount
-
-        XCTAssertFalse(restarted)
-        XCTAssertEqual(stopCount, 1)
+        XCTAssertEqual(restartCount, 1)
+        XCTAssertEqual(invalidations.count, 1)
     }
 
     func testStartServiceReturnsFalseWhenRuntimeNeverBecomesHealthy() async {
@@ -204,6 +186,7 @@ private enum ServiceOperationError: Error {
 private actor ServiceOperationRecorder {
     private(set) var startCount = 0
     private(set) var stopCount = 0
+    private(set) var restartCount = 0
 
     func recordStart() {
         startCount += 1
@@ -211,6 +194,10 @@ private actor ServiceOperationRecorder {
 
     func recordStop() {
         stopCount += 1
+    }
+
+    func recordRestart() {
+        restartCount += 1
     }
 }
 


### PR DESCRIPTION
## Summary
- add one privileged-helper restart operation backed by `launchctl kickstart -k`
- route CLI restart through that atomic launchd operation and verify the final healthy runtime
- make helper stop idempotent when the registered job has no current process
- bump the helper contract and bundle version to 1.3.0

## Why
Installed acceptance of #1234 captured the concrete remaining race: immediately after fast deploy, Kanata was registered but in launchd `spawn scheduled` state. The helper stop returned `No process to signal`, so CLI restart failed even though launchd later restored a healthy runtime. A native `kickstart -k` restart avoids the stop/start transition window entirely.

## Validation
- `TEST_FILTER=CLIServiceTests TIMEOUT_SECONDS=180 ./Scripts/run-tests-safe.sh` — 10 XCTest cases, 0 failures
- `TEST_FILTER=HelperVersionContractTests TIMEOUT_SECONDS=120 ./Scripts/run-tests-safe.sh` — 2 cases, 0 failures
- `TEST_FILTER=CLIPrivilegeBoundaryLintTests TIMEOUT_SECONDS=120 ./Scripts/run-tests-safe.sh` — 1 case, 0 failures
- reproduced helper error from unified log: `stopKanataService failed ... No process to signal` while `launchctl print` showed the job registered and subsequently running
