### PR TITLE
Serialize direct service writes and preserve trusted recovery

### DIFF
--- a/Sources/KeyPathAppKit/Infrastructure/Config/ConfigurationService.swift
+++ b/Sources/KeyPathAppKit/Infrastructure/Config/ConfigurationService.swift
@@ -70,12 +70,16 @@ public final class ConfigurationService: FileConfigurationProviding {
     // MARK: - ConfigurationProviding Protocol
 
     public func current() async -> KanataConfiguration {
+        await current(mutationPermit: nil)
+    }
+
+    func current(mutationPermit: ConfigurationOperationGate.Permit?) async -> KanataConfiguration {
         // Fast path: return cached config if available
         if let cached = withLockedCurrentConfig() { return cached }
 
         // Try to load existing configuration, fallback to empty if not found
         do {
-            return try await reload()
+            return try await reload(mutationPermit: mutationPermit)
         } catch {
             AppLogger.shared.log("⚠️ [ConfigService] Failed to load current config, using empty: \(error)")
             let emptyConfig = KanataConfiguration(
@@ -90,6 +94,10 @@ public final class ConfigurationService: FileConfigurationProviding {
     }
 
     public func reload() async throws -> KanataConfiguration {
+        try await reload(mutationPermit: nil)
+    }
+
+    func reload(mutationPermit: ConfigurationOperationGate.Permit?) async throws -> KanataConfiguration {
         var exists = await fileExistsAsync(path: configurationPath)
         // Same semantics as createInitialConfigIfNeeded: a truncated/empty
         // config is as unparseable as a missing one, so let the self-heal
@@ -105,7 +113,7 @@ public final class ConfigurationService: FileConfigurationProviding {
                 "⚠️ [ConfigService] Config missing or empty at \(configurationPath) – creating default before reload"
             )
             do {
-                try await createInitialConfigIfNeeded()
+                try await createInitialConfigIfNeeded(mutationPermit: mutationPermit)
                 exists = await fileExistsAsync(path: configurationPath)
             } catch {
                 AppLogger.shared.log(
@@ -225,49 +233,56 @@ public final class ConfigurationService: FileConfigurationProviding {
 
     /// Create the configuration directory and initial config if needed
     public func createInitialConfigIfNeeded() async throws {
-        // Create config directory if it doesn't exist (off-main)
-        try await createDirectoryAsync(path: configDirectory)
-        AppLogger.shared.log("✅ [ConfigService] Config directory created at \(configDirectory)")
+        try await createInitialConfigIfNeeded(mutationPermit: nil)
+    }
 
-        // Check if config file exists. A 0-byte/whitespace-only file counts as
-        // missing: legacy helper scaffolding used to `touch` an empty keypath.kbd
-        // (#929), which kanata can't parse and which blocked this path from ever
-        // writing the default template.
-        let exists = await fileExistsAsync(path: configurationPath)
-        let effectivelyEmpty: Bool = if exists {
-            await fileIsEffectivelyEmptyAsync(path: configurationPath)
-        } else {
-            false
-        }
-        if !exists || effectivelyEmpty {
-            if effectivelyEmpty {
+    func createInitialConfigIfNeeded(mutationPermit: ConfigurationOperationGate.Permit?) async throws {
+        try await operationGate.withOperation(using: mutationPermit) { @MainActor [self] permit in
+            // Create config directory if it doesn't exist (off-main)
+            try await createDirectoryAsync(path: configDirectory)
+            AppLogger.shared.log("✅ [ConfigService] Config directory created at \(configDirectory)")
+
+            // Check if config file exists. A 0-byte/whitespace-only file counts as
+            // missing: legacy helper scaffolding used to `touch` an empty keypath.kbd
+            // (#929), which kanata can't parse and which blocked this path from ever
+            // writing the default template.
+            let exists = await fileExistsAsync(path: configurationPath)
+            let effectivelyEmpty: Bool = if exists {
+                await fileIsEffectivelyEmptyAsync(path: configurationPath)
+            } else {
+                false
+            }
+            if !exists || effectivelyEmpty {
+                if effectivelyEmpty {
+                    AppLogger.shared.log(
+                        "⚠️ [ConfigService] Config at \(configurationPath) exists but is empty — rewriting default"
+                    )
+                } else {
+                    AppLogger.shared.log("⚠️ [ConfigService] No existing config found at \(configurationPath)")
+                }
+
+                // Rehydrate from persisted rule/custom stores so user state survives file deletion/reset
+                let storedCollections = await ruleCollectionStore.loadCollections()
+                let storedCustomRules = await customRulesStore.loadRules()
+                let collectionsToSave = storedCollections.isEmpty
+                    ? RuleCollectionCatalog().defaultCollections()
+                    : storedCollections
+
                 AppLogger.shared.log(
-                    "⚠️ [ConfigService] Config at \(configurationPath) exists but is empty — rewriting default"
+                    "🆕 [ConfigService] Creating initial config from stores: \(collectionsToSave.count) collections, \(storedCustomRules.count) custom rules"
+                )
+
+                try await saveConfiguration(
+                    ruleCollections: collectionsToSave,
+                    customRules: storedCustomRules,
+                    mutationPermit: permit
+                )
+                AppLogger.shared.log(
+                    "✅ [ConfigService] Created initial configuration with \(collectionsToSave.count) collections"
                 )
             } else {
-                AppLogger.shared.log("⚠️ [ConfigService] No existing config found at \(configurationPath)")
+                AppLogger.shared.log("✅ [ConfigService] Existing config found at \(configurationPath)")
             }
-
-            // Rehydrate from persisted rule/custom stores so user state survives file deletion/reset
-            let storedCollections = await ruleCollectionStore.loadCollections()
-            let storedCustomRules = await customRulesStore.loadRules()
-            let collectionsToSave = storedCollections.isEmpty
-                ? RuleCollectionCatalog().defaultCollections()
-                : storedCollections
-
-            AppLogger.shared.log(
-                "🆕 [ConfigService] Creating initial config from stores: \(collectionsToSave.count) collections, \(storedCustomRules.count) custom rules"
-            )
-
-            try await saveConfiguration(
-                ruleCollections: collectionsToSave,
-                customRules: storedCustomRules
-            )
-            AppLogger.shared.log(
-                "✅ [ConfigService] Created initial configuration with \(collectionsToSave.count) collections"
-            )
-        } else {
-            AppLogger.shared.log("✅ [ConfigService] Existing config found at \(configurationPath)")
         }
     }
 
@@ -277,9 +292,19 @@ public final class ConfigurationService: FileConfigurationProviding {
         ruleCollections: [RuleCollection],
         customRules: [CustomRule] = []
     ) async throws {
-        let newConfig = try await preparedConfiguration(ruleCollections: ruleCollections, customRules: customRules)
-        try await writeFileAsync(string: newConfig.content, to: configurationPath)
-        await publishSavedConfiguration(newConfig)
+        try await saveConfiguration(ruleCollections: ruleCollections, customRules: customRules, mutationPermit: nil)
+    }
+
+    func saveConfiguration(
+        ruleCollections: [RuleCollection],
+        customRules: [CustomRule] = [],
+        mutationPermit: ConfigurationOperationGate.Permit?
+    ) async throws {
+        try await operationGate.withOperation(using: mutationPermit) { @MainActor [self] _ in
+            let newConfig = try await preparedConfiguration(ruleCollections: ruleCollections, customRules: customRules)
+            try await writeFileAsync(string: newConfig.content, to: configurationPath)
+            await publishSavedConfiguration(newConfig)
+        }
     }
 
     /// Persist the generated file and its two source stores as one recoverable
@@ -287,34 +312,39 @@ public final class ConfigurationService: FileConfigurationProviding {
     /// this service's defaults in tests and isolated CLI workflows.
     func saveRuleState(
         ruleCollections: [RuleCollection], customRules: [CustomRule],
-        collectionStore: RuleCollectionStore, customStore: CustomRulesStore
+        collectionStore: RuleCollectionStore, customStore: CustomRulesStore,
+        mutationPermit: ConfigurationOperationGate.Permit? = nil
     ) async throws {
-        try await recoverPendingRuleWrite(collectionStore: collectionStore, customStore: customStore)
-        let newConfig = try await preparedConfiguration(ruleCollections: ruleCollections, customRules: customRules)
-        let files = await ruleWriteFiles(collectionStore: collectionStore, customStore: customStore)
-        let contents = try await [
-            "config": Data(newConfig.content.utf8),
-            "collections": collectionStore.encodedCollections(ruleCollections),
-            "customRules": customStore.encodedRules(customRules)
-        ]
-        try Task.checkCancellation()
-        let directory = URL(fileURLWithPath: configDirectory)
-        try await performRuleFileOperation {
-            try RecoverableRuleWrite.apply(files: files, contents: contents, directory: directory)
+        try await operationGate.withOperation(using: mutationPermit) { @MainActor [self] permit in
+            try await recoverPendingRuleWrite(collectionStore: collectionStore, customStore: customStore, mutationPermit: permit)
+            let newConfig = try await preparedConfiguration(ruleCollections: ruleCollections, customRules: customRules)
+            let files = await ruleWriteFiles(collectionStore: collectionStore, customStore: customStore)
+            let contents = try await [
+                "config": Data(newConfig.content.utf8),
+                "collections": collectionStore.encodedCollections(ruleCollections),
+                "customRules": customStore.encodedRules(customRules)
+            ]
+            try Task.checkCancellation()
+            let directory = URL(fileURLWithPath: configDirectory)
+            try await performRuleFileOperation {
+                try RecoverableRuleWrite.apply(files: files, contents: contents, directory: directory)
+            }
+            await publishSavedConfiguration(newConfig)
         }
-        await publishSavedConfiguration(newConfig)
     }
 
     /// Run before loading source stores on startup. Refuse further rule writes
     /// when recovery detects a corrupt journal or an unrelated external edit.
-    func recoverPendingRuleWrite(collectionStore: RuleCollectionStore, customStore: CustomRulesStore) async throws {
-        let files = await ruleWriteFiles(collectionStore: collectionStore, customStore: customStore)
-        let directory = URL(fileURLWithPath: configDirectory)
-        let recovered = try await performRuleFileOperation {
-            try RecoverableRuleWrite.recover(files: files, directory: directory)
-        }
-        if recovered {
-            stateLock.withLock { currentConfiguration = nil }
+    func recoverPendingRuleWrite(collectionStore: RuleCollectionStore, customStore: CustomRulesStore, mutationPermit: ConfigurationOperationGate.Permit? = nil) async throws {
+        try await operationGate.withOperation(using: mutationPermit) { @MainActor [self] _ in
+            let files = await ruleWriteFiles(collectionStore: collectionStore, customStore: customStore)
+            let directory = URL(fileURLWithPath: configDirectory)
+            let recovered = try await performRuleFileOperation {
+                try RecoverableRuleWrite.recover(files: files, directory: directory)
+            }
+            if recovered {
+                stateLock.withLock { currentConfiguration = nil }
+            }
         }
     }
 
@@ -473,10 +503,16 @@ public final class ConfigurationService: FileConfigurationProviding {
 
     /// Write raw configuration content to file (for restoration/repair)
     public func writeConfigurationContent(_ content: String) async throws {
-        try await writeFileAsync(string: content, to: configurationPath)
-        // Update current configuration
-        let newConfig = try validate(content: content)
-        setCurrentConfiguration(newConfig)
+        try await writeConfigurationContent(content, mutationPermit: nil)
+    }
+
+    func writeConfigurationContent(_ content: String, mutationPermit: ConfigurationOperationGate.Permit?) async throws {
+        try await operationGate.withOperation(using: mutationPermit) { @MainActor [self] _ in
+            try await writeFileAsync(string: content, to: configurationPath)
+            // Update current configuration
+            let newConfig = try validate(content: content)
+            setCurrentConfiguration(newConfig)
+        }
     }
 
     // MARK: - Backup and Recovery
@@ -486,52 +522,54 @@ public final class ConfigurationService: FileConfigurationProviding {
         async throws
         -> String
     {
-        AppLogger.shared.log("🛡️ [Config] Backing up failed config and applying safe default")
+        try await operationGate.withOperation { @MainActor [self] _ in
+            AppLogger.shared.log("🛡️ [Config] Backing up failed config and applying safe default")
 
-        // Create backup directory if it doesn't exist
-        let backupDir = "\(configDirectory)/backups"
-        let backupDirURL = URL(fileURLWithPath: backupDir)
-        try Foundation.FileManager().createDirectory(at: backupDirURL, withIntermediateDirectories: true)
+            // Create backup directory if it doesn't exist
+            let backupDir = "\(configDirectory)/backups"
+            let backupDirURL = URL(fileURLWithPath: backupDir)
+            try Foundation.FileManager().createDirectory(at: backupDirURL, withIntermediateDirectories: true)
 
-        // Create timestamped backup filename
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy-MM-dd_HH-mm-ss"
-        let timestamp = formatter.string(from: Date())
+            // Create timestamped backup filename
+            let formatter = DateFormatter()
+            formatter.dateFormat = "yyyy-MM-dd_HH-mm-ss"
+            let timestamp = formatter.string(from: Date())
 
-        let backupPath = "\(backupDir)/failed_config_\(timestamp).kbd"
-        let backupURL = URL(fileURLWithPath: backupPath)
+            let backupPath = "\(backupDir)/failed_config_\(timestamp).kbd"
+            let backupURL = URL(fileURLWithPath: backupPath)
 
-        // Write the failed config to backup
-        let backupContent = """
-        ;; FAILED CONFIG - AUTOMATICALLY BACKED UP
-        ;; Timestamp: \(timestamp)
-        ;; Errors: \(mappings.count) mapping(s) could not be applied
+            // Write the failed config to backup
+            let backupContent = """
+            ;; FAILED CONFIG - AUTOMATICALLY BACKED UP
+            ;; Timestamp: \(timestamp)
+            ;; Errors: \(mappings.count) mapping(s) could not be applied
 
-        \(failedConfig)
-        """
-        try await writeFileURLAsync(string: backupContent, to: backupURL)
+            \(failedConfig)
+            """
+            try await writeFileURLAsync(string: backupContent, to: backupURL)
 
-        AppLogger.shared.log("💾 [Config] Failed config backed up to: \(backupPath)")
+            AppLogger.shared.log("💾 [Config] Failed config backed up to: \(backupPath)")
 
-        // Apply safe default config using the standard generator
-        let safeConfig = KanataConfiguration.generateFromMappings(mappings)
+            // Apply safe default config using the standard generator
+            let safeConfig = KanataConfiguration.generateFromMappings(mappings)
 
-        let configURL = URL(fileURLWithPath: configurationPath)
-        try await writeFileURLAsync(string: safeConfig, to: configURL)
+            let configURL = URL(fileURLWithPath: configurationPath)
+            try await writeFileURLAsync(string: safeConfig, to: configURL)
 
-        AppLogger.shared.log("✅ [Config] Safe default config applied")
+            AppLogger.shared.log("✅ [Config] Safe default config applied")
 
-        // Update current configuration
-        setCurrentConfiguration(
-            KanataConfiguration(
-                content: safeConfig,
-                keyMappings: [KeyMapping(input: "caps", action: .keystroke(key: "escape"))],
-                lastModified: Date(),
-                path: configurationPath
+            // Update current configuration
+            setCurrentConfiguration(
+                KanataConfiguration(
+                    content: safeConfig,
+                    keyMappings: [KeyMapping(input: "caps", action: .keystroke(key: "escape"))],
+                    lastModified: Date(),
+                    path: configurationPath
+                )
             )
-        )
 
-        return backupPath
+            return backupPath
+        }
     }
 
     /// Repair configuration using rule-based strategies (keeps output Kanata-compatible).
@@ -580,35 +618,37 @@ public final class ConfigurationService: FileConfigurationProviding {
     /// Create a timestamped backup of the current config before AI repair
     /// Returns the backup file path for user reference
     public func backupConfigBeforeAIRepair() async throws -> String {
-        AppLogger.shared.log("📦 [Config] Creating pre-AI-repair backup")
+        try await operationGate.withOperation { @MainActor [self] _ in
+            AppLogger.shared.log("📦 [Config] Creating pre-AI-repair backup")
 
-        // Create backup directory if it doesn't exist
-        let backupDir = "\(configDirectory)/backups"
-        let backupDirURL = URL(fileURLWithPath: backupDir)
-        try Foundation.FileManager().createDirectory(at: backupDirURL, withIntermediateDirectories: true)
+            // Create backup directory if it doesn't exist
+            let backupDir = "\(configDirectory)/backups"
+            let backupDirURL = URL(fileURLWithPath: backupDir)
+            try Foundation.FileManager().createDirectory(at: backupDirURL, withIntermediateDirectories: true)
 
-        // Create timestamped backup filename
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy-MM-dd_HH-mm-ss"
-        let timestamp = formatter.string(from: Date())
+            // Create timestamped backup filename
+            let formatter = DateFormatter()
+            formatter.dateFormat = "yyyy-MM-dd_HH-mm-ss"
+            let timestamp = formatter.string(from: Date())
 
-        let backupPath = "\(backupDir)/pre-repair_\(timestamp).kbd"
-        let backupURL = URL(fileURLWithPath: backupPath)
+            let backupPath = "\(backupDir)/pre-repair_\(timestamp).kbd"
+            let backupURL = URL(fileURLWithPath: backupPath)
 
-        // Read current config and write to backup
-        let currentContent = try await readFileAsync(path: configurationPath)
-        let backupContent = """
-        ;; PRE-AI-REPAIR BACKUP
-        ;; Original config before AI repair attempt
-        ;; Timestamp: \(timestamp)
-        ;; Original path: \(configurationPath)
+            // Read current config and write to backup
+            let currentContent = try await readFileAsync(path: configurationPath)
+            let backupContent = """
+            ;; PRE-AI-REPAIR BACKUP
+            ;; Original config before AI repair attempt
+            ;; Timestamp: \(timestamp)
+            ;; Original path: \(configurationPath)
 
-        \(currentContent)
-        """
-        try await writeFileURLAsync(string: backupContent, to: backupURL)
+            \(currentContent)
+            """
+            try await writeFileURLAsync(string: backupContent, to: backupURL)
 
-        AppLogger.shared.log("💾 [Config] Pre-repair backup created: \(backupPath)")
-        return backupPath
+            AppLogger.shared.log("💾 [Config] Pre-repair backup created: \(backupPath)")
+            return backupPath
+        }
     }
 
     /// Save a repaired config (from AI repair)
@@ -622,22 +662,24 @@ public final class ConfigurationService: FileConfigurationProviding {
     /// was removed with the policy. The repair prompt also instructs the model
     /// not to emit the header.
     public func saveRepairedConfig(_ repairedContent: String) async throws {
-        AppLogger.shared.log("💾 [Config] Saving AI-repaired config")
+        try await operationGate.withOperation { @MainActor [self] _ in
+            AppLogger.shared.log("💾 [Config] Saving AI-repaired config")
 
-        let configURL = URL(fileURLWithPath: configurationPath)
-        try await writeFileURLAsync(string: repairedContent, to: configURL)
+            let configURL = URL(fileURLWithPath: configurationPath)
+            try await writeFileURLAsync(string: repairedContent, to: configURL)
 
-        // Update current configuration
-        setCurrentConfiguration(
-            KanataConfiguration(
-                content: repairedContent,
-                keyMappings: [], // Will be re-parsed on next reload
-                lastModified: Date(),
-                path: configurationPath
+            // Update current configuration
+            setCurrentConfiguration(
+                KanataConfiguration(
+                    content: repairedContent,
+                    keyMappings: [], // Will be re-parsed on next reload
+                    lastModified: Date(),
+                    path: configurationPath
+                )
             )
-        )
 
-        AppLogger.shared.log("✅ [Config] AI-repaired config saved")
+            AppLogger.shared.log("✅ [Config] AI-repaired config saved")
+        }
     }
 
     // MARK: - Private Methods

--- a/Sources/KeyPathAppKit/Managers/SaveCoordinator.swift
+++ b/Sources/KeyPathAppKit/Managers/SaveCoordinator.swift
@@ -133,7 +133,7 @@ final class SaveCoordinator {
                     )
 
                     // Step 2: Backup current config
-                    let previousContent = try await snapshotCurrentConfig()
+                    let previousContent = try await snapshotCurrentConfig(mutationPermit: permit)
                     try Task.checkCancellation()
                     backupCurrentConfig(previousContent)
 
@@ -176,7 +176,7 @@ final class SaveCoordinator {
                         AppLogger.shared.error("❌ [SaveCoordinator] Restoring backup")
 
                         playErrorSound()
-                        let recoveryResult = await restoreConfig(previousContent)
+                        let recoveryResult = await restoreConfig(previousContent, mutationPermit: permit)
 
                         saveStatus = .failed("TCP server reload failed: \(errorMessage)")
                         return .failure(
@@ -212,7 +212,7 @@ final class SaveCoordinator {
         reloadHandler: @escaping () async -> ReloadResult
     ) async -> SaveResult {
         do {
-            return try await configurationService.operationGate.withOperation { @MainActor [self] _ in
+            return try await configurationService.operationGate.withOperation { @MainActor [self] permit in
                 // Suppress file watcher to prevent double reload
                 configFileWatcher?.suppressEvents(for: 1.0, reason: "Internal saveGeneratedConfiguration")
                 saveStatus = .saving
@@ -239,7 +239,7 @@ final class SaveCoordinator {
                     AppLogger.shared.info("✅ [SaveCoordinator] Generated config validation passed")
 
                     // Step 2: Backup current config
-                    let previousContent = try await snapshotCurrentConfig()
+                    let previousContent = try await snapshotCurrentConfig(mutationPermit: permit)
                     try Task.checkCancellation()
                     backupCurrentConfig(previousContent)
 
@@ -288,7 +288,7 @@ final class SaveCoordinator {
                         AppLogger.shared.error("❌ [SaveCoordinator] TCP reload FAILED: \(errorMessage)")
 
                         playErrorSound()
-                        let recoveryResult = await restoreConfig(previousContent)
+                        let recoveryResult = await restoreConfig(previousContent, mutationPermit: permit)
 
                         saveStatus = .failed("Config reload failed: \(errorMessage)")
                         return .failure(
@@ -332,8 +332,8 @@ final class SaveCoordinator {
 
     @discardableResult
     func restoreLastGoodConfig() async throws -> SaveRecoveryResult {
-        try await configurationService.operationGate.withOperation { @MainActor [self] _ in
-            let result = await restoreConfig(lastGoodConfig)
+        try await configurationService.operationGate.withOperation { @MainActor [self] permit in
+            let result = await restoreConfig(lastGoodConfig, mutationPermit: permit)
             // Preserve the throwing contract for existing explicit-restore callers.
             if case let .failed(backupError, fallbackError) = result {
                 throw SaveRecoveryError(backupError: backupError, fallbackError: fallbackError)
@@ -342,12 +342,12 @@ final class SaveCoordinator {
         }
     }
 
-    private func restoreConfig(_ content: String?) async -> SaveRecoveryResult {
+    private func restoreConfig(_ content: String?, mutationPermit: ConfigurationOperationGate.Permit) async -> SaveRecoveryResult {
         var backupError: Error?
         if let backup = content {
             AppLogger.shared.info("🔄 [SaveCoordinator] Restoring last good config")
             do {
-                try await configurationService.writeConfigurationContent(backup)
+                try await configurationService.writeConfigurationContent(backup, mutationPermit: mutationPermit)
                 return .restoredPreviousConfig
             } catch {
                 backupError = error
@@ -443,10 +443,10 @@ final class SaveCoordinator {
 
     // MARK: - Private Helpers
 
-    private func snapshotCurrentConfig() async throws -> String {
+    private func snapshotCurrentConfig(mutationPermit: ConfigurationOperationGate.Permit) async throws -> String {
         let path = configurationService.configurationPath
         if await !(configurationService.fileExistsAsync(path: path)) {
-            return await configurationService.current().content
+            return await configurationService.current(mutationPermit: mutationPermit).content
         }
         // Generated saves write raw content without refreshing the parsed cache.
         // Back up the actual file, never a possibly older cached configuration.

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+Bootstrap.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+Bootstrap.swift
@@ -11,7 +11,7 @@ extension RuleCollectionsManager {
         await withRuleMutation(failure: ()) { [self] permit in
             do {
                 try await configurationService.recoverPendingRuleWrite(
-                    collectionStore: ruleCollectionStore, customStore: customRulesStore
+                    collectionStore: ruleCollectionStore, customStore: customRulesStore, mutationPermit: permit
                 )
             } catch {
                 onError?("Could not recover the previous rule edit: \(error.localizedDescription)")

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+Migrations.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+Migrations.swift
@@ -77,7 +77,8 @@ extension RuleCollectionsManager {
                         ruleCollections: ruleCollections,
                         customRules: customRules,
                         collectionStore: ruleCollectionStore,
-                        customStore: customRulesStore
+                        customStore: customRulesStore,
+                        mutationPermit: permit
                     )
                     AppLogger.shared.log("✅ [RuleCollections] configurationService.saveRuleState succeeded")
 

--- a/Tests/KeyPathTests/Managers/SharedConfigurationAdmissionTests.swift
+++ b/Tests/KeyPathTests/Managers/SharedConfigurationAdmissionTests.swift
@@ -282,6 +282,91 @@ final class SharedConfigurationAdmissionTests: KeyPathTestCase {
         }
     }
 
+    func testReloadCallbackCannotUseDirectServiceWriters() async throws {
+        try await withFixture { service, manager, coordinator in
+            let content = "(defcfg)\n(defsrc a)\n(deflayer base b)"
+            let replacement = "(defcfg)\n(defsrc a)\n(deflayer base c)"
+            let attempts: [(String, @MainActor () async throws -> Void)] = [
+                ("collections", { try await service.saveConfiguration(ruleCollections: []) }),
+                ("legacy mapping", { try await service.saveConfiguration(input: "a", output: "c") }),
+                ("raw restore", { try await service.writeConfigurationContent(replacement) }),
+                ("repair", { try await service.saveRepairedConfig(replacement) }),
+                ("safe fallback", { _ = try await service.backupFailedConfigAndApplySafe(failedConfig: content, mappings: []) }),
+                ("backup", { _ = try await service.backupConfigBeforeAIRepair() }),
+                ("initial creation", { try await service.createInitialConfigIfNeeded() }),
+                ("journal recovery", {
+                    try await service.recoverPendingRuleWrite(collectionStore: manager.ruleCollectionStore, customStore: manager.customRulesStore)
+                }),
+                ("rule write", {
+                    try await service.saveRuleState(ruleCollections: [], customRules: [], collectionStore: manager.ruleCollectionStore, customStore: manager.customRulesStore)
+                }),
+            ]
+            let result = await coordinator.saveGeneratedConfig(content: content) {
+                for (name, attempt) in attempts {
+                    do {
+                        try await attempt()
+                        XCTFail("Callback writer entered: \(name)")
+                    } catch ConfigurationOperationGate.Failure.recursiveOperation {
+                        // Each public entry refuses before writing or notifying.
+                    } catch {
+                        XCTFail("Unexpected \(name) failure: \(error)")
+                    }
+                }
+                return ReloadResult(success: true, response: nil, errorMessage: nil, protocol: nil)
+            }
+            XCTAssertTrue(result.success)
+            XCTAssertEqual(try String(contentsOfFile: service.configurationPath, encoding: .utf8), content)
+            XCTAssertFalse(FileManager.default.fileExists(atPath: service.configDirectory + "/backups"))
+        }
+    }
+
+    func testDirectServiceSaveRetainsAdmissionThroughObserverCallbacks() async throws {
+        try await withFixture { service, _, coordinator in
+            let entered = self.expectation(description: "service observer entered")
+            let started = self.expectation(description: "coordinator save requested")
+            var resume: CheckedContinuation<Void, Never>?
+            let observation = service.observe { @MainActor _ in
+                await withCheckedContinuation { continuation in
+                    resume = continuation
+                    entered.fulfill()
+                }
+            }
+            defer { observation.cancel() }
+            let first = Task { @MainActor in try await service.saveConfiguration(ruleCollections: []) }
+            await self.fulfillment(of: [entered], timeout: 5)
+            let firstContent = try String(contentsOfFile: service.configurationPath, encoding: .utf8)
+            let content = "(defcfg)\n(defsrc a)\n(deflayer base c)"
+            let second = Task { @MainActor in
+                started.fulfill()
+                return await coordinator.saveGeneratedConfig(content: content) {
+                    ReloadResult(success: true, response: nil, errorMessage: nil, protocol: nil)
+                }
+            }
+            await self.fulfillment(of: [started], timeout: 5)
+            XCTAssertEqual(try String(contentsOfFile: service.configurationPath, encoding: .utf8), firstContent)
+            resume?.resume()
+            try await first.value
+            let result = await second.value
+            XCTAssertTrue(result.success)
+            XCTAssertEqual(try String(contentsOfFile: service.configurationPath, encoding: .utf8), content)
+        }
+    }
+
+    func testMissingFileSaveBacksUpRehydratedStoredRules() async throws {
+        try await withFixture { service, manager, coordinator in
+            let rule = manager.makeCustomRule(input: "f13", output: "f14")
+            try await manager.customRulesStore.saveRules([rule])
+            try FileManager.default.removeItem(atPath: service.configurationPath)
+            let result = await coordinator.saveGeneratedConfig(content: "(defcfg)\n(defsrc a)\n(deflayer base b)") {
+                ReloadResult(success: false, response: nil, errorMessage: "reject", protocol: nil, disposition: .rejected)
+            }
+            XCTAssertFalse(result.success)
+            let restored = try String(contentsOfFile: service.configurationPath, encoding: .utf8)
+            let parsed = try service.parseConfigurationFromString(restored)
+            XCTAssertEqual(parsed.keyMappings.first { $0.input == "f13" }?.action.outputString, "f14")
+        }
+    }
+
     private func withFixture(
         _ body: @MainActor (ConfigurationService, RuleCollectionsManager, SaveCoordinator) async throws -> Void
     ) async throws {

--- a/docs/architecture/configuration-save-pipeline.md
+++ b/docs/architecture/configuration-save-pipeline.md
@@ -83,7 +83,15 @@ existing completion/recovery behavior remains unchanged.
 
 This is admission for one service instance, not a global or cross-process lock.
 Callers that compose a coordinator and collection manager must share the same
-service. Direct service writes, CLI writers and external edits still need migration. Pack operations hold admission while staging
+service. Direct service writers now acquire this gate too: collection/raw/repaired saves,
+initial creation, backup/fallback and journal recovery. Public signatures remain
+unchanged; trusted coordinator restoration and collection persistence forward
+permits through internal overloads. Missing-file backup reads carry the permit
+through self-healing creation so the backup retains stored rules. CLI operation
+ownership, separate service instances, external edits and feature-specific writers
+(such as SimpleModsService and AppConfigGenerator include-file saves) still need
+migration. Those callers using this service only for validation do not acquire
+write admission merely by validating. Pack operations hold admission while staging
 arrays, making nested collection calls, updating metadata and running their
 existing recovery paths; their multiple writes are still separate durable commits.
 The collection journal below provides a separate durable file recovery boundary;

--- a/docs/bugs/shared-configuration-admission.md
+++ b/docs/bugs/shared-configuration-admission.md
@@ -29,6 +29,12 @@ permits, so normal recovery does not reacquire its own queue. Tests hold a
 standalone reload open while another edit queues, and verify that callbacks
 cannot regenerate or restore a snapshot inside the active save.
 
-Direct service and CLI paths still require migration. The durable journal and runtime
+Direct service writers, backups and journal recovery now acquire admission.
+Trusted restore and missing-file self-healing calls forward the permit. Tests
+exercise direct writer attempts from reload callbacks, observer-held saves and
+restoring persisted rules after a rejected save with a missing initial file.
+
+CLI operation ownership and cross-instance/process concurrency still require
+migration. The durable journal and runtime
 rollback also remain distinct boundaries. Do not treat this queue as proof of
 whole-operation rollback or protection against external editors.

--- a/docs/planning/catalog-led-consolidation-plan.md
+++ b/docs/planning/catalog-led-consolidation-plan.md
@@ -259,17 +259,18 @@ Implemented slices (the table describes the merged state of this checkpoint):
 | #1264 | Collection persistence and retry callbacks retain applied/pending/rejected/failed outcomes. | Compatibility Boolean continues to mean persisted. |
 | #1265 | Durable journal for config plus both rule stores, startup recovery, external-change checks, and observers after file-set commit. | Preferences, pack metadata and runtime rollback remain outside this file transaction. |
 | #1266 | Failed keymap writes restore the prior collection, manager preferences and attempted overlay selection, preserving unrelated layout preferences and newer display choices. | UserDefaults is not crash-atomic with the journal. |
-| #1267 | Shared service admission before public collection/keymap mutation and across coordinator save/recovery, with explicit nested permits and callback rejection. | Pack/bootstrap admission was added by #1268; direct service, CLI and external writers remain. |
-| #1268 | Pack install/uninstall/settings and bootstrap hold shared admission across nested mutations, metadata and recovery. | Direct service, CLI and external writers still require migration; pack commits remain separate. |
+| #1267 | Shared service admission before public collection/keymap mutation and across coordinator save/recovery, with explicit nested permits and callback rejection. | Pack/bootstrap admission was added by #1268; CLI operation ownership and external writers remain. |
+| #1268 | Pack install/uninstall/settings and bootstrap hold shared admission across nested mutations, metadata and recovery. | CLI operation ownership and external writers still require migration; pack commits remain separate. |
+| #1269 | Standalone regeneration, conflict retries, prerequisite application and snapshot restoration share admission with explicit nested permits. | Cross-instance/process ownership and whole-operation recovery remain. |
 
-Standalone regeneration, conflict retries, prerequisite application and snapshot
-restoration now participate in shared admission with explicit nested permits.
+Direct service writers and trusted self-healing/restore paths now participate
+in shared admission as well.
 The first migrated persistence journey now has interruption and failure tests.
 This is a useful foundation, not completion of Phase 1 or the program.
 
 Next implementation sequence:
 
-1. Complete direct service and CLI writer admission before mutation;
+1. Complete feature-specific writers, CLI operation ownership and cross-instance/process admission before mutation;
    preserve explicit ownership through trusted nested calls, and reject recursive
    callback writes rather than allowing stale rollback or deadlock.
 2. Keep the prior source revision through runtime classification and restore


### PR DESCRIPTION
Direct ConfigurationService writes could bypass an admitted coordinator or collection operation. Acquire the existing service gate around collection/raw/repaired writes, initial creation, backup/fallback and journal recovery, preserving public signatures. Trusted callers forward permits through internal overloads.

Carry admission through SaveCoordinator restore and missing-file backup reads as well: self-healing creation must remain authorized while backing up the stored rule state. Existing validation, persistence and recovery result semantics are preserved.

This remains per-service admission. Separate instances/processes, CLI operation ownership, external edits and feature-specific writers (SimpleModsService/AppConfigGenerator) still need migration. It does not claim whole-operation source/preference/metadata rollback.

Validation:
- 234 focused tests passed, including ConfigurationService, SaveCoordinator, recoverable writes, shared admission and existing pack rollback suites; no compiler warnings.
- New tests attempt nine direct writer paths from a reload callback, hold a service observer while a coordinator queues, and verify stored rules are restored after rejection when the original config file was missing.
- Full safe suite reported 5,129 passes and only the four previously reproduced macOS 27 baseline snapshots: EasyViewSnapshotTests.testHomeRowTimingFastTyping, testHomeRowTimingPerFinger, testHomeRowTimingSlider; HardViewSnapshotTests.testRepairSettingsTabView. No compiler warnings and no snapshot reference changes.
- Accessibility and diff whitespace checks passed.
- remote review gate selected; GitHub claude-review must pass before merge.

Review follow-up: backupConfigBeforeAIRepair and saveRepairedConfig have no production call sites. backupFailedConfigAndApplySafe is exposed through ConfigurationManager → RuntimeCoordinator → KanataViewModel forwarding methods; none is called from an admitted save/mutation path. The current trusted restore path uses writeConfigurationContent with its permit, and the fallback stays within SaveCoordinator's own admitted body. Therefore these three standalone backup/repair methods need no trusted nesting overload today; their callback rejection is intentional. Future composition must add explicit ownership rather than allowing automatic callback reentry.
