### PR TITLE
Preserve configuration recovery outcomes after failed reloads

### DIFF
--- a/Sources/KeyPathAppKit/Managers/SaveCoordinator.swift
+++ b/Sources/KeyPathAppKit/Managers/SaveCoordinator.swift
@@ -16,6 +16,26 @@ protocol SaveCoordinatorDelegate: AnyObject {
     func configDidUpdate(mappings: [KeyMapping])
 }
 
+/// File recovery only: this does not claim that source stores or the running
+/// engine were restored. Preserve both failures when fallback also fails.
+enum SaveRecoveryResult {
+    case notAttempted
+    case restoredPreviousConfig
+    case wroteMinimalSafeConfig(backupError: Error?)
+    case failed(backupError: Error?, fallbackError: Error)
+}
+
+/// Keeps both causes available to explicit-restore callers while retaining the
+/// fallback error's existing user-facing description.
+struct SaveRecoveryError: LocalizedError {
+    let backupError: Error?
+    let fallbackError: Error
+
+    var errorDescription: String? {
+        fallbackError.localizedDescription
+    }
+}
+
 /// Result of a save operation
 struct SaveResult {
     /// A pending application is still a successful save. Consult `reloadResult`
@@ -26,12 +46,18 @@ struct SaveResult {
     /// Nil when validation or persistence failed before the reload was attempted.
     let reloadResult: ReloadResult?
 
+    let recoveryResult: SaveRecoveryResult
+
     static func success(mappings: [KeyMapping], reloadResult: ReloadResult) -> SaveResult {
-        SaveResult(success: true, error: nil, mappings: mappings, reloadResult: reloadResult)
+        SaveResult(success: true, error: nil, mappings: mappings, reloadResult: reloadResult, recoveryResult: .notAttempted)
     }
 
-    static func failure(_ error: Error, reloadResult: ReloadResult? = nil) -> SaveResult {
-        SaveResult(success: false, error: error, mappings: nil, reloadResult: reloadResult)
+    static func failure(
+        _ error: Error,
+        reloadResult: ReloadResult? = nil,
+        recoveryResult: SaveRecoveryResult = .notAttempted
+    ) -> SaveResult {
+        SaveResult(success: false, error: error, mappings: nil, reloadResult: reloadResult, recoveryResult: recoveryResult)
     }
 }
 
@@ -168,11 +194,7 @@ final class SaveCoordinator {
                 AppLogger.shared.error("❌ [SaveCoordinator] Restoring backup")
 
                 playErrorSound()
-                do {
-                    try await restoreConfig(previousContent)
-                } catch {
-                    AppLogger.shared.error("❌ [SaveCoordinator] Rollback also failed: \(error)")
-                }
+                let recoveryResult = await restoreConfig(previousContent)
 
                 saveStatus = .failed("TCP server reload failed: \(errorMessage)")
                 return .failure(
@@ -182,7 +204,8 @@ final class SaveCoordinator {
                             "TCP server required for validation-on-demand failed: \(errorMessage)"
                         )
                     ),
-                    reloadResult: reloadResult
+                    reloadResult: reloadResult,
+                    recoveryResult: recoveryResult
                 )
             }
 
@@ -284,18 +307,15 @@ final class SaveCoordinator {
                 AppLogger.shared.error("❌ [SaveCoordinator] TCP reload FAILED: \(errorMessage)")
 
                 playErrorSound()
-                do {
-                    try await restoreConfig(previousContent)
-                } catch {
-                    AppLogger.shared.error("❌ [SaveCoordinator] Rollback also failed: \(error)")
-                }
+                let recoveryResult = await restoreConfig(previousContent)
 
                 saveStatus = .failed("Config reload failed: \(errorMessage)")
                 return .failure(
                     KeyPathError.configuration(
                         .loadFailed(reason: "Hot reload failed: \(errorMessage)")
                     ),
-                    reloadResult: reloadResult
+                    reloadResult: reloadResult,
+                    recoveryResult: recoveryResult
                 )
             }
 
@@ -325,24 +345,38 @@ final class SaveCoordinator {
         }
     }
 
