### PR TITLE
Add direct onboarding tour replay command

### DIFF
--- a/Sources/KeyPathAppKit/Core/AppMenuCommands.swift
+++ b/Sources/KeyPathAppKit/Core/AppMenuCommands.swift
@@ -225,6 +225,22 @@ struct AppMenuCommands: Commands {
                 HelpWindowController.shared.showBrowser()
             }
             .keyboardShortcut("?", modifiers: .command)
+
+            Divider()
+
+            Button(
+                action: {
+                    replayFirstSuccessTour()
+                },
+                label: {
+                    Text(
+                        "Replay KeyPath Tour…",
+                        bundle: KeyPathAppKitResources.bundle,
+                        comment: "Help menu command that reopens KeyPath's optional keyboard onboarding tour."
+                    )
+                }
+            )
+            .accessibilityIdentifier("menu-replay-keypath-tour")
         }
     }
 
@@ -248,6 +264,12 @@ struct AppMenuCommands: Commands {
                 NSApplication.AboutPanelOptionKey.version: "Build \(info.build)"
             ]
         )
+    }
+
+    @MainActor
+    private func replayFirstSuccessTour() {
+        AppLogger.shared.log("🎓 [Menu] Replaying first-success tour")
+        FirstSuccessOnboardingWindowController.show(kanataViewModel: viewModel)
     }
 
     private func installCommandLineTool() {

--- a/Sources/KeyPathAppKit/Resources/Localizable.xcstrings
+++ b/Sources/KeyPathAppKit/Resources/Localizable.xcstrings
@@ -5920,6 +5920,16 @@
         }
       }
     },
+    "Replay KeyPath Tour…": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Replay KeyPath Tour…"
+          }
+        }
+      }
+    },
     "SECOND WIN": {
       "localizations": {
         "en": {

--- a/Tests/KeyPathTests/Lint/FirstSuccessOnboardingReplayMenuTests.swift
+++ b/Tests/KeyPathTests/Lint/FirstSuccessOnboardingReplayMenuTests.swift
@@ -1,0 +1,62 @@
+import Foundation
+import XCTest
+
+final class FirstSuccessOnboardingReplayMenuTests: XCTestCase {
+    func testHelpMenuReplaysTourDirectlyWithoutInstallerOrDefaults() throws {
+        let source = try String(
+            contentsOf: onboardingReplayRepositoryRoot()
+                .appendingPathComponent("Sources/KeyPathAppKit/Core/AppMenuCommands.swift"),
+            encoding: .utf8
+        )
+
+        let helpMenu = try XCTUnwrap(source.range(of: "CommandGroup(replacing: .help)"))
+        let privateHelpers = try XCTUnwrap(
+            source.range(
+                of: "// MARK: - Private Helpers",
+                range: helpMenu.upperBound ..< source.endIndex
+            )
+        )
+        let helpMenuSource = source[helpMenu.lowerBound ..< privateHelpers.lowerBound]
+
+        XCTAssertTrue(helpMenuSource.contains("Replay KeyPath Tour…"))
+        XCTAssertTrue(helpMenuSource.contains("replayFirstSuccessTour()"))
+        XCTAssertTrue(helpMenuSource.contains("menu-replay-keypath-tour"))
+
+        let replayMethod = try XCTUnwrap(
+            source.range(of: "private func replayFirstSuccessTour()")
+        )
+        let nextMethod = try XCTUnwrap(
+            source.range(
+                of: "private func installCommandLineTool()",
+                range: replayMethod.upperBound ..< source.endIndex
+            )
+        )
+        let replaySource = source[replayMethod.lowerBound ..< nextMethod.lowerBound]
+
+        XCTAssertTrue(
+            replaySource.contains(
+                "FirstSuccessOnboardingWindowController.show(kanataViewModel: viewModel)"
+            )
+        )
+        for forbiddenDependency in [
+            "FirstSuccessOnboardingGate",
+            "NotificationCenter",
+            "UserDefaults",
+            "WizardWindowController",
+            ".showWizard",
+        ] {
+            XCTAssertFalse(
+                replaySource.contains(forbiddenDependency),
+                "Tour replay must not route through \(forbiddenDependency)."
+            )
+        }
+    }
+}
+
+private func onboardingReplayRepositoryRoot(file: StaticString = #filePath) -> URL {
+    URL(fileURLWithPath: file.description)
+        .deletingLastPathComponent() // Lint
+        .deletingLastPathComponent() // KeyPathTests
+        .deletingLastPathComponent() // Tests
+        .deletingLastPathComponent() // repository root
+}

--- a/guides/installation-wizard.md
+++ b/guides/installation-wizard.md
@@ -107,11 +107,15 @@ The same key can do a second job: tap it for Escape, but hold it for **Hyper**. 
 
 ### 3. Launch a favorite app
 
-The tour enables **Quick Launcher**, then takes you to its real controls in **Rules**. Click an available letter on the keyboard — or choose **Add Mapping** — select **App** or **Website**, pick what you want to open, and choose **Save**. To use it, hold Caps Lock and press the letter you chose.
+Choose a real app and a memorable letter inside the tour. KeyPath saves that
+Quick Launcher shortcut before presenting it as complete. To use it, hold Caps
+Lock and press the letter you chose.
 
 ### Continue in Rules
 
-The handoff opens **Rules** with **Quick Launcher** in view, so the app and key choice happens in the same controls you will use later. From there, browse other Rules to discover another remap, turn a behavior off, or change any choice from the tour.
+The handoff opens **Rules** with **Quick Launcher** in view, where the saved app
+and letter remain visible and editable. From there, browse other Rules to discover
+another remap, turn a behavior off, or change any choice from the tour.
 
 ---
 
@@ -127,12 +131,18 @@ The wizard is designed to handle problems gracefully:
 
 **Service won't start:** The wizard runs diagnostics and shows what's blocking the service. Common causes: permissions not granted, driver not installed, or a conflicting process.
 
-### Running the wizard again
+### Replaying the first-success tour
+
+To revisit the optional keyboard tour, choose **Help > Replay KeyPath Tour…**.
+KeyPath opens the tour directly at the first keyboard win. It does not re-run setup,
+permission checks, or the installation wizard.
+
+### Running setup again
 
 If you need to re-run the wizard (e.g., after a macOS update that reset permissions):
 
 1. Open KeyPath
-2. Go to **File > Installation Wizard**
+2. Go to **File > Install wizard…**
 
 Or from the menu bar icon: click the KeyPath icon → **Setup Wizard**.
 


### PR DESCRIPTION
## Summary
- add Help > Replay KeyPath Tour… as a direct onboarding entry point
- bypass the installer wizard, one-shot eligibility gate, and hidden defaults
- localize and accessibility-label the command, with guide and source-contract coverage

## Validation
- targeted onboarding gate/session/replay tests: 18 passed
- catalog sequence regressions: 3 passed
- python3 Scripts/check-accessibility.py
- git diff --check
- ./Scripts/ui-deploy.sh
- installed-app Computer Use validation with onboarding_first_success_shown=1: Help command opened onboarding step 1 directly; no setup wizard appeared

## Review gate
- Local review tooling selected the remote review gate; do not merge until GitHub claude-review passes.