### PR TITLE
Restore keymap selection and preferences after failed saves

### DIFF
--- a/Sources/KeyPathAppKit/Models/LogicalKeymap.swift
+++ b/Sources/KeyPathAppKit/Models/LogicalKeymap.swift
@@ -360,6 +360,28 @@ enum KeymapPreferences {
         return encodeIncludeMap(map)
     }
 
+    static func restoreFailedSelection(
+        attemptedID: String, attemptedPunctuation: Bool,
+        previousID: String, previousPunctuation: Bool,
+        userDefaults: UserDefaults
+    ) {
+        guard includePunctuation(for: attemptedID, userDefaults: userDefaults) == attemptedPunctuation
+        else { return }
+        // Keep remembered settings for all other layouts. A layout switch does
+        // not itself edit the destination layout's punctuation preference.
+        if attemptedID == previousID {
+            let store = userDefaults.string(forKey: includePunctuationStoreKey) ?? "{}"
+            userDefaults.set(updatedIncludePunctuationStore(
+                from: store, keymapId: previousID, includePunctuation: previousPunctuation
+            ), forKey: includePunctuationStoreKey)
+        }
+        // A failed punctuation edit still belongs to its original layout even
+        // if another layout has since been selected. Preserve that newer choice.
+        if userDefaults.string(forKey: keymapIdKey) == attemptedID {
+            userDefaults.set(previousID, forKey: keymapIdKey)
+        }
+    }
+
     private static func decodeIncludeMap(from store: String) -> [String: Bool] {
         let normalized = store.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !normalized.isEmpty,

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+Keymap.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+Keymap.swift
@@ -20,6 +20,9 @@ extension RuleCollectionsManager {
         AppLogger.shared.log("⌨️ [RuleCollections] Setting active keymap to '\(keymapId)' (punctuation: \(includePunctuation))")
 
         let previousKeymapId = activeKeymapId
+        let previousPunctuation = keymapIncludesPunctuation
+        let previousKeymapIndex = ruleCollections.firstIndex { $0.id == RuleCollectionIdentifier.keymapLayout }
+        let previousKeymapCollection = previousKeymapIndex.map { ruleCollections[$0] }
         activeKeymapId = keymapId
         keymapIncludesPunctuation = includePunctuation
 
@@ -49,22 +52,25 @@ extension RuleCollectionsManager {
             AppLogger.shared.log("⌨️ [RuleCollections] QWERTY selected - no keymap collection needed")
         }
 
-        // Persist keymap state
-        await persistKeymapState()
-
-        // Regenerate config
+        // Persist preferences only after the config/source-store write succeeds.
         let success = await regenerateConfigFromCollections()
-
-        if !success {
-            // Rollback on failure
+        if success {
+            await persistKeymapState()
+        } else {
             AppLogger.shared.log("⌨️ [RuleCollections] Keymap change failed - rolling back")
             activeKeymapId = previousKeymapId
+            keymapIncludesPunctuation = previousPunctuation
+            // The overlay optimistically updates its shared display preferences
+            // before invoking this operation. Revert only this attempted selection;
+            // a newer UI choice must survive an older failed completion.
+            KeymapPreferences.restoreFailedSelection(
+                attemptedID: keymapId, attemptedPunctuation: includePunctuation,
+                previousID: previousKeymapId, previousPunctuation: previousPunctuation,
+                userDefaults: keymapPreferences
+            )
             ruleCollections.removeAll { $0.id == RuleCollectionIdentifier.keymapLayout }
-            if let previousCollection = KeymapMappingGenerator.generateCollection(
-                for: previousKeymapId,
-                includePunctuation: keymapIncludesPunctuation
-            ) {
-                ruleCollections.insert(previousCollection, at: 0)
+            if let previousKeymapCollection, let previousKeymapIndex {
+                ruleCollections.insert(previousKeymapCollection, at: min(previousKeymapIndex, ruleCollections.count))
             }
         }
 
@@ -103,17 +109,17 @@ extension RuleCollectionsManager {
 
     /// Persist the current keymap state to UserDefaults
     func persistKeymapState() async {
-        UserDefaults.standard.set(activeKeymapId, forKey: "activeKeymapId")
-        UserDefaults.standard.set(keymapIncludesPunctuation, forKey: "keymapIncludesPunctuation")
+        keymapPreferences.set(activeKeymapId, forKey: "activeKeymapId")
+        keymapPreferences.set(keymapIncludesPunctuation, forKey: "keymapIncludesPunctuation")
         AppLogger.shared.log("💾 [RuleCollections] Persisted keymap state: \(activeKeymapId)")
     }
 
     /// Restore keymap state from UserDefaults (called during bootstrap)
     func restoreKeymapState() {
-        if let storedKeymapId = UserDefaults.standard.string(forKey: "activeKeymapId") {
+        if let storedKeymapId = keymapPreferences.string(forKey: "activeKeymapId") {
             activeKeymapId = storedKeymapId
         }
-        keymapIncludesPunctuation = UserDefaults.standard.bool(forKey: "keymapIncludesPunctuation")
+        keymapIncludesPunctuation = keymapPreferences.bool(forKey: "keymapIncludesPunctuation")
         AppLogger.shared.log("📂 [RuleCollections] Restored keymap state: \(activeKeymapId) (punctuation: \(keymapIncludesPunctuation))")
     }
 }

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager.swift
@@ -76,6 +76,7 @@ final class RuleCollectionsManager {
     let customRulesStore: CustomRulesStore
     let configurationService: ConfigurationService
     let eventListener: KanataEventListener
+    let keymapPreferences: UserDefaults
 
     /// Apply already-persisted rules and retain the runtime disposition.
     var onRulesChanged: (() async -> ReloadResult)?
@@ -122,12 +123,14 @@ final class RuleCollectionsManager {
         ruleCollectionStore: RuleCollectionStore = .shared,
         customRulesStore: CustomRulesStore = .shared,
         configurationService: ConfigurationService,
-        eventListener: KanataEventListener = KanataEventListener()
+        eventListener: KanataEventListener = KanataEventListener(),
+        keymapPreferences: UserDefaults = .standard
     ) {
         self.ruleCollectionStore = ruleCollectionStore
         self.customRulesStore = customRulesStore
         self.configurationService = configurationService
         self.eventListener = eventListener
+        self.keymapPreferences = keymapPreferences
     }
 
     deinit {

--- a/Sources/KeyPathAppKit/UI/Overlay/LiveKeyboardOverlayController+KeyClickHandling.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/LiveKeyboardOverlayController+KeyClickHandling.swift
@@ -13,6 +13,11 @@ extension LiveKeyboardOverlayController {
         AppLogger.shared.log("⌨️ [OverlayController] Keymap changed to '\(keymapId)' (punctuation: \(includePunctuation))")
 
         Task { @MainActor in
+            // AppStorage observes rollback too. Do not turn restoration of the
+            // already-active selection into another save/reload attempt.
+            guard ruleCollectionsManager.activeKeymapId != keymapId
+                || ruleCollectionsManager.keymapIncludesPunctuation != includePunctuation
+            else { return }
             let conflicts = await ruleCollectionsManager.setActiveKeymap(keymapId, includePunctuation: includePunctuation)
 
             if !conflicts.isEmpty {

--- a/Tests/KeyPathTests/RuleCollections/KeymapPreferenceRollbackTests.swift
+++ b/Tests/KeyPathTests/RuleCollections/KeymapPreferenceRollbackTests.swift
@@ -1,0 +1,130 @@
+import Foundation
+@testable import KeyPathAppKit
+import KeyPathCore
+import KeyPathRulesCore
+@preconcurrency import XCTest
+
+@MainActor
+final class KeymapPreferenceRollbackTests: KeyPathTestCase {
+    func testFailedChangePreservesPunctuationPreferencesAndExactPreviousCollection() async throws {
+        for previouslyStored in [true, false] {
+            try await withManager(blockWrites: true) { manager, preferences in
+                let oldID = LogicalKeymap.dvorak.id
+                manager.activeKeymapId = oldID
+                manager.keymapIncludesPunctuation = false
+                var previous = try XCTUnwrap(KeymapMappingGenerator.generateCollection(for: oldID, includePunctuation: false))
+                previous.name = "Customized Dvorak"
+                manager.ruleCollections = [previous]
+                if previouslyStored {
+                    preferences.set(oldID, forKey: "activeKeymapId")
+                    preferences.set(false, forKey: "keymapIncludesPunctuation")
+                }
+                var reloadCount = 0
+                manager.onRulesChanged = {
+                    reloadCount += 1
+                    return ReloadResult(success: true, response: nil, errorMessage: nil, protocol: nil)
+                }
+                _ = await manager.setActiveKeymap(LogicalKeymap.colemak.id, includePunctuation: true)
+                XCTAssertEqual(manager.activeKeymapId, oldID)
+                XCTAssertFalse(manager.keymapIncludesPunctuation)
+                XCTAssertEqual(manager.ruleCollections.map(\.id), [previous.id])
+                XCTAssertEqual(manager.ruleCollections.first?.name, previous.name)
+                XCTAssertEqual(manager.ruleCollections.first?.mappings, previous.mappings)
+                XCTAssertEqual(reloadCount, 0)
+                if previouslyStored {
+                    XCTAssertEqual(preferences.string(forKey: "activeKeymapId"), oldID)
+                    XCTAssertEqual(preferences.object(forKey: "keymapIncludesPunctuation") as? Bool, false)
+                } else {
+                    XCTAssertNil(preferences.object(forKey: "activeKeymapId"))
+                    XCTAssertNil(preferences.object(forKey: "keymapIncludesPunctuation"))
+                }
+            }
+        }
+    }
+
+    func testFailedOverlaySelectionRestoresDisplayAndPreservesOtherLayoutPreferences() async throws {
+        for changesPunctuation in [false, true] {
+            try await withManager(blockWrites: true) { manager, preferences in
+                let oldID = LogicalKeymap.dvorak.id
+                let requestedID = changesPunctuation ? oldID : LogicalKeymap.colemak.id
+                manager.activeKeymapId = oldID
+                manager.keymapIncludesPunctuation = false
+                manager.ruleCollections = try [XCTUnwrap(KeymapMappingGenerator.generateCollection(for: oldID, includePunctuation: false))]
+                preferences.set(requestedID, forKey: KeymapPreferences.keymapIdKey)
+                let store = KeymapPreferences.updatedIncludePunctuationStore(
+                    from: "{\"unrelated-layout\":true}", keymapId: requestedID, includePunctuation: changesPunctuation
+                )
+                preferences.set(store, forKey: KeymapPreferences.includePunctuationStoreKey)
+                _ = await manager.setActiveKeymap(requestedID, includePunctuation: changesPunctuation)
+                XCTAssertEqual(preferences.string(forKey: KeymapPreferences.keymapIdKey), oldID)
+                XCTAssertFalse(KeymapPreferences.includePunctuation(for: oldID, userDefaults: preferences))
+                XCTAssertTrue(KeymapPreferences.includePunctuation(for: "unrelated-layout", userDefaults: preferences))
+            }
+        }
+    }
+
+    func testFailedSelectionDoesNotOverwriteANewerDisplayChoice() throws {
+        let suite = "KeymapRollbackTests.\(UUID().uuidString)"
+        let preferences = try XCTUnwrap(UserDefaults(suiteName: suite))
+        defer { preferences.removePersistentDomain(forName: suite) }
+        preferences.set(LogicalKeymap.colemak.id, forKey: KeymapPreferences.keymapIdKey)
+        KeymapPreferences.restoreFailedSelection(
+            attemptedID: LogicalKeymap.dvorak.id, attemptedPunctuation: true,
+            previousID: LogicalKeymap.qwertyUSId, previousPunctuation: false,
+            userDefaults: preferences
+        )
+        XCTAssertEqual(preferences.string(forKey: KeymapPreferences.keymapIdKey), LogicalKeymap.colemak.id)
+        XCTAssertNil(preferences.object(forKey: KeymapPreferences.includePunctuationStoreKey))
+    }
+
+    func testFailedPunctuationEditIsRestoredAfterSelectingAnotherLayout() throws {
+        let suite = "KeymapRollbackTests.\(UUID().uuidString)"
+        let preferences = try XCTUnwrap(UserDefaults(suiteName: suite))
+        defer { preferences.removePersistentDomain(forName: suite) }
+        preferences.set(LogicalKeymap.colemak.id, forKey: KeymapPreferences.keymapIdKey)
+        preferences.set(KeymapPreferences.updatedIncludePunctuationStore(
+            from: "{}", keymapId: LogicalKeymap.dvorak.id, includePunctuation: true
+        ), forKey: KeymapPreferences.includePunctuationStoreKey)
+        KeymapPreferences.restoreFailedSelection(
+            attemptedID: LogicalKeymap.dvorak.id, attemptedPunctuation: true,
+            previousID: LogicalKeymap.dvorak.id, previousPunctuation: false,
+            userDefaults: preferences
+        )
+        XCTAssertEqual(preferences.string(forKey: KeymapPreferences.keymapIdKey), LogicalKeymap.colemak.id)
+        XCTAssertFalse(KeymapPreferences.includePunctuation(for: LogicalKeymap.dvorak.id, userDefaults: preferences))
+    }
+
+    func testPendingSavePersistsTheSelectedKeymapAndPunctuation() async throws {
+        try await withManager(blockWrites: false) { manager, preferences in
+            manager.onRulesChanged = {
+                ReloadResult(success: false, response: nil, errorMessage: "offline", protocol: nil, disposition: .pending)
+            }
+            _ = await manager.setActiveKeymap(LogicalKeymap.dvorak.id, includePunctuation: true)
+            XCTAssertEqual(preferences.string(forKey: "activeKeymapId"), LogicalKeymap.dvorak.id)
+            XCTAssertTrue(preferences.bool(forKey: "keymapIncludesPunctuation"))
+            let stored = await manager.ruleCollectionStore.loadCollections()
+            XCTAssertTrue(stored.contains { $0.id == RuleCollectionIdentifier.keymapLayout })
+            manager.activeKeymapId = LogicalKeymap.qwertyUSId
+            manager.keymapIncludesPunctuation = false
+            manager.restoreKeymapState()
+            XCTAssertEqual(manager.activeKeymapId, LogicalKeymap.dvorak.id)
+            XCTAssertTrue(manager.keymapIncludesPunctuation)
+        }
+    }
+
+    private func withManager(blockWrites: Bool, test: @MainActor (RuleCollectionsManager, UserDefaults) async throws -> Void) async throws {
+        let suite = "KeymapRollbackTests.\(UUID().uuidString)"
+        let preferences = try XCTUnwrap(UserDefaults(suiteName: suite))
+        defer { preferences.removePersistentDomain(forName: suite) }
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let configDirectory = directory.appendingPathComponent("config")
+        if blockWrites { try "blocked".write(to: configDirectory, atomically: true, encoding: .utf8) }
+        let collections = RuleCollectionStore.testStore(at: directory.appendingPathComponent("RuleCollections.json"))
+        let rules = CustomRulesStore.testStore(at: directory.appendingPathComponent("CustomRules.json"))
+        let service = ConfigurationService(configDirectory: configDirectory.path, ruleCollectionStore: collections, customRulesStore: rules)
+        let manager = RuleCollectionsManager(ruleCollectionStore: collections, customRulesStore: rules, configurationService: service, keymapPreferences: preferences)
+        try await test(manager, preferences)
+    }
+}

--- a/docs/architecture/configuration-save-pipeline.md
+++ b/docs/architecture/configuration-save-pipeline.md
@@ -70,8 +70,8 @@ parsed cache or read a mutable shared backup at rollback time. Queued cancellati
 is observed at admission without a write or reload; after mutation begins the
 existing completion/recovery path runs to completion.
 
-This gate covers this coordinator only. Collection/pack/CLI writers, source-store
-transactions, external edits, and durable crash recovery still need migration.
+This gate covers this coordinator only. Collection/pack/CLI operation ownership and external edits still need migration.
+The collection file journal below provides a separate durable recovery boundary.
 See [the reproduced rollback race](../bugs/save-coordinator-overlapping-rollback.md).
 
 Explicit-restore failure throws `SaveRecoveryError`, retaining both causes while
@@ -89,8 +89,8 @@ back to the original caller without another reload.
 `regenerateConfigFromCollections()` remains a compatibility adapter returning
 `didPersist`. Do not reinterpret its Boolean as live application: callers perform
 their own partial rollback on false, so changing it on reload rejection before
-migrating multi-store recovery would create inconsistent state. This stage does
-not change notification timing or claim recovery after a partial store write.
+migrating multi-store recovery would create inconsistent state. Notifications follow the file-set commit; recovery from a partial store write is
+provided by the journal below, separately from runtime rejection recovery.
 
 Collection file persistence now uses [recoverable rule writes](recoverable-rule-writes.md).
 It journals the generated file and both source stores, recovers before bootstrap

--- a/docs/bugs/keymap-preferences-survived-failed-save.md
+++ b/docs/bugs/keymap-preferences-survived-failed-save.md
@@ -1,0 +1,27 @@
+# Keymap preferences survived a failed save
+
+A failed `setActiveKeymap` call restored only `activeKeymapId`. It had already
+written the requested ID and punctuation flag to UserDefaults, left the new
+punctuation flag in memory, and rebuilt the old collection using that new flag.
+Rebuilding also discarded custom attributes of the prior keymap collection.
+
+A temporary-directory write failure with isolated UserDefaults reproduced ten
+assertion failures across stored and previously absent preference values. The
+regression checks the ID, punctuation, exact prior collection, and preferences.
+
+Preferences now persist only after config/source-store persistence completes.
+Failure restores the previous punctuation option and the exact previous keymap
+collection at its prior position, preserving unrelated collections. UserDefaults
+is injectable for isolated tests; production still uses the existing standard
+domain and keys. A pending engine reload remains a successful persisted edit.
+
+The overlay also writes its display selection before calling the manager.
+Failure restores that attempted display selection, and reverts a failed
+punctuation toggle without replacing other layouts' remembered settings. The
+comparison with the attempted selection preserves a newer display choice. The
+overlay ignores a callback for the already-active selection so AppStorage's
+rollback notification does not trigger a second save.
+
+This fixes ordinary persistence-failure rollback. It does not make UserDefaults
+and the file journal one crash-atomic transaction or serialize all collection
+mutations; those remain part of the broader application-operation migration.

--- a/docs/planning/catalog-led-consolidation-plan.md
+++ b/docs/planning/catalog-led-consolidation-plan.md
@@ -1,7 +1,7 @@
 # KeyPath: catalog-led consolidation execution plan
 
 Date: 2026-09-04
-Status: approved direction; Phase 0 inventory recorded, Phase 1 internal save/recovery contract in progress.
+Status: approved direction; Phase 0 inventory recorded; Phase 1 persistence/recovery foundation implemented, operation migration still open.
 Baseline: `master` at `a12bb07d5`; recheck code, branches, and issues before implementation.
 
 ## Outcome
@@ -109,11 +109,10 @@ gaps are named. No claim that the entire app is healthy based on test counts.
 
 First implementation milestone; do this before a broad module split.
 
-Current evidence to verify: `RuleCollectionsManager.onRulesChanged` returns Void;
-the callback in `RuntimeCoordinator` discards `applyPersistedRuleChanges()`'s
-result. `SaveCoordinator` separately handles reload dispositions. This is a
-structural inconsistency, not a reproduced end-user failure. The save-pipeline
-document also needs reconciliation with current source ordering.
+Initial evidence: the collection callback discarded reload results while
+`SaveCoordinator` classified them. PR #1264 now retains the original result
+through that boundary. The compatibility Boolean still means persisted, not
+applied; changing it awaits recovery across the entire operation.
 
 Proposed PR sequence:
 
@@ -248,14 +247,55 @@ them. Suggested mappings, not automatic closure instructions:
 - #213, #212, #211: conversion expansion remains deferred; no parity commitment.
 - #204: inventory Insights and decide disposition, not an automatic completion task.
 
-Completed internal slices: #1260 retains reload dispositions; #1262 serializes
-coordinator saves and uses operation-local file snapshots. The next slice exposes
-file recovery outcomes and failure fixtures. These do not yet migrate collection
-source stores into the same transaction.
+## Implementation checkpoint — September 5
 
-Next work packet: carry collection regeneration results through the callback
-boundary, then design multi-store commit/recovery before changing its Boolean
-callers or presenting new status in the UI. Stop for assessment after the first migrated configuration
-journey: verify that ownership and failure behavior improved before extending the
-pattern. Estimate remaining work from that evidence; this plan makes no calendar
-commitment based on source-line counts.
+Implemented slices (the table describes the merged state of this checkpoint):
+
+| PR | Result | Remaining boundary |
+| --- | --- | --- |
+| #1260 | Mutation inventory and retained save reload results; unused alternative writer methods removed. | Other mutation surfaces still need migration. |
+| #1262 | FIFO coordinator saves, operation-local file snapshots, queued cancellation and recursive callback protection. | Admission is coordinator-local, not shared by every collection/pack mutation. |
+| #1263 | Explicit previous-file, minimal-safe-file, and failed recovery outcomes retaining both errors. | File recovery does not assert source-store or engine restoration. |
+| #1264 | Collection persistence and retry callbacks retain applied/pending/rejected/failed outcomes. | Compatibility Boolean continues to mean persisted. |
+| #1265 | Durable journal for config plus both rule stores, startup recovery, external-change checks, and observers after file-set commit. | Preferences, pack metadata, in-memory mutation ordering and runtime rollback remain outside this file transaction. |
+| #1266 | Failed keymap writes restore the prior collection, manager preferences and attempted overlay selection, preserving unrelated layout preferences and newer display choices. | UserDefaults is not crash-atomic with the journal; admission still needs to precede every mutation. |
+
+The first migrated persistence journey now has interruption and failure tests.
+This is a useful foundation, not completion of Phase 1 or the program.
+
+Next implementation sequence:
+
+1. Admit collection, mapper and pack operations before in-memory mutation;
+   preserve explicit ownership through trusted nested calls, and reject recursive
+   callback writes rather than allowing stale rollback or deadlock.
+2. Keep the prior source revision through runtime classification and restore
+   sources/preferences/metadata consistently after rejection or failure.
+3. Replace time-only watcher suppression with recognition of actual internal
+   revisions. Buffer during the write operation and reconcile external changes
+   afterward. Cover atomic replacement, directory creation, overlapping edits,
+   cancellation and stop/restart; do not use a longer blind suppression window.
+4. Migrate remaining CLI/raw/pack paths, then move stable pure generation out of
+   app dependencies. Do not start a broad module move while save ownership is
+   still changing.
+
+UI decisions awaiting Micah's discussion: consistent conflict confirmation with
+an affected-key preview; saved/pending/recovery status wording in the existing
+status area; and explicit pack ownership behavior. No navigation redesign,
+feature removal or public release is authorized by this checkpoint.
+
+Validation limits: supported-runner CI has passed the merged internal slices.
+The local macOS 27 host retains four independently reproduced baseline snapshot
+failures (three HomeRowTiming variants and RepairSettingsTabView). Signed,
+notarized installation has passed. Earlier local checks encountered incomplete
+Kanata setup; subsequent installed-CLI inspection reported `isOperational: true`
+with no issues and a responding runtime. This is readiness evidence, not a
+physical remap test. A managed macOS 15 lab guest installed the signed
+#1265 artifact and opened the first-run screen; helper registration was denied,
+and its newer Peekaboo bridge could read but could not advance setup reliably.
+Artifacts were collected and the lease destroyed. This is not successful
+first-remap, unmanaged-permission or physical-HID verification.
+
+Runner storage: PR #1261 remains separate and unmerged until the actual CI
+process has removable-volume permission and completes validation. Existing CI
+can run above the disk reserve; do not lower that reserve or claim that external
+storage migration is complete.


### PR DESCRIPTION
A failed keymap save previously left the selected keymap and punctuation preference changed even though its configuration could not be persisted. Restore the previous keymap collection and selection on failure, and persist those preferences only after the rule files have been saved. Unrelated collections are preserved during rollback.

The overlay also writes its display selection optimistically. Restore only the failed attempted display selection, revert a failed punctuation toggle without replacing other layouts' preferences, and preserve a newer display choice. Ignore AppStorage's notification for the already-active selection to prevent a second save on rollback. This addresses the review finding about the separate overlay keys.

Adds isolated preference-store regression tests for failed saves and successful saves with a pending runtime reload. This does not change the UI or claim crash-atomic transactions across UserDefaults and rule files.

Validation: focused tests passed (26 tests), stable-toolchain build passed, accessibility and pinned SwiftFormat checks passed. Full local suite before the final punctuation guard follow-up: 5,114 passed; the same four previously reproduced macOS 27 baseline snapshot failures remain (three HomeRowTiming snapshots and RepairSettingsTabView). The final guard follow-up passed the focused suite; full CI validates the final head in the supported runner environment. Remote review gate selected.

Review follow-up: a failed per-layout punctuation edit is reverted even after a different layout has been selected; restoring its punctuation entry is independent of restoring the selected ID. The newer selected ID and unrelated per-layout settings remain intact. Added that regression after review.

Updates the consolidation checkpoint and save-pipeline documentation to record the merged persistence work and its remaining limits; this does not declare the full refactor complete.

Final review observations assessed:
- Concurrent collection reordering remains part of the explicitly documented shared-operation admission work. The rollback preserves unrelated collection contents and restores the prior keymap at its captured index, clamped to the remaining list; it does not claim to serialize every manager mutation.
- A different punctuation value for the same selected ID represents a newer selection tuple. Skipping ID restoration in that case is intentional: restoring the old ID would overwrite that newer choice. A failed punctuation entry is independently corrected after switching to another ID when its attempted value is still present.
- The overlay guard handles rollback feedback, not general operation serialization. Both methods run on MainActor, and setActiveKeymap updates its ID/punctuation before its first suspension; there is no intervening await between the guard and that same-actor call. The broader overlapping-mutation limitation is recorded rather than claimed fixed here.
