### PR TITLE
Recover interrupted configuration and rule-store writes

### DIFF
--- a/Sources/KeyPathAppKit/Infrastructure/Config/ConfigurationService.swift
+++ b/Sources/KeyPathAppKit/Infrastructure/Config/ConfigurationService.swift
@@ -275,37 +275,82 @@ public final class ConfigurationService: FileConfigurationProviding {
         ruleCollections: [RuleCollection],
         customRules: [CustomRule] = []
     ) async throws {
-        let newConfig = try await generateConfiguration(
-            ruleCollections: ruleCollections,
-            customRules: customRules
-        )
+        let newConfig = try await preparedConfiguration(ruleCollections: ruleCollections, customRules: customRules)
+        try await writeFileAsync(string: newConfig.content, to: configurationPath)
+        await publishSavedConfiguration(newConfig)
+    }
 
-        // VALIDATE BEFORE SAVING - prevent writing broken configs
-        AppLogger.shared.log("🔍 [ConfigService] Validating config before save...")
+    /// Persist the generated file and its two source stores as one recoverable
+    /// write set. The manager supplies its actual stores, which can differ from
+    /// this service's defaults in tests and isolated CLI workflows.
+    func saveRuleState(
+        ruleCollections: [RuleCollection], customRules: [CustomRule],
+        collectionStore: RuleCollectionStore, customStore: CustomRulesStore
+    ) async throws {
+        try await recoverPendingRuleWrite(collectionStore: collectionStore, customStore: customStore)
+        let newConfig = try await preparedConfiguration(ruleCollections: ruleCollections, customRules: customRules)
+        let files = await ruleWriteFiles(collectionStore: collectionStore, customStore: customStore)
+        let contents = try await [
+            "config": Data(newConfig.content.utf8),
+            "collections": collectionStore.encodedCollections(ruleCollections),
+            "customRules": customStore.encodedRules(customRules)
+        ]
+        try Task.checkCancellation()
+        let directory = URL(fileURLWithPath: configDirectory)
+        try await performRuleFileOperation {
+            try RecoverableRuleWrite.apply(files: files, contents: contents, directory: directory)
+        }
+        await publishSavedConfiguration(newConfig)
+    }
+
+    /// Run before loading source stores on startup. Refuse further rule writes
+    /// when recovery detects a corrupt journal or an unrelated external edit.
+    func recoverPendingRuleWrite(collectionStore: RuleCollectionStore, customStore: CustomRulesStore) async throws {
+        let files = await ruleWriteFiles(collectionStore: collectionStore, customStore: customStore)
+        let directory = URL(fileURLWithPath: configDirectory)
+        let recovered = try await performRuleFileOperation {
+            try RecoverableRuleWrite.recover(files: files, directory: directory)
+        }
+        if recovered {
+            stateLock.withLock { currentConfiguration = nil }
+        }
+    }
+
+    private func ruleWriteFiles(collectionStore: RuleCollectionStore, customStore: CustomRulesStore) async -> [String: URL] {
+        await [
+            "config": URL(fileURLWithPath: configurationPath),
+            "collections": collectionStore.persistenceURL,
+            "customRules": customStore.persistenceURL
+        ]
+    }
+
+    private func performRuleFileOperation<T: Sendable>(_ operation: @escaping @Sendable () throws -> T) async throws -> T {
+        try await withCheckedThrowingContinuation { continuation in
+            ioQueue.async {
+                do { try continuation.resume(returning: operation()) }
+                catch { continuation.resume(throwing: error) }
+            }
+        }
+    }
+
+    private func preparedConfiguration(ruleCollections: [RuleCollection], customRules: [CustomRule]) async throws -> KanataConfiguration {
+        let newConfig = try await generateConfiguration(ruleCollections: ruleCollections, customRules: customRules)
         let validation = await validateConfiguration(newConfig.content)
-
-        if !validation.isValid {
-            AppLogger.shared.log(
-                "❌ [ConfigService] Config validation failed: \(validation.errors.joined(separator: ", "))"
-            )
+        guard validation.isValid else {
             throw KeyPathError.configuration(.validationFailed(errors: validation.errors))
         }
+        return newConfig
+    }
 
-        AppLogger.shared.log("✅ [ConfigService] Config validation passed")
-
-        try await writeFileAsync(string: newConfig.content, to: configurationPath)
-
+    private func publishSavedConfiguration(_ newConfig: KanataConfiguration) async {
         setCurrentConfiguration(newConfig)
-
-        // Notify observers on main actor
         let snapshot = observersSnapshot()
         let tasks = snapshot.map { observer in
             Task { @MainActor in await observer(newConfig) }
         }
-        for t in tasks {
-            await t.value
+        for task in tasks {
+            await task.value
         }
-
         AppLogger.shared.log("✅ [ConfigService] Configuration saved with \(newConfig.keyMappings.count) mappings")
     }
 

--- a/Sources/KeyPathAppKit/Infrastructure/Config/RecoverableRuleWrite.swift
+++ b/Sources/KeyPathAppKit/Infrastructure/Config/RecoverableRuleWrite.swift
@@ -1,0 +1,200 @@
+import Darwin
+import Foundation
+
+/// The file-persistence portion of a rule edit. Call off the main actor.
+/// Fixed caller-supplied roles resolve journal entries; journal data cannot choose
+/// arbitrary target paths. Runtime application and preferences are separate stages.
+enum RecoverableRuleWrite {
+    struct Entry: Codable {
+        let role: String
+        let path: String
+        let before: Data?
+        let after: Data
+    }
+
+    struct Journal: Codable {
+        let version: Int
+        var committed: Bool
+        let entries: [Entry]
+    }
+
+    struct WriteFailure: LocalizedError {
+        let cause: Error
+        let recoveryError: Error?
+
+        var errorDescription: String? {
+            if let recoveryError {
+                return "Rule files could not be saved: \(cause.localizedDescription). Recovery also failed: \(recoveryError.localizedDescription)"
+            }
+            return "Rule files could not be saved; the prior files were restored: \(cause.localizedDescription)"
+        }
+    }
+
+    enum Failure: LocalizedError {
+        case invalidJournal
+        case changedFile(String)
+        case systemCall(String, Int32)
+
+        var errorDescription: String? {
+            switch self {
+            case .invalidJournal: "The pending rule-write journal does not match these rule stores."
+            case let .changedFile(role): "The \(role) file changed outside this operation. Recovery was stopped to preserve it."
+            case let .systemCall(operation, code): "Rule-write \(operation) failed (errno \(code))."
+            }
+        }
+    }
+
+    static func apply(
+        files: [String: URL], contents: [String: Data], directory: URL,
+        writeFile: (Data, URL) throws -> Void = durableWrite
+    ) throws {
+        try validateFiles(files, directory: directory)
+        try withLock(directory: directory) {
+            try recoverLocked(files: files, directory: directory, writeFile: writeFile)
+            guard Set(files.keys) == Set(contents.keys),
+                  Set(files.values.map(\.standardizedFileURL)).count == files.count,
+                  !files.isEmpty
+            else { throw Failure.invalidJournal }
+            let entries = try files.keys.sorted().map { role in
+                try Entry(role: role, path: files[role]!.standardizedFileURL.path, before: read(files[role]!), after: contents[role]!)
+            }
+            var journal = Journal(version: 1, committed: false, entries: entries)
+            try durableWrite(JSONEncoder().encode(journal), journalURL(directory))
+            var committing = false
+            do {
+                for entry in entries {
+                    let url = files[entry.role]!
+                    guard try read(url) == entry.before else { throw Failure.changedFile(entry.role) }
+                    try writeFile(entry.after, url)
+                }
+                // A committed journal may safely be cleaned up at the next startup.
+                committing = true
+                journal.committed = true
+                try durableWrite(JSONEncoder().encode(journal), journalURL(directory))
+            } catch {
+                let cause = error
+                do {
+                    if committing {
+                        // The marker write may have replaced the journal before
+                        // fsync failed. Re-establish rollback intent durably first.
+                        journal.committed = false
+                        try durableWrite(JSONEncoder().encode(journal), journalURL(directory))
+                    }
+                    try recoverLocked(files: files, directory: directory, writeFile: writeFile)
+                } catch {
+                    throw WriteFailure(cause: cause, recoveryError: error)
+                }
+                throw WriteFailure(cause: cause, recoveryError: nil)
+            }
+            // Persistence is committed even if journal cleanup must be retried.
+            try? removeJournal(directory)
+        }
+    }
+
+    @discardableResult
+    static func recover(files: [String: URL], directory: URL) throws -> Bool {
+        try validateFiles(files, directory: directory)
+        return try withLock(directory: directory) {
+            let hadJournal = try read(journalURL(directory)) != nil
+            try recoverLocked(files: files, directory: directory, writeFile: durableWrite)
+            return hadJournal
+        }
+    }
+
+    private static func recoverLocked(
+        files: [String: URL], directory: URL,
+        writeFile: (Data, URL) throws -> Void
+    ) throws {
+        let url = journalURL(directory)
+        guard let data = try read(url) else { return }
+        let journal = try JSONDecoder().decode(Journal.self, from: data)
+        guard journal.version == 1,
+              journal.entries.count == files.count,
+              Set(journal.entries.map(\.role)) == Set(files.keys),
+              journal.entries.allSatisfy({ files[$0.role]?.standardizedFileURL.path == $0.path }),
+              Set(files.values.map(\.standardizedFileURL)).count == files.count
+        else { throw Failure.invalidJournal }
+        if journal.committed {
+            try removeJournal(directory)
+            return
+        }
+        // Check the whole set first so a conflict does not cause partial recovery.
+        for entry in journal.entries {
+            let actual = try read(files[entry.role]!)
+            guard actual == entry.before || actual == entry.after else {
+                throw Failure.changedFile(entry.role)
+            }
+        }
+        for entry in journal.entries {
+            let target = files[entry.role]!
+            let actual = try read(target)
+            guard actual == entry.before || actual == entry.after else {
+                throw Failure.changedFile(entry.role)
+            }
+            if actual == entry.before { continue }
+            if let previous = entry.before {
+                try writeFile(previous, target)
+            } else {
+                try FileManager.default.removeItem(at: target)
+                try syncDirectory(target.deletingLastPathComponent())
+            }
+        }
+        try removeJournal(directory)
+    }
+
+    static func journalURL(_ directory: URL) -> URL {
+        directory.appendingPathComponent(".keypath-rule-write.json")
+    }
+
+    private static func validateFiles(_ files: [String: URL], directory: URL) throws {
+        let targets = Set(files.values.map(\.standardizedFileURL))
+        let reserved = Set([journalURL(directory), directory.appendingPathComponent(".keypath-rule-write.lock")].map(\.standardizedFileURL))
+        guard Set(files.keys) == Set(["config", "collections", "customRules"]),
+              targets.count == files.count, targets.isDisjoint(with: reserved)
+        else { throw Failure.invalidJournal }
+    }
+
+    private static func removeJournal(_ directory: URL) throws {
+        try FileManager.default.removeItem(at: journalURL(directory))
+        try syncDirectory(directory)
+    }
+
+    private static func read(_ url: URL) throws -> Data? {
+        do {
+            return try Data(contentsOf: url)
+        } catch let error as NSError where error.domain == NSCocoaErrorDomain && error.code == NSFileReadNoSuchFileError {
+            return nil
+        }
+    }
+
+    static func durableWrite(_ data: Data, _ url: URL) throws {
+        let parent = url.deletingLastPathComponent()
+        try FileManager.default.createDirectory(at: parent, withIntermediateDirectories: true)
+        try data.write(to: url, options: .atomic)
+        let descriptor = open(url.path, O_RDONLY | O_CLOEXEC)
+        guard descriptor >= 0 else { throw Failure.systemCall("open", errno) }
+        defer { close(descriptor) }
+        guard fsync(descriptor) == 0 else { throw Failure.systemCall("fsync", errno) }
+        try syncDirectory(parent)
+    }
+
+    private static func syncDirectory(_ url: URL) throws {
+        let descriptor = open(url.path, O_RDONLY | O_CLOEXEC)
+        guard descriptor >= 0 else { throw Failure.systemCall("open directory", errno) }
+        defer { close(descriptor) }
+        guard fsync(descriptor) == 0 else { throw Failure.systemCall("fsync directory", errno) }
+    }
+
+    private static func withLock<T>(directory: URL, operation: () throws -> T) throws -> T {
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let lockURL = directory.appendingPathComponent(".keypath-rule-write.lock")
+        let descriptor = open(lockURL.path, O_CREAT | O_RDWR | O_CLOEXEC, S_IRUSR | S_IWUSR)
+        guard descriptor >= 0 else { throw Failure.systemCall("open lock", errno) }
+        defer { close(descriptor) }
+        while flock(descriptor, LOCK_EX) != 0 {
+            if errno != EINTR { throw Failure.systemCall("lock", errno) }
+        }
+        defer { flock(descriptor, LOCK_UN) }
+        return try operation()
+    }
+}

--- a/Sources/KeyPathAppKit/Services/Configuration/CustomRulesStore.swift
+++ b/Sources/KeyPathAppKit/Services/Configuration/CustomRulesStore.swift
@@ -49,6 +49,14 @@ actor CustomRulesStore {
         }
     }
 
+    func encodedRules(_ rules: [CustomRule]) throws -> Data {
+        try encoder.encode(rules)
+    }
+
+    var persistenceURL: URL {
+        fileURL
+    }
+
     func saveRules(_ rules: [CustomRule]) throws {
         AppLogger.shared.log("💾 [CustomRulesStore] saveRules: \(rules.count) rules to \(fileURL.path)")
         for rule in rules {
@@ -56,7 +64,7 @@ actor CustomRulesStore {
         }
         let directory = fileURL.deletingLastPathComponent()
         try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
-        let data = try encoder.encode(rules)
+        let data = try encodedRules(rules)
         try data.write(to: fileURL, options: .atomic)
         AppLogger.shared.log("💾 [CustomRulesStore] Saved \(data.count) bytes")
     }

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionStore.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionStore.swift
@@ -206,12 +206,15 @@ actor RuleCollectionStore {
     func saveCollections(_ collections: [RuleCollection]) throws {
         let directory = fileURL.deletingLastPathComponent()
         try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
-        let versioned = VersionedCollections(
-            schemaVersion: Self.currentSchemaVersion,
-            collections: collections
-        )
-        let data = try encoder.encode(versioned)
-        try data.write(to: fileURL, options: .atomic)
+        try encodedCollections(collections).write(to: fileURL, options: .atomic)
+    }
+
+    func encodedCollections(_ collections: [RuleCollection]) throws -> Data {
+        try encoder.encode(VersionedCollections(schemaVersion: Self.currentSchemaVersion, collections: collections))
+    }
+
+    var persistenceURL: URL {
+        fileURL
     }
 
     // MARK: - Helper Types

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+Bootstrap.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+Bootstrap.swift
@@ -8,6 +8,14 @@ extension RuleCollectionsManager {
 
     /// Load rule collections and custom rules from persistent storage
     func bootstrap() async {
+        do {
+            try await configurationService.recoverPendingRuleWrite(
+                collectionStore: ruleCollectionStore, customStore: customRulesStore
+            )
+        } catch {
+            onError?("Could not recover the previous rule edit: \(error.localizedDescription)")
+            return
+        }
         // Restore keymap state first (before loading collections)
         restoreKeymapState()
 

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+Migrations.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+Migrations.swift
@@ -67,20 +67,19 @@ extension RuleCollectionsManager {
             // which can race with onRulesChanged reload and cause an error beep
             onBeforeSave?()
 
-            AppLogger.shared.log("🔄 [RuleCollections] Calling configurationService.saveConfiguration...")
+            AppLogger.shared.log("🔄 [RuleCollections] Calling configurationService.saveRuleState...")
             AppLogger.shared.log("🔄 [RuleCollections] Custom rules to save: \(customRules.map { "'\($0.input)' → '\($0.action.displayName)'" }.joined(separator: ", "))")
-            // IMPORTANT: Save config FIRST (validates before writing)
-            // Only persist to stores AFTER config is successfully written
-            // This prevents store/config mismatch if validation fails
-            try await configurationService.saveConfiguration(
+            // Validate before replacing the generated file and both source stores.
+            // The write journal restores the prior set if a persistence stage fails.
+            try await configurationService.saveRuleState(
                 ruleCollections: ruleCollections,
-                customRules: customRules
+                customRules: customRules,
+                collectionStore: ruleCollectionStore,
+                customStore: customRulesStore
             )
-            AppLogger.shared.log("✅ [RuleCollections] configurationService.saveConfiguration succeeded")
+            AppLogger.shared.log("✅ [RuleCollections] configurationService.saveRuleState succeeded")
 
-            // Config write succeeded - now persist to stores
-            try await ruleCollectionStore.saveCollections(ruleCollections)
-            try await customRulesStore.saveRules(customRules)
+            // The generated file and both stores are committed before notification.
             AppLogger.shared.log("✅ [RuleCollections] Stores persisted")
 
             // Notify observers and play success sound

--- a/Tests/KeyPathTests/Config/ConfigurationRuleWriteTests.swift
+++ b/Tests/KeyPathTests/Config/ConfigurationRuleWriteTests.swift
@@ -1,0 +1,113 @@
+import Foundation
+@testable import KeyPathAppKit
+import KeyPathCore
+import KeyPathRulesCore
+@preconcurrency import XCTest
+
+@MainActor
+final class ConfigurationRuleWriteTests: KeyPathTestCase {
+    private var directory: URL!
+    private var collections: RuleCollectionStore!
+    private var customRules: CustomRulesStore!
+    private var service: ConfigurationService!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        collections = .testStore(at: directory.appendingPathComponent("RuleCollections.json"))
+        customRules = .testStore(at: directory.appendingPathComponent("CustomRules.json"))
+        service = ConfigurationService(configDirectory: directory.path, ruleCollectionStore: collections, customRulesStore: customRules)
+    }
+
+    override func tearDown() async throws {
+        try? FileManager.default.removeItem(at: directory)
+        collections = nil
+        customRules = nil
+        service = nil
+        directory = nil
+        try await super.tearDown()
+    }
+
+    private func collection(_ name: String) -> RuleCollection {
+        RuleCollection(name: name, summary: name, category: .custom,
+                       mappings: [KeyMapping(input: "a", action: .keystroke(key: "b"))], isEnabled: true)
+    }
+
+    func testObserversSeeBothSourceStoresAlreadyCommitted() async throws {
+        let expected = collection("Committed")
+        let collectionStore = try XCTUnwrap(collections)
+        let customStore = try XCTUnwrap(customRules)
+        let observed = expectation(description: "committed observer")
+        let token = service.observe { _ in
+            let storedCollections = await collectionStore.loadCollections()
+            let storedRules = await customStore.loadRules()
+            XCTAssertTrue(storedCollections.contains { $0.id == expected.id })
+            XCTAssertTrue(storedRules.isEmpty)
+            observed.fulfill()
+        }
+        try await service.saveRuleState(ruleCollections: [expected], customRules: [], collectionStore: collections, customStore: customRules)
+        await fulfillment(of: [observed], timeout: 2)
+        withExtendedLifetime(token) {}
+        XCTAssertFalse(FileManager.default.fileExists(atPath: RecoverableRuleWrite.journalURL(directory).path))
+    }
+
+    func testUnreadableSourceStoreLeavesPriorConfigAndOtherStoreUntouched() async throws {
+        let original = collection("Original")
+        try await service.saveRuleState(ruleCollections: [original], customRules: [], collectionStore: collections, customStore: customRules)
+        let configURL = URL(fileURLWithPath: service.configurationPath)
+        let collectionURL = await collections.persistenceURL
+        let customURL = await customRules.persistenceURL
+        let oldConfig = try Data(contentsOf: configURL)
+        let oldCollections = try Data(contentsOf: collectionURL)
+        try FileManager.default.removeItem(at: customURL)
+        try FileManager.default.createDirectory(at: customURL, withIntermediateDirectories: true)
+        let count = ObservationCount()
+        let token = service.observe { _ in await count.increment() }
+        do {
+            try await service.saveRuleState(ruleCollections: [collection("Candidate")], customRules: [], collectionStore: collections, customStore: customRules)
+            XCTFail("An unreadable preimage must stop the operation")
+        } catch {
+            XCTAssertEqual(try Data(contentsOf: configURL), oldConfig)
+            XCTAssertEqual(try Data(contentsOf: collectionURL), oldCollections)
+            let notifications = await count.value
+            XCTAssertEqual(notifications, 0)
+        }
+        withExtendedLifetime(token) {}
+    }
+
+    func testBootstrapRecoversInterruptedWriteBeforeLoadingSourceStores() async throws {
+        let original = collection("Original")
+        let candidate = collection("Candidate")
+        try await service.saveRuleState(ruleCollections: [original], customRules: [], collectionStore: collections, customStore: customRules)
+        let files = await [
+            "config": URL(fileURLWithPath: service.configurationPath),
+            "collections": collections.persistenceURL,
+            "customRules": customRules.persistenceURL
+        ]
+        var entries: [RecoverableRuleWrite.Entry] = []
+        for role in files.keys.sorted() {
+            let url = files[role]!
+            let before = try Data(contentsOf: url)
+            let after = role == "collections" ? try await collections.encodedCollections([candidate]) : before
+            entries.append(.init(role: role, path: url.path, before: before, after: after))
+        }
+        let journal = RecoverableRuleWrite.Journal(version: 1, committed: false, entries: entries)
+        try JSONEncoder().encode(journal).write(to: RecoverableRuleWrite.journalURL(directory))
+        for entry in entries {
+            try entry.after.write(to: files[entry.role]!)
+        }
+        let manager = RuleCollectionsManager(ruleCollectionStore: collections, customRulesStore: customRules, configurationService: service)
+        await manager.bootstrap()
+        XCTAssertTrue(manager.ruleCollections.contains { $0.id == original.id })
+        XCTAssertFalse(manager.ruleCollections.contains { $0.id == candidate.id })
+        XCTAssertFalse(FileManager.default.fileExists(atPath: RecoverableRuleWrite.journalURL(directory).path))
+    }
+}
+
+private actor ObservationCount {
+    var value = 0
+    func increment() {
+        value += 1
+    }
+}

--- a/Tests/KeyPathTests/Config/RecoverableRuleWriteTests.swift
+++ b/Tests/KeyPathTests/Config/RecoverableRuleWriteTests.swift
@@ -1,0 +1,161 @@
+import Foundation
+@testable import KeyPathAppKit
+import XCTest
+
+final class RecoverableRuleWriteTests: XCTestCase {
+    private enum Injected: Error { case write, rollback }
+
+    private func fixture(_ test: (URL, [String: URL], [String: Data], [String: Data]) throws -> Void) throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let files = Dictionary(uniqueKeysWithValues: ["config", "collections", "customRules"].map {
+            ($0, directory.appendingPathComponent($0))
+        })
+        let old = files.mapValues { Data("old \($0.lastPathComponent)".utf8) }
+        let new = files.mapValues { Data("new \($0.lastPathComponent)".utf8) }
+        for (role, url) in files {
+            try old[role]!.write(to: url)
+        }
+        try test(directory, files, old, new)
+    }
+
+    private func assertFiles(_ files: [String: URL], equal contents: [String: Data], file: StaticString = #filePath, line: UInt = #line) throws {
+        for (role, url) in files {
+            XCTAssertEqual(try Data(contentsOf: url), contents[role], file: file, line: line)
+        }
+    }
+
+    private func journal(_ directory: URL, files: [String: URL], old: [String: Data], new: [String: Data], committed: Bool = false) throws {
+        let entries = files.keys.sorted().map {
+            RecoverableRuleWrite.Entry(role: $0, path: files[$0]!.path, before: old[$0], after: new[$0]!)
+        }
+        let journal = RecoverableRuleWrite.Journal(version: 1, committed: committed, entries: entries)
+        try JSONEncoder().encode(journal).write(to: RecoverableRuleWrite.journalURL(directory), options: .atomic)
+    }
+
+    func testSuccessfulCommitWritesAllFilesAndRemovesJournal() throws {
+        try fixture { directory, files, _, new in
+            try RecoverableRuleWrite.apply(files: files, contents: new, directory: directory)
+            try assertFiles(files, equal: new)
+            XCTAssertFalse(FileManager.default.fileExists(atPath: RecoverableRuleWrite.journalURL(directory).path))
+        }
+    }
+
+    func testFailureAfterEachWriteRestoresEveryPreviousFile() throws {
+        for failAfter in 1 ... 3 {
+            try fixture { directory, files, old, new in
+                var writes = 0
+                XCTAssertThrowsError(try RecoverableRuleWrite.apply(files: files, contents: new, directory: directory) { data, url in
+                    try RecoverableRuleWrite.durableWrite(data, url)
+                    writes += 1
+                    if writes == failAfter { throw Injected.write }
+                }) { error in
+                    guard let failure = error as? RecoverableRuleWrite.WriteFailure else { return XCTFail("Missing recovery outcome") }
+                    XCTAssertTrue(failure.cause is Injected)
+                    XCTAssertNil(failure.recoveryError)
+                }
+                try assertFiles(files, equal: old)
+                XCTAssertFalse(FileManager.default.fileExists(atPath: RecoverableRuleWrite.journalURL(directory).path))
+            }
+        }
+    }
+
+    func testInterruptedWriteRecoversAtEveryBoundary() throws {
+        for written in 0 ... 3 {
+            try fixture { directory, files, old, new in
+                try journal(directory, files: files, old: old, new: new)
+                for role in files.keys.sorted().prefix(written) {
+                    try new[role]!.write(to: files[role]!, options: .atomic)
+                }
+                XCTAssertTrue(try RecoverableRuleWrite.recover(files: files, directory: directory))
+                try assertFiles(files, equal: old)
+                XCTAssertFalse(try RecoverableRuleWrite.recover(files: files, directory: directory), "Recovery is idempotent")
+            }
+        }
+    }
+
+    func testRecoveryRemovesFilesThatDidNotPreviouslyExist() throws {
+        try fixture { directory, files, old, new in
+            var previous = old
+            previous.removeValue(forKey: "customRules")
+            try journal(directory, files: files, old: previous, new: new)
+            for (role, url) in files {
+                try new[role]!.write(to: url)
+            }
+            try RecoverableRuleWrite.recover(files: files, directory: directory)
+            XCTAssertFalse(FileManager.default.fileExists(atPath: files["customRules"]!.path))
+            for role in previous.keys {
+                XCTAssertEqual(try Data(contentsOf: files[role]!), previous[role])
+            }
+        }
+    }
+
+    func testRollbackFailureRetainsJournalAndNextRecoveryCompletes() throws {
+        try fixture { directory, files, old, new in
+            var writes = 0
+            XCTAssertThrowsError(try RecoverableRuleWrite.apply(files: files, contents: new, directory: directory) { data, url in
+                writes += 1
+                if writes == 2 { throw Injected.write }
+                if writes == 3 { throw Injected.rollback }
+                try RecoverableRuleWrite.durableWrite(data, url)
+            }) { error in
+                guard let failure = error as? RecoverableRuleWrite.WriteFailure else { return XCTFail("Missing recovery error") }
+                XCTAssertNotNil(failure.recoveryError)
+            }
+            XCTAssertTrue(FileManager.default.fileExists(atPath: RecoverableRuleWrite.journalURL(directory).path))
+            try RecoverableRuleWrite.recover(files: files, directory: directory)
+            try assertFiles(files, equal: old)
+        }
+    }
+
+    func testExternalEditStopsRecoveryWithoutOverwritingAnyFile() throws {
+        try fixture { directory, files, old, new in
+            try journal(directory, files: files, old: old, new: new)
+            for (role, url) in files {
+                try new[role]!.write(to: url)
+            }
+            let external = Data("external edit".utf8)
+            try external.write(to: files["customRules"]!)
+            XCTAssertThrowsError(try RecoverableRuleWrite.recover(files: files, directory: directory))
+            XCTAssertEqual(try Data(contentsOf: files["customRules"]!), external)
+            XCTAssertEqual(try Data(contentsOf: files["config"]!), new["config"])
+            XCTAssertEqual(try Data(contentsOf: files["collections"]!), new["collections"])
+            XCTAssertTrue(FileManager.default.fileExists(atPath: RecoverableRuleWrite.journalURL(directory).path))
+            XCTAssertThrowsError(try RecoverableRuleWrite.apply(files: files, contents: old, directory: directory), "A new save must not discard unresolved recovery")
+        }
+    }
+
+    func testCommittedJournalDoesNotUndoACompletedEditOrLaterExternalEdit() throws {
+        try fixture { directory, files, old, new in
+            try journal(directory, files: files, old: old, new: new, committed: true)
+            for (role, url) in files {
+                try new[role]!.write(to: url)
+            }
+            let external = Data("later edit".utf8)
+            try external.write(to: files["config"]!)
+            try RecoverableRuleWrite.recover(files: files, directory: directory)
+            XCTAssertEqual(try Data(contentsOf: files["config"]!), external)
+            XCTAssertEqual(try Data(contentsOf: files["collections"]!), new["collections"])
+        }
+    }
+
+    func testJournalCannotRedirectRecoveryToOtherStores() throws {
+        try fixture { directory, files, old, new in
+            try journal(directory, files: files, old: old, new: new)
+            var otherFiles = files
+            otherFiles["config"] = directory.appendingPathComponent("different-config")
+            try old["config"]!.write(to: otherFiles["config"]!)
+            XCTAssertThrowsError(try RecoverableRuleWrite.recover(files: otherFiles, directory: directory))
+            try assertFiles(files, equal: old)
+        }
+    }
+
+    func testCorruptJournalFailsClosed() throws {
+        try fixture { directory, files, old, new in
+            try Data("broken json".utf8).write(to: RecoverableRuleWrite.journalURL(directory))
+            XCTAssertThrowsError(try RecoverableRuleWrite.apply(files: files, contents: new, directory: directory))
+            try assertFiles(files, equal: old)
+        }
+    }
+}

--- a/docs/architecture/configuration-save-pipeline.md
+++ b/docs/architecture/configuration-save-pipeline.md
@@ -11,7 +11,7 @@ completed. CLI apply/restore remain separate paths.
 | --- | --- | --- |
 | Generate and validate collection-backed configuration | `ConfigurationService` | `saveConfiguration` validates before its atomic write and updates the in-memory configuration and observers. |
 | Coordinate generated/raw configuration saves | `SaveCoordinator` | Suppresses the watcher, validates, snapshots the last good file, writes, classifies reload, and rolls the file back after rejection or failure. |
-| Persist rule and custom-rule source data | `RuleCollectionsManager` | Mutates in-memory state, generates/validates/writes config, then persists collection and custom-rule stores. Notifications precede its reload callback. These are separate writes, not an atomic multi-store transaction. |
+| Persist rule and custom-rule source data | `RuleCollectionsManager` | Mutates in-memory state and requests a recoverable config/source-store write from `ConfigurationService`. Notifications follow the file-set commit and precede reload. Runtime rollback and preferences remain separate. |
 | Reload the running engine | `ConfigReloadCoordinator` | Produces the four reload dispositions; `pending` means the write succeeded but the runtime is unavailable. |
 | Handle external file edits | `ConfigHotReloadService` | Validates and reloads changes that were not suppressed as internal writes. |
 | Create durable pre-edit backups | `ConfigBackupManager` | Used by explicit backup/recovery flows, not as an alternate writer. |
@@ -91,3 +91,9 @@ back to the original caller without another reload.
 their own partial rollback on false, so changing it on reload rejection before
 migrating multi-store recovery would create inconsistent state. This stage does
 not change notification timing or claim recovery after a partial store write.
+
+Collection file persistence now uses [recoverable rule writes](recoverable-rule-writes.md).
+It journals the generated file and both source stores, recovers before bootstrap
+loads them, and defers configuration observers until the file set commits. This
+does not yet change the collection Boolean's persistence-only meaning or couple
+engine rejection to source-store recovery.

--- a/docs/architecture/recoverable-rule-writes.md
+++ b/docs/architecture/recoverable-rule-writes.md
@@ -1,0 +1,55 @@
+# Recoverable rule-file persistence
+
+Collection regeneration prepares and validates the generated config and encodes
+both source stores before replacing any file. `ConfigurationService.saveRuleState`
+uses the existing store encoders, preserving the JSON formats and configured paths.
+It publishes its configuration cache and observer callbacks only after the three
+files have been committed.
+
+The files are still replaced individually. This is recoverable persistence,
+not a filesystem-wide atomic snapshot for arbitrary readers.
+
+## Protocol
+
+1. Take the directory's `.keypath-rule-write.lock` using `flock` off the main
+   actor. Resolve any previous journal before starting another write.
+2. Read prior bytes (including absence) for `config`, `collections`, and
+   `customRules`. Record old and new bytes in `.keypath-rule-write.json` and sync
+   the journal and its directory before replacing targets.
+3. Replace and sync each target, verifying it still matches the recorded prior
+   bytes immediately before replacement.
+4. Mark and sync the journal as committed. Cleanup can be retried on startup if
+   deleting the committed journal fails.
+5. Publish the committed configuration and then notify rule observers/reload
+   through the existing manager flow.
+
+A write failure attempts restoration of the entire recorded prior set. If that
+also fails, return both errors and keep the journal for a later recovery attempt.
+Startup recovers the journal before the manager loads either rule store. Recovery
+failure stops bootstrap and blocks subsequent journaled saves rather than
+regenerating configuration from an ambiguous partial state.
+
+A prepared journal restores old bytes; a committed journal only needs cleanup.
+Recovery is idempotent and removes files whose prior state was absence. Journal
+roles and recorded paths must match the caller's actual stores; the journal cannot
+redirect recovery to arbitrary paths. Corrupt or mismatched journals fail closed.
+
+## External changes and remaining boundaries
+
+Recovery checks all targets before starting and checks each target again before
+restoration. If a file matches neither the old nor the new bytes, it preserves
+that external edit and leaves recovery unresolved. This is not a lock on editors
+that do not cooperate with `flock`; a non-cooperating writer can still race the
+last check and replacement. Watcher revision tracking and the shared application
+operation remain necessary for the complete Phase 1 contract.
+
+This slice covers persistence failure and interruption, not engine rejection.
+Reload occurs after file commit under existing behavior. Preferences, installed
+pack metadata, non-collection writers, and in-memory mutation ordering are not
+included yet. Do not infer a successful live remap from a committed file set.
+Cancellation is checked before journaled mutation; once mutation starts it
+finishes commit or recovery rather than abandoning the write set midway.
+
+Tests use temporary files to interrupt every write boundary, inject primary and
+rollback failures, retain external edits, reject corrupt/misdirected journals,
+verify bootstrap recovery, and assert observers see both source stores committed.


### PR DESCRIPTION
A collection edit could write its generated config successfully and then fail to save a source store, leaving different files at different revisions. `ConfigurationService.saveRuleState` now prepares and validates the config, uses the existing JSON encoders, and journals all three prior/new file contents before replacement. It commits the file set before publishing configuration observers. The manager recovers an unfinished journal before loading source stores on startup.

Write failure restores the prior set; failed recovery preserves both errors and leaves the journal for retry. Interrupted prepared writes roll back; committed journals only need cleanup. Recovery checks every file against recorded old/new bytes and refuses to overwrite a different external edit. Journal roles and paths must match the actual configured stores. Writes and journal markers are synced, with a directory flock off the main actor.

This is recoverable file persistence, not a claim of a filesystem-wide atomic snapshot. Engine rejection, preferences, pack metadata, in-memory mutation ordering, and non-cooperating external writers remain subsequent Phase 1 work. Current reload policy and UI remain unchanged.

Validation:
- 50 focused tests pass, including interruption at each write boundary, primary/rollback failures, absent prior files, corrupt/misdirected journals, external edit preservation, bootstrap recovery, and committed-store observer timing.
- Stable app/test builds: zero Swift warnings. Pinned formatting, accessibility, and diff checks pass.
- Full local safe suite: runner reports 5,110 passed, with only the same four baseline snapshot mismatches (three home-row timing snapshots and Repair Settings).
- Remote review gate selected; GitHub CI and claude-review required before merge.

No installer or service-lifecycle changes. Actual remap verification still needs the host's helper/service setup.

Review disposition: bootstrap remains fail-closed for I/O recovery failures. A prepared journal does not imply the old files are intact: the interruption tests cover zero through all three replacements. An EIO/fsync/open failure can occur after partial replacement or restoration, so ignoring it or deleting the journal would accept an unknown mixed state. Lock contention waits rather than throwing and EINTR retries. The error is not log-only: RuntimeCoordinator's onError wiring sets lastError and notifies UI observers. The journal stays intact and each subsequent bootstrap/save retries recovery; there is deliberately no destructive delete-journal fallback. A material new repair interaction remains subject to the user's UI review gate.
