### PR TITLE
Move runner CI scratch to guarded external storage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,9 @@ concurrency:
   group: ci-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+env:
+  KEYPATH_CI_VOLUME_UUID: ${{ vars.KEYPATH_CI_VOLUME_UUID }}
+
 jobs:
   build-and-test:
     # macOS 27 AppSSO traps SwiftPM binary-artifact requests from a headless
@@ -51,6 +54,12 @@ jobs:
 
     - name: Verify runner disk reserve
       run: ./Scripts/lab/host-disk-reserve
+
+    - name: Test CI storage safeguards
+      run: python3 -m unittest discover -s Scripts/tests -p test_ci_storage.py
+
+    - name: Prepare external CI scratch
+      run: python3 Scripts/ci-storage.py prepare
 
     - name: Ensure Metal toolchain
       run: ./Scripts/ensure-metal-toolchain.sh
@@ -121,7 +130,6 @@ jobs:
         KEYPATH_TEST_ENFORCE_CLEAN_SUMMARY: "1"
         KEYPATH_TEST_RESET_MODULE_CACHE: "0"
         KEYPATH_SWIFT_BUILD_JOBS: "4"
-        SCRATCH_PATH: ${{ runner.temp }}/keypath-build
       run: |
         echo "Running full named test lane..."
         export CI_ENVIRONMENT=true
@@ -135,6 +143,10 @@ jobs:
           echo "TEST_STATUS=failed" >> $GITHUB_ENV
           exit 1
         fi
+
+    - name: Mark CI scratch completed
+      if: always() && env.SCRATCH_PATH != ''
+      run: python3 Scripts/ci-storage.py finish
 
     - name: Parse Installer Reliability Matrix from Test Log
       if: always()

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -9,6 +9,9 @@ concurrency:
   group: coverage-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  KEYPATH_CI_VOLUME_UUID: ${{ vars.KEYPATH_CI_VOLUME_UUID }}
+
 jobs:
   narrow-coverage:
     runs-on: [self-hosted, macOS, keypath, swiftpm-safe]
@@ -32,6 +35,9 @@ jobs:
       - name: Verify runner disk reserve
         run: ./Scripts/lab/host-disk-reserve
 
+      - name: Prepare external CI scratch
+        run: python3 Scripts/ci-storage.py prepare
+
       - name: Ensure Metal toolchain
         run: ./Scripts/ensure-metal-toolchain.sh
 
@@ -46,9 +52,13 @@ jobs:
           SKIP_EVENT_TAP_TESTS: "1"
         run: |
           echo "Generating narrow-lane coverage..."
-          swift test --enable-code-coverage --filter 'KeyPathErrorTests|PermissionOracleTests'
+          swift test --scratch-path "$SCRATCH_PATH" --enable-code-coverage --filter 'KeyPathErrorTests|PermissionOracleTests'
           chmod +x ./Scripts/generate-coverage.sh
           ./Scripts/generate-coverage.sh coverage
+
+      - name: Mark CI scratch completed
+        if: always() && env.SCRATCH_PATH != ''
+        run: python3 Scripts/ci-storage.py finish
 
       - name: Enforce coverage non-regression
         run: |
@@ -123,6 +133,9 @@ jobs:
       - name: Verify runner disk reserve
         run: ./Scripts/lab/host-disk-reserve
 
+      - name: Prepare external CI scratch
+        run: python3 Scripts/ci-storage.py prepare
+
       - name: Ensure Metal toolchain
         run: ./Scripts/ensure-metal-toolchain.sh
 
@@ -137,9 +150,13 @@ jobs:
           SKIP_EVENT_TAP_TESTS: "1"
         run: |
           echo "Generating full-suite coverage (no filter)..."
-          swift test --enable-code-coverage
+          swift test --scratch-path "$SCRATCH_PATH" --enable-code-coverage
           chmod +x ./Scripts/generate-coverage.sh
           ./Scripts/generate-coverage.sh coverage-full
+
+      - name: Mark CI scratch completed
+        if: always() && env.SCRATCH_PATH != ''
+        run: python3 Scripts/ci-storage.py finish
 
       - name: Upload full coverage artifacts
         if: always()

