### PR TITLE
Serialize config saves to prevent rollback over newer edits

### DIFF
--- a/Sources/KeyPathAppKit/Managers/SaveCoordinator.swift
+++ b/Sources/KeyPathAppKit/Managers/SaveCoordinator.swift
@@ -2,6 +2,13 @@ import Foundation
 import KeyPathCore
 import KeyPathRulesCore
 
+/// Task-local scope is intentionally shared: nested callbacks can cross coordinator
+/// instances. Unique rotating operation tokens distinguish their ownership, while
+/// carrying the full set lets an A -> B -> A callback cycle fail instead of hang.
+private enum SaveOperationContext {
+    @TaskLocal static var activeOperations: Set<UUID> = []
+}
+
 /// Callback interface for save status updates
 @MainActor
 protocol SaveCoordinatorDelegate: AnyObject {
@@ -58,6 +65,12 @@ final class SaveCoordinator {
     /// In-memory backup of last known good config
     private var lastGoodConfig: String?
 
+    // MainActor methods can interleave at every await. Keep the entire save,
+    // including reload and recovery, exclusive within this coordinator.
+    private var operationInProgress = false
+    private var operationID = UUID()
+    private var operationWaiters: [CheckedContinuation<Void, Never>] = []
+
     // MARK: - Initialization
 
     init(
@@ -94,6 +107,13 @@ final class SaveCoordinator {
         ruleCollectionsManager: RuleCollectionsManager,
         reloadHandler: @escaping () async -> ReloadResult
     ) async -> SaveResult {
+        do {
+            try await beginOperation()
+        } catch {
+            return .failure(error)
+        }
+        defer { endOperation() }
+
         // Suppress file watcher to prevent double reload
         configFileWatcher?.suppressEvents(for: 1.0, reason: "Internal saveConfiguration")
         saveStatus = .saving
@@ -105,8 +125,9 @@ final class SaveCoordinator {
             )
 
             // Step 2: Backup current config
-            let currentConfig = await configurationService.current()
-            backupCurrentConfig(currentConfig.content)
+            let previousContent = try await snapshotCurrentConfig()
+            try Task.checkCancellation()
+            backupCurrentConfig(previousContent)
 
             // Step 3: Create and save custom rule
             let rule = ruleCollectionsManager.makeCustomRule(
@@ -125,7 +146,7 @@ final class SaveCoordinator {
 
             // Step 5: Trigger reload for validation
             AppLogger.shared.debug("📡 [SaveCoordinator] Triggering TCP reload for validation")
-            let reloadResult = await reloadHandler()
+            let reloadResult = await reloadWithinOperation(reloadHandler)
 
             if reloadResult.disposition == .applied || reloadResult.disposition == .pending {
                 // Success!
@@ -148,7 +169,7 @@ final class SaveCoordinator {
 
                 playErrorSound()
                 do {
-                    try await restoreLastGoodConfig()
+                    try await restoreConfig(previousContent)
                 } catch {
                     AppLogger.shared.error("❌ [SaveCoordinator] Rollback also failed: \(error)")
                 }
@@ -181,6 +202,13 @@ final class SaveCoordinator {
         content: String,
         reloadHandler: @escaping () async -> ReloadResult
     ) async -> SaveResult {
+        do {
+            try await beginOperation()
+        } catch {
+            return .failure(error)
+        }
+        defer { endOperation() }
+
         // Suppress file watcher to prevent double reload
         configFileWatcher?.suppressEvents(for: 1.0, reason: "Internal saveGeneratedConfiguration")
         saveStatus = .saving
@@ -207,8 +235,9 @@ final class SaveCoordinator {
             AppLogger.shared.info("✅ [SaveCoordinator] Generated config validation passed")
 
             // Step 2: Backup current config
-            let currentConfig = await configurationService.current()
-            backupCurrentConfig(currentConfig.content)
+            let previousContent = try await snapshotCurrentConfig()
+            try Task.checkCancellation()
+            backupCurrentConfig(previousContent)
 
             // Step 3: Write the configuration file
             let configPath = configurationService.configurationPath
@@ -233,7 +262,7 @@ final class SaveCoordinator {
             playWriteSound()
 
             // Step 6: Trigger reload for validation
-            let reloadResult = await reloadHandler()
+            let reloadResult = await reloadWithinOperation(reloadHandler)
 
             if reloadResult.disposition == .applied || reloadResult.disposition == .pending {
                 if reloadResult.disposition == .applied {
@@ -256,7 +285,7 @@ final class SaveCoordinator {
 
                 playErrorSound()
                 do {
-                    try await restoreLastGoodConfig()
+                    try await restoreConfig(previousContent)
                 } catch {
                     AppLogger.shared.error("❌ [SaveCoordinator] Rollback also failed: \(error)")
                 }
@@ -297,7 +326,13 @@ final class SaveCoordinator {
     }
 
     func restoreLastGoodConfig() async throws {
-        guard let backup = lastGoodConfig else {
+        try await beginOperation()
+        defer { endOperation() }
+        try await restoreConfig(lastGoodConfig)
+    }
+
+    private func restoreConfig(_ content: String?) async throws {
+        guard let backup = content else {
             AppLogger.shared.warnUnlessQuietTest("⚠️ [SaveCoordinator] No backup available - writing minimal safe config")
             try await writeMinimalSafeConfig()
             return
@@ -388,6 +423,60 @@ final class SaveCoordinator {
     }
 
     // MARK: - Private Helpers
+
+    /// Cancellation before admission never writes or changes the active status.
+    /// A queued cancellation is observed when its FIFO turn arrives. Once a write
+    /// starts, finish reload/recovery rather than abandoning a half-applied edit.
+    private func beginOperation() async throws {
+        try Task.checkCancellation()
+        if operationInProgress, SaveOperationContext.activeOperations.contains(operationID) {
+            throw KeyPathError.configuration(.loadFailed(
+                reason: "A reload callback cannot recursively save or restore through the same coordinator."
+            ))
+        }
+        if operationInProgress {
+            await withCheckedContinuation { operationWaiters.append($0) }
+        } else {
+            operationInProgress = true
+        }
+        do {
+            try Task.checkCancellation()
+        } catch {
+            endOperation()
+            throw error
+        }
+    }
+
+    private func endOperation() {
+        // Inherited task-local context from a finished reload must not reject
+        // a later independent operation (including child tasks that outlive it).
+        operationID = UUID()
+        if operationWaiters.isEmpty {
+            operationInProgress = false
+        } else {
+            // Transfer ownership directly; do not leave a gap for a new caller
+            // to overtake an already queued save.
+            operationWaiters.removeFirst().resume()
+        }
+    }
+
+    private func reloadWithinOperation(_ reloadHandler: () async -> ReloadResult) async -> ReloadResult {
+        var activeOperations = SaveOperationContext.activeOperations
+        activeOperations.insert(operationID)
+        return await SaveOperationContext.$activeOperations.withValue(activeOperations) {
+            await reloadHandler()
+        }
+    }
+
+    private func snapshotCurrentConfig() async throws -> String {
+        let path = configurationService.configurationPath
+        if await !(configurationService.fileExistsAsync(path: path)) {
+            return await configurationService.current().content
+        }
+        // Generated saves write raw content without refreshing the parsed cache.
+        // Back up the actual file, never a possibly older cached configuration.
+        return try await configurationService.readCurrentConfig()
+    }
 
     private func scheduleStatusReset() {
         Task { @MainActor [weak self] in

--- a/Tests/KeyPathTests/Managers/SaveCoordinatorTests.swift
+++ b/Tests/KeyPathTests/Managers/SaveCoordinatorTests.swift
@@ -1,6 +1,7 @@
 import Foundation
 @testable import KeyPathAppKit
 @testable import KeyPathCore
+import KeyPathRulesCore
 @preconcurrency import XCTest
 
 @MainActor
@@ -159,6 +160,161 @@ final class SaveCoordinatorTests: KeyPathTestCase {
         XCTAssertEqual(try String(contentsOf: url, encoding: .utf8), saved ? updated : original, file: file, line: line)
     }
 
+    // MARK: - Save Isolation
+
+    func testOverlappingGeneratedSavesWaitForPreviousReloadAndRollback() async throws {
+        try await assertQueuedSave()
+    }
+
+    func testMappingSaveWaitsForGeneratedSaveRecovery() async throws {
+        try await assertQueuedSave(mappingSecond: true)
+    }
+
+    func testCancelledQueuedSaveDoesNotWriteReloadOrBlockLaterSaves() async throws {
+        try await assertQueuedSave(cancelSecond: true)
+    }
+
+    private func assertQueuedSave(mappingSecond: Bool = false, cancelSecond: Bool = false) async throws {
+        let original = "(defcfg)\n(defsrc a)\n(deflayer base b)"
+        let firstContent = "(defcfg)\n(defsrc a)\n(deflayer base c)"
+        let secondContent = "(defcfg)\n(defsrc a)\n(deflayer base d)"
+        let url = URL(fileURLWithPath: configService.configurationPath)
+        try original.write(to: url, atomically: true, encoding: .utf8)
+        let firstReloadStarted = expectation(description: "first reload suspended")
+        let secondStarted = expectation(description: "second save requested")
+        let recorder = SaveStatusRecorder()
+        coordinator.delegate = recorder
+        var releaseFirst: CheckedContinuation<Void, Never>?
+        let coordinator = try XCTUnwrap(coordinator)
+
+        let first = Task { @MainActor in
+            await coordinator.saveGeneratedConfig(content: firstContent) {
+                await withCheckedContinuation { continuation in
+                    releaseFirst = continuation
+                    firstReloadStarted.fulfill()
+                }
+                return ReloadResult(success: false, response: nil, errorMessage: "rejected", protocol: nil, disposition: .rejected)
+            }
+        }
+        await fulfillment(of: [firstReloadStarted], timeout: 5)
+        let manager = RuleCollectionsManager(
+            ruleCollectionStore: .testStore(at: tempDir.appendingPathComponent("RuleCollections.json")),
+            customRulesStore: .testStore(at: tempDir.appendingPathComponent("CustomRules.json")),
+            configurationService: configService
+        )
+        var secondReloadCount = 0
+        let second = Task { @MainActor in
+            secondStarted.fulfill()
+            let reload = {
+                secondReloadCount += 1
+                return ReloadResult(success: true, response: "ok", errorMessage: nil, protocol: nil)
+            }
+            if mappingSecond {
+                return await coordinator.saveMapping(input: "a", output: "d", ruleCollectionsManager: manager, reloadHandler: reload)
+            }
+            return await coordinator.saveGeneratedConfig(content: secondContent, reloadHandler: reload)
+        }
+        await fulfillment(of: [secondStarted], timeout: 5)
+        XCTAssertEqual(recorder.savingCount, 1, "Queued saves must not begin validation, backup, or status updates")
+        XCTAssertEqual(try String(contentsOf: url, encoding: .utf8), firstContent)
+        if cancelSecond { second.cancel() }
+        releaseFirst?.resume()
+        let firstResult = await first.value
+        let secondResult = await second.value
+        XCTAssertFalse(firstResult.success)
+        if cancelSecond {
+            XCTAssertFalse(secondResult.success)
+            XCTAssertTrue(secondResult.error is CancellationError)
+            XCTAssertNil(secondResult.reloadResult)
+            XCTAssertEqual(secondReloadCount, 0)
+            XCTAssertEqual(try String(contentsOf: url, encoding: .utf8), original)
+            let nextResult = await coordinator.saveGeneratedConfig(content: secondContent) {
+                ReloadResult(success: true, response: "ok", errorMessage: nil, protocol: nil)
+            }
+            XCTAssertTrue(nextResult.success, "Cancellation must release the operation slot")
+        } else {
+            XCTAssertTrue(secondResult.success)
+            XCTAssertEqual(secondReloadCount, 1)
+        }
+        if mappingSecond {
+            let savedRule = try XCTUnwrap(manager.customRules.first { $0.input == "a" })
+            XCTAssertEqual(savedRule.action, .keystroke(key: "d"))
+            XCTAssertNotEqual(try String(contentsOf: url, encoding: .utf8), original)
+        } else {
+            XCTAssertEqual(try String(contentsOf: url, encoding: .utf8), secondContent)
+        }
+        // The second save must have backed up the restored original, not the
+        // uncommitted first edit. Exercise that backup through the public API.
+        try await coordinator.restoreLastGoodConfig()
+        XCTAssertEqual(try String(contentsOf: url, encoding: .utf8), original)
+    }
+
+    func testRejectedSaveRestoresLatestFileRatherThanStaleParsedCache() async throws {
+        let original = "(defcfg)\n(defsrc a)\n(deflayer base b)"
+        let accepted = "(defcfg)\n(defsrc a)\n(deflayer base c)"
+        let rejected = "(defcfg)\n(defsrc a)\n(deflayer base d)"
+        let url = URL(fileURLWithPath: configService.configurationPath)
+        try original.write(to: url, atomically: true, encoding: .utf8)
+        _ = await configService.current() // Deliberately prime the older parsed cache.
+        let first = await coordinator.saveGeneratedConfig(content: accepted) {
+            ReloadResult(success: true, response: "ok", errorMessage: nil, protocol: nil)
+        }
+        XCTAssertTrue(first.success)
+        let second = await coordinator.saveGeneratedConfig(content: rejected) {
+            // A separate backup request must not replace this save's snapshot.
+            self.coordinator.backupCurrentConfig("unrelated backup")
+            return ReloadResult(success: false, response: nil, errorMessage: "rejected", protocol: nil, disposition: .rejected)
+        }
+        XCTAssertFalse(second.success)
+        XCTAssertEqual(try String(contentsOf: url, encoding: .utf8), accepted)
+    }
+
+    func testReentrantReloadSaveAndRestoreFailWithoutBlockingOuterSave() async throws {
+        let original = "(defcfg)\n(defsrc a)\n(deflayer base b)"
+        let updated = "(defcfg)\n(defsrc a)\n(deflayer base c)"
+        let url = URL(fileURLWithPath: configService.configurationPath)
+        try original.write(to: url, atomically: true, encoding: .utf8)
+        let coordinator = try XCTUnwrap(coordinator)
+        let outer = await coordinator.saveGeneratedConfig(content: updated) {
+            let nested = await coordinator.saveGeneratedConfig(content: original) {
+                XCTFail("Recursive save must not reach reload")
+                return ReloadResult(success: true, response: "ok", errorMessage: nil, protocol: nil)
+            }
+            XCTAssertFalse(nested.success)
+            XCTAssertNil(nested.reloadResult)
+            XCTAssertTrue(nested.error?.localizedDescription.contains("recursively") == true)
+            do {
+                try await coordinator.restoreLastGoodConfig()
+                XCTFail("Recursive restoration must fail rather than queue behind itself")
+            } catch {
+                XCTAssertTrue(error.localizedDescription.contains("recursively"))
+            }
+            return ReloadResult(success: true, response: "ok", errorMessage: nil, protocol: nil)
+        }
+        XCTAssertTrue(outer.success)
+        XCTAssertEqual(try String(contentsOf: url, encoding: .utf8), updated)
+        try await coordinator.restoreLastGoodConfig()
+        XCTAssertEqual(try String(contentsOf: url, encoding: .utf8), original)
+    }
+
+    func testMissingConfigInitializesBackupBeforeGeneratedSave() async throws {
+        let updated = "(defcfg)\n(defsrc a)\n(deflayer base c)"
+        let url = URL(fileURLWithPath: configService.configurationPath)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: url.path))
+        var initializedContent: String?
+        let result = await coordinator.saveGeneratedConfig(content: updated) {
+            initializedContent = await self.configService.current().content
+            XCTAssertEqual(try? String(contentsOf: url, encoding: .utf8), updated)
+            return ReloadResult(success: false, response: nil, errorMessage: "rejected", protocol: nil, disposition: .rejected)
+        }
+        XCTAssertFalse(result.success)
+        XCTAssertEqual(result.reloadResult?.disposition, .rejected)
+        let backup = try XCTUnwrap(initializedContent)
+        XCTAssertFalse(backup.isEmpty)
+        XCTAssertNotEqual(backup, updated)
+        XCTAssertEqual(try String(contentsOf: url, encoding: .utf8), backup)
+    }
+
     // MARK: - Rollback Fallback Tests
 
     func testRestoreLastGoodConfig_WritesMinimalSafeConfig_WhenNoBackupExists() async throws {
@@ -210,4 +366,15 @@ final class SaveCoordinatorTests: KeyPathTestCase {
 
         XCTAssertTrue(coordinator.hasBackup(), "Should have backup after ensureBackupExists")
     }
+}
+
+@MainActor
+private final class SaveStatusRecorder: SaveCoordinatorDelegate {
+    var savingCount = 0
+
+    func saveStatusDidChange(_ status: SaveStatus) {
+        if case .saving = status { savingCount += 1 }
+    }
+
+    func configDidUpdate(mappings _: [KeyMapping]) {}
 }

--- a/docs/architecture/configuration-save-pipeline.md
+++ b/docs/architecture/configuration-save-pipeline.md
@@ -47,3 +47,16 @@ The removed `ConfigurationManager.writeGeneratedConfig`,
 sites. They performed direct file writes outside the supported ownership model,
 which could bypass current-configuration updates and rollback classification if
 they were reused later.
+
+## Coordinator-local operation isolation
+
+Mapping saves, generated saves, and explicit backup restoration now share a FIFO
+admission gate in `SaveCoordinator`. The slot is held across async reload and file
+recovery. Each save snapshots the file itself; it does not use the possibly stale
+parsed cache or read a mutable shared backup at rollback time. Queued cancellation
+is observed at admission without a write or reload; after mutation begins the
+existing completion/recovery path runs to completion.
+
+This gate covers this coordinator only. Collection/pack/CLI writers, source-store
+transactions, external edits, and durable crash recovery still need migration.
+See [the reproduced rollback race](../bugs/save-coordinator-overlapping-rollback.md).

--- a/docs/bugs/save-coordinator-overlapping-rollback.md
+++ b/docs/bugs/save-coordinator-overlapping-rollback.md
@@ -1,0 +1,49 @@
+# Overlapping saves could roll back a newer edit
+
+## Reproduction
+
+A deterministic SaveCoordinator test holds the first generated save in its reload
+callback, starts a second save, then rejects the first. Before the fix the second
+save entered the pipeline and wrote its file while the first was suspended. The
+first operation's rollback then replaced that later edit. The test failed on the
+second `.saving` notification, the file while reload was suspended, and the final
+file after both operations returned.
+
+`@MainActor` protects synchronous access, but does not make an async method a
+transaction. Both save APIs await configuration work and the reload callback.
+They also used one mutable `lastGoodConfig` and the service's parsed cache as the
+source for backups. Generated saves write raw content without updating that cache,
+so even sequential edits could back up an older revision.
+
+## Fix and boundaries
+
+The existing coordinator now admits mapping saves, generated saves, and explicit
+file restoration through one FIFO operation gate. Ownership spans validation,
+write, reload, and recovery. Internal recovery does not reacquire the gate. A task-local operation token rejects recursive saves or restoration from a reload
+callback with an explicit error, rather than queuing behind itself. Tokens rotate
+at completion so inherited context cannot reject a later independent operation.
+
+Each save reads its own pre-edit file snapshot and uses that value for recovery;
+changing the public fallback backup cannot change an in-flight operation's
+snapshot. An unreadable existing file fails before the edit. Missing-file behavior
+continues through ConfigurationService's existing initialization path.
+
+Already-cancelled requests never enter the gate. A queued cancellation is checked
+when its turn arrives and releases the slot without writing, reloading, or changing
+the active operation's status. Cancellation is checked again before mutation.
+After mutation starts, the operation finishes reload/recovery rather than adding
+an abandonment path that would leave partially applied state.
+
+This is a prerequisite for the broader transaction migration, not a claim that all
+configuration writes are now serialized. Direct collection/pack/CLI mutations,
+external edits, source-store recovery, durable interruption recovery, runtime
+reapplication of restored content, and stale presentation status timers remain
+outside this coordinator-local change. Reload rejection still restores only the
+file; the existing fallback behavior is unchanged. No UI or format changes.
+
+## Verification
+
+SaveCoordinator tests cover generated/generated overlap, generated/mapping overlap,
+queued cancellation followed by another successful save, recursive reload save/restoration rejection, and restoration of the
+latest file despite stale parsed cache or a changed shared fallback backup. The
+existing four-disposition result and file-restoration tests remain in place.


### PR DESCRIPTION
A generated save could suspend during reload, allow another save to write, then reject and roll back over the newer result. Reproduced with a held reload callback: the original code failed three assertions covering entry/status, intermediate file content, and final file content.

Serialize generated saves, mapping saves, and explicit file restoration through the existing SaveCoordinator. Hold the operation slot through reload and recovery. Each save snapshots the actual file and retains that snapshot for rollback, so stale parsed cache and changes to the shared fallback backup cannot change its recovery target. Queued cancellation releases its turn without writing or reloading.

This is a coordinator-local prerequisite for Phase 1 transaction consolidation. It does not serialize direct collection/pack/CLI/external writers or provide multi-store/crash recovery. No UI changes, feature removals, or config-format changes. See the linked bug record for limitations and callback reentrancy rules.

Validation:
- 18 SaveCoordinator tests pass: existing reload-disposition coverage plus generated/generated overlap, generated/mapping overlap, queued cancellation and subsequent save, and stale-cache/shared-backup recovery, recursive reload save/restoration rejection, and missing-file initialization.
- Stable-Xcode package/test build passes without Swift warnings. SwiftFormat 0.61.1, accessibility, and diff checks pass.
- Final full local safe suite completed: the same four baseline snapshot failures remain (three home-row timing snapshots and repair settings), previously reproduced on master. The runner summary reports 5,045 passes. No new failure or Swift warning; snapshot references remain unchanged.
- Remote review gate selected. Initial review passed with a reentrancy concern; addressed with task-local operation tokens and a regression test. Review passed after the reentrancy fix. Non-blocking follow-ups are also addressed: snapshots now use ConfigurationService’s existing async I/O, the shared task-local context is documented as intentional for cross-coordinator cycles, and missing-file initialization has a regression test. Final broad suite completed with only the same four baseline snapshot failures; refreshed claude-review passed. Queued cancellation intentionally waits for admission, as documented; it does not abandon another operation’s in-flight write/reload.

#1260 is merged. This branch was rebased onto master and the PR retargeted; the source tree is byte-for-byte identical to the locally tested candidate. Required build-and-test, code-quality, and refreshed claude-review all passed against `ba895b1f7` (CI run 33972454267; review run 33972454154). Merge approval for this PR remains a separate gate.


Final review disposition: retained the existing configuration error taxonomy for this bounded packet. Production RuntimeCoordinator save callers propagate the error rather than switching on `loadFailed`; the error text explicitly identifies recursive operation rejection. A dedicated operation-error taxonomy belongs with the broader result-contract migration.

The recursion guard requires inherited task-local context. A detached callback must not await a recursive save/restore: FIFO exclusion would still prevent overlapping writes, but that detached cycle could deadlock. Inspected RuntimeCoordinator, ConfigReloadCoordinator, and SaveCoordinator; none uses `Task.detached`. The supported reload callbacks preserve task context. No claim of detecting arbitrary detached task dependency cycles is made.


Post-rebase review disposition: queued async save methods retain their coordinator across the await and through their deferred `endOperation()` call, so deinitialization cannot drop the waiters while those calls are outstanding. A deinit cancellation hook would not address a hung reload; completion remains the existing reload handler's responsibility. Also, ordinary `Task { ... }` does inherit task-local values (verified with a standalone Swift runtime probe returning token 42 from a child task). The previously documented limitation concerns `Task.detached`, not ordinary child tasks. No code change was warranted by those two review notes.
