### PR TITLE
Share save admission with collection mutations

### DIFF
--- a/Sources/KeyPathAppKit/Infrastructure/Config/ConfigurationOperationGate.swift
+++ b/Sources/KeyPathAppKit/Infrastructure/Config/ConfigurationOperationGate.swift
@@ -1,0 +1,73 @@
+import Foundation
+
+/// Shared admission for app operations using one ConfigurationService. Owns no
+/// persistence or UI state; a permit explicitly identifies trusted nested work.
+actor ConfigurationOperationGate {
+    struct Permit: Sendable {
+        fileprivate let owner: UUID
+        fileprivate let operation: UUID
+    }
+
+    enum Failure: LocalizedError {
+        case recursiveOperation
+        case invalidPermit
+
+        var errorDescription: String? {
+            switch self {
+            case .recursiveOperation:
+                "An operation callback cannot recursively save or restore through the same configuration service."
+            case .invalidPermit:
+                "The configuration operation permit is no longer active."
+            }
+        }
+    }
+
+    @TaskLocal private static var activeOperations: Set<UUID> = []
+    private let owner = UUID()
+    private var active: Permit?
+    private var waiters: [CheckedContinuation<Permit, Never>] = []
+
+    func withOperation<Result: Sendable>(
+        using permit: Permit? = nil,
+        _ operation: @Sendable (Permit) async throws -> Result
+    ) async throws -> Result {
+        if let permit {
+            guard permit.owner == owner, permit.operation == active?.operation else {
+                throw Failure.invalidPermit
+            }
+            return try await operation(permit)
+        }
+        try Task.checkCancellation()
+        if let active, Self.activeOperations.contains(active.operation) {
+            throw Failure.recursiveOperation
+        }
+        let admitted = await acquire()
+        defer { release() }
+        // Cancelled waiters retain their FIFO place, then leave without mutation.
+        try Task.checkCancellation()
+        var context = Self.activeOperations
+        context.insert(admitted.operation)
+        return try await Self.$activeOperations.withValue(context) {
+            try await operation(admitted)
+        }
+    }
+
+    private func acquire() async -> Permit {
+        if active != nil {
+            return await withCheckedContinuation { waiters.append($0) }
+        }
+        let permit = Permit(owner: owner, operation: UUID())
+        active = permit
+        return permit
+    }
+
+    private func release() {
+        guard !waiters.isEmpty else {
+            active = nil
+            return
+        }
+        let next = Permit(owner: owner, operation: UUID())
+        active = next
+        waiters.removeFirst().resume(returning: next)
+    }
+}

