### PR TITLE
Fix setup wizard runtime spinner and prepare 1.0.2 hotfix

### DIFF
--- a/Sources/KeyPathApp/Info.plist
+++ b/Sources/KeyPathApp/Info.plist
@@ -11,9 +11,9 @@
 	<key>CFBundleDisplayName</key>
 	<string>KeyPath</string>
 	<key>CFBundleVersion</key>
-	<string>12</string>
+	<string>13</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.1</string>
+	<string>1.0.2</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleIconFile</key>

--- a/Sources/KeyPathInstallationWizard/Core/ServiceStatusEvaluator.swift
+++ b/Sources/KeyPathInstallationWizard/Core/ServiceStatusEvaluator.swift
@@ -26,14 +26,35 @@ public enum ServiceStatusEvaluator {
         completedAttempts: Int
     ) -> Bool {
         guard completedAttempts < transientRefreshAttemptLimit else { return false }
+        return isTransientStartupStatus(
+            runtimeStatus: runtimeStatus,
+            isInTransientStartupWindow: isInTransientStartupWindow
+        )
+    }
 
+    public static func didExhaustTransientStatus(
+        runtimeStatus: WizardRuntimeStatus,
+        isInTransientStartupWindow: Bool,
+        completedAttempts: Int
+    ) -> Bool {
+        guard completedAttempts >= transientRefreshAttemptLimit else { return false }
+        return isTransientStartupStatus(
+            runtimeStatus: runtimeStatus,
+            isInTransientStartupWindow: isInTransientStartupWindow
+        )
+    }
+
+    private static func isTransientStartupStatus(
+        runtimeStatus: WizardRuntimeStatus,
+        isInTransientStartupWindow: Bool
+    ) -> Bool {
         switch runtimeStatus {
         case .starting:
-            return true
+            true
         case .stopped:
-            return isInTransientStartupWindow
+            isInTransientStartupWindow
         case .running, .failed, .unknown:
-            return false
+            false
         }
     }
 

