### PR TITLE
Apply recovered configuration before the next editor callback

### DIFF
--- a/Sources/KeyPathAppKit/Infrastructure/Config/ConfigurationService.swift
+++ b/Sources/KeyPathAppKit/Infrastructure/Config/ConfigurationService.swift
@@ -33,6 +33,9 @@ public final class ConfigurationService: FileConfigurationProviding {
     private let ruleCollectionStore: RuleCollectionStore
     private let customRulesStore: CustomRulesStore
 
+    @MainActor private var needsRecoveredRuntimeRefresh = false
+    @MainActor private(set) var ruleRecoveryRevision: UInt64 = 0
+
     let operationGate: ConfigurationOperationGate
 
     /// Perform blocking file I/O off the main actor
@@ -412,13 +415,13 @@ public final class ConfigurationService: FileConfigurationProviding {
     /// when recovery detects a corrupt journal or an unrelated external edit.
     @discardableResult
     func recoverPendingRuleWrite(
-        collectionStore: RuleCollectionStore,
-        customStore: CustomRulesStore,
+        collectionStore: RuleCollectionStore? = nil,
+        customStore: CustomRulesStore? = nil,
         mutationPermit: ConfigurationOperationGate.Permit? = nil,
         installedPackTracker: InstalledPackTracker? = nil
     ) async throws -> Bool {
         try await operationGate.withOperation(using: mutationPermit) { @MainActor [self] _ in
-            let files = await ruleWriteFiles(collectionStore: collectionStore, customStore: customStore)
+            let files = await ruleWriteFiles(collectionStore: collectionStore ?? ruleCollectionStore, customStore: customStore ?? customRulesStore)
             let directory = URL(fileURLWithPath: configDirectory)
             var packTargets = files
             if let installedPackTracker {
@@ -434,6 +437,8 @@ public final class ConfigurationService: FileConfigurationProviding {
             }
             if recovered {
                 stateLock.withLock { currentConfiguration = nil }
+                needsRecoveredRuntimeRefresh = true
+                ruleRecoveryRevision &+= 1
             }
             return recovered
         }
@@ -532,11 +537,31 @@ public final class ConfigurationService: FileConfigurationProviding {
             }
             if recovered {
                 stateLock.withLock { currentConfiguration = nil }
+                needsRecoveredRuntimeRefresh = true
                 await resolvedStore.invalidateCache()
                 if await AppKeymapStore.shared.persistenceURL.standardizedFileURL == resolvedStore.persistenceURL.standardizedFileURL {
                     await AppKeymapStore.shared.invalidateCache()
                 }
             }
+        }
+    }
+
+    /// Recovery can remove its journal before an editor rejects/cancels its next
+    /// candidate. Keep runtime recovery required until an existing reload owner
+    /// accepts or defers it. A later save owner can retry using this same service.
+    @MainActor
+    func applyRecoveredRuntimeIfNeeded(
+        mutationPermit: ConfigurationOperationGate.Permit,
+        reloadHandler: (() async -> ReloadResult)?
+    ) async throws -> ReloadResult? {
+        try await operationGate.withOperation(using: mutationPermit) { @MainActor [self] _ in
+            guard needsRecoveredRuntimeRefresh, let reloadHandler else { return nil }
+            let result = await Task { @MainActor in await reloadHandler() }.value
+            guard result.disposition == .applied || result.disposition == .pending else {
+                throw KeyPathError.configuration(.loadFailed(reason: "Recovered files could not be applied: \(result.errorMessage ?? "keyboard service rejected recovery")"))
+            }
+            needsRecoveredRuntimeRefresh = false
+            return result
         }
     }
 

--- a/Sources/KeyPathAppKit/Managers/SaveCoordinator.swift
+++ b/Sources/KeyPathAppKit/Managers/SaveCoordinator.swift
@@ -121,6 +121,9 @@ final class SaveCoordinator {
                 var reload: ReloadResult?
                 do {
                     configFileWatcher?.suppressEvents(for: 1.0, reason: "Internal app-specific save")
+                    try await recoverBeforeEditing(appStore: store, mutationPermit: permit,
+                                                   runtimeDidApply: runtimeDidApply, reloadHandler: reloadHandler)
+                    configFileWatcher?.suppressEvents(for: 1.0, reason: "Internal app-specific save after recovery")
                     staged = try await configurationService.stageAppKeymapChange(store: store, mutationPermit: permit, mutate: mutate)
                     try Task.checkCancellation()
                     let result = await reloadHandler()
@@ -159,7 +162,7 @@ final class SaveCoordinator {
                             reportedError = SaveApplicationError(cause: error, recovery: recoveryError.localizedDescription)
                         }
                     }
-                    saveStatus = .failed(reportedError.localizedDescription)
+                    saveStatus = reportedError is CancellationError ? .idle : .failed(reportedError.localizedDescription)
                     return .failure(reportedError, reloadResult: reload, recoveryResult: recovery)
                 }
             }
@@ -189,8 +192,11 @@ final class SaveCoordinator {
                 configFileWatcher?.suppressEvents(for: 1.0, reason: "Internal saveConfiguration")
                 saveStatus = .saving
 
-                let snapshot = ruleCollectionsManager.snapshotRuleState()
                 do {
+                    try await ruleCollectionsManager.recoverRuleState(mutationPermit: permit)
+                    _ = try await configurationService.applyRecoveredRuntimeIfNeeded(mutationPermit: permit, reloadHandler: reloadHandler)
+                    configFileWatcher?.suppressEvents(for: 1.0, reason: "Internal mapping save after recovery")
+                    let snapshot = ruleCollectionsManager.snapshotRuleState()
                     let (sanitizedInput, sanitizedOutput) = try validateInputOutput(input: input, output: output)
                     let rule = ruleCollectionsManager.makeCustomRule(input: sanitizedInput, output: sanitizedOutput)
                     guard await ruleCollectionsManager.updateCustomRuleInMemory(rule, mutationPermit: permit) else {
@@ -211,7 +217,7 @@ final class SaveCoordinator {
                     }
                     return result
                 } catch {
-                    saveStatus = .failed(error.localizedDescription)
+                    saveStatus = error is CancellationError ? .idle : .failed(error.localizedDescription)
                     return .failure(error)
                 }
             }
@@ -232,6 +238,7 @@ final class SaveCoordinator {
         do {
             return try await configurationService.operationGate.withOperation(using: mutationPermit) { @MainActor [self] permit in
                 saveStatus = .saving
+                _ = try await configurationService.applyRecoveredRuntimeIfNeeded(mutationPermit: permit, reloadHandler: reloadHandler)
                 var conflictDepth = 0
                 while true {
                     var staged: ConfigurationService.RuleWrite?
@@ -280,12 +287,32 @@ final class SaveCoordinator {
                                 reportedError = SaveApplicationError(cause: error, recovery: recoveryError.localizedDescription)
                             }
                         }
-                        saveStatus = .failed(reportedError.localizedDescription)
+                        saveStatus = reportedError is CancellationError ? .idle : .failed(reportedError.localizedDescription)
                         return .failure(reportedError, reloadResult: reload, recoveryResult: recovery)
                     }
                 }
             }
-        } catch { return .failure(error) }
+        } catch {
+            saveStatus = error is CancellationError ? .idle : .failed(error.localizedDescription)
+            return .failure(error)
+        }
+    }
+
+    /// Run before reading a candidate or invoking an editor callback: either can
+    /// exit without staging, but an interrupted prior edit still needs recovery.
+    private func recoverBeforeEditing(
+        appStore: AppKeymapStore? = nil,
+        mutationPermit: ConfigurationOperationGate.Permit,
+        runtimeDidApply: @escaping @MainActor @Sendable () async -> Void,
+        reloadHandler: @escaping () async -> ReloadResult
+    ) async throws {
+        try await configurationService.recoverPendingRuleWrite(mutationPermit: mutationPermit)
+        try await configurationService.recoverPendingAppKeymapWrite(store: appStore, mutationPermit: mutationPermit)
+        let recovery = try await configurationService.applyRecoveredRuntimeIfNeeded(mutationPermit: mutationPermit, reloadHandler: reloadHandler)
+        if recovery?.disposition == .applied {
+            await Task { @MainActor in await runtimeDidApply() }.value
+        }
+        try Task.checkCancellation()
     }
 
     /// Capture and transform raw content under the same admission as its save.
