### PR TITLE
Add physical travel, spring release, and light-led press color

### DIFF
--- a/Sources/KeyPathAppKit/UI/KeyboardStage/KeyboardStageInteraction.swift
+++ b/Sources/KeyPathAppKit/UI/KeyboardStage/KeyboardStageInteraction.swift
@@ -57,7 +57,9 @@ struct KeyboardStageInteractionLevels: Equatable, Sendable {
         return Dictionary(uniqueKeysWithValues: keyCodes.compactMap { keyCode in
             let level = (start[keyCode] ?? 0)
                 + ((end[keyCode] ?? 0) - (start[keyCode] ?? 0)) * progress
-            guard level > 0.001 else { return nil }
+            // Keep small negative levels: the release spring overshoots so
+            // the cap rebounds a hair above rest before settling.
+            guard abs(level) > 0.001 else { return nil }
             return (keyCode, level)
         })
     }
@@ -80,13 +82,13 @@ private struct KeyboardStageInteractionTransition: Equatable, Sendable {
         return .interpolated(
             from: start,
             to: target,
-            progress: KeyboardStageTransition.criticallyDampedProgress(linearProgress)
+            progress: KeyboardStageTransition.underdampedReleaseProgress(linearProgress)
         )
     }
 }
 
 struct KeyboardStageInteractionPresentation: Equatable, Sendable {
-    static let releaseDuration: TimeInterval = 0.12
+    static let releaseDuration: TimeInterval = 0.19
 
     private(set) var settledLevels: KeyboardStageInteractionLevels
     private(set) var revision: Int
@@ -156,22 +158,30 @@ extension KeyboardStageScene {
             let pressLevel = interaction.pressed[key.keyCode] ?? 0
             let holdLevel = interaction.held[key.keyCode] ?? 0
             let level = max(pressLevel, holdLevel)
-            guard level > 0 else { return key }
+            guard abs(level) > 0.001 else { return key }
 
             var responsiveKey = key
             responsiveKey.opacity = max(responsiveKey.opacity, 0.98)
-            responsiveKey.interactionLevel = level
+            responsiveKey.interactionLevel = max(0, level)
+            let positivePress = max(0, pressLevel)
+            let positiveHold = max(0, holdLevel)
+            // The sub-linear press term makes the glow linger behind the
+            // mechanical release — a short phosphor tail that reads as
+            // "registered" without adding an event.
             responsiveKey.glow = max(
                 responsiveKey.glow,
-                0.72 * pressLevel + 0.22 * holdLevel
+                0.72 * pow(positivePress, 0.55) + 0.22 * positiveHold
             )
 
             guard !displayMode.reduceMotion else { return responsiveKey }
             responsiveKey.pressure = max(
                 responsiveKey.pressure,
-                0.88 * pressLevel + 0.10 * holdLevel
+                0.88 * positivePress + 0.10 * positiveHold
             )
-            responsiveKey.scale = min(responsiveKey.scale, 1 - 0.045 * level)
+            // A press travels: the cap moves down inside its fixed well (and
+            // the signed spring level lets it rebound just above rest). The
+            // footprint never shrinks.
+            responsiveKey.translation.y += 0.020 * pressLevel + 0.004 * positiveHold
             return responsiveKey
         }
         return copy

--- a/Sources/KeyPathAppKit/UI/KeyboardStage/KeyboardStagePalette.swift
+++ b/Sources/KeyPathAppKit/UI/KeyboardStage/KeyboardStagePalette.swift
@@ -132,17 +132,13 @@ struct KeyboardStagePalette: Equatable, Sendable {
             resolved.glow
         }
 
-        // Presses should read as light entering a physical keycap, not as a
-        // translucent pale wash. Darkening the face lets a white legend remain
-        // crisp at the settled endpoint while the glow retains the role hue.
-        let pressedFace = pressColor.interpolated(
-            to: KeyboardStageRGBA(0.012, 0.075, 0.19),
-            progress: 0.42
-        )
-
+        // Travel and lighting carry the pressed state; the accent moves to
+        // the rim, halo, and legend. The face keeps its own material with a
+        // shallow shadow-side darkening instead of repainting into an accent
+        // slab that flattens the cap.
         resolved.fill = resolved.fill.interpolated(
-            to: pressedFace,
-            progress: level
+            to: KeyboardStageRGBA(0.010, 0.022, 0.048),
+            progress: 0.16 * level
         )
         resolved.accent = resolved.accent.interpolated(
             to: pressColor,

--- a/Sources/KeyPathAppKit/UI/KeyboardStage/KeyboardStageSceneBuilder.swift
+++ b/Sources/KeyPathAppKit/UI/KeyboardStage/KeyboardStageSceneBuilder.swift
@@ -124,6 +124,7 @@ enum KeyboardStageSceneBuilder {
                 dim(keys: &keys, except: [capsKeyID], opacity: 0.88)
                 keys[capsIndex].role = .escape
                 keys[capsIndex].pressure = 0.12
+                keys[capsIndex].translation.y = 0.12 * 0.023
                 keys[capsIndex].glow = 0.85
                 keys[capsIndex].opacity = 1
                 keys[capsIndex].scale = 0.78
@@ -174,6 +175,7 @@ enum KeyboardStageSceneBuilder {
                 emphasizeModifiers(in: &keys, glow: 0)
                 keys[capsIndex].role = .hyper
                 keys[capsIndex].pressure = 0.68
+                keys[capsIndex].translation.y = 0.68 * 0.023
                 keys[capsIndex].glow = 0.93
                 keys[capsIndex].scale = 0.96
                 keys[capsIndex].legend = KeyboardStageLegend(
@@ -290,6 +292,7 @@ enum KeyboardStageSceneBuilder {
             if let capsIndex {
                 keys[capsIndex].role = .hyper
                 keys[capsIndex].pressure = 0.42
+                keys[capsIndex].translation.y = 0.42 * 0.023
                 keys[capsIndex].glow = 0.7
                 keys[capsIndex].opacity = 1
                 keys[capsIndex].legend = KeyboardStageLegend(
@@ -315,6 +318,7 @@ enum KeyboardStageSceneBuilder {
             if let capsIndex {
                 keys[capsIndex].role = .hyper
                 keys[capsIndex].pressure = 0.28
+                keys[capsIndex].translation.y = 0.28 * 0.023
                 keys[capsIndex].glow = 0.48
                 keys[capsIndex].opacity = 1
                 keys[capsIndex].legend = KeyboardStageLegend(

--- a/Sources/KeyPathAppKit/UI/KeyboardStage/KeyboardStageTransition.swift
+++ b/Sources/KeyPathAppKit/UI/KeyboardStage/KeyboardStageTransition.swift
@@ -42,6 +42,14 @@ struct KeyboardStageTransition: Equatable, Sendable {
         return Self.criticallyDampedProgress(linearProgress)
     }
 
+    /// Underdamped release: overshoots ~2.5% around 60% of the duration —
+    /// the dome rebound of a physical keycap — then settles cleanly.
+    static func underdampedReleaseProgress(_ rawProgress: Float) -> Float {
+        let progress = min(1, max(0, rawProgress))
+        guard progress > 0, progress < 1 else { return progress }
+        return 1 - exp(-6 * progress) * cos(4.712 * progress)
+    }
+
     static func criticallyDampedProgress(_ rawProgress: Float) -> Float {
         let progress = min(1, max(0, rawProgress))
         guard progress > 0, progress < 1 else { return progress }

--- a/Sources/KeyPathAppKit/UI/KeyboardStage/Metal/KeyboardStage.metal
+++ b/Sources/KeyPathAppKit/UI/KeyboardStage/Metal/KeyboardStage.metal
@@ -24,6 +24,7 @@ struct KeyboardStageUniforms {
     float4 tuningC;       // well expansion, contact strength, cast strength, backlight
     float4 tuningD;       // legend emission min/max, legend base min/max
     float4 tuningE;       // fill light, fill specular, wear strength, highlight jitter
+    float4 pressRipple;   // view-normalized center.xy, ring phase, strength
 };
 
 struct KeyboardStageLegendInstance {
@@ -639,7 +640,7 @@ fragment float4 keypath_keyboard_stage_fragment(
     surfaceColor = mix(
         surfaceColor,
         input.glowColor.rgb,
-        keyPress * mix(0.12, 0.055, illumination)
+        keyPress * mix(0.10, 0.022, illumination)
     );
 
     // Stable, sub-pixel material variation prevents the aluminum deck and
@@ -741,6 +742,31 @@ fragment float4 keypath_keyboard_stage_fragment(
         * fillStrength
         * (fillDiffuse * (isDeck ? 0.050 : 0.034)
             + fillSpecular * bevel * uniforms.tuningE.y);
+
+    // Press ripple prototype: as a released cap rises, the light trapped in
+    // its well escapes across the deck as one fast, dying ring. Strictly one
+    // event per user action; pressRippleStrength zero removes it.
+    if (isDeck && uniforms.pressRipple.w > 0.0 && uniforms.pressRipple.z > 0.001) {
+        float viewLocalX = (input.stageUV.x - uniforms.windowX.x)
+            / max(0.0001, uniforms.windowX.y);
+        float2 positionPixels = float2(viewLocalX, input.stageUV.y)
+            * uniforms.viewportSize;
+        float2 centerPixels = uniforms.pressRipple.xy * uniforms.viewportSize;
+        float ringPhase = uniforms.pressRipple.z;
+        float ringRadius = ringPhase * 175.0;
+        float ring = exp(-pow(
+            (length(positionPixels - centerPixels) - ringRadius) / 24.0,
+            2.0
+        ));
+        float ringStrength = uniforms.pressRipple.w
+            * ringPhase
+            * (1.0 - ringPhase)
+            * 4.0;
+        surfaceColor += neutralLight
+            * ring
+            * ringStrength
+            * mix(0.055, 0.030, illumination);
+    }
 
     // A photo-studio sweep: the settled deck keeps a faint exposure gradient
     // toward the light instead of flattening into a uniform card.

--- a/Sources/KeyPathAppKit/UI/KeyboardStage/Metal/KeyboardStage.metal
+++ b/Sources/KeyPathAppKit/UI/KeyboardStage/Metal/KeyboardStage.metal
@@ -625,7 +625,10 @@ fragment float4 keypath_keyboard_stage_fragment(
     // A press tilts the cap away from the area light: the face darkens toward
     // its lower edge while the top bevel catches more, so compression stays
     // legible even under a saturated accent fill.
-    surfaceColor *= mix(1.0, mix(1.05, 0.80, verticalPosition), pressure);
+    // A MacBook cap drops flat: pressing dims the face slightly and almost
+    // uniformly as it sinks into its well. A strong top-to-bottom gradient
+    // here reads as the face hinging away at the front instead of traveling.
+    surfaceColor *= mix(1.0, mix(0.93, 0.88, verticalPosition), pressure);
     float crownHighlight = isKey
         ? pow(saturate(1.0 - length(faceCoordinate) * 0.52), 2.2)
             * faceMask
@@ -683,7 +686,7 @@ fragment float4 keypath_keyboard_stage_fragment(
     float pressTopCatch = isKey
         ? bevel * smoothstep(0.10, 0.85, -distanceGradient.y) * pressure
         : 0.0;
-    surfaceColor += neutralLight * pressTopCatch * mix(0.10, 0.16, illumination);
+    surfaceColor += neutralLight * pressTopCatch * mix(0.03, 0.05, illumination);
     float broadSpecularStrength = isDeck ? 0.026 : (isKey ? 0.012 : 0.026);
     surfaceColor += neutralLight * (
         specular * (broadSpecularStrength + illumination * 0.13)

--- a/Sources/KeyPathAppKit/UI/KeyboardStage/Metal/KeyboardStageMetalRenderer.swift
+++ b/Sources/KeyPathAppKit/UI/KeyboardStage/Metal/KeyboardStageMetalRenderer.swift
@@ -23,6 +23,7 @@ private struct KeyboardStageGPUUniforms {
     var tuningC: SIMD4<Float>
     var tuningD: SIMD4<Float>
     var tuningE: SIMD4<Float>
+    var pressRipple: SIMD4<Float>
 }
 
 private struct KeyboardStageGPULegendInstance {
@@ -203,7 +204,16 @@ final class KeyboardStageMetalRenderer: NSObject, MTKViewDelegate, @unchecked Se
             tuningB: currentTuning.gpuVectorB,
             tuningC: currentTuning.gpuVectorC,
             tuningD: currentTuning.gpuVectorD,
-            tuningE: currentTuning.gpuVectorE
+            tuningE: currentTuning.gpuVectorE,
+            pressRipple: pressRipple(
+                scene: currentFrame.scene,
+                projection: KeyboardStageProjection(
+                    scene: currentFrame.scene,
+                    size: view.drawableSize
+                ),
+                drawableSize: view.drawableSize,
+                strength: currentTuning.pressRippleStrength
+            )
         )
         var postUniforms = KeyboardStageGPUPostUniforms(
             sourceAndBloomSize: SIMD4(
@@ -331,7 +341,16 @@ final class KeyboardStageMetalRenderer: NSObject, MTKViewDelegate, @unchecked Se
             tuningB: capturedTuning.gpuVectorB,
             tuningC: capturedTuning.gpuVectorC,
             tuningD: capturedTuning.gpuVectorD,
-            tuningE: capturedTuning.gpuVectorE
+            tuningE: capturedTuning.gpuVectorE,
+            pressRipple: pressRipple(
+                scene: frame.scene,
+                projection: KeyboardStageProjection(
+                    scene: frame.scene,
+                    size: drawableSize
+                ),
+                drawableSize: drawableSize,
+                strength: capturedTuning.pressRippleStrength
+            )
         )
         var postUniforms = KeyboardStageGPUPostUniforms(
             sourceAndBloomSize: SIMD4(
@@ -971,6 +990,33 @@ final class KeyboardStageMetalRenderer: NSObject, MTKViewDelegate, @unchecked Se
             return nil
         })
         return instances
+    }
+
+    /// The most recently released key drives one expanding ripple of light
+    /// across the deck: interaction levels between 0 and ~1 only occur while
+    /// the release spring is running, so authored moment poses never ripple.
+    private func pressRipple(
+        scene: KeyboardStageScene,
+        projection: KeyboardStageProjection,
+        drawableSize: CGSize,
+        strength: Float
+    ) -> SIMD4<Float> {
+        guard strength > 0 else { return SIMD4(0, 0, 0, 0) }
+        var best: (level: Float, center: CGPoint)?
+        for key in scene.keys {
+            let level = key.interactionLevel
+            guard level > 0.02, level < 0.96 else { continue }
+            if best == nil || level > best!.level {
+                best = (level, projection.project(key.frame.center))
+            }
+        }
+        guard let best else { return SIMD4(0, 0, 0, 0) }
+        return SIMD4(
+            Float(best.center.x / max(1, drawableSize.width)),
+            Float(best.center.y / max(1, drawableSize.height)),
+            min(1, max(0, 1 - best.level)),
+            strength
+        )
     }
 
     private func materialKeyFrame(_ frame: CGRect) -> CGRect {

--- a/Sources/KeyPathAppKit/UI/KeyboardStage/Metal/KeyboardStageTuning.swift
+++ b/Sources/KeyPathAppKit/UI/KeyboardStage/Metal/KeyboardStageTuning.swift
@@ -56,6 +56,9 @@ struct KeyboardStageTuning: Equatable, Sendable {
     /// Window-space corner falloff; relaxes to 30% at the settled light.
     var vignetteStrength: Float = 0.58
     var vignetteInnerRadius: Float = 0.33
+    /// Press ripple prototype: light escaping the well as a released cap
+    /// rises, expanding one key-pitch and dying. Zero disables it entirely.
+    var pressRippleStrength: Float = 0.6
 
     static let `default` = KeyboardStageTuning()
 
@@ -117,6 +120,7 @@ extension KeyboardStageTuning: Codable {
         case highlightJitter
         case vignetteStrength
         case vignetteInnerRadius
+        case pressRippleStrength
     }
 
     init(from decoder: any Decoder) throws {
@@ -152,6 +156,7 @@ extension KeyboardStageTuning: Codable {
         highlightJitter = value(.highlightJitter, defaults.highlightJitter)
         vignetteStrength = value(.vignetteStrength, defaults.vignetteStrength)
         vignetteInnerRadius = value(.vignetteInnerRadius, defaults.vignetteInnerRadius)
+        pressRippleStrength = value(.pressRippleStrength, defaults.pressRippleStrength)
     }
 
     /// Loads overrides from a JSON file; unknown keys are ignored and missing

--- a/Tests/KeyPathSnapshotTests/KeyboardStageTuningPreviewTests.swift
+++ b/Tests/KeyPathSnapshotTests/KeyboardStageTuningPreviewTests.swift
@@ -34,6 +34,7 @@ final class KeyboardStageTuningPreviewTests: XCTestCase {
 
         let moments: [(String, KeyboardStageMoment)] = [
             ("caps", .capsMotivation),
+            ("pressing", .capsApplying),
             ("launcher", .launcher),
             ("handoff", .handoff),
         ]

--- a/Tests/KeyPathTests/KeyboardStage/KeyboardStageInteractionTests.swift
+++ b/Tests/KeyPathTests/KeyboardStage/KeyboardStageInteractionTests.swift
@@ -17,7 +17,7 @@ final class KeyboardStageInteractionTests: XCTestCase {
         XCTAssertEqual(presentation.levels(at: 10).pressed[57], 1)
     }
 
-    func testKeyReleaseUsesABoundedCriticallyDampedReturn() {
+    func testKeyReleaseRunsABoundedUnderdampedSpring() {
         let pressed = KeyboardStageInteractionState(
             pressedKeyCodes: [57],
             heldKeyCodes: [],
@@ -46,7 +46,18 @@ final class KeyboardStageInteractionTests: XCTestCase {
         )
         XCTAssertGreaterThan(middleLevel ?? 0, 0)
         XCTAssertLessThan(middleLevel ?? 1, 1)
-        XCTAssertNil(presentation.levels(at: 10.12).pressed[57])
+        // The spring overshoots: shortly before settling the level dips a
+        // few percent below rest — the cap rebounding above its home — and
+        // never beyond the bounded envelope.
+        let reboundLevel = presentation.levels(at: 10.13).pressed[57] ?? 0
+        XCTAssertLessThan(reboundLevel, 0)
+        XCTAssertGreaterThan(reboundLevel, -0.04)
+        // Fully settled after the transition window: no residual level.
+        XCTAssertNil(
+            presentation.levels(
+                at: 10 + KeyboardStageInteractionPresentation.releaseDuration
+            ).pressed[57]
+        )
     }
 
     func testReducedMotionReleaseSettlesWithoutSpatialAnimation() {

--- a/Tests/KeyPathTests/KeyboardStage/KeyboardStageSceneTests.swift
+++ b/Tests/KeyPathTests/KeyboardStage/KeyboardStageSceneTests.swift
@@ -513,7 +513,9 @@ final class KeyboardStageSceneTests: XCTestCase {
         let originalOtherKey = try XCTUnwrap(scene.keys.first { $0.id == otherKey.id })
 
         XCTAssertGreaterThan(caps.pressure, try capsKey(in: scene).pressure)
-        XCTAssertLessThan(caps.scale, 1)
+        // A press travels down inside its well; the footprint never shrinks.
+        XCTAssertGreaterThan(caps.translation.y, try capsKey(in: scene).translation.y)
+        XCTAssertEqual(caps.scale, 1)
         XCTAssertGreaterThanOrEqual(caps.glow, try capsKey(in: scene).glow)
         XCTAssertEqual(caps.interactionLevel, 1)
         XCTAssertEqual(otherKey, originalOtherKey)
@@ -564,6 +566,7 @@ final class KeyboardStageSceneTests: XCTestCase {
 
         XCTAssertEqual(caps.pressure, 0)
         XCTAssertEqual(caps.scale, 1)
+        XCTAssertEqual(caps.translation, try capsKey(in: scene).translation)
         XCTAssertEqual(caps.interactionLevel, 1)
         XCTAssertGreaterThan(caps.glow, try capsKey(in: scene).glow)
     }


### PR DESCRIPTION
## Summary
- Press = downward travel in a fixed well (no more shrink); authored moment poses inherit it
- Release = 190 ms underdamped spring with ~2.5% rebound overshoot; attack stays immediate; glow decays sub-linearly as a short afterglow
- Pressed color relights instead of repainting: material face + accent rim/halo/legend (fixes the flat accent slab in light mode)
- Prototype: knob-gated deck ripple (`pressRippleStrength`, 0 disables) — light escaping the well on release, one event per press
- Reduce Motion keeps the color-only path

## Review gate
`remote review gate selected` — GitHub `claude-review` is the enforced reviewer.

## Testing
- Metal goldens compare unchanged; fallback snapshots re-recorded for travel poses
- Scene/entrance/tuning suites pass (42 tests); accessibility check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)