### PR TITLE
Relax wall-clock bound in canonical capture timeout test

### DIFF
--- a/Tests/KeyPathTests/Services/SystemValidatorTests.swift
+++ b/Tests/KeyPathTests/Services/SystemValidatorTests.swift
@@ -300,7 +300,9 @@ struct SystemValidatorTests {
         }
 
         #expect(snapshot.captureStatus == .timedOut)
-        #expect(started.duration(to: clock.now) < .milliseconds(250))
+        // Generous bound: only guards against boundedCapture hanging past its
+        // 10ms deadline, not scheduling latency on a loaded runner.
+        #expect(started.duration(to: clock.now) < .seconds(5))
     }
 
     @Test("Canonical capture returns completed evidence before its deadline")


### PR DESCRIPTION
## Summary
- The Swift Testing test "Canonical capture timeout returns first-class timed-out evidence" asserted `started.duration(to: clock.now) < .milliseconds(250)` against a real `ContinuousClock`. On a loaded CI runner it measured 268 ms and failed PR #1243's build-and-test job (run 30470376137) despite being unrelated to that change.
- `SystemValidator.boundedCapture` has no injectable clock (its timeout uses `Task.sleep` on the default clock), so rather than a larger refactor, the assertion keeps the real-clock measurement but widens the bound to a generous 5-second hang guard with a comment. The test still fails if the timeout path hangs instead of promptly returning first-class timed-out evidence, and the `captureStatus == .timedOut` assertion is unchanged.

## Testing
- `TEST_FILTER=SystemValidatorTests ./Scripts/run-tests-safe.sh` — all 17 tests passed.

## Review gate
- `./Scripts/review-gate.sh`: remote review gate selected; GitHub `claude-review` must pass before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)