### PR TITLE
Recover collection setting and prerequisite changes together

### DIFF
--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+Mutation.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+Mutation.swift
@@ -67,10 +67,31 @@ extension RuleCollectionsManager {
         }
     }
 
+    /// Preserve the editor's existing enable policy while sharing preparation and
+    /// settlement. The Boolean means newly enabled AND committed, not applied.
+    func updateCollectionSettings(id: UUID, enableExisting: Bool = true,
+                                  update: @escaping @MainActor @Sendable (inout RuleCollection) -> Void) async -> Bool
+    {
+        await withRuleMutation(failure: false) { [self] permit in
+            guard let snapshot = await recoverAndSnapshotRuleState(mutationPermit: permit) else { return false }
+            let existing = ruleCollections.first(where: { $0.id == id })
+            guard var candidate = existing ?? RuleCollectionCatalog().defaultCollections().first(where: { $0.id == id }) else { return false }
+            let wasNewlyEnabled = existing == nil || (enableExisting && !candidate.isEnabled)
+            update(&candidate)
+            if enableExisting || existing == nil { candidate.isEnabled = true }
+            if let index = ruleCollections.firstIndex(where: { $0.id == id }) { ruleCollections[index] = candidate }
+            else { ruleCollections.append(candidate) }
+            dedupeRuleCollectionsInPlace()
+            refreshLayerIndicatorState()
+            guard await commitRuleMutation(snapshot: snapshot, failureContext: candidate.name, mutationPermit: permit) else { return false }
+            return wasNewlyEnabled
+        }
+    }
+
     /// The save owner restores files/runtime; the manager restores its in-memory
     /// candidate without regenerating over the recovered or externally edited files.
     @discardableResult
