### PR TITLE
Coordinate CLI source edits through configuration apply

### DIFF
--- a/Sources/KeyPathAppKit/CLI/CLIConfigurationOperation.swift
+++ b/Sources/KeyPathAppKit/CLI/CLIConfigurationOperation.swift
@@ -1,0 +1,54 @@
+import Foundation
+import KeyPathCore
+
+/// A command-scoped view of the existing configuration operation gate.
+/// Scoped facades may compose writes and apply without releasing ownership.
+/// They cannot be used to mutate after the command returns.
+public struct CLIConfigurationOperation: Sendable {
+    let service: ConfigurationService
+    let permit: ConfigurationOperationGate.Permit
+    let directory: String
+    let installedPackTracker: InstalledPackTracker
+
+    public var rules: RulesFacade {
+        RulesFacade(operation: self)
+    }
+
+    public var collections: CollectionsFacade {
+        CollectionsFacade(operation: self)
+    }
+
+    public var packs: PacksFacade {
+        PacksFacade(operation: self)
+    }
+
+    public var config: ConfigFacade {
+        ConfigFacade(operation: self)
+    }
+
+    public static func run<Result: Sendable>(
+        _ body: @escaping @Sendable (CLIConfigurationOperation) async throws -> Result
+    ) async throws -> Result {
+        try await run(configDirectory: KeyPathConstants.Config.directory, body)
+    }
+
+    /// Test seam for isolated rule/config operations. Pack uninstall snapshots
+    /// still use the standard user directory, so this is not a public workspace API.
+    static func run<Result: Sendable>(
+        configDirectory: String,
+        _ body: @escaping @Sendable (CLIConfigurationOperation) async throws -> Result
+    ) async throws -> Result {
+        let directory = URL(fileURLWithPath: configDirectory, isDirectory: true)
+        let service = await MainActor.run {
+            ConfigurationService(
+                configDirectory: configDirectory,
+                ruleCollectionStore: RuleCollectionStore(fileURL: directory.appendingPathComponent("RuleCollections.json")),
+                customRulesStore: CustomRulesStore(fileURL: directory.appendingPathComponent("CustomRules.json"))
+            )
+        }
+        return try await service.operationGate.withOperation { permit in
+            try await body(Self(service: service, permit: permit, directory: configDirectory,
+                                installedPackTracker: InstalledPackTracker(fileURL: directory.appendingPathComponent("installed-packs.json"))))
+        }
+    }
+}

