### PR TITLE
Clarify prerequisite resolution and replay safety

### DIFF
--- a/Sources/KeyPathAppKit/Core/AppMenuCommands.swift
+++ b/Sources/KeyPathAppKit/Core/AppMenuCommands.swift
@@ -269,7 +269,10 @@ struct AppMenuCommands: Commands {
     @MainActor
     private func replayFirstSuccessTour() {
         AppLogger.shared.log("🎓 [Menu] Replaying first-success tour")
-        FirstSuccessOnboardingWindowController.show(kanataViewModel: viewModel)
+        FirstSuccessOnboardingWindowController.show(
+            kanataViewModel: viewModel,
+            source: .replay
+        )
     }
 
     private func installCommandLineTool() {

--- a/Sources/KeyPathAppKit/InstallationWizard/WizardWindowController.swift
+++ b/Sources/KeyPathAppKit/InstallationWizard/WizardWindowController.swift
@@ -230,7 +230,8 @@ final class WizardWindowController {
         let viewModel = onboardingViewModel ?? (NSApp.delegate as? AppDelegate)?.viewModel
         closeCompletion.schedule {
             FirstSuccessOnboardingWindowController.show(
-                kanataViewModel: viewModel
+                kanataViewModel: viewModel,
+                source: .firstRun
             )
         }
     }

--- a/Sources/KeyPathAppKit/Services/Packs/PackInstaller.swift
+++ b/Sources/KeyPathAppKit/Services/Packs/PackInstaller.swift
@@ -74,6 +74,8 @@ public final class PackInstaller {
     ///   `.useRecommended` after the user has explicitly approved the change.
     /// - Parameter autoResolveCollectionConflicts: Whether a collection-backed
     ///   pack may automatically disable conflicting rules while it is enabled.
+    /// - Parameter additionalCollectionIDsToDisable: Related catalog
+    ///   collections to turn off in the same collection-backed transaction.
     /// - Parameter manager: the app's RuleCollectionsManager. Required.
     /// - Parameter skipFinalReload: Persist and validate the resulting config
     ///   without notifying the runtime; the caller owns the live reload.
@@ -85,6 +87,7 @@ public final class PackInstaller {
         collectionConfiguration: RuleCollectionConfiguration? = nil,
         managedDefaultPolicy: ManagedDefaultInstallPolicy = .promptWhenCustomized,
         autoResolveCollectionConflicts: Bool = true,
+        additionalCollectionIDsToDisable: Set<UUID> = [],
         manager: RuleCollectionsManager,
         skipFinalReload: Bool = false,
         installedPackTracker: InstalledPackTracker = .shared
@@ -224,6 +227,7 @@ public final class PackInstaller {
                 autoResolveConflicts: autoResolveCollectionConflicts,
                 bypassOwnershipCheck: true,
                 configurationOverride: collectionConfiguration,
+                additionalCollectionIDsToDisable: additionalCollectionIDsToDisable,
                 skipReload: skipFinalReload
             )
             if !ok {

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+ConflictDetection.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+ConflictDetection.swift
@@ -24,7 +24,10 @@ extension RuleCollectionsManager {
         return (KanataKeyConverter.convertToKanataKey(activator.input), activator.targetLayer)
     }
 
-    func conflictInfo(for candidate: RuleCollection) -> RuleConflictInfo? {
+    func conflictInfo(
+        for candidate: RuleCollection,
+        ignoringCollectionIDs: Set<UUID> = []
+    ) -> RuleConflictInfo? {
         // Neovim Terminal is app-scoped educational content; it intentionally coexists
         // with other navigation collections without forcing toggle conflicts.
         if isNeovimAppScopedReference(candidate) {
@@ -34,7 +37,11 @@ extension RuleCollectionsManager {
         let candidateKeys = normalizedKeys(for: candidate)
         let candidateActivator = normalizedActivator(for: candidate)
 
-        for other in ruleCollections where other.isEnabled && other.id != candidate.id {
+        for other in ruleCollections where
+            other.isEnabled
+            && other.id != candidate.id
+            && !ignoringCollectionIDs.contains(other.id)
+        {
             if isNeovimAppScopedReference(other) {
                 continue
             }

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+PrerequisiteDetection.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+PrerequisiteDetection.swift
@@ -26,9 +26,11 @@ extension RuleCollectionsManager {
     ///
     /// An existing collection is replaced in place so its display order remains
     /// stable. A new collection is appended. The proposal is always analyzed as
-    /// enabled because this query runs before the enable/save mutation.
+    /// enabled because this query runs before the enable/save mutation. A caller
+    /// may also stage collection disables that belong to the same transaction.
     func prerequisites(
-        for proposedCollection: RuleCollection
+        for proposedCollection: RuleCollection,
+        disablingCollectionIDs: Set<UUID> = []
     ) -> [RulePrerequisite] {
         let adapter = RuleCollectionDependencyGraphAdapter()
         let currentGraph = adapter.build(
@@ -38,12 +40,18 @@ extension RuleCollectionsManager {
 
         var candidate = proposedCollection
         candidate.isEnabled = true
+        let stagedDisableIDs = disablingCollectionIDs.subtracting([candidate.id])
 
         var proposedCollections = ruleCollections
         if let index = proposedCollections.firstIndex(where: { $0.id == candidate.id }) {
             proposedCollections[index] = candidate
         } else {
             proposedCollections.append(candidate)
+        }
+        for index in proposedCollections.indices where
+            stagedDisableIDs.contains(proposedCollections[index].id)
+        {
+            proposedCollections[index].isEnabled = false
         }
 
         let proposedGraph = adapter.build(
@@ -69,6 +77,7 @@ extension RuleCollectionsManager {
                 }
 
                 let providers = proposedGraph.knownProviders(for: requirement.capability)
+                    .filter { !stagedDisableIDs.contains($0) }
                 return RulePrerequisite(
                     consumerCollectionID: consumerID,
                     missingCapability: requirement.capability,

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+PrerequisiteResolution.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+PrerequisiteResolution.swift
@@ -49,9 +49,13 @@ extension RuleCollectionsManager {
     func confirmedPrerequisiteProviderIDs(
         for candidate: RuleCollection,
         operation: RulePrerequisiteOperation,
+        disablingCollectionIDs: Set<UUID> = [],
         nonInteractiveChoice: RulePrerequisiteResolutionChoice = .applyWithoutProviders
     ) async -> [UUID]? {
-        let missing = prerequisites(for: candidate)
+        let missing = prerequisites(
+            for: candidate,
+            disablingCollectionIDs: disablingCollectionIDs
+        )
         guard !missing.isEmpty else { return [] }
 
         let context = prerequisiteResolutionContext(
@@ -75,7 +79,7 @@ extension RuleCollectionsManager {
         case .enableRequiredProvidersAndApply:
             guard let providerIDs = context.recommendedProviderIDs else {
                 AppLogger.shared.log(
-                    "⚠️ [RuleCollections] Automatic prerequisite resolution aborted because a requirement has multiple providers"
+                    "⚠️ [RuleCollections] Automatic prerequisite resolution aborted because a requirement has no unambiguous supporting rule"
                 )
                 return nil
             }

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+PublicAPI.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+PublicAPI.swift
@@ -33,6 +33,9 @@ extension RuleCollectionsManager {
     /// user selection in the same save/reload transaction as enabling the
     /// collection. It is intentionally optional so existing callers retain
     /// their current configuration.
+    /// `additionalCollectionIDsToDisable` stages related catalog collections
+    /// in the same transaction. It is used when activating one managed pack
+    /// replaces an untouched, not-yet-installed catalog experience.
     /// `skipReload` lets a higher-level transaction validate the resulting
     /// live reload itself without triggering a duplicate cooldown-blocked
     /// attempt. The configuration is still validated and persisted.
@@ -44,6 +47,7 @@ extension RuleCollectionsManager {
         autoResolveConflicts: Bool = false,
         bypassOwnershipCheck: Bool = false,
         configurationOverride: RuleCollectionConfiguration? = nil,
+        additionalCollectionIDsToDisable: Set<UUID> = [],
         skipReload: Bool = false
     ) async -> Bool {
         AppLogger.shared.log("🔀 [RuleCollections] toggleCollection called: id=\(id), isEnabled=\(isEnabled)")
@@ -92,13 +96,17 @@ extension RuleCollectionsManager {
         if isEnabled {
             guard let confirmedProviderIDs = await confirmedPrerequisiteProviderIDs(
                 for: candidate,
-                operation: .enable
+                operation: .enable,
+                disablingCollectionIDs: additionalCollectionIDsToDisable
             ) else {
                 return false
             }
             prerequisiteProviderIDs = confirmedProviderIDs
 
-            if let conflict = conflictInfo(for: candidate) {
+            if let conflict = conflictInfo(
+                for: candidate,
+                ignoringCollectionIDs: additionalCollectionIDsToDisable
+            ) {
                 if autoResolveConflicts {
                     AppLogger.shared.log(
                         "🔄 [RuleCollections] Auto-resolving conflict: \(candidate.name) wins over \(conflict.displayName) on \(conflict.keys)"
@@ -127,6 +135,13 @@ extension RuleCollectionsManager {
                     }
                 }
             }
+        }
+
+        for index in ruleCollections.indices where
+            additionalCollectionIDsToDisable.contains(ruleCollections[index].id)
+            && ruleCollections[index].id != candidate.id
+        {
+            ruleCollections[index].isEnabled = false
         }
 
         applyPrerequisiteChangeInMemory(

--- a/Sources/KeyPathAppKit/UI/Rules/FirstSuccessOnboardingDialog.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/FirstSuccessOnboardingDialog.swift
@@ -741,10 +741,10 @@ private struct FirstSuccessBenefits: View {
                 )
                 FirstSuccessBenefitRow(
                     icon: "shield",
-                    title: session.hyperPhase.isInstalled
+                    title: session.capsLockHasHyperHold
                         ? "Your hold shortcut stays Hyper"
                         : "Keep what you need",
-                    detail: session.hyperPhase.isInstalled
+                    detail: session.capsLockHasHyperHold
                         ? "Holding Caps Lock still prepares Hyper. You can change or turn off either action in Rules at any time."
                         : "Hold Caps Lock when you want its original action. You can change or turn this off in Rules at any time.",
                     tone: palette.accent.color
@@ -1150,7 +1150,7 @@ private struct FirstSuccessKeyboardHero: View {
         case .capsApplying:
             Text("Caps Lock is being changed to type Escape when tapped.", bundle: KeyPathAppKitResources.bundle)
         case .capsInstalled:
-            if session.hyperPhase.isInstalled {
+            if session.capsLockHasHyperHold {
                 Text("Caps Lock types Escape when tapped and prepares Hyper when held.", bundle: KeyPathAppKitResources.bundle)
             } else {
                 Text("Caps Lock now types Escape when tapped. Its hold action remains available and unchanged.", bundle: KeyPathAppKitResources.bundle)

--- a/Sources/KeyPathAppKit/UI/Rules/FirstSuccessOnboardingSession.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/FirstSuccessOnboardingSession.swift
@@ -137,12 +137,17 @@ final class FirstSuccessOnboardingSession {
     var capsLockPhase: LessonPhase = .explaining
     var hyperPhase: LessonPhase = .explaining
     var launcherPhase: LessonPhase = .explaining
+    private(set) var capsLockHoldIsHyper = false
     var isCapsPracticeMenuPresented = false
     var failure: ActionKind?
     var savedButNotActive: ActionKind?
 
     var isApplying: Bool {
         capsLockPhase == .applying || hyperPhase == .applying || launcherPhase == .applying
+    }
+
+    var capsLockHasHyperHold: Bool {
+        capsLockHoldIsHyper || hyperPhase.isInstalled
     }
 
     var isLauncherChoiceEditable: Bool {
@@ -227,6 +232,10 @@ final class FirstSuccessOnboardingSession {
             case .launcherShortcut: launcherPhase = .explaining
             }
         }
+    }
+
+    func recordCapsLockHold(isHyper: Bool) {
+        capsLockHoldIsHyper = isHyper
     }
 
     func markCapsLockPracticed() {

--- a/Sources/KeyPathAppKit/UI/Rules/FirstSuccessOnboardingWindowController.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/FirstSuccessOnboardingWindowController.swift
@@ -4,27 +4,47 @@ import KeyPathInstallationWizard
 import KeyPathRulesCore
 import SwiftUI
 
+enum FirstSuccessCapsStepLauncherPreparation: Equatable, Sendable {
+    case leaveAsIs
+    case disableCatalogDefault
+    case requiresRules
+}
+
+enum FirstSuccessOnboardingPresentationSource: Equatable, Sendable {
+    case firstRun
+    case replay
+}
+
 /// Presents the first-success learning path after a healthy first setup.
 @MainActor
 final class FirstSuccessOnboardingWindowController: NSWindowController {
     private static var currentController: FirstSuccessOnboardingWindowController?
     private let actionCoordinator: FirstSuccessOnboardingActionCoordinator
 
-    static func show(kanataViewModel: KanataViewModel?) {
+    static func show(
+        kanataViewModel: KanataViewModel?,
+        source: FirstSuccessOnboardingPresentationSource
+    ) {
         if let currentController {
             currentController.showWindow(nil)
             currentController.window?.makeKeyAndOrderFront(nil)
             return
         }
 
-        let controller = FirstSuccessOnboardingWindowController(kanataViewModel: kanataViewModel)
+        let controller = FirstSuccessOnboardingWindowController(
+            kanataViewModel: kanataViewModel,
+            source: source
+        )
         currentController = controller
         LiveKeyboardOverlayController.shared.autoHideOnceForSettings()
         controller.showWindow(nil)
         FirstSuccessOnboardingGate.markPresented()
     }
 
-    private init(kanataViewModel: KanataViewModel?) {
+    private init(
+        kanataViewModel: KanataViewModel?,
+        source: FirstSuccessOnboardingPresentationSource
+    ) {
         let actionCoordinator = FirstSuccessOnboardingActionCoordinator()
         let existingLauncher = kanataViewModel?.underlyingManager.rulesManager
             .ruleCollections.first(where: {
@@ -46,7 +66,21 @@ final class FirstSuccessOnboardingWindowController: NSWindowController {
                     return await Self.previewActionResult()
                 }
                 guard let kanataViewModel else { return .failed }
-                return await Self.installCapsLockEscape(using: kanataViewModel)
+                let result = await Self.installCapsLockEscape(
+                    using: kanataViewModel,
+                    source: source
+                )
+                switch result {
+                case .applied, .alreadyConfigured:
+                    actionCoordinator.session.recordCapsLockHold(
+                        isHyper: Self.capsLockHoldIsHyper(
+                            in: kanataViewModel.underlyingManager.rulesManager.ruleCollections
+                        )
+                    )
+                case .savedButNotActive, .needsRules, .failed:
+                    break
+                }
+                return result
             },
             addHyperHold: {
                 if Self.usesNonMutatingVisualPreviewActions() {
@@ -138,29 +172,58 @@ final class FirstSuccessOnboardingWindowController: NSWindowController {
     }
 
     private static func installCapsLockEscape(
-        using viewModel: KanataViewModel
+        using viewModel: KanataViewModel,
+        source: FirstSuccessOnboardingPresentationSource
     ) async -> FirstSuccessOnboardingSession.ActionResult {
         let manager = viewModel.underlyingManager.rulesManager
 
-        guard let catalogConfiguration = RuleCollectionCatalog().defaultCollections()
+        let catalogCollections = RuleCollectionCatalog().defaultCollections()
+        guard let catalogConfiguration = catalogCollections
             .first(where: { $0.id == RuleCollectionIdentifier.capsLockRemap })?
+            .configuration,
+            let catalogLauncherConfiguration = catalogCollections
+            .first(where: { $0.id == RuleCollectionIdentifier.launcher })?
             .configuration
         else {
-            AppLogger.shared.error("❌ [FirstSuccessOnboarding] Caps Lock catalog collection is unavailable")
+            AppLogger.shared.error("❌ [FirstSuccessOnboarding] Required catalog collections are unavailable")
             return .failed
         }
 
-        guard let configuration = escapeOnlyCapsLockConfiguration(from: catalogConfiguration) else {
+        let existingCapsLock = manager.ruleCollections.first(where: {
+            $0.id == RuleCollectionIdentifier.capsLockRemap
+        })
+        let existingLauncher = manager.ruleCollections.first(where: {
+            $0.id == RuleCollectionIdentifier.launcher
+        })
+        let quickLauncherInstalled = await PackInstaller.shared.isInstalled(
+            packID: PackRegistry.launcher.id
+        )
+        let launcherPreparation = capsStepLauncherPreparation(
+            existing: existingLauncher,
+            catalogConfiguration: catalogLauncherConfiguration,
+            quickLauncherInstalled: quickLauncherInstalled,
+            source: source
+        )
+        guard launcherPreparation != .requiresRules else {
+            AppLogger.shared.log(
+                "🛡️ [FirstSuccessOnboarding] Existing Quick Launcher behavior left untouched"
+            )
+            return .needsRules
+        }
+
+        guard let configuration = escapeOnlyCapsLockConfiguration(
+            from: catalogConfiguration,
+            preservingHoldFrom: capsHoldConfigurationToPreserve(
+                existing: existingCapsLock,
+                quickLauncherInstalled: quickLauncherInstalled,
+                source: source
+            )
+        ) else {
             AppLogger.shared.error("❌ [FirstSuccessOnboarding] Caps Lock catalog configuration is invalid")
             return .failed
         }
 
-        if let existing = manager.ruleCollections.first(where: {
-            $0.id == RuleCollectionIdentifier.capsLockRemap
-        }) {
-            let quickLauncherInstalled = await PackInstaller.shared.isInstalled(
-                packID: PackRegistry.launcher.id
-            )
+        if let existing = existingCapsLock {
             if capsLockAlreadyProvidesFirstWin(
                 existing: existing,
                 quickLauncherInstalled: quickLauncherInstalled
@@ -173,6 +236,7 @@ final class FirstSuccessOnboardingWindowController: NSWindowController {
 
             if existing.isEnabled,
                existing.configuration == configuration,
+               launcherPreparation != .disableCatalogDefault,
                await PackInstaller.shared.isInstalled(packID: PackRegistry.capsLockToEscape.id)
             {
                 return await verifyLiveRuleApplication(
@@ -209,6 +273,9 @@ final class FirstSuccessOnboardingWindowController: NSWindowController {
                 PackRegistry.capsLockToEscape,
                 collectionConfiguration: configuration,
                 autoResolveCollectionConflicts: false,
+                additionalCollectionIDsToDisable: launcherPreparation == .disableCatalogDefault
+                    ? [RuleCollectionIdentifier.launcher]
+                    : [],
                 manager: manager,
                 skipFinalReload: true
             )
@@ -223,9 +290,13 @@ final class FirstSuccessOnboardingWindowController: NSWindowController {
             return .failed
         }
 
+        let launcherPrepared = launcherPreparation != .disableCatalogDefault
+            || manager.ruleCollections.first(where: {
+                $0.id == RuleCollectionIdentifier.launcher
+            })?.isEnabled == false
         let installed = capsLock.isEnabled
-            && capsLock.configuration.tapHoldPickerConfig?.selectedTapOutput == "esc"
-            && capsLock.configuration.tapHoldPickerConfig?.selectedHoldOutput == "caps"
+            && capsLock.configuration == configuration
+            && launcherPrepared
         guard installed else { return .failed }
         return await verifyLiveRuleApplication(using: viewModel)
     }
@@ -237,6 +308,28 @@ final class FirstSuccessOnboardingWindowController: NSWindowController {
     ) -> Bool {
         existing.configuration != catalogConfiguration
             && existing.configuration != onboardingConfiguration
+    }
+
+    static func capsStepLauncherPreparation(
+        existing: RuleCollection?,
+        catalogConfiguration: RuleCollectionConfiguration,
+        quickLauncherInstalled: Bool,
+        source: FirstSuccessOnboardingPresentationSource = .firstRun
+    ) -> FirstSuccessCapsStepLauncherPreparation {
+        guard !quickLauncherInstalled,
+              let existing,
+              existing.isEnabled
+        else {
+            return .leaveAsIs
+        }
+
+        if source == .replay {
+            return .leaveAsIs
+        }
+
+        return existing.configuration == catalogConfiguration
+            ? .disableCatalogDefault
+            : .requiresRules
     }
 
     static func capsLockRequiresHyperRulesHandoff(
@@ -265,8 +358,24 @@ final class FirstSuccessOnboardingWindowController: NSWindowController {
             && tapHold.selectedHoldOutput == "hyper"
     }
 
+    static func capsLockHoldIsHyper(in collections: [RuleCollection]) -> Bool {
+        collections.first(where: {
+            $0.id == RuleCollectionIdentifier.capsLockRemap
+        })?.configuration.tapHoldPickerConfig?.selectedHoldOutput == "hyper"
+    }
+
+    static func capsHoldConfigurationToPreserve(
+        existing: RuleCollection?,
+        quickLauncherInstalled: Bool,
+        source: FirstSuccessOnboardingPresentationSource
+    ) -> RuleCollectionConfiguration? {
+        guard quickLauncherInstalled || source == .replay else { return nil }
+        return existing?.configuration
+    }
+
     static func escapeOnlyCapsLockConfiguration(
-        from configuration: RuleCollectionConfiguration
+        from configuration: RuleCollectionConfiguration,
+        preservingHoldFrom existingConfiguration: RuleCollectionConfiguration? = nil
     ) -> RuleCollectionConfiguration? {
         guard let tapHold = configuration.tapHoldPickerConfig else { return nil }
 
@@ -280,12 +389,22 @@ final class FirstSuccessOnboardingWindowController: NSWindowController {
             ))
         }
 
+        let existingHoldOutput = existingConfiguration?
+            .tapHoldPickerConfig?
+            .selectedHoldOutput
+        // Step 1 owns only the tap action. Keep any supported hold action the
+        // person already has (notably Hyper for Quick Launcher) so replaying
+        // the tour cannot break an existing shortcut layer.
+        let selectedHoldOutput = existingHoldOutput.flatMap { output in
+            holdOptions.contains(where: { $0.output == output }) ? output : nil
+        } ?? "caps"
+
         return .tapHoldPicker(TapHoldPickerConfig(
             inputKey: tapHold.inputKey,
             tapOptions: tapHold.tapOptions,
             holdOptions: holdOptions,
             selectedTapOutput: "esc",
-            selectedHoldOutput: "caps"
+            selectedHoldOutput: selectedHoldOutput
         ))
     }
 

--- a/Sources/KeyPathAppKit/UI/Rules/RulePrerequisiteResolutionDialog.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/RulePrerequisiteResolutionDialog.swift
@@ -4,14 +4,47 @@ import SwiftUI
 struct RulePrerequisiteDialogRowID: Hashable, Sendable {
     let consumerID: UUID
     let capability: RuleCapability
+
+    var accessibilityIdentifier: String {
+        let capabilityComponent = switch capability {
+        case let .layerContent(layer): "layer-content-\(layer.rawValue)"
+        case let .layerActivation(layer): "layer-activation-\(layer.rawValue)"
+        case let .keyAlias(alias): "key-alias-\(alias.rawValue)"
+        }
+        return "rule-prerequisite-requirement-\(consumerID.uuidString)-\(capabilityComponent)"
+    }
+}
+
+enum RulePrerequisiteProviderState: Equatable, Sendable {
+    case unavailable
+    case automatic(providerName: String)
+    case choices(providerNames: [String])
+}
+
+enum RulePrerequisiteDialogResolution: Equatable, Sendable {
+    case automatic
+    case unavailable
+    case ambiguous
+    case unavailableAndAmbiguous
 }
 
 struct RulePrerequisiteDialogRow: Equatable, Identifiable, Sendable {
     let id: RulePrerequisiteDialogRowID
     let consumerName: String
     let capabilityName: String
-    let providerSummary: String
+    let providerState: RulePrerequisiteProviderState
     let evidence: [String]
+
+    var providerSummary: String {
+        switch providerState {
+        case .unavailable:
+            "No available rule provides this."
+        case let .automatic(providerName):
+            "KeyPath will turn on \(providerName)."
+        case let .choices(providerNames):
+            "Turn on one first: \(RulePrerequisiteDialogModel.joinedAlternatives(providerNames))."
+        }
+    }
 }
 
 /// A prepared, presentation-only snapshot for the prerequisite dialog.
@@ -23,7 +56,7 @@ struct RulePrerequisiteDialogModel: Equatable, Sendable {
     let candidateName: String
     let rows: [RulePrerequisiteDialogRow]
     let recommendedProviderNames: [String]
-    let canEnableAll: Bool
+    let resolution: RulePrerequisiteDialogResolution
 
     init(context: RulePrerequisiteResolutionContext) {
         operation = context.operation
@@ -39,8 +72,8 @@ struct RulePrerequisiteDialogModel: Equatable, Sendable {
         )
 
         rows = context.prerequisites.map { prerequisite in
-            let providerNames = prerequisite.availableProviderCollectionIDs.compactMap {
-                providersByID[$0]?.name
+            let providerNames = prerequisite.availableProviderCollectionIDs.map {
+                providersByID[$0]?.name ?? "Another rule"
             }
             return RulePrerequisiteDialogRow(
                 id: RulePrerequisiteDialogRowID(
@@ -50,44 +83,113 @@ struct RulePrerequisiteDialogModel: Equatable, Sendable {
                 consumerName: consumersByID[prerequisite.consumerCollectionID]?.name
                     ?? context.candidate.name,
                 capabilityName: Self.capabilityName(prerequisite.missingCapability),
-                providerSummary: Self.providerSummary(providerNames),
+                providerState: Self.providerState(providerNames),
                 evidence: Self.evidenceDescriptions(prerequisite.requirement.sortedEvidence)
             )
         }
 
+        let hasUnavailable = rows.contains { $0.providerState == .unavailable }
+        let hasAmbiguous = rows.contains {
+            if case .choices = $0.providerState { return true }
+            return false
+        }
+        switch (hasUnavailable, hasAmbiguous) {
+        case (false, false):
+            resolution = .automatic
+        case (true, false):
+            resolution = .unavailable
+        case (false, true):
+            resolution = .ambiguous
+        case (true, true):
+            resolution = .unavailableAndAmbiguous
+        }
+
         if let providerIDs = context.recommendedProviderIDs {
-            canEnableAll = true
             recommendedProviderNames = providerIDs.compactMap { providersByID[$0]?.name }
         } else {
-            canEnableAll = false
             recommendedProviderNames = []
+        }
+    }
+
+    var canEnableAll: Bool {
+        resolution == .automatic
+    }
+
+    var title: String {
+        switch resolution {
+        case .automatic:
+            "Turn on supporting rules?"
+        case .unavailable:
+            if rows.count == 1, let row = rows.first {
+                "\(row.consumerName) would lose \(row.capabilityName)"
+            } else {
+                "Some rules would lose behavior they need"
+            }
+        case .ambiguous:
+            "Choose a supporting rule first"
+        case .unavailableAndAmbiguous:
+            "This change needs attention first"
         }
     }
 
     var primaryActionTitle: String {
         switch operation {
         case .enable:
-            "Enable Required Rules & Turn On"
+            "Turn On Required Rules"
         case .save:
-            "Enable Required Rules & Save"
+            "Save & Turn On Required Rules"
         }
     }
 
     var secondaryActionTitle: String {
         switch operation {
         case .enable:
-            "Turn On Without Them"
+            "Turn On Anyway"
         case .save:
-            "Save Without Them"
+            "Save Anyway"
+        }
+    }
+
+    var cancelActionTitle: String {
+        switch operation {
+        case .enable:
+            "Keep Off"
+        case .save:
+            "Keep Editing"
         }
     }
 
     var consequenceSummary: String {
-        switch operation {
-        case .enable:
-            "Turning on \(candidateName) introduces requirements that are not active."
-        case .save:
-            "Saving \(candidateName) introduces requirements that are not active."
+        let action = switch operation {
+        case .enable: "Turning on \(candidateName)"
+        case .save: "Saving changes to \(candidateName)"
+        }
+
+        switch resolution {
+        case .automatic:
+            return "\(action) also requires the supporting rules below."
+        case .unavailable:
+            if rows.count == 1, let row = rows.first {
+                return "\(action) would remove behavior that \(row.consumerName) needs."
+            }
+            return "\(action) would remove behavior that other enabled rules need."
+        case .ambiguous:
+            return "\(action) would leave enabled rules without behavior they use, and more than one supporting rule could replace it."
+        case .unavailableAndAmbiguous:
+            return "\(action) would leave enabled rules without behavior they use. Some missing behavior has no automatic fix, while other behavior has more than one choice."
+        }
+    }
+
+    var guidanceSummary: String {
+        switch resolution {
+        case .automatic:
+            "KeyPath can turn on every required rule in the same change."
+        case .unavailable:
+            "Keep your current setup, or continue knowing the affected shortcuts may not work."
+        case .ambiguous:
+            "Turn on one of the listed rules first, or continue knowing the affected shortcuts may not work."
+        case .unavailableAndAmbiguous:
+            "Resolve the items below first, or continue knowing the affected shortcuts may not work."
         }
     }
 
@@ -105,37 +207,34 @@ struct RulePrerequisiteDialogModel: Equatable, Sendable {
         }
     }
 
-    private static func providerSummary(_ providerNames: [String]) -> String {
+    private static func providerState(
+        _ providerNames: [String]
+    ) -> RulePrerequisiteProviderState {
         switch providerNames.count {
         case 0:
-            "No matching rule is currently available."
+            .unavailable
         case 1:
-            "Provided by \(providerNames[0])."
+            .automatic(providerName: providerNames[0])
         default:
-            "Available from \(joinedList(providerNames))."
+            .choices(providerNames: providerNames)
         }
     }
 
     static func evidenceDescriptions(
         _ evidence: [RuleDependencyEvidence]
     ) -> [String] {
-        evidence.map { item in
+        evidence.compactMap { item in
             switch item {
             case let .keys(keys):
                 let noun = keys.count == 1 ? "key" : "keys"
                 return "\(keys.count) affected \(noun): \(joinedList(keys.map(displayName)))"
-            case let .mappingIDs(ids):
-                let noun = ids.count == 1 ? "mapping" : "mappings"
-                return "\(ids.count) affected \(noun)"
-            case let .layerPath(source, target):
-                return "Layer path: \(displayName(source.rawValue)) to \(displayName(target.rawValue))"
-            case let .configuration(field, value):
-                return "\(displayName(field)): \(displayName(value))"
+            case .mappingIDs, .layerPath, .configuration:
+                return nil
             }
         }
     }
 
-    private static func joinedList(_ values: [String]) -> String {
+    fileprivate static func joinedList(_ values: [String]) -> String {
         switch values.count {
         case 0:
             ""
@@ -145,6 +244,19 @@ struct RulePrerequisiteDialogModel: Equatable, Sendable {
             "\(values[0]) and \(values[1])"
         default:
             "\(values.dropLast().joined(separator: ", ")), and \(values.last ?? "")"
+        }
+    }
+
+    fileprivate static func joinedAlternatives(_ values: [String]) -> String {
+        switch values.count {
+        case 0:
+            ""
+        case 1:
+            values[0]
+        case 2:
+            "\(values[0]) or \(values[1])"
+        default:
+            "\(values.dropLast().joined(separator: ", ")), or \(values.last ?? "")"
         }
     }
 
@@ -164,63 +276,73 @@ struct RulePrerequisiteResolutionDialog: View {
     let onCancel: () -> Void
 
     var body: some View {
-        VStack(spacing: 0) {
-            RulePrerequisiteDialogHeader(
-                consequenceSummary: model.consequenceSummary,
-                onCancel: onCancel
-            )
-
-            Divider()
+        VStack(alignment: .leading, spacing: 20) {
+            RulePrerequisiteDialogHeader(model: model)
 
             RulePrerequisiteRequirementsSection(rows: model.rows)
+
+            Text(model.guidanceSummary)
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
 
             Divider()
 
             RulePrerequisiteActionsSection(
                 model: model,
-                onChoice: onChoice
+                onChoice: onChoice,
+                onCancel: onCancel
             )
         }
-        .frame(width: 500)
+        .padding(24)
+        .frame(width: 540)
         .background(Color(NSColor.windowBackgroundColor))
+        .accessibilityIdentifier("rule-prerequisite-resolution-dialog")
+        .onExitCommand(perform: onCancel)
     }
 }
 
 private struct RulePrerequisiteDialogHeader: View {
-    let consequenceSummary: String
-    let onCancel: () -> Void
+    let model: RulePrerequisiteDialogModel
 
     var body: some View {
-        ZStack(alignment: .topTrailing) {
-            VStack(spacing: 8) {
-                Text("Enable the rules this change needs?")
-                    .font(.title2.weight(.semibold))
+        HStack(alignment: .top, spacing: 14) {
+            Image(systemName: headerIcon)
+                .font(.system(size: 18, weight: .semibold))
+                .foregroundStyle(headerColor)
+                .frame(width: 36, height: 36)
+                .background(
+                    Circle()
+                        .fill(headerColor.opacity(0.12))
+                )
+                .accessibilityHidden(true)
 
-                Text(consequenceSummary)
+            VStack(alignment: .leading, spacing: 7) {
+                Text(model.title)
+                    .font(.title2.weight(.semibold))
+                    .accessibilityAddTraits(.isHeader)
+
+                Text(model.consequenceSummary)
                     .font(.body)
                     .foregroundStyle(.secondary)
-                    .multilineTextAlignment(.center)
                     .fixedSize(horizontal: false, vertical: true)
-
-                Text("Without them, the affected keys or actions may do nothing.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
             }
-            .padding(.horizontal, 24)
-
-            Button(action: onCancel) {
-                Image(systemName: "xmark")
-                    .font(.subheadline.weight(.semibold))
-                    .foregroundStyle(.secondary)
-                    .frame(width: 22, height: 22)
-                    .background(Circle().fill(Color.secondary.opacity(0.16)))
-            }
-            .buttonStyle(.plain)
-            .keyboardShortcut(.cancelAction)
-            .accessibilityIdentifier("rule-prerequisite-close-button")
-            .accessibilityLabel("Cancel")
         }
-        .padding(20)
+    }
+
+    private var headerIcon: String {
+        switch model.resolution {
+        case .automatic: "link.badge.plus"
+        case .unavailable, .unavailableAndAmbiguous: "exclamationmark.triangle.fill"
+        case .ambiguous: "arrow.triangle.branch"
+        }
+    }
+
+    private var headerColor: Color {
+        switch model.resolution {
+        case .automatic: .accentColor
+        case .unavailable, .ambiguous, .unavailableAndAmbiguous: .orange
+        }
     }
 }
 
@@ -228,12 +350,14 @@ private struct RulePrerequisiteRequirementsSection: View {
     let rows: [RulePrerequisiteDialogRow]
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            ForEach(rows) { row in
-                RulePrerequisiteRequirementRow(row: row)
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: 10) {
+                ForEach(rows) { row in
+                    RulePrerequisiteRequirementRow(row: row)
+                }
             }
         }
-        .padding(20)
+        .frame(maxHeight: 280)
     }
 }
 
@@ -242,16 +366,22 @@ private struct RulePrerequisiteRequirementRow: View {
 
     var body: some View {
         HStack(alignment: .top, spacing: 12) {
-            Image(systemName: "link")
-                .foregroundStyle(.secondary)
-                .frame(width: 20)
+            Image(systemName: statusIcon)
+                .font(.body.weight(.semibold))
+                .foregroundStyle(statusColor)
+                .frame(width: 20, height: 22)
+                .accessibilityHidden(true)
 
-            VStack(alignment: .leading, spacing: 4) {
-                Text("\(row.consumerName) needs \(row.capabilityName).")
-                    .font(.body.weight(.medium))
+            VStack(alignment: .leading, spacing: 5) {
+                Text(row.consumerName)
+                    .font(.body.weight(.semibold))
+
+                Text("Needs \(row.capabilityName)")
+                    .foregroundStyle(.secondary)
 
                 Text(row.providerSummary)
-                    .foregroundStyle(.secondary)
+                    .font(.callout.weight(.medium))
+                    .foregroundStyle(statusColor)
 
                 ForEach(row.evidence, id: \.self) { evidence in
                     Text(evidence)
@@ -261,44 +391,66 @@ private struct RulePrerequisiteRequirementRow: View {
             }
             .fixedSize(horizontal: false, vertical: true)
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(14)
+        .background(
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .fill(Color(NSColor.controlBackgroundColor))
+        )
+        .overlay {
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .strokeBorder(Color.primary.opacity(0.08))
+        }
         .accessibilityElement(children: .combine)
+        .accessibilityIdentifier(row.id.accessibilityIdentifier)
+    }
+
+    private var statusIcon: String {
+        switch row.providerState {
+        case .unavailable: "exclamationmark.circle.fill"
+        case .automatic: "checkmark.circle.fill"
+        case .choices: "arrow.triangle.branch"
+        }
+    }
+
+    private var statusColor: Color {
+        switch row.providerState {
+        case .unavailable, .choices: .orange
+        case .automatic: .accentColor
+        }
     }
 }
 
 private struct RulePrerequisiteActionsSection: View {
     let model: RulePrerequisiteDialogModel
     let onChoice: (RulePrerequisiteResolutionChoice) -> Void
+    let onCancel: () -> Void
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            if !model.canEnableAll {
-                Text("KeyPath found more than one possible provider for at least one requirement. Choose one manually later, or continue without it.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
+        ViewThatFits(in: .horizontal) {
+            HStack(spacing: 10) {
+                Spacer(minLength: 0)
+                actionButtons
             }
 
-            ViewThatFits {
-                HStack(spacing: 12) {
-                    actionButtons
-                }
-
-                VStack(spacing: 10) {
-                    actionButtons
-                }
+            VStack(alignment: .trailing, spacing: 10) {
+                actionButtons
             }
         }
-        .padding(20)
     }
 
     @ViewBuilder
     private var actionButtons: some View {
-        Button {
+        if model.canEnableAll {
+            Button(model.cancelActionTitle, action: onCancel)
+                .keyboardShortcut(.cancelAction)
+                .accessibilityIdentifier("rule-prerequisite-cancel-button")
+        }
+
+        Button(role: .destructive) {
             onChoice(.applyWithoutProviders)
         } label: {
             Text(model.secondaryActionTitle)
-                .frame(maxWidth: .infinity)
-                .padding(.vertical, 6)
         }
         .buttonStyle(.bordered)
         .accessibilityIdentifier("rule-prerequisite-apply-without-button")
@@ -308,12 +460,15 @@ private struct RulePrerequisiteActionsSection: View {
                 onChoice(.enableRequiredProvidersAndApply)
             } label: {
                 Text(model.primaryActionTitle)
-                    .frame(maxWidth: .infinity)
-                    .padding(.vertical, 6)
             }
             .buttonStyle(.borderedProminent)
             .keyboardShortcut(.defaultAction)
             .accessibilityIdentifier("rule-prerequisite-enable-required-button")
+        } else {
+            Button(model.cancelActionTitle, action: onCancel)
+                .buttonStyle(.borderedProminent)
+                .keyboardShortcut(.defaultAction)
+                .accessibilityIdentifier("rule-prerequisite-cancel-button")
         }
     }
 }

--- a/Tests/KeyPathTests/FirstSuccessOnboardingSessionTests.swift
+++ b/Tests/KeyPathTests/FirstSuccessOnboardingSessionTests.swift
@@ -91,6 +91,32 @@ final class FirstSuccessOnboardingSessionTests: XCTestCase {
     }
 
     @MainActor
+    func testReplayCanDescribePreservedHyperWithoutSkippingItsLesson() {
+        let session = FirstSuccessOnboardingSession()
+
+        session.begin(.capsLockEscape)
+        session.recordCapsLockHold(isHyper: true)
+        session.finish(.capsLockEscape, result: .alreadyConfigured)
+
+        XCTAssertTrue(session.capsLockHoldIsHyper)
+        XCTAssertEqual(session.capsLockPhase, .installed)
+        XCTAssertEqual(session.hyperPhase, .explaining)
+    }
+
+    @MainActor
+    func testReturningToCapsDescribesHyperAddedByTheSecondLesson() {
+        let session = FirstSuccessOnboardingSession()
+
+        session.finish(.capsLockEscape, result: .applied)
+        session.moveForward()
+        session.finish(.hyper, result: .applied)
+        session.moveBack()
+
+        XCTAssertEqual(session.step, .capsLock)
+        XCTAssertTrue(session.capsLockHasHyperHold)
+    }
+
+    @MainActor
     func testLauncherShortcutMustApplyBeforeTheThirdWinCompletes() {
         let session = FirstSuccessOnboardingSession()
         session.step = .launcher

--- a/Tests/KeyPathTests/GenericPackConfigTests.swift
+++ b/Tests/KeyPathTests/GenericPackConfigTests.swift
@@ -168,6 +168,203 @@ final class GenericPackConfigTests: XCTestCase {
     }
 
     @MainActor
+    func testFirstSuccessCapsLockConfigurationPreservesExistingHyperHold() throws {
+        let catalogConfiguration = try XCTUnwrap(
+            RuleCollectionCatalog().defaultCollections()
+                .first(where: { $0.id == RuleCollectionIdentifier.capsLockRemap })?
+                .configuration
+        )
+
+        let configuration = try XCTUnwrap(
+            FirstSuccessOnboardingWindowController.escapeOnlyCapsLockConfiguration(
+                from: catalogConfiguration,
+                preservingHoldFrom: catalogConfiguration
+            )
+        )
+
+        XCTAssertEqual(configuration.tapHoldPickerConfig?.selectedTapOutput, "esc")
+        XCTAssertEqual(configuration.tapHoldPickerConfig?.selectedHoldOutput, "hyper")
+    }
+
+    @MainActor
+    func testFirstSuccessCapsLockConfigurationRejectsUnknownExistingHold() throws {
+        let catalogConfiguration = try XCTUnwrap(
+            RuleCollectionCatalog().defaultCollections()
+                .first(where: { $0.id == RuleCollectionIdentifier.capsLockRemap })?
+                .configuration
+        )
+        var unsupportedConfiguration = catalogConfiguration
+        unsupportedConfiguration.updateSelectedHoldOutput("unsupported-hold")
+
+        let configuration = try XCTUnwrap(
+            FirstSuccessOnboardingWindowController.escapeOnlyCapsLockConfiguration(
+                from: catalogConfiguration,
+                preservingHoldFrom: unsupportedConfiguration
+            )
+        )
+
+        XCTAssertEqual(configuration.tapHoldPickerConfig?.selectedTapOutput, "esc")
+        XCTAssertEqual(configuration.tapHoldPickerConfig?.selectedHoldOutput, "caps")
+    }
+
+    @MainActor
+    func testFirstSuccessCapsInstallStagesFreshLauncherOffWithoutPrerequisitePrompt() async throws {
+        TestEnvironment.forceTestMode = true
+        defer { TestEnvironment.forceTestMode = false }
+
+        let (manager, tempDir) = try makeTestManager()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        manager.ruleCollections = RuleCollectionCatalog().defaultCollections()
+
+        let catalogCapsLock = try XCTUnwrap(
+            manager.ruleCollections.first {
+                $0.id == RuleCollectionIdentifier.capsLockRemap
+            }
+        )
+        let catalogLauncher = try XCTUnwrap(
+            manager.ruleCollections.first {
+                $0.id == RuleCollectionIdentifier.launcher
+            }
+        )
+        let configuration = try XCTUnwrap(
+            FirstSuccessOnboardingWindowController.escapeOnlyCapsLockConfiguration(
+                from: catalogCapsLock.configuration
+            )
+        )
+        let launcherPreparation = FirstSuccessOnboardingWindowController
+            .capsStepLauncherPreparation(
+                existing: catalogLauncher,
+                catalogConfiguration: catalogLauncher.configuration,
+                quickLauncherInstalled: false
+            )
+        var prerequisitePromptCount = 0
+        manager.onPrerequisiteResolution = { _ in
+            prerequisitePromptCount += 1
+            return .applyWithoutProviders
+        }
+
+        _ = try await PackInstaller.shared.install(
+            PackRegistry.capsLockToEscape,
+            collectionConfiguration: configuration,
+            autoResolveCollectionConflicts: false,
+            additionalCollectionIDsToDisable: [RuleCollectionIdentifier.launcher],
+            manager: manager,
+            skipFinalReload: true
+        )
+
+        let capsLock = manager.ruleCollections.first {
+            $0.id == RuleCollectionIdentifier.capsLockRemap
+        }
+        XCTAssertEqual(prerequisitePromptCount, 0)
+        XCTAssertEqual(launcherPreparation, .disableCatalogDefault)
+        XCTAssertEqual(capsLock?.configuration.tapHoldPickerConfig?.selectedTapOutput, "esc")
+        XCTAssertEqual(capsLock?.configuration.tapHoldPickerConfig?.selectedHoldOutput, "caps")
+        XCTAssertFalse(manager.ruleCollections.first {
+            $0.id == RuleCollectionIdentifier.launcher
+        }?.isEnabled ?? true)
+    }
+
+    @MainActor
+    func testFirstSuccessCapsStepPreservesHyperOnlyForInstalledLauncher() throws {
+        let catalog = RuleCollectionCatalog().defaultCollections()
+        let capsLock = try XCTUnwrap(catalog.first {
+            $0.id == RuleCollectionIdentifier.capsLockRemap
+        })
+        let launcher = try XCTUnwrap(catalog.first {
+            $0.id == RuleCollectionIdentifier.launcher
+        })
+
+        XCTAssertEqual(
+            FirstSuccessOnboardingWindowController.capsStepLauncherPreparation(
+                existing: launcher,
+                catalogConfiguration: launcher.configuration,
+                quickLauncherInstalled: false,
+                source: .firstRun
+            ),
+            .disableCatalogDefault
+        )
+        XCTAssertEqual(
+            FirstSuccessOnboardingWindowController.capsStepLauncherPreparation(
+                existing: launcher,
+                catalogConfiguration: launcher.configuration,
+                quickLauncherInstalled: false,
+                source: .replay
+            ),
+            .leaveAsIs
+        )
+        XCTAssertEqual(
+            FirstSuccessOnboardingWindowController.capsStepLauncherPreparation(
+                existing: launcher,
+                catalogConfiguration: launcher.configuration,
+                quickLauncherInstalled: true
+            ),
+            .leaveAsIs
+        )
+        var customizedLauncher = launcher
+        var customizedConfiguration = try XCTUnwrap(
+            customizedLauncher.configuration.launcherGridConfig
+        )
+        customizedConfiguration.hasSeenWelcome = true
+        customizedLauncher.configuration = .launcherGrid(customizedConfiguration)
+        XCTAssertEqual(
+            FirstSuccessOnboardingWindowController.capsStepLauncherPreparation(
+                existing: customizedLauncher,
+                catalogConfiguration: launcher.configuration,
+                quickLauncherInstalled: false
+            ),
+            .requiresRules
+        )
+
+        let replayConfiguration = try XCTUnwrap(
+            FirstSuccessOnboardingWindowController.escapeOnlyCapsLockConfiguration(
+                from: capsLock.configuration,
+                preservingHoldFrom: capsLock.configuration
+            )
+        )
+        XCTAssertEqual(replayConfiguration.tapHoldPickerConfig?.selectedTapOutput, "esc")
+        XCTAssertEqual(replayConfiguration.tapHoldPickerConfig?.selectedHoldOutput, "hyper")
+    }
+
+    @MainActor
+    func testFirstSuccessReplayPreservesCapsHoldWithLauncherOff() throws {
+        let catalog = RuleCollectionCatalog().defaultCollections()
+        let capsLock = try XCTUnwrap(catalog.first {
+            $0.id == RuleCollectionIdentifier.capsLockRemap
+        })
+        var launcher = try XCTUnwrap(catalog.first {
+            $0.id == RuleCollectionIdentifier.launcher
+        })
+        launcher.isEnabled = false
+
+        XCTAssertEqual(
+            FirstSuccessOnboardingWindowController.capsStepLauncherPreparation(
+                existing: launcher,
+                catalogConfiguration: launcher.configuration,
+                quickLauncherInstalled: false,
+                source: .replay
+            ),
+            .leaveAsIs
+        )
+        let preserved = FirstSuccessOnboardingWindowController
+            .capsHoldConfigurationToPreserve(
+                existing: capsLock,
+                quickLauncherInstalled: false,
+                source: .replay
+            )
+        XCTAssertEqual(
+            preserved?.tapHoldPickerConfig?.selectedHoldOutput,
+            "hyper"
+        )
+        XCTAssertNil(
+            FirstSuccessOnboardingWindowController.capsHoldConfigurationToPreserve(
+                existing: capsLock,
+                quickLauncherInstalled: false,
+                source: .firstRun
+            )
+        )
+    }
+
+    @MainActor
     func testFirstSuccessCapsStepPreservesLauncherOwnedHyper() throws {
         var launcherOwnedCapsLock = try XCTUnwrap(
             RuleCollectionCatalog().defaultCollections()

--- a/Tests/KeyPathTests/Lint/FirstSuccessOnboardingReplayMenuTests.swift
+++ b/Tests/KeyPathTests/Lint/FirstSuccessOnboardingReplayMenuTests.swift
@@ -35,7 +35,7 @@ final class FirstSuccessOnboardingReplayMenuTests: XCTestCase {
 
         XCTAssertTrue(
             replaySource.contains(
-                "FirstSuccessOnboardingWindowController.show(kanataViewModel: viewModel)"
+                "source: .replay"
             )
         )
         for forbiddenDependency in [

--- a/Tests/KeyPathTests/RuleCollections/RuleCollectionsManagerPrerequisiteResolutionTests.swift
+++ b/Tests/KeyPathTests/RuleCollections/RuleCollectionsManagerPrerequisiteResolutionTests.swift
@@ -45,13 +45,15 @@ final class RuleCollectionsManagerPrerequisiteResolutionTests: XCTestCase {
             RulePrerequisiteDialogModel.init(context:)
         ))
         XCTAssertTrue(dialogModel.canEnableAll)
+        XCTAssertEqual(dialogModel.resolution, .automatic)
         XCTAssertEqual(dialogModel.candidateName, "Home Row Layer Toggles")
         XCTAssertEqual(dialogModel.recommendedProviderNames, ["Function"])
         XCTAssertEqual(
             dialogModel.primaryActionTitle,
-            "Enable Required Rules & Turn On"
+            "Turn On Required Rules"
         )
-        XCTAssertEqual(dialogModel.secondaryActionTitle, "Turn On Without Them")
+        XCTAssertEqual(dialogModel.secondaryActionTitle, "Turn On Anyway")
+        XCTAssertEqual(dialogModel.cancelActionTitle, "Keep Off")
         XCTAssertEqual(dialogModel.rows.map(\.consumerName), [
             "Home Row Layer Toggles",
         ])
@@ -59,7 +61,7 @@ final class RuleCollectionsManagerPrerequisiteResolutionTests: XCTestCase {
             "Fun layer content",
         ])
         XCTAssertEqual(dialogModel.rows.map(\.providerSummary), [
-            "Provided by Function.",
+            "KeyPath will turn on Function.",
         ])
         XCTAssertEqual(dialogModel.rows.flatMap(\.evidence), [
             "1 affected key: A",
@@ -457,11 +459,135 @@ final class RuleCollectionsManagerPrerequisiteResolutionTests: XCTestCase {
         let context = try XCTUnwrap(receivedContext)
         let dialogModel = RulePrerequisiteDialogModel(context: context)
         XCTAssertFalse(dialogModel.canEnableAll)
+        XCTAssertEqual(dialogModel.resolution, .ambiguous)
+        XCTAssertEqual(dialogModel.title, "Choose a supporting rule first")
         XCTAssertEqual(dialogModel.rows.map(\.providerSummary), [
-            "Available from First Function and Second Function.",
+            "Turn on one first: First Function or Second Function.",
         ])
         XCTAssertTrue(manager.ruleCollections[id: first.id]?.isEnabled == false)
         XCTAssertTrue(manager.ruleCollections[id: second.id]?.isEnabled == false)
+    }
+
+    func testUnavailableProviderHasTruthfulCopyAndHidesConfigurationEvidence() {
+        let capsLock = RuleCollection(
+            id: RuleCollectionIdentifier.capsLockRemap,
+            name: "Caps Lock Remap",
+            summary: "Test",
+            category: .custom,
+            mappings: [],
+            isEnabled: true
+        )
+        let launcher = RuleCollection(
+            id: RuleCollectionIdentifier.launcher,
+            name: "Quick Launcher",
+            summary: "Test",
+            category: .custom,
+            mappings: [],
+            isEnabled: true
+        )
+        let requirement = RuleRequirement(
+            capability: .keyAlias(.hyper),
+            evidence: [
+                .configuration(field: "activationMode", value: "holdHyper"),
+                .configuration(field: "hyperTriggerMode", value: "hold"),
+            ]
+        )
+        let context = RulePrerequisiteResolutionContext(
+            operation: .enable,
+            candidate: capsLock,
+            prerequisites: [
+                RulePrerequisite(
+                    consumerCollectionID: launcher.id,
+                    missingCapability: .keyAlias(.hyper),
+                    requirement: requirement,
+                    availableProviderCollectionIDs: [],
+                    recommendedProviderCollectionID: nil
+                ),
+            ],
+            affectedConsumers: [launcher],
+            availableProviders: []
+        )
+
+        let dialogModel = RulePrerequisiteDialogModel(context: context)
+
+        XCTAssertEqual(dialogModel.resolution, .unavailable)
+        XCTAssertFalse(dialogModel.canEnableAll)
+        XCTAssertEqual(dialogModel.title, "Quick Launcher would lose the Hyper key")
+        XCTAssertEqual(
+            dialogModel.consequenceSummary,
+            "Turning on Caps Lock Remap would remove behavior that Quick Launcher needs."
+        )
+        XCTAssertEqual(dialogModel.rows.map(\.providerSummary), [
+            "No available rule provides this.",
+        ])
+        XCTAssertEqual(dialogModel.rows.flatMap(\.evidence), [])
+        XCTAssertFalse(dialogModel.guidanceSummary.contains("more than one"))
+    }
+
+    func testUnavailableAndAmbiguousProvidersRemainDistinct() {
+        let candidate = homeRowToggles(
+            id: uuid(46),
+            enabled: false,
+            assignments: [:]
+        )
+        let unavailableConsumer = RuleCollection(
+            id: uuid(47),
+            name: "Quick Launcher",
+            summary: "Test",
+            category: .custom,
+            mappings: [],
+            isEnabled: true
+        )
+        let ambiguousConsumer = homeRowToggles(
+            id: uuid(48),
+            enabled: true,
+            assignments: ["a": "fun"]
+        )
+        let firstProvider = layerContentProvider(
+            id: uuid(49),
+            name: "First Function",
+            enabled: false
+        )
+        let secondProvider = layerContentProvider(
+            id: uuid(50),
+            name: "Second Function",
+            enabled: false
+        )
+        let context = RulePrerequisiteResolutionContext(
+            operation: .save,
+            candidate: candidate,
+            prerequisites: [
+                RulePrerequisite(
+                    consumerCollectionID: unavailableConsumer.id,
+                    missingCapability: .keyAlias(.hyper),
+                    requirement: RuleRequirement(capability: .keyAlias(.hyper)),
+                    availableProviderCollectionIDs: [],
+                    recommendedProviderCollectionID: nil
+                ),
+                RulePrerequisite(
+                    consumerCollectionID: ambiguousConsumer.id,
+                    missingCapability: .layerContent(.init("fun")),
+                    requirement: RuleRequirement(
+                        capability: .layerContent(.init("fun"))
+                    ),
+                    availableProviderCollectionIDs: [firstProvider.id, secondProvider.id],
+                    recommendedProviderCollectionID: nil
+                ),
+            ],
+            affectedConsumers: [unavailableConsumer, ambiguousConsumer],
+            availableProviders: [firstProvider, secondProvider]
+        )
+
+        let dialogModel = RulePrerequisiteDialogModel(context: context)
+
+        XCTAssertEqual(dialogModel.resolution, .unavailableAndAmbiguous)
+        XCTAssertFalse(dialogModel.canEnableAll)
+        XCTAssertEqual(dialogModel.cancelActionTitle, "Keep Editing")
+        XCTAssertEqual(dialogModel.secondaryActionTitle, "Save Anyway")
+        XCTAssertEqual(dialogModel.rows.map(\.providerState), [
+            .unavailable,
+            .choices(providerNames: ["First Function", "Second Function"]),
+        ])
     }
 
     func testNonInteractiveAutomaticFixAbortsWhenProvidersAreAmbiguous() async throws {
@@ -498,6 +624,100 @@ final class RuleCollectionsManagerPrerequisiteResolutionTests: XCTestCase {
         XCTAssertTrue(manager.ruleCollections[id: candidate.id]?.isEnabled == false)
         XCTAssertTrue(manager.ruleCollections[id: first.id]?.isEnabled == false)
         XCTAssertTrue(manager.ruleCollections[id: second.id]?.isEnabled == false)
+    }
+
+    func testStagedProviderDisableCannotBeAutomaticallyUndone() async throws {
+        let manager = try makeManager()
+        defer { TestEnvironment.forceTestMode = false }
+        let provider = layerContentProvider(
+            id: uuid(60),
+            name: "Function",
+            enabled: true
+        )
+        let dependent = homeRowToggles(
+            id: uuid(61),
+            enabled: true,
+            assignments: ["a": "fun"]
+        )
+        let candidate = RuleCollection(
+            id: uuid(62),
+            name: "Replacement",
+            summary: "Test",
+            category: .custom,
+            mappings: [],
+            isEnabled: false
+        )
+        manager.ruleCollections = [provider, dependent, candidate]
+
+        var receivedContext: RulePrerequisiteResolutionContext?
+        manager.onPrerequisiteResolution = { context in
+            receivedContext = context
+            return .enableRequiredProvidersAndApply
+        }
+        var regenerationCount = 0
+        manager.onBeforeSave = { regenerationCount += 1 }
+
+        let applied = await manager.toggleCollection(
+            id: candidate.id,
+            isEnabled: true,
+            bypassOwnershipCheck: true,
+            additionalCollectionIDsToDisable: [provider.id]
+        )
+
+        XCTAssertFalse(applied)
+        XCTAssertEqual(receivedContext?.recommendedProviderIDs, nil)
+        XCTAssertEqual(
+            receivedContext?.prerequisites.first?.availableProviderCollectionIDs,
+            []
+        )
+        XCTAssertEqual(regenerationCount, 0)
+        XCTAssertTrue(manager.ruleCollections[id: candidate.id]?.isEnabled == false)
+        XCTAssertTrue(manager.ruleCollections[id: provider.id]?.isEnabled == true)
+        XCTAssertTrue(manager.ruleCollections[id: dependent.id]?.isEnabled == true)
+    }
+
+    func testStagedDisableIsIgnoredDuringConflictAnalysis() async throws {
+        let manager = try makeManager()
+        defer { TestEnvironment.forceTestMode = false }
+        let stagedOff = RuleCollection(
+            id: uuid(63),
+            name: "Old Mapping",
+            summary: "Test",
+            category: .custom,
+            mappings: [
+                KeyMapping(input: "x", action: .keystroke(key: "a")),
+            ],
+            isEnabled: true
+        )
+        let candidate = RuleCollection(
+            id: uuid(64),
+            name: "New Mapping",
+            summary: "Test",
+            category: .custom,
+            mappings: [
+                KeyMapping(input: "x", action: .keystroke(key: "b")),
+            ],
+            isEnabled: false
+        )
+        manager.ruleCollections = [stagedOff, candidate]
+        manager.onConflictResolution = { _ in
+            XCTFail("A collection staged off in the same transaction is not a conflict")
+            return nil
+        }
+        var regenerationCount = 0
+        manager.onBeforeSave = { regenerationCount += 1 }
+
+        let applied = await manager.toggleCollection(
+            id: candidate.id,
+            isEnabled: true,
+            bypassOwnershipCheck: true,
+            additionalCollectionIDsToDisable: [stagedOff.id]
+        )
+
+        XCTAssertTrue(applied)
+        XCTAssertEqual(regenerationCount, 1)
+        XCTAssertTrue(manager.ruleCollections[id: candidate.id]?.isEnabled == true)
+        XCTAssertTrue(manager.ruleCollections[id: stagedOff.id]?.isEnabled == false)
     }
 
     func testFailedAtomicSaveRestoresCandidateAndProvider() async throws {


### PR DESCRIPTION
## What changed

- replace the prerequisite dialog's collapsed boolean with explicit automatic, unavailable, ambiguous, and mixed resolution states
- use truthful, benefit-oriented copy with a clear safe default and no raw configuration evidence
- model onboarding's staged catalog disables as part of the same prerequisite/conflict transaction
- distinguish first-run onboarding from manual replay so replay preserves enabled launcher behavior and existing Caps Lock hold actions
- keep replay copy and accessibility descriptions aligned with the live Escape + Hyper configuration

## Why

The old dialog represented both zero providers and multiple providers as the same state. That produced contradictory copy such as “No matching rule” alongside “more than one possible provider,” exposed implementation details, and offered no obvious safe exit. The shared first-run/replay path could also disable or overwrite working legacy launcher behavior.

## Validation

- required catalog sequence: 2/2 passed via `Scripts/run-tests-safe.sh`
- focused onboarding, replay, transaction, and dialog suite: 40/40 passed
- `python3 Scripts/check-accessibility.py`
- `git diff --check`
- `./Scripts/ui-deploy.sh`
- installed-app UI automation verified the exact dialog in light and dark appearance, safe default behavior, and unchanged rule/config/pack checksums after cancel
- installed-app replay verified the existing Hyper hold is preserved and described accurately
- local review gate selected the required remote `claude-review` gate
