### PR TITLE
Retain collection reload results through persistence callbacks

### DIFF
--- a/Sources/KeyPathAppKit/Managers/RuntimeCoordinator.swift
+++ b/Sources/KeyPathAppKit/Managers/RuntimeCoordinator.swift
@@ -417,8 +417,10 @@ public class RuntimeCoordinator: SaveCoordinatorDelegate {
 
         // Wire up RuleCollectionsManager callbacks
         ruleCollectionsManager.onRulesChanged = { [weak self] in
-            guard let self else { return }
-            _ = await applyPersistedRuleChanges()
+            guard let self else {
+                return ReloadResult(success: false, response: nil, errorMessage: "Runtime coordinator unavailable", protocol: nil, disposition: .failed)
+            }
+            return await applyPersistedRuleChanges()
         }
         ruleCollectionsManager.onLayerChanged = { [weak self] layerName in
             self?.currentLayerName = layerName

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+ConflictResolution.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+ConflictResolution.swift
@@ -45,7 +45,7 @@ extension RuleCollectionsManager {
     /// real collections, prompt the user to disable one and retry the save (#460).
     /// - Returns: the retry result, or nil when the failure wasn't a resolvable
     ///   mapping conflict or the user cancelled (caller falls back to its error path).
-    func tryResolveMappingConflict(_ error: Error, skipReload: Bool, depth: Int) async -> Bool? {
+    func tryResolveMappingConflict(_ error: Error, skipReload: Bool, depth: Int) async -> RulePersistenceResult? {
         // Bound retries: each resolution disables one collection (strictly shrinking
         // the enabled set), so this terminates, but the guard prevents pathological loops.
         guard depth < 5,
@@ -79,8 +79,8 @@ extension RuleCollectionsManager {
         let snapshot = ruleCollections
         ruleCollections[index].isEnabled = false
         refreshLayerIndicatorState()
-        let saved = await regenerateConfigFromCollections(skipReload: skipReload, conflictResolutionDepth: depth + 1)
-        if !saved {
+        let saved = await persistRules(skipReload: skipReload, conflictResolutionDepth: depth + 1)
+        if !saved.didPersist {
             ruleCollections = snapshot
             refreshLayerIndicatorState()
         }

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+Migrations.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+Migrations.swift
@@ -35,9 +35,16 @@ extension RuleCollectionsManager {
     }
 
     /// Regenerates the Kanata configuration from collections and custom rules.
-    /// Returns `true` on success, `false` if validation or saving fails.
+    /// Compatibility API: `true` means persistence completed, not engine application.
+    /// Keep this meaning until callers participate in the multi-store transaction.
     @discardableResult
     func regenerateConfigFromCollections(skipReload: Bool = false, conflictResolutionDepth: Int = 0) async -> Bool {
+        await persistRules(skipReload: skipReload, conflictResolutionDepth: conflictResolutionDepth).didPersist
+    }
+
+    /// Returns persistence failure or the actual reload result after persistence.
+    /// Nil reload means explicitly skipped or no callback, never presumed applied.
+    func persistRules(skipReload: Bool = false, conflictResolutionDepth: Int = 0) async -> RulePersistenceResult {
         dedupeRuleCollectionsInPlace()
 
         AppLogger.shared.log("🔄 [RuleCollections] regenerateConfigFromCollections: \(ruleCollections.count) collections, \(customRules.count) custom rules")
@@ -82,16 +89,13 @@ extension RuleCollectionsManager {
                 SoundManager.shared.playTinkSound()
             }
 
-            if !skipReload {
-                await onRulesChanged?()
-            }
-
-            return true
-        } catch is CancellationError {
+            let reloadResult = skipReload ? nil : await onRulesChanged?()
+            return .persisted(reloadResult: reloadResult)
+        } catch let error as CancellationError {
             // Task was cancelled (e.g., view disappeared mid-save) — silently ignore
             // rather than showing a misleading "validation failed" dialog
             AppLogger.shared.log("⚠️ [RuleCollections] Config save cancelled (task cancellation)")
-            return false
+            return .failed(error)
         } catch {
             // #460: if the failure is a mapping conflict between real collections,
             // offer to disable one inline and retry, instead of just showing an error.
@@ -111,7 +115,7 @@ extension RuleCollectionsManager {
                errors.contains(where: { $0.contains("cancelled") })
             {
                 AppLogger.shared.log("⚠️ [RuleCollections] Config validation was cancelled — not showing error dialog")
-                return false
+                return .failed(error)
             }
 
             // Extract user-friendly error message
@@ -138,7 +142,7 @@ extension RuleCollectionsManager {
                 SoundManager.shared.playErrorSound()
             }
 
-            return false
+            return .failed(error)
         }
     }
 }

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager.swift
@@ -28,6 +28,19 @@ struct RuleConflictInfo {
     }
 }
 
+/// Collection persistence and runtime application are separate stages until the
+/// multi-store transaction migration. A failed stage may have partially written
+/// files; this result does not promise rollback.
+enum RulePersistenceResult {
+    case persisted(reloadResult: ReloadResult?)
+    case failed(Error)
+
+    var didPersist: Bool {
+        if case .persisted = self { return true }
+        return false
+    }
+}
+
 // MARK: - RuleCollectionsManager
 
 /// Manages rule collections and custom rules with conflict detection.
@@ -64,8 +77,8 @@ final class RuleCollectionsManager {
     let configurationService: ConfigurationService
     let eventListener: KanataEventListener
 
-    /// Callback invoked when rules change (for config regeneration)
-    var onRulesChanged: (() async -> Void)?
+    /// Apply already-persisted rules and retain the runtime disposition.
+    var onRulesChanged: (() async -> ReloadResult)?
 
     /// Callback invoked when layer changes (for UI updates)
     var onLayerChanged: ((String) -> Void)?

--- a/Tests/KeyPathTests/GenericPackConfigTests.swift
+++ b/Tests/KeyPathTests/GenericPackConfigTests.swift
@@ -102,7 +102,10 @@ final class GenericPackConfigTests: XCTestCase {
         defer { try? FileManager.default.removeItem(at: tempDir) }
         manager.ruleCollections = RuleCollectionCatalog().defaultCollections()
         var reloadCallbackCount = 0
-        manager.onRulesChanged = { reloadCallbackCount += 1 }
+        manager.onRulesChanged = {
+            reloadCallbackCount += 1
+            return ReloadResult(success: true, response: "ok", errorMessage: nil, protocol: nil)
+        }
 
         guard let catalogConfiguration = RuleCollectionCatalog().defaultCollections()
             .first(where: { $0.id == RuleCollectionIdentifier.capsLockRemap })?
@@ -932,7 +935,10 @@ final class GenericPackConfigTests: XCTestCase {
         }
         manager.ruleCollections = RuleCollectionCatalog().defaultCollections()
         var reloadCallbackCount = 0
-        manager.onRulesChanged = { reloadCallbackCount += 1 }
+        manager.onRulesChanged = {
+            reloadCallbackCount += 1
+            return ReloadResult(success: true, response: "ok", errorMessage: nil, protocol: nil)
+        }
 
         guard let catalogConfiguration = RuleCollectionCatalog().defaultCollections()
             .first(where: { $0.id == RuleCollectionIdentifier.capsLockRemap })?

--- a/Tests/KeyPathTests/RuleCollections/RuleCollectionsManagerPrerequisiteResolutionTests.swift
+++ b/Tests/KeyPathTests/RuleCollections/RuleCollectionsManagerPrerequisiteResolutionTests.swift
@@ -182,7 +182,10 @@ final class RuleCollectionsManagerPrerequisiteResolutionTests: XCTestCase {
         var regenerationCount = 0
         var reloadCount = 0
         manager.onBeforeSave = { regenerationCount += 1 }
-        manager.onRulesChanged = { reloadCount += 1 }
+        manager.onRulesChanged = {
+            reloadCount += 1
+            return ReloadResult(success: true, response: "ok", errorMessage: nil, protocol: nil)
+        }
 
         let applied = await manager.applyLauncherConfig(
             id: RuleCollectionIdentifier.launcher,
@@ -223,7 +226,10 @@ final class RuleCollectionsManagerPrerequisiteResolutionTests: XCTestCase {
         var regenerationCount = 0
         var reloadCount = 0
         manager.onBeforeSave = { regenerationCount += 1 }
-        manager.onRulesChanged = { reloadCount += 1 }
+        manager.onRulesChanged = {
+            reloadCount += 1
+            return ReloadResult(success: true, response: "ok", errorMessage: nil, protocol: nil)
+        }
 
         let applied = await manager.applyLauncherConfig(
             id: capsLock.id,
@@ -270,7 +276,10 @@ final class RuleCollectionsManagerPrerequisiteResolutionTests: XCTestCase {
         var regenerationCount = 0
         var reloadCount = 0
         manager.onBeforeSave = { regenerationCount += 1 }
-        manager.onRulesChanged = { reloadCount += 1 }
+        manager.onRulesChanged = {
+            reloadCount += 1
+            return ReloadResult(success: true, response: "ok", errorMessage: nil, protocol: nil)
+        }
 
         var proposed = try XCTUnwrap(
             originalState.collections[id: RuleCollectionIdentifier.launcher]?

--- a/Tests/KeyPathTests/RuleCollections/RulePersistenceResultTests.swift
+++ b/Tests/KeyPathTests/RuleCollections/RulePersistenceResultTests.swift
@@ -1,0 +1,116 @@
+import Foundation
+@testable import KeyPathAppKit
+import KeyPathCore
+import KeyPathRulesCore
+@preconcurrency import XCTest
+
+@MainActor
+final class RulePersistenceResultTests: KeyPathTestCase {
+    private var directory: URL!
+    private var manager: RuleCollectionsManager!
+    private var service: ConfigurationService!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let collections = RuleCollectionStore.testStore(at: directory.appendingPathComponent("RuleCollections.json"))
+        let rules = CustomRulesStore.testStore(at: directory.appendingPathComponent("CustomRules.json"))
+        service = ConfigurationService(configDirectory: directory.path, ruleCollectionStore: collections, customRulesStore: rules)
+        manager = RuleCollectionsManager(ruleCollectionStore: collections, customRulesStore: rules, configurationService: service)
+        manager.ruleCollections = [collection("Test", output: "b")]
+    }
+
+    override func tearDown() async throws {
+        try? FileManager.default.removeItem(at: directory)
+        manager = nil
+        service = nil
+        directory = nil
+        try await super.tearDown()
+    }
+
+    private func collection(_ name: String, output: String) -> RuleCollection {
+        RuleCollection(name: name, summary: name, category: .productivity,
+                       mappings: [KeyMapping(input: "a", action: .keystroke(key: output))], isEnabled: true)
+    }
+
+    func testPersistenceRetainsEveryReloadDispositionAndOccursBeforeCallback() async {
+        for disposition: ReloadDisposition in [.applied, .pending, .rejected, .failed] {
+            var reloadCount = 0
+            manager.onRulesChanged = {
+                reloadCount += 1
+                XCTAssertTrue(FileManager.default.fileExists(atPath: self.service.configurationPath))
+                let stored = await self.manager.ruleCollectionStore.loadCollections()
+                XCTAssertTrue(stored.contains { $0.name == "Test" })
+                return ReloadResult(success: disposition == .applied, response: "response", errorMessage: "detail", protocol: nil, disposition: disposition)
+            }
+            let result = await manager.persistRules()
+            guard case let .persisted(reloadResult) = result else {
+                return XCTFail("Expected persistence to complete for \(disposition)")
+            }
+            XCTAssertTrue(result.didPersist)
+            XCTAssertEqual(reloadResult?.disposition, disposition)
+            XCTAssertEqual(reloadResult?.response, "response")
+            XCTAssertEqual(reloadResult?.errorMessage, "detail")
+            XCTAssertEqual(reloadCount, 1)
+        }
+    }
+
+    func testCompatibilityBooleanStillMeansPersistedAfterRejectedReload() async {
+        manager.onRulesChanged = {
+            ReloadResult(success: false, response: nil, errorMessage: "rejected", protocol: nil, disposition: .rejected)
+        }
+        let persisted = await manager.regenerateConfigFromCollections()
+        XCTAssertTrue(persisted, "Do not trigger partial caller rollback before transaction migration")
+    }
+
+    func testSkippedAndAbsentCallbacksDoNotInventApplicationResult() async {
+        manager.onRulesChanged = {
+            XCTFail("Explicitly skipped reload must not run")
+            return ReloadResult(success: true, response: nil, errorMessage: nil, protocol: nil)
+        }
+        let skipped = await manager.persistRules(skipReload: true)
+        manager.onRulesChanged = nil
+        let absent = await manager.persistRules()
+        for result in [skipped, absent] {
+            guard case let .persisted(reloadResult) = result else {
+                return XCTFail("Persistence should still complete")
+            }
+            XCTAssertNil(reloadResult)
+        }
+    }
+
+    func testPersistenceFailureRetainsErrorWithoutCallingReload() async throws {
+        try FileManager.default.removeItem(at: directory)
+        try "blocked".write(to: directory, atomically: true, encoding: .utf8)
+        manager.onRulesChanged = {
+            XCTFail("Persistence failure must not reload")
+            return ReloadResult(success: true, response: nil, errorMessage: nil, protocol: nil)
+        }
+        let result = await manager.persistRules()
+        guard case let .failed(error) = result else { return XCTFail("Expected persistence failure") }
+        XCTAssertFalse(result.didPersist)
+        XCTAssertFalse(error.localizedDescription.isEmpty)
+    }
+
+    func testConflictRetryPreservesReloadResultWithoutSecondAttempt() async {
+        let first = collection("First", output: "b")
+        let second = collection("Second", output: "c")
+        manager.ruleCollections = [first, second]
+        manager.onMappingConflictResolution = { _ in second.id }
+        var reloadCount = 0
+        manager.onRulesChanged = {
+            reloadCount += 1
+            return ReloadResult(success: false, response: nil, errorMessage: "pending detail", protocol: nil, disposition: .pending)
+        }
+        let conflict = KeyPathError.configuration(.mappingConflicts(conflicts: [
+            KeyPathError.MappingConflictInfo(inputKey: "a", layer: "Base", conflictingCollections: [first.name, second.name])
+        ]))
+        let result = await manager.tryResolveMappingConflict(conflict, skipReload: false, depth: 0)
+        guard case let .persisted(reloadResult)? = result else { return XCTFail("Conflict retry should persist") }
+        XCTAssertEqual(reloadResult?.disposition, .pending)
+        XCTAssertEqual(reloadResult?.errorMessage, "pending detail")
+        XCTAssertEqual(reloadCount, 1)
+        XCTAssertEqual(manager.ruleCollections.first { $0.id == second.id }?.isEnabled, false)
+    }
+}

--- a/docs/architecture/configuration-save-pipeline.md
+++ b/docs/architecture/configuration-save-pipeline.md
@@ -3,8 +3,9 @@
 KeyPath has two principal app configuration-write paths. Reload execution uses
 the dispositions introduced by #732: `applied`, `pending`, `rejected`, and
 `failed`. Propagation is currently uneven: `SaveCoordinator` preserves the reload
-result, but collection regeneration still returns a Boolean and its runtime
-callback discards the reload outcome. CLI apply/restore are separate paths.
+result. Collection persistence now retains that same `ReloadResult` through
+its runtime callback, while its compatibility Boolean still means persistence
+completed. CLI apply/restore remain separate paths.
 
 | Responsibility | Owner | Notes |
 | --- | --- | --- |
@@ -75,3 +76,18 @@ See [the reproduced rollback race](../bugs/save-coordinator-overlapping-rollback
 
 Explicit-restore failure throws `SaveRecoveryError`, retaining both causes while
 preserving the fallback error description used by existing presentation.
+
+## Collection persistence boundary
+
+`RuleCollectionsManager.persistRules()` returns `RulePersistenceResult`: either
+`persisted(reloadResult:)` after configuration and both source-store writes, or
+`failed(Error)`. The callback returns the original `ReloadResult`; applied,
+pending, rejected, and failed remain distinct. Nil means the callback was absent
+or intentionally skipped. Conflict-resolution retries carry the final result
+back to the original caller without another reload.
+
+`regenerateConfigFromCollections()` remains a compatibility adapter returning
+`didPersist`. Do not reinterpret its Boolean as live application: callers perform
+their own partial rollback on false, so changing it on reload rejection before
+migrating multi-store recovery would create inconsistent state. This stage does
+not change notification timing or claim recovery after a partial store write.

--- a/docs/bugs/collection-reload-result-was-discarded.md
+++ b/docs/bugs/collection-reload-result-was-discarded.md
@@ -1,0 +1,22 @@
+# Collection reload result was discarded
+
+The runtime callback for `RuleCollectionsManager.onRulesChanged` awaited
+`applyPersistedRuleChanges()` but discarded its `ReloadResult`. The manager then
+returned true after any completed callback, including rejection or failure.
+
+The callback now returns that same application result. `persistRules()` retains
+it alongside completed persistence, or returns the persistence error without
+calling reload. Missing/skipped callbacks produce nil instead of inventing an
+applied or pending result. Conflict-resolution recursion retains the final retry
+result and keeps its existing persistence-based rollback decision.
+
+The old Boolean adapter intentionally continues to mean persistence completed.
+Several callers respond to false by restoring only in-memory snapshots or
+preferences; switching them to false after a persisted-but-rejected reload would
+introduce disagreement with disk. Migrate these callers with multi-store recovery,
+not by relabelling their existing Boolean. UI, sounds, notifications, and current
+recovery behavior are unchanged by this contract step.
+
+Temporary-store tests cover all four reload dispositions, exactly one reload,
+persistence before callback, absent/skipped callbacks, filesystem failure before
+reload, conflict retry, and compatibility Boolean semantics.


### PR DESCRIPTION
Collection regeneration discarded the engine reload result at its runtime callback. `persistRules()` now retains the original applied/pending/rejected/failed `ReloadResult` after persistence, including conflict-resolution retries. Missing or explicitly skipped callbacks remain nil. Persistence errors return without a reload.

The existing Boolean adapter intentionally retains its meaning: persistence completed. Existing callers perform partial in-memory or preference rollback on false, so making it false after a persisted-but-rejected reload before the multi-store transaction migration would introduce disagreement with disk. This is the next bounded Phase 1 contract step, with no UI, notification, sound, or recovery-policy change.

Validation:
- 95 focused tests pass across collection results, packs, prerequisites, conflict resolution and SaveCoordinator. New temporary-store fixtures cover all reload dispositions, callbacks after persistence, skipped/missing callbacks, failed writes, and conflict retry without a second reload.
- Stable-toolchain builds have zero Swift warnings; pinned SwiftFormat, accessibility and diff checks pass.
- Full local safe suite: runner reports 5,098 passed and only the same four previously reproduced baseline snapshot mismatches (three home-row timing snapshots and Repair Settings).
- Remote review gate selected; GitHub CI and claude-review required before merge.

No installer/lifecycle changes. Live runtime verification remains separately gated by the host's helper/service setup.

Review disposition: searched all `onRulesChanged` assignments in Sources and Tests; all six assignments across the three files are migrated, and full app/test builds plus CI pass. Persistence-based conflict rollback is intentionally retained as documented; it changes with multi-store recovery, not this API migration. The defensive deallocated-runtime branch was reviewed directly (no reachable runtime owner to perform a reload); it returns failed with no protocol/response and does not claim application.
