### PR TITLE
Give the review action enough turns to finish

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -125,8 +125,10 @@ jobs:
 
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
+          # Leave room to post the assessment and finish the result turn. A
+          # six-turn limit repeatedly aborted completed reviews with error_max_turns.
           claude_args: >-
-            --max-turns 6
+            --max-turns 12
             --allowed-tools "Bash(gh pr comment:*)"
 
       - name: Skip Claude review for workflow-file changes


### PR DESCRIPTION
The review action repeatedly reaches `error_max_turns` at six turns, including after it has already posted a completed assessment. PR #1275 hit this on both attempts of run 33995264216. Increase the allowance to twelve so the reviewer can post and finish.

Only the execution budget changes. No reviewer tools, findings policy, merge requirement, or skip conditions change. This is isolated from #1275 because this workflow intentionally skips its own edits; after merge, #1275 will be rebased and must pass a real review under the repaired workflow.

Validation: inspected both failed job logs, checked the one-setting diff and `git diff --check`. Remote review gate selected; the existing workflow-file self-skip is expected for this workflow-only PR. No Swift source changed; no local application build is required.
