### PR TITLE
Hold CLI configuration admission from source loading through reload

### DIFF
--- a/Sources/KeyPathAppKit/CLI/ConfigFacade.swift
+++ b/Sources/KeyPathAppKit/CLI/ConfigFacade.swift
@@ -10,8 +10,11 @@ public struct ConfigFacade: Sendable {
 
     public init(configDirectory: String = KeyPathConstants.Config.directory) {
         self.configDirectory = configDirectory
-        ruleCollectionLoader = { await RuleCollectionStore.shared.loadCollections() }
-        customRuleLoader = { await CustomRulesStore.shared.loadRules() }
+        let directory = URL(fileURLWithPath: configDirectory, isDirectory: true)
+        let collectionStore = RuleCollectionStore(fileURL: directory.appendingPathComponent("RuleCollections.json"))
+        let customStore = CustomRulesStore(fileURL: directory.appendingPathComponent("CustomRules.json"))
+        ruleCollectionLoader = { await collectionStore.loadCollections() }
+        customRuleLoader = { await customStore.loadRules() }
         reloadHandler = nil
     }
 
@@ -55,6 +58,15 @@ public struct ConfigFacade: Sendable {
     // MARK: - Apply
 
     public func applyConfiguration(dryRun: Bool = false) async throws -> CLIApplyResult {
+        let service = await MainActor.run { ConfigurationService(configDirectory: configDirectory) }
+        return try await service.operationGate.withOperation { permit in
+            try await applyConfiguration(dryRun: dryRun, service: service, permit: permit)
+        }
+    }
+
+    private func applyConfiguration(
+        dryRun: Bool, service: ConfigurationService, permit: ConfigurationOperationGate.Permit
+    ) async throws -> CLIApplyResult {
         let collections = await ruleCollectionLoader()
         let customRules = await customRuleLoader()
         let enabledCount = collections.filter(\.isEnabled).count
@@ -75,8 +87,6 @@ public struct ConfigFacade: Sendable {
             )
         } ?? collections
         let leaderSnapshot = reconcile?.previous
-
-        let service = await MainActor.run { ConfigurationService(configDirectory: configDirectory) }
 
         if dryRun {
             // A dry run must not persist the reconciled preference. Generation reads the live
@@ -107,7 +117,8 @@ public struct ConfigFacade: Sendable {
 
         try await service.saveConfiguration(
             ruleCollections: reconciledCollections,
-            customRules: customRules
+            customRules: customRules,
+            mutationPermit: permit
         )
 
         let reloadSuccess = if let reloadHandler {
@@ -158,7 +169,14 @@ public struct ConfigFacade: Sendable {
 
     // MARK: - Backup / Restore
 
-    public func backupConfig(outputPath: String? = nil) throws -> CLIConfigBackupResult {
+    public func backupConfig(outputPath: String? = nil) async throws -> CLIConfigBackupResult {
+        let gate = ConfigurationOperationGate(configurationDirectory: URL(fileURLWithPath: configDirectory, isDirectory: true))
+        return try await gate.withOperation { _ in
+            try copyConfigBackup(outputPath: outputPath)
+        }
+    }
+
+    private func copyConfigBackup(outputPath: String?) throws -> CLIConfigBackupResult {
         let fileManager = FileManager.default
         let sourceURL = URL(fileURLWithPath: configDirectory, isDirectory: true)
         let sourceCopyURL = try resolvedExistingDirectory(sourceURL, fileManager: fileManager)
@@ -189,6 +207,13 @@ public struct ConfigFacade: Sendable {
     }
 
     public func restoreConfig(from backupPath: String, reload: Bool) async throws -> CLIConfigRestoreResult {
+        let gate = ConfigurationOperationGate(configurationDirectory: URL(fileURLWithPath: configDirectory, isDirectory: true))
+        return try await gate.withOperation { _ in
+            try await restoreConfigContents(from: backupPath, reload: reload)
+        }
+    }
+
+    private func restoreConfigContents(from backupPath: String, reload: Bool) async throws -> CLIConfigRestoreResult {
         let fileManager = FileManager.default
         let sourceURL = URL(fileURLWithPath: (backupPath as NSString).expandingTildeInPath, isDirectory: true)
         var isDirectory: ObjCBool = false

--- a/Sources/KeyPathCLI/Commands/Config/ConfigBackupCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Config/ConfigBackupCommand.swift
@@ -18,7 +18,7 @@ struct ConfigBackup: AsyncParsableCommand {
         let facade = ConfigFacade()
 
         do {
-            let result = try facade.backupConfig(outputPath: outputPath)
+            let result = try await facade.backupConfig(outputPath: outputPath)
             CLIOutput.write(result, context: ctx) {
                 """
                 Backup created: \(result.backupPath)

--- a/Tests/KeyPathTests/CLI/ConfigFacadeAdmissionTests.swift
+++ b/Tests/KeyPathTests/CLI/ConfigFacadeAdmissionTests.swift
@@ -1,0 +1,137 @@
+import Foundation
+@testable import KeyPathAppKit
+import KeyPathRulesCore
+@preconcurrency import XCTest
+
+@MainActor
+final class ConfigFacadeAdmissionTests: KeyPathTestCase {
+    func testApplyLoadsSourcesOnlyAfterThePreviousWriterFinishes() async throws {
+        try await withDirectory { directory in
+            let gate = ConfigurationOperationGate(configurationDirectory: directory)
+            let store = CustomRulesStore(fileURL: directory.appendingPathComponent("CustomRules.json"))
+            let entered = self.expectation(description: "writer admitted")
+            let prematureLoad = self.expectation(description: "sources must wait")
+            prematureLoad.isInverted = true
+            let phase = Phase()
+            var resume: CheckedContinuation<Void, Never>?
+            let first = Task { @MainActor in
+                try await gate.withOperation { @MainActor _ in
+                    await withCheckedContinuation { continuation in
+                        resume = continuation
+                        entered.fulfill()
+                    }
+                    try await store.saveRules([CustomRule(input: "f13", action: .keystroke(key: "f14"))])
+                }
+            }
+            await self.fulfillment(of: [entered], timeout: 5)
+            let facade = ConfigFacade(
+                configDirectory: directory.path,
+                ruleCollectionLoader: { [] },
+                customRuleLoader: { @MainActor in
+                    if phase.isWaiting { prematureLoad.fulfill() }
+                    return await store.loadRules()
+                },
+                reloadHandler: { true }
+            )
+            let apply = Task { try await facade.applyConfiguration(dryRun: true) }
+            await self.fulfillment(of: [prematureLoad], timeout: 0.15)
+            phase.isWaiting = false
+            resume?.resume()
+            try await first.value
+            let result = try await apply.value
+            XCTAssertEqual(result.customRulesCount, 1, "Read the newly committed source, not a pre-admission snapshot")
+        }
+    }
+
+    func testReloadCallbackCannotApplyBackUpOrRestoreThroughAnotherFacade() async throws {
+        try await withDirectory { directory in
+            let backup = directory.deletingLastPathComponent().appendingPathComponent("backup")
+            try FileManager.default.createDirectory(at: backup, withIntermediateDirectories: true)
+            try "must not replace generated config".write(to: backup.appendingPathComponent("keypath.kbd"), atomically: true, encoding: .utf8)
+            let output = directory.deletingLastPathComponent().appendingPathComponent("forbidden-backup")
+            let nested = ConfigFacade(configDirectory: directory.path)
+            let facade = ConfigFacade(
+                configDirectory: directory.path,
+                ruleCollectionLoader: { [] },
+                customRuleLoader: { [] },
+                reloadHandler: {
+                    do {
+                        _ = try await nested.applyConfiguration(dryRun: true)
+                        XCTFail("Callback apply must be rejected")
+                    } catch ConfigurationOperationGate.Failure.recursiveOperation {} catch { XCTFail("Unexpected error: \(error)") }
+                    do {
+                        _ = try await nested.backupConfig(outputPath: output.path)
+                        XCTFail("Callback backup must be rejected")
+                    } catch ConfigurationOperationGate.Failure.recursiveOperation {} catch { XCTFail("Unexpected error: \(error)") }
+                    do {
+                        _ = try await nested.restoreConfig(from: backup.path, reload: false)
+                        XCTFail("Callback restore must be rejected")
+                    } catch ConfigurationOperationGate.Failure.recursiveOperation {} catch { XCTFail("Unexpected error: \(error)") }
+                    return true
+                }
+            )
+            let result = try await facade.applyConfiguration()
+            XCTAssertTrue(result.reloadSuccess)
+            XCTAssertFalse(FileManager.default.fileExists(atPath: output.path))
+            let content = try String(contentsOf: directory.appendingPathComponent("keypath.kbd"), encoding: .utf8)
+            XCTAssertFalse(content.contains("must not replace"))
+        }
+    }
+
+    func testBackupWaitsForAdmittedWriterAndCopiesItsCompletedRevision() async throws {
+        try await withDirectory { directory in
+            let gate = ConfigurationOperationGate(configurationDirectory: directory)
+            let output = directory.deletingLastPathComponent().appendingPathComponent("backup")
+            let entered = self.expectation(description: "writer admitted")
+            let prematureBackup = self.expectation(description: "backup must wait")
+            prematureBackup.isInverted = true
+            let phase = Phase()
+            var resume: CheckedContinuation<Void, Never>?
+            let first = Task { @MainActor in
+                try await gate.withOperation { @MainActor _ in
+                    await withCheckedContinuation { continuation in
+                        resume = continuation
+                        entered.fulfill()
+                    }
+                    try "completed".write(to: directory.appendingPathComponent("keypath.kbd"), atomically: true, encoding: .utf8)
+                }
+            }
+            await self.fulfillment(of: [entered], timeout: 5)
+            let backup = Task { @MainActor in
+                let result = try await ConfigFacade(configDirectory: directory.path).backupConfig(outputPath: output.path)
+                if phase.isWaiting { prematureBackup.fulfill() }
+                return result
+            }
+            await self.fulfillment(of: [prematureBackup], timeout: 0.15)
+            XCTAssertFalse(FileManager.default.fileExists(atPath: output.path))
+            phase.isWaiting = false
+            resume?.resume()
+            try await first.value
+            _ = try await backup.value
+            XCTAssertEqual(try String(contentsOf: output.appendingPathComponent("keypath.kbd"), encoding: .utf8), "completed")
+        }
+    }
+
+    func testDefaultLoadersReadTheRequestedConfigurationDirectory() async throws {
+        try await withDirectory { directory in
+            let store = CustomRulesStore(fileURL: directory.appendingPathComponent("CustomRules.json"))
+            try await store.saveRules([CustomRule(input: "f13", action: .keystroke(key: "f14"))])
+            let result = try await ConfigFacade(configDirectory: directory.path).applyConfiguration(dryRun: true)
+            XCTAssertEqual(result.customRulesCount, 1)
+            XCTAssertEqual(result.changeset?.customRules, ["f13 → f14"])
+        }
+    }
+
+    private func withDirectory(_ body: (URL) async throws -> Void) async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent("cli-admission-\(UUID().uuidString)")
+        let directory = root.appendingPathComponent("config")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        try "original".write(to: directory.appendingPathComponent("keypath.kbd"), atomically: true, encoding: .utf8)
+        try await body(directory)
+    }
+
+    private final class Phase {
+        var isWaiting = true
+    }
+}

--- a/Tests/KeyPathTests/CLI/ConfigFacadeTests.swift
+++ b/Tests/KeyPathTests/CLI/ConfigFacadeTests.swift
@@ -18,7 +18,7 @@ final class ConfigFacadeTests: XCTestCase {
         tempRoot = nil
     }
 
-    func testBackupConfigSnapshotsResolvedSymlinkDirectory() throws {
+    func testBackupConfigSnapshotsResolvedSymlinkDirectory() async throws {
         let liveTarget = tempRoot.appendingPathComponent("dotfiles-keypath", isDirectory: true)
         let configLink = tempRoot.appendingPathComponent(".config/keypath", isDirectory: true)
         let backup = tempRoot.appendingPathComponent("backup", isDirectory: true)
@@ -27,7 +27,7 @@ final class ConfigFacadeTests: XCTestCase {
         try "original".write(to: liveTarget.appendingPathComponent("RuleCollections.json"), atomically: true, encoding: .utf8)
 
         let facade = ConfigFacade(configDirectory: configLink.path)
-        let result = try facade.backupConfig(outputPath: backup.path)
+        let result = try await facade.backupConfig(outputPath: backup.path)
 
         XCTAssertEqual(result.sourcePath, configLink.path)
         XCTAssertEqual(result.backupPath, backup.path)
@@ -48,7 +48,7 @@ final class ConfigFacadeTests: XCTestCase {
         try "original".write(to: liveTarget.appendingPathComponent("RuleCollections.json"), atomically: true, encoding: .utf8)
 
         let facade = ConfigFacade(configDirectory: configLink.path)
-        _ = try facade.backupConfig(outputPath: backup.path)
+        _ = try await facade.backupConfig(outputPath: backup.path)
 
         try "mutated".write(to: liveTarget.appendingPathComponent("RuleCollections.json"), atomically: true, encoding: .utf8)
         _ = try await facade.restoreConfig(from: backup.path, reload: false)
@@ -69,7 +69,7 @@ final class ConfigFacadeTests: XCTestCase {
         try "kbd".write(to: configDir.appendingPathComponent("keypath.kbd"), atomically: true, encoding: .utf8)
 
         let facade = ConfigFacade(configDirectory: configDir.path)
-        _ = try facade.backupConfig(outputPath: backup.path)
+        _ = try await facade.backupConfig(outputPath: backup.path)
 
         // Post-backup drift: one mutation, one new file that isn't in the backup.
         try "mutated".write(to: configDir.appendingPathComponent("RuleCollections.json"), atomically: true, encoding: .utf8)
@@ -94,7 +94,7 @@ final class ConfigFacadeTests: XCTestCase {
         try "rules".write(to: configDir.appendingPathComponent("RuleCollections.json"), atomically: true, encoding: .utf8)
 
         let facade = ConfigFacade(configDirectory: configDir.path)
-        _ = try facade.backupConfig(outputPath: backup.path)
+        _ = try await facade.backupConfig(outputPath: backup.path)
 
         // The #881 trigger: a transient validation temp file appears in the
         // config dir before restore. The restore must neither fail on it nor
@@ -112,7 +112,7 @@ final class ConfigFacadeTests: XCTestCase {
         )
     }
 
-    func testBackupConfigSkipsTransientValidationArtifacts() throws {
+    func testBackupConfigSkipsTransientValidationArtifacts() async throws {
         let configDir = tempRoot.appendingPathComponent("config", isDirectory: true)
         let backup = tempRoot.appendingPathComponent("backup", isDirectory: true)
         try FileManager.default.createDirectory(at: configDir, withIntermediateDirectories: true)
@@ -121,7 +121,7 @@ final class ConfigFacadeTests: XCTestCase {
         try "tmp".write(to: configDir.appendingPathComponent("temp_validation_AB12.kbd"), atomically: true, encoding: .utf8)
 
         let facade = ConfigFacade(configDirectory: configDir.path)
-        let result = try facade.backupConfig(outputPath: backup.path)
+        let result = try await facade.backupConfig(outputPath: backup.path)
 
         XCTAssertEqual(result.copiedItems, ["RuleCollections.json"], "Backups should not capture transient validation temp files")
     }

--- a/docs/architecture/configuration-save-pipeline.md
+++ b/docs/architecture/configuration-save-pipeline.md
@@ -81,8 +81,8 @@ same service fail instead of deadlocking. Permits expire with their operation.
 Queued cancellation is observed at admission before mutation. Once admitted,
 existing completion/recovery behavior remains unchanged.
 
-Each service retains its FIFO queue. Services targeting the same configuration
-directory also acquire a cooperative OS file lock, held through the admitted
+Each service retains its FIFO queue. Services running as the same macOS user
+and targeting the same configuration directory acquire a cooperative OS file lock, held through the admitted
 operation. Cross-process ordering is exclusive but not globally FIFO. Callers
 that compose trusted nested work still share the same service/permit owner. Direct service writers now acquire this gate too: collection/raw/repaired saves,
 initial creation, backup/fallback and journal recovery. Public signatures remain
@@ -142,7 +142,28 @@ the OS lock. File identity detects recursive callbacks through another service
 or a directory alias. Inherited contexts carry a lease that becomes inactive
 on release, allowing a child that outlives its operation to write later.
 
-This is cooperation between migrated writers, not protection against external
-editors. It also does not refresh cached source/pack state or hold admission over
+This is cooperation between migrated writers running as the same macOS user,
+not protection against external editors or custom-directory writes from another
+UID. Privileged helper callers do not use this gate. It also does not refresh cached source/pack state or hold admission over
 CLI work performed outside service calls. Those remaining ownership/freshness
 changes are necessary before claiming whole-operation cross-process safety.
+
+## CLI configuration ownership
+
+`ConfigFacade.applyConfiguration` admits before loading collections/custom rules
+and reconciling the leader preference, then retains admission through generation,
+validation, save and the reload callback. The nested service save receives the
+explicit permit. Dry-run generation also participates because it temporarily
+reconciles a shared preference. The default loaders read the facade's requested
+configuration directory rather than the singleton stores' default directory.
+
+CLI backup and restore hold the same directory lease through copying and optional
+reload. Backup is now an async API so lock contention does not block an actor;
+the CLI command syntax and output are unchanged. A callback attempting another
+apply, backup or restore is rejected before copying or staging preferences.
+
+This does not yet change reload-result semantics, make directory restore atomic,
+or include preference restoration in rejected-apply recovery. CLI pack/collection
+commands and feature-specific writers remain separate migration work. Backups
+remain copies of current disk state; this scope does not recover pending journals
+or refresh the app's cached state following a CLI restore.

--- a/docs/planning/catalog-led-consolidation-plan.md
+++ b/docs/planning/catalog-led-consolidation-plan.md
@@ -263,10 +263,13 @@ Implemented slices (the table describes the merged state of this checkpoint):
 | #1268 | Pack install/uninstall/settings and bootstrap hold shared admission across nested mutations, metadata and recovery. | CLI operation ownership and external writers still require migration; pack commits remain separate. |
 | #1269 | Standalone regeneration, conflict retries, prerequisite application and snapshot restoration share admission with explicit nested permits. | Cross-instance/process ownership and whole-operation recovery remain. |
 | #1270 | Direct service writes, journal recovery, trusted restoration and missing-file self-healing share admission. | CLI ownership, feature-specific writers, source/cache freshness and complete recovery remain. |
+| #1271 | Per-user directory leases exclude cooperating services/processes, with cancellation, alias reentry protection and off-actor sentinel I/O. | CLI operation scope, cached state, external editors and cross-UID writers remain distinct boundaries. |
 
 Admission now also holds a cooperative OS lease across service instances and
-processes for the same directory; external edits and stale cached state remain
-separate boundaries.
+processes for the same directory. CLI configuration apply now holds admission
+from source loading through reload; backup/restore also participate. CLI pack and
+collection operations, external edits and stale cached app state remain separate
+boundaries.
 The first migrated persistence journey now has interruption and failure tests.
 This is a useful foundation, not completion of Phase 1 or the program.
 


### PR DESCRIPTION
CLI apply previously loaded sources before service admission and released admission before reload, allowing another operation to interleave. It now holds the directory lease from source loading and leader-preference reconciliation through save and reload, forwarding the trusted permit to the nested service write.

Backup and restore use the same admission boundary through copying and optional reload. Backup becomes an async Swift API; CLI syntax and output are unchanged. Default source loaders now respect the requested configuration directory rather than always reading singleton stores.

This preserves existing reload/recovery semantics. Whole-operation rejected-apply recovery, pending-journal reconciliation, cached app state, CLI collection/pack mutations and feature-specific writers remain tracked separately.

Validation:
- 23 focused tests passed without compiler warnings, including source freshness after waiting, callback reentry rejection, completed-revision backup and custom-directory loading.
- Full safe gate on the final directory-lease implementation: runner reported 5,143 passes, with only the four previously reproduced macOS 27 baseline snapshots failing (three HomeRowTiming snapshots and RepairSettingsTabView). No compiler warnings; supported CI must pass.
- Accessibility and diff checks passed.
- Local review gate: remote review gate selected; GitHub claude-review required before merge.

Review clarification: repository-wide Swift search finds backup callers only in ConfigBackupCommand and ConfigFacadeTests; all now await the API and the full package builds. RuleCollectionStore and CustomRulesStore read disk on each load and hold no observable rule cache, so no shared-instance identity is required. Admission tests also assert the final freshly committed content, beyond the short inverted expectation window.