@@ -296,12 +323,16 @@ final class SaveCoordinator {
     ) async -> SaveResult {
         do {
             return try await configurationService.operationGate.withOperation { @MainActor [self] permit in
+                try await recoverBeforeEditing(mutationPermit: permit, runtimeDidApply: runtimeDidApply, reloadHandler: reloadHandler)
                 let original = try await snapshotCurrentConfig(mutationPermit: permit)
                 let content = try transform(original)
                 return await saveGeneratedConfig(content: content, mutationPermit: permit, expectedContent: original,
                                                  runtimeDidApply: runtimeDidApply, reloadHandler: reloadHandler)
             }
-        } catch { return .failure(error) }
+        } catch {
+            saveStatus = error is CancellationError ? .idle : .failed(error.localizedDescription)
+            return .failure(error)
+        }
     }
 
     /// Save a complete generated configuration (e.g., from AI)
@@ -324,6 +355,7 @@ final class SaveCoordinator {
                 saveStatus = .saving
 
                 do {
+                    try await recoverBeforeEditing(mutationPermit: permit, runtimeDidApply: runtimeDidApply, reloadHandler: reloadHandler)
                     // Step 1: Validate generated config before saving
                     AppLogger.shared.debug(
                         "🔍 [SaveCoordinator] Validating generated config before save..."
@@ -343,6 +375,8 @@ final class SaveCoordinator {
                     }
 
                     AppLogger.shared.info("✅ [SaveCoordinator] Generated config validation passed")
+
+                    configFileWatcher?.suppressEvents(for: 1.0, reason: "Internal generated save after recovery")
 
                     // Step 2: Backup current config
                     let previousContent = try await snapshotCurrentConfig(mutationPermit: permit)

--- a/Sources/KeyPathAppKit/Services/Packs/PackInstaller.swift
+++ b/Sources/KeyPathAppKit/Services/Packs/PackInstaller.swift
@@ -64,12 +64,13 @@ public final class PackInstaller {
     func recoverAndValidateState(manager: RuleCollectionsManager, tracker: InstalledPackTracker,
                                  permit: ConfigurationOperationGate.Permit) async throws
     {
+        try await manager.configurationService.recoverPendingAppKeymapWrite(mutationPermit: permit)
         let recovered = try await manager.configurationService.recoverPendingRuleWrite(
             collectionStore: manager.ruleCollectionStore, customStore: manager.customRulesStore,
             mutationPermit: permit, installedPackTracker: tracker
         )
         do {
-            try await manager.refreshRecoveredRuleStateIfNeeded(recovered)
+            try await manager.refreshRecoveredRuleStateIfNeeded(recovered, mutationPermit: permit)
         } catch let error as KeyPathError {
             if case let .configuration(.loadFailed(reason)) = error {
                 throw InstallError.saveFailed(reason)

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+Mutation.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+Mutation.swift
@@ -25,10 +25,7 @@ extension RuleCollectionsManager {
     /// Recover interrupted source writes before taking the next editor snapshot.
     func recoverAndSnapshotRuleState(mutationPermit: ConfigurationOperationGate.Permit) async -> RuleStateSnapshot? {
         do {
-            let recovered = try await configurationService.recoverPendingRuleWrite(
-                collectionStore: ruleCollectionStore, customStore: customRulesStore, mutationPermit: mutationPermit
-            )
-            try await refreshRecoveredRuleStateIfNeeded(recovered)
+            try await recoverRuleState(mutationPermit: mutationPermit)
             return snapshotRuleState()
         } catch is CancellationError {
             return nil
@@ -38,11 +35,20 @@ extension RuleCollectionsManager {
         }
     }
 
+    /// Throwing preparation for save owners that report their own failure result.
+    func recoverRuleState(mutationPermit: ConfigurationOperationGate.Permit) async throws {
+        try await configurationService.recoverPendingAppKeymapWrite(mutationPermit: mutationPermit)
+        let recovered = try await configurationService.recoverPendingRuleWrite(
+            collectionStore: ruleCollectionStore, customStore: customRulesStore, mutationPermit: mutationPermit
+        )
+        try await refreshRecoveredRuleStateIfNeeded(recovered, mutationPermit: mutationPermit)
+    }
+
     /// Do not let a retry use stale arrays after journal recovery succeeded but
     /// source decoding failed. Clear the requirement only after both stores load.
-    func refreshRecoveredRuleStateIfNeeded(_ recovered: Bool) async throws {
+    func refreshRecoveredRuleStateIfNeeded(_ recovered: Bool, mutationPermit: ConfigurationOperationGate.Permit) async throws {
         needsRecoveredRuleStateRefresh = needsRecoveredRuleStateRefresh || recovered
-        needsRecoveredRuleRuntimeRefresh = needsRecoveredRuleRuntimeRefresh || recovered
+            || observedRuleRecoveryRevision != configurationService.ruleRecoveryRevision
         if needsRecoveredRuleStateRefresh {
             let collections = await ruleCollectionStore.loadCollectionsDetailed()
             guard !collections.wasFullReset, collections.failedCollectionNames.isEmpty else {
@@ -52,19 +58,12 @@ extension RuleCollectionsManager {
             ruleCollections = RuleCollectionDeduplicator.dedupe(collections.collections)
             customRules = rules
             needsRecoveredRuleStateRefresh = false
+            observedRuleRecoveryRevision = configurationService.ruleRecoveryRevision
             refreshLayerIndicatorState()
         }
-        // Restore runtime before any caller can cancel a prompt or return for a
-        // missing rule. A failed attempt remains required after the journal is gone.
-        // Headless persistence-only callers may have no runtime callback; retain
-        // the requirement in case one is attached to this manager later.
-        if needsRecoveredRuleRuntimeRefresh, let onRulesChanged {
-            let result = await Task { @MainActor in await onRulesChanged() }.value
-            guard result.disposition == .applied || result.disposition == .pending else {
-                throw KeyPathError.configuration(.loadFailed(reason: "Recovered files could not be applied: \(result.errorMessage ?? "keyboard service rejected recovery")"))
-            }
-            needsRecoveredRuleRuntimeRefresh = false
-        }
+        // The configuration owner retains this requirement across app/rule/raw
+        // editors sharing it, including failed recovery after journal removal.
+        _ = try await configurationService.applyRecoveredRuntimeIfNeeded(mutationPermit: mutationPermit, reloadHandler: onRulesChanged)
     }
 
     /// Preserve the editor's existing enable policy while sharing preparation and

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager.swift
@@ -59,7 +59,7 @@ final class RuleCollectionsManager {
     var customRules: [CustomRule] = []
     /// Remains set when recovered files cannot yet be read completely.
     var needsRecoveredRuleStateRefresh = false
-    var needsRecoveredRuleRuntimeRefresh = false
+    var observedRuleRecoveryRevision: UInt64 = 0
     var currentLayerName: String = RuleCollectionLayer.base.displayName
 
     /// Active keymap layout ID (e.g., "colemak-dh", "dvorak")

--- a/Tests/KeyPathTests/CustomRuleMutationRecoveryTests.swift
+++ b/Tests/KeyPathTests/CustomRuleMutationRecoveryTests.swift
@@ -62,6 +62,69 @@ final class CustomRuleMutationRecoveryTests: KeyPathTestCase {
         XCTAssertEqual(errors.count, 1)
     }
 
+    func testRawEditorRecoveryRefreshesManagerBeforeItsNextMissingRuleExit() async throws {
+        let originalRules = manager.customRules
+        let before = try files()
+        let service = manager.configurationService
+        try await service.operationGate.withOperation { @MainActor permit in
+            _ = try await service.stageRuleState(ruleCollections: [], customRules: [],
+                                                 collectionStore: self.manager.ruleCollectionStore,
+                                                 customStore: self.manager.customRulesStore, mutationPermit: permit)
+        }
+        manager.customRules = [] // Interrupted candidate still visible to this editor.
+        var reloads = 0
+        let result = await SaveCoordinator(configurationService: service).editConfiguration(transform: { _ in
+            throw CancellationError()
+        }) {
+            reloads += 1
+            return Self.reload(.applied)
+        }
+        XCTAssertFalse(result.success)
+        XCTAssertEqual(reloads, 1)
+        XCTAssertEqual(try files(), before)
+        manager.onRulesChanged = { XCTFail("Recovery already applied through the raw editor"); return Self.reload(.applied) }
+        await manager.toggleCustomRule(id: UUID(), isEnabled: false)
+        XCTAssertEqual(manager.customRules, originalRules)
+    }
+
+    func testMapperSaveRefreshesRuleStateRecoveredByRawEditor() async throws {
+        let original = manager.customRules[0]
+        let service = manager.configurationService
+        try await service.operationGate.withOperation { @MainActor permit in
+            _ = try await service.stageRuleState(ruleCollections: [], customRules: [],
+                                                 collectionStore: self.manager.ruleCollectionStore,
+                                                 customStore: self.manager.customRulesStore, mutationPermit: permit)
+        }
+        manager.customRules = []
+        let owner = SaveCoordinator(configurationService: service)
+        _ = await owner.editConfiguration(transform: { _ in throw CancellationError() }) { Self.reload(.applied) }
+        let saved = await owner.saveMapping(input: "f13", output: "f14", ruleCollectionsManager: manager) { Self.reload(.applied) }
+        XCTAssertTrue(saved.success)
+        XCTAssertTrue(manager.customRules.contains(original))
+        let stored = try await manager.customRulesStore.loadForMutation()
+        XCTAssertTrue(stored.contains(original))
+        XCTAssertTrue(stored.contains { $0.input == "f13" })
+    }
+
+    func testMapperRecoversRuntimeBeforeInputValidationCanReject() async throws {
+        let service = manager.configurationService
+        let before = try files()
+        try await service.operationGate.withOperation { @MainActor permit in
+            _ = try await service.stageRuleState(ruleCollections: [], customRules: [],
+                                                 collectionStore: self.manager.ruleCollectionStore,
+                                                 customStore: self.manager.customRulesStore, mutationPermit: permit)
+        }
+        var reloads = 0
+        let result = await SaveCoordinator(configurationService: service).saveMapping(input: "", output: "f14", ruleCollectionsManager: manager) {
+            reloads += 1
+            XCTAssertEqual(try? self.files(), before)
+            return Self.reload(.applied)
+        }
+        XCTAssertFalse(result.success)
+        XCTAssertEqual(reloads, 1)
+        XCTAssertEqual(try files(), before)
+    }
+
     func testRejectedSaveRestoresFilesAndReportsFailure() async throws {
         try await assertRejectedMutationRestores {
             let saved = await self.manager.saveCustomRule(CustomRule(input: "f13", action: .keystroke(key: "f14")))

--- a/Tests/KeyPathTests/Managers/AppKeymapSaveTests.swift
+++ b/Tests/KeyPathTests/Managers/AppKeymapSaveTests.swift
@@ -76,6 +76,180 @@ final class AppKeymapSaveTests: KeyPathTestCase {
         }
     }
 
+    func testInterruptedAppWriteReloadsOriginalBeforeRejectedEditorCallback() async throws {
+        try await withFixture { fixture in
+            try await self.interruptAppWrite(fixture)
+            var reloads = 0
+            var applied = 0
+            let result = await fixture.coordinator.saveAppKeymaps(store: fixture.store, mutate: { _ in
+                XCTAssertEqual(reloads, 1)
+                XCTAssertEqual(applied, 1)
+                throw CancellationError()
+            }, runtimeDidApply: { applied += 1 }) {
+                reloads += 1
+                do { try self.assertOriginalFiles(fixture) } catch { XCTFail("\(error)") }
+                return Self.reload(.applied)
+            }
+            XCTAssertFalse(result.success)
+            XCTAssertTrue(result.error is CancellationError)
+            if case .idle = fixture.coordinator.saveStatus {} else { XCTFail("Cancellation should leave the editor idle") }
+            XCTAssertEqual(reloads, 1)
+            try self.assertOriginalFiles(fixture)
+        }
+    }
+
+    func testFailedInterruptedRecoveryRetriesWithAnotherSaveOwnerBeforeMutation() async throws {
+        try await withFixture { fixture in
+            try await self.interruptAppWrite(fixture)
+            let failed = await fixture.coordinator.saveAppKeymaps(store: fixture.store, mutate: { _ in
+                XCTFail("Must not edit while recovery is rejected")
+            }) { Self.reload(.rejected) }
+            XCTAssertFalse(failed.success)
+            XCTAssertTrue(failed.error?.localizedDescription.contains("Recovered files could not be applied") == true)
+            XCTAssertFalse(FileManager.default.fileExists(atPath: RecoverableRuleWrite.journalURL(fixture.directory, scope: .appKeymaps).path))
+            var reloads = 0
+            let nextOwner = SaveCoordinator(configurationService: fixture.service)
+            let result = await nextOwner.saveAppKeymaps(store: fixture.store, mutate: { _ in
+                XCTAssertEqual(reloads, 1)
+                throw CancellationError()
+            }) {
+                reloads += 1
+                return Self.reload(.pending)
+            }
+            XCTAssertFalse(result.success)
+            XCTAssertTrue(result.error is CancellationError)
+            XCTAssertEqual(reloads, 1)
+            try self.assertOriginalFiles(fixture)
+        }
+    }
+
+    func testRawTransformRecoversAppWriteBeforeReadingOriginal() async throws {
+        try await withFixture { fixture in
+            try await self.interruptAppWrite(fixture)
+            var reloads = 0
+            let result = await fixture.coordinator.editConfiguration(transform: { content in
+                XCTAssertEqual(reloads, 1)
+                XCTAssertEqual(Data(content.utf8), fixture.before["keypath.kbd"])
+                throw CancellationError()
+            }) {
+                reloads += 1
+                return Self.reload(.applied)
+            }
+            XCTAssertFalse(result.success)
+            XCTAssertTrue(result.error is CancellationError)
+            XCTAssertEqual(reloads, 1)
+            try self.assertOriginalFiles(fixture)
+        }
+    }
+
+    func testRawTransformRechecksRecoveryWithoutDuplicateReload() async throws {
+        try await withFixture { fixture in
+            try await self.interruptAppWrite(fixture)
+            var reloads = 0
+            let result = await fixture.coordinator.editConfiguration(transform: { content in
+                XCTAssertEqual(reloads, 1)
+                return content
+            }) {
+                reloads += 1
+                return Self.reload(.applied)
+            }
+            XCTAssertTrue(result.success)
+            XCTAssertEqual(reloads, 2, "One recovery reload and one accepted edit reload")
+            try self.assertOriginalFiles(fixture)
+        }
+    }
+
+    func testGeneratedValidationCannotSkipInterruptedAppRecovery() async throws {
+        try await withFixture { fixture in
+            try await self.interruptAppWrite(fixture)
+            var reloads = 0
+            let result = await fixture.coordinator.saveGeneratedConfig(content: "(invalid") {
+                reloads += 1
+                return Self.reload(.rejected)
+            }
+            XCTAssertFalse(result.success)
+            XCTAssertEqual(reloads, 1)
+            XCTAssertTrue(result.error?.localizedDescription.contains("Recovered files could not be applied") == true)
+            try self.assertOriginalFiles(fixture)
+        }
+    }
+
+    func testHeadlessRecoveryRetainsRuntimeRequirementForLaterOwner() async throws {
+        try await withFixture { fixture in
+            try await self.interruptAppWrite(fixture)
+            try await fixture.service.recoverPendingAppKeymapWrite(store: fixture.store)
+            let headless = try await fixture.service.operationGate.withOperation { @MainActor permit in
+                try await fixture.service.applyRecoveredRuntimeIfNeeded(mutationPermit: permit, reloadHandler: nil)
+            }
+            XCTAssertNil(headless)
+            var reloads = 0
+            let result = await fixture.coordinator.saveAppKeymaps(store: fixture.store, mutate: { _ in
+                XCTAssertEqual(reloads, 1)
+                throw CancellationError()
+            }) {
+                reloads += 1
+                return Self.reload(.applied)
+            }
+            XCTAssertFalse(result.success)
+            XCTAssertEqual(reloads, 1)
+        }
+    }
+
+    func testRuleEditorRecoversAppWriteBeforeMissingRuleExit() async throws {
+        try await withFixture { fixture in
+            try await self.interruptAppWrite(fixture)
+            let manager = RuleCollectionsManager(
+                ruleCollectionStore: RuleCollectionStore(fileURL: fixture.directory.appendingPathComponent("RuleCollections.json")),
+                customRulesStore: CustomRulesStore(fileURL: fixture.directory.appendingPathComponent("CustomRules.json")),
+                configurationService: fixture.service
+            )
+            var reloads = 0
+            manager.onRulesChanged = {
+                reloads += 1
+                do { try self.assertOriginalFiles(fixture) } catch { XCTFail("\(error)") }
+                return Self.reload(.applied)
+            }
+            await manager.toggleCustomRule(id: UUID(), isEnabled: false)
+            XCTAssertEqual(reloads, 1)
+            try self.assertOriginalFiles(fixture)
+        }
+    }
+
+    func testCancellationDuringRecoveryStillAppliesOriginalBeforeReturning() async throws {
+        try await withFixture { fixture in
+            try await self.interruptAppWrite(fixture)
+            let started = expectation(description: "Recovery started")
+            var resume: CheckedContinuation<Void, Never>?
+            var applied = false
+            let task = Task { @MainActor in
+                await fixture.coordinator.saveAppKeymaps(store: fixture.store, mutate: { _ in
+                    XCTFail("Cancelled editor must not mutate")
+                }, runtimeDidApply: { applied = true }) {
+                    await withCheckedContinuation { continuation in
+                        resume = continuation
+                        started.fulfill()
+                    }
+                    XCTAssertFalse(Task.isCancelled)
+                    return Self.reload(.applied)
+                }
+            }
+            await fulfillment(of: [started], timeout: 5)
+            task.cancel()
+            resume?.resume()
+            let result = await task.value
+            XCTAssertFalse(result.success)
+            XCTAssertTrue(result.error is CancellationError)
+            XCTAssertTrue(applied)
+            try self.assertOriginalFiles(fixture)
+        }
+    }
+
+    private func interruptAppWrite(_ fixture: Fixture) async throws {
+        try await fixture.service.operationGate.withOperation { @MainActor permit in
+            _ = try await fixture.service.stageAppKeymapChange(store: fixture.store, mutationPermit: permit, mutate: Self.addOverride)
+        }
+    }
+
     func testExternalEditDuringRejectedReloadStopsRecoveryWithoutOverwritingIt() async throws {
         try await withFixture { fixture in
             let config = fixture.directory.appendingPathComponent("keypath.kbd")

--- a/docs/architecture/configuration-save-pipeline.md
+++ b/docs/architecture/configuration-save-pipeline.md
@@ -355,3 +355,11 @@ The commit helper optionally receives the prior leader preference. On failure it
 restores that preference before error feedback only if it still equals the prepared
 value; a newer value is preserved and reported. This is in-process preference
 rollback only. UserDefaults is not yet part of the crash-recovery journal.
+
+Interrupted-save runtime admission is owned by `ConfigurationService`. Recovering
+rule or app journals marks a runtime refresh requirement; editor callbacks cannot
+run until the existing reload owner accepts or defers that refresh. Failure retains
+the requirement for later owners sharing the service, even after journal removal.
+Rule-source recovery also advances a revision observed by the manager so recovery
+through an app/raw editor cannot leave that manager's arrays stale. This state is
+in-process and does not replace durable raw-save or cross-process cache recovery.

--- a/docs/bugs/interrupted-save-runtime-admission.md
+++ b/docs/bugs/interrupted-save-runtime-admission.md
@@ -1,0 +1,23 @@
+# Runtime recovery before the next editor callback
+
+Interrupted rule/app writes were restored from their journals during preparation,
+but app and raw editors could then reject a candidate or cancel a callback before
+reloading the restored files. The disk could contain the previous revision while
+the keyboard service still used the interrupted one. A manager-local retry flag
+also could not follow recovery performed by another save coordinator.
+
+ConfigurationService now owns the in-process requirement to apply recovered files.
+Rule and app recovery set it; only an applied or explicitly pending reload clears
+it. Headless calls retain it, and failed reloads can be retried through another save
+coordinator using that service after the journal has been removed. Recovery runs
+through existing reload callbacks without inheriting the editor task's cancellation.
+
+App and raw save entry points recover before invoking a mutation/transform callback
+or validating a candidate. Rule and pack editors check app journals before early
+returns. A rule recovery revision lets a manager refresh its arrays when recovery
+was performed by another editor sharing its configuration service.
+
+This does not make raw saves crash-atomic or coordinate caches across distinct
+ConfigurationService instances/processes. The runtime retry marker is in-process;
+startup still needs to establish runtime readiness. Preferences, managed-pack
+snapshots, and revision-aware watching remain separate boundaries.

--- a/docs/planning/catalog-led-consolidation-plan.md
+++ b/docs/planning/catalog-led-consolidation-plan.md
@@ -425,7 +425,7 @@ keep confirmed providers in the same transaction. Existing enable policies and
 newly-enabled Boolean semantics remain. Leader/single-output settings, collection
 toggles, replace-all, preferences, managed snapshots, and watching remain open.
 
-### Collection toggles and leader recovery in progress
+### Collection toggles and leader recovery merged in #1284
 
 Toggles, replace-all, single-output editing, and direct leader edits now retain
 rule snapshots through application. Leader preference rollback happens before
@@ -441,3 +441,11 @@ backup from the same evening. Startup free space recovered to 112 GiB; the faile
 CI job was retried and passed before merge. Network backups and active updater
 caches were preserved. External scratch routing (#1261) still awaits the runner's
 normal removable-volume permission; this recovery does not complete that migration.
+
+### Interrupted-save runtime admission in progress
+
+Move the runtime recovery retry requirement into ConfigurationService and recover
+before app/raw editor callbacks, candidate validation, and rule/pack early returns.
+Managers observe rule-source recovery performed through another editor sharing the
+service. This closes an in-process cross-editor gap; raw journals, preferences,
+managed snapshots, cross-instance/process caches, and watcher revisions remain open.


### PR DESCRIPTION
## Problem and result

After an interrupted rule/app save, the next app or raw edit could restore files and then reject or cancel before reloading them. The keyboard service could keep the discarded revision. The manager-local retry flag also could not follow recovery performed by another editor.

ConfigurationService now retains the runtime recovery requirement until its existing reload owner accepts or defers it. App/raw edits recover before reading, transforming, or validating a candidate. Rule/pack edits check app journals before early returns. A recovery revision makes managers reload source arrays recovered through another editor sharing the service. Recovery retains operation admission and runs without inheriting editor cancellation; failed and headless attempts remain retryable after journal removal.

This is in-process coordination through the shared service. Raw-save journaling, preferences, managed-pack snapshots, cross-instance/process cache freshness, and revision-aware watching remain separate work. Existing handwritten-config preservation, pending outcomes, and presentation remain.

## Validation

103 focused XCTest cases passed, including eight new regressions for rejected/cancelled callbacks, retry through another save coordinator, raw transforms/validation, headless recovery, missing-rule exits, task cancellation during recovery, and stale manager arrays. Pinned SwiftFormat and accessibility checks passed. Full safe suite completed in 170 seconds: 5,259 passed, with only the four previously documented macOS 27 snapshot mismatches (HomeRowTimingFastTyping, HomeRowTimingPerFinger, HomeRowTimingSlider, RepairSettingsTabView). No compiler warnings.

Remote review gate selected; GitHub claude-review required before merge. Installer matrix coverage: Running and TCP responding; Running but TCP not responding. Signed/notarized deployment follows merge; no public release.

Review follow-up: re-arm app/raw watcher suppression after potentially slow recovery, before preparing the new write. The raw transform deliberately rechecks under the same retained operation permit; a new regression verifies exactly one recovery reload plus one edit reload. All 54 final focused XCTest cases passed. Revision-aware watching remains the durable follow-up.

Second review follow-up: mapper saves now refresh recovered manager state before snapshot, validation, or mutation; regressions cover a raw editor recovering its journal first and a mapper validation early exit. Cancellation returns idle unless recovery itself failed. All save kinds share keypath.kbd, so a corrupt journal deliberately blocks app/raw writes too: proceeding would risk overwriting the unresolved revision. App staging already had this rule-journal prerequisite; recovery now occurs before callbacks.

Final verification after mapper/cancellation follow-up: 5,262 full-suite passes with only the same four baseline snapshots, 163 seconds, zero compiler warnings. The final focused mapper/app/raw run passed all 78 XCTest cases.

Final review rationale: SaveCoordinator.saveRuleState commits an already prepared manager under its retained permit. Its production callers are saveMapping (now explicit recovery before snapshot), commitRuleMutation (recovery before each mutation), and PackInstaller.commitPreparedPackRules (recoverAndValidateState before preparation). Re-running source recovery there could discard the prepared candidate; stageRuleState still checks pending journals at its file boundary. Incomplete source decoding deliberately stops the edit and retains both refresh requirements for retry; it does not claim runtime success. Existing source-decoding retry regressions remain green.
