### PR TITLE
Recover collection toggles and leader changes together

### DIFF
--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+Mutation.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+Mutation.swift
@@ -91,19 +91,28 @@ extension RuleCollectionsManager {
     /// The save owner restores files/runtime; the manager restores its in-memory
     /// candidate without regenerating over the recovered or externally edited files.
     @discardableResult
-    func commitRuleMutation(snapshot: RuleStateSnapshot, skipReload: Bool = false, failureContext: String? = nil,
+    func commitRuleMutation(snapshot: RuleStateSnapshot, skipReload: Bool = false, failureContext: String? = nil, leaderPreferenceBefore: LeaderKeyPreference? = nil,
                             mutationPermit: ConfigurationOperationGate.Permit) async -> Bool
     {
+        let preparedLeaderPreference = PreferencesService.shared.leaderKeyPreference
         let result = await SaveCoordinator(configurationService: configurationService).saveRuleState(
             manager: self, mutationPermit: mutationPermit, reloadHandler: skipReload ? nil : onRulesChanged
         )
         guard result.success else {
             ruleCollections = snapshot.collections
             customRules = snapshot.customRules
+            var preferenceRecoveryDetail = ""
+            if let leaderPreferenceBefore {
+                if PreferencesService.shared.leaderKeyPreference == preparedLeaderPreference {
+                    PreferencesService.shared.leaderKeyPreference = leaderPreferenceBefore
+                } else {
+                    preferenceRecoveryDetail = " A newer leader-key preference was preserved."
+                }
+            }
             refreshLayerIndicatorState()
             if let error = result.error, !(error is CancellationError) {
                 let message = failureContext.map { "Could not save \($0): \(error.localizedDescription)" } ?? error.localizedDescription
-                onError?(message)
+                onError?(message + preferenceRecoveryDetail)
                 SoundManager.shared.playErrorSound()
             }
             return false

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+PublicAPI.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+PublicAPI.swift
@@ -14,18 +14,14 @@ extension RuleCollectionsManager {
     /// Replace all rule collections
     func replaceCollections(_ collections: [RuleCollection]) async {
         await withRuleMutation(failure: ()) { [self] permit in
+            guard let snapshot = await recoverAndSnapshotRuleState(mutationPermit: permit) else { return }
+            let leaderSnapshot = PreferencesService.shared.leaderKeyPreference
             ruleCollections = RuleCollectionDeduplicator.dedupe(collections)
             dedupeRuleCollectionsInPlace()
             refreshLayerIndicatorState()
-
-            let leaderSnapshot = PreferencesService.shared.leaderKeyPreference
-            let collectionsSnapshot = ruleCollections
             let didReconcileLeader = reconcileLeaderKeyFromCollection()
-
-            let applied = await regenerateConfigFromCollections(mutationPermit: permit)
-            if didReconcileLeader, !applied {
-                rollbackLeaderReconcile(preference: leaderSnapshot, collections: collectionsSnapshot)
-            }
+            await commitRuleMutation(snapshot: snapshot, failureContext: "rule collections",
+                                     leaderPreferenceBefore: didReconcileLeader ? leaderSnapshot : nil, mutationPermit: permit)
         }
     }
 
@@ -56,6 +52,7 @@ extension RuleCollectionsManager {
         await withRuleMutation(using: mutationPermit, failure: false) { [self] permit in
             AppLogger.shared.log("🔀 [RuleCollections] toggleCollection called: id=\(id), isEnabled=\(isEnabled)")
 
+            guard let snapshot = await recoverAndSnapshotRuleState(mutationPermit: permit) else { return false }
             if !bypassOwnershipCheck {
                 if let owner = await InstalledPackTracker.shared.packManagingCollection(id) {
                     AppLogger.shared.log(
@@ -65,7 +62,6 @@ extension RuleCollectionsManager {
                 }
             }
 
-            let snapshot = snapshotRuleState()
             let leaderPreferenceSnapshot = PreferencesService.shared.leaderKeyPreference
 
             let catalogMatch = RuleCollectionCatalog().defaultCollections().first { $0.id == id }
@@ -166,16 +162,10 @@ extension RuleCollectionsManager {
                 }
             }
 
-            AppLogger.shared.log("🔀 [RuleCollections] Calling regenerateConfigFromCollections...")
-            let applied = await regenerateConfigFromCollections(skipReload: skipReload, mutationPermit: permit)
-            guard applied else {
-                if id == RuleCollectionIdentifier.leaderKey {
-                    PreferencesService.shared.leaderKeyPreference = leaderPreferenceSnapshot
-                }
-                AppLogger.shared.log("↩️ [RuleCollections] Toggle apply failed; rolling back to previous state")
-                await rollbackToSnapshot(snapshot, userMessage: "Could not apply this rule change. Your previous rule state was restored.", mutationPermit: permit)
-                return false
-            }
+            guard await commitRuleMutation(snapshot: snapshot, skipReload: skipReload, failureContext: candidate.name,
+                                           leaderPreferenceBefore: id == RuleCollectionIdentifier.leaderKey ? leaderPreferenceSnapshot : nil,
+                                           mutationPermit: permit)
+            else { return false }
 
             // Pre-cache icons for collections with app launches (e.g., Vim nav layer)
             if isEnabled, let collection = ruleCollections.first(where: { $0.id == id }) {
@@ -350,48 +340,29 @@ extension RuleCollectionsManager {
     /// Update a single-key picker collection's selected output and regenerate its mapping
     func updateCollectionOutput(id: UUID, output: String) async {
         await withRuleMutation(failure: ()) { [self] permit in
-            guard let index = ruleCollections.firstIndex(where: { $0.id == id }) else {
-                // Try to find in catalog and add it
-                let catalog = RuleCollectionCatalog()
-                if var catalogCollection = catalog.defaultCollections().first(where: { $0.id == id }) {
-                    catalogCollection.configuration.updateSelectedOutput(output)
-                    catalogCollection.isEnabled = true
-                    // Update the mapping based on selected output
-                    if let config = catalogCollection.configuration.singleKeyPickerConfig {
-                        let description = config.presetOptions.first { $0.output == output }?.label ?? "Custom"
-                        let keyAction: KeyAction = output.hasPrefix("(") ? .rawKanata(output) : .keystroke(key: output)
-                        catalogCollection.mappings = [KeyMapping(input: config.inputKey, action: keyAction, description: description)]
-                    }
-                    ruleCollections.append(catalogCollection)
-                    dedupeRuleCollectionsInPlace()
-                    refreshLayerIndicatorState()
-                    await regenerateConfigFromCollections(mutationPermit: permit)
-                }
-                return
-            }
-
-            ruleCollections[index].configuration.updateSelectedOutput(output)
-            ruleCollections[index].isEnabled = true
-
-            // Update the mapping based on selected output (skip for Leader Key which has no mappings)
-            if let config = ruleCollections[index].configuration.singleKeyPickerConfig,
-               config.inputKey != "leader"
-            {
+            guard let snapshot = await recoverAndSnapshotRuleState(mutationPermit: permit) else { return }
+            guard var candidate = ruleCollections.first(where: { $0.id == id })
+                ?? RuleCollectionCatalog().defaultCollections().first(where: { $0.id == id })
+            else { return }
+            let leaderSnapshot = PreferencesService.shared.leaderKeyPreference
+            candidate.configuration.updateSelectedOutput(output)
+            candidate.isEnabled = true
+            if let config = candidate.configuration.singleKeyPickerConfig, config.inputKey != "leader" {
                 let description = config.presetOptions.first { $0.output == output }?.label ?? "Custom"
-                let keyAction: KeyAction = output.hasPrefix("(") ? .rawKanata(output) : .keystroke(key: output)
-                ruleCollections[index].mappings = [KeyMapping(input: config.inputKey, action: keyAction, description: description)]
+                let action: KeyAction = output.hasPrefix("(") ? .rawKanata(output) : .keystroke(key: output)
+                candidate.mappings = [KeyMapping(input: config.inputKey, action: action, description: description)]
             }
-
-            dedupeRuleCollectionsInPlace()
-
-            // Special handling: If this is the Leader Key collection, update all momentary activators
+            if let index = ruleCollections.firstIndex(where: { $0.id == id }) { ruleCollections[index] = candidate }
+            else { ruleCollections.append(candidate) }
             if id == RuleCollectionIdentifier.leaderKey {
-                await updateLeaderKey(output, mutationPermit: permit)
-                return
+                applyLeaderKeyToMomentaryActivators(output)
+                syncLeaderKeyPreference(key: output, enabled: true)
             }
-
+            dedupeRuleCollectionsInPlace()
             refreshLayerIndicatorState()
-            await regenerateConfigFromCollections(mutationPermit: permit)
+            await commitRuleMutation(snapshot: snapshot, failureContext: candidate.name,
+                                     leaderPreferenceBefore: id == RuleCollectionIdentifier.leaderKey ? leaderSnapshot : nil,
+                                     mutationPermit: permit)
         }
     }
 
@@ -634,19 +605,15 @@ extension RuleCollectionsManager {
     func updateLeaderKey(_ newKey: String, mutationPermit: ConfigurationOperationGate.Permit? = nil) async {
         await withRuleMutation(using: mutationPermit, failure: ()) { [self] permit in
             AppLogger.shared.log("🔑 [RuleCollections] Updating leader key to '\(newKey)'")
-            let snapshot = snapshotRuleState()
+            guard let snapshot = await recoverAndSnapshotRuleState(mutationPermit: permit) else { return }
             let leaderPreferenceSnapshot = PreferencesService.shared.leaderKeyPreference
 
             applyLeaderKeyToMomentaryActivators(newKey)
             syncLeaderKeyPreference(key: newKey, enabled: true)
             dedupeRuleCollectionsInPlace()
             refreshLayerIndicatorState()
-            let applied = await regenerateConfigFromCollections(mutationPermit: permit)
-            guard applied else {
-                PreferencesService.shared.leaderKeyPreference = leaderPreferenceSnapshot
-                await rollbackToSnapshot(snapshot, userMessage: "Could not apply this leader key change. Your previous rule state was restored.", mutationPermit: permit)
-                return
-            }
+            await commitRuleMutation(snapshot: snapshot, failureContext: "Leader Key",
+                                     leaderPreferenceBefore: leaderPreferenceSnapshot, mutationPermit: permit)
         }
     }
 

--- a/Sources/KeyPathAppKit/UI/Gallery/PackDetailView+PackActions.swift
+++ b/Sources/KeyPathAppKit/UI/Gallery/PackDetailView+PackActions.swift
@@ -159,12 +159,20 @@ extension PackDetailView {
     /// collection's `selectedOutput` is persisted via the same VM API the
     /// Rules tab uses.
     func applySingleKeyEdit(output: String) async {
-        singleKeySelection = output
         guard let collectionID = pack.associatedCollectionID else { return }
+        let editID = UUID()
+        singleKeyEditID = editID
+        singleKeySelection = output
         if !isInstalled {
             await install(skipFinalReload: true)
         }
-        await kanataManager.updateCollectionOutput(collectionID, output: output)
+        if isInstalled {
+            await kanataManager.updateCollectionOutput(collectionID, output: output)
+        }
+        let persistedSelection = await liveSingleKeySelection()
+        guard singleKeyEditID == editID else { return }
+        singleKeyEditID = nil
+        singleKeySelection = persistedSelection
     }
 
     /// Apply a Home Row Mods edit — analogous to the tap-hold `updateTapHold`

--- a/Sources/KeyPathAppKit/UI/Gallery/PackDetailView.swift
+++ b/Sources/KeyPathAppKit/UI/Gallery/PackDetailView.swift
@@ -47,6 +47,7 @@ struct PackDetailView: View {
     @State var pickerTapSelection: String?
     @State var pickerHoldSelection: String?
     @State var singleKeySelection: String?
+    @State var singleKeyEditID: UUID?
 
     /// Local state for the embedded Home Row Mods editor. Mirrors the
     /// config shape Rules uses so we can drop `HomeRowModsCollectionView`

--- a/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView+RowBuilder.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView+RowBuilder.swift
@@ -53,8 +53,15 @@ extension RulesTabView {
             displayStyle: style,
             collection: needsCollection ? collection : nil,
             onSelectOutput: style == .singleKeyPicker ? { output in
+                let editID = UUID()
+                pendingSelectionEdits[collection.id] = editID
                 pendingSelections[collection.id] = output
-                Task { await kanataManager.updateCollectionOutput(collection.id, output: output) }
+                Task {
+                    await kanataManager.updateCollectionOutput(collection.id, output: output)
+                    guard pendingSelectionEdits[collection.id] == editID else { return }
+                    pendingSelectionEdits.removeValue(forKey: collection.id)
+                    pendingSelections.removeValue(forKey: collection.id)
+                }
             } : nil,
             onSelectTapOutput: style == .tapHoldPicker ? { tap in
                 Task { await kanataManager.updateCollectionTapOutput(collection.id, tapOutput: tap) }

--- a/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView.swift
+++ b/Sources/KeyPathAppKit/UI/Rules/RulesSummaryView.swift
@@ -19,6 +19,7 @@ struct RulesTabView: View {
     @State private var createButtonHovered = false
     @State var stableSortOrder: [UUID] = []
     @State var pendingSelections: [UUID: String] = [:]
+    @State var pendingSelectionEdits: [UUID: UUID] = [:]
     @State var pendingToggles: [UUID: Bool] = [:]
     @State var showingHomeRowModsHelp = false
     @State var homeRowModsEditState: HomeRowModsEditState?

--- a/Tests/KeyPathTests/CollectionLeaderRecoveryTests.swift
+++ b/Tests/KeyPathTests/CollectionLeaderRecoveryTests.swift
@@ -1,0 +1,142 @@
+import Foundation
+@testable import KeyPathAppKit
+import KeyPathRulesCore
+@preconcurrency import XCTest
+
+@MainActor
+final class CollectionLeaderRecoveryTests: KeyPathTestCase {
+    private var directory: URL!
+    private var manager: RuleCollectionsManager!
+    private var originalLeaderPreference: LeaderKeyPreference!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        originalLeaderPreference = PreferencesService.shared.leaderKeyPreference
+        PreferencesService.shared.leaderKeyPreference = .default
+        directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let collections = RuleCollectionStore.testStore(at: directory.appendingPathComponent("RuleCollections.json"))
+        let rules = CustomRulesStore.testStore(at: directory.appendingPathComponent("CustomRules.json"))
+        let service = ConfigurationService(configDirectory: directory.path, ruleCollectionStore: collections, customRulesStore: rules)
+        manager = RuleCollectionsManager(ruleCollectionStore: collections, customRulesStore: rules, configurationService: service)
+        manager.ruleCollections = RuleCollectionCatalog().defaultCollections().map { collection in
+            var copy = collection
+            copy.isEnabled = copy.id == RuleCollectionIdentifier.leaderKey
+            return copy
+        }
+        manager.customRules = []
+        try await service.saveRuleState(ruleCollections: manager.ruleCollections, customRules: [], collectionStore: collections, customStore: rules)
+    }
+
+    override func tearDown() async throws {
+        if let originalLeaderPreference { PreferencesService.shared.leaderKeyPreference = originalLeaderPreference }
+        try? FileManager.default.removeItem(at: directory)
+        manager = nil
+        directory = nil
+        try await super.tearDown()
+    }
+
+    private func files() throws -> [String: Data] {
+        try Dictionary(uniqueKeysWithValues: ["keypath.kbd", "RuleCollections.json", "CustomRules.json"].map {
+            try ($0, Data(contentsOf: directory.appendingPathComponent($0)))
+        })
+    }
+
+    private static func reload(_ disposition: ReloadDisposition) -> ReloadResult {
+        ReloadResult(success: disposition == .applied, response: nil, errorMessage: "injected \(disposition)", protocol: nil, disposition: disposition)
+    }
+
+    private func assertRejectedMutationRestores(_ mutate: @MainActor () async -> Void) async throws {
+        let before = try files()
+        let snapshot = manager.snapshotRuleState()
+        let leaderBefore = PreferencesService.shared.leaderKeyPreference
+        var reloads = 0
+        var errors: [String] = []
+        manager.onError = {
+            errors.append($0)
+            XCTAssertEqual(PreferencesService.shared.leaderKeyPreference, leaderBefore, "Restore preferences before error feedback")
+        }
+        manager.onRulesChanged = {
+            reloads += 1
+            if reloads == 2 {
+                do {
+                    let restored = try self.files()
+                    XCTAssertEqual(restored, before)
+                } catch { XCTFail("Could not read restored files: \(error)") }
+            }
+            return Self.reload(reloads == 1 ? .rejected : .applied)
+        }
+        await mutate()
+        XCTAssertEqual(reloads, 2)
+        XCTAssertEqual(try files(), before)
+        XCTAssertEqual(manager.ruleCollections, snapshot.collections)
+        XCTAssertEqual(manager.customRules, snapshot.customRules)
+        XCTAssertEqual(PreferencesService.shared.leaderKeyPreference, leaderBefore)
+        XCTAssertEqual(errors.count, 1)
+    }
+
+    func testRejectedCollectionToggleRestoresDisabledState() async throws {
+        try await assertRejectedMutationRestores {
+            let enabled = await self.manager.toggleCollection(id: RuleCollectionIdentifier.homeRowMods, isEnabled: true, bypassOwnershipCheck: true)
+            XCTAssertFalse(enabled)
+        }
+    }
+
+    func testRejectedLeaderToggleRestoresPreferenceAndCollections() async throws {
+        try await assertRejectedMutationRestores {
+            let enabled = await self.manager.toggleCollection(id: RuleCollectionIdentifier.leaderKey, isEnabled: false, bypassOwnershipCheck: true)
+            XCTAssertFalse(enabled)
+        }
+    }
+
+    func testRejectedLeaderPickerRestoresSelectionBeforeNestedMutation() async throws {
+        try await assertRejectedMutationRestores {
+            await self.manager.updateCollectionOutput(id: RuleCollectionIdentifier.leaderKey, output: "f18")
+        }
+    }
+
+    func testRejectedDirectLeaderEditRestoresPreferenceAndActivators() async throws {
+        try await assertRejectedMutationRestores { await self.manager.updateLeaderKey("f18") }
+    }
+
+    func testRejectedReplacementRestoresOriginalCollectionSet() async throws {
+        try await assertRejectedMutationRestores { await self.manager.replaceCollections([]) }
+    }
+
+    func testRejectedReplacementRestoresReconciledLeaderPreference() async throws {
+        var replacement = manager.ruleCollections
+        let index = try XCTUnwrap(replacement.firstIndex { $0.id == RuleCollectionIdentifier.leaderKey })
+        replacement[index].configuration.updateSelectedOutput("f18")
+        try await assertRejectedMutationRestores { await self.manager.replaceCollections(replacement) }
+    }
+
+    func testPendingLeaderPickerCommitsSelectionAndPreference() async throws {
+        var reloads = 0
+        manager.onRulesChanged = { reloads += 1; return Self.reload(.pending) }
+        await manager.updateCollectionOutput(id: RuleCollectionIdentifier.leaderKey, output: "f18")
+        XCTAssertEqual(reloads, 1)
+        XCTAssertEqual(PreferencesService.shared.leaderKeyPreference.key, "f18")
+        let stored = await manager.ruleCollectionStore.loadCollections()
+        let leader = try XCTUnwrap(stored.first { $0.id == RuleCollectionIdentifier.leaderKey })
+        XCTAssertEqual(leader.configuration.singleKeyPickerConfig?.selectedOutput, "f18")
+    }
+
+    func testFailedLeaderEditPreservesNewerPreference() async throws {
+        let before = try files()
+        var reloads = 0
+        var errors: [String] = []
+        manager.onError = { errors.append($0) }
+        manager.onRulesChanged = {
+            reloads += 1
+            if reloads == 1 {
+                PreferencesService.shared.leaderKeyPreference = LeaderKeyPreference(key: "f17", targetLayer: .navigation, enabled: true)
+            }
+            return Self.reload(reloads == 1 ? .rejected : .applied)
+        }
+        await manager.updateLeaderKey("f18")
+        XCTAssertEqual(reloads, 2)
+        XCTAssertEqual(try files(), before)
+        XCTAssertEqual(PreferencesService.shared.leaderKeyPreference.key, "f17")
+        XCTAssertTrue(errors.first?.contains("newer leader-key preference was preserved") == true)
+    }
+}

--- a/Tests/KeyPathTests/RuleCollections/RuleCollectionsManagerDependentResolutionTests.swift
+++ b/Tests/KeyPathTests/RuleCollections/RuleCollectionsManagerDependentResolutionTests.swift
@@ -281,8 +281,8 @@ final class RuleCollectionsManagerDependentResolutionTests: XCTestCase {
         XCTAssertFalse(applied)
         XCTAssertEqual(
             regenerationCount,
-            2,
-            "The failed disable and rollback should each regenerate once"
+            1,
+            "Validation failure must not regenerate a rollback revision"
         )
         XCTAssertTrue(manager.ruleCollections[id: leader.id]?.isEnabled == true)
         XCTAssertEqual(

--- a/Tests/KeyPathTests/RuleCollections/RuleCollectionsManagerTests.swift
+++ b/Tests/KeyPathTests/RuleCollections/RuleCollectionsManagerTests.swift
@@ -761,6 +761,8 @@ final class RuleCollectionsManagerTests: XCTestCase {
             "test premise: an enabled base-layer 'f' activator must exist to collide with"
         )
 
+        let originalCollections = manager.ruleCollections
+        let originalRules = manager.customRules
         await manager.replaceCollections(collections)
 
         // Regen must have failed — this proves the reconcile+collision path executed
@@ -774,21 +776,10 @@ final class RuleCollectionsManagerTests: XCTestCase {
             "leaderKeyPreference must revert to its pre-reconcile value after a failed regen"
         )
 
-        // The in-memory collections revert too: the base → nav leader activator that
-        // reconcile rewrote to "f" is restored to its original "space".
-        let navInputs = manager.ruleCollections
-            .compactMap(\.momentaryActivator)
-            .filter { $0.sourceLayer == .base && $0.targetLayer == .navigation }
-            .map(\.input)
-        XCTAssertFalse(navInputs.isEmpty)
-        XCTAssertTrue(
-            navInputs.allSatisfy { $0 == "space" },
-            "the base → nav activator must be restored to 'space' after rollback (was rewritten to 'f')"
-        )
-        XCTAssertFalse(
-            navInputs.contains("f"),
-            "no base → nav activator should retain the reconciled-then-rolled-back 'f'"
-        )
+        // A failed replacement restores the pre-operation arrays, not the proposed
+        // catalog with only its reconciled activator reverted.
+        XCTAssertEqual(manager.ruleCollections, originalCollections)
+        XCTAssertEqual(manager.customRules, originalRules)
     }
 
     @MainActor

--- a/docs/architecture/configuration-save-pipeline.md
+++ b/docs/architecture/configuration-save-pipeline.md
@@ -343,3 +343,15 @@ apply helper then keeps the candidate and confirmed providers in one retained
 transaction, with no separate snapshot-regeneration rollback. Explicit skipReload
 still means persistence-only for higher-level callers. These changes do not
 include leader preferences or alter prerequisite/conflict choices.
+
+### Collection toggles, replacement, and leader edits
+
+These public mutations now take recovered snapshots before any candidate changes
+and settle through `commitRuleMutation`. Single-output editing handles the leader
+preference/activators in the same operation, rather than calling another save
+after changing the selected output. Replace-all snapshots the original arrays.
+
+The commit helper optionally receives the prior leader preference. On failure it
+restores that preference before error feedback only if it still equals the prepared
+value; a newer value is preserved and reported. This is in-process preference
+rollback only. UserDefaults is not yet part of the crash-recovery journal.

--- a/docs/bugs/collection-leader-recovery.md
+++ b/docs/bugs/collection-leader-recovery.md
@@ -1,0 +1,33 @@
+# Collection toggle and leader recovery
+
+Collection toggles and leader/output edits treated persistence as success and
+regenerated a second revision on failure. Replace-all took its collection snapshot
+after replacement. The leader picker changed its selected output before invoking
+a nested leader save, so that nested snapshot already contained the proposed value.
+
+These operations now recover before reading state and keep the original snapshot
+through SaveCoordinator settlement. Replace-all snapshots before replacement. The
+leader picker prepares its selection and activators in one operation instead of
+delegating after a partial mutation. File/runtime rollback never regenerates a
+new snapshot over an external edit.
+
+If an operation changes the leader preference, the manager restores its prior
+value before reporting an ordinary save failure, but only if the current preference
+still matches the prepared value. A newer preference is preserved and named in
+the error. Existing conflict/ownership/disable decisions and the broad explicit
+leader-activator rewrite are unchanged.
+
+**Remaining boundary:** preferences are still stored in UserDefaults outside the
+durable file journal. This provides in-process rollback, not crash-atomic preference
+recovery. Managed-pack snapshots, keymap preferences, and external-write watching
+also remain separate work.
+
+Tests cover rejected toggles, direct/picker leader edits, collection replacement
+with and without reconciliation, pending commits, exact file restoration before
+recovery reload, preference restoration before feedback, and preservation of a
+newer preference.
+
+The Rules and catalog single-key pickers clear their optimistic selection after
+settlement and show the current model value, including after rejection. Edit IDs
+prevent an older completion from clearing a newer pending choice. A catalog edit
+also stops if its prerequisite pack installation did not succeed.

--- a/docs/planning/catalog-led-consolidation-plan.md
+++ b/docs/planning/catalog-led-consolidation-plan.md
@@ -416,7 +416,7 @@ wrappers. Failed collection imports use the existing partial-import error;
 failed mapper layer creation does not select an unsaved layer. The broader
 saved/pending status design and combined import transaction remain open.
 
-### Collection settings recovery in progress
+### Collection settings recovery merged in #1283
 
 Tap/hold and preset pickers, window/function key settings, chord/sequence settings,
 Auto Shift, and repeat settings now share recovery before preparation and retained
@@ -424,3 +424,20 @@ rule settlement. Prerequisite-aware Home Row and Launcher/window activation save
 keep confirmed providers in the same transaction. Existing enable policies and
 newly-enabled Boolean semantics remain. Leader/single-output settings, collection
 toggles, replace-all, preferences, managed snapshots, and watching remain open.
+
+### Collection toggles and leader recovery in progress
+
+Toggles, replace-all, single-output editing, and direct leader edits now retain
+rule snapshots through application. Leader preference rollback happens before
+failure feedback and preserves newer preference edits. Replace-all and the leader
+picker no longer capture already-mutated state. Preferences still need durable
+crash recovery; managed-pack snapshots, keymap preferences, raw saves and watching
+remain open. Existing ownership/conflict/disable choices are retained.
+
+Runner follow-up during #1283: CI again stopped at the unchanged 100 GiB reserve
+(94 GiB reported by CI). Cleared the runner account's npm download cache and used
+macOS local-snapshot thinning after verifying a completed network Time Machine
+backup from the same evening. Startup free space recovered to 112 GiB; the failed
+CI job was retried and passed before merge. Network backups and active updater
+caches were preserved. External scratch routing (#1261) still awaits the runner's
+normal removable-volume permission; this recovery does not complete that migration.


### PR DESCRIPTION
## Problem and result

Collection toggles and leader/output edits could commit files despite rejected reloads, then regenerate a second revision for rollback. Replace-all captured its snapshot after replacement; the leader picker changed selection before its nested leader save took a snapshot.

These paths now recover before preparation and use SaveCoordinator's retained rule transaction. Replace-all snapshots the original arrays, and the leader picker changes its selection and activators in one save. On failure, manager arrays and the prior leader preference are restored before error feedback. A newer preference value is preserved and reported instead of overwritten.

Rules and catalog pickers now settle their optimistic selection from the restored/current model; per-edit IDs protect newer pending choices. Catalog edits stop if prerequisite installation fails. Existing conflict, ownership, dependent-disable choices, and explicit leader-activator behavior remain. Preference rollback is in-process only: UserDefaults is still outside the durable file journal. Crash-atomic preferences, keymap preferences, managed-pack snapshots, raw saves, and watcher revisions remain separate work.

## Validation

Full safe suite completed: 5,250 passed, four known macOS 27 snapshot mismatches, and one legacy replacement test expecting the incorrect partially replaced state. That assertion now checks both original arrays; all 46 final focused XCTest cases passed, including the corrected test. No compiler warnings. An earlier full attempt hit the 240-second deadline while a release build was running; the uncontended rerun completed in 205 seconds.

New temporary-store regressions cover rejected toggles, direct/picker leader changes, replacement with/without reconciliation, pending commit, exact recovery reload ordering, and newer-preference preservation. Pinned SwiftFormat, accessibility checks, and diff checks passed.

Remote review gate selected; GitHub claude-review required before merge. Installer state matrix: Running and TCP responding; Running but TCP not responding. Signed/notarized deployment follows merge. No public release or UI redesign.

Review follow-up: 55 focused XCTest cases passed (6 existing skips), including compilation of both picker surfaces. The recovery helper already calls onError on non-cancellation failures; only cancellation returns silently. This confirms the conditional review concern without adding duplicate errors.

Final review confirmation: PackDetailView.install already reports installation failures through showTemporaryError or the existing conflict sheet and refreshes isInstalled before returning. The picker therefore preserves that feedback and does not bypass a failed install.
