### PR TITLE
Fix onboarding crash from packaged SwiftPM resources

### DIFF
--- a/Scripts/verify-installed-app.sh
+++ b/Scripts/verify-installed-app.sh
@@ -27,6 +27,21 @@ if [[ ! -d "$APP_PATH" ]]; then
     exit 1
 fi
 
+for resource_bundle in \
+    KeyPath_KeyPath.bundle \
+    KeyPath_KeyPathAppKit.bundle \
+    KeyPath_KeyPathInstallationWizard.bundle; do
+    packaged_bundle="$APP_PATH/Contents/Resources/$resource_bundle"
+    if [[ ! -d "$packaged_bundle" ]]; then
+        echo "❌ Packaged SwiftPM resource bundle is missing: $packaged_bundle" >&2
+        exit 1
+    fi
+done
+if [[ ! -f "$APP_PATH/Contents/Resources/KeyPath_KeyPathAppKit.bundle/default.metallib" ]]; then
+    echo "❌ Packaged Metal library is missing from the KeyPathAppKit resource bundle" >&2
+    exit 1
+fi
+
 CLI_PATH="$APP_PATH/Contents/MacOS/keypath-cli"
 if [[ ! -x "$CLI_PATH" ]]; then
     echo "❌ Bundled CLI is missing or not executable: $CLI_PATH" >&2

--- a/Sources/KeyPathAppKit/Support/KeyPathAppKitResources.swift
+++ b/Sources/KeyPathAppKit/Support/KeyPathAppKitResources.swift
@@ -2,10 +2,17 @@ import Foundation
 
 private final class KeyPathAppKitBundleSentinel {}
 