-    func restoreLastGoodConfig() async throws {
+    @discardableResult
+    func restoreLastGoodConfig() async throws -> SaveRecoveryResult {
         try await beginOperation()
         defer { endOperation() }
-        try await restoreConfig(lastGoodConfig)
+        let result = await restoreConfig(lastGoodConfig)
+        // Preserve the throwing contract for existing explicit-restore callers.
+        if case let .failed(backupError, fallbackError) = result {
+            throw SaveRecoveryError(backupError: backupError, fallbackError: fallbackError)
+        }
+        return result
     }
 
-    private func restoreConfig(_ content: String?) async throws {
-        guard let backup = content else {
+    private func restoreConfig(_ content: String?) async -> SaveRecoveryResult {
+        var backupError: Error?
+        if let backup = content {
+            AppLogger.shared.info("🔄 [SaveCoordinator] Restoring last good config")
+            do {
+                try await configurationService.writeConfigurationContent(backup)
+                return .restoredPreviousConfig
+            } catch {
+                backupError = error
+                AppLogger.shared.error("❌ [SaveCoordinator] Failed to restore backup: \(error) - writing minimal safe config")
+            }
+        } else {
             AppLogger.shared.warnUnlessQuietTest("⚠️ [SaveCoordinator] No backup available - writing minimal safe config")
-            try await writeMinimalSafeConfig()
-            return
         }
-        AppLogger.shared.info("🔄 [SaveCoordinator] Restoring last good config")
         do {
-            try await configurationService.writeConfigurationContent(backup)
-        } catch {
-            AppLogger.shared.error("❌ [SaveCoordinator] Failed to restore backup: \(error) - writing minimal safe config")
             try await writeMinimalSafeConfig()
+            return .wroteMinimalSafeConfig(backupError: backupError)
+        } catch {
+            AppLogger.shared.error("❌ [SaveCoordinator] Minimal safe config recovery failed: \(error)")
+            return .failed(backupError: backupError, fallbackError: error)
         }
     }
 

--- a/Tests/KeyPathTests/Managers/SaveCoordinatorTests.swift
+++ b/Tests/KeyPathTests/Managers/SaveCoordinatorTests.swift
@@ -99,6 +99,15 @@ final class SaveCoordinatorTests: KeyPathTestCase {
         XCTAssertEqual(reloadCount, 1, file: file, line: line)
         let saved = disposition == .applied || disposition == .pending
         XCTAssertEqual(result.success, saved, file: file, line: line)
+        if saved {
+            guard case .notAttempted = result.recoveryResult else {
+                return XCTFail("Successful saves must not claim recovery", file: file, line: line)
+            }
+        } else {
+            guard case .restoredPreviousConfig = result.recoveryResult else {
+                return XCTFail("Rejected/failed reload must report restored file", file: file, line: line)
+            }
+        }
         let content = try String(contentsOf: url, encoding: .utf8)
         if saved {
             XCTAssertNotEqual(content, original, file: file, line: line)
@@ -121,6 +130,9 @@ final class SaveCoordinatorTests: KeyPathTestCase {
         XCTAssertFalse(result.success)
         XCTAssertNotNil(result.error)
         XCTAssertNil(result.reloadResult)
+        guard case .notAttempted = result.recoveryResult else {
+            return XCTFail("Validation rejection must not attempt recovery")
+        }
         XCTAssertEqual(reloadCount, 0)
         XCTAssertEqual(try String(contentsOf: url, encoding: .utf8), original)
     }
@@ -151,6 +163,15 @@ final class SaveCoordinatorTests: KeyPathTestCase {
 
         let saved = disposition == .applied || disposition == .pending
         XCTAssertEqual(result.success, saved, file: file, line: line)
+        if saved {
+            guard case .notAttempted = result.recoveryResult else {
+                return XCTFail("Successful saves must not claim recovery", file: file, line: line)
+            }
+        } else {
+            guard case .restoredPreviousConfig = result.recoveryResult else {
+                return XCTFail("Rejected/failed reload must report restored file", file: file, line: line)
+            }
+        }
         XCTAssertEqual(result.error == nil, saved, file: file, line: line)
         XCTAssertEqual(result.reloadResult?.disposition, disposition, file: file, line: line)
         XCTAssertEqual(result.reloadResult?.success, expected.success, file: file, line: line)
@@ -317,12 +338,117 @@ final class SaveCoordinatorTests: KeyPathTestCase {
 
     // MARK: - Rollback Fallback Tests
 
+    func testGeneratedSaveReportsMinimalFallbackWhenPreviousFileIsEmpty() async throws {
+        try await assertRecoveryOutcome(mapping: false, blockWrites: false)
+    }
+
+    func testMappingSaveReportsMinimalFallbackWhenPreviousFileIsEmpty() async throws {
+        try await assertRecoveryOutcome(mapping: true, blockWrites: false)
+    }
+
+    func testGeneratedSavePreservesBothRecoveryErrorsAndReleasesOperation() async throws {
+        try await assertRecoveryOutcome(mapping: false, blockWrites: true)
+    }
+
+    func testMappingSavePreservesBothRecoveryErrorsAndReleasesOperation() async throws {
+        try await assertRecoveryOutcome(mapping: true, blockWrites: true)
+    }
+
+    private func assertRecoveryOutcome(mapping: Bool, blockWrites: Bool) async throws {
+        let original = blockWrites ? "(defcfg)\n(defsrc a)\n(deflayer base b)" : ""
+        let updated = "(defcfg)\n(defsrc a)\n(deflayer base c)"
+        let url = URL(fileURLWithPath: configService.configurationPath)
+        try original.write(to: url, atomically: true, encoding: .utf8)
+        let manager = RuleCollectionsManager(
+            ruleCollectionStore: .testStore(at: tempDir.appendingPathComponent("RuleCollections.json")),
+            customRulesStore: .testStore(at: tempDir.appendingPathComponent("CustomRules.json")),
+            configurationService: configService
+        )
+        var reloadCount = 0
+        let reload: () async -> ReloadResult = {
+            reloadCount += 1
+            if blockWrites {
+                // Replace this test's directory with a regular file. Both recovery
+                // writes must fail, without relying on permissions or real services.
+                do {
+                    try FileManager.default.removeItem(at: self.tempDir)
+                    try "blocked".write(to: self.tempDir, atomically: true, encoding: .utf8)
+                } catch {
+                    XCTFail("Could not inject write failure: \(error)")
+                }
+            }
+            return ReloadResult(success: false, response: nil, errorMessage: "injected rejection", protocol: nil, disposition: .rejected)
+        }
+        let result: KeyPathAppKit.SaveResult = if mapping {
+            await coordinator.saveMapping(input: "a", output: "c", ruleCollectionsManager: manager, reloadHandler: reload)
+        } else {
+            await coordinator.saveGeneratedConfig(content: updated, reloadHandler: reload)
+        }
+        XCTAssertFalse(result.success)
+        XCTAssertNotNil(result.error)
+        XCTAssertEqual(result.reloadResult?.errorMessage, "injected rejection")
+        XCTAssertEqual(result.reloadResult?.disposition, .rejected)
+        XCTAssertEqual(reloadCount, 1, "Recovery must not issue a second reload")
+        if blockWrites {
+            guard case let .failed(backupError, fallbackError) = result.recoveryResult else {
+                return XCTFail("Both recovery failures must be returned")
+            }
+            XCTAssertNotNil(backupError)
+            XCTAssertFalse(fallbackError.localizedDescription.isEmpty)
+            XCTAssertEqual(try String(contentsOf: tempDir, encoding: .utf8), "blocked")
+            try FileManager.default.removeItem(at: tempDir)
+            try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+            try original.write(to: url, atomically: true, encoding: .utf8)
+            let next = await coordinator.saveGeneratedConfig(content: updated) {
+                ReloadResult(success: true, response: "ok", errorMessage: nil, protocol: nil)
+            }
+            XCTAssertTrue(next.success, "Failed recovery must release the save operation")
+            XCTAssertEqual(try String(contentsOf: url, encoding: .utf8), updated)
+        } else {
+            guard case let .wroteMinimalSafeConfig(backupError) = result.recoveryResult else {
+                return XCTFail("An empty prior file must report minimal fallback, not restoration")
+            }
+            XCTAssertNotNil(backupError)
+            let content = try String(contentsOf: url, encoding: .utf8)
+            XCTAssertTrue(content.contains("(deflayer base)"))
+            XCTAssertNotEqual(content, original)
+            XCTAssertNotEqual(content, updated)
+        }
+    }
+
+    func testExplicitRestorePreservesBothFailuresWhenFallbackCannotBeWritten() async throws {
+        coordinator.backupCurrentConfig("(defcfg)\n(defsrc a)\n(deflayer base b)")
+        try await assertExplicitRestoreFailure(hasBackup: true)
+    }
+
+    func testExplicitRestorePreservesMissingBackupWhenFallbackCannotBeWritten() async throws {
+        try await assertExplicitRestoreFailure(hasBackup: false)
+    }
+
+    private func assertExplicitRestoreFailure(hasBackup: Bool) async throws {
+        try FileManager.default.removeItem(at: tempDir)
+        try "blocked".write(to: tempDir, atomically: true, encoding: .utf8)
+        do {
+            try await coordinator.restoreLastGoodConfig()
+            XCTFail("Explicit restore must continue to throw on total recovery failure")
+        } catch {
+            let recoveryError = try XCTUnwrap(error as? SaveRecoveryError)
+            XCTAssertEqual(recoveryError.backupError != nil, hasBackup)
+            XCTAssertFalse(recoveryError.fallbackError.localizedDescription.isEmpty)
+            XCTAssertEqual(recoveryError.localizedDescription, recoveryError.fallbackError.localizedDescription)
+        }
+    }
+
     func testRestoreLastGoodConfig_WritesMinimalSafeConfig_WhenNoBackupExists() async throws {
         // No backup has been set (lastGoodConfig is nil).
         // restoreLastGoodConfig should fall back to writing a minimal safe config.
         XCTAssertFalse(coordinator.hasBackup(), "Should have no backup initially")
 
-        try await coordinator.restoreLastGoodConfig()
+        let recovery = try await coordinator.restoreLastGoodConfig()
+        guard case let .wroteMinimalSafeConfig(backupError) = recovery else {
+            return XCTFail("No backup must report minimal config fallback")
+        }
+        XCTAssertNil(backupError, "A missing backup is distinct from a failed backup write")
 
         // Verify the safe config was written
         let configPath = configService.configurationPath

--- a/docs/architecture/configuration-save-pipeline.md
+++ b/docs/architecture/configuration-save-pipeline.md
@@ -36,8 +36,20 @@ the operation failed before that attempt. Existing `success` consumers retain
 their behavior: applied and pending are successful saves. `success` alone does
 not mean the runtime applied the configuration.
 
-The retained reload result describes the application attempt, not whether backup
-restoration succeeded. File rollback/fallback still exists, but source stores,
+The retained reload result describes the application attempt. The separate
+`SaveResult.recoveryResult` describes file recovery: `notAttempted`,
+`restoredPreviousConfig`, `wroteMinimalSafeConfig(backupError:)`, or
+`failed(backupError:fallbackError:)`. A minimal safe file is not restoration of
+the prior revision. Both recovery errors are retained if neither write succeeds;
+the original reload result and save error remain available. Applied/pending saves
+and failures before reload report no recovery attempt.
+
+Explicit restoration returns the same successful recovery outcomes and retains
+its throwing contract when even the fallback cannot be written. These outcomes
+assert only file recovery, not a second engine reload or a multi-store rollback.
+Existing presentation and Boolean success semantics are unchanged.
+
+File rollback/fallback still exists, but source stores,
 preferences, and installed-pack records do not yet share one transaction.
 See the [consolidation baseline](../planning/consolidation-baseline.md) for paths
 and remaining gaps. UI presentation changes require discussion before implementation.
@@ -60,3 +72,6 @@ existing completion/recovery path runs to completion.
 This gate covers this coordinator only. Collection/pack/CLI writers, source-store
 transactions, external edits, and durable crash recovery still need migration.
 See [the reproduced rollback race](../bugs/save-coordinator-overlapping-rollback.md).
+
+Explicit-restore failure throws `SaveRecoveryError`, retaining both causes while
+preserving the fallback error description used by existing presentation.

--- a/docs/bugs/save-recovery-outcome-was-discarded.md
+++ b/docs/bugs/save-recovery-outcome-was-discarded.md
@@ -1,0 +1,38 @@
+# Save recovery outcome was discarded
+
+## Evidence
+
+`SaveCoordinator` used to catch and log backup restoration errors in both mapping
+and generated saves, then return only the original reload error. Its restoration
+helper also returned normally after writing a minimal safe configuration. Callers
+could not distinguish restoration of the previous file, replacement with a safe
+fallback, or complete recovery failure.
+
+Temporary-directory tests exercise both save APIs. An empty prior file triggers
+restoration validation failure after writing the backup, followed by a successful
+minimal fallback. Replacing the test config directory with a regular file during
+the reload callback makes both recovery writes fail. No live service or user
+configuration is used to inject these failures.
+
+## Change
+
+`SaveResult.recoveryResult` carries a separate file-recovery outcome. Failed
+fallback retains both the backup error and the fallback error; the original
+reload disposition and error are preserved. Missing backup and failed backup
+restoration are distinct. Existing explicit-restore callers still receive a
+thrown error if fallback fails, and can now inspect successful fallback results.
+
+The save remains unsuccessful even when file recovery succeeds. The operation
+gate releases after all recovery outcomes, so a failed recovery cannot prevent
+the next save. Recovery adds no engine reload.
+
+## Boundary
+
+This is an internal result-contract step in Phase 1, not a complete transaction.
+Source stores, preferences, pack records, runtime reapplication and durable crash
+recovery remain separate work. Existing status presentation is unchanged; a
+material UI treatment of recovery requires product discussion first. In
+particular, a restored file is not proof of an operational keyboard engine.
+
+Explicit-restore failure throws `SaveRecoveryError`, retaining both causes while
+preserving the fallback error description used by existing presentation.

--- a/docs/planning/catalog-led-consolidation-plan.md
+++ b/docs/planning/catalog-led-consolidation-plan.md
@@ -1,7 +1,7 @@
 # KeyPath: catalog-led consolidation execution plan
 
 Date: 2026-09-04
-Status: approved direction; Phase 0 and the first internal result-contract step in progress.
+Status: approved direction; Phase 0 inventory recorded, Phase 1 internal save/recovery contract in progress.
 Baseline: `master` at `a12bb07d5`; recheck code, branches, and issues before implementation.
 
 ## Outcome
@@ -248,8 +248,14 @@ them. Suggested mappings, not automatic closure instructions:
 - #213, #212, #211: conversion expansion remains deferred; no parity commitment.
 - #204: inventory Insights and decide disposition, not an automatic completion task.
 
-Next work packet: Phase 0 matrices plus the proposed Phase 1 result contract and
-failure fixtures. Stop for assessment after the first migrated configuration
+Completed internal slices: #1260 retains reload dispositions; #1262 serializes
+coordinator saves and uses operation-local file snapshots. The next slice exposes
+file recovery outcomes and failure fixtures. These do not yet migrate collection
+source stores into the same transaction.
+
+Next work packet: carry collection regeneration results through the callback
+boundary, then design multi-store commit/recovery before changing its Boolean
+callers or presenting new status in the UI. Stop for assessment after the first migrated configuration
 journey: verify that ownership and failure behavior improved before extending the
 pattern. Estimate remaining work from that evidence; this plan makes no calendar
 commitment based on source-line counts.


### PR DESCRIPTION
A failed reload previously returned no evidence of what happened during file recovery. Both save paths now retain a separate outcome for prior-file restoration, minimal safe fallback, or complete recovery failure. Complete failure preserves both recovery errors alongside the original reload result. Existing Boolean results, sounds, and status presentation stay unchanged.

Explicit restore returns successful recovery outcomes and continues to throw when fallback also fails. This is a bounded Phase 1 result-contract step: it does not claim source-store rollback, runtime reapplication, or crash recovery.

Validation:
- 24 focused SaveCoordinator tests pass. Temporary filesystem failures cover both save APIs, minimal fallback, both recovery errors, one reload, and successful subsequent saves after recovery failure.
- Stable-toolchain app/test build: no Swift warnings. Pinned formatting, accessibility check, and diff checks pass.
- Full local suite: runner reports 5,093 passed, with only the four previously reproduced baseline snapshot mismatches (three home-row timing snapshots and Repair Settings).
- Remote review gate selected; GitHub claude-review and CI required before merge.

No UI or installer/lifecycle behavior changes. The installed runtime's helper/service setup remains a separately documented manual verification gap.

Review follow-up: explicit restoration now throws `SaveRecoveryError` with both causes, while preserving the fallback error text. Tests cover total failure with and without a backup. This addresses the initial Claude review finding.