--- a/Scripts/ci-storage.py
+++ b/Scripts/ci-storage.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Admit CI scratch on a verified external volume; prune only finished jobs."""
+import argparse
+import fcntl
+import os
+from pathlib import Path
+import plistlib
+import re
+import shutil
+import subprocess
+import time
+
+GIB = 1024 ** 3
+
+
+def checked_volume(path, expected_uuid):
+    if not expected_uuid:
+        raise RuntimeError("KEYPATH_CI_VOLUME_UUID is required")
+    info = plistlib.loads(subprocess.check_output(["diskutil", "info", "-plist", str(path)]))
+    if (info.get("VolumeUUID", "").upper() != expected_uuid.upper()
+            or info.get("MountPoint") != str(path) or path.is_symlink()):
+        raise RuntimeError("CI volume identity/mount mismatch; refusing startup-disk fallback")
+
+
+def component(value):
+    if not re.fullmatch(r"[A-Za-z0-9_-]+", value):
+        raise RuntimeError("Invalid CI path component")
+    return value
+
+
+def size(path):
+    return int(subprocess.check_output(["du", "-sk", str(path)]).split()[0]) * 1024
+
+
+def prune(root, now=None, budget=50 * GIB, age_days=7):
+    """Never touch unmarked, active, or symlinked entries."""
+    now = time.time() if now is None else now
+    entries = []
+    for path in root.iterdir():
+        marker = path / ".completed"
+        if path.is_symlink() or not path.is_dir() or not re.fullmatch(r"[0-9]+-[0-9]+-[A-Za-z0-9_-]+", path.name):
+            continue
+        if marker.is_symlink() or not marker.is_file():
+            continue
+        entries.append((marker.stat().st_mtime, path, size(path)))
+    total = sum(item[2] for item in entries)
+    for timestamp, path, byte_count in sorted(entries):
+        if now - timestamp > age_days * 86400 or total > budget:
+            print(f"Removing completed CI scratch: {path} ({byte_count // GIB} GiB)")
+            shutil.rmtree(path)
+            total -= byte_count
+
+
+def run(action, env):
+    volume = Path(env.get("KEYPATH_CI_VOLUME", "/Volumes/Foot Locker"))
+    checked_volume(volume, env.get("KEYPATH_CI_VOLUME_UUID", ""))
+    runner = component(env.get("RUNNER_NAME", ""))
+    root = volume / "KeyPathCI" / runner
+    # No writes until volume identity is verified. Refuse symlink redirects.
+    for path in (volume / "KeyPathCI", root):
+        if path.is_symlink():
+            raise RuntimeError("CI scratch root cannot be a symlink")
+        path.mkdir(exist_ok=True)
+
+    lock_path = root / ".maintenance.lock"
+    if lock_path.is_symlink():
+        raise RuntimeError("CI maintenance lock cannot be a symlink")
+    with lock_path.open("a") as lock:
+        fcntl.flock(lock, fcntl.LOCK_EX)
+        operate(action, env, root, volume)
+
+
+def operate(action, env, root, volume):
+
+    if action == "finish":
+        value = env.get("SCRATCH_PATH")
+        if not value:
+            return
+        scratch = Path(value)
+        if scratch.parent != root or scratch.is_symlink() or not scratch.is_dir():
+            raise RuntimeError("Invalid scratch completion path")
+        marker = scratch / ".completed"
+        if marker.is_symlink():
+            raise RuntimeError("CI completion marker cannot be a symlink")
+        marker.touch()
+        return
+
+    # GitHub assigns one job at a time to a runner. Cleanup is confined to its
+    # own completed jobs and never scans worktrees or other runners' directories.
+    prune(root)
+    if action == "cleanup":
+        return
+    startup_free = shutil.disk_usage("/System/Volumes/Data").free
+    external_free = shutil.disk_usage(volume).free
+    if startup_free < 100 * GIB or external_free < 100 * GIB:
+        raise RuntimeError("CI requires 100 GiB free on both startup and scratch volumes")
+    if startup_free < 150 * GIB or external_free < 200 * GIB:
+        print("::warning::CI disk headroom is low; schedule targeted storage maintenance")
+    run_id = component(env.get("GITHUB_RUN_ID", ""))
+    attempt = component(env.get("GITHUB_RUN_ATTEMPT", ""))
+    if not run_id.isdigit() or not attempt.isdigit():
+        raise RuntimeError("Run ID and attempt must be numeric")
+    output_path = env.get("GITHUB_ENV")
+    if not output_path:
+        raise RuntimeError("GITHUB_ENV is required for scratch admission")
+    scratch = root / f"{run_id}-{attempt}-{component(env.get('GITHUB_JOB', ''))}"
+    # Never reuse a previous job's completion marker or adopt unknown data.
+    scratch.mkdir()
+    with open(output_path, "a") as output:
+        output.write(f"SCRATCH_PATH={scratch}\n")
+    print(f"CI scratch admitted: {scratch}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("action", choices=("prepare", "finish", "cleanup"))
+    args = parser.parse_args()
+    try:
+        run(args.action, os.environ)
+    except (RuntimeError, OSError, subprocess.SubprocessError, ValueError) as error:
+        parser.exit(1, f"ci-storage: {error}\n")

--- a/Scripts/generate-coverage.sh
+++ b/Scripts/generate-coverage.sh
@@ -7,8 +7,10 @@ cd "$ROOT_DIR"
 OUT_DIR="${1:-coverage}"
 mkdir -p "$OUT_DIR"
 
-TEST_BINARY="$(find .build -path '*debug/KeyPathPackageTests.xctest/Contents/MacOS/KeyPathPackageTests' | head -n1)"
-PROFDATA="$(find .build -path '*debug/codecov/default.profdata' | head -n1)"
+SCRATCH_PATH="${SCRATCH_PATH:-.build}"
+
+TEST_BINARY="$(find "$SCRATCH_PATH" -path '*debug/KeyPathPackageTests.xctest/Contents/MacOS/KeyPathPackageTests' | head -n1)"
+PROFDATA="$(find "$SCRATCH_PATH" -path '*debug/codecov/default.profdata' | head -n1)"
 
 if [[ -z "${TEST_BINARY:-}" || ! -f "$TEST_BINARY" ]]; then
   echo "ERROR: Coverage test binary not found. Run: swift test --enable-code-coverage"

--- a/Scripts/runner-cleanup.sh
+++ b/Scripts/runner-cleanup.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Installed as ~/actions-runner-cleanup.sh; replaces the old worktree sweep.
+set -euo pipefail
+export PATH=/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin
+config="$HOME/.config/keypath-ci-storage.env"
+[[ -f "$config" ]] || { echo "Missing $config"; exit 1; }
+source "$config"
+if pgrep -x Runner.Worker >/dev/null; then
+    echo "Runner busy; skipping scheduled CI storage maintenance"
+    exit 0
+fi
+for runner in keypath-mini keypath-mini-2; do
+    RUNNER_NAME="$runner" python3 "$HOME/.local/lib/keypath/ci-storage.py" cleanup
+done
+df -h /System/Volumes/Data "$KEYPATH_CI_VOLUME"
+# A warning arrives before the 100 GiB admission floor is crossed. The existing
+# weekly LaunchAgent provides the cadence; CI also emits a warning on each run.
+headroom=$(python3 - "$KEYPATH_CI_VOLUME" <<'PYTHON'
+import shutil
+import sys
+startup = shutil.disk_usage("/System/Volumes/Data").free // (1024 ** 3)
+scratch = shutil.disk_usage(sys.argv[1]).free // (1024 ** 3)
+if startup < 150 or scratch < 200:
+    print(f"Startup: {startup} GiB free; CI scratch: {scratch} GiB free. Maintenance recommended; CI stops below 100 GiB.")
+PYTHON
+)
+if [[ -n "$headroom" ]]; then
+    echo "WARNING: $headroom"
+    "$HOME/.local/bin/notify-push" "KeyPath runner disk headroom" "$headroom" 0
+fi

--- a/Scripts/tests/test_ci_storage.py
+++ b/Scripts/tests/test_ci_storage.py
@@ -1,0 +1,127 @@
+import importlib.util
+import os
+from pathlib import Path
+import plistlib
+import tempfile
+import unittest
+from unittest.mock import patch
+
+spec = importlib.util.spec_from_file_location("ci_storage", Path(__file__).parents[1] / "ci-storage.py")
+storage = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(storage)
+
+
+class StorageTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+
+    def test_wrong_volume_refused_without_creating_directory(self):
+        volume = self.root / "missing"
+        info = plistlib.dumps({"VolumeUUID": "wrong", "MountPoint": str(volume)})
+        with patch.object(storage.subprocess, "check_output", return_value=info):
+            with self.assertRaises(RuntimeError):
+                storage.run("prepare", {"KEYPATH_CI_VOLUME": str(volume), "KEYPATH_CI_VOLUME_UUID": "expected"})
+        self.assertFalse(volume.exists())
+
+    def test_parent_filesystem_is_not_accepted_as_mount(self):
+        info = plistlib.dumps({"VolumeUUID": "expected", "MountPoint": "/"})
+        with patch.object(storage.subprocess, "check_output", return_value=info):
+            with self.assertRaises(RuntimeError):
+                storage.checked_volume(self.root, "expected")
+
+    def test_unmounted_volume_error_does_not_create_fallback(self):
+        env = {**self.environment(), "KEYPATH_CI_VOLUME": str(self.root / "absent")}
+        with patch.object(storage.subprocess, "check_output", side_effect=storage.subprocess.CalledProcessError(1, "diskutil")):
+            with self.assertRaises(storage.subprocess.CalledProcessError):
+                storage.run("prepare", env)
+        self.assertFalse((self.root / "absent").exists())
+
+    def test_symlink_root_is_refused(self):
+        outside = self.root / "outside"
+        outside.mkdir()
+        (self.root / "KeyPathCI").symlink_to(outside, target_is_directory=True)
+        with patch.object(storage, "checked_volume"):
+            with self.assertRaises(RuntimeError):
+                storage.run("prepare", self.environment())
+        self.assertEqual(list(outside.iterdir()), [])
+
+    def test_missing_uuid_refused(self):
+        with self.assertRaises(RuntimeError):
+            storage.checked_volume(self.root, "")
+
+    def test_pruning_preserves_active_unknown_and_symlinked_data(self):
+        old = self.root / "1-1-tests"
+        old.mkdir()
+        (old / ".completed").touch()
+        os.utime(old / ".completed", (0, 0))
+        active = self.root / "2-1-tests"
+        active.mkdir()
+        outside = self.root / "unknown"
+        outside.mkdir()
+        (outside / ".completed").touch()
+        (self.root / "3-1-tests").symlink_to(outside, target_is_directory=True)
+        with patch.object(storage, "size", return_value=10):
+            storage.prune(self.root, now=10 * 86400)
+        self.assertFalse(old.exists())
+        self.assertTrue(active.exists())
+        self.assertTrue(outside.exists())
+        self.assertTrue((self.root / "3-1-tests").is_symlink())
+
+    def test_budget_removes_oldest_completed_only(self):
+        for i in [1, 2]:
+            path = self.root / f"{i}-1-tests"
+            path.mkdir()
+            marker = path / ".completed"
+            marker.touch()
+            os.utime(marker, (i, i))
+        with patch.object(storage, "size", return_value=10):
+            storage.prune(self.root, now=3, budget=10)
+        self.assertFalse((self.root / "1-1-tests").exists())
+        self.assertTrue((self.root / "2-1-tests").exists())
+
+    def environment(self):
+        return {"KEYPATH_CI_VOLUME": str(self.root), "KEYPATH_CI_VOLUME_UUID": "expected",
+                "RUNNER_NAME": "runner", "GITHUB_RUN_ID": "12", "GITHUB_RUN_ATTEMPT": "1",
+                "GITHUB_JOB": "tests", "GITHUB_ENV": str(self.root / "env")}
+
+    def test_prepare_finish_and_collision(self):
+        env = self.environment()
+        with patch.object(storage, "checked_volume"), patch.object(storage.shutil, "disk_usage") as usage:
+            usage.return_value.free = 300 * storage.GIB
+            storage.run("prepare", env)
+            scratch = self.root / "KeyPathCI/runner/12-1-tests"
+            self.assertTrue(scratch.is_dir())
+            self.assertFalse((scratch / ".completed").exists())
+            self.assertEqual((self.root / "env").read_text(), f"SCRATCH_PATH={scratch}\n")
+            with self.assertRaises(FileExistsError):
+                storage.run("prepare", env)
+            storage.run("finish", {**env, "SCRATCH_PATH": str(scratch)})
+            self.assertTrue((scratch / ".completed").exists())
+
+    def test_missing_output_file_refused_without_orphan_directory(self):
+        env = self.environment()
+        del env["GITHUB_ENV"]
+        with patch.object(storage, "checked_volume"), patch.object(storage.shutil, "disk_usage") as usage:
+            usage.return_value.free = 300 * storage.GIB
+            with self.assertRaisesRegex(RuntimeError, "GITHUB_ENV is required"):
+                storage.run("prepare", env)
+        self.assertFalse((self.root / "KeyPathCI/runner/12-1-tests").exists())
+
+    def test_reserve_failure_does_not_admit_scratch(self):
+        env = self.environment()
+        with patch.object(storage, "checked_volume"), patch.object(storage.shutil, "disk_usage") as usage:
+            usage.return_value.free = 50 * storage.GIB
+            with self.assertRaises(RuntimeError):
+                storage.run("prepare", env)
+        self.assertFalse((self.root / "env").exists())
+
+    def test_completion_rejects_outside_path(self):
+        with patch.object(storage, "checked_volume"):
+            with self.assertRaises(RuntimeError):
+                storage.run("finish", {**self.environment(), "SCRATCH_PATH": str(self.root)})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/testing/ci-storage.md
+++ b/docs/testing/ci-storage.md
@@ -1,0 +1,99 @@
+# CI storage on the Mac mini
+
+SwiftPM test and coverage scratch belongs on `/Volumes/Foot Locker`, under
+`KeyPathCI/<runner>/<run-id>-<attempt>-<job>`. Source checkouts and the runner
+service remain on the startup disk. No app interface or installed runtime changes.
+
+`Scripts/ci-storage.py prepare` verifies the exact mount point and the APFS volume
+UUID before making directories. GitHub repository variable `KEYPATH_CI_VOLUME_UUID`
+holds that identity. A missing variable, missing mount, wrong volume, or symlinked
+root fails closed: it must never create a substitute directory on the startup disk.
+The workflows retain the existing startup reserve check, and preparation requires
+100 GiB free on **both** startup and external storage. Warnings begin below
+150 GiB startup or 200 GiB external. These are free-space thresholds, not quotas;
+the external APFS volumes share their container's available capacity.
+
+Each job owns a new scratch directory. Its final build/coverage step is followed
+by an `always()` completion step. Only directories with a regular `.completed`
+marker and the expected job naming pattern are eligible for cleanup. Preparation
+and weekly cleanup remove completed directories older than seven days, then the
+oldest completed directories until at most 50 GiB remains per runner. This limit
+applies at cleanup time, not continuously during a build. Active or interrupted
+jobs without a completion marker, unknown directories, and symlinked directories
+are preserved. Inspect abandoned jobs against GitHub and running processes before
+removing their scratch manually. A per-runner filesystem lock serializes maintenance.
+
+Coverage uses the same `SCRATCH_PATH` for compilation and report extraction.
+Local coverage keeps its `.build` default.
+
+## Runner installation
+
+On the mini's `clawd` account, install the checked-in scripts:
+
+```bash
+mkdir -p ~/.local/lib/keypath ~/.config
+cp Scripts/ci-storage.py ~/.local/lib/keypath/ci-storage.py
+install -m 755 Scripts/runner-cleanup.sh ~/actions-runner-cleanup.sh
+```
+
+Create `~/.config/keypath-ci-storage.env` (mode 600) with:
+
+```bash
+export KEYPATH_CI_VOLUME="/Volumes/Foot Locker"
+export KEYPATH_CI_VOLUME_UUID="<VolumeUUID from diskutil info -plist>"
+```
+
+Use the same UUID in the GitHub repository variable. Never derive the expected
+UUID dynamically during a job: that would accept an unintended replacement disk.
+
+### macOS removable-volume permission
+
+An SSH probe does not prove that the LaunchAgent runner can access removable
+volumes. The first real CI probe hit `Operation not permitted` opening the lock;
+TCC logs attributed the request to the runner's bundled Node executable at
+`/Users/clawd/actions-runner-2/externals.2.337.0/node20/bin/node`, not Python.
+The removable-volume prompt timed out while `malpern` owned the desktop.
+
+Sign into the runner account (`clawd`) and approve its Removable Volumes request
+through the normal macOS UI (Privacy & Security → Files & Folders). Rerun CI while
+that desktop is active if the prompt needs to be presented again. Do not edit the
+TCC database or route writes through SSH to bypass the runner permission. Runner
+updates can replace the executable, so verify access again after an update.
+
+The existing `com.keypath.runner-cleanup` LaunchAgent runs Sundays at 03:00 and
+logs to `~/Library/Logs/runner-cleanup.log`. It skips maintenance when a runner
+worker is active. It prunes only the two configured KeyPath runner scratch roots,
+then sends a Pushover warning through the existing `notify-push` wrapper if free
+space is below the warning thresholds. CI also reports low headroom as a workflow
+warning. No additional scheduler is required.
+
+## Recovery and rollback
+
+If admission fails, verify the mount and free space first. Do not lower the reserve
+or create the mount directory by hand. Reconnect the expected volume, or deliberately
+configure and verify a replacement UUID. To revert external scratch routing, revert
+the workflow changes; keep the startup reserve guard. Retained external scratch can
+be inspected and removed after its jobs finish.
+
+The initial September 2026 recovery removed a discarded iPhone restore image and
+rebuildable package/Xcode caches, then used `tmutil thinlocalsnapshots` to release
+blocks retained by local Time Machine snapshots after confirming a recent network
+backup. Startup free space rose from 61 to 104 GiB. Network backups, VM lab volumes,
+working trees, installed toolchains, and personal Downloads were preserved. This
+cleared the hard gate but did not reach the 150 GiB warning target.
+
+The prior weekly cleanup script was backed up at
+`~/runner-storage-backup-20260904/actions-runner-cleanup.sh`. It swept `.build`
+directories by age; the replacement deliberately confines deletion to completed CI
+scratch. Prefer retaining that safer cleanup even if workflow routing is reverted.
+
+## Validation
+
+```bash
+python3 -m unittest discover -s Scripts/tests -p test_ci_storage.py
+bash -n Scripts/runner-cleanup.sh Scripts/generate-coverage.sh
+```
+
+A live probe must confirm a new directory on the external volume, a completion
+marker, and rejection of a wrong UUID without a startup-disk fallback. The final
+integration check is a full GitHub `build-and-test` job using the admitted path.


### PR DESCRIPTION
## Problem and change

KeyPath CI was blocked before testing because the mini had only 61 GiB free against its 100 GiB startup reserve. Move SwiftPM CI and coverage scratch to the existing external volume, verifying its configured UUID and exact mount before writing. Keep the 100 GiB floor on both filesystems and warn below 150/200 GiB.

Each job gets isolated scratch. Cleanup retains at most seven days or 50 GiB of completed builds per runner, preserves unmarked/unknown/symlinked directories, and serializes maintenance. Replace the old weekly `.build` sweep with this bounded cleanup and a low-space notification. Coverage extraction follows the new scratch path. No app or UI changes.

## Validation and operational recovery

- Eleven Python storage tests pass, covering volume refusal, reserve refusal, isolation, completion, and retention; bash syntax and diff checks pass.
- Full local safe suite: build passed with zero Swift warnings; 5,030 tests passed and four existing snapshot failures remained (three home-row timing snapshots and repair settings). These same failures were reproduced on master during #1260; this PR changes no Swift or snapshots. Log: `test_output.safe.txt`.
- Live mini probe admitted external scratch, marked it complete, and rejected an incorrect UUID. Weekly cleanup ran successfully; the alert transport returned HTTP 200.
- Removed discarded restore firmware and rebuildable caches; thinned local Time Machine snapshots after checking a recent network backup. Free startup space rose from 61 to 104 GiB. The 150 GiB warning target is not yet reached; NAS backups and personal data were preserved.
- Installed cleanup scripts/config on clawd and configured the GitHub repository UUID variable. Workflow routing awaits this PR.
- Remote review gate selected; GitHub `claude-review` must pass before merge.

Review follow-up: marked the cleanup script executable and made installation explicitly preserve mode 755; verified the live script permissions. Missing `GITHUB_ENV` now fails cleanly before creating scratch (regression test added). Verified `run-tests-safe.sh` already passes `--scratch-path "$SCRATCH_PATH"` to both its Swift build and test commands.

First real CI passed the disk reserve and storage tests, but macOS blocked the runner Node executable's removable-volume access. The SSH probe alone was insufficient. Normal UI permission approval in the clawd desktop is pending; no bypass or TCC database changes were made. Refactor PR #1260 has been retried using its existing workflow now that startup space is recovered.

Full CI on external scratch remains blocked on that OS permission. See `docs/testing/ci-storage.md` for installation, retention, and rollback.
