### PR TITLE
Let pointer presses reach the keyboard stage's hit targets

### DIFF
--- a/Sources/KeyPathAppKit/UI/KeyboardStage/Metal/KeyboardStageMetalView.swift
+++ b/Sources/KeyPathAppKit/UI/KeyboardStage/Metal/KeyboardStageMetalView.swift
@@ -244,6 +244,16 @@ final class KeyboardStageMTKView: MTKView {
     private var retryTask: Task<Void, Never>?
     private var reportedWindowX = SIMD2<Float>(0, 1)
 
+    /// The renderer is visual output only; the native semantic overlay stacked
+    /// above it owns pointer interaction and accessibility. As a real `NSView`
+    /// this would otherwise return itself for every point inside the keyboard
+    /// and swallow clicks before those hit targets could see them, so pointer
+    /// presses worked in the SwiftUI fallback and silently failed whenever
+    /// Metal was active.
+    override func hitTest(_: NSPoint) -> NSView? {
+        nil
+    }
+
     override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
         stopObservingWindow()

--- a/Tests/KeyPathTests/KeyboardStage/KeyboardStageInteractionTests.swift
+++ b/Tests/KeyPathTests/KeyboardStage/KeyboardStageInteractionTests.swift
@@ -1,7 +1,22 @@
+import AppKit
 @testable import KeyPathAppKit
 import XCTest
 
 final class KeyboardStageInteractionTests: XCTestCase {
+    /// The Metal view must stay transparent to the mouse. It is a real NSView,
+    /// so without this it returns itself for every point inside the keyboard
+    /// and swallows clicks before the semantic overlay's per-key hit targets
+    /// receive them — pointer presses then work only in the SwiftUI fallback.
+    @MainActor
+    func testMetalStageViewPassesPointerEventsToTheOverlayAbove() {
+        let view = KeyboardStageMTKView(
+            frame: NSRect(x: 0, y: 0, width: 400, height: 300)
+        )
+
+        XCTAssertNil(view.hitTest(NSPoint(x: 200, y: 150)))
+        XCTAssertNil(view.hitTest(NSPoint(x: 1, y: 1)))
+    }
+
     func testKeyDownFeedbackIsImmediate() {
         var presentation = KeyboardStageInteractionPresentation()
         let pressed = KeyboardStageInteractionState(


### PR DESCRIPTION
## Summary
Clicking a key in the onboarding tour did nothing whenever Metal was active (the shipped default). `KeyboardStageMTKView` is a real `NSView` with no `hitTest` override, so it returned itself for every point inside the keyboard and swallowed mouse events before the semantic overlay's per-key hit targets — which sit above it and own pointer interaction — could receive them.

- Return `nil` from `hitTest`, matching the plan's boundary that the renderer is visual output only
- Regression test pinning the contract, verified failing without the fix

## Note on how this survived
Snapshot/golden coverage renders scenes but never exercises input, so no automated test could catch a pointer-routing defect in the Metal path. Worth follow-up interaction-level coverage; see PR discussion.

## Review gate
`remote review gate selected` — GitHub `claude-review` is the enforced reviewer.

## Testing
- `KeyboardStageInteractionTests` pass (6); the new test fails without the fix and passes with it

🤖 Generated with [Claude Code](https://claude.com/claude-code)