+/// Resolves this target's SwiftPM resources without using `Bundle.module`.
+/// KeyPath wraps a SwiftPM command-line executable in a signed macOS `.app`, so
+/// target bundles live in `Contents/Resources` rather than beside the app root
+/// where SwiftPM's generated accessor searches.
 enum KeyPathAppKitResources {
-    static let bundle: Bundle = {
-        let mainBundle = Bundle.main
-        let codeBundle = Bundle(for: KeyPathAppKitBundleSentinel.self)
+    static let bundle = resolveBundle(
+        mainBundle: .main,
+        codeBundle: Bundle(for: KeyPathAppKitBundleSentinel.self)
+    )
+
+    static func resolveBundle(mainBundle: Bundle, codeBundle: Bundle) -> Bundle {
         let candidates = [
             mainBundle.resourceURL?.appendingPathComponent("KeyPath_KeyPathAppKit.bundle"),
             codeBundle.resourceURL?.appendingPathComponent("KeyPath_KeyPathAppKit.bundle"),
@@ -22,7 +29,7 @@ enum KeyPathAppKitResources {
         }
 
         return mainBundle
-    }()
+    }
 
     static var resourceURL: URL? {
         bundle.resourceURL ?? Bundle.main.resourceURL

--- a/Sources/KeyPathAppKit/UI/Components/TimingCopy.swift
+++ b/Sources/KeyPathAppKit/UI/Components/TimingCopy.swift
@@ -47,17 +47,17 @@ enum TimingCopy {
     static let holdActivationDelayExplanation = "How long to hold this key before its hold action activates."
     static let leaderHoldDelay = LocalizedStringResource(
         "Leader hold delay",
-        bundle: #bundle,
+        bundle: KeyPathAppKitResources.bundle,
         comment: "Label for the setting that controls how long the Leader key must be held."
     )
     static let leaderHoldDelayExplanation = LocalizedStringResource(
         "How long to hold the Leader key before KeyPath shows the Shortcut List. Default is Long (300 ms). Medium (200 ms) matches previous behavior.",
-        bundle: #bundle,
+        bundle: KeyPathAppKitResources.bundle,
         comment: "Explains the Leader hold delay and its default and compatibility presets."
     )
     static let customLeaderHoldDelayAccessibilityLabel = LocalizedStringResource(
         "Custom Leader hold delay in milliseconds",
-        bundle: #bundle,
+        bundle: KeyPathAppKitResources.bundle,
         comment: "Accessibility label for the custom Leader hold delay field."
     )
     static let multiTapWindow = "Multi-tap window"

--- a/Sources/KeyPathAppKit/UI/KeyboardStage/KeyboardStageSemanticOverlay.swift
+++ b/Sources/KeyPathAppKit/UI/KeyboardStage/KeyboardStageSemanticOverlay.swift
@@ -217,16 +217,16 @@ private struct KeyboardStageKeyLegendOverlay: View {
     private var accessibilityLabel: Text {
         switch key.accessibilityRole {
         case .capsToEscape:
-            Text("Caps Lock changes to Escape", bundle: #bundle)
+            Text("Caps Lock changes to Escape", bundle: KeyPathAppKitResources.bundle)
         case .capsToHyper:
             Text(
                 "Holding Caps Lock produces Hyper: Control, Option, Shift, and Command",
-                bundle: #bundle
+                bundle: KeyPathAppKitResources.bundle
             )
         case let .launcherKey(letter, application):
             Text(
                 "Hyper plus \(letter) launches \(application.name)",
-                bundle: #bundle
+                bundle: KeyPathAppKitResources.bundle
             )
         case nil:
             Text(verbatim: "")
@@ -279,7 +279,7 @@ private struct KeyboardStageDecorationLegendOverlay: View {
             case .launcherChoiceTarget:
                 HStack(spacing: 7) {
                     Image(systemName: "app.fill")
-                    Text("Choose a letter + app", bundle: #bundle)
+                    Text("Choose a letter + app", bundle: KeyPathAppKitResources.bundle)
                         .lineLimit(1)
                         .minimumScaleFactor(0.72)
                 }
@@ -289,7 +289,7 @@ private struct KeyboardStageDecorationLegendOverlay: View {
                 .accessibilityLabel(
                     Text(
                         "Choose a letter and favorite app here",
-                        bundle: #bundle
+                        bundle: KeyPathAppKitResources.bundle
                     )
                 )
                 .accessibilityIdentifier("keyboard-stage-launcher-choice")
@@ -297,7 +297,7 @@ private struct KeyboardStageDecorationLegendOverlay: View {
             case .handoffTarget:
                 HStack(spacing: 7) {
                     Image(systemName: "square.grid.2x2.fill")
-                    Text("Rules", bundle: #bundle)
+                    Text("Rules", bundle: KeyPathAppKitResources.bundle)
                         .lineLimit(1)
                         .minimumScaleFactor(0.8)
                 }
@@ -307,7 +307,7 @@ private struct KeyboardStageDecorationLegendOverlay: View {
                 .accessibilityLabel(
                     Text(
                         "Continue in Rules to discover more keyboard changes",
-                        bundle: #bundle
+                        bundle: KeyPathAppKitResources.bundle
                     )
                 )
                 .accessibilityIdentifier("keyboard-stage-rules-handoff")

--- a/Sources/KeyPathAppKit/UI/Rules/FirstSuccessLauncherChoice.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/FirstSuccessLauncherChoice.swift
@@ -87,21 +87,21 @@ final class FirstSuccessLauncherChoiceModel {
         if selectedApp == nil, canonicalKey.isEmpty {
             return LocalizedStringResource(
                 "Choose an app and a letter.",
-                bundle: #bundle,
+                bundle: KeyPathAppKitResources.bundle,
                 comment: "Validation shown before an onboarding launcher app and shortcut letter are selected."
             )
         }
         if selectedApp == nil {
             return LocalizedStringResource(
                 "Choose an app to launch.",
-                bundle: #bundle,
+                bundle: KeyPathAppKitResources.bundle,
                 comment: "Validation shown when an onboarding launcher letter is selected without an app."
             )
         }
         if canonicalKey.isEmpty {
             return LocalizedStringResource(
                 "Choose one letter for the shortcut.",
-                bundle: #bundle,
+                bundle: KeyPathAppKitResources.bundle,
                 comment: "Validation shown when an onboarding launcher app is selected without a shortcut letter."
             )
         }
@@ -110,14 +110,14 @@ final class FirstSuccessLauncherChoiceModel {
         else {
             return LocalizedStringResource(
                 "Use a single letter.",
-                bundle: #bundle,
+                bundle: KeyPathAppKitResources.bundle,
                 comment: "Validation shown when the onboarding launcher shortcut is not one supported key."
             )
         }
         if occupiedCanonicalKeys.contains(canonicalKey) {
             return LocalizedStringResource(
                 "That letter already has a shortcut. Choose another.",
-                bundle: #bundle,
+                bundle: KeyPathAppKitResources.bundle,
                 comment: "Validation shown when the onboarding launcher shortcut letter is already assigned."
             )
         }
@@ -210,7 +210,7 @@ private struct FirstSuccessChosenAppRow: View {
             } label: {
                 Text(
                     selectedApp == nil ? "Choose App" : "Change",
-                    bundle: #bundle,
+                    bundle: KeyPathAppKitResources.bundle,
                     comment: "Button that opens the onboarding application picker."
                 )
             }
@@ -219,7 +219,7 @@ private struct FirstSuccessChosenAppRow: View {
             .accessibilityLabel(
                 Text(
                     "Choose an app to launch",
-                    bundle: #bundle,
+                    bundle: KeyPathAppKitResources.bundle,
                     comment: "Accessibility label for the onboarding application picker button."
                 )
             )
@@ -249,7 +249,7 @@ private struct FirstSuccessChosenAppIdentity: View {
                     .accessibilityHidden(true)
                 Text(
                     "Favorite app",
-                    bundle: #bundle,
+                    bundle: KeyPathAppKitResources.bundle,
                     comment: "Placeholder shown before an onboarding launcher app is selected."
                 )
                 .font(.subheadline.weight(.medium))
@@ -273,13 +273,13 @@ private struct FirstSuccessLauncherShortcutField: View {
             VStack(alignment: .leading, spacing: 2) {
                 Text(
                     "Shortcut letter",
-                    bundle: #bundle,
+                    bundle: KeyPathAppKitResources.bundle,
                     comment: "Label for the onboarding Quick Launcher shortcut letter field."
                 )
                 .font(.subheadline.weight(.medium))
                 Text(
                     "Hold Caps Lock, then press",
-                    bundle: #bundle,
+                    bundle: KeyPathAppKitResources.bundle,
                     comment: "Gesture reminder beside the onboarding Quick Launcher shortcut letter field."
                 )
                 .font(.caption)
@@ -288,7 +288,7 @@ private struct FirstSuccessLauncherShortcutField: View {
 
             Spacer(minLength: 8)
 
-            Text("Hyper +", bundle: #bundle)
+            Text("Hyper +", bundle: KeyPathAppKitResources.bundle)
                 .font(.caption.weight(.medium))
                 .foregroundStyle(.secondary)
             TextField(
@@ -296,7 +296,7 @@ private struct FirstSuccessLauncherShortcutField: View {
                 text: $displayKey,
                 prompt: Text(
                     "Q",
-                    bundle: #bundle,
+                    bundle: KeyPathAppKitResources.bundle,
                     comment: "Example letter in the onboarding Quick Launcher shortcut field."
                 )
             )
@@ -308,14 +308,14 @@ private struct FirstSuccessLauncherShortcutField: View {
             .accessibilityLabel(
                 Text(
                     "Shortcut letter",
-                    bundle: #bundle,
+                    bundle: KeyPathAppKitResources.bundle,
                     comment: "Accessibility label for the onboarding Quick Launcher shortcut field."
                 )
             )
             .accessibilityHint(
                 Text(
                     "Enter one letter to press while holding Caps Lock.",
-                    bundle: #bundle,
+                    bundle: KeyPathAppKitResources.bundle,
                     comment: "Accessibility hint for the onboarding Quick Launcher shortcut field."
                 )
             )
@@ -393,7 +393,7 @@ private struct FirstSuccessRunningAppPicker: View {
                     if runningApps.isEmpty {
                         Text(
                             "No user-facing apps are running.",
-                            bundle: #bundle,
+                            bundle: KeyPathAppKitResources.bundle,
                             comment: "Empty state in the onboarding running-app picker."
                         )
                         .font(.subheadline)
@@ -418,7 +418,7 @@ private struct FirstSuccessRunningAppPicker: View {
                 Label {
                     Text(
                         "Browse for another app…",
-                        bundle: #bundle,
+                        bundle: KeyPathAppKitResources.bundle,
                         comment: "Button that opens a file picker from the onboarding running-app sheet."
                     )
                 } icon: {
@@ -446,7 +446,7 @@ private struct FirstSuccessRunningAppPickerHeader: View {
         HStack {
             Text(
                 "Choose an App",
-                bundle: #bundle,
+                bundle: KeyPathAppKitResources.bundle,
                 comment: "Title of the onboarding running-app picker."
             )
             .font(.headline)
@@ -454,7 +454,7 @@ private struct FirstSuccessRunningAppPickerHeader: View {
             Button(action: cancel) {
                 Text(
                     "Cancel",
-                    bundle: #bundle,
+                    bundle: KeyPathAppKitResources.bundle,
                     comment: "Button that closes the onboarding running-app picker."
                 )
             }
@@ -492,14 +492,14 @@ private struct FirstSuccessRunningAppRow: View {
         .accessibilityLabel(
             Text(
                 "Choose \(choice.app.name)",
-                bundle: #bundle,
+                bundle: KeyPathAppKitResources.bundle,
                 comment: "Running-app picker row. The variable is the application name."
             )
         )
         .accessibilityHint(
             Text(
                 "Uses this app for the new launcher shortcut.",
-                bundle: #bundle,
+                bundle: KeyPathAppKitResources.bundle,
                 comment: "Accessibility hint for an onboarding running-app picker row."
             )
         )
@@ -567,12 +567,12 @@ private enum FirstSuccessApplicationBrowser {
         panel.directoryURL = URL(fileURLWithPath: "/Applications", isDirectory: true)
         panel.message = String(
             localized: "Choose the app this shortcut should open.",
-            bundle: #bundle,
+            bundle: KeyPathAppKitResources.bundle,
             comment: "Message in the onboarding application file picker."
         )
         panel.prompt = String(
             localized: "Choose App",
-            bundle: #bundle,
+            bundle: KeyPathAppKitResources.bundle,
             comment: "Confirmation button in the onboarding application file picker."
         )
 

--- a/Sources/KeyPathAppKit/UI/Rules/FirstSuccessOnboardingDialog.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/FirstSuccessOnboardingDialog.swift
@@ -387,7 +387,7 @@ struct FirstSuccessOnboardingDialog: View {
                 cancel: .init(
                     title: String(
                         localized: "Skip tour",
-                        bundle: #bundle,
+                        bundle: KeyPathAppKitResources.bundle,
                         comment: "Button that dismisses the optional first-success tour."
                     ),
                     action: skipTour,
@@ -397,7 +397,7 @@ struct FirstSuccessOnboardingDialog: View {
                 secondary: .init(
                     title: String(
                         localized: "Back",
-                        bundle: #bundle,
+                        bundle: KeyPathAppKitResources.bundle,
                         comment: "Button that returns to the previous first-success lesson."
                     ),
                     action: goBack,
@@ -429,48 +429,48 @@ struct FirstSuccessOnboardingDialog: View {
         case .capsLock:
             return switch session.capsLockPhase {
             case .installed, .practiced:
-                String(localized: "Continue", bundle: #bundle)
+                String(localized: "Continue", bundle: KeyPathAppKitResources.bundle)
             case .blocked:
-                String(localized: "Keep my current setup", bundle: #bundle)
+                String(localized: "Keep my current setup", bundle: KeyPathAppKitResources.bundle)
             case .explaining where session.failure == .capsLockEscape:
-                String(localized: "Try again", bundle: #bundle)
+                String(localized: "Try again", bundle: KeyPathAppKitResources.bundle)
             case .explaining, .applying:
-                String(localized: "Use Caps Lock for Escape", bundle: #bundle)
+                String(localized: "Use Caps Lock for Escape", bundle: KeyPathAppKitResources.bundle)
             }
         case .hyper:
             return switch session.hyperPhase {
             case .installed, .practiced:
-                String(localized: "Continue", bundle: #bundle)
+                String(localized: "Continue", bundle: KeyPathAppKitResources.bundle)
             case .blocked:
-                String(localized: "Keep my current setup", bundle: #bundle)
+                String(localized: "Keep my current setup", bundle: KeyPathAppKitResources.bundle)
             case .explaining where session.failure == .hyper:
-                String(localized: "Try again", bundle: #bundle)
+                String(localized: "Try again", bundle: KeyPathAppKitResources.bundle)
             case .explaining, .applying:
-                String(localized: "Add Hyper on hold", bundle: #bundle)
+                String(localized: "Add Hyper on hold", bundle: KeyPathAppKitResources.bundle)
             }
         case .launcher:
             guard session.hyperPhase.isInstalled else {
-                return String(localized: "Continue", bundle: #bundle)
+                return String(localized: "Continue", bundle: KeyPathAppKitResources.bundle)
             }
             switch session.launcherPhase {
             case .installed, .practiced:
-                return String(localized: "Continue", bundle: #bundle)
+                return String(localized: "Continue", bundle: KeyPathAppKitResources.bundle)
             case .explaining where session.failure == .launcherShortcut:
-                return String(localized: "Try again", bundle: #bundle)
+                return String(localized: "Try again", bundle: KeyPathAppKitResources.bundle)
             case .explaining, .blocked, .applying:
                 if let app = launcherChoice.selectedApp,
                    !launcherChoice.canonicalKey.isEmpty
                 {
                     return String(
                         localized: "Save Hyper + \(launcherChoice.displayedKey.uppercased()) for \(app.name)",
-                        bundle: #bundle,
+                        bundle: KeyPathAppKitResources.bundle,
                         comment: "Button that saves the selected Quick Launcher app and key during onboarding."
                     )
                 }
-                return String(localized: "Choose an app and letter", bundle: #bundle)
+                return String(localized: "Choose an app and letter", bundle: KeyPathAppKitResources.bundle)
             }
         case .rules:
-            return String(localized: "Explore Rules", bundle: #bundle)
+            return String(localized: "Explore Rules", bundle: KeyPathAppKitResources.bundle)
         }
     }
 
@@ -587,7 +587,7 @@ private struct FirstSuccessProgressHeader: View {
             }
             .accessibilityHidden(true)
 
-            Text("\(step.ordinal) of \(FirstSuccessOnboardingSession.Step.allCases.count)", bundle: #bundle)
+            Text("\(step.ordinal) of \(FirstSuccessOnboardingSession.Step.allCases.count)", bundle: KeyPathAppKitResources.bundle)
                 .font(.caption)
                 .foregroundStyle(palette.mutedText.color)
                 .padding(.leading, 28)
@@ -601,7 +601,7 @@ private struct FirstSuccessProgressHeader: View {
         .accessibilityLabel(
             Text(
                 "Onboarding step \(step.ordinal) of \(FirstSuccessOnboardingSession.Step.allCases.count)",
-                bundle: #bundle
+                bundle: KeyPathAppKitResources.bundle
             )
         )
         .accessibilityIdentifier("first-success-onboarding-progress")
@@ -874,10 +874,10 @@ private struct FirstSuccessBenefitRow: View {
                 .accessibilityHidden(true)
 
             VStack(alignment: .leading, spacing: 4) {
-                Text(title, bundle: #bundle)
+                Text(title, bundle: KeyPathAppKitResources.bundle)
                     .font(.subheadline.weight(.semibold))
                     .foregroundStyle(palette.primaryText.color)
-                Text(detail, bundle: #bundle)
+                Text(detail, bundle: KeyPathAppKitResources.bundle)
                     .font(.callout)
                     .foregroundStyle(palette.detailText.color)
                     .lineSpacing(3)
@@ -890,7 +890,7 @@ private struct FirstSuccessBenefitRow: View {
     @ViewBuilder
     private var iconContent: some View {
         if icon == "keypath.esc" {
-            Text("esc", bundle: #bundle)
+            Text("esc", bundle: KeyPathAppKitResources.bundle)
                 .font(.system(size: 16, weight: .semibold))
         } else {
             Image(systemName: icon)
@@ -927,9 +927,9 @@ private struct CapsLockPracticeControl: View {
             .buttonStyle(.plain)
             .popover(isPresented: $session.isCapsPracticeMenuPresented, arrowEdge: .trailing) {
                 VStack(alignment: .leading, spacing: 8) {
-                    Text("A tiny practice menu", bundle: #bundle)
+                    Text("A tiny practice menu", bundle: KeyPathAppKitResources.bundle)
                         .font(.headline)
-                    Text("Tap Caps Lock. It should dismiss this menu just like Escape.", bundle: #bundle)
+                    Text("Tap Caps Lock. It should dismiss this menu just like Escape.", bundle: KeyPathAppKitResources.bundle)
                         .font(.body)
                         .foregroundStyle(.secondary)
                         .fixedSize(horizontal: false, vertical: true)
@@ -988,7 +988,7 @@ private struct FirstSuccessStatusRegion: View {
             if session.isApplying {
                 ProgressView()
                     .controlSize(.small)
-                Text("Saving and reloading your keyboard…", bundle: #bundle)
+                Text("Saving and reloading your keyboard…", bundle: KeyPathAppKitResources.bundle)
                     .font(.callout)
                     .foregroundStyle(palette.detailText.color)
             } else if let failure = session.failure {
@@ -1021,19 +1021,19 @@ private struct FirstSuccessStatusRegion: View {
             case .capsLockEscape:
                 LocalizedStringResource(
                     "Caps Lock already has a custom job, so KeyPath left it untouched.",
-                    bundle: #bundle,
+                    bundle: KeyPathAppKitResources.bundle,
                     comment: "Safe conflict message when onboarding will not overwrite Caps Lock."
                 )
             case .hyper:
                 LocalizedStringResource(
                     "Your current Caps Lock or shortcut setup is already customized, so KeyPath left it untouched.",
-                    bundle: #bundle,
+                    bundle: KeyPathAppKitResources.bundle,
                     comment: "Safe conflict message when onboarding will not overwrite the current Caps Lock or shortcut setup."
                 )
             case .launcherShortcut:
                 LocalizedStringResource(
                     "That letter is already in use, so KeyPath left your launcher untouched. Choose another letter and try again.",
-                    bundle: #bundle,
+                    bundle: KeyPathAppKitResources.bundle,
                     comment: "Safe conflict message when an onboarding launcher shortcut cannot be added."
                 )
             }
@@ -1042,14 +1042,14 @@ private struct FirstSuccessStatusRegion: View {
         if session.savedButNotActive == failure {
             return LocalizedStringResource(
                 "Your choice was saved, but KeyPath could not make it active yet. Try again when KeyPath is ready.",
-                bundle: #bundle,
+                bundle: KeyPathAppKitResources.bundle,
                 comment: "Recoverable error shown when an onboarding choice is durable but its live reload is not active."
             )
         }
 
         return LocalizedStringResource(
             "KeyPath could not save that change. Nothing new was applied; try again.",
-            bundle: #bundle,
+            bundle: KeyPathAppKitResources.bundle,
             comment: "Recoverable error shown when an onboarding catalog install fails."
         )
     }
@@ -1144,36 +1144,36 @@ private struct FirstSuccessKeyboardHero: View {
     private var accessibilityLabel: Text {
         switch moment {
         case .welcome:
-            Text("A keyboard ready for three guided changes.", bundle: #bundle)
+            Text("A keyboard ready for three guided changes.", bundle: KeyPathAppKitResources.bundle)
         case .capsMotivation:
-            Text("Caps Lock is highlighted. It still types Caps Lock; the proposed tap action is Escape.", bundle: #bundle)
+            Text("Caps Lock is highlighted. It still types Caps Lock; the proposed tap action is Escape.", bundle: KeyPathAppKitResources.bundle)
         case .capsApplying:
-            Text("Caps Lock is being changed to type Escape when tapped.", bundle: #bundle)
+            Text("Caps Lock is being changed to type Escape when tapped.", bundle: KeyPathAppKitResources.bundle)
         case .capsInstalled:
             if session.hyperPhase.isInstalled {
-                Text("Caps Lock types Escape when tapped and prepares Hyper when held.", bundle: #bundle)
+                Text("Caps Lock types Escape when tapped and prepares Hyper when held.", bundle: KeyPathAppKitResources.bundle)
             } else {
-                Text("Caps Lock now types Escape when tapped. Its hold action remains available and unchanged.", bundle: #bundle)
+                Text("Caps Lock now types Escape when tapped. Its hold action remains available and unchanged.", bundle: KeyPathAppKitResources.bundle)
             }
         case .hyperMotivation:
-            Text("Caps Lock types Escape when tapped. The proposed hold action is Hyper.", bundle: #bundle)
+            Text("Caps Lock types Escape when tapped. The proposed hold action is Hyper.", bundle: KeyPathAppKitResources.bundle)
         case .hyperApplying:
-            Text("Held Caps Lock is being changed to Hyper: Control, Option, Shift, and Command.", bundle: #bundle)
+            Text("Held Caps Lock is being changed to Hyper: Control, Option, Shift, and Command.", bundle: KeyPathAppKitResources.bundle)
         case .hyperInstalled:
-            Text("Caps Lock now types Escape when tapped and Hyper when held.", bundle: #bundle)
+            Text("Caps Lock now types Escape when tapped and Hyper when held.", bundle: KeyPathAppKitResources.bundle)
         case .launcher:
             if let app = launcherChoice.selectedApp,
                !launcherChoice.canonicalKey.isEmpty
             {
                 Text(
                     "Hold Caps Lock and press \(launcherChoice.displayedKey.uppercased()) to open \(app.name).",
-                    bundle: #bundle
+                    bundle: KeyPathAppKitResources.bundle
                 )
             } else {
-                Text("Held Caps Lock prepares Hyper, and the highlighted letters are available shortcut keys you can choose.", bundle: #bundle)
+                Text("Held Caps Lock prepares Hyper, and the highlighted letters are available shortcut keys you can choose.", bundle: KeyPathAppKitResources.bundle)
             }
         case .handoff:
-            Text("The guided shortcuts are ready. The next action opens Rules to discover more keyboard changes.", bundle: #bundle)
+            Text("The guided shortcuts are ready. The next action opens Rules to discover more keyboard changes.", bundle: KeyPathAppKitResources.bundle)
         }
     }
 }

--- a/Sources/KeyPathAppKit/UI/Rules/FirstSuccessOnboardingSession.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/FirstSuccessOnboardingSession.swift
@@ -24,25 +24,25 @@ final class FirstSuccessOnboardingSession {
             case .capsLock:
                 LocalizedStringResource(
                     "FIRST SUCCESS",
-                    bundle: #bundle,
+                    bundle: KeyPathAppKitResources.bundle,
                     comment: "Eyebrow above the first onboarding lesson."
                 )
             case .hyper:
                 LocalizedStringResource(
                     "SECOND WIN",
-                    bundle: #bundle,
+                    bundle: KeyPathAppKitResources.bundle,
                     comment: "Eyebrow above the Hyper onboarding lesson."
                 )
             case .launcher:
                 LocalizedStringResource(
                     "THIRD WIN",
-                    bundle: #bundle,
+                    bundle: KeyPathAppKitResources.bundle,
                     comment: "Eyebrow above the Quick Launcher onboarding lesson."
                 )
             case .rules:
                 LocalizedStringResource(
                     "MAKE IT YOURS",
-                    bundle: #bundle,
+                    bundle: KeyPathAppKitResources.bundle,
                     comment: "Eyebrow above the Rules handoff at the end of onboarding."
                 )
             }
@@ -53,25 +53,25 @@ final class FirstSuccessOnboardingSession {
             case .capsLock:
                 LocalizedStringResource(
                     "Make a useful key yours",
-                    bundle: #bundle,
+                    bundle: KeyPathAppKitResources.bundle,
                     comment: "Title of the Caps Lock to Escape onboarding lesson."
                 )
             case .hyper:
                 LocalizedStringResource(
                     "Make shortcuts that stay yours",
-                    bundle: #bundle,
+                    bundle: KeyPathAppKitResources.bundle,
                     comment: "Title of the Hyper onboarding lesson."
                 )
             case .launcher:
                 LocalizedStringResource(
                     "Put a favorite app on a letter",
-                    bundle: #bundle,
+                    bundle: KeyPathAppKitResources.bundle,
                     comment: "Title of the Quick Launcher onboarding lesson."
                 )
             case .rules:
                 LocalizedStringResource(
                     "Your keyboard has room to grow",
-                    bundle: #bundle,
+                    bundle: KeyPathAppKitResources.bundle,
                     comment: "Title of the Rules discovery handoff at the end of onboarding."
                 )
             }
@@ -82,25 +82,25 @@ final class FirstSuccessOnboardingSession {
             case .capsLock:
                 LocalizedStringResource(
                     "Reclaim a rarely used key for Escape. A small change. A big upgrade.",
-                    bundle: #bundle,
+                    bundle: KeyPathAppKitResources.bundle,
                     comment: "Short motivation for moving Escape to Caps Lock."
                 )
             case .hyper:
                 LocalizedStringResource(
                     "Hold Caps Lock to prepare a clean shortcut prefix that other apps are unlikely to own.",
-                    bundle: #bundle,
+                    bundle: KeyPathAppKitResources.bundle,
                     comment: "Short motivation for assigning Hyper to held Caps Lock."
                 )
             case .launcher:
                 LocalizedStringResource(
                     "Hold Caps Lock, press a letter you choose, and your app opens.",
-                    bundle: #bundle,
+                    bundle: KeyPathAppKitResources.bundle,
                     comment: "Short explanation of the Quick Launcher interaction."
                 )
             case .rules:
                 LocalizedStringResource(
                     "You have the pattern: tap, hold, then combine. Rules is where you can discover what else KeyPath can make yours.",
-                    bundle: #bundle,
+                    bundle: KeyPathAppKitResources.bundle,
                     comment: "Explanation of the Rules discovery handoff after the guided wins are complete."
                 )
             }

--- a/Sources/KeyPathAppKit/UI/Rules/KeyRepeatControlView.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/KeyRepeatControlView.swift
@@ -198,7 +198,7 @@ struct KeyRepeatControlView: View {
                 VStack(alignment: .leading, spacing: 20) {
                     Text(
                         "Repeat start delay is how long you hold a key before it begins repeating. Repeat speed is how quickly it continues.",
-                        bundle: #bundle
+                        bundle: KeyPathAppKitResources.bundle
                     )
                     .font(.callout)
                     .foregroundStyle(.secondary)
@@ -509,14 +509,14 @@ private struct KeyRepeatTimingSummary: View {
         VStack(alignment: .trailing, spacing: 1) {
             Text(
                 "\(repeatsPerSecond, format: repeatSpeedFormat(repeatsPerSecond)) repeats/sec",
-                bundle: #bundle,
+                bundle: KeyPathAppKitResources.bundle,
                 comment: "Primary summary of a keyboard key's automatic repeat speed."
             )
             .font(.caption.monospaced().weight(.medium))
 
             Text(
                 "\(delayMs) ms start · \(intervalMs) ms interval",
-                bundle: #bundle,
+                bundle: KeyPathAppKitResources.bundle,
                 comment: "Secondary technical summary: repeat start delay followed by the interval between repeats."
             )
             .font(.caption2.monospaced())
@@ -536,7 +536,7 @@ private struct RepeatStartDelaySliderRow: View {
             HStack {
                 Text(
                     "Repeat start delay",
-                    bundle: #bundle,
+                    bundle: KeyPathAppKitResources.bundle,
                     comment: "Label for how long a key must be held before automatic repetition begins."
                 )
                 .font(.caption)
@@ -544,7 +544,7 @@ private struct RepeatStartDelaySliderRow: View {
                 Spacer()
                 Text(
                     "\(delayMs) ms",
-                    bundle: #bundle,
+                    bundle: KeyPathAppKitResources.bundle,
                     comment: "Current keyboard repeat start delay in milliseconds."
                 )
                 .font(.caption.monospaced().weight(.medium))
@@ -556,13 +556,13 @@ private struct RepeatStartDelaySliderRow: View {
             )
             .controlSize(.small)
             .accessibilityIdentifier(accessibilityID)
-            .accessibilityLabel(Text("Repeat start delay", bundle: #bundle))
-            .accessibilityValue(Text("\(delayMs) milliseconds", bundle: #bundle))
+            .accessibilityLabel(Text("Repeat start delay", bundle: KeyPathAppKitResources.bundle))
+            .accessibilityValue(Text("\(delayMs) milliseconds", bundle: KeyPathAppKitResources.bundle))
 
             HStack {
-                Text("Starts sooner", bundle: #bundle)
+                Text("Starts sooner", bundle: KeyPathAppKitResources.bundle)
                 Spacer()
-                Text("Starts later", bundle: #bundle)
+                Text("Starts later", bundle: KeyPathAppKitResources.bundle)
             }
             .font(.caption2)
             .foregroundStyle(.tertiary)
@@ -584,7 +584,7 @@ private struct RepeatSpeedSliderRow: View {
             HStack {
                 Text(
                     "Repeat speed",
-                    bundle: #bundle,
+                    bundle: KeyPathAppKitResources.bundle,
                     comment: "Label for how quickly a held key repeats after its start delay."
                 )
                 .font(.caption)
@@ -593,13 +593,13 @@ private struct RepeatSpeedSliderRow: View {
                 VStack(alignment: .trailing, spacing: 1) {
                     Text(
                         "\(repeatsPerSecond, format: repeatSpeedFormat(repeatsPerSecond)) repeats/sec",
-                        bundle: #bundle,
+                        bundle: KeyPathAppKitResources.bundle,
                         comment: "Primary value for a keyboard key's automatic repeat speed."
                     )
                     .font(.caption.monospaced().weight(.medium))
                     Text(
                         "\(intervalMs) ms interval",
-                        bundle: #bundle,
+                        bundle: KeyPathAppKitResources.bundle,
                         comment: "Secondary technical value for the interval between keyboard repeats."
                     )
                     .font(.caption2.monospaced())
@@ -613,25 +613,25 @@ private struct RepeatSpeedSliderRow: View {
             )
             .controlSize(.small)
             .accessibilityIdentifier(accessibilityID)
-            .accessibilityLabel(Text("Repeat speed", bundle: #bundle))
+            .accessibilityLabel(Text("Repeat speed", bundle: KeyPathAppKitResources.bundle))
             .accessibilityValue(
                 Text(
                     "\(repeatsPerSecond, format: repeatSpeedFormat(repeatsPerSecond)) repeats per second",
-                    bundle: #bundle,
+                    bundle: KeyPathAppKitResources.bundle,
                     comment: "Accessibility value for a keyboard key's automatic repeat speed."
                 )
             )
             .accessibilityHint(
                 Text(
                     "The equivalent interval is \(intervalMs) milliseconds. Moving right repeats faster.",
-                    bundle: #bundle
+                    bundle: KeyPathAppKitResources.bundle
                 )
             )
 
             HStack {
-                Text("Slower", bundle: #bundle)
+                Text("Slower", bundle: KeyPathAppKitResources.bundle)
                 Spacer()
-                Text("Faster", bundle: #bundle)
+                Text("Faster", bundle: KeyPathAppKitResources.bundle)
             }
             .font(.caption2)
             .foregroundStyle(.tertiary)

--- a/Sources/KeyPathInstallationWizard/Core/KeyPathInstallationWizardResources.swift
+++ b/Sources/KeyPathInstallationWizard/Core/KeyPathInstallationWizardResources.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+private final class KeyPathInstallationWizardBundleSentinel {}
+
+/// Resolves this target's SwiftPM resource bundle from both local builds and
+/// KeyPath's signed macOS app layout. Packaged bundles live in
+/// `Contents/Resources`; SwiftPM's generated `Bundle.module` accessor does not
+/// search there when a command-line executable is wrapped in an `.app`.
+enum KeyPathInstallationWizardResources {
+    static let bundle = resolveBundle(
+        mainBundle: .main,
+        codeBundle: Bundle(for: KeyPathInstallationWizardBundleSentinel.self)
+    )
+
+    static func resolveBundle(mainBundle: Bundle, codeBundle: Bundle) -> Bundle {
+        let bundleName = "KeyPath_KeyPathInstallationWizard.bundle"
+        let candidates = [
+            mainBundle.resourceURL?.appendingPathComponent(bundleName),
+            codeBundle.resourceURL?.appendingPathComponent(bundleName),
+            mainBundle.bundleURL.deletingLastPathComponent().appendingPathComponent(bundleName),
+            codeBundle.bundleURL.deletingLastPathComponent().appendingPathComponent(bundleName),
+            mainBundle.resourceURL,
+            codeBundle.resourceURL,
+        ].compactMap { $0 }
+
+        for candidate in candidates {
+            if let bundle = Bundle(url: candidate) {
+                return bundle
+            }
+        }
+
+        return mainBundle
+    }
+}

--- a/Sources/KeyPathInstallationWizard/UI/Pages/WizardKarabinerComponentsPage.swift
+++ b/Sources/KeyPathInstallationWizard/UI/Pages/WizardKarabinerComponentsPage.swift
@@ -768,8 +768,11 @@ private struct DriverExtensionApprovalGuide: View {
 
     private var screenshot: NSImage? {
         let resourceName = "karabiner-driver-extension-switch"
-        if let moduleURL = Bundle.module.url(forResource: resourceName, withExtension: "png"),
-           let image = NSImage(contentsOf: moduleURL)
+        if let moduleURL = KeyPathInstallationWizardResources.bundle.url(
+            forResource: resourceName,
+            withExtension: "png"
+        ),
+            let image = NSImage(contentsOf: moduleURL)
         {
             return image
         }

--- a/Tests/KeyPathTests/InstallationWizard/KeyPathInstallationWizardResourcesTests.swift
+++ b/Tests/KeyPathTests/InstallationWizard/KeyPathInstallationWizardResourcesTests.swift
@@ -1,0 +1,103 @@
+import Foundation
+@testable import KeyPathAppKit
+@testable import KeyPathInstallationWizard
+import XCTest
+
+final class KeyPathInstallationWizardResourcesTests: XCTestCase {
+    func testDriverApprovalScreenshotResolvesThroughPackagedResourceContract() {
+        XCTAssertNotNil(
+            KeyPathInstallationWizardResources.bundle.url(
+                forResource: "karabiner-driver-extension-switch",
+                withExtension: "png"
+            )
+        )
+    }
+
+    func testExplicitResolversFindResourcesInPackagedAppLayout() throws {
+        let fixture = try PackagedResourceBundleFixture()
+        defer { fixture.remove() }
+
+        let appKitBundle = KeyPathAppKitResources.resolveBundle(
+            mainBundle: fixture.appBundle,
+            codeBundle: fixture.appBundle
+        )
+        let wizardBundle = KeyPathInstallationWizardResources.resolveBundle(
+            mainBundle: fixture.appBundle,
+            codeBundle: fixture.appBundle
+        )
+
+        XCTAssertEqual(
+            appKitBundle.bundleURL.standardizedFileURL,
+            fixture.bundleURL(named: "KeyPath_KeyPathAppKit.bundle").standardizedFileURL
+        )
+        XCTAssertNotNil(appKitBundle.url(forResource: "packaged-probe", withExtension: "txt"))
+        XCTAssertEqual(
+            wizardBundle.bundleURL.standardizedFileURL,
+            fixture.bundleURL(named: "KeyPath_KeyPathInstallationWizard.bundle").standardizedFileURL
+        )
+        XCTAssertNotNil(wizardBundle.url(forResource: "packaged-probe", withExtension: "txt"))
+    }
+}
+
+private struct PackagedResourceBundleFixture {
+    let rootURL: URL
+    let appBundle: Bundle
+
+    init() throws {
+        let fileManager = FileManager.default
+        rootURL = fileManager.temporaryDirectory
+            .appendingPathComponent("keypath-packaged-resources-\(UUID().uuidString)", isDirectory: true)
+        let appURL = rootURL.appendingPathComponent("KeyPath.app", isDirectory: true)
+        let contentsURL = appURL.appendingPathComponent("Contents", isDirectory: true)
+        let resourcesURL = contentsURL.appendingPathComponent("Resources", isDirectory: true)
+        try fileManager.createDirectory(at: resourcesURL, withIntermediateDirectories: true)
+        try Self.writeInfoPlist(
+            to: contentsURL.appendingPathComponent("Info.plist"),
+            identifier: "com.keypath.tests.packaged-resources",
+            packageType: "APPL"
+        )
+
+        for name in ["KeyPath_KeyPathAppKit.bundle", "KeyPath_KeyPathInstallationWizard.bundle"] {
+            let bundleURL = resourcesURL.appendingPathComponent(name, isDirectory: true)
+            try fileManager.createDirectory(at: bundleURL, withIntermediateDirectories: true)
+            try Self.writeInfoPlist(
+                to: bundleURL.appendingPathComponent("Info.plist"),
+                identifier: "com.keypath.tests.\(name)",
+                packageType: "BNDL"
+            )
+            try Data("packaged".utf8).write(
+                to: bundleURL.appendingPathComponent("packaged-probe.txt")
+            )
+        }
+
+        appBundle = try XCTUnwrap(Bundle(url: appURL))
+    }
+
+    func bundleURL(named name: String) -> URL {
+        rootURL
+            .appendingPathComponent("KeyPath.app/Contents/Resources", isDirectory: true)
+            .appendingPathComponent(name, isDirectory: true)
+    }
+
+    func remove() {
+        try? FileManager.default.removeItem(at: rootURL)
+    }
+
+    private static func writeInfoPlist(
+        to url: URL,
+        identifier: String,
+        packageType: String
+    ) throws {
+        let data = try PropertyListSerialization.data(
+            fromPropertyList: [
+                "CFBundleIdentifier": identifier,
+                "CFBundleName": "KeyPath Resource Fixture",
+                "CFBundlePackageType": packageType,
+                "CFBundleVersion": "1",
+            ],
+            format: .xml,
+            options: 0
+        )
+        try data.write(to: url)
+    }
+}

--- a/Tests/KeyPathTests/Lint/DeploymentScriptContractTests.swift
+++ b/Tests/KeyPathTests/Lint/DeploymentScriptContractTests.swift
@@ -106,6 +106,18 @@ final class DeploymentScriptContractTests: XCTestCase {
         )
     }
 
+    func testInstalledAppVerifierRequiresPackagedSwiftPMResources() throws {
+        let verifier = try contents(
+            of: repositoryRoot().appendingPathComponent("Scripts/verify-installed-app.sh")
+        )
+
+        XCTAssertTrue(verifier.contains("KeyPath_KeyPath.bundle"))
+        XCTAssertTrue(verifier.contains("KeyPath_KeyPathAppKit.bundle"))
+        XCTAssertTrue(verifier.contains("KeyPath_KeyPathInstallationWizard.bundle"))
+        XCTAssertTrue(verifier.contains("Contents/Resources/$resource_bundle"))
+        XCTAssertTrue(verifier.contains("default.metallib"))
+    }
+
     func testQuickDeployPreservesBuildFailureDiagnostics() throws {
         let root = repositoryRoot()
         let quickDeploy = try contents(of: root.appendingPathComponent("Scripts/quick-deploy.sh"))

--- a/Tests/KeyPathTests/Lint/PackagedResourceBundleAccessLintTests.swift
+++ b/Tests/KeyPathTests/Lint/PackagedResourceBundleAccessLintTests.swift
@@ -1,0 +1,31 @@
+import Foundation
+@preconcurrency import XCTest
+
+/// KeyPath wraps SwiftPM executables in a signed macOS app. Target resource
+/// bundles are packaged in Contents/Resources, while SwiftPM's generated
+/// Bundle.module accessor searches the app root and then an absolute build path.
+final class PackagedResourceBundleAccessLintTests: XCTestCase {
+    func testPackagedLibraryTargetsUseExplicitResourceResolvers() throws {
+        let roots = [
+            LintScanner.path("Sources/KeyPathApp"),
+            LintScanner.path("Sources/KeyPathAppKit"),
+            LintScanner.path("Sources/KeyPathInstallationWizard"),
+        ]
+        let violations = try roots.flatMap {
+            try LintScanner.matchingLines(
+                under: $0,
+                patterns: [#"#bundle\b"#, #"Bundle\.module\b"#]
+            )
+        }
+
+        XCTAssertTrue(
+            violations.isEmpty,
+            """
+            Packaged library code must use KeyPath's explicit target resource
+            resolver. SwiftPM's generated accessor crashes after its absolute
+            build-worktree fallback disappears:
+            \(violations.sorted().joined(separator: "\n"))
+            """
+        )
+    }
+}

--- a/docs/bugs/swiftpm-resource-bundle-packaging.md
+++ b/docs/bugs/swiftpm-resource-bundle-packaging.md
@@ -1,0 +1,35 @@
+# SwiftPM resource bundles in the packaged macOS app
+
+## Symptom
+
+Opening first-success onboarding crashed in SwiftPM's generated
+`Bundle.module` accessor. The crash occurred only after the feature worktree had
+been removed.
+
+## Root cause
+
+SwiftPM generates an accessor that searches for target resource bundles at
+`Bundle.main.bundleURL/<target>.bundle`. For KeyPath's macOS app, that is the
+root of `KeyPath.app`.
+
+KeyPath's deploy and release scripts copied the physical bundles only into
+`KeyPath.app/Contents/Resources`. Development builds appeared to work because
+the generated accessor also embeds an absolute fallback path into the current
+worktree's `.build` directory. Removing that worktree exposed the invalid
+packaged layout.
+
+An app-root compatibility link was considered, but `codesign` rejects extra
+contents at the macOS bundle root as unsealed. The runtime fix therefore cannot
+change the signed app layout to satisfy SwiftPM's generated accessor.
+
+## Invariant
+
+Physical SwiftPM resource bundles remain in `Contents/Resources`. Code shipped
+inside `KeyPathAppKit` and `KeyPathInstallationWizard` must use their explicit
+packaged-resource resolvers instead of `#bundle` or `Bundle.module`.
+Installed-app verification must reject an app missing any target bundle or the
+AppKit Metal library.
+
+Never use successful execution from an extant build worktree as proof that a
+packaged SwiftPM resource is available. Verify the app-root runtime lookup path
+inside the installed app.


### PR DESCRIPTION
## Summary
- resolve KeyPathAppKit and installation-wizard resources from the signed `Contents/Resources` app layout instead of SwiftPMs generated app-root/worktree fallback
- prevent recurrence with packaged-layout resolver tests and lint coverage across the app, AppKit, and installation-wizard targets
- make installed-app verification fail closed when SwiftPM bundles or the Metal library are missing, and document the packaging invariant

## Validation
- `git diff --check`
- focused resource, Metal, deployment-contract, and lint suite: 16 passed
- required Caps Lock and Quick Launcher catalog regressions: 3 runner tests passed
- `python3 Scripts/check-accessibility.py`: 378 files passed
- `./Scripts/ui-deploy.sh`
- `REQUIRE_NOTARIZED=0 REQUIRE_STAPLED=0 ./Scripts/verify-installed-app.sh`
- UI automation against `/Applications/KeyPath.app`: first-success window opened without a crash; verified the initial dark illuminated Metal state and completed light transition
- independent code re-review: no remaining P0-P2 findings

## Broad gate note
`./Scripts/test-full.sh` completed with 5,003 passing tests and three stale Home Row Timing snapshot references. Those references predate `1ea3b9f55` (which made quick-tap UI conditional on timing mode); this branch does not change that view or its snapshots. All seven first-success onboarding snapshots passed, including dark-room and directional-light states.

Local review gate selected the remote path (exit 2); do not merge until the GitHub `claude-review` check passes.