### PR TITLE
Recover pack removal and timing updates as complete revisions

### DIFF
--- a/Sources/KeyPathAppKit/Infrastructure/Config/ConfigurationService.swift
+++ b/Sources/KeyPathAppKit/Infrastructure/Config/ConfigurationService.swift
@@ -356,7 +356,7 @@ public final class ConfigurationService: FileConfigurationProviding {
             let before = try await snapshotRuleFiles(files)
             let packUpdate: InstalledPackTracker.PreparedRecordUpdate?
             if let packRecord {
-                packUpdate = try await packRecord.tracker.prepareUpsert(packRecord.record)
+                packUpdate = try await packRecord.tracker.prepareUpdate(packRecord)
                 guard packUpdate?.before == before["installedPacks"] else { throw RecoverableRuleWrite.Failure.changedFile("installedPacks") }
             } else { packUpdate = nil }
             let newConfig = try await preparedConfiguration(ruleCollections: ruleCollections, customRules: customRules)

--- a/Sources/KeyPathAppKit/Services/Packs/InstalledPackTracker.swift
+++ b/Sources/KeyPathAppKit/Services/Packs/InstalledPackTracker.swift
@@ -77,7 +77,20 @@ public actor InstalledPackTracker {
 
     struct RecordChange: Sendable {
         let tracker: InstalledPackTracker
-        let record: InstalledPackRecord
+        let packID: String
+        let record: InstalledPackRecord?
+
+        init(tracker: InstalledPackTracker, record: InstalledPackRecord) {
+            self.tracker = tracker
+            packID = record.packID
+            self.record = record
+        }
+
+        init(tracker: InstalledPackTracker, removing packID: String) {
+            self.tracker = tracker
+            self.packID = packID
+            record = nil
+        }
     }
 
     struct PreparedRecordUpdate: Sendable {
@@ -92,13 +105,13 @@ public actor InstalledPackTracker {
 
     /// Build a metadata revision without writing or notifying. The configuration
     /// transaction compares this preimage before staging it with the rule files.
-    func prepareUpsert(_ record: InstalledPackRecord) throws -> PreparedRecordUpdate {
+    func prepareUpdate(_ change: RecordChange) throws -> PreparedRecordUpdate {
         let before: Data?
         do { before = try Data(contentsOf: fileURL) }
         catch let error as NSError where error.domain == NSCocoaErrorDomain && error.code == NSFileReadNoSuchFileError { before = nil }
         let previous = try decodeRecords(before)
         var updated = previous
-        updated[record.packID] = record
+        updated[change.packID] = change.record
         return try PreparedRecordUpdate(tracker: self, fileURL: fileURL, before: before,
                                         contents: encodedRecords(updated), previousRecords: previous,
                                         records: updated, writeFile: writeFile)

--- a/Sources/KeyPathAppKit/Services/Packs/PackInstaller.swift
+++ b/Sources/KeyPathAppKit/Services/Packs/PackInstaller.swift
@@ -346,19 +346,9 @@ public final class PackInstaller {
             }
             let record = InstalledPackRecord(packID: pack.id, version: pack.version,
                                              installedAt: Date(), quickSettingValues: resolvedSettings)
-            let result = await SaveCoordinator(configurationService: manager.configurationService).saveRuleState(
-                manager: manager, mutationPermit: permit,
-                packRecord: .init(tracker: installedPackTracker, record: record),
-                reloadHandler: skipFinalReload ? nil : manager.onRulesChanged
-            )
-            guard result.success else {
-                manager.ruleCollections = ruleStateSnapshot.collections
-                manager.customRules = ruleStateSnapshot.customRules
-                manager.refreshLayerIndicatorState()
-                if result.error is CancellationError { throw CancellationError() }
-                throw InstallError.saveFailed(result.error?.localizedDescription ?? "Pack installation could not be committed")
-            }
-            NotificationCenter.default.post(name: .ruleCollectionsChanged, object: nil)
+            try await commitPreparedPackRules(manager: manager, snapshot: ruleStateSnapshot,
+                                              record: .init(tracker: installedPackTracker, record: record),
+                                              skipReload: skipFinalReload, permit: permit)
 
             AppLogger.shared.log(
                 "✅ [PackInstaller] Installed pack '\(pack.name)': \(rules.count) binding(s)"
@@ -434,30 +424,16 @@ public final class PackInstaller {
                 return
             }
 
-            // Snapshot current rule set, drop those owned by this pack.
-            let before = await manager.snapshotCurrentRules()
-            let packRules = before.filter { $0.packSource == packID }
-
+            let snapshot = manager.snapshotRuleState()
+            let packRules = snapshot.customRules.filter { $0.packSource == packID }
             guard !packRules.isEmpty else {
-                // Nothing to remove from rules, but still clear the tracker
-                // record in case it drifted out of sync.
                 try await installedPackTracker.remove(packID: packID)
-                AppLogger.shared.log(
-                    "ℹ️ [PackInstaller] No rules tagged with pack '\(packID)'; cleared tracker record"
-                )
                 return
             }
-
-            for (index, rule) in packRules.enumerated() {
-                let isLast = (index == packRules.count - 1)
-                // We remove directly — skipReload avoided here since
-                // removeCustomRule regenerates on each call. For M1 we accept
-                // N regenerations; M2 will batch.
-                _ = isLast // reserved for future batching
-                await manager.removeCustomRule(id: rule.id, mutationPermit: permit)
-            }
-
-            try await installedPackTracker.remove(packID: packID)
+            manager.customRules.removeAll { $0.packSource == packID }
+            try await commitPreparedPackRules(manager: manager, snapshot: snapshot,
+                                              record: .init(tracker: installedPackTracker, removing: packID),
+                                              permit: permit)
 
             AppLogger.shared.log(
                 "✅ [PackInstaller] Uninstalled pack '\(packID)': removed \(packRules.count) rule(s)"
@@ -581,39 +557,70 @@ public final class PackInstaller {
             // Clamp to valid ranges
             let resolved = resolveQuickSettings(pack: pack, overrides: mergedSettings)
 
+            let snapshot = manager.snapshotRuleState()
+            var hasRuleChanges = false
             if let collectionID = pack.associatedCollectionID {
-                // Collection-backed pack: update timing config
-                if let holdTimeout = resolved["holdTimeout"],
-                   let index = manager.ruleCollections.firstIndex(where: { $0.id == collectionID })
-                {
-                    if case var .homeRowMods(config) = manager.ruleCollections[index].configuration {
-                        config.timing.tapWindow = holdTimeout
-                        config.timing.holdDelay = holdTimeout
-                        manager.ruleCollections[index].configuration = .homeRowMods(config)
-                        await manager.regenerateConfigFromCollections(mutationPermit: permit)
+                if let holdTimeout = resolved["holdTimeout"] {
+                    guard let index = manager.ruleCollections.firstIndex(where: { $0.id == collectionID }),
+                          case var .homeRowMods(config) = manager.ruleCollections[index].configuration
+                    else {
+                        throw InstallError.saveFailed("The pack's timing collection is missing or cannot be edited. Your settings were not changed.")
                     }
+                    config.timing.tapWindow = holdTimeout
+                    config.timing.holdDelay = holdTimeout
+                    manager.ruleCollections[index].configuration = .homeRowMods(config)
+                    hasRuleChanges = true
                 }
             } else if !pack.bindings.isEmpty {
-                // Rule-based pack: re-render bindings with new settings
-                let oldRules = await manager.snapshotCurrentRules().filter { $0.packSource == packID }
-                for rule in oldRules {
-                    await manager.removeCustomRule(id: rule.id, mutationPermit: permit)
+                manager.customRules.removeAll { $0.packSource == packID }
+                for rule in renderBindings(for: pack, quickSettings: resolved) {
+                    guard await manager.updateCustomRuleInMemory(rule, mutationPermit: permit) else {
+                        restorePreparedRuleState(snapshot, manager: manager)
+                        throw InstallError.saveFailed("updated pack rules could not be prepared")
+                    }
                 }
-                let newRules = renderBindings(for: pack, quickSettings: resolved)
-                for (index, rule) in newRules.enumerated() {
-                    let isLast = (index == newRules.count - 1)
-                    _ = await manager.saveCustomRule(rule, skipReload: !isLast, mutationPermit: permit)
-                }
+                hasRuleChanges = true
             }
 
-            // Persist updated record
             record.quickSettingValues = resolved
-            try await installedPackTracker.upsert(record)
+            if hasRuleChanges {
+                try await commitPreparedPackRules(manager: manager, snapshot: snapshot,
+                                                  record: .init(tracker: installedPackTracker, record: record),
+                                                  permit: permit)
+            } else {
+                try await installedPackTracker.upsert(record)
+            }
 
             AppLogger.shared.log(
                 "✅ [PackInstaller] Updated quick settings for '\(pack.name)': \(resolved)"
             )
         }
+    }
+
+    /// One application/recovery boundary for prepared pack rule mutations.
+    private func commitPreparedPackRules(
+        manager: RuleCollectionsManager, snapshot: RuleCollectionsManager.RuleStateSnapshot,
+        record: InstalledPackTracker.RecordChange, skipReload: Bool = false,
+        permit: ConfigurationOperationGate.Permit
+    ) async throws {
+        let result = await SaveCoordinator(configurationService: manager.configurationService).saveRuleState(
+            manager: manager, mutationPermit: permit, packRecord: record,
+            reloadHandler: skipReload ? nil : manager.onRulesChanged
+        )
+        guard result.success else {
+            restorePreparedRuleState(snapshot, manager: manager)
+            if result.error is CancellationError { throw CancellationError() }
+            throw InstallError.saveFailed(result.error?.localizedDescription ?? "Pack change could not be committed")
+        }
+        NotificationCenter.default.post(name: .ruleCollectionsChanged, object: nil)
+    }
+
+    private func restorePreparedRuleState(_ snapshot: RuleCollectionsManager.RuleStateSnapshot,
+                                          manager: RuleCollectionsManager)
+    {
+        manager.ruleCollections = snapshot.collections
+        manager.customRules = snapshot.customRules
+        manager.refreshLayerIndicatorState()
     }
 
     // MARK: - Rendering

--- a/Tests/KeyPathTests/PackRuleTransactionTests.swift
+++ b/Tests/KeyPathTests/PackRuleTransactionTests.swift
@@ -19,7 +19,7 @@ final class PackRuleTransactionTests: KeyPathTestCase {
         let service = ConfigurationService(configDirectory: directory.path, ruleCollectionStore: collections, customRulesStore: rules)
         manager = RuleCollectionsManager(ruleCollectionStore: collections, customRulesStore: rules, configurationService: service)
         manager.ruleCollections = []
-        manager.customRules = [CustomRule(input: "f20", action: .keystroke(key: "f19"))]
+        manager.customRules = [CustomRule(input: "f20", action: .keystroke(key: "f19"), createdAt: Date(timeIntervalSince1970: 42))]
         try await service.saveRuleState(ruleCollections: [], customRules: manager.customRules, collectionStore: collections, customStore: rules)
         tracker = InstalledPackTracker(fileURL: directory.appendingPathComponent("installed-packs.json"))
         try await tracker.upsert(InstalledPackRecord(packID: "unrelated", version: "1", installedAt: Date(timeIntervalSince1970: 42)))
@@ -214,6 +214,118 @@ final class PackRuleTransactionTests: KeyPathTestCase {
         XCTAssertEqual(stored.count, priorRules.count + pack.bindings.count)
         let interrupted = await tracker.record(for: "interrupted")
         XCTAssertNil(interrupted)
+    }
+
+    func testUninstallCommitsAllRemovalsWithOneReload() async throws {
+        _ = try await PackInstaller.shared.install(pack, manager: manager, installedPackTracker: tracker)
+        var reloads = 0
+        manager.onRulesChanged = {
+            reloads += 1
+            return Self.reload(.applied)
+        }
+        try await PackInstaller.shared.uninstall(packID: pack.id, manager: manager, installedPackTracker: tracker)
+        XCTAssertEqual(reloads, 1)
+        XCTAssertEqual(manager.customRules.map(\.input), ["f20"])
+        let record = await tracker.record(for: pack.id)
+        XCTAssertNil(record)
+        let stored = try await manager.customRulesStore.loadForMutation()
+        XCTAssertEqual(stored, manager.customRules)
+    }
+
+    func testRejectedUninstallRestoresRulesAndInstalledRecord() async throws {
+        _ = try await PackInstaller.shared.install(pack, manager: manager, installedPackTracker: tracker)
+        let before = try snapshot()
+        let rules = manager.customRules
+        var reloads = 0
+        manager.onRulesChanged = {
+            reloads += 1
+            return Self.reload(reloads == 1 ? .rejected : .applied)
+        }
+        do {
+            try await PackInstaller.shared.uninstall(packID: pack.id, manager: manager, installedPackTracker: tracker)
+            XCTFail("Rejected removal must fail")
+        } catch {}
+        XCTAssertEqual(reloads, 2)
+        XCTAssertEqual(try snapshot(), before)
+        XCTAssertEqual(manager.customRules, rules)
+    }
+
+    func testUninstallMetadataWriteFailureRestoresExactRevisionWithoutReload() async throws {
+        _ = try await PackInstaller.shared.install(pack, manager: manager, installedPackTracker: tracker)
+        let before = try snapshot()
+        let rules = manager.customRules
+        let failingTracker = InstalledPackTracker(fileURL: directory.appendingPathComponent("installed-packs.json")) { _, _ in
+            throw CocoaError(.fileWriteNoPermission)
+        }
+        manager.onRulesChanged = { XCTFail("Failed stage must not reload"); return Self.reload(.applied) }
+        do {
+            try await PackInstaller.shared.uninstall(packID: pack.id, manager: manager, installedPackTracker: failingTracker)
+            XCTFail("Metadata failure must fail removal")
+        } catch {}
+        XCTAssertEqual(try snapshot(), before)
+        XCTAssertEqual(manager.customRules, rules)
+    }
+
+    private func prepareHomeRowSettings() async throws {
+        var collection = try XCTUnwrap(RuleCollectionCatalog().defaultCollections().first { $0.id == RuleCollectionIdentifier.homeRowMods })
+        collection.isEnabled = true
+        manager.ruleCollections = [collection]
+        try await manager.configurationService.saveRuleState(ruleCollections: manager.ruleCollections,
+                                                             customRules: manager.customRules, collectionStore: manager.ruleCollectionStore, customStore: manager.customRulesStore)
+        try await tracker.upsert(InstalledPackRecord(packID: PackRegistry.homeRowMods.id, version: "1", quickSettingValues: ["holdTimeout": 180]))
+    }
+
+    func testPendingTimingChangeCommitsSettingAndCollectionWithOneReload() async throws {
+        try await prepareHomeRowSettings()
+        var reloads = 0
+        manager.onRulesChanged = { reloads += 1; return Self.reload(.pending) }
+        try await PackInstaller.shared.updateQuickSettings(packID: PackRegistry.homeRowMods.id, newValues: ["holdTimeout": 280], manager: manager, installedPackTracker: tracker)
+        XCTAssertEqual(reloads, 1)
+        let record = await tracker.record(for: PackRegistry.homeRowMods.id)
+        XCTAssertEqual(record?.quickSettingValues["holdTimeout"], 280)
+        guard case let .homeRowMods(config) = manager.ruleCollections[0].configuration else { return XCTFail("Missing timing configuration") }
+        XCTAssertEqual(config.timing.holdDelay, 280)
+        let stored = await manager.ruleCollectionStore.loadCollections()
+        XCTAssertEqual(stored.first(where: { $0.id == RuleCollectionIdentifier.homeRowMods }), manager.ruleCollections[0])
+    }
+
+    func testMissingTimingCollectionDoesNotWriteMetadata() async throws {
+        try await prepareHomeRowSettings()
+        manager.ruleCollections = []
+        try await assertInvalidTimingTargetDoesNotWrite()
+    }
+
+    func testMalformedTimingCollectionDoesNotWriteMetadata() async throws {
+        try await prepareHomeRowSettings()
+        manager.ruleCollections[0].configuration = .list
+        try await assertInvalidTimingTargetDoesNotWrite()
+    }
+
+    private func assertInvalidTimingTargetDoesNotWrite() async throws {
+        let before = try snapshot()
+        let collections = manager.ruleCollections
+        manager.onRulesChanged = { XCTFail("Invalid target must not reload"); return Self.reload(.applied) }
+        do {
+            try await PackInstaller.shared.updateQuickSettings(packID: PackRegistry.homeRowMods.id, newValues: ["holdTimeout": 280], manager: manager, installedPackTracker: tracker)
+            XCTFail("Invalid timing target must fail")
+        } catch { XCTAssertTrue(error.localizedDescription.contains("timing collection")) }
+        XCTAssertEqual(try snapshot(), before)
+        XCTAssertEqual(manager.ruleCollections, collections)
+    }
+
+    func testRejectedTimingChangeRestoresCollectionAndSetting() async throws {
+        try await prepareHomeRowSettings()
+        let before = try snapshot()
+        let collections = manager.ruleCollections
+        var reloads = 0
+        manager.onRulesChanged = { reloads += 1; return Self.reload(reloads == 1 ? .rejected : .applied) }
+        do {
+            try await PackInstaller.shared.updateQuickSettings(packID: PackRegistry.homeRowMods.id, newValues: ["holdTimeout": 280], manager: manager, installedPackTracker: tracker)
+            XCTFail("Rejected timing must fail")
+        } catch {}
+        XCTAssertEqual(reloads, 2)
+        XCTAssertEqual(try snapshot(), before)
+        XCTAssertEqual(manager.ruleCollections, collections)
     }
 
     func testExternalMetadataEditStopsRecoveryWithoutOverwritingAnyFile() async throws {

--- a/docs/architecture/configuration-save-pipeline.md
+++ b/docs/architecture/configuration-save-pipeline.md
@@ -288,3 +288,10 @@ supply their tracker explicitly to recovery, just as custom rule stores must be
 supplied; journal contents cannot select restoration targets. System packs,
 collection-backed packs, settings updates, removal, and pack collection snapshots
 still have their existing separate commit boundaries.
+
+Custom-rule pack removal and quick-setting updates now use that same retained
+pack transaction. Record changes can upsert or remove one pack while preserving
+other records. Preparation performs no per-binding writes; notifications follow
+commit. Settings that affect a collection, such as Home Row Mods timing, restore
+the collection and stored setting together after rejected application. Metadata-only
+operations still skip config generation and runtime reload.

--- a/docs/bugs/pack-rule-write-recovery.md
+++ b/docs/bugs/pack-rule-write-recovery.md
@@ -34,3 +34,24 @@ than blocking admission itself, retaining their snapshot rollback coverage.
 Recovery also refreshes the admitted pack manager from the restored source stores
 before preparing another mutation. CLI pack commands recover before installed-state
 shortcuts, so an interrupted installation cannot be reported as already installed.
+
+## Removal and quick-setting mutations
+
+Custom-rule removal now stages all owned-rule removals and deletion of the
+installation record in the same transaction. It reloads once after preparation,
+not once per removed rule. Metadata write failure and runtime rejection restore
+the complete prior revision, including the installed record. The existing
+pack-tag ownership/removal policy is unchanged.
+
+Quick-setting changes stage the updated collection timing or replacement custom
+rules with the new setting values. A rejected timing update restores the old
+collection and metadata together. Metadata-only settings and cleanup of a pack
+with no tagged rules still avoid generating or reloading configuration.
+
+System-pack install/removal, collection-backed install/removal, and tap/hold
+picker edits remain separate migrations. This change does not include preference
+or managed-snapshot recovery or change the catalog's conflict/ownership policy.
+
+Timing settings reject a missing collection or incompatible configuration before
+writing the installed record. Such a target is not a metadata-only setting; treating
+it as one would claim the new timing while leaving the rules unchanged.

--- a/docs/planning/catalog-led-consolidation-plan.md
+++ b/docs/planning/catalog-led-consolidation-plan.md
@@ -378,9 +378,17 @@ the mapper no longer invokes the legacy immediate-commit save before reloading.
 External revision conflicts preserve files and the journal rather than regenerating
 a snapshot over them. Other collection mutators and pack-wide recovery remain open.
 
-### Custom-rule pack transactions in progress
+### Custom-rule pack installation merged in #1279
 
 Custom-rule installs prepare the complete batch before persistence and retain a
 four-file journal including installed-packs.json through runtime classification.
 Startup rule recovery recognizes this scope. System/collection-backed packs,
 removal, quick-setting changes, and preference/snapshot transactions remain open.
+
+### Pack removal and quick-setting recovery in progress
+
+Custom-rule pack removal and quick-setting updates now share the retained pack
+transaction, including collection-backed Home Row Mods timing settings. Tests
+cover single-reload removal, exact rollback on rejection/metadata write failure,
+and pending/rejected timing updates. System/collection-backed install and removal,
+preferences, managed snapshots, and tap/hold picker edits remain open.


### PR DESCRIPTION
## Problem and result

Removing a custom-rule pack saved and reloaded once per rule, then deleted the installation record separately. Timing updates could persist their new settings even when writing or applying the corresponding rules failed.

Pack removal now prepares all rule removals and the record deletion as one recoverable revision. Quick-setting changes use the same SaveCoordinator transaction for collection timing or rendered bindings and metadata. Pending/applied updates commit; rejected, failed, or cancelled application restores the exact prior files and attempts runtime recovery where appropriate. Failed operations also restore the manager snapshot without regenerating over external edits.

The tracker transaction now supports record deletion as well as upsert. One private PackInstaller helper shares installation, removal, and settings application/recovery. Metadata-only changes continue to avoid generation and reload. Existing pack ownership, conflict choices, and UI presentation remain unchanged.

## Validation

- 103 focused tests passed across pack transactions, generic pack behavior, CLI CRUD, and installed tracker persistence.
- New tests cover one-reload removal, rejected removal, metadata write failure, pending timing changes, and rejected timing changes with exact prior-file restoration.
- Full safe suite: 5,211 passed; only the four known macOS 27 snapshot baseline failures (three Home Row Timing views and Repair Settings). No compiler warnings. Supported-runner CI required.
- SwiftFormat 0.61.1, accessibility and diff checks passed.
- Remote review gate selected; GitHub claude-review required before merge.
- Installer matrix: Running and TCP responding; Running but TCP not responding. File restoration and recovery reload are separate outcomes.

System/collection-backed installation and removal, preference/managed snapshot recovery, tap/hold picker saves, and CLI's separate apply remain open migrations. No ownership/removal policy changes or public release. Signed master deployment follows merge.

Review follow-up: timing updates now reject a missing associated collection or incompatible configuration before changing any files or metadata. Both cases have regression tests checking the exact prior file revision and no reload.

The review's extra layer-refresh concern was addressed by removing the added success-path refresh. These operations do not change collection activation, and conflict helpers already handle their own layer state. The refresh helper can emit a TCP heartbeat, so avoiding an unnecessary call also avoids introducing misleading health evidence.

Final review note: manager arrays retain the existing optimistic in-memory update pattern and restore the prior snapshot on failure. File/tracker commit notifications remain deferred. This PR does not claim isolation for every SwiftUI property observer; changing that presentation is part of the separately discussed status/state work.
