### PR TITLE
Retain raw configuration recovery through runtime application

### DIFF
--- a/Sources/KeyPathAppKit/Infrastructure/Config/ConfigurationService.swift
+++ b/Sources/KeyPathAppKit/Infrastructure/Config/ConfigurationService.swift
@@ -430,17 +430,56 @@ public final class ConfigurationService: FileConfigurationProviding {
                 packTargets["installedPacks"] = directory.appendingPathComponent("installed-packs.json")
             }
             let packFiles = packTargets
+            let rawFiles = ["config": URL(fileURLWithPath: configurationPath)]
             let recovered = try await performRuleFileOperation {
+                let rawRecovered = try RecoverableRuleWrite.recover(files: rawFiles, directory: directory, scope: .rawConfig)
                 let packRecovered = try RecoverableRuleWrite.recover(files: packFiles, directory: directory, scope: .packRules)
                 let rulesRecovered = try RecoverableRuleWrite.recover(files: files, directory: directory)
-                return packRecovered || rulesRecovered
+                return (raw: rawRecovered, rules: packRecovered || rulesRecovered)
             }
-            if recovered {
+            if recovered.raw || recovered.rules {
                 stateLock.withLock { currentConfiguration = nil }
                 needsRecoveredRuntimeRefresh = true
-                ruleRecoveryRevision &+= 1
             }
-            return recovered
+            if recovered.rules { ruleRecoveryRevision &+= 1 }
+            return recovered.rules
+        }
+    }
+
+    struct RawConfigurationWrite: Sendable {
+        let pending: RecoverableRuleWrite.PendingWrite
+    }
+
+    /// Raw editing owns only the main file. Sidecars and handwritten syntax are
+    /// preserved; the expected original detects edits during validation/preparation.
+    func stageRawConfiguration(content: String, expectedContent: String,
+                               mutationPermit: ConfigurationOperationGate.Permit) async throws -> RawConfigurationWrite
+    {
+        try await operationGate.withOperation(using: mutationPermit) { @MainActor [self] _ in
+            let files = ["config": URL(fileURLWithPath: configurationPath)]
+            let directory = URL(fileURLWithPath: configDirectory)
+            try Task.checkCancellation()
+            let pending = try await performRuleFileOperation {
+                try RecoverableRuleWrite.stage(files: files, contents: ["config": Data(content.utf8)],
+                                               directory: directory, scope: .rawConfig,
+                                               expectedBefore: ["config": Data(expectedContent.utf8)])
+            }
+            return RawConfigurationWrite(pending: pending)
+        }
+    }
+
+    func settleRawConfiguration(_ write: RawConfigurationWrite, commit: Bool,
+                                requireRuntimeRecovery: Bool = false,
+                                mutationPermit: ConfigurationOperationGate.Permit) async throws
+    {
+        try await operationGate.withOperation(using: mutationPermit) { @MainActor [self] _ in
+            try await performRuleFileOperation {
+                if commit { try RecoverableRuleWrite.commit(write.pending) }
+                else { try RecoverableRuleWrite.rollback(write.pending) }
+            }
+            stateLock.withLock { currentConfiguration = nil }
+            if commit { needsRecoveredRuntimeRefresh = false }
+            else if requireRuntimeRecovery { needsRecoveredRuntimeRefresh = true }
         }
     }
 

--- a/Sources/KeyPathAppKit/Infrastructure/Config/RecoverableRuleWrite.swift
+++ b/Sources/KeyPathAppKit/Infrastructure/Config/RecoverableRuleWrite.swift
@@ -10,12 +10,14 @@ enum RecoverableRuleWrite {
         case rules
         case appKeymaps
         case packRules
+        case rawConfig
 
         var roles: Set<String> {
             switch self {
             case .rules: ["config", "collections", "customRules"]
             case .appKeymaps: ["config", "appKeymaps", "appInclude"]
             case .packRules: ["config", "collections", "customRules", "installedPacks"]
+            case .rawConfig: ["config"]
             }
         }
     }
