### PR TITLE
Lower CI runner disk reserve to 90 GiB

### DIFF
--- a/Scripts/lab/host-disk-reserve
+++ b/Scripts/lab/host-disk-reserve
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 path=${KEYPATH_DISK_RESERVE_PATH:-/System/Volumes/Data}
-minimum_gib=${KEYPATH_MIN_FREE_DISK_GIB:-100}
+minimum_gib=${KEYPATH_MIN_FREE_DISK_GIB:-90}
 
 [[ "$minimum_gib" =~ ^[0-9]+$ && "$minimum_gib" -gt 0 ]] || {
   echo "host-disk-reserve: KEYPATH_MIN_FREE_DISK_GIB must be a positive integer" >&2

--- a/docs/testing/remote-installer-lab.md
+++ b/docs/testing/remote-installer-lab.md
@@ -28,16 +28,16 @@ matching the maximum lifecycle exposed by the existing launchers.
 
 ## Host disk reserve
 
-The Mini keeps a 100 GiB internal-data-volume reserve for runner builds,
+The Mini keeps a 90 GiB internal-data-volume reserve for runner builds,
 indexing, and host OS work. `create` checks this reserve after taking the
 provider admission lock and exits 75 with `disk_reserve_busy` when admitting a
 new lease would be unsafe. It is an infrastructure wait, not a product failure.
 `preflight` reports the current reserve evidence. Set
-`KEYPATH_LAB_MIN_FREE_DISK_GIB` only for a deliberately different host policy.
+`KEYPATH_MIN_FREE_DISK_GIB` only for a deliberately different host policy.
 
 The primary self-hosted CI and cache-warm workflows run
 `Scripts/lab/host-disk-reserve` before expensive compilation. It exits 75 when
-the same 100 GiB threshold is not met.
+the same 90 GiB threshold is not met.
 
 Check the non-mutating host/provider contract:
 


### PR DESCRIPTION
Lower the default self-hosted runner free-space guard from 100 GiB to 90 GiB so builds can proceed while the external scratch migration remains pending. Update the lab documentation and correct the documented override variable to match the script.