### PR TITLE
Install custom-rule packs as one recoverable transaction

### DIFF
--- a/Sources/KeyPathAppKit/CLI/PacksFacade.swift
+++ b/Sources/KeyPathAppKit/CLI/PacksFacade.swift
@@ -296,7 +296,7 @@ public struct PacksFacade: Sendable {
     ) async throws -> Result {
         let manager = await makePackManager()
         return try await manager.configurationService.operationGate.withOperation(using: self.operation?.permit) { @MainActor permit in
-            try await installedPackTracker.validateForMutation()
+            try await PackInstaller.shared.recoverAndValidateState(manager: manager, tracker: installedPackTracker, permit: permit)
             return try await operation(manager, permit)
         }
     }

--- a/Sources/KeyPathAppKit/Infrastructure/Config/ConfigurationService.swift
+++ b/Sources/KeyPathAppKit/Infrastructure/Config/ConfigurationService.swift
@@ -336,6 +336,7 @@ public final class ConfigurationService: FileConfigurationProviding {
     struct RuleWrite: Sendable {
         let pending: RecoverableRuleWrite.PendingWrite
         let configuration: KanataConfiguration
+        let packUpdate: InstalledPackTracker.PreparedRecordUpdate?
     }
 
     /// Stage the generated configuration and both source stores without notifying
@@ -343,26 +344,40 @@ public final class ConfigurationService: FileConfigurationProviding {
     func stageRuleState(
         ruleCollections: [RuleCollection], customRules: [CustomRule],
         collectionStore: RuleCollectionStore, customStore: CustomRulesStore,
-        mutationPermit: ConfigurationOperationGate.Permit
+        mutationPermit: ConfigurationOperationGate.Permit,
+        packRecord: InstalledPackTracker.RecordChange? = nil
     ) async throws -> RuleWrite {
         try await operationGate.withOperation(using: mutationPermit) { @MainActor [self] permit in
-            try await recoverPendingRuleWrite(collectionStore: collectionStore, customStore: customStore, mutationPermit: permit)
+            try await recoverPendingRuleWrite(collectionStore: collectionStore, customStore: customStore, mutationPermit: permit, installedPackTracker: packRecord?.tracker)
             try await recoverPendingAppKeymapWrite(mutationPermit: permit)
-            let files = await ruleWriteFiles(collectionStore: collectionStore, customStore: customStore)
+            var targets = await ruleWriteFiles(collectionStore: collectionStore, customStore: customStore)
+            if let packRecord { targets["installedPacks"] = await packRecord.tracker.persistenceURL }
+            let files = targets
             let before = try await snapshotRuleFiles(files)
+            let packUpdate: InstalledPackTracker.PreparedRecordUpdate?
+            if let packRecord {
+                packUpdate = try await packRecord.tracker.prepareUpsert(packRecord.record)
+                guard packUpdate?.before == before["installedPacks"] else { throw RecoverableRuleWrite.Failure.changedFile("installedPacks") }
+            } else { packUpdate = nil }
             let newConfig = try await preparedConfiguration(ruleCollections: ruleCollections, customRules: customRules)
-            let contents = try await [
+            var payload = try await [
                 "config": Data(newConfig.content.utf8),
                 "collections": collectionStore.encodedCollections(ruleCollections),
                 "customRules": customStore.encodedRules(customRules)
             ]
+            if let packUpdate { payload["installedPacks"] = packUpdate.contents }
+            let contents = payload
             try Task.checkCancellation()
             let directory = URL(fileURLWithPath: configDirectory)
             let pending = try await performRuleFileOperation {
                 try RecoverableRuleWrite.stage(files: files, contents: contents, directory: directory,
-                                               scope: .rules, expectedBefore: before)
+                                               scope: packUpdate == nil ? .rules : .packRules, expectedBefore: before)
+                { data, url in
+                    if let packUpdate, url == packUpdate.fileURL { try packUpdate.writeFile(data, url) }
+                    else { try RecoverableRuleWrite.durableWrite(data, url) }
+                }
             }
-            return RuleWrite(pending: pending, configuration: newConfig)
+            return RuleWrite(pending: pending, configuration: newConfig, packUpdate: packUpdate)
         }
     }
 
@@ -372,8 +387,13 @@ public final class ConfigurationService: FileConfigurationProviding {
                 if commit { try RecoverableRuleWrite.commit(write.pending) }
                 else { try RecoverableRuleWrite.rollback(write.pending) }
             }
-            if commit { await publishSavedConfiguration(write.configuration) }
-            else { stateLock.withLock { currentConfiguration = nil } }
+            if commit {
+                await publishSavedConfiguration(write.configuration)
+                if let update = write.packUpdate { await update.tracker.publishCommittedUpdate(update) }
+            } else {
+                stateLock.withLock { currentConfiguration = nil }
+                if let update = write.packUpdate { await update.tracker.restorePublishedUpdate(update) }
+            }
         }
     }
 
