### PR TITLE
Serialize standalone regeneration and recovery helpers

### DIFF
--- a/Sources/KeyPathAppKit/Services/Packs/PackInstaller.swift
+++ b/Sources/KeyPathAppKit/Services/Packs/PackInstaller.swift
@@ -159,7 +159,8 @@ public final class PackInstaller {
                         manager: manager,
                         policy: managedDefaultPolicy,
                         associatedCollectionConfiguration: collectionConfiguration,
-                        skipReload: skipFinalReload
+                        skipReload: skipFinalReload,
+                        mutationPermit: permit
                     )
                 } catch {
                     AppLogger.shared.errorUnlessQuietTest(
@@ -176,7 +177,8 @@ public final class PackInstaller {
                     )
                     let rollbackApplied = await manager.rollbackToSnapshot(
                         ruleStateSnapshot,
-                        userMessage: "Could not apply this system pack. Your previous rule state was restored."
+                        userMessage: "Could not apply this system pack. Your previous rule state was restored.",
+                        mutationPermit: permit
                     )
                     guard rollbackApplied, collectionSnapshotRestored, installRecordRestored else {
                         throw InstallError.saveFailed(
@@ -202,7 +204,8 @@ public final class PackInstaller {
                     )
                     let rollbackApplied = await manager.rollbackToSnapshot(
                         ruleStateSnapshot,
-                        userMessage: "Could not record this system pack installation. Your previous rule state was restored."
+                        userMessage: "Could not record this system pack installation. Your previous rule state was restored.",
+                        mutationPermit: permit
                     )
                     guard rollbackApplied, collectionSnapshotRestored, installRecordRestored else {
                         throw InstallError.saveFailed(
@@ -255,7 +258,8 @@ public final class PackInstaller {
                     )
                     let rollbackApplied = await manager.rollbackToSnapshot(
                         ruleStateSnapshot,
-                        userMessage: "Could not record this pack installation. Your previous rule state was restored."
+                        userMessage: "Could not record this pack installation. Your previous rule state was restored.",
+                        mutationPermit: permit
                     )
                     guard rollbackApplied, installRecordRestored else {
                         throw InstallError.saveFailed(
@@ -315,7 +319,8 @@ public final class PackInstaller {
                 )
                 let rollbackApplied = await manager.rollbackToSnapshot(
                     ruleStateSnapshot,
-                    userMessage: "Could not record this pack installation. Your previous rule state was restored."
+                    userMessage: "Could not record this pack installation. Your previous rule state was restored.",
+                    mutationPermit: permit
                 )
                 guard rollbackApplied, installRecordRestored else {
                     throw InstallError.saveFailed(
@@ -361,12 +366,12 @@ public final class PackInstaller {
                     manager.ruleCollections[i].isEnabled = false
                 }
 
-                var applied = await manager.regenerateConfigFromCollections()
+                var applied = await manager.regenerateConfigFromCollections(mutationPermit: permit)
                 if !applied, didRestore, disableRestoreConflictCollections(for: pack, manager: manager) {
                     AppLogger.shared.log(
                         "⚠️ [PackInstaller] Retrying managed restore for '\(packID)' after disabling install-conflict collections"
                     )
-                    applied = await manager.regenerateConfigFromCollections()
+                    applied = await manager.regenerateConfigFromCollections(mutationPermit: permit)
                 }
 
                 guard applied else {
@@ -551,7 +556,7 @@ public final class PackInstaller {
                         config.timing.tapWindow = holdTimeout
                         config.timing.holdDelay = holdTimeout
                         manager.ruleCollections[index].configuration = .homeRowMods(config)
-                        await manager.regenerateConfigFromCollections()
+                        await manager.regenerateConfigFromCollections(mutationPermit: permit)
                     }
                 }
             } else if !pack.bindings.isEmpty {
@@ -782,7 +787,8 @@ public final class PackInstaller {
         manager: RuleCollectionsManager,
         policy: ManagedDefaultInstallPolicy,
         associatedCollectionConfiguration: RuleCollectionConfiguration?,
-        skipReload: Bool
+        skipReload: Bool,
+        mutationPermit: ConfigurationOperationGate.Permit
     ) async throws {
         let snapshot = snapshotManagedCollections(pack: pack, manager: manager)
         let catalog = RuleCollectionCatalog().defaultCollections()
@@ -826,7 +832,7 @@ public final class PackInstaller {
 
         try PackCollectionSnapshot.save(snapshot)
 
-        let applied = await manager.regenerateConfigFromCollections(skipReload: skipReload)
+        let applied = await manager.regenerateConfigFromCollections(skipReload: skipReload, mutationPermit: mutationPermit)
         guard applied else {
             throw InstallError.saveFailed("could not apply managed collection defaults")
         }

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+Bootstrap.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+Bootstrap.swift
@@ -8,7 +8,7 @@ extension RuleCollectionsManager {
 
     /// Load rule collections and custom rules from persistent storage
     func bootstrap() async {
-        await withRuleMutation(failure: ()) { [self] _ in
+        await withRuleMutation(failure: ()) { [self] permit in
             do {
                 try await configurationService.recoverPendingRuleWrite(
                     collectionStore: ruleCollectionStore, customStore: customRulesStore
@@ -61,7 +61,7 @@ extension RuleCollectionsManager {
             let collectionsSnapshot = ruleCollections
             let didReconcileLeader = reconcileLeaderKeyFromCollection()
 
-            let applied = await regenerateConfigFromCollections()
+            let applied = await regenerateConfigFromCollections(mutationPermit: permit)
             if didReconcileLeader, !applied {
                 rollbackLeaderReconcile(preference: leaderSnapshot, collections: collectionsSnapshot)
             }

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+ConflictResolution.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+ConflictResolution.swift
@@ -45,46 +45,48 @@ extension RuleCollectionsManager {
     /// real collections, prompt the user to disable one and retry the save (#460).
     /// - Returns: the retry result, or nil when the failure wasn't a resolvable
     ///   mapping conflict or the user cancelled (caller falls back to its error path).
-    func tryResolveMappingConflict(_ error: Error, skipReload: Bool, depth: Int) async -> RulePersistenceResult? {
-        // Bound retries: each resolution disables one collection (strictly shrinking
-        // the enabled set), so this terminates, but the guard prevents pathological loops.
-        guard depth < 5,
-              let keyPathError = error as? KeyPathError,
-              case let .configuration(configError) = keyPathError,
-              case let .mappingConflicts(conflicts) = configError,
-              let callback = onMappingConflictResolution,
-              let resolvable = Self.resolvableCollectionConflict(
-                  conflicts: conflicts, collections: ruleCollections
-              )
-        else { return nil }
+    func tryResolveMappingConflict(_ error: Error, skipReload: Bool, depth: Int, mutationPermit: ConfigurationOperationGate.Permit? = nil) async -> RulePersistenceResult? {
+        await withRuleMutation(using: mutationPermit, failure: nil) { [self] permit in
+            // Bound retries: each resolution disables one collection (strictly shrinking
+            // the enabled set), so this terminates, but the guard prevents pathological loops.
+            guard depth < 5,
+                  let keyPathError = error as? KeyPathError,
+                  case let .configuration(configError) = keyPathError,
+                  case let .mappingConflicts(conflicts) = configError,
+                  let callback = onMappingConflictResolution,
+                  let resolvable = Self.resolvableCollectionConflict(
+                      conflicts: conflicts, collections: ruleCollections
+                  )
+            else { return nil }
 
-        let context = MappingConflictContext(
-            explanation: conflicts.map(\.userExplanation).joined(separator: "\n\n"),
-            options: resolvable.map {
-                MappingConflictOption(id: $0.id, name: $0.name, icon: $0.icon ?? "square.stack.3d.up")
-            }
-        )
+            let context = MappingConflictContext(
+                explanation: conflicts.map(\.userExplanation).joined(separator: "\n\n"),
+                options: resolvable.map {
+                    MappingConflictOption(id: $0.id, name: $0.name, icon: $0.icon ?? "square.stack.3d.up")
+                }
+            )
 
-        guard let chosenID = await callback(context),
-              let index = ruleCollections.firstIndex(where: { $0.id == chosenID })
-        else { return nil } // cancelled → fall back to explanation
+            guard let chosenID = await callback(context),
+                  let index = ruleCollections.firstIndex(where: { $0.id == chosenID })
+            else { return nil } // cancelled → fall back to explanation
 
-        AppLogger.shared.log(
-            "🔧 [RuleCollections] Resolving mapping conflict by disabling '\(ruleCollections[index].name)' (#460)"
-        )
-        // Make the disable atomic: snapshot first, disable in-memory, retry the full
-        // save. If the retry still fails (another conflict, depth guard, validation),
-        // restore so in-memory state never diverges from what was actually persisted —
-        // callers that ignore the `false` return must not see an unsaved disable.
-        let snapshot = ruleCollections
-        ruleCollections[index].isEnabled = false
-        refreshLayerIndicatorState()
-        let saved = await persistRules(skipReload: skipReload, conflictResolutionDepth: depth + 1)
-        if !saved.didPersist {
-            ruleCollections = snapshot
+            AppLogger.shared.log(
+                "🔧 [RuleCollections] Resolving mapping conflict by disabling '\(ruleCollections[index].name)' (#460)"
+            )
+            // Make the disable atomic: snapshot first, disable in-memory, retry the full
+            // save. If the retry still fails (another conflict, depth guard, validation),
+            // restore so in-memory state never diverges from what was actually persisted —
+            // callers that ignore the `false` return must not see an unsaved disable.
+            let snapshot = ruleCollections
+            ruleCollections[index].isEnabled = false
             refreshLayerIndicatorState()
+            let saved = await persistRules(skipReload: skipReload, conflictResolutionDepth: depth + 1, mutationPermit: permit)
+            if !saved.didPersist {
+                ruleCollections = snapshot
+                refreshLayerIndicatorState()
+            }
+            return saved
         }
-        return saved
     }
 
     // MARK: - Conflict Resolution
@@ -98,19 +100,21 @@ extension RuleCollectionsManager {
 
     /// Restore state snapshot and attempt to re-apply previous config.
     @discardableResult
-    func rollbackToSnapshot(_ snapshot: RuleStateSnapshot, userMessage: String) async -> Bool {
-        ruleCollections = snapshot.collections
-        customRules = snapshot.customRules
-        refreshLayerIndicatorState()
+    func rollbackToSnapshot(_ snapshot: RuleStateSnapshot, userMessage: String, mutationPermit: ConfigurationOperationGate.Permit? = nil) async -> Bool {
+        await withRuleMutation(using: mutationPermit, failure: false) { [self] permit in
+            ruleCollections = snapshot.collections
+            customRules = snapshot.customRules
+            refreshLayerIndicatorState()
 
-        let rollbackApplied = await regenerateConfigFromCollections()
-        if rollbackApplied {
-            onError?(userMessage)
-        } else {
-            onError?("\(userMessage) Automatic rollback failed. Please review your configuration.")
+            let rollbackApplied = await regenerateConfigFromCollections(mutationPermit: permit)
+            if rollbackApplied {
+                onError?(userMessage)
+            } else {
+                onError?("\(userMessage) Automatic rollback failed. Please review your configuration.")
+            }
+
+            return rollbackApplied
         }
-
-        return rollbackApplied
     }
 
     /// Disable a conflicting rule source (collection or custom rule)

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+Keymap.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+Keymap.swift
@@ -17,7 +17,7 @@ extension RuleCollectionsManager {
     /// - Returns: Array of conflicting custom rules, if any
     @discardableResult
     func setActiveKeymap(_ keymapId: String, includePunctuation: Bool) async -> [RuleConflictInfo] {
-        await withRuleMutation(failure: []) { [self] _ in
+        await withRuleMutation(failure: []) { [self] permit in
             AppLogger.shared.log("⌨️ [RuleCollections] Setting active keymap to '\(keymapId)' (punctuation: \(includePunctuation))")
 
             let previousKeymapId = activeKeymapId
@@ -54,7 +54,7 @@ extension RuleCollectionsManager {
             }
 
             // Persist preferences only after the config/source-store write succeeds.
-            let success = await regenerateConfigFromCollections()
+            let success = await regenerateConfigFromCollections(mutationPermit: permit)
             if success {
                 await persistKeymapState()
             } else {

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+Migrations.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+Migrations.swift
@@ -38,109 +38,117 @@ extension RuleCollectionsManager {
     /// Compatibility API: `true` means persistence completed, not engine application.
     /// Keep this meaning until callers participate in the multi-store transaction.
     @discardableResult
-    func regenerateConfigFromCollections(skipReload: Bool = false, conflictResolutionDepth: Int = 0) async -> Bool {
-        await persistRules(skipReload: skipReload, conflictResolutionDepth: conflictResolutionDepth).didPersist
+    func regenerateConfigFromCollections(skipReload: Bool = false, conflictResolutionDepth: Int = 0, mutationPermit: ConfigurationOperationGate.Permit? = nil) async -> Bool {
+        await persistRules(skipReload: skipReload, conflictResolutionDepth: conflictResolutionDepth, mutationPermit: mutationPermit).didPersist
     }
 
     /// Returns persistence failure or the actual reload result after persistence.
     /// Nil reload means explicitly skipped or no callback, never presumed applied.
-    func persistRules(skipReload: Bool = false, conflictResolutionDepth: Int = 0) async -> RulePersistenceResult {
-        dedupeRuleCollectionsInPlace()
-
-        AppLogger.shared.log("🔄 [RuleCollections] regenerateConfigFromCollections: \(ruleCollections.count) collections, \(customRules.count) custom rules")
-
-        // INVARIANT: In production, ruleCollections should never be empty (at minimum, macOS Function Keys)
-        // Tests may create isolated scenarios with empty collections, so only warn in debug builds
-        if ruleCollections.isEmpty {
-            AppLogger.shared.log("⚠️ [RuleCollections] regenerateConfigFromCollections called with empty collections")
-        }
-
-        // INVARIANT: At least one collection should be enabled (macOS Function Keys is system default)
-        // Log warning instead of assert to avoid crashing in edge cases
-        if !ruleCollections.contains(where: \.isEnabled), !ruleCollections.isEmpty {
-            AppLogger.shared.log("⚠️ [RuleCollections] No enabled collections - config will only have defaults")
-        }
-
+    func persistRules(skipReload: Bool = false, conflictResolutionDepth: Int = 0, mutationPermit: ConfigurationOperationGate.Permit? = nil) async -> RulePersistenceResult {
         do {
-            // Suppress file watcher before saving to prevent double-reload race condition
-            // Without this, the file watcher detects our write and tries to reload,
-            // which can race with onRulesChanged reload and cause an error beep
-            onBeforeSave?()
+            return try await configurationService.operationGate.withOperation(using: mutationPermit) { @MainActor [self] permit in
+                dedupeRuleCollectionsInPlace()
 
-            AppLogger.shared.log("🔄 [RuleCollections] Calling configurationService.saveRuleState...")
-            AppLogger.shared.log("🔄 [RuleCollections] Custom rules to save: \(customRules.map { "'\($0.input)' → '\($0.action.displayName)'" }.joined(separator: ", "))")
-            // Validate before replacing the generated file and both source stores.
-            // The write journal restores the prior set if a persistence stage fails.
-            try await configurationService.saveRuleState(
-                ruleCollections: ruleCollections,
-                customRules: customRules,
-                collectionStore: ruleCollectionStore,
-                customStore: customRulesStore
-            )
-            AppLogger.shared.log("✅ [RuleCollections] configurationService.saveRuleState succeeded")
+                AppLogger.shared.log("🔄 [RuleCollections] regenerateConfigFromCollections: \(ruleCollections.count) collections, \(customRules.count) custom rules")
 
-            // The generated file and both stores are committed before notification.
-            AppLogger.shared.log("✅ [RuleCollections] Stores persisted")
+                // INVARIANT: In production, ruleCollections should never be empty (at minimum, macOS Function Keys)
+                // Tests may create isolated scenarios with empty collections, so only warn in debug builds
+                if ruleCollections.isEmpty {
+                    AppLogger.shared.log("⚠️ [RuleCollections] regenerateConfigFromCollections called with empty collections")
+                }
 
-            // Notify observers and play success sound
-            await MainActor.run {
-                NotificationCenter.default.post(name: .ruleCollectionsChanged, object: nil)
-                SoundManager.shared.playTinkSound()
+                // INVARIANT: At least one collection should be enabled (macOS Function Keys is system default)
+                // Log warning instead of assert to avoid crashing in edge cases
+                if !ruleCollections.contains(where: \.isEnabled), !ruleCollections.isEmpty {
+                    AppLogger.shared.log("⚠️ [RuleCollections] No enabled collections - config will only have defaults")
+                }
+
+                do {
+                    // Suppress file watcher before saving to prevent double-reload race condition
+                    // Without this, the file watcher detects our write and tries to reload,
+                    // which can race with onRulesChanged reload and cause an error beep
+                    onBeforeSave?()
+
+                    AppLogger.shared.log("🔄 [RuleCollections] Calling configurationService.saveRuleState...")
+                    AppLogger.shared.log("🔄 [RuleCollections] Custom rules to save: \(customRules.map { "'\($0.input)' → '\($0.action.displayName)'" }.joined(separator: ", "))")
+                    // Validate before replacing the generated file and both source stores.
+                    // The write journal restores the prior set if a persistence stage fails.
+                    try await configurationService.saveRuleState(
+                        ruleCollections: ruleCollections,
+                        customRules: customRules,
+                        collectionStore: ruleCollectionStore,
+                        customStore: customRulesStore
+                    )
+                    AppLogger.shared.log("✅ [RuleCollections] configurationService.saveRuleState succeeded")
+
+                    // The generated file and both stores are committed before notification.
+                    AppLogger.shared.log("✅ [RuleCollections] Stores persisted")
+
+                    // Notify observers and play success sound
+                    await MainActor.run {
+                        NotificationCenter.default.post(name: .ruleCollectionsChanged, object: nil)
+                        SoundManager.shared.playTinkSound()
+                    }
+
+                    let reloadResult = skipReload ? nil : await onRulesChanged?()
+                    return .persisted(reloadResult: reloadResult)
+                } catch let error as CancellationError {
+                    // Task was cancelled (e.g., view disappeared mid-save) — silently ignore
+                    // rather than showing a misleading "validation failed" dialog
+                    AppLogger.shared.log("⚠️ [RuleCollections] Config save cancelled (task cancellation)")
+                    return .failed(error)
+                } catch {
+                    // #460: if the failure is a mapping conflict between real collections,
+                    // offer to disable one inline and retry, instead of just showing an error.
+                    if let resolved = await tryResolveMappingConflict(
+                        error, skipReload: skipReload, depth: conflictResolutionDepth,
+                        mutationPermit: permit
+                    ) {
+                        return resolved
+                    }
+
+                    AppLogger.shared.log("❌ [RuleCollections] Failed to regenerate config: \(error)")
+                    AppLogger.shared.log("❌ [RuleCollections] Error details: \(String(describing: error))")
+
+                    // Detect validation cancellation (propagated through KeyPathError wrapper)
+                    if let keyPathError = error as? KeyPathError,
+                       case let .configuration(configError) = keyPathError,
+                       case let .validationFailed(errors) = configError,
+                       errors.contains(where: { $0.contains("cancelled") })
+                    {
+                        AppLogger.shared.log("⚠️ [RuleCollections] Config validation was cancelled — not showing error dialog")
+                        return .failed(error)
+                    }
+
+                    // Extract user-friendly error message
+                    let userMessage: String = if let keyPathError = error as? KeyPathError,
+                                                 case let .configuration(configError) = keyPathError,
+                                                 case let .validationFailed(errors) = configError
+                    {
+                        "Configuration validation failed:\n\n" + errors.joined(separator: "\n")
+                    } else if let keyPathError = error as? KeyPathError,
+                              case let .configuration(configError) = keyPathError,
+                              case let .mappingConflicts(conflicts) = configError
+                    {
+                        // Non-actionable (or cancelled) mapping conflict — explain it (#460).
+                        conflicts.map(\.userExplanation).joined(separator: "\n\n")
+                    } else {
+                        "Failed to save configuration: \(error.localizedDescription)"
+                    }
+
+                    // Notify user via callback
+                    AppLogger.shared.debug("🚨 [RuleCollectionsManager] About to call onError, callback is \(onError == nil ? "nil" : "set"): \(userMessage)")
+                    onError?(userMessage)
+
+                    await MainActor.run {
+                        SoundManager.shared.playErrorSound()
+                    }
+
+                    return .failed(error)
+                }
             }
-
-            let reloadResult = skipReload ? nil : await onRulesChanged?()
-            return .persisted(reloadResult: reloadResult)
-        } catch let error as CancellationError {
-            // Task was cancelled (e.g., view disappeared mid-save) — silently ignore
-            // rather than showing a misleading "validation failed" dialog
-            AppLogger.shared.log("⚠️ [RuleCollections] Config save cancelled (task cancellation)")
-            return .failed(error)
         } catch {
-            // #460: if the failure is a mapping conflict between real collections,
-            // offer to disable one inline and retry, instead of just showing an error.
-            if let resolved = await tryResolveMappingConflict(
-                error, skipReload: skipReload, depth: conflictResolutionDepth
-            ) {
-                return resolved
-            }
-
-            AppLogger.shared.log("❌ [RuleCollections] Failed to regenerate config: \(error)")
-            AppLogger.shared.log("❌ [RuleCollections] Error details: \(String(describing: error))")
-
-            // Detect validation cancellation (propagated through KeyPathError wrapper)
-            if let keyPathError = error as? KeyPathError,
-               case let .configuration(configError) = keyPathError,
-               case let .validationFailed(errors) = configError,
-               errors.contains(where: { $0.contains("cancelled") })
-            {
-                AppLogger.shared.log("⚠️ [RuleCollections] Config validation was cancelled — not showing error dialog")
-                return .failed(error)
-            }
-
-            // Extract user-friendly error message
-            let userMessage: String = if let keyPathError = error as? KeyPathError,
-                                         case let .configuration(configError) = keyPathError,
-                                         case let .validationFailed(errors) = configError
-            {
-                "Configuration validation failed:\n\n" + errors.joined(separator: "\n")
-            } else if let keyPathError = error as? KeyPathError,
-                      case let .configuration(configError) = keyPathError,
-                      case let .mappingConflicts(conflicts) = configError
-            {
-                // Non-actionable (or cancelled) mapping conflict — explain it (#460).
-                conflicts.map(\.userExplanation).joined(separator: "\n\n")
-            } else {
-                "Failed to save configuration: \(error.localizedDescription)"
-            }
-
-            // Notify user via callback
-            AppLogger.shared.debug("🚨 [RuleCollectionsManager] About to call onError, callback is \(onError == nil ? "nil" : "set"): \(userMessage)")
-            onError?(userMessage)
-
-            await MainActor.run {
-                SoundManager.shared.playErrorSound()
-            }
-
+            if !(error is CancellationError) { onError?(error.localizedDescription) }
             return .failed(error)
         }
     }

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+PrerequisiteResolution.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+PrerequisiteResolution.swift
@@ -121,31 +121,34 @@ extension RuleCollectionsManager {
         _ candidate: RuleCollection,
         rollbackMessage: String,
         nonInteractiveChoice: RulePrerequisiteResolutionChoice = .applyWithoutProviders,
-        skipReload: Bool = false
+        skipReload: Bool = false,
+        mutationPermit: ConfigurationOperationGate.Permit? = nil
     ) async -> [UUID]? {
-        let snapshot = snapshotRuleState()
-        guard let providerIDs = await confirmedPrerequisiteProviderIDs(
-            for: candidate,
-            operation: .save,
-            nonInteractiveChoice: nonInteractiveChoice
-        ) else {
-            return nil
-        }
+        await withRuleMutation(using: mutationPermit, failure: nil) { [self] permit in
+            let snapshot = snapshotRuleState()
+            guard let providerIDs = await confirmedPrerequisiteProviderIDs(
+                for: candidate,
+                operation: .save,
+                nonInteractiveChoice: nonInteractiveChoice
+            ) else {
+                return nil
+            }
 
-        applyPrerequisiteChangeInMemory(
-            candidate: candidate,
-            providerIDs: providerIDs
-        )
-
-        guard await regenerateConfigFromCollections(skipReload: skipReload) else {
-            AppLogger.shared.log(
-                "↩️ [RuleCollections] Prerequisite-aware save failed; rolling back"
+            applyPrerequisiteChangeInMemory(
+                candidate: candidate,
+                providerIDs: providerIDs
             )
-            await rollbackToSnapshot(snapshot, userMessage: rollbackMessage)
-            return nil
-        }
 
-        return providerIDs
+            guard await regenerateConfigFromCollections(skipReload: skipReload, mutationPermit: permit) else {
+                AppLogger.shared.log(
+                    "↩️ [RuleCollections] Prerequisite-aware save failed; rolling back"
+                )
+                await rollbackToSnapshot(snapshot, userMessage: rollbackMessage, mutationPermit: permit)
+                return nil
+            }
+
+            return providerIDs
+        }
     }
 
     private func prerequisiteResolutionContext(

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+PublicAPI.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+PublicAPI.swift
@@ -13,7 +13,7 @@ extension RuleCollectionsManager {
 
     /// Replace all rule collections
     func replaceCollections(_ collections: [RuleCollection]) async {
-        await withRuleMutation(failure: ()) { [self] _ in
+        await withRuleMutation(failure: ()) { [self] permit in
             ruleCollections = RuleCollectionDeduplicator.dedupe(collections)
             dedupeRuleCollectionsInPlace()
             refreshLayerIndicatorState()
@@ -22,7 +22,7 @@ extension RuleCollectionsManager {
             let collectionsSnapshot = ruleCollections
             let didReconcileLeader = reconcileLeaderKeyFromCollection()
 
-            let applied = await regenerateConfigFromCollections()
+            let applied = await regenerateConfigFromCollections(mutationPermit: permit)
             if didReconcileLeader, !applied {
                 rollbackLeaderReconcile(preference: leaderSnapshot, collections: collectionsSnapshot)
             }
@@ -53,7 +53,7 @@ extension RuleCollectionsManager {
         skipReload: Bool = false,
         mutationPermit: ConfigurationOperationGate.Permit? = nil
     ) async -> Bool {
-        await withRuleMutation(using: mutationPermit, failure: false) { [self] _ in
+        await withRuleMutation(using: mutationPermit, failure: false) { [self] permit in
             AppLogger.shared.log("🔀 [RuleCollections] toggleCollection called: id=\(id), isEnabled=\(isEnabled)")
 
             if !bypassOwnershipCheck {
@@ -167,13 +167,13 @@ extension RuleCollectionsManager {
             }
 
             AppLogger.shared.log("🔀 [RuleCollections] Calling regenerateConfigFromCollections...")
-            let applied = await regenerateConfigFromCollections(skipReload: skipReload)
+            let applied = await regenerateConfigFromCollections(skipReload: skipReload, mutationPermit: permit)
             guard applied else {
                 if id == RuleCollectionIdentifier.leaderKey {
                     PreferencesService.shared.leaderKeyPreference = leaderPreferenceSnapshot
                 }
                 AppLogger.shared.log("↩️ [RuleCollections] Toggle apply failed; rolling back to previous state")
-                await rollbackToSnapshot(snapshot, userMessage: "Could not apply this rule change. Your previous rule state was restored.")
+                await rollbackToSnapshot(snapshot, userMessage: "Could not apply this rule change. Your previous rule state was restored.", mutationPermit: permit)
                 return false
             }
 
@@ -189,7 +189,7 @@ extension RuleCollectionsManager {
     /// Used when a mode switch (e.g., home row mods → layers) needs to enable several
     /// layer collections at once without 4 separate save/validate/reload cycles.
     func batchEnableCollections(ids: [UUID]) async {
-        await withRuleMutation(failure: ()) { [self] _ in
+        await withRuleMutation(failure: ()) { [self] permit in
             let catalog = RuleCollectionCatalog().defaultCollections()
 
             for id in ids {
@@ -206,13 +206,13 @@ extension RuleCollectionsManager {
 
             dedupeRuleCollectionsInPlace()
             refreshLayerIndicatorState()
-            await regenerateConfigFromCollections()
+            await regenerateConfigFromCollections(mutationPermit: permit)
         }
     }
 
     /// Add or update a rule collection
     func addCollection(_ collection: RuleCollection, mutationPermit: ConfigurationOperationGate.Permit? = nil) async {
-        await withRuleMutation(using: mutationPermit, failure: ()) { [self] _ in
+        await withRuleMutation(using: mutationPermit, failure: ()) { [self] permit in
             let snapshot = snapshotRuleState()
 
             if collection.isEnabled, let conflict = conflictInfo(for: collection) {
@@ -253,27 +253,27 @@ extension RuleCollectionsManager {
             }
             dedupeRuleCollectionsInPlace()
             refreshLayerIndicatorState()
-            let applied = await regenerateConfigFromCollections()
+            let applied = await regenerateConfigFromCollections(mutationPermit: permit)
             if !applied {
                 AppLogger.shared.log("↩️ [RuleCollections] Add collection failed; rolling back to previous state")
-                await rollbackToSnapshot(snapshot, userMessage: "Could not apply this rule change. Your previous rule state was restored.")
+                await rollbackToSnapshot(snapshot, userMessage: "Could not apply this rule change. Your previous rule state was restored.", mutationPermit: permit)
             }
         }
     }
 
     /// Remove a rule collection by ID
     func removeCollection(id: UUID) async {
-        await withRuleMutation(failure: ()) { [self] _ in
+        await withRuleMutation(failure: ()) { [self] permit in
             ruleCollections.removeAll { $0.id == id }
             refreshLayerIndicatorState()
-            await regenerateConfigFromCollections()
+            await regenerateConfigFromCollections(mutationPermit: permit)
             AppLogger.shared.log("🗑️ [RuleCollections] Removed collection: \(id)")
         }
     }
 
     /// Remove all collections and custom rules for a specific layer
     func removeLayer(_ layerName: String) async {
-        await withRuleMutation(failure: ()) { [self] _ in
+        await withRuleMutation(failure: ()) { [self] permit in
             let normalizedName = layerName.lowercased()
 
             // Remove collections targeting this layer
@@ -298,7 +298,7 @@ extension RuleCollectionsManager {
             }
 
             refreshLayerIndicatorState()
-            await regenerateConfigFromCollections()
+            await regenerateConfigFromCollections(mutationPermit: permit)
 
             AppLogger.shared.log("🗑️ [RuleCollections] Removed layer '\(layerName)': \(removedCollections) collections, \(removedRules) rules")
         }
@@ -370,7 +370,7 @@ extension RuleCollectionsManager {
                     ruleCollections.append(catalogCollection)
                     dedupeRuleCollectionsInPlace()
                     refreshLayerIndicatorState()
-                    await regenerateConfigFromCollections()
+                    await regenerateConfigFromCollections(mutationPermit: permit)
                 }
                 return
             }
@@ -396,13 +396,13 @@ extension RuleCollectionsManager {
             }
 
             refreshLayerIndicatorState()
-            await regenerateConfigFromCollections()
+            await regenerateConfigFromCollections(mutationPermit: permit)
         }
     }
 
     /// Update a tap-hold picker collection's tap output
     func updateCollectionTapOutput(id: UUID, tapOutput: String) async {
-        await withRuleMutation(failure: ()) { [self] _ in
+        await withRuleMutation(failure: ()) { [self] permit in
             guard let index = ruleCollections.firstIndex(where: { $0.id == id }) else {
                 // Try to find in catalog and add it
                 let catalog = RuleCollectionCatalog()
@@ -412,7 +412,7 @@ extension RuleCollectionsManager {
                     ruleCollections.append(catalogCollection)
                     dedupeRuleCollectionsInPlace()
                     refreshLayerIndicatorState()
-                    await regenerateConfigFromCollections()
+                    await regenerateConfigFromCollections(mutationPermit: permit)
                 }
                 return
             }
@@ -421,13 +421,13 @@ extension RuleCollectionsManager {
             ruleCollections[index].isEnabled = true
             dedupeRuleCollectionsInPlace()
             refreshLayerIndicatorState()
-            await regenerateConfigFromCollections()
+            await regenerateConfigFromCollections(mutationPermit: permit)
         }
     }
 
     /// Update a tap-hold picker collection's hold output
     func updateCollectionHoldOutput(id: UUID, holdOutput: String) async {
-        await withRuleMutation(failure: ()) { [self] _ in
+        await withRuleMutation(failure: ()) { [self] permit in
             guard let index = ruleCollections.firstIndex(where: { $0.id == id }) else {
                 // Try to find in catalog and add it
                 let catalog = RuleCollectionCatalog()
@@ -437,7 +437,7 @@ extension RuleCollectionsManager {
                     ruleCollections.append(catalogCollection)
                     dedupeRuleCollectionsInPlace()
                     refreshLayerIndicatorState()
-                    await regenerateConfigFromCollections()
+                    await regenerateConfigFromCollections(mutationPermit: permit)
                 }
                 return
             }
@@ -446,13 +446,13 @@ extension RuleCollectionsManager {
             ruleCollections[index].isEnabled = true
             dedupeRuleCollectionsInPlace()
             refreshLayerIndicatorState()
-            await regenerateConfigFromCollections()
+            await regenerateConfigFromCollections(mutationPermit: permit)
         }
     }
 
     /// Update a layer preset picker collection's selected preset
     func updateCollectionLayerPreset(id: UUID, presetId: String) async {
-        await withRuleMutation(failure: ()) { [self] _ in
+        await withRuleMutation(failure: ()) { [self] permit in
             guard let index = ruleCollections.firstIndex(where: { $0.id == id }) else {
                 // Try to find in catalog and add it
                 let catalog = RuleCollectionCatalog()
@@ -462,7 +462,7 @@ extension RuleCollectionsManager {
                     ruleCollections.append(catalogCollection)
                     dedupeRuleCollectionsInPlace()
                     refreshLayerIndicatorState()
-                    await regenerateConfigFromCollections()
+                    await regenerateConfigFromCollections(mutationPermit: permit)
                 }
                 return
             }
@@ -471,13 +471,13 @@ extension RuleCollectionsManager {
             ruleCollections[index].isEnabled = true
             dedupeRuleCollectionsInPlace()
             refreshLayerIndicatorState()
-            await regenerateConfigFromCollections()
+            await regenerateConfigFromCollections(mutationPermit: permit)
         }
     }
 
     /// Update window snapping key convention (Standard vs Vim)
     func updateWindowKeyConvention(id: UUID, convention: WindowKeyConvention) async {
-        await withRuleMutation(failure: ()) { [self] _ in
+        await withRuleMutation(failure: ()) { [self] permit in
             guard let index = ruleCollections.firstIndex(where: { $0.id == id }) else {
                 // Try to find in catalog and add it
                 let catalog = RuleCollectionCatalog()
@@ -488,7 +488,7 @@ extension RuleCollectionsManager {
                     ruleCollections.append(catalogCollection)
                     dedupeRuleCollectionsInPlace()
                     refreshLayerIndicatorState()
-                    await regenerateConfigFromCollections()
+                    await regenerateConfigFromCollections(mutationPermit: permit)
                 }
                 return
             }
@@ -498,13 +498,13 @@ extension RuleCollectionsManager {
             ruleCollections[index].isEnabled = true
             dedupeRuleCollectionsInPlace()
             refreshLayerIndicatorState()
-            await regenerateConfigFromCollections()
+            await regenerateConfigFromCollections(mutationPermit: permit)
         }
     }
 
     /// Update function key mode (Media Keys vs Function Keys)
     func updateFunctionKeyMode(id: UUID, mode: FunctionKeyMode) async {
-        await withRuleMutation(failure: ()) { [self] _ in
+        await withRuleMutation(failure: ()) { [self] permit in
             guard let index = ruleCollections.firstIndex(where: { $0.id == id }) else {
                 // Try to find in catalog and add it
                 let catalog = RuleCollectionCatalog()
@@ -515,7 +515,7 @@ extension RuleCollectionsManager {
                     ruleCollections.append(catalogCollection)
                     dedupeRuleCollectionsInPlace()
                     refreshLayerIndicatorState()
-                    await regenerateConfigFromCollections()
+                    await regenerateConfigFromCollections(mutationPermit: permit)
                 }
                 return
             }
@@ -525,7 +525,7 @@ extension RuleCollectionsManager {
             ruleCollections[index].isEnabled = true
             dedupeRuleCollectionsInPlace()
             refreshLayerIndicatorState()
-            await regenerateConfigFromCollections()
+            await regenerateConfigFromCollections(mutationPermit: permit)
         }
     }
 
@@ -533,7 +533,7 @@ extension RuleCollectionsManager {
     /// - Returns: `true` if the collection was newly enabled (was disabled before this call)
     @discardableResult
     func updateHomeRowModsConfig(id: UUID, config: HomeRowModsConfig) async -> Bool {
-        await withRuleMutation(failure: false) { [self] _ in
+        await withRuleMutation(failure: false) { [self] permit in
             guard var candidate = ruleCollections.first(where: { $0.id == id })
                 ?? RuleCollectionCatalog().defaultCollections().first(where: { $0.id == id })
             else {
@@ -547,7 +547,8 @@ extension RuleCollectionsManager {
             let appliedProviderIDs = await applyProposedCollectionWithPrerequisites(
                 candidate,
                 rollbackMessage:
-                "Could not save Home Row Mods. Your previous rule state was restored."
+                "Could not save Home Row Mods. Your previous rule state was restored.",
+                mutationPermit: permit
             )
             return appliedProviderIDs != nil && wasNewlyEnabled
         }
@@ -557,7 +558,7 @@ extension RuleCollectionsManager {
     /// - Returns: `true` if the collection was newly enabled (was disabled before this call)
     @discardableResult
     func updateHomeRowLayerTogglesConfig(id: UUID, config: HomeRowLayerTogglesConfig) async -> Bool {
-        await withRuleMutation(failure: false) { [self] _ in
+        await withRuleMutation(failure: false) { [self] permit in
             guard var candidate = ruleCollections.first(where: { $0.id == id })
                 ?? RuleCollectionCatalog().defaultCollections().first(where: { $0.id == id })
             else {
@@ -571,7 +572,8 @@ extension RuleCollectionsManager {
             let appliedProviderIDs = await applyProposedCollectionWithPrerequisites(
                 candidate,
                 rollbackMessage:
-                "Could not save Home Row Layer Toggles. Your previous rule state was restored."
+                "Could not save Home Row Layer Toggles. Your previous rule state was restored.",
+                mutationPermit: permit
             )
             return appliedProviderIDs != nil && wasNewlyEnabled
         }
@@ -581,7 +583,7 @@ extension RuleCollectionsManager {
     /// - Returns: `true` if the collection was newly enabled (was disabled before this call)
     @discardableResult
     func updateChordGroupsConfig(id: UUID, config: ChordGroupsConfig) async -> Bool {
-        await withRuleMutation(failure: false) { [self] _ in
+        await withRuleMutation(failure: false) { [self] permit in
             guard let index = ruleCollections.firstIndex(where: { $0.id == id }) else {
                 // Try to find in catalog and add it
                 let catalog = RuleCollectionCatalog()
@@ -591,7 +593,7 @@ extension RuleCollectionsManager {
                     ruleCollections.append(catalogCollection)
                     dedupeRuleCollectionsInPlace()
                     refreshLayerIndicatorState()
-                    await regenerateConfigFromCollections()
+                    await regenerateConfigFromCollections(mutationPermit: permit)
                     return true
                 }
                 return false
@@ -603,7 +605,7 @@ extension RuleCollectionsManager {
 
             dedupeRuleCollectionsInPlace()
             refreshLayerIndicatorState()
-            await regenerateConfigFromCollections()
+            await regenerateConfigFromCollections(mutationPermit: permit)
             return wasNewlyEnabled
         }
     }
@@ -612,7 +614,7 @@ extension RuleCollectionsManager {
     /// - Returns: `true` if the collection was newly enabled (was disabled before this call)
     @discardableResult
     func updateSequencesConfig(id: UUID, config: SequencesConfig) async -> Bool {
-        await withRuleMutation(failure: false) { [self] _ in
+        await withRuleMutation(failure: false) { [self] permit in
             guard let index = ruleCollections.firstIndex(where: { $0.id == id }) else {
                 // Try to find in catalog and add it
                 let catalog = RuleCollectionCatalog()
@@ -622,7 +624,7 @@ extension RuleCollectionsManager {
                     ruleCollections.append(catalogCollection)
                     dedupeRuleCollectionsInPlace()
                     refreshLayerIndicatorState()
-                    await regenerateConfigFromCollections()
+                    await regenerateConfigFromCollections(mutationPermit: permit)
                     return true
                 }
                 return false
@@ -634,7 +636,7 @@ extension RuleCollectionsManager {
 
             dedupeRuleCollectionsInPlace()
             refreshLayerIndicatorState()
-            await regenerateConfigFromCollections()
+            await regenerateConfigFromCollections(mutationPermit: permit)
             return wasNewlyEnabled
         }
     }
@@ -666,7 +668,7 @@ extension RuleCollectionsManager {
         skipReload: Bool = false,
         mutationPermit: ConfigurationOperationGate.Permit? = nil
     ) async -> Bool {
-        await withRuleMutation(using: mutationPermit, failure: false) { [self] _ in
+        await withRuleMutation(using: mutationPermit, failure: false) { [self] permit in
             guard var candidate = ruleCollections.first(where: { $0.id == id })
                 ?? RuleCollectionCatalog().defaultCollections().first(where: { $0.id == id })
             else {
@@ -683,7 +685,8 @@ extension RuleCollectionsManager {
                 candidate,
                 rollbackMessage:
                 "Could not save Launcher. Your previous rule state was restored.",
-                skipReload: skipReload
+                skipReload: skipReload,
+                mutationPermit: permit
             )
             guard appliedProviderIDs != nil else {
                 return false
@@ -698,7 +701,7 @@ extension RuleCollectionsManager {
     /// - Returns: `true` if the collection was newly enabled (was disabled before this call)
     @discardableResult
     func updateAutoShiftSymbolsConfig(id: UUID, config: AutoShiftSymbolsConfig) async -> Bool {
-        await withRuleMutation(failure: false) { [self] _ in
+        await withRuleMutation(failure: false) { [self] permit in
             guard let index = ruleCollections.firstIndex(where: { $0.id == id }) else {
                 let catalog = RuleCollectionCatalog()
                 if var catalogCollection = catalog.defaultCollections().first(where: { $0.id == id }) {
@@ -707,7 +710,7 @@ extension RuleCollectionsManager {
                     ruleCollections.append(catalogCollection)
                     dedupeRuleCollectionsInPlace()
                     refreshLayerIndicatorState()
-                    await regenerateConfigFromCollections()
+                    await regenerateConfigFromCollections(mutationPermit: permit)
                     return true
                 }
                 return false
@@ -719,7 +722,7 @@ extension RuleCollectionsManager {
 
             dedupeRuleCollectionsInPlace()
             refreshLayerIndicatorState()
-            await regenerateConfigFromCollections()
+            await regenerateConfigFromCollections(mutationPermit: permit)
             return wasNewlyEnabled
         }
     }
@@ -728,7 +731,7 @@ extension RuleCollectionsManager {
     /// - Returns: `true` if the collection was newly enabled (was disabled before this call)
     @discardableResult
     func updateKeyRepeatControlConfig(id: UUID, config: KeyRepeatControlConfig) async -> Bool {
-        await withRuleMutation(failure: false) { [self] _ in
+        await withRuleMutation(failure: false) { [self] permit in
             guard let index = ruleCollections.firstIndex(where: { $0.id == id }) else {
                 let catalog = RuleCollectionCatalog()
                 if var catalogCollection = catalog.defaultCollections().first(where: { $0.id == id }) {
@@ -737,7 +740,7 @@ extension RuleCollectionsManager {
                     ruleCollections.append(catalogCollection)
                     dedupeRuleCollectionsInPlace()
                     refreshLayerIndicatorState()
-                    await regenerateConfigFromCollections()
+                    await regenerateConfigFromCollections(mutationPermit: permit)
                     return true
                 }
                 return false
@@ -748,7 +751,7 @@ extension RuleCollectionsManager {
 
             dedupeRuleCollectionsInPlace()
             refreshLayerIndicatorState()
-            await regenerateConfigFromCollections()
+            await regenerateConfigFromCollections(mutationPermit: permit)
             return wasNewlyEnabled
         }
     }
@@ -756,7 +759,7 @@ extension RuleCollectionsManager {
     /// Update window snapping activation mode
     /// - Returns: name of auto-enabled dependency, or nil
     func updateWindowSnappingActivationMode(id: UUID, mode: WindowSnappingActivationMode) async -> String? {
-        await withRuleMutation(failure: nil) { [self] _ in
+        await withRuleMutation(failure: nil) { [self] permit in
             guard var candidate = ruleCollections.first(where: { $0.id == id }) else {
                 return nil
             }
@@ -769,7 +772,8 @@ extension RuleCollectionsManager {
                 candidate,
                 rollbackMessage:
                 "Could not save Window Snapping. Your previous rule state was restored.",
-                nonInteractiveChoice: .enableRequiredProvidersAndApply
+                nonInteractiveChoice: .enableRequiredProvidersAndApply,
+                mutationPermit: permit
             ) else {
                 return nil
             }
@@ -813,7 +817,7 @@ extension RuleCollectionsManager {
 
     /// Update the leader key for all collections that use momentary activation
     func updateLeaderKey(_ newKey: String, mutationPermit: ConfigurationOperationGate.Permit? = nil) async {
-        await withRuleMutation(using: mutationPermit, failure: ()) { [self] _ in
+        await withRuleMutation(using: mutationPermit, failure: ()) { [self] permit in
             AppLogger.shared.log("🔑 [RuleCollections] Updating leader key to '\(newKey)'")
             let snapshot = snapshotRuleState()
             let leaderPreferenceSnapshot = PreferencesService.shared.leaderKeyPreference
@@ -822,10 +826,10 @@ extension RuleCollectionsManager {
             syncLeaderKeyPreference(key: newKey, enabled: true)
             dedupeRuleCollectionsInPlace()
             refreshLayerIndicatorState()
-            let applied = await regenerateConfigFromCollections()
+            let applied = await regenerateConfigFromCollections(mutationPermit: permit)
             guard applied else {
                 PreferencesService.shared.leaderKeyPreference = leaderPreferenceSnapshot
-                await rollbackToSnapshot(snapshot, userMessage: "Could not apply this leader key change. Your previous rule state was restored.")
+                await rollbackToSnapshot(snapshot, userMessage: "Could not apply this leader key change. Your previous rule state was restored.", mutationPermit: permit)
                 return
             }
         }
@@ -954,7 +958,7 @@ extension RuleCollectionsManager {
     ///   - autoResolveConflicts: When true, automatically wins over conflicting rules without prompting.
     @discardableResult
     func saveCustomRule(_ rule: CustomRule, skipReload: Bool = false, autoResolveConflicts: Bool = false, mutationPermit: ConfigurationOperationGate.Permit? = nil) async -> Bool {
-        await withRuleMutation(using: mutationPermit, failure: false) { [self] _ in
+        await withRuleMutation(using: mutationPermit, failure: false) { [self] permit in
             AppLogger.shared.log("💾 [CustomRules] saveCustomRule called: id=\(rule.id), input='\(rule.input)', action='\(rule.action.displayName)'")
             let snapshot = snapshotRuleState()
 
@@ -1000,13 +1004,13 @@ extension RuleCollectionsManager {
                 customRules.append(rule)
             }
 
-            let success = await regenerateConfigFromCollections(skipReload: skipReload)
+            let success = await regenerateConfigFromCollections(skipReload: skipReload, mutationPermit: permit)
 
             if success {
                 AppLogger.shared.log("💾 [CustomRules] Save complete, customRules.count = \(customRules.count)")
             } else {
                 AppLogger.shared.log("💾 [CustomRules] Save failed - rolling back to snapshot")
-                await rollbackToSnapshot(snapshot, userMessage: "Could not apply this rule change. Your previous rule state was restored.")
+                await rollbackToSnapshot(snapshot, userMessage: "Could not apply this rule change. Your previous rule state was restored.", mutationPermit: permit)
                 AppLogger.shared.log("💾 [CustomRules] Rollback complete, customRules.count = \(customRules.count)")
             }
 
@@ -1016,7 +1020,7 @@ extension RuleCollectionsManager {
 
     /// Toggle a custom rule on/off
     func toggleCustomRule(id: UUID, isEnabled: Bool) async {
-        await withRuleMutation(failure: ()) { [self] _ in
+        await withRuleMutation(failure: ()) { [self] permit in
             let snapshot = snapshotRuleState()
             guard let existing = customRules.first(where: { $0.id == id }) else { return }
 
@@ -1061,33 +1065,33 @@ extension RuleCollectionsManager {
             if let index = customRules.firstIndex(where: { $0.id == id }) {
                 customRules[index].isEnabled = isEnabled
             }
-            let applied = await regenerateConfigFromCollections()
+            let applied = await regenerateConfigFromCollections(mutationPermit: permit)
             if !applied {
                 AppLogger.shared.log("↩️ [CustomRules] Toggle apply failed; rolling back to previous state")
-                await rollbackToSnapshot(snapshot, userMessage: "Could not apply this rule change. Your previous rule state was restored.")
+                await rollbackToSnapshot(snapshot, userMessage: "Could not apply this rule change. Your previous rule state was restored.", mutationPermit: permit)
             }
         }
     }
 
     /// Remove a custom rule
     func removeCustomRule(id: UUID, mutationPermit: ConfigurationOperationGate.Permit? = nil) async {
-        await withRuleMutation(using: mutationPermit, failure: ()) { [self] _ in
+        await withRuleMutation(using: mutationPermit, failure: ()) { [self] permit in
             let beforeCount = customRules.count
             AppLogger.shared.log("🗑️ [CustomRules] removeCustomRule called: id=\(id), beforeCount=\(beforeCount)")
             customRules.removeAll { $0.id == id }
             let afterCount = customRules.count
             AppLogger.shared.log("🗑️ [CustomRules] After removal: afterCount=\(afterCount), removed=\(beforeCount - afterCount)")
-            await regenerateConfigFromCollections()
+            await regenerateConfigFromCollections(mutationPermit: permit)
         }
     }
 
     /// Clear all custom rules (without affecting rule collections)
     func clearAllCustomRules() async {
-        await withRuleMutation(failure: ()) { [self] _ in
+        await withRuleMutation(failure: ()) { [self] permit in
             let count = customRules.count
             AppLogger.shared.log("🧹 [CustomRules] Clearing all \(count) custom rules")
             customRules.removeAll()
-            await regenerateConfigFromCollections()
+            await regenerateConfigFromCollections(mutationPermit: permit)
             AppLogger.shared.log("✅ [CustomRules] All custom rules cleared")
         }
     }

--- a/Tests/KeyPathTests/Managers/SharedConfigurationAdmissionTests.swift
+++ b/Tests/KeyPathTests/Managers/SharedConfigurationAdmissionTests.swift
@@ -215,6 +215,73 @@ final class SharedConfigurationAdmissionTests: KeyPathTestCase {
         }
     }
 
+    func testReloadCallbackCannotRegenerateConfigurationDirectly() async throws {
+        try await withFixture { service, manager, coordinator in
+            let content = "(defcfg)\n(defsrc a)\n(deflayer base b)"
+            var extraReloads = 0
+            manager.onRulesChanged = {
+                extraReloads += 1
+                return ReloadResult(success: true, response: nil, errorMessage: nil, protocol: nil)
+            }
+            let result = await coordinator.saveGeneratedConfig(content: content) {
+                let regenerated = await manager.regenerateConfigFromCollections()
+                XCTAssertFalse(regenerated)
+                return ReloadResult(success: true, response: nil, errorMessage: nil, protocol: nil)
+            }
+            XCTAssertTrue(result.success)
+            XCTAssertEqual(extraReloads, 0)
+            XCTAssertEqual(try String(contentsOfFile: service.configurationPath, encoding: .utf8), content)
+        }
+    }
+
+    func testReloadCallbackCannotRestoreAnUnrelatedRuleSnapshot() async throws {
+        try await withFixture { _, manager, coordinator in
+            let rule = manager.makeCustomRule(input: "a", output: "c")
+            let result = await coordinator.saveGeneratedConfig(content: "(defcfg)\n(defsrc a)\n(deflayer base b)") {
+                let restored = await manager.rollbackToSnapshot((collections: [], customRules: [rule]), userMessage: "Restored")
+                XCTAssertFalse(restored)
+                return ReloadResult(success: true, response: nil, errorMessage: nil, protocol: nil)
+            }
+            XCTAssertTrue(result.success)
+            XCTAssertTrue(manager.customRules.isEmpty)
+        }
+    }
+
+    func testStandalonePersistenceHoldsAdmissionThroughReload() async throws {
+        try await withFixture { _, manager, _ in
+            let entered = self.expectation(description: "standalone reload entered")
+            let started = self.expectation(description: "collection edit requested")
+            var resume: CheckedContinuation<Void, Never>?
+            var reloads = 0
+            manager.onRulesChanged = {
+                reloads += 1
+                if reloads == 1 {
+                    await withCheckedContinuation { continuation in
+                        resume = continuation
+                        entered.fulfill()
+                    }
+                }
+                return ReloadResult(success: true, response: nil, errorMessage: nil, protocol: nil)
+            }
+            let first = Task { @MainActor in await manager.persistRules() }
+            await self.fulfillment(of: [entered], timeout: 5)
+            let rule = manager.makeCustomRule(input: "a", output: "c")
+            let second = Task { @MainActor in
+                started.fulfill()
+                return await manager.saveCustomRule(rule)
+            }
+            await self.fulfillment(of: [started], timeout: 5)
+            XCTAssertTrue(manager.customRules.isEmpty)
+            resume?.resume()
+            let persisted = await first.value
+            let saved = await second.value
+            XCTAssertTrue(persisted.didPersist)
+            XCTAssertTrue(saved)
+            XCTAssertEqual(manager.customRules.map(\.id), [rule.id])
+            XCTAssertEqual(reloads, 2)
+        }
+    }
+
     private func withFixture(
         _ body: @MainActor (ConfigurationService, RuleCollectionsManager, SaveCoordinator) async throws -> Void
     ) async throws {

--- a/docs/architecture/configuration-save-pipeline.md
+++ b/docs/architecture/configuration-save-pipeline.md
@@ -66,7 +66,9 @@ they were reused later.
 `ConfigurationService.operationGate` provides FIFO admission for generated and
 mapping saves, explicit restoration, and the collection manager's public async
 mutation APIs (including keymap selection), bootstrap reconciliation, and pack
-install/uninstall/settings operations. Admission happens before staging
+install/uninstall/settings operations. Standalone regeneration, persistence,
+prerequisite application, conflict retries and snapshot restoration also acquire
+admission; their trusted nested callers pass the active permit. Admission happens before staging
 in-memory collection state and remains held through persistence, reload and
 recovery. Two coordinators using the same service share that admission queue.
 Each save snapshots the file itself rather than using the parsed cache or a
@@ -81,8 +83,7 @@ existing completion/recovery behavior remains unchanged.
 
 This is admission for one service instance, not a global or cross-process lock.
 Callers that compose a coordinator and collection manager must share the same
-service. Direct service writes, standalone regeneration entry points, CLI writers and
-external edits still need migration. Pack operations hold admission while staging
+service. Direct service writes, CLI writers and external edits still need migration. Pack operations hold admission while staging
 arrays, making nested collection calls, updating metadata and running their
 existing recovery paths; their multiple writes are still separate durable commits.
 The collection journal below provides a separate durable file recovery boundary;

--- a/docs/bugs/shared-configuration-admission.md
+++ b/docs/bugs/shared-configuration-admission.md
@@ -23,7 +23,12 @@ queue before staging state. Their nested toggle/save/remove calls pass the
 active permit explicitly. Regression tests cover callback attempts to install
 visual-only metadata or bootstrap, and cancellation before pack metadata writes.
 
-This does not make every writer exclusive: direct service, standalone
-regeneration and CLI paths still require migration. The durable journal and runtime
+Standalone regeneration and persistence now acquire admission as well. Conflict
+retries, prerequisite application and snapshot restoration accept explicit nested
+permits, so normal recovery does not reacquire its own queue. Tests hold a
+standalone reload open while another edit queues, and verify that callbacks
+cannot regenerate or restore a snapshot inside the active save.
+
+Direct service and CLI paths still require migration. The durable journal and runtime
 rollback also remain distinct boundaries. Do not treat this queue as proof of
 whole-operation rollback or protection against external editors.

--- a/docs/planning/catalog-led-consolidation-plan.md
+++ b/docs/planning/catalog-led-consolidation-plan.md
@@ -254,19 +254,22 @@ Implemented slices (the table describes the merged state of this checkpoint):
 | PR | Result | Remaining boundary |
 | --- | --- | --- |
 | #1260 | Mutation inventory and retained save reload results; unused alternative writer methods removed. | Other mutation surfaces still need migration. |
-| #1262 | FIFO coordinator saves, operation-local file snapshots, queued cancellation and recursive callback protection. | Admission is coordinator-local, not shared by every collection/pack mutation. |
+| #1262 | FIFO coordinator saves, operation-local file snapshots, queued cancellation and recursive callback protection. | Admission was extended to collection/pack/bootstrap paths by #1267–#1268; full runtime recovery still needs migration. |
 | #1263 | Explicit previous-file, minimal-safe-file, and failed recovery outcomes retaining both errors. | File recovery does not assert source-store or engine restoration. |
 | #1264 | Collection persistence and retry callbacks retain applied/pending/rejected/failed outcomes. | Compatibility Boolean continues to mean persisted. |
-| #1265 | Durable journal for config plus both rule stores, startup recovery, external-change checks, and observers after file-set commit. | Preferences, pack metadata, in-memory mutation ordering and runtime rollback remain outside this file transaction. |
-| #1266 | Failed keymap writes restore the prior collection, manager preferences and attempted overlay selection, preserving unrelated layout preferences and newer display choices. | UserDefaults is not crash-atomic with the journal; admission still needs to precede every mutation. |
-| #1267 | Shared service admission before public collection/keymap mutation and across coordinator save/recovery, with explicit nested permits and callback rejection. | Direct service, pack, bootstrap, CLI and external writers require migration; file admission is not whole-operation rollback. |
+| #1265 | Durable journal for config plus both rule stores, startup recovery, external-change checks, and observers after file-set commit. | Preferences, pack metadata and runtime rollback remain outside this file transaction. |
+| #1266 | Failed keymap writes restore the prior collection, manager preferences and attempted overlay selection, preserving unrelated layout preferences and newer display choices. | UserDefaults is not crash-atomic with the journal. |
+| #1267 | Shared service admission before public collection/keymap mutation and across coordinator save/recovery, with explicit nested permits and callback rejection. | Pack/bootstrap admission was added by #1268; direct service, CLI and external writers remain. |
+| #1268 | Pack install/uninstall/settings and bootstrap hold shared admission across nested mutations, metadata and recovery. | Direct service, CLI and external writers still require migration; pack commits remain separate. |
 
+Standalone regeneration, conflict retries, prerequisite application and snapshot
+restoration now participate in shared admission with explicit nested permits.
 The first migrated persistence journey now has interruption and failure tests.
 This is a useful foundation, not completion of Phase 1 or the program.
 
 Next implementation sequence:
 
-1. Complete admission of pack and bootstrap operations, then direct writers, before in-memory mutation;
+1. Complete direct service and CLI writer admission before mutation;
    preserve explicit ownership through trusted nested calls, and reject recursive
    callback writes rather than allowing stale rollback or deadlock.
 2. Keep the prior source revision through runtime classification and restore


### PR DESCRIPTION
Standalone regeneration (including RuntimeCoordinator repair callers) could bypass the shared operation queue, and callbacks could directly regenerate or restore a rule snapshot inside a pending save. Admit persistence before source deduplication or snapshots; hold the slot through reload and retry/recovery.

Conflict retries, prerequisite application and snapshot rollback accept the active permit. Thread it through collection, keymap, bootstrap and pack callers, including managed-default recovery, so trusted nested work does not reacquire its own queue. Standalone calls still work without a permit and acquire admission themselves. Callback attempts fail before mutation.

No UI or persistence/reload success semantics change. Direct ConfigurationService writers, CLI and external edits still need migration; admission does not establish a whole-operation durable transaction. Update the checkpoint to remove completed pack/bootstrap work from the next-actions list, addressing the late documentation review on #1268.

Validation:
- 128 focused tests passed, including shared admission, existing pack rollback, SaveCoordinator, persistence result and prerequisite resolution suites. No compiler warnings.
- New tests exercise direct regeneration and snapshot-restore callback rejection, plus a queued collection edit while standalone persistence waits for reload.
- Full safe suite reported 5,126 passes and only the four previously reproduced macOS 27 baseline snapshots: EasyViewSnapshotTests.testHomeRowTimingFastTyping, testHomeRowTimingPerFinger, testHomeRowTimingSlider; HardViewSnapshotTests.testRepairSettingsTabView. No compiler warnings and no snapshot reference changes.
- Accessibility and diff whitespace checks passed.
- remote review gate selected; GitHub claude-review must pass before merge.

Review follow-up: the outer persistence catch handles admission errors only (recursive callback, expired/foreign permit, or cancellation), before validation runs. It deliberately matches withRuleMutation: report non-cancellation errors through onError without a validation error sound; cancellation remains silent. Validation and mapping-conflict failures still use their existing inner formatting/sound path. Queue contention waits rather than throwing. The final clearAllCustomRules call forwards its permit, and the focused/full runs cover the new tests beyond the review diff truncation.
