### PR TITLE
Serialize whole pack operations and startup reconciliation

### DIFF
--- a/Sources/KeyPathAppKit/Services/Packs/PackInstaller.swift
+++ b/Sources/KeyPathAppKit/Services/Packs/PackInstaller.swift
@@ -92,148 +92,210 @@ public final class PackInstaller {
         skipFinalReload: Bool = false,
         installedPackTracker: InstalledPackTracker = .shared
     ) async throws -> InstalledPackRecord {
-        AppLogger.shared.log(
-            "📦 [PackInstaller] Installing pack '\(pack.name)' (id=\(pack.id), v\(pack.version))"
-        )
-
-        try await enforcePreInstallGates(
-            for: pack,
-            manager: manager,
-            installedPackTracker: installedPackTracker
-        )
-
-        // Resolve effective quick-setting values (user-provided ∪ defaults).
-        let resolvedSettings = resolveQuickSettings(pack: pack, overrides: quickSettingValues)
-
-        // Visual-only packs (e.g. KindaVim Mode Display) don't touch the
-        // kanata config at all — install just persists the tracker record
-        // so other parts of the app (overlay, mode monitor) can react to
-        // "this pack is active". No collection toggle, no reload.
-        if pack.visualOnly {
-            let previousInstallRecord = await installedPackTracker.record(for: pack.id)
-            let record = InstalledPackRecord(
-                packID: pack.id,
-                version: pack.version,
-                installedAt: Date(),
-                quickSettingValues: resolvedSettings
-            )
-            do {
-                try await installedPackTracker.upsert(record)
-            } catch {
-                AppLogger.shared.errorUnlessQuietTest(
-                    "❌ [PackInstaller] Could not persist visual-only install record for '\(pack.name)'; restoring previous state"
-                )
-                let installRecordRestored = await restoreInstallRecord(
-                    previousInstallRecord,
-                    packID: pack.id,
-                    installedPackTracker: installedPackTracker
-                )
-                guard installRecordRestored else {
-                    throw InstallError.saveFailed(
-                        "visual-only installed-pack record could not be saved and the previous state could not be fully restored"
-                    )
-                }
-                throw error
-            }
+        try await manager.configurationService.operationGate.withOperation { @MainActor [self] permit in
             AppLogger.shared.log(
-                "✅ [PackInstaller] Installed visual-only pack '\(pack.name)' (no kanata side effects)"
+                "📦 [PackInstaller] Installing pack '\(pack.name)' (id=\(pack.id), v\(pack.version))"
             )
-            return record
-        }
 
-        // System packs batch all collection changes into a single config regen.
-        if pack.isSystemPack {
+            try await enforcePreInstallGates(
+                for: pack,
+                manager: manager,
+                installedPackTracker: installedPackTracker
+            )
+
+            // Resolve effective quick-setting values (user-provided ∪ defaults).
+            let resolvedSettings = resolveQuickSettings(pack: pack, overrides: quickSettingValues)
+
+            // Visual-only packs (e.g. KindaVim Mode Display) don't touch the
+            // kanata config at all — install just persists the tracker record
+            // so other parts of the app (overlay, mode monitor) can react to
+            // "this pack is active". No collection toggle, no reload.
+            if pack.visualOnly {
+                let previousInstallRecord = await installedPackTracker.record(for: pack.id)
+                let record = InstalledPackRecord(
+                    packID: pack.id,
+                    version: pack.version,
+                    installedAt: Date(),
+                    quickSettingValues: resolvedSettings
+                )
+                do {
+                    try await installedPackTracker.upsert(record)
+                } catch {
+                    AppLogger.shared.errorUnlessQuietTest(
+                        "❌ [PackInstaller] Could not persist visual-only install record for '\(pack.name)'; restoring previous state"
+                    )
+                    let installRecordRestored = await restoreInstallRecord(
+                        previousInstallRecord,
+                        packID: pack.id,
+                        installedPackTracker: installedPackTracker
+                    )
+                    guard installRecordRestored else {
+                        throw InstallError.saveFailed(
+                            "visual-only installed-pack record could not be saved and the previous state could not be fully restored"
+                        )
+                    }
+                    throw error
+                }
+                AppLogger.shared.log(
+                    "✅ [PackInstaller] Installed visual-only pack '\(pack.name)' (no kanata side effects)"
+                )
+                return record
+            }
+
+            // System packs batch all collection changes into a single config regen.
+            if pack.isSystemPack {
+                let ruleStateSnapshot = manager.snapshotRuleState()
+                let previousInstallRecord = await installedPackTracker.record(for: pack.id)
+                let previousCollectionSnapshot = PackCollectionSnapshot.load(for: pack.id)
+                let record = InstalledPackRecord(
+                    packID: pack.id,
+                    version: pack.version,
+                    installedAt: Date(),
+                    quickSettingValues: resolvedSettings
+                )
+                do {
+                    try await applyManagedDefaults(
+                        pack: pack,
+                        manager: manager,
+                        policy: managedDefaultPolicy,
+                        associatedCollectionConfiguration: collectionConfiguration,
+                        skipReload: skipFinalReload
+                    )
+                } catch {
+                    AppLogger.shared.errorUnlessQuietTest(
+                        "❌ [PackInstaller] Could not apply system-pack defaults for '\(pack.name)'; restoring previous state"
+                    )
+                    let installRecordRestored = await restoreInstallRecord(
+                        previousInstallRecord,
+                        packID: pack.id,
+                        installedPackTracker: installedPackTracker
+                    )
+                    let collectionSnapshotRestored = restoreManagedCollectionSnapshot(
+                        previousCollectionSnapshot,
+                        packID: pack.id
+                    )
+                    let rollbackApplied = await manager.rollbackToSnapshot(
+                        ruleStateSnapshot,
+                        userMessage: "Could not apply this system pack. Your previous rule state was restored."
+                    )
+                    guard rollbackApplied, collectionSnapshotRestored, installRecordRestored else {
+                        throw InstallError.saveFailed(
+                            "system-pack defaults could not be applied and the previous state could not be fully restored"
+                        )
+                    }
+                    throw error
+                }
+                do {
+                    try await installedPackTracker.upsert(record)
+                } catch {
+                    AppLogger.shared.errorUnlessQuietTest(
+                        "❌ [PackInstaller] Could not persist system-pack record for '\(pack.name)'; restoring previous state"
+                    )
+                    let installRecordRestored = await restoreInstallRecord(
+                        previousInstallRecord,
+                        packID: pack.id,
+                        installedPackTracker: installedPackTracker
+                    )
+                    let collectionSnapshotRestored = restoreManagedCollectionSnapshot(
+                        previousCollectionSnapshot,
+                        packID: pack.id
+                    )
+                    let rollbackApplied = await manager.rollbackToSnapshot(
+                        ruleStateSnapshot,
+                        userMessage: "Could not record this system pack installation. Your previous rule state was restored."
+                    )
+                    guard rollbackApplied, collectionSnapshotRestored, installRecordRestored else {
+                        throw InstallError.saveFailed(
+                            "installed-pack record could not be saved and the previous system-pack state could not be fully restored"
+                        )
+                    }
+                    throw error
+                }
+                AppLogger.shared.log(
+                    "✅ [PackInstaller] Installed system pack '\(pack.name)'"
+                )
+                return record
+            }
+
+            // Collection-backed packs (e.g. Home Row Mods) don't generate custom
+            // rules — they just toggle the built-in RuleCollection on.
+            if let collectionID = pack.associatedCollectionID {
+                let ruleStateSnapshot = manager.snapshotRuleState()
+                let previousInstallRecord = await installedPackTracker.record(for: pack.id)
+                let ok = await manager.toggleCollection(
+                    id: collectionID,
+                    isEnabled: true,
+                    autoResolveConflicts: autoResolveCollectionConflicts,
+                    bypassOwnershipCheck: true,
+                    configurationOverride: collectionConfiguration,
+                    additionalCollectionIDsToDisable: additionalCollectionIDsToDisable,
+                    skipReload: skipFinalReload,
+                    mutationPermit: permit
+                )
+                if !ok {
+                    throw InstallError.saveFailed("could not enable associated rule collection")
+                }
+
+                let record = InstalledPackRecord(
+                    packID: pack.id,
+                    version: pack.version,
+                    installedAt: Date(),
+                    quickSettingValues: resolvedSettings
+                )
+                do {
+                    try await installedPackTracker.upsert(record)
+                } catch {
+                    AppLogger.shared.errorUnlessQuietTest(
+                        "❌ [PackInstaller] Could not persist install record for '\(pack.name)'; restoring previous rule state"
+                    )
+                    let installRecordRestored = await restoreInstallRecord(
+                        previousInstallRecord,
+                        packID: pack.id,
+                        installedPackTracker: installedPackTracker
+                    )
+                    let rollbackApplied = await manager.rollbackToSnapshot(
+                        ruleStateSnapshot,
+                        userMessage: "Could not record this pack installation. Your previous rule state was restored."
+                    )
+                    guard rollbackApplied, installRecordRestored else {
+                        throw InstallError.saveFailed(
+                            "installed-pack record could not be saved and the previous state could not be fully restored"
+                        )
+                    }
+                    throw error
+                }
+                AppLogger.shared.log(
+                    "✅ [PackInstaller] Installed pack '\(pack.name)' via collection toggle (id=\(collectionID))"
+                )
+                return record
+            }
+
+            // Build CustomRule entries from templates.
             let ruleStateSnapshot = manager.snapshotRuleState()
             let previousInstallRecord = await installedPackTracker.record(for: pack.id)
-            let previousCollectionSnapshot = PackCollectionSnapshot.load(for: pack.id)
-            let record = InstalledPackRecord(
-                packID: pack.id,
-                version: pack.version,
-                installedAt: Date(),
-                quickSettingValues: resolvedSettings
-            )
-            do {
-                try await applyManagedDefaults(
-                    pack: pack,
-                    manager: manager,
-                    policy: managedDefaultPolicy,
-                    associatedCollectionConfiguration: collectionConfiguration,
-                    skipReload: skipFinalReload
-                )
-            } catch {
-                AppLogger.shared.errorUnlessQuietTest(
-                    "❌ [PackInstaller] Could not apply system-pack defaults for '\(pack.name)'; restoring previous state"
-                )
-                let installRecordRestored = await restoreInstallRecord(
-                    previousInstallRecord,
-                    packID: pack.id,
-                    installedPackTracker: installedPackTracker
-                )
-                let collectionSnapshotRestored = restoreManagedCollectionSnapshot(
-                    previousCollectionSnapshot,
-                    packID: pack.id
-                )
-                let rollbackApplied = await manager.rollbackToSnapshot(
-                    ruleStateSnapshot,
-                    userMessage: "Could not apply this system pack. Your previous rule state was restored."
-                )
-                guard rollbackApplied, collectionSnapshotRestored, installRecordRestored else {
-                    throw InstallError.saveFailed(
-                        "system-pack defaults could not be applied and the previous state could not be fully restored"
-                    )
-                }
-                throw error
-            }
-            do {
-                try await installedPackTracker.upsert(record)
-            } catch {
-                AppLogger.shared.errorUnlessQuietTest(
-                    "❌ [PackInstaller] Could not persist system-pack record for '\(pack.name)'; restoring previous state"
-                )
-                let installRecordRestored = await restoreInstallRecord(
-                    previousInstallRecord,
-                    packID: pack.id,
-                    installedPackTracker: installedPackTracker
-                )
-                let collectionSnapshotRestored = restoreManagedCollectionSnapshot(
-                    previousCollectionSnapshot,
-                    packID: pack.id
-                )
-                let rollbackApplied = await manager.rollbackToSnapshot(
-                    ruleStateSnapshot,
-                    userMessage: "Could not record this system pack installation. Your previous rule state was restored."
-                )
-                guard rollbackApplied, collectionSnapshotRestored, installRecordRestored else {
-                    throw InstallError.saveFailed(
-                        "installed-pack record could not be saved and the previous system-pack state could not be fully restored"
-                    )
-                }
-                throw error
-            }
-            AppLogger.shared.log(
-                "✅ [PackInstaller] Installed system pack '\(pack.name)'"
-            )
-            return record
-        }
+            let rules = renderBindings(for: pack, quickSettings: resolvedSettings)
 
-        // Collection-backed packs (e.g. Home Row Mods) don't generate custom
-        // rules — they just toggle the built-in RuleCollection on.
-        if let collectionID = pack.associatedCollectionID {
-            let ruleStateSnapshot = manager.snapshotRuleState()
-            let previousInstallRecord = await installedPackTracker.record(for: pack.id)
-            let ok = await manager.toggleCollection(
-                id: collectionID,
-                isEnabled: true,
-                autoResolveConflicts: autoResolveCollectionConflicts,
-                bypassOwnershipCheck: true,
-                configurationOverride: collectionConfiguration,
-                additionalCollectionIDsToDisable: additionalCollectionIDsToDisable,
-                skipReload: skipFinalReload
-            )
-            if !ok {
-                throw InstallError.saveFailed("could not enable associated rule collection")
+            // Append rules in one batch: use skipReload=true for all but the
+            // last, so we only regenerate the config file once at the end.
+            // Callers that chain an immediate edit after install can pass
+            // `skipFinalReload: true` to suppress even the last reload, so a
+            // followup `updateTapHold` fires exactly one reload for the
+            // combined result (and doesn't trip the TCP reload cooldown).
+            for (index, rule) in rules.enumerated() {
+                let isLast = (index == rules.count - 1)
+                let suppressReload = !isLast || skipFinalReload
+                let ok = await manager.saveCustomRule(rule, skipReload: suppressReload, mutationPermit: permit)
+                if !ok {
+                    AppLogger.shared.log(
+                        "❌ [PackInstaller] Failed to save rule \(index + 1)/\(rules.count) for pack '\(pack.id)'"
+                    )
+                    // Roll back: remove whatever got added so far.
+                    await rollbackPartialInstall(packID: pack.id, manager: manager, mutationPermit: permit)
+                    throw InstallError.saveFailed("rule \(index + 1) of \(rules.count) could not be saved")
+                }
             }
 
+            // Record the install.
             let record = InstalledPackRecord(
                 packID: pack.id,
                 version: pack.version,
@@ -244,7 +306,7 @@ public final class PackInstaller {
                 try await installedPackTracker.upsert(record)
             } catch {
                 AppLogger.shared.errorUnlessQuietTest(
-                    "❌ [PackInstaller] Could not persist install record for '\(pack.name)'; restoring previous rule state"
+                    "❌ [PackInstaller] Could not persist install record for '\(pack.name)'; restoring previous state"
                 )
                 let installRecordRestored = await restoreInstallRecord(
                     previousInstallRecord,
@@ -262,71 +324,12 @@ public final class PackInstaller {
                 }
                 throw error
             }
+
             AppLogger.shared.log(
-                "✅ [PackInstaller] Installed pack '\(pack.name)' via collection toggle (id=\(collectionID))"
+                "✅ [PackInstaller] Installed pack '\(pack.name)': \(rules.count) binding(s)"
             )
             return record
         }
-
-        // Build CustomRule entries from templates.
-        let ruleStateSnapshot = manager.snapshotRuleState()
-        let previousInstallRecord = await installedPackTracker.record(for: pack.id)
-        let rules = renderBindings(for: pack, quickSettings: resolvedSettings)
-
-        // Append rules in one batch: use skipReload=true for all but the
-        // last, so we only regenerate the config file once at the end.
-        // Callers that chain an immediate edit after install can pass
-        // `skipFinalReload: true` to suppress even the last reload, so a
-        // followup `updateTapHold` fires exactly one reload for the
-        // combined result (and doesn't trip the TCP reload cooldown).
-        for (index, rule) in rules.enumerated() {
-            let isLast = (index == rules.count - 1)
-            let suppressReload = !isLast || skipFinalReload
-            let ok = await manager.saveCustomRule(rule, skipReload: suppressReload)
-            if !ok {
-                AppLogger.shared.log(
-                    "❌ [PackInstaller] Failed to save rule \(index + 1)/\(rules.count) for pack '\(pack.id)'"
-                )
-                // Roll back: remove whatever got added so far.
-                await rollbackPartialInstall(packID: pack.id, manager: manager)
-                throw InstallError.saveFailed("rule \(index + 1) of \(rules.count) could not be saved")
-            }
-        }
-
-        // Record the install.
-        let record = InstalledPackRecord(
-            packID: pack.id,
-            version: pack.version,
-            installedAt: Date(),
-            quickSettingValues: resolvedSettings
-        )
-        do {
-            try await installedPackTracker.upsert(record)
-        } catch {
-            AppLogger.shared.errorUnlessQuietTest(
-                "❌ [PackInstaller] Could not persist install record for '\(pack.name)'; restoring previous state"
-            )
-            let installRecordRestored = await restoreInstallRecord(
-                previousInstallRecord,
-                packID: pack.id,
-                installedPackTracker: installedPackTracker
-            )
-            let rollbackApplied = await manager.rollbackToSnapshot(
-                ruleStateSnapshot,
-                userMessage: "Could not record this pack installation. Your previous rule state was restored."
-            )
-            guard rollbackApplied, installRecordRestored else {
-                throw InstallError.saveFailed(
-                    "installed-pack record could not be saved and the previous state could not be fully restored"
-                )
-            }
-            throw error
-        }
-
-        AppLogger.shared.log(
-            "✅ [PackInstaller] Installed pack '\(pack.name)': \(rules.count) binding(s)"
-        )
-        return record
     }
 
     /// Uninstall a pack. Removes every `CustomRule` tagged with this pack's
@@ -335,93 +338,95 @@ public final class PackInstaller {
         packID: String,
         manager: RuleCollectionsManager
     ) async throws {
-        AppLogger.shared.log("📦 [PackInstaller] Uninstalling pack '\(packID)'")
+        try await manager.configurationService.operationGate.withOperation { @MainActor [self] permit in
+            AppLogger.shared.log("📦 [PackInstaller] Uninstalling pack '\(packID)'")
 
-        // Visual-only packs just clear the tracker record; no kanata
-        // changes to revert.
-        if let pack = PackRegistry.pack(id: packID), pack.visualOnly {
-            try await InstalledPackTracker.shared.remove(packID: packID)
-            AppLogger.shared.log(
-                "✅ [PackInstaller] Uninstalled visual-only pack '\(packID)'"
-            )
-            return
-        }
-
-        // System packs batch all collection changes into a single config regen.
-        if let pack = PackRegistry.pack(id: packID), pack.isSystemPack {
-            let originalCollections = manager.ruleCollections
-            let didRestore = await restoreOrKeepOnUninstall(pack: pack, manager: manager)
-            if let collectionID = pack.associatedCollectionID,
-               let i = manager.ruleCollections.firstIndex(where: { $0.id == collectionID })
-            {
-                manager.ruleCollections[i].isEnabled = false
-            }
-
-            var applied = await manager.regenerateConfigFromCollections()
-            if !applied, didRestore, disableRestoreConflictCollections(for: pack, manager: manager) {
+            // Visual-only packs just clear the tracker record; no kanata
+            // changes to revert.
+            if let pack = PackRegistry.pack(id: packID), pack.visualOnly {
+                try await InstalledPackTracker.shared.remove(packID: packID)
                 AppLogger.shared.log(
-                    "⚠️ [PackInstaller] Retrying managed restore for '\(packID)' after disabling install-conflict collections"
+                    "✅ [PackInstaller] Uninstalled visual-only pack '\(packID)'"
                 )
-                applied = await manager.regenerateConfigFromCollections()
+                return
             }
 
-            guard applied else {
-                manager.ruleCollections = originalCollections
-                throw InstallError.saveFailed("could not apply managed collection restore")
+            // System packs batch all collection changes into a single config regen.
+            if let pack = PackRegistry.pack(id: packID), pack.isSystemPack {
+                let originalCollections = manager.ruleCollections
+                let didRestore = await restoreOrKeepOnUninstall(pack: pack, manager: manager)
+                if let collectionID = pack.associatedCollectionID,
+                   let i = manager.ruleCollections.firstIndex(where: { $0.id == collectionID })
+                {
+                    manager.ruleCollections[i].isEnabled = false
+                }
+
+                var applied = await manager.regenerateConfigFromCollections()
+                if !applied, didRestore, disableRestoreConflictCollections(for: pack, manager: manager) {
+                    AppLogger.shared.log(
+                        "⚠️ [PackInstaller] Retrying managed restore for '\(packID)' after disabling install-conflict collections"
+                    )
+                    applied = await manager.regenerateConfigFromCollections()
+                }
+
+                guard applied else {
+                    manager.ruleCollections = originalCollections
+                    throw InstallError.saveFailed("could not apply managed collection restore")
+                }
+                removeManagedSnapshot(for: pack)
+                try await InstalledPackTracker.shared.remove(packID: packID)
+                AppLogger.shared.log(
+                    "✅ [PackInstaller] Uninstalled system pack '\(packID)' (restored=\(didRestore))"
+                )
+                return
             }
-            removeManagedSnapshot(for: pack)
-            try await InstalledPackTracker.shared.remove(packID: packID)
-            AppLogger.shared.log(
-                "✅ [PackInstaller] Uninstalled system pack '\(packID)' (restored=\(didRestore))"
-            )
-            return
-        }
 
-        // Collection-backed packs uninstall by disabling the associated
-        // built-in collection; they don't have their own CustomRules to
-        // remove.
-        if let pack = PackRegistry.pack(id: packID),
-           let collectionID = pack.associatedCollectionID
-        {
-            let ok = await manager.toggleCollection(id: collectionID, isEnabled: false, bypassOwnershipCheck: true)
-            guard ok else {
-                throw InstallError.saveFailed("could not disable associated rule collection")
+            // Collection-backed packs uninstall by disabling the associated
+            // built-in collection; they don't have their own CustomRules to
+            // remove.
+            if let pack = PackRegistry.pack(id: packID),
+               let collectionID = pack.associatedCollectionID
+            {
+                let ok = await manager.toggleCollection(id: collectionID, isEnabled: false, bypassOwnershipCheck: true, mutationPermit: permit)
+                guard ok else {
+                    throw InstallError.saveFailed("could not disable associated rule collection")
+                }
+                try await InstalledPackTracker.shared.remove(packID: packID)
+                AppLogger.shared.log(
+                    "✅ [PackInstaller] Uninstalled pack '\(packID)' via collection toggle off (id=\(collectionID))"
+                )
+                return
             }
+
+            // Snapshot current rule set, drop those owned by this pack.
+            let before = await manager.snapshotCurrentRules()
+            let packRules = before.filter { $0.packSource == packID }
+
+            guard !packRules.isEmpty else {
+                // Nothing to remove from rules, but still clear the tracker
+                // record in case it drifted out of sync.
+                try await InstalledPackTracker.shared.remove(packID: packID)
+                AppLogger.shared.log(
+                    "ℹ️ [PackInstaller] No rules tagged with pack '\(packID)'; cleared tracker record"
+                )
+                return
+            }
+
+            for (index, rule) in packRules.enumerated() {
+                let isLast = (index == packRules.count - 1)
+                // We remove directly — skipReload avoided here since
+                // removeCustomRule regenerates on each call. For M1 we accept
+                // N regenerations; M2 will batch.
+                _ = isLast // reserved for future batching
+                await manager.removeCustomRule(id: rule.id, mutationPermit: permit)
+            }
+
             try await InstalledPackTracker.shared.remove(packID: packID)
+
             AppLogger.shared.log(
-                "✅ [PackInstaller] Uninstalled pack '\(packID)' via collection toggle off (id=\(collectionID))"
+                "✅ [PackInstaller] Uninstalled pack '\(packID)': removed \(packRules.count) rule(s)"
             )
-            return
         }
-
-        // Snapshot current rule set, drop those owned by this pack.
-        let before = await manager.snapshotCurrentRules()
-        let packRules = before.filter { $0.packSource == packID }
-
-        guard !packRules.isEmpty else {
-            // Nothing to remove from rules, but still clear the tracker
-            // record in case it drifted out of sync.
-            try await InstalledPackTracker.shared.remove(packID: packID)
-            AppLogger.shared.log(
-                "ℹ️ [PackInstaller] No rules tagged with pack '\(packID)'; cleared tracker record"
-            )
-            return
-        }
-
-        for (index, rule) in packRules.enumerated() {
-            let isLast = (index == packRules.count - 1)
-            // We remove directly — skipReload avoided here since
-            // removeCustomRule regenerates on each call. For M1 we accept
-            // N regenerations; M2 will batch.
-            _ = isLast // reserved for future batching
-            await manager.removeCustomRule(id: rule.id)
-        }
-
-        try await InstalledPackTracker.shared.remove(packID: packID)
-
-        AppLogger.shared.log(
-            "✅ [PackInstaller] Uninstalled pack '\(packID)': removed \(packRules.count) rule(s)"
-        )
     }
 
     /// Update the tap/hold outputs on an installed pack binding. Used by
@@ -442,59 +447,61 @@ public final class PackInstaller {
         hold: String? = nil,
         manager: RuleCollectionsManager
     ) async -> Bool {
-        let snapshot = await manager.snapshotCurrentRules()
-        let normalizedInput = input.lowercased()
-        guard var rule = snapshot.first(where: {
-            $0.packSource == packID && $0.input.lowercased() == normalizedInput
-        }) else {
-            AppLogger.shared.log(
-                "⚠️ [PackInstaller] updateTapHold: no rule found for pack '\(packID)' input '\(input)'"
-            )
-            return false
-        }
-
-        let existingDual: DualRoleBehavior? = {
-            if case let .dualRole(dr) = rule.behavior { return dr }
-            return nil
-        }()
-
-        let newTap = tap ?? existingDual?.tapActionString ?? rule.action.outputString
-        let newHold = hold ?? existingDual?.holdActionString
-
-        if let newHold, !newHold.isEmpty {
-            rule.action = .keystroke(key: newTap)
-            rule.behavior = .dualRole(
-                DualRoleBehavior(
-                    tapAction: KanataBehaviorRenderer.parseActionString(newTap),
-                    holdAction: KanataBehaviorRenderer.parseActionString(newHold),
-                    tapTimeout: existingDual?.tapTimeout ?? 200,
-                    holdTimeout: existingDual?.holdTimeout ?? 200,
-                    activateHoldOnOtherKey: existingDual?.activateHoldOnOtherKey ?? true,
-                    quickTap: existingDual?.quickTap ?? false,
-                    customTapKeys: existingDual?.customTapKeys ?? [],
-                    useOppositeHand: existingDual?.useOppositeHand ?? false,
-                    useOppositeHandRelease: existingDual?.useOppositeHandRelease ?? false,
-                    useReleaseOrder: existingDual?.useReleaseOrder ?? false,
-                    requirePriorIdleOverrideMs: existingDual?.requirePriorIdleOverrideMs
+        await manager.withRuleMutation(failure: false) { @MainActor permit in
+            let snapshot = await manager.snapshotCurrentRules()
+            let normalizedInput = input.lowercased()
+            guard var rule = snapshot.first(where: {
+                $0.packSource == packID && $0.input.lowercased() == normalizedInput
+            }) else {
+                AppLogger.shared.log(
+                    "⚠️ [PackInstaller] updateTapHold: no rule found for pack '\(packID)' input '\(input)'"
                 )
-            )
-        } else {
-            // Simple remap (no hold).
-            rule.action = .keystroke(key: newTap)
-            rule.behavior = nil
-        }
+                return false
+            }
 
-        let ok = await manager.saveCustomRule(rule, skipReload: false)
-        if ok {
-            AppLogger.shared.log(
-                "✅ [PackInstaller] updateTapHold: pack '\(packID)' input '\(input)' tap='\(newTap)' hold='\(newHold ?? "—")'"
-            )
-        } else {
-            AppLogger.shared.log(
-                "❌ [PackInstaller] updateTapHold: save failed for pack '\(packID)' input '\(input)'"
-            )
+            let existingDual: DualRoleBehavior? = {
+                if case let .dualRole(dr) = rule.behavior { return dr }
+                return nil
+            }()
+
+            let newTap = tap ?? existingDual?.tapActionString ?? rule.action.outputString
+            let newHold = hold ?? existingDual?.holdActionString
+
+            if let newHold, !newHold.isEmpty {
+                rule.action = .keystroke(key: newTap)
+                rule.behavior = .dualRole(
+                    DualRoleBehavior(
+                        tapAction: KanataBehaviorRenderer.parseActionString(newTap),
+                        holdAction: KanataBehaviorRenderer.parseActionString(newHold),
+                        tapTimeout: existingDual?.tapTimeout ?? 200,
+                        holdTimeout: existingDual?.holdTimeout ?? 200,
+                        activateHoldOnOtherKey: existingDual?.activateHoldOnOtherKey ?? true,
+                        quickTap: existingDual?.quickTap ?? false,
+                        customTapKeys: existingDual?.customTapKeys ?? [],
+                        useOppositeHand: existingDual?.useOppositeHand ?? false,
+                        useOppositeHandRelease: existingDual?.useOppositeHandRelease ?? false,
+                        useReleaseOrder: existingDual?.useReleaseOrder ?? false,
+                        requirePriorIdleOverrideMs: existingDual?.requirePriorIdleOverrideMs
+                    )
+                )
+            } else {
+                // Simple remap (no hold).
+                rule.action = .keystroke(key: newTap)
+                rule.behavior = nil
+            }
+
+            let ok = await manager.saveCustomRule(rule, skipReload: false, mutationPermit: permit)
+            if ok {
+                AppLogger.shared.log(
+                    "✅ [PackInstaller] updateTapHold: pack '\(packID)' input '\(input)' tap='\(newTap)' hold='\(newHold ?? "—")'"
+                )
+            } else {
+                AppLogger.shared.log(
+                    "❌ [PackInstaller] updateTapHold: save failed for pack '\(packID)' input '\(input)'"
+                )
+            }
+            return ok
         }
-        return ok
     }
 
     /// Is this pack currently installed?
@@ -518,54 +525,56 @@ public final class PackInstaller {
         newValues: [String: Int],
         manager: RuleCollectionsManager
     ) async throws {
-        guard let pack = PackRegistry.pack(id: packID) else {
-            throw InstallError.saveFailed("pack not found in registry: \(packID)")
-        }
-        guard var record = await InstalledPackTracker.shared.record(for: packID) else {
-            throw InstallError.saveFailed("pack is not installed: \(packID)")
-        }
+        try await manager.configurationService.operationGate.withOperation { @MainActor [self] permit in
+            guard let pack = PackRegistry.pack(id: packID) else {
+                throw InstallError.saveFailed("pack not found in registry: \(packID)")
+            }
+            guard var record = await InstalledPackTracker.shared.record(for: packID) else {
+                throw InstallError.saveFailed("pack is not installed: \(packID)")
+            }
 
-        // Merge new values into existing settings
-        var mergedSettings = record.quickSettingValues
-        for (key, value) in newValues {
-            mergedSettings[key] = value
-        }
+            // Merge new values into existing settings
+            var mergedSettings = record.quickSettingValues
+            for (key, value) in newValues {
+                mergedSettings[key] = value
+            }
 
-        // Clamp to valid ranges
-        let resolved = resolveQuickSettings(pack: pack, overrides: mergedSettings)
+            // Clamp to valid ranges
+            let resolved = resolveQuickSettings(pack: pack, overrides: mergedSettings)
 
-        if let collectionID = pack.associatedCollectionID {
-            // Collection-backed pack: update timing config
-            if let holdTimeout = resolved["holdTimeout"],
-               let index = manager.ruleCollections.firstIndex(where: { $0.id == collectionID })
-            {
-                if case var .homeRowMods(config) = manager.ruleCollections[index].configuration {
-                    config.timing.tapWindow = holdTimeout
-                    config.timing.holdDelay = holdTimeout
-                    manager.ruleCollections[index].configuration = .homeRowMods(config)
-                    await manager.regenerateConfigFromCollections()
+            if let collectionID = pack.associatedCollectionID {
+                // Collection-backed pack: update timing config
+                if let holdTimeout = resolved["holdTimeout"],
+                   let index = manager.ruleCollections.firstIndex(where: { $0.id == collectionID })
+                {
+                    if case var .homeRowMods(config) = manager.ruleCollections[index].configuration {
+                        config.timing.tapWindow = holdTimeout
+                        config.timing.holdDelay = holdTimeout
+                        manager.ruleCollections[index].configuration = .homeRowMods(config)
+                        await manager.regenerateConfigFromCollections()
+                    }
+                }
+            } else if !pack.bindings.isEmpty {
+                // Rule-based pack: re-render bindings with new settings
+                let oldRules = await manager.snapshotCurrentRules().filter { $0.packSource == packID }
+                for rule in oldRules {
+                    await manager.removeCustomRule(id: rule.id, mutationPermit: permit)
+                }
+                let newRules = renderBindings(for: pack, quickSettings: resolved)
+                for (index, rule) in newRules.enumerated() {
+                    let isLast = (index == newRules.count - 1)
+                    _ = await manager.saveCustomRule(rule, skipReload: !isLast, mutationPermit: permit)
                 }
             }
-        } else if !pack.bindings.isEmpty {
-            // Rule-based pack: re-render bindings with new settings
-            let oldRules = await manager.snapshotCurrentRules().filter { $0.packSource == packID }
-            for rule in oldRules {
-                await manager.removeCustomRule(id: rule.id)
-            }
-            let newRules = renderBindings(for: pack, quickSettings: resolved)
-            for (index, rule) in newRules.enumerated() {
-                let isLast = (index == newRules.count - 1)
-                _ = await manager.saveCustomRule(rule, skipReload: !isLast)
-            }
+
+            // Persist updated record
+            record.quickSettingValues = resolved
+            try await InstalledPackTracker.shared.upsert(record)
+
+            AppLogger.shared.log(
+                "✅ [PackInstaller] Updated quick settings for '\(pack.name)': \(resolved)"
+            )
         }
-
-        // Persist updated record
-        record.quickSettingValues = resolved
-        try await InstalledPackTracker.shared.upsert(record)
-
-        AppLogger.shared.log(
-            "✅ [PackInstaller] Updated quick settings for '\(pack.name)': \(resolved)"
-        )
     }
 
     // MARK: - Rendering
@@ -1083,7 +1092,8 @@ public final class PackInstaller {
     /// used when an install fails partway through.
     private func rollbackPartialInstall(
         packID: String,
-        manager: RuleCollectionsManager
+        manager: RuleCollectionsManager,
+        mutationPermit: ConfigurationOperationGate.Permit
     ) async {
         let current = await manager.snapshotCurrentRules()
         let partial = current.filter { $0.packSource == packID }
@@ -1091,7 +1101,7 @@ public final class PackInstaller {
             "↩️ [PackInstaller] Rolling back \(partial.count) rule(s) after failed install of '\(packID)'"
         )
         for rule in partial {
-            await manager.removeCustomRule(id: rule.id)
+            await manager.removeCustomRule(id: rule.id, mutationPermit: mutationPermit)
         }
     }
 }

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+Bootstrap.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+Bootstrap.swift
@@ -8,61 +8,63 @@ extension RuleCollectionsManager {
 
     /// Load rule collections and custom rules from persistent storage
     func bootstrap() async {
-        do {
-            try await configurationService.recoverPendingRuleWrite(
-                collectionStore: ruleCollectionStore, customStore: customRulesStore
-            )
-        } catch {
-            onError?("Could not recover the previous rule edit: \(error.localizedDescription)")
-            return
-        }
-        // Restore keymap state first (before loading collections)
-        restoreKeymapState()
-
-        async let storedCollectionsTask = ruleCollectionStore.loadCollectionsDetailed()
-        async let storedCustomRulesTask = customRulesStore.loadRules()
-
-        let loadResult = await storedCollectionsTask
-        let storedCustomRules = await storedCustomRulesTask
-
-        ruleCollections = RuleCollectionDeduplicator.dedupe(loadResult.collections)
-        customRules = storedCustomRules
-        AppLogger.shared.log("📊 [RuleCollectionsManager] bootstrap: loaded \(customRules.count) custom rules from store")
-
-        if !loadResult.failedCollectionNames.isEmpty || loadResult.wasFullReset {
-            notifyConfigRecovery(loadResult)
-        }
-
-        ensureDefaultCollectionsIfNeeded()
-
-        // Re-enable collections that installed packs expect to be active.
-        // Handles drift when RuleCollections.json is reset independently of installed-packs.json.
-        await reconcilePackCollectionState()
-
-        // Restore keymap collection if a non-identity layout was active
-        if activeKeymapId != LogicalKeymap.qwertyUSId, activeKeymapId != LogicalKeymap.systemId {
-            if let keymapCollection = KeymapMappingGenerator.generateCollection(
-                for: activeKeymapId,
-                includePunctuation: keymapIncludesPunctuation
-            ) {
-                // Remove any stale keymap collection first
-                ruleCollections.removeAll { $0.id == RuleCollectionIdentifier.keymapLayout }
-                // Insert at beginning so custom rules take priority
-                ruleCollections.insert(keymapCollection, at: 0)
-                AppLogger.shared.log("⌨️ [RuleCollections] Restored keymap collection for \(activeKeymapId)")
+        await withRuleMutation(failure: ()) { [self] _ in
+            do {
+                try await configurationService.recoverPendingRuleWrite(
+                    collectionStore: ruleCollectionStore, customStore: customRulesStore
+                )
+            } catch {
+                onError?("Could not recover the previous rule edit: \(error.localizedDescription)")
+                return
             }
-        }
+            // Restore keymap state first (before loading collections)
+            restoreKeymapState()
 
-        dedupeRuleCollectionsInPlace()
-        refreshLayerIndicatorState()
+            async let storedCollectionsTask = ruleCollectionStore.loadCollectionsDetailed()
+            async let storedCustomRulesTask = customRulesStore.loadRules()
 
-        let leaderSnapshot = PreferencesService.shared.leaderKeyPreference
-        let collectionsSnapshot = ruleCollections
-        let didReconcileLeader = reconcileLeaderKeyFromCollection()
+            let loadResult = await storedCollectionsTask
+            let storedCustomRules = await storedCustomRulesTask
 
-        let applied = await regenerateConfigFromCollections()
-        if didReconcileLeader, !applied {
-            rollbackLeaderReconcile(preference: leaderSnapshot, collections: collectionsSnapshot)
+            ruleCollections = RuleCollectionDeduplicator.dedupe(loadResult.collections)
+            customRules = storedCustomRules
+            AppLogger.shared.log("📊 [RuleCollectionsManager] bootstrap: loaded \(customRules.count) custom rules from store")
+
+            if !loadResult.failedCollectionNames.isEmpty || loadResult.wasFullReset {
+                notifyConfigRecovery(loadResult)
+            }
+
+            ensureDefaultCollectionsIfNeeded()
+
+            // Re-enable collections that installed packs expect to be active.
+            // Handles drift when RuleCollections.json is reset independently of installed-packs.json.
+            await reconcilePackCollectionState()
+
+            // Restore keymap collection if a non-identity layout was active
+            if activeKeymapId != LogicalKeymap.qwertyUSId, activeKeymapId != LogicalKeymap.systemId {
+                if let keymapCollection = KeymapMappingGenerator.generateCollection(
+                    for: activeKeymapId,
+                    includePunctuation: keymapIncludesPunctuation
+                ) {
+                    // Remove any stale keymap collection first
+                    ruleCollections.removeAll { $0.id == RuleCollectionIdentifier.keymapLayout }
+                    // Insert at beginning so custom rules take priority
+                    ruleCollections.insert(keymapCollection, at: 0)
+                    AppLogger.shared.log("⌨️ [RuleCollections] Restored keymap collection for \(activeKeymapId)")
+                }
+            }
+
+            dedupeRuleCollectionsInPlace()
+            refreshLayerIndicatorState()
+
+            let leaderSnapshot = PreferencesService.shared.leaderKeyPreference
+            let collectionsSnapshot = ruleCollections
+            let didReconcileLeader = reconcileLeaderKeyFromCollection()
+
+            let applied = await regenerateConfigFromCollections()
+            if didReconcileLeader, !applied {
+                rollbackLeaderReconcile(preference: leaderSnapshot, collections: collectionsSnapshot)
+            }
         }
     }
 

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+PublicAPI.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+PublicAPI.swift
@@ -50,9 +50,10 @@ extension RuleCollectionsManager {
         bypassOwnershipCheck: Bool = false,
         configurationOverride: RuleCollectionConfiguration? = nil,
         additionalCollectionIDsToDisable: Set<UUID> = [],
-        skipReload: Bool = false
+        skipReload: Bool = false,
+        mutationPermit: ConfigurationOperationGate.Permit? = nil
     ) async -> Bool {
-        await withRuleMutation(failure: false) { [self] _ in
+        await withRuleMutation(using: mutationPermit, failure: false) { [self] _ in
             AppLogger.shared.log("🔀 [RuleCollections] toggleCollection called: id=\(id), isEnabled=\(isEnabled)")
 
             if !bypassOwnershipCheck {
@@ -1069,8 +1070,8 @@ extension RuleCollectionsManager {
     }
 
     /// Remove a custom rule
-    func removeCustomRule(id: UUID) async {
-        await withRuleMutation(failure: ()) { [self] _ in
+    func removeCustomRule(id: UUID, mutationPermit: ConfigurationOperationGate.Permit? = nil) async {
+        await withRuleMutation(using: mutationPermit, failure: ()) { [self] _ in
             let beforeCount = customRules.count
             AppLogger.shared.log("🗑️ [CustomRules] removeCustomRule called: id=\(id), beforeCount=\(beforeCount)")
             customRules.removeAll { $0.id == id }

--- a/Tests/KeyPathTests/Managers/SharedConfigurationAdmissionTests.swift
+++ b/Tests/KeyPathTests/Managers/SharedConfigurationAdmissionTests.swift
@@ -142,6 +142,79 @@ final class SharedConfigurationAdmissionTests: KeyPathTestCase {
         XCTAssertEqual(next, 9)
     }
 
+    func testReloadCallbackCannotInstallVisualOnlyPackMetadata() async throws {
+        try await withFixture { service, manager, coordinator in
+            let pack = Pack(id: "test.admission.visual", version: "1", name: "Visual",
+                            tagline: "", shortDescription: "", longDescription: "",
+                            category: "Test", iconSymbol: "testtube.2", bindings: [], visualOnly: true)
+            let tracker = InstalledPackTracker(fileURL: URL(fileURLWithPath: service.configurationPath)
+                .deletingLastPathComponent().appendingPathComponent("installed-packs.json"))
+            let result = await coordinator.saveGeneratedConfig(content: "(defcfg)\n(defsrc a)\n(deflayer base b)") {
+                do {
+                    _ = try await PackInstaller.shared.install(pack, manager: manager, installedPackTracker: tracker)
+                    XCTFail("A callback must not mutate pack metadata inside another save")
+                } catch ConfigurationOperationGate.Failure.recursiveOperation {
+                    // Expected before any tracker mutation.
+                } catch {
+                    XCTFail("Unexpected failure: \(error)")
+                }
+                return ReloadResult(success: true, response: nil, errorMessage: nil, protocol: nil)
+            }
+            XCTAssertTrue(result.success)
+            let record = await tracker.record(for: pack.id)
+            XCTAssertNil(record)
+        }
+    }
+
+    func testReloadCallbackCannotReplaceManagerStateThroughBootstrap() async throws {
+        try await withFixture { _, manager, coordinator in
+            var errors: [String] = []
+            manager.onError = { errors.append($0) }
+            let result = await coordinator.saveGeneratedConfig(content: "(defcfg)\n(defsrc a)\n(deflayer base b)") {
+                await manager.bootstrap()
+                return ReloadResult(success: true, response: nil, errorMessage: nil, protocol: nil)
+            }
+            XCTAssertTrue(result.success)
+            XCTAssertTrue(manager.ruleCollections.isEmpty)
+            XCTAssertTrue(errors.contains { $0.contains("recursively") })
+        }
+    }
+
+    func testCancelledPackInstallDoesNotWriteMetadata() async throws {
+        try await withFixture { service, manager, _ in
+            let pack = Pack(id: "test.admission.cancelled", version: "1", name: "Cancelled",
+                            tagline: "", shortDescription: "", longDescription: "",
+                            category: "Test", iconSymbol: "testtube.2", bindings: [], visualOnly: true)
+            let tracker = InstalledPackTracker(fileURL: URL(fileURLWithPath: service.configurationPath)
+                .deletingLastPathComponent().appendingPathComponent("installed-packs.json"))
+            let entered = self.expectation(description: "gate occupied")
+            var resume: CheckedContinuation<Void, Never>?
+            let holder = Task { @MainActor in
+                try await service.operationGate.withOperation { @MainActor _ in
+                    await withCheckedContinuation { continuation in
+                        resume = continuation
+                        entered.fulfill()
+                    }
+                }
+            }
+            await self.fulfillment(of: [entered], timeout: 5)
+            let install = Task { @MainActor in
+                try await PackInstaller.shared.install(pack, manager: manager, installedPackTracker: tracker)
+            }
+            install.cancel()
+            resume?.resume()
+            try await holder.value
+            do {
+                _ = try await install.value
+                XCTFail("Cancelled admission must not install a pack")
+            } catch is CancellationError {
+                // Expected.
+            }
+            let record = await tracker.record(for: pack.id)
+            XCTAssertNil(record)
+        }
+    }
+
     private func withFixture(
         _ body: @MainActor (ConfigurationService, RuleCollectionsManager, SaveCoordinator) async throws -> Void
     ) async throws {

--- a/docs/architecture/configuration-save-pipeline.md
+++ b/docs/architecture/configuration-save-pipeline.md
@@ -65,7 +65,8 @@ they were reused later.
 
 `ConfigurationService.operationGate` provides FIFO admission for generated and
 mapping saves, explicit restoration, and the collection manager's public async
-mutation APIs (including keymap selection). Admission happens before staging
+mutation APIs (including keymap selection), bootstrap reconciliation, and pack
+install/uninstall/settings operations. Admission happens before staging
 in-memory collection state and remains held through persistence, reload and
 recovery. Two coordinators using the same service share that admission queue.
 Each save snapshots the file itself rather than using the parsed cache or a
@@ -80,8 +81,10 @@ existing completion/recovery behavior remains unchanged.
 
 This is admission for one service instance, not a global or cross-process lock.
 Callers that compose a coordinator and collection manager must share the same
-service. Direct service writes, bootstrap/regeneration entry points, pack code
-that stages arrays directly, CLI writers and external edits still need migration.
+service. Direct service writes, standalone regeneration entry points, CLI writers and
+external edits still need migration. Pack operations hold admission while staging
+arrays, making nested collection calls, updating metadata and running their
+existing recovery paths; their multiple writes are still separate durable commits.
 The collection journal below provides a separate durable file recovery boundary;
 admission alone does not restore source stores or preferences after engine
 rejection. See [the original coordinator race](../bugs/save-coordinator-overlapping-rollback.md)

--- a/docs/bugs/shared-configuration-admission.md
+++ b/docs/bugs/shared-configuration-admission.md
@@ -18,7 +18,12 @@ before collection mutation, callback reentry and expired nested permits. Existin
 SaveCoordinator tests retain coverage of FIFO ordering, recovery and callback
 cycles.
 
-This change does not make every writer exclusive: direct service, bootstrap,
-pack and CLI paths still require migration. The durable journal and runtime
+Pack install/uninstall/settings operations and bootstrap now acquire the same
+queue before staging state. Their nested toggle/save/remove calls pass the
+active permit explicitly. Regression tests cover callback attempts to install
+visual-only metadata or bootstrap, and cancellation before pack metadata writes.
+
+This does not make every writer exclusive: direct service, standalone
+regeneration and CLI paths still require migration. The durable journal and runtime
 rollback also remain distinct boundaries. Do not treat this queue as proof of
 whole-operation rollback or protection against external editors.

--- a/docs/planning/catalog-led-consolidation-plan.md
+++ b/docs/planning/catalog-led-consolidation-plan.md
@@ -259,13 +259,14 @@ Implemented slices (the table describes the merged state of this checkpoint):
 | #1264 | Collection persistence and retry callbacks retain applied/pending/rejected/failed outcomes. | Compatibility Boolean continues to mean persisted. |
 | #1265 | Durable journal for config plus both rule stores, startup recovery, external-change checks, and observers after file-set commit. | Preferences, pack metadata, in-memory mutation ordering and runtime rollback remain outside this file transaction. |
 | #1266 | Failed keymap writes restore the prior collection, manager preferences and attempted overlay selection, preserving unrelated layout preferences and newer display choices. | UserDefaults is not crash-atomic with the journal; admission still needs to precede every mutation. |
+| #1267 | Shared service admission before public collection/keymap mutation and across coordinator save/recovery, with explicit nested permits and callback rejection. | Direct service, pack, bootstrap, CLI and external writers require migration; file admission is not whole-operation rollback. |
 
 The first migrated persistence journey now has interruption and failure tests.
 This is a useful foundation, not completion of Phase 1 or the program.
 
 Next implementation sequence:
 
-1. Admit collection, mapper and pack operations before in-memory mutation;
+1. Complete admission of pack and bootstrap operations, then direct writers, before in-memory mutation;
    preserve explicit ownership through trusted nested calls, and reject recursive
    callback writes rather than allowing stale rollback or deadlock.
 2. Keep the prior source revision through runtime classification and restore


### PR DESCRIPTION
Pack operations could interleave with other saves between nested rule edits and metadata updates, and startup reconciliation could replace manager state during a save. Extend the shared ConfigurationService admission queue around each complete pack install, uninstall, tap/hold edit and quick-settings update, and around bootstrap.

Trusted pack calls pass the active permit into collection toggle/save/remove and partial-install cleanup. The slot stays held through existing metadata and rollback paths. A callback cannot install even visual-only metadata or bootstrap inside another save; cancellation before admission does not write metadata.

Existing behavior and UI are preserved. Pack operations still perform multiple durable commits, and this does not fix their existing partial-write/error semantics or provide cross-process locking. Direct service, standalone regeneration, CLI and external writers remain migration targets. Architecture and progress notes record the boundary.

Validation:
- 104 focused tests passed, including existing GenericPackConfigTests/VallackSystemPackTests rollback cases, SaveCoordinatorTests and eight shared-admission tests.
- New regressions cover pack metadata callback reentry, bootstrap callback reentry and cancelled pack installation.
- Full safe suite reported 5,123 passes and only the four previously reproduced macOS 27 baseline snapshots: EasyViewSnapshotTests.testHomeRowTimingFastTyping, testHomeRowTimingPerFinger, testHomeRowTimingSlider; HardViewSnapshotTests.testRepairSettingsTabView. No compiler warnings. Snapshot references were unchanged.
- Accessibility and whitespace checks passed; no compiler warnings in focused build.
- remote review gate selected; GitHub claude-review must pass before merge.

Review follow-up: rollbackToSnapshot restores arrays and calls regenerateConfigFromCollections; regeneration calls persistRules, which is currently gate-free. restoreOrKeepOnUninstall only restores snapshot data into arrays and does not enter a gated public mutation. These paths therefore remain inside the outer pack admission without recursive acquisition. GenericPackConfigTests verifies plain/collection/system pack tracker-write rollback and system collection-store rollback; VallackSystemPackTests covers restore/uninstall. All passed in focused and full runs. The next standalone-regeneration migration must thread the active permit through these helpers; the documented gap is intentional in this bounded patch.
