### PR TITLE
Recover collection and layer membership changes as one revision

### DIFF
--- a/Sources/KeyPathAppKit/InstallationWizard/WizardKarabinerImportPage.swift
+++ b/Sources/KeyPathAppKit/InstallationWizard/WizardKarabinerImportPage.swift
@@ -271,7 +271,9 @@ struct WizardKarabinerImportPage: View {
         var errors: [String] = []
 
         for collection in result.collections where selectedCollectionIds.contains(collection.id) {
-            await kanataManager.addRuleCollection(collection)
+            if await !(kanataManager.addRuleCollection(collection)) {
+                errors.append("Collection '\(collection.name)' was not imported.")
+            }
         }
 
         let appKeymaps = result.appKeymaps.filter { selectedAppKeymapIds.contains($0.id) }

--- a/Sources/KeyPathAppKit/Managers/RuleCollectionsCoordinator.swift
+++ b/Sources/KeyPathAppKit/Managers/RuleCollectionsCoordinator.swift
@@ -62,10 +62,12 @@ final class RuleCollectionsCoordinator {
     }
 
     /// Add a new rule collection
-    func addRuleCollection(_ collection: RuleCollection) async {
-        await ruleCollectionsManager.addCollection(collection)
+    @discardableResult
+    func addRuleCollection(_ collection: RuleCollection) async -> Bool {
+        let saved = await ruleCollectionsManager.addCollection(collection)
         applyMappings(ruleCollectionsManager.enabledMappings())
         notifyStateChanged()
+        return saved
     }
 
     /// Replace all rule collections

--- a/Sources/KeyPathAppKit/Managers/RuntimeCoordinator+RuleCollections.swift
+++ b/Sources/KeyPathAppKit/Managers/RuntimeCoordinator+RuleCollections.swift
@@ -31,7 +31,8 @@ extension RuntimeCoordinator {
         await ruleCollectionsCoordinator.batchEnableCollections(ids: ids)
     }
 
-    func addRuleCollection(_ collection: RuleCollection) async {
+    @discardableResult
+    func addRuleCollection(_ collection: RuleCollection) async -> Bool {
         await ruleCollectionsCoordinator.addRuleCollection(collection)
     }
 

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+Mutation.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+Mutation.swift
@@ -69,8 +69,9 @@ extension RuleCollectionsManager {
 
     /// The save owner restores files/runtime; the manager restores its in-memory
     /// candidate without regenerating over the recovered or externally edited files.
-    func commitCustomRuleMutation(snapshot: RuleStateSnapshot, skipReload: Bool = false,
-                                  mutationPermit: ConfigurationOperationGate.Permit) async -> Bool
+    @discardableResult
+    func commitRuleMutation(snapshot: RuleStateSnapshot, skipReload: Bool = false,
+                            mutationPermit: ConfigurationOperationGate.Permit) async -> Bool
     {
         let result = await SaveCoordinator(configurationService: configurationService).saveRuleState(
             manager: self, mutationPermit: mutationPermit, reloadHandler: skipReload ? nil : onRulesChanged

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+PublicAPI.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+PublicAPI.swift
@@ -190,6 +190,7 @@ extension RuleCollectionsManager {
     /// layer collections at once without 4 separate save/validate/reload cycles.
     func batchEnableCollections(ids: [UUID]) async {
         await withRuleMutation(failure: ()) { [self] permit in
+            guard let snapshot = await recoverAndSnapshotRuleState(mutationPermit: permit) else { return }
             let catalog = RuleCollectionCatalog().defaultCollections()
 
             for id in ids {
@@ -206,14 +207,15 @@ extension RuleCollectionsManager {
 
             dedupeRuleCollectionsInPlace()
             refreshLayerIndicatorState()
-            await regenerateConfigFromCollections(mutationPermit: permit)
+            _ = await commitRuleMutation(snapshot: snapshot, mutationPermit: permit)
         }
     }
 
     /// Add or update a rule collection
-    func addCollection(_ collection: RuleCollection, mutationPermit: ConfigurationOperationGate.Permit? = nil) async {
-        await withRuleMutation(using: mutationPermit, failure: ()) { [self] permit in
-            let snapshot = snapshotRuleState()
+    @discardableResult
+    func addCollection(_ collection: RuleCollection, mutationPermit: ConfigurationOperationGate.Permit? = nil) async -> Bool {
+        await withRuleMutation(using: mutationPermit, failure: false) { [self] permit in
+            guard let snapshot = await recoverAndSnapshotRuleState(mutationPermit: permit) else { return false }
 
             if collection.isEnabled, let conflict = conflictInfo(for: collection) {
                 // Show conflict resolution dialog
@@ -229,7 +231,7 @@ extension RuleCollectionsManager {
 
                 guard let choice = await onConflictResolution?(context) else {
                     // User cancelled - don't add
-                    return
+                    return false
                 }
 
                 switch choice {
@@ -238,7 +240,7 @@ extension RuleCollectionsManager {
                     await disableConflicting(conflict.source, regenerate: false)
                 case .keepExisting:
                     // User chose to keep the existing rule - don't add the new one
-                    return
+                    return false
                 }
             }
 
@@ -253,27 +255,26 @@ extension RuleCollectionsManager {
             }
             dedupeRuleCollectionsInPlace()
             refreshLayerIndicatorState()
-            let applied = await regenerateConfigFromCollections(mutationPermit: permit)
-            if !applied {
-                AppLogger.shared.log("↩️ [RuleCollections] Add collection failed; rolling back to previous state")
-                await rollbackToSnapshot(snapshot, userMessage: "Could not apply this rule change. Your previous rule state was restored.", mutationPermit: permit)
-            }
+            return await commitRuleMutation(snapshot: snapshot, mutationPermit: permit)
         }
     }
 
     /// Remove a rule collection by ID
     func removeCollection(id: UUID) async {
         await withRuleMutation(failure: ()) { [self] permit in
+            guard let snapshot = await recoverAndSnapshotRuleState(mutationPermit: permit) else { return }
             ruleCollections.removeAll { $0.id == id }
             refreshLayerIndicatorState()
-            await regenerateConfigFromCollections(mutationPermit: permit)
-            AppLogger.shared.log("🗑️ [RuleCollections] Removed collection: \(id)")
+            if await commitRuleMutation(snapshot: snapshot, mutationPermit: permit) {
+                AppLogger.shared.log("🗑️ [RuleCollections] Removed collection: \(id)")
+            }
         }
     }
 
     /// Remove all collections and custom rules for a specific layer
     func removeLayer(_ layerName: String) async {
         await withRuleMutation(failure: ()) { [self] permit in
+            guard let snapshot = await recoverAndSnapshotRuleState(mutationPermit: permit) else { return }
             let normalizedName = layerName.lowercased()
 
             // Remove collections targeting this layer
@@ -290,15 +291,8 @@ extension RuleCollectionsManager {
             }
             let removedRules = ruleCount - customRules.count
 
-            // Persist custom rules to disk
-            do {
-                try await customRulesStore.saveRules(customRules)
-            } catch {
-                AppLogger.shared.error("❌ [RuleCollections] Failed to persist custom rules after layer removal: \(error)")
-            }
-
             refreshLayerIndicatorState()
-            await regenerateConfigFromCollections(mutationPermit: permit)
+            guard await commitRuleMutation(snapshot: snapshot, mutationPermit: permit) else { return }
 
             AppLogger.shared.log("🗑️ [RuleCollections] Removed layer '\(layerName)': \(removedCollections) collections, \(removedRules) rules")
         }
@@ -308,6 +302,7 @@ extension RuleCollectionsManager {
     func createLayer(_ name: String) async {
         await withRuleMutation(failure: ()) { [self] permit in
             guard !name.isEmpty else { return }
+            guard await recoverAndSnapshotRuleState(mutationPermit: permit) != nil else { return }
 
             // Sanitize the layer name
             let sanitizedName = name.lowercased()
@@ -347,7 +342,7 @@ extension RuleCollectionsManager {
                 configuration: .list
             )
 
-            await addCollection(collection, mutationPermit: permit)
+            guard await addCollection(collection, mutationPermit: permit) else { return }
             AppLogger.shared.log("📚 [RuleCollections] Created new layer: \(sanitizedName) (Leader → \(activatorKey.uppercased()))")
         }
     }
@@ -964,7 +959,7 @@ extension RuleCollectionsManager {
 
             guard await updateCustomRuleInMemory(rule, autoResolveConflicts: autoResolveConflicts, mutationPermit: permit) else { return false }
 
-            return await commitCustomRuleMutation(snapshot: snapshot, skipReload: skipReload, mutationPermit: permit)
+            return await commitRuleMutation(snapshot: snapshot, skipReload: skipReload, mutationPermit: permit)
         }
     }
 
@@ -1067,7 +1062,7 @@ extension RuleCollectionsManager {
             if let index = customRules.firstIndex(where: { $0.id == id }) {
                 customRules[index].isEnabled = isEnabled
             }
-            _ = await commitCustomRuleMutation(snapshot: snapshot, mutationPermit: permit)
+            _ = await commitRuleMutation(snapshot: snapshot, mutationPermit: permit)
         }
     }
 
@@ -1080,7 +1075,7 @@ extension RuleCollectionsManager {
             customRules.removeAll { $0.id == id }
             let afterCount = customRules.count
             AppLogger.shared.log("🗑️ [CustomRules] After removal: afterCount=\(afterCount), removed=\(beforeCount - afterCount)")
-            _ = await commitCustomRuleMutation(snapshot: snapshot, mutationPermit: permit)
+            _ = await commitRuleMutation(snapshot: snapshot, mutationPermit: permit)
         }
     }
 
@@ -1091,7 +1086,7 @@ extension RuleCollectionsManager {
             let count = customRules.count
             AppLogger.shared.log("🧹 [CustomRules] Clearing all \(count) custom rules")
             customRules.removeAll()
-            if await commitCustomRuleMutation(snapshot: snapshot, mutationPermit: permit) {
+            if await commitRuleMutation(snapshot: snapshot, mutationPermit: permit) {
                 AppLogger.shared.log("✅ [CustomRules] All custom rules cleared")
             }
         }

--- a/Sources/KeyPathAppKit/UI/Mapper/MapperViewModel+LayerManagement.swift
+++ b/Sources/KeyPathAppKit/UI/Mapper/MapperViewModel+LayerManagement.swift
@@ -102,17 +102,16 @@ extension MapperViewModel {
             configuration: .list
         )
 
-        // Persist via rulesManager
+        // Select only a committed layer, and preserve navigation made while saving.
         if let rulesManager {
+            let previousLayer = currentLayer
             Task {
-                await rulesManager.addCollection(collection)
+                guard await rulesManager.addCollection(collection) else { return }
                 AppLogger.shared.log("📚 [MapperViewModel] Created new layer: \(sanitizedName) (Leader → \(activatorKey.uppercased()))")
                 await refreshAvailableLayers()
+                if currentLayer == previousLayer { setLayer(sanitizedName) }
             }
         }
-
-        // Switch to the new layer
-        setLayer(sanitizedName)
     }
 
     /// Delete a layer and all associated rules (only non-system layers)

--- a/Sources/KeyPathAppKit/UI/Overlay/KarabinerImportSheet.swift
+++ b/Sources/KeyPathAppKit/UI/Overlay/KarabinerImportSheet.swift
@@ -543,7 +543,9 @@ struct KarabinerImportSheet: View {
 
         // Import selected collections
         for collection in result.collections where selectedCollectionIds.contains(collection.id) {
-            await kanataManager.addRuleCollection(collection)
+            if await !(kanataManager.addRuleCollection(collection)) {
+                errors.append("Collection '\(collection.name)' was not imported.")
+            }
         }
 
         // Import selected app keymaps

--- a/Sources/KeyPathAppKit/UI/ViewModels/KanataViewModel.swift
+++ b/Sources/KeyPathAppKit/UI/ViewModels/KanataViewModel.swift
@@ -337,7 +337,8 @@ class KanataViewModel {
         }
     }
 
-    func addRuleCollection(_ collection: RuleCollection) async {
+    @discardableResult
+    func addRuleCollection(_ collection: RuleCollection) async -> Bool {
         await manager.addRuleCollection(collection)
     }
 

--- a/Tests/KeyPathTests/CollectionMembershipRecoveryTests.swift
+++ b/Tests/KeyPathTests/CollectionMembershipRecoveryTests.swift
@@ -1,0 +1,190 @@
+import Foundation
+@testable import KeyPathAppKit
+import KeyPathRulesCore
+@preconcurrency import XCTest
+
+@MainActor
+final class CollectionMembershipRecoveryTests: KeyPathTestCase {
+    private var directory: URL!
+    private var manager: RuleCollectionsManager!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let collections = RuleCollectionStore.testStore(at: directory.appendingPathComponent("RuleCollections.json"))
+        let rules = CustomRulesStore.testStore(at: directory.appendingPathComponent("CustomRules.json"))
+        let service = ConfigurationService(configDirectory: directory.path, ruleCollectionStore: collections, customRulesStore: rules)
+        manager = RuleCollectionsManager(ruleCollectionStore: collections, customRulesStore: rules, configurationService: service)
+        manager.ruleCollections = [collection("Existing", layer: .custom("work"))]
+        manager.customRules = [CustomRule(input: "f20", action: .keystroke(key: "f19"), createdAt: Date(timeIntervalSince1970: 42), targetLayer: .custom("work"))]
+        try await persistFixture()
+    }
+
+    override func tearDown() async throws {
+        try? FileManager.default.removeItem(at: directory)
+        manager = nil
+        directory = nil
+        try await super.tearDown()
+    }
+
+    private func collection(_ name: String, layer: RuleCollectionLayer = .base, enabled: Bool = true) -> RuleCollection {
+        RuleCollection(id: UUID(), name: name, summary: "", category: .custom,
+                       mappings: [KeyMapping(input: "f13", action: .keystroke(key: "f14"), description: "")],
+                       isEnabled: enabled, targetLayer: layer)
+    }
+
+    private func persistFixture() async throws {
+        try await manager.configurationService.saveRuleState(ruleCollections: manager.ruleCollections, customRules: manager.customRules,
+                                                             collectionStore: manager.ruleCollectionStore, customStore: manager.customRulesStore)
+    }
+
+    private func files() throws -> [String: Data] {
+        try Dictionary(uniqueKeysWithValues: ["keypath.kbd", "RuleCollections.json", "CustomRules.json"].map {
+            try ($0, Data(contentsOf: directory.appendingPathComponent($0)))
+        })
+    }
+
+    private static func reload(_ disposition: ReloadDisposition) -> ReloadResult {
+        ReloadResult(success: disposition == .applied, response: nil, errorMessage: "injected \(disposition)", protocol: nil, disposition: disposition)
+    }
+
+    private func assertRejectedMutationRestores(_ mutate: @MainActor () async -> Void) async throws {
+        let before = try files()
+        let snapshot = manager.snapshotRuleState()
+        var reloads = 0
+        var errors: [String] = []
+        manager.onError = { errors.append($0) }
+        manager.onRulesChanged = {
+            reloads += 1
+            if reloads == 2 {
+                do {
+                    let restored = try self.files()
+                    XCTAssertEqual(restored, before)
+                } catch { XCTFail("Could not read restored files: \(error)") }
+            }
+            return Self.reload(reloads == 1 ? .rejected : .applied)
+        }
+        await mutate()
+        XCTAssertEqual(reloads, 2)
+        XCTAssertEqual(try files(), before)
+        XCTAssertEqual(manager.ruleCollections, snapshot.collections)
+        XCTAssertEqual(manager.customRules, snapshot.customRules)
+        XCTAssertEqual(errors.count, 1)
+    }
+
+    func testRejectedAdditionRestoresCollections() async throws {
+        try await assertRejectedMutationRestores {
+            let saved = await self.manager.addCollection(self.collection("New"))
+            XCTAssertFalse(saved)
+        }
+    }
+
+    func testCoordinatorReturnsRejectionAndPublishesRestoredMappings() async throws {
+        let coordinator = RuleCollectionsCoordinator(ruleCollectionsManager: manager)
+        var observedMappings: [KeyMapping]?
+        var notifications = 0
+        coordinator.configure(applyMappings: { observedMappings = $0 }, notifyStateChanged: { notifications += 1 })
+        let originalMappings = manager.enabledMappings()
+        try await assertRejectedMutationRestores {
+            let saved = await coordinator.addRuleCollection(self.collection("New"))
+            XCTAssertFalse(saved)
+        }
+        XCTAssertEqual(observedMappings, originalMappings)
+        XCTAssertEqual(notifications, 1)
+    }
+
+    func testMapperDoesNotSelectRejectedNewLayer() async {
+        let runtime = RuntimeCoordinator(injectedConfigurationService: manager.configurationService,
+                                         injectedRuleCollectionsManager: manager)
+        let viewModel = MapperViewModel()
+        viewModel.kanataManager = runtime
+        let previousLayer = viewModel.currentLayer
+        let failure = expectation(description: "Layer creation rejected")
+        var reloads = 0
+        manager.onError = { _ in failure.fulfill() }
+        manager.onRulesChanged = {
+            reloads += 1
+            return Self.reload(reloads == 1 ? .rejected : .applied)
+        }
+        viewModel.createLayer("Research")
+        XCTAssertEqual(viewModel.currentLayer, previousLayer, "Do not select before save settles")
+        await fulfillment(of: [failure], timeout: 2)
+        XCTAssertEqual(viewModel.currentLayer, previousLayer)
+        XCTAssertFalse(manager.ruleCollections.contains { $0.targetLayer == .custom("research") })
+    }
+
+    func testRejectedRemovalRestoresCollection() async throws {
+        try await assertRejectedMutationRestores {
+            await self.manager.removeCollection(id: self.manager.ruleCollections[0].id)
+        }
+    }
+
+    func testRejectedLayerRemovalRestoresBothSources() async throws {
+        try await assertRejectedMutationRestores { await self.manager.removeLayer("WORK") }
+    }
+
+    func testRejectedBatchRestoresAllEnabledStates() async throws {
+        manager.ruleCollections = [collection("First", enabled: false), collection("Second", layer: .custom("work"), enabled: false)]
+        try await persistFixture()
+        try await assertRejectedMutationRestores {
+            await self.manager.batchEnableCollections(ids: self.manager.ruleCollections.map(\.id))
+        }
+    }
+
+    func testRejectedLayerCreationRestoresPreviousRevision() async throws {
+        try await assertRejectedMutationRestores { await self.manager.createLayer("Research") }
+    }
+
+    func testPendingLayerRemovalCommitsBothSourcesWithOneReload() async throws {
+        var reloads = 0
+        manager.onError = { XCTFail("Pending is not failure: \($0)") }
+        manager.onRulesChanged = { reloads += 1; return Self.reload(.pending) }
+        let removedID = manager.ruleCollections[0].id
+        await manager.removeLayer("WORK")
+        XCTAssertEqual(reloads, 1)
+        let storedRules = try await manager.customRulesStore.loadForMutation()
+        let storedCollections = await manager.ruleCollectionStore.loadCollections()
+        XCTAssertTrue(storedRules.isEmpty)
+        XCTAssertFalse(storedCollections.contains { $0.id == removedID })
+        XCTAssertTrue(manager.customRules.isEmpty)
+        XCTAssertFalse(manager.ruleCollections.contains { $0.id == removedID })
+    }
+
+    func testExternalSourceEditSurvivesFailedLayerRemoval() async throws {
+        var expected: [String: Data]?
+        var reloads = 0
+        var errors: [String] = []
+        manager.onError = { errors.append($0) }
+        manager.onRulesChanged = {
+            reloads += 1
+            do {
+                try Data("external edit".utf8).write(to: self.directory.appendingPathComponent("CustomRules.json"))
+                expected = try self.files()
+            } catch { XCTFail("Cannot inject external edit: \(error)") }
+            return Self.reload(.rejected)
+        }
+        await manager.removeLayer("work")
+        XCTAssertEqual(reloads, 1)
+        XCTAssertEqual(try files(), expected)
+        XCTAssertTrue(errors.first?.contains("Recovery needs attention") == true)
+    }
+
+    func testLayerCreationRecoversBeforeDuplicateCheck() async throws {
+        let before = try files()
+        let service = manager.configurationService
+        try await service.operationGate.withOperation { @MainActor permit in
+            _ = try await service.stageRuleState(ruleCollections: [], customRules: [],
+                                                 collectionStore: self.manager.ruleCollectionStore, customStore: self.manager.customRulesStore, mutationPermit: permit)
+        }
+        manager.ruleCollections = []
+        manager.customRules = []
+        var reloads = 0
+        manager.onRulesChanged = { reloads += 1; return Self.reload(.applied) }
+        await manager.createLayer("Work")
+        XCTAssertEqual(reloads, 1, "Recover runtime, then return without creating a duplicate")
+        XCTAssertEqual(try files(), before)
+        XCTAssertEqual(manager.ruleCollections.filter { $0.targetLayer == .custom("work") }.count, 1)
+        XCTAssertEqual(manager.customRules.count, 1)
+    }
+}

--- a/docs/architecture/configuration-save-pipeline.md
+++ b/docs/architecture/configuration-save-pipeline.md
@@ -308,3 +308,24 @@ still mean persistence without an application result.
 
 Local layer-label refreshes do not emit TCP heartbeat notifications. Only an
 observed runtime layer update supplies that evidence, including unchanged layers.
+
+### Collection and layer membership
+
+`RuleCollectionsManager.commitRuleMutation` is the shared settlement path for
+custom rules and collection add/update, removal, batch enable, and layer removal.
+It calls `SaveCoordinator.saveRuleState` and restores only the manager snapshot on
+failure. Do not save CustomRules.json separately before deleting a layer: the
+journal must capture both source stores before either changes.
+
+Layer creation recovers interrupted state before its duplicate check, then calls
+`addCollection` under the same permit. `addCollection` returns whether the save
+committed (applied, pending, or explicitly headless); creation logs completion only
+on success. Existing membership/conflict policy is unchanged. Leader preference
+writes and other collection mutators remain separate migration work.
+
+Collection addition's Boolean now propagates through RuleCollectionsCoordinator,
+RuntimeCoordinator and KanataViewModel. Both Karabiner import surfaces include
+unsaved collections in their existing partial-import error instead of completing
+or dismissing. Mapper creation selects the new layer only after a successful
+save and refresh, and preserves navigation made while saving. This corrects
+existing failure handling; no new status UI or import atomicity is introduced.

--- a/docs/bugs/collection-layer-membership-recovery.md
+++ b/docs/bugs/collection-layer-membership-recovery.md
@@ -1,0 +1,24 @@
+# Collection and layer membership recovery
+
+Collection addition used a persistence-only Boolean and a separate regeneration
+to roll back. Removal and batch enable lacked manager rollback. Layer removal
+wrote CustomRules.json before regeneration, so even a validation failure could
+permanently delete rules while keeping the old configuration.
+
+These entry points now recover interrupted state before snapshots and use the
+same retained three-file transaction as custom-rule edits. A rejected reload
+restores the exact original files before a compensating reload. Manager rollback
+never regenerates over an external edit. Layer creation uses recovered data for
+its duplicate check and respects the add operation's failure result.
+
+Temporary-store tests exercise rejected add/remove/batch/create/delete, pending
+layer deletion with one reload, external-edit preservation, and interrupted
+recovery before a duplicate-layer early exit. This change does not alter conflict
+or ownership decisions, or claim atomicity for leader preferences/managed packs.
+
+Collection addition's Boolean now propagates through RuleCollectionsCoordinator,
+RuntimeCoordinator and KanataViewModel. Both Karabiner import surfaces include
+unsaved collections in their existing partial-import error instead of completing
+or dismissing. Mapper creation selects the new layer only after a successful
+save and refresh, and preserves navigation made while saving. This corrects
+existing failure handling; no new status UI or import atomicity is introduced.

--- a/docs/planning/catalog-led-consolidation-plan.md
+++ b/docs/planning/catalog-led-consolidation-plan.md
@@ -393,10 +393,25 @@ cover single-reload removal, exact rollback on rejection/metadata write failure,
 and pending/rejected timing updates. System/collection-backed install and removal,
 preferences, managed snapshots, and tap/hold picker edits remain open.
 
-### Custom-rule editor recovery in progress
+### Custom-rule editor recovery merged in #1281
 
 Save, toggle, remove, and clear now use the retained rule transaction and restore
 manager snapshots without another file write. Interrupted source recovery precedes
 the next editor snapshot, including the pack tap/hold picker. Local layer-label refresh no longer supplies false TCP
 heartbeat evidence. Collection/preferences/watcher work and agreed UI decisions
 remain open.
+
+### Collection and layer membership recovery in progress
+
+Collection add/update, remove, batch enable, and layer creation/removal now use
+SaveCoordinator's retained rule transaction. Layer removal no longer writes
+CustomRules.json separately before generation. Failed changes restore manager
+arrays without a second file write, and layer creation recovers before checking
+for duplicate layers. Existing conflict decisions and catalog fallback remain.
+Collection toggles, detailed settings, leader preferences, replace-all, managed
+pack snapshots, and revision-aware watching still require migration.
+
+Review follow-up for membership recovery: add results also propagate through UI
+wrappers. Failed collection imports use the existing partial-import error;
+failed mapper layer creation does not select an unsaved layer. The broader
+saved/pending status design and combined import transaction remain open.


### PR DESCRIPTION
## Problem and result

Layer deletion saved CustomRules.json separately before generation, so rejection could leave deleted rules behind. Collection addition used a persistence-only result and a second regeneration for rollback; collection removal and batch enable did not restore manager state.

Collection add/update, remove, batch enable, and layer creation/removal now use the existing SaveCoordinator retained three-file transaction. Failures restore exact files before runtime recovery and restore manager arrays without another write. Creation recovers before checking for duplicate layers and logs completion only after a successful add. The common commit helper is renamed to commitRuleMutation to reflect both callers.

Existing catalog fallback, conflict choices, and membership policy are retained. Collection toggles/settings, leader preferences, managed pack snapshots, and mapper status/selection presentation remain separate work.

## Validation

- 88 focused tests passed, including ten new regressions for rejected add/remove/batch/create/layer deletion, pending single-reload deletion, external-edit preservation, and interrupted recovery before a duplicate-layer exit.
- Full safe suite: 5,236 passed; only the four known macOS 27 snapshot baseline failures (three Home Row Timing variants and Repair Settings). Zero compiler warnings. Application and test builds completed under stable Xcode.
- SwiftFormat 0.61.1, accessibility, and diff checks passed.
- Remote review gate selected; GitHub claude-review required before merge.
- Installer state matrix: Running and TCP responding; Running but TCP not responding. Restored files are verified before compensating reload; this does not claim physical-HID acceptance.

Signed/notarized deployment follows merge. No public release or UI redesign.

Review follow-up: collection-save failure now propagates through the coordinator,
runtime, and view-model wrappers. Both Karabiner import flows add unsuccessful
collections to their existing partial-import error, keeping the flow open.
Mapper layer creation waits for a successful save before selecting/logging the
new layer and does not replace navigation made while saving. A coordinator
regression verifies false plus restored mappings; a mapper regression covers
rejected creation. Mixed collection/app/launcher imports remain multiple commits.
These are corrections to existing success/failure handling, not the pending
broader status/ownership/conflict UI changes.

Final caller validation: 159 focused tests passed, followed by all 10 membership regressions including mapper rejection. The final broad run includes every caller change and retains only the same four baseline snapshots.
