### PR TITLE
Retain system-pack snapshots with their rule transaction

### DIFF
--- a/Sources/KeyPathAppKit/Services/Packs/InstalledPackTracker.swift
+++ b/Sources/KeyPathAppKit/Services/Packs/InstalledPackTracker.swift
@@ -17,17 +17,21 @@ public struct InstalledPackRecord: Codable, Equatable, Sendable {
     /// Current values of the pack's quick settings, keyed by `PackQuickSetting.id`.
     /// Only int values in M1 (sliders). M2 will widen.
     public var quickSettingValues: [String: Int]
+    /// Restore state participates in the same journal as the installed record.
+    public var managedCollectionSnapshot: PackCollectionSnapshot?
 
     public init(
         packID: String,
         version: String,
         installedAt: Date = Date(),
-        quickSettingValues: [String: Int] = [:]
+        quickSettingValues: [String: Int] = [:],
+        managedCollectionSnapshot: PackCollectionSnapshot? = nil
     ) {
         self.packID = packID
         self.version = version
         self.installedAt = installedAt
         self.quickSettingValues = quickSettingValues
+        self.managedCollectionSnapshot = managedCollectionSnapshot
     }
 }
 

--- a/Sources/KeyPathAppKit/Services/Packs/PackCollectionSnapshot.swift
+++ b/Sources/KeyPathAppKit/Services/Packs/PackCollectionSnapshot.swift
@@ -4,12 +4,12 @@ import KeyPathRulesCore
 
 /// Snapshot of managed collections' state before a pack was installed.
 /// Used to restore previous configuration on uninstall.