--- a/Sources/KeyPathAppKit/Infrastructure/Config/ConfigurationService.swift
+++ b/Sources/KeyPathAppKit/Infrastructure/Config/ConfigurationService.swift
@@ -33,6 +33,8 @@ public final class ConfigurationService: FileConfigurationProviding {
     private let ruleCollectionStore: RuleCollectionStore
     private let customRulesStore: CustomRulesStore
 
+    let operationGate = ConfigurationOperationGate()
+
     /// Perform blocking file I/O off the main actor
     private let ioQueue = DispatchQueue(label: "com.keypath.configservice.io", qos: .utility)
     /// Protect shared state when accessed from multiple threads

--- a/Sources/KeyPathAppKit/Managers/SaveCoordinator.swift
+++ b/Sources/KeyPathAppKit/Managers/SaveCoordinator.swift
@@ -2,13 +2,6 @@ import Foundation
 import KeyPathCore
 import KeyPathRulesCore
 
-/// Task-local scope is intentionally shared: nested callbacks can cross coordinator
-/// instances. Unique rotating operation tokens distinguish their ownership, while
-/// carrying the full set lets an A -> B -> A callback cycle fail instead of hang.
-private enum SaveOperationContext {
-    @TaskLocal static var activeOperations: Set<UUID> = []
-}
-
 /// Callback interface for save status updates
 @MainActor
 protocol SaveCoordinatorDelegate: AnyObject {
@@ -91,12 +84,6 @@ final class SaveCoordinator {
     /// In-memory backup of last known good config
     private var lastGoodConfig: String?
 
-    // MainActor methods can interleave at every await. Keep the entire save,
-    // including reload and recovery, exclusive within this coordinator.
-    private var operationInProgress = false
-    private var operationID = UUID()
-    private var operationWaiters: [CheckedContinuation<Void, Never>] = []
-
     // MARK: - Initialization
 
     init(
@@ -134,83 +121,82 @@ final class SaveCoordinator {
         reloadHandler: @escaping () async -> ReloadResult
     ) async -> SaveResult {
         do {
-            try await beginOperation()
-        } catch {
-            return .failure(error)
-        }
-        defer { endOperation() }
+            return try await configurationService.operationGate.withOperation { @MainActor [self] permit in
+                // Suppress file watcher to prevent double reload
+                configFileWatcher?.suppressEvents(for: 1.0, reason: "Internal saveConfiguration")
+                saveStatus = .saving
 
-        // Suppress file watcher to prevent double reload
-        configFileWatcher?.suppressEvents(for: 1.0, reason: "Internal saveConfiguration")
-        saveStatus = .saving
+                do {
+                    // Step 1: Validate input/output
+                    let (sanitizedInput, sanitizedOutput) = try validateInputOutput(
+                        input: input, output: output
+                    )
 
-        do {
-            // Step 1: Validate input/output
-            let (sanitizedInput, sanitizedOutput) = try validateInputOutput(
-                input: input, output: output
-            )
+                    // Step 2: Backup current config
+                    let previousContent = try await snapshotCurrentConfig()
+                    try Task.checkCancellation()
+                    backupCurrentConfig(previousContent)
 
-            // Step 2: Backup current config
-            let previousContent = try await snapshotCurrentConfig()
-            try Task.checkCancellation()
-            backupCurrentConfig(previousContent)
+                    // Step 3: Create and save custom rule
+                    let rule = ruleCollectionsManager.makeCustomRule(
+                        input: sanitizedInput, output: sanitizedOutput
+                    )
+                    let didSave = await ruleCollectionsManager.saveCustomRule(rule, skipReload: true, mutationPermit: permit)
 
-            // Step 3: Create and save custom rule
-            let rule = ruleCollectionsManager.makeCustomRule(
-                input: sanitizedInput, output: sanitizedOutput
-            )
-            let didSave = await ruleCollectionsManager.saveCustomRule(rule, skipReload: true)
+                    guard didSave else {
+                        let message = "Failed to save custom rule (possible conflict)"
+                        saveStatus = .failed(message)
+                        return .failure(KeyPathError.configuration(.validationFailed(errors: [message])))
+                    }
 
-            guard didSave else {
-                let message = "Failed to save custom rule (possible conflict)"
-                saveStatus = .failed(message)
-                return .failure(KeyPathError.configuration(.validationFailed(errors: [message])))
-            }
+                    // Step 4: Play write sound
+                    playWriteSound()
 
-            // Step 4: Play write sound
-            playWriteSound()
+                    // Step 5: Trigger reload for validation
+                    AppLogger.shared.debug("📡 [SaveCoordinator] Triggering TCP reload for validation")
+                    let reloadResult = await reloadHandler()
 
-            // Step 5: Trigger reload for validation
-            AppLogger.shared.debug("📡 [SaveCoordinator] Triggering TCP reload for validation")
-            let reloadResult = await reloadWithinOperation(reloadHandler)
+                    if reloadResult.disposition == .applied || reloadResult.disposition == .pending {
+                        // Success!
+                        if reloadResult.disposition == .applied {
+                            AppLogger.shared.info("✅ [SaveCoordinator] Reload successful, config is valid")
+                        } else {
+                            AppLogger.shared.info("ℹ️ [SaveCoordinator] Config saved; reload pending: \(reloadResult.errorMessage ?? "service unavailable")")
+                        }
+                        playSuccessSound()
+                        saveStatus = .success
+                        scheduleStatusReset()
 
-            if reloadResult.disposition == .applied || reloadResult.disposition == .pending {
-                // Success!
-                if reloadResult.disposition == .applied {
-                    AppLogger.shared.info("✅ [SaveCoordinator] Reload successful, config is valid")
-                } else {
-                    AppLogger.shared.info("ℹ️ [SaveCoordinator] Config saved; reload pending: \(reloadResult.errorMessage ?? "service unavailable")")
-                }
-                playSuccessSound()
-                saveStatus = .success
-                scheduleStatusReset()
+                        let mappings = ruleCollectionsManager.enabledMappings()
+                        return .success(mappings: mappings, reloadResult: reloadResult)
+                    } else {
+                        // Reload failed - restore backup
+                        let errorMessage = reloadResult.errorMessage ?? "TCP server unresponsive"
+                        AppLogger.shared.error("❌ [SaveCoordinator] TCP reload FAILED: \(errorMessage)")
+                        AppLogger.shared.error("❌ [SaveCoordinator] Restoring backup")
 
-                let mappings = ruleCollectionsManager.enabledMappings()
-                return .success(mappings: mappings, reloadResult: reloadResult)
-            } else {
-                // Reload failed - restore backup
-                let errorMessage = reloadResult.errorMessage ?? "TCP server unresponsive"
-                AppLogger.shared.error("❌ [SaveCoordinator] TCP reload FAILED: \(errorMessage)")
-                AppLogger.shared.error("❌ [SaveCoordinator] Restoring backup")
+                        playErrorSound()
+                        let recoveryResult = await restoreConfig(previousContent)
 
-                playErrorSound()
-                let recoveryResult = await restoreConfig(previousContent)
-
-                saveStatus = .failed("TCP server reload failed: \(errorMessage)")
-                return .failure(
-                    KeyPathError.configuration(
-                        .loadFailed(
-                            reason:
-                            "TCP server required for validation-on-demand failed: \(errorMessage)"
+                        saveStatus = .failed("TCP server reload failed: \(errorMessage)")
+                        return .failure(
+                            KeyPathError.configuration(
+                                .loadFailed(
+                                    reason:
+                                    "TCP server required for validation-on-demand failed: \(errorMessage)"
+                                )
+                            ),
+                            reloadResult: reloadResult,
+                            recoveryResult: recoveryResult
                         )
-                    ),
-                    reloadResult: reloadResult,
-                    recoveryResult: recoveryResult
-                )
-            }
+                    }
 
+                } catch {
+                    saveStatus = .failed(error.localizedDescription)
+                    return .failure(error)
+                }
+            }
         } catch {
-            saveStatus = .failed(error.localizedDescription)
             return .failure(error)
         }
     }
@@ -226,103 +212,102 @@ final class SaveCoordinator {
         reloadHandler: @escaping () async -> ReloadResult
     ) async -> SaveResult {
         do {
-            try await beginOperation()
-        } catch {
-            return .failure(error)
-        }
-        defer { endOperation() }
+            return try await configurationService.operationGate.withOperation { @MainActor [self] _ in
+                // Suppress file watcher to prevent double reload
+                configFileWatcher?.suppressEvents(for: 1.0, reason: "Internal saveGeneratedConfiguration")
+                saveStatus = .saving
 
-        // Suppress file watcher to prevent double reload
-        configFileWatcher?.suppressEvents(for: 1.0, reason: "Internal saveGeneratedConfiguration")
-        saveStatus = .saving
-
-        do {
-            // Step 1: Validate generated config before saving
-            AppLogger.shared.debug(
-                "🔍 [SaveCoordinator] Validating generated config before save..."
-            )
-            let validation = await configurationService.validateConfiguration(content)
-
-            if !validation.isValid {
-                AppLogger.shared.error(
-                    "❌ [SaveCoordinator] Generated config validation failed: \(validation.errors.joined(separator: ", "))"
-                )
-                saveStatus = .failed(
-                    "Invalid config: \(validation.errors.first ?? "Unknown error")"
-                )
-                return .failure(
-                    KeyPathError.configuration(.validationFailed(errors: validation.errors))
-                )
-            }
-
-            AppLogger.shared.info("✅ [SaveCoordinator] Generated config validation passed")
-
-            // Step 2: Backup current config
-            let previousContent = try await snapshotCurrentConfig()
-            try Task.checkCancellation()
-            backupCurrentConfig(previousContent)
-
-            // Step 3: Write the configuration file
-            let configPath = configurationService.configurationPath
-            let configDir = configurationService.configDirectory
-
-            let configDirURL = URL(fileURLWithPath: configDir)
-            try Foundation.FileManager().createDirectory(
-                at: configDirURL, withIntermediateDirectories: true
-            )
-
-            let configURL = URL(fileURLWithPath: configPath)
-            try content.write(to: configURL, atomically: true, encoding: .utf8)
-
-            AppLogger.shared.info(
-                "✅ [SaveCoordinator] Generated configuration saved to \(configPath)"
-            )
-
-            // Step 4: Parse saved config to extract mappings
-            let parsedMappings = parseConfig(content)
-
-            // Step 5: Play write sound
-            playWriteSound()
-
-            // Step 6: Trigger reload for validation
-            let reloadResult = await reloadWithinOperation(reloadHandler)
-
-            if reloadResult.disposition == .applied || reloadResult.disposition == .pending {
-                if reloadResult.disposition == .applied {
-                    AppLogger.shared.info(
-                        "✅ [SaveCoordinator] TCP reload successful, config is active"
+                do {
+                    // Step 1: Validate generated config before saving
+                    AppLogger.shared.debug(
+                        "🔍 [SaveCoordinator] Validating generated config before save..."
                     )
-                } else {
-                    AppLogger.shared.info(
-                        "ℹ️ [SaveCoordinator] Config saved; reload pending: \(reloadResult.errorMessage ?? "service unavailable")"
+                    let validation = await configurationService.validateConfiguration(content)
+
+                    if !validation.isValid {
+                        AppLogger.shared.error(
+                            "❌ [SaveCoordinator] Generated config validation failed: \(validation.errors.joined(separator: ", "))"
+                        )
+                        saveStatus = .failed(
+                            "Invalid config: \(validation.errors.first ?? "Unknown error")"
+                        )
+                        return .failure(
+                            KeyPathError.configuration(.validationFailed(errors: validation.errors))
+                        )
+                    }
+
+                    AppLogger.shared.info("✅ [SaveCoordinator] Generated config validation passed")
+
+                    // Step 2: Backup current config
+                    let previousContent = try await snapshotCurrentConfig()
+                    try Task.checkCancellation()
+                    backupCurrentConfig(previousContent)
+
+                    // Step 3: Write the configuration file
+                    let configPath = configurationService.configurationPath
+                    let configDir = configurationService.configDirectory
+
+                    let configDirURL = URL(fileURLWithPath: configDir)
+                    try Foundation.FileManager().createDirectory(
+                        at: configDirURL, withIntermediateDirectories: true
                     )
+
+                    let configURL = URL(fileURLWithPath: configPath)
+                    try content.write(to: configURL, atomically: true, encoding: .utf8)
+
+                    AppLogger.shared.info(
+                        "✅ [SaveCoordinator] Generated configuration saved to \(configPath)"
+                    )
+
+                    // Step 4: Parse saved config to extract mappings
+                    let parsedMappings = parseConfig(content)
+
+                    // Step 5: Play write sound
+                    playWriteSound()
+
+                    // Step 6: Trigger reload for validation
+                    let reloadResult = await reloadHandler()
+
+                    if reloadResult.disposition == .applied || reloadResult.disposition == .pending {
+                        if reloadResult.disposition == .applied {
+                            AppLogger.shared.info(
+                                "✅ [SaveCoordinator] TCP reload successful, config is active"
+                            )
+                        } else {
+                            AppLogger.shared.info(
+                                "ℹ️ [SaveCoordinator] Config saved; reload pending: \(reloadResult.errorMessage ?? "service unavailable")"
+                            )
+                        }
+                        playSuccessSound()
+                        saveStatus = .success
+                        scheduleStatusReset()
+                        return .success(mappings: parsedMappings, reloadResult: reloadResult)
+                    } else {
+                        // TCP reload failed - restore backup
+                        let errorMessage = reloadResult.errorMessage ?? "TCP server unresponsive"
+                        AppLogger.shared.error("❌ [SaveCoordinator] TCP reload FAILED: \(errorMessage)")
+
+                        playErrorSound()
+                        let recoveryResult = await restoreConfig(previousContent)
+
+                        saveStatus = .failed("Config reload failed: \(errorMessage)")
+                        return .failure(
+                            KeyPathError.configuration(
+                                .loadFailed(reason: "Hot reload failed: \(errorMessage)")
+                            ),
+                            reloadResult: reloadResult,
+                            recoveryResult: recoveryResult
+                        )
+                    }
+
+                } catch {
+                    saveStatus = .failed(
+                        "Failed to save generated configuration: \(error.localizedDescription)"
+                    )
+                    return .failure(error)
                 }
-                playSuccessSound()
-                saveStatus = .success
-                scheduleStatusReset()
-                return .success(mappings: parsedMappings, reloadResult: reloadResult)
-            } else {
-                // TCP reload failed - restore backup
-                let errorMessage = reloadResult.errorMessage ?? "TCP server unresponsive"
-                AppLogger.shared.error("❌ [SaveCoordinator] TCP reload FAILED: \(errorMessage)")
-
-                playErrorSound()
-                let recoveryResult = await restoreConfig(previousContent)
-
-                saveStatus = .failed("Config reload failed: \(errorMessage)")
-                return .failure(
-                    KeyPathError.configuration(
-                        .loadFailed(reason: "Hot reload failed: \(errorMessage)")
-                    ),
-                    reloadResult: reloadResult,
-                    recoveryResult: recoveryResult
-                )
             }
-
         } catch {
-            saveStatus = .failed(
-                "Failed to save generated configuration: \(error.localizedDescription)"
-            )
             return .failure(error)
         }
     }
@@ -347,14 +332,14 @@ final class SaveCoordinator {
 
     @discardableResult
     func restoreLastGoodConfig() async throws -> SaveRecoveryResult {
-        try await beginOperation()
-        defer { endOperation() }
-        let result = await restoreConfig(lastGoodConfig)
-        // Preserve the throwing contract for existing explicit-restore callers.
-        if case let .failed(backupError, fallbackError) = result {
-            throw SaveRecoveryError(backupError: backupError, fallbackError: fallbackError)
+        try await configurationService.operationGate.withOperation { @MainActor [self] _ in
+            let result = await restoreConfig(lastGoodConfig)
+            // Preserve the throwing contract for existing explicit-restore callers.
+            if case let .failed(backupError, fallbackError) = result {
+                throw SaveRecoveryError(backupError: backupError, fallbackError: fallbackError)
+            }
+            return result
         }
-        return result
     }
 
     private func restoreConfig(_ content: String?) async -> SaveRecoveryResult {
@@ -457,50 +442,6 @@ final class SaveCoordinator {
     }
 
     // MARK: - Private Helpers
-
-    /// Cancellation before admission never writes or changes the active status.
-    /// A queued cancellation is observed when its FIFO turn arrives. Once a write
-    /// starts, finish reload/recovery rather than abandoning a half-applied edit.
-    private func beginOperation() async throws {
-        try Task.checkCancellation()
-        if operationInProgress, SaveOperationContext.activeOperations.contains(operationID) {
-            throw KeyPathError.configuration(.loadFailed(
-                reason: "A reload callback cannot recursively save or restore through the same coordinator."
-            ))
-        }
-        if operationInProgress {
-            await withCheckedContinuation { operationWaiters.append($0) }
-        } else {
-            operationInProgress = true
-        }
-        do {
-            try Task.checkCancellation()
-        } catch {
-            endOperation()
-            throw error
-        }
-    }
-
-    private func endOperation() {
-        // Inherited task-local context from a finished reload must not reject
-        // a later independent operation (including child tasks that outlive it).
-        operationID = UUID()
-        if operationWaiters.isEmpty {
-            operationInProgress = false
-        } else {
-            // Transfer ownership directly; do not leave a gap for a new caller
-            // to overtake an already queued save.
-            operationWaiters.removeFirst().resume()
-        }
-    }
-
-    private func reloadWithinOperation(_ reloadHandler: () async -> ReloadResult) async -> ReloadResult {
-        var activeOperations = SaveOperationContext.activeOperations
-        activeOperations.insert(operationID)
-        return await SaveOperationContext.$activeOperations.withValue(activeOperations) {
-            await reloadHandler()
-        }
-    }
 
     private func snapshotCurrentConfig() async throws -> String {
         let path = configurationService.configurationPath

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+Keymap.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+Keymap.swift
@@ -17,64 +17,66 @@ extension RuleCollectionsManager {
     /// - Returns: Array of conflicting custom rules, if any
     @discardableResult
     func setActiveKeymap(_ keymapId: String, includePunctuation: Bool) async -> [RuleConflictInfo] {
-        AppLogger.shared.log("⌨️ [RuleCollections] Setting active keymap to '\(keymapId)' (punctuation: \(includePunctuation))")
+        await withRuleMutation(failure: []) { [self] _ in
+            AppLogger.shared.log("⌨️ [RuleCollections] Setting active keymap to '\(keymapId)' (punctuation: \(includePunctuation))")
 
-        let previousKeymapId = activeKeymapId
-        let previousPunctuation = keymapIncludesPunctuation
-        let previousKeymapIndex = ruleCollections.firstIndex { $0.id == RuleCollectionIdentifier.keymapLayout }
-        let previousKeymapCollection = previousKeymapIndex.map { ruleCollections[$0] }
-        activeKeymapId = keymapId
-        keymapIncludesPunctuation = includePunctuation
+            let previousKeymapId = activeKeymapId
+            let previousPunctuation = keymapIncludesPunctuation
+            let previousKeymapIndex = ruleCollections.firstIndex { $0.id == RuleCollectionIdentifier.keymapLayout }
+            let previousKeymapCollection = previousKeymapIndex.map { ruleCollections[$0] }
+            activeKeymapId = keymapId
+            keymapIncludesPunctuation = includePunctuation
 
-        // Check for conflicts with custom rules
-        let conflicts = detectKeymapConflicts(keymapId: keymapId, includePunctuation: includePunctuation)
+            // Check for conflicts with custom rules
+            let conflicts = detectKeymapConflicts(keymapId: keymapId, includePunctuation: includePunctuation)
 
-        if !conflicts.isEmpty {
-            let conflictKeys = conflicts.flatMap(\.keys).joined(separator: ", ")
-            onWarning?(
-                "⚠️ Layout change affects custom rules on: \(conflictKeys). Custom rules will override layout mappings for those keys."
-            )
-            AppLogger.shared.log("⚠️ [RuleCollections] Keymap conflicts with custom rules on: \(conflictKeys)")
-        }
-
-        // Remove any existing keymap collection
-        ruleCollections.removeAll { $0.id == RuleCollectionIdentifier.keymapLayout }
-
-        // Add new keymap collection if not QWERTY
-        if let keymapCollection = KeymapMappingGenerator.generateCollection(
-            for: keymapId,
-            includePunctuation: includePunctuation
-        ) {
-            // Insert at the beginning so custom rules take priority
-            ruleCollections.insert(keymapCollection, at: 0)
-            AppLogger.shared.log("⌨️ [RuleCollections] Added keymap collection with \(keymapCollection.mappings.count) mappings")
-        } else if keymapId == LogicalKeymap.defaultId {
-            AppLogger.shared.log("⌨️ [RuleCollections] QWERTY selected - no keymap collection needed")
-        }
-
-        // Persist preferences only after the config/source-store write succeeds.
-        let success = await regenerateConfigFromCollections()
-        if success {
-            await persistKeymapState()
-        } else {
-            AppLogger.shared.log("⌨️ [RuleCollections] Keymap change failed - rolling back")
-            activeKeymapId = previousKeymapId
-            keymapIncludesPunctuation = previousPunctuation
-            // The overlay optimistically updates its shared display preferences
-            // before invoking this operation. Revert only this attempted selection;
-            // a newer UI choice must survive an older failed completion.
-            KeymapPreferences.restoreFailedSelection(
-                attemptedID: keymapId, attemptedPunctuation: includePunctuation,
-                previousID: previousKeymapId, previousPunctuation: previousPunctuation,
-                userDefaults: keymapPreferences
-            )
-            ruleCollections.removeAll { $0.id == RuleCollectionIdentifier.keymapLayout }
-            if let previousKeymapCollection, let previousKeymapIndex {
-                ruleCollections.insert(previousKeymapCollection, at: min(previousKeymapIndex, ruleCollections.count))
+            if !conflicts.isEmpty {
+                let conflictKeys = conflicts.flatMap(\.keys).joined(separator: ", ")
+                onWarning?(
+                    "⚠️ Layout change affects custom rules on: \(conflictKeys). Custom rules will override layout mappings for those keys."
+                )
+                AppLogger.shared.log("⚠️ [RuleCollections] Keymap conflicts with custom rules on: \(conflictKeys)")
             }
-        }
 
-        return conflicts
+            // Remove any existing keymap collection
+            ruleCollections.removeAll { $0.id == RuleCollectionIdentifier.keymapLayout }
+
+            // Add new keymap collection if not QWERTY
+            if let keymapCollection = KeymapMappingGenerator.generateCollection(
+                for: keymapId,
+                includePunctuation: includePunctuation
+            ) {
+                // Insert at the beginning so custom rules take priority
+                ruleCollections.insert(keymapCollection, at: 0)
+                AppLogger.shared.log("⌨️ [RuleCollections] Added keymap collection with \(keymapCollection.mappings.count) mappings")
+            } else if keymapId == LogicalKeymap.defaultId {
+                AppLogger.shared.log("⌨️ [RuleCollections] QWERTY selected - no keymap collection needed")
+            }
+
+            // Persist preferences only after the config/source-store write succeeds.
+            let success = await regenerateConfigFromCollections()
+            if success {
+                await persistKeymapState()
+            } else {
+                AppLogger.shared.log("⌨️ [RuleCollections] Keymap change failed - rolling back")
+                activeKeymapId = previousKeymapId
+                keymapIncludesPunctuation = previousPunctuation
+                // The overlay optimistically updates its shared display preferences
+                // before invoking this operation. Revert only this attempted selection;
+                // a newer UI choice must survive an older failed completion.
+                KeymapPreferences.restoreFailedSelection(
+                    attemptedID: keymapId, attemptedPunctuation: includePunctuation,
+                    previousID: previousKeymapId, previousPunctuation: previousPunctuation,
+                    userDefaults: keymapPreferences
+                )
+                ruleCollections.removeAll { $0.id == RuleCollectionIdentifier.keymapLayout }
+                if let previousKeymapCollection, let previousKeymapIndex {
+                    ruleCollections.insert(previousKeymapCollection, at: min(previousKeymapIndex, ruleCollections.count))
+                }
+            }
+
+            return conflicts
+        }
     }
 
     /// Detect conflicts between the keymap layout and existing custom rules.

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+Mutation.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+Mutation.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+extension RuleCollectionsManager {
+    /// Admission precedes snapshots and mutation. Nested internal calls carry an
+    /// explicit permit; callbacks without one fail rather than deadlock/reenter.
+    func withRuleMutation<Result: Sendable>(
+        using permit: ConfigurationOperationGate.Permit? = nil,
+        failure: Result,
+        _ operation: @escaping @MainActor @Sendable (ConfigurationOperationGate.Permit) async -> Result
+    ) async -> Result {
+        do {
+            return try await configurationService.operationGate.withOperation(using: permit) { @MainActor admitted in
+                await operation(admitted)
+            }
+        } catch is CancellationError {
+            return failure
+        } catch {
+            onError?(error.localizedDescription)
+            return failure
+        }
+    }
+}

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+PublicAPI.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+PublicAPI.swift
@@ -13,17 +13,19 @@ extension RuleCollectionsManager {
 
     /// Replace all rule collections
     func replaceCollections(_ collections: [RuleCollection]) async {
-        ruleCollections = RuleCollectionDeduplicator.dedupe(collections)
-        dedupeRuleCollectionsInPlace()
-        refreshLayerIndicatorState()
+        await withRuleMutation(failure: ()) { [self] _ in
+            ruleCollections = RuleCollectionDeduplicator.dedupe(collections)
+            dedupeRuleCollectionsInPlace()
+            refreshLayerIndicatorState()
 
-        let leaderSnapshot = PreferencesService.shared.leaderKeyPreference
-        let collectionsSnapshot = ruleCollections
-        let didReconcileLeader = reconcileLeaderKeyFromCollection()
+            let leaderSnapshot = PreferencesService.shared.leaderKeyPreference
+            let collectionsSnapshot = ruleCollections
+            let didReconcileLeader = reconcileLeaderKeyFromCollection()
 
-        let applied = await regenerateConfigFromCollections()
-        if didReconcileLeader, !applied {
-            rollbackLeaderReconcile(preference: leaderSnapshot, collections: collectionsSnapshot)
+            let applied = await regenerateConfigFromCollections()
+            if didReconcileLeader, !applied {
+                rollbackLeaderReconcile(preference: leaderSnapshot, collections: collectionsSnapshot)
+            }
         }
     }
 
@@ -50,573 +52,607 @@ extension RuleCollectionsManager {
         additionalCollectionIDsToDisable: Set<UUID> = [],
         skipReload: Bool = false
     ) async -> Bool {
-        AppLogger.shared.log("🔀 [RuleCollections] toggleCollection called: id=\(id), isEnabled=\(isEnabled)")
+        await withRuleMutation(failure: false) { [self] _ in
+            AppLogger.shared.log("🔀 [RuleCollections] toggleCollection called: id=\(id), isEnabled=\(isEnabled)")
 
-        if !bypassOwnershipCheck {
-            if let owner = await InstalledPackTracker.shared.packManagingCollection(id) {
-                AppLogger.shared.log(
-                    "🔒 [RuleCollections] Toggle blocked: collection \(id) is managed by pack '\(owner.packName)'"
-                )
-                return false
-            }
-        }
-
-        let snapshot = snapshotRuleState()
-        let leaderPreferenceSnapshot = PreferencesService.shared.leaderKeyPreference
-
-        let catalogMatch = RuleCollectionCatalog().defaultCollections().first { $0.id == id }
-        AppLogger.shared.log("🔀 [RuleCollections] catalogMatch=\(catalogMatch?.name ?? "nil")")
-        guard var candidate = ruleCollections.first(where: { $0.id == id }) ?? catalogMatch else {
-            return false
-        }
-        candidate.isEnabled = isEnabled
-        if let configurationOverride {
-            candidate.configuration = configurationOverride
-        }
-
-        if !isEnabled {
-            guard await confirmedDisableOfProvider(
-                id: candidate.id,
-                name: candidate.name
-            ) else {
-                return false
-            }
-        }
-
-        // Ensure home row mods config exists if this is a home row mods collection.
-        if candidate.displayStyle == .homeRowMods,
-           case .homeRowMods = candidate.configuration
-        {
-            // Already configured.
-        } else if candidate.displayStyle == .homeRowMods {
-            candidate.configuration = .homeRowMods(HomeRowModsConfig())
-        }
-
-        var prerequisiteProviderIDs: [UUID] = []
-        if isEnabled {
-            guard let confirmedProviderIDs = await confirmedPrerequisiteProviderIDs(
-                for: candidate,
-                operation: .enable,
-                disablingCollectionIDs: additionalCollectionIDsToDisable
-            ) else {
-                return false
-            }
-            prerequisiteProviderIDs = confirmedProviderIDs
-
-            if let conflict = conflictInfo(
-                for: candidate,
-                ignoringCollectionIDs: additionalCollectionIDsToDisable
-            ) {
-                if autoResolveConflicts {
+            if !bypassOwnershipCheck {
+                if let owner = await InstalledPackTracker.shared.packManagingCollection(id) {
                     AppLogger.shared.log(
-                        "🔄 [RuleCollections] Auto-resolving conflict: \(candidate.name) wins over \(conflict.displayName) on \(conflict.keys)"
+                        "🔒 [RuleCollections] Toggle blocked: collection \(id) is managed by pack '\(owner.packName)'"
                     )
-                    await disableConflicting(conflict.source, regenerate: false)
-                } else {
-                    let context = RuleConflictContext(
-                        newRule: .collection(candidate),
-                        existingRule: conflict.source,
-                        conflictingKeys: conflict.keys
-                    )
+                    return false
+                }
+            }
 
-                    AppLogger.shared.log(
-                        "⚠️ [RuleCollections] Conflict enabling \(candidate.name) vs \(conflict.displayName) on \(conflict.keys)"
-                    )
+            let snapshot = snapshotRuleState()
+            let leaderPreferenceSnapshot = PreferencesService.shared.leaderKeyPreference
 
-                    guard let choice = await onConflictResolution?(context) else {
-                        return false
-                    }
+            let catalogMatch = RuleCollectionCatalog().defaultCollections().first { $0.id == id }
+            AppLogger.shared.log("🔀 [RuleCollections] catalogMatch=\(catalogMatch?.name ?? "nil")")
+            guard var candidate = ruleCollections.first(where: { $0.id == id }) ?? catalogMatch else {
+                return false
+            }
+            candidate.isEnabled = isEnabled
+            if let configurationOverride {
+                candidate.configuration = configurationOverride
+            }
 
-                    switch choice {
-                    case .keepNew:
+            if !isEnabled {
+                guard await confirmedDisableOfProvider(
+                    id: candidate.id,
+                    name: candidate.name
+                ) else {
+                    return false
+                }
+            }
+
+            // Ensure home row mods config exists if this is a home row mods collection.
+            if candidate.displayStyle == .homeRowMods,
+               case .homeRowMods = candidate.configuration
+            {
+                // Already configured.
+            } else if candidate.displayStyle == .homeRowMods {
+                candidate.configuration = .homeRowMods(HomeRowModsConfig())
+            }
+
+            var prerequisiteProviderIDs: [UUID] = []
+            if isEnabled {
+                guard let confirmedProviderIDs = await confirmedPrerequisiteProviderIDs(
+                    for: candidate,
+                    operation: .enable,
+                    disablingCollectionIDs: additionalCollectionIDsToDisable
+                ) else {
+                    return false
+                }
+                prerequisiteProviderIDs = confirmedProviderIDs
+
+                if let conflict = conflictInfo(
+                    for: candidate,
+                    ignoringCollectionIDs: additionalCollectionIDsToDisable
+                ) {
+                    if autoResolveConflicts {
+                        AppLogger.shared.log(
+                            "🔄 [RuleCollections] Auto-resolving conflict: \(candidate.name) wins over \(conflict.displayName) on \(conflict.keys)"
+                        )
                         await disableConflicting(conflict.source, regenerate: false)
-                    case .keepExisting:
-                        return false
+                    } else {
+                        let context = RuleConflictContext(
+                            newRule: .collection(candidate),
+                            existingRule: conflict.source,
+                            conflictingKeys: conflict.keys
+                        )
+
+                        AppLogger.shared.log(
+                            "⚠️ [RuleCollections] Conflict enabling \(candidate.name) vs \(conflict.displayName) on \(conflict.keys)"
+                        )
+
+                        guard let choice = await onConflictResolution?(context) else {
+                            return false
+                        }
+
+                        switch choice {
+                        case .keepNew:
+                            await disableConflicting(conflict.source, regenerate: false)
+                        case .keepExisting:
+                            return false
+                        }
                     }
                 }
             }
-        }
 
-        for index in ruleCollections.indices where
-            additionalCollectionIDsToDisable.contains(ruleCollections[index].id)
-            && ruleCollections[index].id != candidate.id
-        {
-            ruleCollections[index].isEnabled = false
-        }
-
-        applyPrerequisiteChangeInMemory(
-            candidate: candidate,
-            providerIDs: prerequisiteProviderIDs
-        )
-
-        AppLogger.shared.log("🔀 [RuleCollections] After toggle - collections: \(ruleCollections.map { "\($0.name) (enabled: \($0.isEnabled))" }.joined(separator: ", "))")
-
-        // Special handling: If Leader Key collection is toggled off, reset all momentary activators to default (space)
-        if id == RuleCollectionIdentifier.leaderKey {
-            if isEnabled {
-                let key = leaderKeyOutput(from: candidate) ?? leaderPreferenceSnapshot.key
-                syncLeaderKeyPreference(key: key, enabled: true)
-            } else {
-                syncLeaderKeyPreference(enabled: false)
-                applyLeaderKeyToMomentaryActivators("space")
+            for index in ruleCollections.indices where
+                additionalCollectionIDsToDisable.contains(ruleCollections[index].id)
+                && ruleCollections[index].id != candidate.id
+            {
+                ruleCollections[index].isEnabled = false
             }
-        }
 
-        AppLogger.shared.log("🔀 [RuleCollections] Calling regenerateConfigFromCollections...")
-        let applied = await regenerateConfigFromCollections(skipReload: skipReload)
-        guard applied else {
+            applyPrerequisiteChangeInMemory(
+                candidate: candidate,
+                providerIDs: prerequisiteProviderIDs
+            )
+
+            AppLogger.shared.log("🔀 [RuleCollections] After toggle - collections: \(ruleCollections.map { "\($0.name) (enabled: \($0.isEnabled))" }.joined(separator: ", "))")
+
+            // Special handling: If Leader Key collection is toggled off, reset all momentary activators to default (space)
             if id == RuleCollectionIdentifier.leaderKey {
-                PreferencesService.shared.leaderKeyPreference = leaderPreferenceSnapshot
+                if isEnabled {
+                    let key = leaderKeyOutput(from: candidate) ?? leaderPreferenceSnapshot.key
+                    syncLeaderKeyPreference(key: key, enabled: true)
+                } else {
+                    syncLeaderKeyPreference(enabled: false)
+                    applyLeaderKeyToMomentaryActivators("space")
+                }
             }
-            AppLogger.shared.log("↩️ [RuleCollections] Toggle apply failed; rolling back to previous state")
-            await rollbackToSnapshot(snapshot, userMessage: "Could not apply this rule change. Your previous rule state was restored.")
-            return false
-        }
 
-        // Pre-cache icons for collections with app launches (e.g., Vim nav layer)
-        if isEnabled, let collection = ruleCollections.first(where: { $0.id == id }) {
-            await warmLayerIconCache(for: collection)
+            AppLogger.shared.log("🔀 [RuleCollections] Calling regenerateConfigFromCollections...")
+            let applied = await regenerateConfigFromCollections(skipReload: skipReload)
+            guard applied else {
+                if id == RuleCollectionIdentifier.leaderKey {
+                    PreferencesService.shared.leaderKeyPreference = leaderPreferenceSnapshot
+                }
+                AppLogger.shared.log("↩️ [RuleCollections] Toggle apply failed; rolling back to previous state")
+                await rollbackToSnapshot(snapshot, userMessage: "Could not apply this rule change. Your previous rule state was restored.")
+                return false
+            }
+
+            // Pre-cache icons for collections with app launches (e.g., Vim nav layer)
+            if isEnabled, let collection = ruleCollections.first(where: { $0.id == id }) {
+                await warmLayerIconCache(for: collection)
+            }
+            return true
         }
-        return true
     }
 
     /// Enable multiple collections in a single batch, regenerating config only once.
     /// Used when a mode switch (e.g., home row mods → layers) needs to enable several
     /// layer collections at once without 4 separate save/validate/reload cycles.
     func batchEnableCollections(ids: [UUID]) async {
-        let catalog = RuleCollectionCatalog().defaultCollections()
+        await withRuleMutation(failure: ()) { [self] _ in
+            let catalog = RuleCollectionCatalog().defaultCollections()
 
-        for id in ids {
-            let catalogMatch = catalog.first { $0.id == id }
-            let candidate = ruleCollections.first(where: { $0.id == id }) ?? catalogMatch
+            for id in ids {
+                let catalogMatch = catalog.first { $0.id == id }
+                let candidate = ruleCollections.first(where: { $0.id == id }) ?? catalogMatch
 
-            if let index = ruleCollections.firstIndex(where: { $0.id == id }) {
-                ruleCollections[index].isEnabled = true
-            } else if var newCollection = candidate {
-                newCollection.isEnabled = true
-                ruleCollections.append(newCollection)
+                if let index = ruleCollections.firstIndex(where: { $0.id == id }) {
+                    ruleCollections[index].isEnabled = true
+                } else if var newCollection = candidate {
+                    newCollection.isEnabled = true
+                    ruleCollections.append(newCollection)
+                }
             }
-        }
 
-        dedupeRuleCollectionsInPlace()
-        refreshLayerIndicatorState()
-        await regenerateConfigFromCollections()
+            dedupeRuleCollectionsInPlace()
+            refreshLayerIndicatorState()
+            await regenerateConfigFromCollections()
+        }
     }
 
     /// Add or update a rule collection
-    func addCollection(_ collection: RuleCollection) async {
-        let snapshot = snapshotRuleState()
+    func addCollection(_ collection: RuleCollection, mutationPermit: ConfigurationOperationGate.Permit? = nil) async {
+        await withRuleMutation(using: mutationPermit, failure: ()) { [self] _ in
+            let snapshot = snapshotRuleState()
 
-        if collection.isEnabled, let conflict = conflictInfo(for: collection) {
-            // Show conflict resolution dialog
-            let context = RuleConflictContext(
-                newRule: .collection(collection),
-                existingRule: conflict.source,
-                conflictingKeys: conflict.keys
-            )
+            if collection.isEnabled, let conflict = conflictInfo(for: collection) {
+                // Show conflict resolution dialog
+                let context = RuleConflictContext(
+                    newRule: .collection(collection),
+                    existingRule: conflict.source,
+                    conflictingKeys: conflict.keys
+                )
 
-            AppLogger.shared.log(
-                "⚠️ [RuleCollections] Conflict adding \(collection.name) vs \(conflict.displayName) on \(conflict.keys)"
-            )
+                AppLogger.shared.log(
+                    "⚠️ [RuleCollections] Conflict adding \(collection.name) vs \(conflict.displayName) on \(conflict.keys)"
+                )
 
-            guard let choice = await onConflictResolution?(context) else {
-                // User cancelled - don't add
-                return
+                guard let choice = await onConflictResolution?(context) else {
+                    // User cancelled - don't add
+                    return
+                }
+
+                switch choice {
+                case .keepNew:
+                    // Disable the conflicting rule, then proceed with adding this one
+                    await disableConflicting(conflict.source, regenerate: false)
+                case .keepExisting:
+                    // User chose to keep the existing rule - don't add the new one
+                    return
+                }
             }
 
-            switch choice {
-            case .keepNew:
-                // Disable the conflicting rule, then proceed with adding this one
-                await disableConflicting(conflict.source, regenerate: false)
-            case .keepExisting:
-                // User chose to keep the existing rule - don't add the new one
-                return
+            if let index = ruleCollections.firstIndex(where: { $0.id == collection.id }) {
+                ruleCollections[index].isEnabled = true
+                ruleCollections[index].summary = collection.summary
+                ruleCollections[index].mappings = collection.mappings
+                ruleCollections[index].category = collection.category
+                ruleCollections[index].icon = collection.icon
+            } else {
+                ruleCollections.append(collection)
             }
-        }
-
-        if let index = ruleCollections.firstIndex(where: { $0.id == collection.id }) {
-            ruleCollections[index].isEnabled = true
-            ruleCollections[index].summary = collection.summary
-            ruleCollections[index].mappings = collection.mappings
-            ruleCollections[index].category = collection.category
-            ruleCollections[index].icon = collection.icon
-        } else {
-            ruleCollections.append(collection)
-        }
-        dedupeRuleCollectionsInPlace()
-        refreshLayerIndicatorState()
-        let applied = await regenerateConfigFromCollections()
-        if !applied {
-            AppLogger.shared.log("↩️ [RuleCollections] Add collection failed; rolling back to previous state")
-            await rollbackToSnapshot(snapshot, userMessage: "Could not apply this rule change. Your previous rule state was restored.")
+            dedupeRuleCollectionsInPlace()
+            refreshLayerIndicatorState()
+            let applied = await regenerateConfigFromCollections()
+            if !applied {
+                AppLogger.shared.log("↩️ [RuleCollections] Add collection failed; rolling back to previous state")
+                await rollbackToSnapshot(snapshot, userMessage: "Could not apply this rule change. Your previous rule state was restored.")
+            }
         }
     }
 
     /// Remove a rule collection by ID
     func removeCollection(id: UUID) async {
-        ruleCollections.removeAll { $0.id == id }
-        refreshLayerIndicatorState()
-        await regenerateConfigFromCollections()
-        AppLogger.shared.log("🗑️ [RuleCollections] Removed collection: \(id)")
+        await withRuleMutation(failure: ()) { [self] _ in
+            ruleCollections.removeAll { $0.id == id }
+            refreshLayerIndicatorState()
+            await regenerateConfigFromCollections()
+            AppLogger.shared.log("🗑️ [RuleCollections] Removed collection: \(id)")
+        }
     }
 
     /// Remove all collections and custom rules for a specific layer
     func removeLayer(_ layerName: String) async {
-        let normalizedName = layerName.lowercased()
+        await withRuleMutation(failure: ()) { [self] _ in
+            let normalizedName = layerName.lowercased()
 
-        // Remove collections targeting this layer
-        let collectionCount = ruleCollections.count
-        ruleCollections.removeAll { collection in
-            collection.targetLayer.kanataName.lowercased() == normalizedName
+            // Remove collections targeting this layer
+            let collectionCount = ruleCollections.count
+            ruleCollections.removeAll { collection in
+                collection.targetLayer.kanataName.lowercased() == normalizedName
+            }
+            let removedCollections = collectionCount - ruleCollections.count
+
+            // Remove custom rules targeting this layer
+            let ruleCount = customRules.count
+            customRules.removeAll { rule in
+                rule.targetLayer.kanataName.lowercased() == normalizedName
+            }
+            let removedRules = ruleCount - customRules.count
+
+            // Persist custom rules to disk
+            do {
+                try await customRulesStore.saveRules(customRules)
+            } catch {
+                AppLogger.shared.error("❌ [RuleCollections] Failed to persist custom rules after layer removal: \(error)")
+            }
+
+            refreshLayerIndicatorState()
+            await regenerateConfigFromCollections()
+
+            AppLogger.shared.log("🗑️ [RuleCollections] Removed layer '\(layerName)': \(removedCollections) collections, \(removedRules) rules")
         }
-        let removedCollections = collectionCount - ruleCollections.count
-
-        // Remove custom rules targeting this layer
-        let ruleCount = customRules.count
-        customRules.removeAll { rule in
-            rule.targetLayer.kanataName.lowercased() == normalizedName
-        }
-        let removedRules = ruleCount - customRules.count
-
-        // Persist custom rules to disk
-        do {
-            try await customRulesStore.saveRules(customRules)
-        } catch {
-            AppLogger.shared.error("❌ [RuleCollections] Failed to persist custom rules after layer removal: \(error)")
-        }
-
-        refreshLayerIndicatorState()
-        await regenerateConfigFromCollections()
-
-        AppLogger.shared.log("🗑️ [RuleCollections] Removed layer '\(layerName)': \(removedCollections) collections, \(removedRules) rules")
     }
 
     /// Create a new custom layer with Leader key activator
     func createLayer(_ name: String) async {
-        guard !name.isEmpty else { return }
+        await withRuleMutation(failure: ()) { [self] permit in
+            guard !name.isEmpty else { return }
 
-        // Sanitize the layer name
-        let sanitizedName = name.lowercased()
-            .replacingOccurrences(of: " ", with: "_")
-            .filter { $0.isLetter || $0.isNumber || $0 == "_" }
+            // Sanitize the layer name
+            let sanitizedName = name.lowercased()
+                .replacingOccurrences(of: " ", with: "_")
+                .filter { $0.isLetter || $0.isNumber || $0 == "_" }
 
-        guard !sanitizedName.isEmpty else { return }
+            guard !sanitizedName.isEmpty else { return }
 
-        // Check for duplicates by looking at existing collections' target layers
-        let existingLayers = Set(ruleCollections.map { $0.targetLayer.kanataName.lowercased() })
-        if existingLayers.contains(sanitizedName) {
-            AppLogger.shared.warn("⚠️ [RuleCollections] Layer already exists: \(sanitizedName)")
-            return
-        }
+            // Check for duplicates by looking at existing collections' target layers
+            let existingLayers = Set(ruleCollections.map { $0.targetLayer.kanataName.lowercased() })
+            if existingLayers.contains(sanitizedName) {
+                AppLogger.shared.warn("⚠️ [RuleCollections] Layer already exists: \(sanitizedName)")
+                return
+            }
 
-        // Create a RuleCollection for this layer with Leader key activator
-        // Activator: first letter of layer name, from nav layer (Leader → letter)
-        let activatorKey = String(sanitizedName.prefix(1))
-        let targetLayer = RuleCollectionLayer.custom(sanitizedName)
+            // Create a RuleCollection for this layer with Leader key activator
+            // Activator: first letter of layer name, from nav layer (Leader → letter)
+            let activatorKey = String(sanitizedName.prefix(1))
+            let targetLayer = RuleCollectionLayer.custom(sanitizedName)
 
-        let collection = RuleCollection(
-            id: UUID(),
-            name: sanitizedName.capitalized,
-            summary: "Custom layer: \(sanitizedName)",
-            category: .custom,
-            mappings: [],
-            isEnabled: true,
-            icon: "square.stack.3d.up",
-            tags: ["custom-layer"],
-            targetLayer: targetLayer,
-            momentaryActivator: MomentaryActivator(
-                input: activatorKey,
+            let collection = RuleCollection(
+                id: UUID(),
+                name: sanitizedName.capitalized,
+                summary: "Custom layer: \(sanitizedName)",
+                category: .custom,
+                mappings: [],
+                isEnabled: true,
+                icon: "square.stack.3d.up",
+                tags: ["custom-layer"],
                 targetLayer: targetLayer,
-                sourceLayer: .navigation
-            ),
-            activationHint: "Leader → \(activatorKey.uppercased())",
-            configuration: .list
-        )
+                momentaryActivator: MomentaryActivator(
+                    input: activatorKey,
+                    targetLayer: targetLayer,
+                    sourceLayer: .navigation
+                ),
+                activationHint: "Leader → \(activatorKey.uppercased())",
+                configuration: .list
+            )
 
-        await addCollection(collection)
-        AppLogger.shared.log("📚 [RuleCollections] Created new layer: \(sanitizedName) (Leader → \(activatorKey.uppercased()))")
+            await addCollection(collection, mutationPermit: permit)
+            AppLogger.shared.log("📚 [RuleCollections] Created new layer: \(sanitizedName) (Leader → \(activatorKey.uppercased()))")
+        }
     }
 
     /// Update a single-key picker collection's selected output and regenerate its mapping
     func updateCollectionOutput(id: UUID, output: String) async {
-        guard let index = ruleCollections.firstIndex(where: { $0.id == id }) else {
-            // Try to find in catalog and add it
-            let catalog = RuleCollectionCatalog()
-            if var catalogCollection = catalog.defaultCollections().first(where: { $0.id == id }) {
-                catalogCollection.configuration.updateSelectedOutput(output)
-                catalogCollection.isEnabled = true
-                // Update the mapping based on selected output
-                if let config = catalogCollection.configuration.singleKeyPickerConfig {
-                    let description = config.presetOptions.first { $0.output == output }?.label ?? "Custom"
-                    let keyAction: KeyAction = output.hasPrefix("(") ? .rawKanata(output) : .keystroke(key: output)
-                    catalogCollection.mappings = [KeyMapping(input: config.inputKey, action: keyAction, description: description)]
+        await withRuleMutation(failure: ()) { [self] permit in
+            guard let index = ruleCollections.firstIndex(where: { $0.id == id }) else {
+                // Try to find in catalog and add it
+                let catalog = RuleCollectionCatalog()
+                if var catalogCollection = catalog.defaultCollections().first(where: { $0.id == id }) {
+                    catalogCollection.configuration.updateSelectedOutput(output)
+                    catalogCollection.isEnabled = true
+                    // Update the mapping based on selected output
+                    if let config = catalogCollection.configuration.singleKeyPickerConfig {
+                        let description = config.presetOptions.first { $0.output == output }?.label ?? "Custom"
+                        let keyAction: KeyAction = output.hasPrefix("(") ? .rawKanata(output) : .keystroke(key: output)
+                        catalogCollection.mappings = [KeyMapping(input: config.inputKey, action: keyAction, description: description)]
+                    }
+                    ruleCollections.append(catalogCollection)
+                    dedupeRuleCollectionsInPlace()
+                    refreshLayerIndicatorState()
+                    await regenerateConfigFromCollections()
                 }
-                ruleCollections.append(catalogCollection)
-                dedupeRuleCollectionsInPlace()
-                refreshLayerIndicatorState()
-                await regenerateConfigFromCollections()
+                return
             }
-            return
+
+            ruleCollections[index].configuration.updateSelectedOutput(output)
+            ruleCollections[index].isEnabled = true
+
+            // Update the mapping based on selected output (skip for Leader Key which has no mappings)
+            if let config = ruleCollections[index].configuration.singleKeyPickerConfig,
+               config.inputKey != "leader"
+            {
+                let description = config.presetOptions.first { $0.output == output }?.label ?? "Custom"
+                let keyAction: KeyAction = output.hasPrefix("(") ? .rawKanata(output) : .keystroke(key: output)
+                ruleCollections[index].mappings = [KeyMapping(input: config.inputKey, action: keyAction, description: description)]
+            }
+
+            dedupeRuleCollectionsInPlace()
+
+            // Special handling: If this is the Leader Key collection, update all momentary activators
+            if id == RuleCollectionIdentifier.leaderKey {
+                await updateLeaderKey(output, mutationPermit: permit)
+                return
+            }
+
+            refreshLayerIndicatorState()
+            await regenerateConfigFromCollections()
         }
-
-        ruleCollections[index].configuration.updateSelectedOutput(output)
-        ruleCollections[index].isEnabled = true
-
-        // Update the mapping based on selected output (skip for Leader Key which has no mappings)
-        if let config = ruleCollections[index].configuration.singleKeyPickerConfig,
-           config.inputKey != "leader"
-        {
-            let description = config.presetOptions.first { $0.output == output }?.label ?? "Custom"
-            let keyAction: KeyAction = output.hasPrefix("(") ? .rawKanata(output) : .keystroke(key: output)
-            ruleCollections[index].mappings = [KeyMapping(input: config.inputKey, action: keyAction, description: description)]
-        }
-
-        dedupeRuleCollectionsInPlace()
-
-        // Special handling: If this is the Leader Key collection, update all momentary activators
-        if id == RuleCollectionIdentifier.leaderKey {
-            await updateLeaderKey(output)
-            return
-        }
-
-        refreshLayerIndicatorState()
-        await regenerateConfigFromCollections()
     }
 
     /// Update a tap-hold picker collection's tap output
     func updateCollectionTapOutput(id: UUID, tapOutput: String) async {
-        guard let index = ruleCollections.firstIndex(where: { $0.id == id }) else {
-            // Try to find in catalog and add it
-            let catalog = RuleCollectionCatalog()
-            if var catalogCollection = catalog.defaultCollections().first(where: { $0.id == id }) {
-                catalogCollection.configuration.updateSelectedTapOutput(tapOutput)
-                catalogCollection.isEnabled = true
-                ruleCollections.append(catalogCollection)
-                dedupeRuleCollectionsInPlace()
-                refreshLayerIndicatorState()
-                await regenerateConfigFromCollections()
+        await withRuleMutation(failure: ()) { [self] _ in
+            guard let index = ruleCollections.firstIndex(where: { $0.id == id }) else {
+                // Try to find in catalog and add it
+                let catalog = RuleCollectionCatalog()
+                if var catalogCollection = catalog.defaultCollections().first(where: { $0.id == id }) {
+                    catalogCollection.configuration.updateSelectedTapOutput(tapOutput)
+                    catalogCollection.isEnabled = true
+                    ruleCollections.append(catalogCollection)
+                    dedupeRuleCollectionsInPlace()
+                    refreshLayerIndicatorState()
+                    await regenerateConfigFromCollections()
+                }
+                return
             }
-            return
-        }
 
-        ruleCollections[index].configuration.updateSelectedTapOutput(tapOutput)
-        ruleCollections[index].isEnabled = true
-        dedupeRuleCollectionsInPlace()
-        refreshLayerIndicatorState()
-        await regenerateConfigFromCollections()
+            ruleCollections[index].configuration.updateSelectedTapOutput(tapOutput)
+            ruleCollections[index].isEnabled = true
+            dedupeRuleCollectionsInPlace()
+            refreshLayerIndicatorState()
+            await regenerateConfigFromCollections()
+        }
     }
 
     /// Update a tap-hold picker collection's hold output
     func updateCollectionHoldOutput(id: UUID, holdOutput: String) async {
-        guard let index = ruleCollections.firstIndex(where: { $0.id == id }) else {
-            // Try to find in catalog and add it
-            let catalog = RuleCollectionCatalog()
-            if var catalogCollection = catalog.defaultCollections().first(where: { $0.id == id }) {
-                catalogCollection.configuration.updateSelectedHoldOutput(holdOutput)
-                catalogCollection.isEnabled = true
-                ruleCollections.append(catalogCollection)
-                dedupeRuleCollectionsInPlace()
-                refreshLayerIndicatorState()
-                await regenerateConfigFromCollections()
+        await withRuleMutation(failure: ()) { [self] _ in
+            guard let index = ruleCollections.firstIndex(where: { $0.id == id }) else {
+                // Try to find in catalog and add it
+                let catalog = RuleCollectionCatalog()
+                if var catalogCollection = catalog.defaultCollections().first(where: { $0.id == id }) {
+                    catalogCollection.configuration.updateSelectedHoldOutput(holdOutput)
+                    catalogCollection.isEnabled = true
+                    ruleCollections.append(catalogCollection)
+                    dedupeRuleCollectionsInPlace()
+                    refreshLayerIndicatorState()
+                    await regenerateConfigFromCollections()
+                }
+                return
             }
-            return
-        }
 
-        ruleCollections[index].configuration.updateSelectedHoldOutput(holdOutput)
-        ruleCollections[index].isEnabled = true
-        dedupeRuleCollectionsInPlace()
-        refreshLayerIndicatorState()
-        await regenerateConfigFromCollections()
+            ruleCollections[index].configuration.updateSelectedHoldOutput(holdOutput)
+            ruleCollections[index].isEnabled = true
+            dedupeRuleCollectionsInPlace()
+            refreshLayerIndicatorState()
+            await regenerateConfigFromCollections()
+        }
     }
 
     /// Update a layer preset picker collection's selected preset
     func updateCollectionLayerPreset(id: UUID, presetId: String) async {
-        guard let index = ruleCollections.firstIndex(where: { $0.id == id }) else {
-            // Try to find in catalog and add it
-            let catalog = RuleCollectionCatalog()
-            if var catalogCollection = catalog.defaultCollections().first(where: { $0.id == id }) {
-                catalogCollection.configuration.updateSelectedPreset(presetId)
-                catalogCollection.isEnabled = true
-                ruleCollections.append(catalogCollection)
-                dedupeRuleCollectionsInPlace()
-                refreshLayerIndicatorState()
-                await regenerateConfigFromCollections()
+        await withRuleMutation(failure: ()) { [self] _ in
+            guard let index = ruleCollections.firstIndex(where: { $0.id == id }) else {
+                // Try to find in catalog and add it
+                let catalog = RuleCollectionCatalog()
+                if var catalogCollection = catalog.defaultCollections().first(where: { $0.id == id }) {
+                    catalogCollection.configuration.updateSelectedPreset(presetId)
+                    catalogCollection.isEnabled = true
+                    ruleCollections.append(catalogCollection)
+                    dedupeRuleCollectionsInPlace()
+                    refreshLayerIndicatorState()
+                    await regenerateConfigFromCollections()
+                }
+                return
             }
-            return
-        }
 
-        ruleCollections[index].configuration.updateSelectedPreset(presetId)
-        ruleCollections[index].isEnabled = true
-        dedupeRuleCollectionsInPlace()
-        refreshLayerIndicatorState()
-        await regenerateConfigFromCollections()
+            ruleCollections[index].configuration.updateSelectedPreset(presetId)
+            ruleCollections[index].isEnabled = true
+            dedupeRuleCollectionsInPlace()
+            refreshLayerIndicatorState()
+            await regenerateConfigFromCollections()
+        }
     }
 
     /// Update window snapping key convention (Standard vs Vim)
     func updateWindowKeyConvention(id: UUID, convention: WindowKeyConvention) async {
-        guard let index = ruleCollections.firstIndex(where: { $0.id == id }) else {
-            // Try to find in catalog and add it
-            let catalog = RuleCollectionCatalog()
-            if var catalogCollection = catalog.defaultCollections().first(where: { $0.id == id }) {
-                catalogCollection.windowKeyConvention = convention
-                catalogCollection.mappings = RuleCollectionCatalog.windowMappings(for: convention)
-                catalogCollection.isEnabled = true
-                ruleCollections.append(catalogCollection)
-                dedupeRuleCollectionsInPlace()
-                refreshLayerIndicatorState()
-                await regenerateConfigFromCollections()
+        await withRuleMutation(failure: ()) { [self] _ in
+            guard let index = ruleCollections.firstIndex(where: { $0.id == id }) else {
+                // Try to find in catalog and add it
+                let catalog = RuleCollectionCatalog()
+                if var catalogCollection = catalog.defaultCollections().first(where: { $0.id == id }) {
+                    catalogCollection.windowKeyConvention = convention
+                    catalogCollection.mappings = RuleCollectionCatalog.windowMappings(for: convention)
+                    catalogCollection.isEnabled = true
+                    ruleCollections.append(catalogCollection)
+                    dedupeRuleCollectionsInPlace()
+                    refreshLayerIndicatorState()
+                    await regenerateConfigFromCollections()
+                }
+                return
             }
-            return
-        }
 
-        ruleCollections[index].windowKeyConvention = convention
-        ruleCollections[index].mappings = RuleCollectionCatalog.windowMappings(for: convention)
-        ruleCollections[index].isEnabled = true
-        dedupeRuleCollectionsInPlace()
-        refreshLayerIndicatorState()
-        await regenerateConfigFromCollections()
+            ruleCollections[index].windowKeyConvention = convention
+            ruleCollections[index].mappings = RuleCollectionCatalog.windowMappings(for: convention)
+            ruleCollections[index].isEnabled = true
+            dedupeRuleCollectionsInPlace()
+            refreshLayerIndicatorState()
+            await regenerateConfigFromCollections()
+        }
     }
 
     /// Update function key mode (Media Keys vs Function Keys)
     func updateFunctionKeyMode(id: UUID, mode: FunctionKeyMode) async {
-        guard let index = ruleCollections.firstIndex(where: { $0.id == id }) else {
-            // Try to find in catalog and add it
-            let catalog = RuleCollectionCatalog()
-            if var catalogCollection = catalog.defaultCollections().first(where: { $0.id == id }) {
-                catalogCollection.functionKeyMode = mode
-                catalogCollection.mappings = RuleCollectionCatalog.functionKeyMappings(for: mode)
-                catalogCollection.isEnabled = true
-                ruleCollections.append(catalogCollection)
-                dedupeRuleCollectionsInPlace()
-                refreshLayerIndicatorState()
-                await regenerateConfigFromCollections()
+        await withRuleMutation(failure: ()) { [self] _ in
+            guard let index = ruleCollections.firstIndex(where: { $0.id == id }) else {
+                // Try to find in catalog and add it
+                let catalog = RuleCollectionCatalog()
+                if var catalogCollection = catalog.defaultCollections().first(where: { $0.id == id }) {
+                    catalogCollection.functionKeyMode = mode
+                    catalogCollection.mappings = RuleCollectionCatalog.functionKeyMappings(for: mode)
+                    catalogCollection.isEnabled = true
+                    ruleCollections.append(catalogCollection)
+                    dedupeRuleCollectionsInPlace()
+                    refreshLayerIndicatorState()
+                    await regenerateConfigFromCollections()
+                }
+                return
             }
-            return
-        }
 
-        ruleCollections[index].functionKeyMode = mode
-        ruleCollections[index].mappings = RuleCollectionCatalog.functionKeyMappings(for: mode)
-        ruleCollections[index].isEnabled = true
-        dedupeRuleCollectionsInPlace()
-        refreshLayerIndicatorState()
-        await regenerateConfigFromCollections()
+            ruleCollections[index].functionKeyMode = mode
+            ruleCollections[index].mappings = RuleCollectionCatalog.functionKeyMappings(for: mode)
+            ruleCollections[index].isEnabled = true
+            dedupeRuleCollectionsInPlace()
+            refreshLayerIndicatorState()
+            await regenerateConfigFromCollections()
+        }
     }
 
     /// Update home row mods configuration
     /// - Returns: `true` if the collection was newly enabled (was disabled before this call)
     @discardableResult
     func updateHomeRowModsConfig(id: UUID, config: HomeRowModsConfig) async -> Bool {
-        guard var candidate = ruleCollections.first(where: { $0.id == id })
-            ?? RuleCollectionCatalog().defaultCollections().first(where: { $0.id == id })
-        else {
-            return false
+        await withRuleMutation(failure: false) { [self] _ in
+            guard var candidate = ruleCollections.first(where: { $0.id == id })
+                ?? RuleCollectionCatalog().defaultCollections().first(where: { $0.id == id })
+            else {
+                return false
+            }
+
+            let wasNewlyEnabled = !candidate.isEnabled
+            candidate.configuration.updateHomeRowModsConfig(config)
+            candidate.isEnabled = true
+
+            let appliedProviderIDs = await applyProposedCollectionWithPrerequisites(
+                candidate,
+                rollbackMessage:
+                "Could not save Home Row Mods. Your previous rule state was restored."
+            )
+            return appliedProviderIDs != nil && wasNewlyEnabled
         }
-
-        let wasNewlyEnabled = !candidate.isEnabled
-        candidate.configuration.updateHomeRowModsConfig(config)
-        candidate.isEnabled = true
-
-        let appliedProviderIDs = await applyProposedCollectionWithPrerequisites(
-            candidate,
-            rollbackMessage:
-            "Could not save Home Row Mods. Your previous rule state was restored."
-        )
-        return appliedProviderIDs != nil && wasNewlyEnabled
     }
 
     /// Update home row layer toggles configuration
     /// - Returns: `true` if the collection was newly enabled (was disabled before this call)
     @discardableResult
     func updateHomeRowLayerTogglesConfig(id: UUID, config: HomeRowLayerTogglesConfig) async -> Bool {
-        guard var candidate = ruleCollections.first(where: { $0.id == id })
-            ?? RuleCollectionCatalog().defaultCollections().first(where: { $0.id == id })
-        else {
-            return false
+        await withRuleMutation(failure: false) { [self] _ in
+            guard var candidate = ruleCollections.first(where: { $0.id == id })
+                ?? RuleCollectionCatalog().defaultCollections().first(where: { $0.id == id })
+            else {
+                return false
+            }
+
+            let wasNewlyEnabled = !candidate.isEnabled
+            candidate.configuration.updateHomeRowLayerTogglesConfig(config)
+            candidate.isEnabled = true
+
+            let appliedProviderIDs = await applyProposedCollectionWithPrerequisites(
+                candidate,
+                rollbackMessage:
+                "Could not save Home Row Layer Toggles. Your previous rule state was restored."
+            )
+            return appliedProviderIDs != nil && wasNewlyEnabled
         }
-
-        let wasNewlyEnabled = !candidate.isEnabled
-        candidate.configuration.updateHomeRowLayerTogglesConfig(config)
-        candidate.isEnabled = true
-
-        let appliedProviderIDs = await applyProposedCollectionWithPrerequisites(
-            candidate,
-            rollbackMessage:
-            "Could not save Home Row Layer Toggles. Your previous rule state was restored."
-        )
-        return appliedProviderIDs != nil && wasNewlyEnabled
     }
 
     /// Update chord groups configuration
     /// - Returns: `true` if the collection was newly enabled (was disabled before this call)
     @discardableResult
     func updateChordGroupsConfig(id: UUID, config: ChordGroupsConfig) async -> Bool {
-        guard let index = ruleCollections.firstIndex(where: { $0.id == id }) else {
-            // Try to find in catalog and add it
-            let catalog = RuleCollectionCatalog()
-            if var catalogCollection = catalog.defaultCollections().first(where: { $0.id == id }) {
-                catalogCollection.configuration.updateChordGroupsConfig(config)
-                catalogCollection.isEnabled = true
-                ruleCollections.append(catalogCollection)
-                dedupeRuleCollectionsInPlace()
-                refreshLayerIndicatorState()
-                await regenerateConfigFromCollections()
-                return true
+        await withRuleMutation(failure: false) { [self] _ in
+            guard let index = ruleCollections.firstIndex(where: { $0.id == id }) else {
+                // Try to find in catalog and add it
+                let catalog = RuleCollectionCatalog()
+                if var catalogCollection = catalog.defaultCollections().first(where: { $0.id == id }) {
+                    catalogCollection.configuration.updateChordGroupsConfig(config)
+                    catalogCollection.isEnabled = true
+                    ruleCollections.append(catalogCollection)
+                    dedupeRuleCollectionsInPlace()
+                    refreshLayerIndicatorState()
+                    await regenerateConfigFromCollections()
+                    return true
+                }
+                return false
             }
-            return false
+
+            let wasNewlyEnabled = !ruleCollections[index].isEnabled
+            ruleCollections[index].configuration.updateChordGroupsConfig(config)
+            ruleCollections[index].isEnabled = true
+
+            dedupeRuleCollectionsInPlace()
+            refreshLayerIndicatorState()
+            await regenerateConfigFromCollections()
+            return wasNewlyEnabled
         }
-
-        let wasNewlyEnabled = !ruleCollections[index].isEnabled
-        ruleCollections[index].configuration.updateChordGroupsConfig(config)
-        ruleCollections[index].isEnabled = true
-
-        dedupeRuleCollectionsInPlace()
-        refreshLayerIndicatorState()
-        await regenerateConfigFromCollections()
-        return wasNewlyEnabled
     }
 
     /// Update sequences configuration
     /// - Returns: `true` if the collection was newly enabled (was disabled before this call)
     @discardableResult
     func updateSequencesConfig(id: UUID, config: SequencesConfig) async -> Bool {
-        guard let index = ruleCollections.firstIndex(where: { $0.id == id }) else {
-            // Try to find in catalog and add it
-            let catalog = RuleCollectionCatalog()
-            if var catalogCollection = catalog.defaultCollections().first(where: { $0.id == id }) {
-                catalogCollection.configuration.updateSequencesConfig(config)
-                catalogCollection.isEnabled = true
-                ruleCollections.append(catalogCollection)
-                dedupeRuleCollectionsInPlace()
-                refreshLayerIndicatorState()
-                await regenerateConfigFromCollections()
-                return true
+        await withRuleMutation(failure: false) { [self] _ in
+            guard let index = ruleCollections.firstIndex(where: { $0.id == id }) else {
+                // Try to find in catalog and add it
+                let catalog = RuleCollectionCatalog()
+                if var catalogCollection = catalog.defaultCollections().first(where: { $0.id == id }) {
+                    catalogCollection.configuration.updateSequencesConfig(config)
+                    catalogCollection.isEnabled = true
+                    ruleCollections.append(catalogCollection)
+                    dedupeRuleCollectionsInPlace()
+                    refreshLayerIndicatorState()
+                    await regenerateConfigFromCollections()
+                    return true
+                }
+                return false
             }
-            return false
+
+            let wasNewlyEnabled = !ruleCollections[index].isEnabled
+            ruleCollections[index].configuration.updateSequencesConfig(config)
+            ruleCollections[index].isEnabled = true
+
+            dedupeRuleCollectionsInPlace()
+            refreshLayerIndicatorState()
+            await regenerateConfigFromCollections()
+            return wasNewlyEnabled
         }
-
-        let wasNewlyEnabled = !ruleCollections[index].isEnabled
-        ruleCollections[index].configuration.updateSequencesConfig(config)
-        ruleCollections[index].isEnabled = true
-
-        dedupeRuleCollectionsInPlace()
-        refreshLayerIndicatorState()
-        await regenerateConfigFromCollections()
-        return wasNewlyEnabled
     }
 
     /// Update launcher grid configuration
     /// - Returns: `true` if the collection was newly enabled (was disabled before this call)
     @discardableResult
     func updateLauncherConfig(id: UUID, config: LauncherGridConfig) async -> Bool {
-        guard let candidate = ruleCollections.first(where: { $0.id == id })
-            ?? RuleCollectionCatalog().defaultCollections().first(where: { $0.id == id })
-        else {
-            return false
-        }
+        await withRuleMutation(failure: false) { [self] permit in
+            guard let candidate = ruleCollections.first(where: { $0.id == id })
+                ?? RuleCollectionCatalog().defaultCollections().first(where: { $0.id == id })
+            else {
+                return false
+            }
 
-        let wasNewlyEnabled = !candidate.isEnabled
-        let applied = await applyLauncherConfig(id: id, config: config)
-        return applied && wasNewlyEnabled
+            let wasNewlyEnabled = !candidate.isEnabled
+            let applied = await applyLauncherConfig(id: id, config: config, mutationPermit: permit)
+            return applied && wasNewlyEnabled
+        }
     }
 
     /// Applies and persists launcher configuration, optionally leaving the
@@ -626,112 +662,121 @@ extension RuleCollectionsManager {
     func applyLauncherConfig(
         id: UUID,
         config: LauncherGridConfig,
-        skipReload: Bool = false
+        skipReload: Bool = false,
+        mutationPermit: ConfigurationOperationGate.Permit? = nil
     ) async -> Bool {
-        guard var candidate = ruleCollections.first(where: { $0.id == id })
-            ?? RuleCollectionCatalog().defaultCollections().first(where: { $0.id == id })
-        else {
-            return false
-        }
-        guard case .launcherGrid = candidate.configuration else {
-            return false
-        }
+        await withRuleMutation(using: mutationPermit, failure: false) { [self] _ in
+            guard var candidate = ruleCollections.first(where: { $0.id == id })
+                ?? RuleCollectionCatalog().defaultCollections().first(where: { $0.id == id })
+            else {
+                return false
+            }
+            guard case .launcherGrid = candidate.configuration else {
+                return false
+            }
 
-        candidate.configuration.updateLauncherGridConfig(config)
-        candidate.isEnabled = true
+            candidate.configuration.updateLauncherGridConfig(config)
+            candidate.isEnabled = true
 
-        let appliedProviderIDs = await applyProposedCollectionWithPrerequisites(
-            candidate,
-            rollbackMessage:
-            "Could not save Launcher. Your previous rule state was restored.",
-            skipReload: skipReload
-        )
-        guard appliedProviderIDs != nil else {
-            return false
+            let appliedProviderIDs = await applyProposedCollectionWithPrerequisites(
+                candidate,
+                rollbackMessage:
+                "Could not save Launcher. Your previous rule state was restored.",
+                skipReload: skipReload
+            )
+            guard appliedProviderIDs != nil else {
+                return false
+            }
+
+            await warmLauncherIconCache(for: config)
+            return true
         }
-
-        await warmLauncherIconCache(for: config)
-        return true
     }
 
     /// Update auto shift symbols configuration
     /// - Returns: `true` if the collection was newly enabled (was disabled before this call)
     @discardableResult
     func updateAutoShiftSymbolsConfig(id: UUID, config: AutoShiftSymbolsConfig) async -> Bool {
-        guard let index = ruleCollections.firstIndex(where: { $0.id == id }) else {
-            let catalog = RuleCollectionCatalog()
-            if var catalogCollection = catalog.defaultCollections().first(where: { $0.id == id }) {
-                catalogCollection.configuration.updateAutoShiftSymbolsConfig(config)
-                catalogCollection.isEnabled = true
-                ruleCollections.append(catalogCollection)
-                dedupeRuleCollectionsInPlace()
-                refreshLayerIndicatorState()
-                await regenerateConfigFromCollections()
-                return true
+        await withRuleMutation(failure: false) { [self] _ in
+            guard let index = ruleCollections.firstIndex(where: { $0.id == id }) else {
+                let catalog = RuleCollectionCatalog()
+                if var catalogCollection = catalog.defaultCollections().first(where: { $0.id == id }) {
+                    catalogCollection.configuration.updateAutoShiftSymbolsConfig(config)
+                    catalogCollection.isEnabled = true
+                    ruleCollections.append(catalogCollection)
+                    dedupeRuleCollectionsInPlace()
+                    refreshLayerIndicatorState()
+                    await regenerateConfigFromCollections()
+                    return true
+                }
+                return false
             }
-            return false
+
+            // Don't force-enable on every config tweak — preserve current toggle state
+            let wasNewlyEnabled = false
+            ruleCollections[index].configuration.updateAutoShiftSymbolsConfig(config)
+
+            dedupeRuleCollectionsInPlace()
+            refreshLayerIndicatorState()
+            await regenerateConfigFromCollections()
+            return wasNewlyEnabled
         }
-
-        // Don't force-enable on every config tweak — preserve current toggle state
-        let wasNewlyEnabled = false
-        ruleCollections[index].configuration.updateAutoShiftSymbolsConfig(config)
-
-        dedupeRuleCollectionsInPlace()
-        refreshLayerIndicatorState()
-        await regenerateConfigFromCollections()
-        return wasNewlyEnabled
     }
 
     /// Update key repeat control configuration
     /// - Returns: `true` if the collection was newly enabled (was disabled before this call)
     @discardableResult
     func updateKeyRepeatControlConfig(id: UUID, config: KeyRepeatControlConfig) async -> Bool {
-        guard let index = ruleCollections.firstIndex(where: { $0.id == id }) else {
-            let catalog = RuleCollectionCatalog()
-            if var catalogCollection = catalog.defaultCollections().first(where: { $0.id == id }) {
-                catalogCollection.configuration.updateKeyRepeatControlConfig(config)
-                catalogCollection.isEnabled = true
-                ruleCollections.append(catalogCollection)
-                dedupeRuleCollectionsInPlace()
-                refreshLayerIndicatorState()
-                await regenerateConfigFromCollections()
-                return true
+        await withRuleMutation(failure: false) { [self] _ in
+            guard let index = ruleCollections.firstIndex(where: { $0.id == id }) else {
+                let catalog = RuleCollectionCatalog()
+                if var catalogCollection = catalog.defaultCollections().first(where: { $0.id == id }) {
+                    catalogCollection.configuration.updateKeyRepeatControlConfig(config)
+                    catalogCollection.isEnabled = true
+                    ruleCollections.append(catalogCollection)
+                    dedupeRuleCollectionsInPlace()
+                    refreshLayerIndicatorState()
+                    await regenerateConfigFromCollections()
+                    return true
+                }
+                return false
             }
-            return false
+
+            let wasNewlyEnabled = false
+            ruleCollections[index].configuration.updateKeyRepeatControlConfig(config)
+
+            dedupeRuleCollectionsInPlace()
+            refreshLayerIndicatorState()
+            await regenerateConfigFromCollections()
+            return wasNewlyEnabled
         }
-
-        let wasNewlyEnabled = false
-        ruleCollections[index].configuration.updateKeyRepeatControlConfig(config)
-
-        dedupeRuleCollectionsInPlace()
-        refreshLayerIndicatorState()
-        await regenerateConfigFromCollections()
-        return wasNewlyEnabled
     }
 
     /// Update window snapping activation mode
     /// - Returns: name of auto-enabled dependency, or nil
     func updateWindowSnappingActivationMode(id: UUID, mode: WindowSnappingActivationMode) async -> String? {
-        guard var candidate = ruleCollections.first(where: { $0.id == id }) else {
-            return nil
+        await withRuleMutation(failure: nil) { [self] _ in
+            guard var candidate = ruleCollections.first(where: { $0.id == id }) else {
+                return nil
+            }
+
+            candidate.windowSnappingActivationMode = mode
+            candidate.momentaryActivator = Self.momentaryActivatorForWindowSnapping(mode)
+            candidate.activationHint = Self.activationHintForWindowSnapping(mode)
+
+            guard let enabledProviderIDs = await applyProposedCollectionWithPrerequisites(
+                candidate,
+                rollbackMessage:
+                "Could not save Window Snapping. Your previous rule state was restored.",
+                nonInteractiveChoice: .enableRequiredProvidersAndApply
+            ) else {
+                return nil
+            }
+
+            return enabledProviderIDs.compactMap { providerID in
+                ruleCollections.first(where: { $0.id == providerID })?.name
+            }.first
         }
-
-        candidate.windowSnappingActivationMode = mode
-        candidate.momentaryActivator = Self.momentaryActivatorForWindowSnapping(mode)
-        candidate.activationHint = Self.activationHintForWindowSnapping(mode)
-
-        guard let enabledProviderIDs = await applyProposedCollectionWithPrerequisites(
-            candidate,
-            rollbackMessage:
-            "Could not save Window Snapping. Your previous rule state was restored.",
-            nonInteractiveChoice: .enableRequiredProvidersAndApply
-        ) else {
-            return nil
-        }
-
-        return enabledProviderIDs.compactMap { providerID in
-            ruleCollections.first(where: { $0.id == providerID })?.name
-        }.first
     }
 
     private static func momentaryActivatorForWindowSnapping(_ mode: WindowSnappingActivationMode) -> MomentaryActivator {
@@ -766,20 +811,22 @@ extension RuleCollectionsManager {
     }
 
     /// Update the leader key for all collections that use momentary activation
-    func updateLeaderKey(_ newKey: String) async {
-        AppLogger.shared.log("🔑 [RuleCollections] Updating leader key to '\(newKey)'")
-        let snapshot = snapshotRuleState()
-        let leaderPreferenceSnapshot = PreferencesService.shared.leaderKeyPreference
+    func updateLeaderKey(_ newKey: String, mutationPermit: ConfigurationOperationGate.Permit? = nil) async {
+        await withRuleMutation(using: mutationPermit, failure: ()) { [self] _ in
+            AppLogger.shared.log("🔑 [RuleCollections] Updating leader key to '\(newKey)'")
+            let snapshot = snapshotRuleState()
+            let leaderPreferenceSnapshot = PreferencesService.shared.leaderKeyPreference
 
-        applyLeaderKeyToMomentaryActivators(newKey)
-        syncLeaderKeyPreference(key: newKey, enabled: true)
-        dedupeRuleCollectionsInPlace()
-        refreshLayerIndicatorState()
-        let applied = await regenerateConfigFromCollections()
-        guard applied else {
-            PreferencesService.shared.leaderKeyPreference = leaderPreferenceSnapshot
-            await rollbackToSnapshot(snapshot, userMessage: "Could not apply this leader key change. Your previous rule state was restored.")
-            return
+            applyLeaderKeyToMomentaryActivators(newKey)
+            syncLeaderKeyPreference(key: newKey, enabled: true)
+            dedupeRuleCollectionsInPlace()
+            refreshLayerIndicatorState()
+            let applied = await regenerateConfigFromCollections()
+            guard applied else {
+                PreferencesService.shared.leaderKeyPreference = leaderPreferenceSnapshot
+                await rollbackToSnapshot(snapshot, userMessage: "Could not apply this leader key change. Your previous rule state was restored.")
+                return
+            }
         }
     }
 
@@ -905,135 +952,143 @@ extension RuleCollectionsManager {
     /// - Parameters:
     ///   - autoResolveConflicts: When true, automatically wins over conflicting rules without prompting.
     @discardableResult
-    func saveCustomRule(_ rule: CustomRule, skipReload: Bool = false, autoResolveConflicts: Bool = false) async -> Bool {
-        AppLogger.shared.log("💾 [CustomRules] saveCustomRule called: id=\(rule.id), input='\(rule.input)', action='\(rule.action.displayName)'")
-        let snapshot = snapshotRuleState()
+    func saveCustomRule(_ rule: CustomRule, skipReload: Bool = false, autoResolveConflicts: Bool = false, mutationPermit: ConfigurationOperationGate.Permit? = nil) async -> Bool {
+        await withRuleMutation(using: mutationPermit, failure: false) { [self] _ in
+            AppLogger.shared.log("💾 [CustomRules] saveCustomRule called: id=\(rule.id), input='\(rule.input)', action='\(rule.action.displayName)'")
+            let snapshot = snapshotRuleState()
 
-        if rule.isEnabled,
-           let conflict = conflictInfo(for: rule)
-        {
-            if autoResolveConflicts {
-                AppLogger.shared.log(
-                    "🔄 [CustomRules] Auto-resolving conflict: \(rule.displayTitle) wins over \(conflict.displayName) on \(conflict.keys)"
-                )
-                await disableConflicting(conflict.source, regenerate: false)
+            if rule.isEnabled,
+               let conflict = conflictInfo(for: rule)
+            {
+                if autoResolveConflicts {
+                    AppLogger.shared.log(
+                        "🔄 [CustomRules] Auto-resolving conflict: \(rule.displayTitle) wins over \(conflict.displayName) on \(conflict.keys)"
+                    )
+                    await disableConflicting(conflict.source, regenerate: false)
+                } else {
+                    let context = RuleConflictContext(
+                        newRule: .customRule(rule),
+                        existingRule: conflict.source,
+                        conflictingKeys: conflict.keys
+                    )
+
+                    AppLogger.shared.log(
+                        "⚠️ [CustomRules] Conflict saving \(rule.displayTitle) vs \(conflict.displayName) on \(conflict.keys)"
+                    )
+
+                    guard let choice = await onConflictResolution?(context) else {
+                        return false
+                    }
+
+                    switch choice {
+                    case .keepNew:
+                        await disableConflicting(conflict.source, regenerate: false)
+                    case .keepExisting:
+                        return false
+                    }
+                }
+            }
+
+            let existingIndex = customRules.firstIndex(where: { $0.id == rule.id })
+
+            if let index = existingIndex {
+                AppLogger.shared.log("💾 [CustomRules] Updating existing rule at index \(index)")
+                customRules[index] = rule
             } else {
+                AppLogger.shared.log("💾 [CustomRules] Adding new rule (count will be \(customRules.count + 1))")
+                customRules.append(rule)
+            }
+
+            let success = await regenerateConfigFromCollections(skipReload: skipReload)
+
+            if success {
+                AppLogger.shared.log("💾 [CustomRules] Save complete, customRules.count = \(customRules.count)")
+            } else {
+                AppLogger.shared.log("💾 [CustomRules] Save failed - rolling back to snapshot")
+                await rollbackToSnapshot(snapshot, userMessage: "Could not apply this rule change. Your previous rule state was restored.")
+                AppLogger.shared.log("💾 [CustomRules] Rollback complete, customRules.count = \(customRules.count)")
+            }
+
+            return success
+        }
+    }
+
+    /// Toggle a custom rule on/off
+    func toggleCustomRule(id: UUID, isEnabled: Bool) async {
+        await withRuleMutation(failure: ()) { [self] _ in
+            let snapshot = snapshotRuleState()
+            guard let existing = customRules.first(where: { $0.id == id }) else { return }
+
+            if !isEnabled {
+                guard await confirmedDisableOfProvider(
+                    id: existing.id,
+                    name: existing.displayTitle
+                ) else {
+                    return
+                }
+            }
+
+            if isEnabled,
+               let conflict = conflictInfo(for: existing)
+            {
+                // Show conflict resolution dialog
                 let context = RuleConflictContext(
-                    newRule: .customRule(rule),
+                    newRule: .customRule(existing),
                     existingRule: conflict.source,
                     conflictingKeys: conflict.keys
                 )
 
                 AppLogger.shared.log(
-                    "⚠️ [CustomRules] Conflict saving \(rule.displayTitle) vs \(conflict.displayName) on \(conflict.keys)"
+                    "⚠️ [CustomRules] Conflict enabling \(existing.displayTitle) vs \(conflict.displayName) on \(conflict.keys)"
                 )
 
                 guard let choice = await onConflictResolution?(context) else {
-                    return false
+                    // User cancelled - don't enable
+                    return
                 }
 
                 switch choice {
                 case .keepNew:
+                    // Disable the conflicting rule, then proceed with enabling this one
                     await disableConflicting(conflict.source, regenerate: false)
                 case .keepExisting:
-                    return false
+                    // User chose to keep the existing rule - don't enable the new one
+                    return
                 }
             }
-        }
 
-        let existingIndex = customRules.firstIndex(where: { $0.id == rule.id })
-
-        if let index = existingIndex {
-            AppLogger.shared.log("💾 [CustomRules] Updating existing rule at index \(index)")
-            customRules[index] = rule
-        } else {
-            AppLogger.shared.log("💾 [CustomRules] Adding new rule (count will be \(customRules.count + 1))")
-            customRules.append(rule)
-        }
-
-        let success = await regenerateConfigFromCollections(skipReload: skipReload)
-
-        if success {
-            AppLogger.shared.log("💾 [CustomRules] Save complete, customRules.count = \(customRules.count)")
-        } else {
-            AppLogger.shared.log("💾 [CustomRules] Save failed - rolling back to snapshot")
-            await rollbackToSnapshot(snapshot, userMessage: "Could not apply this rule change. Your previous rule state was restored.")
-            AppLogger.shared.log("💾 [CustomRules] Rollback complete, customRules.count = \(customRules.count)")
-        }
-
-        return success
-    }
-
-    /// Toggle a custom rule on/off
-    func toggleCustomRule(id: UUID, isEnabled: Bool) async {
-        let snapshot = snapshotRuleState()
-        guard let existing = customRules.first(where: { $0.id == id }) else { return }
-
-        if !isEnabled {
-            guard await confirmedDisableOfProvider(
-                id: existing.id,
-                name: existing.displayTitle
-            ) else {
-                return
+            if let index = customRules.firstIndex(where: { $0.id == id }) {
+                customRules[index].isEnabled = isEnabled
             }
-        }
-
-        if isEnabled,
-           let conflict = conflictInfo(for: existing)
-        {
-            // Show conflict resolution dialog
-            let context = RuleConflictContext(
-                newRule: .customRule(existing),
-                existingRule: conflict.source,
-                conflictingKeys: conflict.keys
-            )
-
-            AppLogger.shared.log(
-                "⚠️ [CustomRules] Conflict enabling \(existing.displayTitle) vs \(conflict.displayName) on \(conflict.keys)"
-            )
-
-            guard let choice = await onConflictResolution?(context) else {
-                // User cancelled - don't enable
-                return
+            let applied = await regenerateConfigFromCollections()
+            if !applied {
+                AppLogger.shared.log("↩️ [CustomRules] Toggle apply failed; rolling back to previous state")
+                await rollbackToSnapshot(snapshot, userMessage: "Could not apply this rule change. Your previous rule state was restored.")
             }
-
-            switch choice {
-            case .keepNew:
-                // Disable the conflicting rule, then proceed with enabling this one
-                await disableConflicting(conflict.source, regenerate: false)
-            case .keepExisting:
-                // User chose to keep the existing rule - don't enable the new one
-                return
-            }
-        }
-
-        if let index = customRules.firstIndex(where: { $0.id == id }) {
-            customRules[index].isEnabled = isEnabled
-        }
-        let applied = await regenerateConfigFromCollections()
-        if !applied {
-            AppLogger.shared.log("↩️ [CustomRules] Toggle apply failed; rolling back to previous state")
-            await rollbackToSnapshot(snapshot, userMessage: "Could not apply this rule change. Your previous rule state was restored.")
         }
     }
 
     /// Remove a custom rule
     func removeCustomRule(id: UUID) async {
-        let beforeCount = customRules.count
-        AppLogger.shared.log("🗑️ [CustomRules] removeCustomRule called: id=\(id), beforeCount=\(beforeCount)")
-        customRules.removeAll { $0.id == id }
-        let afterCount = customRules.count
-        AppLogger.shared.log("🗑️ [CustomRules] After removal: afterCount=\(afterCount), removed=\(beforeCount - afterCount)")
-        await regenerateConfigFromCollections()
+        await withRuleMutation(failure: ()) { [self] _ in
+            let beforeCount = customRules.count
+            AppLogger.shared.log("🗑️ [CustomRules] removeCustomRule called: id=\(id), beforeCount=\(beforeCount)")
+            customRules.removeAll { $0.id == id }
+            let afterCount = customRules.count
+            AppLogger.shared.log("🗑️ [CustomRules] After removal: afterCount=\(afterCount), removed=\(beforeCount - afterCount)")
+            await regenerateConfigFromCollections()
+        }
     }
 
     /// Clear all custom rules (without affecting rule collections)
     func clearAllCustomRules() async {
-        let count = customRules.count
-        AppLogger.shared.log("🧹 [CustomRules] Clearing all \(count) custom rules")
-        customRules.removeAll()
-        await regenerateConfigFromCollections()
-        AppLogger.shared.log("✅ [CustomRules] All custom rules cleared")
+        await withRuleMutation(failure: ()) { [self] _ in
+            let count = customRules.count
+            AppLogger.shared.log("🧹 [CustomRules] Clearing all \(count) custom rules")
+            customRules.removeAll()
+            await regenerateConfigFromCollections()
+            AppLogger.shared.log("✅ [CustomRules] All custom rules cleared")
+        }
     }
 
     /// Create or update a custom rule for the given input/output

--- a/Tests/KeyPathTests/Managers/SharedConfigurationAdmissionTests.swift
+++ b/Tests/KeyPathTests/Managers/SharedConfigurationAdmissionTests.swift
@@ -1,0 +1,163 @@
+import Foundation
+@testable import KeyPathAppKit
+import KeyPathCore
+import KeyPathRulesCore
+@preconcurrency import XCTest
+
+@MainActor
+final class SharedConfigurationAdmissionTests: KeyPathTestCase {
+    func testCollectionEditWaitsBeforeMutatingDuringGeneratedSaveRollback() async throws {
+        try await withFixture { service, manager, coordinator in
+            let entered = self.expectation(description: "first reload entered")
+            let started = self.expectation(description: "collection edit requested")
+            var resume: CheckedContinuation<Void, Never>?
+            let first = Task { @MainActor in
+                await coordinator.saveGeneratedConfig(content: "(defcfg)\n(defsrc a)\n(deflayer base b)") {
+                    await withCheckedContinuation { continuation in
+                        resume = continuation
+                        entered.fulfill()
+                    }
+                    return ReloadResult(success: false, response: nil, errorMessage: "reject", protocol: nil, disposition: .rejected)
+                }
+            }
+            await self.fulfillment(of: [entered], timeout: 5)
+            let rule = manager.makeCustomRule(input: "a", output: "c")
+            let second = Task { @MainActor in
+                started.fulfill()
+                return await manager.saveCustomRule(rule)
+            }
+            await self.fulfillment(of: [started], timeout: 5)
+            XCTAssertTrue(manager.customRules.isEmpty, "Queued edits must not stage state before admission")
+            resume?.resume()
+            let firstResult = await first.value
+            let secondResult = await second.value
+            XCTAssertFalse(firstResult.success)
+            XCTAssertTrue(secondResult)
+            XCTAssertEqual(manager.customRules.map(\.id), [rule.id])
+            let stored = await manager.customRulesStore.loadRules()
+            XCTAssertEqual(stored.map(\.id), [rule.id])
+            let committed = await service.current()
+            XCTAssertEqual(try String(contentsOfFile: service.configurationPath, encoding: .utf8), committed.content)
+        }
+    }
+
+    func testReloadCallbackCannotReenterCollectionMutation() async throws {
+        try await withFixture { _, manager, coordinator in
+            var errors: [String] = []
+            manager.onError = { errors.append($0) }
+            let result = await coordinator.saveGeneratedConfig(content: "(defcfg)\n(defsrc a)\n(deflayer base b)") {
+                let rule = manager.makeCustomRule(input: "a", output: "c")
+                let nested = await manager.saveCustomRule(rule)
+                XCTAssertFalse(nested)
+                return ReloadResult(success: true, response: nil, errorMessage: nil, protocol: nil)
+            }
+            XCTAssertTrue(result.success)
+            XCTAssertTrue(manager.customRules.isEmpty)
+            XCTAssertTrue(errors.contains { $0.contains("recursively") })
+        }
+    }
+
+    func testQueuedCollectionCancellationDoesNotStageOrPersistRule() async throws {
+        try await withFixture { service, manager, _ in
+            let entered = self.expectation(description: "gate occupied")
+            let started = self.expectation(description: "edit requested")
+            var resume: CheckedContinuation<Void, Never>?
+            let holder = Task { @MainActor in
+                try await service.operationGate.withOperation { @MainActor _ in
+                    await withCheckedContinuation { continuation in
+                        resume = continuation
+                        entered.fulfill()
+                    }
+                }
+            }
+            await self.fulfillment(of: [entered], timeout: 5)
+            let rule = manager.makeCustomRule(input: "a", output: "c")
+            let edit = Task { @MainActor in
+                started.fulfill()
+                return await manager.saveCustomRule(rule)
+            }
+            await self.fulfillment(of: [started], timeout: 5)
+            edit.cancel()
+            resume?.resume()
+            try await holder.value
+            let saved = await edit.value
+            XCTAssertFalse(saved)
+            XCTAssertTrue(manager.customRules.isEmpty)
+            let stored = await manager.customRulesStore.loadRules()
+            XCTAssertTrue(stored.isEmpty)
+        }
+    }
+
+    func testTwoCoordinatorsShareAdmissionAcrossRejectedReload() async throws {
+        try await withFixture { service, _, firstCoordinator in
+            let secondCoordinator = SaveCoordinator(configurationService: service, engineClient: TCPEngineClient())
+            let entered = self.expectation(description: "first reload entered")
+            let started = self.expectation(description: "second save requested")
+            var resume: CheckedContinuation<Void, Never>?
+            var secondReloaded = false
+            let first = Task { @MainActor in
+                await firstCoordinator.saveGeneratedConfig(content: "(defcfg)\n(defsrc a)\n(deflayer base b)") {
+                    await withCheckedContinuation { continuation in
+                        resume = continuation
+                        entered.fulfill()
+                    }
+                    return ReloadResult(success: false, response: nil, errorMessage: "reject", protocol: nil, disposition: .rejected)
+                }
+            }
+            await self.fulfillment(of: [entered], timeout: 5)
+            let finalContent = "(defcfg)\n(defsrc a)\n(deflayer base c)"
+            let second = Task { @MainActor in
+                started.fulfill()
+                return await secondCoordinator.saveGeneratedConfig(content: finalContent) {
+                    secondReloaded = true
+                    return ReloadResult(success: true, response: nil, errorMessage: nil, protocol: nil)
+                }
+            }
+            await self.fulfillment(of: [started], timeout: 5)
+            XCTAssertFalse(secondReloaded)
+            resume?.resume()
+            let rejected = await first.value
+            let accepted = await second.value
+            XCTAssertFalse(rejected.success)
+            XCTAssertTrue(accepted.success)
+            XCTAssertEqual(try String(contentsOfFile: service.configurationPath, encoding: .utf8), finalContent)
+        }
+    }
+
+    func testExplicitNestedPermitAndStalePermit() async throws {
+        let gate = ConfigurationOperationGate()
+        var previous: ConfigurationOperationGate.Permit?
+        let value = try await gate.withOperation { @MainActor permit in
+            previous = permit
+            return try await gate.withOperation(using: permit) { _ in 7 }
+        }
+        XCTAssertEqual(value, 7)
+        do {
+            _ = try await gate.withOperation(using: XCTUnwrap(previous)) { _ in 8 }
+            XCTFail("A finished operation must not authorize later nested writes")
+        } catch ConfigurationOperationGate.Failure.invalidPermit {
+            // Expected.
+        }
+        let next = try await gate.withOperation { _ in 9 }
+        XCTAssertEqual(next, 9)
+    }
+
+    private func withFixture(
+        _ body: @MainActor (ConfigurationService, RuleCollectionsManager, SaveCoordinator) async throws -> Void
+    ) async throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let suite = "SharedAdmissionTests.\(UUID().uuidString)"
+        let preferences = try XCTUnwrap(UserDefaults(suiteName: suite))
+        defer { preferences.removePersistentDomain(forName: suite) }
+        let collections = RuleCollectionStore.testStore(at: directory.appendingPathComponent("RuleCollections.json"))
+        let rules = CustomRulesStore.testStore(at: directory.appendingPathComponent("CustomRules.json"))
+        let service = ConfigurationService(configDirectory: directory.path, ruleCollectionStore: collections, customRulesStore: rules)
+        try "(defcfg)\n(defsrc a)\n(deflayer base a)".write(toFile: service.configurationPath, atomically: true, encoding: .utf8)
+        let manager = RuleCollectionsManager(ruleCollectionStore: collections, customRulesStore: rules, configurationService: service, keymapPreferences: preferences)
+        manager.onRulesChanged = { ReloadResult(success: true, response: nil, errorMessage: nil, protocol: nil) }
+        let coordinator = SaveCoordinator(configurationService: service, engineClient: TCPEngineClient())
+        try await body(service, manager, coordinator)
+    }
+}

--- a/docs/architecture/configuration-save-pipeline.md
+++ b/docs/architecture/configuration-save-pipeline.md
@@ -61,18 +61,31 @@ sites. They performed direct file writes outside the supported ownership model,
 which could bypass current-configuration updates and rollback classification if
 they were reused later.
 
-## Coordinator-local operation isolation
+## Shared operation admission
 
-Mapping saves, generated saves, and explicit backup restoration now share a FIFO
-admission gate in `SaveCoordinator`. The slot is held across async reload and file
-recovery. Each save snapshots the file itself; it does not use the possibly stale
-parsed cache or read a mutable shared backup at rollback time. Queued cancellation
-is observed at admission without a write or reload; after mutation begins the
-existing completion/recovery path runs to completion.
+`ConfigurationService.operationGate` provides FIFO admission for generated and
+mapping saves, explicit restoration, and the collection manager's public async
+mutation APIs (including keymap selection). Admission happens before staging
+in-memory collection state and remains held through persistence, reload and
+recovery. Two coordinators using the same service share that admission queue.
+Each save snapshots the file itself rather than using the parsed cache or a
+mutable backup captured by another save.
 
-This gate covers this coordinator only. Collection/pack/CLI operation ownership and external edits still need migration.
-The collection file journal below provides a separate durable recovery boundary.
-See [the reproduced rollback race](../bugs/save-coordinator-overlapping-rollback.md).
+Trusted nested calls pass the active permit explicitly: mapping saves enter the
+custom-rule API, and collection helpers can enter another public mutation without
+waiting on themselves. Callbacks receive no permit; recursive saves through the
+same service fail instead of deadlocking. Permits expire with their operation.
+Queued cancellation is observed at admission before mutation. Once admitted,
+existing completion/recovery behavior remains unchanged.
+
+This is admission for one service instance, not a global or cross-process lock.
+Callers that compose a coordinator and collection manager must share the same
+service. Direct service writes, bootstrap/regeneration entry points, pack code
+that stages arrays directly, CLI writers and external edits still need migration.
+The collection journal below provides a separate durable file recovery boundary;
+admission alone does not restore source stores or preferences after engine
+rejection. See [the original coordinator race](../bugs/save-coordinator-overlapping-rollback.md)
+and [shared mutation admission](../bugs/shared-configuration-admission.md).
 
 Explicit-restore failure throws `SaveRecoveryError`, retaining both causes while
 preserving the fallback error description used by existing presentation.

--- a/docs/bugs/shared-configuration-admission.md
+++ b/docs/bugs/shared-configuration-admission.md
@@ -1,0 +1,24 @@
+# Shared configuration mutation admission
+
+A generated save could wait for an engine reload while a collection edit changed
+its source state and wrote another configuration. Rejection of the first save
+then restored its earlier file over the second edit. The coordinator's local FIFO
+queue protected only its own callers; a second coordinator and the collection
+manager did not share that queue.
+
+Admission now belongs to the shared ConfigurationService. Public collection
+mutations acquire it before reading snapshots or staging state. SaveCoordinator
+holds it across reload and recovery. Explicit, expiring permits identify trusted
+nested work; callbacks cannot use inherited task context as automatic permission
+to reenter a save.
+
+`SharedConfigurationAdmissionTests` covers a collection edit waiting behind a
+rejected generated save, two coordinators sharing that service, cancellation
+before collection mutation, callback reentry and expired nested permits. Existing
+SaveCoordinator tests retain coverage of FIFO ordering, recovery and callback
+cycles.
+
+This change does not make every writer exclusive: direct service, bootstrap,
+pack and CLI paths still require migration. The durable journal and runtime
+rollback also remain distinct boundaries. Do not treat this queue as proof of
+whole-operation rollback or protection against external editors.


### PR DESCRIPTION
A collection edit could stage new source state while a generated save was waiting for reload; rejection of the earlier save could then restore a stale configuration over the later edit. The old FIFO queue covered only one SaveCoordinator.

Move admission to the shared ConfigurationService and acquire it before public collection/keymap mutations. Coordinators hold the same slot through reload and recovery. Trusted nested calls pass expiring permits; callbacks fail on recursive entry, and cancelled queued operations leave before mutation. Existing persistence/reload return semantics and UI remain unchanged.

Coverage is deliberately bounded to these migrated entry points on one service instance. Direct service writers, bootstrap/regeneration, pack internals, CLI and external edits still need migration; this does not claim whole-operation source/preference rollback after runtime rejection. Architecture and bug notes record those boundaries.

Validation:
- 34 focused tests passed, including five new shared-admission tests and existing save/keymap rollback tests.
- Running the new tests against the prior coordinator/collection implementations reproduced premature in-memory staging and recursive callback writes (four assertions failed); modified sources were restored afterward.
- Full safe suite reported 5,120 passes and only four previously reproduced macOS 27 baseline snapshot failures: EasyViewSnapshotTests.testHomeRowTimingFastTyping, testHomeRowTimingPerFinger, testHomeRowTimingSlider; HardViewSnapshotTests.testRepairSettingsTabView. No compiler warnings. Snapshot references were not changed.
- Accessibility check and diff whitespace check passed.
- remote review gate selected; GitHub claude-review must pass before merge.

Local validation explicitly pairs stable Xcode 26.6 and its SDK because the machine-wide default is a beta.

Review follow-up:
- Shared-instance wiring is required and documented in the architecture note. RuntimeCoordinator constructs both the manager and coordinator with its same configurationService; focused SaveCoordinator/manager fixtures also share it. A foreign or expired permit deliberately fails closed instead of entering a second queue.
- Callback recursion is explicitly exercised by testReloadCallbackCannotReenterCollectionMutation: the reload callback calls saveCustomRule, receives false, reports the recursion error, and leaves rules untouched. Trusted createLayer/addCollection, collection-output/leader-key, launcher update/apply and mapping/custom-rule edges forward permits. Existing collection and SaveCoordinator callback-cycle tests ran in the full suite.
- Queued cancellation intentionally retains FIFO position; after admission it immediately throws before invoking the operation, with no write/reload or UI error. This preserves the prior coordinator contract; testQueuedCollectionCancellationDoesNotStageOrPersistRule covers the manager path.
