### PR TITLE
Recover custom-rule editor mutations through the save coordinator

### DIFF
--- a/Sources/KeyPathAppKit/Services/Packs/PackInstaller.swift
+++ b/Sources/KeyPathAppKit/Services/Packs/PackInstaller.swift
@@ -68,15 +68,13 @@ public final class PackInstaller {
             collectionStore: manager.ruleCollectionStore, customStore: manager.customRulesStore,
             mutationPermit: permit, installedPackTracker: tracker
         )
-        if recovered {
-            let collections = await manager.ruleCollectionStore.loadCollectionsDetailed()
-            guard !collections.wasFullReset, collections.failedCollectionNames.isEmpty else {
-                throw InstallError.saveFailed("Recovered rule collections could not be read completely")
+        do {
+            try await manager.refreshRecoveredRuleStateIfNeeded(recovered)
+        } catch let error as KeyPathError {
+            if case let .configuration(.loadFailed(reason)) = error {
+                throw InstallError.saveFailed(reason)
             }
-            let rules = try await manager.customRulesStore.loadForMutation()
-            manager.ruleCollections = RuleCollectionDeduplicator.dedupe(collections.collections)
-            manager.customRules = rules
-            manager.refreshLayerIndicatorState()
+            throw error
         }
         try await tracker.validateForMutation()
     }
@@ -460,7 +458,8 @@ public final class PackInstaller {
         manager: RuleCollectionsManager
     ) async -> Bool {
         await manager.withRuleMutation(failure: false) { @MainActor permit in
-            let snapshot = await manager.snapshotCurrentRules()
+            guard let recovered = await manager.recoverAndSnapshotRuleState(mutationPermit: permit) else { return false }
+            let snapshot = recovered.customRules
             let normalizedInput = input.lowercased()
             guard var rule = snapshot.first(where: {
                 $0.packSource == packID && $0.input.lowercased() == normalizedInput

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+Migrations.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+Migrations.swift
@@ -11,16 +11,20 @@ extension RuleCollectionsManager {
     func refreshLayerIndicatorState() {
         let hasLayered = ruleCollections.contains { $0.isEnabled && $0.targetLayer != .base }
         if !hasLayered {
-            updateActiveLayerName(RuleCollectionLayer.base.kanataName)
+            setDisplayedLayerName(RuleCollectionLayer.base.kanataName)
         }
     }
 
     func updateActiveLayerName(_ rawName: String) {
+        // Only runtime observations provide heartbeat evidence, including an
+        // unchanged layer. Local rule edits and rollback refreshes do not.
+        NotificationCenter.default.post(name: .kanataTcpHeartbeat, object: nil)
+        setDisplayedLayerName(rawName)
+    }
+
+    private func setDisplayedLayerName(_ rawName: String) {
         let normalized = rawName.isEmpty ? RuleCollectionLayer.base.kanataName : rawName
         let display = normalized.capitalized
-
-        // Heartbeat: any layer poll result means TCP is alive, even if layer is unchanged.
-        NotificationCenter.default.post(name: .kanataTcpHeartbeat, object: nil)
 
         if currentLayerName == display {
             return

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+Mutation.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+Mutation.swift
@@ -1,4 +1,6 @@
 import Foundation
+import KeyPathCore
+import KeyPathRulesCore
 
 extension RuleCollectionsManager {
     /// Admission precedes snapshots and mutation. Nested internal calls carry an
@@ -18,5 +20,72 @@ extension RuleCollectionsManager {
             onError?(error.localizedDescription)
             return failure
         }
+    }
+
+    /// Recover interrupted source writes before taking the next editor snapshot.
+    func recoverAndSnapshotRuleState(mutationPermit: ConfigurationOperationGate.Permit) async -> RuleStateSnapshot? {
+        do {
+            let recovered = try await configurationService.recoverPendingRuleWrite(
+                collectionStore: ruleCollectionStore, customStore: customRulesStore, mutationPermit: mutationPermit
+            )
+            try await refreshRecoveredRuleStateIfNeeded(recovered)
+            return snapshotRuleState()
+        } catch is CancellationError {
+            return nil
+        } catch {
+            onError?(error.localizedDescription)
+            return nil
+        }
+    }
+
+    /// Do not let a retry use stale arrays after journal recovery succeeded but
+    /// source decoding failed. Clear the requirement only after both stores load.
+    func refreshRecoveredRuleStateIfNeeded(_ recovered: Bool) async throws {
+        needsRecoveredRuleStateRefresh = needsRecoveredRuleStateRefresh || recovered
+        needsRecoveredRuleRuntimeRefresh = needsRecoveredRuleRuntimeRefresh || recovered
+        if needsRecoveredRuleStateRefresh {
+            let collections = await ruleCollectionStore.loadCollectionsDetailed()
+            guard !collections.wasFullReset, collections.failedCollectionNames.isEmpty else {
+                throw KeyPathError.configuration(.loadFailed(reason: "Recovered rule collections could not be read completely. No edit was made."))
+            }
+            let rules = try await customRulesStore.loadForMutation()
+            ruleCollections = RuleCollectionDeduplicator.dedupe(collections.collections)
+            customRules = rules
+            needsRecoveredRuleStateRefresh = false
+            refreshLayerIndicatorState()
+        }
+        // Restore runtime before any caller can cancel a prompt or return for a
+        // missing rule. A failed attempt remains required after the journal is gone.
+        // Headless persistence-only callers may have no runtime callback; retain
+        // the requirement in case one is attached to this manager later.
+        if needsRecoveredRuleRuntimeRefresh, let onRulesChanged {
+            let result = await Task { @MainActor in await onRulesChanged() }.value
+            guard result.disposition == .applied || result.disposition == .pending else {
+                throw KeyPathError.configuration(.loadFailed(reason: "Recovered files could not be applied: \(result.errorMessage ?? "keyboard service rejected recovery")"))
+            }
+            needsRecoveredRuleRuntimeRefresh = false
+        }
+    }
+
+    /// The save owner restores files/runtime; the manager restores its in-memory
+    /// candidate without regenerating over the recovered or externally edited files.
+    func commitCustomRuleMutation(snapshot: RuleStateSnapshot, skipReload: Bool = false,
+                                  mutationPermit: ConfigurationOperationGate.Permit) async -> Bool
+    {
+        let result = await SaveCoordinator(configurationService: configurationService).saveRuleState(
+            manager: self, mutationPermit: mutationPermit, reloadHandler: skipReload ? nil : onRulesChanged
+        )
+        guard result.success else {
+            ruleCollections = snapshot.collections
+            customRules = snapshot.customRules
+            refreshLayerIndicatorState()
+            if let error = result.error, !(error is CancellationError) {
+                onError?(error.localizedDescription)
+                SoundManager.shared.playErrorSound()
+            }
+            return false
+        }
+        NotificationCenter.default.post(name: .ruleCollectionsChanged, object: nil)
+        return true
     }
 }

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+PublicAPI.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+PublicAPI.swift
@@ -960,21 +960,11 @@ extension RuleCollectionsManager {
     func saveCustomRule(_ rule: CustomRule, skipReload: Bool = false, autoResolveConflicts: Bool = false, mutationPermit: ConfigurationOperationGate.Permit? = nil) async -> Bool {
         await withRuleMutation(using: mutationPermit, failure: false) { [self] permit in
             AppLogger.shared.log("💾 [CustomRules] saveCustomRule called: id=\(rule.id), input='\(rule.input)', action='\(rule.action.displayName)'")
-            let snapshot = snapshotRuleState()
+            guard let snapshot = await recoverAndSnapshotRuleState(mutationPermit: permit) else { return false }
 
             guard await updateCustomRuleInMemory(rule, autoResolveConflicts: autoResolveConflicts, mutationPermit: permit) else { return false }
 
-            let success = await regenerateConfigFromCollections(skipReload: skipReload, mutationPermit: permit)
-
-            if success {
-                AppLogger.shared.log("💾 [CustomRules] Save complete, customRules.count = \(customRules.count)")
-            } else {
-                AppLogger.shared.log("💾 [CustomRules] Save failed - rolling back to snapshot")
-                await rollbackToSnapshot(snapshot, userMessage: "Could not apply this rule change. Your previous rule state was restored.", mutationPermit: permit)
-                AppLogger.shared.log("💾 [CustomRules] Rollback complete, customRules.count = \(customRules.count)")
-            }
-
-            return success
+            return await commitCustomRuleMutation(snapshot: snapshot, skipReload: skipReload, mutationPermit: permit)
         }
     }
 
@@ -1033,7 +1023,7 @@ extension RuleCollectionsManager {
     /// Toggle a custom rule on/off
     func toggleCustomRule(id: UUID, isEnabled: Bool) async {
         await withRuleMutation(failure: ()) { [self] permit in
-            let snapshot = snapshotRuleState()
+            guard let snapshot = await recoverAndSnapshotRuleState(mutationPermit: permit) else { return }
             guard let existing = customRules.first(where: { $0.id == id }) else { return }
 
             if !isEnabled {
@@ -1077,34 +1067,33 @@ extension RuleCollectionsManager {
             if let index = customRules.firstIndex(where: { $0.id == id }) {
                 customRules[index].isEnabled = isEnabled
             }
-            let applied = await regenerateConfigFromCollections(mutationPermit: permit)
-            if !applied {
-                AppLogger.shared.log("↩️ [CustomRules] Toggle apply failed; rolling back to previous state")
-                await rollbackToSnapshot(snapshot, userMessage: "Could not apply this rule change. Your previous rule state was restored.", mutationPermit: permit)
-            }
+            _ = await commitCustomRuleMutation(snapshot: snapshot, mutationPermit: permit)
         }
     }
 
     /// Remove a custom rule
     func removeCustomRule(id: UUID, mutationPermit: ConfigurationOperationGate.Permit? = nil) async {
         await withRuleMutation(using: mutationPermit, failure: ()) { [self] permit in
+            guard let snapshot = await recoverAndSnapshotRuleState(mutationPermit: permit) else { return }
             let beforeCount = customRules.count
             AppLogger.shared.log("🗑️ [CustomRules] removeCustomRule called: id=\(id), beforeCount=\(beforeCount)")
             customRules.removeAll { $0.id == id }
             let afterCount = customRules.count
             AppLogger.shared.log("🗑️ [CustomRules] After removal: afterCount=\(afterCount), removed=\(beforeCount - afterCount)")
-            await regenerateConfigFromCollections(mutationPermit: permit)
+            _ = await commitCustomRuleMutation(snapshot: snapshot, mutationPermit: permit)
         }
     }
 
     /// Clear all custom rules (without affecting rule collections)
     func clearAllCustomRules() async {
         await withRuleMutation(failure: ()) { [self] permit in
+            guard let snapshot = await recoverAndSnapshotRuleState(mutationPermit: permit) else { return }
             let count = customRules.count
             AppLogger.shared.log("🧹 [CustomRules] Clearing all \(count) custom rules")
             customRules.removeAll()
-            await regenerateConfigFromCollections(mutationPermit: permit)
-            AppLogger.shared.log("✅ [CustomRules] All custom rules cleared")
+            if await commitCustomRuleMutation(snapshot: snapshot, mutationPermit: permit) {
+                AppLogger.shared.log("✅ [CustomRules] All custom rules cleared")
+            }
         }
     }
 

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager.swift
@@ -57,6 +57,9 @@ final class RuleCollectionsManager {
 
     var ruleCollections: [RuleCollection] = []
     var customRules: [CustomRule] = []
+    /// Remains set when recovered files cannot yet be read completely.
+    var needsRecoveredRuleStateRefresh = false
+    var needsRecoveredRuleRuntimeRefresh = false
     var currentLayerName: String = RuleCollectionLayer.base.displayName
 
     /// Active keymap layout ID (e.g., "colemak-dh", "dvorak")

--- a/Tests/KeyPathTests/CustomRuleMutationRecoveryTests.swift
+++ b/Tests/KeyPathTests/CustomRuleMutationRecoveryTests.swift
@@ -1,0 +1,274 @@
+import Foundation
+@testable import KeyPathAppKit
+import KeyPathRulesCore
+@preconcurrency import XCTest
+
+@MainActor
+final class CustomRuleMutationRecoveryTests: KeyPathTestCase {
+    private var directory: URL!
+    private var manager: RuleCollectionsManager!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let collections = RuleCollectionStore.testStore(at: directory.appendingPathComponent("RuleCollections.json"))
+        let rules = CustomRulesStore.testStore(at: directory.appendingPathComponent("CustomRules.json"))
+        let service = ConfigurationService(configDirectory: directory.path, ruleCollectionStore: collections, customRulesStore: rules)
+        manager = RuleCollectionsManager(ruleCollectionStore: collections, customRulesStore: rules, configurationService: service)
+        manager.ruleCollections = []
+        manager.customRules = [CustomRule(input: "f20", action: .keystroke(key: "f19"), createdAt: Date(timeIntervalSince1970: 42))]
+        try await service.saveRuleState(ruleCollections: [], customRules: manager.customRules, collectionStore: collections, customStore: rules)
+    }
+
+    override func tearDown() async throws {
+        try? FileManager.default.removeItem(at: directory)
+        manager = nil
+        directory = nil
+        try await super.tearDown()
+    }
+
+    private func files() throws -> [String: Data] {
+        try Dictionary(uniqueKeysWithValues: ["keypath.kbd", "RuleCollections.json", "CustomRules.json"].map {
+            try ($0, Data(contentsOf: directory.appendingPathComponent($0)))
+        })
+    }
+
+    private static func reload(_ disposition: ReloadDisposition) -> ReloadResult {
+        ReloadResult(success: disposition == .applied, response: nil, errorMessage: "injected \(disposition)", protocol: nil, disposition: disposition)
+    }
+
+    private func assertRejectedMutationRestores(_ mutate: @MainActor () async -> Void) async throws {
+        let before = try files()
+        let snapshot = manager.snapshotRuleState()
+        var reloads = 0
+        var errors: [String] = []
+        manager.onError = { errors.append($0) }
+        manager.onRulesChanged = {
+            reloads += 1
+            if reloads == 2 {
+                do {
+                    let restored = try self.files()
+                    XCTAssertEqual(restored, before)
+                } catch { XCTFail("Could not read restored files: \(error)") }
+            }
+            return Self.reload(reloads == 1 ? .rejected : .applied)
+        }
+        await mutate()
+        XCTAssertEqual(reloads, 2)
+        XCTAssertEqual(try files(), before)
+        XCTAssertEqual(manager.ruleCollections, snapshot.collections)
+        XCTAssertEqual(manager.customRules, snapshot.customRules)
+        XCTAssertEqual(errors.count, 1)
+    }
+
+    func testRejectedSaveRestoresFilesAndReportsFailure() async throws {
+        try await assertRejectedMutationRestores {
+            let saved = await self.manager.saveCustomRule(CustomRule(input: "f13", action: .keystroke(key: "f14")))
+            XCTAssertFalse(saved)
+        }
+    }
+
+    func testRejectedToggleRestoresEnabledState() async throws {
+        try await assertRejectedMutationRestores {
+            await self.manager.toggleCustomRule(id: self.manager.customRules[0].id, isEnabled: false)
+        }
+    }
+
+    func testRejectedRemovalRestoresDeletedRule() async throws {
+        try await assertRejectedMutationRestores {
+            await self.manager.removeCustomRule(id: self.manager.customRules[0].id)
+        }
+    }
+
+    func testRejectedClearRestoresAllRules() async throws {
+        try await assertRejectedMutationRestores { await self.manager.clearAllCustomRules() }
+    }
+
+    func testPendingSaveCommitsWithoutRecoveryOrError() async throws {
+        var reloads = 0
+        manager.onError = { XCTFail("Pending save is not a failure: \($0)") }
+        manager.onRulesChanged = { reloads += 1; return Self.reload(.pending) }
+        let saved = await manager.saveCustomRule(CustomRule(input: "f13", action: .keystroke(key: "f14")))
+        XCTAssertTrue(saved)
+        XCTAssertEqual(reloads, 1)
+        let stored = try await manager.customRulesStore.loadForMutation()
+        XCTAssertEqual(Set(stored.map(\.input)), ["f13", "f20"])
+    }
+
+    func testSkippedReloadCommitsWithoutInventingRuntimeWork() async throws {
+        manager.onRulesChanged = { XCTFail("Reload was explicitly skipped"); return Self.reload(.applied) }
+        let saved = await manager.saveCustomRule(CustomRule(input: "f13", action: .keystroke(key: "f14")), skipReload: true)
+        XCTAssertTrue(saved)
+        let stored = try await manager.customRulesStore.loadForMutation()
+        XCTAssertEqual(stored.count, 2)
+    }
+
+    func testExternalSourceEditIsNotOverwrittenByManagerRollback() async throws {
+        var expected: [String: Data]?
+        var reloads = 0
+        var errors: [String] = []
+        manager.onError = { errors.append($0) }
+        manager.onRulesChanged = {
+            reloads += 1
+            do {
+                try Data("external edit".utf8).write(to: self.directory.appendingPathComponent("CustomRules.json"))
+                expected = try self.files()
+            } catch { XCTFail("Could not inject external edit: \(error)") }
+            return Self.reload(.rejected)
+        }
+        await manager.removeCustomRule(id: manager.customRules[0].id)
+        XCTAssertEqual(reloads, 1)
+        XCTAssertEqual(try files(), expected)
+        XCTAssertEqual(manager.customRules.count, 1)
+        XCTAssertTrue(errors.first?.contains("Recovery needs attention") == true)
+    }
+
+    func testEditRecoversInterruptedSourcesBeforePreparingNextRule() async throws {
+        let service = manager.configurationService
+        try await service.operationGate.withOperation { @MainActor permit in
+            _ = try await service.stageRuleState(ruleCollections: [], customRules: [],
+                                                 collectionStore: self.manager.ruleCollectionStore, customStore: self.manager.customRulesStore, mutationPermit: permit)
+        }
+        manager.customRules = []
+        let saved = await manager.saveCustomRule(CustomRule(input: "f13", action: .keystroke(key: "f14")))
+        XCTAssertTrue(saved)
+        let stored = try await manager.customRulesStore.loadForMutation()
+        XCTAssertEqual(Set(stored.map(\.input)), ["f13", "f20"])
+    }
+
+    func testUnreadableRecoveredSourcesBlockRetriesUntilRepaired() async throws {
+        let service = manager.configurationService
+        let sourceURL = directory.appendingPathComponent("RuleCollections.json")
+        let originalCollections = try Data(contentsOf: sourceURL)
+        try Data("damaged source".utf8).write(to: sourceURL)
+        try await service.operationGate.withOperation { @MainActor permit in
+            _ = try await service.stageRuleState(ruleCollections: [], customRules: [],
+                                                 collectionStore: self.manager.ruleCollectionStore, customStore: self.manager.customRulesStore, mutationPermit: permit)
+        }
+        manager.customRules = []
+        var errors: [String] = []
+        manager.onError = { errors.append($0) }
+        let proposed = CustomRule(input: "f13", action: .keystroke(key: "f14"))
+        let first = await manager.saveCustomRule(proposed)
+        XCTAssertFalse(first)
+        let recoveredFiles = try files()
+        let retry = await manager.saveCustomRule(proposed)
+        XCTAssertFalse(retry)
+        XCTAssertEqual(try files(), recoveredFiles)
+        XCTAssertEqual(errors.count, 2)
+        try originalCollections.write(to: sourceURL)
+        let repaired = await manager.saveCustomRule(proposed)
+        XCTAssertTrue(repaired)
+        let stored = try await manager.customRulesStore.loadForMutation()
+        XCTAssertEqual(Set(stored.map(\.input)), ["f13", "f20"])
+    }
+
+    func testPackPickerReadsRecoveredRuleBeforeEditing() async throws {
+        manager.customRules[0].packSource = "test-pack"
+        let service = manager.configurationService
+        try await service.saveRuleState(ruleCollections: [], customRules: manager.customRules,
+                                        collectionStore: manager.ruleCollectionStore, customStore: manager.customRulesStore)
+        try await service.operationGate.withOperation { @MainActor permit in
+            _ = try await service.stageRuleState(ruleCollections: [], customRules: [],
+                                                 collectionStore: self.manager.ruleCollectionStore, customStore: self.manager.customRulesStore, mutationPermit: permit)
+        }
+        manager.customRules = []
+        let saved = await PackInstaller.shared.updateTapHold(packID: "test-pack", input: "f20", tap: "esc", manager: manager)
+        XCTAssertTrue(saved)
+        let stored = try await manager.customRulesStore.loadForMutation()
+        XCTAssertEqual(stored.count, 1)
+        XCTAssertEqual(stored.first?.action.outputString, "esc")
+        XCTAssertEqual(stored.first?.packSource, "test-pack")
+    }
+
+    func testCancelledSaveRestoresFilesWithoutErrorFeedback() async throws {
+        let before = try files()
+        let rules = manager.customRules
+        var operation: Task<Bool, Never>?
+        var reloads = 0
+        manager.onError = { XCTFail("Cancellation must remain silent: \($0)") }
+        manager.onRulesChanged = {
+            reloads += 1
+            if reloads == 1 { operation?.cancel() }
+            else { XCTAssertFalse(Task.isCancelled, "Recovery must not inherit cancellation") }
+            return Self.reload(.applied)
+        }
+        operation = Task { @MainActor in
+            await self.manager.saveCustomRule(CustomRule(input: "f13", action: .keystroke(key: "f14")))
+        }
+        let saved = await operation!.value
+        XCTAssertFalse(saved)
+        XCTAssertEqual(reloads, 2)
+        XCTAssertEqual(try files(), before)
+        XCTAssertEqual(manager.customRules, rules)
+    }
+
+    func testInterruptedRecoveryReloadsBeforeMissingRuleExit() async throws {
+        let before = try files()
+        try await stageInterruptedEmptyRules()
+        var reloads = 0
+        manager.onRulesChanged = {
+            reloads += 1
+            do {
+                let restored = try self.files()
+                XCTAssertEqual(restored, before)
+            } catch { XCTFail("Cannot read recovery: \(error)") }
+            return Self.reload(.applied)
+        }
+        await manager.toggleCustomRule(id: UUID(), isEnabled: false)
+        XCTAssertEqual(reloads, 1)
+        XCTAssertEqual(try files(), before)
+    }
+
+    func testRejectedInterruptedRecoveryIsRetriedBeforeNextEdit() async throws {
+        let before = try files()
+        try await stageInterruptedEmptyRules()
+        var reloads = 0
+        var errors: [String] = []
+        manager.onError = { errors.append($0) }
+        manager.onRulesChanged = {
+            reloads += 1
+            XCTAssertFalse(Task.isCancelled)
+            return Self.reload(reloads == 1 ? .rejected : .applied)
+        }
+        await manager.toggleCustomRule(id: UUID(), isEnabled: false)
+        XCTAssertEqual(reloads, 1)
+        XCTAssertEqual(errors.count, 1)
+        await manager.toggleCustomRule(id: UUID(), isEnabled: false)
+        XCTAssertEqual(reloads, 2)
+        XCTAssertEqual(errors.count, 1)
+        XCTAssertEqual(try files(), before)
+    }
+
+    private func stageInterruptedEmptyRules() async throws {
+        let service = manager.configurationService
+        try await service.operationGate.withOperation { @MainActor permit in
+            _ = try await service.stageRuleState(ruleCollections: [], customRules: [],
+                                                 collectionStore: self.manager.ruleCollectionStore, customStore: self.manager.customRulesStore, mutationPermit: permit)
+        }
+        manager.customRules = []
+    }
+
+    func testLocalLayerRefreshDoesNotEmitRuntimeHeartbeat() {
+        let counter = HeartbeatCounter()
+        let token = NotificationCenter.default.addObserver(forName: .kanataTcpHeartbeat, object: nil, queue: nil) { _ in counter.increment() }
+        defer { NotificationCenter.default.removeObserver(token) }
+        manager.refreshLayerIndicatorState()
+        XCTAssertEqual(counter.value, 0)
+        manager.updateActiveLayerName("base")
+        XCTAssertEqual(counter.value, 1, "Even an unchanged observed layer is real heartbeat evidence")
+    }
+}
+
+private final class HeartbeatCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var count = 0
+    func increment() {
+        lock.withLock { count += 1 }
+    }
+
+    var value: Int {
+        lock.withLock { count }
+    }
+}

--- a/Tests/KeyPathTests/PackMetadataOperationTests.swift
+++ b/Tests/KeyPathTests/PackMetadataOperationTests.swift
@@ -89,8 +89,18 @@ final class PackMetadataOperationTests: KeyPathTestCase {
                 "customRules": fixture.directory.appendingPathComponent("CustomRules.json")
             ], contents: ["config": Data("(defsrc)\n(deflayer base)".utf8), "collections": proposed, "customRules": Data("[]".utf8)],
             directory: fixture.directory, scope: .rules)
+            var recoveryReloads = 0
+            fixture.manager.onRulesChanged = {
+                recoveryReloads += 1
+                do {
+                    let restored = try Data(contentsOf: sourceURL)
+                    XCTAssertEqual(restored, original)
+                } catch { XCTFail("Could not read restored source: \(error)") }
+                return ReloadResult(success: true, response: nil, errorMessage: nil, protocol: nil, disposition: .applied)
+            }
             let record = try await PackInstaller.shared.reconcileInstallRecord(for: pack, manager: fixture.manager, installedPackTracker: fixture.tracker)
             XCTAssertNil(record)
+            XCTAssertEqual(recoveryReloads, 1)
             XCTAssertEqual(try Data(contentsOf: sourceURL), original)
         }
     }

--- a/Tests/KeyPathTests/PackRuleTransactionTests.swift
+++ b/Tests/KeyPathTests/PackRuleTransactionTests.swift
@@ -328,6 +328,30 @@ final class PackRuleTransactionTests: KeyPathTestCase {
         XCTAssertEqual(manager.ruleCollections, collections)
     }
 
+    func testInstallRefusesRejectedInterruptedRuntimeRecovery() async throws {
+        let before = try snapshot()
+        let service = manager.configurationService
+        try await service.operationGate.withOperation { @MainActor permit in
+            _ = try await service.stageRuleState(ruleCollections: [], customRules: [],
+                                                 collectionStore: self.manager.ruleCollectionStore, customStore: self.manager.customRulesStore,
+                                                 mutationPermit: permit, packRecord: .init(tracker: self.tracker, record: InstalledPackRecord(packID: "interrupted", version: "2")))
+        }
+        manager.customRules = []
+        var reloads = 0
+        manager.onRulesChanged = { reloads += 1; return Self.reload(.rejected) }
+        do {
+            _ = try await PackInstaller.shared.install(pack, manager: manager, installedPackTracker: tracker)
+            XCTFail("Install must wait for successful recovery")
+        } catch let PackInstaller.InstallError.saveFailed(reason) {
+            XCTAssertTrue(reason.contains("Recovered files could not be applied"))
+        }
+        XCTAssertEqual(reloads, 1)
+        XCTAssertEqual(try snapshot(), before)
+        XCTAssertEqual(manager.customRules.map(\.input), ["f20"])
+        let record = await tracker.record(for: pack.id)
+        XCTAssertNil(record)
+    }
+
     func testExternalMetadataEditStopsRecoveryWithoutOverwritingAnyFile() async throws {
         var externalRevision: [String: Data]?
         var reloads = 0

--- a/docs/architecture/configuration-save-pipeline.md
+++ b/docs/architecture/configuration-save-pipeline.md
@@ -295,3 +295,16 @@ other records. Preparation performs no per-binding writes; notifications follow
 commit. Settings that affect a collection, such as Home Row Mods timing, restore
 the collection and stored setting together after rejected application. Metadata-only
 operations still skip config generation and runtime reload.
+
+## Custom-rule editor mutations
+
+The manager's save, toggle, remove, and clear custom-rule operations now prepare
+under admission and use SaveCoordinator's retained rule transaction. They recover
+interrupted source writes before capturing the next in-memory snapshot. Rejected
+application restores the prior files/runtime and manager state; the manager does
+not regenerate a second rollback over externally changed files. Existing conflict
+and provider-disable choices remain in place. Explicitly skipped/absent reloads
+still mean persistence without an application result.
+
+Local layer-label refreshes do not emit TCP heartbeat notifications. Only an
+observed runtime layer update supplies that evidence, including unchanged layers.

--- a/docs/bugs/custom-rule-editor-recovery.md
+++ b/docs/bugs/custom-rule-editor-recovery.md
@@ -1,0 +1,46 @@
+# Custom-rule editor recovery
+
+Custom-rule save and toggle previously treated successful persistence as success
+when reload was rejected. Removal and clear did not retain an in-memory snapshot.
+Save/toggle fallback regenerated from a snapshot, which could overwrite unrelated
+external edits after an earlier recovery conflict.
+
+These four operations now prepare under the existing directory gate and call
+SaveCoordinator.saveRuleState. The coordinator retains config and both source
+stores through application/recovery. The manager restores only its in-memory
+snapshot on failure and reports the original or recovery error. It no longer
+writes a separate rollback revision. Interrupted journals recover before the next
+editor snapshot, followed by a strict source reload when recovery changed disk.
+
+The rollback review also found that refreshLayerIndicatorState called the runtime
+layer-update method, which posts a TCP heartbeat. Local edits/recovery therefore
+could be mistaken for runtime evidence. Display-only updates now use a separate
+private setter; actual runtime observations keep heartbeat reporting.
+
+Regression coverage checks save/toggle/remove/clear rejection, exact recovery
+before the compensating reload, pending/skipped saves, preservation of external
+source edits, interrupted-write recovery, and the heartbeat distinction.
+
+Collection mutations, preferences, revision-aware watching, and UI status/state
+presentation remain separate work. Manager arrays still follow the existing
+optimistic preparation pattern; this is not isolation of every UI property read.
+
+The pack tap/hold picker also recovers before locating and deriving the edited
+rule. Its nested custom-rule save then uses the same transaction; this prevents
+an interrupted write from hiding the target rule or supplying stale tap/hold data.
+Validation cancellation remains silent, while other failed saves retain error
+feedback through the manager's existing callback.
+
+If file recovery succeeds but source decoding fails, the manager retains a pending
+refresh requirement. Every later migrated editor/pack attempt must fully reload
+both stores before preparing an edit. Merely removing the journal is not enough
+to make stale arrays safe. The shared refresh helper clears that requirement only
+after both stores load; tests verify repeated refusal and recovery after repair.
+
+When a recovered journal may already have reached the engine, migrated manager
+paths attempt an uncancelled coordinated reload before returning a snapshot.
+This covers exits for missing rule IDs and cancelled conflict/provider prompts.
+Rejected/failed recovery blocks the edit and remains required on the next attempt,
+even after the file journal has been removed. Explicit headless callers with no
+runtime callback retain their persistence-only contract; the manager retains the
+runtime-refresh requirement if a callback is attached later.

--- a/docs/planning/catalog-led-consolidation-plan.md
+++ b/docs/planning/catalog-led-consolidation-plan.md
@@ -385,10 +385,18 @@ four-file journal including installed-packs.json through runtime classification.
 Startup rule recovery recognizes this scope. System/collection-backed packs,
 removal, quick-setting changes, and preference/snapshot transactions remain open.
 
-### Pack removal and quick-setting recovery in progress
+### Pack removal and quick-setting recovery merged in #1280
 
 Custom-rule pack removal and quick-setting updates now share the retained pack
 transaction, including collection-backed Home Row Mods timing settings. Tests
 cover single-reload removal, exact rollback on rejection/metadata write failure,
 and pending/rejected timing updates. System/collection-backed install and removal,
 preferences, managed snapshots, and tap/hold picker edits remain open.
+
+### Custom-rule editor recovery in progress
+
+Save, toggle, remove, and clear now use the retained rule transaction and restore
+manager snapshots without another file write. Interrupted source recovery precedes
+the next editor snapshot, including the pack tap/hold picker. Local layer-label refresh no longer supplies false TCP
+heartbeat evidence. Collection/preferences/watcher work and agreed UI decisions
+remain open.


### PR DESCRIPTION
## Problem and result

Custom-rule save/toggle treated persistence as success even when the keyboard service rejected the change. Delete and clear lacked in-memory rollback. The older save/toggle fallback regenerated another revision, which could overwrite an unrelated external edit after recovery failed.

Save, toggle, delete, and clear now prepare under directory admission and use SaveCoordinator's retained config/source transaction. On failure, the coordinator restores files/runtime and the manager restores only its in-memory snapshot, without a second rollback write. Interrupted journals recover before capturing the next editor snapshot. The pack tap/hold picker also recovers before deriving its edit from an existing rule.

Local layer-label refreshes no longer call the runtime-observation method or emit TCP heartbeat notifications. Actual runtime layer observations still report heartbeat evidence even when the layer is unchanged. Existing conflict/provider decisions, validation cancellation handling, error feedback and optimistic manager-array preparation remain; status presentation is a separate UI decision.

## Validation

- 190 focused tests passed across custom-rule recovery, collection-manager APIs, prerequisites/dependents, conflict resolution, pack transactions and generic pack behavior.
- New tests cover rejected save/toggle/delete/clear, exact file restoration before recovery reload, pending/skipped saves, external source edits, interrupted source recovery, the tap/hold picker, and heartbeat provenance.
- Full safe suite: 5,225 passed, with only the four known macOS 27 snapshot baseline failures (three Home Row Timing views and Repair Settings). No compiler warnings. Final runtime recovery and metadata expectations are included in that full run; the added pack-install regression is separately checked below and by final CI.
- SwiftFormat 0.61.1, accessibility, and diff checks passed.
- Remote review gate selected; GitHub claude-review required before merge.
- Installer matrix: Running and TCP responding; Running but TCP not responding. File restoration remains separate from runtime recovery success.

Collection/preference transactions, managed-pack snapshots, revision-aware watching, CLI's separate apply, and UI state isolation remain open. Signed deployment follows merge; no public release.

Review follow-up: incomplete source decoding after journal recovery now leaves a pending refresh requirement on the manager. Editor and pack paths share the strict refresh helper, and retries cannot bypass it after the journal is gone. A regression test checks the first refusal, repeated refusal with unchanged files, and a successful edit preserving restored rules after source repair. The tap/hold picker uses the recovered snapshot's `customRules` array throughout; its nested save captures a fresh snapshot, and the dedicated picker test verifies this path.

Final compatibility follow-up: PackInstaller translates an unreadable recovered-collection error back to its existing InstallError.saveFailed case. The new editor path handles CancellationError directly; the legacy string match was removed because saveRuleState does not produce that mapper-only cancellation wrapper. A cancelled-save regression checks exact rollback, uncancelled recovery, and no error callback.

Late runtime-recovery finding addressed: after restoring an interrupted journal, the shared manager recovery helper attempts an uncancelled reload before returning to a caller that might exit early or cancel a prompt. Rejected/failed recovery blocks the edit and remains required on retry after the journal is gone. Tests cover a missing-rule early exit and rejected recovery followed by retry. Headless callers without a runtime callback keep their explicit persistence-only contract; this is not a claim of runtime restoration for CLI no-apply operations.

Review verification: SaveCoordinator.saveRuleState does not post ruleCollectionsChanged; the notification at SaveCoordinator line 203 belongs to the separate saveMapping caller. The editor therefore posts once after its own successful commit. The picker intentionally recovers before reading the target, and saveCustomRule remains independently safe; its second check does not reload stores/runtime after the recovery flags have cleared. Under the same admitted permit no competing cooperating writer can introduce another journal between those steps.

The existing metadata backfill regression now expects exactly one reload after interrupted-rule recovery and verifies restored source bytes before that reload. Its fixture still forbids reloads for ordinary metadata-only work. The focused metadata/recovery group passes all 39 tests.

Pack install intentionally refuses to prepare another change while restoration of a prior interrupted runtime revision is rejected. The new pack-specific regression verifies InstallError.saveFailed, exactly one recovery reload, exact restoration of all four files, and no new installed record.

Final pack/metadata/editor recovery group: 40 tests passed after the added pack-install regression. No application code changed after the final broad local run.
