### PR TITLE
Consolidate pack metadata writes and recover deferred state repair

### DIFF
--- a/Sources/KeyPathAppKit/Services/Monitoring/KeystrokeHistoryService.swift
+++ b/Sources/KeyPathAppKit/Services/Monitoring/KeystrokeHistoryService.swift
@@ -398,6 +398,12 @@ final class KeystrokeHistoryService {
 
     // MARK: - Public API
 
+    /// Apply the committed activation/deactivation of the app's pack.
+    func applyPackState(_ installed: Bool) {
+        isRecording = installed
+        if !installed { clearEvents() }
+    }
+
     func clearEvents() {
         rawEvents.removeAll()
         pendingEvents.removeAll()

--- a/Sources/KeyPathAppKit/Services/Packs/PackInstaller.swift
+++ b/Sources/KeyPathAppKit/Services/Packs/PackInstaller.swift
@@ -59,6 +59,68 @@ public final class PackInstaller {
 
     // MARK: - Public API
 
+    /// Change only a visual capability's installed record. Legacy Rules toggles
+    /// use this narrower operation; catalog installation still enforces its
+    /// dependency/conflict gates before entering here. Nonvisual packs must use install/uninstall.
+    @discardableResult
+    func setVisualPackEnabled(
+        _ pack: Pack, enabled: Bool, quickSettingValues: [String: Int]? = nil,
+        manager: RuleCollectionsManager, installedPackTracker: InstalledPackTracker = .shared,
+        mutationPermit: ConfigurationOperationGate.Permit? = nil
+    ) async throws -> InstalledPackRecord? {
+        try await manager.configurationService.operationGate.withOperation(using: mutationPermit) { @MainActor [self] _ in
+            guard pack.visualOnly else { throw InstallError.saveFailed("This operation requires a visual-only pack") }
+            try await installedPackTracker.validateForMutation()
+            let previous = await installedPackTracker.record(for: pack.id)
+            let record: InstalledPackRecord?
+            if enabled {
+                let next = InstalledPackRecord(packID: pack.id, version: pack.version, installedAt: Date(),
+                                               quickSettingValues: quickSettingValues ?? previous?.quickSettingValues ?? [:])
+                do { try await installedPackTracker.upsert(next) }
+                catch {
+                    guard await restoreInstallRecord(previous, packID: pack.id, installedPackTracker: installedPackTracker) else {
+                        throw InstallError.saveFailed("visual-only installed-pack record could not be saved and the previous state could not be fully restored")
+                    }
+                    throw error
+                }
+                record = next
+            } else {
+                try await installedPackTracker.remove(packID: pack.id)
+                record = nil
+            }
+            // Settle the capability only after its record commits, before releasing admission.
+            if installedPackTracker === InstalledPackTracker.shared, pack.id == PackRegistry.keystrokeHistory.id {
+                KeystrokeHistoryService.shared.applyPackState(enabled)
+            }
+            return record
+        }
+    }
+
+    /// Repair the existing enabled-collection/missing-record case using persisted
+    /// sources under admission. Never turn a failed write into an installed result.
+    func reconcileInstallRecord(
+        for pack: Pack, manager: RuleCollectionsManager,
+        installedPackTracker: InstalledPackTracker = .shared
+    ) async throws -> InstalledPackRecord? {
+        try await manager.configurationService.operationGate.withOperation { @MainActor permit in
+            try await installedPackTracker.validateForMutation()
+            if let existing = await installedPackTracker.record(for: pack.id) { return existing }
+            guard let collectionID = pack.associatedCollectionID else { return nil }
+            try await manager.configurationService.recoverPendingRuleWrite(
+                collectionStore: manager.ruleCollectionStore, customStore: manager.customRulesStore,
+                mutationPermit: permit
+            )
+            let loaded = await manager.ruleCollectionStore.loadCollectionsDetailed()
+            guard !loaded.wasFullReset, loaded.failedCollectionNames.isEmpty else {
+                throw InstallError.saveFailed("Rule collections could not be read completely")
+            }
+            guard loaded.collections.contains(where: { $0.id == collectionID && $0.isEnabled }) else { return nil }
+            let record = InstalledPackRecord(packID: pack.id, version: pack.version, installedAt: Date(), quickSettingValues: [:])
+            try await installedPackTracker.upsert(record)
+            return record
+        }
+    }
+
     /// Install a pack. Expands its binding templates into `CustomRule`s
     /// tagged with the pack's id, adds them to the user's rules, and
     /// regenerates the kanata config (which hot-reloads kanata).
@@ -113,34 +175,10 @@ public final class PackInstaller {
             // so other parts of the app (overlay, mode monitor) can react to
             // "this pack is active". No collection toggle, no reload.
             if pack.visualOnly {
-                let previousInstallRecord = await installedPackTracker.record(for: pack.id)
-                let record = InstalledPackRecord(
-                    packID: pack.id,
-                    version: pack.version,
-                    installedAt: Date(),
-                    quickSettingValues: resolvedSettings
-                )
-                do {
-                    try await installedPackTracker.upsert(record)
-                } catch {
-                    AppLogger.shared.errorUnlessQuietTest(
-                        "❌ [PackInstaller] Could not persist visual-only install record for '\(pack.name)'; restoring previous state"
-                    )
-                    let installRecordRestored = await restoreInstallRecord(
-                        previousInstallRecord,
-                        packID: pack.id,
-                        installedPackTracker: installedPackTracker
-                    )
-                    guard installRecordRestored else {
-                        throw InstallError.saveFailed(
-                            "visual-only installed-pack record could not be saved and the previous state could not be fully restored"
-                        )
-                    }
-                    throw error
-                }
-                AppLogger.shared.log(
-                    "✅ [PackInstaller] Installed visual-only pack '\(pack.name)' (no kanata side effects)"
-                )
+                guard let record = try await setVisualPackEnabled(pack, enabled: true, quickSettingValues: resolvedSettings,
+                                                                  manager: manager, installedPackTracker: installedPackTracker,
+                                                                  mutationPermit: permit)
+                else { throw InstallError.saveFailed("Visual pack activation returned no installed record") }
                 return record
             }
 
@@ -354,10 +392,8 @@ public final class PackInstaller {
             // Visual-only packs just clear the tracker record; no kanata
             // changes to revert.
             if let pack = PackRegistry.pack(id: packID), pack.visualOnly {
-                try await installedPackTracker.remove(packID: packID)
-                AppLogger.shared.log(
-                    "✅ [PackInstaller] Uninstalled visual-only pack '\(packID)'"
-                )
+                try await setVisualPackEnabled(pack, enabled: false, manager: manager,
+                                               installedPackTracker: installedPackTracker, mutationPermit: permit)
                 return
             }
 

--- a/Sources/KeyPathAppKit/UI/Gallery/PackDetailView+Helpers.swift
+++ b/Sources/KeyPathAppKit/UI/Gallery/PackDetailView+Helpers.swift
@@ -5,11 +5,16 @@ import SwiftUI
 extension PackDetailView {
     func debouncedRefresh() {
         refreshTask?.cancel()
-        refreshTask = Task {
-            try? await Task.sleep(nanoseconds: 100_000_000)
-            guard !Task.isCancelled else { return }
-            await refreshInstallState()
-        }
+        // Notifications may arrive inside an active save. Do not inherit its
+        // operation lease: this refresh must queue after the owner finishes.
+        refreshTask = Task.detached { await runDeferredRefresh() }
+    }
+
+    @MainActor
+    private func runDeferredRefresh() async {
+        try? await Task.sleep(nanoseconds: 100_000_000)
+        guard !Task.isCancelled else { return }
+        await refreshInstallState()
     }
 
     func displayLabel(for kanataKey: String) -> String {

--- a/Sources/KeyPathAppKit/UI/Gallery/PackDetailView+LiveState.swift
+++ b/Sources/KeyPathAppKit/UI/Gallery/PackDetailView+LiveState.swift
@@ -5,24 +5,20 @@ import SwiftUI
 
 extension PackDetailView {
     func refreshInstallState() async {
-        var installed = await PackInstaller.shared.isInstalled(packID: pack.id)
-        let saved = await PackInstaller.shared.quickSettings(for: pack.id)
-
-        // Resilience: if collection is enabled but tracker has no record, backfill
-        if !installed, let collectionID = pack.associatedCollectionID {
-            let collections = kanataManager.underlyingManager
-                .ruleCollectionsManager.ruleCollections
-            if let match = collections.first(where: { $0.id == collectionID }), match.isEnabled {
-                let record = InstalledPackRecord(
-                    packID: pack.id,
-                    version: pack.version,
-                    installedAt: Date(),
-                    quickSettingValues: [:]
-                )
-                try? await InstalledPackTracker.shared.upsert(record)
-                installed = true
-            }
+        let record: InstalledPackRecord?
+        do {
+            record = try await PackInstaller.shared.reconcileInstallRecord(
+                for: pack, manager: kanataManager.underlyingManager.ruleCollectionsManager
+            )
+        } catch is CancellationError {
+            return
+        } catch {
+            guard !Task.isCancelled else { return }
+            errorMessage = "Could not refresh pack state: \(error.localizedDescription)"
+            return
         }
+        var installed = record != nil
+        let saved = record?.quickSettingValues ?? [:]
 
         // Check if this pack's collection is managed by a different installed
         // pack (e.g. Home Row Mods managed by Vallack). If so, lock the
@@ -45,6 +41,7 @@ extension PackDetailView {
         let liveSingleKey = await liveSingleKeySelection()
         let liveHomeRow = await liveHomeRowModsConfig()
         await MainActor.run {
+            guard !Task.isCancelled else { return }
             isInstalled = installed
             managingPackName = managedBy?.packName
             managingPackID = managedBy?.packID

--- a/Sources/KeyPathAppKit/UI/Gallery/PackDetailView+PackActions.swift
+++ b/Sources/KeyPathAppKit/UI/Gallery/PackDetailView+PackActions.swift
@@ -28,9 +28,6 @@ extension PackDetailView {
                 skipFinalReload: skipFinalReload
             )
             kanataManager.underlyingManager.notifyStateChanged()
-            if pack.id == PackRegistry.keystrokeHistory.id {
-                KeystrokeHistoryService.shared.isRecording = true
-            }
             lastUndoSnapshot = .init(quickSettingValues: quickSettingValues)
             await refreshInstallState()
             withAnimation(.spring(response: 0.4, dampingFraction: 0.85)) {
@@ -66,10 +63,6 @@ extension PackDetailView {
             let manager = kanataManager.underlyingManager.ruleCollectionsManager
             try await PackInstaller.shared.uninstall(packID: pack.id, manager: manager)
             kanataManager.underlyingManager.notifyStateChanged()
-            if pack.id == PackRegistry.keystrokeHistory.id {
-                KeystrokeHistoryService.shared.isRecording = false
-                KeystrokeHistoryService.shared.clearEvents()
-            }
             await refreshInstallState()
             withAnimation(.spring(response: 0.4, dampingFraction: 0.85)) {
                 justUninstalled = true

--- a/Sources/KeyPathAppKit/UI/Gallery/PackDetailView.swift
+++ b/Sources/KeyPathAppKit/UI/Gallery/PackDetailView.swift
@@ -109,6 +109,10 @@ struct PackDetailView: View {
             await refreshInstallState()
             loadDefaultQuickSettings()
         }
+        .onDisappear {
+            refreshTask?.cancel()
+            refreshTask = nil
+        }
         .onReceive(NotificationCenter.default.publisher(for: .installedPacksChanged)) { _ in
             debouncedRefresh()
         }

--- a/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView+Packs.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView+Packs.swift
@@ -21,20 +21,15 @@ extension RulesTabView {
                 isPackEnabled: isKindaVimInstalled,
                 onToggle: { newValue in
                     isKindaVimInstalled = newValue
+                    let requestID = UUID()
+                    kindaVimMutationID = requestID
                     Task {
                         do {
-                            if newValue {
-                                let record = InstalledPackRecord(
-                                    packID: pack.id,
-                                    version: pack.version,
-                                    installedAt: Date(),
-                                    quickSettingValues: [:]
-                                )
-                                try await InstalledPackTracker.shared.upsert(record)
-                            } else {
-                                try await InstalledPackTracker.shared.remove(packID: pack.id)
-                            }
+                            try await PackInstaller.shared.setVisualPackEnabled(
+                                pack, enabled: newValue, manager: kanataManager.underlyingManager.ruleCollectionsManager
+                            )
                         } catch {
+                            guard kindaVimMutationID == requestID else { return }
                             AppLogger.shared.log("⚠️ [Rules] KindaVim toggle failed: \(error.localizedDescription)")
                             isKindaVimInstalled = !newValue
                             settingsToastManager.showError("Failed to \(newValue ? "enable" : "disable") KindaVim")
@@ -59,23 +54,15 @@ extension RulesTabView {
                 isPackEnabled: isKeystrokeHistoryInstalled,
                 onToggle: { newValue in
                     isKeystrokeHistoryInstalled = newValue
+                    let requestID = UUID()
+                    keystrokeHistoryMutationID = requestID
                     Task {
                         do {
-                            if newValue {
-                                let record = InstalledPackRecord(
-                                    packID: pack.id,
-                                    version: pack.version,
-                                    installedAt: Date(),
-                                    quickSettingValues: [:]
-                                )
-                                try await InstalledPackTracker.shared.upsert(record)
-                                KeystrokeHistoryService.shared.isRecording = true
-                            } else {
-                                try await InstalledPackTracker.shared.remove(packID: pack.id)
-                                KeystrokeHistoryService.shared.isRecording = false
-                                KeystrokeHistoryService.shared.clearEvents()
-                            }
+                            try await PackInstaller.shared.setVisualPackEnabled(
+                                pack, enabled: newValue, manager: kanataManager.underlyingManager.ruleCollectionsManager
+                            )
                         } catch {
+                            guard keystrokeHistoryMutationID == requestID else { return }
                             AppLogger.shared.log("⚠️ [Rules] Keystroke History toggle failed: \(error.localizedDescription)")
                             isKeystrokeHistoryInstalled = !newValue
                         }

--- a/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView.swift
@@ -28,6 +28,8 @@ struct RulesTabView: View {
     @State var appKeymaps: [AppKeymap] = []
     @State var isKindaVimInstalled = false
     @State var isKeystrokeHistoryInstalled = false
+    @State var kindaVimMutationID: UUID?
+    @State var keystrokeHistoryMutationID: UUID?
     @State var pendingEnablePack: Pack?
     @State var pendingEnableUnmetDeps: [UnmetDependency] = []
     @State var pendingDisablePack: Pack?

--- a/Tests/KeyPathTests/PackMetadataOperationTests.swift
+++ b/Tests/KeyPathTests/PackMetadataOperationTests.swift
@@ -1,0 +1,176 @@
+import Foundation
+@testable import KeyPathAppKit
+import KeyPathRulesCore
+@preconcurrency import XCTest
+
+@MainActor
+final class PackMetadataOperationTests: KeyPathTestCase {
+    private struct Fixture {
+        let directory: URL
+        let manager: RuleCollectionsManager
+        let tracker: InstalledPackTracker
+    }
+
+    func testVisualToggleUsesTrustedAdmissionWithoutChangingConfiguration() async throws {
+        try await withFixture { fixture in
+            let pack = PackRegistry.kindaVim
+            try await fixture.manager.configurationService.operationGate.withOperation { permit in
+                let record = try await PackInstaller.shared.setVisualPackEnabled(
+                    pack, enabled: true, quickSettingValues: ["retained": 42], manager: fixture.manager,
+                    installedPackTracker: fixture.tracker, mutationPermit: permit
+                )
+                XCTAssertEqual(record?.quickSettingValues, ["retained": 42])
+            }
+            let repeated = try await PackInstaller.shared.setVisualPackEnabled(pack, enabled: true, manager: fixture.manager, installedPackTracker: fixture.tracker)
+            XCTAssertEqual(repeated?.quickSettingValues, ["retained": 42])
+            try await PackInstaller.shared.setVisualPackEnabled(pack, enabled: false, manager: fixture.manager, installedPackTracker: fixture.tracker)
+            let installed = await fixture.tracker.isInstalled(packID: pack.id)
+            XCTAssertFalse(installed)
+            XCTAssertFalse(FileManager.default.fileExists(atPath: fixture.directory.appendingPathComponent("keypath.kbd").path))
+        }
+    }
+
+    func testMetadataToggleRejectsNonvisualPacks() async throws {
+        try await withFixture { fixture in
+            let pack = try XCTUnwrap(PackRegistry.pack(id: "com.keypath.pack.caps-lock-to-escape"))
+            do {
+                try await PackInstaller.shared.setVisualPackEnabled(pack, enabled: true, manager: fixture.manager, installedPackTracker: fixture.tracker)
+                XCTFail("Nonvisual packs require full installation")
+            } catch {}
+            let records = await fixture.tracker.allInstalled()
+            XCTAssertTrue(records.isEmpty)
+        }
+    }
+
+    func testCatalogInstallStillEnforcesConflicts() async throws {
+        try await withFixture { fixture in
+            try await fixture.tracker.upsert(InstalledPackRecord(packID: "com.keypath.pack.vim-navigation", version: "1"))
+            do {
+                try await PackInstaller.shared.install(PackRegistry.kindaVim, manager: fixture.manager, installedPackTracker: fixture.tracker)
+                XCTFail("Catalog installation must retain its conflict gate")
+            } catch PackInstaller.InstallError.mutuallyExclusive {} catch { XCTFail("Unexpected error: \(error)") }
+            // The existing Rules toggle policy is intentionally unchanged in this internal slice.
+            try await PackInstaller.shared.setVisualPackEnabled(PackRegistry.kindaVim, enabled: true, manager: fixture.manager, installedPackTracker: fixture.tracker)
+        }
+    }
+
+    func testBackfillUsesPersistedStateRatherThanStaleManagerState() async throws {
+        try await withFixture { fixture in
+            let pack = try XCTUnwrap(PackRegistry.pack(id: "com.keypath.pack.caps-lock-to-escape"))
+            var collections = RuleCollectionCatalog().defaultCollections()
+            let index = try XCTUnwrap(collections.firstIndex { $0.id == pack.associatedCollectionID })
+            collections[index].isEnabled = true
+            fixture.manager.ruleCollections = collections
+            collections[index].isEnabled = false
+            try await fixture.manager.ruleCollectionStore.saveCollections(collections)
+            let absent = try await PackInstaller.shared.reconcileInstallRecord(for: pack, manager: fixture.manager, installedPackTracker: fixture.tracker)
+            XCTAssertNil(absent)
+            collections[index].isEnabled = true
+            try await fixture.manager.ruleCollectionStore.saveCollections(collections)
+            let restored = try await PackInstaller.shared.reconcileInstallRecord(for: pack, manager: fixture.manager, installedPackTracker: fixture.tracker)
+            XCTAssertEqual(restored?.packID, pack.id)
+        }
+    }
+
+    func testBackfillRecoversInterruptedRuleWriteBeforeReadingSources() async throws {
+        try await withFixture { fixture in
+            let pack = try XCTUnwrap(PackRegistry.pack(id: "com.keypath.pack.caps-lock-to-escape"))
+            var collections = RuleCollectionCatalog().defaultCollections()
+            let index = try XCTUnwrap(collections.firstIndex { $0.id == pack.associatedCollectionID })
+            collections[index].isEnabled = false
+            try await fixture.manager.ruleCollectionStore.saveCollections(collections)
+            let sourceURL = fixture.directory.appendingPathComponent("RuleCollections.json")
+            let original = try Data(contentsOf: sourceURL)
+            collections[index].isEnabled = true
+            let proposed = try await fixture.manager.ruleCollectionStore.encodedCollections(collections)
+            _ = try RecoverableRuleWrite.stage(files: [
+                "config": fixture.directory.appendingPathComponent("keypath.kbd"),
+                "collections": sourceURL,
+                "customRules": fixture.directory.appendingPathComponent("CustomRules.json")
+            ], contents: ["config": Data("(defsrc)\n(deflayer base)".utf8), "collections": proposed, "customRules": Data("[]".utf8)],
+            directory: fixture.directory, scope: .rules)
+            let record = try await PackInstaller.shared.reconcileInstallRecord(for: pack, manager: fixture.manager, installedPackTracker: fixture.tracker)
+            XCTAssertNil(record)
+            XCTAssertEqual(try Data(contentsOf: sourceURL), original)
+        }
+    }
+
+    func testDeferredRepairWaitsForTheNotificationOwner() async throws {
+        try await withFixture { fixture in
+            let pack = try XCTUnwrap(PackRegistry.pack(id: "com.keypath.pack.caps-lock-to-escape"))
+            let started = expectation(description: "notification refresh started")
+            var refresh: Task<InstalledPackRecord?, Error>?
+            try await fixture.manager.configurationService.operationGate.withOperation { @MainActor _ in
+                var collections = RuleCollectionCatalog().defaultCollections()
+                let index = try XCTUnwrap(collections.firstIndex { $0.id == pack.associatedCollectionID })
+                collections[index].isEnabled = true
+                try await fixture.manager.ruleCollectionStore.saveCollections(collections)
+                refresh = Task.detached { try await Self.deferredRepair(pack, fixture: fixture, started: started) }
+                await fulfillment(of: [started], timeout: 5)
+                let installed = await fixture.tracker.isInstalled(packID: pack.id)
+                XCTAssertFalse(installed, "Repair must wait for the active writer to release admission")
+            }
+            let record = try await refresh?.value
+            XCTAssertEqual(record?.packID, pack.id)
+        }
+    }
+
+    func testFailedBackfillDoesNotReportInstalled() async throws {
+        try await withFixture { fixture in
+            let pack = try XCTUnwrap(PackRegistry.pack(id: "com.keypath.pack.caps-lock-to-escape"))
+            var collections = RuleCollectionCatalog().defaultCollections()
+            let index = try XCTUnwrap(collections.firstIndex { $0.id == pack.associatedCollectionID })
+            collections[index].isEnabled = true
+            try await fixture.manager.ruleCollectionStore.saveCollections(collections)
+            let tracker = InstalledPackTracker(fileURL: fixture.directory.appendingPathComponent("failed.json")) { _, _ in
+                throw NSError(domain: "write", code: 1)
+            }
+            do {
+                _ = try await PackInstaller.shared.reconcileInstallRecord(for: pack, manager: fixture.manager, installedPackTracker: tracker)
+                XCTFail("A failed record write must throw")
+            } catch {}
+            let installed = await tracker.isInstalled(packID: pack.id)
+            XCTAssertFalse(installed)
+        }
+    }
+
+    func testCorruptMetadataIsPreserved() async throws {
+        try await withFixture { fixture in
+            let file = fixture.directory.appendingPathComponent("installed-packs.json")
+            let corrupt = Data("not json".utf8)
+            try corrupt.write(to: file)
+            do {
+                try await PackInstaller.shared.setVisualPackEnabled(PackRegistry.kindaVim, enabled: true, manager: fixture.manager, installedPackTracker: fixture.tracker)
+                XCTFail("Corrupt metadata must prevent mutation")
+            } catch {}
+            XCTAssertEqual(try Data(contentsOf: file), corrupt)
+        }
+    }
+
+    private static func deferredRepair(_ pack: Pack, fixture: Fixture, started: XCTestExpectation) async throws -> InstalledPackRecord? {
+        started.fulfill()
+        return try await PackInstaller.shared.reconcileInstallRecord(for: pack, manager: fixture.manager, installedPackTracker: fixture.tracker)
+    }
+
+    private func withFixture(_ body: (Fixture) async throws -> Void) async throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent("pack-metadata-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer {
+            try? FileManager.default.removeItem(at: directory)
+            try? FileManager.default.removeItem(at: ConfigurationOperationGate.lockFileURL(for: directory))
+        }
+        let collections = RuleCollectionStore.testStore(at: directory.appendingPathComponent("RuleCollections.json"))
+        let rules = CustomRulesStore.testStore(at: directory.appendingPathComponent("CustomRules.json"))
+        let service = ConfigurationService(configDirectory: directory.path, ruleCollectionStore: collections, customRulesStore: rules)
+        let manager = RuleCollectionsManager(ruleCollectionStore: collections, customRulesStore: rules, configurationService: service)
+        manager.onRulesChanged = { XCTFail("Metadata-only work must not reload the engine"); return ReloadResult(
+            success: false,
+            response: nil,
+            errorMessage: "Unexpected reload",
+            protocol: nil,
+            disposition: .failed
+        ) }
+        let tracker = InstalledPackTracker(fileURL: directory.appendingPathComponent("installed-packs.json"))
+        try await body(Fixture(directory: directory, manager: manager, tracker: tracker))
+    }
+}

--- a/Tests/KeyPathTests/Services/KeystrokeHistoryServiceTests.swift
+++ b/Tests/KeyPathTests/Services/KeystrokeHistoryServiceTests.swift
@@ -27,6 +27,20 @@ final class KeystrokeHistoryServiceTests: XCTestCase {
         service.flushPendingEventsForTesting()
     }
 
+    func testDisablingPackStopsRecordingAndClearsHistory() async {
+        let center = NotificationCenter()
+        let service = KeystrokeHistoryService.makeTestInstance(notificationCenter: center)
+        postKeyInput(center, key: "a")
+        await flushNotificationsAndBatch(service)
+        XCTAssertEqual(service.eventCount, 1)
+        service.applyPackState(false)
+        XCTAssertFalse(service.isRecording)
+        XCTAssertEqual(service.eventCount, 0)
+        postKeyInput(center, key: "b")
+        await flushNotificationsAndBatch(service)
+        XCTAssertEqual(service.eventCount, 0)
+    }
+
     // MARK: - Event Ingestion
 
     func testKeyInputCreatesEvent() async {

--- a/docs/architecture/configuration-save-pipeline.md
+++ b/docs/architecture/configuration-save-pipeline.md
@@ -235,3 +235,16 @@ it does not yet provide the app-specific journal or compensating reload. The old
 opt-in smoke test that mutated the user's real file without restoration is replaced
 by temporary-directory save/reload tests. Physical engine acceptance remains a
 separate installed-app QA obligation.
+
+## Pack metadata ownership
+
+Rules visual-only toggles now use PackInstaller.setVisualPackEnabled. It admits
+before strict tracker reads, preserves existing quick settings unless supplied,
+and commits the record before settling the app's visual capability. Catalog
+install still runs its existing dependency/conflict gates first; this internal
+consolidation does not standardize the two entry points' product policy.
+
+Pack detail's missing-record repair uses PackInstaller.reconcileInstallRecord.
+It reads persisted collection state after admission, refuses incomplete reads,
+and propagates persistence failure instead of reporting installed unconditionally.
+It preserves the existing backfill policy; it does not decide new pack ownership.

--- a/docs/bugs/pack-metadata-write-ownership.md
+++ b/docs/bugs/pack-metadata-write-ownership.md
@@ -1,0 +1,30 @@
+# Pack metadata writes outside the installer
+
+The Rules toggles wrote InstalledPackTracker directly. Pack detail also attempted
+record repair with `try?` and then unconditionally displayed installed, even if
+persistence failed. Repair read the view manager's cached collections, so a stale
+view could recreate a record after another writer disabled the collection.
+
+PackInstaller now owns both operations under configuration admission. Visual-only
+toggles cannot install nonvisual packs; catalog installation retains its existing
+pre-install gates. Repair recovers an interrupted rule journal before reading
+persisted collections and refuses incomplete source reads. A failed record write
+throws to the existing detail-view error area.
+
+Keystroke History activation/clearing moves from UI closures to the successful
+app-tracker operation, using the history service's own method. A separate CLI or
+custom-directory tracker does not directly mutate the app singleton. Existing
+notification-based recording updates remain unchanged. Rules toggle failures are
+also tagged with request identities so an older failure cannot revert a newer
+choice.
+
+Tests use temporary source and tracker files: stale manager state, interrupted
+rule writes, failed metadata persistence, corrupt metadata, trusted nested
+admission, visual-only limits, and preserved catalog conflict checks. No new
+ownership/conflict policy or full pack rollback is implied by this consolidation.
+
+Deferred detail refreshes use detached MainActor tasks so notifications posted
+inside a save do not carry its task-local lease into another mutation. They
+queue normally, are cancelled on dismissal, and do not publish cancellation
+errors or stale results. A test starts deferred repair while its notifying owner
+holds admission and verifies that the record is created only after release.

--- a/docs/planning/catalog-led-consolidation-plan.md
+++ b/docs/planning/catalog-led-consolidation-plan.md
@@ -267,6 +267,7 @@ Implemented slices (the table describes the merged state of this checkpoint):
 | #1272 | CLI apply admits before source loading through reload; backup/restore share admission; custom-directory source loading is corrected. | CLI collection/pack commands, cached state and complete recovery remain. |
 | #1273 | CLI rule, collection and pack commands hold admission through optional apply; pack sources refresh after admission and strict metadata reads precede mutations. | Direct UI metadata writers, feature-specific writes and complete recovery remain. |
 | #1274 | App-specific edits retain a three-file journal through runtime apply/recovery, preserve hand-written files, and refresh app context after immediate/deferred reload. | Global/pack recovery, mixed app/global operations and revision-aware watching remain. |
+| #1275 | Simple Modifications transforms captured revisions through SaveCoordinator, preserves external edits, retains reload/recovery outcomes and serializes debounce settlement. | Legacy raw syntax/ownership limitations and full runtime recovery remain. |
 
 Admission now also holds a cooperative OS lease across service instances and
 processes for the same directory. CLI configuration apply now holds admission
@@ -337,7 +338,7 @@ work. Startup include generation also preserves existing differing content.
 Review, supported-runner CI, merge and signed/notarized installed-app verification completed for #1274.
 Global rule/source/preferences/pack recovery and revision-aware watching remain.
 
-### Simple Modifications save consolidation
+### Simple Modifications save consolidation merged in #1275
 
 The editor now transforms a captured file revision through SaveCoordinator under
 the directory lease. It validates the proposed content, retains the reload
@@ -349,3 +350,18 @@ base deflayermap entries rather than mistaking positional layout rows for remaps
 Raw-file recovery still has the existing file-only boundary. External deflayermap
 ownership, status presentation, full runtime recovery and crash recovery remain
 separate work; this slice does not claim those are complete.
+
+### Pack metadata consolidation
+
+The remaining Rules-toggle and detail-view repair writes now enter PackInstaller
+under the directory operation gate. Repair reads persisted collection state,
+refuses incomplete source reads, and returns an installed record only after a
+successful write. Visual-only state changes cannot be used to install nonvisual
+packs. Existing Rules-vs-catalog dependency/conflict policy is retained pending
+the separate product discussion. Keystroke History settlement is removed from
+the UI mutation closures. Full pack transaction/recovery and ownership policy
+remain separate work.
+
+CI maintenance: #1276 increased the review action's turn allowance after repeated
+`error_max_turns` failures. It was merged separately; #1275 then passed actual
+review under that workflow. Both are included in the signed/notarized #1275 deploy.


### PR DESCRIPTION
Rules toggles and pack-detail repair wrote installed-pack metadata outside the installer. A failed repair still displayed “installed,” and stale view state could recreate a record after another writer disabled its collection. Move these writes into PackInstaller under configuration admission, read persisted sources after journal recovery, and propagate failed repairs to the existing error area.

Visual-only installation/removal share the metadata operation; nonvisual packs cannot use it. Existing Rules-vs-catalog dependency/conflict policy is retained for the separate product discussion. Keystroke History activation/clearing moves out of UI closures and settles only for the app's tracker after commit; custom-directory CLI trackers do not directly change the app singleton. Older toggle failures cannot revert newer choices.

Deferred detail refreshes detach from the notifying save's task-local lease, queue normally, cancel on dismissal, and avoid publishing cancellation errors or stale results. No layout, navigation, or ownership-policy change.

Validation: focused pack/store/CLI/history tests pass (75 XCTest cases), plus the final deferred/admission/history group (34 XCTest cases). Covers stale sources, interrupted journal recovery, failed writes, corrupt metadata, nested admission, conflict-gate preservation, deferred repair while a writer holds admission, and history clearing. Formatting, accessibility, and diff checks pass. Full safe-suite result follows. Remote review gate selected; GitHub claude-review is required before merge.

Scope: complete pack/source/preferences/runtime rollback and unified conflict/ownership policy remain outside this metadata slice. Architecture, bug record, and consolidation checkpoint updated, including deployed #1275 and isolated CI repair #1276.

Full safe gate: 5,186 runner-reported passes. Only the four previously reproduced local macOS 27 baseline snapshots fail: EasyViewSnapshotTests.testHomeRowTimingFastTyping, testHomeRowTimingPerFinger, testHomeRowTimingSlider, and HardViewSnapshotTests.testRepairSettingsTabView. No compiler warnings. Supported-runner CI remains required.

### Review disposition

The possible actor-isolation finding is not applicable with the pinned SDK: SwiftUICore declares `View` as `@preconcurrency @MainActor public protocol View` (Xcode 26.6 SDK interface, line 13648). `PackDetailView: View` and its extension methods inherit that isolation; `refreshInstallState()` has no `nonisolated` override. Its catch branch resumes on the main actor after the awaited call. The existing `MainActor.run` is redundant isolation, not evidence that the enclosing method runs off actor. The explicit helper annotation documents the detached-task hop. Compilation with the stable toolchain passed. Backend error propagation is covered by the failed-write and corrupt-metadata tests; a view-specific copy test would not add meaningful coverage for this internal refactor.