--- a/Sources/KeyPathAppKit/CLI/CollectionsFacade.swift
+++ b/Sources/KeyPathAppKit/CLI/CollectionsFacade.swift
@@ -3,51 +3,89 @@ import KeyPathCore
 import KeyPathRulesCore
 
 public struct CollectionsFacade: Sendable {
-    public init() {}
+    private let store: RuleCollectionStore
+    private let operation: CLIConfigurationOperation?
+
+    public init() {
+        store = .shared
+        operation = nil
+    }
+
+    init(operation: CLIConfigurationOperation) {
+        store = RuleCollectionStore(fileURL: URL(fileURLWithPath: operation.directory)
+            .appendingPathComponent("RuleCollections.json"))
+        self.operation = operation
+    }
+
+    init(store: RuleCollectionStore) {
+        self.store = store
+        operation = nil
+    }
+
+    private func withMutation<Result: Sendable>(
+        _ body: @Sendable () async throws -> Result
+    ) async throws -> Result {
+        if let operation {
+            return try await operation.service.operationGate.withOperation(using: operation.permit) { _ in
+                try await body()
+            }
+        }
+        let directory = await store.persistenceURL.deletingLastPathComponent()
+        let gate = ConfigurationOperationGate(configurationDirectory: directory)
+        return try await gate.withOperation { _ in try await body() }
+    }
 
     // MARK: - Collection CRUD
 
     public func loadRuleCollections() async -> [CLIRuleCollection] {
-        let collections = await RuleCollectionStore.shared.loadCollections()
+        let collections = await store.loadCollections()
         return collections.map { CLIRuleCollection(from: $0) }
     }
 
     public func enableCollection(nameOrId: String) async throws -> String? {
-        var collections = await RuleCollectionStore.shared.loadCollections()
-        guard let index = try resolveCollectionIndex(nameOrId: nameOrId, in: collections) else {
-            return nil
+        try await withMutation {
+            var collections = await store.loadCollections()
+            guard let index = try resolveCollectionIndex(nameOrId: nameOrId, in: collections) else {
+                return nil
+            }
+            let tracker = operation?.installedPackTracker ?? InstalledPackTracker.shared
+            try await tracker.validateForMutation()
+            if let owner = await tracker.packManagingCollection(collections[index].id) {
+                throw PackManagedCollectionError(
+                    collectionName: collections[index].name,
+                    packName: owner.packName,
+                    packID: owner.packID
+                )
+            }
+            collections[index].isEnabled = true
+            try await store.saveCollections(collections)
+            return collections[index].name
         }
-        if let owner = await InstalledPackTracker.shared.packManagingCollection(collections[index].id) {
-            throw PackManagedCollectionError(
-                collectionName: collections[index].name,
-                packName: owner.packName,
-                packID: owner.packID
-            )
-        }
-        collections[index].isEnabled = true
-        try await RuleCollectionStore.shared.saveCollections(collections)
-        return collections[index].name
     }
 
     public func disableCollection(nameOrId: String) async throws -> String? {
-        var collections = await RuleCollectionStore.shared.loadCollections()
-        guard let index = try resolveCollectionIndex(nameOrId: nameOrId, in: collections) else {
-            return nil
+        try await withMutation {
+            var collections = await store.loadCollections()
+            guard let index = try resolveCollectionIndex(nameOrId: nameOrId, in: collections) else {
+                return nil
+            }
+            let tracker = operation?.installedPackTracker ?? InstalledPackTracker.shared
+            try await tracker.validateForMutation()
+            if let owner = await tracker.packManagingCollection(collections[index].id) {
+                throw PackManagedCollectionError(
+                    collectionName: collections[index].name,
+                    packName: owner.packName,
+                    packID: owner.packID
+                )
+            }
+            collections[index].isEnabled = false
+            try await store.saveCollections(collections)
+            return collections[index].name
         }
-        if let owner = await InstalledPackTracker.shared.packManagingCollection(collections[index].id) {
-            throw PackManagedCollectionError(
-                collectionName: collections[index].name,
-                packName: owner.packName,
-                packID: owner.packID
-            )
-        }
-        collections[index].isEnabled = false
-        try await RuleCollectionStore.shared.saveCollections(collections)
-        return collections[index].name
     }
 
     public func showCollection(nameOrId: String) async throws -> CLIRuleCollection? {
-        let collections = await RuleCollectionStore.shared.loadCollections()
+        let collections = await store.loadCollections()
         guard let index = try resolveCollectionIndex(nameOrId: nameOrId, in: collections) else {
             return nil
         }
@@ -55,7 +93,7 @@ public struct CollectionsFacade: Sendable {
     }
 
     public func showCollectionDetail(nameOrId: String) async throws -> CLIRuleCollectionDetail? {
-        let collections = await RuleCollectionStore.shared.loadCollections()
+        let collections = await store.loadCollections()
         guard let index = try resolveCollectionIndex(nameOrId: nameOrId, in: collections) else {
             return nil
         }
@@ -63,78 +101,88 @@ public struct CollectionsFacade: Sendable {
     }
 
     public func createCollection(name: String, category: String?, summary: String?) async throws -> CLIRuleCollection {
-        var collections = await RuleCollectionStore.shared.loadCollections()
-        let cat: RuleCollectionCategory = if let category {
-            RuleCollectionCategory(rawValue: category) ?? .custom
-        } else {
-            .custom
+        try await withMutation {
+            var collections = await store.loadCollections()
+            let cat: RuleCollectionCategory = if let category {
+                RuleCollectionCategory(rawValue: category) ?? .custom
+            } else {
+                .custom
+            }
+            let collection = RuleCollection(
+                name: name,
+                summary: summary ?? "",
+                category: cat,
+                mappings: []
+            )
+            collections.append(collection)
+            try await store.saveCollections(collections)
+            return CLIRuleCollection(from: collection)
         }
-        let collection = RuleCollection(
-            name: name,
-            summary: summary ?? "",
-            category: cat,
-            mappings: []
-        )
-        collections.append(collection)
-        try await RuleCollectionStore.shared.saveCollections(collections)
-        return CLIRuleCollection(from: collection)
     }
 
     public func renameCollection(nameOrId: String, newName: String) async throws -> String? {
-        var collections = await RuleCollectionStore.shared.loadCollections()
-        guard let index = try resolveCollectionIndex(nameOrId: nameOrId, in: collections) else {
-            return nil
+        try await withMutation {
+            var collections = await store.loadCollections()
+            guard let index = try resolveCollectionIndex(nameOrId: nameOrId, in: collections) else {
+                return nil
+            }
+            let oldName = collections[index].name
+            collections[index].name = newName
+            try await store.saveCollections(collections)
+            return oldName
         }
-        let oldName = collections[index].name
-        collections[index].name = newName
-        try await RuleCollectionStore.shared.saveCollections(collections)
-        return oldName
     }
 
     public func deleteCollection(nameOrId: String) async throws -> Bool {
-        var collections = await RuleCollectionStore.shared.loadCollections()
-        guard let index = try resolveCollectionIndex(nameOrId: nameOrId, in: collections) else {
-            return false
+        try await withMutation {
+            var collections = await store.loadCollections()
+            guard let index = try resolveCollectionIndex(nameOrId: nameOrId, in: collections) else {
+                return false
+            }
+            collections.remove(at: index)
+            try await store.saveCollections(collections)
+            return true
         }
-        collections.remove(at: index)
-        try await RuleCollectionStore.shared.saveCollections(collections)
-        return true
     }
 
     public func duplicateCollection(nameOrId: String, newName: String?) async throws -> CLIRuleCollection? {
-        var collections = await RuleCollectionStore.shared.loadCollections()
-        guard let index = try resolveCollectionIndex(nameOrId: nameOrId, in: collections) else {
-            return nil
+        try await withMutation {
+            var collections = await store.loadCollections()
+            guard let index = try resolveCollectionIndex(nameOrId: nameOrId, in: collections) else {
+                return nil
+            }
+            var duplicate = collections[index]
+            duplicate = RuleCollection(
+                name: newName ?? "\(duplicate.name) (Copy)",
+                summary: duplicate.summary,
+                category: duplicate.category,
+                mappings: duplicate.mappings,
+                isEnabled: false
+            )
+            collections.insert(duplicate, at: index + 1)
+            try await store.saveCollections(collections)
+            return CLIRuleCollection(from: duplicate)
         }
-        var duplicate = collections[index]
-        duplicate = RuleCollection(
-            name: newName ?? "\(duplicate.name) (Copy)",
-            summary: duplicate.summary,
-            category: duplicate.category,
-            mappings: duplicate.mappings,
-            isEnabled: false
-        )
-        collections.insert(duplicate, at: index + 1)
-        try await RuleCollectionStore.shared.saveCollections(collections)
-        return CLIRuleCollection(from: duplicate)
     }
 
     public func reorderCollection(nameOrId: String, position: Int) async throws -> Bool {
-        var collections = await RuleCollectionStore.shared.loadCollections()
-        guard let index = try resolveCollectionIndex(nameOrId: nameOrId, in: collections) else {
-            return false
+        try await withMutation {
+            var collections = await store.loadCollections()
+            guard let index = try resolveCollectionIndex(nameOrId: nameOrId, in: collections) else {
+                return false
+            }
+            let collection = collections.remove(at: index)
+            let targetIndex = min(max(0, position), collections.count)
+            collections.insert(collection, at: targetIndex)
+            try await store.saveCollections(collections)
+            return true
         }
-        let collection = collections.remove(at: index)
-        let targetIndex = min(max(0, position), collections.count)
-        collections.insert(collection, at: targetIndex)
-        try await RuleCollectionStore.shared.saveCollections(collections)
-        return true
     }
 
     // MARK: - Export / Import
 
     public func exportCollection(nameOrId: String) async throws -> CLIExportedCollection? {
-        let collections = await RuleCollectionStore.shared.loadCollections()
+        let collections = await store.loadCollections()
         guard let index = try resolveCollectionIndex(nameOrId: nameOrId, in: collections) else {
             return nil
         }
@@ -142,33 +190,35 @@ public struct CollectionsFacade: Sendable {
     }
 
     public func exportAllCollections() async -> [CLIExportedCollection] {
-        let collections = await RuleCollectionStore.shared.loadCollections()
+        let collections = await store.loadCollections()
         return collections.map { CLIExportedCollection(from: $0) }
     }
 
     public func importCollection(_ exported: CLIExportedCollection, onConflict: CLIConflictStrategy = .fail) async throws -> CLIRuleCollection {
-        var collections = await RuleCollectionStore.shared.loadCollections()
-        let existingIndex = collections.firstIndex(where: { $0.name == exported.name })
+        try await withMutation {
+            var collections = await store.loadCollections()
+            let existingIndex = collections.firstIndex(where: { $0.name == exported.name })
 
-        if let existingIndex {
-            switch onConflict {
-            case .fail:
-                throw AmbiguousCollectionMatch(
-                    query: exported.name,
-                    matches: [.init(name: collections[existingIndex].name, id: collections[existingIndex].id.uuidString)],
-                    hint: "Use --on-conflict=replace to overwrite or --on-conflict=skip to no-op"
-                )
-            case .skip:
-                return CLIRuleCollection(from: collections[existingIndex])
-            case .replace, .merge:
-                collections.remove(at: existingIndex)
+            if let existingIndex {
+                switch onConflict {
+                case .fail:
+                    throw AmbiguousCollectionMatch(
+                        query: exported.name,
+                        matches: [.init(name: collections[existingIndex].name, id: collections[existingIndex].id.uuidString)],
+                        hint: "Use --on-conflict=replace to overwrite or --on-conflict=skip to no-op"
+                    )
+                case .skip:
+                    return CLIRuleCollection(from: collections[existingIndex])
+                case .replace, .merge:
+                    collections.remove(at: existingIndex)
+                }
             }
-        }
 
-        let collection = exported.toRuleCollection()
-        collections.append(collection)
-        try await RuleCollectionStore.shared.saveCollections(collections)
-        return CLIRuleCollection(from: collection)
+            let collection = exported.toRuleCollection()
+            collections.append(collection)
+            try await store.saveCollections(collections)
+            return CLIRuleCollection(from: collection)
+        }
     }
 
     // MARK: - Karabiner Import
@@ -260,7 +310,7 @@ public struct CollectionsFacade: Sendable {
     // MARK: - Layer CRUD
 
     public func listDefinedLayers() async -> [String] {
-        let collections = await RuleCollectionStore.shared.loadCollections()
+        let collections = await store.loadCollections()
         var layers = Set<String>()
         layers.insert("base")
         for collection in collections {
@@ -270,47 +320,54 @@ public struct CollectionsFacade: Sendable {
     }
 
     public func createLayer(name: String) async throws -> CLIRuleCollection {
-        var collections = await RuleCollectionStore.shared.loadCollections()
-        let layer = Self.parseLayer(name)
-        let collection = RuleCollection(
-            name: "\(name) Layer",
-            summary: "Rules for the \(name) layer",
-            category: .layers,
-            mappings: [],
-            targetLayer: layer
-        )
-        collections.append(collection)
-        try await RuleCollectionStore.shared.saveCollections(collections)
-        return CLIRuleCollection(from: collection)
+        try await withMutation {
+            var collections = await store.loadCollections()
+            let layer = Self.parseLayer(name)
+            let collection = RuleCollection(
+                name: "\(name) Layer",
+                summary: "Rules for the \(name) layer",
+                category: .layers,
+                mappings: [],
+                targetLayer: layer
+            )
+            collections.append(collection)
+            try await store.saveCollections(collections)
+            return CLIRuleCollection(from: collection)
+        }
     }
 
     public func deleteLayer(name: String) async throws -> Int {
-        var collections = await RuleCollectionStore.shared.loadCollections()
-        let targetName = Self.parseLayer(name).kanataName
-        let before = collections.count
-        collections.removeAll { $0.targetLayer.kanataName == targetName }
-        let removed = before - collections.count
-        if removed > 0 {
-            try await RuleCollectionStore.shared.saveCollections(collections)
+        try await withMutation {
+            var collections = await store.loadCollections()
+            let targetName = Self.parseLayer(name).kanataName
+            let before = collections.count
+            collections.removeAll { $0.targetLayer.kanataName == targetName }
+            let removed = before - collections.count
+            if removed > 0 {
+                try await store.saveCollections(collections)
+            }
+            return removed
         }
-        return removed
     }
 
     public func renameLayer(oldName: String, newName: String) async throws -> Int {
-        var collections = await RuleCollectionStore.shared.loadCollections()
-        let oldLayerName = Self.parseLayer(oldName).kanataName
-        let newLayer = Self.parseLayer(newName)
-        var updated = 0
-        for i in collections.indices {
-            if collections[i].targetLayer.kanataName == oldLayerName {
-                collections[i].targetLayer = newLayer
-                updated += 1
+        try await withMutation {
+
+            var collections = await store.loadCollections()
+            let oldLayerName = Self.parseLayer(oldName).kanataName
+            let newLayer = Self.parseLayer(newName)
+            var updated = 0
+            for i in collections.indices {
+                if collections[i].targetLayer.kanataName == oldLayerName {
+                    collections[i].targetLayer = newLayer
+                    updated += 1
+                }
             }
+            if updated > 0 {
+                try await store.saveCollections(collections)
+            }
+            return updated
         }
-        if updated > 0 {
-            try await RuleCollectionStore.shared.saveCollections(collections)
-        }
-        return updated
     }
 
     // MARK: - Helpers

--- a/Sources/KeyPathAppKit/CLI/ConfigFacade.swift
+++ b/Sources/KeyPathAppKit/CLI/ConfigFacade.swift
@@ -3,6 +3,7 @@ import KeyPathCore
 import KeyPathRulesCore
 
 public struct ConfigFacade: Sendable {
+    private var operation: CLIConfigurationOperation?
     private let configDirectory: String
     private let ruleCollectionLoader: @Sendable () async -> [RuleCollection]
     private let customRuleLoader: @Sendable () async -> [CustomRule]
@@ -28,6 +29,11 @@ public struct ConfigFacade: Sendable {
         self.ruleCollectionLoader = ruleCollectionLoader
         self.customRuleLoader = customRuleLoader
         self.reloadHandler = reloadHandler
+    }
+
+    init(operation: CLIConfigurationOperation) {
+        self.init(configDirectory: operation.directory)
+        self.operation = operation
     }
 
     // MARK: - Configuration
@@ -58,8 +64,9 @@ public struct ConfigFacade: Sendable {
     // MARK: - Apply
 
     public func applyConfiguration(dryRun: Bool = false) async throws -> CLIApplyResult {
-        let service = await MainActor.run { ConfigurationService(configDirectory: configDirectory) }
-        return try await service.operationGate.withOperation { permit in
+        let service: ConfigurationService = if let operation { operation.service }
+        else { await MainActor.run { ConfigurationService(configDirectory: configDirectory) } }
+        return try await service.operationGate.withOperation(using: operation?.permit) { permit in
             try await applyConfiguration(dryRun: dryRun, service: service, permit: permit)
         }
     }

--- a/Sources/KeyPathAppKit/CLI/PacksFacade.swift
+++ b/Sources/KeyPathAppKit/CLI/PacksFacade.swift
@@ -10,7 +10,19 @@ public struct PacksFacade: Sendable {
 
     /// Test seam: overrides the manager used by install/uninstall/configure so tests
     /// can inject temp-backed stores instead of the shared persistent ones (#953).
+    /// Construct only; source hydration happens after admission.
     private let managerFactory: (@Sendable @MainActor () async -> RuleCollectionsManager)?
+
+    private var installedPackTracker: InstalledPackTracker {
+        operation?.installedPackTracker ?? .shared
+    }
+
+    private var operation: CLIConfigurationOperation?
+
+    init(operation: CLIConfigurationOperation) {
+        self.init()
+        self.operation = operation
+    }
 
     public init() {
         managerFactory = nil
@@ -24,7 +36,7 @@ public struct PacksFacade: Sendable {
 
     public func listPacks() async -> [CLIPack] {
         let allPacks = PackRegistry.starterKit
-        let installed = await InstalledPackTracker.shared.allInstalled()
+        let installed = await installedPackTracker.allInstalled()
         let installedMap = Dictionary(uniqueKeysWithValues: installed.map { ($0.packID, $0) })
 
         return allPacks.map { pack in
@@ -43,7 +55,7 @@ public struct PacksFacade: Sendable {
 
     public func showPack(nameOrId: String) async throws -> CLIPackDetail? {
         guard let pack = try resolvePack(nameOrId: nameOrId) else { return nil }
-        let record = await InstalledPackTracker.shared.record(for: pack.id)
+        let record = await installedPackTracker.record(for: pack.id)
         return CLIPackDetail(from: pack, record: record)
     }
 
@@ -53,62 +65,66 @@ public struct PacksFacade: Sendable {
         settingValues: [String: Int] = [:],
         dryRun: Bool = false
     ) async throws -> CLIPackInstallResult {
-        guard let pack = try resolvePack(nameOrId: nameOrId) else {
-            throw CLIPackNotFound(query: nameOrId)
-        }
+        try await withPackOperation { manager, permit in
+            guard let pack = try resolvePack(nameOrId: nameOrId) else {
+                throw CLIPackNotFound(query: nameOrId)
+            }
 
-        let isAlready = await InstalledPackTracker.shared.isInstalled(packID: pack.id)
-        if isAlready {
-            return CLIPackInstallResult(
-                packID: pack.id,
-                packName: pack.name,
-                action: "already-installed",
-                warnings: [],
-                quickSettingValues: [:]
+            let isAlready = await installedPackTracker.isInstalled(packID: pack.id)
+            if isAlready {
+                return CLIPackInstallResult(
+                    packID: pack.id,
+                    packName: pack.name,
+                    action: "already-installed",
+                    warnings: [],
+                    quickSettingValues: [:]
+                )
+            }
+
+            try validateQuickSettings(settingValues, for: pack)
+
+            if dryRun {
+                var warnings: [String] = []
+                let installedIDs = await Set(installedPackTracker.allInstalled().map(\.packID))
+                let suggestions = PackDependencyChecker.suggestions(for: pack.id, installedPackIDs: installedIDs)
+                for dep in suggestions {
+                    let depName = PackRegistry.pack(id: dep.packID)?.name ?? dep.packID
+                    warnings.append("Enhanced by '\(depName)' — install it for best results")
+                }
+                return CLIPackInstallResult(
+                    packID: pack.id,
+                    packName: pack.name,
+                    action: "would-install",
+                    warnings: warnings,
+                    quickSettingValues: settingValues
+                )
+            }
+
+            await loadPackSources(into: manager)
+            let record = try await PackInstaller.shared.install(
+                pack,
+                quickSettingValues: settingValues,
+                manager: manager,
+                installedPackTracker: installedPackTracker,
+                mutationPermit: permit
             )
-        }
 
-        try validateQuickSettings(settingValues, for: pack)
-
-        if dryRun {
             var warnings: [String] = []
-            let installedIDs = await Set(InstalledPackTracker.shared.allInstalled().map(\.packID))
+            let installedIDs = await Set(installedPackTracker.allInstalled().map(\.packID))
             let suggestions = PackDependencyChecker.suggestions(for: pack.id, installedPackIDs: installedIDs)
             for dep in suggestions {
                 let depName = PackRegistry.pack(id: dep.packID)?.name ?? dep.packID
                 warnings.append("Enhanced by '\(depName)' — install it for best results")
             }
+
             return CLIPackInstallResult(
                 packID: pack.id,
                 packName: pack.name,
-                action: "would-install",
+                action: "installed",
                 warnings: warnings,
-                quickSettingValues: settingValues
+                quickSettingValues: record.quickSettingValues
             )
         }
-
-        let manager = await makePackManager()
-        let record = try await PackInstaller.shared.install(
-            pack,
-            quickSettingValues: settingValues,
-            manager: manager
-        )
-
-        var warnings: [String] = []
-        let installedIDs = await Set(InstalledPackTracker.shared.allInstalled().map(\.packID))
-        let suggestions = PackDependencyChecker.suggestions(for: pack.id, installedPackIDs: installedIDs)
-        for dep in suggestions {
-            let depName = PackRegistry.pack(id: dep.packID)?.name ?? dep.packID
-            warnings.append("Enhanced by '\(depName)' — install it for best results")
-        }
-
-        return CLIPackInstallResult(
-            packID: pack.id,
-            packName: pack.name,
-            action: "installed",
-            warnings: warnings,
-            quickSettingValues: record.quickSettingValues
-        )
     }
 
     @MainActor
@@ -116,41 +132,43 @@ public struct PacksFacade: Sendable {
         nameOrId: String,
         dryRun: Bool = false
     ) async throws -> CLIPackInstallResult {
-        guard let pack = try resolvePack(nameOrId: nameOrId) else {
-            throw CLIPackNotFound(query: nameOrId)
-        }
+        try await withPackOperation { manager, permit in
+            guard let pack = try resolvePack(nameOrId: nameOrId) else {
+                throw CLIPackNotFound(query: nameOrId)
+            }
 
-        let isInstalled = await InstalledPackTracker.shared.isInstalled(packID: pack.id)
-        guard isInstalled else {
+            let isInstalled = await installedPackTracker.isInstalled(packID: pack.id)
+            guard isInstalled else {
+                return CLIPackInstallResult(
+                    packID: pack.id,
+                    packName: pack.name,
+                    action: "not-installed",
+                    warnings: [],
+                    quickSettingValues: [:]
+                )
+            }
+
+            if dryRun {
+                return CLIPackInstallResult(
+                    packID: pack.id,
+                    packName: pack.name,
+                    action: "would-uninstall",
+                    warnings: [],
+                    quickSettingValues: [:]
+                )
+            }
+
+            await loadPackSources(into: manager)
+            try await PackInstaller.shared.uninstall(packID: pack.id, manager: manager, installedPackTracker: installedPackTracker, mutationPermit: permit)
+
             return CLIPackInstallResult(
                 packID: pack.id,
                 packName: pack.name,
-                action: "not-installed",
+                action: "uninstalled",
                 warnings: [],
                 quickSettingValues: [:]
             )
         }
-
-        if dryRun {
-            return CLIPackInstallResult(
-                packID: pack.id,
-                packName: pack.name,
-                action: "would-uninstall",
-                warnings: [],
-                quickSettingValues: [:]
-            )
-        }
-
-        let manager = await makePackManager()
-        try await PackInstaller.shared.uninstall(packID: pack.id, manager: manager)
-
-        return CLIPackInstallResult(
-            packID: pack.id,
-            packName: pack.name,
-            action: "uninstalled",
-            warnings: [],
-            quickSettingValues: [:]
-        )
     }
 
     @MainActor
@@ -159,62 +177,66 @@ public struct PacksFacade: Sendable {
         settingValues: [String: Int],
         dryRun: Bool = false
     ) async throws -> CLIPackInstallResult {
-        guard let pack = try resolvePack(nameOrId: nameOrId) else {
-            throw CLIPackNotFound(query: nameOrId)
-        }
-
-        let isInstalled = await InstalledPackTracker.shared.isInstalled(packID: pack.id)
-        guard isInstalled else {
-            return CLIPackInstallResult(
-                packID: pack.id,
-                packName: pack.name,
-                action: "not-installed",
-                warnings: ["Pack must be installed before configuring settings."],
-                quickSettingValues: [:]
-            )
-        }
-
-        guard !pack.quickSettings.isEmpty else {
-            throw CLIPackSettingError(
-                packName: pack.name,
-                settingKey: settingValues.keys.first ?? "",
-                validKeys: []
-            )
-        }
-
-        try validateQuickSettings(settingValues, for: pack)
-
-        if dryRun {
-            let current = await PackInstaller.shared.quickSettings(for: pack.id)
-            var merged = current
-            for (k, v) in settingValues {
-                merged[k] = v
+        try await withPackOperation { manager, permit in
+            guard let pack = try resolvePack(nameOrId: nameOrId) else {
+                throw CLIPackNotFound(query: nameOrId)
             }
+
+            let isInstalled = await installedPackTracker.isInstalled(packID: pack.id)
+            guard isInstalled else {
+                return CLIPackInstallResult(
+                    packID: pack.id,
+                    packName: pack.name,
+                    action: "not-installed",
+                    warnings: ["Pack must be installed before configuring settings."],
+                    quickSettingValues: [:]
+                )
+            }
+
+            guard !pack.quickSettings.isEmpty else {
+                throw CLIPackSettingError(
+                    packName: pack.name,
+                    settingKey: settingValues.keys.first ?? "",
+                    validKeys: []
+                )
+            }
+
+            try validateQuickSettings(settingValues, for: pack)
+
+            if dryRun {
+                let current = await installedPackTracker.record(for: pack.id)?.quickSettingValues ?? [:]
+                var merged = current
+                for (k, v) in settingValues {
+                    merged[k] = v
+                }
+                return CLIPackInstallResult(
+                    packID: pack.id,
+                    packName: pack.name,
+                    action: "would-configure",
+                    warnings: [],
+                    quickSettingValues: merged
+                )
+            }
+
+            await loadPackSources(into: manager)
+            try await PackInstaller.shared.updateQuickSettings(
+                packID: pack.id,
+                newValues: settingValues,
+                manager: manager,
+                installedPackTracker: installedPackTracker,
+                mutationPermit: permit
+            )
+
+            let updatedSettings = await installedPackTracker.record(for: pack.id)?.quickSettingValues ?? [:]
+
             return CLIPackInstallResult(
                 packID: pack.id,
                 packName: pack.name,
-                action: "would-configure",
+                action: "configured",
                 warnings: [],
-                quickSettingValues: merged
+                quickSettingValues: updatedSettings
             )
         }
-
-        let manager = await makePackManager()
-        try await PackInstaller.shared.updateQuickSettings(
-            packID: pack.id,
-            newValues: settingValues,
-            manager: manager
-        )
-
-        let updatedSettings = await PackInstaller.shared.quickSettings(for: pack.id)
-
-        return CLIPackInstallResult(
-            packID: pack.id,
-            packName: pack.name,
-            action: "configured",
-            warnings: [],
-            quickSettingValues: updatedSettings
-        )
     }
 
     func resolvePack(nameOrId: String) throws -> Pack? {
@@ -269,22 +291,44 @@ public struct PacksFacade: Sendable {
     }
 
     @MainActor
+    private func withPackOperation<Result: Sendable>(
+        _ operation: @MainActor @Sendable (RuleCollectionsManager, ConfigurationOperationGate.Permit) async throws -> Result
+    ) async throws -> Result {
+        let manager = await makePackManager()
+        return try await manager.configurationService.operationGate.withOperation(using: self.operation?.permit) { @MainActor permit in
+            try await installedPackTracker.validateForMutation()
+            return try await operation(manager, permit)
+        }
+    }
+
+    /// Load source state only after admission, immediately before a real mutation.
+    /// Dry-run and already-installed/not-installed exits do not hydrate or write sources.
+    @MainActor
+    private func loadPackSources(into manager: RuleCollectionsManager) async {
+        manager.ruleCollections = await RuleCollectionDeduplicator.dedupe(manager.ruleCollectionStore.loadCollections())
+        manager.customRules = await manager.customRulesStore.loadRules()
+    }
+
+    @MainActor
     func makePackManager() async -> RuleCollectionsManager {
         if let managerFactory {
             return await managerFactory()
         }
 
+        if let operation {
+            let directory = URL(fileURLWithPath: operation.directory)
+            return RuleCollectionsManager(
+                ruleCollectionStore: RuleCollectionStore(fileURL: directory.appendingPathComponent("RuleCollections.json")),
+                customRulesStore: CustomRulesStore(fileURL: directory.appendingPathComponent("CustomRules.json")),
+                configurationService: operation.service
+            )
+        }
         let configService = ConfigurationService()
-        let manager = RuleCollectionsManager(
+        return RuleCollectionsManager(
             ruleCollectionStore: .shared,
             customRulesStore: .shared,
             configurationService: configService
         )
-        let collections = await RuleCollectionStore.shared.loadCollections()
-        let customRules = await CustomRulesStore.shared.loadRules()
-        manager.ruleCollections = RuleCollectionDeduplicator.dedupe(collections)
-        manager.customRules = customRules
-        return manager
     }
 
     private func validateQuickSettings(_ values: [String: Int], for pack: Pack) throws {

--- a/Sources/KeyPathAppKit/CLI/RulesFacade.swift
+++ b/Sources/KeyPathAppKit/CLI/RulesFacade.swift
@@ -3,10 +3,40 @@ import KeyPathCore
 import KeyPathRulesCore
 
 public struct RulesFacade: Sendable {
-    public init() {}
+    private let store: CustomRulesStore
+    private let operation: CLIConfigurationOperation?
+
+    public init() {
+        store = .shared
+        operation = nil
+    }
+
+    init(operation: CLIConfigurationOperation) {
+        store = CustomRulesStore(fileURL: URL(fileURLWithPath: operation.directory)
+            .appendingPathComponent("CustomRules.json"))
+        self.operation = operation
+    }
+
+    init(store: CustomRulesStore) {
+        self.store = store
+        operation = nil
+    }
+
+    private func withMutation<Result: Sendable>(
+        _ body: @Sendable () async throws -> Result
+    ) async throws -> Result {
+        if let operation {
+            return try await operation.service.operationGate.withOperation(using: operation.permit) { _ in
+                try await body()
+            }
+        }
+        let directory = await store.persistenceURL.deletingLastPathComponent()
+        let gate = ConfigurationOperationGate(configurationDirectory: directory)
+        return try await gate.withOperation { _ in try await body() }
+    }
 
     public func loadCustomRules() async -> [CLICustomRule] {
-        let rules = await CustomRulesStore.shared.loadRules()
+        let rules = await store.loadRules()
         return rules.map { CLICustomRule(input: $0.input, output: $0.action.outputString, behavior: $0.behavior.map(Self.describeBehavior)) }
     }
 
@@ -27,32 +57,36 @@ public struct RulesFacade: Sendable {
 
     @discardableResult
     public func addSimpleRemap(input: String, output: String) async throws -> Bool {
-        var rules = await CustomRulesStore.shared.loadRules()
-        let hadExisting = rules.contains { $0.input == input }
-        rules.removeAll { $0.input == input }
-        let rule = CustomRule(input: input, action: .keystroke(key: output))
-        rules.append(rule)
-        try await CustomRulesStore.shared.saveRules(rules)
-        return hadExisting
+        try await withMutation {
+            var rules = await store.loadRules()
+            let hadExisting = rules.contains { $0.input == input }
+            rules.removeAll { $0.input == input }
+            let rule = CustomRule(input: input, action: .keystroke(key: output))
+            rules.append(rule)
+            try await store.saveRules(rules)
+            return hadExisting
+        }
     }
 
     @discardableResult
     public func addTapHoldRemap(input: String, tap: String, hold: String, timeout: Int = 200) async throws -> Bool {
-        var rules = await CustomRulesStore.shared.loadRules()
-        let hadExisting = rules.contains { $0.input == input }
-        rules.removeAll { $0.input == input }
-        let rule = CustomRule(
-            input: input,
-            action: .keystroke(key: tap),
-            behavior: .dualRole(DualRoleBehavior(
-                tapAction: .keystroke(key: tap),
-                holdAction: .keystroke(key: hold),
-                tapTimeout: timeout
-            ))
-        )
-        rules.append(rule)
-        try await CustomRulesStore.shared.saveRules(rules)
-        return hadExisting
+        try await withMutation {
+            var rules = await store.loadRules()
+            let hadExisting = rules.contains { $0.input == input }
+            rules.removeAll { $0.input == input }
+            let rule = CustomRule(
+                input: input,
+                action: .keystroke(key: tap),
+                behavior: .dualRole(DualRoleBehavior(
+                    tapAction: .keystroke(key: tap),
+                    holdAction: .keystroke(key: hold),
+                    tapTimeout: timeout
+                ))
+            )
+            rules.append(rule)
+            try await store.saveRules(rules)
+            return hadExisting
+        }
     }
 
     public func addRule(
@@ -66,88 +100,96 @@ public struct RulesFacade: Sendable {
         deviceOverrides: [DeviceKeyOverride]? = nil,
         onConflict: CLIConflictStrategy = .fail
     ) async throws -> RuleAddResult {
-        var rules = await CustomRulesStore.shared.loadRules()
-        let existingIndex = rules.firstIndex(where: { $0.input == input })
+        try await withMutation {
+            var rules = await store.loadRules()
+            let existingIndex = rules.firstIndex(where: { $0.input == input })
 
-        if let existingIndex {
-            switch onConflict {
-            case .fail:
-                throw CLIConflictError(input: input)
-            case .skip:
-                return .skipped
-            case .replace:
-                rules.removeAll { $0.input == input }
-            case .merge:
-                let existing = rules[existingIndex]
-                let merged = try Self.mergeRules(existing: existing, newAction: action, newBehavior: behavior)
-                rules[existingIndex] = merged
-                try await CustomRulesStore.shared.saveRules(rules)
-                return .merged(CLIRuleDetail(from: merged))
+            if let existingIndex {
+                switch onConflict {
+                case .fail:
+                    throw CLIConflictError(input: input)
+                case .skip:
+                    return .skipped
+                case .replace:
+                    rules.removeAll { $0.input == input }
+                case .merge:
+                    let existing = rules[existingIndex]
+                    let merged = try Self.mergeRules(existing: existing, newAction: action, newBehavior: behavior)
+                    rules[existingIndex] = merged
+                    try await store.saveRules(rules)
+                    return .merged(CLIRuleDetail(from: merged))
+                }
             }
+
+            let layer: RuleCollectionLayer = if let targetLayer {
+                Self.parseLayer(targetLayer)
+            } else {
+                .base
+            }
+
+            let rule = CustomRule(
+                title: title ?? "",
+                input: input,
+                action: action,
+                shiftedOutput: shiftedOutput,
+                notes: notes,
+                behavior: behavior,
+                targetLayer: layer,
+                deviceOverrides: deviceOverrides
+            )
+            rules.append(rule)
+            try await store.saveRules(rules)
+
+            let detail = CLIRuleDetail(from: rule)
+            return existingIndex != nil ? .replaced(detail) : .created(detail)
         }
-
-        let layer: RuleCollectionLayer = if let targetLayer {
-            Self.parseLayer(targetLayer)
-        } else {
-            .base
-        }
-
-        let rule = CustomRule(
-            title: title ?? "",
-            input: input,
-            action: action,
-            shiftedOutput: shiftedOutput,
-            notes: notes,
-            behavior: behavior,
-            targetLayer: layer,
-            deviceOverrides: deviceOverrides
-        )
-        rules.append(rule)
-        try await CustomRulesStore.shared.saveRules(rules)
-
-        let detail = CLIRuleDetail(from: rule)
-        return existingIndex != nil ? .replaced(detail) : .created(detail)
     }
 
     public func listRules(enabledOnly: Bool = false) async -> [CLIRuleDetail] {
-        let rules = await CustomRulesStore.shared.loadRules()
+        let rules = await store.loadRules()
         let filtered = enabledOnly ? rules.filter(\.isEnabled) : rules
         return filtered.map { CLIRuleDetail(from: $0) }
     }
 
     public func showRule(input: String) async -> CLIRuleDetail? {
-        let rules = await CustomRulesStore.shared.loadRules()
+        let rules = await store.loadRules()
         guard let rule = rules.first(where: { $0.input == input }) else { return nil }
         return CLIRuleDetail(from: rule)
     }
 
     public func removeRemap(input: String) async throws -> Bool {
-        var rules = await CustomRulesStore.shared.loadRules()
-        let before = rules.count
-        rules.removeAll { $0.input == input }
-        if rules.count == before { return false }
-        try await CustomRulesStore.shared.saveRules(rules)
-        return true
+        try await withMutation {
+            var rules = await store.loadRules()
+            let before = rules.count
+            rules.removeAll { $0.input == input }
+            if rules.count == before { return false }
+            try await store.saveRules(rules)
+            return true
+        }
     }
 
     public func enableRule(input: String) async throws -> String? {
-        var rules = await CustomRulesStore.shared.loadRules()
-        guard let index = rules.firstIndex(where: { $0.input.caseInsensitiveCompare(input) == .orderedSame }) else {
-            return nil
+        try await withMutation {
+            var rules = await store.loadRules()
+            guard let index = rules.firstIndex(where: { $0.input.caseInsensitiveCompare(input) == .orderedSame }) else {
+                return nil
+            }
+            rules[index].isEnabled = true
+            try await store.saveRules(rules)
+            return rules[index].displayTitle
         }
-        rules[index].isEnabled = true
-        try await CustomRulesStore.shared.saveRules(rules)
-        return rules[index].displayTitle
     }
 
     public func disableRule(input: String) async throws -> String? {
-        var rules = await CustomRulesStore.shared.loadRules()
-        guard let index = rules.firstIndex(where: { $0.input.caseInsensitiveCompare(input) == .orderedSame }) else {
-            return nil
+        try await withMutation {
+            var rules = await store.loadRules()
+            guard let index = rules.firstIndex(where: { $0.input.caseInsensitiveCompare(input) == .orderedSame }) else {
+                return nil
+            }
+            rules[index].isEnabled = false
+            try await store.saveRules(rules)
+            return rules[index].displayTitle
         }
-        rules[index].isEnabled = false
-        try await CustomRulesStore.shared.saveRules(rules)
-        return rules[index].displayTitle
     }
 
     static func parseLayer(_ name: String) -> RuleCollectionLayer {

--- a/Sources/KeyPathAppKit/Services/Packs/InstalledPackTracker.swift
+++ b/Sources/KeyPathAppKit/Services/Packs/InstalledPackTracker.swift
@@ -36,8 +36,8 @@ public actor InstalledPackTracker {
     public static let shared = InstalledPackTracker()
 
     private let fileURL: URL
-    private var records: [String: InstalledPackRecord] = [:]
-    private var hasLoaded = false
+    private var writeFile: @Sendable (Data, URL) throws -> Void = { try $0.write(to: $1, options: [.atomic]) }
+    private var lastReadableRecords: [String: InstalledPackRecord] = [:]
 
     public init(fileURL: URL? = nil) {
         if let fileURL {
@@ -60,29 +60,40 @@ public actor InstalledPackTracker {
         }
     }
 
+    init(fileURL: URL, writeFile: @escaping @Sendable (Data, URL) throws -> Void) {
+        self.fileURL = fileURL
+        self.writeFile = writeFile
+    }
+
+    /// Mutating decisions cannot rely on the display-only fallback snapshot.
+    /// Call under configuration admission before staging source changes.
+    func validateForMutation() throws {
+        lastReadableRecords = try readRecords()
+    }
+
     // MARK: - Public API
 
     /// Return a copy of every installed pack's record.
     public func allInstalled() async -> [InstalledPackRecord] {
-        await ensureLoaded()
+        let records = readSnapshot()
         return Array(records.values).sorted(by: { $0.installedAt > $1.installedAt })
     }
 
     /// Is this pack installed right now?
     public func isInstalled(packID: String) async -> Bool {
-        await ensureLoaded()
+        let records = readSnapshot()
         return records[packID] != nil
     }
 
     /// Return the record for a specific pack, or nil if not installed.
     public func record(for packID: String) async -> InstalledPackRecord? {
-        await ensureLoaded()
+        let records = readSnapshot()
         return records[packID]
     }
 
     /// Returns the installed pack that manages a given collection, or nil.
     public func packManagingCollection(_ collectionID: UUID) async -> (packID: String, packName: String)? {
-        await ensureLoaded()
+        let records = readSnapshot()
         // Prefer a pack that manages this collection WITHOUT it being the
         // pack's own associated collection (i.e. a parent pack like Vallack
         // managing Home Row Mods). Fall back to self-managing pack only if
@@ -103,17 +114,17 @@ public actor InstalledPackTracker {
 
     /// Mark a pack as installed (or update an existing record). Persists.
     public func upsert(_ record: InstalledPackRecord) async throws {
-        await ensureLoaded()
+        var records = try readRecords()
         records[record.packID] = record
-        try persist()
+        try persist(records)
         await postChangeNotification()
     }
 
     /// Remove an installed-pack record. Persists.
     public func remove(packID: String) async throws {
-        await ensureLoaded()
+        var records = try readRecords()
         records.removeValue(forKey: packID)
-        try persist()
+        try persist(records)
         await postChangeNotification()
     }
 
@@ -128,32 +139,33 @@ public actor InstalledPackTracker {
 
     // MARK: - Persistence
 
-    private func ensureLoaded() async {
-        guard !hasLoaded else { return }
-        hasLoaded = true
-
-        guard FileManager.default.fileExists(atPath: fileURL.path) else {
-            return
-        }
-
+    /// Query APIs refresh every time. An unreadable file retains the last known
+    /// committed snapshot; a missing file or a readable replacement supersedes it.
+    private func readSnapshot() -> [String: InstalledPackRecord] {
         do {
-            let data = try Data(contentsOf: fileURL)
-            let decoder = JSONDecoder()
-            decoder.dateDecodingStrategy = .iso8601
-            let decoded = try decoder.decode([String: InstalledPackRecord].self, from: data)
-            records = decoded
-            AppLogger.shared.log(
-                "📦 [PackTracker] Loaded \(records.count) installed pack record(s)"
-            )
+            let records = try readRecords()
+            lastReadableRecords = records
+            return records
         } catch {
-            AppLogger.shared.log(
-                "⚠️ [PackTracker] Failed to load installed-packs.json: \(error.localizedDescription). Starting fresh."
-            )
-            records = [:]
+            AppLogger.shared.log("⚠️ [PackTracker] Could not read installed-packs.json: \(error.localizedDescription)")
+            return lastReadableRecords
         }
     }
 
-    private func persist() throws {
+    /// Writes must fail closed on unreadable metadata. Treat only a missing file
+    /// as empty; malformed or inaccessible data must never be silently replaced.
+    private func readRecords() throws -> [String: InstalledPackRecord] {
+        let data: Data
+        do { data = try Data(contentsOf: fileURL) }
+        catch let error as NSError where error.domain == NSCocoaErrorDomain && error.code == NSFileReadNoSuchFileError {
+            return [:]
+        }
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try decoder.decode([String: InstalledPackRecord].self, from: data)
+    }
+
+    private func persist(_ records: [String: InstalledPackRecord]) throws {
         // Ensure parent directory exists. (First run creates ~/.config/keypath/.)
         let parent = fileURL.deletingLastPathComponent()
         try FileManager.default.createDirectory(
@@ -165,7 +177,8 @@ public actor InstalledPackTracker {
         encoder.dateEncodingStrategy = .iso8601
         let data = try encoder.encode(records)
 
-        try data.write(to: fileURL, options: [.atomic])
+        try writeFile(data, fileURL)
+        lastReadableRecords = records
         AppLogger.shared.log(
             "📦 [PackTracker] Persisted \(records.count) installed pack record(s)"
         )

--- a/Sources/KeyPathAppKit/Services/Packs/PackInstaller.swift
+++ b/Sources/KeyPathAppKit/Services/Packs/PackInstaller.swift
@@ -90,9 +90,11 @@ public final class PackInstaller {
         additionalCollectionIDsToDisable: Set<UUID> = [],
         manager: RuleCollectionsManager,
         skipFinalReload: Bool = false,
-        installedPackTracker: InstalledPackTracker = .shared
+        installedPackTracker: InstalledPackTracker = .shared,
+        mutationPermit: ConfigurationOperationGate.Permit? = nil
     ) async throws -> InstalledPackRecord {
-        try await manager.configurationService.operationGate.withOperation { @MainActor [self] permit in
+        try await manager.configurationService.operationGate.withOperation(using: mutationPermit) { @MainActor [self] permit in
+            try await installedPackTracker.validateForMutation()
             AppLogger.shared.log(
                 "📦 [PackInstaller] Installing pack '\(pack.name)' (id=\(pack.id), v\(pack.version))"
             )
@@ -341,15 +343,18 @@ public final class PackInstaller {
     /// id, regenerates the config, and drops the install record.
     func uninstall(
         packID: String,
-        manager: RuleCollectionsManager
+        manager: RuleCollectionsManager,
+        installedPackTracker: InstalledPackTracker = .shared,
+        mutationPermit: ConfigurationOperationGate.Permit? = nil
     ) async throws {
-        try await manager.configurationService.operationGate.withOperation { @MainActor [self] permit in
+        try await manager.configurationService.operationGate.withOperation(using: mutationPermit) { @MainActor [self] permit in
+            try await installedPackTracker.validateForMutation()
             AppLogger.shared.log("📦 [PackInstaller] Uninstalling pack '\(packID)'")
 
             // Visual-only packs just clear the tracker record; no kanata
             // changes to revert.
             if let pack = PackRegistry.pack(id: packID), pack.visualOnly {
-                try await InstalledPackTracker.shared.remove(packID: packID)
+                try await installedPackTracker.remove(packID: packID)
                 AppLogger.shared.log(
                     "✅ [PackInstaller] Uninstalled visual-only pack '\(packID)'"
                 )
@@ -379,7 +384,7 @@ public final class PackInstaller {
                     throw InstallError.saveFailed("could not apply managed collection restore")
                 }
                 removeManagedSnapshot(for: pack)
-                try await InstalledPackTracker.shared.remove(packID: packID)
+                try await installedPackTracker.remove(packID: packID)
                 AppLogger.shared.log(
                     "✅ [PackInstaller] Uninstalled system pack '\(packID)' (restored=\(didRestore))"
                 )
@@ -396,7 +401,7 @@ public final class PackInstaller {
                 guard ok else {
                     throw InstallError.saveFailed("could not disable associated rule collection")
                 }
-                try await InstalledPackTracker.shared.remove(packID: packID)
+                try await installedPackTracker.remove(packID: packID)
                 AppLogger.shared.log(
                     "✅ [PackInstaller] Uninstalled pack '\(packID)' via collection toggle off (id=\(collectionID))"
                 )
@@ -410,7 +415,7 @@ public final class PackInstaller {
             guard !packRules.isEmpty else {
                 // Nothing to remove from rules, but still clear the tracker
                 // record in case it drifted out of sync.
-                try await InstalledPackTracker.shared.remove(packID: packID)
+                try await installedPackTracker.remove(packID: packID)
                 AppLogger.shared.log(
                     "ℹ️ [PackInstaller] No rules tagged with pack '\(packID)'; cleared tracker record"
                 )
@@ -426,7 +431,7 @@ public final class PackInstaller {
                 await manager.removeCustomRule(id: rule.id, mutationPermit: permit)
             }
 
-            try await InstalledPackTracker.shared.remove(packID: packID)
+            try await installedPackTracker.remove(packID: packID)
 
             AppLogger.shared.log(
                 "✅ [PackInstaller] Uninstalled pack '\(packID)': removed \(packRules.count) rule(s)"
@@ -528,13 +533,16 @@ public final class PackInstaller {
     func updateQuickSettings(
         packID: String,
         newValues: [String: Int],
-        manager: RuleCollectionsManager
+        manager: RuleCollectionsManager,
+        installedPackTracker: InstalledPackTracker = .shared,
+        mutationPermit: ConfigurationOperationGate.Permit? = nil
     ) async throws {
-        try await manager.configurationService.operationGate.withOperation { @MainActor [self] permit in
+        try await manager.configurationService.operationGate.withOperation(using: mutationPermit) { @MainActor [self] permit in
+            try await installedPackTracker.validateForMutation()
             guard let pack = PackRegistry.pack(id: packID) else {
                 throw InstallError.saveFailed("pack not found in registry: \(packID)")
             }
-            guard var record = await InstalledPackTracker.shared.record(for: packID) else {
+            guard var record = await installedPackTracker.record(for: packID) else {
                 throw InstallError.saveFailed("pack is not installed: \(packID)")
             }
 
@@ -574,7 +582,7 @@ public final class PackInstaller {
 
             // Persist updated record
             record.quickSettingValues = resolved
-            try await InstalledPackTracker.shared.upsert(record)
+            try await installedPackTracker.upsert(record)
 
             AppLogger.shared.log(
                 "✅ [PackInstaller] Updated quick settings for '\(pack.name)': \(resolved)"
@@ -696,9 +704,8 @@ public final class PackInstaller {
             return true
         } catch {
             // A failed atomic write leaves the prior on-disk record intact.
-            // InstalledPackTracker mutates its in-memory dictionary before
-            // writing, so the compensating call above is still required even
-            // when its persistence attempt reports the same underlying error.
+            // The tracker reads committed disk state, so no speculative cache
+            // can claim the compensating write succeeded.
             AppLogger.shared.errorUnlessQuietTest(
                 "❌ [PackInstaller] Could not persist tracker rollback for '\(packID)': \(error)"
             )

--- a/Sources/KeyPathCLI/Commands/Collection/CollectionDisableCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Collection/CollectionDisableCommand.swift
@@ -17,8 +17,15 @@ struct CollectionDisable: AsyncParsableCommand {
     var apply: Bool = false
 
     mutating func run() async throws {
+        let command = self
+        try await CLIConfigurationOperation.run { operation in
+            try await command.run(operation: operation)
+        }
+    }
+
+    private func run(operation: CLIConfigurationOperation) async throws {
         let ctx = globals.outputContext
-        let facade = CollectionsFacade()
+        let facade = operation.collections
 
         do {
             guard let name = try await facade.disableCollection(nameOrId: nameOrId) else {
@@ -47,6 +54,6 @@ struct CollectionDisable: AsyncParsableCommand {
             throw error.code.exitCode
         }
 
-        try await applyConfigurationOrHint(apply: apply, context: ctx)
+        try await applyConfigurationOrHint(apply: apply, context: ctx, facade: operation.config)
     }
 }

--- a/Sources/KeyPathCLI/Commands/Collection/CollectionEnableCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Collection/CollectionEnableCommand.swift
@@ -17,8 +17,15 @@ struct CollectionEnable: AsyncParsableCommand {
     var apply: Bool = false
 
     mutating func run() async throws {
+        let command = self
+        try await CLIConfigurationOperation.run { operation in
+            try await command.run(operation: operation)
+        }
+    }
+
+    private func run(operation: CLIConfigurationOperation) async throws {
         let ctx = globals.outputContext
-        let facade = CollectionsFacade()
+        let facade = operation.collections
 
         do {
             guard let name = try await facade.enableCollection(nameOrId: nameOrId) else {
@@ -47,6 +54,6 @@ struct CollectionEnable: AsyncParsableCommand {
             throw error.code.exitCode
         }
 
-        try await applyConfigurationOrHint(apply: apply, context: ctx)
+        try await applyConfigurationOrHint(apply: apply, context: ctx, facade: operation.config)
     }
 }

--- a/Sources/KeyPathCLI/Commands/Pack/PackConfigureCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Pack/PackConfigureCommand.swift
@@ -20,6 +20,13 @@ struct PackConfigure: AsyncParsableCommand {
     var apply: Bool = false
 
     mutating func run() async throws {
+        let command = self
+        try await CLIConfigurationOperation.run { operation in
+            try await command.run(operation: operation)
+        }
+    }
+
+    private func run(operation: CLIConfigurationOperation) async throws {
         let ctx = globals.outputContext
 
         guard !settings.isEmpty else {
@@ -45,7 +52,7 @@ struct PackConfigure: AsyncParsableCommand {
             settingValues[String(parts[0])] = value
         }
 
-        let facade = PacksFacade()
+        let facade = operation.packs
 
         do {
             let result = try await facade.configurePack(
@@ -68,7 +75,7 @@ struct PackConfigure: AsyncParsableCommand {
             }
 
             if result.action == "configured" {
-                try await applyConfigurationOrHint(apply: apply, context: ctx)
+                try await applyConfigurationOrHint(apply: apply, context: ctx, facade: operation.config)
             }
         } catch let notFound as CLIPackNotFound {
             let allPacks = await facade.listPacks()

--- a/Sources/KeyPathCLI/Commands/Pack/PackInstallCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Pack/PackInstallCommand.swift
@@ -20,6 +20,13 @@ struct PackInstall: AsyncParsableCommand {
     var apply: Bool = false
 
     mutating func run() async throws {
+        let command = self
+        try await CLIConfigurationOperation.run { operation in
+            try await command.run(operation: operation)
+        }
+    }
+
+    private func run(operation: CLIConfigurationOperation) async throws {
         let ctx = globals.outputContext
 
         var settingValues: [String: Int] = [:]
@@ -36,7 +43,7 @@ struct PackInstall: AsyncParsableCommand {
             settingValues[String(parts[0])] = value
         }
 
-        let facade = PacksFacade()
+        let facade = operation.packs
         let spinner = CLISpinner(context: ctx)
 
         do {
@@ -87,7 +94,7 @@ struct PackInstall: AsyncParsableCommand {
             }
 
             if result.action == "installed" {
-                try await applyConfigurationOrHint(apply: apply, context: ctx)
+                try await applyConfigurationOrHint(apply: apply, context: ctx, facade: operation.config)
             }
         } catch let notFound as CLIPackNotFound {
             spinner.fail("Pack not found: '\(notFound.query)'")

--- a/Sources/KeyPathCLI/Commands/Pack/PackUninstallCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Pack/PackUninstallCommand.swift
@@ -17,8 +17,15 @@ struct PackUninstall: AsyncParsableCommand {
     var apply: Bool = false
 
     mutating func run() async throws {
+        let command = self
+        try await CLIConfigurationOperation.run { operation in
+            try await command.run(operation: operation)
+        }
+    }
+
+    private func run(operation: CLIConfigurationOperation) async throws {
         let ctx = globals.outputContext
-        let facade = PacksFacade()
+        let facade = operation.packs
 
         let spinner = CLISpinner(context: ctx)
 
@@ -53,7 +60,7 @@ struct PackUninstall: AsyncParsableCommand {
             }
 
             if result.action == "uninstalled" {
-                try await applyConfigurationOrHint(apply: apply, context: ctx)
+                try await applyConfigurationOrHint(apply: apply, context: ctx, facade: operation.config)
             }
         } catch let notFound as CLIPackNotFound {
             spinner.fail("Pack not found: '\(notFound.query)'")

--- a/Sources/KeyPathCLI/Commands/Rule/RuleAddCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Rule/RuleAddCommand.swift
@@ -61,9 +61,16 @@ struct RuleAdd: AsyncParsableCommand {
     }
 
     mutating func run() async throws {
+        let command = self
+        try await CLIConfigurationOperation.run { operation in
+            try await command.run(operation: operation)
+        }
+    }
+
+    private func run(operation: CLIConfigurationOperation) async throws {
         let ctx = globals.outputContext
         let validator = SimulatorFacade()
-        let rules = RulesFacade()
+        let rules = operation.rules
 
         guard validator.validateKey(input) != nil else {
             let error = CLIError.invalidKey(input, label: "input")
@@ -171,7 +178,7 @@ struct RuleAdd: AsyncParsableCommand {
             throw CLIExitCode.conflict.exitCode
         }
 
-        try await applyConfigurationOrHint(apply: apply, context: ctx)
+        try await applyConfigurationOrHint(apply: apply, context: ctx, facade: operation.config)
     }
 
     private func decodeAction(_ json: String, context: OutputContext) throws -> KeyAction {

--- a/Sources/KeyPathCLI/Commands/Rule/RuleDisableCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Rule/RuleDisableCommand.swift
@@ -17,8 +17,15 @@ struct RuleDisable: AsyncParsableCommand {
     var apply: Bool = false
 
     mutating func run() async throws {
+        let command = self
+        try await CLIConfigurationOperation.run { operation in
+            try await command.run(operation: operation)
+        }
+    }
+
+    private func run(operation: CLIConfigurationOperation) async throws {
         let ctx = globals.outputContext
-        let facade = RulesFacade()
+        let facade = operation.rules
 
         guard let title = try await facade.disableRule(input: input) else {
             let error = CLIError.notFound("Rule", query: input, listCommand: "keypath rule list")
@@ -30,6 +37,6 @@ struct RuleDisable: AsyncParsableCommand {
             "Disabled '\(title)' (\(input))"
         }
 
-        try await applyConfigurationOrHint(apply: apply, context: ctx)
+        try await applyConfigurationOrHint(apply: apply, context: ctx, facade: operation.config)
     }
 }

--- a/Sources/KeyPathCLI/Commands/Rule/RuleEnableCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Rule/RuleEnableCommand.swift
@@ -17,8 +17,15 @@ struct RuleEnable: AsyncParsableCommand {
     var apply: Bool = false
 
     mutating func run() async throws {
+        let command = self
+        try await CLIConfigurationOperation.run { operation in
+            try await command.run(operation: operation)
+        }
+    }
+
+    private func run(operation: CLIConfigurationOperation) async throws {
         let ctx = globals.outputContext
-        let facade = RulesFacade()
+        let facade = operation.rules
 
         guard let title = try await facade.enableRule(input: input) else {
             let error = CLIError.notFound("Rule", query: input, listCommand: "keypath rule list")
@@ -30,6 +37,6 @@ struct RuleEnable: AsyncParsableCommand {
             "Enabled '\(title)' (\(input))"
         }
 
-        try await applyConfigurationOrHint(apply: apply, context: ctx)
+        try await applyConfigurationOrHint(apply: apply, context: ctx, facade: operation.config)
     }
 }

--- a/Sources/KeyPathCLI/Commands/Rule/RuleEnsureCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Rule/RuleEnsureCommand.swift
@@ -29,11 +29,18 @@ struct RuleEnsure: AsyncParsableCommand {
     var apply: Bool = false
 
     mutating func run() async throws {
+        let command = self
+        try await CLIConfigurationOperation.run { operation in
+            try await command.run(operation: operation)
+        }
+    }
+
+    private func run(operation: CLIConfigurationOperation) async throws {
         let ctx = globals.outputContext
-        let facade = RulesFacade()
+        let facade = operation.rules
 
         if let fromFile {
-            try await runBatch(file: fromFile, facade: facade, ctx: ctx)
+            try await runBatch(file: fromFile, facade: facade, ctx: ctx, operation: operation)
         } else {
             guard let input, let output else {
                 let error = CLIError.validation(
@@ -64,12 +71,12 @@ struct RuleEnsure: AsyncParsableCommand {
             }
 
             if result.action == "created" || result.action == "updated" {
-                try await applyConfigurationOrHint(apply: apply, context: ctx)
+                try await applyConfigurationOrHint(apply: apply, context: ctx, facade: operation.config)
             }
         }
     }
 
-    private func runBatch(file: String, facade: RulesFacade, ctx: OutputContext) async throws {
+    private func runBatch(file: String, facade: RulesFacade, ctx: OutputContext, operation: CLIConfigurationOperation) async throws {
         let path = (file as NSString).expandingTildeInPath
         guard let data = FileManager.default.contents(atPath: path) else {
             let error = CLIError.validation("Cannot read file: '\(file)'")
@@ -121,7 +128,7 @@ struct RuleEnsure: AsyncParsableCommand {
 
         let hadChanges = results.contains { $0.action == "created" || $0.action == "updated" }
         if hadChanges {
-            try await applyConfigurationOrHint(apply: apply, context: ctx)
+            try await applyConfigurationOrHint(apply: apply, context: ctx, facade: operation.config)
         }
     }
 

--- a/Sources/KeyPathCLI/Commands/Rule/RuleRemoveCommand.swift
+++ b/Sources/KeyPathCLI/Commands/Rule/RuleRemoveCommand.swift
@@ -17,8 +17,15 @@ struct RuleRemove: AsyncParsableCommand {
     var apply: Bool = false
 
     mutating func run() async throws {
+        let command = self
+        try await CLIConfigurationOperation.run { operation in
+            try await command.run(operation: operation)
+        }
+    }
+
+    private func run(operation: CLIConfigurationOperation) async throws {
         let ctx = globals.outputContext
-        let facade = RulesFacade()
+        let facade = operation.rules
 
         if globals.dryRun {
             let rule = await facade.showRule(input: input)
@@ -45,6 +52,6 @@ struct RuleRemove: AsyncParsableCommand {
             "Removed mapping for '\(input)'"
         }
 
-        try await applyConfigurationOrHint(apply: apply, context: ctx)
+        try await applyConfigurationOrHint(apply: apply, context: ctx, facade: operation.config)
     }
 }

--- a/Sources/KeyPathCLI/Utilities/ApplyHelper.swift
+++ b/Sources/KeyPathCLI/Utilities/ApplyHelper.swift
@@ -3,9 +3,8 @@ import Foundation
 import KeyPathAppKit
 import KeyPathCLISupport
 
-func applyConfigurationOrHint(apply: Bool, context: OutputContext) async throws {
+func applyConfigurationOrHint(apply: Bool, context: OutputContext, facade: ConfigFacade) async throws {
     if apply {
-        let facade = ConfigFacade()
         let result = try await facade.applyConfiguration()
         if result.reloadSuccess {
             CLIOutput.write(["applied": true], context: context) {

--- a/Tests/KeyPathTests/CLI/CLIConfigurationOperationTests.swift
+++ b/Tests/KeyPathTests/CLI/CLIConfigurationOperationTests.swift
@@ -1,0 +1,123 @@
+import Foundation
+@testable import KeyPathAppKit
+import KeyPathRulesCore
+@preconcurrency import XCTest
+
+@MainActor
+final class CLIConfigurationOperationTests: KeyPathTestCase {
+    func testCommandComposesSourceEditsAndPreviewUnderOneOwner() async throws {
+        try await withDirectory { directory in
+            try await CLIConfigurationOperation.run(configDirectory: directory.path) { operation in
+                _ = try await operation.rules.addSimpleRemap(input: "f13", output: "f14")
+                _ = try await operation.rules.addSimpleRemap(input: "f15", output: "f16")
+                _ = try await operation.collections.createCollection(name: "Command test", category: "custom", summary: nil)
+                let result = try await operation.config.applyConfiguration(dryRun: true)
+                XCTAssertEqual(result.customRulesCount, 2)
+                let collections = await operation.collections.loadRuleCollections()
+                XCTAssertTrue(collections.contains { $0.name == "Command test" })
+            }
+            let stored = await CustomRulesStore(fileURL: directory.appendingPathComponent("CustomRules.json")).loadRules()
+            XCTAssertEqual(Set(stored.map(\.input)), ["f13", "f15"])
+        }
+    }
+
+    func testEscapedCommandCannotWriteOrApplyAfterOwnershipEnds() async throws {
+        try await withDirectory { directory in
+            let escaped = try await CLIConfigurationOperation.run(configDirectory: directory.path) { $0 }
+            do {
+                _ = try await escaped.rules.addSimpleRemap(input: "f13", output: "f14")
+                XCTFail("Expired command wrote rules")
+            } catch ConfigurationOperationGate.Failure.invalidPermit {}
+            do {
+                _ = try await escaped.collections.createLayer(name: "expired")
+                XCTFail("Expired command wrote collections")
+            } catch ConfigurationOperationGate.Failure.invalidPermit {}
+            do {
+                _ = try await escaped.config.applyConfiguration(dryRun: true)
+                XCTFail("Expired command applied")
+            } catch ConfigurationOperationGate.Failure.invalidPermit {}
+            XCTAssertFalse(FileManager.default.fileExists(atPath: directory.appendingPathComponent("CustomRules.json").path))
+        }
+    }
+
+    func testIndependentRuleWriterWaitsForWholeCommandAndPreservesBothEdits() async throws {
+        try await withDirectory { directory in
+            let entered = self.expectation(description: "command holds ownership")
+            let prematureWrite = self.expectation(description: "independent write waits")
+            prematureWrite.isInverted = true
+            let phase = Phase()
+            var resume: CheckedContinuation<Void, Never>?
+            let command = Task { @MainActor in
+                try await CLIConfigurationOperation.run(configDirectory: directory.path) { @MainActor operation in
+                    _ = try await operation.rules.addSimpleRemap(input: "f13", output: "f14")
+                    await withCheckedContinuation { continuation in
+                        resume = continuation
+                        entered.fulfill()
+                    }
+                    _ = try await operation.rules.addSimpleRemap(input: "f15", output: "f16")
+                }
+            }
+            await self.fulfillment(of: [entered], timeout: 5)
+            let store = CustomRulesStore(fileURL: directory.appendingPathComponent("CustomRules.json"))
+            let second = Task { @MainActor in
+                _ = try await RulesFacade(store: store).addSimpleRemap(input: "f17", output: "f18")
+                if phase.waiting { prematureWrite.fulfill() }
+            }
+            await self.fulfillment(of: [prematureWrite], timeout: 0.15)
+            phase.waiting = false
+            resume?.resume()
+            try await command.value
+            try await second.value
+            let rules = await store.loadRules()
+            XCTAssertEqual(Set(rules.map(\.input)), ["f13", "f15", "f17"])
+        }
+    }
+
+    func testIndependentCollectionMutationsDoNotLoseConcurrentCreates() async throws {
+        try await withDirectory { directory in
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                for index in 0 ..< 12 {
+                    group.addTask {
+                        let store = RuleCollectionStore(fileURL: directory.appendingPathComponent("RuleCollections.json"))
+                        _ = try await CollectionsFacade(store: store).createCollection(
+                            name: "Concurrent \(index)", category: "custom", summary: nil
+                        )
+                    }
+                }
+                try await group.waitForAll()
+            }
+            let store = RuleCollectionStore(fileURL: directory.appendingPathComponent("RuleCollections.json"))
+            let collections = await store.loadCollections()
+            XCTAssertEqual(Set(collections.map(\.name)).intersection(Set((0 ..< 12).map { "Concurrent \($0)" })).count, 12)
+        }
+    }
+
+    func testUnreadableMetadataStopsPackCommandsBeforeSourceMutation() async throws {
+        try await withDirectory { directory in
+            let metadata = directory.appendingPathComponent("installed-packs.json")
+            let malformed = Data("invalid metadata".utf8)
+            try malformed.write(to: metadata)
+            try await CLIConfigurationOperation.run(configDirectory: directory.path) { operation in
+                do {
+                    _ = try await operation.packs.installPack(nameOrId: "chord-groups")
+                    XCTFail("Unreadable metadata must stop installation")
+                } catch is DecodingError {}
+            }
+            XCTAssertFalse(FileManager.default.fileExists(atPath: directory.appendingPathComponent("CustomRules.json").path))
+            XCTAssertFalse(FileManager.default.fileExists(atPath: directory.appendingPathComponent("RuleCollections.json").path))
+            XCTAssertEqual(try Data(contentsOf: metadata), malformed)
+        }
+    }
+
+    private final class Phase { var waiting = true }
+
+    private func withDirectory(_ body: (URL) async throws -> Void) async throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent("cli-operation-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer {
+            try? FileManager.default.removeItem(at: directory)
+            try? FileManager.default.removeItem(at: ConfigurationOperationGate.lockFileURL(for: directory))
+        }
+        try await body(directory)
+    }
+}

--- a/Tests/KeyPathTests/CLI/CLIPackCRUDTests.swift
+++ b/Tests/KeyPathTests/CLI/CLIPackCRUDTests.swift
@@ -1,5 +1,6 @@
 @testable import KeyPathAppKit
 import KeyPathCore
+import KeyPathRulesCore
 @preconcurrency import XCTest
 
 @MainActor
@@ -33,16 +34,11 @@ final class CLIPackCRUDTests: XCTestCase {
             fileURL: dir.appendingPathComponent("CustomRules.json")
         )
         facade = PacksFacade(managerFactory: {
-            let manager = RuleCollectionsManager(
+            RuleCollectionsManager(
                 ruleCollectionStore: collectionStore,
                 customRulesStore: customStore,
                 configurationService: ConfigurationService(configDirectory: dir.path)
             )
-            manager.ruleCollections = await RuleCollectionDeduplicator.dedupe(
-                collectionStore.loadCollections()
-            )
-            manager.customRules = await customStore.loadRules()
-            return manager
         })
 
         originalInstalledPacks = await InstalledPackTracker.shared.allInstalled()
@@ -65,6 +61,68 @@ final class CLIPackCRUDTests: XCTestCase {
         }
         TestEnvironment.forceTestMode = false
         try await super.tearDown()
+    }
+
+    func testInstallHydratesSourcesAfterThePreviousWriterCommits() async throws {
+        try await ensureUninstalled(testPackID)
+        let directory = try XCTUnwrap(tempDir)
+        let facade = try XCTUnwrap(facade)
+        let gate = ConfigurationOperationGate(configurationDirectory: directory)
+        let store = CustomRulesStore(fileURL: directory.appendingPathComponent("CustomRules.json"))
+        let entered = expectation(description: "previous writer admitted")
+        let earlyInstall = expectation(description: "install waits")
+        earlyInstall.isInverted = true
+        let phase = AdmissionPhase()
+        var resume: CheckedContinuation<Void, Never>?
+        let first = Task { @MainActor in
+            try await gate.withOperation { @MainActor _ in
+                await withCheckedContinuation { continuation in
+                    resume = continuation
+                    entered.fulfill()
+                }
+                try await store.saveRules([CustomRule(input: "f13", action: .keystroke(key: "f14"))])
+            }
+        }
+        await fulfillment(of: [entered], timeout: 5)
+        let install = Task { @MainActor in
+            let result = try await facade.installPack(nameOrId: testPackSlug)
+            if phase.waiting { earlyInstall.fulfill() }
+            return result
+        }
+        await fulfillment(of: [earlyInstall], timeout: 0.15)
+        phase.waiting = false
+        resume?.resume()
+        try await first.value
+        let result = try await install.value
+        XCTAssertEqual(result.action, "installed")
+        let rules = await store.loadRules()
+        XCTAssertEqual(rules.first(where: { $0.input == "f13" })?.action.outputString, "f14",
+                       "Pack install must preserve the source committed while it waited")
+    }
+
+    func testCallbackCannotReenterAnyPackCommand() async throws {
+        let directory = try XCTUnwrap(tempDir)
+        let facade = try XCTUnwrap(facade)
+        let gate = ConfigurationOperationGate(configurationDirectory: directory)
+        let operations: [@MainActor @Sendable () async throws -> CLIPackInstallResult] = [
+            { try await facade.installPack(nameOrId: "chord-groups", dryRun: true) },
+            { try await facade.uninstallPack(nameOrId: "chord-groups", dryRun: true) },
+            { try await facade.configurePack(nameOrId: "home-row-mods", settingValues: ["holdTimeout": 200], dryRun: true) }
+        ]
+        try await gate.withOperation { @MainActor _ in
+            for operation in operations {
+                do {
+                    _ = try await operation()
+                    XCTFail("Pack commands must reject callback reentry before reading or staging state")
+                } catch ConfigurationOperationGate.Failure.recursiveOperation {
+                    // Expected before early exits as well as actual mutations.
+                }
+            }
+        }
+    }
+
+    private final class AdmissionPhase {
+        var waiting = true
     }
 
     private func ensureUninstalled(_ packID: String) async throws {

--- a/Tests/KeyPathTests/GenericPackConfigTests.swift
+++ b/Tests/KeyPathTests/GenericPackConfigTests.swift
@@ -529,19 +529,16 @@ final class GenericPackConfigTests: XCTestCase {
         defer { try? FileManager.default.removeItem(at: tempDir) }
 
         let trackerURL = tempDir.appendingPathComponent("visual-installed-packs.json")
-        let failingTracker = InstalledPackTracker(fileURL: trackerURL)
         let previousRecord = InstalledPackRecord(
             packID: PackRegistry.keystrokeHistory.id,
             version: "0.9.0",
             installedAt: Date(timeIntervalSince1970: 21),
             quickSettingValues: [:]
         )
-        try await failingTracker.upsert(previousRecord)
-        try FileManager.default.removeItem(at: trackerURL)
-        try FileManager.default.createDirectory(
-            at: trackerURL,
-            withIntermediateDirectories: true
-        )
+        try await InstalledPackTracker(fileURL: trackerURL).upsert(previousRecord)
+        let failingTracker = InstalledPackTracker(fileURL: trackerURL) { _, _ in
+            throw CocoaError(.fileWriteNoPermission)
+        }
 
         do {
             _ = try await PackInstaller.shared.install(
@@ -613,19 +610,16 @@ final class GenericPackConfigTests: XCTestCase {
         )
 
         let trackerURL = tempDir.appendingPathComponent("plain-installed-packs.json")
-        let failingTracker = InstalledPackTracker(fileURL: trackerURL)
         let previousRecord = InstalledPackRecord(
             packID: pack.id,
             version: "0.9.0",
             installedAt: Date(timeIntervalSince1970: 42),
             quickSettingValues: [:]
         )
-        try await failingTracker.upsert(previousRecord)
-        try FileManager.default.removeItem(at: trackerURL)
-        try FileManager.default.createDirectory(
-            at: trackerURL,
-            withIntermediateDirectories: true
-        )
+        try await InstalledPackTracker(fileURL: trackerURL).upsert(previousRecord)
+        let failingTracker = InstalledPackTracker(fileURL: trackerURL) { _, _ in
+            throw CocoaError(.fileWriteNoPermission)
+        }
 
         do {
             _ = try await PackInstaller.shared.install(
@@ -682,12 +676,10 @@ final class GenericPackConfigTests: XCTestCase {
         var regenerationCount = 0
         manager.onBeforeSave = { regenerationCount += 1 }
 
-        let unwritableTrackerURL = tempDir.appendingPathComponent("installed-packs-is-a-directory")
-        try FileManager.default.createDirectory(
-            at: unwritableTrackerURL,
-            withIntermediateDirectories: true
-        )
-        let failingTracker = InstalledPackTracker(fileURL: unwritableTrackerURL)
+        let trackerURL = tempDir.appendingPathComponent("installed-packs.json")
+        let failingTracker = InstalledPackTracker(fileURL: trackerURL) { _, _ in
+            throw CocoaError(.fileWriteNoPermission)
+        }
 
         var configuration = capsLock.configuration
         configuration.updateSelectedTapOutput("esc")
@@ -768,19 +760,16 @@ final class GenericPackConfigTests: XCTestCase {
         try PackCollectionSnapshot.save(previousSnapshot)
 
         let trackerURL = tempDir.appendingPathComponent("system-installed-packs.json")
-        let failingTracker = InstalledPackTracker(fileURL: trackerURL)
         let previousRecord = InstalledPackRecord(
             packID: PackRegistry.launcher.id,
             version: "0.9.0",
             installedAt: Date(timeIntervalSince1970: 42),
             quickSettingValues: [:]
         )
-        try await failingTracker.upsert(previousRecord)
-        try FileManager.default.removeItem(at: trackerURL)
-        try FileManager.default.createDirectory(
-            at: trackerURL,
-            withIntermediateDirectories: true
-        )
+        try await InstalledPackTracker(fileURL: trackerURL).upsert(previousRecord)
+        let failingTracker = InstalledPackTracker(fileURL: trackerURL) { _, _ in
+            throw CocoaError(.fileWriteNoPermission)
+        }
 
         do {
             _ = try await PackInstaller.shared.install(

--- a/Tests/KeyPathTests/InstalledPackTrackerTests.swift
+++ b/Tests/KeyPathTests/InstalledPackTrackerTests.swift
@@ -21,6 +21,38 @@ final class InstalledPackTrackerTests: XCTestCase {
         return InstalledPackTracker(fileURL: fileURL)
     }
 
+    func testExistingTrackerObservesAnotherInstancesEditsAndDeletion() async throws {
+        let first = makeTracker()
+        let second = makeTracker()
+        let initiallyEmpty = await first.allInstalled()
+        XCTAssertTrue(initiallyEmpty.isEmpty)
+        try await second.upsert(InstalledPackRecord(packID: "external", version: "1"))
+        let external = await first.record(for: "external")
+        XCTAssertEqual(external?.version, "1")
+        try await first.upsert(InstalledPackRecord(packID: "local", version: "1"))
+        let combined = await second.allInstalled()
+        XCTAssertEqual(Set(combined.map(\.packID)), ["external", "local"])
+        try FileManager.default.removeItem(at: tempDir.appendingPathComponent("installed-packs.json"))
+        let afterDeletion = await first.allInstalled()
+        XCTAssertTrue(afterDeletion.isEmpty)
+    }
+
+    func testMutationDoesNotOverwriteMalformedMetadata() async throws {
+        let file = tempDir.appendingPathComponent("installed-packs.json")
+        let original = Data("not valid JSON".utf8)
+        try original.write(to: file)
+        let tracker = makeTracker()
+        do {
+            try await tracker.upsert(InstalledPackRecord(packID: "new", version: "1"))
+            XCTFail("Must preserve unreadable metadata")
+        } catch is DecodingError {}
+        do {
+            try await tracker.remove(packID: "old")
+            XCTFail("Must preserve unreadable metadata")
+        } catch is DecodingError {}
+        XCTAssertEqual(try Data(contentsOf: file), original)
+    }
+
     // MARK: - Empty state
 
     func testEmptyTracker_AllInstalledReturnsEmpty() async {

--- a/docs/architecture/configuration-save-pipeline.md
+++ b/docs/architecture/configuration-save-pipeline.md
@@ -144,9 +144,9 @@ on release, allowing a child that outlives its operation to write later.
 
 This is cooperation between migrated writers running as the same macOS user,
 not protection against external editors or custom-directory writes from another
-UID. Privileged helper callers do not use this gate. It also does not refresh cached source/pack state or hold admission over
-CLI work performed outside service calls. Those remaining ownership/freshness
-changes are necessary before claiming whole-operation cross-process safety.
+UID. Privileged helper callers do not use this gate. The gate alone does not
+refresh cached app source state or coordinate unmigrated feature writers. Those
+remaining changes are necessary before claiming whole-operation safety.
 
 ## CLI configuration ownership
 
@@ -163,7 +163,47 @@ the CLI command syntax and output are unchanged. A callback attempting another
 apply, backup or restore is rejected before copying or staging preferences.
 
 This does not yet change reload-result semantics, make directory restore atomic,
-or include preference restoration in rejected-apply recovery. CLI pack/collection
-commands and feature-specific writers remain separate migration work. Backups
-remain copies of current disk state; this scope does not recover pending journals
+or include preference restoration in rejected-apply recovery. Feature-specific
+writers remain separate migration work. Backups remain copies of current disk state; this scope does not recover pending journals
 or refresh the app's cached state following a CLI restore.
+
+## CLI pack ownership
+
+`PacksFacade` admits install, uninstall and configure before inspecting installed
+state. A facade manager factory constructs its dependencies only. Immediately
+before an actual mutation, the admitted command reads the manager's collection
+and custom-rule stores and hydrates the manager; dry-run and no-op paths skip
+that source hydration. Nested installer calls receive the existing permit.
+
+This closes the pre-admission source snapshot window for CLI pack mutations.
+Some gallery/summary paths still write metadata directly. Writer consolidation
+and whole-operation recovery remain necessary; the operation lease alone does
+not solve those gaps.
+
+### CLI command scope
+
+`CLIConfigurationOperation.run` adapts the existing service gate to the CLI module.
+Its scoped rule, collection, pack, and config facades carry an explicit active permit.
+Commands compose source edits and optional `--apply` sequentially inside that scope;
+batch ensure holds ownership across all its items. Scoped mutation after return is
+rejected as an expired permit. A fresh facade in a callback still cannot reenter.
+The scope is for sequential command composition, not concurrent child mutations.
+
+Standalone rule and collection mutations also acquire directory admission before
+loading their source stores. Read-modify-write operations therefore see the last
+cooperating writer's committed data. Scoped stores and pack metadata resolve from
+the command's configuration directory. Default standalone stores preserve their
+existing test isolation. This is ownership, not rollback: failed apply retains the
+existing persistence behavior until the whole-operation recovery work is complete.
+
+Installed-pack queries refresh from the current file; only an unreadable file
+falls back to the last successfully read/persisted snapshot. A missing file clears
+that fallback. Mutations read strictly and persist before notification; malformed metadata
+is preserved with an error. Pack operations hold directory ownership around those
+reads and writes. Direct UI metadata writers still need consolidation under the
+same operation boundary; the tracker actor alone is not a cross-process lock.
+
+Pack install/uninstall/configure and CLI collection ownership decisions perform a
+strict metadata read under admission before staging source edits. Display-only
+fallback state is never sufficient to authorize these mutations. Each CLI command
+retains one tracker instance for its scope.

--- a/docs/planning/catalog-led-consolidation-plan.md
+++ b/docs/planning/catalog-led-consolidation-plan.md
@@ -264,6 +264,7 @@ Implemented slices (the table describes the merged state of this checkpoint):
 | #1269 | Standalone regeneration, conflict retries, prerequisite application and snapshot restoration share admission with explicit nested permits. | Cross-instance/process ownership and whole-operation recovery remain. |
 | #1270 | Direct service writes, journal recovery, trusted restoration and missing-file self-healing share admission. | CLI ownership, feature-specific writers, source/cache freshness and complete recovery remain. |
 | #1271 | Per-user directory leases exclude cooperating services/processes, with cancellation, alias reentry protection and off-actor sentinel I/O. | CLI operation scope, cached state, external editors and cross-UID writers remain distinct boundaries. |
+| #1272 | CLI apply admits before source loading through reload; backup/restore share admission; custom-directory source loading is corrected. | CLI collection/pack commands, cached state and complete recovery remain. |
 
 Admission now also holds a cooperative OS lease across service instances and
 processes for the same directory. CLI configuration apply now holds admission
@@ -275,7 +276,10 @@ This is a useful foundation, not completion of Phase 1 or the program.
 
 Next implementation sequence:
 
-1. Complete feature-specific writers and CLI operation ownership, loading/reconciling current source and metadata state after admission;
+1. Complete feature-specific writers and direct UI installed-pack metadata
+   writer consolidation. CLI rule/collection commands now hold ownership through
+   optional apply, and pack metadata reads refresh from disk. CLI pack commands hydrate
+   source rules after admission and forward their permit into the installer;
    preserve explicit ownership through trusted nested calls, and reject recursive
    callback writes rather than allowing stale rollback or deadlock.
 2. Keep the prior source revision through runtime classification and restore

--- a/docs/planning/consolidation-baseline.md
+++ b/docs/planning/consolidation-baseline.md
@@ -49,6 +49,22 @@ Source anchors: `Managers/RuntimeCoordinator.swift` callback and
 `Services/Packs/PackInstaller.swift`; `CLI/ConfigFacade.swift`;
 `Services/Configuration/ConfigHotReloadService.swift`.
 
+## Additional writer inventory — September 5
+
+The original matrix above records the starting behavior. The execution plan's
+checkpoint records merged changes; these additional paths remain migration work:
+
+| Entry | Current owner / behavior | Remaining boundary |
+| --- | --- | --- |
+| Catalog detail state refresh | `UI/Gallery/PackDetailView+LiveState.swift` backfills InstalledPackTracker directly when an associated collection is enabled; the write error is discarded. | A read-like UI refresh mutates metadata outside installer admission and can mark installed after a failed write. |
+| Rules visual-only toggles | `UI/Rules/RulesSummaryView+Packs.swift` directly upserts/removes KindaVim and keystroke-history metadata; history recording effects are handled in the view. | Move operation ownership while preserving current dependency checks and recording behavior; do not silently substitute different catalog install policy. |
+| App-specific rule deletion | The same summary extension changes AppKeymapStore, regenerates the include file, reloads app mappings and restarts the runtime. | Source/include/reload recovery is separate from the main rule journal. |
+| App-specific include generation | `Services/Configuration/AppConfigGenerator.swift` validates through ConfigurationService, then writes the include file itself. | Validation alone does not acquire write admission. |
+| Simple modifications | `Services/SimpleMods/SimpleModsService.swift` has its own write/reload/restoration path and uses ConfigurationService for validation. | Migrate operation ownership and recovery explicitly. |
+
+InstalledPackTracker's one-time cache also requires freshness handling before
+pack decisions and writes; a directory lease does not refresh cached records.
+
 ## First bounded implementation
 
 Preserve the existing reload outcome at the `SaveCoordinator` result boundary


### PR DESCRIPTION
CLI source edits could load an old revision before another writer finished, and commands with `--apply` released ownership between editing rules and generating/reloading configuration. Pack metadata also retained a process-lifetime cache, hiding changes made by another process.

This change holds the existing configuration operation gate across CLI rule, collection, and pack commands through optional apply, including batch ensure. Standalone rule/collection mutations acquire admission before loading; pack managers hydrate after admission and forward an explicit permit to installer operations. Scoped facades reject mutation after their command ends. Pack queries read current disk state, and metadata mutations fail without overwriting malformed data or publishing speculative cached state. Nonthrowing queries retain the last known committed snapshot only while the file is unreadable; readable replacement or deletion supersedes it.

Validation:
- Stable Xcode app and CLI build passed.
- 108 focused tests passed, covering command composition, waiting writers, concurrent creates, expired permits, pack hydration, metadata freshness, and malformed-data preservation.
- Full local gate reported 5,151 passes and only the four independently reproduced baseline macOS 27 snapshot differences: EasyViewSnapshotTests home-row timing (FastTyping, PerFinger, Slider) and HardViewSnapshotTests RepairSettingsTabView. No compiler warnings. Supported CI remains required.
- 90 recovery-focused tests passed after preserving the unreadable-file fallback. A final visibility-only API wrapper keeps alternate-directory command scopes internal to tests; focused command tests/build validate that final wrapper.
- Accessibility and diff checks passed.
- `remote review gate selected`; GitHub `claude-review` must pass before merge.

Scope: sequential command composition and cooperating same-user writers. Direct UI metadata writers, cached app rule state, full rollback across sources/preferences/metadata, and watcher reconciliation remain tracked in the consolidation plan. Existing reload-result semantics are retained; there are no significant UI changes.

Review follow-up: pack operations and CLI ownership checks now perform strict
metadata reads before staging source edits. Display-only fallback cannot authorize
a mutation. The operation retains one tracker instance. All 98 affected tests pass,
including unreadable metadata rejection before any rule file is created and late
metadata write failures with rollback. The final full local gate reported 5,152 passes and only the same four baseline snapshot differences, with no compiler warnings.

Review decisions:
- Dry-run pack commands intentionally wait for admission and reject unreadable metadata: the preview must describe a completed, trustworthy revision, and recursive callbacks must not bypass ownership by using dry-run. They still skip source hydration and writes.
- Tracker call sites were checked: KindaVimPackController and KeystrokeHistoryService read at startup/installed-pack notifications; overlay and rules views refresh on appearance or changes. Per-key ingestion uses cached view/service flags, not tracker disk reads. No polling or per-keystroke tracker read was found.
- Nonthrowing display queries retain the established last-readable fallback and log read errors. Strict checks now guard the migrated mutating decisions. Broader UI status/error presentation and remaining direct UI writers remain separately tracked rather than silently changing their contract here.
- The automated review's diff was truncated. The command/helper changes were also inspected locally: all ten optional-apply command paths pass their scoped config facade, including both batch and single-rule ensure paths; no fresh facade is created between source editing and apply.