-    func commitRuleMutation(snapshot: RuleStateSnapshot, skipReload: Bool = false,
+    func commitRuleMutation(snapshot: RuleStateSnapshot, skipReload: Bool = false, failureContext: String? = nil,
                             mutationPermit: ConfigurationOperationGate.Permit) async -> Bool
     {
         let result = await SaveCoordinator(configurationService: configurationService).saveRuleState(
@@ -81,7 +102,8 @@ extension RuleCollectionsManager {
             customRules = snapshot.customRules
             refreshLayerIndicatorState()
             if let error = result.error, !(error is CancellationError) {
-                onError?(error.localizedDescription)
+                let message = failureContext.map { "Could not save \($0): \(error.localizedDescription)" } ?? error.localizedDescription
+                onError?(message)
                 SoundManager.shared.playErrorSound()
             }
             return false

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+PrerequisiteResolution.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+PrerequisiteResolution.swift
@@ -88,7 +88,7 @@ extension RuleCollectionsManager {
     }
 
     /// Replaces or appends the candidate and enables confirmed providers
-    /// in memory. The caller owns the single regeneration and rollback.
+    /// in memory. The caller owns save settlement and recovery.
     func applyPrerequisiteChangeInMemory(
         candidate: RuleCollection,
         providerIDs: [UUID]
@@ -116,16 +116,15 @@ extension RuleCollectionsManager {
     }
 
     /// Applies one proposed save plus its confirmed provider enables as a
-    /// single mutation and regeneration, restoring the full snapshot on failure.
+    /// single retained transaction, restoring the full snapshot on failure.
     func applyProposedCollectionWithPrerequisites(
         _ candidate: RuleCollection,
-        rollbackMessage: String,
         nonInteractiveChoice: RulePrerequisiteResolutionChoice = .applyWithoutProviders,
         skipReload: Bool = false,
         mutationPermit: ConfigurationOperationGate.Permit? = nil
     ) async -> [UUID]? {
         await withRuleMutation(using: mutationPermit, failure: nil) { [self] permit in
-            let snapshot = snapshotRuleState()
+            guard let snapshot = await recoverAndSnapshotRuleState(mutationPermit: permit) else { return nil }
             guard let providerIDs = await confirmedPrerequisiteProviderIDs(
                 for: candidate,
                 operation: .save,
@@ -139,11 +138,7 @@ extension RuleCollectionsManager {
                 providerIDs: providerIDs
             )
 
-            guard await regenerateConfigFromCollections(skipReload: skipReload, mutationPermit: permit) else {
-                AppLogger.shared.log(
-                    "↩️ [RuleCollections] Prerequisite-aware save failed; rolling back"
-                )
-                await rollbackToSnapshot(snapshot, userMessage: rollbackMessage, mutationPermit: permit)
+            guard await commitRuleMutation(snapshot: snapshot, skipReload: skipReload, failureContext: candidate.name, mutationPermit: permit) else {
                 return nil
             }
 

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+PublicAPI.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+PublicAPI.swift
@@ -397,130 +397,38 @@ extension RuleCollectionsManager {
 
     /// Update a tap-hold picker collection's tap output
     func updateCollectionTapOutput(id: UUID, tapOutput: String) async {
-        await withRuleMutation(failure: ()) { [self] permit in
-            guard let index = ruleCollections.firstIndex(where: { $0.id == id }) else {
-                // Try to find in catalog and add it
-                let catalog = RuleCollectionCatalog()
-                if var catalogCollection = catalog.defaultCollections().first(where: { $0.id == id }) {
-                    catalogCollection.configuration.updateSelectedTapOutput(tapOutput)
-                    catalogCollection.isEnabled = true
-                    ruleCollections.append(catalogCollection)
-                    dedupeRuleCollectionsInPlace()
-                    refreshLayerIndicatorState()
-                    await regenerateConfigFromCollections(mutationPermit: permit)
-                }
-                return
-            }
-
-            ruleCollections[index].configuration.updateSelectedTapOutput(tapOutput)
-            ruleCollections[index].isEnabled = true
-            dedupeRuleCollectionsInPlace()
-            refreshLayerIndicatorState()
-            await regenerateConfigFromCollections(mutationPermit: permit)
+        _ = await updateCollectionSettings(id: id) { rule in
+            rule.configuration.updateSelectedTapOutput(tapOutput)
         }
     }
 
     /// Update a tap-hold picker collection's hold output
     func updateCollectionHoldOutput(id: UUID, holdOutput: String) async {
-        await withRuleMutation(failure: ()) { [self] permit in
-            guard let index = ruleCollections.firstIndex(where: { $0.id == id }) else {
-                // Try to find in catalog and add it
-                let catalog = RuleCollectionCatalog()
-                if var catalogCollection = catalog.defaultCollections().first(where: { $0.id == id }) {
-                    catalogCollection.configuration.updateSelectedHoldOutput(holdOutput)
-                    catalogCollection.isEnabled = true
-                    ruleCollections.append(catalogCollection)
-                    dedupeRuleCollectionsInPlace()
-                    refreshLayerIndicatorState()
-                    await regenerateConfigFromCollections(mutationPermit: permit)
-                }
-                return
-            }
-
-            ruleCollections[index].configuration.updateSelectedHoldOutput(holdOutput)
-            ruleCollections[index].isEnabled = true
-            dedupeRuleCollectionsInPlace()
-            refreshLayerIndicatorState()
-            await regenerateConfigFromCollections(mutationPermit: permit)
+        _ = await updateCollectionSettings(id: id) { rule in
+            rule.configuration.updateSelectedHoldOutput(holdOutput)
         }
     }
 
     /// Update a layer preset picker collection's selected preset
     func updateCollectionLayerPreset(id: UUID, presetId: String) async {
-        await withRuleMutation(failure: ()) { [self] permit in
-            guard let index = ruleCollections.firstIndex(where: { $0.id == id }) else {
-                // Try to find in catalog and add it
-                let catalog = RuleCollectionCatalog()
-                if var catalogCollection = catalog.defaultCollections().first(where: { $0.id == id }) {
-                    catalogCollection.configuration.updateSelectedPreset(presetId)
-                    catalogCollection.isEnabled = true
-                    ruleCollections.append(catalogCollection)
-                    dedupeRuleCollectionsInPlace()
-                    refreshLayerIndicatorState()
-                    await regenerateConfigFromCollections(mutationPermit: permit)
-                }
-                return
-            }
-
-            ruleCollections[index].configuration.updateSelectedPreset(presetId)
-            ruleCollections[index].isEnabled = true
-            dedupeRuleCollectionsInPlace()
-            refreshLayerIndicatorState()
-            await regenerateConfigFromCollections(mutationPermit: permit)
+        _ = await updateCollectionSettings(id: id) { rule in
+            rule.configuration.updateSelectedPreset(presetId)
         }
     }
 
     /// Update window snapping key convention (Standard vs Vim)
     func updateWindowKeyConvention(id: UUID, convention: WindowKeyConvention) async {
-        await withRuleMutation(failure: ()) { [self] permit in
-            guard let index = ruleCollections.firstIndex(where: { $0.id == id }) else {
-                // Try to find in catalog and add it
-                let catalog = RuleCollectionCatalog()
-                if var catalogCollection = catalog.defaultCollections().first(where: { $0.id == id }) {
-                    catalogCollection.windowKeyConvention = convention
-                    catalogCollection.mappings = RuleCollectionCatalog.windowMappings(for: convention)
-                    catalogCollection.isEnabled = true
-                    ruleCollections.append(catalogCollection)
-                    dedupeRuleCollectionsInPlace()
-                    refreshLayerIndicatorState()
-                    await regenerateConfigFromCollections(mutationPermit: permit)
-                }
-                return
-            }
-
-            ruleCollections[index].windowKeyConvention = convention
-            ruleCollections[index].mappings = RuleCollectionCatalog.windowMappings(for: convention)
-            ruleCollections[index].isEnabled = true
-            dedupeRuleCollectionsInPlace()
-            refreshLayerIndicatorState()
-            await regenerateConfigFromCollections(mutationPermit: permit)
+        _ = await updateCollectionSettings(id: id) { rule in
+            rule.windowKeyConvention = convention
+            rule.mappings = RuleCollectionCatalog.windowMappings(for: convention)
         }
     }
 
     /// Update function key mode (Media Keys vs Function Keys)
     func updateFunctionKeyMode(id: UUID, mode: FunctionKeyMode) async {
-        await withRuleMutation(failure: ()) { [self] permit in
-            guard let index = ruleCollections.firstIndex(where: { $0.id == id }) else {
-                // Try to find in catalog and add it
-                let catalog = RuleCollectionCatalog()
-                if var catalogCollection = catalog.defaultCollections().first(where: { $0.id == id }) {
-                    catalogCollection.functionKeyMode = mode
-                    catalogCollection.mappings = RuleCollectionCatalog.functionKeyMappings(for: mode)
-                    catalogCollection.isEnabled = true
-                    ruleCollections.append(catalogCollection)
-                    dedupeRuleCollectionsInPlace()
-                    refreshLayerIndicatorState()
-                    await regenerateConfigFromCollections(mutationPermit: permit)
-                }
-                return
-            }
-
-            ruleCollections[index].functionKeyMode = mode
-            ruleCollections[index].mappings = RuleCollectionCatalog.functionKeyMappings(for: mode)
-            ruleCollections[index].isEnabled = true
-            dedupeRuleCollectionsInPlace()
-            refreshLayerIndicatorState()
-            await regenerateConfigFromCollections(mutationPermit: permit)
+        _ = await updateCollectionSettings(id: id) { rule in
+            rule.functionKeyMode = mode
+            rule.mappings = RuleCollectionCatalog.functionKeyMappings(for: mode)
         }
     }
 
@@ -529,6 +437,7 @@ extension RuleCollectionsManager {
     @discardableResult
     func updateHomeRowModsConfig(id: UUID, config: HomeRowModsConfig) async -> Bool {
         await withRuleMutation(failure: false) { [self] permit in
+            guard await recoverAndSnapshotRuleState(mutationPermit: permit) != nil else { return false }
             guard var candidate = ruleCollections.first(where: { $0.id == id })
                 ?? RuleCollectionCatalog().defaultCollections().first(where: { $0.id == id })
             else {
@@ -541,8 +450,6 @@ extension RuleCollectionsManager {
 
             let appliedProviderIDs = await applyProposedCollectionWithPrerequisites(
                 candidate,
-                rollbackMessage:
-                "Could not save Home Row Mods. Your previous rule state was restored.",
                 mutationPermit: permit
             )
             return appliedProviderIDs != nil && wasNewlyEnabled
@@ -554,6 +461,7 @@ extension RuleCollectionsManager {
     @discardableResult
     func updateHomeRowLayerTogglesConfig(id: UUID, config: HomeRowLayerTogglesConfig) async -> Bool {
         await withRuleMutation(failure: false) { [self] permit in
+            guard await recoverAndSnapshotRuleState(mutationPermit: permit) != nil else { return false }
             guard var candidate = ruleCollections.first(where: { $0.id == id })
                 ?? RuleCollectionCatalog().defaultCollections().first(where: { $0.id == id })
             else {
@@ -566,8 +474,6 @@ extension RuleCollectionsManager {
 
             let appliedProviderIDs = await applyProposedCollectionWithPrerequisites(
                 candidate,
-                rollbackMessage:
-                "Could not save Home Row Layer Toggles. Your previous rule state was restored.",
                 mutationPermit: permit
             )
             return appliedProviderIDs != nil && wasNewlyEnabled
@@ -578,30 +484,8 @@ extension RuleCollectionsManager {
     /// - Returns: `true` if the collection was newly enabled (was disabled before this call)
     @discardableResult
     func updateChordGroupsConfig(id: UUID, config: ChordGroupsConfig) async -> Bool {
-        await withRuleMutation(failure: false) { [self] permit in
-            guard let index = ruleCollections.firstIndex(where: { $0.id == id }) else {
-                // Try to find in catalog and add it
-                let catalog = RuleCollectionCatalog()
-                if var catalogCollection = catalog.defaultCollections().first(where: { $0.id == id }) {
-                    catalogCollection.configuration.updateChordGroupsConfig(config)
-                    catalogCollection.isEnabled = true
-                    ruleCollections.append(catalogCollection)
-                    dedupeRuleCollectionsInPlace()
-                    refreshLayerIndicatorState()
-                    await regenerateConfigFromCollections(mutationPermit: permit)
-                    return true
-                }
-                return false
-            }
-
-            let wasNewlyEnabled = !ruleCollections[index].isEnabled
-            ruleCollections[index].configuration.updateChordGroupsConfig(config)
-            ruleCollections[index].isEnabled = true
-
-            dedupeRuleCollectionsInPlace()
-            refreshLayerIndicatorState()
-            await regenerateConfigFromCollections(mutationPermit: permit)
-            return wasNewlyEnabled
+        await updateCollectionSettings(id: id) { rule in
+            rule.configuration.updateChordGroupsConfig(config)
         }
     }
 
@@ -609,30 +493,8 @@ extension RuleCollectionsManager {
     /// - Returns: `true` if the collection was newly enabled (was disabled before this call)
     @discardableResult
     func updateSequencesConfig(id: UUID, config: SequencesConfig) async -> Bool {
-        await withRuleMutation(failure: false) { [self] permit in
-            guard let index = ruleCollections.firstIndex(where: { $0.id == id }) else {
-                // Try to find in catalog and add it
-                let catalog = RuleCollectionCatalog()
-                if var catalogCollection = catalog.defaultCollections().first(where: { $0.id == id }) {
-                    catalogCollection.configuration.updateSequencesConfig(config)
-                    catalogCollection.isEnabled = true
-                    ruleCollections.append(catalogCollection)
-                    dedupeRuleCollectionsInPlace()
-                    refreshLayerIndicatorState()
-                    await regenerateConfigFromCollections(mutationPermit: permit)
-                    return true
-                }
-                return false
-            }
-
-            let wasNewlyEnabled = !ruleCollections[index].isEnabled
-            ruleCollections[index].configuration.updateSequencesConfig(config)
-            ruleCollections[index].isEnabled = true
-
-            dedupeRuleCollectionsInPlace()
-            refreshLayerIndicatorState()
-            await regenerateConfigFromCollections(mutationPermit: permit)
-            return wasNewlyEnabled
+        await updateCollectionSettings(id: id) { rule in
+            rule.configuration.updateSequencesConfig(config)
         }
     }
 
@@ -641,6 +503,7 @@ extension RuleCollectionsManager {
     @discardableResult
     func updateLauncherConfig(id: UUID, config: LauncherGridConfig) async -> Bool {
         await withRuleMutation(failure: false) { [self] permit in
+            guard await recoverAndSnapshotRuleState(mutationPermit: permit) != nil else { return false }
             guard let candidate = ruleCollections.first(where: { $0.id == id })
                 ?? RuleCollectionCatalog().defaultCollections().first(where: { $0.id == id })
             else {
@@ -664,6 +527,7 @@ extension RuleCollectionsManager {
         mutationPermit: ConfigurationOperationGate.Permit? = nil
     ) async -> Bool {
         await withRuleMutation(using: mutationPermit, failure: false) { [self] permit in
+            guard await recoverAndSnapshotRuleState(mutationPermit: permit) != nil else { return false }
             guard var candidate = ruleCollections.first(where: { $0.id == id })
                 ?? RuleCollectionCatalog().defaultCollections().first(where: { $0.id == id })
             else {
@@ -678,8 +542,6 @@ extension RuleCollectionsManager {
 
             let appliedProviderIDs = await applyProposedCollectionWithPrerequisites(
                 candidate,
-                rollbackMessage:
-                "Could not save Launcher. Your previous rule state was restored.",
                 skipReload: skipReload,
                 mutationPermit: permit
             )
@@ -696,29 +558,8 @@ extension RuleCollectionsManager {
     /// - Returns: `true` if the collection was newly enabled (was disabled before this call)
     @discardableResult
     func updateAutoShiftSymbolsConfig(id: UUID, config: AutoShiftSymbolsConfig) async -> Bool {
-        await withRuleMutation(failure: false) { [self] permit in
-            guard let index = ruleCollections.firstIndex(where: { $0.id == id }) else {
-                let catalog = RuleCollectionCatalog()
-                if var catalogCollection = catalog.defaultCollections().first(where: { $0.id == id }) {
-                    catalogCollection.configuration.updateAutoShiftSymbolsConfig(config)
-                    catalogCollection.isEnabled = true
-                    ruleCollections.append(catalogCollection)
-                    dedupeRuleCollectionsInPlace()
-                    refreshLayerIndicatorState()
-                    await regenerateConfigFromCollections(mutationPermit: permit)
-                    return true
-                }
-                return false
-            }
-
-            // Don't force-enable on every config tweak — preserve current toggle state
-            let wasNewlyEnabled = false
-            ruleCollections[index].configuration.updateAutoShiftSymbolsConfig(config)
-
-            dedupeRuleCollectionsInPlace()
-            refreshLayerIndicatorState()
-            await regenerateConfigFromCollections(mutationPermit: permit)
-            return wasNewlyEnabled
+        await updateCollectionSettings(id: id, enableExisting: false) { rule in
+            rule.configuration.updateAutoShiftSymbolsConfig(config)
         }
     }
 
@@ -726,28 +567,8 @@ extension RuleCollectionsManager {
     /// - Returns: `true` if the collection was newly enabled (was disabled before this call)
     @discardableResult
     func updateKeyRepeatControlConfig(id: UUID, config: KeyRepeatControlConfig) async -> Bool {
-        await withRuleMutation(failure: false) { [self] permit in
-            guard let index = ruleCollections.firstIndex(where: { $0.id == id }) else {
-                let catalog = RuleCollectionCatalog()
-                if var catalogCollection = catalog.defaultCollections().first(where: { $0.id == id }) {
-                    catalogCollection.configuration.updateKeyRepeatControlConfig(config)
-                    catalogCollection.isEnabled = true
-                    ruleCollections.append(catalogCollection)
-                    dedupeRuleCollectionsInPlace()
-                    refreshLayerIndicatorState()
-                    await regenerateConfigFromCollections(mutationPermit: permit)
-                    return true
-                }
-                return false
-            }
-
-            let wasNewlyEnabled = false
-            ruleCollections[index].configuration.updateKeyRepeatControlConfig(config)
-
-            dedupeRuleCollectionsInPlace()
-            refreshLayerIndicatorState()
-            await regenerateConfigFromCollections(mutationPermit: permit)
-            return wasNewlyEnabled
+        await updateCollectionSettings(id: id, enableExisting: false) { rule in
+            rule.configuration.updateKeyRepeatControlConfig(config)
         }
     }
 
@@ -755,6 +576,7 @@ extension RuleCollectionsManager {
     /// - Returns: name of auto-enabled dependency, or nil
     func updateWindowSnappingActivationMode(id: UUID, mode: WindowSnappingActivationMode) async -> String? {
         await withRuleMutation(failure: nil) { [self] permit in
+            guard await recoverAndSnapshotRuleState(mutationPermit: permit) != nil else { return nil }
             guard var candidate = ruleCollections.first(where: { $0.id == id }) else {
                 return nil
             }
@@ -765,8 +587,6 @@ extension RuleCollectionsManager {
 
             guard let enabledProviderIDs = await applyProposedCollectionWithPrerequisites(
                 candidate,
-                rollbackMessage:
-                "Could not save Window Snapping. Your previous rule state was restored.",
                 nonInteractiveChoice: .enableRequiredProvidersAndApply,
                 mutationPermit: permit
             ) else {

--- a/Tests/KeyPathTests/CollectionSettingsRecoveryTests.swift
+++ b/Tests/KeyPathTests/CollectionSettingsRecoveryTests.swift
@@ -1,0 +1,169 @@
+import Foundation
+@testable import KeyPathAppKit
+import KeyPathRulesCore
+@preconcurrency import XCTest
+
+@MainActor
+final class CollectionSettingsRecoveryTests: KeyPathTestCase {
+    private var directory: URL!
+    private var manager: RuleCollectionsManager!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let collections = RuleCollectionStore.testStore(at: directory.appendingPathComponent("RuleCollections.json"))
+        let rules = CustomRulesStore.testStore(at: directory.appendingPathComponent("CustomRules.json"))
+        let service = ConfigurationService(configDirectory: directory.path, ruleCollectionStore: collections, customRulesStore: rules)
+        manager = RuleCollectionsManager(ruleCollectionStore: collections, customRulesStore: rules, configurationService: service)
+        manager.ruleCollections = RuleCollectionCatalog().defaultCollections().map { collection in
+            var disabled = collection
+            disabled.isEnabled = false
+            return disabled
+        }
+        manager.customRules = []
+        try await persistFixture()
+    }
+
+    override func tearDown() async throws {
+        try? FileManager.default.removeItem(at: directory)
+        manager = nil
+        directory = nil
+        try await super.tearDown()
+    }
+
+    private func persistFixture() async throws {
+        try await manager.configurationService.saveRuleState(ruleCollections: manager.ruleCollections, customRules: manager.customRules,
+                                                             collectionStore: manager.ruleCollectionStore, customStore: manager.customRulesStore)
+    }
+
+    private func files() throws -> [String: Data] {
+        try Dictionary(uniqueKeysWithValues: ["keypath.kbd", "RuleCollections.json", "CustomRules.json"].map {
+            try ($0, Data(contentsOf: directory.appendingPathComponent($0)))
+        })
+    }
+
+    private static func reload(_ disposition: ReloadDisposition) -> ReloadResult {
+        ReloadResult(success: disposition == .applied, response: nil, errorMessage: "injected \(disposition)", protocol: nil, disposition: disposition)
+    }
+
+    private func assertRejectedMutationRestores(_ mutate: @MainActor () async -> Void) async throws {
+        let before = try files()
+        let snapshot = manager.snapshotRuleState()
+        var reloads = 0
+        var errors: [String] = []
+        manager.onError = { errors.append($0) }
+        manager.onRulesChanged = {
+            reloads += 1
+            if reloads == 2 {
+                do {
+                    let restored = try self.files()
+                    XCTAssertEqual(restored, before)
+                } catch { XCTFail("Could not read restored files: \(error)") }
+            }
+            return Self.reload(reloads == 1 ? .rejected : .applied)
+        }
+        await mutate()
+        XCTAssertEqual(reloads, 2)
+        XCTAssertEqual(try files(), before)
+        XCTAssertEqual(manager.ruleCollections, snapshot.collections)
+        XCTAssertEqual(manager.customRules, snapshot.customRules)
+        XCTAssertEqual(errors.count, 1)
+        XCTAssertTrue(errors.first?.contains("Could not save") == true)
+    }
+
+    func testRejectedTapPickerRestoresOutputAndEnabledState() async throws {
+        let id = UUID()
+        manager.ruleCollections.append(RuleCollection(
+            id: id, name: "Tap picker", summary: "", category: .custom, mappings: [], isEnabled: false,
+            configuration: .tapHoldPicker(TapHoldPickerConfig(inputKey: "f13", tapOptions: [], holdOptions: [],
+                                                              selectedTapOutput: "f13", selectedHoldOutput: "lctl"))
+        ))
+        try await persistFixture()
+        try await assertRejectedMutationRestores {
+            await self.manager.updateCollectionTapOutput(id: id, tapOutput: "esc")
+        }
+    }
+
+    func testRejectedSequenceSettingsDoNotReportNewlyEnabled() async throws {
+        try await assertRejectedMutationRestores {
+            let enabled = await self.manager.updateSequencesConfig(id: RuleCollectionIdentifier.sequences, config: SequencesConfig(globalTimeout: 900))
+            XCTAssertFalse(enabled)
+        }
+    }
+
+    func testRejectedHomeRowSettingsRestorePrerequisitesAndCandidate() async throws {
+        manager.onPrerequisiteResolution = { _ in .enableRequiredProvidersAndApply }
+        try await assertRejectedMutationRestores {
+            let enabled = await self.manager.updateHomeRowLayerTogglesConfig(
+                id: RuleCollectionIdentifier.homeRowLayerToggles,
+                config: HomeRowLayerTogglesConfig(layerAssignments: ["a": "fun"])
+            )
+            XCTAssertFalse(enabled)
+        }
+    }
+
+    func testPendingAutoShiftSettingPreservesDisabledState() async throws {
+        var reloads = 0
+        manager.onRulesChanged = { reloads += 1; return Self.reload(.pending) }
+        let newlyEnabled = await manager.updateAutoShiftSymbolsConfig(id: RuleCollectionIdentifier.autoShiftSymbols,
+                                                                      config: AutoShiftSymbolsConfig(timeoutMs: 280))
+        XCTAssertFalse(newlyEnabled)
+        XCTAssertEqual(reloads, 1)
+        let stored = await manager.ruleCollectionStore.loadCollections()
+        let collection = try XCTUnwrap(stored.first { $0.id == RuleCollectionIdentifier.autoShiftSymbols })
+        XCTAssertFalse(collection.isEnabled)
+        guard case let .autoShiftSymbols(config) = collection.configuration else { return XCTFail("Wrong configuration") }
+        XCTAssertEqual(config.timeoutMs, 280)
+    }
+
+    func testPendingCatalogFallbackReportsNewlyEnabledOnlyAfterCommit() async throws {
+        manager.ruleCollections.removeAll { $0.id == RuleCollectionIdentifier.sequences }
+        try await persistFixture()
+        var reloads = 0
+        manager.onRulesChanged = { reloads += 1; return Self.reload(.pending) }
+        let enabled = await manager.updateSequencesConfig(id: RuleCollectionIdentifier.sequences, config: SequencesConfig(globalTimeout: 900))
+        XCTAssertTrue(enabled)
+        XCTAssertEqual(reloads, 1)
+        let stored = await manager.ruleCollectionStore.loadCollections()
+        let collection = try XCTUnwrap(stored.first { $0.id == RuleCollectionIdentifier.sequences })
+        XCTAssertTrue(collection.isEnabled)
+        guard case let .sequences(config) = collection.configuration else { return XCTFail("Wrong configuration") }
+        XCTAssertEqual(config.globalTimeout, 900)
+    }
+
+    func testInterruptedRecoveryPrecedesSettingSnapshot() async throws {
+        let service = manager.configurationService
+        try await service.operationGate.withOperation { @MainActor permit in
+            _ = try await service.stageRuleState(ruleCollections: [], customRules: [],
+                                                 collectionStore: self.manager.ruleCollectionStore, customStore: self.manager.customRulesStore, mutationPermit: permit)
+        }
+        manager.ruleCollections = []
+        var reloads = 0
+        manager.onRulesChanged = { reloads += 1; return Self.reload(.applied) }
+        let enabled = await manager.updateAutoShiftSymbolsConfig(id: RuleCollectionIdentifier.autoShiftSymbols,
+                                                                 config: AutoShiftSymbolsConfig(timeoutMs: 280))
+        XCTAssertFalse(enabled, "Read the restored disabled collection, not catalog fallback")
+        XCTAssertEqual(reloads, 2, "One recovery and one edit")
+        XCTAssertFalse(try XCTUnwrap(manager.ruleCollections.first { $0.id == RuleCollectionIdentifier.autoShiftSymbols }).isEnabled)
+    }
+
+    func testPrerequisiteSaveRecoversOnceBeforeReadingEnabledState() async throws {
+        let id = RuleCollectionIdentifier.homeRowMods
+        let index = try XCTUnwrap(manager.ruleCollections.firstIndex { $0.id == id })
+        manager.ruleCollections[index].isEnabled = true
+        try await persistFixture()
+        let service = manager.configurationService
+        try await service.operationGate.withOperation { @MainActor permit in
+            _ = try await service.stageRuleState(ruleCollections: [], customRules: [],
+                                                 collectionStore: self.manager.ruleCollectionStore, customStore: self.manager.customRulesStore, mutationPermit: permit)
+        }
+        manager.ruleCollections = []
+        var reloads = 0
+        manager.onRulesChanged = { reloads += 1; return Self.reload(.applied) }
+        let newlyEnabled = await manager.updateHomeRowModsConfig(id: id, config: HomeRowModsConfig())
+        XCTAssertFalse(newlyEnabled, "The recovered collection was already enabled")
+        XCTAssertEqual(reloads, 2, "One recovery and one edit despite both admission checks")
+        XCTAssertTrue(try XCTUnwrap(manager.ruleCollections.first { $0.id == id }).isEnabled)
+    }
+}

--- a/Tests/KeyPathTests/RuleCollections/RuleCollectionsManagerPrerequisiteResolutionTests.swift
+++ b/Tests/KeyPathTests/RuleCollections/RuleCollectionsManagerPrerequisiteResolutionTests.swift
@@ -243,7 +243,7 @@ final class RuleCollectionsManagerPrerequisiteResolutionTests: XCTestCase {
         XCTAssertEqual(manager.ruleCollections, [capsLock])
     }
 
-    func testApplyLauncherConfigFailureRestoresPersistedState() async throws {
+    func testApplyLauncherConfigUnreadableSourceIsNotOverwritten() async throws {
         let manager = try makeManager()
         defer { TestEnvironment.forceTestMode = false }
         manager.ruleCollections = RuleCollectionCatalog().defaultCollections()
@@ -258,7 +258,6 @@ final class RuleCollectionsManagerPrerequisiteResolutionTests: XCTestCase {
         let customRulesStoreURL = collectionStoreURL.deletingLastPathComponent()
             .appendingPathComponent("CustomRules.json")
         let originalConfigData = try Data(contentsOf: configURL)
-        let originalCollectionStoreData = try Data(contentsOf: collectionStoreURL)
         let originalCustomRulesStoreData = try Data(contentsOf: customRulesStoreURL)
 
         try FileManager.default.removeItem(at: collectionStoreURL)
@@ -266,12 +265,10 @@ final class RuleCollectionsManagerPrerequisiteResolutionTests: XCTestCase {
             at: collectionStoreURL,
             withIntermediateDirectories: false
         )
-        var shouldRemoveFailedStore = true
-        manager.onError = { _ in
-            guard shouldRemoveFailedStore else { return }
-            shouldRemoveFailedStore = false
-            try? FileManager.default.removeItem(at: collectionStoreURL)
-        }
+        let externalMarker = collectionStoreURL.appendingPathComponent("external.txt")
+        try Data("external directory".utf8).write(to: externalMarker)
+        var errors: [String] = []
+        manager.onError = { errors.append($0) }
 
         var regenerationCount = 0
         var reloadCount = 0
@@ -295,19 +292,17 @@ final class RuleCollectionsManagerPrerequisiteResolutionTests: XCTestCase {
         )
 
         XCTAssertFalse(applied)
-        XCTAssertEqual(regenerationCount, 2)
+        XCTAssertEqual(regenerationCount, 1)
         XCTAssertEqual(
             reloadCount,
-            1,
-            "The failed caller-owned save should reload only the restored state"
+            0,
+            "An unreadable preimage must fail before any write or reload"
         )
         XCTAssertEqual(manager.ruleCollections, originalState.collections)
         XCTAssertEqual(manager.customRules, originalState.customRules)
         XCTAssertEqual(try Data(contentsOf: configURL), originalConfigData)
-        XCTAssertEqual(
-            try Data(contentsOf: collectionStoreURL),
-            originalCollectionStoreData
-        )
+        XCTAssertEqual(errors.count, 1)
+        XCTAssertEqual(try Data(contentsOf: externalMarker), Data("external directory".utf8))
         XCTAssertEqual(
             try Data(contentsOf: customRulesStoreURL),
             originalCustomRulesStoreData
@@ -624,7 +619,6 @@ final class RuleCollectionsManagerPrerequisiteResolutionTests: XCTestCase {
 
         let appliedProviderIDs = await manager.applyProposedCollectionWithPrerequisites(
             candidate,
-            rollbackMessage: "Test rollback",
             nonInteractiveChoice: .enableRequiredProvidersAndApply
         )
 
@@ -780,8 +774,8 @@ final class RuleCollectionsManagerPrerequisiteResolutionTests: XCTestCase {
         XCTAssertFalse(newlyEnabled)
         XCTAssertEqual(
             regenerationCount,
-            2,
-            "The failed apply and rollback should each regenerate exactly once"
+            1,
+            "Validation failure must not regenerate a rollback revision"
         )
         XCTAssertTrue(manager.ruleCollections[id: candidate.id]?.isEnabled == false)
         XCTAssertTrue(manager.ruleCollections[id: provider.id]?.isEnabled == false)

--- a/docs/architecture/configuration-save-pipeline.md
+++ b/docs/architecture/configuration-save-pipeline.md
@@ -329,3 +329,17 @@ unsaved collections in their existing partial-import error instead of completing
 or dismissing. Mapper creation selects the new layer only after a successful
 save and refresh, and preserves navigation made while saving. This corrects
 existing failure handling; no new status UI or import atomicity is introduced.
+
+### Collection settings and prerequisites
+
+Simple collection setting edits use `updateCollectionSettings` to recover before
+reading the candidate, preserve each editor's enable policy, and settle through
+`commitRuleMutation`. A `true` return still means newly enabled and committed;
+it does not independently assert application. Auto Shift and repeat edits keep
+existing disabled collections disabled; catalog fallback is enabled as before.
+
+Prerequisite-aware callers recover before deriving their candidate. Their common
+apply helper then keeps the candidate and confirmed providers in one retained
+transaction, with no separate snapshot-regeneration rollback. Explicit skipReload
+still means persistence-only for higher-level callers. These changes do not
+include leader preferences or alter prerequisite/conflict choices.

--- a/docs/bugs/collection-settings-recovery.md
+++ b/docs/bugs/collection-settings-recovery.md
@@ -1,0 +1,21 @@
+# Collection setting recovery
+
+Several collection setting methods persisted configuration and source stores
+before classifying the reload result. They could leave edited settings enabled
+after a rejected reload and return newly-enabled success. Prerequisite-aware
+settings used a second regeneration to roll back, which could overwrite a later
+external revision and did not retain exact file contents.
+
+Simple setting methods now share preparation and settlement. Interrupted journal
+recovery precedes candidate lookup. Failed application restores the source/config
+transaction and in-memory snapshot, and only committed changes can return newly
+enabled. Existing Auto Shift/repeat enable policies and catalog fallback remain.
+
+Home Row, Launcher, and window activation prerequisite saves use the same retained
+transaction for both candidate and confirmed providers. Callers recover before
+constructing the candidate, so settings cannot be derived from discarded state.
+The shared helper also independently recovers for direct admitted callers.
+
+Temporary-store regressions cover rejection, provider rollback, pending saves,
+disabled-state preservation, catalog fallback, and interrupted source recovery.
+Leader preferences, collection toggles, and external-write watching remain open.

--- a/docs/planning/catalog-led-consolidation-plan.md
+++ b/docs/planning/catalog-led-consolidation-plan.md
@@ -401,7 +401,7 @@ the next editor snapshot, including the pack tap/hold picker. Local layer-label 
 heartbeat evidence. Collection/preferences/watcher work and agreed UI decisions
 remain open.
 
-### Collection and layer membership recovery in progress
+### Collection and layer membership recovery merged in #1282
 
 Collection add/update, remove, batch enable, and layer creation/removal now use
 SaveCoordinator's retained rule transaction. Layer removal no longer writes
@@ -415,3 +415,12 @@ Review follow-up for membership recovery: add results also propagate through UI
 wrappers. Failed collection imports use the existing partial-import error;
 failed mapper layer creation does not select an unsaved layer. The broader
 saved/pending status design and combined import transaction remain open.
+
+### Collection settings recovery in progress
+
+Tap/hold and preset pickers, window/function key settings, chord/sequence settings,
+Auto Shift, and repeat settings now share recovery before preparation and retained
+rule settlement. Prerequisite-aware Home Row and Launcher/window activation saves
+keep confirmed providers in the same transaction. Existing enable policies and
+newly-enabled Boolean semantics remain. Leader/single-output settings, collection
+toggles, replace-all, preferences, managed snapshots, and watching remain open.


### PR DESCRIPTION
## Problem and result

Collection setting editors could keep edited settings after a rejected reload and return newly-enabled success. Prerequisite saves used a separate regeneration for rollback, which could overwrite an external revision.

Tap/hold and preset pickers, window/function key settings, chord/sequence settings, Auto Shift, and repeat settings now share recovery before candidate lookup and retained rule settlement. Home Row, Launcher, and window activation saves keep confirmed providers in the same recoverable transaction. The duplicate setting-write branches and prerequisite rollback regeneration are removed.

Existing catalog fallback, conflict/prerequisite choices, and enable policies remain. In particular, Auto Shift/repeat edits preserve an existing disabled state. The Boolean return still means newly enabled and committed, not necessarily applied. Leader/single-output settings, collection toggles, replace-all, preferences, managed snapshots, and revision-aware watching remain separate work.

## Validation

- 170 focused tests passed. Seven new regressions cover rejection and exact restoration, provider rollback, pending saves, disabled-state preservation, catalog fallback, and recovery before source lookup.
- Full safe suite: 5,243 passed, with only the four known macOS 27 snapshot baseline failures (three Home Row Timing variants and Repair Settings). Zero compiler warnings; stable-Xcode application/test builds completed.
- SwiftFormat 0.61.1, accessibility, and diff checks passed.
- Existing failure tests now verify no rollback regeneration and preservation of an unreadable external source directory, rather than deleting that directory in an error callback and expecting a second write.

Remote review gate selected; GitHub claude-review required before merge. Installer state matrix: Running and TCP responding; Running but TCP not responding. Signed/notarized deployment follows merge. No new UI or public release.

Review follow-up: setting errors retain the candidate name through the shared
commit helper, followed by the actual failure/recovery detail. The old unconditional
"previous state restored" text is intentionally not reused because restoration
can itself fail or preserve an external change. Both prerequisite and simple
setters use this contextual feedback.

Recovery checks before candidate lookup and inside the independently callable
prerequisite helper are intentional under the same permit. Once source/runtime
recovery succeeds, the second check does not reload. A new interrupted Home Row
Mods test verifies exactly one recovery plus one edit reload and that the
newly-enabled result uses the restored collection's enabled state.

Final focused recovery group: 47 tests passed. The final broad run includes the error-context and interrupted-prerequisite follow-ups, with no compiler warnings.

Final review verification: commitRuleMutation restores ruleCollections from
snapshot.collections immediately before restoring customRules; that line is
outside the changed hunk. assertRejectedMutationRestores checks both arrays after
the awaited public setter returns, so the existing assertions cover the complete
call path. The setting name is retained in error feedback. We intentionally do
not reuse an unconditional restoration reassurance when recovery can fail or
preserve external changes; broader status wording remains a separate UI decision.
