### PR TITLE
Commit collection-backed packs with their installation records

### DIFF
--- a/Sources/KeyPathAppKit/Services/Packs/PackInstaller.swift
+++ b/Sources/KeyPathAppKit/Services/Packs/PackInstaller.swift
@@ -277,12 +277,13 @@ public final class PackInstaller {
                 return record
             }
 
-            // Collection-backed packs (e.g. Home Row Mods) don't generate custom
-            // rules — they just toggle the built-in RuleCollection on.
+            // Commit the collection and installation record as one revision.
             if let collectionID = pack.associatedCollectionID {
-                let ruleStateSnapshot = manager.snapshotRuleState()
-                let previousInstallRecord = await installedPackTracker.record(for: pack.id)
-                let ok = await manager.toggleCollection(
+                let record = InstalledPackRecord(
+                    packID: pack.id, version: pack.version,
+                    installedAt: Date(), quickSettingValues: resolvedSettings
+                )
+                let result = await manager.toggleCollectionResult(
                     id: collectionID,
                     isEnabled: true,
                     autoResolveConflicts: autoResolveCollectionConflicts,
@@ -290,40 +291,11 @@ public final class PackInstaller {
                     configurationOverride: collectionConfiguration,
                     additionalCollectionIDsToDisable: additionalCollectionIDsToDisable,
                     skipReload: skipFinalReload,
+                    packRecord: .init(tracker: installedPackTracker, record: record),
                     mutationPermit: permit
                 )
-                if !ok {
-                    throw InstallError.saveFailed("could not enable associated rule collection")
-                }
-
-                let record = InstalledPackRecord(
-                    packID: pack.id,
-                    version: pack.version,
-                    installedAt: Date(),
-                    quickSettingValues: resolvedSettings
-                )
-                do {
-                    try await installedPackTracker.upsert(record)
-                } catch {
-                    AppLogger.shared.errorUnlessQuietTest(
-                        "❌ [PackInstaller] Could not persist install record for '\(pack.name)'; restoring previous rule state"
-                    )
-                    let installRecordRestored = await restoreInstallRecord(
-                        previousInstallRecord,
-                        packID: pack.id,
-                        installedPackTracker: installedPackTracker
-                    )
-                    let rollbackApplied = await manager.rollbackToSnapshot(
-                        ruleStateSnapshot,
-                        userMessage: "Could not record this pack installation. Your previous rule state was restored.",
-                        mutationPermit: permit
-                    )
-                    guard rollbackApplied, installRecordRestored else {
-                        throw InstallError.saveFailed(
-                            "installed-pack record could not be saved and the previous state could not be fully restored"
-                        )
-                    }
-                    throw error
+                guard result.success else {
+                    throw InstallError.saveFailed(result.error?.localizedDescription ?? "could not enable associated rule collection")
                 }
                 AppLogger.shared.log(
                     "✅ [PackInstaller] Installed pack '\(pack.name)' via collection toggle (id=\(collectionID))"
@@ -412,11 +384,11 @@ public final class PackInstaller {
             if let pack = PackRegistry.pack(id: packID),
                let collectionID = pack.associatedCollectionID
             {
-                let ok = await manager.toggleCollection(id: collectionID, isEnabled: false, bypassOwnershipCheck: true, mutationPermit: permit)
-                guard ok else {
-                    throw InstallError.saveFailed("could not disable associated rule collection")
+                let result = await manager.toggleCollectionResult(id: collectionID, isEnabled: false, bypassOwnershipCheck: true,
+                                                                  packRecord: .init(tracker: installedPackTracker, removing: packID), mutationPermit: permit)
+                guard result.success else {
+                    throw InstallError.saveFailed(result.error?.localizedDescription ?? "could not disable associated rule collection")
                 }
-                try await installedPackTracker.remove(packID: packID)
                 AppLogger.shared.log(
                     "✅ [PackInstaller] Uninstalled pack '\(packID)' via collection toggle off (id=\(collectionID))"
                 )

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+Mutation.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+Mutation.swift
@@ -87,17 +87,30 @@ extension RuleCollectionsManager {
         }
     }
 
+    /// Compatibility for editor callers that only need committed/not committed.
+    @discardableResult
+    func commitRuleMutation(snapshot: RuleStateSnapshot, skipReload: Bool = false, failureContext: String? = nil,
+                            leaderPreferenceBefore: LeaderKeyPreference? = nil,
+                            keymapBefore: (id: String, includePunctuation: Bool)? = nil,
+                            mutationPermit: ConfigurationOperationGate.Permit) async -> Bool
+    {
+        await commitRuleMutationResult(snapshot: snapshot, skipReload: skipReload, failureContext: failureContext,
+                                       leaderPreferenceBefore: leaderPreferenceBefore, keymapBefore: keymapBefore,
+                                       mutationPermit: mutationPermit).success
+    }
+
     /// The save owner restores files/runtime; the manager restores its in-memory
     /// candidate without regenerating over the recovered or externally edited files.
     @discardableResult
-    func commitRuleMutation(snapshot: RuleStateSnapshot, skipReload: Bool = false, failureContext: String? = nil, leaderPreferenceBefore: LeaderKeyPreference? = nil,
-                            keymapBefore: (id: String, includePunctuation: Bool)? = nil,
-                            mutationPermit: ConfigurationOperationGate.Permit) async -> Bool
+    func commitRuleMutationResult(snapshot: RuleStateSnapshot, skipReload: Bool = false, failureContext: String? = nil, leaderPreferenceBefore: LeaderKeyPreference? = nil,
+                                  keymapBefore: (id: String, includePunctuation: Bool)? = nil,
+                                  packRecord: InstalledPackTracker.RecordChange? = nil,
+                                  mutationPermit: ConfigurationOperationGate.Permit) async -> SaveResult
     {
         let preparedLeaderPreference = PreferencesService.shared.leaderKeyPreference
         let preparedKeymap = (id: activeKeymapId, includePunctuation: keymapIncludesPunctuation)
         let result = await SaveCoordinator(configurationService: configurationService).saveRuleState(
-            manager: self, mutationPermit: mutationPermit, reloadHandler: skipReload ? nil : onRulesChanged
+            manager: self, mutationPermit: mutationPermit, packRecord: packRecord, reloadHandler: skipReload ? nil : onRulesChanged
         )
         guard result.success else {
             ruleCollections = snapshot.collections
@@ -125,9 +138,9 @@ extension RuleCollectionsManager {
                 onError?(message + preferenceRecoveryDetail)
                 SoundManager.shared.playErrorSound()
             }
-            return false
+            return result
         }
         NotificationCenter.default.post(name: .ruleCollectionsChanged, object: nil)
-        return true
+        return result
     }
 }

--- a/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+PublicAPI.swift
+++ b/Sources/KeyPathAppKit/Services/RuleCollections/RuleCollectionsManager+PublicAPI.swift
@@ -49,129 +49,153 @@ extension RuleCollectionsManager {
         skipReload: Bool = false,
         mutationPermit: ConfigurationOperationGate.Permit? = nil
     ) async -> Bool {
-        await withRuleMutation(using: mutationPermit, failure: false) { [self] permit in
-            AppLogger.shared.log("🔀 [RuleCollections] toggleCollection called: id=\(id), isEnabled=\(isEnabled)")
+        await toggleCollectionResult(id: id, isEnabled: isEnabled, autoResolveConflicts: autoResolveConflicts,
+                                     bypassOwnershipCheck: bypassOwnershipCheck, configurationOverride: configurationOverride,
+                                     additionalCollectionIDsToDisable: additionalCollectionIDsToDisable, skipReload: skipReload,
+                                     mutationPermit: mutationPermit).success
+    }
 
-            guard let snapshot = await recoverAndSnapshotRuleState(mutationPermit: permit) else { return false }
-            if !bypassOwnershipCheck {
-                if let owner = await InstalledPackTracker.shared.packManagingCollection(id) {
-                    AppLogger.shared.log(
-                        "🔒 [RuleCollections] Toggle blocked: collection \(id) is managed by pack '\(owner.packName)'"
-                    )
-                    return false
-                }
-            }
+    @discardableResult
+    func toggleCollectionResult(
+        id: UUID,
+        isEnabled: Bool,
+        autoResolveConflicts: Bool = false,
+        bypassOwnershipCheck: Bool = false,
+        configurationOverride: RuleCollectionConfiguration? = nil,
+        additionalCollectionIDsToDisable: Set<UUID> = [],
+        skipReload: Bool = false,
+        packRecord: InstalledPackTracker.RecordChange? = nil,
+        mutationPermit: ConfigurationOperationGate.Permit? = nil
+    ) async -> SaveResult {
+        do {
+            return try await configurationService.operationGate.withOperation(using: mutationPermit) { @MainActor [self] permit in
+                AppLogger.shared.log("🔀 [RuleCollections] toggleCollection called: id=\(id), isEnabled=\(isEnabled)")
 
-            let leaderPreferenceSnapshot = PreferencesService.shared.leaderKeyPreference
-
-            let catalogMatch = RuleCollectionCatalog().defaultCollections().first { $0.id == id }
-            AppLogger.shared.log("🔀 [RuleCollections] catalogMatch=\(catalogMatch?.name ?? "nil")")
-            guard var candidate = ruleCollections.first(where: { $0.id == id }) ?? catalogMatch else {
-                return false
-            }
-            candidate.isEnabled = isEnabled
-            if let configurationOverride {
-                candidate.configuration = configurationOverride
-            }
-
-            if !isEnabled {
-                guard await confirmedDisableOfProvider(
-                    id: candidate.id,
-                    name: candidate.name
-                ) else {
-                    return false
-                }
-            }
-
-            // Ensure home row mods config exists if this is a home row mods collection.
-            if candidate.displayStyle == .homeRowMods,
-               case .homeRowMods = candidate.configuration
-            {
-                // Already configured.
-            } else if candidate.displayStyle == .homeRowMods {
-                candidate.configuration = .homeRowMods(HomeRowModsConfig())
-            }
-
-            var prerequisiteProviderIDs: [UUID] = []
-            if isEnabled {
-                guard let confirmedProviderIDs = await confirmedPrerequisiteProviderIDs(
-                    for: candidate,
-                    operation: .enable,
-                    disablingCollectionIDs: additionalCollectionIDsToDisable
-                ) else {
-                    return false
-                }
-                prerequisiteProviderIDs = confirmedProviderIDs
-
-                if let conflict = conflictInfo(
-                    for: candidate,
-                    ignoringCollectionIDs: additionalCollectionIDsToDisable
-                ) {
-                    if autoResolveConflicts {
+                try await recoverRuleState(mutationPermit: permit)
+                let snapshot = snapshotRuleState()
+                if !bypassOwnershipCheck {
+                    if let owner = await InstalledPackTracker.shared.packManagingCollection(id) {
                         AppLogger.shared.log(
-                            "🔄 [RuleCollections] Auto-resolving conflict: \(candidate.name) wins over \(conflict.displayName) on \(conflict.keys)"
+                            "🔒 [RuleCollections] Toggle blocked: collection \(id) is managed by pack '\(owner.packName)'"
                         )
-                        await disableConflicting(conflict.source, regenerate: false)
-                    } else {
-                        let context = RuleConflictContext(
-                            newRule: .collection(candidate),
-                            existingRule: conflict.source,
-                            conflictingKeys: conflict.keys
-                        )
+                        return .failure(KeyPathError.configuration(.validationFailed(errors: ["Collection is managed by \(owner.packName); change it through that pack."])))
+                    }
+                }
 
-                        AppLogger.shared.log(
-                            "⚠️ [RuleCollections] Conflict enabling \(candidate.name) vs \(conflict.displayName) on \(conflict.keys)"
-                        )
+                let leaderPreferenceSnapshot = PreferencesService.shared.leaderKeyPreference
 
-                        guard let choice = await onConflictResolution?(context) else {
-                            return false
-                        }
+                let catalogMatch = RuleCollectionCatalog().defaultCollections().first { $0.id == id }
+                AppLogger.shared.log("🔀 [RuleCollections] catalogMatch=\(catalogMatch?.name ?? "nil")")
+                guard var candidate = ruleCollections.first(where: { $0.id == id }) ?? catalogMatch else {
+                    return .failure(KeyPathError.configuration(.validationFailed(errors: ["No matching collection was found."])))
+                }
+                candidate.isEnabled = isEnabled
+                if let configurationOverride {
+                    candidate.configuration = configurationOverride
+                }
 
-                        switch choice {
-                        case .keepNew:
+                if !isEnabled {
+                    guard await confirmedDisableOfProvider(
+                        id: candidate.id,
+                        name: candidate.name
+                    ) else {
+                        return .failure(KeyPathError.configuration(.validationFailed(errors: ["Disabling \(candidate.name) was declined."])))
+                    }
+                }
+
+                // Ensure home row mods config exists if this is a home row mods collection.
+                if candidate.displayStyle == .homeRowMods,
+                   case .homeRowMods = candidate.configuration
+                {
+                    // Already configured.
+                } else if candidate.displayStyle == .homeRowMods {
+                    candidate.configuration = .homeRowMods(HomeRowModsConfig())
+                }
+
+                var prerequisiteProviderIDs: [UUID] = []
+                if isEnabled {
+                    guard let confirmedProviderIDs = await confirmedPrerequisiteProviderIDs(
+                        for: candidate,
+                        operation: .enable,
+                        disablingCollectionIDs: additionalCollectionIDsToDisable
+                    ) else {
+                        return .failure(KeyPathError.configuration(.validationFailed(errors: ["Required collections were not enabled; \(candidate.name) was left unchanged."])))
+                    }
+                    prerequisiteProviderIDs = confirmedProviderIDs
+
+                    if let conflict = conflictInfo(
+                        for: candidate,
+                        ignoringCollectionIDs: additionalCollectionIDsToDisable
+                    ) {
+                        if autoResolveConflicts {
+                            AppLogger.shared.log(
+                                "🔄 [RuleCollections] Auto-resolving conflict: \(candidate.name) wins over \(conflict.displayName) on \(conflict.keys)"
+                            )
                             await disableConflicting(conflict.source, regenerate: false)
-                        case .keepExisting:
-                            return false
+                        } else {
+                            let context = RuleConflictContext(
+                                newRule: .collection(candidate),
+                                existingRule: conflict.source,
+                                conflictingKeys: conflict.keys
+                            )
+
+                            AppLogger.shared.log(
+                                "⚠️ [RuleCollections] Conflict enabling \(candidate.name) vs \(conflict.displayName) on \(conflict.keys)"
+                            )
+
+                            guard let choice = await onConflictResolution?(context) else {
+                                return .failure(KeyPathError.configuration(.validationFailed(errors: ["The mapping conflict was not resolved; \(candidate.name) was left unchanged."])))
+                            }
+
+                            switch choice {
+                            case .keepNew:
+                                await disableConflicting(conflict.source, regenerate: false)
+                            case .keepExisting:
+                                return .failure(KeyPathError.configuration(.validationFailed(errors: ["The existing mapping was kept; \(candidate.name) was not enabled."])))
+                            }
                         }
                     }
                 }
-            }
 
-            for index in ruleCollections.indices where
-                additionalCollectionIDsToDisable.contains(ruleCollections[index].id)
-                && ruleCollections[index].id != candidate.id
-            {
-                ruleCollections[index].isEnabled = false
-            }
-
-            applyPrerequisiteChangeInMemory(
-                candidate: candidate,
-                providerIDs: prerequisiteProviderIDs
-            )
-
-            AppLogger.shared.log("🔀 [RuleCollections] After toggle - collections: \(ruleCollections.map { "\($0.name) (enabled: \($0.isEnabled))" }.joined(separator: ", "))")
-
-            // Special handling: If Leader Key collection is toggled off, reset all momentary activators to default (space)
-            if id == RuleCollectionIdentifier.leaderKey {
-                if isEnabled {
-                    let key = leaderKeyOutput(from: candidate) ?? leaderPreferenceSnapshot.key
-                    syncLeaderKeyPreference(key: key, enabled: true)
-                } else {
-                    syncLeaderKeyPreference(enabled: false)
-                    applyLeaderKeyToMomentaryActivators("space")
+                for index in ruleCollections.indices where
+                    additionalCollectionIDsToDisable.contains(ruleCollections[index].id)
+                    && ruleCollections[index].id != candidate.id
+                {
+                    ruleCollections[index].isEnabled = false
                 }
-            }
 
-            guard await commitRuleMutation(snapshot: snapshot, skipReload: skipReload, failureContext: candidate.name,
-                                           leaderPreferenceBefore: id == RuleCollectionIdentifier.leaderKey ? leaderPreferenceSnapshot : nil,
-                                           mutationPermit: permit)
-            else { return false }
+                applyPrerequisiteChangeInMemory(
+                    candidate: candidate,
+                    providerIDs: prerequisiteProviderIDs
+                )
 
-            // Pre-cache icons for collections with app launches (e.g., Vim nav layer)
-            if isEnabled, let collection = ruleCollections.first(where: { $0.id == id }) {
-                await warmLayerIconCache(for: collection)
+                AppLogger.shared.log("🔀 [RuleCollections] After toggle - collections: \(ruleCollections.map { "\($0.name) (enabled: \($0.isEnabled))" }.joined(separator: ", "))")
+
+                // Special handling: If Leader Key collection is toggled off, reset all momentary activators to default (space)
+                if id == RuleCollectionIdentifier.leaderKey {
+                    if isEnabled {
+                        let key = leaderKeyOutput(from: candidate) ?? leaderPreferenceSnapshot.key
+                        syncLeaderKeyPreference(key: key, enabled: true)
+                    } else {
+                        syncLeaderKeyPreference(enabled: false)
+                        applyLeaderKeyToMomentaryActivators("space")
+                    }
+                }
+
+                let result = await commitRuleMutationResult(snapshot: snapshot, skipReload: skipReload, failureContext: candidate.name,
+                                                            leaderPreferenceBefore: id == RuleCollectionIdentifier.leaderKey ? leaderPreferenceSnapshot : nil,
+                                                            packRecord: packRecord, mutationPermit: permit)
+                guard result.success else { return result }
+
+                // Pre-cache icons for collections with app launches (e.g., Vim nav layer)
+                if isEnabled, let collection = ruleCollections.first(where: { $0.id == id }) {
+                    await warmLayerIconCache(for: collection)
+                }
+                return result
             }
-            return true
+        } catch {
+            if !(error is CancellationError) { onError?(error.localizedDescription) }
+            return .failure(error)
         }
     }
 

--- a/Tests/KeyPathTests/GenericPackConfigTests.swift
+++ b/Tests/KeyPathTests/GenericPackConfigTests.swift
@@ -669,6 +669,12 @@ final class GenericPackConfigTests: XCTestCase {
         capsLock.isEnabled = false
         manager.ruleCollections = [capsLock]
         let originalCollections = manager.ruleCollections
+        try await manager.configurationService.saveRuleState(
+            ruleCollections: manager.ruleCollections, customRules: manager.customRules,
+            collectionStore: manager.ruleCollectionStore, customStore: manager.customRulesStore
+        )
+        let files = ["keypath.kbd", "RuleCollections.json", "CustomRules.json"].map { tempDir.appendingPathComponent($0) }
+        let originalFiles = try files.map { try Data(contentsOf: $0) }
 
         var regenerationCount = 0
         manager.onBeforeSave = { regenerationCount += 1 }
@@ -693,16 +699,16 @@ final class GenericPackConfigTests: XCTestCase {
             guard case let .saveFailed(reason) = error else {
                 return XCTFail("Expected saveFailed, got \(error)")
             }
-            XCTAssertEqual(
-                reason,
-                "installed-pack record could not be saved and the previous state could not be fully restored"
-            )
+            XCTAssertTrue(reason.contains(CocoaError(.fileWriteNoPermission).localizedDescription))
+            XCTAssertTrue(reason.contains("prior files were restored"))
         } catch {
-            XCTFail("Expected full-restore saveFailed, got \(error)")
+            XCTFail("Expected staging saveFailed, got \(error)")
         }
 
         XCTAssertEqual(manager.ruleCollections, originalCollections)
-        XCTAssertEqual(regenerationCount, 2, "Install and rollback should each regenerate once")
+        XCTAssertEqual(regenerationCount, 1, "Only the candidate is generated; staging rollback restores exact files")
+        XCTAssertEqual(try files.map { try Data(contentsOf: $0) }, originalFiles)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: trackerURL.path), "Originally absent metadata must remain absent")
         let isInstalled = await failingTracker.isInstalled(packID: PackRegistry.capsLockToEscape.id)
         XCTAssertFalse(isInstalled, "A failed install must not remain authoritative in memory")
     }

--- a/Tests/KeyPathTests/PackRuleTransactionTests.swift
+++ b/Tests/KeyPathTests/PackRuleTransactionTests.swift
@@ -52,6 +52,145 @@ final class PackRuleTransactionTests: KeyPathTestCase {
                      errorMessage: disposition == .applied ? nil : "injected \(disposition)", protocol: nil, disposition: disposition)
     }
 
+    func testMissingCollectionResultExplainsFailureWithoutClaimingCancellation() async throws {
+        let before = try snapshot()
+        let result = await manager.toggleCollectionResult(id: UUID(), isEnabled: true)
+        XCTAssertFalse(result.success)
+        XCTAssertFalse(result.error is CancellationError)
+        XCTAssertTrue(result.error?.localizedDescription.contains("No matching collection") == true)
+        XCTAssertEqual(try snapshot(), before)
+    }
+
+    func testDeclinedCollectionConflictPreservesExistingRuleAndExplainsFailure() async throws {
+        pack = PackRegistry.capsLockToEscape
+        manager.customRules.append(CustomRule(input: "caps", action: .keystroke(key: "f13")))
+        let before = try snapshot()
+        let originalRules = manager.customRules
+        manager.onConflictResolution = { _ in .keepExisting }
+        manager.onRulesChanged = { XCTFail("Declined conflict must not reload"); return Self.reload(.applied) }
+        do {
+            _ = try await PackInstaller.shared.install(pack, autoResolveCollectionConflicts: false, manager: manager, installedPackTracker: tracker)
+            XCTFail("Declined installation must fail")
+        } catch {
+            XCTAssertFalse(error is CancellationError)
+            XCTAssertTrue(error.localizedDescription.contains("existing mapping was kept"))
+        }
+        XCTAssertEqual(try snapshot(), before)
+        XCTAssertEqual(manager.customRules, originalRules)
+    }
+
+    func testCollectionPackStagesRecordWithCollectionBeforeOneAcceptedReload() async throws {
+        pack = PackRegistry.capsLockToEscape
+        var reloads = 0
+        manager.onRulesChanged = {
+            reloads += 1
+            let record = await self.tracker.record(for: self.pack.id)
+            XCTAssertNotNil(record)
+            XCTAssertTrue(self.manager.ruleCollections.contains { $0.id == self.pack.associatedCollectionID && $0.isEnabled })
+            XCTAssertTrue(FileManager.default.fileExists(atPath: RecoverableRuleWrite.journalURL(self.directory, scope: .packRules).path))
+            return Self.reload(.applied)
+        }
+        _ = try await PackInstaller.shared.install(pack, manager: manager, installedPackTracker: tracker)
+        XCTAssertEqual(reloads, 1)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: RecoverableRuleWrite.journalURL(directory, scope: .packRules).path))
+    }
+
+    func testCollectionPackMetadataWriteFailureLeavesNoPartialActivation() async throws {
+        pack = PackRegistry.capsLockToEscape
+        let before = try snapshot()
+        let collections = manager.ruleCollections
+        let failing = InstalledPackTracker(fileURL: directory.appendingPathComponent("installed-packs.json"), writeFile: { _, _ in
+            throw CocoaError(.fileWriteNoPermission)
+        })
+        manager.onRulesChanged = { XCTFail("Failed staging must not reload"); return Self.reload(.applied) }
+        do {
+            _ = try await PackInstaller.shared.install(pack, manager: manager, installedPackTracker: failing)
+            XCTFail("Metadata staging failure must fail installation")
+        } catch let error as PackInstaller.InstallError {
+            guard case let .saveFailed(reason) = error else { return XCTFail("Wrong failure: \(error)") }
+            XCTAssertTrue(reason.contains(CocoaError(.fileWriteNoPermission).localizedDescription))
+            XCTAssertTrue(reason.contains("prior files were restored"))
+        }
+        XCTAssertEqual(try snapshot(), before)
+        XCTAssertEqual(manager.ruleCollections, collections)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: RecoverableRuleWrite.journalURL(directory, scope: .packRules).path))
+    }
+
+    func testRejectedCollectionPackInstallRestoresFourFiles() async throws {
+        pack = PackRegistry.capsLockToEscape
+        let before = try snapshot()
+        let collections = manager.ruleCollections
+        var reloads = 0
+        manager.onRulesChanged = {
+            reloads += 1
+            if reloads == 2 { XCTAssertEqual(try? self.snapshot(), before) }
+            return Self.reload(reloads == 1 ? .rejected : .applied)
+        }
+        do {
+            _ = try await PackInstaller.shared.install(pack, manager: manager, installedPackTracker: tracker)
+            XCTFail("Rejected collection installation must fail")
+        } catch {}
+        XCTAssertEqual(reloads, 2)
+        XCTAssertEqual(try snapshot(), before)
+        XCTAssertEqual(manager.ruleCollections, collections)
+    }
+
+    func testRejectedCollectionPackUninstallRestoresRecordAndCollection() async throws {
+        pack = PackRegistry.capsLockToEscape
+        _ = try await PackInstaller.shared.install(pack, manager: manager, installedPackTracker: tracker)
+        let before = try snapshot()
+        let collections = manager.ruleCollections
+        var reloads = 0
+        manager.onRulesChanged = {
+            reloads += 1
+            let record = await self.tracker.record(for: self.pack.id)
+            if reloads == 1 { XCTAssertNil(record) }
+            else { XCTAssertNotNil(record); XCTAssertEqual(try? self.snapshot(), before) }
+            return Self.reload(reloads == 1 ? .rejected : .applied)
+        }
+        do {
+            try await PackInstaller.shared.uninstall(packID: pack.id, manager: manager, installedPackTracker: tracker)
+            XCTFail("Rejected removal must fail")
+        } catch {}
+        XCTAssertEqual(reloads, 2)
+        XCTAssertEqual(try snapshot(), before)
+        XCTAssertEqual(manager.ruleCollections, collections)
+    }
+
+    func testCollectionPackUninstallPendingCommitsRecordRemovalWithOneReload() async throws {
+        pack = PackRegistry.capsLockToEscape
+        _ = try await PackInstaller.shared.install(pack, manager: manager, installedPackTracker: tracker)
+        var reloads = 0
+        manager.onRulesChanged = { reloads += 1; return Self.reload(.pending) }
+        try await PackInstaller.shared.uninstall(packID: pack.id, manager: manager, installedPackTracker: tracker)
+        XCTAssertEqual(reloads, 1)
+        let record = await tracker.record(for: pack.id)
+        XCTAssertNil(record)
+        XCTAssertFalse(manager.ruleCollections.first { $0.id == pack.associatedCollectionID }?.isEnabled ?? true)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: RecoverableRuleWrite.journalURL(directory, scope: .packRules).path))
+    }
+
+    func testCollectionPackExternalMetadataEditPreservesConflictingRevision() async throws {
+        pack = PackRegistry.capsLockToEscape
+        var external: [String: Data]?
+        var reloads = 0
+        manager.onRulesChanged = {
+            reloads += 1
+            do {
+                try Data("external metadata".utf8).write(to: self.directory.appendingPathComponent("installed-packs.json"))
+                external = try self.snapshot()
+            } catch { XCTFail("\(error)") }
+            return Self.reload(.rejected)
+        }
+        do {
+            _ = try await PackInstaller.shared.install(pack, manager: manager, installedPackTracker: tracker)
+            XCTFail("External conflict must fail")
+        } catch {}
+        XCTAssertEqual(reloads, 1)
+        XCTAssertEqual(try snapshot(), external)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: RecoverableRuleWrite.journalURL(directory, scope: .packRules).path))
+    }
+
     func testBatchPublishesOnceAfterAllRulesAndRecordCommitWithOneReload() async throws {
         let count = PackCommitCount()
         let token = manager.configurationService.observe { _ in await count.increment() }

--- a/docs/architecture/configuration-save-pipeline.md
+++ b/docs/architecture/configuration-save-pipeline.md
@@ -382,3 +382,13 @@ edits. The manager recovers before candidate preparation and restores its layout
 fields plus the matching optimistic display preference on failure. Persistent
 keymap preferences update only after accepted settlement; they are not yet part
 of the durable file journal.
+
+Collection-backed pack install/removal passes its record change through the existing
+collection toggle into the canonical rule save. The pack record and three rule files
+share the retained pack journal and runtime settlement; there is no second metadata
+write or fallback regeneration. System packs retain a separate path until their
+managed snapshots join the transaction.
+
+The collection toggle and rule-mutation settlement expose the canonical SaveResult
+for callers that need its cause and recovery outcome. Existing Boolean editor APIs
+adapt that result; pack callers retain it so metadata failures remain actionable.

--- a/docs/bugs/collection-pack-transaction.md
+++ b/docs/bugs/collection-pack-transaction.md
@@ -1,0 +1,19 @@
+# Keep collection-backed pack records with their rules
+
+Collection-backed pack installation first committed its collection change, then
+wrote the installed-pack record. A metadata failure needed a second rollback save;
+a process interruption between writes could leave an enabled collection without an
+installation record. Removal had the inverse gap.
+
+The existing collection toggle now accepts the pack owner's prepared record change
+and passes it to the canonical rule save. Configuration, collections, custom rules,
+and installed-pack metadata remain in one retained journal through runtime
+classification. Rejection restores the four-file revision before manager rollback.
+Pack callers retain the full save result so metadata, permission, and recovery
+failures keep their underlying cause rather than becoming a generic toggle failure.
+External conflicts preserve the newer revision and journal rather than regenerating
+over them. Existing ownership, prerequisite, conflict, and disable confirmations
+are unchanged.
+
+System packs and their managed-collection snapshots remain separate work. This does
+not make preferences crash-atomic or change the pending-save policy.

--- a/docs/planning/catalog-led-consolidation-plan.md
+++ b/docs/planning/catalog-led-consolidation-plan.md
@@ -450,7 +450,7 @@ Managers observe rule-source recovery performed through another editor sharing t
 service. This closes an in-process cross-editor gap; raw journals, preferences,
 managed snapshots, cross-instance/process caches, and watcher revisions remain open.
 
-### Raw configuration recovery in progress
+### Raw configuration recovery merged in #1286
 
 Move raw/generated/Simple Modifications saves onto a retained config-only journal,
 including exact rollback, conflict preservation, runtime recovery, and startup/next
@@ -458,9 +458,22 @@ editor recovery. Preserve accepted-save cancellation semantics and explicit-rest
 fallback behavior. Preferences, managed-pack snapshots, cross-instance/process
 cache freshness, and watcher revisions remain open.
 
-### Keymap save recovery in progress
+### Keymap save recovery merged in #1287
 
 Move logical keymap changes onto retained rule-state settlement. Recover interrupted
 writes before preparing the layout, restore keymap fields and matching optimistic
 display preferences before failure feedback, and preserve newer display choices.
 Preferences remain in-process state; durable preference recovery remains open.
+
+### Collection-backed pack transactions in progress
+
+Commit associated collection toggles and their installed-pack records in one retained
+rule transaction on install and removal. Preserve existing confirmation and ownership
+policies. System packs, managed snapshots, preferences, and watcher/cache revisions
+remain open.
+
+Deployment checkpoint: #1285, #1286, and #1287 were installed together from merged
+master `5bf5b09ac8e28125c1d665fbee059d051e35f691`. Signed/notarized/stapled app
+verification passed, including process and TCP readiness; installed and distribution
+executable hashes matched. This is installation/runtime-readiness evidence, not
+clean-VM first-run or physical-keyboard acceptance.


### PR DESCRIPTION
## Problem and result

Collection-backed packs committed collection changes before updating installation records. Metadata-write failure or process interruption could leave the catalog's installed state inconsistent with the generated configuration. Removal had the inverse gap.

Install and removal now pass the record change through the existing collection toggle into the canonical retained rule save. The three rule files and pack metadata settle together after runtime classification. Rejection restores the exact previous revision; external conflicts preserve the newer files and journal. This removes the second metadata write and fallback regeneration. Existing ownership, prerequisite, conflict, and disable confirmations remain in place.

System packs and managed snapshots, durable preferences, and watcher/cache revisions remain separate work.

## Validation

104 focused tests passed after the final reporting correction. The full safe suite after typed-result propagation completed in 147 seconds with 5,284 passed, only the four known macOS 27 snapshot mismatches (HomeRowTimingFastTyping, HomeRowTimingPerFinger, HomeRowTimingSlider, RepairSettingsTabView), and zero compiler warnings. Pinned formatting and accessibility checks passed. New coverage checks metadata staging before reload, injected metadata-write failure, rejected install and removal, pending removal, and preservation of an external metadata revision. The legacy metadata-failure test now verifies exact restored files and one candidate generation rather than the removed second regeneration.

Review follow-up: pack callers now retain the full SaveResult through collection toggle and mutation settlement, including the underlying permission/write error and recovery outcome. Existing Boolean editor APIs adapt that result. The failure tests assert that both the original permission cause and successful restoration remain in the reported message.

Remote review gate selected; GitHub claude-review required before merge. Signed/notarized deployment follows merge. No public release or UI redesign.

Final review follow-up: declined confirmations, unresolved conflicts, managed ownership, and missing collections now carry specific validation explanations instead of using CancellationError as a sentinel. Actual operation cancellation retains its original error. Two added regressions cover missing collections and an explicitly declined conflict; all 104 focused tests pass after this message-only adjustment.

Final review found no correctness issues. The fallback text is intentionally retained because SaveResult models its error as optional; current paths populate it, but preserving a readable fallback keeps callers robust if that result contract gains another failure source.