-public struct PackCollectionSnapshot: Codable {
+public struct PackCollectionSnapshot: Codable, Equatable, Sendable {
     public let packID: String
     public let snapshotDate: Date
     public var entries: [Entry]
 
-    public struct Entry: Codable {
+    public struct Entry: Codable, Equatable, Sendable {
         public let collectionID: UUID
         public var wasEnabled: Bool
         public var configurationJSON: Data
@@ -45,6 +45,14 @@ public struct PackCollectionSnapshot: Codable {
         return try? JSONDecoder().decode(PackCollectionSnapshot.self, from: data)
     }
 
+    /// Mutation paths distinguish an absent legacy snapshot from unreadable data.
+    static func loadForMutation(for packID: String) throws -> PackCollectionSnapshot? {
+        let data: Data
+        do { data = try Data(contentsOf: snapshotURL(for: packID)) }
+        catch let error as NSError where error.domain == NSCocoaErrorDomain && error.code == NSFileReadNoSuchFileError { return nil }
+        return try JSONDecoder().decode(PackCollectionSnapshot.self, from: data)
+    }
+
     static func remove(for packID: String) {
         try? FileManager.default.removeItem(at: snapshotURL(for: packID))
     }
@@ -64,34 +72,36 @@ public struct PackCollectionSnapshot: Codable {
     }
 
     static func loadLegacyVallack() -> PackCollectionSnapshot? {
-        let url = legacyVallackURL
-        guard let data = try? Data(contentsOf: url),
-              let legacy = try? JSONDecoder().decode(LegacyVallackSnapshot.self, from: data)
-        else { return nil }
+        try? loadLegacyVallackForMutation()
+    }
+
+    static func loadLegacyVallackForMutation() throws -> PackCollectionSnapshot? {
+        let data: Data
+        do { data = try Data(contentsOf: legacyVallackURL) }
+        catch let error as NSError where error.domain == NSCocoaErrorDomain && error.code == NSFileReadNoSuchFileError { return nil }
+        let legacy = try JSONDecoder().decode(LegacyVallackSnapshot.self, from: data)
 
         var entries: [Entry] = []
 
         let modsConfig: RuleCollectionConfiguration = legacy.homeRowModsConfig.map {
             .homeRowMods($0)
         } ?? .homeRowMods(HomeRowModsConfig())
-        if let modsJSON = try? JSONEncoder().encode(modsConfig) {
-            entries.append(Entry(
-                collectionID: RuleCollectionIdentifier.homeRowMods,
-                wasEnabled: legacy.homeRowModsEnabled,
-                configurationJSON: modsJSON
-            ))
-        }
+        let modsJSON = try JSONEncoder().encode(modsConfig)
+        entries.append(Entry(
+            collectionID: RuleCollectionIdentifier.homeRowMods,
+            wasEnabled: legacy.homeRowModsEnabled,
+            configurationJSON: modsJSON
+        ))
 
         let togglesConfig: RuleCollectionConfiguration = legacy.homeRowLayerTogglesConfig.map {
             .homeRowLayerToggles($0)
         } ?? .homeRowLayerToggles(HomeRowLayerTogglesConfig())
-        if let togglesJSON = try? JSONEncoder().encode(togglesConfig) {
-            entries.append(Entry(
-                collectionID: RuleCollectionIdentifier.homeRowLayerToggles,
-                wasEnabled: legacy.homeRowLayerTogglesEnabled,
-                configurationJSON: togglesJSON
-            ))
-        }
+        let togglesJSON = try JSONEncoder().encode(togglesConfig)
+        entries.append(Entry(
+            collectionID: RuleCollectionIdentifier.homeRowLayerToggles,
+            wasEnabled: legacy.homeRowLayerTogglesEnabled,
+            configurationJSON: togglesJSON
+        ))
 
         return PackCollectionSnapshot(
             packID: "com.keypath.pack.vallack-system",
@@ -104,8 +114,7 @@ public struct PackCollectionSnapshot: Codable {
         try? removeLegacyVallackIfPresent()
     }
 
-    /// Throwing variant used by transactional rollback so cleanup failures are
-    /// surfaced instead of being reported as a complete restoration.
+    /// Throwing cleanup for callers that need to report a legacy-file failure.
     static func removeLegacyVallackIfPresent() throws {
         guard FileManager.default.fileExists(atPath: legacyVallackURL.path) else {
             return

--- a/Sources/KeyPathAppKit/Services/Packs/PackInstaller.swift
+++ b/Sources/KeyPathAppKit/Services/Packs/PackInstaller.swift
@@ -199,81 +199,27 @@ public final class PackInstaller {
                 return record
             }
 
-            // System packs batch all collection changes into a single config regen.
+            // The pre-install snapshot travels inside the journaled record.
             if pack.isSystemPack {
-                let ruleStateSnapshot = manager.snapshotRuleState()
-                let previousInstallRecord = await installedPackTracker.record(for: pack.id)
-                let previousCollectionSnapshot = PackCollectionSnapshot.load(for: pack.id)
-                let record = InstalledPackRecord(
-                    packID: pack.id,
-                    version: pack.version,
-                    installedAt: Date(),
-                    quickSettingValues: resolvedSettings
-                )
+                let before = manager.snapshotRuleState()
+                let managedSnapshot: PackCollectionSnapshot
                 do {
-                    try await applyManagedDefaults(
-                        pack: pack,
-                        manager: manager,
-                        policy: managedDefaultPolicy,
-                        associatedCollectionConfiguration: collectionConfiguration,
-                        skipReload: skipFinalReload,
-                        mutationPermit: permit
+                    managedSnapshot = try await prepareManagedDefaults(
+                        pack: pack, manager: manager, policy: managedDefaultPolicy,
+                        associatedCollectionConfiguration: collectionConfiguration
                     )
                 } catch {
-                    AppLogger.shared.errorUnlessQuietTest(
-                        "❌ [PackInstaller] Could not apply system-pack defaults for '\(pack.name)'; restoring previous state"
-                    )
-                    let installRecordRestored = await restoreInstallRecord(
-                        previousInstallRecord,
-                        packID: pack.id,
-                        installedPackTracker: installedPackTracker
-                    )
-                    let collectionSnapshotRestored = restoreManagedCollectionSnapshot(
-                        previousCollectionSnapshot,
-                        packID: pack.id
-                    )
-                    let rollbackApplied = await manager.rollbackToSnapshot(
-                        ruleStateSnapshot,
-                        userMessage: "Could not apply this system pack. Your previous rule state was restored.",
-                        mutationPermit: permit
-                    )
-                    guard rollbackApplied, collectionSnapshotRestored, installRecordRestored else {
-                        throw InstallError.saveFailed(
-                            "system-pack defaults could not be applied and the previous state could not be fully restored"
-                        )
-                    }
+                    restorePreparedRuleState(before, manager: manager)
                     throw error
                 }
-                do {
-                    try await installedPackTracker.upsert(record)
-                } catch {
-                    AppLogger.shared.errorUnlessQuietTest(
-                        "❌ [PackInstaller] Could not persist system-pack record for '\(pack.name)'; restoring previous state"
-                    )
-                    let installRecordRestored = await restoreInstallRecord(
-                        previousInstallRecord,
-                        packID: pack.id,
-                        installedPackTracker: installedPackTracker
-                    )
-                    let collectionSnapshotRestored = restoreManagedCollectionSnapshot(
-                        previousCollectionSnapshot,
-                        packID: pack.id
-                    )
-                    let rollbackApplied = await manager.rollbackToSnapshot(
-                        ruleStateSnapshot,
-                        userMessage: "Could not record this system pack installation. Your previous rule state was restored.",
-                        mutationPermit: permit
-                    )
-                    guard rollbackApplied, collectionSnapshotRestored, installRecordRestored else {
-                        throw InstallError.saveFailed(
-                            "installed-pack record could not be saved and the previous system-pack state could not be fully restored"
-                        )
-                    }
-                    throw error
-                }
-                AppLogger.shared.log(
-                    "✅ [PackInstaller] Installed system pack '\(pack.name)'"
-                )
+                let record = InstalledPackRecord(packID: pack.id, version: pack.version,
+                                                 installedAt: Date(), quickSettingValues: resolvedSettings,
+                                                 managedCollectionSnapshot: managedSnapshot)
+                manager.refreshLayerIndicatorState()
+                try await commitPreparedPackRules(manager: manager, snapshot: before,
+                                                  record: .init(tracker: installedPackTracker, record: record),
+                                                  skipReload: skipFinalReload, permit: permit)
+                AppLogger.shared.log("✅ [PackInstaller] Installed system pack '\(pack.name)'")
                 return record
             }
 
@@ -348,33 +294,41 @@ public final class PackInstaller {
                 return
             }
 
-            // System packs batch all collection changes into a single config regen.
             if let pack = PackRegistry.pack(id: packID), pack.isSystemPack {
-                let originalCollections = manager.ruleCollections
-                let didRestore = await restoreOrKeepOnUninstall(pack: pack, manager: manager)
-                if let collectionID = pack.associatedCollectionID,
-                   let i = manager.ruleCollections.firstIndex(where: { $0.id == collectionID })
-                {
-                    manager.ruleCollections[i].isEnabled = false
+                let before = manager.snapshotRuleState()
+                let installed = await installedPackTracker.record(for: packID)
+                do {
+                    let didRestore = try await restoreOrKeepOnUninstall(pack: pack, manager: manager,
+                                                                        installedSnapshot: installed?.managedCollectionSnapshot)
+                    if let collectionID = pack.associatedCollectionID,
+                       let index = manager.ruleCollections.firstIndex(where: { $0.id == collectionID })
+                    {
+                        manager.ruleCollections[index].isEnabled = false
+                    }
+                    manager.refreshLayerIndicatorState()
+                    let candidate = manager.snapshotRuleState()
+                    let removal = InstalledPackTracker.RecordChange(tracker: installedPackTracker, removing: packID)
+                    var result = await savePreparedPackRules(manager: manager, snapshot: before, record: removal, permit: permit)
+                    // Preserve the existing known-conflict fallback, but only for
+                    // generation conflicts, never for runtime or file failures.
+                    if !result.success, didRestore,
+                       let error = result.error as? KeyPathError,
+                       case .configuration(.mappingConflicts) = error
+                    {
+                        restorePreparedRuleState(candidate, manager: manager)
+                        if disableRestoreConflictCollections(for: pack, manager: manager) {
+                            result = await savePreparedPackRules(manager: manager, snapshot: before, record: removal, permit: permit)
+                        }
+                    }
+                    guard result.success else {
+                        throw InstallError.saveFailed(result.error?.localizedDescription ?? "could not apply managed collection restore")
+                    }
+                    removeManagedSnapshot(for: pack)
+                    AppLogger.shared.log("✅ [PackInstaller] Uninstalled system pack '\(packID)' (restored=\(didRestore))")
+                } catch {
+                    restorePreparedRuleState(before, manager: manager)
+                    throw error
                 }
-
-                var applied = await manager.regenerateConfigFromCollections(mutationPermit: permit)
-                if !applied, didRestore, disableRestoreConflictCollections(for: pack, manager: manager) {
-                    AppLogger.shared.log(
-                        "⚠️ [PackInstaller] Retrying managed restore for '\(packID)' after disabling install-conflict collections"
-                    )
-                    applied = await manager.regenerateConfigFromCollections(mutationPermit: permit)
-                }
-
-                guard applied else {
-                    manager.ruleCollections = originalCollections
-                    throw InstallError.saveFailed("could not apply managed collection restore")
-                }
-                removeManagedSnapshot(for: pack)
-                try await installedPackTracker.remove(packID: packID)
-                AppLogger.shared.log(
-                    "✅ [PackInstaller] Uninstalled system pack '\(packID)' (restored=\(didRestore))"
-                )
                 return
             }
 
@@ -575,16 +529,26 @@ public final class PackInstaller {
         record: InstalledPackTracker.RecordChange, skipReload: Bool = false,
         permit: ConfigurationOperationGate.Permit
     ) async throws {
+        let result = await savePreparedPackRules(manager: manager, snapshot: snapshot, record: record,
+                                                 skipReload: skipReload, permit: permit)
+        guard result.success else {
+            if result.error is CancellationError { throw CancellationError() }
+            throw InstallError.saveFailed(result.error?.localizedDescription ?? "Pack change could not be committed")
+        }
+    }
+
+    private func savePreparedPackRules(
+        manager: RuleCollectionsManager, snapshot: RuleCollectionsManager.RuleStateSnapshot,
+        record: InstalledPackTracker.RecordChange, skipReload: Bool = false,
+        permit: ConfigurationOperationGate.Permit
+    ) async -> SaveResult {
         let result = await SaveCoordinator(configurationService: manager.configurationService).saveRuleState(
             manager: manager, mutationPermit: permit, packRecord: record,
             reloadHandler: skipReload ? nil : manager.onRulesChanged
         )
-        guard result.success else {
-            restorePreparedRuleState(snapshot, manager: manager)
-            if result.error is CancellationError { throw CancellationError() }
-            throw InstallError.saveFailed(result.error?.localizedDescription ?? "Pack change could not be committed")
-        }
-        NotificationCenter.default.post(name: .ruleCollectionsChanged, object: nil)
+        if result.success { NotificationCenter.default.post(name: .ruleCollectionsChanged, object: nil) }
+        else { restorePreparedRuleState(snapshot, manager: manager) }
+        return result
     }
 
     private func restorePreparedRuleState(_ snapshot: RuleCollectionsManager.RuleStateSnapshot,
@@ -718,35 +682,6 @@ public final class PackInstaller {
         }
     }
 
-    private func restoreManagedCollectionSnapshot(
-        _ previousSnapshot: PackCollectionSnapshot?,
-        packID: String
-    ) -> Bool {
-        do {
-            if let previousSnapshot {
-                try PackCollectionSnapshot.save(previousSnapshot)
-            } else {
-                let snapshotURL = PackCollectionSnapshot.snapshotURL(for: packID)
-                if FileManager.default.fileExists(atPath: snapshotURL.path) {
-                    try FileManager.default.removeItem(at: snapshotURL)
-                }
-            }
-            // Preserve the Vallack rollback contract from the original managed
-            // install path: a failed modern install supersedes and removes the
-            // legacy migration file. Any modern snapshot that predated this
-            // attempt has already been restored above.
-            if packID == PackRegistry.vallackSystem.id {
-                try PackCollectionSnapshot.removeLegacyVallackIfPresent()
-            }
-            return true
-        } catch {
-            AppLogger.shared.errorUnlessQuietTest(
-                "❌ [PackInstaller] Could not restore managed-collection snapshot for '\(packID)': \(error)"
-            )
-            return false
-        }
-    }
-
     private func resolveQuickSettings(
         pack: Pack,
         overrides: [String: Int]
@@ -777,13 +712,13 @@ public final class PackInstaller {
     private func snapshotManagedCollections(
         pack: Pack,
         manager: RuleCollectionsManager
-    ) -> PackCollectionSnapshot {
+    ) throws -> PackCollectionSnapshot {
         let encoder = JSONEncoder()
         var entries: [PackCollectionSnapshot.Entry] = []
 
         for managed in pack.managedDefaults {
             let collection = manager.ruleCollections.first { $0.id == managed.collectionID }
-            let configJSON = (try? encoder.encode(collection?.configuration ?? .list)) ?? Data()
+            let configJSON = try encoder.encode(collection?.configuration ?? .list)
             entries.append(PackCollectionSnapshot.Entry(
                 collectionID: managed.collectionID,
                 wasEnabled: collection?.isEnabled ?? false,
@@ -794,15 +729,13 @@ public final class PackInstaller {
         return PackCollectionSnapshot(packID: pack.id, entries: entries)
     }
 
-    private func applyManagedDefaults(
+    private func prepareManagedDefaults(
         pack: Pack,
         manager: RuleCollectionsManager,
         policy: ManagedDefaultInstallPolicy,
-        associatedCollectionConfiguration: RuleCollectionConfiguration?,
-        skipReload: Bool,
-        mutationPermit: ConfigurationOperationGate.Permit
-    ) async throws {
-        let snapshot = snapshotManagedCollections(pack: pack, manager: manager)
+        associatedCollectionConfiguration: RuleCollectionConfiguration?
+    ) async throws -> PackCollectionSnapshot {
+        let snapshot = try snapshotManagedCollections(pack: pack, manager: manager)
         let catalog = RuleCollectionCatalog().defaultCollections()
 
         // Ensure the pack's own associated collection exists too
@@ -842,13 +775,7 @@ public final class PackInstaller {
             }
         }
 
-        try PackCollectionSnapshot.save(snapshot)
-
-        let applied = await manager.regenerateConfigFromCollections(skipReload: skipReload, mutationPermit: mutationPermit)
-        guard applied else {
-            throw InstallError.saveFailed("could not apply managed collection defaults")
-        }
-        AppLogger.shared.log("📦 [PackInstaller] Applied managed defaults for '\(pack.name)'")
+        return snapshot
     }
 
     private func shouldApplyManagedDefault(
@@ -914,18 +841,25 @@ public final class PackInstaller {
     @discardableResult
     private func restoreOrKeepOnUninstall(
         pack: Pack,
-        manager: RuleCollectionsManager
-    ) async -> Bool {
-        var snapshot = PackCollectionSnapshot.load(for: pack.id)
-
-        // Legacy migration for Vallack System
+        manager: RuleCollectionsManager,
+        installedSnapshot: PackCollectionSnapshot?
+    ) async throws -> Bool {
+        var snapshot = try installedSnapshot ?? PackCollectionSnapshot.loadForMutation(for: pack.id)
         if snapshot == nil, pack.id == "com.keypath.pack.vallack-system" {
-            snapshot = PackCollectionSnapshot.loadLegacyVallack()
+            snapshot = try PackCollectionSnapshot.loadLegacyVallackForMutation()
         }
-
         guard let snapshot else {
             AppLogger.shared.log("⚠️ [PackInstaller] No snapshot found for '\(pack.id)' — skipping restore")
             return false
+        }
+        let ids = snapshot.entries.map(\.collectionID)
+        guard snapshot.packID == pack.id, Set(ids).count == ids.count,
+              Set(ids).isSubset(of: Set(pack.managedDefaults.map(\.collectionID)))
+        else {
+            throw InstallError.saveFailed("Saved settings do not match this pack; no changes were made")
+        }
+        for entry in snapshot.entries {
+            _ = try JSONDecoder().decode(RuleCollectionConfiguration.self, from: entry.configurationJSON)
         }
 
         let decoder = JSONDecoder()

--- a/Tests/KeyPathTests/GenericPackConfigTests.swift
+++ b/Tests/KeyPathTests/GenericPackConfigTests.swift
@@ -786,17 +786,15 @@ final class GenericPackConfigTests: XCTestCase {
             guard case let .saveFailed(reason) = error else {
                 return XCTFail("Expected saveFailed, got \(error)")
             }
-            XCTAssertEqual(
-                reason,
-                "installed-pack record could not be saved and the previous system-pack state could not be fully restored"
-            )
+            XCTAssertTrue(reason.contains(CocoaError(.fileWriteNoPermission).localizedDescription))
+            XCTAssertTrue(reason.contains("prior files were restored"))
         } catch {
-            XCTFail("Expected full-restore saveFailed, got \(error)")
+            XCTFail("Expected staging saveFailed, got \(error)")
         }
 
         XCTAssertEqual(manager.ruleCollections, originalRuleState.collections)
         XCTAssertEqual(manager.customRules, originalRuleState.customRules)
-        XCTAssertEqual(regenerationCount, 2, "Install and rollback should each regenerate once")
+        XCTAssertEqual(regenerationCount, 1, "Staging rollback restores files without a second generation")
         let restoredRecord = await failingTracker.record(for: PackRegistry.launcher.id)
         XCTAssertEqual(restoredRecord, previousRecord)
 
@@ -810,7 +808,7 @@ final class GenericPackConfigTests: XCTestCase {
     }
 
     @MainActor
-    func testSystemPackInstallRestoresDurableStateWhenCollectionStoreWriteFails() async throws {
+    func testSystemPackInstallPreservesExternalDirectoryAtCollectionStore() async throws {
         TestEnvironment.forceTestMode = true
         defer { TestEnvironment.forceTestMode = false }
 
@@ -834,7 +832,6 @@ final class GenericPackConfigTests: XCTestCase {
         let collectionStoreURL = tempDir.appendingPathComponent("RuleCollections.json")
         let customRulesStoreURL = tempDir.appendingPathComponent("CustomRules.json")
         let originalConfigData = try Data(contentsOf: configURL)
-        let originalCollectionStoreData = try Data(contentsOf: collectionStoreURL)
         let originalCustomRulesStoreData = try Data(contentsOf: customRulesStoreURL)
 
         let previousSnapshot = try PackCollectionSnapshot(
@@ -870,14 +867,8 @@ final class GenericPackConfigTests: XCTestCase {
             at: collectionStoreURL,
             withIntermediateDirectories: false
         )
-        var shouldRemoveFailedStore = true
-        manager.onError = { _ in
-            // Make this a one-shot persistence failure so the compensating
-            // rollback can prove it rewrites every durable representation.
-            guard shouldRemoveFailedStore else { return }
-            shouldRemoveFailedStore = false
-            try? FileManager.default.removeItem(at: collectionStoreURL)
-        }
+        let externalMarker = collectionStoreURL.appendingPathComponent("external.txt")
+        try Data("external directory".utf8).write(to: externalMarker)
 
         do {
             _ = try await PackInstaller.shared.install(
@@ -896,10 +887,7 @@ final class GenericPackConfigTests: XCTestCase {
         XCTAssertEqual(restoredRuleState.collections, originalRuleState.collections)
         XCTAssertEqual(restoredRuleState.customRules, originalRuleState.customRules)
         XCTAssertEqual(try Data(contentsOf: configURL), originalConfigData)
-        XCTAssertEqual(
-            try Data(contentsOf: collectionStoreURL),
-            originalCollectionStoreData
-        )
+        XCTAssertEqual(try Data(contentsOf: externalMarker), Data("external directory".utf8))
         XCTAssertEqual(
             try Data(contentsOf: customRulesStoreURL),
             originalCustomRulesStoreData
@@ -1245,7 +1233,7 @@ final class GenericPackConfigTests: XCTestCase {
     }
 
     @MainActor
-    func testQuickLauncherInstallCreatesSnapshotFile() async throws {
+    func testQuickLauncherInstallEmbedsSnapshotInRecord() async throws {
         TestEnvironment.forceTestMode = true
         defer { TestEnvironment.forceTestMode = false }
 
@@ -1255,9 +1243,9 @@ final class GenericPackConfigTests: XCTestCase {
             PackCollectionSnapshot.remove(for: PackRegistry.launcher.id)
         }
 
-        _ = try await PackInstaller.shared.install(PackRegistry.launcher, manager: manager)
+        let installed = try await PackInstaller.shared.install(PackRegistry.launcher, manager: manager)
 
-        let snapshot = PackCollectionSnapshot.load(for: PackRegistry.launcher.id)
+        let snapshot = installed.managedCollectionSnapshot
         XCTAssertNotNil(snapshot, "Snapshot should exist after install")
         XCTAssertEqual(snapshot?.entries.count, 1, "Should snapshot one managed collection")
         XCTAssertEqual(snapshot?.entries.first?.collectionID, RuleCollectionIdentifier.capsLockRemap)
@@ -1292,7 +1280,7 @@ final class GenericPackConfigTests: XCTestCase {
         }
 
         // Install launcher — should apply its defaults (auto-approved in test env)
-        _ = try await PackInstaller.shared.install(PackRegistry.launcher, manager: manager)
+        let installed = try await PackInstaller.shared.install(PackRegistry.launcher, manager: manager)
 
         // Verify pack defaults were applied
         let capsCollection = manager.ruleCollections.first { $0.id == RuleCollectionIdentifier.capsLockRemap }
@@ -1300,7 +1288,7 @@ final class GenericPackConfigTests: XCTestCase {
         XCTAssertEqual(capsCollection?.configuration.tapHoldPickerConfig?.selectedHoldOutput, "hyper")
 
         // Verify snapshot captured the PRE-INSTALL custom config
-        let snapshot = PackCollectionSnapshot.load(for: PackRegistry.launcher.id)
+        let snapshot = installed.managedCollectionSnapshot
         XCTAssertNotNil(snapshot)
         let capsEntry = snapshot?.entries.first { $0.collectionID == RuleCollectionIdentifier.capsLockRemap }
         XCTAssertNotNil(capsEntry)
@@ -1740,6 +1728,7 @@ final class GenericPackConfigTests: XCTestCase {
 
     func testLegacyVallackSnapshotMigration() throws {
         let legacyURL = AppPaths.configDirectory.appendingPathComponent("vallack-system-snapshot.json")
+        try FileManager.default.createDirectory(at: legacyURL.deletingLastPathComponent(), withIntermediateDirectories: true)
 
         let legacySnapshot: [String: Any] = [
             "homeRowModsEnabled": true,

--- a/Tests/KeyPathTests/SystemPackTransactionTests.swift
+++ b/Tests/KeyPathTests/SystemPackTransactionTests.swift
@@ -1,0 +1,213 @@
+import Foundation
+@testable import KeyPathAppKit
+import KeyPathRulesCore
+@preconcurrency import XCTest
+
+@MainActor
+final class SystemPackTransactionTests: KeyPathTestCase {
+    private var directory: URL!
+    private var manager: RuleCollectionsManager!
+    private var tracker: InstalledPackTracker!
+    private let pack = PackRegistry.launcher
+
+    override func setUp() async throws {
+        try await super.setUp()
+        directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let collections = RuleCollectionStore.testStore(at: directory.appendingPathComponent("RuleCollections.json"))
+        let rules = CustomRulesStore.testStore(at: directory.appendingPathComponent("CustomRules.json"))
+        let service = ConfigurationService(configDirectory: directory.path, ruleCollectionStore: collections, customRulesStore: rules)
+        manager = RuleCollectionsManager(ruleCollectionStore: collections, customRulesStore: rules, configurationService: service)
+        manager.ruleCollections = RuleCollectionCatalog().defaultCollections().map { collection in
+            var value = collection
+            value.isEnabled = false
+            return value
+        }
+        try await service.saveRuleState(ruleCollections: manager.ruleCollections, customRules: [], collectionStore: collections, customStore: rules)
+        tracker = InstalledPackTracker(fileURL: directory.appendingPathComponent("installed-packs.json"))
+        try await tracker.upsert(InstalledPackRecord(packID: "unrelated", version: "1", installedAt: Date(timeIntervalSince1970: 42)))
+    }
+
+    override func tearDown() async throws {
+        try? FileManager.default.removeItem(at: directory)
+        try? FileManager.default.removeItem(at: ConfigurationOperationGate.lockFileURL(for: directory))
+        manager = nil
+        tracker = nil
+        directory = nil
+        try await super.tearDown()
+    }
+
+    private func files() throws -> [Data] {
+        try ["keypath.kbd", "RuleCollections.json", "CustomRules.json", "installed-packs.json"].map {
+            try Data(contentsOf: directory.appendingPathComponent($0))
+        }
+    }
+
+    private static func reload(_ disposition: ReloadDisposition) -> ReloadResult {
+        ReloadResult(success: disposition == .applied, response: nil, errorMessage: "injected \(disposition)", protocol: nil, disposition: disposition)
+    }
+
+    @discardableResult
+    private func install(using tracker: InstalledPackTracker? = nil) async throws -> InstalledPackRecord {
+        try await PackInstaller.shared.install(pack, managedDefaultPolicy: .useRecommended, manager: manager,
+                                               installedPackTracker: tracker ?? self.tracker)
+    }
+
+    func testSnapshotIsPresentInJournaledRecordBeforeRuntimeApplication() async throws {
+        var reloads = 0
+        manager.onRulesChanged = {
+            reloads += 1
+            let record = await self.tracker.record(for: self.pack.id)
+            XCTAssertEqual(record?.managedCollectionSnapshot?.packID, self.pack.id)
+            XCTAssertFalse(record?.managedCollectionSnapshot?.entries.isEmpty ?? true)
+            XCTAssertTrue(FileManager.default.fileExists(atPath: RecoverableRuleWrite.journalURL(self.directory, scope: .packRules).path))
+            return Self.reload(.applied)
+        }
+        let record = try await install()
+        XCTAssertEqual(reloads, 1)
+        let fresh = InstalledPackTracker(fileURL: directory.appendingPathComponent("installed-packs.json"))
+        let restoredRecord = await fresh.record(for: pack.id)
+        XCTAssertEqual(restoredRecord?.packID, record.packID)
+        XCTAssertEqual(restoredRecord?.version, record.version)
+        XCTAssertEqual(restoredRecord?.quickSettingValues, record.quickSettingValues)
+        XCTAssertEqual(restoredRecord?.managedCollectionSnapshot?.entries, record.managedCollectionSnapshot?.entries)
+        // Tracker dates use its existing ISO-8601 seconds precision.
+        let restoredDate = try XCTUnwrap(restoredRecord?.managedCollectionSnapshot?.snapshotDate)
+        let originalDate = try XCTUnwrap(record.managedCollectionSnapshot?.snapshotDate)
+        XCTAssertLessThan(abs(restoredDate.timeIntervalSince(originalDate)), 1)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: RecoverableRuleWrite.journalURL(directory, scope: .packRules).path))
+    }
+
+    func testRejectedInstallRestoresAllFilesAndOriginalCollections() async throws {
+        let before = try files()
+        let collections = manager.ruleCollections
+        var reloads = 0
+        manager.onRulesChanged = {
+            reloads += 1
+            if reloads == 2 { XCTAssertEqual(try? self.files(), before) }
+            return Self.reload(reloads == 1 ? .rejected : .applied)
+        }
+        do { try await install(); XCTFail("Rejected system pack must fail") }
+        catch {}
+        XCTAssertEqual(reloads, 2)
+        XCTAssertEqual(try files(), before)
+        XCTAssertEqual(manager.ruleCollections, collections)
+    }
+
+    func testMetadataFailureDoesNotApplyOrLeaveSnapshotRecord() async throws {
+        let before = try files()
+        let collections = manager.ruleCollections
+        let failing = InstalledPackTracker(fileURL: directory.appendingPathComponent("installed-packs.json"), writeFile: { _, _ in
+            throw CocoaError(.fileWriteNoPermission)
+        })
+        manager.onRulesChanged = { XCTFail("Failed staging must not reload"); return Self.reload(.applied) }
+        do { try await install(using: failing); XCTFail("Metadata write must fail") }
+        catch {}
+        XCTAssertEqual(try files(), before)
+        XCTAssertEqual(manager.ruleCollections, collections)
+    }
+
+    func testRejectedRemovalRestoresInstalledSnapshotWithoutDisablingMoreCollections() async throws {
+        try await install()
+        let before = try files()
+        let collections = manager.ruleCollections
+        var reloads = 0
+        manager.onRulesChanged = {
+            reloads += 1
+            if reloads == 2 { XCTAssertEqual(try? self.files(), before) }
+            return Self.reload(reloads == 1 ? .rejected : .applied)
+        }
+        do {
+            try await PackInstaller.shared.uninstall(packID: pack.id, manager: manager, installedPackTracker: tracker)
+            XCTFail("Rejected removal must fail")
+        } catch {}
+        XCTAssertEqual(reloads, 2, "A runtime rejection must not trigger a conflict-disable retry")
+        XCTAssertEqual(try files(), before)
+        XCTAssertEqual(manager.ruleCollections, collections)
+        let record = await tracker.record(for: pack.id)
+        XCTAssertNotNil(record?.managedCollectionSnapshot)
+    }
+
+    func testPendingRemovalCommitsRestorationAndRemovesSnapshotRecord() async throws {
+        let before = manager.ruleCollections
+        try await install()
+        var reloads = 0
+        manager.onRulesChanged = { reloads += 1; return Self.reload(.pending) }
+        try await PackInstaller.shared.uninstall(packID: pack.id, manager: manager, installedPackTracker: tracker)
+        XCTAssertEqual(reloads, 1)
+        for managed in pack.managedDefaults {
+            XCTAssertEqual(manager.ruleCollections.first { $0.id == managed.collectionID }, before.first { $0.id == managed.collectionID })
+        }
+        let record = await tracker.record(for: pack.id)
+        XCTAssertNil(record)
+    }
+
+    func testInvalidEmbeddedSnapshotBlocksRemovalBeforeAnyWrite() async throws {
+        var record = try await install()
+        record.managedCollectionSnapshot = PackCollectionSnapshot(packID: pack.id, entries: [
+            .init(collectionID: pack.managedDefaults[0].collectionID, wasEnabled: true, configurationJSON: Data("invalid".utf8))
+        ])
+        try await tracker.upsert(record)
+        let before = try files()
+        let collections = manager.ruleCollections
+        manager.onRulesChanged = { XCTFail("Invalid restore data must not reload"); return Self.reload(.applied) }
+        do {
+            try await PackInstaller.shared.uninstall(packID: pack.id, manager: manager, installedPackTracker: tracker)
+            XCTFail("Invalid saved settings must block removal")
+        } catch {}
+        XCTAssertEqual(try files(), before)
+        XCTAssertEqual(manager.ruleCollections, collections)
+    }
+
+    func testLegacySnapshotStillRestoresAnOlderInstallation() async throws {
+        let original = manager.ruleCollections
+        var record = try await install()
+        let saved = try XCTUnwrap(record.managedCollectionSnapshot)
+        record.managedCollectionSnapshot = nil
+        try await tracker.upsert(record)
+        try await withLegacySnapshot(JSONEncoder().encode(saved)) {
+            self.manager.onRulesChanged = { Self.reload(.pending) }
+            try await PackInstaller.shared.uninstall(packID: self.pack.id, manager: self.manager, installedPackTracker: self.tracker)
+            for managed in self.pack.managedDefaults {
+                XCTAssertEqual(self.manager.ruleCollections.first { $0.id == managed.collectionID }, original.first { $0.id == managed.collectionID })
+            }
+            let installed = await self.tracker.record(for: self.pack.id)
+            XCTAssertNil(installed)
+        }
+    }
+
+    func testCorruptLegacySnapshotPreservesInstalledRevision() async throws {
+        var record = try await install()
+        record.managedCollectionSnapshot = nil
+        try await tracker.upsert(record)
+        let before = try files()
+        let original = manager.ruleCollections
+        try await withLegacySnapshot(Data("corrupt legacy snapshot".utf8)) {
+            self.manager.onRulesChanged = { XCTFail("Corrupt restore data must not reload"); return Self.reload(.applied) }
+            do {
+                try await PackInstaller.shared.uninstall(packID: self.pack.id, manager: self.manager, installedPackTracker: self.tracker)
+                XCTFail("Unreadable legacy data must block removal")
+            } catch {}
+            XCTAssertEqual(try self.files(), before)
+            XCTAssertEqual(self.manager.ruleCollections, original)
+        }
+    }
+
+    private func withLegacySnapshot(_ data: Data, operation: () async throws -> Void) async throws {
+        let url = PackCollectionSnapshot.snapshotURL(for: pack.id)
+        let previous = FileManager.default.fileExists(atPath: url.path) ? try Data(contentsOf: url) : nil
+        try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try data.write(to: url, options: .atomic)
+        defer {
+            if let previous { try? previous.write(to: url, options: .atomic) }
+            else { try? FileManager.default.removeItem(at: url) }
+        }
+        try await operation()
+    }
+
+    func testOlderRecordsDecodeWithoutEmbeddedSnapshot() throws {
+        let data = Data("{\"packID\":\"old\",\"version\":\"1\",\"installedAt\":0,\"quickSettingValues\":{}}".utf8)
+        let record = try JSONDecoder().decode(InstalledPackRecord.self, from: data)
+        XCTAssertNil(record.managedCollectionSnapshot)
+    }
+}

--- a/Tests/KeyPathTests/VallackSystemPackTests.swift
+++ b/Tests/KeyPathTests/VallackSystemPackTests.swift
@@ -270,28 +270,21 @@ final class VallackSystemPackTests: XCTestCase {
     }
 
     @MainActor
-    func testVallackInstallCreatesSnapshotFile() async throws {
+    func testVallackInstallEmbedsSnapshotInRecord() async throws {
         TestEnvironment.forceTestMode = true
         defer { TestEnvironment.forceTestMode = false }
 
         let (manager, tempDir) = try makeTestManager()
         defer { try? FileManager.default.removeItem(at: tempDir) }
 
-        _ = try await PackInstaller.shared.install(
+        let installed = try await PackInstaller.shared.install(
             PackRegistry.vallackSystem,
             manager: manager
         )
 
-        let snapshotURL = PackCollectionSnapshot.snapshotURL(for: PackRegistry.vallackSystem.id)
-        XCTAssertTrue(
-            FileManager.default.fileExists(atPath: snapshotURL.path),
-            "Snapshot file should exist after install"
-        )
-        // Clean up snapshot
-        defer { try? FileManager.default.removeItem(at: snapshotURL) }
-
-        let data = try Data(contentsOf: snapshotURL)
-        XCTAssertFalse(data.isEmpty, "Snapshot file should not be empty")
+        let snapshot = try XCTUnwrap(installed.managedCollectionSnapshot)
+        XCTAssertEqual(snapshot.packID, PackRegistry.vallackSystem.id)
+        XCTAssertFalse(snapshot.entries.isEmpty)
     }
 
     @MainActor
@@ -464,7 +457,7 @@ final class VallackSystemPackTests: XCTestCase {
     }
 
     @MainActor
-    func testVallackFailedInstallRestoresModernSnapshotAndRemovesLegacySnapshot() async throws {
+    func testVallackFailedInstallPreservesModernAndLegacySnapshots() async throws {
         TestEnvironment.forceTestMode = true
         defer { TestEnvironment.forceTestMode = false }
 
@@ -559,9 +552,9 @@ final class VallackSystemPackTests: XCTestCase {
 
         XCTAssertEqual(manager.ruleCollections, originalRuleState.collections)
         XCTAssertEqual(manager.customRules, originalRuleState.customRules)
-        XCTAssertFalse(
+        XCTAssertTrue(
             FileManager.default.fileExists(atPath: legacySnapshotURL.path),
-            "The legacy Vallack migration snapshot should retain its historical rollback cleanup"
+            "A rejected installation must preserve the legacy restore data"
         )
 
         let restoredSnapshot = try XCTUnwrap(PackCollectionSnapshot.load(for: packID))

--- a/docs/architecture/configuration-save-pipeline.md
+++ b/docs/architecture/configuration-save-pipeline.md
@@ -392,3 +392,9 @@ managed snapshots join the transaction.
 The collection toggle and rule-mutation settlement expose the canonical SaveResult
 for callers that need its cause and recovery outcome. Existing Boolean editor APIs
 adapt that result; pack callers retain it so metadata failures remain actionable.
+
+System-pack installation records carry an optional managedCollectionSnapshot. New
+system installations and removals settle that restore state with the four-file pack
+transaction. Older records omit the field and retain legacy snapshot-file fallback.
+The record is authoritative for new snapshots; no independent snapshot write must
+succeed between source preparation and runtime acceptance.

--- a/docs/bugs/system-pack-transaction.md
+++ b/docs/bugs/system-pack-transaction.md
@@ -1,0 +1,19 @@
+# Keep system-pack restore snapshots with the installation record
+
+System packs wrote a standalone managed-collection snapshot, regenerated rules,
+and then wrote the installation record. Interruption or metadata failure could
+separate those states. Removal also committed restored rules before deleting its
+record and snapshot, and retried some runtime failures as though they were mapping
+conflicts.
+
+New installations embed their managed-collection snapshot in the installed-pack
+record. The record, snapshot, and three rule files participate in the existing
+retained pack transaction. Rejection restores the exact previous revision. Removal
+uses the embedded snapshot, falling back to standalone snapshots for older records.
+Malformed restore data blocks mutation. Legacy snapshot cleanup follows successful
+settlement; it is not needed to recover the authoritative revision.
+
+The existing Restore Previous / Keep Current choice and managed-default confirmation
+remain. The known conflict-disable retry is restricted to generation mapping
+conflicts; a rejected runtime reload must not silently disable more collections.
+Preferences, cross-instance cache freshness, and revision-aware watching remain open.

--- a/docs/planning/catalog-led-consolidation-plan.md
+++ b/docs/planning/catalog-led-consolidation-plan.md
@@ -465,7 +465,7 @@ writes before preparing the layout, restore keymap fields and matching optimisti
 display preferences before failure feedback, and preserve newer display choices.
 Preferences remain in-process state; durable preference recovery remains open.
 
-### Collection-backed pack transactions in progress
+### Collection-backed pack transactions merged in #1288
 
 Commit associated collection toggles and their installed-pack records in one retained
 rule transaction on install and removal. Preserve existing confirmation and ownership
@@ -477,3 +477,14 @@ master `5bf5b09ac8e28125c1d665fbee059d051e35f691`. Signed/notarized/stapled app
 verification passed, including process and TCP readiness; installed and distribution
 executable hashes matched. This is installation/runtime-readiness evidence, not
 clean-VM first-run or physical-keyboard acceptance.
+
+### System-pack transactions in progress
+
+Embed managed-collection restore snapshots in installed-pack records so the existing
+pack journal covers both with the rule revision. Preserve legacy snapshot reading
+and existing restore/default choices. Keep runtime rejection separate from the known
+generation-conflict retry. Validate before retiring the legacy multi-write paths.
+
+Deployment checkpoint: #1288 was installed from merged master
+`f77e2c2ad63dff743a6aba8fb19c31e3704387fe`. Signing, notarization, stapling,
+process, and TCP checks passed; installed/distribution executable hashes matched.


### PR DESCRIPTION
# Keep system-pack restore snapshots with the installation record

System packs wrote a standalone managed-collection snapshot, regenerated rules,
and then wrote the installation record. Interruption or metadata failure could
separate those states. Removal also committed restored rules before deleting its
record and snapshot, and retried some runtime failures as though they were mapping
conflicts.

New installations embed their managed-collection snapshot in the installed-pack
record. The record, snapshot, and three rule files participate in the existing
retained pack transaction. Rejection restores the exact previous revision. Removal
uses the embedded snapshot, falling back to standalone snapshots for older records.
Malformed restore data blocks mutation. Legacy snapshot cleanup follows successful
settlement; it is not needed to recover the authoritative revision.

The existing Restore Previous / Keep Current choice and managed-default confirmation
remain. The known conflict-disable retry is restricted to generation mapping
conflicts; a rejected runtime reload must not silently disable more collections.
Preferences, cross-instance cache freshness, and revision-aware watching remain open.
