### PR TITLE
Serialize configuration operations across service instances and processes

### DIFF
--- a/Sources/KeyPathAppKit/Infrastructure/Config/ConfigurationOperationGate.swift
+++ b/Sources/KeyPathAppKit/Infrastructure/Config/ConfigurationOperationGate.swift
@@ -1,7 +1,9 @@
+import CryptoKit
+import Darwin
 import Foundation
 
-/// Shared admission for app operations using one ConfigurationService. Owns no
-/// persistence or UI state; a permit explicitly identifies trusted nested work.
+/// FIFO admission within one service, plus a process-safe lease for its config
+/// directory. Owns no persistence/UI state; trusted nested work uses a permit.
 actor ConfigurationOperationGate {
     struct Permit: Sendable {
         fileprivate let owner: UUID
@@ -11,6 +13,8 @@ actor ConfigurationOperationGate {
     enum Failure: LocalizedError {
         case recursiveOperation
         case invalidPermit
+        case fileLock(String, Int32)
+        case invalidLockFile
 
         var errorDescription: String? {
             switch self {
@@ -18,14 +22,41 @@ actor ConfigurationOperationGate {
                 "An operation callback cannot recursively save or restore through the same configuration service."
             case .invalidPermit:
                 "The configuration operation permit is no longer active."
+            case let .fileLock(operation, code):
+                "Configuration operation lock \(operation) failed (errno \(code))."
+            case .invalidLockFile:
+                "The configuration operation lock is not a regular file."
             }
         }
     }
 
     @TaskLocal private static var activeOperations: Set<UUID> = []
+    @TaskLocal private static var fileLeases: [FileLease] = []
+    private let configurationDirectory: URL?
     private let owner = UUID()
     private var active: Permit?
     private var waiters: [CheckedContinuation<Permit, Never>] = []
+
+    init(configurationDirectory: URL? = nil) {
+        self.configurationDirectory = configurationDirectory
+    }
+
+    /// Keep locks in user-owned state, not a possibly read-only config parent.
+    /// Never unlink at operation end; waiters must keep one inode even on restore.
+    nonisolated static func lockFileURL(for directory: URL) -> URL {
+        let canonical = directory.standardizedFileURL.resolvingSymlinksInPath()
+        var ancestor = canonical
+        while !FileManager.default.fileExists(atPath: ancestor.path), ancestor.path != "/" {
+            ancestor = ancestor.deletingLastPathComponent()
+        }
+        let caseSensitive = try? ancestor.resourceValues(forKeys: [.volumeSupportsCaseSensitiveNamesKey]).volumeSupportsCaseSensitiveNames
+        var path = canonical.path.precomposedStringWithCanonicalMapping
+        if caseSensitive == false { path = path.lowercased() }
+        let key = SHA256.hash(data: Data(path.utf8)).map { String(format: "%02x", $0) }.joined()
+        return FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Application Support/KeyPath/ConfigurationLocks", isDirectory: true)
+            .appendingPathComponent("\(key).lock")
+    }
 
     func withOperation<Result: Sendable>(
         using permit: Permit? = nil,
@@ -41,14 +72,36 @@ actor ConfigurationOperationGate {
         if let active, Self.activeOperations.contains(active.operation) {
             throw Failure.recursiveOperation
         }
+        // Check inherited directory ownership before joining this service's queue:
+        // its current operation may itself be waiting for the callback owner's lease.
+        let lease: FileLease? = if let configurationDirectory {
+            try await FileLease.open(directory: configurationDirectory)
+        } else {
+            nil
+        }
+        defer { lease?.release() }
+        if let lease {
+            // File identity also catches case and symlink aliases across service instances.
+            guard !Self.fileLeases.contains(where: { $0.identity == lease.identity && $0.isActive }) else {
+                throw Failure.recursiveOperation
+            }
+        }
         let admitted = await acquire()
-        defer { release() }
+        defer {
+            lease?.release()
+            release()
+        }
         // Cancelled waiters retain their FIFO place, then leave without mutation.
+        try Task.checkCancellation()
+        try await lease?.acquire()
         try Task.checkCancellation()
         var context = Self.activeOperations
         context.insert(admitted.operation)
+        let leases = Self.fileLeases + (lease.map { [$0] } ?? [])
         return try await Self.$activeOperations.withValue(context) {
-            try await operation(admitted)
+            try await Self.$fileLeases.withValue(leases) {
+                try await operation(admitted)
+            }
         }
     }
 
@@ -69,5 +122,81 @@ actor ConfigurationOperationGate {
         let next = Permit(owner: owner, operation: UUID())
         active = next
         waiters.removeFirst().resume(returning: next)
+    }
+
+    private final nonisolated class FileLease: @unchecked Sendable {
+        struct Identity: Equatable, Sendable {
+            let device: dev_t
+            let inode: ino_t
+        }
+
+        let identity: Identity
+        private let stateLock = NSLock()
+        private var descriptor: Int32?
+
+        private init(descriptor: Int32, identity: Identity) {
+            self.descriptor = descriptor
+            self.identity = identity
+        }
+
+        var isActive: Bool {
+            stateLock.withLock { descriptor != nil }
+        }
+
+        private static let ioQueue = DispatchQueue(label: "com.keypath.configuration-operation-lock", qos: .utility, attributes: .concurrent)
+
+        static func open(directory: URL) async throws -> FileLease {
+            try await withCheckedThrowingContinuation { continuation in
+                ioQueue.async {
+                    do {
+                        try continuation.resume(returning: openFile(directory: directory))
+                    } catch {
+                        continuation.resume(throwing: error)
+                    }
+                }
+            }
+        }
+
+        private static func openFile(directory: URL) throws -> FileLease {
+            let url = ConfigurationOperationGate.lockFileURL(for: directory)
+            try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+            let fd = Darwin.open(url.path, O_CREAT | O_RDWR | O_CLOEXEC | O_NOFOLLOW | O_NONBLOCK, S_IRUSR | S_IWUSR)
+            guard fd >= 0 else { throw Failure.fileLock("open", errno) }
+            do {
+                var info = stat()
+                guard fstat(fd, &info) == 0 else { throw Failure.fileLock("stat", errno) }
+                guard info.st_mode & S_IFMT == S_IFREG else { throw Failure.invalidLockFile }
+                return FileLease(descriptor: fd, identity: Identity(device: info.st_dev, inode: info.st_ino))
+            } catch {
+                Darwin.close(fd)
+                throw error
+            }
+        }
+
+        func acquire() async throws {
+            guard let fd = stateLock.withLock({ descriptor }) else { throw Failure.invalidPermit }
+            while true {
+                try Task.checkCancellation()
+                if flock(fd, LOCK_EX | LOCK_NB) == 0 { return }
+                let code = errno
+                if code == EINTR { continue }
+                guard code == EWOULDBLOCK || code == EAGAIN else { throw Failure.fileLock("acquire", code) }
+                // Never block the main actor or a serial file-I/O queue while waiting.
+                try await Task.sleep(for: .milliseconds(50))
+            }
+        }
+
+        func release() {
+            let fd = stateLock.withLock {
+                let previous = descriptor
+                descriptor = nil
+                return previous
+            }
+            guard let fd else { return }
+            flock(fd, LOCK_UN)
+            Darwin.close(fd)
+        }
+
+        deinit { release() }
     }
 }

--- a/Sources/KeyPathAppKit/Infrastructure/Config/ConfigurationService.swift
+++ b/Sources/KeyPathAppKit/Infrastructure/Config/ConfigurationService.swift
@@ -33,7 +33,7 @@ public final class ConfigurationService: FileConfigurationProviding {
     private let ruleCollectionStore: RuleCollectionStore
     private let customRulesStore: CustomRulesStore
 
-    let operationGate = ConfigurationOperationGate()
+    let operationGate: ConfigurationOperationGate
 
     /// Perform blocking file I/O off the main actor
     private let ioQueue = DispatchQueue(label: "com.keypath.configservice.io", qos: .utility)
@@ -65,6 +65,7 @@ public final class ConfigurationService: FileConfigurationProviding {
             self.configDirectory = KeyPathConstants.Config.directory
         }
         configurationPath = "\(self.configDirectory)/\(configFileName)"
+        operationGate = ConfigurationOperationGate(configurationDirectory: URL(fileURLWithPath: self.configDirectory, isDirectory: true))
     }
 
     // MARK: - ConfigurationProviding Protocol

--- a/Tests/KeyPathTests/Managers/ConfigurationFileAdmissionTests.swift
+++ b/Tests/KeyPathTests/Managers/ConfigurationFileAdmissionTests.swift
@@ -1,0 +1,280 @@
+import Darwin
+import Foundation
+@testable import KeyPathAppKit
+@preconcurrency import XCTest
+
+@MainActor
+final class ConfigurationFileAdmissionTests: KeyPathTestCase {
+    private let original = "(defcfg)\n(defsrc a)\n(deflayer base a)"
+    private let replacement = "(defcfg)\n(defsrc a)\n(deflayer base b)"
+
+    func testWritableDirectoryDoesNotRequireAWritableParent() async throws {
+        // /private is not writable by this user, while /private/tmp is.
+        let directory = URL(fileURLWithPath: "/private/tmp", isDirectory: true)
+        let gate = ConfigurationOperationGate(configurationDirectory: directory)
+        let result = try await gate.withOperation { _ in 17 }
+        XCTAssertEqual(result, 17)
+        XCTAssertNotEqual(ConfigurationOperationGate.lockFileURL(for: directory).deletingLastPathComponent().path, "/private")
+    }
+
+    func testDirectoryBackedGateAllowsExplicitNestedPermit() async throws {
+        try await withDirectory { directory in
+            let gate = ConfigurationOperationGate(configurationDirectory: directory)
+            let result = try await gate.withOperation { permit in
+                try await gate.withOperation(using: permit) { _ in 42 }
+            }
+            XCTAssertEqual(result, 42)
+        }
+    }
+
+    func testLeaseExcludesAnotherProcessAndReleasesAfterCompletion() async throws {
+        try await withDirectory { directory in
+            let gate = ConfigurationOperationGate(configurationDirectory: directory)
+            let lockURL = ConfigurationOperationGate.lockFileURL(for: directory)
+            try await gate.withOperation { _ in
+                let status = try await Self.probeFromChildProcess(lockURL)
+                XCTAssertEqual(status, 23, "A separate process must observe the held lease")
+            }
+            let status = try await Self.probeFromChildProcess(lockURL)
+            XCTAssertEqual(status, 0)
+        }
+    }
+
+    func testIndependentServicesWaitForTheSameDirectory() async throws {
+        try await withDirectory { directory in
+            let firstService = ConfigurationService(configDirectory: directory.path)
+            let secondService = ConfigurationService(configDirectory: directory.path)
+            let entered = self.expectation(description: "first operation entered")
+            let forbidden = self.expectation(description: "second write must wait")
+            forbidden.isInverted = true
+            let completionCheck = CompletionCheck()
+            var resume: CheckedContinuation<Void, Never>?
+            let first = Task { @MainActor in
+                try await firstService.operationGate.withOperation { @MainActor _ in
+                    await withCheckedContinuation { continuation in
+                        resume = continuation
+                        entered.fulfill()
+                    }
+                }
+            }
+            await self.fulfillment(of: [entered], timeout: 5)
+            let second = Task { @MainActor in
+                try await secondService.writeConfigurationContent(self.replacement)
+                if completionCheck.isBlocked { forbidden.fulfill() }
+            }
+            await self.fulfillment(of: [forbidden], timeout: 0.15)
+            completionCheck.isBlocked = false
+            XCTAssertEqual(try String(contentsOfFile: firstService.configurationPath, encoding: .utf8), self.original)
+            resume?.resume()
+            try await first.value
+            try await second.value
+            XCTAssertEqual(try String(contentsOfFile: secondService.configurationPath, encoding: .utf8), self.replacement)
+        }
+    }
+
+    func testAliasCallbackCannotReenterOrReleaseTheOriginalLease() async throws {
+        try await withDirectory { directory in
+            let alias = directory.deletingLastPathComponent().appendingPathComponent("alias")
+            try FileManager.default.createSymbolicLink(at: alias, withDestinationURL: directory)
+            let first = ConfigurationService(configDirectory: directory.path)
+            let second = ConfigurationService(configDirectory: alias.path)
+            try await first.operationGate.withOperation { @MainActor _ in
+                do {
+                    try await second.writeConfigurationContent(self.replacement)
+                    XCTFail("An alias must not let a callback reenter the same directory")
+                } catch ConfigurationOperationGate.Failure.recursiveOperation {
+                    // Expected before writing.
+                }
+                let status = try await Self.probeFromChildProcess(ConfigurationOperationGate.lockFileURL(for: directory))
+                XCTAssertEqual(status, 23, "Closing the rejected caller's descriptor must not unlock the owner")
+            }
+            XCTAssertEqual(try String(contentsOfFile: first.configurationPath, encoding: .utf8), self.original)
+        }
+    }
+
+    func testCallbackRejectsBeforeQueueingBehindAnotherFileLockWaiter() async throws {
+        try await withDirectory { directory in
+            let owner = ConfigurationOperationGate(configurationDirectory: directory)
+            let other = ConfigurationOperationGate(configurationDirectory: directory)
+            let entered = self.expectation(description: "owner entered")
+            let waiting = self.expectation(description: "other service is waiting")
+            waiting.isInverted = true
+            let callbackFinished = self.expectation(description: "callback rejects without waiting for owner release")
+            let callbackStarted = self.expectation(description: "callback started")
+            let phase = CompletionCheck()
+            var startCallback: CheckedContinuation<Void, Never>?
+            var releaseOwner: CheckedContinuation<Void, Never>?
+            var callback: Task<Void, Never>?
+            let first = Task { @MainActor in
+                try await owner.withOperation { @MainActor _ in
+                    await withCheckedContinuation { continuation in
+                        startCallback = continuation
+                        entered.fulfill()
+                    }
+                    callback = Task {
+                        do {
+                            _ = try await other.withOperation { _ in true }
+                            XCTFail("Callback must reject before the other service's FIFO queue")
+                        } catch ConfigurationOperationGate.Failure.recursiveOperation {
+                            // Expected while the original lease remains held.
+                        } catch { XCTFail("Unexpected error: \(error)") }
+                        callbackFinished.fulfill()
+                    }
+                    await withCheckedContinuation { continuation in
+                        releaseOwner = continuation
+                        callbackStarted.fulfill()
+                    }
+                }
+            }
+            await self.fulfillment(of: [entered], timeout: 5)
+            let second = Task {
+                try await other.withOperation { @MainActor _ in
+                    if phase.isBlocked { waiting.fulfill() }
+                }
+            }
+            await self.fulfillment(of: [waiting], timeout: 0.15)
+            startCallback?.resume()
+            await self.fulfillment(of: [callbackStarted, callbackFinished], timeout: 2)
+            phase.isBlocked = false
+            releaseOwner?.resume()
+            try await first.value
+            try await second.value
+            await callback?.value
+        }
+    }
+
+    func testDirectoryReplacementAndThrowPreserveThenReleaseTheLease() async throws {
+        enum Expected: Error { case failure }
+        try await withDirectory { directory in
+            let gate = ConfigurationOperationGate(configurationDirectory: directory)
+            let lockURL = ConfigurationOperationGate.lockFileURL(for: directory)
+            do {
+                try await gate.withOperation { _ in
+                    let backup = directory.deletingLastPathComponent().appendingPathComponent("old-config")
+                    try FileManager.default.moveItem(at: directory, to: backup)
+                    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+                    XCTAssertEqual(ConfigurationOperationGate.lockFileURL(for: directory), lockURL)
+                    let status = try await Self.probeFromChildProcess(lockURL)
+                    XCTAssertEqual(status, 23)
+                    throw Expected.failure
+                }
+            } catch Expected.failure {
+                // Expected, including descriptor release.
+            }
+            let status = try await Self.probeFromChildProcess(lockURL)
+            XCTAssertEqual(status, 0)
+            let value = try await gate.withOperation { _ in 7 }
+            XCTAssertEqual(value, 7)
+        }
+    }
+
+    func testCancelledFileWaitLeavesNoMutationAndReleasesItsQueueSlot() async throws {
+        try await withDirectory { directory in
+            let gate = ConfigurationOperationGate(configurationDirectory: directory)
+            let lockURL = ConfigurationOperationGate.lockFileURL(for: directory)
+            let fd = Darwin.open(lockURL.path, O_CREAT | O_RDWR | O_CLOEXEC, S_IRUSR | S_IWUSR)
+            XCTAssertGreaterThanOrEqual(fd, 0)
+            guard fd >= 0 else { return }
+            defer { Darwin.close(fd) }
+            XCTAssertEqual(flock(fd, LOCK_EX | LOCK_NB), 0)
+            let started = self.expectation(description: "wait requested")
+            let forbidden = self.expectation(description: "operation cannot enter")
+            forbidden.isInverted = true
+            let waiting = Task { @MainActor in
+                started.fulfill()
+                try await gate.withOperation { _ in forbidden.fulfill() }
+            }
+            await self.fulfillment(of: [started], timeout: 5)
+            await self.fulfillment(of: [forbidden], timeout: 0.15)
+            waiting.cancel()
+            do {
+                try await waiting.value
+                XCTFail("A cancelled file wait must not enter its operation")
+            } catch is CancellationError {
+                // Expected while the other file description still owns the lock.
+            }
+            XCTAssertEqual(flock(fd, LOCK_UN), 0)
+            let value = try await gate.withOperation { _ in 9 }
+            XCTAssertEqual(value, 9)
+        }
+    }
+
+    func testChildOutlivingItsLeaseCanUseAnotherServiceLater() async throws {
+        try await withDirectory { directory in
+            let first = ConfigurationOperationGate(configurationDirectory: directory)
+            let second = ConfigurationOperationGate(configurationDirectory: directory)
+            let childWaiting = self.expectation(description: "child waiting")
+            var resume: CheckedContinuation<Void, Never>?
+            let child = try await first.withOperation { @MainActor _ in
+                let child = Task { @MainActor in
+                    await withCheckedContinuation { continuation in
+                        resume = continuation
+                        childWaiting.fulfill()
+                    }
+                    return try await second.withOperation { _ in 11 }
+                }
+                await self.fulfillment(of: [childWaiting], timeout: 5)
+                return child
+            }
+            resume?.resume()
+            let value = try await child.value
+            XCTAssertEqual(value, 11)
+        }
+    }
+
+    @MainActor
+    private final class CompletionCheck {
+        var isBlocked = true
+    }
+
+    func testSymlinkSentinelIsRejectedBeforeMutation() async throws {
+        try await withDirectory { directory in
+            let lockURL = ConfigurationOperationGate.lockFileURL(for: directory)
+            let target = directory.deletingLastPathComponent().appendingPathComponent("unrelated")
+            try "preserve".write(to: target, atomically: true, encoding: .utf8)
+            try FileManager.default.createSymbolicLink(at: lockURL, withDestinationURL: target)
+            let gate = ConfigurationOperationGate(configurationDirectory: directory)
+            do {
+                try await gate.withOperation { _ in XCTFail("A symlink sentinel must not admit a write") }
+                XCTFail("Expected lock-open failure")
+            } catch ConfigurationOperationGate.Failure.fileLock {
+                // O_NOFOLLOW rejects it before acquiring or invoking the operation.
+            }
+            XCTAssertEqual(try String(contentsOf: target, encoding: .utf8), "preserve")
+        }
+    }
+
+    private nonisolated static func probeFromChildProcess(_ lockURL: URL) async throws -> Int32 {
+        try await Task.detached {
+            let process = Process()
+            process.executableURL = URL(fileURLWithPath: "/usr/bin/python3")
+            process.arguments = ["-c", """
+            import fcntl, sys
+            with open(sys.argv[1], 'a') as lock:
+                try:
+                    fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                except BlockingIOError:
+                    sys.exit(23)
+            """, lockURL.path]
+            process.standardOutput = FileHandle.nullDevice
+            process.standardError = FileHandle.nullDevice
+            try process.run()
+            process.waitUntilExit()
+            return process.terminationStatus
+        }.value
+    }
+
+    private func withDirectory(_ body: @MainActor (URL) async throws -> Void) async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let directory = root.appendingPathComponent("config")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: ConfigurationOperationGate.lockFileURL(for: directory).deletingLastPathComponent(), withIntermediateDirectories: true)
+        defer {
+            // Only remove this test's unique sentinel after all its operations finish.
+            try? FileManager.default.removeItem(at: ConfigurationOperationGate.lockFileURL(for: directory))
+            try? FileManager.default.removeItem(at: root)
+        }
+        try original.write(to: directory.appendingPathComponent("keypath.kbd"), atomically: true, encoding: .utf8)
+        try await body(directory)
+    }
+}

--- a/docs/architecture/configuration-save-pipeline.md
+++ b/docs/architecture/configuration-save-pipeline.md
@@ -81,14 +81,15 @@ same service fail instead of deadlocking. Permits expire with their operation.
 Queued cancellation is observed at admission before mutation. Once admitted,
 existing completion/recovery behavior remains unchanged.
 
-This is admission for one service instance, not a global or cross-process lock.
-Callers that compose a coordinator and collection manager must share the same
-service. Direct service writers now acquire this gate too: collection/raw/repaired saves,
+Each service retains its FIFO queue. Services targeting the same configuration
+directory also acquire a cooperative OS file lock, held through the admitted
+operation. Cross-process ordering is exclusive but not globally FIFO. Callers
+that compose trusted nested work still share the same service/permit owner. Direct service writers now acquire this gate too: collection/raw/repaired saves,
 initial creation, backup/fallback and journal recovery. Public signatures remain
 unchanged; trusted coordinator restoration and collection persistence forward
 permits through internal overloads. Missing-file backup reads carry the permit
 through self-healing creation so the backup retains stored rules. CLI operation
-ownership, separate service instances, external edits and feature-specific writers
+ownership, source/cache freshness, external edits and feature-specific writers
 (such as SimpleModsService and AppConfigGenerator include-file saves) still need
 migration. Those callers using this service only for validation do not acquire
 write admission merely by validating. Pack operations hold admission while staging
@@ -122,3 +123,26 @@ It journals the generated file and both source stores, recovers before bootstrap
 loads them, and defers configuration observers until the file set commits. This
 does not yet change the collection Boolean's persistence-only meaning or couple
 engine rejection to source-store recovery.
+
+## Directory lease
+
+The gate opens a persistent SHA-256-named sentinel under the current user’s
+`Library/Application Support/KeyPath/ConfigurationLocks`. The key is the canonical
+configuration path, folded on case-insensitive volumes. This avoids requiring a
+writable configuration parent and survives replacement of the configuration directory.
+Do not unlink the sentinel after an operation: existing waiters may already hold
+handles to it. Its presence alone does not mean an operation is running.
+
+Path inspection, sentinel creation and opening run on a utility dispatch queue.
+`flock(LOCK_EX | LOCK_NB)` retries asynchronously and observes cancellation while
+waiting; it never blocks the main actor or the serial file-I/O queue. As with the
+service FIFO, a hung owner can keep a caller waiting until cancellation or release. The handle
+is close-on-exec and released after completion or failure; process exit releases
+the OS lock. File identity detects recursive callbacks through another service
+or a directory alias. Inherited contexts carry a lease that becomes inactive
+on release, allowing a child that outlives its operation to write later.
+
+This is cooperation between migrated writers, not protection against external
+editors. It also does not refresh cached source/pack state or hold admission over
+CLI work performed outside service calls. Those remaining ownership/freshness
+changes are necessary before claiming whole-operation cross-process safety.

--- a/docs/bugs/shared-configuration-admission.md
+++ b/docs/bugs/shared-configuration-admission.md
@@ -34,7 +34,9 @@ Trusted restore and missing-file self-healing calls forward the permit. Tests
 exercise direct writer attempts from reload callbacks, observer-held saves and
 restoring persisted rules after a rejected save with a missing initial file.
 
-CLI operation ownership and cross-instance/process concurrency still require
-migration. The durable journal and runtime
+Services now hold a cooperative OS directory lease as well. A child-process
+probe verifies exclusion/release; tests cover independent services, alias
+callbacks, directory replacement, cancellation and inherited expired contexts.
+CLI operation ownership and source/cache freshness still require migration. The durable journal and runtime
 rollback also remain distinct boundaries. Do not treat this queue as proof of
 whole-operation rollback or protection against external editors.

--- a/docs/planning/catalog-led-consolidation-plan.md
+++ b/docs/planning/catalog-led-consolidation-plan.md
@@ -262,15 +262,17 @@ Implemented slices (the table describes the merged state of this checkpoint):
 | #1267 | Shared service admission before public collection/keymap mutation and across coordinator save/recovery, with explicit nested permits and callback rejection. | Pack/bootstrap admission was added by #1268; CLI operation ownership and external writers remain. |
 | #1268 | Pack install/uninstall/settings and bootstrap hold shared admission across nested mutations, metadata and recovery. | CLI operation ownership and external writers still require migration; pack commits remain separate. |
 | #1269 | Standalone regeneration, conflict retries, prerequisite application and snapshot restoration share admission with explicit nested permits. | Cross-instance/process ownership and whole-operation recovery remain. |
+| #1270 | Direct service writes, journal recovery, trusted restoration and missing-file self-healing share admission. | CLI ownership, feature-specific writers, source/cache freshness and complete recovery remain. |
 
-Direct service writers and trusted self-healing/restore paths now participate
-in shared admission as well.
+Admission now also holds a cooperative OS lease across service instances and
+processes for the same directory; external edits and stale cached state remain
+separate boundaries.
 The first migrated persistence journey now has interruption and failure tests.
 This is a useful foundation, not completion of Phase 1 or the program.
 
 Next implementation sequence:
 
-1. Complete feature-specific writers, CLI operation ownership and cross-instance/process admission before mutation;
+1. Complete feature-specific writers and CLI operation ownership, loading/reconciling current source and metadata state after admission;
    preserve explicit ownership through trusted nested calls, and reject recursive
    callback writes rather than allowing stale rollback or deadlock.
 2. Keep the prior source revision through runtime classification and restore


### PR DESCRIPTION
Configuration services previously serialized only their own callers, so two services or processes could overlap writes to the same directory. Each admitted operation now holds a cooperative OS file lock through its existing save, reload, and recovery scope.

The persistent sentinel lives in user-owned application state, keyed by the canonical configuration path (case-folded on case-insensitive volumes). This supports writable config directories with read-only parents and survives directory restoration. Path inspection and sentinel opening run on a utility dispatch queue; lock waiting is asynchronous and cancellable. File identity rejects callback reentry through aliases or another service before joining its FIFO queue, avoiding a callback/file-waiter deadlock; expired inherited leases allow child tasks to write after their original operation finishes. Existing trusted nesting still requires a permit from the same service.

This does not yet migrate CLI work performed outside service calls, refresh cached source/pack state, or coordinate external editors. Those boundaries remain explicit in the execution plan.

Validation:
- 240 focused tests passed before the final test-only update; final 24 admission tests passed, including separate-process contention, alias recursion, directory replacement, cancellation, expired contexts and symlink rejection, read-only configuration parents, nested permits and callback/waiter deadlock prevention. No compiler warnings.
- Full safe gate: runner reported 5,139 passes, with only the four previously reproduced macOS 27 baseline snapshots failing (three HomeRowTiming snapshots and RepairSettingsTabView). No compiler warnings; supported CI must pass.
- Accessibility and diff checks passed.
- Local review gate: remote review gate selected; GitHub claude-review required before merge.

Review follow-up: the suggested nested-permit regression does not occur: a validated permit returns at the top of `withOperation`, before file-lease acquisition. An explicit directory-backed nested-permit test passes, as do the existing trusted restoration tests. The read-only-parent finding is addressed by the user-owned lock location.

The follow-up filesystem-I/O finding is addressed by dispatching path resolution, directory creation, open and fstat off the cooperative pool. No lock is forcibly expired: a hung owner requires cancellation or release, matching existing non-preemptive operation ownership.

Final review clarification: exclusion is per macOS user. Privileged helper sources do not use ConfigurationService/ConfigurationOperationGate; cross-UID custom-directory writes are outside this cooperative guarantee. The two idempotent release defers are intentional: the outer covers pre-admission failures; the inner closes the lease before handing off the FIFO slot.