--- a/Sources/KeyPathInstallationWizard/Core/ServiceStatusEvaluator.swift
+++ b/Sources/KeyPathInstallationWizard/Core/ServiceStatusEvaluator.swift
@@ -15,6 +15,28 @@ public enum ServiceProcessStatus: Equatable {
 /// Single source of truth for service status evaluation across all wizard pages
 /// Pure function approach - no side effects, consistent results
 public enum ServiceStatusEvaluator {
+    /// The service page rechecks only while the runtime is genuinely in a
+    /// transient startup state. The cap prevents a stale lifecycle signal from
+    /// leaving the wizard in an endless spinner.
+    public static let transientRefreshAttemptLimit = 30
+
+    public static func shouldRetryTransientStatus(
+        runtimeStatus: WizardRuntimeStatus,
+        isInTransientStartupWindow: Bool,
+        completedAttempts: Int
+    ) -> Bool {
+        guard completedAttempts < transientRefreshAttemptLimit else { return false }
+
+        switch runtimeStatus {
+        case .starting:
+            return true
+        case .stopped:
+            return isInTransientStartupWindow
+        case .running, .failed, .unknown:
+            return false
+        }
+    }
+
     /// Evaluates a fresh runtime observation after an explicit lifecycle action.
     ///
     /// A successful lifecycle operation has already verified runtime readiness, so

--- a/Sources/KeyPathInstallationWizard/UI/Pages/WizardKanataServicePage.swift
+++ b/Sources/KeyPathInstallationWizard/UI/Pages/WizardKanataServicePage.swift
@@ -8,7 +8,6 @@ public struct WizardKanataServicePage: View {
 
     @State private var isPerformingAction = false
     @State private var serviceStatus: ServiceStatus = .unknown
-    @State private var refreshTimer: Timer?
     @State private var actionStatus: WizardDesign.ActionStatus = .idle
     @State private var refreshTask: Task<Void, Never>?
 
@@ -113,11 +112,9 @@ public struct WizardKanataServicePage: View {
         .background(WizardDesign.Colors.wizardBackground)
         .wizardDetailPage()
         .onAppear {
-            startAutoRefresh()
             refreshStatus()
         }
         .onDisappear {
-            stopAutoRefresh()
             refreshTask?.cancel()
             refreshTask = nil
         }
@@ -295,34 +292,62 @@ public struct WizardKanataServicePage: View {
             AppLogger.shared.log("⚠️ [WizardKanataServicePage] kanataManager not configured — skipping status refresh")
             return
         }
-        let runtimeStatus = await kanataManager.currentRuntimeStatus()
-        let isInTransientStartupWindow = await kanataManager.isInTransientRuntimeStartupWindow()
+        var completedAttempts = 0
 
-        let processStatus = if let actionSucceeded {
-            ServiceStatusEvaluator.evaluateAfterAction(
-                operationSucceeded: actionSucceeded,
-                kanataIsRunning: runtimeStatus.isRunning,
-                systemState: systemState,
-                issues: issues
-            )
-        } else {
-            ServiceStatusEvaluator.evaluate(
-                kanataIsRunning: runtimeStatus.isRunning,
-                systemState: systemState,
-                issues: issues
-            )
-        }
+        while !Task.isCancelled {
+            let runtimeStatus = await kanataManager.currentRuntimeStatus()
+            let isInTransientStartupWindow = await kanataManager.isInTransientRuntimeStartupWindow()
 
-        guard !Task.isCancelled else { return }
-
-        await MainActor.run {
-            withAnimation(.easeInOut(duration: 0.3)) {
-                applyStatusUpdate(
-                    runtimeStatus: runtimeStatus,
-                    processStatus: processStatus,
-                    isInTransientStartupWindow: isInTransientStartupWindow
+            let processStatus = if let actionSucceeded {
+                ServiceStatusEvaluator.evaluateAfterAction(
+                    operationSucceeded: actionSucceeded,
+                    kanataIsRunning: runtimeStatus.isRunning,
+                    systemState: systemState,
+                    issues: issues
+                )
+            } else {
+                ServiceStatusEvaluator.evaluate(
+                    kanataIsRunning: runtimeStatus.isRunning,
+                    systemState: systemState,
+                    issues: issues
                 )
             }
+
+            guard !Task.isCancelled else { return }
+
+            await MainActor.run {
+                withAnimation(.easeInOut(duration: 0.3)) {
+                    applyStatusUpdate(
+                        runtimeStatus: runtimeStatus,
+                        processStatus: processStatus,
+                        isInTransientStartupWindow: isInTransientStartupWindow
+                    )
+                }
+            }
+
+            completedAttempts += 1
+            let shouldRetry = ServiceStatusEvaluator.shouldRetryTransientStatus(
+                runtimeStatus: runtimeStatus,
+                isInTransientStartupWindow: isInTransientStartupWindow,
+                completedAttempts: completedAttempts
+            )
+            guard shouldRetry else {
+                if completedAttempts >= ServiceStatusEvaluator.transientRefreshAttemptLimit,
+                   runtimeStatus == .starting
+                {
+                    await MainActor.run {
+                        serviceStatus = .failed(
+                            error: "Runtime startup did not finish. Click Restart to retry."
+                        )
+                    }
+                }
+                return
+            }
+
+            AppLogger.shared.log(
+                "⏳ [WizardKanataServicePage] Runtime is still starting; scheduling bounded status retry \(completedAttempts)/\(ServiceStatusEvaluator.transientRefreshAttemptLimit)"
+            )
+            guard await WizardSleep.seconds(1) else { return }
         }
     }
 
@@ -591,21 +616,5 @@ public struct WizardKanataServicePage: View {
         } else {
             "Check log file for details"
         }
-    }
-
-    // MARK: - Auto Refresh
-
-    private func startAutoRefresh() {
-        // DISABLED: This timer calls refreshStatus() which may trigger invasive permission checks
-        // that cause KeyPath to auto-add to Input Monitoring system preferences
-
-        AppLogger.shared.log(
-            "🔄 [WizardKanataServicePage] Auto-refresh timer DISABLED to prevent invasive permission checks"
-        )
-    }
-
-    private func stopAutoRefresh() {
-        refreshTimer?.invalidate()
-        refreshTimer = nil
     }
 }

--- a/Sources/KeyPathInstallationWizard/UI/Pages/WizardKanataServicePage.swift
+++ b/Sources/KeyPathInstallationWizard/UI/Pages/WizardKanataServicePage.swift
@@ -332,9 +332,11 @@ public struct WizardKanataServicePage: View {
                 completedAttempts: completedAttempts
             )
             guard shouldRetry else {
-                if completedAttempts >= ServiceStatusEvaluator.transientRefreshAttemptLimit,
-                   runtimeStatus == .starting
-                {
+                if ServiceStatusEvaluator.didExhaustTransientStatus(
+                    runtimeStatus: runtimeStatus,
+                    isInTransientStartupWindow: isInTransientStartupWindow,
+                    completedAttempts: completedAttempts
+                ) {
                     await MainActor.run {
                         serviceStatus = .failed(
                             error: "Runtime startup did not finish. Click Restart to retry."

--- a/Tests/KeyPathTests/InstallationWizard/ServiceStatusEvaluatorActionTests.swift
+++ b/Tests/KeyPathTests/InstallationWizard/ServiceStatusEvaluatorActionTests.swift
@@ -35,6 +35,13 @@ final class ServiceStatusEvaluatorActionTests: XCTestCase {
                 completedAttempts: 1
             )
         )
+        XCTAssertTrue(
+            ServiceStatusEvaluator.didExhaustTransientStatus(
+                runtimeStatus: .stopped,
+                isInTransientStartupWindow: true,
+                completedAttempts: ServiceStatusEvaluator.transientRefreshAttemptLimit
+            )
+        )
     }
 
     func testSettledRuntimeStatusDoesNotRetry() {
@@ -50,6 +57,13 @@ final class ServiceStatusEvaluatorActionTests: XCTestCase {
                 runtimeStatus: .failed(reason: "boom"),
                 isInTransientStartupWindow: true,
                 completedAttempts: 1
+            )
+        )
+        XCTAssertFalse(
+            ServiceStatusEvaluator.didExhaustTransientStatus(
+                runtimeStatus: .running(pid: 42),
+                isInTransientStartupWindow: true,
+                completedAttempts: ServiceStatusEvaluator.transientRefreshAttemptLimit
             )
         )
     }

--- a/Tests/KeyPathTests/InstallationWizard/ServiceStatusEvaluatorActionTests.swift
+++ b/Tests/KeyPathTests/InstallationWizard/ServiceStatusEvaluatorActionTests.swift
@@ -3,6 +3,57 @@ import KeyPathWizardCore
 import XCTest
 
 final class ServiceStatusEvaluatorActionTests: XCTestCase {
+    func testTransientStartingStatusRetriesUntilAttemptLimit() {
+        XCTAssertTrue(
+            ServiceStatusEvaluator.shouldRetryTransientStatus(
+                runtimeStatus: .starting,
+                isInTransientStartupWindow: false,
+                completedAttempts: 1
+            )
+        )
+        XCTAssertFalse(
+            ServiceStatusEvaluator.shouldRetryTransientStatus(
+                runtimeStatus: .starting,
+                isInTransientStartupWindow: false,
+                completedAttempts: ServiceStatusEvaluator.transientRefreshAttemptLimit
+            )
+        )
+    }
+
+    func testStoppedStatusRetriesOnlyInsideTransientStartupWindow() {
+        XCTAssertTrue(
+            ServiceStatusEvaluator.shouldRetryTransientStatus(
+                runtimeStatus: .stopped,
+                isInTransientStartupWindow: true,
+                completedAttempts: 1
+            )
+        )
+        XCTAssertFalse(
+            ServiceStatusEvaluator.shouldRetryTransientStatus(
+                runtimeStatus: .stopped,
+                isInTransientStartupWindow: false,
+                completedAttempts: 1
+            )
+        )
+    }
+
+    func testSettledRuntimeStatusDoesNotRetry() {
+        XCTAssertFalse(
+            ServiceStatusEvaluator.shouldRetryTransientStatus(
+                runtimeStatus: .running(pid: 42),
+                isInTransientStartupWindow: true,
+                completedAttempts: 1
+            )
+        )
+        XCTAssertFalse(
+            ServiceStatusEvaluator.shouldRetryTransientStatus(
+                runtimeStatus: .failed(reason: "boom"),
+                isInTransientStartupWindow: true,
+                completedAttempts: 1
+            )
+        )
+    }
+
     func testSuccessfulActionUsesFreshRunningObservationOverStaleIssue() {
         let status = ServiceStatusEvaluator.evaluateAfterAction(
             operationSucceeded: true,


### PR DESCRIPTION
## What changed

- Recheck runtime status once per second only while the service page is in a transient startup state.
- Stop polling immediately when the runtime settles.
- Cap transient checks at 30 and surface an actionable Restart state instead of an endless spinner.
- Remove the obsolete disabled timer scaffolding.
- Bump the hotfix to KeyPath 1.0.2 build 13.

## Root cause

The runtime service page performed a single status observation. Its broad auto-refresh timer had previously been disabled to avoid invasive permission checks. If the one observation landed during the brief runtime startup window, the page rendered “Starting KeyPath runtime…” forever even after the runtime became healthy.

## User impact

Users who launch KeyPath during that transition can now progress automatically once the already-healthy runtime is observed. The retry is bounded and runtime-only; it does not restore broad permission polling.

## Validation

- Reproduced on the notarized 1.0.1 build while the CLI and validator showed a healthy runtime.
- Relaunching the UI confirmed the runtime remained continuously operational and the main interface appeared.
- `swift test --filter ServiceStatusEvaluatorActionTests` — 7 passed.
- Pinned SwiftFormat 0.61.1 lint — passed.
- `plutil -lint Sources/KeyPathApp/Info.plist` — passed.
- `git diff --check` — passed.