@@ -390,16 +410,32 @@ public final class ConfigurationService: FileConfigurationProviding {
 
     /// Run before loading source stores on startup. Refuse further rule writes
     /// when recovery detects a corrupt journal or an unrelated external edit.
-    func recoverPendingRuleWrite(collectionStore: RuleCollectionStore, customStore: CustomRulesStore, mutationPermit: ConfigurationOperationGate.Permit? = nil) async throws {
+    @discardableResult
+    func recoverPendingRuleWrite(
+        collectionStore: RuleCollectionStore,
+        customStore: CustomRulesStore,
+        mutationPermit: ConfigurationOperationGate.Permit? = nil,
+        installedPackTracker: InstalledPackTracker? = nil
+    ) async throws -> Bool {
         try await operationGate.withOperation(using: mutationPermit) { @MainActor [self] _ in
             let files = await ruleWriteFiles(collectionStore: collectionStore, customStore: customStore)
             let directory = URL(fileURLWithPath: configDirectory)
+            var packTargets = files
+            if let installedPackTracker {
+                packTargets["installedPacks"] = await installedPackTracker.persistenceURL
+            } else {
+                packTargets["installedPacks"] = directory.appendingPathComponent("installed-packs.json")
+            }
+            let packFiles = packTargets
             let recovered = try await performRuleFileOperation {
-                try RecoverableRuleWrite.recover(files: files, directory: directory)
+                let packRecovered = try RecoverableRuleWrite.recover(files: packFiles, directory: directory, scope: .packRules)
+                let rulesRecovered = try RecoverableRuleWrite.recover(files: files, directory: directory)
+                return packRecovered || rulesRecovered
             }
             if recovered {
                 stateLock.withLock { currentConfiguration = nil }
             }
+            return recovered
         }
     }
 

--- a/Sources/KeyPathAppKit/Infrastructure/Config/RecoverableRuleWrite.swift
+++ b/Sources/KeyPathAppKit/Infrastructure/Config/RecoverableRuleWrite.swift
@@ -9,11 +9,13 @@ enum RecoverableRuleWrite {
     enum Scope: Sendable, Equatable {
         case rules
         case appKeymaps
+        case packRules
 
         var roles: Set<String> {
             switch self {
             case .rules: ["config", "collections", "customRules"]
             case .appKeymaps: ["config", "appKeymaps", "appInclude"]
+            case .packRules: ["config", "collections", "customRules", "installedPacks"]
             }
         }
     }
@@ -228,12 +230,18 @@ enum RecoverableRuleWrite {
     }
 
     static func journalURL(_ directory: URL, scope: Scope = .rules) -> URL {
-        directory.appendingPathComponent(scope == .rules ? ".keypath-rule-write.json" : ".keypath-app-write.json")
+        let name = switch scope {
+        case .rules: ".keypath-rule-write.json"
+        case .appKeymaps: ".keypath-app-write.json"
+        case .packRules: ".keypath-pack-rule-write.json"
+        }
+        return directory.appendingPathComponent(name)
     }
 
     private static func validateFiles(_ files: [String: URL], directory: URL, scope: Scope) throws {
         let targets = Set(files.values.map(\.standardizedFileURL))
-        let reserved = Set([journalURL(directory), journalURL(directory, scope: .appKeymaps), directory.appendingPathComponent(".keypath-rule-write.lock")].map(\.standardizedFileURL))
+        let reserved = Set([journalURL(directory), journalURL(directory, scope: .appKeymaps), journalURL(directory, scope: .packRules), directory.appendingPathComponent(".keypath-rule-write.lock")]
+            .map(\.standardizedFileURL))
         guard Set(files.keys) == scope.roles,
               targets.count == files.count, targets.isDisjoint(with: reserved)
         else { throw Failure.invalidJournal }

--- a/Sources/KeyPathAppKit/Managers/SaveCoordinator.swift
+++ b/Sources/KeyPathAppKit/Managers/SaveCoordinator.swift
@@ -198,16 +198,7 @@ final class SaveCoordinator {
                         saveStatus = .failed(error.localizedDescription)
                         return .failure(error)
                     }
-                    var result: SaveResult
-                    var conflictDepth = 0
-                    while true {
-                        result = await saveRuleState(manager: ruleCollectionsManager, mutationPermit: permit, reloadHandler: reloadHandler)
-                        guard !result.success, result.reloadResult == nil,
-                              let error = result.error,
-                              await ruleCollectionsManager.resolveMappingConflictInMemory(error, depth: conflictDepth, mutationPermit: permit)
-                        else { break }
-                        conflictDepth += 1
-                    }
+                    let result = await saveRuleState(manager: ruleCollectionsManager, mutationPermit: permit, reloadHandler: reloadHandler)
                     if result.success {
                         NotificationCenter.default.post(name: .ruleCollectionsChanged, object: nil)
                         playSuccessSound()
@@ -235,50 +226,63 @@ final class SaveCoordinator {
     func saveRuleState(
         manager: RuleCollectionsManager,
         mutationPermit: ConfigurationOperationGate.Permit,
-        reloadHandler: @escaping () async -> ReloadResult
+        packRecord: InstalledPackTracker.RecordChange? = nil,
+        reloadHandler: (() async -> ReloadResult)?
     ) async -> SaveResult {
         do {
             return try await configurationService.operationGate.withOperation(using: mutationPermit) { @MainActor [self] permit in
-                var staged: ConfigurationService.RuleWrite?
-                var reload: ReloadResult?
-                do {
-                    manager.dedupeRuleCollectionsInPlace()
-                    staged = try await configurationService.stageRuleState(
-                        ruleCollections: manager.ruleCollections, customRules: manager.customRules,
-                        collectionStore: manager.ruleCollectionStore, customStore: manager.customRulesStore,
-                        mutationPermit: permit
-                    )
-                    try Task.checkCancellation()
-                    playWriteSound()
-                    let result = await reloadHandler()
-                    reload = result
-                    try Task.checkCancellation()
-                    guard result.disposition == .applied || result.disposition == .pending else {
-                        throw KeyPathError.configuration(.loadFailed(reason: result.errorMessage ?? "The rule configuration could not be applied"))
-                    }
-                    guard let staged else { throw AppConfigError.validationUnavailable }
-                    try await configurationService.settleRuleWrite(staged, commit: true, mutationPermit: permit)
-                    saveStatus = .success
-                    scheduleStatusReset()
-                    return .success(mappings: manager.enabledMappings(), reloadResult: result)
-                } catch {
-                    var recovery: SaveRecoveryResult = .notAttempted
-                    var reportedError: Error = error
-                    if let staged {
-                        do {
-                            try await configurationService.settleRuleWrite(staged, commit: false, mutationPermit: permit)
-                            let recoveryReload = reload == nil ? nil : await Task { @MainActor in await reloadHandler() }.value
-                            recovery = .restoredPreviousRuleState(reloadResult: recoveryReload)
-                            if let recoveryReload, recoveryReload.disposition == .failed || recoveryReload.disposition == .rejected {
-                                reportedError = SaveApplicationError(cause: error, recovery: recoveryReload.errorMessage ?? "Prior rule files were restored, but runtime recovery failed")
-                            }
-                        } catch let recoveryError {
-                            recovery = .ruleStateRecoveryFailed(recoveryError)
-                            reportedError = SaveApplicationError(cause: error, recovery: recoveryError.localizedDescription)
+                saveStatus = .saving
+                var conflictDepth = 0
+                while true {
+                    var staged: ConfigurationService.RuleWrite?
+                    var reload: ReloadResult?
+                    do {
+                        manager.dedupeRuleCollectionsInPlace()
+                        manager.onBeforeSave?()
+                        staged = try await configurationService.stageRuleState(
+                            ruleCollections: manager.ruleCollections, customRules: manager.customRules,
+                            collectionStore: manager.ruleCollectionStore, customStore: manager.customRulesStore,
+                            mutationPermit: permit, packRecord: packRecord
+                        )
+                        try Task.checkCancellation()
+                        playWriteSound()
+                        let result = await reloadHandler?()
+                        reload = result
+                        try Task.checkCancellation()
+                        if let result, result.disposition != .applied, result.disposition != .pending {
+                            throw KeyPathError.configuration(.loadFailed(reason: result.errorMessage ?? "The rule configuration could not be applied"))
                         }
+                        guard let staged else { throw AppConfigError.validationUnavailable }
+                        try await configurationService.settleRuleWrite(staged, commit: true, mutationPermit: permit)
+                        saveStatus = .success
+                        scheduleStatusReset()
+                        return SaveResult(success: true, error: nil, mappings: manager.enabledMappings(),
+                                          reloadResult: result, recoveryResult: .notAttempted)
+                    } catch {
+                        if staged == nil, reload == nil,
+                           await manager.resolveMappingConflictInMemory(error, depth: conflictDepth, mutationPermit: permit)
+                        {
+                            conflictDepth += 1
+                            continue
+                        }
+                        var recovery: SaveRecoveryResult = .notAttempted
+                        var reportedError: Error = error
+                        if let staged {
+                            do {
+                                try await configurationService.settleRuleWrite(staged, commit: false, mutationPermit: permit)
+                                let recoveryReload = reload == nil ? nil : await Task { @MainActor in await reloadHandler?() }.value
+                                recovery = .restoredPreviousRuleState(reloadResult: recoveryReload)
+                                if let recoveryReload, recoveryReload.disposition == .failed || recoveryReload.disposition == .rejected {
+                                    reportedError = SaveApplicationError(cause: error, recovery: recoveryReload.errorMessage ?? "Prior rule files were restored, but runtime recovery failed")
+                                }
+                            } catch let recoveryError {
+                                recovery = .ruleStateRecoveryFailed(recoveryError)
+                                reportedError = SaveApplicationError(cause: error, recovery: recoveryError.localizedDescription)
+                            }
+                        }
+                        saveStatus = .failed(reportedError.localizedDescription)
+                        return .failure(reportedError, reloadResult: reload, recoveryResult: recovery)
                     }
-                    saveStatus = .failed(reportedError.localizedDescription)
-                    return .failure(reportedError, reloadResult: reload, recoveryResult: recovery)
                 }
             }
         } catch { return .failure(error) }

--- a/Sources/KeyPathAppKit/Services/Packs/InstalledPackTracker.swift
+++ b/Sources/KeyPathAppKit/Services/Packs/InstalledPackTracker.swift
@@ -36,7 +36,7 @@ public actor InstalledPackTracker {
     public static let shared = InstalledPackTracker()
 
     private let fileURL: URL
-    private var writeFile: @Sendable (Data, URL) throws -> Void = { try $0.write(to: $1, options: [.atomic]) }
+    private var writeFile: @Sendable (Data, URL) throws -> Void = { try RecoverableRuleWrite.durableWrite($0, $1) }
     private var lastReadableRecords: [String: InstalledPackRecord] = [:]
 
     public init(fileURL: URL? = nil) {
@@ -69,6 +69,48 @@ public actor InstalledPackTracker {
     /// Call under configuration admission before staging source changes.
     func validateForMutation() throws {
         lastReadableRecords = try readRecords()
+    }
+
+    var persistenceURL: URL {
+        fileURL
+    }
+
+    struct RecordChange: Sendable {
+        let tracker: InstalledPackTracker
+        let record: InstalledPackRecord
+    }
+
+    struct PreparedRecordUpdate: Sendable {
+        let tracker: InstalledPackTracker
+        let fileURL: URL
+        let before: Data?
+        let contents: Data
+        let previousRecords: [String: InstalledPackRecord]
+        let records: [String: InstalledPackRecord]
+        let writeFile: @Sendable (Data, URL) throws -> Void
+    }
+
+    /// Build a metadata revision without writing or notifying. The configuration
+    /// transaction compares this preimage before staging it with the rule files.
+    func prepareUpsert(_ record: InstalledPackRecord) throws -> PreparedRecordUpdate {
+        let before: Data?
+        do { before = try Data(contentsOf: fileURL) }
+        catch let error as NSError where error.domain == NSCocoaErrorDomain && error.code == NSFileReadNoSuchFileError { before = nil }
+        let previous = try decodeRecords(before)
+        var updated = previous
+        updated[record.packID] = record
+        return try PreparedRecordUpdate(tracker: self, fileURL: fileURL, before: before,
+                                        contents: encodedRecords(updated), previousRecords: previous,
+                                        records: updated, writeFile: writeFile)
+    }
+
+    func publishCommittedUpdate(_ update: PreparedRecordUpdate) async {
+        lastReadableRecords = update.records
+        await postChangeNotification()
+    }
+
+    func restorePublishedUpdate(_ update: PreparedRecordUpdate) {
+        lastReadableRecords = update.previousRecords
     }
 
     // MARK: - Public API
@@ -160,9 +202,21 @@ public actor InstalledPackTracker {
         catch let error as NSError where error.domain == NSCocoaErrorDomain && error.code == NSFileReadNoSuchFileError {
             return [:]
         }
+        return try decodeRecords(data)
+    }
+
+    private func decodeRecords(_ data: Data?) throws -> [String: InstalledPackRecord] {
+        guard let data else { return [:] }
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
         return try decoder.decode([String: InstalledPackRecord].self, from: data)
+    }
+
+    private func encodedRecords(_ records: [String: InstalledPackRecord]) throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+        return try encoder.encode(records)
     }
 
     private func persist(_ records: [String: InstalledPackRecord]) throws {
@@ -172,10 +226,7 @@ public actor InstalledPackTracker {
             at: parent, withIntermediateDirectories: true
         )
 
-        let encoder = JSONEncoder()
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-        encoder.dateEncodingStrategy = .iso8601
-        let data = try encoder.encode(records)
+        let data = try encodedRecords(records)
 
         try writeFile(data, fileURL)
         lastReadableRecords = records

--- a/Sources/KeyPathAppKit/Services/Packs/PackCollectionSnapshot.swift
+++ b/Sources/KeyPathAppKit/Services/Packs/PackCollectionSnapshot.swift
@@ -1,4 +1,5 @@
 import Foundation
+import KeyPathCore
 import KeyPathRulesCore
 
 /// Snapshot of managed collections' state before a pack was installed.
@@ -23,9 +24,7 @@ public struct PackCollectionSnapshot: Codable {
     // MARK: - Persistence
 
     private static var snapshotsDirectory: URL {
-        FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent(".config", isDirectory: true)
-            .appendingPathComponent("keypath", isDirectory: true)
+        AppPaths.configDirectory
             .appendingPathComponent("pack-snapshots", isDirectory: true)
     }
 
@@ -53,9 +52,7 @@ public struct PackCollectionSnapshot: Codable {
     // MARK: - Legacy Vallack Migration
 
     private static var legacyVallackURL: URL {
-        FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent(".config", isDirectory: true)
-            .appendingPathComponent("keypath", isDirectory: true)
+        AppPaths.configDirectory
             .appendingPathComponent("vallack-system-snapshot.json")
     }
 

--- a/Sources/KeyPathAppKit/Services/Packs/PackInstaller.swift
+++ b/Sources/KeyPathAppKit/Services/Packs/PackInstaller.swift
@@ -59,6 +59,28 @@ public final class PackInstaller {
 
     // MARK: - Public API
 
+    /// Recover before reading installed state, including metadata-only operations
+    /// that would otherwise overwrite the pending transaction's record revision.
+    func recoverAndValidateState(manager: RuleCollectionsManager, tracker: InstalledPackTracker,
+                                 permit: ConfigurationOperationGate.Permit) async throws
+    {
+        let recovered = try await manager.configurationService.recoverPendingRuleWrite(
+            collectionStore: manager.ruleCollectionStore, customStore: manager.customRulesStore,
+            mutationPermit: permit, installedPackTracker: tracker
+        )
+        if recovered {
+            let collections = await manager.ruleCollectionStore.loadCollectionsDetailed()
+            guard !collections.wasFullReset, collections.failedCollectionNames.isEmpty else {
+                throw InstallError.saveFailed("Recovered rule collections could not be read completely")
+            }
+            let rules = try await manager.customRulesStore.loadForMutation()
+            manager.ruleCollections = RuleCollectionDeduplicator.dedupe(collections.collections)
+            manager.customRules = rules
+            manager.refreshLayerIndicatorState()
+        }
+        try await tracker.validateForMutation()
+    }
+
     /// Change only a visual capability's installed record. Legacy Rules toggles
     /// use this narrower operation; catalog installation still enforces its
     /// dependency/conflict gates before entering here. Nonvisual packs must use install/uninstall.
@@ -68,9 +90,9 @@ public final class PackInstaller {
         manager: RuleCollectionsManager, installedPackTracker: InstalledPackTracker = .shared,
         mutationPermit: ConfigurationOperationGate.Permit? = nil
     ) async throws -> InstalledPackRecord? {
-        try await manager.configurationService.operationGate.withOperation(using: mutationPermit) { @MainActor [self] _ in
+        try await manager.configurationService.operationGate.withOperation(using: mutationPermit) { @MainActor [self] permit in
             guard pack.visualOnly else { throw InstallError.saveFailed("This operation requires a visual-only pack") }
-            try await installedPackTracker.validateForMutation()
+            try await recoverAndValidateState(manager: manager, tracker: installedPackTracker, permit: permit)
             let previous = await installedPackTracker.record(for: pack.id)
             let record: InstalledPackRecord?
             if enabled {
@@ -103,13 +125,9 @@ public final class PackInstaller {
         installedPackTracker: InstalledPackTracker = .shared
     ) async throws -> InstalledPackRecord? {
         try await manager.configurationService.operationGate.withOperation { @MainActor permit in
-            try await installedPackTracker.validateForMutation()
+            try await self.recoverAndValidateState(manager: manager, tracker: installedPackTracker, permit: permit)
             if let existing = await installedPackTracker.record(for: pack.id) { return existing }
             guard let collectionID = pack.associatedCollectionID else { return nil }
-            try await manager.configurationService.recoverPendingRuleWrite(
-                collectionStore: manager.ruleCollectionStore, customStore: manager.customRulesStore,
-                mutationPermit: permit
-            )
             let loaded = await manager.ruleCollectionStore.loadCollectionsDetailed()
             guard !loaded.wasFullReset, loaded.failedCollectionNames.isEmpty else {
                 throw InstallError.saveFailed("Rule collections could not be read completely")
@@ -156,7 +174,7 @@ public final class PackInstaller {
         mutationPermit: ConfigurationOperationGate.Permit? = nil
     ) async throws -> InstalledPackRecord {
         try await manager.configurationService.operationGate.withOperation(using: mutationPermit) { @MainActor [self] permit in
-            try await installedPackTracker.validateForMutation()
+            try await recoverAndValidateState(manager: manager, tracker: installedPackTracker, permit: permit)
             AppLogger.shared.log(
                 "📦 [PackInstaller] Installing pack '\(pack.name)' (id=\(pack.id), v\(pack.version))"
             )
@@ -314,61 +332,33 @@ public final class PackInstaller {
                 return record
             }
 
-            // Build CustomRule entries from templates.
+            // Prepare the entire custom-rule pack before writing. The metadata and
+            // all rules remain one recoverable revision through runtime application.
             let ruleStateSnapshot = manager.snapshotRuleState()
-            let previousInstallRecord = await installedPackTracker.record(for: pack.id)
             let rules = renderBindings(for: pack, quickSettings: resolvedSettings)
-
-            // Append rules in one batch: use skipReload=true for all but the
-            // last, so we only regenerate the config file once at the end.
-            // Callers that chain an immediate edit after install can pass
-            // `skipFinalReload: true` to suppress even the last reload, so a
-            // followup `updateTapHold` fires exactly one reload for the
-            // combined result (and doesn't trip the TCP reload cooldown).
             for (index, rule) in rules.enumerated() {
-                let isLast = (index == rules.count - 1)
-                let suppressReload = !isLast || skipFinalReload
-                let ok = await manager.saveCustomRule(rule, skipReload: suppressReload, mutationPermit: permit)
-                if !ok {
-                    AppLogger.shared.log(
-                        "❌ [PackInstaller] Failed to save rule \(index + 1)/\(rules.count) for pack '\(pack.id)'"
-                    )
-                    // Roll back: remove whatever got added so far.
-                    await rollbackPartialInstall(packID: pack.id, manager: manager, mutationPermit: permit)
-                    throw InstallError.saveFailed("rule \(index + 1) of \(rules.count) could not be saved")
+                guard await manager.updateCustomRuleInMemory(rule, mutationPermit: permit) else {
+                    manager.ruleCollections = ruleStateSnapshot.collections
+                    manager.customRules = ruleStateSnapshot.customRules
+                    manager.refreshLayerIndicatorState()
+                    throw InstallError.saveFailed("rule \(index + 1) of \(rules.count) could not be prepared")
                 }
             }
-
-            // Record the install.
-            let record = InstalledPackRecord(
-                packID: pack.id,
-                version: pack.version,
-                installedAt: Date(),
-                quickSettingValues: resolvedSettings
+            let record = InstalledPackRecord(packID: pack.id, version: pack.version,
+                                             installedAt: Date(), quickSettingValues: resolvedSettings)
+            let result = await SaveCoordinator(configurationService: manager.configurationService).saveRuleState(
+                manager: manager, mutationPermit: permit,
+                packRecord: .init(tracker: installedPackTracker, record: record),
+                reloadHandler: skipFinalReload ? nil : manager.onRulesChanged
             )
-            do {
-                try await installedPackTracker.upsert(record)
-            } catch {
-                AppLogger.shared.errorUnlessQuietTest(
-                    "❌ [PackInstaller] Could not persist install record for '\(pack.name)'; restoring previous state"
-                )
-                let installRecordRestored = await restoreInstallRecord(
-                    previousInstallRecord,
-                    packID: pack.id,
-                    installedPackTracker: installedPackTracker
-                )
-                let rollbackApplied = await manager.rollbackToSnapshot(
-                    ruleStateSnapshot,
-                    userMessage: "Could not record this pack installation. Your previous rule state was restored.",
-                    mutationPermit: permit
-                )
-                guard rollbackApplied, installRecordRestored else {
-                    throw InstallError.saveFailed(
-                        "installed-pack record could not be saved and the previous state could not be fully restored"
-                    )
-                }
-                throw error
+            guard result.success else {
+                manager.ruleCollections = ruleStateSnapshot.collections
+                manager.customRules = ruleStateSnapshot.customRules
+                manager.refreshLayerIndicatorState()
+                if result.error is CancellationError { throw CancellationError() }
+                throw InstallError.saveFailed(result.error?.localizedDescription ?? "Pack installation could not be committed")
             }
+            NotificationCenter.default.post(name: .ruleCollectionsChanged, object: nil)
 
             AppLogger.shared.log(
                 "✅ [PackInstaller] Installed pack '\(pack.name)': \(rules.count) binding(s)"
@@ -386,7 +376,7 @@ public final class PackInstaller {
         mutationPermit: ConfigurationOperationGate.Permit? = nil
     ) async throws {
         try await manager.configurationService.operationGate.withOperation(using: mutationPermit) { @MainActor [self] permit in
-            try await installedPackTracker.validateForMutation()
+            try await recoverAndValidateState(manager: manager, tracker: installedPackTracker, permit: permit)
             AppLogger.shared.log("📦 [PackInstaller] Uninstalling pack '\(packID)'")
 
             // Visual-only packs just clear the tracker record; no kanata
@@ -574,7 +564,7 @@ public final class PackInstaller {
         mutationPermit: ConfigurationOperationGate.Permit? = nil
     ) async throws {
         try await manager.configurationService.operationGate.withOperation(using: mutationPermit) { @MainActor [self] permit in
-            try await installedPackTracker.validateForMutation()
+            try await recoverAndValidateState(manager: manager, tracker: installedPackTracker, permit: permit)
             guard let pack = PackRegistry.pack(id: packID) else {
                 throw InstallError.saveFailed("pack not found in registry: \(packID)")
             }
@@ -1134,23 +1124,6 @@ public final class PackInstaller {
         guard !manager.ruleCollections.contains(where: { $0.id == id }) else { return }
         if let catalogCollection = catalog.first(where: { $0.id == id }) {
             manager.ruleCollections.append(catalogCollection)
-        }
-    }
-
-    /// Remove any rules already committed for this pack id. Best-effort —
-    /// used when an install fails partway through.
-    private func rollbackPartialInstall(
-        packID: String,
-        manager: RuleCollectionsManager,
-        mutationPermit: ConfigurationOperationGate.Permit
-    ) async {
-        let current = await manager.snapshotCurrentRules()
-        let partial = current.filter { $0.packSource == packID }
-        AppLogger.shared.log(
-            "↩️ [PackInstaller] Rolling back \(partial.count) rule(s) after failed install of '\(packID)'"
-        )
-        for rule in partial {
-            await manager.removeCustomRule(id: rule.id, mutationPermit: mutationPermit)
         }
     }
 }

--- a/Tests/KeyPathTests/GenericPackConfigTests.swift
+++ b/Tests/KeyPathTests/GenericPackConfigTests.swift
@@ -633,10 +633,7 @@ final class GenericPackConfigTests: XCTestCase {
             guard case let .saveFailed(reason) = error else {
                 return XCTFail("Expected saveFailed, got \(error)")
             }
-            XCTAssertEqual(
-                reason,
-                "installed-pack record could not be saved and the previous state could not be fully restored"
-            )
+            XCTAssertTrue(reason.contains("prior files were restored"), "Journal recovery should restore the complete original revision: \(reason)")
         } catch {
             XCTFail("Expected full-restore saveFailed, got \(error)")
         }
@@ -1736,8 +1733,7 @@ final class GenericPackConfigTests: XCTestCase {
     // MARK: - Legacy Vallack Migration
 
     func testLegacyVallackSnapshotMigration() throws {
-        let legacyURL = FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent(".config/keypath/vallack-system-snapshot.json")
+        let legacyURL = AppPaths.configDirectory.appendingPathComponent("vallack-system-snapshot.json")
 
         let legacySnapshot: [String: Any] = [
             "homeRowModsEnabled": true,

--- a/Tests/KeyPathTests/PackRuleTransactionTests.swift
+++ b/Tests/KeyPathTests/PackRuleTransactionTests.swift
@@ -1,0 +1,245 @@
+import Foundation
+@testable import KeyPathAppKit
+import KeyPathRulesCore
+@preconcurrency import XCTest
+
+@MainActor
+final class PackRuleTransactionTests: KeyPathTestCase {
+    private var directory: URL!
+    private var manager: RuleCollectionsManager!
+    private var tracker: InstalledPackTracker!
+    private var pack: Pack!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let collections = RuleCollectionStore.testStore(at: directory.appendingPathComponent("RuleCollections.json"))
+        let rules = CustomRulesStore.testStore(at: directory.appendingPathComponent("CustomRules.json"))
+        let service = ConfigurationService(configDirectory: directory.path, ruleCollectionStore: collections, customRulesStore: rules)
+        manager = RuleCollectionsManager(ruleCollectionStore: collections, customRulesStore: rules, configurationService: service)
+        manager.ruleCollections = []
+        manager.customRules = [CustomRule(input: "f20", action: .keystroke(key: "f19"))]
+        try await service.saveRuleState(ruleCollections: [], customRules: manager.customRules, collectionStore: collections, customStore: rules)
+        tracker = InstalledPackTracker(fileURL: directory.appendingPathComponent("installed-packs.json"))
+        try await tracker.upsert(InstalledPackRecord(packID: "unrelated", version: "1", installedAt: Date(timeIntervalSince1970: 42)))
+        pack = makePack(inputs: ["f13", "f15"])
+    }
+
+    override func tearDown() async throws {
+        try? FileManager.default.removeItem(at: directory)
+        manager = nil
+        tracker = nil
+        pack = nil
+        directory = nil
+        try await super.tearDown()
+    }
+
+    private func makePack(inputs: [String]) -> Pack {
+        Pack(id: "com.keypath.test.batch", version: "1", name: "Batch", tagline: "Batch",
+             shortDescription: "Batch", longDescription: "", category: "Test", iconSymbol: "testtube.2",
+             bindings: inputs.map { PackBindingTemplate(input: $0, output: "f14", title: $0) })
+    }
+
+    private func snapshot() throws -> [String: Data] {
+        try Dictionary(uniqueKeysWithValues: ["keypath.kbd", "RuleCollections.json", "CustomRules.json", "installed-packs.json"].map {
+            try ($0, Data(contentsOf: directory.appendingPathComponent($0)))
+        })
+    }
+
+    private static func reload(_ disposition: ReloadDisposition) -> ReloadResult {
+        ReloadResult(success: disposition == .applied, response: nil,
+                     errorMessage: disposition == .applied ? nil : "injected \(disposition)", protocol: nil, disposition: disposition)
+    }
+
+    func testBatchPublishesOnceAfterAllRulesAndRecordCommitWithOneReload() async throws {
+        let count = PackCommitCount()
+        let token = manager.configurationService.observe { _ in await count.increment() }
+        var reloads = 0
+        manager.onRulesChanged = {
+            reloads += 1
+            let staged = try? await self.manager.customRulesStore.loadForMutation()
+            XCTAssertEqual(staged?.count, 3)
+            let record = await self.tracker.record(for: self.pack.id)
+            XCTAssertNotNil(record)
+            let notifications = await count.value
+            XCTAssertEqual(notifications, 0)
+            XCTAssertTrue(FileManager.default.fileExists(atPath: RecoverableRuleWrite.journalURL(self.directory, scope: .packRules).path))
+            return Self.reload(.applied)
+        }
+        _ = try await PackInstaller.shared.install(pack, manager: manager, installedPackTracker: tracker)
+        XCTAssertEqual(reloads, 1)
+        let notifications = await count.value
+        XCTAssertEqual(notifications, 1)
+        XCTAssertEqual(manager.customRules.count, 3)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: RecoverableRuleWrite.journalURL(directory, scope: .packRules).path))
+        withExtendedLifetime(token) {}
+    }
+
+    func testRejectedReloadRestoresFourFilesBeforeRecoveryAndManagerOnFailure() async throws {
+        let before = try snapshot()
+        let oldRules = manager.customRules
+        var reloads = 0
+        manager.onRulesChanged = {
+            reloads += 1
+            if reloads > 1 {
+                do {
+                    let restored = try self.snapshot()
+                    XCTAssertEqual(restored, before)
+                } catch { XCTFail("Missing restored revision: \(error)") }
+            }
+            return Self.reload(reloads == 1 ? .rejected : .applied)
+        }
+        do {
+            _ = try await PackInstaller.shared.install(pack, manager: manager, installedPackTracker: tracker)
+            XCTFail("Rejected installation must fail")
+        } catch {}
+        XCTAssertEqual(reloads, 2)
+        XCTAssertEqual(try snapshot(), before)
+        XCTAssertEqual(manager.customRules, oldRules)
+    }
+
+    func testConflictingLaterBindingLeavesNoPartialInstall() async throws {
+        manager.customRules[0].packSource = pack.id
+        try await manager.configurationService.saveRuleState(ruleCollections: [], customRules: manager.customRules,
+                                                             collectionStore: manager.ruleCollectionStore, customStore: manager.customRulesStore)
+        let before = try snapshot()
+        let oldRules = manager.customRules
+        pack = makePack(inputs: ["f13", "f20"])
+        manager.onConflictResolution = { _ in .keepExisting }
+        manager.onRulesChanged = { XCTFail("A declined batch must not reload"); return Self.reload(.applied) }
+        do {
+            _ = try await PackInstaller.shared.install(pack, manager: manager, installedPackTracker: tracker)
+            XCTFail("Conflict should cancel preparation")
+        } catch {}
+        XCTAssertEqual(try snapshot(), before)
+        XCTAssertEqual(manager.customRules, oldRules)
+    }
+
+    func testSkippedReloadCommitsTheWholeBatchWithoutCallingRuntime() async throws {
+        manager.onRulesChanged = { XCTFail("Explicit skip must remain a skip"); return Self.reload(.applied) }
+        _ = try await PackInstaller.shared.install(pack, manager: manager, skipFinalReload: true, installedPackTracker: tracker)
+        let record = await tracker.record(for: pack.id)
+        XCTAssertNotNil(record)
+        XCTAssertEqual(manager.customRules.count, 3)
+    }
+
+    func testPendingReloadCommitsWithoutRecoveryOrSecondReload() async throws {
+        var reloads = 0
+        manager.onRulesChanged = { reloads += 1; return Self.reload(.pending) }
+        _ = try await PackInstaller.shared.install(pack, manager: manager, installedPackTracker: tracker)
+        XCTAssertEqual(reloads, 1)
+        let record = await tracker.record(for: pack.id)
+        XCTAssertNotNil(record)
+        XCTAssertEqual(manager.customRules.count, 3)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: RecoverableRuleWrite.journalURL(directory, scope: .packRules).path))
+    }
+
+    func testCancellationRestoresFourFilesAndUsesUncancelledRecovery() async throws {
+        let before = try snapshot()
+        let oldRules = manager.customRules
+        var operation: Task<InstalledPackRecord, Error>?
+        var reloads = 0
+        manager.onRulesChanged = {
+            reloads += 1
+            if reloads == 1 { operation?.cancel() }
+            else { XCTAssertFalse(Task.isCancelled) }
+            return Self.reload(.applied)
+        }
+        operation = Task { @MainActor in
+            try await PackInstaller.shared.install(self.pack, manager: self.manager, installedPackTracker: self.tracker)
+        }
+        do {
+            _ = try await operation!.value
+            XCTFail("Cancelled application must recover")
+        } catch { XCTAssertTrue(error is CancellationError) }
+        XCTAssertEqual(reloads, 2)
+        XCTAssertEqual(try snapshot(), before)
+        XCTAssertEqual(manager.customRules, oldRules)
+    }
+
+    func testInterruptedPackStageRecoversThroughStandardStartupRuleRecovery() async throws {
+        let before = try snapshot()
+        let service = manager.configurationService
+        try await service.operationGate.withOperation { @MainActor permit in
+            _ = try await service.stageRuleState(
+                ruleCollections: [], customRules: [], collectionStore: self.manager.ruleCollectionStore,
+                customStore: self.manager.customRulesStore, mutationPermit: permit,
+                packRecord: .init(tracker: self.tracker, record: InstalledPackRecord(packID: self.pack.id, version: "2"))
+            )
+        }
+        let fresh = ConfigurationService(configDirectory: directory.path, ruleCollectionStore: manager.ruleCollectionStore, customRulesStore: manager.customRulesStore)
+        try await fresh.recoverPendingRuleWrite(collectionStore: manager.ruleCollectionStore, customStore: manager.customRulesStore)
+        XCTAssertEqual(try snapshot(), before)
+    }
+
+    func testMetadataOnlyToggleRecoversInterruptedPackBeforeChangingRecords() async throws {
+        let before = try snapshot()
+        let service = manager.configurationService
+        try await service.operationGate.withOperation { @MainActor permit in
+            _ = try await service.stageRuleState(
+                ruleCollections: [], customRules: [], collectionStore: self.manager.ruleCollectionStore,
+                customStore: self.manager.customRulesStore, mutationPermit: permit,
+                packRecord: .init(tracker: self.tracker, record: InstalledPackRecord(packID: self.pack.id, version: "2"))
+            )
+        }
+        _ = try await PackInstaller.shared.setVisualPackEnabled(PackRegistry.keystrokeHistory, enabled: true,
+                                                                manager: manager, installedPackTracker: tracker)
+        let after = try snapshot()
+        for name in ["keypath.kbd", "RuleCollections.json", "CustomRules.json"] {
+            XCTAssertEqual(after[name], before[name])
+        }
+        let interruptedRecord = await tracker.record(for: pack.id)
+        let visualRecord = await tracker.record(for: PackRegistry.keystrokeHistory.id)
+        let originalRecord = await tracker.record(for: "unrelated")
+        XCTAssertNil(interruptedRecord)
+        XCTAssertNotNil(visualRecord)
+        XCTAssertNotNil(originalRecord)
+    }
+
+    func testNextInstallUsesRecoveredSourcesInsteadOfInterruptedManagerState() async throws {
+        let priorRules = manager.customRules
+        let service = manager.configurationService
+        try await service.operationGate.withOperation { @MainActor permit in
+            _ = try await service.stageRuleState(
+                ruleCollections: [], customRules: [], collectionStore: self.manager.ruleCollectionStore,
+                customStore: self.manager.customRulesStore, mutationPermit: permit,
+                packRecord: .init(tracker: self.tracker, record: InstalledPackRecord(packID: "interrupted", version: "2"))
+            )
+        }
+        manager.customRules = []
+        _ = try await PackInstaller.shared.install(pack, manager: manager, installedPackTracker: tracker)
+        XCTAssertTrue(manager.customRules.contains(where: { $0.id == priorRules[0].id }))
+        let stored = try await manager.customRulesStore.loadForMutation()
+        XCTAssertEqual(stored.count, priorRules.count + pack.bindings.count)
+        let interrupted = await tracker.record(for: "interrupted")
+        XCTAssertNil(interrupted)
+    }
+
+    func testExternalMetadataEditStopsRecoveryWithoutOverwritingAnyFile() async throws {
+        var externalRevision: [String: Data]?
+        var reloads = 0
+        manager.onRulesChanged = {
+            reloads += 1
+            do {
+                try Data("external metadata edit".utf8).write(to: self.directory.appendingPathComponent("installed-packs.json"))
+                externalRevision = try self.snapshot()
+            } catch { XCTFail("External edit failed: \(error)") }
+            return Self.reload(.rejected)
+        }
+        do {
+            _ = try await PackInstaller.shared.install(pack, manager: manager, installedPackTracker: tracker)
+            XCTFail("Recovery conflict must fail")
+        } catch { XCTAssertTrue(error.localizedDescription.contains("Recovery needs attention")) }
+        XCTAssertEqual(reloads, 1)
+        XCTAssertEqual(try snapshot(), externalRevision)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: RecoverableRuleWrite.journalURL(directory, scope: .packRules).path))
+    }
+}
+
+private actor PackCommitCount {
+    var value = 0
+    func increment() {
+        value += 1
+    }
+}

--- a/Tests/KeyPathTests/VallackSystemPackTests.swift
+++ b/Tests/KeyPathTests/VallackSystemPackTests.swift
@@ -4,6 +4,15 @@ import KeyPathRulesCore
 import XCTest
 
 final class VallackSystemPackTests: XCTestCase {
+    func testSnapshotWritesStayInsideTestSandbox() throws {
+        let id = "sandbox-\(UUID().uuidString)"
+        let url = PackCollectionSnapshot.snapshotURL(for: id)
+        XCTAssertTrue(url.path.hasPrefix(AppPaths.testSandboxDirectory.path + "/"))
+        defer { PackCollectionSnapshot.remove(for: id) }
+        try PackCollectionSnapshot.save(PackCollectionSnapshot(packID: id, entries: []))
+        XCTAssertNotNil(PackCollectionSnapshot.load(for: id))
+    }
+
     private var originalInstalledPacks: [InstalledPackRecord] = []
 
     override func setUp() async throws {
@@ -273,8 +282,7 @@ final class VallackSystemPackTests: XCTestCase {
             manager: manager
         )
 
-        let snapshotURL = FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent(".config/keypath/pack-snapshots/com.keypath.pack.vallack-system.json")
+        let snapshotURL = PackCollectionSnapshot.snapshotURL(for: PackRegistry.vallackSystem.id)
         XCTAssertTrue(
             FileManager.default.fileExists(atPath: snapshotURL.path),
             "Snapshot file should exist after install"
@@ -295,8 +303,7 @@ final class VallackSystemPackTests: XCTestCase {
         defer { try? FileManager.default.removeItem(at: tempDir) }
         manager.ruleCollections = RuleCollectionCatalog().defaultCollections()
 
-        let snapshotURL = FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent(".config/keypath/pack-snapshots/com.keypath.pack.vallack-system.json")
+        let snapshotURL = PackCollectionSnapshot.snapshotURL(for: PackRegistry.vallackSystem.id)
         defer { try? FileManager.default.removeItem(at: snapshotURL) }
 
         // Capture pre-install state
@@ -357,8 +364,7 @@ final class VallackSystemPackTests: XCTestCase {
         defer { try? FileManager.default.removeItem(at: tempDir) }
         manager.ruleCollections = RuleCollectionCatalog().defaultCollections()
 
-        let snapshotURL = FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent(".config/keypath/pack-snapshots/com.keypath.pack.vallack-system.json")
+        let snapshotURL = PackCollectionSnapshot.snapshotURL(for: PackRegistry.vallackSystem.id)
         defer { try? FileManager.default.removeItem(at: snapshotURL) }
 
         guard let modsIndex = manager.ruleCollections.firstIndex(where: { $0.id == RuleCollectionIdentifier.homeRowMods }),
@@ -413,8 +419,10 @@ final class VallackSystemPackTests: XCTestCase {
             PackCollectionSnapshot.remove(for: PackRegistry.vallackSystem.id)
         }
 
-        let blockedConfigDirectory = tempDir.appendingPathComponent("not-a-directory")
-        try "file blocks config directory".write(to: blockedConfigDirectory, atomically: true, encoding: .utf8)
+        // Keep admission/recovery usable; fail the later source-write stage so
+        // this still exercises managed-default snapshot rollback and cleanup.
+        let blockedSource = tempDir.appendingPathComponent("CustomRules.json")
+        try FileManager.default.createDirectory(at: blockedSource, withIntermediateDirectories: true)
 
         let manager = RuleCollectionsManager(
             ruleCollectionStore: RuleCollectionStore(
@@ -423,7 +431,7 @@ final class VallackSystemPackTests: XCTestCase {
             customRulesStore: CustomRulesStore(
                 fileURL: tempDir.appendingPathComponent("CustomRules.json")
             ),
-            configurationService: ConfigurationService(configDirectory: blockedConfigDirectory.path),
+            configurationService: ConfigurationService(configDirectory: tempDir.path),
             eventListener: KanataEventListener()
         )
         manager.ruleCollections = RuleCollectionCatalog().defaultCollections()
@@ -462,8 +470,7 @@ final class VallackSystemPackTests: XCTestCase {
 
         let packID = PackRegistry.vallackSystem.id
         let modernSnapshotURL = PackCollectionSnapshot.snapshotURL(for: packID)
-        let legacySnapshotURL = FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent(".config/keypath/vallack-system-snapshot.json")
+        let legacySnapshotURL = AppPaths.configDirectory.appendingPathComponent("vallack-system-snapshot.json")
         let originalModernSnapshotData = try? Data(contentsOf: modernSnapshotURL)
         let originalLegacySnapshotData = try? Data(contentsOf: legacySnapshotURL)
         defer {
@@ -518,12 +525,11 @@ final class VallackSystemPackTests: XCTestCase {
         try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: tempDir) }
 
-        let blockedConfigDirectory = tempDir.appendingPathComponent("not-a-directory")
-        try "file blocks config directory".write(
-            to: blockedConfigDirectory,
-            atomically: true,
-            encoding: .utf8
-        )
+        // Keep admission/recovery usable; fail the later source-write stage so
+        // this still exercises managed-default snapshot rollback and cleanup.
+        let blockedSource = tempDir.appendingPathComponent("CustomRules.json")
+        try FileManager.default.createDirectory(at: blockedSource, withIntermediateDirectories: true)
+
         let manager = RuleCollectionsManager(
             ruleCollectionStore: RuleCollectionStore(
                 fileURL: tempDir.appendingPathComponent("RuleCollections.json")
@@ -531,7 +537,7 @@ final class VallackSystemPackTests: XCTestCase {
             customRulesStore: CustomRulesStore(
                 fileURL: tempDir.appendingPathComponent("CustomRules.json")
             ),
-            configurationService: ConfigurationService(configDirectory: blockedConfigDirectory.path),
+            configurationService: ConfigurationService(configDirectory: tempDir.path),
             eventListener: KanataEventListener()
         )
         manager.ruleCollections = catalog
@@ -548,7 +554,7 @@ final class VallackSystemPackTests: XCTestCase {
             )
             XCTFail("Install should fail when managed defaults cannot be applied")
         } catch {
-            // Expected: the config directory is deliberately blocked.
+            // Expected: the custom-rule source is deliberately unreadable.
         }
 
         XCTAssertEqual(manager.ruleCollections, originalRuleState.collections)
@@ -594,8 +600,7 @@ final class VallackSystemPackTests: XCTestCase {
         ))
 
         // Ensure no snapshot file exists
-        let snapshotURL = FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent(".config/keypath/pack-snapshots/com.keypath.pack.vallack-system.json")
+        let snapshotURL = PackCollectionSnapshot.snapshotURL(for: PackRegistry.vallackSystem.id)
         try? FileManager.default.removeItem(at: snapshotURL)
 
         // Uninstall should not crash — just skip the revert

--- a/docs/architecture/configuration-save-pipeline.md
+++ b/docs/architecture/configuration-save-pipeline.md
@@ -271,3 +271,20 @@ Other collection mutators still use their existing immediate-commit compatibilit
 path. Their snapshot regeneration, pack-wide preferences/metadata recovery,
 stale manager caches, revision-aware watching, and raw-file runtime recovery
 remain separate migrations. This mapper change does not claim those are complete.
+
+## Custom-rule pack installation
+
+PackInstaller prepares all custom-rule bindings in memory, then invokes the same
+SaveCoordinator rule operation with an installed-record change. ConfigurationService
+stages the config, collections, custom rules, and installed metadata under the
+`.packRules` journal scope. Both configuration and tracker observers are notified
+after commit. Failed preparation makes no file changes; failed apply or persistence
+restores the prior revision, preserving external edits if restoration conflicts.
+The old per-binding persistence loop and pack-ID-based partial cleanup are removed.
+
+Rule startup recovery resolves the installed-packs.json path from the configuration
+directory by default. Tests or integrations using a nonstandard metadata path must
+supply their tracker explicitly to recovery, just as custom rule stores must be
+supplied; journal contents cannot select restoration targets. System packs,
+collection-backed packs, settings updates, removal, and pack collection snapshots
+still have their existing separate commit boundaries.

--- a/docs/bugs/pack-rule-write-recovery.md
+++ b/docs/bugs/pack-rule-write-recovery.md
@@ -1,0 +1,36 @@
+# Custom-rule pack installs need one durable revision
+
+Installing a pack with several bindings called `saveCustomRule` for each binding.
+`skipReload` suppressed only the engine callback: each call still generated and
+persisted files. A later conflict or failure could leave earlier bindings written.
+The best-effort cleanup removed rules by pack ID, which could also remove rules
+that existed before a reinstall attempt. The installed record was a later write,
+and runtime rejection did not roll back the source files.
+
+Custom-rule installs now prepare every binding using the existing conflict logic
+before any persistence. SaveCoordinator stages the generated config, both source
+stores, and installed-packs.json in a single `.packRules` journal. Applied or
+pending runtime outcomes commit. Rejection, failure, cancellation, and metadata
+write failures recover the entire prior revision; compensating reload runs only
+when runtime application was attempted and file recovery succeeded. External
+changes stop recovery without overwriting any member of the file set.
+
+Startup rule recovery also recognizes the pack journal before loading sources.
+Nonstandard injected metadata paths require the same tracker to be supplied for
+recovery; journal contents cannot redirect restoration to arbitrary paths.
+
+Only committed revisions publish configuration and installed-pack notifications.
+Explicitly skipped or absent reload callbacks remain absent outcomes, not an
+invented applied status. System/collection-backed packs, removal, quick-setting
+updates, and preference/snapshot recovery remain separate migrations.
+
+During validation, the existing system-pack tests were found writing modern and
+legacy uninstall snapshots under the real user configuration directory. Both
+snapshot paths now resolve through AppPaths.configDirectory, whose per-process
+test sandbox preserves production paths. The tests use those same resolved paths.
+The managed-apply failure fixtures now fail a source read after admission rather
+than blocking admission itself, retaining their snapshot rollback coverage.
+
+Recovery also refreshes the admitted pack manager from the restored source stores
+before preparing another mutation. CLI pack commands recover before installed-state
+shortcuts, so an interrupted installation cannot be reported as already installed.

--- a/docs/planning/catalog-led-consolidation-plan.md
+++ b/docs/planning/catalog-led-consolidation-plan.md
@@ -269,6 +269,7 @@ Implemented slices (the table describes the merged state of this checkpoint):
 | #1274 | App-specific edits retain a three-file journal through runtime apply/recovery, preserve hand-written files, and refresh app context after immediate/deferred reload. | Global/pack recovery, mixed app/global operations and revision-aware watching remain. |
 | #1275 | Simple Modifications transforms captured revisions through SaveCoordinator, preserves external edits, retains reload/recovery outcomes and serializes debounce settlement. | Legacy raw syntax/ownership limitations and full runtime recovery remain. |
 | #1277 | Pack metadata writes share PackInstaller admission; deferred repair reads durable state without inheriting a live operation lease. | Full pack transaction/recovery and ownership policy remain. |
+| #1278 | Mapper saves retain config and both source stores through reload/recovery, restoring the manager snapshot without regenerating. | Other collection mutations, pack transactions, preferences and watching remain. |
 
 Admission now also holds a cooperative OS lease across service instances and
 processes for the same directory. CLI configuration apply now holds admission
@@ -367,7 +368,7 @@ CI maintenance: #1276 increased the review action's turn allowance after repeate
 `error_max_turns` failures. It was merged separately; #1275 then passed actual
 review under that workflow. Both are included in the signed/notarized #1275 deploy.
 
-### Mapper rule-state recovery in progress
+### Mapper rule-state recovery merged in #1278
 
 The mapper now keeps the configuration and both source stores recoverable through
 runtime classification in SaveCoordinator. Failure restores the exact file set
@@ -376,3 +377,10 @@ Existing rule and collection conflict choices are shared as in-memory preparatio
 the mapper no longer invokes the legacy immediate-commit save before reloading.
 External revision conflicts preserve files and the journal rather than regenerating
 a snapshot over them. Other collection mutators and pack-wide recovery remain open.
+
+### Custom-rule pack transactions in progress
+
+Custom-rule installs prepare the complete batch before persistence and retain a
+four-file journal including installed-packs.json through runtime classification.
+Startup rule recovery recognizes this scope. System/collection-backed packs,
+removal, quick-setting changes, and preference/snapshot transactions remain open.


### PR DESCRIPTION
## Problem and result

Custom-rule pack installation saved once per binding and wrote installed-packs.json afterward. A later conflict or failure could leave a partial install, and best-effort cleanup by pack ID could delete rules that existed before a reinstall attempt.

PackInstaller now prepares the entire custom-rule batch with the existing conflict decisions, then uses SaveCoordinator to stage the generated config, both rule stores, and installed metadata together. Applied/pending results commit; rejected, failed, or cancelled application restores the exact prior revision and attempts an uncancelled recovery reload when appropriate. External edits preserve the journal and stop recovery. The old per-binding save loop and pack-ID cleanup are removed.

Startup rule recovery recognizes the four-file pack journal. Pack metadata reads/writes recover unfinished transactions before inspecting installed state, including visual-only toggles and CLI installed-state shortcuts. After recovery, the manager reloads the restored sources before preparing another edit. Configuration and tracker notifications follow commit. Explicitly skipped or absent reload callbacks remain absent outcomes.

## Validation

- 112 focused tests passed across pack transactions, generic pack behavior, mapper recovery, tracker persistence, app-keymap saves and rule writes.
- Further focused runs passed: 60 tests including metadata-only recovery; 82 tests covering system packs and sandboxed snapshots.
- Final focused run: 48 tests passed, including CLI CRUD and recovery after stale manager state.
- New tests cover one batch/one reload, rejected and pending application, cancellation, conflict cancellation preserving pre-existing tagged rules, skipped reload, startup recovery and external metadata changes.
- Full safe suite: 5,204 passed; only the four known macOS 27 snapshot baseline failures (three Home Row Timing views and Repair Settings). No compiler warnings. Supported-runner CI is required.
- SwiftFormat 0.61.1 lint, accessibility and diff checks passed.
- Remote review gate selected; GitHub claude-review is required before merge.
- Installer matrix: `Running but TCP not responding` and `Running and TCP responding`. Restored files and the compensating reload have separate outcomes; no installation or permission policy changes.

Existing modern/legacy pack snapshot tests were also found using the real user configuration directory. PackCollectionSnapshot now uses AppPaths.configDirectory so test runs stay in the per-process sandbox; production paths are unchanged. System-pack failure fixtures continue to exercise the later source-write failure after admission.

## Boundaries

This migrates custom-rule pack installation. System/collection-backed packs, removal, settings changes, preference/collection-snapshot transactions and CLI's separately requested apply remain separate migrations. Custom metadata paths require the same tracker when recovering; journal contents cannot redirect restoration targets. No new UI flow, conflict policy or feature removal. Signed deployment follows merge.

## Review follow-up

The catalog already owns its progress/error state through `isWorking`, `refreshInstallState`, and thrown installer errors; it does not observe the mapper's SaveCoordinator delegate. A per-operation coordinator therefore does not remove any existing catalog indicator. `saveRuleState` retains the shared write-sound path independently of its delegate. Sharing the mapper's delegate would introduce unrelated UI coupling; status presentation remains a separate approved-discussion item.

Recovery now resolves the default tracker URL directly without allocating an actor. The default is deliberately relative to the service's requested configuration directory, not the global shared tracker. Explicit custom trackers still supply their own URL.

Final review verification: journal recovery checks every role's exact standardized path against the caller's resolved targets before restoring anything (RecoverableRuleWrite lines 197–204). A nonstandard tracker path fails closed; it cannot silently bind to a different file. Comparing against the shared tracker would be incorrect for custom-directory CLI operations. The standard directory/name is covered by the interrupted-pack startup recovery test. The generic tracker-write-failure assertion matches RecoverableRuleWrite.Failure exactly: "Rule files could not be saved; the prior files were restored: ..."; that specific test passed in the final full suite.
