### PR TITLE
Recover mapper rule sources after rejected reloads

### DIFF
--- a/Sources/KeyPathAppKit/Infrastructure/Config/ConfigurationService.swift
+++ b/Sources/KeyPathAppKit/Infrastructure/Config/ConfigurationService.swift
@@ -317,9 +317,40 @@ public final class ConfigurationService: FileConfigurationProviding {
         mutationPermit: ConfigurationOperationGate.Permit? = nil
     ) async throws {
         try await operationGate.withOperation(using: mutationPermit) { @MainActor [self] permit in
+            let write = try await stageRuleState(
+                ruleCollections: ruleCollections, customRules: customRules,
+                collectionStore: collectionStore, customStore: customStore, mutationPermit: permit
+            )
+            do {
+                try Task.checkCancellation()
+                try await settleRuleWrite(write, commit: true, mutationPermit: permit)
+            } catch {
+                let cause = error
+                do { try await settleRuleWrite(write, commit: false, mutationPermit: permit) }
+                catch { throw RecoverableRuleWrite.WriteFailure(cause: cause, recoveryError: error) }
+                throw cause
+            }
+        }
+    }
+
+    struct RuleWrite: Sendable {
+        let pending: RecoverableRuleWrite.PendingWrite
+        let configuration: KanataConfiguration
+    }
+
+    /// Stage the generated configuration and both source stores without notifying
+    /// observers. The caller must retain admission through commit or recovery.
+    func stageRuleState(
+        ruleCollections: [RuleCollection], customRules: [CustomRule],
+        collectionStore: RuleCollectionStore, customStore: CustomRulesStore,
+        mutationPermit: ConfigurationOperationGate.Permit
+    ) async throws -> RuleWrite {
+        try await operationGate.withOperation(using: mutationPermit) { @MainActor [self] permit in
             try await recoverPendingRuleWrite(collectionStore: collectionStore, customStore: customStore, mutationPermit: permit)
-            let newConfig = try await preparedConfiguration(ruleCollections: ruleCollections, customRules: customRules)
+            try await recoverPendingAppKeymapWrite(mutationPermit: permit)
             let files = await ruleWriteFiles(collectionStore: collectionStore, customStore: customStore)
+            let before = try await snapshotRuleFiles(files)
+            let newConfig = try await preparedConfiguration(ruleCollections: ruleCollections, customRules: customRules)
             let contents = try await [
                 "config": Data(newConfig.content.utf8),
                 "collections": collectionStore.encodedCollections(ruleCollections),
@@ -327,10 +358,33 @@ public final class ConfigurationService: FileConfigurationProviding {
             ]
             try Task.checkCancellation()
             let directory = URL(fileURLWithPath: configDirectory)
-            try await performRuleFileOperation {
-                try RecoverableRuleWrite.apply(files: files, contents: contents, directory: directory)
+            let pending = try await performRuleFileOperation {
+                try RecoverableRuleWrite.stage(files: files, contents: contents, directory: directory,
+                                               scope: .rules, expectedBefore: before)
             }
-            await publishSavedConfiguration(newConfig)
+            return RuleWrite(pending: pending, configuration: newConfig)
+        }
+    }
+
+    func settleRuleWrite(_ write: RuleWrite, commit: Bool, mutationPermit: ConfigurationOperationGate.Permit) async throws {
+        try await operationGate.withOperation(using: mutationPermit) { @MainActor [self] _ in
+            try await performRuleFileOperation {
+                if commit { try RecoverableRuleWrite.commit(write.pending) }
+                else { try RecoverableRuleWrite.rollback(write.pending) }
+            }
+            if commit { await publishSavedConfiguration(write.configuration) }
+            else { stateLock.withLock { currentConfiguration = nil } }
+        }
+    }
+
+    private func snapshotRuleFiles(_ files: [String: URL]) async throws -> [String: Data] {
+        try await performRuleFileOperation {
+            var snapshot: [String: Data] = [:]
+            for (role, url) in files {
+                do { snapshot[role] = try Data(contentsOf: url) }
+                catch let error as NSError where error.domain == NSCocoaErrorDomain && error.code == NSFileReadNoSuchFileError {}
+            }
+            return snapshot
         }
     }
 
@@ -368,14 +422,7 @@ public final class ConfigurationService: FileConfigurationProviding {
             try await recoverPendingRuleWrite(collectionStore: ruleCollectionStore, customStore: customRulesStore, mutationPermit: permit)
             try await recoverPendingAppKeymapWrite(store: store, mutationPermit: permit)
             let files = await appKeymapWriteFiles(store: store)
-            let before = try await performRuleFileOperation {
-                var snapshot: [String: Data] = [:]
-                for (role, url) in files {
-                    do { snapshot[role] = try Data(contentsOf: url) }
-                    catch let error as NSError where error.domain == NSCocoaErrorDomain && error.code == NSFileReadNoSuchFileError {}
-                }
-                return snapshot
-            }
+            let before = try await snapshotRuleFiles(files)
             let previous = try await store.loadForMutation()
             var keymaps = previous
             try mutate(&keymaps)

--- a/Sources/KeyPathAppKit/Managers/RuntimeCoordinator.swift
+++ b/Sources/KeyPathAppKit/Managers/RuntimeCoordinator.swift
@@ -282,7 +282,6 @@ public class RuntimeCoordinator: SaveCoordinatorDelegate {
         // Initialize extracted coordinators
         saveCoordinator = SaveCoordinator(
             configurationService: configurationService,
-            engineClient: engineClient ?? TCPEngineClient(),
             configFileWatcher: configFileWatcher
         )
         installationCoordinator = InstallationCoordinator()

--- a/Sources/KeyPathAppKit/Managers/SaveCoordinator.swift
+++ b/Sources/KeyPathAppKit/Managers/SaveCoordinator.swift
@@ -9,12 +9,14 @@ protocol SaveCoordinatorDelegate: AnyObject {
     func configDidUpdate(mappings: [KeyMapping])
 }
 
-/// App-keymap recovery includes its source files and an explicit reload result.
+/// Rule and app-keymap recovery include source files and an explicit reload result.
 /// Legacy config-only recovery does not claim source or runtime restoration.
 enum SaveRecoveryResult {
     case notAttempted
     case restoredPreviousAppKeymapState(reloadResult: ReloadResult?)
     case appKeymapRecoveryFailed(Error)
+    case restoredPreviousRuleState(reloadResult: ReloadResult?)
+    case ruleStateRecoveryFailed(Error)
     case restoredPreviousConfig
     case wroteMinimalSafeConfig(backupError: Error?)
     case failed(backupError: Error?, fallbackError: Error)
@@ -70,7 +72,6 @@ final class SaveCoordinator {
     // MARK: - Dependencies
 
     private let configurationService: ConfigurationService
-    private let engineClient: EngineClient
     private weak var configFileWatcher: ConfigFileWatcher?
 
     // MARK: - Properties
@@ -90,19 +91,16 @@ final class SaveCoordinator {
 
     init(
         configurationService: ConfigurationService,
-        engineClient: EngineClient,
         configFileWatcher: ConfigFileWatcher? = nil
     ) {
         self.configurationService = configurationService
-        self.engineClient = engineClient
         self.configFileWatcher = configFileWatcher
     }
 
     /// Convenience initializer for legacy code (will be deprecated)
     convenience init() {
         let configService = ConfigurationService(configDirectory: KeyPathConstants.Config.directory)
-        let engine = TCPEngineClient()
-        self.init(configurationService: configService, engineClient: engine, configFileWatcher: nil)
+        self.init(configurationService: configService, configFileWatcher: nil)
     }
 
     // MARK: - Public Save API
@@ -154,11 +152,11 @@ final class SaveCoordinator {
                             }.value
                             recovery = .restoredPreviousAppKeymapState(reloadResult: recoveryReload)
                             if let recoveryReload, recoveryReload.disposition == .failed || recoveryReload.disposition == .rejected {
-                                reportedError = AppKeymapSaveError(cause: error, recovery: recoveryReload.errorMessage ?? "The prior files were restored, but runtime recovery failed")
+                                reportedError = SaveApplicationError(cause: error, recovery: recoveryReload.errorMessage ?? "The prior files were restored, but runtime recovery failed")
                             }
                         } catch let recoveryError {
                             recovery = .appKeymapRecoveryFailed(recoveryError)
-                            reportedError = AppKeymapSaveError(cause: error, recovery: recoveryError.localizedDescription)
+                            reportedError = SaveApplicationError(cause: error, recovery: recoveryError.localizedDescription)
                         }
                     }
                     saveStatus = .failed(reportedError.localizedDescription)
@@ -191,71 +189,36 @@ final class SaveCoordinator {
                 configFileWatcher?.suppressEvents(for: 1.0, reason: "Internal saveConfiguration")
                 saveStatus = .saving
 
+                let snapshot = ruleCollectionsManager.snapshotRuleState()
                 do {
-                    // Step 1: Validate input/output
-                    let (sanitizedInput, sanitizedOutput) = try validateInputOutput(
-                        input: input, output: output
-                    )
-
-                    // Step 2: Backup current config
-                    let previousContent = try await snapshotCurrentConfig(mutationPermit: permit)
-                    try Task.checkCancellation()
-                    backupCurrentConfig(previousContent)
-
-                    // Step 3: Create and save custom rule
-                    let rule = ruleCollectionsManager.makeCustomRule(
-                        input: sanitizedInput, output: sanitizedOutput
-                    )
-                    let didSave = await ruleCollectionsManager.saveCustomRule(rule, skipReload: true, mutationPermit: permit)
-
-                    guard didSave else {
-                        let message = "Failed to save custom rule (possible conflict)"
-                        saveStatus = .failed(message)
-                        return .failure(KeyPathError.configuration(.validationFailed(errors: [message])))
+                    let (sanitizedInput, sanitizedOutput) = try validateInputOutput(input: input, output: output)
+                    let rule = ruleCollectionsManager.makeCustomRule(input: sanitizedInput, output: sanitizedOutput)
+                    guard await ruleCollectionsManager.updateCustomRuleInMemory(rule, mutationPermit: permit) else {
+                        let error = KeyPathError.configuration(.validationFailed(errors: ["The rule change was cancelled or conflicts with an existing mapping."]))
+                        saveStatus = .failed(error.localizedDescription)
+                        return .failure(error)
                     }
-
-                    // Step 4: Play write sound
-                    playWriteSound()
-
-                    // Step 5: Trigger reload for validation
-                    AppLogger.shared.debug("📡 [SaveCoordinator] Triggering TCP reload for validation")
-                    let reloadResult = await reloadHandler()
-
-                    if reloadResult.disposition == .applied || reloadResult.disposition == .pending {
-                        // Success!
-                        if reloadResult.disposition == .applied {
-                            AppLogger.shared.info("✅ [SaveCoordinator] Reload successful, config is valid")
-                        } else {
-                            AppLogger.shared.info("ℹ️ [SaveCoordinator] Config saved; reload pending: \(reloadResult.errorMessage ?? "service unavailable")")
-                        }
+                    var result: SaveResult
+                    var conflictDepth = 0
+                    while true {
+                        result = await saveRuleState(manager: ruleCollectionsManager, mutationPermit: permit, reloadHandler: reloadHandler)
+                        guard !result.success, result.reloadResult == nil,
+                              let error = result.error,
+                              await ruleCollectionsManager.resolveMappingConflictInMemory(error, depth: conflictDepth, mutationPermit: permit)
+                        else { break }
+                        conflictDepth += 1
+                    }
+                    if result.success {
+                        NotificationCenter.default.post(name: .ruleCollectionsChanged, object: nil)
                         playSuccessSound()
-                        saveStatus = .success
-                        scheduleStatusReset()
-
-                        let mappings = ruleCollectionsManager.enabledMappings()
-                        return .success(mappings: mappings, reloadResult: reloadResult)
                     } else {
-                        // Reload failed - restore backup
-                        let errorMessage = reloadResult.errorMessage ?? "TCP server unresponsive"
-                        AppLogger.shared.error("❌ [SaveCoordinator] TCP reload FAILED: \(errorMessage)")
-                        AppLogger.shared.error("❌ [SaveCoordinator] Restoring backup")
-
-                        playErrorSound()
-                        let recoveryResult = await restoreConfig(previousContent, mutationPermit: permit)
-
-                        saveStatus = .failed("TCP server reload failed: \(errorMessage)")
-                        return .failure(
-                            KeyPathError.configuration(
-                                .loadFailed(
-                                    reason:
-                                    "TCP server required for validation-on-demand failed: \(errorMessage)"
-                                )
-                            ),
-                            reloadResult: reloadResult,
-                            recoveryResult: recoveryResult
-                        )
+                        // The transaction already restored (or preserved) the files.
+                        // Never regenerate here: that could overwrite an external edit.
+                        ruleCollectionsManager.ruleCollections = snapshot.collections
+                        ruleCollectionsManager.customRules = snapshot.customRules
+                        ruleCollectionsManager.refreshLayerIndicatorState()
                     }
-
+                    return result
                 } catch {
                     saveStatus = .failed(error.localizedDescription)
                     return .failure(error)
@@ -264,6 +227,61 @@ final class SaveCoordinator {
         } catch {
             return .failure(error)
         }
+    }
+
+    /// Keep all rule files recoverable until the engine accepts or defers them.
+    /// The manager owns its optimistic in-memory snapshot; this owner settles disk
+    /// and runtime before the caller restores that snapshot on failure.
+    func saveRuleState(
+        manager: RuleCollectionsManager,
+        mutationPermit: ConfigurationOperationGate.Permit,
+        reloadHandler: @escaping () async -> ReloadResult
+    ) async -> SaveResult {
+        do {
+            return try await configurationService.operationGate.withOperation(using: mutationPermit) { @MainActor [self] permit in
+                var staged: ConfigurationService.RuleWrite?
+                var reload: ReloadResult?
+                do {
+                    manager.dedupeRuleCollectionsInPlace()
+                    staged = try await configurationService.stageRuleState(
+                        ruleCollections: manager.ruleCollections, customRules: manager.customRules,
+                        collectionStore: manager.ruleCollectionStore, customStore: manager.customRulesStore,
+                        mutationPermit: permit
+                    )
+                    try Task.checkCancellation()
+                    playWriteSound()
+                    let result = await reloadHandler()
+                    reload = result
+                    try Task.checkCancellation()
+                    guard result.disposition == .applied || result.disposition == .pending else {
+                        throw KeyPathError.configuration(.loadFailed(reason: result.errorMessage ?? "The rule configuration could not be applied"))
+                    }
+                    guard let staged else { throw AppConfigError.validationUnavailable }
+                    try await configurationService.settleRuleWrite(staged, commit: true, mutationPermit: permit)
+                    saveStatus = .success
+                    scheduleStatusReset()
+                    return .success(mappings: manager.enabledMappings(), reloadResult: result)
+                } catch {
+                    var recovery: SaveRecoveryResult = .notAttempted
+                    var reportedError: Error = error
+                    if let staged {
+                        do {
+                            try await configurationService.settleRuleWrite(staged, commit: false, mutationPermit: permit)
+                            let recoveryReload = reload == nil ? nil : await Task { @MainActor in await reloadHandler() }.value
+                            recovery = .restoredPreviousRuleState(reloadResult: recoveryReload)
+                            if let recoveryReload, recoveryReload.disposition == .failed || recoveryReload.disposition == .rejected {
+                                reportedError = SaveApplicationError(cause: error, recovery: recoveryReload.errorMessage ?? "Prior rule files were restored, but runtime recovery failed")
+                            }
+                        } catch let recoveryError {
+                            recovery = .ruleStateRecoveryFailed(recoveryError)
+                            reportedError = SaveApplicationError(cause: error, recovery: recoveryError.localizedDescription)
+                        }
+                    }
+                    saveStatus = .failed(reportedError.localizedDescription)
+                    return .failure(reportedError, reloadResult: reload, recoveryResult: recovery)
+                }
+            }
+        } catch { return .failure(error) }
     }
 
     /// Capture and transform raw content under the same admission as its save.
@@ -562,7 +580,7 @@ final class SaveCoordinator {
     }
 }
 
-private struct AppKeymapSaveError: LocalizedError {
+private struct SaveApplicationError: LocalizedError {
     let cause: Error
     let recovery: String
     var errorDescription: String? {

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+ConflictResolution.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+ConflictResolution.swift
@@ -47,6 +47,21 @@ extension RuleCollectionsManager {
     ///   mapping conflict or the user cancelled (caller falls back to its error path).
     func tryResolveMappingConflict(_ error: Error, skipReload: Bool, depth: Int, mutationPermit: ConfigurationOperationGate.Permit? = nil) async -> RulePersistenceResult? {
         await withRuleMutation(using: mutationPermit, failure: nil) { [self] permit in
+            let snapshot = ruleCollections
+            guard await resolveMappingConflictInMemory(error, depth: depth, mutationPermit: permit) else { return nil }
+            let saved = await persistRules(skipReload: skipReload, conflictResolutionDepth: depth + 1, mutationPermit: permit)
+            if !saved.didPersist {
+                ruleCollections = snapshot
+                refreshLayerIndicatorState()
+            }
+            return saved
+        }
+    }
+
+    /// Resolve the same existing conflict choice without choosing a persistence
+    /// owner. The caller retains the original snapshot until its save settles.
+    func resolveMappingConflictInMemory(_ error: Error, depth: Int, mutationPermit: ConfigurationOperationGate.Permit) async -> Bool {
+        await withRuleMutation(using: mutationPermit, failure: false) { [self] _ in
             // Bound retries: each resolution disables one collection (strictly shrinking
             // the enabled set), so this terminates, but the guard prevents pathological loops.
             guard depth < 5,
@@ -57,7 +72,7 @@ extension RuleCollectionsManager {
                   let resolvable = Self.resolvableCollectionConflict(
                       conflicts: conflicts, collections: ruleCollections
                   )
-            else { return nil }
+            else { return false }
 
             let context = MappingConflictContext(
                 explanation: conflicts.map(\.userExplanation).joined(separator: "\n\n"),
@@ -68,24 +83,14 @@ extension RuleCollectionsManager {
 
             guard let chosenID = await callback(context),
                   let index = ruleCollections.firstIndex(where: { $0.id == chosenID })
-            else { return nil } // cancelled → fall back to explanation
+            else { return false } // cancelled → fall back to explanation
 
             AppLogger.shared.log(
                 "🔧 [RuleCollections] Resolving mapping conflict by disabling '\(ruleCollections[index].name)' (#460)"
             )
-            // Make the disable atomic: snapshot first, disable in-memory, retry the full
-            // save. If the retry still fails (another conflict, depth guard, validation),
-            // restore so in-memory state never diverges from what was actually persisted —
-            // callers that ignore the `false` return must not see an unsaved disable.
-            let snapshot = ruleCollections
             ruleCollections[index].isEnabled = false
             refreshLayerIndicatorState()
-            let saved = await persistRules(skipReload: skipReload, conflictResolutionDepth: depth + 1, mutationPermit: permit)
-            if !saved.didPersist {
-                ruleCollections = snapshot
-                refreshLayerIndicatorState()
-            }
-            return saved
+            return true
         }
     }
 

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+PublicAPI.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+PublicAPI.swift
@@ -962,6 +962,28 @@ extension RuleCollectionsManager {
             AppLogger.shared.log("💾 [CustomRules] saveCustomRule called: id=\(rule.id), input='\(rule.input)', action='\(rule.action.displayName)'")
             let snapshot = snapshotRuleState()
 
+            guard await updateCustomRuleInMemory(rule, autoResolveConflicts: autoResolveConflicts, mutationPermit: permit) else { return false }
+
+            let success = await regenerateConfigFromCollections(skipReload: skipReload, mutationPermit: permit)
+
+            if success {
+                AppLogger.shared.log("💾 [CustomRules] Save complete, customRules.count = \(customRules.count)")
+            } else {
+                AppLogger.shared.log("💾 [CustomRules] Save failed - rolling back to snapshot")
+                await rollbackToSnapshot(snapshot, userMessage: "Could not apply this rule change. Your previous rule state was restored.", mutationPermit: permit)
+                AppLogger.shared.log("💾 [CustomRules] Rollback complete, customRules.count = \(customRules.count)")
+            }
+
+            return success
+        }
+    }
+
+    /// Prepare the intended rule state under admission. Persistence belongs to the
+    /// caller so the mapper can retain its transaction through runtime recovery.
+    func updateCustomRuleInMemory(_ rule: CustomRule, autoResolveConflicts: Bool = false,
+                                  mutationPermit: ConfigurationOperationGate.Permit) async -> Bool
+    {
+        await withRuleMutation(using: mutationPermit, failure: false) { [self] _ in
             if rule.isEnabled,
                let conflict = conflictInfo(for: rule)
             {
@@ -1004,17 +1026,7 @@ extension RuleCollectionsManager {
                 customRules.append(rule)
             }
 
-            let success = await regenerateConfigFromCollections(skipReload: skipReload, mutationPermit: permit)
-
-            if success {
-                AppLogger.shared.log("💾 [CustomRules] Save complete, customRules.count = \(customRules.count)")
-            } else {
-                AppLogger.shared.log("💾 [CustomRules] Save failed - rolling back to snapshot")
-                await rollbackToSnapshot(snapshot, userMessage: "Could not apply this rule change. Your previous rule state was restored.", mutationPermit: permit)
-                AppLogger.shared.log("💾 [CustomRules] Rollback complete, customRules.count = \(customRules.count)")
-            }
-
-            return success
+            return true
         }
     }
 

--- a/Sources/KeyPathAppKit/Services/SimpleMods/SimpleModsService.swift
+++ b/Sources/KeyPathAppKit/Services/SimpleMods/SimpleModsService.swift
@@ -214,7 +214,7 @@ public final class SimpleModsService {
                 lastError = "\(cause) Configuration recovery failed: \(backupError?.localizedDescription ?? "") \(fallbackError.localizedDescription)"
             case .notAttempted:
                 lastError = cause
-            case .restoredPreviousAppKeymapState, .appKeymapRecoveryFailed:
+            case .restoredPreviousAppKeymapState, .appKeymapRecoveryFailed, .restoredPreviousRuleState, .ruleStateRecoveryFailed:
                 // This editor uses raw-file saves, not the app-keymap transaction.
                 lastError = cause
             }

--- a/Tests/KeyPathTests/Config/ConfigurationRuleWriteTests.swift
+++ b/Tests/KeyPathTests/Config/ConfigurationRuleWriteTests.swift
@@ -76,6 +76,84 @@ final class ConfigurationRuleWriteTests: KeyPathTestCase {
         withExtendedLifetime(token) {}
     }
 
+    func testStagedRevisionNotifiesOnlyAfterCommit() async throws {
+        let count = ObservationCount()
+        let token = service.observe { _ in await count.increment() }
+        try await service.operationGate.withOperation { @MainActor permit in
+            let write = try await self.service.stageRuleState(
+                ruleCollections: [self.collection("Staged")], customRules: [],
+                collectionStore: self.collections, customStore: self.customRules, mutationPermit: permit
+            )
+            let stagedCount = await count.value
+            XCTAssertEqual(stagedCount, 0)
+            XCTAssertTrue(FileManager.default.fileExists(atPath: RecoverableRuleWrite.journalURL(self.directory).path))
+            try await self.service.settleRuleWrite(write, commit: true, mutationPermit: permit)
+            let committedCount = await count.value
+            XCTAssertEqual(committedCount, 1)
+        }
+        withExtendedLifetime(token) {}
+        XCTAssertFalse(FileManager.default.fileExists(atPath: RecoverableRuleWrite.journalURL(directory).path))
+    }
+
+    func testStagedRollbackRestoresExactThreeFileRevisionWithoutNotification() async throws {
+        try await service.saveRuleState(ruleCollections: [collection("Original")], customRules: [], collectionStore: collections, customStore: customRules)
+        let before = try snapshot()
+        let count = ObservationCount()
+        let token = service.observe { _ in await count.increment() }
+        try await service.operationGate.withOperation { @MainActor permit in
+            let write = try await self.service.stageRuleState(
+                ruleCollections: [self.collection("Candidate")], customRules: [],
+                collectionStore: self.collections, customStore: self.customRules, mutationPermit: permit
+            )
+            try await self.service.settleRuleWrite(write, commit: false, mutationPermit: permit)
+        }
+        XCTAssertEqual(try snapshot(), before)
+        let notifications = await count.value
+        XCTAssertEqual(notifications, 0)
+        withExtendedLifetime(token) {}
+    }
+
+    func testExternalEditAfterStagePreventsCommitAndRollback() async throws {
+        try await service.saveRuleState(ruleCollections: [collection("Original")], customRules: [], collectionStore: collections, customStore: customRules)
+        try await service.operationGate.withOperation { @MainActor permit in
+            let write = try await self.service.stageRuleState(
+                ruleCollections: [self.collection("Candidate")], customRules: [],
+                collectionStore: self.collections, customStore: self.customRules, mutationPermit: permit
+            )
+            try "external edit".write(toFile: self.service.configurationPath, atomically: true, encoding: .utf8)
+            let externalRevision = try self.snapshot()
+            for commit in [true, false] {
+                do {
+                    try await self.service.settleRuleWrite(write, commit: commit, mutationPermit: permit)
+                    XCTFail("External changes must stop settlement")
+                } catch {
+                    XCTAssertEqual(try self.snapshot(), externalRevision)
+                }
+            }
+        }
+        XCTAssertTrue(FileManager.default.fileExists(atPath: RecoverableRuleWrite.journalURL(directory).path))
+    }
+
+    func testInterruptedStageIsRecoveredByFreshService() async throws {
+        try await service.saveRuleState(ruleCollections: [collection("Original")], customRules: [], collectionStore: collections, customStore: customRules)
+        let before = try snapshot()
+        try await service.operationGate.withOperation { @MainActor permit in
+            _ = try await self.service.stageRuleState(
+                ruleCollections: [self.collection("Interrupted")], customRules: [],
+                collectionStore: self.collections, customStore: self.customRules, mutationPermit: permit
+            )
+        }
+        let fresh = ConfigurationService(configDirectory: directory.path, ruleCollectionStore: collections, customRulesStore: customRules)
+        try await fresh.recoverPendingRuleWrite(collectionStore: collections, customStore: customRules)
+        XCTAssertEqual(try snapshot(), before)
+    }
+
+    private func snapshot() throws -> [String: Data] {
+        try Dictionary(uniqueKeysWithValues: ["keypath.kbd", "RuleCollections.json", "CustomRules.json"].map {
+            try ($0, Data(contentsOf: directory.appendingPathComponent($0)))
+        })
+    }
+
     func testBootstrapRecoversInterruptedWriteBeforeLoadingSourceStores() async throws {
         let original = collection("Original")
         let candidate = collection("Candidate")

--- a/Tests/KeyPathTests/Managers/AppKeymapSaveTests.swift
+++ b/Tests/KeyPathTests/Managers/AppKeymapSaveTests.swift
@@ -243,7 +243,7 @@ final class AppKeymapSaveTests: KeyPathTestCase {
         for name in ["AppKeymaps.json", "keypath.kbd", "keypath-apps.kbd"] {
             before[name] = try Data(contentsOf: directory.appendingPathComponent(name))
         }
-        let coordinator = SaveCoordinator(configurationService: service, engineClient: TCPEngineClient())
+        let coordinator = SaveCoordinator(configurationService: service)
         try await body(Fixture(directory: directory, service: service, store: store, coordinator: coordinator, before: before))
     }
 }

--- a/Tests/KeyPathTests/Managers/SaveCoordinatorTests.swift
+++ b/Tests/KeyPathTests/Managers/SaveCoordinatorTests.swift
@@ -21,10 +21,8 @@ final class SaveCoordinatorTests: KeyPathTestCase {
             ruleCollectionStore: .testStore(at: tempDir.appendingPathComponent("RuleCollections.json")),
             customRulesStore: .testStore(at: tempDir.appendingPathComponent("CustomRules.json"))
         )
-        let engine = TCPEngineClient()
         coordinator = SaveCoordinator(
             configurationService: configService,
-            engineClient: engine,
             configFileWatcher: nil
         )
     }
@@ -87,6 +85,7 @@ final class SaveCoordinatorTests: KeyPathTestCase {
         var reloadCount = 0
         let result = await coordinator.saveMapping(input: "a", output: "c", ruleCollectionsManager: manager) {
             reloadCount += 1
+            if reloadCount > 1 { return ReloadResult(success: true, response: nil, errorMessage: nil, protocol: nil) }
             return ReloadResult(
                 success: disposition == .applied,
                 response: nil,
@@ -96,15 +95,15 @@ final class SaveCoordinatorTests: KeyPathTestCase {
             )
         }
         XCTAssertEqual(result.reloadResult?.disposition, disposition, file: file, line: line)
-        XCTAssertEqual(reloadCount, 1, file: file, line: line)
         let saved = disposition == .applied || disposition == .pending
         XCTAssertEqual(result.success, saved, file: file, line: line)
+        XCTAssertEqual(reloadCount, saved ? 1 : 2, file: file, line: line)
         if saved {
             guard case .notAttempted = result.recoveryResult else {
                 return XCTFail("Successful saves must not claim recovery", file: file, line: line)
             }
         } else {
-            guard case .restoredPreviousConfig = result.recoveryResult else {
+            guard case .restoredPreviousRuleState = result.recoveryResult else {
                 return XCTFail("Rejected/failed reload must report restored file", file: file, line: line)
             }
         }
@@ -113,6 +112,9 @@ final class SaveCoordinatorTests: KeyPathTestCase {
             XCTAssertNotEqual(content, original, file: file, line: line)
         } else {
             XCTAssertEqual(content, original, file: file, line: line)
+            XCTAssertTrue(manager.customRules.isEmpty)
+            XCTAssertFalse(FileManager.default.fileExists(atPath: tempDir.appendingPathComponent("CustomRules.json").path))
+            XCTAssertFalse(FileManager.default.fileExists(atPath: tempDir.appendingPathComponent("RuleCollections.json").path))
         }
     }
 
@@ -336,13 +338,114 @@ final class SaveCoordinatorTests: KeyPathTestCase {
         XCTAssertEqual(try String(contentsOf: url, encoding: .utf8), backup)
     }
 
+    func testMappingCancellationRestoresSourcesAndRunsUncancelledRecovery() async throws {
+        let manager = RuleCollectionsManager(
+            ruleCollectionStore: .testStore(at: tempDir.appendingPathComponent("RuleCollections.json")),
+            customRulesStore: .testStore(at: tempDir.appendingPathComponent("CustomRules.json")),
+            configurationService: configService
+        )
+        manager.customRules = [manager.makeCustomRule(input: "a", output: "b")]
+        try await configService.saveRuleState(ruleCollections: [], customRules: manager.customRules,
+                                              collectionStore: manager.ruleCollectionStore, customStore: manager.customRulesStore)
+        let before = try ruleFiles()
+        let oldRules = manager.customRules
+        var reloadCount = 0
+        var operation: Task<KeyPathAppKit.SaveResult, Never>?
+        operation = Task { @MainActor in
+            await self.coordinator.saveMapping(input: "c", output: "d", ruleCollectionsManager: manager) {
+                reloadCount += 1
+                if reloadCount == 1 { operation?.cancel() }
+                else {
+                    XCTAssertFalse(Task.isCancelled, "Recovery must survive caller cancellation")
+                    do {
+                        let restored = try self.ruleFiles()
+                        XCTAssertEqual(restored, before)
+                    } catch { XCTFail("Recovery files unavailable: \(error)") }
+                }
+                return ReloadResult(success: true, response: nil, errorMessage: nil, protocol: nil)
+            }
+        }
+        let result = await operation!.value
+        XCTAssertFalse(result.success)
+        XCTAssertTrue(result.error is CancellationError)
+        XCTAssertEqual(reloadCount, 2)
+        XCTAssertEqual(try ruleFiles(), before)
+        XCTAssertEqual(manager.customRules.map(\.id), oldRules.map(\.id))
+        guard case let .restoredPreviousRuleState(recovery) = result.recoveryResult else { return XCTFail("Missing complete recovery") }
+        XCTAssertEqual(recovery?.disposition, .applied)
+    }
+
+    func testMappingExternalEditPreservesJournalAndDoesNotRegenerateSnapshot() async throws {
+        let manager = RuleCollectionsManager(
+            ruleCollectionStore: .testStore(at: tempDir.appendingPathComponent("RuleCollections.json")),
+            customRulesStore: .testStore(at: tempDir.appendingPathComponent("CustomRules.json")),
+            configurationService: configService
+        )
+        try await configService.saveRuleState(ruleCollections: [], customRules: [],
+                                              collectionStore: manager.ruleCollectionStore, customStore: manager.customRulesStore)
+        var reloads = 0
+        var externalRevision: [String: Data]?
+        let result = await coordinator.saveMapping(input: "a", output: "b", ruleCollectionsManager: manager) {
+            reloads += 1
+            do {
+                try "external edit".write(toFile: self.configService.configurationPath, atomically: true, encoding: .utf8)
+                externalRevision = try self.ruleFiles()
+            } catch { XCTFail("Could not inject external edit: \(error)") }
+            return ReloadResult(success: false, response: nil, errorMessage: "rejected", protocol: nil, disposition: .rejected)
+        }
+        XCTAssertFalse(result.success)
+        XCTAssertEqual(reloads, 1, "Do not reload a conflicted revision as recovery")
+        guard case .ruleStateRecoveryFailed = result.recoveryResult else { return XCTFail("Missing recovery conflict") }
+        XCTAssertEqual(try ruleFiles(), externalRevision)
+        XCTAssertTrue(manager.customRules.isEmpty)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: RecoverableRuleWrite.journalURL(tempDir).path))
+    }
+
+    func testMappingRetainsExistingCollectionConflictChoiceBeforeSingleReload() async {
+        let manager = RuleCollectionsManager(
+            ruleCollectionStore: .testStore(at: tempDir.appendingPathComponent("RuleCollections.json")),
+            customRulesStore: .testStore(at: tempDir.appendingPathComponent("CustomRules.json")),
+            configurationService: configService
+        )
+        var first = RuleCollection(name: "First", summary: "First", category: .custom,
+                                   mappings: [KeyMapping(input: "a", action: .keystroke(key: "b")),
+                                              KeyMapping(input: "a", action: .keystroke(key: "b"))], isEnabled: true)
+        first.configuration = .tapHoldPicker(TapHoldPickerConfig(inputKey: "a", tapOptions: [], holdOptions: [], selectedTapOutput: "b", selectedHoldOutput: "lctl"))
+        var second = RuleCollection(name: "Second", summary: "Second", category: .custom, mappings: [], isEnabled: true)
+        second.configuration = .tapHoldPicker(TapHoldPickerConfig(inputKey: "a", tapOptions: [], holdOptions: [], selectedTapOutput: "c", selectedHoldOutput: "lalt"))
+        manager.ruleCollections = [first, second]
+        var choices = 0
+        manager.onMappingConflictResolution = { _ in
+            choices += 1
+            return second.id
+        }
+        var reloads = 0
+        let result = await coordinator.saveMapping(input: "d", output: "e", ruleCollectionsManager: manager) {
+            reloads += 1
+            return ReloadResult(success: true, response: nil, errorMessage: nil, protocol: nil)
+        }
+        XCTAssertTrue(result.success)
+        XCTAssertEqual(choices, 1)
+        XCTAssertEqual(manager.ruleCollections.first?.mappings.count, 1, "Keep the existing pre-save mapping deduplication")
+        XCTAssertEqual(reloads, 1)
+        XCTAssertEqual(manager.ruleCollections.first { $0.id == second.id }?.isEnabled, false)
+        let stored = await manager.ruleCollectionStore.loadCollections()
+        XCTAssertEqual(stored.first { $0.id == second.id }?.isEnabled, false)
+    }
+
+    private func ruleFiles() throws -> [String: Data] {
+        try Dictionary(uniqueKeysWithValues: ["keypath.kbd", "RuleCollections.json", "CustomRules.json"].map {
+            try ($0, Data(contentsOf: tempDir.appendingPathComponent($0)))
+        })
+    }
+
     // MARK: - Rollback Fallback Tests
 
     func testGeneratedSaveReportsMinimalFallbackWhenPreviousFileIsEmpty() async throws {
         try await assertRecoveryOutcome(mapping: false, blockWrites: false)
     }
 
-    func testMappingSaveReportsMinimalFallbackWhenPreviousFileIsEmpty() async throws {
+    func testMappingSaveRestoresExactEmptyFileAndSources() async throws {
         try await assertRecoveryOutcome(mapping: true, blockWrites: false)
     }
 
@@ -350,7 +453,7 @@ final class SaveCoordinatorTests: KeyPathTestCase {
         try await assertRecoveryOutcome(mapping: false, blockWrites: true)
     }
 
-    func testMappingSavePreservesBothRecoveryErrorsAndReleasesOperation() async throws {
+    func testMappingSaveReportsJournalRecoveryFailureAndReleasesOperation() async throws {
         try await assertRecoveryOutcome(mapping: true, blockWrites: true)
     }
 
@@ -388,6 +491,29 @@ final class SaveCoordinatorTests: KeyPathTestCase {
         XCTAssertNotNil(result.error)
         XCTAssertEqual(result.reloadResult?.errorMessage, "injected rejection")
         XCTAssertEqual(result.reloadResult?.disposition, .rejected)
+        if mapping {
+            if blockWrites {
+                XCTAssertEqual(reloadCount, 1)
+                guard case .ruleStateRecoveryFailed = result.recoveryResult else { return XCTFail("Missing journal recovery failure") }
+                XCTAssertTrue(result.error?.localizedDescription.contains("Recovery needs attention") == true)
+                XCTAssertEqual(try String(contentsOf: tempDir, encoding: .utf8), "blocked")
+                try FileManager.default.removeItem(at: tempDir)
+                try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+                try original.write(to: url, atomically: true, encoding: .utf8)
+                let next = await coordinator.saveGeneratedConfig(content: updated) {
+                    ReloadResult(success: true, response: "ok", errorMessage: nil, protocol: nil)
+                }
+                XCTAssertTrue(next.success)
+            } else {
+                XCTAssertEqual(reloadCount, 2)
+                guard case let .restoredPreviousRuleState(recoveryReload) = result.recoveryResult else { return XCTFail("Missing exact rule revision recovery") }
+                XCTAssertEqual(recoveryReload?.disposition, .rejected)
+                XCTAssertTrue(result.error?.localizedDescription.contains("Recovery needs attention") == true)
+                XCTAssertEqual(try String(contentsOf: url, encoding: .utf8), original)
+                XCTAssertTrue(manager.customRules.isEmpty)
+            }
+            return
+        }
         XCTAssertEqual(reloadCount, 1, "Recovery must not issue a second reload")
         if blockWrites {
             guard case let .failed(backupError, fallbackError) = result.recoveryResult else {

--- a/Tests/KeyPathTests/Managers/SharedConfigurationAdmissionTests.swift
+++ b/Tests/KeyPathTests/Managers/SharedConfigurationAdmissionTests.swift
@@ -90,7 +90,7 @@ final class SharedConfigurationAdmissionTests: KeyPathTestCase {
 
     func testTwoCoordinatorsShareAdmissionAcrossRejectedReload() async throws {
         try await withFixture { service, _, firstCoordinator in
-            let secondCoordinator = SaveCoordinator(configurationService: service, engineClient: TCPEngineClient())
+            let secondCoordinator = SaveCoordinator(configurationService: service)
             let entered = self.expectation(description: "first reload entered")
             let started = self.expectation(description: "second save requested")
             var resume: CheckedContinuation<Void, Never>?
@@ -382,7 +382,7 @@ final class SharedConfigurationAdmissionTests: KeyPathTestCase {
         try "(defcfg)\n(defsrc a)\n(deflayer base a)".write(toFile: service.configurationPath, atomically: true, encoding: .utf8)
         let manager = RuleCollectionsManager(ruleCollectionStore: collections, customRulesStore: rules, configurationService: service, keymapPreferences: preferences)
         manager.onRulesChanged = { ReloadResult(success: true, response: nil, errorMessage: nil, protocol: nil) }
-        let coordinator = SaveCoordinator(configurationService: service, engineClient: TCPEngineClient())
+        let coordinator = SaveCoordinator(configurationService: service)
         try await body(service, manager, coordinator)
     }
 }

--- a/Tests/KeyPathTests/Services/SimpleModsSaveTests.swift
+++ b/Tests/KeyPathTests/Services/SimpleModsSaveTests.swift
@@ -186,6 +186,6 @@ final class SimpleModsSaveTests: KeyPathTestCase {
         let service = ConfigurationService(configDirectory: directory.path,
                                            ruleCollectionStore: .testStore(at: directory.appendingPathComponent("RuleCollections.json")),
                                            customRulesStore: .testStore(at: directory.appendingPathComponent("CustomRules.json")))
-        try await body(Fixture(url: url, original: original, coordinator: SaveCoordinator(configurationService: service, engineClient: TCPEngineClient())))
+        try await body(Fixture(url: url, original: original, coordinator: SaveCoordinator(configurationService: service)))
     }
 }

--- a/docs/architecture/configuration-save-pipeline.md
+++ b/docs/architecture/configuration-save-pipeline.md
@@ -38,12 +38,12 @@ their behavior: applied and pending are successful saves. `success` alone does
 not mean the runtime applied the configuration.
 
 The retained reload result describes the application attempt. The separate
-`SaveResult.recoveryResult` describes file recovery: `notAttempted`,
+For raw/generated saves, `SaveResult.recoveryResult` describes file recovery: `notAttempted`,
 `restoredPreviousConfig`, `wroteMinimalSafeConfig(backupError:)`, or
 `failed(backupError:fallbackError:)`. A minimal safe file is not restoration of
 the prior revision. Both recovery errors are retained if neither write succeeds;
 the original reload result and save error remain available. Applied/pending saves
-and failures before reload report no recovery attempt.
+and failures before a write report no recovery attempt. Staged rule/app edits cancelled before reload can still require file recovery.
 
 Explicit restoration returns the same successful recovery outcomes and retains
 its throwing contract when even the fallback cannot be written. These outcomes
@@ -248,3 +248,26 @@ Pack detail's missing-record repair uses PackInstaller.reconcileInstallRecord.
 It reads persisted collection state after admission, refuses incomplete reads,
 and propagates persistence failure instead of reporting installed unconditionally.
 It preserves the existing backfill policy; it does not decide new pack ownership.
+
+## Mapper rule-state recovery
+
+`SaveCoordinator.saveMapping` uses the manager's conflict resolution and in-memory
+rule preparation, then retains the configuration and both source stores in one
+journal until reload classification. Applied/pending commits; rejected, failed,
+or cancelled application restores the exact previous files (including absence or
+an empty file), then attempts a compensating reload if application was attempted.
+The result keeps the original reload and a separate `restoredPreviousRuleState`
+recovery reload, or `ruleStateRecoveryFailed`. Restoring files does not imply
+that the recovery reload succeeded.
+
+Only a committed revision notifies configuration/collection observers. On failure,
+the manager's optimistic snapshot is restored without generating or writing again.
+External edits after staging stop commit and rollback, preserving the files and
+journal for attention. The staged writer also compares the captured pre-validation
+revision before writing. SaveCoordinator's unused engine-client dependency is
+removed; runtime work continues through the injected reload callback.
+
+Other collection mutators still use their existing immediate-commit compatibility
+path. Their snapshot regeneration, pack-wide preferences/metadata recovery,
+stale manager caches, revision-aware watching, and raw-file runtime recovery
+remain separate migrations. This mapper change does not claim those are complete.

--- a/docs/bugs/mapper-rule-source-recovery.md
+++ b/docs/bugs/mapper-rule-source-recovery.md
@@ -1,0 +1,20 @@
+# Mapper rollback must restore rule sources
+
+The mapper previously called `saveCustomRule(skipReload: true)`, committing the
+configuration and both source stores before SaveCoordinator attempted a reload.
+A rejected reload restored only keypath.kbd; subsequent regeneration could revive
+the rejected rule from CustomRules.json. The caller's optimistic manager state
+also retained the rejected rule.
+
+The mapper now prepares the same conflict decision in memory and lets
+SaveCoordinator retain the three-file transaction through reload. Failure restores
+an exact receipt and the manager snapshot; compensating reload runs without
+inheriting cancellation while admission remains held. No caller regeneration is
+used for this rollback, because it could clobber an external edit. External
+revision conflicts preserve the journal and report recovery failure.
+
+ConfigurationRuleWriteTests cover stage/commit observer timing, exact rollback,
+external changes, and interrupted recovery. SaveCoordinatorTests cover mapper
+reload dispositions, source absence restoration, empty-file preservation, and
+failed recovery. Collection/pack mutators are not yet migrated to this runtime
+transaction; their compatibility Boolean continues to mean persisted.

--- a/docs/planning/catalog-led-consolidation-plan.md
+++ b/docs/planning/catalog-led-consolidation-plan.md
@@ -268,6 +268,7 @@ Implemented slices (the table describes the merged state of this checkpoint):
 | #1273 | CLI rule, collection and pack commands hold admission through optional apply; pack sources refresh after admission and strict metadata reads precede mutations. | Direct UI metadata writers, feature-specific writes and complete recovery remain. |
 | #1274 | App-specific edits retain a three-file journal through runtime apply/recovery, preserve hand-written files, and refresh app context after immediate/deferred reload. | Global/pack recovery, mixed app/global operations and revision-aware watching remain. |
 | #1275 | Simple Modifications transforms captured revisions through SaveCoordinator, preserves external edits, retains reload/recovery outcomes and serializes debounce settlement. | Legacy raw syntax/ownership limitations and full runtime recovery remain. |
+| #1277 | Pack metadata writes share PackInstaller admission; deferred repair reads durable state without inheriting a live operation lease. | Full pack transaction/recovery and ownership policy remain. |
 
 Admission now also holds a cooperative OS lease across service instances and
 processes for the same directory. CLI configuration apply now holds admission
@@ -351,7 +352,7 @@ Raw-file recovery still has the existing file-only boundary. External deflayerma
 ownership, status presentation, full runtime recovery and crash recovery remain
 separate work; this slice does not claim those are complete.
 
-### Pack metadata consolidation
+### Pack metadata consolidation merged in #1277
 
 The remaining Rules-toggle and detail-view repair writes now enter PackInstaller
 under the directory operation gate. Repair reads persisted collection state,
@@ -365,3 +366,13 @@ remain separate work.
 CI maintenance: #1276 increased the review action's turn allowance after repeated
 `error_max_turns` failures. It was merged separately; #1275 then passed actual
 review under that workflow. Both are included in the signed/notarized #1275 deploy.
+
+### Mapper rule-state recovery in progress
+
+The mapper now keeps the configuration and both source stores recoverable through
+runtime classification in SaveCoordinator. Failure restores the exact file set
+and optimistic manager snapshot, with a separate compensating reload outcome.
+Existing rule and collection conflict choices are shared as in-memory preparation;
+the mapper no longer invokes the legacy immediate-commit save before reloading.
+External revision conflicts preserve files and the journal rather than regenerating
+a snapshot over them. Other collection mutators and pack-wide recovery remain open.


### PR DESCRIPTION
## Problem and result

A mapper save committed RuleCollections.json and CustomRules.json before reloading Kanata. If reload failed, only keypath.kbd was restored, leaving rejected source data available for the next regeneration.

The mapper now retains the three-file journal through reload. Applied/pending results commit; rejection, failure, or cancellation restores the exact previous file set and optimistic manager state, then attempts an uncancelled recovery reload when needed. External edits stop settlement and preserve the journal. Recovery retains its own outcome and never regenerates a snapshot over newer content.

The existing custom-rule and save-time collection conflict choices are reused as in-memory preparation, including pre-save deduplication. ConfigurationService exposes stage/settle operations and checks the captured pre-validation revision. Its immediate-commit compatibility path uses those same primitives. SaveCoordinator's unused engine-client dependency is removed.

## Validation

- Focused mapper, configuration-journal, app-keymap, admission and conflict tests passed. Tests cover cancellation, external edits, exact empty/absent file restoration, failed recovery, observer timing and interrupted writes.
- Full safe suite: 5,193 passed; four previously reproduced macOS 27 snapshot failures (three HomeRowTiming cases and RepairSettingsTabView). Supported-runner CI is the full green gate.
- SwiftFormat 0.61.1 lint, accessibility coverage and diff checks passed.
- Remote review gate selected; GitHub claude-review is required before merge.
- Installer matrix: `Running but TCP not responding` and `Running and TCP responding`. The original and compensating reload dispositions are tested; restoring files alone does not claim runtime readiness. No installer/registration policy changes.

## Boundaries

Other collection mutators still use their immediate-commit compatibility path. Pack-wide preferences/metadata recovery, stale manager caches, revision-aware watching and raw-file runtime recovery remain separate migrations. No navigation, ownership/conflict policy, or feature-removal changes. Post-merge signed deployment remains required.

## Review disposition

The cache-invalidation finding does not apply to the public API. `currentConfiguration` is private; `current()` returns a nonoptional configuration and reloads the restored file whenever that cache is absent. Keeping the cached value is unsafe because an explicit read/reload during staging may have cached the candidate revision. Clearing it on rollback ensures the next reader reparses the restored bytes, matching the existing app-keymap rollback and interrupted-write recovery behavior. No caller can observe a nil configuration through `FileConfigurationProviding`.
