### PR TITLE
Recover keymap changes with retained rule state

### DIFF
--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+Keymap.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+Keymap.swift
@@ -20,10 +20,19 @@ extension RuleCollectionsManager {
         await withRuleMutation(failure: []) { [self] permit in
             AppLogger.shared.log("⌨️ [RuleCollections] Setting active keymap to '\(keymapId)' (punctuation: \(includePunctuation))")
 
-            let previousKeymapId = activeKeymapId
-            let previousPunctuation = keymapIncludesPunctuation
-            let previousKeymapIndex = ruleCollections.firstIndex { $0.id == RuleCollectionIdentifier.keymapLayout }
-            let previousKeymapCollection = previousKeymapIndex.map { ruleCollections[$0] }
+            let keymapBefore = (id: activeKeymapId, includePunctuation: keymapIncludesPunctuation)
+            do {
+                try await recoverRuleState(mutationPermit: permit)
+            } catch {
+                KeymapPreferences.restoreFailedSelection(
+                    attemptedID: keymapId, attemptedPunctuation: includePunctuation,
+                    previousID: keymapBefore.id, previousPunctuation: keymapBefore.includePunctuation,
+                    userDefaults: keymapPreferences
+                )
+                if !(error is CancellationError) { onError?(error.localizedDescription) }
+                return []
+            }
+            let snapshot = snapshotRuleState()
             activeKeymapId = keymapId
             keymapIncludesPunctuation = includePunctuation
 
@@ -53,26 +62,9 @@ extension RuleCollectionsManager {
                 AppLogger.shared.log("⌨️ [RuleCollections] QWERTY selected - no keymap collection needed")
             }
 
-            // Persist preferences only after the config/source-store write succeeds.
-            let success = await regenerateConfigFromCollections(mutationPermit: permit)
-            if success {
+            refreshLayerIndicatorState()
+            if await commitRuleMutation(snapshot: snapshot, failureContext: "keyboard layout", keymapBefore: keymapBefore, mutationPermit: permit) {
                 await persistKeymapState()
-            } else {
-                AppLogger.shared.log("⌨️ [RuleCollections] Keymap change failed - rolling back")
-                activeKeymapId = previousKeymapId
-                keymapIncludesPunctuation = previousPunctuation
-                // The overlay optimistically updates its shared display preferences
-                // before invoking this operation. Revert only this attempted selection;
-                // a newer UI choice must survive an older failed completion.
-                KeymapPreferences.restoreFailedSelection(
-                    attemptedID: keymapId, attemptedPunctuation: includePunctuation,
-                    previousID: previousKeymapId, previousPunctuation: previousPunctuation,
-                    userDefaults: keymapPreferences
-                )
-                ruleCollections.removeAll { $0.id == RuleCollectionIdentifier.keymapLayout }
-                if let previousKeymapCollection, let previousKeymapIndex {
-                    ruleCollections.insert(previousKeymapCollection, at: min(previousKeymapIndex, ruleCollections.count))
-                }
             }
 
             return conflicts

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+Mutation.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+Mutation.swift
@@ -91,9 +91,11 @@ extension RuleCollectionsManager {
     /// candidate without regenerating over the recovered or externally edited files.
     @discardableResult
     func commitRuleMutation(snapshot: RuleStateSnapshot, skipReload: Bool = false, failureContext: String? = nil, leaderPreferenceBefore: LeaderKeyPreference? = nil,
+                            keymapBefore: (id: String, includePunctuation: Bool)? = nil,
                             mutationPermit: ConfigurationOperationGate.Permit) async -> Bool
     {
         let preparedLeaderPreference = PreferencesService.shared.leaderKeyPreference
+        let preparedKeymap = (id: activeKeymapId, includePunctuation: keymapIncludesPunctuation)
         let result = await SaveCoordinator(configurationService: configurationService).saveRuleState(
             manager: self, mutationPermit: mutationPermit, reloadHandler: skipReload ? nil : onRulesChanged
         )
@@ -107,6 +109,15 @@ extension RuleCollectionsManager {
                 } else {
                     preferenceRecoveryDetail = " A newer leader-key preference was preserved."
                 }
+            }
+            if let keymapBefore {
+                activeKeymapId = keymapBefore.id
+                keymapIncludesPunctuation = keymapBefore.includePunctuation
+                KeymapPreferences.restoreFailedSelection(
+                    attemptedID: preparedKeymap.id, attemptedPunctuation: preparedKeymap.includePunctuation,
+                    previousID: keymapBefore.id, previousPunctuation: keymapBefore.includePunctuation,
+                    userDefaults: keymapPreferences
+                )
             }
             refreshLayerIndicatorState()
             if let error = result.error, !(error is CancellationError) {

--- a/Tests/KeyPathTests/RuleCollections/KeymapPreferenceRollbackTests.swift
+++ b/Tests/KeyPathTests/RuleCollections/KeymapPreferenceRollbackTests.swift
@@ -112,6 +112,131 @@ final class KeymapPreferenceRollbackTests: KeyPathTestCase {
         }
     }
 
+    func testRejectedReloadRestoresExactFilesAndPreferencesBeforeFeedback() async throws {
+        try await withManager(blockWrites: false) { manager, preferences in
+            _ = await manager.setActiveKeymap(LogicalKeymap.dvorak.id, includePunctuation: false)
+            let originalCollections = manager.ruleCollections
+            let before = try await self.files(manager)
+            preferences.set(LogicalKeymap.colemak.id, forKey: KeymapPreferences.keymapIdKey)
+            preferences.set(
+                KeymapPreferences.updatedIncludePunctuationStore(from: "{}", keymapId: LogicalKeymap.colemak.id, includePunctuation: true),
+                forKey: KeymapPreferences.includePunctuationStoreKey
+            )
+            var reloads = 0
+            var errors = 0
+            manager.onRulesChanged = {
+                reloads += 1
+                if reloads == 2 {
+                    do { let restored = try await self.files(manager); XCTAssertEqual(restored, before) }
+                    catch { XCTFail("\(error)") }
+                }
+                return Self.reload(reloads == 1 ? .rejected : .applied)
+            }
+            manager.onError = { _ in
+                errors += 1
+                XCTAssertEqual(manager.activeKeymapId, LogicalKeymap.dvorak.id)
+                XCTAssertFalse(manager.keymapIncludesPunctuation)
+                XCTAssertEqual(manager.ruleCollections, originalCollections)
+                XCTAssertEqual(preferences.string(forKey: KeymapPreferences.keymapIdKey), LogicalKeymap.dvorak.id)
+            }
+            _ = await manager.setActiveKeymap(LogicalKeymap.colemak.id, includePunctuation: true)
+            XCTAssertEqual(reloads, 2)
+            XCTAssertEqual(errors, 1)
+            let after = try await self.files(manager)
+            XCTAssertEqual(after, before)
+            XCTAssertEqual(preferences.string(forKey: "activeKeymapId"), LogicalKeymap.dvorak.id)
+        }
+    }
+
+    func testExternalConfigDuringFailedKeymapSaveIsPreserved() async throws {
+        try await withManager(blockWrites: false) { manager, _ in
+            _ = await manager.setActiveKeymap(LogicalKeymap.dvorak.id, includePunctuation: false)
+            let url = URL(fileURLWithPath: manager.configurationService.configurationPath)
+            let external = ";; external editor revision"
+            var reloads = 0
+            var message: String?
+            manager.onError = { message = $0 }
+            manager.onRulesChanged = {
+                reloads += 1
+                do { try external.write(to: url, atomically: true, encoding: .utf8) }
+                catch { XCTFail("\(error)") }
+                return Self.reload(.rejected)
+            }
+            _ = await manager.setActiveKeymap(LogicalKeymap.colemak.id, includePunctuation: true)
+            XCTAssertEqual(reloads, 1)
+            XCTAssertEqual(try String(contentsOf: url, encoding: .utf8), external)
+            XCTAssertEqual(manager.activeKeymapId, LogicalKeymap.dvorak.id)
+            XCTAssertTrue(message?.contains("Recovery needs attention") == true)
+            XCTAssertTrue(FileManager.default.fileExists(atPath: RecoverableRuleWrite.journalURL(url.deletingLastPathComponent()).path))
+        }
+    }
+
+    func testInterruptedStateRecoversBeforeKeymapSnapshot() async throws {
+        try await withManager(blockWrites: false) { manager, _ in
+            manager.ruleCollections = RuleCollectionCatalog().defaultCollections().map { collection in
+                var disabled = collection
+                disabled.isEnabled = false
+                return disabled
+            }
+            manager.customRules = [CustomRule(input: "f20", action: .keystroke(key: "f19"), createdAt: Date(timeIntervalSince1970: 42))]
+            _ = await manager.setActiveKeymap(LogicalKeymap.dvorak.id, includePunctuation: false)
+            let originalRules = manager.customRules
+            let before = try await self.files(manager)
+            let service = manager.configurationService
+            try await service.operationGate.withOperation { @MainActor permit in
+                _ = try await service.stageRuleState(ruleCollections: [], customRules: [], collectionStore: manager.ruleCollectionStore,
+                                                     customStore: manager.customRulesStore, mutationPermit: permit)
+            }
+            manager.customRules = []
+            var reloads = 0
+            manager.onRulesChanged = {
+                reloads += 1
+                if reloads != 2 {
+                    do { let restored = try await self.files(manager); XCTAssertEqual(restored, before) }
+                    catch { XCTFail("\(error)") }
+                }
+                return Self.reload(reloads == 2 ? .rejected : .applied)
+            }
+            _ = await manager.setActiveKeymap(LogicalKeymap.colemak.id, includePunctuation: true)
+            XCTAssertEqual(reloads, 3, "Recover old operation, reject new edit, then recover the old layout")
+            XCTAssertEqual(manager.customRules, originalRules)
+            XCTAssertEqual(manager.activeKeymapId, LogicalKeymap.dvorak.id)
+            let after = try await self.files(manager)
+            XCTAssertEqual(after, before)
+        }
+    }
+
+    func testRejectedReloadPreservesNewerOverlaySelection() async throws {
+        try await withManager(blockWrites: false) { manager, preferences in
+            _ = await manager.setActiveKeymap(LogicalKeymap.dvorak.id, includePunctuation: false)
+            preferences.set(LogicalKeymap.colemak.id, forKey: KeymapPreferences.keymapIdKey)
+            preferences.set(
+                KeymapPreferences.updatedIncludePunctuationStore(from: "{}", keymapId: LogicalKeymap.colemak.id, includePunctuation: true),
+                forKey: KeymapPreferences.includePunctuationStoreKey
+            )
+            var reloads = 0
+            manager.onRulesChanged = {
+                reloads += 1
+                if reloads == 1 { preferences.set(LogicalKeymap.systemId, forKey: KeymapPreferences.keymapIdKey) }
+                return Self.reload(reloads == 1 ? .rejected : .applied)
+            }
+            _ = await manager.setActiveKeymap(LogicalKeymap.colemak.id, includePunctuation: true)
+            XCTAssertEqual(manager.activeKeymapId, LogicalKeymap.dvorak.id)
+            XCTAssertEqual(preferences.string(forKey: KeymapPreferences.keymapIdKey), LogicalKeymap.systemId)
+        }
+    }
+
+    private static func reload(_ disposition: ReloadDisposition) -> ReloadResult {
+        ReloadResult(success: disposition == .applied, response: nil, errorMessage: "injected \(disposition)", protocol: nil, disposition: disposition)
+    }
+
+    private func files(_ manager: RuleCollectionsManager) async throws -> [String: Data] {
+        let paths = await ["config": URL(fileURLWithPath: manager.configurationService.configurationPath),
+                           "collections": manager.ruleCollectionStore.persistenceURL,
+                           "customRules": manager.customRulesStore.persistenceURL]
+        return try paths.mapValues { try Data(contentsOf: $0) }
+    }
+
     private func withManager(blockWrites: Bool, test: @MainActor (RuleCollectionsManager, UserDefaults) async throws -> Void) async throws {
         let suite = "KeymapRollbackTests.\(UUID().uuidString)"
         let preferences = try XCTUnwrap(UserDefaults(suiteName: suite))

--- a/docs/architecture/configuration-save-pipeline.md
+++ b/docs/architecture/configuration-save-pipeline.md
@@ -376,3 +376,9 @@ A restored raw original that fails validation may be replaced by a separately
 validated raw edit after recovery reload fails. Only an accepted replacement
 clears that recovery requirement; cancellation, invalid candidates, and journal
 conflicts never silently clear it.
+
+Logical keymap changes use the same retained rule-state transaction as collection
+edits. The manager recovers before candidate preparation and restores its layout
+fields plus the matching optimistic display preference on failure. Persistent
+keymap preferences update only after accepted settlement; they are not yet part
+of the durable file journal.

--- a/docs/bugs/keymap-save-recovery.md
+++ b/docs/bugs/keymap-save-recovery.md
@@ -1,0 +1,15 @@
+# Recover keymap edits with their rule sources
+
+Changing the logical keymap prepared a collection and regenerated configuration
+through the legacy save path. A rejected reload could leave generated/source files
+on the attempted layout while the in-memory keymap fields reverted.
+
+Keymap changes now recover interrupted operations before preparing their candidate
+and use the retained rule-state transaction. Rejection restores the exact config
+and source files, then restores the manager's keymap fields and the matching
+optimistic display preference before reporting the error. A newer display choice
+is preserved. External-file conflicts retain the newer file and recovery journal.
+
+The existing custom-rule conflict warning and pending-save policy are unchanged.
+UserDefaults preferences still require durable crash recovery; this change only
+makes their in-process rollback consistent with rule-source settlement.

--- a/docs/planning/catalog-led-consolidation-plan.md
+++ b/docs/planning/catalog-led-consolidation-plan.md
@@ -457,3 +457,10 @@ including exact rollback, conflict preservation, runtime recovery, and startup/n
 editor recovery. Preserve accepted-save cancellation semantics and explicit-restore
 fallback behavior. Preferences, managed-pack snapshots, cross-instance/process
 cache freshness, and watcher revisions remain open.
+
+### Keymap save recovery in progress
+
+Move logical keymap changes onto retained rule-state settlement. Recover interrupted
+writes before preparing the layout, restore keymap fields and matching optimistic
+display preferences before failure feedback, and preserve newer display choices.
+Preferences remain in-process state; durable preference recovery remains open.


### PR DESCRIPTION
## Problem and result

A rejected logical-keymap change could restore the selected layout in memory while leaving rule-source and generated files on the attempted layout. Keymap changes now recover interrupted writes before preparation and use the retained rule-state transaction. Failure restores exact files and keymap fields, then restores the matching optimistic display preference before reporting the error. Newer display selections and external config edits are preserved.

The existing conflict warning and pending-save behavior are preserved. UserDefaults preferences are still outside the durable journal; crash-atomic preferences, managed-pack snapshots, and watcher/cache revision handling remain separate work.

## Validation

Nine focused keymap tests passed with zero compiler warnings. Coverage includes pending settlement, exact three-file rollback before feedback, interrupted-write recovery before snapshot, external-edit conflict preservation, and newer display selections. The full safe suite completed in 170 seconds with 5,278 passed, only the four known macOS 27 snapshot mismatches (HomeRowTimingFastTyping, HomeRowTimingPerFinger, HomeRowTimingSlider, RepairSettingsTabView), and zero compiler warnings.

Remote review gate selected; GitHub claude-review must pass before merge. Signed/notarized deployment follows merge. No public release or UI redesign.

Review note: the final `activeKeymapId` assertion intentionally checks the persisted manager/engine keymap field written by `persistKeymapState`, while `KeymapPreferences.keymapIdKey` checks the separate optimistic display preference. Both are asserted in that test. Replacing the former with the display constant would remove persistent-state coverage.