@@ -234,14 +236,21 @@ enum RecoverableRuleWrite {
         case .rules: ".keypath-rule-write.json"
         case .appKeymaps: ".keypath-app-write.json"
         case .packRules: ".keypath-pack-rule-write.json"
+        case .rawConfig: ".keypath-raw-write.json"
         }
         return directory.appendingPathComponent(name)
     }
 
     private static func validateFiles(_ files: [String: URL], directory: URL, scope: Scope) throws {
         let targets = Set(files.values.map(\.standardizedFileURL))
-        let reserved = Set([journalURL(directory), journalURL(directory, scope: .appKeymaps), journalURL(directory, scope: .packRules), directory.appendingPathComponent(".keypath-rule-write.lock")]
-            .map(\.standardizedFileURL))
+        let reserved = Set([
+            journalURL(directory),
+            journalURL(directory, scope: .appKeymaps),
+            journalURL(directory, scope: .packRules),
+            journalURL(directory, scope: .rawConfig),
+            directory.appendingPathComponent(".keypath-rule-write.lock")
+        ]
+        .map(\.standardizedFileURL))
         guard Set(files.keys) == scope.roles,
               targets.count == files.count, targets.isDisjoint(with: reserved)
         else { throw Failure.invalidJournal }

--- a/Sources/KeyPathAppKit/Managers/SaveCoordinator.swift
+++ b/Sources/KeyPathAppKit/Managers/SaveCoordinator.swift
@@ -9,14 +9,16 @@ protocol SaveCoordinatorDelegate: AnyObject {
     func configDidUpdate(mappings: [KeyMapping])
 }
 
-/// Rule and app-keymap recovery include source files and an explicit reload result.
-/// Legacy config-only recovery does not claim source or runtime restoration.
+/// Retained writes report their recovery scope and runtime outcome.
+/// Legacy explicit restore does not claim source or runtime restoration.
 enum SaveRecoveryResult {
     case notAttempted
     case restoredPreviousAppKeymapState(reloadResult: ReloadResult?)
     case appKeymapRecoveryFailed(Error)
     case restoredPreviousRuleState(reloadResult: ReloadResult?)
     case ruleStateRecoveryFailed(Error)
+    case restoredPreviousRawConfig(reloadResult: ReloadResult?)
+    case rawConfigRecoveryFailed(Error)
     case restoredPreviousConfig
     case wroteMinimalSafeConfig(backupError: Error?)
     case failed(backupError: Error?, fallbackError: Error)
@@ -300,19 +302,36 @@ final class SaveCoordinator {
 
     /// Run before reading a candidate or invoking an editor callback: either can
     /// exit without staging, but an interrupted prior edit still needs recovery.
+    @discardableResult
     private func recoverBeforeEditing(
         appStore: AppKeymapStore? = nil,
+        allowInvalidRawRecovery: Bool = false,
         mutationPermit: ConfigurationOperationGate.Permit,
         runtimeDidApply: @escaping @MainActor @Sendable () async -> Void,
         reloadHandler: @escaping () async -> ReloadResult
-    ) async throws {
+    ) async throws -> Error? {
         try await configurationService.recoverPendingRuleWrite(mutationPermit: mutationPermit)
         try await configurationService.recoverPendingAppKeymapWrite(store: appStore, mutationPermit: mutationPermit)
-        let recovery = try await configurationService.applyRecoveredRuntimeIfNeeded(mutationPermit: mutationPermit, reloadHandler: reloadHandler)
-        if recovery?.disposition == .applied {
-            await Task { @MainActor in await runtimeDidApply() }.value
+        do {
+            let recovery = try await configurationService.applyRecoveredRuntimeIfNeeded(mutationPermit: mutationPermit, reloadHandler: reloadHandler)
+            if recovery?.disposition == .applied {
+                await Task { @MainActor in await runtimeDidApply() }.value
+            }
+        } catch {
+            // Journal conflicts remain blocking. Only a raw replacement may
+            // supersede restored content that fails validation; the replacement
+            // must independently validate and be accepted before recovery clears.
+            guard allowInvalidRawRecovery else { throw error }
+            let current = try await snapshotCurrentConfig(mutationPermit: mutationPermit)
+            let validation = await configurationService.validateConfiguration(current)
+            guard !validation.isValid else { throw error }
+            if Task.isCancelled {
+                throw SaveApplicationError(cause: CancellationError(), recovery: error.localizedDescription)
+            }
+            return error
         }
         try Task.checkCancellation()
+        return nil
     }
 
     /// Capture and transform raw content under the same admission as its save.
@@ -321,17 +340,19 @@ final class SaveCoordinator {
         runtimeDidApply: @escaping @MainActor @Sendable () async -> Void = {},
         reloadHandler: @escaping @MainActor @Sendable () async -> ReloadResult
     ) async -> SaveResult {
+        var deferredRecovery: Error?
         do {
             return try await configurationService.operationGate.withOperation { @MainActor [self] permit in
-                try await recoverBeforeEditing(mutationPermit: permit, runtimeDidApply: runtimeDidApply, reloadHandler: reloadHandler)
+                deferredRecovery = try await recoverBeforeEditing(allowInvalidRawRecovery: true, mutationPermit: permit, runtimeDidApply: runtimeDidApply, reloadHandler: reloadHandler)
                 let original = try await snapshotCurrentConfig(mutationPermit: permit)
                 let content = try transform(original)
                 return await saveGeneratedConfig(content: content, mutationPermit: permit, expectedContent: original,
                                                  runtimeDidApply: runtimeDidApply, reloadHandler: reloadHandler)
             }
         } catch {
-            saveStatus = error is CancellationError ? .idle : .failed(error.localizedDescription)
-            return .failure(error)
+            let reportedError: Error = deferredRecovery.map { SaveApplicationError(cause: error, recovery: $0.localizedDescription) } ?? error
+            saveStatus = reportedError is CancellationError ? .idle : .failed(reportedError.localizedDescription)
+            return .failure(reportedError)
         }
     }
 
@@ -354,104 +375,60 @@ final class SaveCoordinator {
                 configFileWatcher?.suppressEvents(for: 1.0, reason: "Internal saveGeneratedConfiguration")
                 saveStatus = .saving
 
+                var staged: ConfigurationService.RawConfigurationWrite?
+                var reload: ReloadResult?
+                var deferredRecovery: Error?
                 do {
-                    try await recoverBeforeEditing(mutationPermit: permit, runtimeDidApply: runtimeDidApply, reloadHandler: reloadHandler)
-                    // Step 1: Validate generated config before saving
-                    AppLogger.shared.debug(
-                        "🔍 [SaveCoordinator] Validating generated config before save..."
-                    )
+                    deferredRecovery = try await recoverBeforeEditing(allowInvalidRawRecovery: true, mutationPermit: permit, runtimeDidApply: runtimeDidApply, reloadHandler: reloadHandler)
                     let validation = await configurationService.validateConfiguration(content)
-
-                    if !validation.isValid {
-                        AppLogger.shared.error(
-                            "❌ [SaveCoordinator] Generated config validation failed: \(validation.errors.joined(separator: ", "))"
-                        )
-                        saveStatus = .failed(
-                            "Invalid config: \(validation.errors.first ?? "Unknown error")"
-                        )
-                        return .failure(
-                            KeyPathError.configuration(.validationFailed(errors: validation.errors))
-                        )
+                    guard validation.isValid else {
+                        throw KeyPathError.configuration(.validationFailed(errors: validation.errors))
                     }
-
-                    AppLogger.shared.info("✅ [SaveCoordinator] Generated config validation passed")
-
-                    configFileWatcher?.suppressEvents(for: 1.0, reason: "Internal generated save after recovery")
-
-                    // Step 2: Backup current config
                     let previousContent = try await snapshotCurrentConfig(mutationPermit: permit)
                     if let expectedContent, previousContent != expectedContent {
                         throw KeyPathError.configuration(.loadFailed(reason: "The configuration changed while this edit was being prepared. Reload mappings and try again."))
                     }
                     try Task.checkCancellation()
                     backupCurrentConfig(previousContent)
-
-                    // Step 3: Write the configuration file
-                    let configPath = configurationService.configurationPath
-                    let configDir = configurationService.configDirectory
-
-                    let configDirURL = URL(fileURLWithPath: configDir)
-                    try Foundation.FileManager().createDirectory(
-                        at: configDirURL, withIntermediateDirectories: true
-                    )
-
-                    let configURL = URL(fileURLWithPath: configPath)
-                    try content.write(to: configURL, atomically: true, encoding: .utf8)
-
-                    AppLogger.shared.info(
-                        "✅ [SaveCoordinator] Generated configuration saved to \(configPath)"
-                    )
-
-                    // Step 4: Parse saved config to extract mappings
-                    let parsedMappings = parseConfig(content)
-
-                    // Step 5: Play write sound
+                    configFileWatcher?.suppressEvents(for: 1.0, reason: "Internal raw save after recovery")
+                    staged = try await configurationService.stageRawConfiguration(content: content, expectedContent: previousContent, mutationPermit: permit)
+                    try Task.checkCancellation()
                     playWriteSound()
-
-                    // Step 6: Trigger reload for validation
-                    let reloadResult = await reloadHandler()
-
-                    if reloadResult.disposition == .applied || reloadResult.disposition == .pending {
-                        if reloadResult.disposition == .applied {
-                            AppLogger.shared.info(
-                                "✅ [SaveCoordinator] TCP reload successful, config is active"
-                            )
-                        } else {
-                            AppLogger.shared.info(
-                                "ℹ️ [SaveCoordinator] Config saved; reload pending: \(reloadResult.errorMessage ?? "service unavailable")"
-                            )
-                        }
-                        if reloadResult.disposition == .applied {
-                            // Settle applied runtime state even if a newer edit cancelled this task.
-                            await Task { @MainActor in await runtimeDidApply() }.value
-                        }
-                        playSuccessSound()
-                        saveStatus = .success
-                        scheduleStatusReset()
-                        return .success(mappings: parsedMappings, reloadResult: reloadResult)
-                    } else {
-                        // TCP reload failed - restore backup
-                        let errorMessage = reloadResult.errorMessage ?? "TCP server unresponsive"
-                        AppLogger.shared.error("❌ [SaveCoordinator] TCP reload FAILED: \(errorMessage)")
-
-                        playErrorSound()
-                        let recoveryResult = await restoreConfig(previousContent, mutationPermit: permit)
-
-                        saveStatus = .failed("Config reload failed: \(errorMessage)")
-                        return .failure(
-                            KeyPathError.configuration(
-                                .loadFailed(reason: "Hot reload failed: \(errorMessage)")
-                            ),
-                            reloadResult: reloadResult,
-                            recoveryResult: recoveryResult
-                        )
+                    let result = await reloadHandler()
+                    reload = result
+                    guard result.disposition == .applied || result.disposition == .pending else {
+                        throw KeyPathError.configuration(.loadFailed(reason: result.errorMessage ?? "The configuration could not be applied"))
                     }
-
+                    guard let staged else { throw AppConfigError.validationUnavailable }
+                    // Preserve the existing raw-editor contract: an accepted revision
+                    // settles even if a newer editor task cancelled this one meanwhile.
+                    try await configurationService.settleRawConfiguration(staged, commit: true, mutationPermit: permit)
+                    if result.disposition == .applied {
+                        await Task { @MainActor in await runtimeDidApply() }.value
+                    }
+                    playSuccessSound()
+                    saveStatus = .success
+                    scheduleStatusReset()
+                    return .success(mappings: parseConfig(content), reloadResult: result)
                 } catch {
-                    saveStatus = .failed(
-                        "Failed to save generated configuration: \(error.localizedDescription)"
-                    )
-                    return .failure(error)
+                    var recovery: SaveRecoveryResult = .notAttempted
+                    var reportedError: Error = deferredRecovery.map { SaveApplicationError(cause: error, recovery: $0.localizedDescription) } ?? error
+                    if let staged {
+                        do {
+                            try await configurationService.settleRawConfiguration(staged, commit: false, requireRuntimeRecovery: reload != nil, mutationPermit: permit)
+                            let recovered = try await configurationService.applyRecoveredRuntimeIfNeeded(mutationPermit: permit, reloadHandler: reloadHandler)
+                            if recovered?.disposition == .applied {
+                                await Task { @MainActor in await runtimeDidApply() }.value
+                            }
+                            recovery = .restoredPreviousRawConfig(reloadResult: recovered)
+                        } catch let recoveryError {
+                            recovery = .rawConfigRecoveryFailed(recoveryError)
+                            reportedError = SaveApplicationError(cause: error, recovery: recoveryError.localizedDescription)
+                        }
+                    }
+                    if !(reportedError is CancellationError) { playErrorSound() }
+                    saveStatus = reportedError is CancellationError ? .idle : .failed(reportedError.localizedDescription)
+                    return .failure(reportedError, reloadResult: reload, recoveryResult: recovery)
                 }
             }
         } catch {
@@ -469,17 +446,33 @@ final class SaveCoordinator {
     /// Ensure we have a backup by loading the current config if none exists.
     /// Call this early in the app lifecycle so rollback always has a fallback.
     func ensureBackupExists() async {
-        guard lastGoodConfig == nil else { return }
-        let current = await configurationService.current()
-        if !current.content.isEmpty {
-            lastGoodConfig = current.content
-            AppLogger.shared.log("💾 [SaveCoordinator] Initialized backup from current config on disk")
+        do {
+            try await configurationService.operationGate.withOperation { @MainActor [self] permit in
+                guard lastGoodConfig == nil else { return }
+                try await configurationService.recoverPendingRuleWrite(mutationPermit: permit)
+                try await configurationService.recoverPendingAppKeymapWrite(mutationPermit: permit)
+                let current = await configurationService.current(mutationPermit: permit)
+                if !current.content.isEmpty {
+                    lastGoodConfig = current.content
+                    AppLogger.shared.log("💾 [SaveCoordinator] Initialized backup from recovered config on disk")
+                }
+            }
+        } catch {
+            AppLogger.shared.error("Could not prepare configuration backup: \(error.localizedDescription)")
         }
     }
 
     @discardableResult
     func restoreLastGoodConfig() async throws -> SaveRecoveryResult {
         try await configurationService.operationGate.withOperation { @MainActor [self] permit in
+            // A non-directory cannot contain a journal. Preserve the explicit
+            // restore contract's backup/fallback write errors for that broken path.
+            var isDirectory: ObjCBool = false
+            let exists = FileManager.default.fileExists(atPath: configurationService.configDirectory, isDirectory: &isDirectory)
+            if !exists || isDirectory.boolValue {
+                try await configurationService.recoverPendingRuleWrite(mutationPermit: permit)
+                try await configurationService.recoverPendingAppKeymapWrite(mutationPermit: permit)
+            }
             let result = await restoreConfig(lastGoodConfig, mutationPermit: permit)
             // Preserve the throwing contract for existing explicit-restore callers.
             if case let .failed(backupError, fallbackError) = result {

--- a/Sources/KeyPathAppKit/Services/SimpleMods/SimpleModsService.swift
+++ b/Sources/KeyPathAppKit/Services/SimpleMods/SimpleModsService.swift
@@ -204,6 +204,12 @@ public final class SimpleModsService {
             lastRollbackDetails = nil
             let cause = result.error?.localizedDescription ?? "The mappings could not be saved."
             switch result.recoveryResult {
+            case .restoredPreviousRawConfig:
+                lastRollbackReason = cause
+                lastRollbackDetails = "The previous configuration file was restored."
+                lastError = cause
+            case .rawConfigRecoveryFailed:
+                lastError = cause
             case .restoredPreviousConfig:
                 lastRollbackReason = cause
                 lastRollbackDetails = "The previous configuration file was restored. Runtime recovery has not been verified."

--- a/Tests/KeyPathTests/Managers/SaveCoordinatorTests.swift
+++ b/Tests/KeyPathTests/Managers/SaveCoordinatorTests.swift
@@ -159,8 +159,8 @@ final class SaveCoordinatorTests: KeyPathTestCase {
 
         let result = await coordinator.saveGeneratedConfig(content: updated) {
             reloadCount += 1
-            XCTAssertEqual(try? String(contentsOf: url, encoding: .utf8), updated, file: file, line: line)
-            return expected
+            XCTAssertEqual(try? String(contentsOf: url, encoding: .utf8), reloadCount == 1 ? updated : original, file: file, line: line)
+            return reloadCount == 1 ? expected : ReloadResult(success: true, response: "recovered", errorMessage: nil, protocol: nil)
         }
 
         let saved = disposition == .applied || disposition == .pending
@@ -170,7 +170,7 @@ final class SaveCoordinatorTests: KeyPathTestCase {
                 return XCTFail("Successful saves must not claim recovery", file: file, line: line)
             }
         } else {
-            guard case .restoredPreviousConfig = result.recoveryResult else {
+            guard case .restoredPreviousRawConfig = result.recoveryResult else {
                 return XCTFail("Rejected/failed reload must report restored file", file: file, line: line)
             }
         }
@@ -179,7 +179,7 @@ final class SaveCoordinatorTests: KeyPathTestCase {
         XCTAssertEqual(result.reloadResult?.success, expected.success, file: file, line: line)
         XCTAssertEqual(result.reloadResult?.response, expected.response, file: file, line: line)
         XCTAssertEqual(result.reloadResult?.errorMessage, expected.errorMessage, file: file, line: line)
-        XCTAssertEqual(reloadCount, 1, file: file, line: line)
+        XCTAssertEqual(reloadCount, saved ? 1 : 2, file: file, line: line)
         XCTAssertEqual(try String(contentsOf: url, encoding: .utf8), saved ? updated : original, file: file, line: line)
     }
 
@@ -210,13 +210,18 @@ final class SaveCoordinatorTests: KeyPathTestCase {
         var releaseFirst: CheckedContinuation<Void, Never>?
         let coordinator = try XCTUnwrap(coordinator)
 
+        var firstReloadCount = 0
         let first = Task { @MainActor in
             await coordinator.saveGeneratedConfig(content: firstContent) {
-                await withCheckedContinuation { continuation in
-                    releaseFirst = continuation
-                    firstReloadStarted.fulfill()
+                firstReloadCount += 1
+                if firstReloadCount == 1 {
+                    await withCheckedContinuation { continuation in
+                        releaseFirst = continuation
+                        firstReloadStarted.fulfill()
+                    }
+                    return ReloadResult(success: false, response: nil, errorMessage: "rejected", protocol: nil, disposition: .rejected)
                 }
-                return ReloadResult(success: false, response: nil, errorMessage: "rejected", protocol: nil, disposition: .rejected)
+                return ReloadResult(success: true, response: "recovered", errorMessage: nil, protocol: nil)
             }
         }
         await fulfillment(of: [firstReloadStarted], timeout: 5)
@@ -325,7 +330,10 @@ final class SaveCoordinatorTests: KeyPathTestCase {
         let url = URL(fileURLWithPath: configService.configurationPath)
         XCTAssertFalse(FileManager.default.fileExists(atPath: url.path))
         var initializedContent: String?
+        var reloads = 0
         let result = await coordinator.saveGeneratedConfig(content: updated) {
+            reloads += 1
+            if reloads > 1 { return ReloadResult(success: true, response: "recovered", errorMessage: nil, protocol: nil) }
             initializedContent = await self.configService.current().content
             XCTAssertEqual(try? String(contentsOf: url, encoding: .utf8), updated)
             return ReloadResult(success: false, response: nil, errorMessage: "rejected", protocol: nil, disposition: .rejected)
@@ -441,7 +449,7 @@ final class SaveCoordinatorTests: KeyPathTestCase {
 
     // MARK: - Rollback Fallback Tests
 
-    func testGeneratedSaveReportsMinimalFallbackWhenPreviousFileIsEmpty() async throws {
+    func testGeneratedSaveRestoresExactEmptyFileAndReportsRejectedRecovery() async throws {
         try await assertRecoveryOutcome(mapping: false, blockWrites: false)
     }
 
@@ -449,7 +457,7 @@ final class SaveCoordinatorTests: KeyPathTestCase {
         try await assertRecoveryOutcome(mapping: true, blockWrites: false)
     }
 
-    func testGeneratedSavePreservesBothRecoveryErrorsAndReleasesOperation() async throws {
+    func testGeneratedSaveReportsJournalRecoveryFailureAndReleasesOperation() async throws {
         try await assertRecoveryOutcome(mapping: false, blockWrites: true)
     }
 
@@ -514,13 +522,12 @@ final class SaveCoordinatorTests: KeyPathTestCase {
             }
             return
         }
-        XCTAssertEqual(reloadCount, 1, "Recovery must not issue a second reload")
         if blockWrites {
-            guard case let .failed(backupError, fallbackError) = result.recoveryResult else {
-                return XCTFail("Both recovery failures must be returned")
+            XCTAssertEqual(reloadCount, 1)
+            guard case .rawConfigRecoveryFailed = result.recoveryResult else {
+                return XCTFail("Raw journal recovery failure must be returned")
             }
-            XCTAssertNotNil(backupError)
-            XCTAssertFalse(fallbackError.localizedDescription.isEmpty)
+            XCTAssertTrue(result.error?.localizedDescription.contains("Recovery needs attention") == true)
             XCTAssertEqual(try String(contentsOf: tempDir, encoding: .utf8), "blocked")
             try FileManager.default.removeItem(at: tempDir)
             try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
@@ -531,14 +538,12 @@ final class SaveCoordinatorTests: KeyPathTestCase {
             XCTAssertTrue(next.success, "Failed recovery must release the save operation")
             XCTAssertEqual(try String(contentsOf: url, encoding: .utf8), updated)
         } else {
-            guard case let .wroteMinimalSafeConfig(backupError) = result.recoveryResult else {
-                return XCTFail("An empty prior file must report minimal fallback, not restoration")
+            XCTAssertEqual(reloadCount, 2)
+            guard case .rawConfigRecoveryFailed = result.recoveryResult else {
+                return XCTFail("Rejected runtime recovery must be reported")
             }
-            XCTAssertNotNil(backupError)
-            let content = try String(contentsOf: url, encoding: .utf8)
-            XCTAssertTrue(content.contains("(deflayer base)"))
-            XCTAssertNotEqual(content, original)
-            XCTAssertNotEqual(content, updated)
+            XCTAssertTrue(result.error?.localizedDescription.contains("Recovered files could not be applied") == true)
+            XCTAssertEqual(try String(contentsOf: url, encoding: .utf8), original)
         }
     }
 

--- a/Tests/KeyPathTests/Managers/SharedConfigurationAdmissionTests.swift
+++ b/Tests/KeyPathTests/Managers/SharedConfigurationAdmissionTests.swift
@@ -11,13 +11,24 @@ final class SharedConfigurationAdmissionTests: KeyPathTestCase {
             let entered = self.expectation(description: "first reload entered")
             let started = self.expectation(description: "collection edit requested")
             var resume: CheckedContinuation<Void, Never>?
+            let recovering = self.expectation(description: "recovery reload entered")
+            var resumeRecovery: CheckedContinuation<Void, Never>?
+            var reloads = 0
             let first = Task { @MainActor in
                 await coordinator.saveGeneratedConfig(content: "(defcfg)\n(defsrc a)\n(deflayer base b)") {
-                    await withCheckedContinuation { continuation in
-                        resume = continuation
-                        entered.fulfill()
+                    reloads += 1
+                    if reloads == 1 {
+                        await withCheckedContinuation { continuation in
+                            resume = continuation
+                            entered.fulfill()
+                        }
+                        return ReloadResult(success: false, response: nil, errorMessage: "reject", protocol: nil, disposition: .rejected)
                     }
-                    return ReloadResult(success: false, response: nil, errorMessage: "reject", protocol: nil, disposition: .rejected)
+                    await withCheckedContinuation { continuation in
+                        resumeRecovery = continuation
+                        recovering.fulfill()
+                    }
+                    return ReloadResult(success: true, response: "recovered", errorMessage: nil, protocol: nil)
                 }
             }
             await self.fulfillment(of: [entered], timeout: 5)
@@ -29,9 +40,13 @@ final class SharedConfigurationAdmissionTests: KeyPathTestCase {
             await self.fulfillment(of: [started], timeout: 5)
             XCTAssertTrue(manager.customRules.isEmpty, "Queued edits must not stage state before admission")
             resume?.resume()
+            await self.fulfillment(of: [recovering], timeout: 5)
+            XCTAssertTrue(manager.customRules.isEmpty, "Queued mutation must also wait for runtime recovery")
+            resumeRecovery?.resume()
             let firstResult = await first.value
             let secondResult = await second.value
             XCTAssertFalse(firstResult.success)
+            XCTAssertEqual(reloads, 2)
             XCTAssertTrue(secondResult)
             XCTAssertEqual(manager.customRules.map(\.id), [rule.id])
             let stored = await manager.customRulesStore.loadRules()
@@ -95,13 +110,19 @@ final class SharedConfigurationAdmissionTests: KeyPathTestCase {
             let started = self.expectation(description: "second save requested")
             var resume: CheckedContinuation<Void, Never>?
             var secondReloaded = false
+            var reloads = 0
             let first = Task { @MainActor in
                 await firstCoordinator.saveGeneratedConfig(content: "(defcfg)\n(defsrc a)\n(deflayer base b)") {
-                    await withCheckedContinuation { continuation in
-                        resume = continuation
-                        entered.fulfill()
+                    reloads += 1
+                    if reloads == 1 {
+                        await withCheckedContinuation { continuation in
+                            resume = continuation
+                            entered.fulfill()
+                        }
+                        return ReloadResult(success: false, response: nil, errorMessage: "reject", protocol: nil, disposition: .rejected)
                     }
-                    return ReloadResult(success: false, response: nil, errorMessage: "reject", protocol: nil, disposition: .rejected)
+                    XCTAssertFalse(secondReloaded, "The other coordinator must wait through recovery")
+                    return ReloadResult(success: true, response: "recovered", errorMessage: nil, protocol: nil)
                 }
             }
             await self.fulfillment(of: [entered], timeout: 5)
@@ -119,6 +140,7 @@ final class SharedConfigurationAdmissionTests: KeyPathTestCase {
             let rejected = await first.value
             let accepted = await second.value
             XCTAssertFalse(rejected.success)
+            XCTAssertEqual(reloads, 2)
             XCTAssertTrue(accepted.success)
             XCTAssertEqual(try String(contentsOfFile: service.configurationPath, encoding: .utf8), finalContent)
         }

--- a/Tests/KeyPathTests/RawConfigurationRecoveryTests.swift
+++ b/Tests/KeyPathTests/RawConfigurationRecoveryTests.swift
@@ -1,0 +1,255 @@
+import Foundation
+@testable import KeyPathAppKit
+@preconcurrency import XCTest
+
+@MainActor
+final class RawConfigurationRecoveryTests: KeyPathTestCase {
+    private var directory: URL!
+    private var service: ConfigurationService!
+    private var coordinator: SaveCoordinator!
+    private let original = ";; handwritten comment\n(defcfg)\n(defsrc a)\n(deflayer base b)\n"
+    private let proposed = "(defcfg)\n(defsrc a)\n(deflayer base c)\n"
+    private var config: URL {
+        directory.appendingPathComponent("keypath.kbd")
+    }
+
+    private var journal: URL {
+        RecoverableRuleWrite.journalURL(directory, scope: .rawConfig)
+    }
+
+    override func setUp() async throws {
+        try await super.setUp()
+        directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        try original.write(to: config, atomically: true, encoding: .utf8)
+        service = ConfigurationService(configDirectory: directory.path,
+                                       ruleCollectionStore: .testStore(at: directory.appendingPathComponent("RuleCollections.json")),
+                                       customRulesStore: .testStore(at: directory.appendingPathComponent("CustomRules.json")))
+        coordinator = SaveCoordinator(configurationService: service)
+    }
+
+    override func tearDown() async throws {
+        try? FileManager.default.removeItem(at: directory)
+        try? FileManager.default.removeItem(at: ConfigurationOperationGate.lockFileURL(for: directory))
+        coordinator = nil
+        service = nil
+        directory = nil
+        try await super.tearDown()
+    }
+
+    private static func reload(_ disposition: ReloadDisposition) -> ReloadResult {
+        ReloadResult(success: disposition == .applied, response: nil, errorMessage: "injected \(disposition)", protocol: nil, disposition: disposition)
+    }
+
+    private func interruptRawWrite() async throws {
+        try await service.operationGate.withOperation { @MainActor permit in
+            _ = try await self.service.stageRawConfiguration(content: self.proposed, expectedContent: self.original, mutationPermit: permit)
+        }
+        XCTAssertTrue(FileManager.default.fileExists(atPath: journal.path))
+    }
+
+    func testInterruptedRawWriteRecoversBeforeCancelledTransform() async throws {
+        try await interruptRawWrite()
+        var reloads = 0
+        let result = await coordinator.editConfiguration(transform: { content in
+            XCTAssertEqual(reloads, 1)
+            XCTAssertEqual(content, self.original)
+            throw CancellationError()
+        }) {
+            reloads += 1
+            XCTAssertEqual(try? String(contentsOf: self.config, encoding: .utf8), self.original)
+            return Self.reload(.applied)
+        }
+        XCTAssertFalse(result.success)
+        XCTAssertTrue(result.error is CancellationError)
+        XCTAssertEqual(reloads, 1)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: journal.path))
+    }
+
+    func testInterruptedRawWriteRecoversBeforeAppMutation() async throws {
+        try await interruptRawWrite()
+        var reloads = 0
+        let result = await coordinator.saveAppKeymaps(store: AppKeymapStore(fileURL: directory.appendingPathComponent("AppKeymaps.json")), mutate: { _ in
+            XCTAssertEqual(reloads, 1)
+            throw CancellationError()
+        }) {
+            reloads += 1
+            XCTAssertEqual(try? String(contentsOf: self.config, encoding: .utf8), self.original)
+            return Self.reload(.pending)
+        }
+        XCTAssertFalse(result.success)
+        XCTAssertTrue(result.error is CancellationError)
+        XCTAssertEqual(reloads, 1)
+    }
+
+    func testFreshServiceRecoversInterruptedRawWriteBeforeEditing() async throws {
+        try await interruptRawWrite()
+        let fresh = ConfigurationService(configDirectory: directory.path,
+                                         ruleCollectionStore: .testStore(at: directory.appendingPathComponent("RuleCollections.json")),
+                                         customRulesStore: .testStore(at: directory.appendingPathComponent("CustomRules.json")))
+        var reloads = 0
+        let result = await SaveCoordinator(configurationService: fresh).editConfiguration(transform: { content in
+            XCTAssertEqual(content, self.original)
+            throw CancellationError()
+        }) {
+            reloads += 1
+            return Self.reload(.applied)
+        }
+        XCTAssertFalse(result.success)
+        XCTAssertEqual(reloads, 1)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: journal.path))
+    }
+
+    func testChangedOriginalIsPreservedBeforeRawStage() async throws {
+        let external = ";; external edit during preparation"
+        try external.write(to: config, atomically: true, encoding: .utf8)
+        do {
+            try await service.operationGate.withOperation { @MainActor permit in
+                _ = try await self.service.stageRawConfiguration(content: self.proposed, expectedContent: self.original, mutationPermit: permit)
+            }
+            XCTFail("Stale original must be rejected")
+        } catch {
+            XCTAssertTrue(error.localizedDescription.contains("changed outside this operation"))
+        }
+        XCTAssertEqual(try String(contentsOf: config, encoding: .utf8), external)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: journal.path))
+    }
+
+    func testStartupBackupCapturesRecoveredOriginal() async throws {
+        try await interruptRawWrite()
+        await coordinator.ensureBackupExists()
+        XCTAssertFalse(FileManager.default.fileExists(atPath: journal.path))
+        try proposed.write(to: config, atomically: true, encoding: .utf8)
+        _ = try await coordinator.restoreLastGoodConfig()
+        XCTAssertEqual(try String(contentsOf: config, encoding: .utf8), original)
+    }
+
+    func testExplicitRestoreResolvesPendingRawJournalBeforeWritingBackup() async throws {
+        let backup = "(defcfg)\n(defsrc a)\n(deflayer base z)\n"
+        coordinator.backupCurrentConfig(backup)
+        try await interruptRawWrite()
+        _ = try await coordinator.restoreLastGoodConfig()
+        XCTAssertEqual(try String(contentsOf: config, encoding: .utf8), backup)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: journal.path))
+        var reloads = 0
+        let next = await coordinator.editConfiguration(transform: { _ in throw CancellationError() }) {
+            reloads += 1
+            XCTAssertEqual(try? String(contentsOf: self.config, encoding: .utf8), backup)
+            return Self.reload(.applied)
+        }
+        XCTAssertFalse(next.success)
+        XCTAssertEqual(reloads, 1)
+    }
+
+    func testExplicitRestorePreservesUnreadablePendingJournal() async throws {
+        try await interruptRawWrite()
+        let corrupt = Data("invalid journal".utf8)
+        try corrupt.write(to: journal)
+        coordinator.backupCurrentConfig(original)
+        do {
+            _ = try await coordinator.restoreLastGoodConfig()
+            XCTFail("Explicit restore must not bypass a corrupt pending journal")
+        } catch {}
+        XCTAssertEqual(try String(contentsOf: config, encoding: .utf8), proposed)
+        XCTAssertEqual(try Data(contentsOf: journal), corrupt)
+    }
+
+    func testExternalEditDuringRejectedReloadIsPreservedWithJournal() async throws {
+        let external = ";; newer external revision"
+        let result = await coordinator.saveGeneratedConfig(content: proposed) {
+            do { try external.write(to: self.config, atomically: true, encoding: .utf8) }
+            catch { XCTFail("\(error)") }
+            return Self.reload(.rejected)
+        }
+        XCTAssertFalse(result.success)
+        guard case .rawConfigRecoveryFailed = result.recoveryResult else { return XCTFail("Expected preserved recovery conflict") }
+        XCTAssertEqual(try String(contentsOf: config, encoding: .utf8), external)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: journal.path))
+    }
+
+    func testFailedRecoveryIsRetriedBeforeAnotherRawTransform() async throws {
+        var reloads = 0
+        let result = await coordinator.saveGeneratedConfig(content: proposed) {
+            reloads += 1
+            return Self.reload(.rejected)
+        }
+        XCTAssertFalse(result.success)
+        XCTAssertEqual(reloads, 2)
+        guard case .rawConfigRecoveryFailed = result.recoveryResult else { return XCTFail("Recovery rejection must be explicit") }
+        XCTAssertEqual(try String(contentsOf: config, encoding: .utf8), original)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: journal.path))
+        let nextOwner = SaveCoordinator(configurationService: service)
+        let next = await nextOwner.editConfiguration(transform: { _ in
+            XCTAssertEqual(reloads, 3)
+            throw CancellationError()
+        }) {
+            reloads += 1
+            return Self.reload(.applied)
+        }
+        XCTAssertFalse(next.success)
+        XCTAssertTrue(next.error is CancellationError)
+        XCTAssertEqual(reloads, 3)
+    }
+
+    func testValidatedReplacementCanRepairRejectedEmptyOriginal() async throws {
+        try "".write(to: config, atomically: true, encoding: .utf8)
+        let failed = await coordinator.saveGeneratedConfig(content: proposed) { Self.reload(.rejected) }
+        XCTAssertFalse(failed.success)
+        XCTAssertEqual(try String(contentsOf: config, encoding: .utf8), "")
+        let cancelled = await coordinator.editConfiguration(transform: { _ in throw CancellationError() }) { Self.reload(.rejected) }
+        XCTAssertFalse(cancelled.success)
+        XCTAssertFalse(cancelled.error is CancellationError, "Unresolved recovery must remain visible")
+        let invalid = await coordinator.saveGeneratedConfig(content: "") { Self.reload(.rejected) }
+        XCTAssertFalse(invalid.success)
+        XCTAssertEqual(try String(contentsOf: config, encoding: .utf8), "")
+        let corrected = await coordinator.editConfiguration(transform: { current in
+            XCTAssertEqual(current, "")
+            return self.proposed
+        }) {
+            let current = try? String(contentsOf: self.config, encoding: .utf8)
+            return Self.reload(current == self.proposed ? .applied : .rejected)
+        }
+        XCTAssertTrue(corrected.success)
+        XCTAssertEqual(try String(contentsOf: config, encoding: .utf8), proposed)
+        let next = await coordinator.editConfiguration(transform: { _ in throw CancellationError() }) {
+            XCTFail("Accepted replacement must clear previous recovery")
+            return Self.reload(.rejected)
+        }
+        XCTAssertTrue(next.error is CancellationError)
+    }
+
+    func testRawWriteDoesNotTouchSidecarFilesAndRefreshesCommittedCache() async throws {
+        let sidecar = directory.appendingPathComponent("RuleCollections.json")
+        let marker = Data("external source bytes".utf8)
+        try marker.write(to: sidecar)
+        _ = await service.current()
+        let result = await coordinator.saveGeneratedConfig(content: proposed) { Self.reload(.pending) }
+        XCTAssertTrue(result.success)
+        XCTAssertEqual(try Data(contentsOf: sidecar), marker)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: journal.path))
+        let current = await service.current()
+        XCTAssertEqual(current.content, proposed)
+    }
+
+    func testRejectedRawSaveRunsRecoveryWithoutCallerCancellation() async throws {
+        var reloads = 0
+        let owner = try XCTUnwrap(coordinator)
+        let task = Task { @MainActor in
+            await owner.saveGeneratedConfig(content: self.proposed) {
+                reloads += 1
+                if reloads == 1 {
+                    withUnsafeCurrentTask { $0?.cancel() }
+                    return Self.reload(.rejected)
+                }
+                XCTAssertFalse(Task.isCancelled)
+                XCTAssertEqual(try? String(contentsOf: self.config, encoding: .utf8), self.original)
+                return Self.reload(.applied)
+            }
+        }
+        let result = await task.value
+        XCTAssertFalse(result.success)
+        XCTAssertEqual(reloads, 2)
+        guard case let .restoredPreviousRawConfig(reload) = result.recoveryResult else { return XCTFail("Expected verified recovery") }
+        XCTAssertEqual(reload?.disposition, .applied)
+    }
+}

--- a/Tests/KeyPathTests/Services/SimpleModsSaveTests.swift
+++ b/Tests/KeyPathTests/Services/SimpleModsSaveTests.swift
@@ -16,14 +16,18 @@ final class SimpleModsSaveTests: KeyPathTestCase {
             let service = SimpleModsService(configPath: fixture.url.path) { transform in
                 await fixture.coordinator.editConfiguration(transform: transform) {
                     reloads += 1
-                    XCTAssertTrue((try? String(contentsOf: fixture.url, encoding: .utf8))?.contains("f1 f2") == true)
-                    return Self.reload(.rejected)
+                    if reloads == 1 {
+                        XCTAssertTrue((try? String(contentsOf: fixture.url, encoding: .utf8))?.contains("f1 f2") == true)
+                    } else {
+                        XCTAssertEqual(try? String(contentsOf: fixture.url, encoding: .utf8), fixture.original)
+                    }
+                    return Self.reload(reloads == 1 ? .rejected : .applied)
                 }
             }
             try service.load()
             service.addMapping(fromKey: "f1", toKey: "f2")
             await service.flushPendingApplyForTesting()
-            XCTAssertEqual(reloads, 1)
+            XCTAssertEqual(reloads, 2)
             XCTAssertEqual(try String(contentsOf: fixture.url, encoding: .utf8), fixture.original)
             XCTAssertFalse(service.installedMappings.contains { $0.fromKey == "f1" })
             XCTAssertNotNil(service.lastError)

--- a/docs/architecture/configuration-save-pipeline.md
+++ b/docs/architecture/configuration-save-pipeline.md
@@ -363,3 +363,16 @@ the requirement for later owners sharing the service, even after journal removal
 Rule-source recovery also advances a revision observed by the manager so recovery
 through an app/raw editor cannot leave that manager's arrays stale. This state is
 in-process and does not replace durable raw-save or cross-process cache recovery.
+
+Raw/generated saves retain a `rawConfig` journal for the main file through engine
+classification. They restore exact bytes and recover runtime on rejection, preserve
+external conflicts, and invalidate the parsed cache only after settlement. Accepted
+raw revisions still settle under caller cancellation. Explicit restore keeps its
+separate fallback path; ordinary save rollback does not replace an empty original
+with generated content. Raw journal recovery participates in editor admission and
+startup recovery without marking unchanged rule source arrays as stale.
+
+A restored raw original that fails validation may be replaced by a separately
+validated raw edit after recovery reload fails. Only an accepted replacement
+clears that recovery requirement; cancellation, invalid candidates, and journal
+conflicts never silently clear it.

--- a/docs/bugs/raw-save-recovery.md
+++ b/docs/bugs/raw-save-recovery.md
@@ -1,0 +1,27 @@
+# Retained recovery for raw configuration saves
+
+Raw/generated saves used an in-memory backup and restored only the main file after
+an engine rejection. They neither retained a crash journal nor reloaded the restored
+revision. Recovery could overwrite a newer external edit and could replace an empty
+original with a generated fallback while the editor still reported rollback.
+
+Raw saves now retain a config-only journal through reload classification. Applied
+and pending revisions commit; rejection restores the exact previous bytes and uses
+the existing reload owner to recover runtime before returning. A failed recovery
+remains required in ConfigurationService for the next editor. External conflicts
+preserve the external file and journal instead of regenerating a fallback over it.
+A raw corrective edit may proceed when the restored original fails validation and
+cannot reload. Its replacement must independently validate and receive an accepted
+reload before the old recovery requirement clears. Invalid or cancelled corrective
+edits keep the recovery failure visible; journal conflicts still block all edits.
+Other source/sidecar files are not part of a raw edit. Existing first-run config
+initialization still precedes the captured backup when the main file is absent.
+
+Startup backup capture, explicit restore, and subsequent rule/app/raw editors recover the raw journal through the
+shared configuration owner. Raw-only recovery does not imply that rule source
+arrays changed. Explicit restore retains its separate fallback behavior; ordinary
+failed saves no longer take that path. Accepted raw saves still settle when a newer
+editor task has cancelled the original caller, preserving the existing contract.
+
+This does not make preferences or managed-pack snapshots crash-atomic and does not
+solve cross-instance/process cache freshness or revision-aware file watching.

--- a/docs/planning/catalog-led-consolidation-plan.md
+++ b/docs/planning/catalog-led-consolidation-plan.md
@@ -442,10 +442,18 @@ CI job was retried and passed before merge. Network backups and active updater
 caches were preserved. External scratch routing (#1261) still awaits the runner's
 normal removable-volume permission; this recovery does not complete that migration.
 
-### Interrupted-save runtime admission in progress
+### Interrupted-save runtime admission merged in #1285
 
 Move the runtime recovery retry requirement into ConfigurationService and recover
 before app/raw editor callbacks, candidate validation, and rule/pack early returns.
 Managers observe rule-source recovery performed through another editor sharing the
 service. This closes an in-process cross-editor gap; raw journals, preferences,
 managed snapshots, cross-instance/process caches, and watcher revisions remain open.
+
+### Raw configuration recovery in progress
+
+Move raw/generated/Simple Modifications saves onto a retained config-only journal,
+including exact rollback, conflict preservation, runtime recovery, and startup/next
+editor recovery. Preserve accepted-save cancellation semantics and explicit-restore
+fallback behavior. Preferences, managed-pack snapshots, cross-instance/process
+cache freshness, and watcher revisions remain open.


### PR DESCRIPTION
## Problem and result

Raw/generated configuration saves used an in-memory backup and restored only the file after a rejected reload. An interrupted process lost that backup; rollback could overwrite a newer external edit or replace an empty original with a generated fallback while the service still used the rejected configuration.

Raw saves now retain a config-only journal until the existing reload owner accepts or defers the revision. Rejection restores the exact original and recovers runtime before returning. External conflicts preserve the file and journal; failed runtime recovery stays retryable through the configuration service. Startup backup capture and explicit restore resolve pending journals first, so they cannot adopt or overwrite an interrupted revision. Parsed caches refresh after settlement. Sidecars remain outside a raw edit.

Accepted raw saves retain their existing cancellation semantics. Explicit restore retains its separate fallback behavior, and initial missing-file creation still precedes the captured backup. Preferences, managed-pack snapshots, cross-instance/process cache freshness, and revision-aware watching remain open. There is no UI redesign or public release.

## Validation

100 focused save tests and 35 focused admission/recovery tests passed. After review correction, 61 focused tests passed. The final full safe suite completed in 158 seconds: 5,274 passed with only the four known macOS 27 snapshot mismatches (HomeRowTimingFastTyping, HomeRowTimingPerFinger, HomeRowTimingSlider, RepairSettingsTabView), no crash, and zero compiler warnings. Pinned SwiftFormat and accessibility checks passed. Regressions cover raw-to-raw/app recovery, a fresh service recovering an interrupted journal, external changes before/during save, rejected recovery retry, sidecar preservation and cache freshness, uncancelled runtime recovery, startup backup capture, and explicit restore with an interrupted journal. Existing save/Simple Modifications fixtures now require compensating reload and exact empty-file recovery instead of fallback generation.

Remote review gate selected; GitHub claude-review required before merge. Installer matrix coverage: Running and TCP responding; Running but TCP not responding. Signed/notarized deployment follows merge.

An earlier broad run hit a runner signal crash in an old admission fixture whose reload mock suspended/fulfilled the same expectation again during the new compensating reload. The fixtures now model rejection and recovery separately and assert that queued mutations wait through both; the focused and full reruns completed. Explicit restore still returns both backup/fallback write errors when the config path is a non-directory, which cannot contain a pending journal. Corrupt journals in valid directories remain blocking and preserved.

## Review follow-up

A restored invalid or empty raw file must not block every corrective save. Raw editors now defer a failed runtime recovery only when the current file fails validation, and require independent replacement validation plus accepted reload before clearing it. Invalid or cancelled corrective edits still report unresolved recovery. Journal errors remain blocking. Error feedback uses the final recovery-aware error.

Startup backup capture deliberately refuses a corrupt pending journal: those bytes cannot be trusted as a last-good revision. Explicit restore preserves that journal and file rather than bypassing it; the regression test covers this boundary.

Final review's two observations are intentional: rejection performs one compensating reload through the existing reload owner so restored bytes are actually applied, rather than reporting file-only rollback as runtime recovery. This adds a bounded recovery attempt with the owner's existing timeout behavior. Exact restoration also deliberately preserves an empty original instead of synthesizing unrequested content; the new corrective-save regression proves that a validated replacement remains possible when that original cannot load. Explicit user-requested restore keeps its fallback behavior.
